### PR TITLE
Use public conversion methods to avoid reflection

### DIFF
--- a/cmd/genconversion/conversion.go
+++ b/cmd/genconversion/conversion.go
@@ -118,7 +118,10 @@ func main() {
 
 	b, err := imports.Process("", data.Bytes(), nil)
 	if err != nil {
-		glog.Fatalf("Error while update imports: %v", err)
+		for i, s := range bytes.Split(data.Bytes(), []byte("\n")) {
+			glog.Infof("%d:\t%s", i, s)
+		}
+		glog.Fatalf("Error while update imports: %v\n", err)
 	}
 	if _, err := funcOut.Write(b); err != nil {
 		glog.Fatalf("Error while writing out the resulting file: %v", err)

--- a/pkg/api/conversion.go
+++ b/pkg/api/conversion.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/intstr"
 )
 
 // Codec is the identity codec for this package - it can only convert itself
@@ -41,45 +42,75 @@ func init() {
 		},
 	)
 	Scheme.AddConversionFuncs(
-		func(in *unversioned.Time, out *unversioned.Time, s conversion.Scope) error {
-			// Cannot deep copy these, because time.Time has unexported fields.
-			*out = *in
-			return nil
-		},
-		func(in *string, out *labels.Selector, s conversion.Scope) error {
-			selector, err := labels.Parse(*in)
-			if err != nil {
-				return err
-			}
-			*out = selector
-			return nil
-		},
-		func(in *string, out *fields.Selector, s conversion.Scope) error {
-			selector, err := fields.ParseSelector(*in)
-			if err != nil {
-				return err
-			}
-			*out = selector
-			return nil
-		},
-		func(in *labels.Selector, out *string, s conversion.Scope) error {
-			if *in == nil {
-				return nil
-			}
-			*out = (*in).String()
-			return nil
-		},
-		func(in *fields.Selector, out *string, s conversion.Scope) error {
-			if *in == nil {
-				return nil
-			}
-			*out = (*in).String()
-			return nil
-		},
-		func(in *resource.Quantity, out *resource.Quantity, s conversion.Scope) error {
-			// Cannot deep copy these, because inf.Dec has unexported fields.
-			*out = *in.Copy()
-			return nil
-		},
+		Convert_unversioned_TypeMeta_To_unversioned_TypeMeta,
+		Convert_unversioned_ListMeta_To_unversioned_ListMeta,
+		Convert_intstr_IntOrString_To_intstr_IntOrString,
+		Convert_unversioned_Time_To_unversioned_Time,
+		Convert_string_To_labels_Selector,
+		Convert_string_To_fields_Selector,
+		Convert_labels_Selector_To_string,
+		Convert_fields_Selector_To_string,
+		Convert_resource_Quantity_To_resource_Quantity,
 	)
+}
+
+func Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(in, out *unversioned.TypeMeta, s conversion.Scope) error {
+	// These values are explicitly not copied
+	//out.APIVersion = in.APIVersion
+	//out.Kind = in.Kind
+	return nil
+}
+
+func Convert_unversioned_ListMeta_To_unversioned_ListMeta(in, out *unversioned.ListMeta, s conversion.Scope) error {
+	out.ResourceVersion = in.ResourceVersion
+	out.SelfLink = in.SelfLink
+	return nil
+}
+
+func Convert_intstr_IntOrString_To_intstr_IntOrString(in, out *intstr.IntOrString, s conversion.Scope) error {
+	out.Type = in.Type
+	out.IntVal = in.IntVal
+	out.StrVal = in.StrVal
+	return nil
+}
+
+func Convert_unversioned_Time_To_unversioned_Time(in *unversioned.Time, out *unversioned.Time, s conversion.Scope) error {
+	// Cannot deep copy these, because time.Time has unexported fields.
+	*out = *in
+	return nil
+}
+func Convert_string_To_labels_Selector(in *string, out *labels.Selector, s conversion.Scope) error {
+	selector, err := labels.Parse(*in)
+	if err != nil {
+		return err
+	}
+	*out = selector
+	return nil
+}
+func Convert_string_To_fields_Selector(in *string, out *fields.Selector, s conversion.Scope) error {
+	selector, err := fields.ParseSelector(*in)
+	if err != nil {
+		return err
+	}
+	*out = selector
+	return nil
+}
+func Convert_labels_Selector_To_string(in *labels.Selector, out *string, s conversion.Scope) error {
+	if *in == nil {
+		return nil
+	}
+	*out = (*in).String()
+	return nil
+}
+func Convert_fields_Selector_To_string(in *fields.Selector, out *string, s conversion.Scope) error {
+	if *in == nil {
+		return nil
+	}
+	*out = (*in).String()
+	return nil
+}
+func Convert_resource_Quantity_To_resource_Quantity(in *resource.Quantity, out *resource.Quantity, s conversion.Scope) error {
+	// Cannot deep copy these, because inf.Dec has unexported fields.
+	*out = *in.Copy()
+	return nil
 }

--- a/pkg/api/v1/conversion.go
+++ b/pkg/api/v1/conversion.go
@@ -36,14 +36,14 @@ const (
 func addConversionFuncs(scheme *runtime.Scheme) {
 	// Add non-generated conversion functions
 	err := scheme.AddConversionFuncs(
-		convert_api_Pod_To_v1_Pod,
-		convert_api_PodSpec_To_v1_PodSpec,
-		convert_api_ReplicationControllerSpec_To_v1_ReplicationControllerSpec,
-		convert_api_ServiceSpec_To_v1_ServiceSpec,
-		convert_v1_Pod_To_api_Pod,
-		convert_v1_PodSpec_To_api_PodSpec,
-		convert_v1_ReplicationControllerSpec_To_api_ReplicationControllerSpec,
-		convert_v1_ServiceSpec_To_api_ServiceSpec,
+		Convert_api_Pod_To_v1_Pod,
+		Convert_api_PodSpec_To_v1_PodSpec,
+		Convert_api_ReplicationControllerSpec_To_v1_ReplicationControllerSpec,
+		Convert_api_ServiceSpec_To_v1_ServiceSpec,
+		Convert_v1_Pod_To_api_Pod,
+		Convert_v1_PodSpec_To_api_PodSpec,
+		Convert_v1_ReplicationControllerSpec_To_api_ReplicationControllerSpec,
+		Convert_v1_ServiceSpec_To_api_ServiceSpec,
 	)
 	if err != nil {
 		// If one of the conversion functions is malformed, detect it immediately.
@@ -200,7 +200,7 @@ func addConversionFuncs(scheme *runtime.Scheme) {
 	}
 }
 
-func convert_api_ReplicationControllerSpec_To_v1_ReplicationControllerSpec(in *api.ReplicationControllerSpec, out *ReplicationControllerSpec, s conversion.Scope) error {
+func Convert_api_ReplicationControllerSpec_To_v1_ReplicationControllerSpec(in *api.ReplicationControllerSpec, out *ReplicationControllerSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ReplicationControllerSpec))(in)
 	}
@@ -216,7 +216,7 @@ func convert_api_ReplicationControllerSpec_To_v1_ReplicationControllerSpec(in *a
 	}
 	//if in.TemplateRef != nil {
 	//	out.TemplateRef = new(ObjectReference)
-	//	if err := convert_api_ObjectReference_To_v1_ObjectReference(in.TemplateRef, out.TemplateRef, s); err != nil {
+	//	if err := Convert_api_ObjectReference_To_v1_ObjectReference(in.TemplateRef, out.TemplateRef, s); err != nil {
 	//		return err
 	//	}
 	//} else {
@@ -224,7 +224,7 @@ func convert_api_ReplicationControllerSpec_To_v1_ReplicationControllerSpec(in *a
 	//}
 	if in.Template != nil {
 		out.Template = new(PodTemplateSpec)
-		if err := convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in.Template, out.Template, s); err != nil {
+		if err := Convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in.Template, out.Template, s); err != nil {
 			return err
 		}
 	} else {
@@ -233,7 +233,7 @@ func convert_api_ReplicationControllerSpec_To_v1_ReplicationControllerSpec(in *a
 	return nil
 }
 
-func convert_v1_ReplicationControllerSpec_To_api_ReplicationControllerSpec(in *ReplicationControllerSpec, out *api.ReplicationControllerSpec, s conversion.Scope) error {
+func Convert_v1_ReplicationControllerSpec_To_api_ReplicationControllerSpec(in *ReplicationControllerSpec, out *api.ReplicationControllerSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ReplicationControllerSpec))(in)
 	}
@@ -248,7 +248,7 @@ func convert_v1_ReplicationControllerSpec_To_api_ReplicationControllerSpec(in *R
 	}
 	//if in.TemplateRef != nil {
 	//	out.TemplateRef = new(api.ObjectReference)
-	//	if err := convert_v1_ObjectReference_To_api_ObjectReference(in.TemplateRef, out.TemplateRef, s); err != nil {
+	//	if err := Convert_v1_ObjectReference_To_api_ObjectReference(in.TemplateRef, out.TemplateRef, s); err != nil {
 	//		return err
 	//	}
 	//} else {
@@ -256,7 +256,7 @@ func convert_v1_ReplicationControllerSpec_To_api_ReplicationControllerSpec(in *R
 	//}
 	if in.Template != nil {
 		out.Template = new(api.PodTemplateSpec)
-		if err := convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in.Template, out.Template, s); err != nil {
+		if err := Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in.Template, out.Template, s); err != nil {
 			return err
 		}
 	} else {
@@ -267,14 +267,14 @@ func convert_v1_ReplicationControllerSpec_To_api_ReplicationControllerSpec(in *R
 
 // The following two PodSpec conversions are done here to support ServiceAccount
 // as an alias for ServiceAccountName.
-func convert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *PodSpec, s conversion.Scope) error {
+func Convert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *PodSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodSpec))(in)
 	}
 	if in.Volumes != nil {
 		out.Volumes = make([]Volume, len(in.Volumes))
 		for i := range in.Volumes {
-			if err := convert_api_Volume_To_v1_Volume(&in.Volumes[i], &out.Volumes[i], s); err != nil {
+			if err := Convert_api_Volume_To_v1_Volume(&in.Volumes[i], &out.Volumes[i], s); err != nil {
 				return err
 			}
 		}
@@ -284,7 +284,7 @@ func convert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *PodSpec, s conversi
 	if in.Containers != nil {
 		out.Containers = make([]Container, len(in.Containers))
 		for i := range in.Containers {
-			if err := convert_api_Container_To_v1_Container(&in.Containers[i], &out.Containers[i], s); err != nil {
+			if err := Convert_api_Container_To_v1_Container(&in.Containers[i], &out.Containers[i], s); err != nil {
 				return err
 			}
 		}
@@ -319,7 +319,7 @@ func convert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *PodSpec, s conversi
 	out.NodeName = in.NodeName
 	if in.SecurityContext != nil {
 		out.SecurityContext = new(PodSecurityContext)
-		if err := convert_api_PodSecurityContext_To_v1_PodSecurityContext(in.SecurityContext, out.SecurityContext, s); err != nil {
+		if err := Convert_api_PodSecurityContext_To_v1_PodSecurityContext(in.SecurityContext, out.SecurityContext, s); err != nil {
 			return err
 		}
 
@@ -332,7 +332,7 @@ func convert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *PodSpec, s conversi
 	if in.ImagePullSecrets != nil {
 		out.ImagePullSecrets = make([]LocalObjectReference, len(in.ImagePullSecrets))
 		for i := range in.ImagePullSecrets {
-			if err := convert_api_LocalObjectReference_To_v1_LocalObjectReference(&in.ImagePullSecrets[i], &out.ImagePullSecrets[i], s); err != nil {
+			if err := Convert_api_LocalObjectReference_To_v1_LocalObjectReference(&in.ImagePullSecrets[i], &out.ImagePullSecrets[i], s); err != nil {
 				return err
 			}
 		}
@@ -342,14 +342,14 @@ func convert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *PodSpec, s conversi
 	return nil
 }
 
-func convert_v1_PodSpec_To_api_PodSpec(in *PodSpec, out *api.PodSpec, s conversion.Scope) error {
+func Convert_v1_PodSpec_To_api_PodSpec(in *PodSpec, out *api.PodSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PodSpec))(in)
 	}
 	if in.Volumes != nil {
 		out.Volumes = make([]api.Volume, len(in.Volumes))
 		for i := range in.Volumes {
-			if err := convert_v1_Volume_To_api_Volume(&in.Volumes[i], &out.Volumes[i], s); err != nil {
+			if err := Convert_v1_Volume_To_api_Volume(&in.Volumes[i], &out.Volumes[i], s); err != nil {
 				return err
 			}
 		}
@@ -359,7 +359,7 @@ func convert_v1_PodSpec_To_api_PodSpec(in *PodSpec, out *api.PodSpec, s conversi
 	if in.Containers != nil {
 		out.Containers = make([]api.Container, len(in.Containers))
 		for i := range in.Containers {
-			if err := convert_v1_Container_To_api_Container(&in.Containers[i], &out.Containers[i], s); err != nil {
+			if err := Convert_v1_Container_To_api_Container(&in.Containers[i], &out.Containers[i], s); err != nil {
 				return err
 			}
 		}
@@ -397,7 +397,7 @@ func convert_v1_PodSpec_To_api_PodSpec(in *PodSpec, out *api.PodSpec, s conversi
 	out.NodeName = in.NodeName
 	if in.SecurityContext != nil {
 		out.SecurityContext = new(api.PodSecurityContext)
-		if err := convert_v1_PodSecurityContext_To_api_PodSecurityContext(in.SecurityContext, out.SecurityContext, s); err != nil {
+		if err := Convert_v1_PodSecurityContext_To_api_PodSecurityContext(in.SecurityContext, out.SecurityContext, s); err != nil {
 			return err
 		}
 	}
@@ -413,7 +413,7 @@ func convert_v1_PodSpec_To_api_PodSpec(in *PodSpec, out *api.PodSpec, s conversi
 	if in.ImagePullSecrets != nil {
 		out.ImagePullSecrets = make([]api.LocalObjectReference, len(in.ImagePullSecrets))
 		for i := range in.ImagePullSecrets {
-			if err := convert_v1_LocalObjectReference_To_api_LocalObjectReference(&in.ImagePullSecrets[i], &out.ImagePullSecrets[i], s); err != nil {
+			if err := Convert_v1_LocalObjectReference_To_api_LocalObjectReference(&in.ImagePullSecrets[i], &out.ImagePullSecrets[i], s); err != nil {
 				return err
 			}
 		}
@@ -424,8 +424,8 @@ func convert_v1_PodSpec_To_api_PodSpec(in *PodSpec, out *api.PodSpec, s conversi
 	return nil
 }
 
-func convert_api_Pod_To_v1_Pod(in *api.Pod, out *Pod, s conversion.Scope) error {
-	if err := autoconvert_api_Pod_To_v1_Pod(in, out, s); err != nil {
+func Convert_api_Pod_To_v1_Pod(in *api.Pod, out *Pod, s conversion.Scope) error {
+	if err := autoConvert_api_Pod_To_v1_Pod(in, out, s); err != nil {
 		return err
 	}
 	// We need to reset certain fields for mirror pods from pre-v1.1 kubelet
@@ -442,12 +442,12 @@ func convert_api_Pod_To_v1_Pod(in *api.Pod, out *Pod, s conversion.Scope) error 
 	return nil
 }
 
-func convert_v1_Pod_To_api_Pod(in *Pod, out *api.Pod, s conversion.Scope) error {
-	return autoconvert_v1_Pod_To_api_Pod(in, out, s)
+func Convert_v1_Pod_To_api_Pod(in *Pod, out *api.Pod, s conversion.Scope) error {
+	return autoConvert_v1_Pod_To_api_Pod(in, out, s)
 }
 
-func convert_api_ServiceSpec_To_v1_ServiceSpec(in *api.ServiceSpec, out *ServiceSpec, s conversion.Scope) error {
-	if err := autoconvert_api_ServiceSpec_To_v1_ServiceSpec(in, out, s); err != nil {
+func Convert_api_ServiceSpec_To_v1_ServiceSpec(in *api.ServiceSpec, out *ServiceSpec, s conversion.Scope) error {
+	if err := autoConvert_api_ServiceSpec_To_v1_ServiceSpec(in, out, s); err != nil {
 		return err
 	}
 	// Publish both externalIPs and deprecatedPublicIPs fields in v1.
@@ -457,8 +457,8 @@ func convert_api_ServiceSpec_To_v1_ServiceSpec(in *api.ServiceSpec, out *Service
 	return nil
 }
 
-func convert_v1_ServiceSpec_To_api_ServiceSpec(in *ServiceSpec, out *api.ServiceSpec, s conversion.Scope) error {
-	if err := autoconvert_v1_ServiceSpec_To_api_ServiceSpec(in, out, s); err != nil {
+func Convert_v1_ServiceSpec_To_api_ServiceSpec(in *ServiceSpec, out *api.ServiceSpec, s conversion.Scope) error {
+	if err := autoConvert_v1_ServiceSpec_To_api_ServiceSpec(in, out, s); err != nil {
 		return err
 	}
 	// Prefer the legacy deprecatedPublicIPs field, if provided.
@@ -471,7 +471,7 @@ func convert_v1_ServiceSpec_To_api_ServiceSpec(in *ServiceSpec, out *api.Service
 	return nil
 }
 
-func convert_api_PodSecurityContext_To_v1_PodSecurityContext(in *api.PodSecurityContext, out *PodSecurityContext, s conversion.Scope) error {
+func Convert_api_PodSecurityContext_To_v1_PodSecurityContext(in *api.PodSecurityContext, out *PodSecurityContext, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodSecurityContext))(in)
 	}
@@ -479,7 +479,7 @@ func convert_api_PodSecurityContext_To_v1_PodSecurityContext(in *api.PodSecurity
 	out.SupplementalGroups = in.SupplementalGroups
 	if in.SELinuxOptions != nil {
 		out.SELinuxOptions = new(SELinuxOptions)
-		if err := convert_api_SELinuxOptions_To_v1_SELinuxOptions(in.SELinuxOptions, out.SELinuxOptions, s); err != nil {
+		if err := Convert_api_SELinuxOptions_To_v1_SELinuxOptions(in.SELinuxOptions, out.SELinuxOptions, s); err != nil {
 			return err
 		}
 	} else {
@@ -506,7 +506,7 @@ func convert_api_PodSecurityContext_To_v1_PodSecurityContext(in *api.PodSecurity
 	return nil
 }
 
-func convert_v1_PodSecurityContext_To_api_PodSecurityContext(in *PodSecurityContext, out *api.PodSecurityContext, s conversion.Scope) error {
+func Convert_v1_PodSecurityContext_To_api_PodSecurityContext(in *PodSecurityContext, out *api.PodSecurityContext, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PodSecurityContext))(in)
 	}
@@ -514,7 +514,7 @@ func convert_v1_PodSecurityContext_To_api_PodSecurityContext(in *PodSecurityCont
 	out.SupplementalGroups = in.SupplementalGroups
 	if in.SELinuxOptions != nil {
 		out.SELinuxOptions = new(api.SELinuxOptions)
-		if err := convert_v1_SELinuxOptions_To_api_SELinuxOptions(in.SELinuxOptions, out.SELinuxOptions, s); err != nil {
+		if err := Convert_v1_SELinuxOptions_To_api_SELinuxOptions(in.SELinuxOptions, out.SELinuxOptions, s); err != nil {
 			return err
 		}
 	} else {

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -27,7 +27,7 @@ import (
 	conversion "k8s.io/kubernetes/pkg/conversion"
 )
 
-func autoconvert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVolumeSource(in *api.AWSElasticBlockStoreVolumeSource, out *AWSElasticBlockStoreVolumeSource, s conversion.Scope) error {
+func autoConvert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVolumeSource(in *api.AWSElasticBlockStoreVolumeSource, out *AWSElasticBlockStoreVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.AWSElasticBlockStoreVolumeSource))(in)
 	}
@@ -38,31 +38,31 @@ func autoconvert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStore
 	return nil
 }
 
-func convert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVolumeSource(in *api.AWSElasticBlockStoreVolumeSource, out *AWSElasticBlockStoreVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVolumeSource(in, out, s)
+func Convert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVolumeSource(in *api.AWSElasticBlockStoreVolumeSource, out *AWSElasticBlockStoreVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVolumeSource(in, out, s)
 }
 
-func autoconvert_api_Binding_To_v1_Binding(in *api.Binding, out *Binding, s conversion.Scope) error {
+func autoConvert_api_Binding_To_v1_Binding(in *api.Binding, out *Binding, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Binding))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ObjectReference_To_v1_ObjectReference(&in.Target, &out.Target, s); err != nil {
+	if err := Convert_api_ObjectReference_To_v1_ObjectReference(&in.Target, &out.Target, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_api_Binding_To_v1_Binding(in *api.Binding, out *Binding, s conversion.Scope) error {
-	return autoconvert_api_Binding_To_v1_Binding(in, out, s)
+func Convert_api_Binding_To_v1_Binding(in *api.Binding, out *Binding, s conversion.Scope) error {
+	return autoConvert_api_Binding_To_v1_Binding(in, out, s)
 }
 
-func autoconvert_api_Capabilities_To_v1_Capabilities(in *api.Capabilities, out *Capabilities, s conversion.Scope) error {
+func autoConvert_api_Capabilities_To_v1_Capabilities(in *api.Capabilities, out *Capabilities, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Capabilities))(in)
 	}
@@ -85,11 +85,11 @@ func autoconvert_api_Capabilities_To_v1_Capabilities(in *api.Capabilities, out *
 	return nil
 }
 
-func convert_api_Capabilities_To_v1_Capabilities(in *api.Capabilities, out *Capabilities, s conversion.Scope) error {
-	return autoconvert_api_Capabilities_To_v1_Capabilities(in, out, s)
+func Convert_api_Capabilities_To_v1_Capabilities(in *api.Capabilities, out *Capabilities, s conversion.Scope) error {
+	return autoConvert_api_Capabilities_To_v1_Capabilities(in, out, s)
 }
 
-func autoconvert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in *api.CephFSVolumeSource, out *CephFSVolumeSource, s conversion.Scope) error {
+func autoConvert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in *api.CephFSVolumeSource, out *CephFSVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.CephFSVolumeSource))(in)
 	}
@@ -103,9 +103,10 @@ func autoconvert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in *api.CephFSV
 	}
 	out.User = in.User
 	out.SecretFile = in.SecretFile
+	// unable to generate simple pointer conversion for api.LocalObjectReference -> v1.LocalObjectReference
 	if in.SecretRef != nil {
 		out.SecretRef = new(LocalObjectReference)
-		if err := convert_api_LocalObjectReference_To_v1_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
+		if err := Convert_api_LocalObjectReference_To_v1_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
 			return err
 		}
 	} else {
@@ -115,11 +116,11 @@ func autoconvert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in *api.CephFSV
 	return nil
 }
 
-func convert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in *api.CephFSVolumeSource, out *CephFSVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in, out, s)
+func Convert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in *api.CephFSVolumeSource, out *CephFSVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in, out, s)
 }
 
-func autoconvert_api_CinderVolumeSource_To_v1_CinderVolumeSource(in *api.CinderVolumeSource, out *CinderVolumeSource, s conversion.Scope) error {
+func autoConvert_api_CinderVolumeSource_To_v1_CinderVolumeSource(in *api.CinderVolumeSource, out *CinderVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.CinderVolumeSource))(in)
 	}
@@ -129,11 +130,11 @@ func autoconvert_api_CinderVolumeSource_To_v1_CinderVolumeSource(in *api.CinderV
 	return nil
 }
 
-func convert_api_CinderVolumeSource_To_v1_CinderVolumeSource(in *api.CinderVolumeSource, out *CinderVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_CinderVolumeSource_To_v1_CinderVolumeSource(in, out, s)
+func Convert_api_CinderVolumeSource_To_v1_CinderVolumeSource(in *api.CinderVolumeSource, out *CinderVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_CinderVolumeSource_To_v1_CinderVolumeSource(in, out, s)
 }
 
-func autoconvert_api_ComponentCondition_To_v1_ComponentCondition(in *api.ComponentCondition, out *ComponentCondition, s conversion.Scope) error {
+func autoConvert_api_ComponentCondition_To_v1_ComponentCondition(in *api.ComponentCondition, out *ComponentCondition, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ComponentCondition))(in)
 	}
@@ -144,24 +145,24 @@ func autoconvert_api_ComponentCondition_To_v1_ComponentCondition(in *api.Compone
 	return nil
 }
 
-func convert_api_ComponentCondition_To_v1_ComponentCondition(in *api.ComponentCondition, out *ComponentCondition, s conversion.Scope) error {
-	return autoconvert_api_ComponentCondition_To_v1_ComponentCondition(in, out, s)
+func Convert_api_ComponentCondition_To_v1_ComponentCondition(in *api.ComponentCondition, out *ComponentCondition, s conversion.Scope) error {
+	return autoConvert_api_ComponentCondition_To_v1_ComponentCondition(in, out, s)
 }
 
-func autoconvert_api_ComponentStatus_To_v1_ComponentStatus(in *api.ComponentStatus, out *ComponentStatus, s conversion.Scope) error {
+func autoConvert_api_ComponentStatus_To_v1_ComponentStatus(in *api.ComponentStatus, out *ComponentStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ComponentStatus))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
 	if in.Conditions != nil {
 		out.Conditions = make([]ComponentCondition, len(in.Conditions))
 		for i := range in.Conditions {
-			if err := convert_api_ComponentCondition_To_v1_ComponentCondition(&in.Conditions[i], &out.Conditions[i], s); err != nil {
+			if err := Convert_api_ComponentCondition_To_v1_ComponentCondition(&in.Conditions[i], &out.Conditions[i], s); err != nil {
 				return err
 			}
 		}
@@ -171,24 +172,24 @@ func autoconvert_api_ComponentStatus_To_v1_ComponentStatus(in *api.ComponentStat
 	return nil
 }
 
-func convert_api_ComponentStatus_To_v1_ComponentStatus(in *api.ComponentStatus, out *ComponentStatus, s conversion.Scope) error {
-	return autoconvert_api_ComponentStatus_To_v1_ComponentStatus(in, out, s)
+func Convert_api_ComponentStatus_To_v1_ComponentStatus(in *api.ComponentStatus, out *ComponentStatus, s conversion.Scope) error {
+	return autoConvert_api_ComponentStatus_To_v1_ComponentStatus(in, out, s)
 }
 
-func autoconvert_api_ComponentStatusList_To_v1_ComponentStatusList(in *api.ComponentStatusList, out *ComponentStatusList, s conversion.Scope) error {
+func autoConvert_api_ComponentStatusList_To_v1_ComponentStatusList(in *api.ComponentStatusList, out *ComponentStatusList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ComponentStatusList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]ComponentStatus, len(in.Items))
 		for i := range in.Items {
-			if err := convert_api_ComponentStatus_To_v1_ComponentStatus(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_api_ComponentStatus_To_v1_ComponentStatus(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -198,11 +199,11 @@ func autoconvert_api_ComponentStatusList_To_v1_ComponentStatusList(in *api.Compo
 	return nil
 }
 
-func convert_api_ComponentStatusList_To_v1_ComponentStatusList(in *api.ComponentStatusList, out *ComponentStatusList, s conversion.Scope) error {
-	return autoconvert_api_ComponentStatusList_To_v1_ComponentStatusList(in, out, s)
+func Convert_api_ComponentStatusList_To_v1_ComponentStatusList(in *api.ComponentStatusList, out *ComponentStatusList, s conversion.Scope) error {
+	return autoConvert_api_ComponentStatusList_To_v1_ComponentStatusList(in, out, s)
 }
 
-func autoconvert_api_Container_To_v1_Container(in *api.Container, out *Container, s conversion.Scope) error {
+func autoConvert_api_Container_To_v1_Container(in *api.Container, out *Container, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Container))(in)
 	}
@@ -228,7 +229,7 @@ func autoconvert_api_Container_To_v1_Container(in *api.Container, out *Container
 	if in.Ports != nil {
 		out.Ports = make([]ContainerPort, len(in.Ports))
 		for i := range in.Ports {
-			if err := convert_api_ContainerPort_To_v1_ContainerPort(&in.Ports[i], &out.Ports[i], s); err != nil {
+			if err := Convert_api_ContainerPort_To_v1_ContainerPort(&in.Ports[i], &out.Ports[i], s); err != nil {
 				return err
 			}
 		}
@@ -238,45 +239,48 @@ func autoconvert_api_Container_To_v1_Container(in *api.Container, out *Container
 	if in.Env != nil {
 		out.Env = make([]EnvVar, len(in.Env))
 		for i := range in.Env {
-			if err := convert_api_EnvVar_To_v1_EnvVar(&in.Env[i], &out.Env[i], s); err != nil {
+			if err := Convert_api_EnvVar_To_v1_EnvVar(&in.Env[i], &out.Env[i], s); err != nil {
 				return err
 			}
 		}
 	} else {
 		out.Env = nil
 	}
-	if err := convert_api_ResourceRequirements_To_v1_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
+	if err := Convert_api_ResourceRequirements_To_v1_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
 		return err
 	}
 	if in.VolumeMounts != nil {
 		out.VolumeMounts = make([]VolumeMount, len(in.VolumeMounts))
 		for i := range in.VolumeMounts {
-			if err := convert_api_VolumeMount_To_v1_VolumeMount(&in.VolumeMounts[i], &out.VolumeMounts[i], s); err != nil {
+			if err := Convert_api_VolumeMount_To_v1_VolumeMount(&in.VolumeMounts[i], &out.VolumeMounts[i], s); err != nil {
 				return err
 			}
 		}
 	} else {
 		out.VolumeMounts = nil
 	}
+	// unable to generate simple pointer conversion for api.Probe -> v1.Probe
 	if in.LivenessProbe != nil {
 		out.LivenessProbe = new(Probe)
-		if err := convert_api_Probe_To_v1_Probe(in.LivenessProbe, out.LivenessProbe, s); err != nil {
+		if err := Convert_api_Probe_To_v1_Probe(in.LivenessProbe, out.LivenessProbe, s); err != nil {
 			return err
 		}
 	} else {
 		out.LivenessProbe = nil
 	}
+	// unable to generate simple pointer conversion for api.Probe -> v1.Probe
 	if in.ReadinessProbe != nil {
 		out.ReadinessProbe = new(Probe)
-		if err := convert_api_Probe_To_v1_Probe(in.ReadinessProbe, out.ReadinessProbe, s); err != nil {
+		if err := Convert_api_Probe_To_v1_Probe(in.ReadinessProbe, out.ReadinessProbe, s); err != nil {
 			return err
 		}
 	} else {
 		out.ReadinessProbe = nil
 	}
+	// unable to generate simple pointer conversion for api.Lifecycle -> v1.Lifecycle
 	if in.Lifecycle != nil {
 		out.Lifecycle = new(Lifecycle)
-		if err := convert_api_Lifecycle_To_v1_Lifecycle(in.Lifecycle, out.Lifecycle, s); err != nil {
+		if err := Convert_api_Lifecycle_To_v1_Lifecycle(in.Lifecycle, out.Lifecycle, s); err != nil {
 			return err
 		}
 	} else {
@@ -284,9 +288,10 @@ func autoconvert_api_Container_To_v1_Container(in *api.Container, out *Container
 	}
 	out.TerminationMessagePath = in.TerminationMessagePath
 	out.ImagePullPolicy = PullPolicy(in.ImagePullPolicy)
+	// unable to generate simple pointer conversion for api.SecurityContext -> v1.SecurityContext
 	if in.SecurityContext != nil {
 		out.SecurityContext = new(SecurityContext)
-		if err := convert_api_SecurityContext_To_v1_SecurityContext(in.SecurityContext, out.SecurityContext, s); err != nil {
+		if err := Convert_api_SecurityContext_To_v1_SecurityContext(in.SecurityContext, out.SecurityContext, s); err != nil {
 			return err
 		}
 	} else {
@@ -298,11 +303,11 @@ func autoconvert_api_Container_To_v1_Container(in *api.Container, out *Container
 	return nil
 }
 
-func convert_api_Container_To_v1_Container(in *api.Container, out *Container, s conversion.Scope) error {
-	return autoconvert_api_Container_To_v1_Container(in, out, s)
+func Convert_api_Container_To_v1_Container(in *api.Container, out *Container, s conversion.Scope) error {
+	return autoConvert_api_Container_To_v1_Container(in, out, s)
 }
 
-func autoconvert_api_ContainerPort_To_v1_ContainerPort(in *api.ContainerPort, out *ContainerPort, s conversion.Scope) error {
+func autoConvert_api_ContainerPort_To_v1_ContainerPort(in *api.ContainerPort, out *ContainerPort, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ContainerPort))(in)
 	}
@@ -314,33 +319,36 @@ func autoconvert_api_ContainerPort_To_v1_ContainerPort(in *api.ContainerPort, ou
 	return nil
 }
 
-func convert_api_ContainerPort_To_v1_ContainerPort(in *api.ContainerPort, out *ContainerPort, s conversion.Scope) error {
-	return autoconvert_api_ContainerPort_To_v1_ContainerPort(in, out, s)
+func Convert_api_ContainerPort_To_v1_ContainerPort(in *api.ContainerPort, out *ContainerPort, s conversion.Scope) error {
+	return autoConvert_api_ContainerPort_To_v1_ContainerPort(in, out, s)
 }
 
-func autoconvert_api_ContainerState_To_v1_ContainerState(in *api.ContainerState, out *ContainerState, s conversion.Scope) error {
+func autoConvert_api_ContainerState_To_v1_ContainerState(in *api.ContainerState, out *ContainerState, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ContainerState))(in)
 	}
+	// unable to generate simple pointer conversion for api.ContainerStateWaiting -> v1.ContainerStateWaiting
 	if in.Waiting != nil {
 		out.Waiting = new(ContainerStateWaiting)
-		if err := convert_api_ContainerStateWaiting_To_v1_ContainerStateWaiting(in.Waiting, out.Waiting, s); err != nil {
+		if err := Convert_api_ContainerStateWaiting_To_v1_ContainerStateWaiting(in.Waiting, out.Waiting, s); err != nil {
 			return err
 		}
 	} else {
 		out.Waiting = nil
 	}
+	// unable to generate simple pointer conversion for api.ContainerStateRunning -> v1.ContainerStateRunning
 	if in.Running != nil {
 		out.Running = new(ContainerStateRunning)
-		if err := convert_api_ContainerStateRunning_To_v1_ContainerStateRunning(in.Running, out.Running, s); err != nil {
+		if err := Convert_api_ContainerStateRunning_To_v1_ContainerStateRunning(in.Running, out.Running, s); err != nil {
 			return err
 		}
 	} else {
 		out.Running = nil
 	}
+	// unable to generate simple pointer conversion for api.ContainerStateTerminated -> v1.ContainerStateTerminated
 	if in.Terminated != nil {
 		out.Terminated = new(ContainerStateTerminated)
-		if err := convert_api_ContainerStateTerminated_To_v1_ContainerStateTerminated(in.Terminated, out.Terminated, s); err != nil {
+		if err := Convert_api_ContainerStateTerminated_To_v1_ContainerStateTerminated(in.Terminated, out.Terminated, s); err != nil {
 			return err
 		}
 	} else {
@@ -349,25 +357,25 @@ func autoconvert_api_ContainerState_To_v1_ContainerState(in *api.ContainerState,
 	return nil
 }
 
-func convert_api_ContainerState_To_v1_ContainerState(in *api.ContainerState, out *ContainerState, s conversion.Scope) error {
-	return autoconvert_api_ContainerState_To_v1_ContainerState(in, out, s)
+func Convert_api_ContainerState_To_v1_ContainerState(in *api.ContainerState, out *ContainerState, s conversion.Scope) error {
+	return autoConvert_api_ContainerState_To_v1_ContainerState(in, out, s)
 }
 
-func autoconvert_api_ContainerStateRunning_To_v1_ContainerStateRunning(in *api.ContainerStateRunning, out *ContainerStateRunning, s conversion.Scope) error {
+func autoConvert_api_ContainerStateRunning_To_v1_ContainerStateRunning(in *api.ContainerStateRunning, out *ContainerStateRunning, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ContainerStateRunning))(in)
 	}
-	if err := s.Convert(&in.StartedAt, &out.StartedAt, 0); err != nil {
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.StartedAt, &out.StartedAt, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_api_ContainerStateRunning_To_v1_ContainerStateRunning(in *api.ContainerStateRunning, out *ContainerStateRunning, s conversion.Scope) error {
-	return autoconvert_api_ContainerStateRunning_To_v1_ContainerStateRunning(in, out, s)
+func Convert_api_ContainerStateRunning_To_v1_ContainerStateRunning(in *api.ContainerStateRunning, out *ContainerStateRunning, s conversion.Scope) error {
+	return autoConvert_api_ContainerStateRunning_To_v1_ContainerStateRunning(in, out, s)
 }
 
-func autoconvert_api_ContainerStateTerminated_To_v1_ContainerStateTerminated(in *api.ContainerStateTerminated, out *ContainerStateTerminated, s conversion.Scope) error {
+func autoConvert_api_ContainerStateTerminated_To_v1_ContainerStateTerminated(in *api.ContainerStateTerminated, out *ContainerStateTerminated, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ContainerStateTerminated))(in)
 	}
@@ -375,21 +383,21 @@ func autoconvert_api_ContainerStateTerminated_To_v1_ContainerStateTerminated(in 
 	out.Signal = int32(in.Signal)
 	out.Reason = in.Reason
 	out.Message = in.Message
-	if err := s.Convert(&in.StartedAt, &out.StartedAt, 0); err != nil {
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.StartedAt, &out.StartedAt, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.FinishedAt, &out.FinishedAt, 0); err != nil {
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.FinishedAt, &out.FinishedAt, s); err != nil {
 		return err
 	}
 	out.ContainerID = in.ContainerID
 	return nil
 }
 
-func convert_api_ContainerStateTerminated_To_v1_ContainerStateTerminated(in *api.ContainerStateTerminated, out *ContainerStateTerminated, s conversion.Scope) error {
-	return autoconvert_api_ContainerStateTerminated_To_v1_ContainerStateTerminated(in, out, s)
+func Convert_api_ContainerStateTerminated_To_v1_ContainerStateTerminated(in *api.ContainerStateTerminated, out *ContainerStateTerminated, s conversion.Scope) error {
+	return autoConvert_api_ContainerStateTerminated_To_v1_ContainerStateTerminated(in, out, s)
 }
 
-func autoconvert_api_ContainerStateWaiting_To_v1_ContainerStateWaiting(in *api.ContainerStateWaiting, out *ContainerStateWaiting, s conversion.Scope) error {
+func autoConvert_api_ContainerStateWaiting_To_v1_ContainerStateWaiting(in *api.ContainerStateWaiting, out *ContainerStateWaiting, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ContainerStateWaiting))(in)
 	}
@@ -398,19 +406,19 @@ func autoconvert_api_ContainerStateWaiting_To_v1_ContainerStateWaiting(in *api.C
 	return nil
 }
 
-func convert_api_ContainerStateWaiting_To_v1_ContainerStateWaiting(in *api.ContainerStateWaiting, out *ContainerStateWaiting, s conversion.Scope) error {
-	return autoconvert_api_ContainerStateWaiting_To_v1_ContainerStateWaiting(in, out, s)
+func Convert_api_ContainerStateWaiting_To_v1_ContainerStateWaiting(in *api.ContainerStateWaiting, out *ContainerStateWaiting, s conversion.Scope) error {
+	return autoConvert_api_ContainerStateWaiting_To_v1_ContainerStateWaiting(in, out, s)
 }
 
-func autoconvert_api_ContainerStatus_To_v1_ContainerStatus(in *api.ContainerStatus, out *ContainerStatus, s conversion.Scope) error {
+func autoConvert_api_ContainerStatus_To_v1_ContainerStatus(in *api.ContainerStatus, out *ContainerStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ContainerStatus))(in)
 	}
 	out.Name = in.Name
-	if err := convert_api_ContainerState_To_v1_ContainerState(&in.State, &out.State, s); err != nil {
+	if err := Convert_api_ContainerState_To_v1_ContainerState(&in.State, &out.State, s); err != nil {
 		return err
 	}
-	if err := convert_api_ContainerState_To_v1_ContainerState(&in.LastTerminationState, &out.LastTerminationState, s); err != nil {
+	if err := Convert_api_ContainerState_To_v1_ContainerState(&in.LastTerminationState, &out.LastTerminationState, s); err != nil {
 		return err
 	}
 	out.Ready = in.Ready
@@ -421,11 +429,11 @@ func autoconvert_api_ContainerStatus_To_v1_ContainerStatus(in *api.ContainerStat
 	return nil
 }
 
-func convert_api_ContainerStatus_To_v1_ContainerStatus(in *api.ContainerStatus, out *ContainerStatus, s conversion.Scope) error {
-	return autoconvert_api_ContainerStatus_To_v1_ContainerStatus(in, out, s)
+func Convert_api_ContainerStatus_To_v1_ContainerStatus(in *api.ContainerStatus, out *ContainerStatus, s conversion.Scope) error {
+	return autoConvert_api_ContainerStatus_To_v1_ContainerStatus(in, out, s)
 }
 
-func autoconvert_api_DaemonEndpoint_To_v1_DaemonEndpoint(in *api.DaemonEndpoint, out *DaemonEndpoint, s conversion.Scope) error {
+func autoConvert_api_DaemonEndpoint_To_v1_DaemonEndpoint(in *api.DaemonEndpoint, out *DaemonEndpoint, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.DaemonEndpoint))(in)
 	}
@@ -433,15 +441,15 @@ func autoconvert_api_DaemonEndpoint_To_v1_DaemonEndpoint(in *api.DaemonEndpoint,
 	return nil
 }
 
-func convert_api_DaemonEndpoint_To_v1_DaemonEndpoint(in *api.DaemonEndpoint, out *DaemonEndpoint, s conversion.Scope) error {
-	return autoconvert_api_DaemonEndpoint_To_v1_DaemonEndpoint(in, out, s)
+func Convert_api_DaemonEndpoint_To_v1_DaemonEndpoint(in *api.DaemonEndpoint, out *DaemonEndpoint, s conversion.Scope) error {
+	return autoConvert_api_DaemonEndpoint_To_v1_DaemonEndpoint(in, out, s)
 }
 
-func autoconvert_api_DeleteOptions_To_v1_DeleteOptions(in *api.DeleteOptions, out *DeleteOptions, s conversion.Scope) error {
+func autoConvert_api_DeleteOptions_To_v1_DeleteOptions(in *api.DeleteOptions, out *DeleteOptions, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.DeleteOptions))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
 	if in.GracePeriodSeconds != nil {
@@ -453,33 +461,33 @@ func autoconvert_api_DeleteOptions_To_v1_DeleteOptions(in *api.DeleteOptions, ou
 	return nil
 }
 
-func convert_api_DeleteOptions_To_v1_DeleteOptions(in *api.DeleteOptions, out *DeleteOptions, s conversion.Scope) error {
-	return autoconvert_api_DeleteOptions_To_v1_DeleteOptions(in, out, s)
+func Convert_api_DeleteOptions_To_v1_DeleteOptions(in *api.DeleteOptions, out *DeleteOptions, s conversion.Scope) error {
+	return autoConvert_api_DeleteOptions_To_v1_DeleteOptions(in, out, s)
 }
 
-func autoconvert_api_DownwardAPIVolumeFile_To_v1_DownwardAPIVolumeFile(in *api.DownwardAPIVolumeFile, out *DownwardAPIVolumeFile, s conversion.Scope) error {
+func autoConvert_api_DownwardAPIVolumeFile_To_v1_DownwardAPIVolumeFile(in *api.DownwardAPIVolumeFile, out *DownwardAPIVolumeFile, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.DownwardAPIVolumeFile))(in)
 	}
 	out.Path = in.Path
-	if err := convert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector(&in.FieldRef, &out.FieldRef, s); err != nil {
+	if err := Convert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector(&in.FieldRef, &out.FieldRef, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_api_DownwardAPIVolumeFile_To_v1_DownwardAPIVolumeFile(in *api.DownwardAPIVolumeFile, out *DownwardAPIVolumeFile, s conversion.Scope) error {
-	return autoconvert_api_DownwardAPIVolumeFile_To_v1_DownwardAPIVolumeFile(in, out, s)
+func Convert_api_DownwardAPIVolumeFile_To_v1_DownwardAPIVolumeFile(in *api.DownwardAPIVolumeFile, out *DownwardAPIVolumeFile, s conversion.Scope) error {
+	return autoConvert_api_DownwardAPIVolumeFile_To_v1_DownwardAPIVolumeFile(in, out, s)
 }
 
-func autoconvert_api_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource(in *api.DownwardAPIVolumeSource, out *DownwardAPIVolumeSource, s conversion.Scope) error {
+func autoConvert_api_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource(in *api.DownwardAPIVolumeSource, out *DownwardAPIVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.DownwardAPIVolumeSource))(in)
 	}
 	if in.Items != nil {
 		out.Items = make([]DownwardAPIVolumeFile, len(in.Items))
 		for i := range in.Items {
-			if err := convert_api_DownwardAPIVolumeFile_To_v1_DownwardAPIVolumeFile(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_api_DownwardAPIVolumeFile_To_v1_DownwardAPIVolumeFile(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -489,11 +497,11 @@ func autoconvert_api_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource(in *a
 	return nil
 }
 
-func convert_api_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource(in *api.DownwardAPIVolumeSource, out *DownwardAPIVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource(in, out, s)
+func Convert_api_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource(in *api.DownwardAPIVolumeSource, out *DownwardAPIVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource(in, out, s)
 }
 
-func autoconvert_api_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource(in *api.EmptyDirVolumeSource, out *EmptyDirVolumeSource, s conversion.Scope) error {
+func autoConvert_api_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource(in *api.EmptyDirVolumeSource, out *EmptyDirVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.EmptyDirVolumeSource))(in)
 	}
@@ -501,18 +509,19 @@ func autoconvert_api_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource(in *api.Emp
 	return nil
 }
 
-func convert_api_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource(in *api.EmptyDirVolumeSource, out *EmptyDirVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource(in, out, s)
+func Convert_api_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource(in *api.EmptyDirVolumeSource, out *EmptyDirVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource(in, out, s)
 }
 
-func autoconvert_api_EndpointAddress_To_v1_EndpointAddress(in *api.EndpointAddress, out *EndpointAddress, s conversion.Scope) error {
+func autoConvert_api_EndpointAddress_To_v1_EndpointAddress(in *api.EndpointAddress, out *EndpointAddress, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.EndpointAddress))(in)
 	}
 	out.IP = in.IP
+	// unable to generate simple pointer conversion for api.ObjectReference -> v1.ObjectReference
 	if in.TargetRef != nil {
 		out.TargetRef = new(ObjectReference)
-		if err := convert_api_ObjectReference_To_v1_ObjectReference(in.TargetRef, out.TargetRef, s); err != nil {
+		if err := Convert_api_ObjectReference_To_v1_ObjectReference(in.TargetRef, out.TargetRef, s); err != nil {
 			return err
 		}
 	} else {
@@ -521,11 +530,11 @@ func autoconvert_api_EndpointAddress_To_v1_EndpointAddress(in *api.EndpointAddre
 	return nil
 }
 
-func convert_api_EndpointAddress_To_v1_EndpointAddress(in *api.EndpointAddress, out *EndpointAddress, s conversion.Scope) error {
-	return autoconvert_api_EndpointAddress_To_v1_EndpointAddress(in, out, s)
+func Convert_api_EndpointAddress_To_v1_EndpointAddress(in *api.EndpointAddress, out *EndpointAddress, s conversion.Scope) error {
+	return autoConvert_api_EndpointAddress_To_v1_EndpointAddress(in, out, s)
 }
 
-func autoconvert_api_EndpointPort_To_v1_EndpointPort(in *api.EndpointPort, out *EndpointPort, s conversion.Scope) error {
+func autoConvert_api_EndpointPort_To_v1_EndpointPort(in *api.EndpointPort, out *EndpointPort, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.EndpointPort))(in)
 	}
@@ -535,18 +544,18 @@ func autoconvert_api_EndpointPort_To_v1_EndpointPort(in *api.EndpointPort, out *
 	return nil
 }
 
-func convert_api_EndpointPort_To_v1_EndpointPort(in *api.EndpointPort, out *EndpointPort, s conversion.Scope) error {
-	return autoconvert_api_EndpointPort_To_v1_EndpointPort(in, out, s)
+func Convert_api_EndpointPort_To_v1_EndpointPort(in *api.EndpointPort, out *EndpointPort, s conversion.Scope) error {
+	return autoConvert_api_EndpointPort_To_v1_EndpointPort(in, out, s)
 }
 
-func autoconvert_api_EndpointSubset_To_v1_EndpointSubset(in *api.EndpointSubset, out *EndpointSubset, s conversion.Scope) error {
+func autoConvert_api_EndpointSubset_To_v1_EndpointSubset(in *api.EndpointSubset, out *EndpointSubset, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.EndpointSubset))(in)
 	}
 	if in.Addresses != nil {
 		out.Addresses = make([]EndpointAddress, len(in.Addresses))
 		for i := range in.Addresses {
-			if err := convert_api_EndpointAddress_To_v1_EndpointAddress(&in.Addresses[i], &out.Addresses[i], s); err != nil {
+			if err := Convert_api_EndpointAddress_To_v1_EndpointAddress(&in.Addresses[i], &out.Addresses[i], s); err != nil {
 				return err
 			}
 		}
@@ -556,7 +565,7 @@ func autoconvert_api_EndpointSubset_To_v1_EndpointSubset(in *api.EndpointSubset,
 	if in.NotReadyAddresses != nil {
 		out.NotReadyAddresses = make([]EndpointAddress, len(in.NotReadyAddresses))
 		for i := range in.NotReadyAddresses {
-			if err := convert_api_EndpointAddress_To_v1_EndpointAddress(&in.NotReadyAddresses[i], &out.NotReadyAddresses[i], s); err != nil {
+			if err := Convert_api_EndpointAddress_To_v1_EndpointAddress(&in.NotReadyAddresses[i], &out.NotReadyAddresses[i], s); err != nil {
 				return err
 			}
 		}
@@ -566,7 +575,7 @@ func autoconvert_api_EndpointSubset_To_v1_EndpointSubset(in *api.EndpointSubset,
 	if in.Ports != nil {
 		out.Ports = make([]EndpointPort, len(in.Ports))
 		for i := range in.Ports {
-			if err := convert_api_EndpointPort_To_v1_EndpointPort(&in.Ports[i], &out.Ports[i], s); err != nil {
+			if err := Convert_api_EndpointPort_To_v1_EndpointPort(&in.Ports[i], &out.Ports[i], s); err != nil {
 				return err
 			}
 		}
@@ -576,24 +585,24 @@ func autoconvert_api_EndpointSubset_To_v1_EndpointSubset(in *api.EndpointSubset,
 	return nil
 }
 
-func convert_api_EndpointSubset_To_v1_EndpointSubset(in *api.EndpointSubset, out *EndpointSubset, s conversion.Scope) error {
-	return autoconvert_api_EndpointSubset_To_v1_EndpointSubset(in, out, s)
+func Convert_api_EndpointSubset_To_v1_EndpointSubset(in *api.EndpointSubset, out *EndpointSubset, s conversion.Scope) error {
+	return autoConvert_api_EndpointSubset_To_v1_EndpointSubset(in, out, s)
 }
 
-func autoconvert_api_Endpoints_To_v1_Endpoints(in *api.Endpoints, out *Endpoints, s conversion.Scope) error {
+func autoConvert_api_Endpoints_To_v1_Endpoints(in *api.Endpoints, out *Endpoints, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Endpoints))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
 	if in.Subsets != nil {
 		out.Subsets = make([]EndpointSubset, len(in.Subsets))
 		for i := range in.Subsets {
-			if err := convert_api_EndpointSubset_To_v1_EndpointSubset(&in.Subsets[i], &out.Subsets[i], s); err != nil {
+			if err := Convert_api_EndpointSubset_To_v1_EndpointSubset(&in.Subsets[i], &out.Subsets[i], s); err != nil {
 				return err
 			}
 		}
@@ -603,24 +612,24 @@ func autoconvert_api_Endpoints_To_v1_Endpoints(in *api.Endpoints, out *Endpoints
 	return nil
 }
 
-func convert_api_Endpoints_To_v1_Endpoints(in *api.Endpoints, out *Endpoints, s conversion.Scope) error {
-	return autoconvert_api_Endpoints_To_v1_Endpoints(in, out, s)
+func Convert_api_Endpoints_To_v1_Endpoints(in *api.Endpoints, out *Endpoints, s conversion.Scope) error {
+	return autoConvert_api_Endpoints_To_v1_Endpoints(in, out, s)
 }
 
-func autoconvert_api_EndpointsList_To_v1_EndpointsList(in *api.EndpointsList, out *EndpointsList, s conversion.Scope) error {
+func autoConvert_api_EndpointsList_To_v1_EndpointsList(in *api.EndpointsList, out *EndpointsList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.EndpointsList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]Endpoints, len(in.Items))
 		for i := range in.Items {
-			if err := convert_api_Endpoints_To_v1_Endpoints(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_api_Endpoints_To_v1_Endpoints(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -630,19 +639,20 @@ func autoconvert_api_EndpointsList_To_v1_EndpointsList(in *api.EndpointsList, ou
 	return nil
 }
 
-func convert_api_EndpointsList_To_v1_EndpointsList(in *api.EndpointsList, out *EndpointsList, s conversion.Scope) error {
-	return autoconvert_api_EndpointsList_To_v1_EndpointsList(in, out, s)
+func Convert_api_EndpointsList_To_v1_EndpointsList(in *api.EndpointsList, out *EndpointsList, s conversion.Scope) error {
+	return autoConvert_api_EndpointsList_To_v1_EndpointsList(in, out, s)
 }
 
-func autoconvert_api_EnvVar_To_v1_EnvVar(in *api.EnvVar, out *EnvVar, s conversion.Scope) error {
+func autoConvert_api_EnvVar_To_v1_EnvVar(in *api.EnvVar, out *EnvVar, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.EnvVar))(in)
 	}
 	out.Name = in.Name
 	out.Value = in.Value
+	// unable to generate simple pointer conversion for api.EnvVarSource -> v1.EnvVarSource
 	if in.ValueFrom != nil {
 		out.ValueFrom = new(EnvVarSource)
-		if err := convert_api_EnvVarSource_To_v1_EnvVarSource(in.ValueFrom, out.ValueFrom, s); err != nil {
+		if err := Convert_api_EnvVarSource_To_v1_EnvVarSource(in.ValueFrom, out.ValueFrom, s); err != nil {
 			return err
 		}
 	} else {
@@ -651,17 +661,18 @@ func autoconvert_api_EnvVar_To_v1_EnvVar(in *api.EnvVar, out *EnvVar, s conversi
 	return nil
 }
 
-func convert_api_EnvVar_To_v1_EnvVar(in *api.EnvVar, out *EnvVar, s conversion.Scope) error {
-	return autoconvert_api_EnvVar_To_v1_EnvVar(in, out, s)
+func Convert_api_EnvVar_To_v1_EnvVar(in *api.EnvVar, out *EnvVar, s conversion.Scope) error {
+	return autoConvert_api_EnvVar_To_v1_EnvVar(in, out, s)
 }
 
-func autoconvert_api_EnvVarSource_To_v1_EnvVarSource(in *api.EnvVarSource, out *EnvVarSource, s conversion.Scope) error {
+func autoConvert_api_EnvVarSource_To_v1_EnvVarSource(in *api.EnvVarSource, out *EnvVarSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.EnvVarSource))(in)
 	}
+	// unable to generate simple pointer conversion for api.ObjectFieldSelector -> v1.ObjectFieldSelector
 	if in.FieldRef != nil {
 		out.FieldRef = new(ObjectFieldSelector)
-		if err := convert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector(in.FieldRef, out.FieldRef, s); err != nil {
+		if err := Convert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector(in.FieldRef, out.FieldRef, s); err != nil {
 			return err
 		}
 	} else {
@@ -670,32 +681,32 @@ func autoconvert_api_EnvVarSource_To_v1_EnvVarSource(in *api.EnvVarSource, out *
 	return nil
 }
 
-func convert_api_EnvVarSource_To_v1_EnvVarSource(in *api.EnvVarSource, out *EnvVarSource, s conversion.Scope) error {
-	return autoconvert_api_EnvVarSource_To_v1_EnvVarSource(in, out, s)
+func Convert_api_EnvVarSource_To_v1_EnvVarSource(in *api.EnvVarSource, out *EnvVarSource, s conversion.Scope) error {
+	return autoConvert_api_EnvVarSource_To_v1_EnvVarSource(in, out, s)
 }
 
-func autoconvert_api_Event_To_v1_Event(in *api.Event, out *Event, s conversion.Scope) error {
+func autoConvert_api_Event_To_v1_Event(in *api.Event, out *Event, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Event))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ObjectReference_To_v1_ObjectReference(&in.InvolvedObject, &out.InvolvedObject, s); err != nil {
+	if err := Convert_api_ObjectReference_To_v1_ObjectReference(&in.InvolvedObject, &out.InvolvedObject, s); err != nil {
 		return err
 	}
 	out.Reason = in.Reason
 	out.Message = in.Message
-	if err := convert_api_EventSource_To_v1_EventSource(&in.Source, &out.Source, s); err != nil {
+	if err := Convert_api_EventSource_To_v1_EventSource(&in.Source, &out.Source, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.FirstTimestamp, &out.FirstTimestamp, 0); err != nil {
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.FirstTimestamp, &out.FirstTimestamp, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.LastTimestamp, &out.LastTimestamp, 0); err != nil {
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.LastTimestamp, &out.LastTimestamp, s); err != nil {
 		return err
 	}
 	out.Count = int32(in.Count)
@@ -703,24 +714,24 @@ func autoconvert_api_Event_To_v1_Event(in *api.Event, out *Event, s conversion.S
 	return nil
 }
 
-func convert_api_Event_To_v1_Event(in *api.Event, out *Event, s conversion.Scope) error {
-	return autoconvert_api_Event_To_v1_Event(in, out, s)
+func Convert_api_Event_To_v1_Event(in *api.Event, out *Event, s conversion.Scope) error {
+	return autoConvert_api_Event_To_v1_Event(in, out, s)
 }
 
-func autoconvert_api_EventList_To_v1_EventList(in *api.EventList, out *EventList, s conversion.Scope) error {
+func autoConvert_api_EventList_To_v1_EventList(in *api.EventList, out *EventList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.EventList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]Event, len(in.Items))
 		for i := range in.Items {
-			if err := convert_api_Event_To_v1_Event(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_api_Event_To_v1_Event(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -730,11 +741,11 @@ func autoconvert_api_EventList_To_v1_EventList(in *api.EventList, out *EventList
 	return nil
 }
 
-func convert_api_EventList_To_v1_EventList(in *api.EventList, out *EventList, s conversion.Scope) error {
-	return autoconvert_api_EventList_To_v1_EventList(in, out, s)
+func Convert_api_EventList_To_v1_EventList(in *api.EventList, out *EventList, s conversion.Scope) error {
+	return autoConvert_api_EventList_To_v1_EventList(in, out, s)
 }
 
-func autoconvert_api_EventSource_To_v1_EventSource(in *api.EventSource, out *EventSource, s conversion.Scope) error {
+func autoConvert_api_EventSource_To_v1_EventSource(in *api.EventSource, out *EventSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.EventSource))(in)
 	}
@@ -743,11 +754,11 @@ func autoconvert_api_EventSource_To_v1_EventSource(in *api.EventSource, out *Eve
 	return nil
 }
 
-func convert_api_EventSource_To_v1_EventSource(in *api.EventSource, out *EventSource, s conversion.Scope) error {
-	return autoconvert_api_EventSource_To_v1_EventSource(in, out, s)
+func Convert_api_EventSource_To_v1_EventSource(in *api.EventSource, out *EventSource, s conversion.Scope) error {
+	return autoConvert_api_EventSource_To_v1_EventSource(in, out, s)
 }
 
-func autoconvert_api_ExecAction_To_v1_ExecAction(in *api.ExecAction, out *ExecAction, s conversion.Scope) error {
+func autoConvert_api_ExecAction_To_v1_ExecAction(in *api.ExecAction, out *ExecAction, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ExecAction))(in)
 	}
@@ -762,11 +773,11 @@ func autoconvert_api_ExecAction_To_v1_ExecAction(in *api.ExecAction, out *ExecAc
 	return nil
 }
 
-func convert_api_ExecAction_To_v1_ExecAction(in *api.ExecAction, out *ExecAction, s conversion.Scope) error {
-	return autoconvert_api_ExecAction_To_v1_ExecAction(in, out, s)
+func Convert_api_ExecAction_To_v1_ExecAction(in *api.ExecAction, out *ExecAction, s conversion.Scope) error {
+	return autoConvert_api_ExecAction_To_v1_ExecAction(in, out, s)
 }
 
-func autoconvert_api_FCVolumeSource_To_v1_FCVolumeSource(in *api.FCVolumeSource, out *FCVolumeSource, s conversion.Scope) error {
+func autoConvert_api_FCVolumeSource_To_v1_FCVolumeSource(in *api.FCVolumeSource, out *FCVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.FCVolumeSource))(in)
 	}
@@ -789,19 +800,20 @@ func autoconvert_api_FCVolumeSource_To_v1_FCVolumeSource(in *api.FCVolumeSource,
 	return nil
 }
 
-func convert_api_FCVolumeSource_To_v1_FCVolumeSource(in *api.FCVolumeSource, out *FCVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_FCVolumeSource_To_v1_FCVolumeSource(in, out, s)
+func Convert_api_FCVolumeSource_To_v1_FCVolumeSource(in *api.FCVolumeSource, out *FCVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_FCVolumeSource_To_v1_FCVolumeSource(in, out, s)
 }
 
-func autoconvert_api_FlexVolumeSource_To_v1_FlexVolumeSource(in *api.FlexVolumeSource, out *FlexVolumeSource, s conversion.Scope) error {
+func autoConvert_api_FlexVolumeSource_To_v1_FlexVolumeSource(in *api.FlexVolumeSource, out *FlexVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.FlexVolumeSource))(in)
 	}
 	out.Driver = in.Driver
 	out.FSType = in.FSType
+	// unable to generate simple pointer conversion for api.LocalObjectReference -> v1.LocalObjectReference
 	if in.SecretRef != nil {
 		out.SecretRef = new(LocalObjectReference)
-		if err := convert_api_LocalObjectReference_To_v1_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
+		if err := Convert_api_LocalObjectReference_To_v1_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
 			return err
 		}
 	} else {
@@ -819,11 +831,11 @@ func autoconvert_api_FlexVolumeSource_To_v1_FlexVolumeSource(in *api.FlexVolumeS
 	return nil
 }
 
-func convert_api_FlexVolumeSource_To_v1_FlexVolumeSource(in *api.FlexVolumeSource, out *FlexVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_FlexVolumeSource_To_v1_FlexVolumeSource(in, out, s)
+func Convert_api_FlexVolumeSource_To_v1_FlexVolumeSource(in *api.FlexVolumeSource, out *FlexVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_FlexVolumeSource_To_v1_FlexVolumeSource(in, out, s)
 }
 
-func autoconvert_api_FlockerVolumeSource_To_v1_FlockerVolumeSource(in *api.FlockerVolumeSource, out *FlockerVolumeSource, s conversion.Scope) error {
+func autoConvert_api_FlockerVolumeSource_To_v1_FlockerVolumeSource(in *api.FlockerVolumeSource, out *FlockerVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.FlockerVolumeSource))(in)
 	}
@@ -831,11 +843,11 @@ func autoconvert_api_FlockerVolumeSource_To_v1_FlockerVolumeSource(in *api.Flock
 	return nil
 }
 
-func convert_api_FlockerVolumeSource_To_v1_FlockerVolumeSource(in *api.FlockerVolumeSource, out *FlockerVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_FlockerVolumeSource_To_v1_FlockerVolumeSource(in, out, s)
+func Convert_api_FlockerVolumeSource_To_v1_FlockerVolumeSource(in *api.FlockerVolumeSource, out *FlockerVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_FlockerVolumeSource_To_v1_FlockerVolumeSource(in, out, s)
 }
 
-func autoconvert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSource(in *api.GCEPersistentDiskVolumeSource, out *GCEPersistentDiskVolumeSource, s conversion.Scope) error {
+func autoConvert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSource(in *api.GCEPersistentDiskVolumeSource, out *GCEPersistentDiskVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.GCEPersistentDiskVolumeSource))(in)
 	}
@@ -846,11 +858,11 @@ func autoconvert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolume
 	return nil
 }
 
-func convert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSource(in *api.GCEPersistentDiskVolumeSource, out *GCEPersistentDiskVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSource(in, out, s)
+func Convert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSource(in *api.GCEPersistentDiskVolumeSource, out *GCEPersistentDiskVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSource(in, out, s)
 }
 
-func autoconvert_api_GitRepoVolumeSource_To_v1_GitRepoVolumeSource(in *api.GitRepoVolumeSource, out *GitRepoVolumeSource, s conversion.Scope) error {
+func autoConvert_api_GitRepoVolumeSource_To_v1_GitRepoVolumeSource(in *api.GitRepoVolumeSource, out *GitRepoVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.GitRepoVolumeSource))(in)
 	}
@@ -860,11 +872,11 @@ func autoconvert_api_GitRepoVolumeSource_To_v1_GitRepoVolumeSource(in *api.GitRe
 	return nil
 }
 
-func convert_api_GitRepoVolumeSource_To_v1_GitRepoVolumeSource(in *api.GitRepoVolumeSource, out *GitRepoVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_GitRepoVolumeSource_To_v1_GitRepoVolumeSource(in, out, s)
+func Convert_api_GitRepoVolumeSource_To_v1_GitRepoVolumeSource(in *api.GitRepoVolumeSource, out *GitRepoVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_GitRepoVolumeSource_To_v1_GitRepoVolumeSource(in, out, s)
 }
 
-func autoconvert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource(in *api.GlusterfsVolumeSource, out *GlusterfsVolumeSource, s conversion.Scope) error {
+func autoConvert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource(in *api.GlusterfsVolumeSource, out *GlusterfsVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.GlusterfsVolumeSource))(in)
 	}
@@ -874,16 +886,16 @@ func autoconvert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource(in *api.G
 	return nil
 }
 
-func convert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource(in *api.GlusterfsVolumeSource, out *GlusterfsVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource(in, out, s)
+func Convert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource(in *api.GlusterfsVolumeSource, out *GlusterfsVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource(in, out, s)
 }
 
-func autoconvert_api_HTTPGetAction_To_v1_HTTPGetAction(in *api.HTTPGetAction, out *HTTPGetAction, s conversion.Scope) error {
+func autoConvert_api_HTTPGetAction_To_v1_HTTPGetAction(in *api.HTTPGetAction, out *HTTPGetAction, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.HTTPGetAction))(in)
 	}
 	out.Path = in.Path
-	if err := s.Convert(&in.Port, &out.Port, 0); err != nil {
+	if err := api.Convert_intstr_IntOrString_To_intstr_IntOrString(&in.Port, &out.Port, s); err != nil {
 		return err
 	}
 	out.Host = in.Host
@@ -891,33 +903,36 @@ func autoconvert_api_HTTPGetAction_To_v1_HTTPGetAction(in *api.HTTPGetAction, ou
 	return nil
 }
 
-func convert_api_HTTPGetAction_To_v1_HTTPGetAction(in *api.HTTPGetAction, out *HTTPGetAction, s conversion.Scope) error {
-	return autoconvert_api_HTTPGetAction_To_v1_HTTPGetAction(in, out, s)
+func Convert_api_HTTPGetAction_To_v1_HTTPGetAction(in *api.HTTPGetAction, out *HTTPGetAction, s conversion.Scope) error {
+	return autoConvert_api_HTTPGetAction_To_v1_HTTPGetAction(in, out, s)
 }
 
-func autoconvert_api_Handler_To_v1_Handler(in *api.Handler, out *Handler, s conversion.Scope) error {
+func autoConvert_api_Handler_To_v1_Handler(in *api.Handler, out *Handler, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Handler))(in)
 	}
+	// unable to generate simple pointer conversion for api.ExecAction -> v1.ExecAction
 	if in.Exec != nil {
 		out.Exec = new(ExecAction)
-		if err := convert_api_ExecAction_To_v1_ExecAction(in.Exec, out.Exec, s); err != nil {
+		if err := Convert_api_ExecAction_To_v1_ExecAction(in.Exec, out.Exec, s); err != nil {
 			return err
 		}
 	} else {
 		out.Exec = nil
 	}
+	// unable to generate simple pointer conversion for api.HTTPGetAction -> v1.HTTPGetAction
 	if in.HTTPGet != nil {
 		out.HTTPGet = new(HTTPGetAction)
-		if err := convert_api_HTTPGetAction_To_v1_HTTPGetAction(in.HTTPGet, out.HTTPGet, s); err != nil {
+		if err := Convert_api_HTTPGetAction_To_v1_HTTPGetAction(in.HTTPGet, out.HTTPGet, s); err != nil {
 			return err
 		}
 	} else {
 		out.HTTPGet = nil
 	}
+	// unable to generate simple pointer conversion for api.TCPSocketAction -> v1.TCPSocketAction
 	if in.TCPSocket != nil {
 		out.TCPSocket = new(TCPSocketAction)
-		if err := convert_api_TCPSocketAction_To_v1_TCPSocketAction(in.TCPSocket, out.TCPSocket, s); err != nil {
+		if err := Convert_api_TCPSocketAction_To_v1_TCPSocketAction(in.TCPSocket, out.TCPSocket, s); err != nil {
 			return err
 		}
 	} else {
@@ -926,11 +941,11 @@ func autoconvert_api_Handler_To_v1_Handler(in *api.Handler, out *Handler, s conv
 	return nil
 }
 
-func convert_api_Handler_To_v1_Handler(in *api.Handler, out *Handler, s conversion.Scope) error {
-	return autoconvert_api_Handler_To_v1_Handler(in, out, s)
+func Convert_api_Handler_To_v1_Handler(in *api.Handler, out *Handler, s conversion.Scope) error {
+	return autoConvert_api_Handler_To_v1_Handler(in, out, s)
 }
 
-func autoconvert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource(in *api.HostPathVolumeSource, out *HostPathVolumeSource, s conversion.Scope) error {
+func autoConvert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource(in *api.HostPathVolumeSource, out *HostPathVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.HostPathVolumeSource))(in)
 	}
@@ -938,11 +953,11 @@ func autoconvert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource(in *api.Hos
 	return nil
 }
 
-func convert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource(in *api.HostPathVolumeSource, out *HostPathVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource(in, out, s)
+func Convert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource(in *api.HostPathVolumeSource, out *HostPathVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource(in, out, s)
 }
 
-func autoconvert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource(in *api.ISCSIVolumeSource, out *ISCSIVolumeSource, s conversion.Scope) error {
+func autoConvert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource(in *api.ISCSIVolumeSource, out *ISCSIVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ISCSIVolumeSource))(in)
 	}
@@ -955,25 +970,27 @@ func autoconvert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource(in *api.ISCSIVolu
 	return nil
 }
 
-func convert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource(in *api.ISCSIVolumeSource, out *ISCSIVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource(in, out, s)
+func Convert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource(in *api.ISCSIVolumeSource, out *ISCSIVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource(in, out, s)
 }
 
-func autoconvert_api_Lifecycle_To_v1_Lifecycle(in *api.Lifecycle, out *Lifecycle, s conversion.Scope) error {
+func autoConvert_api_Lifecycle_To_v1_Lifecycle(in *api.Lifecycle, out *Lifecycle, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Lifecycle))(in)
 	}
+	// unable to generate simple pointer conversion for api.Handler -> v1.Handler
 	if in.PostStart != nil {
 		out.PostStart = new(Handler)
-		if err := convert_api_Handler_To_v1_Handler(in.PostStart, out.PostStart, s); err != nil {
+		if err := Convert_api_Handler_To_v1_Handler(in.PostStart, out.PostStart, s); err != nil {
 			return err
 		}
 	} else {
 		out.PostStart = nil
 	}
+	// unable to generate simple pointer conversion for api.Handler -> v1.Handler
 	if in.PreStop != nil {
 		out.PreStop = new(Handler)
-		if err := convert_api_Handler_To_v1_Handler(in.PreStop, out.PreStop, s); err != nil {
+		if err := Convert_api_Handler_To_v1_Handler(in.PreStop, out.PreStop, s); err != nil {
 			return err
 		}
 	} else {
@@ -982,31 +999,31 @@ func autoconvert_api_Lifecycle_To_v1_Lifecycle(in *api.Lifecycle, out *Lifecycle
 	return nil
 }
 
-func convert_api_Lifecycle_To_v1_Lifecycle(in *api.Lifecycle, out *Lifecycle, s conversion.Scope) error {
-	return autoconvert_api_Lifecycle_To_v1_Lifecycle(in, out, s)
+func Convert_api_Lifecycle_To_v1_Lifecycle(in *api.Lifecycle, out *Lifecycle, s conversion.Scope) error {
+	return autoConvert_api_Lifecycle_To_v1_Lifecycle(in, out, s)
 }
 
-func autoconvert_api_LimitRange_To_v1_LimitRange(in *api.LimitRange, out *LimitRange, s conversion.Scope) error {
+func autoConvert_api_LimitRange_To_v1_LimitRange(in *api.LimitRange, out *LimitRange, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.LimitRange))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_LimitRangeSpec_To_v1_LimitRangeSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_api_LimitRangeSpec_To_v1_LimitRangeSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_api_LimitRange_To_v1_LimitRange(in *api.LimitRange, out *LimitRange, s conversion.Scope) error {
-	return autoconvert_api_LimitRange_To_v1_LimitRange(in, out, s)
+func Convert_api_LimitRange_To_v1_LimitRange(in *api.LimitRange, out *LimitRange, s conversion.Scope) error {
+	return autoConvert_api_LimitRange_To_v1_LimitRange(in, out, s)
 }
 
-func autoconvert_api_LimitRangeItem_To_v1_LimitRangeItem(in *api.LimitRangeItem, out *LimitRangeItem, s conversion.Scope) error {
+func autoConvert_api_LimitRangeItem_To_v1_LimitRangeItem(in *api.LimitRangeItem, out *LimitRangeItem, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.LimitRangeItem))(in)
 	}
@@ -1015,7 +1032,7 @@ func autoconvert_api_LimitRangeItem_To_v1_LimitRangeItem(in *api.LimitRangeItem,
 		out.Max = make(ResourceList)
 		for key, val := range in.Max {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.Max[ResourceName(key)] = newVal
@@ -1027,7 +1044,7 @@ func autoconvert_api_LimitRangeItem_To_v1_LimitRangeItem(in *api.LimitRangeItem,
 		out.Min = make(ResourceList)
 		for key, val := range in.Min {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.Min[ResourceName(key)] = newVal
@@ -1039,7 +1056,7 @@ func autoconvert_api_LimitRangeItem_To_v1_LimitRangeItem(in *api.LimitRangeItem,
 		out.Default = make(ResourceList)
 		for key, val := range in.Default {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.Default[ResourceName(key)] = newVal
@@ -1051,7 +1068,7 @@ func autoconvert_api_LimitRangeItem_To_v1_LimitRangeItem(in *api.LimitRangeItem,
 		out.DefaultRequest = make(ResourceList)
 		for key, val := range in.DefaultRequest {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.DefaultRequest[ResourceName(key)] = newVal
@@ -1063,7 +1080,7 @@ func autoconvert_api_LimitRangeItem_To_v1_LimitRangeItem(in *api.LimitRangeItem,
 		out.MaxLimitRequestRatio = make(ResourceList)
 		for key, val := range in.MaxLimitRequestRatio {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.MaxLimitRequestRatio[ResourceName(key)] = newVal
@@ -1074,24 +1091,24 @@ func autoconvert_api_LimitRangeItem_To_v1_LimitRangeItem(in *api.LimitRangeItem,
 	return nil
 }
 
-func convert_api_LimitRangeItem_To_v1_LimitRangeItem(in *api.LimitRangeItem, out *LimitRangeItem, s conversion.Scope) error {
-	return autoconvert_api_LimitRangeItem_To_v1_LimitRangeItem(in, out, s)
+func Convert_api_LimitRangeItem_To_v1_LimitRangeItem(in *api.LimitRangeItem, out *LimitRangeItem, s conversion.Scope) error {
+	return autoConvert_api_LimitRangeItem_To_v1_LimitRangeItem(in, out, s)
 }
 
-func autoconvert_api_LimitRangeList_To_v1_LimitRangeList(in *api.LimitRangeList, out *LimitRangeList, s conversion.Scope) error {
+func autoConvert_api_LimitRangeList_To_v1_LimitRangeList(in *api.LimitRangeList, out *LimitRangeList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.LimitRangeList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]LimitRange, len(in.Items))
 		for i := range in.Items {
-			if err := convert_api_LimitRange_To_v1_LimitRange(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_api_LimitRange_To_v1_LimitRange(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -1101,18 +1118,18 @@ func autoconvert_api_LimitRangeList_To_v1_LimitRangeList(in *api.LimitRangeList,
 	return nil
 }
 
-func convert_api_LimitRangeList_To_v1_LimitRangeList(in *api.LimitRangeList, out *LimitRangeList, s conversion.Scope) error {
-	return autoconvert_api_LimitRangeList_To_v1_LimitRangeList(in, out, s)
+func Convert_api_LimitRangeList_To_v1_LimitRangeList(in *api.LimitRangeList, out *LimitRangeList, s conversion.Scope) error {
+	return autoConvert_api_LimitRangeList_To_v1_LimitRangeList(in, out, s)
 }
 
-func autoconvert_api_LimitRangeSpec_To_v1_LimitRangeSpec(in *api.LimitRangeSpec, out *LimitRangeSpec, s conversion.Scope) error {
+func autoConvert_api_LimitRangeSpec_To_v1_LimitRangeSpec(in *api.LimitRangeSpec, out *LimitRangeSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.LimitRangeSpec))(in)
 	}
 	if in.Limits != nil {
 		out.Limits = make([]LimitRangeItem, len(in.Limits))
 		for i := range in.Limits {
-			if err := convert_api_LimitRangeItem_To_v1_LimitRangeItem(&in.Limits[i], &out.Limits[i], s); err != nil {
+			if err := Convert_api_LimitRangeItem_To_v1_LimitRangeItem(&in.Limits[i], &out.Limits[i], s); err != nil {
 				return err
 			}
 		}
@@ -1122,18 +1139,18 @@ func autoconvert_api_LimitRangeSpec_To_v1_LimitRangeSpec(in *api.LimitRangeSpec,
 	return nil
 }
 
-func convert_api_LimitRangeSpec_To_v1_LimitRangeSpec(in *api.LimitRangeSpec, out *LimitRangeSpec, s conversion.Scope) error {
-	return autoconvert_api_LimitRangeSpec_To_v1_LimitRangeSpec(in, out, s)
+func Convert_api_LimitRangeSpec_To_v1_LimitRangeSpec(in *api.LimitRangeSpec, out *LimitRangeSpec, s conversion.Scope) error {
+	return autoConvert_api_LimitRangeSpec_To_v1_LimitRangeSpec(in, out, s)
 }
 
-func autoconvert_api_List_To_v1_List(in *api.List, out *List, s conversion.Scope) error {
+func autoConvert_api_List_To_v1_List(in *api.List, out *List, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.List))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if err := s.Convert(&in.Items, &out.Items, 0); err != nil {
@@ -1142,21 +1159,21 @@ func autoconvert_api_List_To_v1_List(in *api.List, out *List, s conversion.Scope
 	return nil
 }
 
-func convert_api_List_To_v1_List(in *api.List, out *List, s conversion.Scope) error {
-	return autoconvert_api_List_To_v1_List(in, out, s)
+func Convert_api_List_To_v1_List(in *api.List, out *List, s conversion.Scope) error {
+	return autoConvert_api_List_To_v1_List(in, out, s)
 }
 
-func autoconvert_api_ListOptions_To_v1_ListOptions(in *api.ListOptions, out *ListOptions, s conversion.Scope) error {
+func autoConvert_api_ListOptions_To_v1_ListOptions(in *api.ListOptions, out *ListOptions, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ListOptions))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.LabelSelector, &out.LabelSelector, 0); err != nil {
+	if err := api.Convert_labels_Selector_To_string(&in.LabelSelector, &out.LabelSelector, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.FieldSelector, &out.FieldSelector, 0); err != nil {
+	if err := api.Convert_fields_Selector_To_string(&in.FieldSelector, &out.FieldSelector, s); err != nil {
 		return err
 	}
 	out.Watch = in.Watch
@@ -1170,11 +1187,11 @@ func autoconvert_api_ListOptions_To_v1_ListOptions(in *api.ListOptions, out *Lis
 	return nil
 }
 
-func convert_api_ListOptions_To_v1_ListOptions(in *api.ListOptions, out *ListOptions, s conversion.Scope) error {
-	return autoconvert_api_ListOptions_To_v1_ListOptions(in, out, s)
+func Convert_api_ListOptions_To_v1_ListOptions(in *api.ListOptions, out *ListOptions, s conversion.Scope) error {
+	return autoConvert_api_ListOptions_To_v1_ListOptions(in, out, s)
 }
 
-func autoconvert_api_LoadBalancerIngress_To_v1_LoadBalancerIngress(in *api.LoadBalancerIngress, out *LoadBalancerIngress, s conversion.Scope) error {
+func autoConvert_api_LoadBalancerIngress_To_v1_LoadBalancerIngress(in *api.LoadBalancerIngress, out *LoadBalancerIngress, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.LoadBalancerIngress))(in)
 	}
@@ -1183,18 +1200,18 @@ func autoconvert_api_LoadBalancerIngress_To_v1_LoadBalancerIngress(in *api.LoadB
 	return nil
 }
 
-func convert_api_LoadBalancerIngress_To_v1_LoadBalancerIngress(in *api.LoadBalancerIngress, out *LoadBalancerIngress, s conversion.Scope) error {
-	return autoconvert_api_LoadBalancerIngress_To_v1_LoadBalancerIngress(in, out, s)
+func Convert_api_LoadBalancerIngress_To_v1_LoadBalancerIngress(in *api.LoadBalancerIngress, out *LoadBalancerIngress, s conversion.Scope) error {
+	return autoConvert_api_LoadBalancerIngress_To_v1_LoadBalancerIngress(in, out, s)
 }
 
-func autoconvert_api_LoadBalancerStatus_To_v1_LoadBalancerStatus(in *api.LoadBalancerStatus, out *LoadBalancerStatus, s conversion.Scope) error {
+func autoConvert_api_LoadBalancerStatus_To_v1_LoadBalancerStatus(in *api.LoadBalancerStatus, out *LoadBalancerStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.LoadBalancerStatus))(in)
 	}
 	if in.Ingress != nil {
 		out.Ingress = make([]LoadBalancerIngress, len(in.Ingress))
 		for i := range in.Ingress {
-			if err := convert_api_LoadBalancerIngress_To_v1_LoadBalancerIngress(&in.Ingress[i], &out.Ingress[i], s); err != nil {
+			if err := Convert_api_LoadBalancerIngress_To_v1_LoadBalancerIngress(&in.Ingress[i], &out.Ingress[i], s); err != nil {
 				return err
 			}
 		}
@@ -1204,11 +1221,11 @@ func autoconvert_api_LoadBalancerStatus_To_v1_LoadBalancerStatus(in *api.LoadBal
 	return nil
 }
 
-func convert_api_LoadBalancerStatus_To_v1_LoadBalancerStatus(in *api.LoadBalancerStatus, out *LoadBalancerStatus, s conversion.Scope) error {
-	return autoconvert_api_LoadBalancerStatus_To_v1_LoadBalancerStatus(in, out, s)
+func Convert_api_LoadBalancerStatus_To_v1_LoadBalancerStatus(in *api.LoadBalancerStatus, out *LoadBalancerStatus, s conversion.Scope) error {
+	return autoConvert_api_LoadBalancerStatus_To_v1_LoadBalancerStatus(in, out, s)
 }
 
-func autoconvert_api_LocalObjectReference_To_v1_LocalObjectReference(in *api.LocalObjectReference, out *LocalObjectReference, s conversion.Scope) error {
+func autoConvert_api_LocalObjectReference_To_v1_LocalObjectReference(in *api.LocalObjectReference, out *LocalObjectReference, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.LocalObjectReference))(in)
 	}
@@ -1216,11 +1233,11 @@ func autoconvert_api_LocalObjectReference_To_v1_LocalObjectReference(in *api.Loc
 	return nil
 }
 
-func convert_api_LocalObjectReference_To_v1_LocalObjectReference(in *api.LocalObjectReference, out *LocalObjectReference, s conversion.Scope) error {
-	return autoconvert_api_LocalObjectReference_To_v1_LocalObjectReference(in, out, s)
+func Convert_api_LocalObjectReference_To_v1_LocalObjectReference(in *api.LocalObjectReference, out *LocalObjectReference, s conversion.Scope) error {
+	return autoConvert_api_LocalObjectReference_To_v1_LocalObjectReference(in, out, s)
 }
 
-func autoconvert_api_NFSVolumeSource_To_v1_NFSVolumeSource(in *api.NFSVolumeSource, out *NFSVolumeSource, s conversion.Scope) error {
+func autoConvert_api_NFSVolumeSource_To_v1_NFSVolumeSource(in *api.NFSVolumeSource, out *NFSVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.NFSVolumeSource))(in)
 	}
@@ -1230,47 +1247,47 @@ func autoconvert_api_NFSVolumeSource_To_v1_NFSVolumeSource(in *api.NFSVolumeSour
 	return nil
 }
 
-func convert_api_NFSVolumeSource_To_v1_NFSVolumeSource(in *api.NFSVolumeSource, out *NFSVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_NFSVolumeSource_To_v1_NFSVolumeSource(in, out, s)
+func Convert_api_NFSVolumeSource_To_v1_NFSVolumeSource(in *api.NFSVolumeSource, out *NFSVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_NFSVolumeSource_To_v1_NFSVolumeSource(in, out, s)
 }
 
-func autoconvert_api_Namespace_To_v1_Namespace(in *api.Namespace, out *Namespace, s conversion.Scope) error {
+func autoConvert_api_Namespace_To_v1_Namespace(in *api.Namespace, out *Namespace, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Namespace))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_NamespaceSpec_To_v1_NamespaceSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_api_NamespaceSpec_To_v1_NamespaceSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := convert_api_NamespaceStatus_To_v1_NamespaceStatus(&in.Status, &out.Status, s); err != nil {
+	if err := Convert_api_NamespaceStatus_To_v1_NamespaceStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_api_Namespace_To_v1_Namespace(in *api.Namespace, out *Namespace, s conversion.Scope) error {
-	return autoconvert_api_Namespace_To_v1_Namespace(in, out, s)
+func Convert_api_Namespace_To_v1_Namespace(in *api.Namespace, out *Namespace, s conversion.Scope) error {
+	return autoConvert_api_Namespace_To_v1_Namespace(in, out, s)
 }
 
-func autoconvert_api_NamespaceList_To_v1_NamespaceList(in *api.NamespaceList, out *NamespaceList, s conversion.Scope) error {
+func autoConvert_api_NamespaceList_To_v1_NamespaceList(in *api.NamespaceList, out *NamespaceList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.NamespaceList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]Namespace, len(in.Items))
 		for i := range in.Items {
-			if err := convert_api_Namespace_To_v1_Namespace(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_api_Namespace_To_v1_Namespace(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -1280,11 +1297,11 @@ func autoconvert_api_NamespaceList_To_v1_NamespaceList(in *api.NamespaceList, ou
 	return nil
 }
 
-func convert_api_NamespaceList_To_v1_NamespaceList(in *api.NamespaceList, out *NamespaceList, s conversion.Scope) error {
-	return autoconvert_api_NamespaceList_To_v1_NamespaceList(in, out, s)
+func Convert_api_NamespaceList_To_v1_NamespaceList(in *api.NamespaceList, out *NamespaceList, s conversion.Scope) error {
+	return autoConvert_api_NamespaceList_To_v1_NamespaceList(in, out, s)
 }
 
-func autoconvert_api_NamespaceSpec_To_v1_NamespaceSpec(in *api.NamespaceSpec, out *NamespaceSpec, s conversion.Scope) error {
+func autoConvert_api_NamespaceSpec_To_v1_NamespaceSpec(in *api.NamespaceSpec, out *NamespaceSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.NamespaceSpec))(in)
 	}
@@ -1299,11 +1316,11 @@ func autoconvert_api_NamespaceSpec_To_v1_NamespaceSpec(in *api.NamespaceSpec, ou
 	return nil
 }
 
-func convert_api_NamespaceSpec_To_v1_NamespaceSpec(in *api.NamespaceSpec, out *NamespaceSpec, s conversion.Scope) error {
-	return autoconvert_api_NamespaceSpec_To_v1_NamespaceSpec(in, out, s)
+func Convert_api_NamespaceSpec_To_v1_NamespaceSpec(in *api.NamespaceSpec, out *NamespaceSpec, s conversion.Scope) error {
+	return autoConvert_api_NamespaceSpec_To_v1_NamespaceSpec(in, out, s)
 }
 
-func autoconvert_api_NamespaceStatus_To_v1_NamespaceStatus(in *api.NamespaceStatus, out *NamespaceStatus, s conversion.Scope) error {
+func autoConvert_api_NamespaceStatus_To_v1_NamespaceStatus(in *api.NamespaceStatus, out *NamespaceStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.NamespaceStatus))(in)
 	}
@@ -1311,34 +1328,34 @@ func autoconvert_api_NamespaceStatus_To_v1_NamespaceStatus(in *api.NamespaceStat
 	return nil
 }
 
-func convert_api_NamespaceStatus_To_v1_NamespaceStatus(in *api.NamespaceStatus, out *NamespaceStatus, s conversion.Scope) error {
-	return autoconvert_api_NamespaceStatus_To_v1_NamespaceStatus(in, out, s)
+func Convert_api_NamespaceStatus_To_v1_NamespaceStatus(in *api.NamespaceStatus, out *NamespaceStatus, s conversion.Scope) error {
+	return autoConvert_api_NamespaceStatus_To_v1_NamespaceStatus(in, out, s)
 }
 
-func autoconvert_api_Node_To_v1_Node(in *api.Node, out *Node, s conversion.Scope) error {
+func autoConvert_api_Node_To_v1_Node(in *api.Node, out *Node, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Node))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_NodeSpec_To_v1_NodeSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_api_NodeSpec_To_v1_NodeSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := convert_api_NodeStatus_To_v1_NodeStatus(&in.Status, &out.Status, s); err != nil {
+	if err := Convert_api_NodeStatus_To_v1_NodeStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_api_Node_To_v1_Node(in *api.Node, out *Node, s conversion.Scope) error {
-	return autoconvert_api_Node_To_v1_Node(in, out, s)
+func Convert_api_Node_To_v1_Node(in *api.Node, out *Node, s conversion.Scope) error {
+	return autoConvert_api_Node_To_v1_Node(in, out, s)
 }
 
-func autoconvert_api_NodeAddress_To_v1_NodeAddress(in *api.NodeAddress, out *NodeAddress, s conversion.Scope) error {
+func autoConvert_api_NodeAddress_To_v1_NodeAddress(in *api.NodeAddress, out *NodeAddress, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.NodeAddress))(in)
 	}
@@ -1347,20 +1364,20 @@ func autoconvert_api_NodeAddress_To_v1_NodeAddress(in *api.NodeAddress, out *Nod
 	return nil
 }
 
-func convert_api_NodeAddress_To_v1_NodeAddress(in *api.NodeAddress, out *NodeAddress, s conversion.Scope) error {
-	return autoconvert_api_NodeAddress_To_v1_NodeAddress(in, out, s)
+func Convert_api_NodeAddress_To_v1_NodeAddress(in *api.NodeAddress, out *NodeAddress, s conversion.Scope) error {
+	return autoConvert_api_NodeAddress_To_v1_NodeAddress(in, out, s)
 }
 
-func autoconvert_api_NodeCondition_To_v1_NodeCondition(in *api.NodeCondition, out *NodeCondition, s conversion.Scope) error {
+func autoConvert_api_NodeCondition_To_v1_NodeCondition(in *api.NodeCondition, out *NodeCondition, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.NodeCondition))(in)
 	}
 	out.Type = NodeConditionType(in.Type)
 	out.Status = ConditionStatus(in.Status)
-	if err := s.Convert(&in.LastHeartbeatTime, &out.LastHeartbeatTime, 0); err != nil {
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.LastHeartbeatTime, &out.LastHeartbeatTime, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.LastTransitionTime, &out.LastTransitionTime, 0); err != nil {
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.LastTransitionTime, &out.LastTransitionTime, s); err != nil {
 		return err
 	}
 	out.Reason = in.Reason
@@ -1368,38 +1385,38 @@ func autoconvert_api_NodeCondition_To_v1_NodeCondition(in *api.NodeCondition, ou
 	return nil
 }
 
-func convert_api_NodeCondition_To_v1_NodeCondition(in *api.NodeCondition, out *NodeCondition, s conversion.Scope) error {
-	return autoconvert_api_NodeCondition_To_v1_NodeCondition(in, out, s)
+func Convert_api_NodeCondition_To_v1_NodeCondition(in *api.NodeCondition, out *NodeCondition, s conversion.Scope) error {
+	return autoConvert_api_NodeCondition_To_v1_NodeCondition(in, out, s)
 }
 
-func autoconvert_api_NodeDaemonEndpoints_To_v1_NodeDaemonEndpoints(in *api.NodeDaemonEndpoints, out *NodeDaemonEndpoints, s conversion.Scope) error {
+func autoConvert_api_NodeDaemonEndpoints_To_v1_NodeDaemonEndpoints(in *api.NodeDaemonEndpoints, out *NodeDaemonEndpoints, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.NodeDaemonEndpoints))(in)
 	}
-	if err := convert_api_DaemonEndpoint_To_v1_DaemonEndpoint(&in.KubeletEndpoint, &out.KubeletEndpoint, s); err != nil {
+	if err := Convert_api_DaemonEndpoint_To_v1_DaemonEndpoint(&in.KubeletEndpoint, &out.KubeletEndpoint, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_api_NodeDaemonEndpoints_To_v1_NodeDaemonEndpoints(in *api.NodeDaemonEndpoints, out *NodeDaemonEndpoints, s conversion.Scope) error {
-	return autoconvert_api_NodeDaemonEndpoints_To_v1_NodeDaemonEndpoints(in, out, s)
+func Convert_api_NodeDaemonEndpoints_To_v1_NodeDaemonEndpoints(in *api.NodeDaemonEndpoints, out *NodeDaemonEndpoints, s conversion.Scope) error {
+	return autoConvert_api_NodeDaemonEndpoints_To_v1_NodeDaemonEndpoints(in, out, s)
 }
 
-func autoconvert_api_NodeList_To_v1_NodeList(in *api.NodeList, out *NodeList, s conversion.Scope) error {
+func autoConvert_api_NodeList_To_v1_NodeList(in *api.NodeList, out *NodeList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.NodeList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]Node, len(in.Items))
 		for i := range in.Items {
-			if err := convert_api_Node_To_v1_Node(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_api_Node_To_v1_Node(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -1409,11 +1426,11 @@ func autoconvert_api_NodeList_To_v1_NodeList(in *api.NodeList, out *NodeList, s 
 	return nil
 }
 
-func convert_api_NodeList_To_v1_NodeList(in *api.NodeList, out *NodeList, s conversion.Scope) error {
-	return autoconvert_api_NodeList_To_v1_NodeList(in, out, s)
+func Convert_api_NodeList_To_v1_NodeList(in *api.NodeList, out *NodeList, s conversion.Scope) error {
+	return autoConvert_api_NodeList_To_v1_NodeList(in, out, s)
 }
 
-func autoconvert_api_NodeSpec_To_v1_NodeSpec(in *api.NodeSpec, out *NodeSpec, s conversion.Scope) error {
+func autoConvert_api_NodeSpec_To_v1_NodeSpec(in *api.NodeSpec, out *NodeSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.NodeSpec))(in)
 	}
@@ -1424,11 +1441,11 @@ func autoconvert_api_NodeSpec_To_v1_NodeSpec(in *api.NodeSpec, out *NodeSpec, s 
 	return nil
 }
 
-func convert_api_NodeSpec_To_v1_NodeSpec(in *api.NodeSpec, out *NodeSpec, s conversion.Scope) error {
-	return autoconvert_api_NodeSpec_To_v1_NodeSpec(in, out, s)
+func Convert_api_NodeSpec_To_v1_NodeSpec(in *api.NodeSpec, out *NodeSpec, s conversion.Scope) error {
+	return autoConvert_api_NodeSpec_To_v1_NodeSpec(in, out, s)
 }
 
-func autoconvert_api_NodeStatus_To_v1_NodeStatus(in *api.NodeStatus, out *NodeStatus, s conversion.Scope) error {
+func autoConvert_api_NodeStatus_To_v1_NodeStatus(in *api.NodeStatus, out *NodeStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.NodeStatus))(in)
 	}
@@ -1436,7 +1453,7 @@ func autoconvert_api_NodeStatus_To_v1_NodeStatus(in *api.NodeStatus, out *NodeSt
 		out.Capacity = make(ResourceList)
 		for key, val := range in.Capacity {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.Capacity[ResourceName(key)] = newVal
@@ -1448,7 +1465,7 @@ func autoconvert_api_NodeStatus_To_v1_NodeStatus(in *api.NodeStatus, out *NodeSt
 		out.Allocatable = make(ResourceList)
 		for key, val := range in.Allocatable {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.Allocatable[ResourceName(key)] = newVal
@@ -1460,7 +1477,7 @@ func autoconvert_api_NodeStatus_To_v1_NodeStatus(in *api.NodeStatus, out *NodeSt
 	if in.Conditions != nil {
 		out.Conditions = make([]NodeCondition, len(in.Conditions))
 		for i := range in.Conditions {
-			if err := convert_api_NodeCondition_To_v1_NodeCondition(&in.Conditions[i], &out.Conditions[i], s); err != nil {
+			if err := Convert_api_NodeCondition_To_v1_NodeCondition(&in.Conditions[i], &out.Conditions[i], s); err != nil {
 				return err
 			}
 		}
@@ -1470,27 +1487,27 @@ func autoconvert_api_NodeStatus_To_v1_NodeStatus(in *api.NodeStatus, out *NodeSt
 	if in.Addresses != nil {
 		out.Addresses = make([]NodeAddress, len(in.Addresses))
 		for i := range in.Addresses {
-			if err := convert_api_NodeAddress_To_v1_NodeAddress(&in.Addresses[i], &out.Addresses[i], s); err != nil {
+			if err := Convert_api_NodeAddress_To_v1_NodeAddress(&in.Addresses[i], &out.Addresses[i], s); err != nil {
 				return err
 			}
 		}
 	} else {
 		out.Addresses = nil
 	}
-	if err := convert_api_NodeDaemonEndpoints_To_v1_NodeDaemonEndpoints(&in.DaemonEndpoints, &out.DaemonEndpoints, s); err != nil {
+	if err := Convert_api_NodeDaemonEndpoints_To_v1_NodeDaemonEndpoints(&in.DaemonEndpoints, &out.DaemonEndpoints, s); err != nil {
 		return err
 	}
-	if err := convert_api_NodeSystemInfo_To_v1_NodeSystemInfo(&in.NodeInfo, &out.NodeInfo, s); err != nil {
+	if err := Convert_api_NodeSystemInfo_To_v1_NodeSystemInfo(&in.NodeInfo, &out.NodeInfo, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_api_NodeStatus_To_v1_NodeStatus(in *api.NodeStatus, out *NodeStatus, s conversion.Scope) error {
-	return autoconvert_api_NodeStatus_To_v1_NodeStatus(in, out, s)
+func Convert_api_NodeStatus_To_v1_NodeStatus(in *api.NodeStatus, out *NodeStatus, s conversion.Scope) error {
+	return autoConvert_api_NodeStatus_To_v1_NodeStatus(in, out, s)
 }
 
-func autoconvert_api_NodeSystemInfo_To_v1_NodeSystemInfo(in *api.NodeSystemInfo, out *NodeSystemInfo, s conversion.Scope) error {
+func autoConvert_api_NodeSystemInfo_To_v1_NodeSystemInfo(in *api.NodeSystemInfo, out *NodeSystemInfo, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.NodeSystemInfo))(in)
 	}
@@ -1505,11 +1522,11 @@ func autoconvert_api_NodeSystemInfo_To_v1_NodeSystemInfo(in *api.NodeSystemInfo,
 	return nil
 }
 
-func convert_api_NodeSystemInfo_To_v1_NodeSystemInfo(in *api.NodeSystemInfo, out *NodeSystemInfo, s conversion.Scope) error {
-	return autoconvert_api_NodeSystemInfo_To_v1_NodeSystemInfo(in, out, s)
+func Convert_api_NodeSystemInfo_To_v1_NodeSystemInfo(in *api.NodeSystemInfo, out *NodeSystemInfo, s conversion.Scope) error {
+	return autoConvert_api_NodeSystemInfo_To_v1_NodeSystemInfo(in, out, s)
 }
 
-func autoconvert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector(in *api.ObjectFieldSelector, out *ObjectFieldSelector, s conversion.Scope) error {
+func autoConvert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector(in *api.ObjectFieldSelector, out *ObjectFieldSelector, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ObjectFieldSelector))(in)
 	}
@@ -1518,11 +1535,11 @@ func autoconvert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector(in *api.Objec
 	return nil
 }
 
-func convert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector(in *api.ObjectFieldSelector, out *ObjectFieldSelector, s conversion.Scope) error {
-	return autoconvert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector(in, out, s)
+func Convert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector(in *api.ObjectFieldSelector, out *ObjectFieldSelector, s conversion.Scope) error {
+	return autoConvert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector(in, out, s)
 }
 
-func autoconvert_api_ObjectMeta_To_v1_ObjectMeta(in *api.ObjectMeta, out *ObjectMeta, s conversion.Scope) error {
+func autoConvert_api_ObjectMeta_To_v1_ObjectMeta(in *api.ObjectMeta, out *ObjectMeta, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ObjectMeta))(in)
 	}
@@ -1533,11 +1550,13 @@ func autoconvert_api_ObjectMeta_To_v1_ObjectMeta(in *api.ObjectMeta, out *Object
 	out.UID = in.UID
 	out.ResourceVersion = in.ResourceVersion
 	out.Generation = in.Generation
-	if err := s.Convert(&in.CreationTimestamp, &out.CreationTimestamp, 0); err != nil {
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.CreationTimestamp, &out.CreationTimestamp, s); err != nil {
 		return err
 	}
+	// unable to generate simple pointer conversion for unversioned.Time -> unversioned.Time
 	if in.DeletionTimestamp != nil {
-		if err := s.Convert(&in.DeletionTimestamp, &out.DeletionTimestamp, 0); err != nil {
+		out.DeletionTimestamp = new(unversioned.Time)
+		if err := api.Convert_unversioned_Time_To_unversioned_Time(in.DeletionTimestamp, out.DeletionTimestamp, s); err != nil {
 			return err
 		}
 	} else {
@@ -1568,11 +1587,11 @@ func autoconvert_api_ObjectMeta_To_v1_ObjectMeta(in *api.ObjectMeta, out *Object
 	return nil
 }
 
-func convert_api_ObjectMeta_To_v1_ObjectMeta(in *api.ObjectMeta, out *ObjectMeta, s conversion.Scope) error {
-	return autoconvert_api_ObjectMeta_To_v1_ObjectMeta(in, out, s)
+func Convert_api_ObjectMeta_To_v1_ObjectMeta(in *api.ObjectMeta, out *ObjectMeta, s conversion.Scope) error {
+	return autoConvert_api_ObjectMeta_To_v1_ObjectMeta(in, out, s)
 }
 
-func autoconvert_api_ObjectReference_To_v1_ObjectReference(in *api.ObjectReference, out *ObjectReference, s conversion.Scope) error {
+func autoConvert_api_ObjectReference_To_v1_ObjectReference(in *api.ObjectReference, out *ObjectReference, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ObjectReference))(in)
 	}
@@ -1586,70 +1605,70 @@ func autoconvert_api_ObjectReference_To_v1_ObjectReference(in *api.ObjectReferen
 	return nil
 }
 
-func convert_api_ObjectReference_To_v1_ObjectReference(in *api.ObjectReference, out *ObjectReference, s conversion.Scope) error {
-	return autoconvert_api_ObjectReference_To_v1_ObjectReference(in, out, s)
+func Convert_api_ObjectReference_To_v1_ObjectReference(in *api.ObjectReference, out *ObjectReference, s conversion.Scope) error {
+	return autoConvert_api_ObjectReference_To_v1_ObjectReference(in, out, s)
 }
 
-func autoconvert_api_PersistentVolume_To_v1_PersistentVolume(in *api.PersistentVolume, out *PersistentVolume, s conversion.Scope) error {
+func autoConvert_api_PersistentVolume_To_v1_PersistentVolume(in *api.PersistentVolume, out *PersistentVolume, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PersistentVolume))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_PersistentVolumeSpec_To_v1_PersistentVolumeSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_api_PersistentVolumeSpec_To_v1_PersistentVolumeSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := convert_api_PersistentVolumeStatus_To_v1_PersistentVolumeStatus(&in.Status, &out.Status, s); err != nil {
+	if err := Convert_api_PersistentVolumeStatus_To_v1_PersistentVolumeStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_api_PersistentVolume_To_v1_PersistentVolume(in *api.PersistentVolume, out *PersistentVolume, s conversion.Scope) error {
-	return autoconvert_api_PersistentVolume_To_v1_PersistentVolume(in, out, s)
+func Convert_api_PersistentVolume_To_v1_PersistentVolume(in *api.PersistentVolume, out *PersistentVolume, s conversion.Scope) error {
+	return autoConvert_api_PersistentVolume_To_v1_PersistentVolume(in, out, s)
 }
 
-func autoconvert_api_PersistentVolumeClaim_To_v1_PersistentVolumeClaim(in *api.PersistentVolumeClaim, out *PersistentVolumeClaim, s conversion.Scope) error {
+func autoConvert_api_PersistentVolumeClaim_To_v1_PersistentVolumeClaim(in *api.PersistentVolumeClaim, out *PersistentVolumeClaim, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PersistentVolumeClaim))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_PersistentVolumeClaimSpec_To_v1_PersistentVolumeClaimSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_api_PersistentVolumeClaimSpec_To_v1_PersistentVolumeClaimSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := convert_api_PersistentVolumeClaimStatus_To_v1_PersistentVolumeClaimStatus(&in.Status, &out.Status, s); err != nil {
+	if err := Convert_api_PersistentVolumeClaimStatus_To_v1_PersistentVolumeClaimStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_api_PersistentVolumeClaim_To_v1_PersistentVolumeClaim(in *api.PersistentVolumeClaim, out *PersistentVolumeClaim, s conversion.Scope) error {
-	return autoconvert_api_PersistentVolumeClaim_To_v1_PersistentVolumeClaim(in, out, s)
+func Convert_api_PersistentVolumeClaim_To_v1_PersistentVolumeClaim(in *api.PersistentVolumeClaim, out *PersistentVolumeClaim, s conversion.Scope) error {
+	return autoConvert_api_PersistentVolumeClaim_To_v1_PersistentVolumeClaim(in, out, s)
 }
 
-func autoconvert_api_PersistentVolumeClaimList_To_v1_PersistentVolumeClaimList(in *api.PersistentVolumeClaimList, out *PersistentVolumeClaimList, s conversion.Scope) error {
+func autoConvert_api_PersistentVolumeClaimList_To_v1_PersistentVolumeClaimList(in *api.PersistentVolumeClaimList, out *PersistentVolumeClaimList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PersistentVolumeClaimList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]PersistentVolumeClaim, len(in.Items))
 		for i := range in.Items {
-			if err := convert_api_PersistentVolumeClaim_To_v1_PersistentVolumeClaim(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_api_PersistentVolumeClaim_To_v1_PersistentVolumeClaim(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -1659,11 +1678,11 @@ func autoconvert_api_PersistentVolumeClaimList_To_v1_PersistentVolumeClaimList(i
 	return nil
 }
 
-func convert_api_PersistentVolumeClaimList_To_v1_PersistentVolumeClaimList(in *api.PersistentVolumeClaimList, out *PersistentVolumeClaimList, s conversion.Scope) error {
-	return autoconvert_api_PersistentVolumeClaimList_To_v1_PersistentVolumeClaimList(in, out, s)
+func Convert_api_PersistentVolumeClaimList_To_v1_PersistentVolumeClaimList(in *api.PersistentVolumeClaimList, out *PersistentVolumeClaimList, s conversion.Scope) error {
+	return autoConvert_api_PersistentVolumeClaimList_To_v1_PersistentVolumeClaimList(in, out, s)
 }
 
-func autoconvert_api_PersistentVolumeClaimSpec_To_v1_PersistentVolumeClaimSpec(in *api.PersistentVolumeClaimSpec, out *PersistentVolumeClaimSpec, s conversion.Scope) error {
+func autoConvert_api_PersistentVolumeClaimSpec_To_v1_PersistentVolumeClaimSpec(in *api.PersistentVolumeClaimSpec, out *PersistentVolumeClaimSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PersistentVolumeClaimSpec))(in)
 	}
@@ -1675,18 +1694,18 @@ func autoconvert_api_PersistentVolumeClaimSpec_To_v1_PersistentVolumeClaimSpec(i
 	} else {
 		out.AccessModes = nil
 	}
-	if err := convert_api_ResourceRequirements_To_v1_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
+	if err := Convert_api_ResourceRequirements_To_v1_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
 		return err
 	}
 	out.VolumeName = in.VolumeName
 	return nil
 }
 
-func convert_api_PersistentVolumeClaimSpec_To_v1_PersistentVolumeClaimSpec(in *api.PersistentVolumeClaimSpec, out *PersistentVolumeClaimSpec, s conversion.Scope) error {
-	return autoconvert_api_PersistentVolumeClaimSpec_To_v1_PersistentVolumeClaimSpec(in, out, s)
+func Convert_api_PersistentVolumeClaimSpec_To_v1_PersistentVolumeClaimSpec(in *api.PersistentVolumeClaimSpec, out *PersistentVolumeClaimSpec, s conversion.Scope) error {
+	return autoConvert_api_PersistentVolumeClaimSpec_To_v1_PersistentVolumeClaimSpec(in, out, s)
 }
 
-func autoconvert_api_PersistentVolumeClaimStatus_To_v1_PersistentVolumeClaimStatus(in *api.PersistentVolumeClaimStatus, out *PersistentVolumeClaimStatus, s conversion.Scope) error {
+func autoConvert_api_PersistentVolumeClaimStatus_To_v1_PersistentVolumeClaimStatus(in *api.PersistentVolumeClaimStatus, out *PersistentVolumeClaimStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PersistentVolumeClaimStatus))(in)
 	}
@@ -1703,7 +1722,7 @@ func autoconvert_api_PersistentVolumeClaimStatus_To_v1_PersistentVolumeClaimStat
 		out.Capacity = make(ResourceList)
 		for key, val := range in.Capacity {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.Capacity[ResourceName(key)] = newVal
@@ -1714,11 +1733,11 @@ func autoconvert_api_PersistentVolumeClaimStatus_To_v1_PersistentVolumeClaimStat
 	return nil
 }
 
-func convert_api_PersistentVolumeClaimStatus_To_v1_PersistentVolumeClaimStatus(in *api.PersistentVolumeClaimStatus, out *PersistentVolumeClaimStatus, s conversion.Scope) error {
-	return autoconvert_api_PersistentVolumeClaimStatus_To_v1_PersistentVolumeClaimStatus(in, out, s)
+func Convert_api_PersistentVolumeClaimStatus_To_v1_PersistentVolumeClaimStatus(in *api.PersistentVolumeClaimStatus, out *PersistentVolumeClaimStatus, s conversion.Scope) error {
+	return autoConvert_api_PersistentVolumeClaimStatus_To_v1_PersistentVolumeClaimStatus(in, out, s)
 }
 
-func autoconvert_api_PersistentVolumeClaimVolumeSource_To_v1_PersistentVolumeClaimVolumeSource(in *api.PersistentVolumeClaimVolumeSource, out *PersistentVolumeClaimVolumeSource, s conversion.Scope) error {
+func autoConvert_api_PersistentVolumeClaimVolumeSource_To_v1_PersistentVolumeClaimVolumeSource(in *api.PersistentVolumeClaimVolumeSource, out *PersistentVolumeClaimVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PersistentVolumeClaimVolumeSource))(in)
 	}
@@ -1727,24 +1746,24 @@ func autoconvert_api_PersistentVolumeClaimVolumeSource_To_v1_PersistentVolumeCla
 	return nil
 }
 
-func convert_api_PersistentVolumeClaimVolumeSource_To_v1_PersistentVolumeClaimVolumeSource(in *api.PersistentVolumeClaimVolumeSource, out *PersistentVolumeClaimVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_PersistentVolumeClaimVolumeSource_To_v1_PersistentVolumeClaimVolumeSource(in, out, s)
+func Convert_api_PersistentVolumeClaimVolumeSource_To_v1_PersistentVolumeClaimVolumeSource(in *api.PersistentVolumeClaimVolumeSource, out *PersistentVolumeClaimVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_PersistentVolumeClaimVolumeSource_To_v1_PersistentVolumeClaimVolumeSource(in, out, s)
 }
 
-func autoconvert_api_PersistentVolumeList_To_v1_PersistentVolumeList(in *api.PersistentVolumeList, out *PersistentVolumeList, s conversion.Scope) error {
+func autoConvert_api_PersistentVolumeList_To_v1_PersistentVolumeList(in *api.PersistentVolumeList, out *PersistentVolumeList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PersistentVolumeList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]PersistentVolume, len(in.Items))
 		for i := range in.Items {
-			if err := convert_api_PersistentVolume_To_v1_PersistentVolume(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_api_PersistentVolume_To_v1_PersistentVolume(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -1754,105 +1773,117 @@ func autoconvert_api_PersistentVolumeList_To_v1_PersistentVolumeList(in *api.Per
 	return nil
 }
 
-func convert_api_PersistentVolumeList_To_v1_PersistentVolumeList(in *api.PersistentVolumeList, out *PersistentVolumeList, s conversion.Scope) error {
-	return autoconvert_api_PersistentVolumeList_To_v1_PersistentVolumeList(in, out, s)
+func Convert_api_PersistentVolumeList_To_v1_PersistentVolumeList(in *api.PersistentVolumeList, out *PersistentVolumeList, s conversion.Scope) error {
+	return autoConvert_api_PersistentVolumeList_To_v1_PersistentVolumeList(in, out, s)
 }
 
-func autoconvert_api_PersistentVolumeSource_To_v1_PersistentVolumeSource(in *api.PersistentVolumeSource, out *PersistentVolumeSource, s conversion.Scope) error {
+func autoConvert_api_PersistentVolumeSource_To_v1_PersistentVolumeSource(in *api.PersistentVolumeSource, out *PersistentVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PersistentVolumeSource))(in)
 	}
+	// unable to generate simple pointer conversion for api.GCEPersistentDiskVolumeSource -> v1.GCEPersistentDiskVolumeSource
 	if in.GCEPersistentDisk != nil {
 		out.GCEPersistentDisk = new(GCEPersistentDiskVolumeSource)
-		if err := convert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSource(in.GCEPersistentDisk, out.GCEPersistentDisk, s); err != nil {
+		if err := Convert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSource(in.GCEPersistentDisk, out.GCEPersistentDisk, s); err != nil {
 			return err
 		}
 	} else {
 		out.GCEPersistentDisk = nil
 	}
+	// unable to generate simple pointer conversion for api.AWSElasticBlockStoreVolumeSource -> v1.AWSElasticBlockStoreVolumeSource
 	if in.AWSElasticBlockStore != nil {
 		out.AWSElasticBlockStore = new(AWSElasticBlockStoreVolumeSource)
-		if err := convert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVolumeSource(in.AWSElasticBlockStore, out.AWSElasticBlockStore, s); err != nil {
+		if err := Convert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVolumeSource(in.AWSElasticBlockStore, out.AWSElasticBlockStore, s); err != nil {
 			return err
 		}
 	} else {
 		out.AWSElasticBlockStore = nil
 	}
+	// unable to generate simple pointer conversion for api.HostPathVolumeSource -> v1.HostPathVolumeSource
 	if in.HostPath != nil {
 		out.HostPath = new(HostPathVolumeSource)
-		if err := convert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource(in.HostPath, out.HostPath, s); err != nil {
+		if err := Convert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource(in.HostPath, out.HostPath, s); err != nil {
 			return err
 		}
 	} else {
 		out.HostPath = nil
 	}
+	// unable to generate simple pointer conversion for api.GlusterfsVolumeSource -> v1.GlusterfsVolumeSource
 	if in.Glusterfs != nil {
 		out.Glusterfs = new(GlusterfsVolumeSource)
-		if err := convert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource(in.Glusterfs, out.Glusterfs, s); err != nil {
+		if err := Convert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource(in.Glusterfs, out.Glusterfs, s); err != nil {
 			return err
 		}
 	} else {
 		out.Glusterfs = nil
 	}
+	// unable to generate simple pointer conversion for api.NFSVolumeSource -> v1.NFSVolumeSource
 	if in.NFS != nil {
 		out.NFS = new(NFSVolumeSource)
-		if err := convert_api_NFSVolumeSource_To_v1_NFSVolumeSource(in.NFS, out.NFS, s); err != nil {
+		if err := Convert_api_NFSVolumeSource_To_v1_NFSVolumeSource(in.NFS, out.NFS, s); err != nil {
 			return err
 		}
 	} else {
 		out.NFS = nil
 	}
+	// unable to generate simple pointer conversion for api.RBDVolumeSource -> v1.RBDVolumeSource
 	if in.RBD != nil {
 		out.RBD = new(RBDVolumeSource)
-		if err := convert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in.RBD, out.RBD, s); err != nil {
+		if err := Convert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in.RBD, out.RBD, s); err != nil {
 			return err
 		}
 	} else {
 		out.RBD = nil
 	}
+	// unable to generate simple pointer conversion for api.ISCSIVolumeSource -> v1.ISCSIVolumeSource
 	if in.ISCSI != nil {
 		out.ISCSI = new(ISCSIVolumeSource)
-		if err := convert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource(in.ISCSI, out.ISCSI, s); err != nil {
+		if err := Convert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource(in.ISCSI, out.ISCSI, s); err != nil {
 			return err
 		}
 	} else {
 		out.ISCSI = nil
 	}
+	// unable to generate simple pointer conversion for api.FlexVolumeSource -> v1.FlexVolumeSource
 	if in.FlexVolume != nil {
 		out.FlexVolume = new(FlexVolumeSource)
-		if err := convert_api_FlexVolumeSource_To_v1_FlexVolumeSource(in.FlexVolume, out.FlexVolume, s); err != nil {
+		if err := Convert_api_FlexVolumeSource_To_v1_FlexVolumeSource(in.FlexVolume, out.FlexVolume, s); err != nil {
 			return err
 		}
 	} else {
 		out.FlexVolume = nil
 	}
+	// unable to generate simple pointer conversion for api.CinderVolumeSource -> v1.CinderVolumeSource
 	if in.Cinder != nil {
 		out.Cinder = new(CinderVolumeSource)
-		if err := convert_api_CinderVolumeSource_To_v1_CinderVolumeSource(in.Cinder, out.Cinder, s); err != nil {
+		if err := Convert_api_CinderVolumeSource_To_v1_CinderVolumeSource(in.Cinder, out.Cinder, s); err != nil {
 			return err
 		}
 	} else {
 		out.Cinder = nil
 	}
+	// unable to generate simple pointer conversion for api.CephFSVolumeSource -> v1.CephFSVolumeSource
 	if in.CephFS != nil {
 		out.CephFS = new(CephFSVolumeSource)
-		if err := convert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in.CephFS, out.CephFS, s); err != nil {
+		if err := Convert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in.CephFS, out.CephFS, s); err != nil {
 			return err
 		}
 	} else {
 		out.CephFS = nil
 	}
+	// unable to generate simple pointer conversion for api.FCVolumeSource -> v1.FCVolumeSource
 	if in.FC != nil {
 		out.FC = new(FCVolumeSource)
-		if err := convert_api_FCVolumeSource_To_v1_FCVolumeSource(in.FC, out.FC, s); err != nil {
+		if err := Convert_api_FCVolumeSource_To_v1_FCVolumeSource(in.FC, out.FC, s); err != nil {
 			return err
 		}
 	} else {
 		out.FC = nil
 	}
+	// unable to generate simple pointer conversion for api.FlockerVolumeSource -> v1.FlockerVolumeSource
 	if in.Flocker != nil {
 		out.Flocker = new(FlockerVolumeSource)
-		if err := convert_api_FlockerVolumeSource_To_v1_FlockerVolumeSource(in.Flocker, out.Flocker, s); err != nil {
+		if err := Convert_api_FlockerVolumeSource_To_v1_FlockerVolumeSource(in.Flocker, out.Flocker, s); err != nil {
 			return err
 		}
 	} else {
@@ -1861,11 +1892,11 @@ func autoconvert_api_PersistentVolumeSource_To_v1_PersistentVolumeSource(in *api
 	return nil
 }
 
-func convert_api_PersistentVolumeSource_To_v1_PersistentVolumeSource(in *api.PersistentVolumeSource, out *PersistentVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_PersistentVolumeSource_To_v1_PersistentVolumeSource(in, out, s)
+func Convert_api_PersistentVolumeSource_To_v1_PersistentVolumeSource(in *api.PersistentVolumeSource, out *PersistentVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_PersistentVolumeSource_To_v1_PersistentVolumeSource(in, out, s)
 }
 
-func autoconvert_api_PersistentVolumeSpec_To_v1_PersistentVolumeSpec(in *api.PersistentVolumeSpec, out *PersistentVolumeSpec, s conversion.Scope) error {
+func autoConvert_api_PersistentVolumeSpec_To_v1_PersistentVolumeSpec(in *api.PersistentVolumeSpec, out *PersistentVolumeSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PersistentVolumeSpec))(in)
 	}
@@ -1873,7 +1904,7 @@ func autoconvert_api_PersistentVolumeSpec_To_v1_PersistentVolumeSpec(in *api.Per
 		out.Capacity = make(ResourceList)
 		for key, val := range in.Capacity {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.Capacity[ResourceName(key)] = newVal
@@ -1881,7 +1912,7 @@ func autoconvert_api_PersistentVolumeSpec_To_v1_PersistentVolumeSpec(in *api.Per
 	} else {
 		out.Capacity = nil
 	}
-	if err := convert_api_PersistentVolumeSource_To_v1_PersistentVolumeSource(&in.PersistentVolumeSource, &out.PersistentVolumeSource, s); err != nil {
+	if err := Convert_api_PersistentVolumeSource_To_v1_PersistentVolumeSource(&in.PersistentVolumeSource, &out.PersistentVolumeSource, s); err != nil {
 		return err
 	}
 	if in.AccessModes != nil {
@@ -1892,9 +1923,10 @@ func autoconvert_api_PersistentVolumeSpec_To_v1_PersistentVolumeSpec(in *api.Per
 	} else {
 		out.AccessModes = nil
 	}
+	// unable to generate simple pointer conversion for api.ObjectReference -> v1.ObjectReference
 	if in.ClaimRef != nil {
 		out.ClaimRef = new(ObjectReference)
-		if err := convert_api_ObjectReference_To_v1_ObjectReference(in.ClaimRef, out.ClaimRef, s); err != nil {
+		if err := Convert_api_ObjectReference_To_v1_ObjectReference(in.ClaimRef, out.ClaimRef, s); err != nil {
 			return err
 		}
 	} else {
@@ -1904,11 +1936,11 @@ func autoconvert_api_PersistentVolumeSpec_To_v1_PersistentVolumeSpec(in *api.Per
 	return nil
 }
 
-func convert_api_PersistentVolumeSpec_To_v1_PersistentVolumeSpec(in *api.PersistentVolumeSpec, out *PersistentVolumeSpec, s conversion.Scope) error {
-	return autoconvert_api_PersistentVolumeSpec_To_v1_PersistentVolumeSpec(in, out, s)
+func Convert_api_PersistentVolumeSpec_To_v1_PersistentVolumeSpec(in *api.PersistentVolumeSpec, out *PersistentVolumeSpec, s conversion.Scope) error {
+	return autoConvert_api_PersistentVolumeSpec_To_v1_PersistentVolumeSpec(in, out, s)
 }
 
-func autoconvert_api_PersistentVolumeStatus_To_v1_PersistentVolumeStatus(in *api.PersistentVolumeStatus, out *PersistentVolumeStatus, s conversion.Scope) error {
+func autoConvert_api_PersistentVolumeStatus_To_v1_PersistentVolumeStatus(in *api.PersistentVolumeStatus, out *PersistentVolumeStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PersistentVolumeStatus))(in)
 	}
@@ -1918,34 +1950,34 @@ func autoconvert_api_PersistentVolumeStatus_To_v1_PersistentVolumeStatus(in *api
 	return nil
 }
 
-func convert_api_PersistentVolumeStatus_To_v1_PersistentVolumeStatus(in *api.PersistentVolumeStatus, out *PersistentVolumeStatus, s conversion.Scope) error {
-	return autoconvert_api_PersistentVolumeStatus_To_v1_PersistentVolumeStatus(in, out, s)
+func Convert_api_PersistentVolumeStatus_To_v1_PersistentVolumeStatus(in *api.PersistentVolumeStatus, out *PersistentVolumeStatus, s conversion.Scope) error {
+	return autoConvert_api_PersistentVolumeStatus_To_v1_PersistentVolumeStatus(in, out, s)
 }
 
-func autoconvert_api_Pod_To_v1_Pod(in *api.Pod, out *Pod, s conversion.Scope) error {
+func autoConvert_api_Pod_To_v1_Pod(in *api.Pod, out *Pod, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Pod))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_PodSpec_To_v1_PodSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_api_PodSpec_To_v1_PodSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := convert_api_PodStatus_To_v1_PodStatus(&in.Status, &out.Status, s); err != nil {
+	if err := Convert_api_PodStatus_To_v1_PodStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func autoconvert_api_PodAttachOptions_To_v1_PodAttachOptions(in *api.PodAttachOptions, out *PodAttachOptions, s conversion.Scope) error {
+func autoConvert_api_PodAttachOptions_To_v1_PodAttachOptions(in *api.PodAttachOptions, out *PodAttachOptions, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodAttachOptions))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
 	out.Stdin = in.Stdin
@@ -1956,20 +1988,20 @@ func autoconvert_api_PodAttachOptions_To_v1_PodAttachOptions(in *api.PodAttachOp
 	return nil
 }
 
-func convert_api_PodAttachOptions_To_v1_PodAttachOptions(in *api.PodAttachOptions, out *PodAttachOptions, s conversion.Scope) error {
-	return autoconvert_api_PodAttachOptions_To_v1_PodAttachOptions(in, out, s)
+func Convert_api_PodAttachOptions_To_v1_PodAttachOptions(in *api.PodAttachOptions, out *PodAttachOptions, s conversion.Scope) error {
+	return autoConvert_api_PodAttachOptions_To_v1_PodAttachOptions(in, out, s)
 }
 
-func autoconvert_api_PodCondition_To_v1_PodCondition(in *api.PodCondition, out *PodCondition, s conversion.Scope) error {
+func autoConvert_api_PodCondition_To_v1_PodCondition(in *api.PodCondition, out *PodCondition, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodCondition))(in)
 	}
 	out.Type = PodConditionType(in.Type)
 	out.Status = ConditionStatus(in.Status)
-	if err := s.Convert(&in.LastProbeTime, &out.LastProbeTime, 0); err != nil {
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.LastProbeTime, &out.LastProbeTime, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.LastTransitionTime, &out.LastTransitionTime, 0); err != nil {
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.LastTransitionTime, &out.LastTransitionTime, s); err != nil {
 		return err
 	}
 	out.Reason = in.Reason
@@ -1977,15 +2009,15 @@ func autoconvert_api_PodCondition_To_v1_PodCondition(in *api.PodCondition, out *
 	return nil
 }
 
-func convert_api_PodCondition_To_v1_PodCondition(in *api.PodCondition, out *PodCondition, s conversion.Scope) error {
-	return autoconvert_api_PodCondition_To_v1_PodCondition(in, out, s)
+func Convert_api_PodCondition_To_v1_PodCondition(in *api.PodCondition, out *PodCondition, s conversion.Scope) error {
+	return autoConvert_api_PodCondition_To_v1_PodCondition(in, out, s)
 }
 
-func autoconvert_api_PodExecOptions_To_v1_PodExecOptions(in *api.PodExecOptions, out *PodExecOptions, s conversion.Scope) error {
+func autoConvert_api_PodExecOptions_To_v1_PodExecOptions(in *api.PodExecOptions, out *PodExecOptions, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodExecOptions))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
 	out.Stdin = in.Stdin
@@ -2004,24 +2036,24 @@ func autoconvert_api_PodExecOptions_To_v1_PodExecOptions(in *api.PodExecOptions,
 	return nil
 }
 
-func convert_api_PodExecOptions_To_v1_PodExecOptions(in *api.PodExecOptions, out *PodExecOptions, s conversion.Scope) error {
-	return autoconvert_api_PodExecOptions_To_v1_PodExecOptions(in, out, s)
+func Convert_api_PodExecOptions_To_v1_PodExecOptions(in *api.PodExecOptions, out *PodExecOptions, s conversion.Scope) error {
+	return autoConvert_api_PodExecOptions_To_v1_PodExecOptions(in, out, s)
 }
 
-func autoconvert_api_PodList_To_v1_PodList(in *api.PodList, out *PodList, s conversion.Scope) error {
+func autoConvert_api_PodList_To_v1_PodList(in *api.PodList, out *PodList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]Pod, len(in.Items))
 		for i := range in.Items {
-			if err := convert_api_Pod_To_v1_Pod(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_api_Pod_To_v1_Pod(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -2031,15 +2063,15 @@ func autoconvert_api_PodList_To_v1_PodList(in *api.PodList, out *PodList, s conv
 	return nil
 }
 
-func convert_api_PodList_To_v1_PodList(in *api.PodList, out *PodList, s conversion.Scope) error {
-	return autoconvert_api_PodList_To_v1_PodList(in, out, s)
+func Convert_api_PodList_To_v1_PodList(in *api.PodList, out *PodList, s conversion.Scope) error {
+	return autoConvert_api_PodList_To_v1_PodList(in, out, s)
 }
 
-func autoconvert_api_PodLogOptions_To_v1_PodLogOptions(in *api.PodLogOptions, out *PodLogOptions, s conversion.Scope) error {
+func autoConvert_api_PodLogOptions_To_v1_PodLogOptions(in *api.PodLogOptions, out *PodLogOptions, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodLogOptions))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
 	out.Container = in.Container
@@ -2051,8 +2083,10 @@ func autoconvert_api_PodLogOptions_To_v1_PodLogOptions(in *api.PodLogOptions, ou
 	} else {
 		out.SinceSeconds = nil
 	}
+	// unable to generate simple pointer conversion for unversioned.Time -> unversioned.Time
 	if in.SinceTime != nil {
-		if err := s.Convert(&in.SinceTime, &out.SinceTime, 0); err != nil {
+		out.SinceTime = new(unversioned.Time)
+		if err := api.Convert_unversioned_Time_To_unversioned_Time(in.SinceTime, out.SinceTime, s); err != nil {
 			return err
 		}
 	} else {
@@ -2074,33 +2108,33 @@ func autoconvert_api_PodLogOptions_To_v1_PodLogOptions(in *api.PodLogOptions, ou
 	return nil
 }
 
-func convert_api_PodLogOptions_To_v1_PodLogOptions(in *api.PodLogOptions, out *PodLogOptions, s conversion.Scope) error {
-	return autoconvert_api_PodLogOptions_To_v1_PodLogOptions(in, out, s)
+func Convert_api_PodLogOptions_To_v1_PodLogOptions(in *api.PodLogOptions, out *PodLogOptions, s conversion.Scope) error {
+	return autoConvert_api_PodLogOptions_To_v1_PodLogOptions(in, out, s)
 }
 
-func autoconvert_api_PodProxyOptions_To_v1_PodProxyOptions(in *api.PodProxyOptions, out *PodProxyOptions, s conversion.Scope) error {
+func autoConvert_api_PodProxyOptions_To_v1_PodProxyOptions(in *api.PodProxyOptions, out *PodProxyOptions, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodProxyOptions))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
 	out.Path = in.Path
 	return nil
 }
 
-func convert_api_PodProxyOptions_To_v1_PodProxyOptions(in *api.PodProxyOptions, out *PodProxyOptions, s conversion.Scope) error {
-	return autoconvert_api_PodProxyOptions_To_v1_PodProxyOptions(in, out, s)
+func Convert_api_PodProxyOptions_To_v1_PodProxyOptions(in *api.PodProxyOptions, out *PodProxyOptions, s conversion.Scope) error {
+	return autoConvert_api_PodProxyOptions_To_v1_PodProxyOptions(in, out, s)
 }
 
-func autoconvert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *PodSpec, s conversion.Scope) error {
+func autoConvert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *PodSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodSpec))(in)
 	}
 	if in.Volumes != nil {
 		out.Volumes = make([]Volume, len(in.Volumes))
 		for i := range in.Volumes {
-			if err := convert_api_Volume_To_v1_Volume(&in.Volumes[i], &out.Volumes[i], s); err != nil {
+			if err := Convert_api_Volume_To_v1_Volume(&in.Volumes[i], &out.Volumes[i], s); err != nil {
 				return err
 			}
 		}
@@ -2110,7 +2144,7 @@ func autoconvert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *PodSpec, s conv
 	if in.Containers != nil {
 		out.Containers = make([]Container, len(in.Containers))
 		for i := range in.Containers {
-			if err := convert_api_Container_To_v1_Container(&in.Containers[i], &out.Containers[i], s); err != nil {
+			if err := Convert_api_Container_To_v1_Container(&in.Containers[i], &out.Containers[i], s); err != nil {
 				return err
 			}
 		}
@@ -2141,6 +2175,7 @@ func autoconvert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *PodSpec, s conv
 	}
 	out.ServiceAccountName = in.ServiceAccountName
 	out.NodeName = in.NodeName
+	// unable to generate simple pointer conversion for api.PodSecurityContext -> v1.PodSecurityContext
 	if in.SecurityContext != nil {
 		if err := s.Convert(&in.SecurityContext, &out.SecurityContext, 0); err != nil {
 			return err
@@ -2151,7 +2186,7 @@ func autoconvert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *PodSpec, s conv
 	if in.ImagePullSecrets != nil {
 		out.ImagePullSecrets = make([]LocalObjectReference, len(in.ImagePullSecrets))
 		for i := range in.ImagePullSecrets {
-			if err := convert_api_LocalObjectReference_To_v1_LocalObjectReference(&in.ImagePullSecrets[i], &out.ImagePullSecrets[i], s); err != nil {
+			if err := Convert_api_LocalObjectReference_To_v1_LocalObjectReference(&in.ImagePullSecrets[i], &out.ImagePullSecrets[i], s); err != nil {
 				return err
 			}
 		}
@@ -2161,7 +2196,7 @@ func autoconvert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *PodSpec, s conv
 	return nil
 }
 
-func autoconvert_api_PodStatus_To_v1_PodStatus(in *api.PodStatus, out *PodStatus, s conversion.Scope) error {
+func autoConvert_api_PodStatus_To_v1_PodStatus(in *api.PodStatus, out *PodStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodStatus))(in)
 	}
@@ -2169,7 +2204,7 @@ func autoconvert_api_PodStatus_To_v1_PodStatus(in *api.PodStatus, out *PodStatus
 	if in.Conditions != nil {
 		out.Conditions = make([]PodCondition, len(in.Conditions))
 		for i := range in.Conditions {
-			if err := convert_api_PodCondition_To_v1_PodCondition(&in.Conditions[i], &out.Conditions[i], s); err != nil {
+			if err := Convert_api_PodCondition_To_v1_PodCondition(&in.Conditions[i], &out.Conditions[i], s); err != nil {
 				return err
 			}
 		}
@@ -2180,8 +2215,10 @@ func autoconvert_api_PodStatus_To_v1_PodStatus(in *api.PodStatus, out *PodStatus
 	out.Reason = in.Reason
 	out.HostIP = in.HostIP
 	out.PodIP = in.PodIP
+	// unable to generate simple pointer conversion for unversioned.Time -> unversioned.Time
 	if in.StartTime != nil {
-		if err := s.Convert(&in.StartTime, &out.StartTime, 0); err != nil {
+		out.StartTime = new(unversioned.Time)
+		if err := api.Convert_unversioned_Time_To_unversioned_Time(in.StartTime, out.StartTime, s); err != nil {
 			return err
 		}
 	} else {
@@ -2190,7 +2227,7 @@ func autoconvert_api_PodStatus_To_v1_PodStatus(in *api.PodStatus, out *PodStatus
 	if in.ContainerStatuses != nil {
 		out.ContainerStatuses = make([]ContainerStatus, len(in.ContainerStatuses))
 		for i := range in.ContainerStatuses {
-			if err := convert_api_ContainerStatus_To_v1_ContainerStatus(&in.ContainerStatuses[i], &out.ContainerStatuses[i], s); err != nil {
+			if err := Convert_api_ContainerStatus_To_v1_ContainerStatus(&in.ContainerStatuses[i], &out.ContainerStatuses[i], s); err != nil {
 				return err
 			}
 		}
@@ -2200,64 +2237,64 @@ func autoconvert_api_PodStatus_To_v1_PodStatus(in *api.PodStatus, out *PodStatus
 	return nil
 }
 
-func convert_api_PodStatus_To_v1_PodStatus(in *api.PodStatus, out *PodStatus, s conversion.Scope) error {
-	return autoconvert_api_PodStatus_To_v1_PodStatus(in, out, s)
+func Convert_api_PodStatus_To_v1_PodStatus(in *api.PodStatus, out *PodStatus, s conversion.Scope) error {
+	return autoConvert_api_PodStatus_To_v1_PodStatus(in, out, s)
 }
 
-func autoconvert_api_PodStatusResult_To_v1_PodStatusResult(in *api.PodStatusResult, out *PodStatusResult, s conversion.Scope) error {
+func autoConvert_api_PodStatusResult_To_v1_PodStatusResult(in *api.PodStatusResult, out *PodStatusResult, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodStatusResult))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_PodStatus_To_v1_PodStatus(&in.Status, &out.Status, s); err != nil {
+	if err := Convert_api_PodStatus_To_v1_PodStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_api_PodStatusResult_To_v1_PodStatusResult(in *api.PodStatusResult, out *PodStatusResult, s conversion.Scope) error {
-	return autoconvert_api_PodStatusResult_To_v1_PodStatusResult(in, out, s)
+func Convert_api_PodStatusResult_To_v1_PodStatusResult(in *api.PodStatusResult, out *PodStatusResult, s conversion.Scope) error {
+	return autoConvert_api_PodStatusResult_To_v1_PodStatusResult(in, out, s)
 }
 
-func autoconvert_api_PodTemplate_To_v1_PodTemplate(in *api.PodTemplate, out *PodTemplate, s conversion.Scope) error {
+func autoConvert_api_PodTemplate_To_v1_PodTemplate(in *api.PodTemplate, out *PodTemplate, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodTemplate))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
+	if err := Convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_api_PodTemplate_To_v1_PodTemplate(in *api.PodTemplate, out *PodTemplate, s conversion.Scope) error {
-	return autoconvert_api_PodTemplate_To_v1_PodTemplate(in, out, s)
+func Convert_api_PodTemplate_To_v1_PodTemplate(in *api.PodTemplate, out *PodTemplate, s conversion.Scope) error {
+	return autoConvert_api_PodTemplate_To_v1_PodTemplate(in, out, s)
 }
 
-func autoconvert_api_PodTemplateList_To_v1_PodTemplateList(in *api.PodTemplateList, out *PodTemplateList, s conversion.Scope) error {
+func autoConvert_api_PodTemplateList_To_v1_PodTemplateList(in *api.PodTemplateList, out *PodTemplateList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodTemplateList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]PodTemplate, len(in.Items))
 		for i := range in.Items {
-			if err := convert_api_PodTemplate_To_v1_PodTemplate(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_api_PodTemplate_To_v1_PodTemplate(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -2267,32 +2304,32 @@ func autoconvert_api_PodTemplateList_To_v1_PodTemplateList(in *api.PodTemplateLi
 	return nil
 }
 
-func convert_api_PodTemplateList_To_v1_PodTemplateList(in *api.PodTemplateList, out *PodTemplateList, s conversion.Scope) error {
-	return autoconvert_api_PodTemplateList_To_v1_PodTemplateList(in, out, s)
+func Convert_api_PodTemplateList_To_v1_PodTemplateList(in *api.PodTemplateList, out *PodTemplateList, s conversion.Scope) error {
+	return autoConvert_api_PodTemplateList_To_v1_PodTemplateList(in, out, s)
 }
 
-func autoconvert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in *api.PodTemplateSpec, out *PodTemplateSpec, s conversion.Scope) error {
+func autoConvert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in *api.PodTemplateSpec, out *PodTemplateSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodTemplateSpec))(in)
 	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_PodSpec_To_v1_PodSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_api_PodSpec_To_v1_PodSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in *api.PodTemplateSpec, out *PodTemplateSpec, s conversion.Scope) error {
-	return autoconvert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in, out, s)
+func Convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in *api.PodTemplateSpec, out *PodTemplateSpec, s conversion.Scope) error {
+	return autoConvert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in, out, s)
 }
 
-func autoconvert_api_Probe_To_v1_Probe(in *api.Probe, out *Probe, s conversion.Scope) error {
+func autoConvert_api_Probe_To_v1_Probe(in *api.Probe, out *Probe, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Probe))(in)
 	}
-	if err := convert_api_Handler_To_v1_Handler(&in.Handler, &out.Handler, s); err != nil {
+	if err := Convert_api_Handler_To_v1_Handler(&in.Handler, &out.Handler, s); err != nil {
 		return err
 	}
 	out.InitialDelaySeconds = int32(in.InitialDelaySeconds)
@@ -2303,11 +2340,11 @@ func autoconvert_api_Probe_To_v1_Probe(in *api.Probe, out *Probe, s conversion.S
 	return nil
 }
 
-func convert_api_Probe_To_v1_Probe(in *api.Probe, out *Probe, s conversion.Scope) error {
-	return autoconvert_api_Probe_To_v1_Probe(in, out, s)
+func Convert_api_Probe_To_v1_Probe(in *api.Probe, out *Probe, s conversion.Scope) error {
+	return autoConvert_api_Probe_To_v1_Probe(in, out, s)
 }
 
-func autoconvert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in *api.RBDVolumeSource, out *RBDVolumeSource, s conversion.Scope) error {
+func autoConvert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in *api.RBDVolumeSource, out *RBDVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.RBDVolumeSource))(in)
 	}
@@ -2324,9 +2361,10 @@ func autoconvert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in *api.RBDVolumeSour
 	out.RBDPool = in.RBDPool
 	out.RadosUser = in.RadosUser
 	out.Keyring = in.Keyring
+	// unable to generate simple pointer conversion for api.LocalObjectReference -> v1.LocalObjectReference
 	if in.SecretRef != nil {
 		out.SecretRef = new(LocalObjectReference)
-		if err := convert_api_LocalObjectReference_To_v1_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
+		if err := Convert_api_LocalObjectReference_To_v1_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
 			return err
 		}
 	} else {
@@ -2336,68 +2374,68 @@ func autoconvert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in *api.RBDVolumeSour
 	return nil
 }
 
-func convert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in *api.RBDVolumeSource, out *RBDVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in, out, s)
+func Convert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in *api.RBDVolumeSource, out *RBDVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in, out, s)
 }
 
-func autoconvert_api_RangeAllocation_To_v1_RangeAllocation(in *api.RangeAllocation, out *RangeAllocation, s conversion.Scope) error {
+func autoConvert_api_RangeAllocation_To_v1_RangeAllocation(in *api.RangeAllocation, out *RangeAllocation, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.RangeAllocation))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
 	out.Range = in.Range
-	if err := s.Convert(&in.Data, &out.Data, 0); err != nil {
+	if err := conversion.ByteSliceCopy(&in.Data, &out.Data, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_api_RangeAllocation_To_v1_RangeAllocation(in *api.RangeAllocation, out *RangeAllocation, s conversion.Scope) error {
-	return autoconvert_api_RangeAllocation_To_v1_RangeAllocation(in, out, s)
+func Convert_api_RangeAllocation_To_v1_RangeAllocation(in *api.RangeAllocation, out *RangeAllocation, s conversion.Scope) error {
+	return autoConvert_api_RangeAllocation_To_v1_RangeAllocation(in, out, s)
 }
 
-func autoconvert_api_ReplicationController_To_v1_ReplicationController(in *api.ReplicationController, out *ReplicationController, s conversion.Scope) error {
+func autoConvert_api_ReplicationController_To_v1_ReplicationController(in *api.ReplicationController, out *ReplicationController, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ReplicationController))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ReplicationControllerSpec_To_v1_ReplicationControllerSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_api_ReplicationControllerSpec_To_v1_ReplicationControllerSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := convert_api_ReplicationControllerStatus_To_v1_ReplicationControllerStatus(&in.Status, &out.Status, s); err != nil {
+	if err := Convert_api_ReplicationControllerStatus_To_v1_ReplicationControllerStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_api_ReplicationController_To_v1_ReplicationController(in *api.ReplicationController, out *ReplicationController, s conversion.Scope) error {
-	return autoconvert_api_ReplicationController_To_v1_ReplicationController(in, out, s)
+func Convert_api_ReplicationController_To_v1_ReplicationController(in *api.ReplicationController, out *ReplicationController, s conversion.Scope) error {
+	return autoConvert_api_ReplicationController_To_v1_ReplicationController(in, out, s)
 }
 
-func autoconvert_api_ReplicationControllerList_To_v1_ReplicationControllerList(in *api.ReplicationControllerList, out *ReplicationControllerList, s conversion.Scope) error {
+func autoConvert_api_ReplicationControllerList_To_v1_ReplicationControllerList(in *api.ReplicationControllerList, out *ReplicationControllerList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ReplicationControllerList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]ReplicationController, len(in.Items))
 		for i := range in.Items {
-			if err := convert_api_ReplicationController_To_v1_ReplicationController(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_api_ReplicationController_To_v1_ReplicationController(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -2407,11 +2445,11 @@ func autoconvert_api_ReplicationControllerList_To_v1_ReplicationControllerList(i
 	return nil
 }
 
-func convert_api_ReplicationControllerList_To_v1_ReplicationControllerList(in *api.ReplicationControllerList, out *ReplicationControllerList, s conversion.Scope) error {
-	return autoconvert_api_ReplicationControllerList_To_v1_ReplicationControllerList(in, out, s)
+func Convert_api_ReplicationControllerList_To_v1_ReplicationControllerList(in *api.ReplicationControllerList, out *ReplicationControllerList, s conversion.Scope) error {
+	return autoConvert_api_ReplicationControllerList_To_v1_ReplicationControllerList(in, out, s)
 }
 
-func autoconvert_api_ReplicationControllerSpec_To_v1_ReplicationControllerSpec(in *api.ReplicationControllerSpec, out *ReplicationControllerSpec, s conversion.Scope) error {
+func autoConvert_api_ReplicationControllerSpec_To_v1_ReplicationControllerSpec(in *api.ReplicationControllerSpec, out *ReplicationControllerSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ReplicationControllerSpec))(in)
 	}
@@ -2426,9 +2464,10 @@ func autoconvert_api_ReplicationControllerSpec_To_v1_ReplicationControllerSpec(i
 	} else {
 		out.Selector = nil
 	}
+	// unable to generate simple pointer conversion for api.PodTemplateSpec -> v1.PodTemplateSpec
 	if in.Template != nil {
 		out.Template = new(PodTemplateSpec)
-		if err := convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in.Template, out.Template, s); err != nil {
+		if err := Convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in.Template, out.Template, s); err != nil {
 			return err
 		}
 	} else {
@@ -2437,7 +2476,7 @@ func autoconvert_api_ReplicationControllerSpec_To_v1_ReplicationControllerSpec(i
 	return nil
 }
 
-func autoconvert_api_ReplicationControllerStatus_To_v1_ReplicationControllerStatus(in *api.ReplicationControllerStatus, out *ReplicationControllerStatus, s conversion.Scope) error {
+func autoConvert_api_ReplicationControllerStatus_To_v1_ReplicationControllerStatus(in *api.ReplicationControllerStatus, out *ReplicationControllerStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ReplicationControllerStatus))(in)
 	}
@@ -2446,47 +2485,47 @@ func autoconvert_api_ReplicationControllerStatus_To_v1_ReplicationControllerStat
 	return nil
 }
 
-func convert_api_ReplicationControllerStatus_To_v1_ReplicationControllerStatus(in *api.ReplicationControllerStatus, out *ReplicationControllerStatus, s conversion.Scope) error {
-	return autoconvert_api_ReplicationControllerStatus_To_v1_ReplicationControllerStatus(in, out, s)
+func Convert_api_ReplicationControllerStatus_To_v1_ReplicationControllerStatus(in *api.ReplicationControllerStatus, out *ReplicationControllerStatus, s conversion.Scope) error {
+	return autoConvert_api_ReplicationControllerStatus_To_v1_ReplicationControllerStatus(in, out, s)
 }
 
-func autoconvert_api_ResourceQuota_To_v1_ResourceQuota(in *api.ResourceQuota, out *ResourceQuota, s conversion.Scope) error {
+func autoConvert_api_ResourceQuota_To_v1_ResourceQuota(in *api.ResourceQuota, out *ResourceQuota, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ResourceQuota))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ResourceQuotaSpec_To_v1_ResourceQuotaSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_api_ResourceQuotaSpec_To_v1_ResourceQuotaSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := convert_api_ResourceQuotaStatus_To_v1_ResourceQuotaStatus(&in.Status, &out.Status, s); err != nil {
+	if err := Convert_api_ResourceQuotaStatus_To_v1_ResourceQuotaStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_api_ResourceQuota_To_v1_ResourceQuota(in *api.ResourceQuota, out *ResourceQuota, s conversion.Scope) error {
-	return autoconvert_api_ResourceQuota_To_v1_ResourceQuota(in, out, s)
+func Convert_api_ResourceQuota_To_v1_ResourceQuota(in *api.ResourceQuota, out *ResourceQuota, s conversion.Scope) error {
+	return autoConvert_api_ResourceQuota_To_v1_ResourceQuota(in, out, s)
 }
 
-func autoconvert_api_ResourceQuotaList_To_v1_ResourceQuotaList(in *api.ResourceQuotaList, out *ResourceQuotaList, s conversion.Scope) error {
+func autoConvert_api_ResourceQuotaList_To_v1_ResourceQuotaList(in *api.ResourceQuotaList, out *ResourceQuotaList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ResourceQuotaList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]ResourceQuota, len(in.Items))
 		for i := range in.Items {
-			if err := convert_api_ResourceQuota_To_v1_ResourceQuota(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_api_ResourceQuota_To_v1_ResourceQuota(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -2496,11 +2535,11 @@ func autoconvert_api_ResourceQuotaList_To_v1_ResourceQuotaList(in *api.ResourceQ
 	return nil
 }
 
-func convert_api_ResourceQuotaList_To_v1_ResourceQuotaList(in *api.ResourceQuotaList, out *ResourceQuotaList, s conversion.Scope) error {
-	return autoconvert_api_ResourceQuotaList_To_v1_ResourceQuotaList(in, out, s)
+func Convert_api_ResourceQuotaList_To_v1_ResourceQuotaList(in *api.ResourceQuotaList, out *ResourceQuotaList, s conversion.Scope) error {
+	return autoConvert_api_ResourceQuotaList_To_v1_ResourceQuotaList(in, out, s)
 }
 
-func autoconvert_api_ResourceQuotaSpec_To_v1_ResourceQuotaSpec(in *api.ResourceQuotaSpec, out *ResourceQuotaSpec, s conversion.Scope) error {
+func autoConvert_api_ResourceQuotaSpec_To_v1_ResourceQuotaSpec(in *api.ResourceQuotaSpec, out *ResourceQuotaSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ResourceQuotaSpec))(in)
 	}
@@ -2508,7 +2547,7 @@ func autoconvert_api_ResourceQuotaSpec_To_v1_ResourceQuotaSpec(in *api.ResourceQ
 		out.Hard = make(ResourceList)
 		for key, val := range in.Hard {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.Hard[ResourceName(key)] = newVal
@@ -2519,11 +2558,11 @@ func autoconvert_api_ResourceQuotaSpec_To_v1_ResourceQuotaSpec(in *api.ResourceQ
 	return nil
 }
 
-func convert_api_ResourceQuotaSpec_To_v1_ResourceQuotaSpec(in *api.ResourceQuotaSpec, out *ResourceQuotaSpec, s conversion.Scope) error {
-	return autoconvert_api_ResourceQuotaSpec_To_v1_ResourceQuotaSpec(in, out, s)
+func Convert_api_ResourceQuotaSpec_To_v1_ResourceQuotaSpec(in *api.ResourceQuotaSpec, out *ResourceQuotaSpec, s conversion.Scope) error {
+	return autoConvert_api_ResourceQuotaSpec_To_v1_ResourceQuotaSpec(in, out, s)
 }
 
-func autoconvert_api_ResourceQuotaStatus_To_v1_ResourceQuotaStatus(in *api.ResourceQuotaStatus, out *ResourceQuotaStatus, s conversion.Scope) error {
+func autoConvert_api_ResourceQuotaStatus_To_v1_ResourceQuotaStatus(in *api.ResourceQuotaStatus, out *ResourceQuotaStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ResourceQuotaStatus))(in)
 	}
@@ -2531,7 +2570,7 @@ func autoconvert_api_ResourceQuotaStatus_To_v1_ResourceQuotaStatus(in *api.Resou
 		out.Hard = make(ResourceList)
 		for key, val := range in.Hard {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.Hard[ResourceName(key)] = newVal
@@ -2543,7 +2582,7 @@ func autoconvert_api_ResourceQuotaStatus_To_v1_ResourceQuotaStatus(in *api.Resou
 		out.Used = make(ResourceList)
 		for key, val := range in.Used {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.Used[ResourceName(key)] = newVal
@@ -2554,11 +2593,11 @@ func autoconvert_api_ResourceQuotaStatus_To_v1_ResourceQuotaStatus(in *api.Resou
 	return nil
 }
 
-func convert_api_ResourceQuotaStatus_To_v1_ResourceQuotaStatus(in *api.ResourceQuotaStatus, out *ResourceQuotaStatus, s conversion.Scope) error {
-	return autoconvert_api_ResourceQuotaStatus_To_v1_ResourceQuotaStatus(in, out, s)
+func Convert_api_ResourceQuotaStatus_To_v1_ResourceQuotaStatus(in *api.ResourceQuotaStatus, out *ResourceQuotaStatus, s conversion.Scope) error {
+	return autoConvert_api_ResourceQuotaStatus_To_v1_ResourceQuotaStatus(in, out, s)
 }
 
-func autoconvert_api_ResourceRequirements_To_v1_ResourceRequirements(in *api.ResourceRequirements, out *ResourceRequirements, s conversion.Scope) error {
+func autoConvert_api_ResourceRequirements_To_v1_ResourceRequirements(in *api.ResourceRequirements, out *ResourceRequirements, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ResourceRequirements))(in)
 	}
@@ -2566,7 +2605,7 @@ func autoconvert_api_ResourceRequirements_To_v1_ResourceRequirements(in *api.Res
 		out.Limits = make(ResourceList)
 		for key, val := range in.Limits {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.Limits[ResourceName(key)] = newVal
@@ -2578,7 +2617,7 @@ func autoconvert_api_ResourceRequirements_To_v1_ResourceRequirements(in *api.Res
 		out.Requests = make(ResourceList)
 		for key, val := range in.Requests {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.Requests[ResourceName(key)] = newVal
@@ -2589,11 +2628,11 @@ func autoconvert_api_ResourceRequirements_To_v1_ResourceRequirements(in *api.Res
 	return nil
 }
 
-func convert_api_ResourceRequirements_To_v1_ResourceRequirements(in *api.ResourceRequirements, out *ResourceRequirements, s conversion.Scope) error {
-	return autoconvert_api_ResourceRequirements_To_v1_ResourceRequirements(in, out, s)
+func Convert_api_ResourceRequirements_To_v1_ResourceRequirements(in *api.ResourceRequirements, out *ResourceRequirements, s conversion.Scope) error {
+	return autoConvert_api_ResourceRequirements_To_v1_ResourceRequirements(in, out, s)
 }
 
-func autoconvert_api_SELinuxOptions_To_v1_SELinuxOptions(in *api.SELinuxOptions, out *SELinuxOptions, s conversion.Scope) error {
+func autoConvert_api_SELinuxOptions_To_v1_SELinuxOptions(in *api.SELinuxOptions, out *SELinuxOptions, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.SELinuxOptions))(in)
 	}
@@ -2604,25 +2643,25 @@ func autoconvert_api_SELinuxOptions_To_v1_SELinuxOptions(in *api.SELinuxOptions,
 	return nil
 }
 
-func convert_api_SELinuxOptions_To_v1_SELinuxOptions(in *api.SELinuxOptions, out *SELinuxOptions, s conversion.Scope) error {
-	return autoconvert_api_SELinuxOptions_To_v1_SELinuxOptions(in, out, s)
+func Convert_api_SELinuxOptions_To_v1_SELinuxOptions(in *api.SELinuxOptions, out *SELinuxOptions, s conversion.Scope) error {
+	return autoConvert_api_SELinuxOptions_To_v1_SELinuxOptions(in, out, s)
 }
 
-func autoconvert_api_Secret_To_v1_Secret(in *api.Secret, out *Secret, s conversion.Scope) error {
+func autoConvert_api_Secret_To_v1_Secret(in *api.Secret, out *Secret, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Secret))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
 	if in.Data != nil {
 		out.Data = make(map[string][]uint8)
 		for key, val := range in.Data {
 			newVal := []uint8{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := conversion.ByteSliceCopy(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.Data[key] = newVal
@@ -2634,24 +2673,24 @@ func autoconvert_api_Secret_To_v1_Secret(in *api.Secret, out *Secret, s conversi
 	return nil
 }
 
-func convert_api_Secret_To_v1_Secret(in *api.Secret, out *Secret, s conversion.Scope) error {
-	return autoconvert_api_Secret_To_v1_Secret(in, out, s)
+func Convert_api_Secret_To_v1_Secret(in *api.Secret, out *Secret, s conversion.Scope) error {
+	return autoConvert_api_Secret_To_v1_Secret(in, out, s)
 }
 
-func autoconvert_api_SecretList_To_v1_SecretList(in *api.SecretList, out *SecretList, s conversion.Scope) error {
+func autoConvert_api_SecretList_To_v1_SecretList(in *api.SecretList, out *SecretList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.SecretList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]Secret, len(in.Items))
 		for i := range in.Items {
-			if err := convert_api_Secret_To_v1_Secret(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_api_Secret_To_v1_Secret(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -2661,11 +2700,11 @@ func autoconvert_api_SecretList_To_v1_SecretList(in *api.SecretList, out *Secret
 	return nil
 }
 
-func convert_api_SecretList_To_v1_SecretList(in *api.SecretList, out *SecretList, s conversion.Scope) error {
-	return autoconvert_api_SecretList_To_v1_SecretList(in, out, s)
+func Convert_api_SecretList_To_v1_SecretList(in *api.SecretList, out *SecretList, s conversion.Scope) error {
+	return autoConvert_api_SecretList_To_v1_SecretList(in, out, s)
 }
 
-func autoconvert_api_SecretVolumeSource_To_v1_SecretVolumeSource(in *api.SecretVolumeSource, out *SecretVolumeSource, s conversion.Scope) error {
+func autoConvert_api_SecretVolumeSource_To_v1_SecretVolumeSource(in *api.SecretVolumeSource, out *SecretVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.SecretVolumeSource))(in)
 	}
@@ -2673,17 +2712,18 @@ func autoconvert_api_SecretVolumeSource_To_v1_SecretVolumeSource(in *api.SecretV
 	return nil
 }
 
-func convert_api_SecretVolumeSource_To_v1_SecretVolumeSource(in *api.SecretVolumeSource, out *SecretVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_SecretVolumeSource_To_v1_SecretVolumeSource(in, out, s)
+func Convert_api_SecretVolumeSource_To_v1_SecretVolumeSource(in *api.SecretVolumeSource, out *SecretVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_SecretVolumeSource_To_v1_SecretVolumeSource(in, out, s)
 }
 
-func autoconvert_api_SecurityContext_To_v1_SecurityContext(in *api.SecurityContext, out *SecurityContext, s conversion.Scope) error {
+func autoConvert_api_SecurityContext_To_v1_SecurityContext(in *api.SecurityContext, out *SecurityContext, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.SecurityContext))(in)
 	}
+	// unable to generate simple pointer conversion for api.Capabilities -> v1.Capabilities
 	if in.Capabilities != nil {
 		out.Capabilities = new(Capabilities)
-		if err := convert_api_Capabilities_To_v1_Capabilities(in.Capabilities, out.Capabilities, s); err != nil {
+		if err := Convert_api_Capabilities_To_v1_Capabilities(in.Capabilities, out.Capabilities, s); err != nil {
 			return err
 		}
 	} else {
@@ -2695,9 +2735,10 @@ func autoconvert_api_SecurityContext_To_v1_SecurityContext(in *api.SecurityConte
 	} else {
 		out.Privileged = nil
 	}
+	// unable to generate simple pointer conversion for api.SELinuxOptions -> v1.SELinuxOptions
 	if in.SELinuxOptions != nil {
 		out.SELinuxOptions = new(SELinuxOptions)
-		if err := convert_api_SELinuxOptions_To_v1_SELinuxOptions(in.SELinuxOptions, out.SELinuxOptions, s); err != nil {
+		if err := Convert_api_SELinuxOptions_To_v1_SELinuxOptions(in.SELinuxOptions, out.SELinuxOptions, s); err != nil {
 			return err
 		}
 	} else {
@@ -2718,64 +2759,64 @@ func autoconvert_api_SecurityContext_To_v1_SecurityContext(in *api.SecurityConte
 	return nil
 }
 
-func convert_api_SecurityContext_To_v1_SecurityContext(in *api.SecurityContext, out *SecurityContext, s conversion.Scope) error {
-	return autoconvert_api_SecurityContext_To_v1_SecurityContext(in, out, s)
+func Convert_api_SecurityContext_To_v1_SecurityContext(in *api.SecurityContext, out *SecurityContext, s conversion.Scope) error {
+	return autoConvert_api_SecurityContext_To_v1_SecurityContext(in, out, s)
 }
 
-func autoconvert_api_SerializedReference_To_v1_SerializedReference(in *api.SerializedReference, out *SerializedReference, s conversion.Scope) error {
+func autoConvert_api_SerializedReference_To_v1_SerializedReference(in *api.SerializedReference, out *SerializedReference, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.SerializedReference))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ObjectReference_To_v1_ObjectReference(&in.Reference, &out.Reference, s); err != nil {
+	if err := Convert_api_ObjectReference_To_v1_ObjectReference(&in.Reference, &out.Reference, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_api_SerializedReference_To_v1_SerializedReference(in *api.SerializedReference, out *SerializedReference, s conversion.Scope) error {
-	return autoconvert_api_SerializedReference_To_v1_SerializedReference(in, out, s)
+func Convert_api_SerializedReference_To_v1_SerializedReference(in *api.SerializedReference, out *SerializedReference, s conversion.Scope) error {
+	return autoConvert_api_SerializedReference_To_v1_SerializedReference(in, out, s)
 }
 
-func autoconvert_api_Service_To_v1_Service(in *api.Service, out *Service, s conversion.Scope) error {
+func autoConvert_api_Service_To_v1_Service(in *api.Service, out *Service, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Service))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ServiceSpec_To_v1_ServiceSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_api_ServiceSpec_To_v1_ServiceSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := convert_api_ServiceStatus_To_v1_ServiceStatus(&in.Status, &out.Status, s); err != nil {
+	if err := Convert_api_ServiceStatus_To_v1_ServiceStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_api_Service_To_v1_Service(in *api.Service, out *Service, s conversion.Scope) error {
-	return autoconvert_api_Service_To_v1_Service(in, out, s)
+func Convert_api_Service_To_v1_Service(in *api.Service, out *Service, s conversion.Scope) error {
+	return autoConvert_api_Service_To_v1_Service(in, out, s)
 }
 
-func autoconvert_api_ServiceAccount_To_v1_ServiceAccount(in *api.ServiceAccount, out *ServiceAccount, s conversion.Scope) error {
+func autoConvert_api_ServiceAccount_To_v1_ServiceAccount(in *api.ServiceAccount, out *ServiceAccount, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ServiceAccount))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
 	if in.Secrets != nil {
 		out.Secrets = make([]ObjectReference, len(in.Secrets))
 		for i := range in.Secrets {
-			if err := convert_api_ObjectReference_To_v1_ObjectReference(&in.Secrets[i], &out.Secrets[i], s); err != nil {
+			if err := Convert_api_ObjectReference_To_v1_ObjectReference(&in.Secrets[i], &out.Secrets[i], s); err != nil {
 				return err
 			}
 		}
@@ -2785,7 +2826,7 @@ func autoconvert_api_ServiceAccount_To_v1_ServiceAccount(in *api.ServiceAccount,
 	if in.ImagePullSecrets != nil {
 		out.ImagePullSecrets = make([]LocalObjectReference, len(in.ImagePullSecrets))
 		for i := range in.ImagePullSecrets {
-			if err := convert_api_LocalObjectReference_To_v1_LocalObjectReference(&in.ImagePullSecrets[i], &out.ImagePullSecrets[i], s); err != nil {
+			if err := Convert_api_LocalObjectReference_To_v1_LocalObjectReference(&in.ImagePullSecrets[i], &out.ImagePullSecrets[i], s); err != nil {
 				return err
 			}
 		}
@@ -2795,24 +2836,24 @@ func autoconvert_api_ServiceAccount_To_v1_ServiceAccount(in *api.ServiceAccount,
 	return nil
 }
 
-func convert_api_ServiceAccount_To_v1_ServiceAccount(in *api.ServiceAccount, out *ServiceAccount, s conversion.Scope) error {
-	return autoconvert_api_ServiceAccount_To_v1_ServiceAccount(in, out, s)
+func Convert_api_ServiceAccount_To_v1_ServiceAccount(in *api.ServiceAccount, out *ServiceAccount, s conversion.Scope) error {
+	return autoConvert_api_ServiceAccount_To_v1_ServiceAccount(in, out, s)
 }
 
-func autoconvert_api_ServiceAccountList_To_v1_ServiceAccountList(in *api.ServiceAccountList, out *ServiceAccountList, s conversion.Scope) error {
+func autoConvert_api_ServiceAccountList_To_v1_ServiceAccountList(in *api.ServiceAccountList, out *ServiceAccountList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ServiceAccountList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]ServiceAccount, len(in.Items))
 		for i := range in.Items {
-			if err := convert_api_ServiceAccount_To_v1_ServiceAccount(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_api_ServiceAccount_To_v1_ServiceAccount(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -2822,24 +2863,24 @@ func autoconvert_api_ServiceAccountList_To_v1_ServiceAccountList(in *api.Service
 	return nil
 }
 
-func convert_api_ServiceAccountList_To_v1_ServiceAccountList(in *api.ServiceAccountList, out *ServiceAccountList, s conversion.Scope) error {
-	return autoconvert_api_ServiceAccountList_To_v1_ServiceAccountList(in, out, s)
+func Convert_api_ServiceAccountList_To_v1_ServiceAccountList(in *api.ServiceAccountList, out *ServiceAccountList, s conversion.Scope) error {
+	return autoConvert_api_ServiceAccountList_To_v1_ServiceAccountList(in, out, s)
 }
 
-func autoconvert_api_ServiceList_To_v1_ServiceList(in *api.ServiceList, out *ServiceList, s conversion.Scope) error {
+func autoConvert_api_ServiceList_To_v1_ServiceList(in *api.ServiceList, out *ServiceList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ServiceList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]Service, len(in.Items))
 		for i := range in.Items {
-			if err := convert_api_Service_To_v1_Service(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_api_Service_To_v1_Service(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -2849,29 +2890,29 @@ func autoconvert_api_ServiceList_To_v1_ServiceList(in *api.ServiceList, out *Ser
 	return nil
 }
 
-func convert_api_ServiceList_To_v1_ServiceList(in *api.ServiceList, out *ServiceList, s conversion.Scope) error {
-	return autoconvert_api_ServiceList_To_v1_ServiceList(in, out, s)
+func Convert_api_ServiceList_To_v1_ServiceList(in *api.ServiceList, out *ServiceList, s conversion.Scope) error {
+	return autoConvert_api_ServiceList_To_v1_ServiceList(in, out, s)
 }
 
-func autoconvert_api_ServicePort_To_v1_ServicePort(in *api.ServicePort, out *ServicePort, s conversion.Scope) error {
+func autoConvert_api_ServicePort_To_v1_ServicePort(in *api.ServicePort, out *ServicePort, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ServicePort))(in)
 	}
 	out.Name = in.Name
 	out.Protocol = Protocol(in.Protocol)
 	out.Port = int32(in.Port)
-	if err := s.Convert(&in.TargetPort, &out.TargetPort, 0); err != nil {
+	if err := api.Convert_intstr_IntOrString_To_intstr_IntOrString(&in.TargetPort, &out.TargetPort, s); err != nil {
 		return err
 	}
 	out.NodePort = int32(in.NodePort)
 	return nil
 }
 
-func convert_api_ServicePort_To_v1_ServicePort(in *api.ServicePort, out *ServicePort, s conversion.Scope) error {
-	return autoconvert_api_ServicePort_To_v1_ServicePort(in, out, s)
+func Convert_api_ServicePort_To_v1_ServicePort(in *api.ServicePort, out *ServicePort, s conversion.Scope) error {
+	return autoConvert_api_ServicePort_To_v1_ServicePort(in, out, s)
 }
 
-func autoconvert_api_ServiceSpec_To_v1_ServiceSpec(in *api.ServiceSpec, out *ServiceSpec, s conversion.Scope) error {
+func autoConvert_api_ServiceSpec_To_v1_ServiceSpec(in *api.ServiceSpec, out *ServiceSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ServiceSpec))(in)
 	}
@@ -2879,7 +2920,7 @@ func autoconvert_api_ServiceSpec_To_v1_ServiceSpec(in *api.ServiceSpec, out *Ser
 	if in.Ports != nil {
 		out.Ports = make([]ServicePort, len(in.Ports))
 		for i := range in.Ports {
-			if err := convert_api_ServicePort_To_v1_ServicePort(&in.Ports[i], &out.Ports[i], s); err != nil {
+			if err := Convert_api_ServicePort_To_v1_ServicePort(&in.Ports[i], &out.Ports[i], s); err != nil {
 				return err
 			}
 		}
@@ -2908,50 +2949,50 @@ func autoconvert_api_ServiceSpec_To_v1_ServiceSpec(in *api.ServiceSpec, out *Ser
 	return nil
 }
 
-func autoconvert_api_ServiceStatus_To_v1_ServiceStatus(in *api.ServiceStatus, out *ServiceStatus, s conversion.Scope) error {
+func autoConvert_api_ServiceStatus_To_v1_ServiceStatus(in *api.ServiceStatus, out *ServiceStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ServiceStatus))(in)
 	}
-	if err := convert_api_LoadBalancerStatus_To_v1_LoadBalancerStatus(&in.LoadBalancer, &out.LoadBalancer, s); err != nil {
+	if err := Convert_api_LoadBalancerStatus_To_v1_LoadBalancerStatus(&in.LoadBalancer, &out.LoadBalancer, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_api_ServiceStatus_To_v1_ServiceStatus(in *api.ServiceStatus, out *ServiceStatus, s conversion.Scope) error {
-	return autoconvert_api_ServiceStatus_To_v1_ServiceStatus(in, out, s)
+func Convert_api_ServiceStatus_To_v1_ServiceStatus(in *api.ServiceStatus, out *ServiceStatus, s conversion.Scope) error {
+	return autoConvert_api_ServiceStatus_To_v1_ServiceStatus(in, out, s)
 }
 
-func autoconvert_api_TCPSocketAction_To_v1_TCPSocketAction(in *api.TCPSocketAction, out *TCPSocketAction, s conversion.Scope) error {
+func autoConvert_api_TCPSocketAction_To_v1_TCPSocketAction(in *api.TCPSocketAction, out *TCPSocketAction, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.TCPSocketAction))(in)
 	}
-	if err := s.Convert(&in.Port, &out.Port, 0); err != nil {
+	if err := api.Convert_intstr_IntOrString_To_intstr_IntOrString(&in.Port, &out.Port, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_api_TCPSocketAction_To_v1_TCPSocketAction(in *api.TCPSocketAction, out *TCPSocketAction, s conversion.Scope) error {
-	return autoconvert_api_TCPSocketAction_To_v1_TCPSocketAction(in, out, s)
+func Convert_api_TCPSocketAction_To_v1_TCPSocketAction(in *api.TCPSocketAction, out *TCPSocketAction, s conversion.Scope) error {
+	return autoConvert_api_TCPSocketAction_To_v1_TCPSocketAction(in, out, s)
 }
 
-func autoconvert_api_Volume_To_v1_Volume(in *api.Volume, out *Volume, s conversion.Scope) error {
+func autoConvert_api_Volume_To_v1_Volume(in *api.Volume, out *Volume, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Volume))(in)
 	}
 	out.Name = in.Name
-	if err := convert_api_VolumeSource_To_v1_VolumeSource(&in.VolumeSource, &out.VolumeSource, s); err != nil {
+	if err := Convert_api_VolumeSource_To_v1_VolumeSource(&in.VolumeSource, &out.VolumeSource, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_api_Volume_To_v1_Volume(in *api.Volume, out *Volume, s conversion.Scope) error {
-	return autoconvert_api_Volume_To_v1_Volume(in, out, s)
+func Convert_api_Volume_To_v1_Volume(in *api.Volume, out *Volume, s conversion.Scope) error {
+	return autoConvert_api_Volume_To_v1_Volume(in, out, s)
 }
 
-func autoconvert_api_VolumeMount_To_v1_VolumeMount(in *api.VolumeMount, out *VolumeMount, s conversion.Scope) error {
+func autoConvert_api_VolumeMount_To_v1_VolumeMount(in *api.VolumeMount, out *VolumeMount, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.VolumeMount))(in)
 	}
@@ -2961,145 +3002,162 @@ func autoconvert_api_VolumeMount_To_v1_VolumeMount(in *api.VolumeMount, out *Vol
 	return nil
 }
 
-func convert_api_VolumeMount_To_v1_VolumeMount(in *api.VolumeMount, out *VolumeMount, s conversion.Scope) error {
-	return autoconvert_api_VolumeMount_To_v1_VolumeMount(in, out, s)
+func Convert_api_VolumeMount_To_v1_VolumeMount(in *api.VolumeMount, out *VolumeMount, s conversion.Scope) error {
+	return autoConvert_api_VolumeMount_To_v1_VolumeMount(in, out, s)
 }
 
-func autoconvert_api_VolumeSource_To_v1_VolumeSource(in *api.VolumeSource, out *VolumeSource, s conversion.Scope) error {
+func autoConvert_api_VolumeSource_To_v1_VolumeSource(in *api.VolumeSource, out *VolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.VolumeSource))(in)
 	}
+	// unable to generate simple pointer conversion for api.HostPathVolumeSource -> v1.HostPathVolumeSource
 	if in.HostPath != nil {
 		out.HostPath = new(HostPathVolumeSource)
-		if err := convert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource(in.HostPath, out.HostPath, s); err != nil {
+		if err := Convert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource(in.HostPath, out.HostPath, s); err != nil {
 			return err
 		}
 	} else {
 		out.HostPath = nil
 	}
+	// unable to generate simple pointer conversion for api.EmptyDirVolumeSource -> v1.EmptyDirVolumeSource
 	if in.EmptyDir != nil {
 		out.EmptyDir = new(EmptyDirVolumeSource)
-		if err := convert_api_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource(in.EmptyDir, out.EmptyDir, s); err != nil {
+		if err := Convert_api_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource(in.EmptyDir, out.EmptyDir, s); err != nil {
 			return err
 		}
 	} else {
 		out.EmptyDir = nil
 	}
+	// unable to generate simple pointer conversion for api.GCEPersistentDiskVolumeSource -> v1.GCEPersistentDiskVolumeSource
 	if in.GCEPersistentDisk != nil {
 		out.GCEPersistentDisk = new(GCEPersistentDiskVolumeSource)
-		if err := convert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSource(in.GCEPersistentDisk, out.GCEPersistentDisk, s); err != nil {
+		if err := Convert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSource(in.GCEPersistentDisk, out.GCEPersistentDisk, s); err != nil {
 			return err
 		}
 	} else {
 		out.GCEPersistentDisk = nil
 	}
+	// unable to generate simple pointer conversion for api.AWSElasticBlockStoreVolumeSource -> v1.AWSElasticBlockStoreVolumeSource
 	if in.AWSElasticBlockStore != nil {
 		out.AWSElasticBlockStore = new(AWSElasticBlockStoreVolumeSource)
-		if err := convert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVolumeSource(in.AWSElasticBlockStore, out.AWSElasticBlockStore, s); err != nil {
+		if err := Convert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVolumeSource(in.AWSElasticBlockStore, out.AWSElasticBlockStore, s); err != nil {
 			return err
 		}
 	} else {
 		out.AWSElasticBlockStore = nil
 	}
+	// unable to generate simple pointer conversion for api.GitRepoVolumeSource -> v1.GitRepoVolumeSource
 	if in.GitRepo != nil {
 		out.GitRepo = new(GitRepoVolumeSource)
-		if err := convert_api_GitRepoVolumeSource_To_v1_GitRepoVolumeSource(in.GitRepo, out.GitRepo, s); err != nil {
+		if err := Convert_api_GitRepoVolumeSource_To_v1_GitRepoVolumeSource(in.GitRepo, out.GitRepo, s); err != nil {
 			return err
 		}
 	} else {
 		out.GitRepo = nil
 	}
+	// unable to generate simple pointer conversion for api.SecretVolumeSource -> v1.SecretVolumeSource
 	if in.Secret != nil {
 		out.Secret = new(SecretVolumeSource)
-		if err := convert_api_SecretVolumeSource_To_v1_SecretVolumeSource(in.Secret, out.Secret, s); err != nil {
+		if err := Convert_api_SecretVolumeSource_To_v1_SecretVolumeSource(in.Secret, out.Secret, s); err != nil {
 			return err
 		}
 	} else {
 		out.Secret = nil
 	}
+	// unable to generate simple pointer conversion for api.NFSVolumeSource -> v1.NFSVolumeSource
 	if in.NFS != nil {
 		out.NFS = new(NFSVolumeSource)
-		if err := convert_api_NFSVolumeSource_To_v1_NFSVolumeSource(in.NFS, out.NFS, s); err != nil {
+		if err := Convert_api_NFSVolumeSource_To_v1_NFSVolumeSource(in.NFS, out.NFS, s); err != nil {
 			return err
 		}
 	} else {
 		out.NFS = nil
 	}
+	// unable to generate simple pointer conversion for api.ISCSIVolumeSource -> v1.ISCSIVolumeSource
 	if in.ISCSI != nil {
 		out.ISCSI = new(ISCSIVolumeSource)
-		if err := convert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource(in.ISCSI, out.ISCSI, s); err != nil {
+		if err := Convert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource(in.ISCSI, out.ISCSI, s); err != nil {
 			return err
 		}
 	} else {
 		out.ISCSI = nil
 	}
+	// unable to generate simple pointer conversion for api.GlusterfsVolumeSource -> v1.GlusterfsVolumeSource
 	if in.Glusterfs != nil {
 		out.Glusterfs = new(GlusterfsVolumeSource)
-		if err := convert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource(in.Glusterfs, out.Glusterfs, s); err != nil {
+		if err := Convert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource(in.Glusterfs, out.Glusterfs, s); err != nil {
 			return err
 		}
 	} else {
 		out.Glusterfs = nil
 	}
+	// unable to generate simple pointer conversion for api.PersistentVolumeClaimVolumeSource -> v1.PersistentVolumeClaimVolumeSource
 	if in.PersistentVolumeClaim != nil {
 		out.PersistentVolumeClaim = new(PersistentVolumeClaimVolumeSource)
-		if err := convert_api_PersistentVolumeClaimVolumeSource_To_v1_PersistentVolumeClaimVolumeSource(in.PersistentVolumeClaim, out.PersistentVolumeClaim, s); err != nil {
+		if err := Convert_api_PersistentVolumeClaimVolumeSource_To_v1_PersistentVolumeClaimVolumeSource(in.PersistentVolumeClaim, out.PersistentVolumeClaim, s); err != nil {
 			return err
 		}
 	} else {
 		out.PersistentVolumeClaim = nil
 	}
+	// unable to generate simple pointer conversion for api.RBDVolumeSource -> v1.RBDVolumeSource
 	if in.RBD != nil {
 		out.RBD = new(RBDVolumeSource)
-		if err := convert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in.RBD, out.RBD, s); err != nil {
+		if err := Convert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in.RBD, out.RBD, s); err != nil {
 			return err
 		}
 	} else {
 		out.RBD = nil
 	}
+	// unable to generate simple pointer conversion for api.FlexVolumeSource -> v1.FlexVolumeSource
 	if in.FlexVolume != nil {
 		out.FlexVolume = new(FlexVolumeSource)
-		if err := convert_api_FlexVolumeSource_To_v1_FlexVolumeSource(in.FlexVolume, out.FlexVolume, s); err != nil {
+		if err := Convert_api_FlexVolumeSource_To_v1_FlexVolumeSource(in.FlexVolume, out.FlexVolume, s); err != nil {
 			return err
 		}
 	} else {
 		out.FlexVolume = nil
 	}
+	// unable to generate simple pointer conversion for api.CinderVolumeSource -> v1.CinderVolumeSource
 	if in.Cinder != nil {
 		out.Cinder = new(CinderVolumeSource)
-		if err := convert_api_CinderVolumeSource_To_v1_CinderVolumeSource(in.Cinder, out.Cinder, s); err != nil {
+		if err := Convert_api_CinderVolumeSource_To_v1_CinderVolumeSource(in.Cinder, out.Cinder, s); err != nil {
 			return err
 		}
 	} else {
 		out.Cinder = nil
 	}
+	// unable to generate simple pointer conversion for api.CephFSVolumeSource -> v1.CephFSVolumeSource
 	if in.CephFS != nil {
 		out.CephFS = new(CephFSVolumeSource)
-		if err := convert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in.CephFS, out.CephFS, s); err != nil {
+		if err := Convert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in.CephFS, out.CephFS, s); err != nil {
 			return err
 		}
 	} else {
 		out.CephFS = nil
 	}
+	// unable to generate simple pointer conversion for api.FlockerVolumeSource -> v1.FlockerVolumeSource
 	if in.Flocker != nil {
 		out.Flocker = new(FlockerVolumeSource)
-		if err := convert_api_FlockerVolumeSource_To_v1_FlockerVolumeSource(in.Flocker, out.Flocker, s); err != nil {
+		if err := Convert_api_FlockerVolumeSource_To_v1_FlockerVolumeSource(in.Flocker, out.Flocker, s); err != nil {
 			return err
 		}
 	} else {
 		out.Flocker = nil
 	}
+	// unable to generate simple pointer conversion for api.DownwardAPIVolumeSource -> v1.DownwardAPIVolumeSource
 	if in.DownwardAPI != nil {
 		out.DownwardAPI = new(DownwardAPIVolumeSource)
-		if err := convert_api_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource(in.DownwardAPI, out.DownwardAPI, s); err != nil {
+		if err := Convert_api_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource(in.DownwardAPI, out.DownwardAPI, s); err != nil {
 			return err
 		}
 	} else {
 		out.DownwardAPI = nil
 	}
+	// unable to generate simple pointer conversion for api.FCVolumeSource -> v1.FCVolumeSource
 	if in.FC != nil {
 		out.FC = new(FCVolumeSource)
-		if err := convert_api_FCVolumeSource_To_v1_FCVolumeSource(in.FC, out.FC, s); err != nil {
+		if err := Convert_api_FCVolumeSource_To_v1_FCVolumeSource(in.FC, out.FC, s); err != nil {
 			return err
 		}
 	} else {
@@ -3108,15 +3166,15 @@ func autoconvert_api_VolumeSource_To_v1_VolumeSource(in *api.VolumeSource, out *
 	return nil
 }
 
-func convert_api_VolumeSource_To_v1_VolumeSource(in *api.VolumeSource, out *VolumeSource, s conversion.Scope) error {
-	return autoconvert_api_VolumeSource_To_v1_VolumeSource(in, out, s)
+func Convert_api_VolumeSource_To_v1_VolumeSource(in *api.VolumeSource, out *VolumeSource, s conversion.Scope) error {
+	return autoConvert_api_VolumeSource_To_v1_VolumeSource(in, out, s)
 }
 
-func autoconvert_unversioned_ExportOptions_To_v1_ExportOptions(in *unversioned.ExportOptions, out *ExportOptions, s conversion.Scope) error {
+func autoConvert_unversioned_ExportOptions_To_v1_ExportOptions(in *unversioned.ExportOptions, out *ExportOptions, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*unversioned.ExportOptions))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
 	out.Export = in.Export
@@ -3124,11 +3182,11 @@ func autoconvert_unversioned_ExportOptions_To_v1_ExportOptions(in *unversioned.E
 	return nil
 }
 
-func convert_unversioned_ExportOptions_To_v1_ExportOptions(in *unversioned.ExportOptions, out *ExportOptions, s conversion.Scope) error {
-	return autoconvert_unversioned_ExportOptions_To_v1_ExportOptions(in, out, s)
+func Convert_unversioned_ExportOptions_To_v1_ExportOptions(in *unversioned.ExportOptions, out *ExportOptions, s conversion.Scope) error {
+	return autoConvert_unversioned_ExportOptions_To_v1_ExportOptions(in, out, s)
 }
 
-func autoconvert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource(in *AWSElasticBlockStoreVolumeSource, out *api.AWSElasticBlockStoreVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource(in *AWSElasticBlockStoreVolumeSource, out *api.AWSElasticBlockStoreVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*AWSElasticBlockStoreVolumeSource))(in)
 	}
@@ -3139,31 +3197,31 @@ func autoconvert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStore
 	return nil
 }
 
-func convert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource(in *AWSElasticBlockStoreVolumeSource, out *api.AWSElasticBlockStoreVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource(in, out, s)
+func Convert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource(in *AWSElasticBlockStoreVolumeSource, out *api.AWSElasticBlockStoreVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_Binding_To_api_Binding(in *Binding, out *api.Binding, s conversion.Scope) error {
+func autoConvert_v1_Binding_To_api_Binding(in *Binding, out *api.Binding, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Binding))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ObjectReference_To_api_ObjectReference(&in.Target, &out.Target, s); err != nil {
+	if err := Convert_v1_ObjectReference_To_api_ObjectReference(&in.Target, &out.Target, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1_Binding_To_api_Binding(in *Binding, out *api.Binding, s conversion.Scope) error {
-	return autoconvert_v1_Binding_To_api_Binding(in, out, s)
+func Convert_v1_Binding_To_api_Binding(in *Binding, out *api.Binding, s conversion.Scope) error {
+	return autoConvert_v1_Binding_To_api_Binding(in, out, s)
 }
 
-func autoconvert_v1_Capabilities_To_api_Capabilities(in *Capabilities, out *api.Capabilities, s conversion.Scope) error {
+func autoConvert_v1_Capabilities_To_api_Capabilities(in *Capabilities, out *api.Capabilities, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Capabilities))(in)
 	}
@@ -3186,11 +3244,11 @@ func autoconvert_v1_Capabilities_To_api_Capabilities(in *Capabilities, out *api.
 	return nil
 }
 
-func convert_v1_Capabilities_To_api_Capabilities(in *Capabilities, out *api.Capabilities, s conversion.Scope) error {
-	return autoconvert_v1_Capabilities_To_api_Capabilities(in, out, s)
+func Convert_v1_Capabilities_To_api_Capabilities(in *Capabilities, out *api.Capabilities, s conversion.Scope) error {
+	return autoConvert_v1_Capabilities_To_api_Capabilities(in, out, s)
 }
 
-func autoconvert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in *CephFSVolumeSource, out *api.CephFSVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in *CephFSVolumeSource, out *api.CephFSVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*CephFSVolumeSource))(in)
 	}
@@ -3204,9 +3262,10 @@ func autoconvert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in *CephFSVolum
 	}
 	out.User = in.User
 	out.SecretFile = in.SecretFile
+	// unable to generate simple pointer conversion for v1.LocalObjectReference -> api.LocalObjectReference
 	if in.SecretRef != nil {
 		out.SecretRef = new(api.LocalObjectReference)
-		if err := convert_v1_LocalObjectReference_To_api_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
+		if err := Convert_v1_LocalObjectReference_To_api_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
 			return err
 		}
 	} else {
@@ -3216,11 +3275,11 @@ func autoconvert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in *CephFSVolum
 	return nil
 }
 
-func convert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in *CephFSVolumeSource, out *api.CephFSVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in, out, s)
+func Convert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in *CephFSVolumeSource, out *api.CephFSVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_CinderVolumeSource_To_api_CinderVolumeSource(in *CinderVolumeSource, out *api.CinderVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_CinderVolumeSource_To_api_CinderVolumeSource(in *CinderVolumeSource, out *api.CinderVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*CinderVolumeSource))(in)
 	}
@@ -3230,11 +3289,11 @@ func autoconvert_v1_CinderVolumeSource_To_api_CinderVolumeSource(in *CinderVolum
 	return nil
 }
 
-func convert_v1_CinderVolumeSource_To_api_CinderVolumeSource(in *CinderVolumeSource, out *api.CinderVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_CinderVolumeSource_To_api_CinderVolumeSource(in, out, s)
+func Convert_v1_CinderVolumeSource_To_api_CinderVolumeSource(in *CinderVolumeSource, out *api.CinderVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_CinderVolumeSource_To_api_CinderVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_ComponentCondition_To_api_ComponentCondition(in *ComponentCondition, out *api.ComponentCondition, s conversion.Scope) error {
+func autoConvert_v1_ComponentCondition_To_api_ComponentCondition(in *ComponentCondition, out *api.ComponentCondition, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ComponentCondition))(in)
 	}
@@ -3245,24 +3304,24 @@ func autoconvert_v1_ComponentCondition_To_api_ComponentCondition(in *ComponentCo
 	return nil
 }
 
-func convert_v1_ComponentCondition_To_api_ComponentCondition(in *ComponentCondition, out *api.ComponentCondition, s conversion.Scope) error {
-	return autoconvert_v1_ComponentCondition_To_api_ComponentCondition(in, out, s)
+func Convert_v1_ComponentCondition_To_api_ComponentCondition(in *ComponentCondition, out *api.ComponentCondition, s conversion.Scope) error {
+	return autoConvert_v1_ComponentCondition_To_api_ComponentCondition(in, out, s)
 }
 
-func autoconvert_v1_ComponentStatus_To_api_ComponentStatus(in *ComponentStatus, out *api.ComponentStatus, s conversion.Scope) error {
+func autoConvert_v1_ComponentStatus_To_api_ComponentStatus(in *ComponentStatus, out *api.ComponentStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ComponentStatus))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
 	if in.Conditions != nil {
 		out.Conditions = make([]api.ComponentCondition, len(in.Conditions))
 		for i := range in.Conditions {
-			if err := convert_v1_ComponentCondition_To_api_ComponentCondition(&in.Conditions[i], &out.Conditions[i], s); err != nil {
+			if err := Convert_v1_ComponentCondition_To_api_ComponentCondition(&in.Conditions[i], &out.Conditions[i], s); err != nil {
 				return err
 			}
 		}
@@ -3272,24 +3331,24 @@ func autoconvert_v1_ComponentStatus_To_api_ComponentStatus(in *ComponentStatus, 
 	return nil
 }
 
-func convert_v1_ComponentStatus_To_api_ComponentStatus(in *ComponentStatus, out *api.ComponentStatus, s conversion.Scope) error {
-	return autoconvert_v1_ComponentStatus_To_api_ComponentStatus(in, out, s)
+func Convert_v1_ComponentStatus_To_api_ComponentStatus(in *ComponentStatus, out *api.ComponentStatus, s conversion.Scope) error {
+	return autoConvert_v1_ComponentStatus_To_api_ComponentStatus(in, out, s)
 }
 
-func autoconvert_v1_ComponentStatusList_To_api_ComponentStatusList(in *ComponentStatusList, out *api.ComponentStatusList, s conversion.Scope) error {
+func autoConvert_v1_ComponentStatusList_To_api_ComponentStatusList(in *ComponentStatusList, out *api.ComponentStatusList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ComponentStatusList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]api.ComponentStatus, len(in.Items))
 		for i := range in.Items {
-			if err := convert_v1_ComponentStatus_To_api_ComponentStatus(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_v1_ComponentStatus_To_api_ComponentStatus(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -3299,11 +3358,11 @@ func autoconvert_v1_ComponentStatusList_To_api_ComponentStatusList(in *Component
 	return nil
 }
 
-func convert_v1_ComponentStatusList_To_api_ComponentStatusList(in *ComponentStatusList, out *api.ComponentStatusList, s conversion.Scope) error {
-	return autoconvert_v1_ComponentStatusList_To_api_ComponentStatusList(in, out, s)
+func Convert_v1_ComponentStatusList_To_api_ComponentStatusList(in *ComponentStatusList, out *api.ComponentStatusList, s conversion.Scope) error {
+	return autoConvert_v1_ComponentStatusList_To_api_ComponentStatusList(in, out, s)
 }
 
-func autoconvert_v1_Container_To_api_Container(in *Container, out *api.Container, s conversion.Scope) error {
+func autoConvert_v1_Container_To_api_Container(in *Container, out *api.Container, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Container))(in)
 	}
@@ -3329,7 +3388,7 @@ func autoconvert_v1_Container_To_api_Container(in *Container, out *api.Container
 	if in.Ports != nil {
 		out.Ports = make([]api.ContainerPort, len(in.Ports))
 		for i := range in.Ports {
-			if err := convert_v1_ContainerPort_To_api_ContainerPort(&in.Ports[i], &out.Ports[i], s); err != nil {
+			if err := Convert_v1_ContainerPort_To_api_ContainerPort(&in.Ports[i], &out.Ports[i], s); err != nil {
 				return err
 			}
 		}
@@ -3339,45 +3398,48 @@ func autoconvert_v1_Container_To_api_Container(in *Container, out *api.Container
 	if in.Env != nil {
 		out.Env = make([]api.EnvVar, len(in.Env))
 		for i := range in.Env {
-			if err := convert_v1_EnvVar_To_api_EnvVar(&in.Env[i], &out.Env[i], s); err != nil {
+			if err := Convert_v1_EnvVar_To_api_EnvVar(&in.Env[i], &out.Env[i], s); err != nil {
 				return err
 			}
 		}
 	} else {
 		out.Env = nil
 	}
-	if err := convert_v1_ResourceRequirements_To_api_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
+	if err := Convert_v1_ResourceRequirements_To_api_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
 		return err
 	}
 	if in.VolumeMounts != nil {
 		out.VolumeMounts = make([]api.VolumeMount, len(in.VolumeMounts))
 		for i := range in.VolumeMounts {
-			if err := convert_v1_VolumeMount_To_api_VolumeMount(&in.VolumeMounts[i], &out.VolumeMounts[i], s); err != nil {
+			if err := Convert_v1_VolumeMount_To_api_VolumeMount(&in.VolumeMounts[i], &out.VolumeMounts[i], s); err != nil {
 				return err
 			}
 		}
 	} else {
 		out.VolumeMounts = nil
 	}
+	// unable to generate simple pointer conversion for v1.Probe -> api.Probe
 	if in.LivenessProbe != nil {
 		out.LivenessProbe = new(api.Probe)
-		if err := convert_v1_Probe_To_api_Probe(in.LivenessProbe, out.LivenessProbe, s); err != nil {
+		if err := Convert_v1_Probe_To_api_Probe(in.LivenessProbe, out.LivenessProbe, s); err != nil {
 			return err
 		}
 	} else {
 		out.LivenessProbe = nil
 	}
+	// unable to generate simple pointer conversion for v1.Probe -> api.Probe
 	if in.ReadinessProbe != nil {
 		out.ReadinessProbe = new(api.Probe)
-		if err := convert_v1_Probe_To_api_Probe(in.ReadinessProbe, out.ReadinessProbe, s); err != nil {
+		if err := Convert_v1_Probe_To_api_Probe(in.ReadinessProbe, out.ReadinessProbe, s); err != nil {
 			return err
 		}
 	} else {
 		out.ReadinessProbe = nil
 	}
+	// unable to generate simple pointer conversion for v1.Lifecycle -> api.Lifecycle
 	if in.Lifecycle != nil {
 		out.Lifecycle = new(api.Lifecycle)
-		if err := convert_v1_Lifecycle_To_api_Lifecycle(in.Lifecycle, out.Lifecycle, s); err != nil {
+		if err := Convert_v1_Lifecycle_To_api_Lifecycle(in.Lifecycle, out.Lifecycle, s); err != nil {
 			return err
 		}
 	} else {
@@ -3385,9 +3447,10 @@ func autoconvert_v1_Container_To_api_Container(in *Container, out *api.Container
 	}
 	out.TerminationMessagePath = in.TerminationMessagePath
 	out.ImagePullPolicy = api.PullPolicy(in.ImagePullPolicy)
+	// unable to generate simple pointer conversion for v1.SecurityContext -> api.SecurityContext
 	if in.SecurityContext != nil {
 		out.SecurityContext = new(api.SecurityContext)
-		if err := convert_v1_SecurityContext_To_api_SecurityContext(in.SecurityContext, out.SecurityContext, s); err != nil {
+		if err := Convert_v1_SecurityContext_To_api_SecurityContext(in.SecurityContext, out.SecurityContext, s); err != nil {
 			return err
 		}
 	} else {
@@ -3399,11 +3462,11 @@ func autoconvert_v1_Container_To_api_Container(in *Container, out *api.Container
 	return nil
 }
 
-func convert_v1_Container_To_api_Container(in *Container, out *api.Container, s conversion.Scope) error {
-	return autoconvert_v1_Container_To_api_Container(in, out, s)
+func Convert_v1_Container_To_api_Container(in *Container, out *api.Container, s conversion.Scope) error {
+	return autoConvert_v1_Container_To_api_Container(in, out, s)
 }
 
-func autoconvert_v1_ContainerPort_To_api_ContainerPort(in *ContainerPort, out *api.ContainerPort, s conversion.Scope) error {
+func autoConvert_v1_ContainerPort_To_api_ContainerPort(in *ContainerPort, out *api.ContainerPort, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ContainerPort))(in)
 	}
@@ -3415,33 +3478,36 @@ func autoconvert_v1_ContainerPort_To_api_ContainerPort(in *ContainerPort, out *a
 	return nil
 }
 
-func convert_v1_ContainerPort_To_api_ContainerPort(in *ContainerPort, out *api.ContainerPort, s conversion.Scope) error {
-	return autoconvert_v1_ContainerPort_To_api_ContainerPort(in, out, s)
+func Convert_v1_ContainerPort_To_api_ContainerPort(in *ContainerPort, out *api.ContainerPort, s conversion.Scope) error {
+	return autoConvert_v1_ContainerPort_To_api_ContainerPort(in, out, s)
 }
 
-func autoconvert_v1_ContainerState_To_api_ContainerState(in *ContainerState, out *api.ContainerState, s conversion.Scope) error {
+func autoConvert_v1_ContainerState_To_api_ContainerState(in *ContainerState, out *api.ContainerState, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ContainerState))(in)
 	}
+	// unable to generate simple pointer conversion for v1.ContainerStateWaiting -> api.ContainerStateWaiting
 	if in.Waiting != nil {
 		out.Waiting = new(api.ContainerStateWaiting)
-		if err := convert_v1_ContainerStateWaiting_To_api_ContainerStateWaiting(in.Waiting, out.Waiting, s); err != nil {
+		if err := Convert_v1_ContainerStateWaiting_To_api_ContainerStateWaiting(in.Waiting, out.Waiting, s); err != nil {
 			return err
 		}
 	} else {
 		out.Waiting = nil
 	}
+	// unable to generate simple pointer conversion for v1.ContainerStateRunning -> api.ContainerStateRunning
 	if in.Running != nil {
 		out.Running = new(api.ContainerStateRunning)
-		if err := convert_v1_ContainerStateRunning_To_api_ContainerStateRunning(in.Running, out.Running, s); err != nil {
+		if err := Convert_v1_ContainerStateRunning_To_api_ContainerStateRunning(in.Running, out.Running, s); err != nil {
 			return err
 		}
 	} else {
 		out.Running = nil
 	}
+	// unable to generate simple pointer conversion for v1.ContainerStateTerminated -> api.ContainerStateTerminated
 	if in.Terminated != nil {
 		out.Terminated = new(api.ContainerStateTerminated)
-		if err := convert_v1_ContainerStateTerminated_To_api_ContainerStateTerminated(in.Terminated, out.Terminated, s); err != nil {
+		if err := Convert_v1_ContainerStateTerminated_To_api_ContainerStateTerminated(in.Terminated, out.Terminated, s); err != nil {
 			return err
 		}
 	} else {
@@ -3450,25 +3516,25 @@ func autoconvert_v1_ContainerState_To_api_ContainerState(in *ContainerState, out
 	return nil
 }
 
-func convert_v1_ContainerState_To_api_ContainerState(in *ContainerState, out *api.ContainerState, s conversion.Scope) error {
-	return autoconvert_v1_ContainerState_To_api_ContainerState(in, out, s)
+func Convert_v1_ContainerState_To_api_ContainerState(in *ContainerState, out *api.ContainerState, s conversion.Scope) error {
+	return autoConvert_v1_ContainerState_To_api_ContainerState(in, out, s)
 }
 
-func autoconvert_v1_ContainerStateRunning_To_api_ContainerStateRunning(in *ContainerStateRunning, out *api.ContainerStateRunning, s conversion.Scope) error {
+func autoConvert_v1_ContainerStateRunning_To_api_ContainerStateRunning(in *ContainerStateRunning, out *api.ContainerStateRunning, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ContainerStateRunning))(in)
 	}
-	if err := s.Convert(&in.StartedAt, &out.StartedAt, 0); err != nil {
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.StartedAt, &out.StartedAt, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1_ContainerStateRunning_To_api_ContainerStateRunning(in *ContainerStateRunning, out *api.ContainerStateRunning, s conversion.Scope) error {
-	return autoconvert_v1_ContainerStateRunning_To_api_ContainerStateRunning(in, out, s)
+func Convert_v1_ContainerStateRunning_To_api_ContainerStateRunning(in *ContainerStateRunning, out *api.ContainerStateRunning, s conversion.Scope) error {
+	return autoConvert_v1_ContainerStateRunning_To_api_ContainerStateRunning(in, out, s)
 }
 
-func autoconvert_v1_ContainerStateTerminated_To_api_ContainerStateTerminated(in *ContainerStateTerminated, out *api.ContainerStateTerminated, s conversion.Scope) error {
+func autoConvert_v1_ContainerStateTerminated_To_api_ContainerStateTerminated(in *ContainerStateTerminated, out *api.ContainerStateTerminated, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ContainerStateTerminated))(in)
 	}
@@ -3476,21 +3542,21 @@ func autoconvert_v1_ContainerStateTerminated_To_api_ContainerStateTerminated(in 
 	out.Signal = int(in.Signal)
 	out.Reason = in.Reason
 	out.Message = in.Message
-	if err := s.Convert(&in.StartedAt, &out.StartedAt, 0); err != nil {
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.StartedAt, &out.StartedAt, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.FinishedAt, &out.FinishedAt, 0); err != nil {
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.FinishedAt, &out.FinishedAt, s); err != nil {
 		return err
 	}
 	out.ContainerID = in.ContainerID
 	return nil
 }
 
-func convert_v1_ContainerStateTerminated_To_api_ContainerStateTerminated(in *ContainerStateTerminated, out *api.ContainerStateTerminated, s conversion.Scope) error {
-	return autoconvert_v1_ContainerStateTerminated_To_api_ContainerStateTerminated(in, out, s)
+func Convert_v1_ContainerStateTerminated_To_api_ContainerStateTerminated(in *ContainerStateTerminated, out *api.ContainerStateTerminated, s conversion.Scope) error {
+	return autoConvert_v1_ContainerStateTerminated_To_api_ContainerStateTerminated(in, out, s)
 }
 
-func autoconvert_v1_ContainerStateWaiting_To_api_ContainerStateWaiting(in *ContainerStateWaiting, out *api.ContainerStateWaiting, s conversion.Scope) error {
+func autoConvert_v1_ContainerStateWaiting_To_api_ContainerStateWaiting(in *ContainerStateWaiting, out *api.ContainerStateWaiting, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ContainerStateWaiting))(in)
 	}
@@ -3499,19 +3565,19 @@ func autoconvert_v1_ContainerStateWaiting_To_api_ContainerStateWaiting(in *Conta
 	return nil
 }
 
-func convert_v1_ContainerStateWaiting_To_api_ContainerStateWaiting(in *ContainerStateWaiting, out *api.ContainerStateWaiting, s conversion.Scope) error {
-	return autoconvert_v1_ContainerStateWaiting_To_api_ContainerStateWaiting(in, out, s)
+func Convert_v1_ContainerStateWaiting_To_api_ContainerStateWaiting(in *ContainerStateWaiting, out *api.ContainerStateWaiting, s conversion.Scope) error {
+	return autoConvert_v1_ContainerStateWaiting_To_api_ContainerStateWaiting(in, out, s)
 }
 
-func autoconvert_v1_ContainerStatus_To_api_ContainerStatus(in *ContainerStatus, out *api.ContainerStatus, s conversion.Scope) error {
+func autoConvert_v1_ContainerStatus_To_api_ContainerStatus(in *ContainerStatus, out *api.ContainerStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ContainerStatus))(in)
 	}
 	out.Name = in.Name
-	if err := convert_v1_ContainerState_To_api_ContainerState(&in.State, &out.State, s); err != nil {
+	if err := Convert_v1_ContainerState_To_api_ContainerState(&in.State, &out.State, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ContainerState_To_api_ContainerState(&in.LastTerminationState, &out.LastTerminationState, s); err != nil {
+	if err := Convert_v1_ContainerState_To_api_ContainerState(&in.LastTerminationState, &out.LastTerminationState, s); err != nil {
 		return err
 	}
 	out.Ready = in.Ready
@@ -3522,11 +3588,11 @@ func autoconvert_v1_ContainerStatus_To_api_ContainerStatus(in *ContainerStatus, 
 	return nil
 }
 
-func convert_v1_ContainerStatus_To_api_ContainerStatus(in *ContainerStatus, out *api.ContainerStatus, s conversion.Scope) error {
-	return autoconvert_v1_ContainerStatus_To_api_ContainerStatus(in, out, s)
+func Convert_v1_ContainerStatus_To_api_ContainerStatus(in *ContainerStatus, out *api.ContainerStatus, s conversion.Scope) error {
+	return autoConvert_v1_ContainerStatus_To_api_ContainerStatus(in, out, s)
 }
 
-func autoconvert_v1_DaemonEndpoint_To_api_DaemonEndpoint(in *DaemonEndpoint, out *api.DaemonEndpoint, s conversion.Scope) error {
+func autoConvert_v1_DaemonEndpoint_To_api_DaemonEndpoint(in *DaemonEndpoint, out *api.DaemonEndpoint, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*DaemonEndpoint))(in)
 	}
@@ -3534,15 +3600,15 @@ func autoconvert_v1_DaemonEndpoint_To_api_DaemonEndpoint(in *DaemonEndpoint, out
 	return nil
 }
 
-func convert_v1_DaemonEndpoint_To_api_DaemonEndpoint(in *DaemonEndpoint, out *api.DaemonEndpoint, s conversion.Scope) error {
-	return autoconvert_v1_DaemonEndpoint_To_api_DaemonEndpoint(in, out, s)
+func Convert_v1_DaemonEndpoint_To_api_DaemonEndpoint(in *DaemonEndpoint, out *api.DaemonEndpoint, s conversion.Scope) error {
+	return autoConvert_v1_DaemonEndpoint_To_api_DaemonEndpoint(in, out, s)
 }
 
-func autoconvert_v1_DeleteOptions_To_api_DeleteOptions(in *DeleteOptions, out *api.DeleteOptions, s conversion.Scope) error {
+func autoConvert_v1_DeleteOptions_To_api_DeleteOptions(in *DeleteOptions, out *api.DeleteOptions, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*DeleteOptions))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
 	if in.GracePeriodSeconds != nil {
@@ -3554,33 +3620,33 @@ func autoconvert_v1_DeleteOptions_To_api_DeleteOptions(in *DeleteOptions, out *a
 	return nil
 }
 
-func convert_v1_DeleteOptions_To_api_DeleteOptions(in *DeleteOptions, out *api.DeleteOptions, s conversion.Scope) error {
-	return autoconvert_v1_DeleteOptions_To_api_DeleteOptions(in, out, s)
+func Convert_v1_DeleteOptions_To_api_DeleteOptions(in *DeleteOptions, out *api.DeleteOptions, s conversion.Scope) error {
+	return autoConvert_v1_DeleteOptions_To_api_DeleteOptions(in, out, s)
 }
 
-func autoconvert_v1_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile(in *DownwardAPIVolumeFile, out *api.DownwardAPIVolumeFile, s conversion.Scope) error {
+func autoConvert_v1_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile(in *DownwardAPIVolumeFile, out *api.DownwardAPIVolumeFile, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*DownwardAPIVolumeFile))(in)
 	}
 	out.Path = in.Path
-	if err := convert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector(&in.FieldRef, &out.FieldRef, s); err != nil {
+	if err := Convert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector(&in.FieldRef, &out.FieldRef, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile(in *DownwardAPIVolumeFile, out *api.DownwardAPIVolumeFile, s conversion.Scope) error {
-	return autoconvert_v1_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile(in, out, s)
+func Convert_v1_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile(in *DownwardAPIVolumeFile, out *api.DownwardAPIVolumeFile, s conversion.Scope) error {
+	return autoConvert_v1_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile(in, out, s)
 }
 
-func autoconvert_v1_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource(in *DownwardAPIVolumeSource, out *api.DownwardAPIVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource(in *DownwardAPIVolumeSource, out *api.DownwardAPIVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*DownwardAPIVolumeSource))(in)
 	}
 	if in.Items != nil {
 		out.Items = make([]api.DownwardAPIVolumeFile, len(in.Items))
 		for i := range in.Items {
-			if err := convert_v1_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_v1_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -3590,11 +3656,11 @@ func autoconvert_v1_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource(in *D
 	return nil
 }
 
-func convert_v1_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource(in *DownwardAPIVolumeSource, out *api.DownwardAPIVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource(in, out, s)
+func Convert_v1_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource(in *DownwardAPIVolumeSource, out *api.DownwardAPIVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource(in *EmptyDirVolumeSource, out *api.EmptyDirVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource(in *EmptyDirVolumeSource, out *api.EmptyDirVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*EmptyDirVolumeSource))(in)
 	}
@@ -3602,18 +3668,19 @@ func autoconvert_v1_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource(in *EmptyDi
 	return nil
 }
 
-func convert_v1_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource(in *EmptyDirVolumeSource, out *api.EmptyDirVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource(in, out, s)
+func Convert_v1_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource(in *EmptyDirVolumeSource, out *api.EmptyDirVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_EndpointAddress_To_api_EndpointAddress(in *EndpointAddress, out *api.EndpointAddress, s conversion.Scope) error {
+func autoConvert_v1_EndpointAddress_To_api_EndpointAddress(in *EndpointAddress, out *api.EndpointAddress, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*EndpointAddress))(in)
 	}
 	out.IP = in.IP
+	// unable to generate simple pointer conversion for v1.ObjectReference -> api.ObjectReference
 	if in.TargetRef != nil {
 		out.TargetRef = new(api.ObjectReference)
-		if err := convert_v1_ObjectReference_To_api_ObjectReference(in.TargetRef, out.TargetRef, s); err != nil {
+		if err := Convert_v1_ObjectReference_To_api_ObjectReference(in.TargetRef, out.TargetRef, s); err != nil {
 			return err
 		}
 	} else {
@@ -3622,11 +3689,11 @@ func autoconvert_v1_EndpointAddress_To_api_EndpointAddress(in *EndpointAddress, 
 	return nil
 }
 
-func convert_v1_EndpointAddress_To_api_EndpointAddress(in *EndpointAddress, out *api.EndpointAddress, s conversion.Scope) error {
-	return autoconvert_v1_EndpointAddress_To_api_EndpointAddress(in, out, s)
+func Convert_v1_EndpointAddress_To_api_EndpointAddress(in *EndpointAddress, out *api.EndpointAddress, s conversion.Scope) error {
+	return autoConvert_v1_EndpointAddress_To_api_EndpointAddress(in, out, s)
 }
 
-func autoconvert_v1_EndpointPort_To_api_EndpointPort(in *EndpointPort, out *api.EndpointPort, s conversion.Scope) error {
+func autoConvert_v1_EndpointPort_To_api_EndpointPort(in *EndpointPort, out *api.EndpointPort, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*EndpointPort))(in)
 	}
@@ -3636,18 +3703,18 @@ func autoconvert_v1_EndpointPort_To_api_EndpointPort(in *EndpointPort, out *api.
 	return nil
 }
 
-func convert_v1_EndpointPort_To_api_EndpointPort(in *EndpointPort, out *api.EndpointPort, s conversion.Scope) error {
-	return autoconvert_v1_EndpointPort_To_api_EndpointPort(in, out, s)
+func Convert_v1_EndpointPort_To_api_EndpointPort(in *EndpointPort, out *api.EndpointPort, s conversion.Scope) error {
+	return autoConvert_v1_EndpointPort_To_api_EndpointPort(in, out, s)
 }
 
-func autoconvert_v1_EndpointSubset_To_api_EndpointSubset(in *EndpointSubset, out *api.EndpointSubset, s conversion.Scope) error {
+func autoConvert_v1_EndpointSubset_To_api_EndpointSubset(in *EndpointSubset, out *api.EndpointSubset, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*EndpointSubset))(in)
 	}
 	if in.Addresses != nil {
 		out.Addresses = make([]api.EndpointAddress, len(in.Addresses))
 		for i := range in.Addresses {
-			if err := convert_v1_EndpointAddress_To_api_EndpointAddress(&in.Addresses[i], &out.Addresses[i], s); err != nil {
+			if err := Convert_v1_EndpointAddress_To_api_EndpointAddress(&in.Addresses[i], &out.Addresses[i], s); err != nil {
 				return err
 			}
 		}
@@ -3657,7 +3724,7 @@ func autoconvert_v1_EndpointSubset_To_api_EndpointSubset(in *EndpointSubset, out
 	if in.NotReadyAddresses != nil {
 		out.NotReadyAddresses = make([]api.EndpointAddress, len(in.NotReadyAddresses))
 		for i := range in.NotReadyAddresses {
-			if err := convert_v1_EndpointAddress_To_api_EndpointAddress(&in.NotReadyAddresses[i], &out.NotReadyAddresses[i], s); err != nil {
+			if err := Convert_v1_EndpointAddress_To_api_EndpointAddress(&in.NotReadyAddresses[i], &out.NotReadyAddresses[i], s); err != nil {
 				return err
 			}
 		}
@@ -3667,7 +3734,7 @@ func autoconvert_v1_EndpointSubset_To_api_EndpointSubset(in *EndpointSubset, out
 	if in.Ports != nil {
 		out.Ports = make([]api.EndpointPort, len(in.Ports))
 		for i := range in.Ports {
-			if err := convert_v1_EndpointPort_To_api_EndpointPort(&in.Ports[i], &out.Ports[i], s); err != nil {
+			if err := Convert_v1_EndpointPort_To_api_EndpointPort(&in.Ports[i], &out.Ports[i], s); err != nil {
 				return err
 			}
 		}
@@ -3677,24 +3744,24 @@ func autoconvert_v1_EndpointSubset_To_api_EndpointSubset(in *EndpointSubset, out
 	return nil
 }
 
-func convert_v1_EndpointSubset_To_api_EndpointSubset(in *EndpointSubset, out *api.EndpointSubset, s conversion.Scope) error {
-	return autoconvert_v1_EndpointSubset_To_api_EndpointSubset(in, out, s)
+func Convert_v1_EndpointSubset_To_api_EndpointSubset(in *EndpointSubset, out *api.EndpointSubset, s conversion.Scope) error {
+	return autoConvert_v1_EndpointSubset_To_api_EndpointSubset(in, out, s)
 }
 
-func autoconvert_v1_Endpoints_To_api_Endpoints(in *Endpoints, out *api.Endpoints, s conversion.Scope) error {
+func autoConvert_v1_Endpoints_To_api_Endpoints(in *Endpoints, out *api.Endpoints, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Endpoints))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
 	if in.Subsets != nil {
 		out.Subsets = make([]api.EndpointSubset, len(in.Subsets))
 		for i := range in.Subsets {
-			if err := convert_v1_EndpointSubset_To_api_EndpointSubset(&in.Subsets[i], &out.Subsets[i], s); err != nil {
+			if err := Convert_v1_EndpointSubset_To_api_EndpointSubset(&in.Subsets[i], &out.Subsets[i], s); err != nil {
 				return err
 			}
 		}
@@ -3704,24 +3771,24 @@ func autoconvert_v1_Endpoints_To_api_Endpoints(in *Endpoints, out *api.Endpoints
 	return nil
 }
 
-func convert_v1_Endpoints_To_api_Endpoints(in *Endpoints, out *api.Endpoints, s conversion.Scope) error {
-	return autoconvert_v1_Endpoints_To_api_Endpoints(in, out, s)
+func Convert_v1_Endpoints_To_api_Endpoints(in *Endpoints, out *api.Endpoints, s conversion.Scope) error {
+	return autoConvert_v1_Endpoints_To_api_Endpoints(in, out, s)
 }
 
-func autoconvert_v1_EndpointsList_To_api_EndpointsList(in *EndpointsList, out *api.EndpointsList, s conversion.Scope) error {
+func autoConvert_v1_EndpointsList_To_api_EndpointsList(in *EndpointsList, out *api.EndpointsList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*EndpointsList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]api.Endpoints, len(in.Items))
 		for i := range in.Items {
-			if err := convert_v1_Endpoints_To_api_Endpoints(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_v1_Endpoints_To_api_Endpoints(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -3731,19 +3798,20 @@ func autoconvert_v1_EndpointsList_To_api_EndpointsList(in *EndpointsList, out *a
 	return nil
 }
 
-func convert_v1_EndpointsList_To_api_EndpointsList(in *EndpointsList, out *api.EndpointsList, s conversion.Scope) error {
-	return autoconvert_v1_EndpointsList_To_api_EndpointsList(in, out, s)
+func Convert_v1_EndpointsList_To_api_EndpointsList(in *EndpointsList, out *api.EndpointsList, s conversion.Scope) error {
+	return autoConvert_v1_EndpointsList_To_api_EndpointsList(in, out, s)
 }
 
-func autoconvert_v1_EnvVar_To_api_EnvVar(in *EnvVar, out *api.EnvVar, s conversion.Scope) error {
+func autoConvert_v1_EnvVar_To_api_EnvVar(in *EnvVar, out *api.EnvVar, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*EnvVar))(in)
 	}
 	out.Name = in.Name
 	out.Value = in.Value
+	// unable to generate simple pointer conversion for v1.EnvVarSource -> api.EnvVarSource
 	if in.ValueFrom != nil {
 		out.ValueFrom = new(api.EnvVarSource)
-		if err := convert_v1_EnvVarSource_To_api_EnvVarSource(in.ValueFrom, out.ValueFrom, s); err != nil {
+		if err := Convert_v1_EnvVarSource_To_api_EnvVarSource(in.ValueFrom, out.ValueFrom, s); err != nil {
 			return err
 		}
 	} else {
@@ -3752,17 +3820,18 @@ func autoconvert_v1_EnvVar_To_api_EnvVar(in *EnvVar, out *api.EnvVar, s conversi
 	return nil
 }
 
-func convert_v1_EnvVar_To_api_EnvVar(in *EnvVar, out *api.EnvVar, s conversion.Scope) error {
-	return autoconvert_v1_EnvVar_To_api_EnvVar(in, out, s)
+func Convert_v1_EnvVar_To_api_EnvVar(in *EnvVar, out *api.EnvVar, s conversion.Scope) error {
+	return autoConvert_v1_EnvVar_To_api_EnvVar(in, out, s)
 }
 
-func autoconvert_v1_EnvVarSource_To_api_EnvVarSource(in *EnvVarSource, out *api.EnvVarSource, s conversion.Scope) error {
+func autoConvert_v1_EnvVarSource_To_api_EnvVarSource(in *EnvVarSource, out *api.EnvVarSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*EnvVarSource))(in)
 	}
+	// unable to generate simple pointer conversion for v1.ObjectFieldSelector -> api.ObjectFieldSelector
 	if in.FieldRef != nil {
 		out.FieldRef = new(api.ObjectFieldSelector)
-		if err := convert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector(in.FieldRef, out.FieldRef, s); err != nil {
+		if err := Convert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector(in.FieldRef, out.FieldRef, s); err != nil {
 			return err
 		}
 	} else {
@@ -3771,32 +3840,32 @@ func autoconvert_v1_EnvVarSource_To_api_EnvVarSource(in *EnvVarSource, out *api.
 	return nil
 }
 
-func convert_v1_EnvVarSource_To_api_EnvVarSource(in *EnvVarSource, out *api.EnvVarSource, s conversion.Scope) error {
-	return autoconvert_v1_EnvVarSource_To_api_EnvVarSource(in, out, s)
+func Convert_v1_EnvVarSource_To_api_EnvVarSource(in *EnvVarSource, out *api.EnvVarSource, s conversion.Scope) error {
+	return autoConvert_v1_EnvVarSource_To_api_EnvVarSource(in, out, s)
 }
 
-func autoconvert_v1_Event_To_api_Event(in *Event, out *api.Event, s conversion.Scope) error {
+func autoConvert_v1_Event_To_api_Event(in *Event, out *api.Event, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Event))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ObjectReference_To_api_ObjectReference(&in.InvolvedObject, &out.InvolvedObject, s); err != nil {
+	if err := Convert_v1_ObjectReference_To_api_ObjectReference(&in.InvolvedObject, &out.InvolvedObject, s); err != nil {
 		return err
 	}
 	out.Reason = in.Reason
 	out.Message = in.Message
-	if err := convert_v1_EventSource_To_api_EventSource(&in.Source, &out.Source, s); err != nil {
+	if err := Convert_v1_EventSource_To_api_EventSource(&in.Source, &out.Source, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.FirstTimestamp, &out.FirstTimestamp, 0); err != nil {
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.FirstTimestamp, &out.FirstTimestamp, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.LastTimestamp, &out.LastTimestamp, 0); err != nil {
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.LastTimestamp, &out.LastTimestamp, s); err != nil {
 		return err
 	}
 	out.Count = int(in.Count)
@@ -3804,24 +3873,24 @@ func autoconvert_v1_Event_To_api_Event(in *Event, out *api.Event, s conversion.S
 	return nil
 }
 
-func convert_v1_Event_To_api_Event(in *Event, out *api.Event, s conversion.Scope) error {
-	return autoconvert_v1_Event_To_api_Event(in, out, s)
+func Convert_v1_Event_To_api_Event(in *Event, out *api.Event, s conversion.Scope) error {
+	return autoConvert_v1_Event_To_api_Event(in, out, s)
 }
 
-func autoconvert_v1_EventList_To_api_EventList(in *EventList, out *api.EventList, s conversion.Scope) error {
+func autoConvert_v1_EventList_To_api_EventList(in *EventList, out *api.EventList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*EventList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]api.Event, len(in.Items))
 		for i := range in.Items {
-			if err := convert_v1_Event_To_api_Event(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_v1_Event_To_api_Event(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -3831,11 +3900,11 @@ func autoconvert_v1_EventList_To_api_EventList(in *EventList, out *api.EventList
 	return nil
 }
 
-func convert_v1_EventList_To_api_EventList(in *EventList, out *api.EventList, s conversion.Scope) error {
-	return autoconvert_v1_EventList_To_api_EventList(in, out, s)
+func Convert_v1_EventList_To_api_EventList(in *EventList, out *api.EventList, s conversion.Scope) error {
+	return autoConvert_v1_EventList_To_api_EventList(in, out, s)
 }
 
-func autoconvert_v1_EventSource_To_api_EventSource(in *EventSource, out *api.EventSource, s conversion.Scope) error {
+func autoConvert_v1_EventSource_To_api_EventSource(in *EventSource, out *api.EventSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*EventSource))(in)
 	}
@@ -3844,11 +3913,11 @@ func autoconvert_v1_EventSource_To_api_EventSource(in *EventSource, out *api.Eve
 	return nil
 }
 
-func convert_v1_EventSource_To_api_EventSource(in *EventSource, out *api.EventSource, s conversion.Scope) error {
-	return autoconvert_v1_EventSource_To_api_EventSource(in, out, s)
+func Convert_v1_EventSource_To_api_EventSource(in *EventSource, out *api.EventSource, s conversion.Scope) error {
+	return autoConvert_v1_EventSource_To_api_EventSource(in, out, s)
 }
 
-func autoconvert_v1_ExecAction_To_api_ExecAction(in *ExecAction, out *api.ExecAction, s conversion.Scope) error {
+func autoConvert_v1_ExecAction_To_api_ExecAction(in *ExecAction, out *api.ExecAction, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ExecAction))(in)
 	}
@@ -3863,15 +3932,15 @@ func autoconvert_v1_ExecAction_To_api_ExecAction(in *ExecAction, out *api.ExecAc
 	return nil
 }
 
-func convert_v1_ExecAction_To_api_ExecAction(in *ExecAction, out *api.ExecAction, s conversion.Scope) error {
-	return autoconvert_v1_ExecAction_To_api_ExecAction(in, out, s)
+func Convert_v1_ExecAction_To_api_ExecAction(in *ExecAction, out *api.ExecAction, s conversion.Scope) error {
+	return autoConvert_v1_ExecAction_To_api_ExecAction(in, out, s)
 }
 
-func autoconvert_v1_ExportOptions_To_unversioned_ExportOptions(in *ExportOptions, out *unversioned.ExportOptions, s conversion.Scope) error {
+func autoConvert_v1_ExportOptions_To_unversioned_ExportOptions(in *ExportOptions, out *unversioned.ExportOptions, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ExportOptions))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
 	out.Export = in.Export
@@ -3879,11 +3948,11 @@ func autoconvert_v1_ExportOptions_To_unversioned_ExportOptions(in *ExportOptions
 	return nil
 }
 
-func convert_v1_ExportOptions_To_unversioned_ExportOptions(in *ExportOptions, out *unversioned.ExportOptions, s conversion.Scope) error {
-	return autoconvert_v1_ExportOptions_To_unversioned_ExportOptions(in, out, s)
+func Convert_v1_ExportOptions_To_unversioned_ExportOptions(in *ExportOptions, out *unversioned.ExportOptions, s conversion.Scope) error {
+	return autoConvert_v1_ExportOptions_To_unversioned_ExportOptions(in, out, s)
 }
 
-func autoconvert_v1_FCVolumeSource_To_api_FCVolumeSource(in *FCVolumeSource, out *api.FCVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_FCVolumeSource_To_api_FCVolumeSource(in *FCVolumeSource, out *api.FCVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*FCVolumeSource))(in)
 	}
@@ -3906,19 +3975,20 @@ func autoconvert_v1_FCVolumeSource_To_api_FCVolumeSource(in *FCVolumeSource, out
 	return nil
 }
 
-func convert_v1_FCVolumeSource_To_api_FCVolumeSource(in *FCVolumeSource, out *api.FCVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_FCVolumeSource_To_api_FCVolumeSource(in, out, s)
+func Convert_v1_FCVolumeSource_To_api_FCVolumeSource(in *FCVolumeSource, out *api.FCVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_FCVolumeSource_To_api_FCVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_FlexVolumeSource_To_api_FlexVolumeSource(in *FlexVolumeSource, out *api.FlexVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_FlexVolumeSource_To_api_FlexVolumeSource(in *FlexVolumeSource, out *api.FlexVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*FlexVolumeSource))(in)
 	}
 	out.Driver = in.Driver
 	out.FSType = in.FSType
+	// unable to generate simple pointer conversion for v1.LocalObjectReference -> api.LocalObjectReference
 	if in.SecretRef != nil {
 		out.SecretRef = new(api.LocalObjectReference)
-		if err := convert_v1_LocalObjectReference_To_api_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
+		if err := Convert_v1_LocalObjectReference_To_api_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
 			return err
 		}
 	} else {
@@ -3936,11 +4006,11 @@ func autoconvert_v1_FlexVolumeSource_To_api_FlexVolumeSource(in *FlexVolumeSourc
 	return nil
 }
 
-func convert_v1_FlexVolumeSource_To_api_FlexVolumeSource(in *FlexVolumeSource, out *api.FlexVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_FlexVolumeSource_To_api_FlexVolumeSource(in, out, s)
+func Convert_v1_FlexVolumeSource_To_api_FlexVolumeSource(in *FlexVolumeSource, out *api.FlexVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_FlexVolumeSource_To_api_FlexVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_FlockerVolumeSource_To_api_FlockerVolumeSource(in *FlockerVolumeSource, out *api.FlockerVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_FlockerVolumeSource_To_api_FlockerVolumeSource(in *FlockerVolumeSource, out *api.FlockerVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*FlockerVolumeSource))(in)
 	}
@@ -3948,11 +4018,11 @@ func autoconvert_v1_FlockerVolumeSource_To_api_FlockerVolumeSource(in *FlockerVo
 	return nil
 }
 
-func convert_v1_FlockerVolumeSource_To_api_FlockerVolumeSource(in *FlockerVolumeSource, out *api.FlockerVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_FlockerVolumeSource_To_api_FlockerVolumeSource(in, out, s)
+func Convert_v1_FlockerVolumeSource_To_api_FlockerVolumeSource(in *FlockerVolumeSource, out *api.FlockerVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_FlockerVolumeSource_To_api_FlockerVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource(in *GCEPersistentDiskVolumeSource, out *api.GCEPersistentDiskVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource(in *GCEPersistentDiskVolumeSource, out *api.GCEPersistentDiskVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*GCEPersistentDiskVolumeSource))(in)
 	}
@@ -3963,11 +4033,11 @@ func autoconvert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolume
 	return nil
 }
 
-func convert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource(in *GCEPersistentDiskVolumeSource, out *api.GCEPersistentDiskVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource(in, out, s)
+func Convert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource(in *GCEPersistentDiskVolumeSource, out *api.GCEPersistentDiskVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_GitRepoVolumeSource_To_api_GitRepoVolumeSource(in *GitRepoVolumeSource, out *api.GitRepoVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_GitRepoVolumeSource_To_api_GitRepoVolumeSource(in *GitRepoVolumeSource, out *api.GitRepoVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*GitRepoVolumeSource))(in)
 	}
@@ -3977,11 +4047,11 @@ func autoconvert_v1_GitRepoVolumeSource_To_api_GitRepoVolumeSource(in *GitRepoVo
 	return nil
 }
 
-func convert_v1_GitRepoVolumeSource_To_api_GitRepoVolumeSource(in *GitRepoVolumeSource, out *api.GitRepoVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_GitRepoVolumeSource_To_api_GitRepoVolumeSource(in, out, s)
+func Convert_v1_GitRepoVolumeSource_To_api_GitRepoVolumeSource(in *GitRepoVolumeSource, out *api.GitRepoVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_GitRepoVolumeSource_To_api_GitRepoVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource(in *GlusterfsVolumeSource, out *api.GlusterfsVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource(in *GlusterfsVolumeSource, out *api.GlusterfsVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*GlusterfsVolumeSource))(in)
 	}
@@ -3991,16 +4061,16 @@ func autoconvert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource(in *Glust
 	return nil
 }
 
-func convert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource(in *GlusterfsVolumeSource, out *api.GlusterfsVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource(in, out, s)
+func Convert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource(in *GlusterfsVolumeSource, out *api.GlusterfsVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_HTTPGetAction_To_api_HTTPGetAction(in *HTTPGetAction, out *api.HTTPGetAction, s conversion.Scope) error {
+func autoConvert_v1_HTTPGetAction_To_api_HTTPGetAction(in *HTTPGetAction, out *api.HTTPGetAction, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*HTTPGetAction))(in)
 	}
 	out.Path = in.Path
-	if err := s.Convert(&in.Port, &out.Port, 0); err != nil {
+	if err := api.Convert_intstr_IntOrString_To_intstr_IntOrString(&in.Port, &out.Port, s); err != nil {
 		return err
 	}
 	out.Host = in.Host
@@ -4008,33 +4078,36 @@ func autoconvert_v1_HTTPGetAction_To_api_HTTPGetAction(in *HTTPGetAction, out *a
 	return nil
 }
 
-func convert_v1_HTTPGetAction_To_api_HTTPGetAction(in *HTTPGetAction, out *api.HTTPGetAction, s conversion.Scope) error {
-	return autoconvert_v1_HTTPGetAction_To_api_HTTPGetAction(in, out, s)
+func Convert_v1_HTTPGetAction_To_api_HTTPGetAction(in *HTTPGetAction, out *api.HTTPGetAction, s conversion.Scope) error {
+	return autoConvert_v1_HTTPGetAction_To_api_HTTPGetAction(in, out, s)
 }
 
-func autoconvert_v1_Handler_To_api_Handler(in *Handler, out *api.Handler, s conversion.Scope) error {
+func autoConvert_v1_Handler_To_api_Handler(in *Handler, out *api.Handler, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Handler))(in)
 	}
+	// unable to generate simple pointer conversion for v1.ExecAction -> api.ExecAction
 	if in.Exec != nil {
 		out.Exec = new(api.ExecAction)
-		if err := convert_v1_ExecAction_To_api_ExecAction(in.Exec, out.Exec, s); err != nil {
+		if err := Convert_v1_ExecAction_To_api_ExecAction(in.Exec, out.Exec, s); err != nil {
 			return err
 		}
 	} else {
 		out.Exec = nil
 	}
+	// unable to generate simple pointer conversion for v1.HTTPGetAction -> api.HTTPGetAction
 	if in.HTTPGet != nil {
 		out.HTTPGet = new(api.HTTPGetAction)
-		if err := convert_v1_HTTPGetAction_To_api_HTTPGetAction(in.HTTPGet, out.HTTPGet, s); err != nil {
+		if err := Convert_v1_HTTPGetAction_To_api_HTTPGetAction(in.HTTPGet, out.HTTPGet, s); err != nil {
 			return err
 		}
 	} else {
 		out.HTTPGet = nil
 	}
+	// unable to generate simple pointer conversion for v1.TCPSocketAction -> api.TCPSocketAction
 	if in.TCPSocket != nil {
 		out.TCPSocket = new(api.TCPSocketAction)
-		if err := convert_v1_TCPSocketAction_To_api_TCPSocketAction(in.TCPSocket, out.TCPSocket, s); err != nil {
+		if err := Convert_v1_TCPSocketAction_To_api_TCPSocketAction(in.TCPSocket, out.TCPSocket, s); err != nil {
 			return err
 		}
 	} else {
@@ -4043,11 +4116,11 @@ func autoconvert_v1_Handler_To_api_Handler(in *Handler, out *api.Handler, s conv
 	return nil
 }
 
-func convert_v1_Handler_To_api_Handler(in *Handler, out *api.Handler, s conversion.Scope) error {
-	return autoconvert_v1_Handler_To_api_Handler(in, out, s)
+func Convert_v1_Handler_To_api_Handler(in *Handler, out *api.Handler, s conversion.Scope) error {
+	return autoConvert_v1_Handler_To_api_Handler(in, out, s)
 }
 
-func autoconvert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource(in *HostPathVolumeSource, out *api.HostPathVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource(in *HostPathVolumeSource, out *api.HostPathVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*HostPathVolumeSource))(in)
 	}
@@ -4055,11 +4128,11 @@ func autoconvert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource(in *HostPat
 	return nil
 }
 
-func convert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource(in *HostPathVolumeSource, out *api.HostPathVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource(in, out, s)
+func Convert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource(in *HostPathVolumeSource, out *api.HostPathVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource(in *ISCSIVolumeSource, out *api.ISCSIVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource(in *ISCSIVolumeSource, out *api.ISCSIVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ISCSIVolumeSource))(in)
 	}
@@ -4072,25 +4145,27 @@ func autoconvert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource(in *ISCSIVolumeSo
 	return nil
 }
 
-func convert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource(in *ISCSIVolumeSource, out *api.ISCSIVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource(in, out, s)
+func Convert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource(in *ISCSIVolumeSource, out *api.ISCSIVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_Lifecycle_To_api_Lifecycle(in *Lifecycle, out *api.Lifecycle, s conversion.Scope) error {
+func autoConvert_v1_Lifecycle_To_api_Lifecycle(in *Lifecycle, out *api.Lifecycle, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Lifecycle))(in)
 	}
+	// unable to generate simple pointer conversion for v1.Handler -> api.Handler
 	if in.PostStart != nil {
 		out.PostStart = new(api.Handler)
-		if err := convert_v1_Handler_To_api_Handler(in.PostStart, out.PostStart, s); err != nil {
+		if err := Convert_v1_Handler_To_api_Handler(in.PostStart, out.PostStart, s); err != nil {
 			return err
 		}
 	} else {
 		out.PostStart = nil
 	}
+	// unable to generate simple pointer conversion for v1.Handler -> api.Handler
 	if in.PreStop != nil {
 		out.PreStop = new(api.Handler)
-		if err := convert_v1_Handler_To_api_Handler(in.PreStop, out.PreStop, s); err != nil {
+		if err := Convert_v1_Handler_To_api_Handler(in.PreStop, out.PreStop, s); err != nil {
 			return err
 		}
 	} else {
@@ -4099,31 +4174,31 @@ func autoconvert_v1_Lifecycle_To_api_Lifecycle(in *Lifecycle, out *api.Lifecycle
 	return nil
 }
 
-func convert_v1_Lifecycle_To_api_Lifecycle(in *Lifecycle, out *api.Lifecycle, s conversion.Scope) error {
-	return autoconvert_v1_Lifecycle_To_api_Lifecycle(in, out, s)
+func Convert_v1_Lifecycle_To_api_Lifecycle(in *Lifecycle, out *api.Lifecycle, s conversion.Scope) error {
+	return autoConvert_v1_Lifecycle_To_api_Lifecycle(in, out, s)
 }
 
-func autoconvert_v1_LimitRange_To_api_LimitRange(in *LimitRange, out *api.LimitRange, s conversion.Scope) error {
+func autoConvert_v1_LimitRange_To_api_LimitRange(in *LimitRange, out *api.LimitRange, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*LimitRange))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_LimitRangeSpec_To_api_LimitRangeSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_v1_LimitRangeSpec_To_api_LimitRangeSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1_LimitRange_To_api_LimitRange(in *LimitRange, out *api.LimitRange, s conversion.Scope) error {
-	return autoconvert_v1_LimitRange_To_api_LimitRange(in, out, s)
+func Convert_v1_LimitRange_To_api_LimitRange(in *LimitRange, out *api.LimitRange, s conversion.Scope) error {
+	return autoConvert_v1_LimitRange_To_api_LimitRange(in, out, s)
 }
 
-func autoconvert_v1_LimitRangeItem_To_api_LimitRangeItem(in *LimitRangeItem, out *api.LimitRangeItem, s conversion.Scope) error {
+func autoConvert_v1_LimitRangeItem_To_api_LimitRangeItem(in *LimitRangeItem, out *api.LimitRangeItem, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*LimitRangeItem))(in)
 	}
@@ -4132,7 +4207,7 @@ func autoconvert_v1_LimitRangeItem_To_api_LimitRangeItem(in *LimitRangeItem, out
 		out.Max = make(api.ResourceList)
 		for key, val := range in.Max {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.Max[api.ResourceName(key)] = newVal
@@ -4144,7 +4219,7 @@ func autoconvert_v1_LimitRangeItem_To_api_LimitRangeItem(in *LimitRangeItem, out
 		out.Min = make(api.ResourceList)
 		for key, val := range in.Min {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.Min[api.ResourceName(key)] = newVal
@@ -4156,7 +4231,7 @@ func autoconvert_v1_LimitRangeItem_To_api_LimitRangeItem(in *LimitRangeItem, out
 		out.Default = make(api.ResourceList)
 		for key, val := range in.Default {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.Default[api.ResourceName(key)] = newVal
@@ -4168,7 +4243,7 @@ func autoconvert_v1_LimitRangeItem_To_api_LimitRangeItem(in *LimitRangeItem, out
 		out.DefaultRequest = make(api.ResourceList)
 		for key, val := range in.DefaultRequest {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.DefaultRequest[api.ResourceName(key)] = newVal
@@ -4180,7 +4255,7 @@ func autoconvert_v1_LimitRangeItem_To_api_LimitRangeItem(in *LimitRangeItem, out
 		out.MaxLimitRequestRatio = make(api.ResourceList)
 		for key, val := range in.MaxLimitRequestRatio {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.MaxLimitRequestRatio[api.ResourceName(key)] = newVal
@@ -4191,24 +4266,24 @@ func autoconvert_v1_LimitRangeItem_To_api_LimitRangeItem(in *LimitRangeItem, out
 	return nil
 }
 
-func convert_v1_LimitRangeItem_To_api_LimitRangeItem(in *LimitRangeItem, out *api.LimitRangeItem, s conversion.Scope) error {
-	return autoconvert_v1_LimitRangeItem_To_api_LimitRangeItem(in, out, s)
+func Convert_v1_LimitRangeItem_To_api_LimitRangeItem(in *LimitRangeItem, out *api.LimitRangeItem, s conversion.Scope) error {
+	return autoConvert_v1_LimitRangeItem_To_api_LimitRangeItem(in, out, s)
 }
 
-func autoconvert_v1_LimitRangeList_To_api_LimitRangeList(in *LimitRangeList, out *api.LimitRangeList, s conversion.Scope) error {
+func autoConvert_v1_LimitRangeList_To_api_LimitRangeList(in *LimitRangeList, out *api.LimitRangeList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*LimitRangeList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]api.LimitRange, len(in.Items))
 		for i := range in.Items {
-			if err := convert_v1_LimitRange_To_api_LimitRange(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_v1_LimitRange_To_api_LimitRange(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -4218,18 +4293,18 @@ func autoconvert_v1_LimitRangeList_To_api_LimitRangeList(in *LimitRangeList, out
 	return nil
 }
 
-func convert_v1_LimitRangeList_To_api_LimitRangeList(in *LimitRangeList, out *api.LimitRangeList, s conversion.Scope) error {
-	return autoconvert_v1_LimitRangeList_To_api_LimitRangeList(in, out, s)
+func Convert_v1_LimitRangeList_To_api_LimitRangeList(in *LimitRangeList, out *api.LimitRangeList, s conversion.Scope) error {
+	return autoConvert_v1_LimitRangeList_To_api_LimitRangeList(in, out, s)
 }
 
-func autoconvert_v1_LimitRangeSpec_To_api_LimitRangeSpec(in *LimitRangeSpec, out *api.LimitRangeSpec, s conversion.Scope) error {
+func autoConvert_v1_LimitRangeSpec_To_api_LimitRangeSpec(in *LimitRangeSpec, out *api.LimitRangeSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*LimitRangeSpec))(in)
 	}
 	if in.Limits != nil {
 		out.Limits = make([]api.LimitRangeItem, len(in.Limits))
 		for i := range in.Limits {
-			if err := convert_v1_LimitRangeItem_To_api_LimitRangeItem(&in.Limits[i], &out.Limits[i], s); err != nil {
+			if err := Convert_v1_LimitRangeItem_To_api_LimitRangeItem(&in.Limits[i], &out.Limits[i], s); err != nil {
 				return err
 			}
 		}
@@ -4239,18 +4314,18 @@ func autoconvert_v1_LimitRangeSpec_To_api_LimitRangeSpec(in *LimitRangeSpec, out
 	return nil
 }
 
-func convert_v1_LimitRangeSpec_To_api_LimitRangeSpec(in *LimitRangeSpec, out *api.LimitRangeSpec, s conversion.Scope) error {
-	return autoconvert_v1_LimitRangeSpec_To_api_LimitRangeSpec(in, out, s)
+func Convert_v1_LimitRangeSpec_To_api_LimitRangeSpec(in *LimitRangeSpec, out *api.LimitRangeSpec, s conversion.Scope) error {
+	return autoConvert_v1_LimitRangeSpec_To_api_LimitRangeSpec(in, out, s)
 }
 
-func autoconvert_v1_List_To_api_List(in *List, out *api.List, s conversion.Scope) error {
+func autoConvert_v1_List_To_api_List(in *List, out *api.List, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*List))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if err := s.Convert(&in.Items, &out.Items, 0); err != nil {
@@ -4259,21 +4334,21 @@ func autoconvert_v1_List_To_api_List(in *List, out *api.List, s conversion.Scope
 	return nil
 }
 
-func convert_v1_List_To_api_List(in *List, out *api.List, s conversion.Scope) error {
-	return autoconvert_v1_List_To_api_List(in, out, s)
+func Convert_v1_List_To_api_List(in *List, out *api.List, s conversion.Scope) error {
+	return autoConvert_v1_List_To_api_List(in, out, s)
 }
 
-func autoconvert_v1_ListOptions_To_api_ListOptions(in *ListOptions, out *api.ListOptions, s conversion.Scope) error {
+func autoConvert_v1_ListOptions_To_api_ListOptions(in *ListOptions, out *api.ListOptions, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ListOptions))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.LabelSelector, &out.LabelSelector, 0); err != nil {
+	if err := api.Convert_string_To_labels_Selector(&in.LabelSelector, &out.LabelSelector, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.FieldSelector, &out.FieldSelector, 0); err != nil {
+	if err := api.Convert_string_To_fields_Selector(&in.FieldSelector, &out.FieldSelector, s); err != nil {
 		return err
 	}
 	out.Watch = in.Watch
@@ -4287,11 +4362,11 @@ func autoconvert_v1_ListOptions_To_api_ListOptions(in *ListOptions, out *api.Lis
 	return nil
 }
 
-func convert_v1_ListOptions_To_api_ListOptions(in *ListOptions, out *api.ListOptions, s conversion.Scope) error {
-	return autoconvert_v1_ListOptions_To_api_ListOptions(in, out, s)
+func Convert_v1_ListOptions_To_api_ListOptions(in *ListOptions, out *api.ListOptions, s conversion.Scope) error {
+	return autoConvert_v1_ListOptions_To_api_ListOptions(in, out, s)
 }
 
-func autoconvert_v1_LoadBalancerIngress_To_api_LoadBalancerIngress(in *LoadBalancerIngress, out *api.LoadBalancerIngress, s conversion.Scope) error {
+func autoConvert_v1_LoadBalancerIngress_To_api_LoadBalancerIngress(in *LoadBalancerIngress, out *api.LoadBalancerIngress, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*LoadBalancerIngress))(in)
 	}
@@ -4300,18 +4375,18 @@ func autoconvert_v1_LoadBalancerIngress_To_api_LoadBalancerIngress(in *LoadBalan
 	return nil
 }
 
-func convert_v1_LoadBalancerIngress_To_api_LoadBalancerIngress(in *LoadBalancerIngress, out *api.LoadBalancerIngress, s conversion.Scope) error {
-	return autoconvert_v1_LoadBalancerIngress_To_api_LoadBalancerIngress(in, out, s)
+func Convert_v1_LoadBalancerIngress_To_api_LoadBalancerIngress(in *LoadBalancerIngress, out *api.LoadBalancerIngress, s conversion.Scope) error {
+	return autoConvert_v1_LoadBalancerIngress_To_api_LoadBalancerIngress(in, out, s)
 }
 
-func autoconvert_v1_LoadBalancerStatus_To_api_LoadBalancerStatus(in *LoadBalancerStatus, out *api.LoadBalancerStatus, s conversion.Scope) error {
+func autoConvert_v1_LoadBalancerStatus_To_api_LoadBalancerStatus(in *LoadBalancerStatus, out *api.LoadBalancerStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*LoadBalancerStatus))(in)
 	}
 	if in.Ingress != nil {
 		out.Ingress = make([]api.LoadBalancerIngress, len(in.Ingress))
 		for i := range in.Ingress {
-			if err := convert_v1_LoadBalancerIngress_To_api_LoadBalancerIngress(&in.Ingress[i], &out.Ingress[i], s); err != nil {
+			if err := Convert_v1_LoadBalancerIngress_To_api_LoadBalancerIngress(&in.Ingress[i], &out.Ingress[i], s); err != nil {
 				return err
 			}
 		}
@@ -4321,11 +4396,11 @@ func autoconvert_v1_LoadBalancerStatus_To_api_LoadBalancerStatus(in *LoadBalance
 	return nil
 }
 
-func convert_v1_LoadBalancerStatus_To_api_LoadBalancerStatus(in *LoadBalancerStatus, out *api.LoadBalancerStatus, s conversion.Scope) error {
-	return autoconvert_v1_LoadBalancerStatus_To_api_LoadBalancerStatus(in, out, s)
+func Convert_v1_LoadBalancerStatus_To_api_LoadBalancerStatus(in *LoadBalancerStatus, out *api.LoadBalancerStatus, s conversion.Scope) error {
+	return autoConvert_v1_LoadBalancerStatus_To_api_LoadBalancerStatus(in, out, s)
 }
 
-func autoconvert_v1_LocalObjectReference_To_api_LocalObjectReference(in *LocalObjectReference, out *api.LocalObjectReference, s conversion.Scope) error {
+func autoConvert_v1_LocalObjectReference_To_api_LocalObjectReference(in *LocalObjectReference, out *api.LocalObjectReference, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*LocalObjectReference))(in)
 	}
@@ -4333,11 +4408,11 @@ func autoconvert_v1_LocalObjectReference_To_api_LocalObjectReference(in *LocalOb
 	return nil
 }
 
-func convert_v1_LocalObjectReference_To_api_LocalObjectReference(in *LocalObjectReference, out *api.LocalObjectReference, s conversion.Scope) error {
-	return autoconvert_v1_LocalObjectReference_To_api_LocalObjectReference(in, out, s)
+func Convert_v1_LocalObjectReference_To_api_LocalObjectReference(in *LocalObjectReference, out *api.LocalObjectReference, s conversion.Scope) error {
+	return autoConvert_v1_LocalObjectReference_To_api_LocalObjectReference(in, out, s)
 }
 
-func autoconvert_v1_NFSVolumeSource_To_api_NFSVolumeSource(in *NFSVolumeSource, out *api.NFSVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_NFSVolumeSource_To_api_NFSVolumeSource(in *NFSVolumeSource, out *api.NFSVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*NFSVolumeSource))(in)
 	}
@@ -4347,47 +4422,47 @@ func autoconvert_v1_NFSVolumeSource_To_api_NFSVolumeSource(in *NFSVolumeSource, 
 	return nil
 }
 
-func convert_v1_NFSVolumeSource_To_api_NFSVolumeSource(in *NFSVolumeSource, out *api.NFSVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_NFSVolumeSource_To_api_NFSVolumeSource(in, out, s)
+func Convert_v1_NFSVolumeSource_To_api_NFSVolumeSource(in *NFSVolumeSource, out *api.NFSVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_NFSVolumeSource_To_api_NFSVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_Namespace_To_api_Namespace(in *Namespace, out *api.Namespace, s conversion.Scope) error {
+func autoConvert_v1_Namespace_To_api_Namespace(in *Namespace, out *api.Namespace, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Namespace))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_NamespaceSpec_To_api_NamespaceSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_v1_NamespaceSpec_To_api_NamespaceSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := convert_v1_NamespaceStatus_To_api_NamespaceStatus(&in.Status, &out.Status, s); err != nil {
+	if err := Convert_v1_NamespaceStatus_To_api_NamespaceStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1_Namespace_To_api_Namespace(in *Namespace, out *api.Namespace, s conversion.Scope) error {
-	return autoconvert_v1_Namespace_To_api_Namespace(in, out, s)
+func Convert_v1_Namespace_To_api_Namespace(in *Namespace, out *api.Namespace, s conversion.Scope) error {
+	return autoConvert_v1_Namespace_To_api_Namespace(in, out, s)
 }
 
-func autoconvert_v1_NamespaceList_To_api_NamespaceList(in *NamespaceList, out *api.NamespaceList, s conversion.Scope) error {
+func autoConvert_v1_NamespaceList_To_api_NamespaceList(in *NamespaceList, out *api.NamespaceList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*NamespaceList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]api.Namespace, len(in.Items))
 		for i := range in.Items {
-			if err := convert_v1_Namespace_To_api_Namespace(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_v1_Namespace_To_api_Namespace(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -4397,11 +4472,11 @@ func autoconvert_v1_NamespaceList_To_api_NamespaceList(in *NamespaceList, out *a
 	return nil
 }
 
-func convert_v1_NamespaceList_To_api_NamespaceList(in *NamespaceList, out *api.NamespaceList, s conversion.Scope) error {
-	return autoconvert_v1_NamespaceList_To_api_NamespaceList(in, out, s)
+func Convert_v1_NamespaceList_To_api_NamespaceList(in *NamespaceList, out *api.NamespaceList, s conversion.Scope) error {
+	return autoConvert_v1_NamespaceList_To_api_NamespaceList(in, out, s)
 }
 
-func autoconvert_v1_NamespaceSpec_To_api_NamespaceSpec(in *NamespaceSpec, out *api.NamespaceSpec, s conversion.Scope) error {
+func autoConvert_v1_NamespaceSpec_To_api_NamespaceSpec(in *NamespaceSpec, out *api.NamespaceSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*NamespaceSpec))(in)
 	}
@@ -4416,11 +4491,11 @@ func autoconvert_v1_NamespaceSpec_To_api_NamespaceSpec(in *NamespaceSpec, out *a
 	return nil
 }
 
-func convert_v1_NamespaceSpec_To_api_NamespaceSpec(in *NamespaceSpec, out *api.NamespaceSpec, s conversion.Scope) error {
-	return autoconvert_v1_NamespaceSpec_To_api_NamespaceSpec(in, out, s)
+func Convert_v1_NamespaceSpec_To_api_NamespaceSpec(in *NamespaceSpec, out *api.NamespaceSpec, s conversion.Scope) error {
+	return autoConvert_v1_NamespaceSpec_To_api_NamespaceSpec(in, out, s)
 }
 
-func autoconvert_v1_NamespaceStatus_To_api_NamespaceStatus(in *NamespaceStatus, out *api.NamespaceStatus, s conversion.Scope) error {
+func autoConvert_v1_NamespaceStatus_To_api_NamespaceStatus(in *NamespaceStatus, out *api.NamespaceStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*NamespaceStatus))(in)
 	}
@@ -4428,34 +4503,34 @@ func autoconvert_v1_NamespaceStatus_To_api_NamespaceStatus(in *NamespaceStatus, 
 	return nil
 }
 
-func convert_v1_NamespaceStatus_To_api_NamespaceStatus(in *NamespaceStatus, out *api.NamespaceStatus, s conversion.Scope) error {
-	return autoconvert_v1_NamespaceStatus_To_api_NamespaceStatus(in, out, s)
+func Convert_v1_NamespaceStatus_To_api_NamespaceStatus(in *NamespaceStatus, out *api.NamespaceStatus, s conversion.Scope) error {
+	return autoConvert_v1_NamespaceStatus_To_api_NamespaceStatus(in, out, s)
 }
 
-func autoconvert_v1_Node_To_api_Node(in *Node, out *api.Node, s conversion.Scope) error {
+func autoConvert_v1_Node_To_api_Node(in *Node, out *api.Node, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Node))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_NodeSpec_To_api_NodeSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_v1_NodeSpec_To_api_NodeSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := convert_v1_NodeStatus_To_api_NodeStatus(&in.Status, &out.Status, s); err != nil {
+	if err := Convert_v1_NodeStatus_To_api_NodeStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1_Node_To_api_Node(in *Node, out *api.Node, s conversion.Scope) error {
-	return autoconvert_v1_Node_To_api_Node(in, out, s)
+func Convert_v1_Node_To_api_Node(in *Node, out *api.Node, s conversion.Scope) error {
+	return autoConvert_v1_Node_To_api_Node(in, out, s)
 }
 
-func autoconvert_v1_NodeAddress_To_api_NodeAddress(in *NodeAddress, out *api.NodeAddress, s conversion.Scope) error {
+func autoConvert_v1_NodeAddress_To_api_NodeAddress(in *NodeAddress, out *api.NodeAddress, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*NodeAddress))(in)
 	}
@@ -4464,20 +4539,20 @@ func autoconvert_v1_NodeAddress_To_api_NodeAddress(in *NodeAddress, out *api.Nod
 	return nil
 }
 
-func convert_v1_NodeAddress_To_api_NodeAddress(in *NodeAddress, out *api.NodeAddress, s conversion.Scope) error {
-	return autoconvert_v1_NodeAddress_To_api_NodeAddress(in, out, s)
+func Convert_v1_NodeAddress_To_api_NodeAddress(in *NodeAddress, out *api.NodeAddress, s conversion.Scope) error {
+	return autoConvert_v1_NodeAddress_To_api_NodeAddress(in, out, s)
 }
 
-func autoconvert_v1_NodeCondition_To_api_NodeCondition(in *NodeCondition, out *api.NodeCondition, s conversion.Scope) error {
+func autoConvert_v1_NodeCondition_To_api_NodeCondition(in *NodeCondition, out *api.NodeCondition, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*NodeCondition))(in)
 	}
 	out.Type = api.NodeConditionType(in.Type)
 	out.Status = api.ConditionStatus(in.Status)
-	if err := s.Convert(&in.LastHeartbeatTime, &out.LastHeartbeatTime, 0); err != nil {
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.LastHeartbeatTime, &out.LastHeartbeatTime, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.LastTransitionTime, &out.LastTransitionTime, 0); err != nil {
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.LastTransitionTime, &out.LastTransitionTime, s); err != nil {
 		return err
 	}
 	out.Reason = in.Reason
@@ -4485,38 +4560,38 @@ func autoconvert_v1_NodeCondition_To_api_NodeCondition(in *NodeCondition, out *a
 	return nil
 }
 
-func convert_v1_NodeCondition_To_api_NodeCondition(in *NodeCondition, out *api.NodeCondition, s conversion.Scope) error {
-	return autoconvert_v1_NodeCondition_To_api_NodeCondition(in, out, s)
+func Convert_v1_NodeCondition_To_api_NodeCondition(in *NodeCondition, out *api.NodeCondition, s conversion.Scope) error {
+	return autoConvert_v1_NodeCondition_To_api_NodeCondition(in, out, s)
 }
 
-func autoconvert_v1_NodeDaemonEndpoints_To_api_NodeDaemonEndpoints(in *NodeDaemonEndpoints, out *api.NodeDaemonEndpoints, s conversion.Scope) error {
+func autoConvert_v1_NodeDaemonEndpoints_To_api_NodeDaemonEndpoints(in *NodeDaemonEndpoints, out *api.NodeDaemonEndpoints, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*NodeDaemonEndpoints))(in)
 	}
-	if err := convert_v1_DaemonEndpoint_To_api_DaemonEndpoint(&in.KubeletEndpoint, &out.KubeletEndpoint, s); err != nil {
+	if err := Convert_v1_DaemonEndpoint_To_api_DaemonEndpoint(&in.KubeletEndpoint, &out.KubeletEndpoint, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1_NodeDaemonEndpoints_To_api_NodeDaemonEndpoints(in *NodeDaemonEndpoints, out *api.NodeDaemonEndpoints, s conversion.Scope) error {
-	return autoconvert_v1_NodeDaemonEndpoints_To_api_NodeDaemonEndpoints(in, out, s)
+func Convert_v1_NodeDaemonEndpoints_To_api_NodeDaemonEndpoints(in *NodeDaemonEndpoints, out *api.NodeDaemonEndpoints, s conversion.Scope) error {
+	return autoConvert_v1_NodeDaemonEndpoints_To_api_NodeDaemonEndpoints(in, out, s)
 }
 
-func autoconvert_v1_NodeList_To_api_NodeList(in *NodeList, out *api.NodeList, s conversion.Scope) error {
+func autoConvert_v1_NodeList_To_api_NodeList(in *NodeList, out *api.NodeList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*NodeList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]api.Node, len(in.Items))
 		for i := range in.Items {
-			if err := convert_v1_Node_To_api_Node(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_v1_Node_To_api_Node(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -4526,11 +4601,11 @@ func autoconvert_v1_NodeList_To_api_NodeList(in *NodeList, out *api.NodeList, s 
 	return nil
 }
 
-func convert_v1_NodeList_To_api_NodeList(in *NodeList, out *api.NodeList, s conversion.Scope) error {
-	return autoconvert_v1_NodeList_To_api_NodeList(in, out, s)
+func Convert_v1_NodeList_To_api_NodeList(in *NodeList, out *api.NodeList, s conversion.Scope) error {
+	return autoConvert_v1_NodeList_To_api_NodeList(in, out, s)
 }
 
-func autoconvert_v1_NodeSpec_To_api_NodeSpec(in *NodeSpec, out *api.NodeSpec, s conversion.Scope) error {
+func autoConvert_v1_NodeSpec_To_api_NodeSpec(in *NodeSpec, out *api.NodeSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*NodeSpec))(in)
 	}
@@ -4541,11 +4616,11 @@ func autoconvert_v1_NodeSpec_To_api_NodeSpec(in *NodeSpec, out *api.NodeSpec, s 
 	return nil
 }
 
-func convert_v1_NodeSpec_To_api_NodeSpec(in *NodeSpec, out *api.NodeSpec, s conversion.Scope) error {
-	return autoconvert_v1_NodeSpec_To_api_NodeSpec(in, out, s)
+func Convert_v1_NodeSpec_To_api_NodeSpec(in *NodeSpec, out *api.NodeSpec, s conversion.Scope) error {
+	return autoConvert_v1_NodeSpec_To_api_NodeSpec(in, out, s)
 }
 
-func autoconvert_v1_NodeStatus_To_api_NodeStatus(in *NodeStatus, out *api.NodeStatus, s conversion.Scope) error {
+func autoConvert_v1_NodeStatus_To_api_NodeStatus(in *NodeStatus, out *api.NodeStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*NodeStatus))(in)
 	}
@@ -4553,7 +4628,7 @@ func autoconvert_v1_NodeStatus_To_api_NodeStatus(in *NodeStatus, out *api.NodeSt
 		out.Capacity = make(api.ResourceList)
 		for key, val := range in.Capacity {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.Capacity[api.ResourceName(key)] = newVal
@@ -4565,7 +4640,7 @@ func autoconvert_v1_NodeStatus_To_api_NodeStatus(in *NodeStatus, out *api.NodeSt
 		out.Allocatable = make(api.ResourceList)
 		for key, val := range in.Allocatable {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.Allocatable[api.ResourceName(key)] = newVal
@@ -4577,7 +4652,7 @@ func autoconvert_v1_NodeStatus_To_api_NodeStatus(in *NodeStatus, out *api.NodeSt
 	if in.Conditions != nil {
 		out.Conditions = make([]api.NodeCondition, len(in.Conditions))
 		for i := range in.Conditions {
-			if err := convert_v1_NodeCondition_To_api_NodeCondition(&in.Conditions[i], &out.Conditions[i], s); err != nil {
+			if err := Convert_v1_NodeCondition_To_api_NodeCondition(&in.Conditions[i], &out.Conditions[i], s); err != nil {
 				return err
 			}
 		}
@@ -4587,27 +4662,27 @@ func autoconvert_v1_NodeStatus_To_api_NodeStatus(in *NodeStatus, out *api.NodeSt
 	if in.Addresses != nil {
 		out.Addresses = make([]api.NodeAddress, len(in.Addresses))
 		for i := range in.Addresses {
-			if err := convert_v1_NodeAddress_To_api_NodeAddress(&in.Addresses[i], &out.Addresses[i], s); err != nil {
+			if err := Convert_v1_NodeAddress_To_api_NodeAddress(&in.Addresses[i], &out.Addresses[i], s); err != nil {
 				return err
 			}
 		}
 	} else {
 		out.Addresses = nil
 	}
-	if err := convert_v1_NodeDaemonEndpoints_To_api_NodeDaemonEndpoints(&in.DaemonEndpoints, &out.DaemonEndpoints, s); err != nil {
+	if err := Convert_v1_NodeDaemonEndpoints_To_api_NodeDaemonEndpoints(&in.DaemonEndpoints, &out.DaemonEndpoints, s); err != nil {
 		return err
 	}
-	if err := convert_v1_NodeSystemInfo_To_api_NodeSystemInfo(&in.NodeInfo, &out.NodeInfo, s); err != nil {
+	if err := Convert_v1_NodeSystemInfo_To_api_NodeSystemInfo(&in.NodeInfo, &out.NodeInfo, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1_NodeStatus_To_api_NodeStatus(in *NodeStatus, out *api.NodeStatus, s conversion.Scope) error {
-	return autoconvert_v1_NodeStatus_To_api_NodeStatus(in, out, s)
+func Convert_v1_NodeStatus_To_api_NodeStatus(in *NodeStatus, out *api.NodeStatus, s conversion.Scope) error {
+	return autoConvert_v1_NodeStatus_To_api_NodeStatus(in, out, s)
 }
 
-func autoconvert_v1_NodeSystemInfo_To_api_NodeSystemInfo(in *NodeSystemInfo, out *api.NodeSystemInfo, s conversion.Scope) error {
+func autoConvert_v1_NodeSystemInfo_To_api_NodeSystemInfo(in *NodeSystemInfo, out *api.NodeSystemInfo, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*NodeSystemInfo))(in)
 	}
@@ -4622,11 +4697,11 @@ func autoconvert_v1_NodeSystemInfo_To_api_NodeSystemInfo(in *NodeSystemInfo, out
 	return nil
 }
 
-func convert_v1_NodeSystemInfo_To_api_NodeSystemInfo(in *NodeSystemInfo, out *api.NodeSystemInfo, s conversion.Scope) error {
-	return autoconvert_v1_NodeSystemInfo_To_api_NodeSystemInfo(in, out, s)
+func Convert_v1_NodeSystemInfo_To_api_NodeSystemInfo(in *NodeSystemInfo, out *api.NodeSystemInfo, s conversion.Scope) error {
+	return autoConvert_v1_NodeSystemInfo_To_api_NodeSystemInfo(in, out, s)
 }
 
-func autoconvert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector(in *ObjectFieldSelector, out *api.ObjectFieldSelector, s conversion.Scope) error {
+func autoConvert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector(in *ObjectFieldSelector, out *api.ObjectFieldSelector, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ObjectFieldSelector))(in)
 	}
@@ -4635,11 +4710,11 @@ func autoconvert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector(in *ObjectFie
 	return nil
 }
 
-func convert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector(in *ObjectFieldSelector, out *api.ObjectFieldSelector, s conversion.Scope) error {
-	return autoconvert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector(in, out, s)
+func Convert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector(in *ObjectFieldSelector, out *api.ObjectFieldSelector, s conversion.Scope) error {
+	return autoConvert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector(in, out, s)
 }
 
-func autoconvert_v1_ObjectMeta_To_api_ObjectMeta(in *ObjectMeta, out *api.ObjectMeta, s conversion.Scope) error {
+func autoConvert_v1_ObjectMeta_To_api_ObjectMeta(in *ObjectMeta, out *api.ObjectMeta, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ObjectMeta))(in)
 	}
@@ -4650,11 +4725,13 @@ func autoconvert_v1_ObjectMeta_To_api_ObjectMeta(in *ObjectMeta, out *api.Object
 	out.UID = in.UID
 	out.ResourceVersion = in.ResourceVersion
 	out.Generation = in.Generation
-	if err := s.Convert(&in.CreationTimestamp, &out.CreationTimestamp, 0); err != nil {
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.CreationTimestamp, &out.CreationTimestamp, s); err != nil {
 		return err
 	}
+	// unable to generate simple pointer conversion for unversioned.Time -> unversioned.Time
 	if in.DeletionTimestamp != nil {
-		if err := s.Convert(&in.DeletionTimestamp, &out.DeletionTimestamp, 0); err != nil {
+		out.DeletionTimestamp = new(unversioned.Time)
+		if err := api.Convert_unversioned_Time_To_unversioned_Time(in.DeletionTimestamp, out.DeletionTimestamp, s); err != nil {
 			return err
 		}
 	} else {
@@ -4685,11 +4762,11 @@ func autoconvert_v1_ObjectMeta_To_api_ObjectMeta(in *ObjectMeta, out *api.Object
 	return nil
 }
 
-func convert_v1_ObjectMeta_To_api_ObjectMeta(in *ObjectMeta, out *api.ObjectMeta, s conversion.Scope) error {
-	return autoconvert_v1_ObjectMeta_To_api_ObjectMeta(in, out, s)
+func Convert_v1_ObjectMeta_To_api_ObjectMeta(in *ObjectMeta, out *api.ObjectMeta, s conversion.Scope) error {
+	return autoConvert_v1_ObjectMeta_To_api_ObjectMeta(in, out, s)
 }
 
-func autoconvert_v1_ObjectReference_To_api_ObjectReference(in *ObjectReference, out *api.ObjectReference, s conversion.Scope) error {
+func autoConvert_v1_ObjectReference_To_api_ObjectReference(in *ObjectReference, out *api.ObjectReference, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ObjectReference))(in)
 	}
@@ -4703,70 +4780,70 @@ func autoconvert_v1_ObjectReference_To_api_ObjectReference(in *ObjectReference, 
 	return nil
 }
 
-func convert_v1_ObjectReference_To_api_ObjectReference(in *ObjectReference, out *api.ObjectReference, s conversion.Scope) error {
-	return autoconvert_v1_ObjectReference_To_api_ObjectReference(in, out, s)
+func Convert_v1_ObjectReference_To_api_ObjectReference(in *ObjectReference, out *api.ObjectReference, s conversion.Scope) error {
+	return autoConvert_v1_ObjectReference_To_api_ObjectReference(in, out, s)
 }
 
-func autoconvert_v1_PersistentVolume_To_api_PersistentVolume(in *PersistentVolume, out *api.PersistentVolume, s conversion.Scope) error {
+func autoConvert_v1_PersistentVolume_To_api_PersistentVolume(in *PersistentVolume, out *api.PersistentVolume, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PersistentVolume))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_PersistentVolumeSpec_To_api_PersistentVolumeSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_v1_PersistentVolumeSpec_To_api_PersistentVolumeSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := convert_v1_PersistentVolumeStatus_To_api_PersistentVolumeStatus(&in.Status, &out.Status, s); err != nil {
+	if err := Convert_v1_PersistentVolumeStatus_To_api_PersistentVolumeStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1_PersistentVolume_To_api_PersistentVolume(in *PersistentVolume, out *api.PersistentVolume, s conversion.Scope) error {
-	return autoconvert_v1_PersistentVolume_To_api_PersistentVolume(in, out, s)
+func Convert_v1_PersistentVolume_To_api_PersistentVolume(in *PersistentVolume, out *api.PersistentVolume, s conversion.Scope) error {
+	return autoConvert_v1_PersistentVolume_To_api_PersistentVolume(in, out, s)
 }
 
-func autoconvert_v1_PersistentVolumeClaim_To_api_PersistentVolumeClaim(in *PersistentVolumeClaim, out *api.PersistentVolumeClaim, s conversion.Scope) error {
+func autoConvert_v1_PersistentVolumeClaim_To_api_PersistentVolumeClaim(in *PersistentVolumeClaim, out *api.PersistentVolumeClaim, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PersistentVolumeClaim))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_PersistentVolumeClaimSpec_To_api_PersistentVolumeClaimSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_v1_PersistentVolumeClaimSpec_To_api_PersistentVolumeClaimSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := convert_v1_PersistentVolumeClaimStatus_To_api_PersistentVolumeClaimStatus(&in.Status, &out.Status, s); err != nil {
+	if err := Convert_v1_PersistentVolumeClaimStatus_To_api_PersistentVolumeClaimStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1_PersistentVolumeClaim_To_api_PersistentVolumeClaim(in *PersistentVolumeClaim, out *api.PersistentVolumeClaim, s conversion.Scope) error {
-	return autoconvert_v1_PersistentVolumeClaim_To_api_PersistentVolumeClaim(in, out, s)
+func Convert_v1_PersistentVolumeClaim_To_api_PersistentVolumeClaim(in *PersistentVolumeClaim, out *api.PersistentVolumeClaim, s conversion.Scope) error {
+	return autoConvert_v1_PersistentVolumeClaim_To_api_PersistentVolumeClaim(in, out, s)
 }
 
-func autoconvert_v1_PersistentVolumeClaimList_To_api_PersistentVolumeClaimList(in *PersistentVolumeClaimList, out *api.PersistentVolumeClaimList, s conversion.Scope) error {
+func autoConvert_v1_PersistentVolumeClaimList_To_api_PersistentVolumeClaimList(in *PersistentVolumeClaimList, out *api.PersistentVolumeClaimList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PersistentVolumeClaimList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]api.PersistentVolumeClaim, len(in.Items))
 		for i := range in.Items {
-			if err := convert_v1_PersistentVolumeClaim_To_api_PersistentVolumeClaim(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_v1_PersistentVolumeClaim_To_api_PersistentVolumeClaim(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -4776,11 +4853,11 @@ func autoconvert_v1_PersistentVolumeClaimList_To_api_PersistentVolumeClaimList(i
 	return nil
 }
 
-func convert_v1_PersistentVolumeClaimList_To_api_PersistentVolumeClaimList(in *PersistentVolumeClaimList, out *api.PersistentVolumeClaimList, s conversion.Scope) error {
-	return autoconvert_v1_PersistentVolumeClaimList_To_api_PersistentVolumeClaimList(in, out, s)
+func Convert_v1_PersistentVolumeClaimList_To_api_PersistentVolumeClaimList(in *PersistentVolumeClaimList, out *api.PersistentVolumeClaimList, s conversion.Scope) error {
+	return autoConvert_v1_PersistentVolumeClaimList_To_api_PersistentVolumeClaimList(in, out, s)
 }
 
-func autoconvert_v1_PersistentVolumeClaimSpec_To_api_PersistentVolumeClaimSpec(in *PersistentVolumeClaimSpec, out *api.PersistentVolumeClaimSpec, s conversion.Scope) error {
+func autoConvert_v1_PersistentVolumeClaimSpec_To_api_PersistentVolumeClaimSpec(in *PersistentVolumeClaimSpec, out *api.PersistentVolumeClaimSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PersistentVolumeClaimSpec))(in)
 	}
@@ -4792,18 +4869,18 @@ func autoconvert_v1_PersistentVolumeClaimSpec_To_api_PersistentVolumeClaimSpec(i
 	} else {
 		out.AccessModes = nil
 	}
-	if err := convert_v1_ResourceRequirements_To_api_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
+	if err := Convert_v1_ResourceRequirements_To_api_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
 		return err
 	}
 	out.VolumeName = in.VolumeName
 	return nil
 }
 
-func convert_v1_PersistentVolumeClaimSpec_To_api_PersistentVolumeClaimSpec(in *PersistentVolumeClaimSpec, out *api.PersistentVolumeClaimSpec, s conversion.Scope) error {
-	return autoconvert_v1_PersistentVolumeClaimSpec_To_api_PersistentVolumeClaimSpec(in, out, s)
+func Convert_v1_PersistentVolumeClaimSpec_To_api_PersistentVolumeClaimSpec(in *PersistentVolumeClaimSpec, out *api.PersistentVolumeClaimSpec, s conversion.Scope) error {
+	return autoConvert_v1_PersistentVolumeClaimSpec_To_api_PersistentVolumeClaimSpec(in, out, s)
 }
 
-func autoconvert_v1_PersistentVolumeClaimStatus_To_api_PersistentVolumeClaimStatus(in *PersistentVolumeClaimStatus, out *api.PersistentVolumeClaimStatus, s conversion.Scope) error {
+func autoConvert_v1_PersistentVolumeClaimStatus_To_api_PersistentVolumeClaimStatus(in *PersistentVolumeClaimStatus, out *api.PersistentVolumeClaimStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PersistentVolumeClaimStatus))(in)
 	}
@@ -4820,7 +4897,7 @@ func autoconvert_v1_PersistentVolumeClaimStatus_To_api_PersistentVolumeClaimStat
 		out.Capacity = make(api.ResourceList)
 		for key, val := range in.Capacity {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.Capacity[api.ResourceName(key)] = newVal
@@ -4831,11 +4908,11 @@ func autoconvert_v1_PersistentVolumeClaimStatus_To_api_PersistentVolumeClaimStat
 	return nil
 }
 
-func convert_v1_PersistentVolumeClaimStatus_To_api_PersistentVolumeClaimStatus(in *PersistentVolumeClaimStatus, out *api.PersistentVolumeClaimStatus, s conversion.Scope) error {
-	return autoconvert_v1_PersistentVolumeClaimStatus_To_api_PersistentVolumeClaimStatus(in, out, s)
+func Convert_v1_PersistentVolumeClaimStatus_To_api_PersistentVolumeClaimStatus(in *PersistentVolumeClaimStatus, out *api.PersistentVolumeClaimStatus, s conversion.Scope) error {
+	return autoConvert_v1_PersistentVolumeClaimStatus_To_api_PersistentVolumeClaimStatus(in, out, s)
 }
 
-func autoconvert_v1_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeClaimVolumeSource(in *PersistentVolumeClaimVolumeSource, out *api.PersistentVolumeClaimVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeClaimVolumeSource(in *PersistentVolumeClaimVolumeSource, out *api.PersistentVolumeClaimVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PersistentVolumeClaimVolumeSource))(in)
 	}
@@ -4844,24 +4921,24 @@ func autoconvert_v1_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeCla
 	return nil
 }
 
-func convert_v1_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeClaimVolumeSource(in *PersistentVolumeClaimVolumeSource, out *api.PersistentVolumeClaimVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeClaimVolumeSource(in, out, s)
+func Convert_v1_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeClaimVolumeSource(in *PersistentVolumeClaimVolumeSource, out *api.PersistentVolumeClaimVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeClaimVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_PersistentVolumeList_To_api_PersistentVolumeList(in *PersistentVolumeList, out *api.PersistentVolumeList, s conversion.Scope) error {
+func autoConvert_v1_PersistentVolumeList_To_api_PersistentVolumeList(in *PersistentVolumeList, out *api.PersistentVolumeList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PersistentVolumeList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]api.PersistentVolume, len(in.Items))
 		for i := range in.Items {
-			if err := convert_v1_PersistentVolume_To_api_PersistentVolume(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_v1_PersistentVolume_To_api_PersistentVolume(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -4871,105 +4948,117 @@ func autoconvert_v1_PersistentVolumeList_To_api_PersistentVolumeList(in *Persist
 	return nil
 }
 
-func convert_v1_PersistentVolumeList_To_api_PersistentVolumeList(in *PersistentVolumeList, out *api.PersistentVolumeList, s conversion.Scope) error {
-	return autoconvert_v1_PersistentVolumeList_To_api_PersistentVolumeList(in, out, s)
+func Convert_v1_PersistentVolumeList_To_api_PersistentVolumeList(in *PersistentVolumeList, out *api.PersistentVolumeList, s conversion.Scope) error {
+	return autoConvert_v1_PersistentVolumeList_To_api_PersistentVolumeList(in, out, s)
 }
 
-func autoconvert_v1_PersistentVolumeSource_To_api_PersistentVolumeSource(in *PersistentVolumeSource, out *api.PersistentVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_PersistentVolumeSource_To_api_PersistentVolumeSource(in *PersistentVolumeSource, out *api.PersistentVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PersistentVolumeSource))(in)
 	}
+	// unable to generate simple pointer conversion for v1.GCEPersistentDiskVolumeSource -> api.GCEPersistentDiskVolumeSource
 	if in.GCEPersistentDisk != nil {
 		out.GCEPersistentDisk = new(api.GCEPersistentDiskVolumeSource)
-		if err := convert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource(in.GCEPersistentDisk, out.GCEPersistentDisk, s); err != nil {
+		if err := Convert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource(in.GCEPersistentDisk, out.GCEPersistentDisk, s); err != nil {
 			return err
 		}
 	} else {
 		out.GCEPersistentDisk = nil
 	}
+	// unable to generate simple pointer conversion for v1.AWSElasticBlockStoreVolumeSource -> api.AWSElasticBlockStoreVolumeSource
 	if in.AWSElasticBlockStore != nil {
 		out.AWSElasticBlockStore = new(api.AWSElasticBlockStoreVolumeSource)
-		if err := convert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource(in.AWSElasticBlockStore, out.AWSElasticBlockStore, s); err != nil {
+		if err := Convert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource(in.AWSElasticBlockStore, out.AWSElasticBlockStore, s); err != nil {
 			return err
 		}
 	} else {
 		out.AWSElasticBlockStore = nil
 	}
+	// unable to generate simple pointer conversion for v1.HostPathVolumeSource -> api.HostPathVolumeSource
 	if in.HostPath != nil {
 		out.HostPath = new(api.HostPathVolumeSource)
-		if err := convert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource(in.HostPath, out.HostPath, s); err != nil {
+		if err := Convert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource(in.HostPath, out.HostPath, s); err != nil {
 			return err
 		}
 	} else {
 		out.HostPath = nil
 	}
+	// unable to generate simple pointer conversion for v1.GlusterfsVolumeSource -> api.GlusterfsVolumeSource
 	if in.Glusterfs != nil {
 		out.Glusterfs = new(api.GlusterfsVolumeSource)
-		if err := convert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource(in.Glusterfs, out.Glusterfs, s); err != nil {
+		if err := Convert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource(in.Glusterfs, out.Glusterfs, s); err != nil {
 			return err
 		}
 	} else {
 		out.Glusterfs = nil
 	}
+	// unable to generate simple pointer conversion for v1.NFSVolumeSource -> api.NFSVolumeSource
 	if in.NFS != nil {
 		out.NFS = new(api.NFSVolumeSource)
-		if err := convert_v1_NFSVolumeSource_To_api_NFSVolumeSource(in.NFS, out.NFS, s); err != nil {
+		if err := Convert_v1_NFSVolumeSource_To_api_NFSVolumeSource(in.NFS, out.NFS, s); err != nil {
 			return err
 		}
 	} else {
 		out.NFS = nil
 	}
+	// unable to generate simple pointer conversion for v1.RBDVolumeSource -> api.RBDVolumeSource
 	if in.RBD != nil {
 		out.RBD = new(api.RBDVolumeSource)
-		if err := convert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in.RBD, out.RBD, s); err != nil {
+		if err := Convert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in.RBD, out.RBD, s); err != nil {
 			return err
 		}
 	} else {
 		out.RBD = nil
 	}
+	// unable to generate simple pointer conversion for v1.ISCSIVolumeSource -> api.ISCSIVolumeSource
 	if in.ISCSI != nil {
 		out.ISCSI = new(api.ISCSIVolumeSource)
-		if err := convert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource(in.ISCSI, out.ISCSI, s); err != nil {
+		if err := Convert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource(in.ISCSI, out.ISCSI, s); err != nil {
 			return err
 		}
 	} else {
 		out.ISCSI = nil
 	}
+	// unable to generate simple pointer conversion for v1.CinderVolumeSource -> api.CinderVolumeSource
 	if in.Cinder != nil {
 		out.Cinder = new(api.CinderVolumeSource)
-		if err := convert_v1_CinderVolumeSource_To_api_CinderVolumeSource(in.Cinder, out.Cinder, s); err != nil {
+		if err := Convert_v1_CinderVolumeSource_To_api_CinderVolumeSource(in.Cinder, out.Cinder, s); err != nil {
 			return err
 		}
 	} else {
 		out.Cinder = nil
 	}
+	// unable to generate simple pointer conversion for v1.CephFSVolumeSource -> api.CephFSVolumeSource
 	if in.CephFS != nil {
 		out.CephFS = new(api.CephFSVolumeSource)
-		if err := convert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in.CephFS, out.CephFS, s); err != nil {
+		if err := Convert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in.CephFS, out.CephFS, s); err != nil {
 			return err
 		}
 	} else {
 		out.CephFS = nil
 	}
+	// unable to generate simple pointer conversion for v1.FCVolumeSource -> api.FCVolumeSource
 	if in.FC != nil {
 		out.FC = new(api.FCVolumeSource)
-		if err := convert_v1_FCVolumeSource_To_api_FCVolumeSource(in.FC, out.FC, s); err != nil {
+		if err := Convert_v1_FCVolumeSource_To_api_FCVolumeSource(in.FC, out.FC, s); err != nil {
 			return err
 		}
 	} else {
 		out.FC = nil
 	}
+	// unable to generate simple pointer conversion for v1.FlockerVolumeSource -> api.FlockerVolumeSource
 	if in.Flocker != nil {
 		out.Flocker = new(api.FlockerVolumeSource)
-		if err := convert_v1_FlockerVolumeSource_To_api_FlockerVolumeSource(in.Flocker, out.Flocker, s); err != nil {
+		if err := Convert_v1_FlockerVolumeSource_To_api_FlockerVolumeSource(in.Flocker, out.Flocker, s); err != nil {
 			return err
 		}
 	} else {
 		out.Flocker = nil
 	}
+	// unable to generate simple pointer conversion for v1.FlexVolumeSource -> api.FlexVolumeSource
 	if in.FlexVolume != nil {
 		out.FlexVolume = new(api.FlexVolumeSource)
-		if err := convert_v1_FlexVolumeSource_To_api_FlexVolumeSource(in.FlexVolume, out.FlexVolume, s); err != nil {
+		if err := Convert_v1_FlexVolumeSource_To_api_FlexVolumeSource(in.FlexVolume, out.FlexVolume, s); err != nil {
 			return err
 		}
 	} else {
@@ -4978,11 +5067,11 @@ func autoconvert_v1_PersistentVolumeSource_To_api_PersistentVolumeSource(in *Per
 	return nil
 }
 
-func convert_v1_PersistentVolumeSource_To_api_PersistentVolumeSource(in *PersistentVolumeSource, out *api.PersistentVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_PersistentVolumeSource_To_api_PersistentVolumeSource(in, out, s)
+func Convert_v1_PersistentVolumeSource_To_api_PersistentVolumeSource(in *PersistentVolumeSource, out *api.PersistentVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_PersistentVolumeSource_To_api_PersistentVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_PersistentVolumeSpec_To_api_PersistentVolumeSpec(in *PersistentVolumeSpec, out *api.PersistentVolumeSpec, s conversion.Scope) error {
+func autoConvert_v1_PersistentVolumeSpec_To_api_PersistentVolumeSpec(in *PersistentVolumeSpec, out *api.PersistentVolumeSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PersistentVolumeSpec))(in)
 	}
@@ -4990,7 +5079,7 @@ func autoconvert_v1_PersistentVolumeSpec_To_api_PersistentVolumeSpec(in *Persist
 		out.Capacity = make(api.ResourceList)
 		for key, val := range in.Capacity {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.Capacity[api.ResourceName(key)] = newVal
@@ -4998,7 +5087,7 @@ func autoconvert_v1_PersistentVolumeSpec_To_api_PersistentVolumeSpec(in *Persist
 	} else {
 		out.Capacity = nil
 	}
-	if err := convert_v1_PersistentVolumeSource_To_api_PersistentVolumeSource(&in.PersistentVolumeSource, &out.PersistentVolumeSource, s); err != nil {
+	if err := Convert_v1_PersistentVolumeSource_To_api_PersistentVolumeSource(&in.PersistentVolumeSource, &out.PersistentVolumeSource, s); err != nil {
 		return err
 	}
 	if in.AccessModes != nil {
@@ -5009,9 +5098,10 @@ func autoconvert_v1_PersistentVolumeSpec_To_api_PersistentVolumeSpec(in *Persist
 	} else {
 		out.AccessModes = nil
 	}
+	// unable to generate simple pointer conversion for v1.ObjectReference -> api.ObjectReference
 	if in.ClaimRef != nil {
 		out.ClaimRef = new(api.ObjectReference)
-		if err := convert_v1_ObjectReference_To_api_ObjectReference(in.ClaimRef, out.ClaimRef, s); err != nil {
+		if err := Convert_v1_ObjectReference_To_api_ObjectReference(in.ClaimRef, out.ClaimRef, s); err != nil {
 			return err
 		}
 	} else {
@@ -5021,11 +5111,11 @@ func autoconvert_v1_PersistentVolumeSpec_To_api_PersistentVolumeSpec(in *Persist
 	return nil
 }
 
-func convert_v1_PersistentVolumeSpec_To_api_PersistentVolumeSpec(in *PersistentVolumeSpec, out *api.PersistentVolumeSpec, s conversion.Scope) error {
-	return autoconvert_v1_PersistentVolumeSpec_To_api_PersistentVolumeSpec(in, out, s)
+func Convert_v1_PersistentVolumeSpec_To_api_PersistentVolumeSpec(in *PersistentVolumeSpec, out *api.PersistentVolumeSpec, s conversion.Scope) error {
+	return autoConvert_v1_PersistentVolumeSpec_To_api_PersistentVolumeSpec(in, out, s)
 }
 
-func autoconvert_v1_PersistentVolumeStatus_To_api_PersistentVolumeStatus(in *PersistentVolumeStatus, out *api.PersistentVolumeStatus, s conversion.Scope) error {
+func autoConvert_v1_PersistentVolumeStatus_To_api_PersistentVolumeStatus(in *PersistentVolumeStatus, out *api.PersistentVolumeStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PersistentVolumeStatus))(in)
 	}
@@ -5035,34 +5125,34 @@ func autoconvert_v1_PersistentVolumeStatus_To_api_PersistentVolumeStatus(in *Per
 	return nil
 }
 
-func convert_v1_PersistentVolumeStatus_To_api_PersistentVolumeStatus(in *PersistentVolumeStatus, out *api.PersistentVolumeStatus, s conversion.Scope) error {
-	return autoconvert_v1_PersistentVolumeStatus_To_api_PersistentVolumeStatus(in, out, s)
+func Convert_v1_PersistentVolumeStatus_To_api_PersistentVolumeStatus(in *PersistentVolumeStatus, out *api.PersistentVolumeStatus, s conversion.Scope) error {
+	return autoConvert_v1_PersistentVolumeStatus_To_api_PersistentVolumeStatus(in, out, s)
 }
 
-func autoconvert_v1_Pod_To_api_Pod(in *Pod, out *api.Pod, s conversion.Scope) error {
+func autoConvert_v1_Pod_To_api_Pod(in *Pod, out *api.Pod, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Pod))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_PodSpec_To_api_PodSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_v1_PodSpec_To_api_PodSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := convert_v1_PodStatus_To_api_PodStatus(&in.Status, &out.Status, s); err != nil {
+	if err := Convert_v1_PodStatus_To_api_PodStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func autoconvert_v1_PodAttachOptions_To_api_PodAttachOptions(in *PodAttachOptions, out *api.PodAttachOptions, s conversion.Scope) error {
+func autoConvert_v1_PodAttachOptions_To_api_PodAttachOptions(in *PodAttachOptions, out *api.PodAttachOptions, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PodAttachOptions))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
 	out.Stdin = in.Stdin
@@ -5073,20 +5163,20 @@ func autoconvert_v1_PodAttachOptions_To_api_PodAttachOptions(in *PodAttachOption
 	return nil
 }
 
-func convert_v1_PodAttachOptions_To_api_PodAttachOptions(in *PodAttachOptions, out *api.PodAttachOptions, s conversion.Scope) error {
-	return autoconvert_v1_PodAttachOptions_To_api_PodAttachOptions(in, out, s)
+func Convert_v1_PodAttachOptions_To_api_PodAttachOptions(in *PodAttachOptions, out *api.PodAttachOptions, s conversion.Scope) error {
+	return autoConvert_v1_PodAttachOptions_To_api_PodAttachOptions(in, out, s)
 }
 
-func autoconvert_v1_PodCondition_To_api_PodCondition(in *PodCondition, out *api.PodCondition, s conversion.Scope) error {
+func autoConvert_v1_PodCondition_To_api_PodCondition(in *PodCondition, out *api.PodCondition, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PodCondition))(in)
 	}
 	out.Type = api.PodConditionType(in.Type)
 	out.Status = api.ConditionStatus(in.Status)
-	if err := s.Convert(&in.LastProbeTime, &out.LastProbeTime, 0); err != nil {
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.LastProbeTime, &out.LastProbeTime, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.LastTransitionTime, &out.LastTransitionTime, 0); err != nil {
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.LastTransitionTime, &out.LastTransitionTime, s); err != nil {
 		return err
 	}
 	out.Reason = in.Reason
@@ -5094,15 +5184,15 @@ func autoconvert_v1_PodCondition_To_api_PodCondition(in *PodCondition, out *api.
 	return nil
 }
 
-func convert_v1_PodCondition_To_api_PodCondition(in *PodCondition, out *api.PodCondition, s conversion.Scope) error {
-	return autoconvert_v1_PodCondition_To_api_PodCondition(in, out, s)
+func Convert_v1_PodCondition_To_api_PodCondition(in *PodCondition, out *api.PodCondition, s conversion.Scope) error {
+	return autoConvert_v1_PodCondition_To_api_PodCondition(in, out, s)
 }
 
-func autoconvert_v1_PodExecOptions_To_api_PodExecOptions(in *PodExecOptions, out *api.PodExecOptions, s conversion.Scope) error {
+func autoConvert_v1_PodExecOptions_To_api_PodExecOptions(in *PodExecOptions, out *api.PodExecOptions, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PodExecOptions))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
 	out.Stdin = in.Stdin
@@ -5121,24 +5211,24 @@ func autoconvert_v1_PodExecOptions_To_api_PodExecOptions(in *PodExecOptions, out
 	return nil
 }
 
-func convert_v1_PodExecOptions_To_api_PodExecOptions(in *PodExecOptions, out *api.PodExecOptions, s conversion.Scope) error {
-	return autoconvert_v1_PodExecOptions_To_api_PodExecOptions(in, out, s)
+func Convert_v1_PodExecOptions_To_api_PodExecOptions(in *PodExecOptions, out *api.PodExecOptions, s conversion.Scope) error {
+	return autoConvert_v1_PodExecOptions_To_api_PodExecOptions(in, out, s)
 }
 
-func autoconvert_v1_PodList_To_api_PodList(in *PodList, out *api.PodList, s conversion.Scope) error {
+func autoConvert_v1_PodList_To_api_PodList(in *PodList, out *api.PodList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PodList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]api.Pod, len(in.Items))
 		for i := range in.Items {
-			if err := convert_v1_Pod_To_api_Pod(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_v1_Pod_To_api_Pod(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -5148,15 +5238,15 @@ func autoconvert_v1_PodList_To_api_PodList(in *PodList, out *api.PodList, s conv
 	return nil
 }
 
-func convert_v1_PodList_To_api_PodList(in *PodList, out *api.PodList, s conversion.Scope) error {
-	return autoconvert_v1_PodList_To_api_PodList(in, out, s)
+func Convert_v1_PodList_To_api_PodList(in *PodList, out *api.PodList, s conversion.Scope) error {
+	return autoConvert_v1_PodList_To_api_PodList(in, out, s)
 }
 
-func autoconvert_v1_PodLogOptions_To_api_PodLogOptions(in *PodLogOptions, out *api.PodLogOptions, s conversion.Scope) error {
+func autoConvert_v1_PodLogOptions_To_api_PodLogOptions(in *PodLogOptions, out *api.PodLogOptions, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PodLogOptions))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
 	out.Container = in.Container
@@ -5168,8 +5258,10 @@ func autoconvert_v1_PodLogOptions_To_api_PodLogOptions(in *PodLogOptions, out *a
 	} else {
 		out.SinceSeconds = nil
 	}
+	// unable to generate simple pointer conversion for unversioned.Time -> unversioned.Time
 	if in.SinceTime != nil {
-		if err := s.Convert(&in.SinceTime, &out.SinceTime, 0); err != nil {
+		out.SinceTime = new(unversioned.Time)
+		if err := api.Convert_unversioned_Time_To_unversioned_Time(in.SinceTime, out.SinceTime, s); err != nil {
 			return err
 		}
 	} else {
@@ -5191,33 +5283,33 @@ func autoconvert_v1_PodLogOptions_To_api_PodLogOptions(in *PodLogOptions, out *a
 	return nil
 }
 
-func convert_v1_PodLogOptions_To_api_PodLogOptions(in *PodLogOptions, out *api.PodLogOptions, s conversion.Scope) error {
-	return autoconvert_v1_PodLogOptions_To_api_PodLogOptions(in, out, s)
+func Convert_v1_PodLogOptions_To_api_PodLogOptions(in *PodLogOptions, out *api.PodLogOptions, s conversion.Scope) error {
+	return autoConvert_v1_PodLogOptions_To_api_PodLogOptions(in, out, s)
 }
 
-func autoconvert_v1_PodProxyOptions_To_api_PodProxyOptions(in *PodProxyOptions, out *api.PodProxyOptions, s conversion.Scope) error {
+func autoConvert_v1_PodProxyOptions_To_api_PodProxyOptions(in *PodProxyOptions, out *api.PodProxyOptions, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PodProxyOptions))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
 	out.Path = in.Path
 	return nil
 }
 
-func convert_v1_PodProxyOptions_To_api_PodProxyOptions(in *PodProxyOptions, out *api.PodProxyOptions, s conversion.Scope) error {
-	return autoconvert_v1_PodProxyOptions_To_api_PodProxyOptions(in, out, s)
+func Convert_v1_PodProxyOptions_To_api_PodProxyOptions(in *PodProxyOptions, out *api.PodProxyOptions, s conversion.Scope) error {
+	return autoConvert_v1_PodProxyOptions_To_api_PodProxyOptions(in, out, s)
 }
 
-func autoconvert_v1_PodSpec_To_api_PodSpec(in *PodSpec, out *api.PodSpec, s conversion.Scope) error {
+func autoConvert_v1_PodSpec_To_api_PodSpec(in *PodSpec, out *api.PodSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PodSpec))(in)
 	}
 	if in.Volumes != nil {
 		out.Volumes = make([]api.Volume, len(in.Volumes))
 		for i := range in.Volumes {
-			if err := convert_v1_Volume_To_api_Volume(&in.Volumes[i], &out.Volumes[i], s); err != nil {
+			if err := Convert_v1_Volume_To_api_Volume(&in.Volumes[i], &out.Volumes[i], s); err != nil {
 				return err
 			}
 		}
@@ -5227,7 +5319,7 @@ func autoconvert_v1_PodSpec_To_api_PodSpec(in *PodSpec, out *api.PodSpec, s conv
 	if in.Containers != nil {
 		out.Containers = make([]api.Container, len(in.Containers))
 		for i := range in.Containers {
-			if err := convert_v1_Container_To_api_Container(&in.Containers[i], &out.Containers[i], s); err != nil {
+			if err := Convert_v1_Container_To_api_Container(&in.Containers[i], &out.Containers[i], s); err != nil {
 				return err
 			}
 		}
@@ -5262,6 +5354,7 @@ func autoconvert_v1_PodSpec_To_api_PodSpec(in *PodSpec, out *api.PodSpec, s conv
 	// in.HostNetwork has no peer in out
 	// in.HostPID has no peer in out
 	// in.HostIPC has no peer in out
+	// unable to generate simple pointer conversion for v1.PodSecurityContext -> api.PodSecurityContext
 	if in.SecurityContext != nil {
 		if err := s.Convert(&in.SecurityContext, &out.SecurityContext, 0); err != nil {
 			return err
@@ -5272,7 +5365,7 @@ func autoconvert_v1_PodSpec_To_api_PodSpec(in *PodSpec, out *api.PodSpec, s conv
 	if in.ImagePullSecrets != nil {
 		out.ImagePullSecrets = make([]api.LocalObjectReference, len(in.ImagePullSecrets))
 		for i := range in.ImagePullSecrets {
-			if err := convert_v1_LocalObjectReference_To_api_LocalObjectReference(&in.ImagePullSecrets[i], &out.ImagePullSecrets[i], s); err != nil {
+			if err := Convert_v1_LocalObjectReference_To_api_LocalObjectReference(&in.ImagePullSecrets[i], &out.ImagePullSecrets[i], s); err != nil {
 				return err
 			}
 		}
@@ -5282,7 +5375,7 @@ func autoconvert_v1_PodSpec_To_api_PodSpec(in *PodSpec, out *api.PodSpec, s conv
 	return nil
 }
 
-func autoconvert_v1_PodStatus_To_api_PodStatus(in *PodStatus, out *api.PodStatus, s conversion.Scope) error {
+func autoConvert_v1_PodStatus_To_api_PodStatus(in *PodStatus, out *api.PodStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PodStatus))(in)
 	}
@@ -5290,7 +5383,7 @@ func autoconvert_v1_PodStatus_To_api_PodStatus(in *PodStatus, out *api.PodStatus
 	if in.Conditions != nil {
 		out.Conditions = make([]api.PodCondition, len(in.Conditions))
 		for i := range in.Conditions {
-			if err := convert_v1_PodCondition_To_api_PodCondition(&in.Conditions[i], &out.Conditions[i], s); err != nil {
+			if err := Convert_v1_PodCondition_To_api_PodCondition(&in.Conditions[i], &out.Conditions[i], s); err != nil {
 				return err
 			}
 		}
@@ -5301,8 +5394,10 @@ func autoconvert_v1_PodStatus_To_api_PodStatus(in *PodStatus, out *api.PodStatus
 	out.Reason = in.Reason
 	out.HostIP = in.HostIP
 	out.PodIP = in.PodIP
+	// unable to generate simple pointer conversion for unversioned.Time -> unversioned.Time
 	if in.StartTime != nil {
-		if err := s.Convert(&in.StartTime, &out.StartTime, 0); err != nil {
+		out.StartTime = new(unversioned.Time)
+		if err := api.Convert_unversioned_Time_To_unversioned_Time(in.StartTime, out.StartTime, s); err != nil {
 			return err
 		}
 	} else {
@@ -5311,7 +5406,7 @@ func autoconvert_v1_PodStatus_To_api_PodStatus(in *PodStatus, out *api.PodStatus
 	if in.ContainerStatuses != nil {
 		out.ContainerStatuses = make([]api.ContainerStatus, len(in.ContainerStatuses))
 		for i := range in.ContainerStatuses {
-			if err := convert_v1_ContainerStatus_To_api_ContainerStatus(&in.ContainerStatuses[i], &out.ContainerStatuses[i], s); err != nil {
+			if err := Convert_v1_ContainerStatus_To_api_ContainerStatus(&in.ContainerStatuses[i], &out.ContainerStatuses[i], s); err != nil {
 				return err
 			}
 		}
@@ -5321,64 +5416,64 @@ func autoconvert_v1_PodStatus_To_api_PodStatus(in *PodStatus, out *api.PodStatus
 	return nil
 }
 
-func convert_v1_PodStatus_To_api_PodStatus(in *PodStatus, out *api.PodStatus, s conversion.Scope) error {
-	return autoconvert_v1_PodStatus_To_api_PodStatus(in, out, s)
+func Convert_v1_PodStatus_To_api_PodStatus(in *PodStatus, out *api.PodStatus, s conversion.Scope) error {
+	return autoConvert_v1_PodStatus_To_api_PodStatus(in, out, s)
 }
 
-func autoconvert_v1_PodStatusResult_To_api_PodStatusResult(in *PodStatusResult, out *api.PodStatusResult, s conversion.Scope) error {
+func autoConvert_v1_PodStatusResult_To_api_PodStatusResult(in *PodStatusResult, out *api.PodStatusResult, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PodStatusResult))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_PodStatus_To_api_PodStatus(&in.Status, &out.Status, s); err != nil {
+	if err := Convert_v1_PodStatus_To_api_PodStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1_PodStatusResult_To_api_PodStatusResult(in *PodStatusResult, out *api.PodStatusResult, s conversion.Scope) error {
-	return autoconvert_v1_PodStatusResult_To_api_PodStatusResult(in, out, s)
+func Convert_v1_PodStatusResult_To_api_PodStatusResult(in *PodStatusResult, out *api.PodStatusResult, s conversion.Scope) error {
+	return autoConvert_v1_PodStatusResult_To_api_PodStatusResult(in, out, s)
 }
 
-func autoconvert_v1_PodTemplate_To_api_PodTemplate(in *PodTemplate, out *api.PodTemplate, s conversion.Scope) error {
+func autoConvert_v1_PodTemplate_To_api_PodTemplate(in *PodTemplate, out *api.PodTemplate, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PodTemplate))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
+	if err := Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1_PodTemplate_To_api_PodTemplate(in *PodTemplate, out *api.PodTemplate, s conversion.Scope) error {
-	return autoconvert_v1_PodTemplate_To_api_PodTemplate(in, out, s)
+func Convert_v1_PodTemplate_To_api_PodTemplate(in *PodTemplate, out *api.PodTemplate, s conversion.Scope) error {
+	return autoConvert_v1_PodTemplate_To_api_PodTemplate(in, out, s)
 }
 
-func autoconvert_v1_PodTemplateList_To_api_PodTemplateList(in *PodTemplateList, out *api.PodTemplateList, s conversion.Scope) error {
+func autoConvert_v1_PodTemplateList_To_api_PodTemplateList(in *PodTemplateList, out *api.PodTemplateList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PodTemplateList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]api.PodTemplate, len(in.Items))
 		for i := range in.Items {
-			if err := convert_v1_PodTemplate_To_api_PodTemplate(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_v1_PodTemplate_To_api_PodTemplate(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -5388,32 +5483,32 @@ func autoconvert_v1_PodTemplateList_To_api_PodTemplateList(in *PodTemplateList, 
 	return nil
 }
 
-func convert_v1_PodTemplateList_To_api_PodTemplateList(in *PodTemplateList, out *api.PodTemplateList, s conversion.Scope) error {
-	return autoconvert_v1_PodTemplateList_To_api_PodTemplateList(in, out, s)
+func Convert_v1_PodTemplateList_To_api_PodTemplateList(in *PodTemplateList, out *api.PodTemplateList, s conversion.Scope) error {
+	return autoConvert_v1_PodTemplateList_To_api_PodTemplateList(in, out, s)
 }
 
-func autoconvert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in *PodTemplateSpec, out *api.PodTemplateSpec, s conversion.Scope) error {
+func autoConvert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in *PodTemplateSpec, out *api.PodTemplateSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PodTemplateSpec))(in)
 	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_PodSpec_To_api_PodSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_v1_PodSpec_To_api_PodSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in *PodTemplateSpec, out *api.PodTemplateSpec, s conversion.Scope) error {
-	return autoconvert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in, out, s)
+func Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in *PodTemplateSpec, out *api.PodTemplateSpec, s conversion.Scope) error {
+	return autoConvert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in, out, s)
 }
 
-func autoconvert_v1_Probe_To_api_Probe(in *Probe, out *api.Probe, s conversion.Scope) error {
+func autoConvert_v1_Probe_To_api_Probe(in *Probe, out *api.Probe, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Probe))(in)
 	}
-	if err := convert_v1_Handler_To_api_Handler(&in.Handler, &out.Handler, s); err != nil {
+	if err := Convert_v1_Handler_To_api_Handler(&in.Handler, &out.Handler, s); err != nil {
 		return err
 	}
 	out.InitialDelaySeconds = int(in.InitialDelaySeconds)
@@ -5424,11 +5519,11 @@ func autoconvert_v1_Probe_To_api_Probe(in *Probe, out *api.Probe, s conversion.S
 	return nil
 }
 
-func convert_v1_Probe_To_api_Probe(in *Probe, out *api.Probe, s conversion.Scope) error {
-	return autoconvert_v1_Probe_To_api_Probe(in, out, s)
+func Convert_v1_Probe_To_api_Probe(in *Probe, out *api.Probe, s conversion.Scope) error {
+	return autoConvert_v1_Probe_To_api_Probe(in, out, s)
 }
 
-func autoconvert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in *RBDVolumeSource, out *api.RBDVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in *RBDVolumeSource, out *api.RBDVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*RBDVolumeSource))(in)
 	}
@@ -5445,9 +5540,10 @@ func autoconvert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in *RBDVolumeSource, 
 	out.RBDPool = in.RBDPool
 	out.RadosUser = in.RadosUser
 	out.Keyring = in.Keyring
+	// unable to generate simple pointer conversion for v1.LocalObjectReference -> api.LocalObjectReference
 	if in.SecretRef != nil {
 		out.SecretRef = new(api.LocalObjectReference)
-		if err := convert_v1_LocalObjectReference_To_api_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
+		if err := Convert_v1_LocalObjectReference_To_api_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
 			return err
 		}
 	} else {
@@ -5457,68 +5553,68 @@ func autoconvert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in *RBDVolumeSource, 
 	return nil
 }
 
-func convert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in *RBDVolumeSource, out *api.RBDVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in, out, s)
+func Convert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in *RBDVolumeSource, out *api.RBDVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_RangeAllocation_To_api_RangeAllocation(in *RangeAllocation, out *api.RangeAllocation, s conversion.Scope) error {
+func autoConvert_v1_RangeAllocation_To_api_RangeAllocation(in *RangeAllocation, out *api.RangeAllocation, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*RangeAllocation))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
 	out.Range = in.Range
-	if err := s.Convert(&in.Data, &out.Data, 0); err != nil {
+	if err := conversion.ByteSliceCopy(&in.Data, &out.Data, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1_RangeAllocation_To_api_RangeAllocation(in *RangeAllocation, out *api.RangeAllocation, s conversion.Scope) error {
-	return autoconvert_v1_RangeAllocation_To_api_RangeAllocation(in, out, s)
+func Convert_v1_RangeAllocation_To_api_RangeAllocation(in *RangeAllocation, out *api.RangeAllocation, s conversion.Scope) error {
+	return autoConvert_v1_RangeAllocation_To_api_RangeAllocation(in, out, s)
 }
 
-func autoconvert_v1_ReplicationController_To_api_ReplicationController(in *ReplicationController, out *api.ReplicationController, s conversion.Scope) error {
+func autoConvert_v1_ReplicationController_To_api_ReplicationController(in *ReplicationController, out *api.ReplicationController, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ReplicationController))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ReplicationControllerSpec_To_api_ReplicationControllerSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_v1_ReplicationControllerSpec_To_api_ReplicationControllerSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ReplicationControllerStatus_To_api_ReplicationControllerStatus(&in.Status, &out.Status, s); err != nil {
+	if err := Convert_v1_ReplicationControllerStatus_To_api_ReplicationControllerStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1_ReplicationController_To_api_ReplicationController(in *ReplicationController, out *api.ReplicationController, s conversion.Scope) error {
-	return autoconvert_v1_ReplicationController_To_api_ReplicationController(in, out, s)
+func Convert_v1_ReplicationController_To_api_ReplicationController(in *ReplicationController, out *api.ReplicationController, s conversion.Scope) error {
+	return autoConvert_v1_ReplicationController_To_api_ReplicationController(in, out, s)
 }
 
-func autoconvert_v1_ReplicationControllerList_To_api_ReplicationControllerList(in *ReplicationControllerList, out *api.ReplicationControllerList, s conversion.Scope) error {
+func autoConvert_v1_ReplicationControllerList_To_api_ReplicationControllerList(in *ReplicationControllerList, out *api.ReplicationControllerList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ReplicationControllerList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]api.ReplicationController, len(in.Items))
 		for i := range in.Items {
-			if err := convert_v1_ReplicationController_To_api_ReplicationController(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_v1_ReplicationController_To_api_ReplicationController(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -5528,11 +5624,11 @@ func autoconvert_v1_ReplicationControllerList_To_api_ReplicationControllerList(i
 	return nil
 }
 
-func convert_v1_ReplicationControllerList_To_api_ReplicationControllerList(in *ReplicationControllerList, out *api.ReplicationControllerList, s conversion.Scope) error {
-	return autoconvert_v1_ReplicationControllerList_To_api_ReplicationControllerList(in, out, s)
+func Convert_v1_ReplicationControllerList_To_api_ReplicationControllerList(in *ReplicationControllerList, out *api.ReplicationControllerList, s conversion.Scope) error {
+	return autoConvert_v1_ReplicationControllerList_To_api_ReplicationControllerList(in, out, s)
 }
 
-func autoconvert_v1_ReplicationControllerSpec_To_api_ReplicationControllerSpec(in *ReplicationControllerSpec, out *api.ReplicationControllerSpec, s conversion.Scope) error {
+func autoConvert_v1_ReplicationControllerSpec_To_api_ReplicationControllerSpec(in *ReplicationControllerSpec, out *api.ReplicationControllerSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ReplicationControllerSpec))(in)
 	}
@@ -5545,9 +5641,10 @@ func autoconvert_v1_ReplicationControllerSpec_To_api_ReplicationControllerSpec(i
 	} else {
 		out.Selector = nil
 	}
+	// unable to generate simple pointer conversion for v1.PodTemplateSpec -> api.PodTemplateSpec
 	if in.Template != nil {
 		out.Template = new(api.PodTemplateSpec)
-		if err := convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in.Template, out.Template, s); err != nil {
+		if err := Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in.Template, out.Template, s); err != nil {
 			return err
 		}
 	} else {
@@ -5556,7 +5653,7 @@ func autoconvert_v1_ReplicationControllerSpec_To_api_ReplicationControllerSpec(i
 	return nil
 }
 
-func autoconvert_v1_ReplicationControllerStatus_To_api_ReplicationControllerStatus(in *ReplicationControllerStatus, out *api.ReplicationControllerStatus, s conversion.Scope) error {
+func autoConvert_v1_ReplicationControllerStatus_To_api_ReplicationControllerStatus(in *ReplicationControllerStatus, out *api.ReplicationControllerStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ReplicationControllerStatus))(in)
 	}
@@ -5565,47 +5662,47 @@ func autoconvert_v1_ReplicationControllerStatus_To_api_ReplicationControllerStat
 	return nil
 }
 
-func convert_v1_ReplicationControllerStatus_To_api_ReplicationControllerStatus(in *ReplicationControllerStatus, out *api.ReplicationControllerStatus, s conversion.Scope) error {
-	return autoconvert_v1_ReplicationControllerStatus_To_api_ReplicationControllerStatus(in, out, s)
+func Convert_v1_ReplicationControllerStatus_To_api_ReplicationControllerStatus(in *ReplicationControllerStatus, out *api.ReplicationControllerStatus, s conversion.Scope) error {
+	return autoConvert_v1_ReplicationControllerStatus_To_api_ReplicationControllerStatus(in, out, s)
 }
 
-func autoconvert_v1_ResourceQuota_To_api_ResourceQuota(in *ResourceQuota, out *api.ResourceQuota, s conversion.Scope) error {
+func autoConvert_v1_ResourceQuota_To_api_ResourceQuota(in *ResourceQuota, out *api.ResourceQuota, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ResourceQuota))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ResourceQuotaSpec_To_api_ResourceQuotaSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_v1_ResourceQuotaSpec_To_api_ResourceQuotaSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ResourceQuotaStatus_To_api_ResourceQuotaStatus(&in.Status, &out.Status, s); err != nil {
+	if err := Convert_v1_ResourceQuotaStatus_To_api_ResourceQuotaStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1_ResourceQuota_To_api_ResourceQuota(in *ResourceQuota, out *api.ResourceQuota, s conversion.Scope) error {
-	return autoconvert_v1_ResourceQuota_To_api_ResourceQuota(in, out, s)
+func Convert_v1_ResourceQuota_To_api_ResourceQuota(in *ResourceQuota, out *api.ResourceQuota, s conversion.Scope) error {
+	return autoConvert_v1_ResourceQuota_To_api_ResourceQuota(in, out, s)
 }
 
-func autoconvert_v1_ResourceQuotaList_To_api_ResourceQuotaList(in *ResourceQuotaList, out *api.ResourceQuotaList, s conversion.Scope) error {
+func autoConvert_v1_ResourceQuotaList_To_api_ResourceQuotaList(in *ResourceQuotaList, out *api.ResourceQuotaList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ResourceQuotaList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]api.ResourceQuota, len(in.Items))
 		for i := range in.Items {
-			if err := convert_v1_ResourceQuota_To_api_ResourceQuota(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_v1_ResourceQuota_To_api_ResourceQuota(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -5615,11 +5712,11 @@ func autoconvert_v1_ResourceQuotaList_To_api_ResourceQuotaList(in *ResourceQuota
 	return nil
 }
 
-func convert_v1_ResourceQuotaList_To_api_ResourceQuotaList(in *ResourceQuotaList, out *api.ResourceQuotaList, s conversion.Scope) error {
-	return autoconvert_v1_ResourceQuotaList_To_api_ResourceQuotaList(in, out, s)
+func Convert_v1_ResourceQuotaList_To_api_ResourceQuotaList(in *ResourceQuotaList, out *api.ResourceQuotaList, s conversion.Scope) error {
+	return autoConvert_v1_ResourceQuotaList_To_api_ResourceQuotaList(in, out, s)
 }
 
-func autoconvert_v1_ResourceQuotaSpec_To_api_ResourceQuotaSpec(in *ResourceQuotaSpec, out *api.ResourceQuotaSpec, s conversion.Scope) error {
+func autoConvert_v1_ResourceQuotaSpec_To_api_ResourceQuotaSpec(in *ResourceQuotaSpec, out *api.ResourceQuotaSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ResourceQuotaSpec))(in)
 	}
@@ -5627,7 +5724,7 @@ func autoconvert_v1_ResourceQuotaSpec_To_api_ResourceQuotaSpec(in *ResourceQuota
 		out.Hard = make(api.ResourceList)
 		for key, val := range in.Hard {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.Hard[api.ResourceName(key)] = newVal
@@ -5638,11 +5735,11 @@ func autoconvert_v1_ResourceQuotaSpec_To_api_ResourceQuotaSpec(in *ResourceQuota
 	return nil
 }
 
-func convert_v1_ResourceQuotaSpec_To_api_ResourceQuotaSpec(in *ResourceQuotaSpec, out *api.ResourceQuotaSpec, s conversion.Scope) error {
-	return autoconvert_v1_ResourceQuotaSpec_To_api_ResourceQuotaSpec(in, out, s)
+func Convert_v1_ResourceQuotaSpec_To_api_ResourceQuotaSpec(in *ResourceQuotaSpec, out *api.ResourceQuotaSpec, s conversion.Scope) error {
+	return autoConvert_v1_ResourceQuotaSpec_To_api_ResourceQuotaSpec(in, out, s)
 }
 
-func autoconvert_v1_ResourceQuotaStatus_To_api_ResourceQuotaStatus(in *ResourceQuotaStatus, out *api.ResourceQuotaStatus, s conversion.Scope) error {
+func autoConvert_v1_ResourceQuotaStatus_To_api_ResourceQuotaStatus(in *ResourceQuotaStatus, out *api.ResourceQuotaStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ResourceQuotaStatus))(in)
 	}
@@ -5650,7 +5747,7 @@ func autoconvert_v1_ResourceQuotaStatus_To_api_ResourceQuotaStatus(in *ResourceQ
 		out.Hard = make(api.ResourceList)
 		for key, val := range in.Hard {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.Hard[api.ResourceName(key)] = newVal
@@ -5662,7 +5759,7 @@ func autoconvert_v1_ResourceQuotaStatus_To_api_ResourceQuotaStatus(in *ResourceQ
 		out.Used = make(api.ResourceList)
 		for key, val := range in.Used {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.Used[api.ResourceName(key)] = newVal
@@ -5673,11 +5770,11 @@ func autoconvert_v1_ResourceQuotaStatus_To_api_ResourceQuotaStatus(in *ResourceQ
 	return nil
 }
 
-func convert_v1_ResourceQuotaStatus_To_api_ResourceQuotaStatus(in *ResourceQuotaStatus, out *api.ResourceQuotaStatus, s conversion.Scope) error {
-	return autoconvert_v1_ResourceQuotaStatus_To_api_ResourceQuotaStatus(in, out, s)
+func Convert_v1_ResourceQuotaStatus_To_api_ResourceQuotaStatus(in *ResourceQuotaStatus, out *api.ResourceQuotaStatus, s conversion.Scope) error {
+	return autoConvert_v1_ResourceQuotaStatus_To_api_ResourceQuotaStatus(in, out, s)
 }
 
-func autoconvert_v1_ResourceRequirements_To_api_ResourceRequirements(in *ResourceRequirements, out *api.ResourceRequirements, s conversion.Scope) error {
+func autoConvert_v1_ResourceRequirements_To_api_ResourceRequirements(in *ResourceRequirements, out *api.ResourceRequirements, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ResourceRequirements))(in)
 	}
@@ -5685,7 +5782,7 @@ func autoconvert_v1_ResourceRequirements_To_api_ResourceRequirements(in *Resourc
 		out.Limits = make(api.ResourceList)
 		for key, val := range in.Limits {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.Limits[api.ResourceName(key)] = newVal
@@ -5697,7 +5794,7 @@ func autoconvert_v1_ResourceRequirements_To_api_ResourceRequirements(in *Resourc
 		out.Requests = make(api.ResourceList)
 		for key, val := range in.Requests {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.Requests[api.ResourceName(key)] = newVal
@@ -5708,11 +5805,11 @@ func autoconvert_v1_ResourceRequirements_To_api_ResourceRequirements(in *Resourc
 	return nil
 }
 
-func convert_v1_ResourceRequirements_To_api_ResourceRequirements(in *ResourceRequirements, out *api.ResourceRequirements, s conversion.Scope) error {
-	return autoconvert_v1_ResourceRequirements_To_api_ResourceRequirements(in, out, s)
+func Convert_v1_ResourceRequirements_To_api_ResourceRequirements(in *ResourceRequirements, out *api.ResourceRequirements, s conversion.Scope) error {
+	return autoConvert_v1_ResourceRequirements_To_api_ResourceRequirements(in, out, s)
 }
 
-func autoconvert_v1_SELinuxOptions_To_api_SELinuxOptions(in *SELinuxOptions, out *api.SELinuxOptions, s conversion.Scope) error {
+func autoConvert_v1_SELinuxOptions_To_api_SELinuxOptions(in *SELinuxOptions, out *api.SELinuxOptions, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*SELinuxOptions))(in)
 	}
@@ -5723,25 +5820,25 @@ func autoconvert_v1_SELinuxOptions_To_api_SELinuxOptions(in *SELinuxOptions, out
 	return nil
 }
 
-func convert_v1_SELinuxOptions_To_api_SELinuxOptions(in *SELinuxOptions, out *api.SELinuxOptions, s conversion.Scope) error {
-	return autoconvert_v1_SELinuxOptions_To_api_SELinuxOptions(in, out, s)
+func Convert_v1_SELinuxOptions_To_api_SELinuxOptions(in *SELinuxOptions, out *api.SELinuxOptions, s conversion.Scope) error {
+	return autoConvert_v1_SELinuxOptions_To_api_SELinuxOptions(in, out, s)
 }
 
-func autoconvert_v1_Secret_To_api_Secret(in *Secret, out *api.Secret, s conversion.Scope) error {
+func autoConvert_v1_Secret_To_api_Secret(in *Secret, out *api.Secret, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Secret))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
 	if in.Data != nil {
 		out.Data = make(map[string][]uint8)
 		for key, val := range in.Data {
 			newVal := []uint8{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := conversion.ByteSliceCopy(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.Data[key] = newVal
@@ -5753,24 +5850,24 @@ func autoconvert_v1_Secret_To_api_Secret(in *Secret, out *api.Secret, s conversi
 	return nil
 }
 
-func convert_v1_Secret_To_api_Secret(in *Secret, out *api.Secret, s conversion.Scope) error {
-	return autoconvert_v1_Secret_To_api_Secret(in, out, s)
+func Convert_v1_Secret_To_api_Secret(in *Secret, out *api.Secret, s conversion.Scope) error {
+	return autoConvert_v1_Secret_To_api_Secret(in, out, s)
 }
 
-func autoconvert_v1_SecretList_To_api_SecretList(in *SecretList, out *api.SecretList, s conversion.Scope) error {
+func autoConvert_v1_SecretList_To_api_SecretList(in *SecretList, out *api.SecretList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*SecretList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]api.Secret, len(in.Items))
 		for i := range in.Items {
-			if err := convert_v1_Secret_To_api_Secret(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_v1_Secret_To_api_Secret(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -5780,11 +5877,11 @@ func autoconvert_v1_SecretList_To_api_SecretList(in *SecretList, out *api.Secret
 	return nil
 }
 
-func convert_v1_SecretList_To_api_SecretList(in *SecretList, out *api.SecretList, s conversion.Scope) error {
-	return autoconvert_v1_SecretList_To_api_SecretList(in, out, s)
+func Convert_v1_SecretList_To_api_SecretList(in *SecretList, out *api.SecretList, s conversion.Scope) error {
+	return autoConvert_v1_SecretList_To_api_SecretList(in, out, s)
 }
 
-func autoconvert_v1_SecretVolumeSource_To_api_SecretVolumeSource(in *SecretVolumeSource, out *api.SecretVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_SecretVolumeSource_To_api_SecretVolumeSource(in *SecretVolumeSource, out *api.SecretVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*SecretVolumeSource))(in)
 	}
@@ -5792,17 +5889,18 @@ func autoconvert_v1_SecretVolumeSource_To_api_SecretVolumeSource(in *SecretVolum
 	return nil
 }
 
-func convert_v1_SecretVolumeSource_To_api_SecretVolumeSource(in *SecretVolumeSource, out *api.SecretVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_SecretVolumeSource_To_api_SecretVolumeSource(in, out, s)
+func Convert_v1_SecretVolumeSource_To_api_SecretVolumeSource(in *SecretVolumeSource, out *api.SecretVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_SecretVolumeSource_To_api_SecretVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_SecurityContext_To_api_SecurityContext(in *SecurityContext, out *api.SecurityContext, s conversion.Scope) error {
+func autoConvert_v1_SecurityContext_To_api_SecurityContext(in *SecurityContext, out *api.SecurityContext, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*SecurityContext))(in)
 	}
+	// unable to generate simple pointer conversion for v1.Capabilities -> api.Capabilities
 	if in.Capabilities != nil {
 		out.Capabilities = new(api.Capabilities)
-		if err := convert_v1_Capabilities_To_api_Capabilities(in.Capabilities, out.Capabilities, s); err != nil {
+		if err := Convert_v1_Capabilities_To_api_Capabilities(in.Capabilities, out.Capabilities, s); err != nil {
 			return err
 		}
 	} else {
@@ -5814,9 +5912,10 @@ func autoconvert_v1_SecurityContext_To_api_SecurityContext(in *SecurityContext, 
 	} else {
 		out.Privileged = nil
 	}
+	// unable to generate simple pointer conversion for v1.SELinuxOptions -> api.SELinuxOptions
 	if in.SELinuxOptions != nil {
 		out.SELinuxOptions = new(api.SELinuxOptions)
-		if err := convert_v1_SELinuxOptions_To_api_SELinuxOptions(in.SELinuxOptions, out.SELinuxOptions, s); err != nil {
+		if err := Convert_v1_SELinuxOptions_To_api_SELinuxOptions(in.SELinuxOptions, out.SELinuxOptions, s); err != nil {
 			return err
 		}
 	} else {
@@ -5837,64 +5936,64 @@ func autoconvert_v1_SecurityContext_To_api_SecurityContext(in *SecurityContext, 
 	return nil
 }
 
-func convert_v1_SecurityContext_To_api_SecurityContext(in *SecurityContext, out *api.SecurityContext, s conversion.Scope) error {
-	return autoconvert_v1_SecurityContext_To_api_SecurityContext(in, out, s)
+func Convert_v1_SecurityContext_To_api_SecurityContext(in *SecurityContext, out *api.SecurityContext, s conversion.Scope) error {
+	return autoConvert_v1_SecurityContext_To_api_SecurityContext(in, out, s)
 }
 
-func autoconvert_v1_SerializedReference_To_api_SerializedReference(in *SerializedReference, out *api.SerializedReference, s conversion.Scope) error {
+func autoConvert_v1_SerializedReference_To_api_SerializedReference(in *SerializedReference, out *api.SerializedReference, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*SerializedReference))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ObjectReference_To_api_ObjectReference(&in.Reference, &out.Reference, s); err != nil {
+	if err := Convert_v1_ObjectReference_To_api_ObjectReference(&in.Reference, &out.Reference, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1_SerializedReference_To_api_SerializedReference(in *SerializedReference, out *api.SerializedReference, s conversion.Scope) error {
-	return autoconvert_v1_SerializedReference_To_api_SerializedReference(in, out, s)
+func Convert_v1_SerializedReference_To_api_SerializedReference(in *SerializedReference, out *api.SerializedReference, s conversion.Scope) error {
+	return autoConvert_v1_SerializedReference_To_api_SerializedReference(in, out, s)
 }
 
-func autoconvert_v1_Service_To_api_Service(in *Service, out *api.Service, s conversion.Scope) error {
+func autoConvert_v1_Service_To_api_Service(in *Service, out *api.Service, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Service))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ServiceSpec_To_api_ServiceSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_v1_ServiceSpec_To_api_ServiceSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ServiceStatus_To_api_ServiceStatus(&in.Status, &out.Status, s); err != nil {
+	if err := Convert_v1_ServiceStatus_To_api_ServiceStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1_Service_To_api_Service(in *Service, out *api.Service, s conversion.Scope) error {
-	return autoconvert_v1_Service_To_api_Service(in, out, s)
+func Convert_v1_Service_To_api_Service(in *Service, out *api.Service, s conversion.Scope) error {
+	return autoConvert_v1_Service_To_api_Service(in, out, s)
 }
 
-func autoconvert_v1_ServiceAccount_To_api_ServiceAccount(in *ServiceAccount, out *api.ServiceAccount, s conversion.Scope) error {
+func autoConvert_v1_ServiceAccount_To_api_ServiceAccount(in *ServiceAccount, out *api.ServiceAccount, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ServiceAccount))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
 	if in.Secrets != nil {
 		out.Secrets = make([]api.ObjectReference, len(in.Secrets))
 		for i := range in.Secrets {
-			if err := convert_v1_ObjectReference_To_api_ObjectReference(&in.Secrets[i], &out.Secrets[i], s); err != nil {
+			if err := Convert_v1_ObjectReference_To_api_ObjectReference(&in.Secrets[i], &out.Secrets[i], s); err != nil {
 				return err
 			}
 		}
@@ -5904,7 +6003,7 @@ func autoconvert_v1_ServiceAccount_To_api_ServiceAccount(in *ServiceAccount, out
 	if in.ImagePullSecrets != nil {
 		out.ImagePullSecrets = make([]api.LocalObjectReference, len(in.ImagePullSecrets))
 		for i := range in.ImagePullSecrets {
-			if err := convert_v1_LocalObjectReference_To_api_LocalObjectReference(&in.ImagePullSecrets[i], &out.ImagePullSecrets[i], s); err != nil {
+			if err := Convert_v1_LocalObjectReference_To_api_LocalObjectReference(&in.ImagePullSecrets[i], &out.ImagePullSecrets[i], s); err != nil {
 				return err
 			}
 		}
@@ -5914,24 +6013,24 @@ func autoconvert_v1_ServiceAccount_To_api_ServiceAccount(in *ServiceAccount, out
 	return nil
 }
 
-func convert_v1_ServiceAccount_To_api_ServiceAccount(in *ServiceAccount, out *api.ServiceAccount, s conversion.Scope) error {
-	return autoconvert_v1_ServiceAccount_To_api_ServiceAccount(in, out, s)
+func Convert_v1_ServiceAccount_To_api_ServiceAccount(in *ServiceAccount, out *api.ServiceAccount, s conversion.Scope) error {
+	return autoConvert_v1_ServiceAccount_To_api_ServiceAccount(in, out, s)
 }
 
-func autoconvert_v1_ServiceAccountList_To_api_ServiceAccountList(in *ServiceAccountList, out *api.ServiceAccountList, s conversion.Scope) error {
+func autoConvert_v1_ServiceAccountList_To_api_ServiceAccountList(in *ServiceAccountList, out *api.ServiceAccountList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ServiceAccountList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]api.ServiceAccount, len(in.Items))
 		for i := range in.Items {
-			if err := convert_v1_ServiceAccount_To_api_ServiceAccount(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_v1_ServiceAccount_To_api_ServiceAccount(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -5941,24 +6040,24 @@ func autoconvert_v1_ServiceAccountList_To_api_ServiceAccountList(in *ServiceAcco
 	return nil
 }
 
-func convert_v1_ServiceAccountList_To_api_ServiceAccountList(in *ServiceAccountList, out *api.ServiceAccountList, s conversion.Scope) error {
-	return autoconvert_v1_ServiceAccountList_To_api_ServiceAccountList(in, out, s)
+func Convert_v1_ServiceAccountList_To_api_ServiceAccountList(in *ServiceAccountList, out *api.ServiceAccountList, s conversion.Scope) error {
+	return autoConvert_v1_ServiceAccountList_To_api_ServiceAccountList(in, out, s)
 }
 
-func autoconvert_v1_ServiceList_To_api_ServiceList(in *ServiceList, out *api.ServiceList, s conversion.Scope) error {
+func autoConvert_v1_ServiceList_To_api_ServiceList(in *ServiceList, out *api.ServiceList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ServiceList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]api.Service, len(in.Items))
 		for i := range in.Items {
-			if err := convert_v1_Service_To_api_Service(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_v1_Service_To_api_Service(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -5968,36 +6067,36 @@ func autoconvert_v1_ServiceList_To_api_ServiceList(in *ServiceList, out *api.Ser
 	return nil
 }
 
-func convert_v1_ServiceList_To_api_ServiceList(in *ServiceList, out *api.ServiceList, s conversion.Scope) error {
-	return autoconvert_v1_ServiceList_To_api_ServiceList(in, out, s)
+func Convert_v1_ServiceList_To_api_ServiceList(in *ServiceList, out *api.ServiceList, s conversion.Scope) error {
+	return autoConvert_v1_ServiceList_To_api_ServiceList(in, out, s)
 }
 
-func autoconvert_v1_ServicePort_To_api_ServicePort(in *ServicePort, out *api.ServicePort, s conversion.Scope) error {
+func autoConvert_v1_ServicePort_To_api_ServicePort(in *ServicePort, out *api.ServicePort, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ServicePort))(in)
 	}
 	out.Name = in.Name
 	out.Protocol = api.Protocol(in.Protocol)
 	out.Port = int(in.Port)
-	if err := s.Convert(&in.TargetPort, &out.TargetPort, 0); err != nil {
+	if err := api.Convert_intstr_IntOrString_To_intstr_IntOrString(&in.TargetPort, &out.TargetPort, s); err != nil {
 		return err
 	}
 	out.NodePort = int(in.NodePort)
 	return nil
 }
 
-func convert_v1_ServicePort_To_api_ServicePort(in *ServicePort, out *api.ServicePort, s conversion.Scope) error {
-	return autoconvert_v1_ServicePort_To_api_ServicePort(in, out, s)
+func Convert_v1_ServicePort_To_api_ServicePort(in *ServicePort, out *api.ServicePort, s conversion.Scope) error {
+	return autoConvert_v1_ServicePort_To_api_ServicePort(in, out, s)
 }
 
-func autoconvert_v1_ServiceSpec_To_api_ServiceSpec(in *ServiceSpec, out *api.ServiceSpec, s conversion.Scope) error {
+func autoConvert_v1_ServiceSpec_To_api_ServiceSpec(in *ServiceSpec, out *api.ServiceSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ServiceSpec))(in)
 	}
 	if in.Ports != nil {
 		out.Ports = make([]api.ServicePort, len(in.Ports))
 		for i := range in.Ports {
-			if err := convert_v1_ServicePort_To_api_ServicePort(&in.Ports[i], &out.Ports[i], s); err != nil {
+			if err := Convert_v1_ServicePort_To_api_ServicePort(&in.Ports[i], &out.Ports[i], s); err != nil {
 				return err
 			}
 		}
@@ -6028,50 +6127,50 @@ func autoconvert_v1_ServiceSpec_To_api_ServiceSpec(in *ServiceSpec, out *api.Ser
 	return nil
 }
 
-func autoconvert_v1_ServiceStatus_To_api_ServiceStatus(in *ServiceStatus, out *api.ServiceStatus, s conversion.Scope) error {
+func autoConvert_v1_ServiceStatus_To_api_ServiceStatus(in *ServiceStatus, out *api.ServiceStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ServiceStatus))(in)
 	}
-	if err := convert_v1_LoadBalancerStatus_To_api_LoadBalancerStatus(&in.LoadBalancer, &out.LoadBalancer, s); err != nil {
+	if err := Convert_v1_LoadBalancerStatus_To_api_LoadBalancerStatus(&in.LoadBalancer, &out.LoadBalancer, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1_ServiceStatus_To_api_ServiceStatus(in *ServiceStatus, out *api.ServiceStatus, s conversion.Scope) error {
-	return autoconvert_v1_ServiceStatus_To_api_ServiceStatus(in, out, s)
+func Convert_v1_ServiceStatus_To_api_ServiceStatus(in *ServiceStatus, out *api.ServiceStatus, s conversion.Scope) error {
+	return autoConvert_v1_ServiceStatus_To_api_ServiceStatus(in, out, s)
 }
 
-func autoconvert_v1_TCPSocketAction_To_api_TCPSocketAction(in *TCPSocketAction, out *api.TCPSocketAction, s conversion.Scope) error {
+func autoConvert_v1_TCPSocketAction_To_api_TCPSocketAction(in *TCPSocketAction, out *api.TCPSocketAction, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*TCPSocketAction))(in)
 	}
-	if err := s.Convert(&in.Port, &out.Port, 0); err != nil {
+	if err := api.Convert_intstr_IntOrString_To_intstr_IntOrString(&in.Port, &out.Port, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1_TCPSocketAction_To_api_TCPSocketAction(in *TCPSocketAction, out *api.TCPSocketAction, s conversion.Scope) error {
-	return autoconvert_v1_TCPSocketAction_To_api_TCPSocketAction(in, out, s)
+func Convert_v1_TCPSocketAction_To_api_TCPSocketAction(in *TCPSocketAction, out *api.TCPSocketAction, s conversion.Scope) error {
+	return autoConvert_v1_TCPSocketAction_To_api_TCPSocketAction(in, out, s)
 }
 
-func autoconvert_v1_Volume_To_api_Volume(in *Volume, out *api.Volume, s conversion.Scope) error {
+func autoConvert_v1_Volume_To_api_Volume(in *Volume, out *api.Volume, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Volume))(in)
 	}
 	out.Name = in.Name
-	if err := convert_v1_VolumeSource_To_api_VolumeSource(&in.VolumeSource, &out.VolumeSource, s); err != nil {
+	if err := Convert_v1_VolumeSource_To_api_VolumeSource(&in.VolumeSource, &out.VolumeSource, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1_Volume_To_api_Volume(in *Volume, out *api.Volume, s conversion.Scope) error {
-	return autoconvert_v1_Volume_To_api_Volume(in, out, s)
+func Convert_v1_Volume_To_api_Volume(in *Volume, out *api.Volume, s conversion.Scope) error {
+	return autoConvert_v1_Volume_To_api_Volume(in, out, s)
 }
 
-func autoconvert_v1_VolumeMount_To_api_VolumeMount(in *VolumeMount, out *api.VolumeMount, s conversion.Scope) error {
+func autoConvert_v1_VolumeMount_To_api_VolumeMount(in *VolumeMount, out *api.VolumeMount, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*VolumeMount))(in)
 	}
@@ -6081,145 +6180,162 @@ func autoconvert_v1_VolumeMount_To_api_VolumeMount(in *VolumeMount, out *api.Vol
 	return nil
 }
 
-func convert_v1_VolumeMount_To_api_VolumeMount(in *VolumeMount, out *api.VolumeMount, s conversion.Scope) error {
-	return autoconvert_v1_VolumeMount_To_api_VolumeMount(in, out, s)
+func Convert_v1_VolumeMount_To_api_VolumeMount(in *VolumeMount, out *api.VolumeMount, s conversion.Scope) error {
+	return autoConvert_v1_VolumeMount_To_api_VolumeMount(in, out, s)
 }
 
-func autoconvert_v1_VolumeSource_To_api_VolumeSource(in *VolumeSource, out *api.VolumeSource, s conversion.Scope) error {
+func autoConvert_v1_VolumeSource_To_api_VolumeSource(in *VolumeSource, out *api.VolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*VolumeSource))(in)
 	}
+	// unable to generate simple pointer conversion for v1.HostPathVolumeSource -> api.HostPathVolumeSource
 	if in.HostPath != nil {
 		out.HostPath = new(api.HostPathVolumeSource)
-		if err := convert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource(in.HostPath, out.HostPath, s); err != nil {
+		if err := Convert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource(in.HostPath, out.HostPath, s); err != nil {
 			return err
 		}
 	} else {
 		out.HostPath = nil
 	}
+	// unable to generate simple pointer conversion for v1.EmptyDirVolumeSource -> api.EmptyDirVolumeSource
 	if in.EmptyDir != nil {
 		out.EmptyDir = new(api.EmptyDirVolumeSource)
-		if err := convert_v1_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource(in.EmptyDir, out.EmptyDir, s); err != nil {
+		if err := Convert_v1_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource(in.EmptyDir, out.EmptyDir, s); err != nil {
 			return err
 		}
 	} else {
 		out.EmptyDir = nil
 	}
+	// unable to generate simple pointer conversion for v1.GCEPersistentDiskVolumeSource -> api.GCEPersistentDiskVolumeSource
 	if in.GCEPersistentDisk != nil {
 		out.GCEPersistentDisk = new(api.GCEPersistentDiskVolumeSource)
-		if err := convert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource(in.GCEPersistentDisk, out.GCEPersistentDisk, s); err != nil {
+		if err := Convert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource(in.GCEPersistentDisk, out.GCEPersistentDisk, s); err != nil {
 			return err
 		}
 	} else {
 		out.GCEPersistentDisk = nil
 	}
+	// unable to generate simple pointer conversion for v1.AWSElasticBlockStoreVolumeSource -> api.AWSElasticBlockStoreVolumeSource
 	if in.AWSElasticBlockStore != nil {
 		out.AWSElasticBlockStore = new(api.AWSElasticBlockStoreVolumeSource)
-		if err := convert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource(in.AWSElasticBlockStore, out.AWSElasticBlockStore, s); err != nil {
+		if err := Convert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource(in.AWSElasticBlockStore, out.AWSElasticBlockStore, s); err != nil {
 			return err
 		}
 	} else {
 		out.AWSElasticBlockStore = nil
 	}
+	// unable to generate simple pointer conversion for v1.GitRepoVolumeSource -> api.GitRepoVolumeSource
 	if in.GitRepo != nil {
 		out.GitRepo = new(api.GitRepoVolumeSource)
-		if err := convert_v1_GitRepoVolumeSource_To_api_GitRepoVolumeSource(in.GitRepo, out.GitRepo, s); err != nil {
+		if err := Convert_v1_GitRepoVolumeSource_To_api_GitRepoVolumeSource(in.GitRepo, out.GitRepo, s); err != nil {
 			return err
 		}
 	} else {
 		out.GitRepo = nil
 	}
+	// unable to generate simple pointer conversion for v1.SecretVolumeSource -> api.SecretVolumeSource
 	if in.Secret != nil {
 		out.Secret = new(api.SecretVolumeSource)
-		if err := convert_v1_SecretVolumeSource_To_api_SecretVolumeSource(in.Secret, out.Secret, s); err != nil {
+		if err := Convert_v1_SecretVolumeSource_To_api_SecretVolumeSource(in.Secret, out.Secret, s); err != nil {
 			return err
 		}
 	} else {
 		out.Secret = nil
 	}
+	// unable to generate simple pointer conversion for v1.NFSVolumeSource -> api.NFSVolumeSource
 	if in.NFS != nil {
 		out.NFS = new(api.NFSVolumeSource)
-		if err := convert_v1_NFSVolumeSource_To_api_NFSVolumeSource(in.NFS, out.NFS, s); err != nil {
+		if err := Convert_v1_NFSVolumeSource_To_api_NFSVolumeSource(in.NFS, out.NFS, s); err != nil {
 			return err
 		}
 	} else {
 		out.NFS = nil
 	}
+	// unable to generate simple pointer conversion for v1.ISCSIVolumeSource -> api.ISCSIVolumeSource
 	if in.ISCSI != nil {
 		out.ISCSI = new(api.ISCSIVolumeSource)
-		if err := convert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource(in.ISCSI, out.ISCSI, s); err != nil {
+		if err := Convert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource(in.ISCSI, out.ISCSI, s); err != nil {
 			return err
 		}
 	} else {
 		out.ISCSI = nil
 	}
+	// unable to generate simple pointer conversion for v1.GlusterfsVolumeSource -> api.GlusterfsVolumeSource
 	if in.Glusterfs != nil {
 		out.Glusterfs = new(api.GlusterfsVolumeSource)
-		if err := convert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource(in.Glusterfs, out.Glusterfs, s); err != nil {
+		if err := Convert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource(in.Glusterfs, out.Glusterfs, s); err != nil {
 			return err
 		}
 	} else {
 		out.Glusterfs = nil
 	}
+	// unable to generate simple pointer conversion for v1.PersistentVolumeClaimVolumeSource -> api.PersistentVolumeClaimVolumeSource
 	if in.PersistentVolumeClaim != nil {
 		out.PersistentVolumeClaim = new(api.PersistentVolumeClaimVolumeSource)
-		if err := convert_v1_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeClaimVolumeSource(in.PersistentVolumeClaim, out.PersistentVolumeClaim, s); err != nil {
+		if err := Convert_v1_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeClaimVolumeSource(in.PersistentVolumeClaim, out.PersistentVolumeClaim, s); err != nil {
 			return err
 		}
 	} else {
 		out.PersistentVolumeClaim = nil
 	}
+	// unable to generate simple pointer conversion for v1.RBDVolumeSource -> api.RBDVolumeSource
 	if in.RBD != nil {
 		out.RBD = new(api.RBDVolumeSource)
-		if err := convert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in.RBD, out.RBD, s); err != nil {
+		if err := Convert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in.RBD, out.RBD, s); err != nil {
 			return err
 		}
 	} else {
 		out.RBD = nil
 	}
+	// unable to generate simple pointer conversion for v1.FlexVolumeSource -> api.FlexVolumeSource
 	if in.FlexVolume != nil {
 		out.FlexVolume = new(api.FlexVolumeSource)
-		if err := convert_v1_FlexVolumeSource_To_api_FlexVolumeSource(in.FlexVolume, out.FlexVolume, s); err != nil {
+		if err := Convert_v1_FlexVolumeSource_To_api_FlexVolumeSource(in.FlexVolume, out.FlexVolume, s); err != nil {
 			return err
 		}
 	} else {
 		out.FlexVolume = nil
 	}
+	// unable to generate simple pointer conversion for v1.CinderVolumeSource -> api.CinderVolumeSource
 	if in.Cinder != nil {
 		out.Cinder = new(api.CinderVolumeSource)
-		if err := convert_v1_CinderVolumeSource_To_api_CinderVolumeSource(in.Cinder, out.Cinder, s); err != nil {
+		if err := Convert_v1_CinderVolumeSource_To_api_CinderVolumeSource(in.Cinder, out.Cinder, s); err != nil {
 			return err
 		}
 	} else {
 		out.Cinder = nil
 	}
+	// unable to generate simple pointer conversion for v1.CephFSVolumeSource -> api.CephFSVolumeSource
 	if in.CephFS != nil {
 		out.CephFS = new(api.CephFSVolumeSource)
-		if err := convert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in.CephFS, out.CephFS, s); err != nil {
+		if err := Convert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in.CephFS, out.CephFS, s); err != nil {
 			return err
 		}
 	} else {
 		out.CephFS = nil
 	}
+	// unable to generate simple pointer conversion for v1.FlockerVolumeSource -> api.FlockerVolumeSource
 	if in.Flocker != nil {
 		out.Flocker = new(api.FlockerVolumeSource)
-		if err := convert_v1_FlockerVolumeSource_To_api_FlockerVolumeSource(in.Flocker, out.Flocker, s); err != nil {
+		if err := Convert_v1_FlockerVolumeSource_To_api_FlockerVolumeSource(in.Flocker, out.Flocker, s); err != nil {
 			return err
 		}
 	} else {
 		out.Flocker = nil
 	}
+	// unable to generate simple pointer conversion for v1.DownwardAPIVolumeSource -> api.DownwardAPIVolumeSource
 	if in.DownwardAPI != nil {
 		out.DownwardAPI = new(api.DownwardAPIVolumeSource)
-		if err := convert_v1_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource(in.DownwardAPI, out.DownwardAPI, s); err != nil {
+		if err := Convert_v1_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource(in.DownwardAPI, out.DownwardAPI, s); err != nil {
 			return err
 		}
 	} else {
 		out.DownwardAPI = nil
 	}
+	// unable to generate simple pointer conversion for v1.FCVolumeSource -> api.FCVolumeSource
 	if in.FC != nil {
 		out.FC = new(api.FCVolumeSource)
-		if err := convert_v1_FCVolumeSource_To_api_FCVolumeSource(in.FC, out.FC, s); err != nil {
+		if err := Convert_v1_FCVolumeSource_To_api_FCVolumeSource(in.FC, out.FC, s); err != nil {
 			return err
 		}
 	} else {
@@ -6228,252 +6344,252 @@ func autoconvert_v1_VolumeSource_To_api_VolumeSource(in *VolumeSource, out *api.
 	return nil
 }
 
-func convert_v1_VolumeSource_To_api_VolumeSource(in *VolumeSource, out *api.VolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_VolumeSource_To_api_VolumeSource(in, out, s)
+func Convert_v1_VolumeSource_To_api_VolumeSource(in *VolumeSource, out *api.VolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_VolumeSource_To_api_VolumeSource(in, out, s)
 }
 
 func init() {
 	err := api.Scheme.AddGeneratedConversionFuncs(
-		autoconvert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVolumeSource,
-		autoconvert_api_Binding_To_v1_Binding,
-		autoconvert_api_Capabilities_To_v1_Capabilities,
-		autoconvert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource,
-		autoconvert_api_CinderVolumeSource_To_v1_CinderVolumeSource,
-		autoconvert_api_ComponentCondition_To_v1_ComponentCondition,
-		autoconvert_api_ComponentStatusList_To_v1_ComponentStatusList,
-		autoconvert_api_ComponentStatus_To_v1_ComponentStatus,
-		autoconvert_api_ContainerPort_To_v1_ContainerPort,
-		autoconvert_api_ContainerStateRunning_To_v1_ContainerStateRunning,
-		autoconvert_api_ContainerStateTerminated_To_v1_ContainerStateTerminated,
-		autoconvert_api_ContainerStateWaiting_To_v1_ContainerStateWaiting,
-		autoconvert_api_ContainerState_To_v1_ContainerState,
-		autoconvert_api_ContainerStatus_To_v1_ContainerStatus,
-		autoconvert_api_Container_To_v1_Container,
-		autoconvert_api_DaemonEndpoint_To_v1_DaemonEndpoint,
-		autoconvert_api_DeleteOptions_To_v1_DeleteOptions,
-		autoconvert_api_DownwardAPIVolumeFile_To_v1_DownwardAPIVolumeFile,
-		autoconvert_api_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource,
-		autoconvert_api_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource,
-		autoconvert_api_EndpointAddress_To_v1_EndpointAddress,
-		autoconvert_api_EndpointPort_To_v1_EndpointPort,
-		autoconvert_api_EndpointSubset_To_v1_EndpointSubset,
-		autoconvert_api_EndpointsList_To_v1_EndpointsList,
-		autoconvert_api_Endpoints_To_v1_Endpoints,
-		autoconvert_api_EnvVarSource_To_v1_EnvVarSource,
-		autoconvert_api_EnvVar_To_v1_EnvVar,
-		autoconvert_api_EventList_To_v1_EventList,
-		autoconvert_api_EventSource_To_v1_EventSource,
-		autoconvert_api_Event_To_v1_Event,
-		autoconvert_api_ExecAction_To_v1_ExecAction,
-		autoconvert_api_FCVolumeSource_To_v1_FCVolumeSource,
-		autoconvert_api_FlexVolumeSource_To_v1_FlexVolumeSource,
-		autoconvert_api_FlockerVolumeSource_To_v1_FlockerVolumeSource,
-		autoconvert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSource,
-		autoconvert_api_GitRepoVolumeSource_To_v1_GitRepoVolumeSource,
-		autoconvert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource,
-		autoconvert_api_HTTPGetAction_To_v1_HTTPGetAction,
-		autoconvert_api_Handler_To_v1_Handler,
-		autoconvert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource,
-		autoconvert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource,
-		autoconvert_api_Lifecycle_To_v1_Lifecycle,
-		autoconvert_api_LimitRangeItem_To_v1_LimitRangeItem,
-		autoconvert_api_LimitRangeList_To_v1_LimitRangeList,
-		autoconvert_api_LimitRangeSpec_To_v1_LimitRangeSpec,
-		autoconvert_api_LimitRange_To_v1_LimitRange,
-		autoconvert_api_ListOptions_To_v1_ListOptions,
-		autoconvert_api_List_To_v1_List,
-		autoconvert_api_LoadBalancerIngress_To_v1_LoadBalancerIngress,
-		autoconvert_api_LoadBalancerStatus_To_v1_LoadBalancerStatus,
-		autoconvert_api_LocalObjectReference_To_v1_LocalObjectReference,
-		autoconvert_api_NFSVolumeSource_To_v1_NFSVolumeSource,
-		autoconvert_api_NamespaceList_To_v1_NamespaceList,
-		autoconvert_api_NamespaceSpec_To_v1_NamespaceSpec,
-		autoconvert_api_NamespaceStatus_To_v1_NamespaceStatus,
-		autoconvert_api_Namespace_To_v1_Namespace,
-		autoconvert_api_NodeAddress_To_v1_NodeAddress,
-		autoconvert_api_NodeCondition_To_v1_NodeCondition,
-		autoconvert_api_NodeDaemonEndpoints_To_v1_NodeDaemonEndpoints,
-		autoconvert_api_NodeList_To_v1_NodeList,
-		autoconvert_api_NodeSpec_To_v1_NodeSpec,
-		autoconvert_api_NodeStatus_To_v1_NodeStatus,
-		autoconvert_api_NodeSystemInfo_To_v1_NodeSystemInfo,
-		autoconvert_api_Node_To_v1_Node,
-		autoconvert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector,
-		autoconvert_api_ObjectMeta_To_v1_ObjectMeta,
-		autoconvert_api_ObjectReference_To_v1_ObjectReference,
-		autoconvert_api_PersistentVolumeClaimList_To_v1_PersistentVolumeClaimList,
-		autoconvert_api_PersistentVolumeClaimSpec_To_v1_PersistentVolumeClaimSpec,
-		autoconvert_api_PersistentVolumeClaimStatus_To_v1_PersistentVolumeClaimStatus,
-		autoconvert_api_PersistentVolumeClaimVolumeSource_To_v1_PersistentVolumeClaimVolumeSource,
-		autoconvert_api_PersistentVolumeClaim_To_v1_PersistentVolumeClaim,
-		autoconvert_api_PersistentVolumeList_To_v1_PersistentVolumeList,
-		autoconvert_api_PersistentVolumeSource_To_v1_PersistentVolumeSource,
-		autoconvert_api_PersistentVolumeSpec_To_v1_PersistentVolumeSpec,
-		autoconvert_api_PersistentVolumeStatus_To_v1_PersistentVolumeStatus,
-		autoconvert_api_PersistentVolume_To_v1_PersistentVolume,
-		autoconvert_api_PodAttachOptions_To_v1_PodAttachOptions,
-		autoconvert_api_PodCondition_To_v1_PodCondition,
-		autoconvert_api_PodExecOptions_To_v1_PodExecOptions,
-		autoconvert_api_PodList_To_v1_PodList,
-		autoconvert_api_PodLogOptions_To_v1_PodLogOptions,
-		autoconvert_api_PodProxyOptions_To_v1_PodProxyOptions,
-		autoconvert_api_PodSpec_To_v1_PodSpec,
-		autoconvert_api_PodStatusResult_To_v1_PodStatusResult,
-		autoconvert_api_PodStatus_To_v1_PodStatus,
-		autoconvert_api_PodTemplateList_To_v1_PodTemplateList,
-		autoconvert_api_PodTemplateSpec_To_v1_PodTemplateSpec,
-		autoconvert_api_PodTemplate_To_v1_PodTemplate,
-		autoconvert_api_Pod_To_v1_Pod,
-		autoconvert_api_Probe_To_v1_Probe,
-		autoconvert_api_RBDVolumeSource_To_v1_RBDVolumeSource,
-		autoconvert_api_RangeAllocation_To_v1_RangeAllocation,
-		autoconvert_api_ReplicationControllerList_To_v1_ReplicationControllerList,
-		autoconvert_api_ReplicationControllerSpec_To_v1_ReplicationControllerSpec,
-		autoconvert_api_ReplicationControllerStatus_To_v1_ReplicationControllerStatus,
-		autoconvert_api_ReplicationController_To_v1_ReplicationController,
-		autoconvert_api_ResourceQuotaList_To_v1_ResourceQuotaList,
-		autoconvert_api_ResourceQuotaSpec_To_v1_ResourceQuotaSpec,
-		autoconvert_api_ResourceQuotaStatus_To_v1_ResourceQuotaStatus,
-		autoconvert_api_ResourceQuota_To_v1_ResourceQuota,
-		autoconvert_api_ResourceRequirements_To_v1_ResourceRequirements,
-		autoconvert_api_SELinuxOptions_To_v1_SELinuxOptions,
-		autoconvert_api_SecretList_To_v1_SecretList,
-		autoconvert_api_SecretVolumeSource_To_v1_SecretVolumeSource,
-		autoconvert_api_Secret_To_v1_Secret,
-		autoconvert_api_SecurityContext_To_v1_SecurityContext,
-		autoconvert_api_SerializedReference_To_v1_SerializedReference,
-		autoconvert_api_ServiceAccountList_To_v1_ServiceAccountList,
-		autoconvert_api_ServiceAccount_To_v1_ServiceAccount,
-		autoconvert_api_ServiceList_To_v1_ServiceList,
-		autoconvert_api_ServicePort_To_v1_ServicePort,
-		autoconvert_api_ServiceSpec_To_v1_ServiceSpec,
-		autoconvert_api_ServiceStatus_To_v1_ServiceStatus,
-		autoconvert_api_Service_To_v1_Service,
-		autoconvert_api_TCPSocketAction_To_v1_TCPSocketAction,
-		autoconvert_api_VolumeMount_To_v1_VolumeMount,
-		autoconvert_api_VolumeSource_To_v1_VolumeSource,
-		autoconvert_api_Volume_To_v1_Volume,
-		autoconvert_unversioned_ExportOptions_To_v1_ExportOptions,
-		autoconvert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource,
-		autoconvert_v1_Binding_To_api_Binding,
-		autoconvert_v1_Capabilities_To_api_Capabilities,
-		autoconvert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource,
-		autoconvert_v1_CinderVolumeSource_To_api_CinderVolumeSource,
-		autoconvert_v1_ComponentCondition_To_api_ComponentCondition,
-		autoconvert_v1_ComponentStatusList_To_api_ComponentStatusList,
-		autoconvert_v1_ComponentStatus_To_api_ComponentStatus,
-		autoconvert_v1_ContainerPort_To_api_ContainerPort,
-		autoconvert_v1_ContainerStateRunning_To_api_ContainerStateRunning,
-		autoconvert_v1_ContainerStateTerminated_To_api_ContainerStateTerminated,
-		autoconvert_v1_ContainerStateWaiting_To_api_ContainerStateWaiting,
-		autoconvert_v1_ContainerState_To_api_ContainerState,
-		autoconvert_v1_ContainerStatus_To_api_ContainerStatus,
-		autoconvert_v1_Container_To_api_Container,
-		autoconvert_v1_DaemonEndpoint_To_api_DaemonEndpoint,
-		autoconvert_v1_DeleteOptions_To_api_DeleteOptions,
-		autoconvert_v1_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile,
-		autoconvert_v1_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource,
-		autoconvert_v1_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource,
-		autoconvert_v1_EndpointAddress_To_api_EndpointAddress,
-		autoconvert_v1_EndpointPort_To_api_EndpointPort,
-		autoconvert_v1_EndpointSubset_To_api_EndpointSubset,
-		autoconvert_v1_EndpointsList_To_api_EndpointsList,
-		autoconvert_v1_Endpoints_To_api_Endpoints,
-		autoconvert_v1_EnvVarSource_To_api_EnvVarSource,
-		autoconvert_v1_EnvVar_To_api_EnvVar,
-		autoconvert_v1_EventList_To_api_EventList,
-		autoconvert_v1_EventSource_To_api_EventSource,
-		autoconvert_v1_Event_To_api_Event,
-		autoconvert_v1_ExecAction_To_api_ExecAction,
-		autoconvert_v1_ExportOptions_To_unversioned_ExportOptions,
-		autoconvert_v1_FCVolumeSource_To_api_FCVolumeSource,
-		autoconvert_v1_FlexVolumeSource_To_api_FlexVolumeSource,
-		autoconvert_v1_FlockerVolumeSource_To_api_FlockerVolumeSource,
-		autoconvert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource,
-		autoconvert_v1_GitRepoVolumeSource_To_api_GitRepoVolumeSource,
-		autoconvert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource,
-		autoconvert_v1_HTTPGetAction_To_api_HTTPGetAction,
-		autoconvert_v1_Handler_To_api_Handler,
-		autoconvert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource,
-		autoconvert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource,
-		autoconvert_v1_Lifecycle_To_api_Lifecycle,
-		autoconvert_v1_LimitRangeItem_To_api_LimitRangeItem,
-		autoconvert_v1_LimitRangeList_To_api_LimitRangeList,
-		autoconvert_v1_LimitRangeSpec_To_api_LimitRangeSpec,
-		autoconvert_v1_LimitRange_To_api_LimitRange,
-		autoconvert_v1_ListOptions_To_api_ListOptions,
-		autoconvert_v1_List_To_api_List,
-		autoconvert_v1_LoadBalancerIngress_To_api_LoadBalancerIngress,
-		autoconvert_v1_LoadBalancerStatus_To_api_LoadBalancerStatus,
-		autoconvert_v1_LocalObjectReference_To_api_LocalObjectReference,
-		autoconvert_v1_NFSVolumeSource_To_api_NFSVolumeSource,
-		autoconvert_v1_NamespaceList_To_api_NamespaceList,
-		autoconvert_v1_NamespaceSpec_To_api_NamespaceSpec,
-		autoconvert_v1_NamespaceStatus_To_api_NamespaceStatus,
-		autoconvert_v1_Namespace_To_api_Namespace,
-		autoconvert_v1_NodeAddress_To_api_NodeAddress,
-		autoconvert_v1_NodeCondition_To_api_NodeCondition,
-		autoconvert_v1_NodeDaemonEndpoints_To_api_NodeDaemonEndpoints,
-		autoconvert_v1_NodeList_To_api_NodeList,
-		autoconvert_v1_NodeSpec_To_api_NodeSpec,
-		autoconvert_v1_NodeStatus_To_api_NodeStatus,
-		autoconvert_v1_NodeSystemInfo_To_api_NodeSystemInfo,
-		autoconvert_v1_Node_To_api_Node,
-		autoconvert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector,
-		autoconvert_v1_ObjectMeta_To_api_ObjectMeta,
-		autoconvert_v1_ObjectReference_To_api_ObjectReference,
-		autoconvert_v1_PersistentVolumeClaimList_To_api_PersistentVolumeClaimList,
-		autoconvert_v1_PersistentVolumeClaimSpec_To_api_PersistentVolumeClaimSpec,
-		autoconvert_v1_PersistentVolumeClaimStatus_To_api_PersistentVolumeClaimStatus,
-		autoconvert_v1_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeClaimVolumeSource,
-		autoconvert_v1_PersistentVolumeClaim_To_api_PersistentVolumeClaim,
-		autoconvert_v1_PersistentVolumeList_To_api_PersistentVolumeList,
-		autoconvert_v1_PersistentVolumeSource_To_api_PersistentVolumeSource,
-		autoconvert_v1_PersistentVolumeSpec_To_api_PersistentVolumeSpec,
-		autoconvert_v1_PersistentVolumeStatus_To_api_PersistentVolumeStatus,
-		autoconvert_v1_PersistentVolume_To_api_PersistentVolume,
-		autoconvert_v1_PodAttachOptions_To_api_PodAttachOptions,
-		autoconvert_v1_PodCondition_To_api_PodCondition,
-		autoconvert_v1_PodExecOptions_To_api_PodExecOptions,
-		autoconvert_v1_PodList_To_api_PodList,
-		autoconvert_v1_PodLogOptions_To_api_PodLogOptions,
-		autoconvert_v1_PodProxyOptions_To_api_PodProxyOptions,
-		autoconvert_v1_PodSpec_To_api_PodSpec,
-		autoconvert_v1_PodStatusResult_To_api_PodStatusResult,
-		autoconvert_v1_PodStatus_To_api_PodStatus,
-		autoconvert_v1_PodTemplateList_To_api_PodTemplateList,
-		autoconvert_v1_PodTemplateSpec_To_api_PodTemplateSpec,
-		autoconvert_v1_PodTemplate_To_api_PodTemplate,
-		autoconvert_v1_Pod_To_api_Pod,
-		autoconvert_v1_Probe_To_api_Probe,
-		autoconvert_v1_RBDVolumeSource_To_api_RBDVolumeSource,
-		autoconvert_v1_RangeAllocation_To_api_RangeAllocation,
-		autoconvert_v1_ReplicationControllerList_To_api_ReplicationControllerList,
-		autoconvert_v1_ReplicationControllerSpec_To_api_ReplicationControllerSpec,
-		autoconvert_v1_ReplicationControllerStatus_To_api_ReplicationControllerStatus,
-		autoconvert_v1_ReplicationController_To_api_ReplicationController,
-		autoconvert_v1_ResourceQuotaList_To_api_ResourceQuotaList,
-		autoconvert_v1_ResourceQuotaSpec_To_api_ResourceQuotaSpec,
-		autoconvert_v1_ResourceQuotaStatus_To_api_ResourceQuotaStatus,
-		autoconvert_v1_ResourceQuota_To_api_ResourceQuota,
-		autoconvert_v1_ResourceRequirements_To_api_ResourceRequirements,
-		autoconvert_v1_SELinuxOptions_To_api_SELinuxOptions,
-		autoconvert_v1_SecretList_To_api_SecretList,
-		autoconvert_v1_SecretVolumeSource_To_api_SecretVolumeSource,
-		autoconvert_v1_Secret_To_api_Secret,
-		autoconvert_v1_SecurityContext_To_api_SecurityContext,
-		autoconvert_v1_SerializedReference_To_api_SerializedReference,
-		autoconvert_v1_ServiceAccountList_To_api_ServiceAccountList,
-		autoconvert_v1_ServiceAccount_To_api_ServiceAccount,
-		autoconvert_v1_ServiceList_To_api_ServiceList,
-		autoconvert_v1_ServicePort_To_api_ServicePort,
-		autoconvert_v1_ServiceSpec_To_api_ServiceSpec,
-		autoconvert_v1_ServiceStatus_To_api_ServiceStatus,
-		autoconvert_v1_Service_To_api_Service,
-		autoconvert_v1_TCPSocketAction_To_api_TCPSocketAction,
-		autoconvert_v1_VolumeMount_To_api_VolumeMount,
-		autoconvert_v1_VolumeSource_To_api_VolumeSource,
-		autoconvert_v1_Volume_To_api_Volume,
+		autoConvert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVolumeSource,
+		autoConvert_api_Binding_To_v1_Binding,
+		autoConvert_api_Capabilities_To_v1_Capabilities,
+		autoConvert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource,
+		autoConvert_api_CinderVolumeSource_To_v1_CinderVolumeSource,
+		autoConvert_api_ComponentCondition_To_v1_ComponentCondition,
+		autoConvert_api_ComponentStatusList_To_v1_ComponentStatusList,
+		autoConvert_api_ComponentStatus_To_v1_ComponentStatus,
+		autoConvert_api_ContainerPort_To_v1_ContainerPort,
+		autoConvert_api_ContainerStateRunning_To_v1_ContainerStateRunning,
+		autoConvert_api_ContainerStateTerminated_To_v1_ContainerStateTerminated,
+		autoConvert_api_ContainerStateWaiting_To_v1_ContainerStateWaiting,
+		autoConvert_api_ContainerState_To_v1_ContainerState,
+		autoConvert_api_ContainerStatus_To_v1_ContainerStatus,
+		autoConvert_api_Container_To_v1_Container,
+		autoConvert_api_DaemonEndpoint_To_v1_DaemonEndpoint,
+		autoConvert_api_DeleteOptions_To_v1_DeleteOptions,
+		autoConvert_api_DownwardAPIVolumeFile_To_v1_DownwardAPIVolumeFile,
+		autoConvert_api_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource,
+		autoConvert_api_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource,
+		autoConvert_api_EndpointAddress_To_v1_EndpointAddress,
+		autoConvert_api_EndpointPort_To_v1_EndpointPort,
+		autoConvert_api_EndpointSubset_To_v1_EndpointSubset,
+		autoConvert_api_EndpointsList_To_v1_EndpointsList,
+		autoConvert_api_Endpoints_To_v1_Endpoints,
+		autoConvert_api_EnvVarSource_To_v1_EnvVarSource,
+		autoConvert_api_EnvVar_To_v1_EnvVar,
+		autoConvert_api_EventList_To_v1_EventList,
+		autoConvert_api_EventSource_To_v1_EventSource,
+		autoConvert_api_Event_To_v1_Event,
+		autoConvert_api_ExecAction_To_v1_ExecAction,
+		autoConvert_api_FCVolumeSource_To_v1_FCVolumeSource,
+		autoConvert_api_FlexVolumeSource_To_v1_FlexVolumeSource,
+		autoConvert_api_FlockerVolumeSource_To_v1_FlockerVolumeSource,
+		autoConvert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSource,
+		autoConvert_api_GitRepoVolumeSource_To_v1_GitRepoVolumeSource,
+		autoConvert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource,
+		autoConvert_api_HTTPGetAction_To_v1_HTTPGetAction,
+		autoConvert_api_Handler_To_v1_Handler,
+		autoConvert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource,
+		autoConvert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource,
+		autoConvert_api_Lifecycle_To_v1_Lifecycle,
+		autoConvert_api_LimitRangeItem_To_v1_LimitRangeItem,
+		autoConvert_api_LimitRangeList_To_v1_LimitRangeList,
+		autoConvert_api_LimitRangeSpec_To_v1_LimitRangeSpec,
+		autoConvert_api_LimitRange_To_v1_LimitRange,
+		autoConvert_api_ListOptions_To_v1_ListOptions,
+		autoConvert_api_List_To_v1_List,
+		autoConvert_api_LoadBalancerIngress_To_v1_LoadBalancerIngress,
+		autoConvert_api_LoadBalancerStatus_To_v1_LoadBalancerStatus,
+		autoConvert_api_LocalObjectReference_To_v1_LocalObjectReference,
+		autoConvert_api_NFSVolumeSource_To_v1_NFSVolumeSource,
+		autoConvert_api_NamespaceList_To_v1_NamespaceList,
+		autoConvert_api_NamespaceSpec_To_v1_NamespaceSpec,
+		autoConvert_api_NamespaceStatus_To_v1_NamespaceStatus,
+		autoConvert_api_Namespace_To_v1_Namespace,
+		autoConvert_api_NodeAddress_To_v1_NodeAddress,
+		autoConvert_api_NodeCondition_To_v1_NodeCondition,
+		autoConvert_api_NodeDaemonEndpoints_To_v1_NodeDaemonEndpoints,
+		autoConvert_api_NodeList_To_v1_NodeList,
+		autoConvert_api_NodeSpec_To_v1_NodeSpec,
+		autoConvert_api_NodeStatus_To_v1_NodeStatus,
+		autoConvert_api_NodeSystemInfo_To_v1_NodeSystemInfo,
+		autoConvert_api_Node_To_v1_Node,
+		autoConvert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector,
+		autoConvert_api_ObjectMeta_To_v1_ObjectMeta,
+		autoConvert_api_ObjectReference_To_v1_ObjectReference,
+		autoConvert_api_PersistentVolumeClaimList_To_v1_PersistentVolumeClaimList,
+		autoConvert_api_PersistentVolumeClaimSpec_To_v1_PersistentVolumeClaimSpec,
+		autoConvert_api_PersistentVolumeClaimStatus_To_v1_PersistentVolumeClaimStatus,
+		autoConvert_api_PersistentVolumeClaimVolumeSource_To_v1_PersistentVolumeClaimVolumeSource,
+		autoConvert_api_PersistentVolumeClaim_To_v1_PersistentVolumeClaim,
+		autoConvert_api_PersistentVolumeList_To_v1_PersistentVolumeList,
+		autoConvert_api_PersistentVolumeSource_To_v1_PersistentVolumeSource,
+		autoConvert_api_PersistentVolumeSpec_To_v1_PersistentVolumeSpec,
+		autoConvert_api_PersistentVolumeStatus_To_v1_PersistentVolumeStatus,
+		autoConvert_api_PersistentVolume_To_v1_PersistentVolume,
+		autoConvert_api_PodAttachOptions_To_v1_PodAttachOptions,
+		autoConvert_api_PodCondition_To_v1_PodCondition,
+		autoConvert_api_PodExecOptions_To_v1_PodExecOptions,
+		autoConvert_api_PodList_To_v1_PodList,
+		autoConvert_api_PodLogOptions_To_v1_PodLogOptions,
+		autoConvert_api_PodProxyOptions_To_v1_PodProxyOptions,
+		autoConvert_api_PodSpec_To_v1_PodSpec,
+		autoConvert_api_PodStatusResult_To_v1_PodStatusResult,
+		autoConvert_api_PodStatus_To_v1_PodStatus,
+		autoConvert_api_PodTemplateList_To_v1_PodTemplateList,
+		autoConvert_api_PodTemplateSpec_To_v1_PodTemplateSpec,
+		autoConvert_api_PodTemplate_To_v1_PodTemplate,
+		autoConvert_api_Pod_To_v1_Pod,
+		autoConvert_api_Probe_To_v1_Probe,
+		autoConvert_api_RBDVolumeSource_To_v1_RBDVolumeSource,
+		autoConvert_api_RangeAllocation_To_v1_RangeAllocation,
+		autoConvert_api_ReplicationControllerList_To_v1_ReplicationControllerList,
+		autoConvert_api_ReplicationControllerSpec_To_v1_ReplicationControllerSpec,
+		autoConvert_api_ReplicationControllerStatus_To_v1_ReplicationControllerStatus,
+		autoConvert_api_ReplicationController_To_v1_ReplicationController,
+		autoConvert_api_ResourceQuotaList_To_v1_ResourceQuotaList,
+		autoConvert_api_ResourceQuotaSpec_To_v1_ResourceQuotaSpec,
+		autoConvert_api_ResourceQuotaStatus_To_v1_ResourceQuotaStatus,
+		autoConvert_api_ResourceQuota_To_v1_ResourceQuota,
+		autoConvert_api_ResourceRequirements_To_v1_ResourceRequirements,
+		autoConvert_api_SELinuxOptions_To_v1_SELinuxOptions,
+		autoConvert_api_SecretList_To_v1_SecretList,
+		autoConvert_api_SecretVolumeSource_To_v1_SecretVolumeSource,
+		autoConvert_api_Secret_To_v1_Secret,
+		autoConvert_api_SecurityContext_To_v1_SecurityContext,
+		autoConvert_api_SerializedReference_To_v1_SerializedReference,
+		autoConvert_api_ServiceAccountList_To_v1_ServiceAccountList,
+		autoConvert_api_ServiceAccount_To_v1_ServiceAccount,
+		autoConvert_api_ServiceList_To_v1_ServiceList,
+		autoConvert_api_ServicePort_To_v1_ServicePort,
+		autoConvert_api_ServiceSpec_To_v1_ServiceSpec,
+		autoConvert_api_ServiceStatus_To_v1_ServiceStatus,
+		autoConvert_api_Service_To_v1_Service,
+		autoConvert_api_TCPSocketAction_To_v1_TCPSocketAction,
+		autoConvert_api_VolumeMount_To_v1_VolumeMount,
+		autoConvert_api_VolumeSource_To_v1_VolumeSource,
+		autoConvert_api_Volume_To_v1_Volume,
+		autoConvert_unversioned_ExportOptions_To_v1_ExportOptions,
+		autoConvert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource,
+		autoConvert_v1_Binding_To_api_Binding,
+		autoConvert_v1_Capabilities_To_api_Capabilities,
+		autoConvert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource,
+		autoConvert_v1_CinderVolumeSource_To_api_CinderVolumeSource,
+		autoConvert_v1_ComponentCondition_To_api_ComponentCondition,
+		autoConvert_v1_ComponentStatusList_To_api_ComponentStatusList,
+		autoConvert_v1_ComponentStatus_To_api_ComponentStatus,
+		autoConvert_v1_ContainerPort_To_api_ContainerPort,
+		autoConvert_v1_ContainerStateRunning_To_api_ContainerStateRunning,
+		autoConvert_v1_ContainerStateTerminated_To_api_ContainerStateTerminated,
+		autoConvert_v1_ContainerStateWaiting_To_api_ContainerStateWaiting,
+		autoConvert_v1_ContainerState_To_api_ContainerState,
+		autoConvert_v1_ContainerStatus_To_api_ContainerStatus,
+		autoConvert_v1_Container_To_api_Container,
+		autoConvert_v1_DaemonEndpoint_To_api_DaemonEndpoint,
+		autoConvert_v1_DeleteOptions_To_api_DeleteOptions,
+		autoConvert_v1_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile,
+		autoConvert_v1_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource,
+		autoConvert_v1_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource,
+		autoConvert_v1_EndpointAddress_To_api_EndpointAddress,
+		autoConvert_v1_EndpointPort_To_api_EndpointPort,
+		autoConvert_v1_EndpointSubset_To_api_EndpointSubset,
+		autoConvert_v1_EndpointsList_To_api_EndpointsList,
+		autoConvert_v1_Endpoints_To_api_Endpoints,
+		autoConvert_v1_EnvVarSource_To_api_EnvVarSource,
+		autoConvert_v1_EnvVar_To_api_EnvVar,
+		autoConvert_v1_EventList_To_api_EventList,
+		autoConvert_v1_EventSource_To_api_EventSource,
+		autoConvert_v1_Event_To_api_Event,
+		autoConvert_v1_ExecAction_To_api_ExecAction,
+		autoConvert_v1_ExportOptions_To_unversioned_ExportOptions,
+		autoConvert_v1_FCVolumeSource_To_api_FCVolumeSource,
+		autoConvert_v1_FlexVolumeSource_To_api_FlexVolumeSource,
+		autoConvert_v1_FlockerVolumeSource_To_api_FlockerVolumeSource,
+		autoConvert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource,
+		autoConvert_v1_GitRepoVolumeSource_To_api_GitRepoVolumeSource,
+		autoConvert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource,
+		autoConvert_v1_HTTPGetAction_To_api_HTTPGetAction,
+		autoConvert_v1_Handler_To_api_Handler,
+		autoConvert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource,
+		autoConvert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource,
+		autoConvert_v1_Lifecycle_To_api_Lifecycle,
+		autoConvert_v1_LimitRangeItem_To_api_LimitRangeItem,
+		autoConvert_v1_LimitRangeList_To_api_LimitRangeList,
+		autoConvert_v1_LimitRangeSpec_To_api_LimitRangeSpec,
+		autoConvert_v1_LimitRange_To_api_LimitRange,
+		autoConvert_v1_ListOptions_To_api_ListOptions,
+		autoConvert_v1_List_To_api_List,
+		autoConvert_v1_LoadBalancerIngress_To_api_LoadBalancerIngress,
+		autoConvert_v1_LoadBalancerStatus_To_api_LoadBalancerStatus,
+		autoConvert_v1_LocalObjectReference_To_api_LocalObjectReference,
+		autoConvert_v1_NFSVolumeSource_To_api_NFSVolumeSource,
+		autoConvert_v1_NamespaceList_To_api_NamespaceList,
+		autoConvert_v1_NamespaceSpec_To_api_NamespaceSpec,
+		autoConvert_v1_NamespaceStatus_To_api_NamespaceStatus,
+		autoConvert_v1_Namespace_To_api_Namespace,
+		autoConvert_v1_NodeAddress_To_api_NodeAddress,
+		autoConvert_v1_NodeCondition_To_api_NodeCondition,
+		autoConvert_v1_NodeDaemonEndpoints_To_api_NodeDaemonEndpoints,
+		autoConvert_v1_NodeList_To_api_NodeList,
+		autoConvert_v1_NodeSpec_To_api_NodeSpec,
+		autoConvert_v1_NodeStatus_To_api_NodeStatus,
+		autoConvert_v1_NodeSystemInfo_To_api_NodeSystemInfo,
+		autoConvert_v1_Node_To_api_Node,
+		autoConvert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector,
+		autoConvert_v1_ObjectMeta_To_api_ObjectMeta,
+		autoConvert_v1_ObjectReference_To_api_ObjectReference,
+		autoConvert_v1_PersistentVolumeClaimList_To_api_PersistentVolumeClaimList,
+		autoConvert_v1_PersistentVolumeClaimSpec_To_api_PersistentVolumeClaimSpec,
+		autoConvert_v1_PersistentVolumeClaimStatus_To_api_PersistentVolumeClaimStatus,
+		autoConvert_v1_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeClaimVolumeSource,
+		autoConvert_v1_PersistentVolumeClaim_To_api_PersistentVolumeClaim,
+		autoConvert_v1_PersistentVolumeList_To_api_PersistentVolumeList,
+		autoConvert_v1_PersistentVolumeSource_To_api_PersistentVolumeSource,
+		autoConvert_v1_PersistentVolumeSpec_To_api_PersistentVolumeSpec,
+		autoConvert_v1_PersistentVolumeStatus_To_api_PersistentVolumeStatus,
+		autoConvert_v1_PersistentVolume_To_api_PersistentVolume,
+		autoConvert_v1_PodAttachOptions_To_api_PodAttachOptions,
+		autoConvert_v1_PodCondition_To_api_PodCondition,
+		autoConvert_v1_PodExecOptions_To_api_PodExecOptions,
+		autoConvert_v1_PodList_To_api_PodList,
+		autoConvert_v1_PodLogOptions_To_api_PodLogOptions,
+		autoConvert_v1_PodProxyOptions_To_api_PodProxyOptions,
+		autoConvert_v1_PodSpec_To_api_PodSpec,
+		autoConvert_v1_PodStatusResult_To_api_PodStatusResult,
+		autoConvert_v1_PodStatus_To_api_PodStatus,
+		autoConvert_v1_PodTemplateList_To_api_PodTemplateList,
+		autoConvert_v1_PodTemplateSpec_To_api_PodTemplateSpec,
+		autoConvert_v1_PodTemplate_To_api_PodTemplate,
+		autoConvert_v1_Pod_To_api_Pod,
+		autoConvert_v1_Probe_To_api_Probe,
+		autoConvert_v1_RBDVolumeSource_To_api_RBDVolumeSource,
+		autoConvert_v1_RangeAllocation_To_api_RangeAllocation,
+		autoConvert_v1_ReplicationControllerList_To_api_ReplicationControllerList,
+		autoConvert_v1_ReplicationControllerSpec_To_api_ReplicationControllerSpec,
+		autoConvert_v1_ReplicationControllerStatus_To_api_ReplicationControllerStatus,
+		autoConvert_v1_ReplicationController_To_api_ReplicationController,
+		autoConvert_v1_ResourceQuotaList_To_api_ResourceQuotaList,
+		autoConvert_v1_ResourceQuotaSpec_To_api_ResourceQuotaSpec,
+		autoConvert_v1_ResourceQuotaStatus_To_api_ResourceQuotaStatus,
+		autoConvert_v1_ResourceQuota_To_api_ResourceQuota,
+		autoConvert_v1_ResourceRequirements_To_api_ResourceRequirements,
+		autoConvert_v1_SELinuxOptions_To_api_SELinuxOptions,
+		autoConvert_v1_SecretList_To_api_SecretList,
+		autoConvert_v1_SecretVolumeSource_To_api_SecretVolumeSource,
+		autoConvert_v1_Secret_To_api_Secret,
+		autoConvert_v1_SecurityContext_To_api_SecurityContext,
+		autoConvert_v1_SerializedReference_To_api_SerializedReference,
+		autoConvert_v1_ServiceAccountList_To_api_ServiceAccountList,
+		autoConvert_v1_ServiceAccount_To_api_ServiceAccount,
+		autoConvert_v1_ServiceList_To_api_ServiceList,
+		autoConvert_v1_ServicePort_To_api_ServicePort,
+		autoConvert_v1_ServiceSpec_To_api_ServiceSpec,
+		autoConvert_v1_ServiceStatus_To_api_ServiceStatus,
+		autoConvert_v1_Service_To_api_Service,
+		autoConvert_v1_TCPSocketAction_To_api_TCPSocketAction,
+		autoConvert_v1_VolumeMount_To_api_VolumeMount,
+		autoConvert_v1_VolumeSource_To_api_VolumeSource,
+		autoConvert_v1_Volume_To_api_Volume,
 	)
 	if err != nil {
 		// If one of the conversion functions is malformed, detect it immediately.

--- a/pkg/apis/componentconfig/v1alpha1/conversion_generated.go
+++ b/pkg/apis/componentconfig/v1alpha1/conversion_generated.go
@@ -26,11 +26,11 @@ import (
 	conversion "k8s.io/kubernetes/pkg/conversion"
 )
 
-func autoconvert_componentconfig_KubeProxyConfiguration_To_v1alpha1_KubeProxyConfiguration(in *componentconfig.KubeProxyConfiguration, out *KubeProxyConfiguration, s conversion.Scope) error {
+func autoConvert_componentconfig_KubeProxyConfiguration_To_v1alpha1_KubeProxyConfiguration(in *componentconfig.KubeProxyConfiguration, out *KubeProxyConfiguration, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*componentconfig.KubeProxyConfiguration))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
 	out.BindAddress = in.BindAddress
@@ -57,15 +57,15 @@ func autoconvert_componentconfig_KubeProxyConfiguration_To_v1alpha1_KubeProxyCon
 	return nil
 }
 
-func convert_componentconfig_KubeProxyConfiguration_To_v1alpha1_KubeProxyConfiguration(in *componentconfig.KubeProxyConfiguration, out *KubeProxyConfiguration, s conversion.Scope) error {
-	return autoconvert_componentconfig_KubeProxyConfiguration_To_v1alpha1_KubeProxyConfiguration(in, out, s)
+func Convert_componentconfig_KubeProxyConfiguration_To_v1alpha1_KubeProxyConfiguration(in *componentconfig.KubeProxyConfiguration, out *KubeProxyConfiguration, s conversion.Scope) error {
+	return autoConvert_componentconfig_KubeProxyConfiguration_To_v1alpha1_KubeProxyConfiguration(in, out, s)
 }
 
-func autoconvert_v1alpha1_KubeProxyConfiguration_To_componentconfig_KubeProxyConfiguration(in *KubeProxyConfiguration, out *componentconfig.KubeProxyConfiguration, s conversion.Scope) error {
+func autoConvert_v1alpha1_KubeProxyConfiguration_To_componentconfig_KubeProxyConfiguration(in *KubeProxyConfiguration, out *componentconfig.KubeProxyConfiguration, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*KubeProxyConfiguration))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
 	out.BindAddress = in.BindAddress
@@ -92,14 +92,14 @@ func autoconvert_v1alpha1_KubeProxyConfiguration_To_componentconfig_KubeProxyCon
 	return nil
 }
 
-func convert_v1alpha1_KubeProxyConfiguration_To_componentconfig_KubeProxyConfiguration(in *KubeProxyConfiguration, out *componentconfig.KubeProxyConfiguration, s conversion.Scope) error {
-	return autoconvert_v1alpha1_KubeProxyConfiguration_To_componentconfig_KubeProxyConfiguration(in, out, s)
+func Convert_v1alpha1_KubeProxyConfiguration_To_componentconfig_KubeProxyConfiguration(in *KubeProxyConfiguration, out *componentconfig.KubeProxyConfiguration, s conversion.Scope) error {
+	return autoConvert_v1alpha1_KubeProxyConfiguration_To_componentconfig_KubeProxyConfiguration(in, out, s)
 }
 
 func init() {
 	err := api.Scheme.AddGeneratedConversionFuncs(
-		autoconvert_componentconfig_KubeProxyConfiguration_To_v1alpha1_KubeProxyConfiguration,
-		autoconvert_v1alpha1_KubeProxyConfiguration_To_componentconfig_KubeProxyConfiguration,
+		autoConvert_componentconfig_KubeProxyConfiguration_To_v1alpha1_KubeProxyConfiguration,
+		autoConvert_v1alpha1_KubeProxyConfiguration_To_componentconfig_KubeProxyConfiguration,
 	)
 	if err != nil {
 		// If one of the conversion functions is malformed, detect it immediately.

--- a/pkg/apis/extensions/v1beta1/conversion.go
+++ b/pkg/apis/extensions/v1beta1/conversion.go
@@ -30,14 +30,14 @@ import (
 func addConversionFuncs(scheme *runtime.Scheme) {
 	// Add non-generated conversion functions
 	err := scheme.AddConversionFuncs(
-		convert_api_PodSpec_To_v1_PodSpec,
-		convert_v1_PodSpec_To_api_PodSpec,
-		convert_extensions_DeploymentSpec_To_v1beta1_DeploymentSpec,
-		convert_v1beta1_DeploymentSpec_To_extensions_DeploymentSpec,
-		convert_extensions_DeploymentStrategy_To_v1beta1_DeploymentStrategy,
-		convert_v1beta1_DeploymentStrategy_To_extensions_DeploymentStrategy,
-		convert_extensions_RollingUpdateDeployment_To_v1beta1_RollingUpdateDeployment,
-		convert_v1beta1_RollingUpdateDeployment_To_extensions_RollingUpdateDeployment,
+		Convert_api_PodSpec_To_v1_PodSpec,
+		Convert_v1_PodSpec_To_api_PodSpec,
+		Convert_extensions_DeploymentSpec_To_v1beta1_DeploymentSpec,
+		Convert_v1beta1_DeploymentSpec_To_extensions_DeploymentSpec,
+		Convert_extensions_DeploymentStrategy_To_v1beta1_DeploymentStrategy,
+		Convert_v1beta1_DeploymentStrategy_To_extensions_DeploymentStrategy,
+		Convert_extensions_RollingUpdateDeployment_To_v1beta1_RollingUpdateDeployment,
+		Convert_v1beta1_RollingUpdateDeployment_To_extensions_RollingUpdateDeployment,
 	)
 	if err != nil {
 		// If one of the conversion functions is malformed, detect it immediately.
@@ -48,14 +48,14 @@ func addConversionFuncs(scheme *runtime.Scheme) {
 // The following two PodSpec conversions functions where copied from pkg/api/conversion.go
 // for the generated functions to work properly.
 // This should be fixed: https://github.com/kubernetes/kubernetes/issues/12977
-func convert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *v1.PodSpec, s conversion.Scope) error {
+func Convert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *v1.PodSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodSpec))(in)
 	}
 	if in.Volumes != nil {
 		out.Volumes = make([]v1.Volume, len(in.Volumes))
 		for i := range in.Volumes {
-			if err := convert_api_Volume_To_v1_Volume(&in.Volumes[i], &out.Volumes[i], s); err != nil {
+			if err := Convert_api_Volume_To_v1_Volume(&in.Volumes[i], &out.Volumes[i], s); err != nil {
 				return err
 			}
 		}
@@ -65,7 +65,7 @@ func convert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *v1.PodSpec, s conve
 	if in.Containers != nil {
 		out.Containers = make([]v1.Container, len(in.Containers))
 		for i := range in.Containers {
-			if err := convert_api_Container_To_v1_Container(&in.Containers[i], &out.Containers[i], s); err != nil {
+			if err := Convert_api_Container_To_v1_Container(&in.Containers[i], &out.Containers[i], s); err != nil {
 				return err
 			}
 		}
@@ -100,7 +100,7 @@ func convert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *v1.PodSpec, s conve
 	out.NodeName = in.NodeName
 	if in.SecurityContext != nil {
 		out.SecurityContext = new(v1.PodSecurityContext)
-		if err := convert_api_PodSecurityContext_To_v1_PodSecurityContext(in.SecurityContext, out.SecurityContext, s); err != nil {
+		if err := Convert_api_PodSecurityContext_To_v1_PodSecurityContext(in.SecurityContext, out.SecurityContext, s); err != nil {
 			return err
 		}
 
@@ -111,7 +111,7 @@ func convert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *v1.PodSpec, s conve
 	if in.ImagePullSecrets != nil {
 		out.ImagePullSecrets = make([]v1.LocalObjectReference, len(in.ImagePullSecrets))
 		for i := range in.ImagePullSecrets {
-			if err := convert_api_LocalObjectReference_To_v1_LocalObjectReference(&in.ImagePullSecrets[i], &out.ImagePullSecrets[i], s); err != nil {
+			if err := Convert_api_LocalObjectReference_To_v1_LocalObjectReference(&in.ImagePullSecrets[i], &out.ImagePullSecrets[i], s); err != nil {
 				return err
 			}
 		}
@@ -121,14 +121,14 @@ func convert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *v1.PodSpec, s conve
 	return nil
 }
 
-func convert_v1_PodSpec_To_api_PodSpec(in *v1.PodSpec, out *api.PodSpec, s conversion.Scope) error {
+func Convert_v1_PodSpec_To_api_PodSpec(in *v1.PodSpec, out *api.PodSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.PodSpec))(in)
 	}
 	if in.Volumes != nil {
 		out.Volumes = make([]api.Volume, len(in.Volumes))
 		for i := range in.Volumes {
-			if err := convert_v1_Volume_To_api_Volume(&in.Volumes[i], &out.Volumes[i], s); err != nil {
+			if err := Convert_v1_Volume_To_api_Volume(&in.Volumes[i], &out.Volumes[i], s); err != nil {
 				return err
 			}
 		}
@@ -138,7 +138,7 @@ func convert_v1_PodSpec_To_api_PodSpec(in *v1.PodSpec, out *api.PodSpec, s conve
 	if in.Containers != nil {
 		out.Containers = make([]api.Container, len(in.Containers))
 		for i := range in.Containers {
-			if err := convert_v1_Container_To_api_Container(&in.Containers[i], &out.Containers[i], s); err != nil {
+			if err := Convert_v1_Container_To_api_Container(&in.Containers[i], &out.Containers[i], s); err != nil {
 				return err
 			}
 		}
@@ -177,7 +177,7 @@ func convert_v1_PodSpec_To_api_PodSpec(in *v1.PodSpec, out *api.PodSpec, s conve
 
 	if in.SecurityContext != nil {
 		out.SecurityContext = new(api.PodSecurityContext)
-		if err := convert_v1_PodSecurityContext_To_api_PodSecurityContext(in.SecurityContext, out.SecurityContext, s); err != nil {
+		if err := Convert_v1_PodSecurityContext_To_api_PodSecurityContext(in.SecurityContext, out.SecurityContext, s); err != nil {
 			return err
 		}
 	}
@@ -190,7 +190,7 @@ func convert_v1_PodSpec_To_api_PodSpec(in *v1.PodSpec, out *api.PodSpec, s conve
 	if in.ImagePullSecrets != nil {
 		out.ImagePullSecrets = make([]api.LocalObjectReference, len(in.ImagePullSecrets))
 		for i := range in.ImagePullSecrets {
-			if err := convert_v1_LocalObjectReference_To_api_LocalObjectReference(&in.ImagePullSecrets[i], &out.ImagePullSecrets[i], s); err != nil {
+			if err := Convert_v1_LocalObjectReference_To_api_LocalObjectReference(&in.ImagePullSecrets[i], &out.ImagePullSecrets[i], s); err != nil {
 				return err
 			}
 		}
@@ -200,7 +200,7 @@ func convert_v1_PodSpec_To_api_PodSpec(in *v1.PodSpec, out *api.PodSpec, s conve
 	return nil
 }
 
-func convert_extensions_DeploymentSpec_To_v1beta1_DeploymentSpec(in *extensions.DeploymentSpec, out *DeploymentSpec, s conversion.Scope) error {
+func Convert_extensions_DeploymentSpec_To_v1beta1_DeploymentSpec(in *extensions.DeploymentSpec, out *DeploymentSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.DeploymentSpec))(in)
 	}
@@ -214,10 +214,10 @@ func convert_extensions_DeploymentSpec_To_v1beta1_DeploymentSpec(in *extensions.
 	} else {
 		out.Selector = nil
 	}
-	if err := convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
+	if err := Convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
-	if err := convert_extensions_DeploymentStrategy_To_v1beta1_DeploymentStrategy(&in.Strategy, &out.Strategy, s); err != nil {
+	if err := Convert_extensions_DeploymentStrategy_To_v1beta1_DeploymentStrategy(&in.Strategy, &out.Strategy, s); err != nil {
 		return err
 	}
 	out.UniqueLabelKey = new(string)
@@ -225,7 +225,7 @@ func convert_extensions_DeploymentSpec_To_v1beta1_DeploymentSpec(in *extensions.
 	return nil
 }
 
-func convert_v1beta1_DeploymentSpec_To_extensions_DeploymentSpec(in *DeploymentSpec, out *extensions.DeploymentSpec, s conversion.Scope) error {
+func Convert_v1beta1_DeploymentSpec_To_extensions_DeploymentSpec(in *DeploymentSpec, out *extensions.DeploymentSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*DeploymentSpec))(in)
 	}
@@ -240,10 +240,10 @@ func convert_v1beta1_DeploymentSpec_To_extensions_DeploymentSpec(in *DeploymentS
 	} else {
 		out.Selector = nil
 	}
-	if err := convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
+	if err := Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
-	if err := convert_v1beta1_DeploymentStrategy_To_extensions_DeploymentStrategy(&in.Strategy, &out.Strategy, s); err != nil {
+	if err := Convert_v1beta1_DeploymentStrategy_To_extensions_DeploymentStrategy(&in.Strategy, &out.Strategy, s); err != nil {
 		return err
 	}
 	if in.UniqueLabelKey != nil {
@@ -252,14 +252,14 @@ func convert_v1beta1_DeploymentSpec_To_extensions_DeploymentSpec(in *DeploymentS
 	return nil
 }
 
-func convert_extensions_DeploymentStrategy_To_v1beta1_DeploymentStrategy(in *extensions.DeploymentStrategy, out *DeploymentStrategy, s conversion.Scope) error {
+func Convert_extensions_DeploymentStrategy_To_v1beta1_DeploymentStrategy(in *extensions.DeploymentStrategy, out *DeploymentStrategy, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.DeploymentStrategy))(in)
 	}
 	out.Type = DeploymentStrategyType(in.Type)
 	if in.RollingUpdate != nil {
 		out.RollingUpdate = new(RollingUpdateDeployment)
-		if err := convert_extensions_RollingUpdateDeployment_To_v1beta1_RollingUpdateDeployment(in.RollingUpdate, out.RollingUpdate, s); err != nil {
+		if err := Convert_extensions_RollingUpdateDeployment_To_v1beta1_RollingUpdateDeployment(in.RollingUpdate, out.RollingUpdate, s); err != nil {
 			return err
 		}
 	} else {
@@ -268,14 +268,14 @@ func convert_extensions_DeploymentStrategy_To_v1beta1_DeploymentStrategy(in *ext
 	return nil
 }
 
-func convert_v1beta1_DeploymentStrategy_To_extensions_DeploymentStrategy(in *DeploymentStrategy, out *extensions.DeploymentStrategy, s conversion.Scope) error {
+func Convert_v1beta1_DeploymentStrategy_To_extensions_DeploymentStrategy(in *DeploymentStrategy, out *extensions.DeploymentStrategy, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*DeploymentStrategy))(in)
 	}
 	out.Type = extensions.DeploymentStrategyType(in.Type)
 	if in.RollingUpdate != nil {
 		out.RollingUpdate = new(extensions.RollingUpdateDeployment)
-		if err := convert_v1beta1_RollingUpdateDeployment_To_extensions_RollingUpdateDeployment(in.RollingUpdate, out.RollingUpdate, s); err != nil {
+		if err := Convert_v1beta1_RollingUpdateDeployment_To_extensions_RollingUpdateDeployment(in.RollingUpdate, out.RollingUpdate, s); err != nil {
 			return err
 		}
 	} else {
@@ -284,7 +284,7 @@ func convert_v1beta1_DeploymentStrategy_To_extensions_DeploymentStrategy(in *Dep
 	return nil
 }
 
-func convert_extensions_RollingUpdateDeployment_To_v1beta1_RollingUpdateDeployment(in *extensions.RollingUpdateDeployment, out *RollingUpdateDeployment, s conversion.Scope) error {
+func Convert_extensions_RollingUpdateDeployment_To_v1beta1_RollingUpdateDeployment(in *extensions.RollingUpdateDeployment, out *RollingUpdateDeployment, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.RollingUpdateDeployment))(in)
 	}
@@ -304,7 +304,7 @@ func convert_extensions_RollingUpdateDeployment_To_v1beta1_RollingUpdateDeployme
 	return nil
 }
 
-func convert_v1beta1_RollingUpdateDeployment_To_extensions_RollingUpdateDeployment(in *RollingUpdateDeployment, out *extensions.RollingUpdateDeployment, s conversion.Scope) error {
+func Convert_v1beta1_RollingUpdateDeployment_To_extensions_RollingUpdateDeployment(in *RollingUpdateDeployment, out *extensions.RollingUpdateDeployment, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*RollingUpdateDeployment))(in)
 	}
@@ -318,7 +318,7 @@ func convert_v1beta1_RollingUpdateDeployment_To_extensions_RollingUpdateDeployme
 	return nil
 }
 
-func convert_api_PodSecurityContext_To_v1_PodSecurityContext(in *api.PodSecurityContext, out *v1.PodSecurityContext, s conversion.Scope) error {
+func Convert_api_PodSecurityContext_To_v1_PodSecurityContext(in *api.PodSecurityContext, out *v1.PodSecurityContext, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodSecurityContext))(in)
 	}
@@ -326,7 +326,7 @@ func convert_api_PodSecurityContext_To_v1_PodSecurityContext(in *api.PodSecurity
 	out.SupplementalGroups = in.SupplementalGroups
 	if in.SELinuxOptions != nil {
 		out.SELinuxOptions = new(v1.SELinuxOptions)
-		if err := convert_api_SELinuxOptions_To_v1_SELinuxOptions(in.SELinuxOptions, out.SELinuxOptions, s); err != nil {
+		if err := Convert_api_SELinuxOptions_To_v1_SELinuxOptions(in.SELinuxOptions, out.SELinuxOptions, s); err != nil {
 			return err
 		}
 	} else {
@@ -353,7 +353,7 @@ func convert_api_PodSecurityContext_To_v1_PodSecurityContext(in *api.PodSecurity
 	return nil
 }
 
-func convert_v1_PodSecurityContext_To_api_PodSecurityContext(in *v1.PodSecurityContext, out *api.PodSecurityContext, s conversion.Scope) error {
+func Convert_v1_PodSecurityContext_To_api_PodSecurityContext(in *v1.PodSecurityContext, out *api.PodSecurityContext, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.PodSecurityContext))(in)
 	}
@@ -361,7 +361,7 @@ func convert_v1_PodSecurityContext_To_api_PodSecurityContext(in *v1.PodSecurityC
 	out.SupplementalGroups = in.SupplementalGroups
 	if in.SELinuxOptions != nil {
 		out.SELinuxOptions = new(api.SELinuxOptions)
-		if err := convert_v1_SELinuxOptions_To_api_SELinuxOptions(in.SELinuxOptions, out.SELinuxOptions, s); err != nil {
+		if err := Convert_v1_SELinuxOptions_To_api_SELinuxOptions(in.SELinuxOptions, out.SELinuxOptions, s); err != nil {
 			return err
 		}
 	} else {

--- a/pkg/apis/extensions/v1beta1/conversion_generated.go
+++ b/pkg/apis/extensions/v1beta1/conversion_generated.go
@@ -23,12 +23,13 @@ import (
 
 	api "k8s.io/kubernetes/pkg/api"
 	resource "k8s.io/kubernetes/pkg/api/resource"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 	extensions "k8s.io/kubernetes/pkg/apis/extensions"
 	conversion "k8s.io/kubernetes/pkg/conversion"
 )
 
-func autoconvert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVolumeSource(in *api.AWSElasticBlockStoreVolumeSource, out *v1.AWSElasticBlockStoreVolumeSource, s conversion.Scope) error {
+func autoConvert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVolumeSource(in *api.AWSElasticBlockStoreVolumeSource, out *v1.AWSElasticBlockStoreVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.AWSElasticBlockStoreVolumeSource))(in)
 	}
@@ -39,11 +40,11 @@ func autoconvert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStore
 	return nil
 }
 
-func convert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVolumeSource(in *api.AWSElasticBlockStoreVolumeSource, out *v1.AWSElasticBlockStoreVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVolumeSource(in, out, s)
+func Convert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVolumeSource(in *api.AWSElasticBlockStoreVolumeSource, out *v1.AWSElasticBlockStoreVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVolumeSource(in, out, s)
 }
 
-func autoconvert_api_Capabilities_To_v1_Capabilities(in *api.Capabilities, out *v1.Capabilities, s conversion.Scope) error {
+func autoConvert_api_Capabilities_To_v1_Capabilities(in *api.Capabilities, out *v1.Capabilities, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Capabilities))(in)
 	}
@@ -66,11 +67,11 @@ func autoconvert_api_Capabilities_To_v1_Capabilities(in *api.Capabilities, out *
 	return nil
 }
 
-func convert_api_Capabilities_To_v1_Capabilities(in *api.Capabilities, out *v1.Capabilities, s conversion.Scope) error {
-	return autoconvert_api_Capabilities_To_v1_Capabilities(in, out, s)
+func Convert_api_Capabilities_To_v1_Capabilities(in *api.Capabilities, out *v1.Capabilities, s conversion.Scope) error {
+	return autoConvert_api_Capabilities_To_v1_Capabilities(in, out, s)
 }
 
-func autoconvert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in *api.CephFSVolumeSource, out *v1.CephFSVolumeSource, s conversion.Scope) error {
+func autoConvert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in *api.CephFSVolumeSource, out *v1.CephFSVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.CephFSVolumeSource))(in)
 	}
@@ -84,9 +85,10 @@ func autoconvert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in *api.CephFSV
 	}
 	out.User = in.User
 	out.SecretFile = in.SecretFile
+	// unable to generate simple pointer conversion for api.LocalObjectReference -> v1.LocalObjectReference
 	if in.SecretRef != nil {
 		out.SecretRef = new(v1.LocalObjectReference)
-		if err := convert_api_LocalObjectReference_To_v1_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
+		if err := Convert_api_LocalObjectReference_To_v1_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
 			return err
 		}
 	} else {
@@ -96,11 +98,11 @@ func autoconvert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in *api.CephFSV
 	return nil
 }
 
-func convert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in *api.CephFSVolumeSource, out *v1.CephFSVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in, out, s)
+func Convert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in *api.CephFSVolumeSource, out *v1.CephFSVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in, out, s)
 }
 
-func autoconvert_api_CinderVolumeSource_To_v1_CinderVolumeSource(in *api.CinderVolumeSource, out *v1.CinderVolumeSource, s conversion.Scope) error {
+func autoConvert_api_CinderVolumeSource_To_v1_CinderVolumeSource(in *api.CinderVolumeSource, out *v1.CinderVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.CinderVolumeSource))(in)
 	}
@@ -110,11 +112,11 @@ func autoconvert_api_CinderVolumeSource_To_v1_CinderVolumeSource(in *api.CinderV
 	return nil
 }
 
-func convert_api_CinderVolumeSource_To_v1_CinderVolumeSource(in *api.CinderVolumeSource, out *v1.CinderVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_CinderVolumeSource_To_v1_CinderVolumeSource(in, out, s)
+func Convert_api_CinderVolumeSource_To_v1_CinderVolumeSource(in *api.CinderVolumeSource, out *v1.CinderVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_CinderVolumeSource_To_v1_CinderVolumeSource(in, out, s)
 }
 
-func autoconvert_api_Container_To_v1_Container(in *api.Container, out *v1.Container, s conversion.Scope) error {
+func autoConvert_api_Container_To_v1_Container(in *api.Container, out *v1.Container, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Container))(in)
 	}
@@ -140,7 +142,7 @@ func autoconvert_api_Container_To_v1_Container(in *api.Container, out *v1.Contai
 	if in.Ports != nil {
 		out.Ports = make([]v1.ContainerPort, len(in.Ports))
 		for i := range in.Ports {
-			if err := convert_api_ContainerPort_To_v1_ContainerPort(&in.Ports[i], &out.Ports[i], s); err != nil {
+			if err := Convert_api_ContainerPort_To_v1_ContainerPort(&in.Ports[i], &out.Ports[i], s); err != nil {
 				return err
 			}
 		}
@@ -150,45 +152,48 @@ func autoconvert_api_Container_To_v1_Container(in *api.Container, out *v1.Contai
 	if in.Env != nil {
 		out.Env = make([]v1.EnvVar, len(in.Env))
 		for i := range in.Env {
-			if err := convert_api_EnvVar_To_v1_EnvVar(&in.Env[i], &out.Env[i], s); err != nil {
+			if err := Convert_api_EnvVar_To_v1_EnvVar(&in.Env[i], &out.Env[i], s); err != nil {
 				return err
 			}
 		}
 	} else {
 		out.Env = nil
 	}
-	if err := convert_api_ResourceRequirements_To_v1_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
+	if err := Convert_api_ResourceRequirements_To_v1_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
 		return err
 	}
 	if in.VolumeMounts != nil {
 		out.VolumeMounts = make([]v1.VolumeMount, len(in.VolumeMounts))
 		for i := range in.VolumeMounts {
-			if err := convert_api_VolumeMount_To_v1_VolumeMount(&in.VolumeMounts[i], &out.VolumeMounts[i], s); err != nil {
+			if err := Convert_api_VolumeMount_To_v1_VolumeMount(&in.VolumeMounts[i], &out.VolumeMounts[i], s); err != nil {
 				return err
 			}
 		}
 	} else {
 		out.VolumeMounts = nil
 	}
+	// unable to generate simple pointer conversion for api.Probe -> v1.Probe
 	if in.LivenessProbe != nil {
 		out.LivenessProbe = new(v1.Probe)
-		if err := convert_api_Probe_To_v1_Probe(in.LivenessProbe, out.LivenessProbe, s); err != nil {
+		if err := Convert_api_Probe_To_v1_Probe(in.LivenessProbe, out.LivenessProbe, s); err != nil {
 			return err
 		}
 	} else {
 		out.LivenessProbe = nil
 	}
+	// unable to generate simple pointer conversion for api.Probe -> v1.Probe
 	if in.ReadinessProbe != nil {
 		out.ReadinessProbe = new(v1.Probe)
-		if err := convert_api_Probe_To_v1_Probe(in.ReadinessProbe, out.ReadinessProbe, s); err != nil {
+		if err := Convert_api_Probe_To_v1_Probe(in.ReadinessProbe, out.ReadinessProbe, s); err != nil {
 			return err
 		}
 	} else {
 		out.ReadinessProbe = nil
 	}
+	// unable to generate simple pointer conversion for api.Lifecycle -> v1.Lifecycle
 	if in.Lifecycle != nil {
 		out.Lifecycle = new(v1.Lifecycle)
-		if err := convert_api_Lifecycle_To_v1_Lifecycle(in.Lifecycle, out.Lifecycle, s); err != nil {
+		if err := Convert_api_Lifecycle_To_v1_Lifecycle(in.Lifecycle, out.Lifecycle, s); err != nil {
 			return err
 		}
 	} else {
@@ -196,9 +201,10 @@ func autoconvert_api_Container_To_v1_Container(in *api.Container, out *v1.Contai
 	}
 	out.TerminationMessagePath = in.TerminationMessagePath
 	out.ImagePullPolicy = v1.PullPolicy(in.ImagePullPolicy)
+	// unable to generate simple pointer conversion for api.SecurityContext -> v1.SecurityContext
 	if in.SecurityContext != nil {
 		out.SecurityContext = new(v1.SecurityContext)
-		if err := convert_api_SecurityContext_To_v1_SecurityContext(in.SecurityContext, out.SecurityContext, s); err != nil {
+		if err := Convert_api_SecurityContext_To_v1_SecurityContext(in.SecurityContext, out.SecurityContext, s); err != nil {
 			return err
 		}
 	} else {
@@ -210,11 +216,11 @@ func autoconvert_api_Container_To_v1_Container(in *api.Container, out *v1.Contai
 	return nil
 }
 
-func convert_api_Container_To_v1_Container(in *api.Container, out *v1.Container, s conversion.Scope) error {
-	return autoconvert_api_Container_To_v1_Container(in, out, s)
+func Convert_api_Container_To_v1_Container(in *api.Container, out *v1.Container, s conversion.Scope) error {
+	return autoConvert_api_Container_To_v1_Container(in, out, s)
 }
 
-func autoconvert_api_ContainerPort_To_v1_ContainerPort(in *api.ContainerPort, out *v1.ContainerPort, s conversion.Scope) error {
+func autoConvert_api_ContainerPort_To_v1_ContainerPort(in *api.ContainerPort, out *v1.ContainerPort, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ContainerPort))(in)
 	}
@@ -226,33 +232,33 @@ func autoconvert_api_ContainerPort_To_v1_ContainerPort(in *api.ContainerPort, ou
 	return nil
 }
 
-func convert_api_ContainerPort_To_v1_ContainerPort(in *api.ContainerPort, out *v1.ContainerPort, s conversion.Scope) error {
-	return autoconvert_api_ContainerPort_To_v1_ContainerPort(in, out, s)
+func Convert_api_ContainerPort_To_v1_ContainerPort(in *api.ContainerPort, out *v1.ContainerPort, s conversion.Scope) error {
+	return autoConvert_api_ContainerPort_To_v1_ContainerPort(in, out, s)
 }
 
-func autoconvert_api_DownwardAPIVolumeFile_To_v1_DownwardAPIVolumeFile(in *api.DownwardAPIVolumeFile, out *v1.DownwardAPIVolumeFile, s conversion.Scope) error {
+func autoConvert_api_DownwardAPIVolumeFile_To_v1_DownwardAPIVolumeFile(in *api.DownwardAPIVolumeFile, out *v1.DownwardAPIVolumeFile, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.DownwardAPIVolumeFile))(in)
 	}
 	out.Path = in.Path
-	if err := convert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector(&in.FieldRef, &out.FieldRef, s); err != nil {
+	if err := Convert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector(&in.FieldRef, &out.FieldRef, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_api_DownwardAPIVolumeFile_To_v1_DownwardAPIVolumeFile(in *api.DownwardAPIVolumeFile, out *v1.DownwardAPIVolumeFile, s conversion.Scope) error {
-	return autoconvert_api_DownwardAPIVolumeFile_To_v1_DownwardAPIVolumeFile(in, out, s)
+func Convert_api_DownwardAPIVolumeFile_To_v1_DownwardAPIVolumeFile(in *api.DownwardAPIVolumeFile, out *v1.DownwardAPIVolumeFile, s conversion.Scope) error {
+	return autoConvert_api_DownwardAPIVolumeFile_To_v1_DownwardAPIVolumeFile(in, out, s)
 }
 
-func autoconvert_api_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource(in *api.DownwardAPIVolumeSource, out *v1.DownwardAPIVolumeSource, s conversion.Scope) error {
+func autoConvert_api_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource(in *api.DownwardAPIVolumeSource, out *v1.DownwardAPIVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.DownwardAPIVolumeSource))(in)
 	}
 	if in.Items != nil {
 		out.Items = make([]v1.DownwardAPIVolumeFile, len(in.Items))
 		for i := range in.Items {
-			if err := convert_api_DownwardAPIVolumeFile_To_v1_DownwardAPIVolumeFile(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_api_DownwardAPIVolumeFile_To_v1_DownwardAPIVolumeFile(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -262,11 +268,11 @@ func autoconvert_api_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource(in *a
 	return nil
 }
 
-func convert_api_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource(in *api.DownwardAPIVolumeSource, out *v1.DownwardAPIVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource(in, out, s)
+func Convert_api_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource(in *api.DownwardAPIVolumeSource, out *v1.DownwardAPIVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource(in, out, s)
 }
 
-func autoconvert_api_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource(in *api.EmptyDirVolumeSource, out *v1.EmptyDirVolumeSource, s conversion.Scope) error {
+func autoConvert_api_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource(in *api.EmptyDirVolumeSource, out *v1.EmptyDirVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.EmptyDirVolumeSource))(in)
 	}
@@ -274,19 +280,20 @@ func autoconvert_api_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource(in *api.Emp
 	return nil
 }
 
-func convert_api_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource(in *api.EmptyDirVolumeSource, out *v1.EmptyDirVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource(in, out, s)
+func Convert_api_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource(in *api.EmptyDirVolumeSource, out *v1.EmptyDirVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource(in, out, s)
 }
 
-func autoconvert_api_EnvVar_To_v1_EnvVar(in *api.EnvVar, out *v1.EnvVar, s conversion.Scope) error {
+func autoConvert_api_EnvVar_To_v1_EnvVar(in *api.EnvVar, out *v1.EnvVar, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.EnvVar))(in)
 	}
 	out.Name = in.Name
 	out.Value = in.Value
+	// unable to generate simple pointer conversion for api.EnvVarSource -> v1.EnvVarSource
 	if in.ValueFrom != nil {
 		out.ValueFrom = new(v1.EnvVarSource)
-		if err := convert_api_EnvVarSource_To_v1_EnvVarSource(in.ValueFrom, out.ValueFrom, s); err != nil {
+		if err := Convert_api_EnvVarSource_To_v1_EnvVarSource(in.ValueFrom, out.ValueFrom, s); err != nil {
 			return err
 		}
 	} else {
@@ -295,17 +302,18 @@ func autoconvert_api_EnvVar_To_v1_EnvVar(in *api.EnvVar, out *v1.EnvVar, s conve
 	return nil
 }
 
-func convert_api_EnvVar_To_v1_EnvVar(in *api.EnvVar, out *v1.EnvVar, s conversion.Scope) error {
-	return autoconvert_api_EnvVar_To_v1_EnvVar(in, out, s)
+func Convert_api_EnvVar_To_v1_EnvVar(in *api.EnvVar, out *v1.EnvVar, s conversion.Scope) error {
+	return autoConvert_api_EnvVar_To_v1_EnvVar(in, out, s)
 }
 
-func autoconvert_api_EnvVarSource_To_v1_EnvVarSource(in *api.EnvVarSource, out *v1.EnvVarSource, s conversion.Scope) error {
+func autoConvert_api_EnvVarSource_To_v1_EnvVarSource(in *api.EnvVarSource, out *v1.EnvVarSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.EnvVarSource))(in)
 	}
+	// unable to generate simple pointer conversion for api.ObjectFieldSelector -> v1.ObjectFieldSelector
 	if in.FieldRef != nil {
 		out.FieldRef = new(v1.ObjectFieldSelector)
-		if err := convert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector(in.FieldRef, out.FieldRef, s); err != nil {
+		if err := Convert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector(in.FieldRef, out.FieldRef, s); err != nil {
 			return err
 		}
 	} else {
@@ -314,11 +322,11 @@ func autoconvert_api_EnvVarSource_To_v1_EnvVarSource(in *api.EnvVarSource, out *
 	return nil
 }
 
-func convert_api_EnvVarSource_To_v1_EnvVarSource(in *api.EnvVarSource, out *v1.EnvVarSource, s conversion.Scope) error {
-	return autoconvert_api_EnvVarSource_To_v1_EnvVarSource(in, out, s)
+func Convert_api_EnvVarSource_To_v1_EnvVarSource(in *api.EnvVarSource, out *v1.EnvVarSource, s conversion.Scope) error {
+	return autoConvert_api_EnvVarSource_To_v1_EnvVarSource(in, out, s)
 }
 
-func autoconvert_api_ExecAction_To_v1_ExecAction(in *api.ExecAction, out *v1.ExecAction, s conversion.Scope) error {
+func autoConvert_api_ExecAction_To_v1_ExecAction(in *api.ExecAction, out *v1.ExecAction, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ExecAction))(in)
 	}
@@ -333,11 +341,11 @@ func autoconvert_api_ExecAction_To_v1_ExecAction(in *api.ExecAction, out *v1.Exe
 	return nil
 }
 
-func convert_api_ExecAction_To_v1_ExecAction(in *api.ExecAction, out *v1.ExecAction, s conversion.Scope) error {
-	return autoconvert_api_ExecAction_To_v1_ExecAction(in, out, s)
+func Convert_api_ExecAction_To_v1_ExecAction(in *api.ExecAction, out *v1.ExecAction, s conversion.Scope) error {
+	return autoConvert_api_ExecAction_To_v1_ExecAction(in, out, s)
 }
 
-func autoconvert_api_FCVolumeSource_To_v1_FCVolumeSource(in *api.FCVolumeSource, out *v1.FCVolumeSource, s conversion.Scope) error {
+func autoConvert_api_FCVolumeSource_To_v1_FCVolumeSource(in *api.FCVolumeSource, out *v1.FCVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.FCVolumeSource))(in)
 	}
@@ -360,19 +368,20 @@ func autoconvert_api_FCVolumeSource_To_v1_FCVolumeSource(in *api.FCVolumeSource,
 	return nil
 }
 
-func convert_api_FCVolumeSource_To_v1_FCVolumeSource(in *api.FCVolumeSource, out *v1.FCVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_FCVolumeSource_To_v1_FCVolumeSource(in, out, s)
+func Convert_api_FCVolumeSource_To_v1_FCVolumeSource(in *api.FCVolumeSource, out *v1.FCVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_FCVolumeSource_To_v1_FCVolumeSource(in, out, s)
 }
 
-func autoconvert_api_FlexVolumeSource_To_v1_FlexVolumeSource(in *api.FlexVolumeSource, out *v1.FlexVolumeSource, s conversion.Scope) error {
+func autoConvert_api_FlexVolumeSource_To_v1_FlexVolumeSource(in *api.FlexVolumeSource, out *v1.FlexVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.FlexVolumeSource))(in)
 	}
 	out.Driver = in.Driver
 	out.FSType = in.FSType
+	// unable to generate simple pointer conversion for api.LocalObjectReference -> v1.LocalObjectReference
 	if in.SecretRef != nil {
 		out.SecretRef = new(v1.LocalObjectReference)
-		if err := convert_api_LocalObjectReference_To_v1_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
+		if err := Convert_api_LocalObjectReference_To_v1_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
 			return err
 		}
 	} else {
@@ -390,11 +399,11 @@ func autoconvert_api_FlexVolumeSource_To_v1_FlexVolumeSource(in *api.FlexVolumeS
 	return nil
 }
 
-func convert_api_FlexVolumeSource_To_v1_FlexVolumeSource(in *api.FlexVolumeSource, out *v1.FlexVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_FlexVolumeSource_To_v1_FlexVolumeSource(in, out, s)
+func Convert_api_FlexVolumeSource_To_v1_FlexVolumeSource(in *api.FlexVolumeSource, out *v1.FlexVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_FlexVolumeSource_To_v1_FlexVolumeSource(in, out, s)
 }
 
-func autoconvert_api_FlockerVolumeSource_To_v1_FlockerVolumeSource(in *api.FlockerVolumeSource, out *v1.FlockerVolumeSource, s conversion.Scope) error {
+func autoConvert_api_FlockerVolumeSource_To_v1_FlockerVolumeSource(in *api.FlockerVolumeSource, out *v1.FlockerVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.FlockerVolumeSource))(in)
 	}
@@ -402,11 +411,11 @@ func autoconvert_api_FlockerVolumeSource_To_v1_FlockerVolumeSource(in *api.Flock
 	return nil
 }
 
-func convert_api_FlockerVolumeSource_To_v1_FlockerVolumeSource(in *api.FlockerVolumeSource, out *v1.FlockerVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_FlockerVolumeSource_To_v1_FlockerVolumeSource(in, out, s)
+func Convert_api_FlockerVolumeSource_To_v1_FlockerVolumeSource(in *api.FlockerVolumeSource, out *v1.FlockerVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_FlockerVolumeSource_To_v1_FlockerVolumeSource(in, out, s)
 }
 
-func autoconvert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSource(in *api.GCEPersistentDiskVolumeSource, out *v1.GCEPersistentDiskVolumeSource, s conversion.Scope) error {
+func autoConvert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSource(in *api.GCEPersistentDiskVolumeSource, out *v1.GCEPersistentDiskVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.GCEPersistentDiskVolumeSource))(in)
 	}
@@ -417,11 +426,11 @@ func autoconvert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolume
 	return nil
 }
 
-func convert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSource(in *api.GCEPersistentDiskVolumeSource, out *v1.GCEPersistentDiskVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSource(in, out, s)
+func Convert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSource(in *api.GCEPersistentDiskVolumeSource, out *v1.GCEPersistentDiskVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSource(in, out, s)
 }
 
-func autoconvert_api_GitRepoVolumeSource_To_v1_GitRepoVolumeSource(in *api.GitRepoVolumeSource, out *v1.GitRepoVolumeSource, s conversion.Scope) error {
+func autoConvert_api_GitRepoVolumeSource_To_v1_GitRepoVolumeSource(in *api.GitRepoVolumeSource, out *v1.GitRepoVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.GitRepoVolumeSource))(in)
 	}
@@ -431,11 +440,11 @@ func autoconvert_api_GitRepoVolumeSource_To_v1_GitRepoVolumeSource(in *api.GitRe
 	return nil
 }
 
-func convert_api_GitRepoVolumeSource_To_v1_GitRepoVolumeSource(in *api.GitRepoVolumeSource, out *v1.GitRepoVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_GitRepoVolumeSource_To_v1_GitRepoVolumeSource(in, out, s)
+func Convert_api_GitRepoVolumeSource_To_v1_GitRepoVolumeSource(in *api.GitRepoVolumeSource, out *v1.GitRepoVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_GitRepoVolumeSource_To_v1_GitRepoVolumeSource(in, out, s)
 }
 
-func autoconvert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource(in *api.GlusterfsVolumeSource, out *v1.GlusterfsVolumeSource, s conversion.Scope) error {
+func autoConvert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource(in *api.GlusterfsVolumeSource, out *v1.GlusterfsVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.GlusterfsVolumeSource))(in)
 	}
@@ -445,16 +454,16 @@ func autoconvert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource(in *api.G
 	return nil
 }
 
-func convert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource(in *api.GlusterfsVolumeSource, out *v1.GlusterfsVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource(in, out, s)
+func Convert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource(in *api.GlusterfsVolumeSource, out *v1.GlusterfsVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource(in, out, s)
 }
 
-func autoconvert_api_HTTPGetAction_To_v1_HTTPGetAction(in *api.HTTPGetAction, out *v1.HTTPGetAction, s conversion.Scope) error {
+func autoConvert_api_HTTPGetAction_To_v1_HTTPGetAction(in *api.HTTPGetAction, out *v1.HTTPGetAction, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.HTTPGetAction))(in)
 	}
 	out.Path = in.Path
-	if err := s.Convert(&in.Port, &out.Port, 0); err != nil {
+	if err := api.Convert_intstr_IntOrString_To_intstr_IntOrString(&in.Port, &out.Port, s); err != nil {
 		return err
 	}
 	out.Host = in.Host
@@ -462,33 +471,36 @@ func autoconvert_api_HTTPGetAction_To_v1_HTTPGetAction(in *api.HTTPGetAction, ou
 	return nil
 }
 
-func convert_api_HTTPGetAction_To_v1_HTTPGetAction(in *api.HTTPGetAction, out *v1.HTTPGetAction, s conversion.Scope) error {
-	return autoconvert_api_HTTPGetAction_To_v1_HTTPGetAction(in, out, s)
+func Convert_api_HTTPGetAction_To_v1_HTTPGetAction(in *api.HTTPGetAction, out *v1.HTTPGetAction, s conversion.Scope) error {
+	return autoConvert_api_HTTPGetAction_To_v1_HTTPGetAction(in, out, s)
 }
 
-func autoconvert_api_Handler_To_v1_Handler(in *api.Handler, out *v1.Handler, s conversion.Scope) error {
+func autoConvert_api_Handler_To_v1_Handler(in *api.Handler, out *v1.Handler, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Handler))(in)
 	}
+	// unable to generate simple pointer conversion for api.ExecAction -> v1.ExecAction
 	if in.Exec != nil {
 		out.Exec = new(v1.ExecAction)
-		if err := convert_api_ExecAction_To_v1_ExecAction(in.Exec, out.Exec, s); err != nil {
+		if err := Convert_api_ExecAction_To_v1_ExecAction(in.Exec, out.Exec, s); err != nil {
 			return err
 		}
 	} else {
 		out.Exec = nil
 	}
+	// unable to generate simple pointer conversion for api.HTTPGetAction -> v1.HTTPGetAction
 	if in.HTTPGet != nil {
 		out.HTTPGet = new(v1.HTTPGetAction)
-		if err := convert_api_HTTPGetAction_To_v1_HTTPGetAction(in.HTTPGet, out.HTTPGet, s); err != nil {
+		if err := Convert_api_HTTPGetAction_To_v1_HTTPGetAction(in.HTTPGet, out.HTTPGet, s); err != nil {
 			return err
 		}
 	} else {
 		out.HTTPGet = nil
 	}
+	// unable to generate simple pointer conversion for api.TCPSocketAction -> v1.TCPSocketAction
 	if in.TCPSocket != nil {
 		out.TCPSocket = new(v1.TCPSocketAction)
-		if err := convert_api_TCPSocketAction_To_v1_TCPSocketAction(in.TCPSocket, out.TCPSocket, s); err != nil {
+		if err := Convert_api_TCPSocketAction_To_v1_TCPSocketAction(in.TCPSocket, out.TCPSocket, s); err != nil {
 			return err
 		}
 	} else {
@@ -497,11 +509,11 @@ func autoconvert_api_Handler_To_v1_Handler(in *api.Handler, out *v1.Handler, s c
 	return nil
 }
 
-func convert_api_Handler_To_v1_Handler(in *api.Handler, out *v1.Handler, s conversion.Scope) error {
-	return autoconvert_api_Handler_To_v1_Handler(in, out, s)
+func Convert_api_Handler_To_v1_Handler(in *api.Handler, out *v1.Handler, s conversion.Scope) error {
+	return autoConvert_api_Handler_To_v1_Handler(in, out, s)
 }
 
-func autoconvert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource(in *api.HostPathVolumeSource, out *v1.HostPathVolumeSource, s conversion.Scope) error {
+func autoConvert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource(in *api.HostPathVolumeSource, out *v1.HostPathVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.HostPathVolumeSource))(in)
 	}
@@ -509,11 +521,11 @@ func autoconvert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource(in *api.Hos
 	return nil
 }
 
-func convert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource(in *api.HostPathVolumeSource, out *v1.HostPathVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource(in, out, s)
+func Convert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource(in *api.HostPathVolumeSource, out *v1.HostPathVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource(in, out, s)
 }
 
-func autoconvert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource(in *api.ISCSIVolumeSource, out *v1.ISCSIVolumeSource, s conversion.Scope) error {
+func autoConvert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource(in *api.ISCSIVolumeSource, out *v1.ISCSIVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ISCSIVolumeSource))(in)
 	}
@@ -526,25 +538,27 @@ func autoconvert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource(in *api.ISCSIVolu
 	return nil
 }
 
-func convert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource(in *api.ISCSIVolumeSource, out *v1.ISCSIVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource(in, out, s)
+func Convert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource(in *api.ISCSIVolumeSource, out *v1.ISCSIVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource(in, out, s)
 }
 
-func autoconvert_api_Lifecycle_To_v1_Lifecycle(in *api.Lifecycle, out *v1.Lifecycle, s conversion.Scope) error {
+func autoConvert_api_Lifecycle_To_v1_Lifecycle(in *api.Lifecycle, out *v1.Lifecycle, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Lifecycle))(in)
 	}
+	// unable to generate simple pointer conversion for api.Handler -> v1.Handler
 	if in.PostStart != nil {
 		out.PostStart = new(v1.Handler)
-		if err := convert_api_Handler_To_v1_Handler(in.PostStart, out.PostStart, s); err != nil {
+		if err := Convert_api_Handler_To_v1_Handler(in.PostStart, out.PostStart, s); err != nil {
 			return err
 		}
 	} else {
 		out.PostStart = nil
 	}
+	// unable to generate simple pointer conversion for api.Handler -> v1.Handler
 	if in.PreStop != nil {
 		out.PreStop = new(v1.Handler)
-		if err := convert_api_Handler_To_v1_Handler(in.PreStop, out.PreStop, s); err != nil {
+		if err := Convert_api_Handler_To_v1_Handler(in.PreStop, out.PreStop, s); err != nil {
 			return err
 		}
 	} else {
@@ -553,21 +567,21 @@ func autoconvert_api_Lifecycle_To_v1_Lifecycle(in *api.Lifecycle, out *v1.Lifecy
 	return nil
 }
 
-func convert_api_Lifecycle_To_v1_Lifecycle(in *api.Lifecycle, out *v1.Lifecycle, s conversion.Scope) error {
-	return autoconvert_api_Lifecycle_To_v1_Lifecycle(in, out, s)
+func Convert_api_Lifecycle_To_v1_Lifecycle(in *api.Lifecycle, out *v1.Lifecycle, s conversion.Scope) error {
+	return autoConvert_api_Lifecycle_To_v1_Lifecycle(in, out, s)
 }
 
-func autoconvert_api_ListOptions_To_v1beta1_ListOptions(in *api.ListOptions, out *ListOptions, s conversion.Scope) error {
+func autoConvert_api_ListOptions_To_v1beta1_ListOptions(in *api.ListOptions, out *ListOptions, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ListOptions))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.LabelSelector, &out.LabelSelector, 0); err != nil {
+	if err := api.Convert_labels_Selector_To_string(&in.LabelSelector, &out.LabelSelector, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.FieldSelector, &out.FieldSelector, 0); err != nil {
+	if err := api.Convert_fields_Selector_To_string(&in.FieldSelector, &out.FieldSelector, s); err != nil {
 		return err
 	}
 	out.Watch = in.Watch
@@ -581,11 +595,11 @@ func autoconvert_api_ListOptions_To_v1beta1_ListOptions(in *api.ListOptions, out
 	return nil
 }
 
-func convert_api_ListOptions_To_v1beta1_ListOptions(in *api.ListOptions, out *ListOptions, s conversion.Scope) error {
-	return autoconvert_api_ListOptions_To_v1beta1_ListOptions(in, out, s)
+func Convert_api_ListOptions_To_v1beta1_ListOptions(in *api.ListOptions, out *ListOptions, s conversion.Scope) error {
+	return autoConvert_api_ListOptions_To_v1beta1_ListOptions(in, out, s)
 }
 
-func autoconvert_api_LoadBalancerIngress_To_v1_LoadBalancerIngress(in *api.LoadBalancerIngress, out *v1.LoadBalancerIngress, s conversion.Scope) error {
+func autoConvert_api_LoadBalancerIngress_To_v1_LoadBalancerIngress(in *api.LoadBalancerIngress, out *v1.LoadBalancerIngress, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.LoadBalancerIngress))(in)
 	}
@@ -594,18 +608,18 @@ func autoconvert_api_LoadBalancerIngress_To_v1_LoadBalancerIngress(in *api.LoadB
 	return nil
 }
 
-func convert_api_LoadBalancerIngress_To_v1_LoadBalancerIngress(in *api.LoadBalancerIngress, out *v1.LoadBalancerIngress, s conversion.Scope) error {
-	return autoconvert_api_LoadBalancerIngress_To_v1_LoadBalancerIngress(in, out, s)
+func Convert_api_LoadBalancerIngress_To_v1_LoadBalancerIngress(in *api.LoadBalancerIngress, out *v1.LoadBalancerIngress, s conversion.Scope) error {
+	return autoConvert_api_LoadBalancerIngress_To_v1_LoadBalancerIngress(in, out, s)
 }
 
-func autoconvert_api_LoadBalancerStatus_To_v1_LoadBalancerStatus(in *api.LoadBalancerStatus, out *v1.LoadBalancerStatus, s conversion.Scope) error {
+func autoConvert_api_LoadBalancerStatus_To_v1_LoadBalancerStatus(in *api.LoadBalancerStatus, out *v1.LoadBalancerStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.LoadBalancerStatus))(in)
 	}
 	if in.Ingress != nil {
 		out.Ingress = make([]v1.LoadBalancerIngress, len(in.Ingress))
 		for i := range in.Ingress {
-			if err := convert_api_LoadBalancerIngress_To_v1_LoadBalancerIngress(&in.Ingress[i], &out.Ingress[i], s); err != nil {
+			if err := Convert_api_LoadBalancerIngress_To_v1_LoadBalancerIngress(&in.Ingress[i], &out.Ingress[i], s); err != nil {
 				return err
 			}
 		}
@@ -615,11 +629,11 @@ func autoconvert_api_LoadBalancerStatus_To_v1_LoadBalancerStatus(in *api.LoadBal
 	return nil
 }
 
-func convert_api_LoadBalancerStatus_To_v1_LoadBalancerStatus(in *api.LoadBalancerStatus, out *v1.LoadBalancerStatus, s conversion.Scope) error {
-	return autoconvert_api_LoadBalancerStatus_To_v1_LoadBalancerStatus(in, out, s)
+func Convert_api_LoadBalancerStatus_To_v1_LoadBalancerStatus(in *api.LoadBalancerStatus, out *v1.LoadBalancerStatus, s conversion.Scope) error {
+	return autoConvert_api_LoadBalancerStatus_To_v1_LoadBalancerStatus(in, out, s)
 }
 
-func autoconvert_api_LocalObjectReference_To_v1_LocalObjectReference(in *api.LocalObjectReference, out *v1.LocalObjectReference, s conversion.Scope) error {
+func autoConvert_api_LocalObjectReference_To_v1_LocalObjectReference(in *api.LocalObjectReference, out *v1.LocalObjectReference, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.LocalObjectReference))(in)
 	}
@@ -627,11 +641,11 @@ func autoconvert_api_LocalObjectReference_To_v1_LocalObjectReference(in *api.Loc
 	return nil
 }
 
-func convert_api_LocalObjectReference_To_v1_LocalObjectReference(in *api.LocalObjectReference, out *v1.LocalObjectReference, s conversion.Scope) error {
-	return autoconvert_api_LocalObjectReference_To_v1_LocalObjectReference(in, out, s)
+func Convert_api_LocalObjectReference_To_v1_LocalObjectReference(in *api.LocalObjectReference, out *v1.LocalObjectReference, s conversion.Scope) error {
+	return autoConvert_api_LocalObjectReference_To_v1_LocalObjectReference(in, out, s)
 }
 
-func autoconvert_api_NFSVolumeSource_To_v1_NFSVolumeSource(in *api.NFSVolumeSource, out *v1.NFSVolumeSource, s conversion.Scope) error {
+func autoConvert_api_NFSVolumeSource_To_v1_NFSVolumeSource(in *api.NFSVolumeSource, out *v1.NFSVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.NFSVolumeSource))(in)
 	}
@@ -641,11 +655,11 @@ func autoconvert_api_NFSVolumeSource_To_v1_NFSVolumeSource(in *api.NFSVolumeSour
 	return nil
 }
 
-func convert_api_NFSVolumeSource_To_v1_NFSVolumeSource(in *api.NFSVolumeSource, out *v1.NFSVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_NFSVolumeSource_To_v1_NFSVolumeSource(in, out, s)
+func Convert_api_NFSVolumeSource_To_v1_NFSVolumeSource(in *api.NFSVolumeSource, out *v1.NFSVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_NFSVolumeSource_To_v1_NFSVolumeSource(in, out, s)
 }
 
-func autoconvert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector(in *api.ObjectFieldSelector, out *v1.ObjectFieldSelector, s conversion.Scope) error {
+func autoConvert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector(in *api.ObjectFieldSelector, out *v1.ObjectFieldSelector, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ObjectFieldSelector))(in)
 	}
@@ -654,11 +668,11 @@ func autoconvert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector(in *api.Objec
 	return nil
 }
 
-func convert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector(in *api.ObjectFieldSelector, out *v1.ObjectFieldSelector, s conversion.Scope) error {
-	return autoconvert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector(in, out, s)
+func Convert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector(in *api.ObjectFieldSelector, out *v1.ObjectFieldSelector, s conversion.Scope) error {
+	return autoConvert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector(in, out, s)
 }
 
-func autoconvert_api_ObjectMeta_To_v1_ObjectMeta(in *api.ObjectMeta, out *v1.ObjectMeta, s conversion.Scope) error {
+func autoConvert_api_ObjectMeta_To_v1_ObjectMeta(in *api.ObjectMeta, out *v1.ObjectMeta, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ObjectMeta))(in)
 	}
@@ -669,11 +683,13 @@ func autoconvert_api_ObjectMeta_To_v1_ObjectMeta(in *api.ObjectMeta, out *v1.Obj
 	out.UID = in.UID
 	out.ResourceVersion = in.ResourceVersion
 	out.Generation = in.Generation
-	if err := s.Convert(&in.CreationTimestamp, &out.CreationTimestamp, 0); err != nil {
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.CreationTimestamp, &out.CreationTimestamp, s); err != nil {
 		return err
 	}
+	// unable to generate simple pointer conversion for unversioned.Time -> unversioned.Time
 	if in.DeletionTimestamp != nil {
-		if err := s.Convert(&in.DeletionTimestamp, &out.DeletionTimestamp, 0); err != nil {
+		out.DeletionTimestamp = new(unversioned.Time)
+		if err := api.Convert_unversioned_Time_To_unversioned_Time(in.DeletionTimestamp, out.DeletionTimestamp, s); err != nil {
 			return err
 		}
 	} else {
@@ -704,11 +720,11 @@ func autoconvert_api_ObjectMeta_To_v1_ObjectMeta(in *api.ObjectMeta, out *v1.Obj
 	return nil
 }
 
-func convert_api_ObjectMeta_To_v1_ObjectMeta(in *api.ObjectMeta, out *v1.ObjectMeta, s conversion.Scope) error {
-	return autoconvert_api_ObjectMeta_To_v1_ObjectMeta(in, out, s)
+func Convert_api_ObjectMeta_To_v1_ObjectMeta(in *api.ObjectMeta, out *v1.ObjectMeta, s conversion.Scope) error {
+	return autoConvert_api_ObjectMeta_To_v1_ObjectMeta(in, out, s)
 }
 
-func autoconvert_api_PersistentVolumeClaimVolumeSource_To_v1_PersistentVolumeClaimVolumeSource(in *api.PersistentVolumeClaimVolumeSource, out *v1.PersistentVolumeClaimVolumeSource, s conversion.Scope) error {
+func autoConvert_api_PersistentVolumeClaimVolumeSource_To_v1_PersistentVolumeClaimVolumeSource(in *api.PersistentVolumeClaimVolumeSource, out *v1.PersistentVolumeClaimVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PersistentVolumeClaimVolumeSource))(in)
 	}
@@ -717,18 +733,18 @@ func autoconvert_api_PersistentVolumeClaimVolumeSource_To_v1_PersistentVolumeCla
 	return nil
 }
 
-func convert_api_PersistentVolumeClaimVolumeSource_To_v1_PersistentVolumeClaimVolumeSource(in *api.PersistentVolumeClaimVolumeSource, out *v1.PersistentVolumeClaimVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_PersistentVolumeClaimVolumeSource_To_v1_PersistentVolumeClaimVolumeSource(in, out, s)
+func Convert_api_PersistentVolumeClaimVolumeSource_To_v1_PersistentVolumeClaimVolumeSource(in *api.PersistentVolumeClaimVolumeSource, out *v1.PersistentVolumeClaimVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_PersistentVolumeClaimVolumeSource_To_v1_PersistentVolumeClaimVolumeSource(in, out, s)
 }
 
-func autoconvert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *v1.PodSpec, s conversion.Scope) error {
+func autoConvert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *v1.PodSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodSpec))(in)
 	}
 	if in.Volumes != nil {
 		out.Volumes = make([]v1.Volume, len(in.Volumes))
 		for i := range in.Volumes {
-			if err := convert_api_Volume_To_v1_Volume(&in.Volumes[i], &out.Volumes[i], s); err != nil {
+			if err := Convert_api_Volume_To_v1_Volume(&in.Volumes[i], &out.Volumes[i], s); err != nil {
 				return err
 			}
 		}
@@ -738,7 +754,7 @@ func autoconvert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *v1.PodSpec, s c
 	if in.Containers != nil {
 		out.Containers = make([]v1.Container, len(in.Containers))
 		for i := range in.Containers {
-			if err := convert_api_Container_To_v1_Container(&in.Containers[i], &out.Containers[i], s); err != nil {
+			if err := Convert_api_Container_To_v1_Container(&in.Containers[i], &out.Containers[i], s); err != nil {
 				return err
 			}
 		}
@@ -769,6 +785,7 @@ func autoconvert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *v1.PodSpec, s c
 	}
 	out.ServiceAccountName = in.ServiceAccountName
 	out.NodeName = in.NodeName
+	// unable to generate simple pointer conversion for api.PodSecurityContext -> v1.PodSecurityContext
 	if in.SecurityContext != nil {
 		if err := s.Convert(&in.SecurityContext, &out.SecurityContext, 0); err != nil {
 			return err
@@ -779,7 +796,7 @@ func autoconvert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *v1.PodSpec, s c
 	if in.ImagePullSecrets != nil {
 		out.ImagePullSecrets = make([]v1.LocalObjectReference, len(in.ImagePullSecrets))
 		for i := range in.ImagePullSecrets {
-			if err := convert_api_LocalObjectReference_To_v1_LocalObjectReference(&in.ImagePullSecrets[i], &out.ImagePullSecrets[i], s); err != nil {
+			if err := Convert_api_LocalObjectReference_To_v1_LocalObjectReference(&in.ImagePullSecrets[i], &out.ImagePullSecrets[i], s); err != nil {
 				return err
 			}
 		}
@@ -789,28 +806,28 @@ func autoconvert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *v1.PodSpec, s c
 	return nil
 }
 
-func autoconvert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in *api.PodTemplateSpec, out *v1.PodTemplateSpec, s conversion.Scope) error {
+func autoConvert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in *api.PodTemplateSpec, out *v1.PodTemplateSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodTemplateSpec))(in)
 	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_PodSpec_To_v1_PodSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_api_PodSpec_To_v1_PodSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in *api.PodTemplateSpec, out *v1.PodTemplateSpec, s conversion.Scope) error {
-	return autoconvert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in, out, s)
+func Convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in *api.PodTemplateSpec, out *v1.PodTemplateSpec, s conversion.Scope) error {
+	return autoConvert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in, out, s)
 }
 
-func autoconvert_api_Probe_To_v1_Probe(in *api.Probe, out *v1.Probe, s conversion.Scope) error {
+func autoConvert_api_Probe_To_v1_Probe(in *api.Probe, out *v1.Probe, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Probe))(in)
 	}
-	if err := convert_api_Handler_To_v1_Handler(&in.Handler, &out.Handler, s); err != nil {
+	if err := Convert_api_Handler_To_v1_Handler(&in.Handler, &out.Handler, s); err != nil {
 		return err
 	}
 	out.InitialDelaySeconds = int32(in.InitialDelaySeconds)
@@ -821,11 +838,11 @@ func autoconvert_api_Probe_To_v1_Probe(in *api.Probe, out *v1.Probe, s conversio
 	return nil
 }
 
-func convert_api_Probe_To_v1_Probe(in *api.Probe, out *v1.Probe, s conversion.Scope) error {
-	return autoconvert_api_Probe_To_v1_Probe(in, out, s)
+func Convert_api_Probe_To_v1_Probe(in *api.Probe, out *v1.Probe, s conversion.Scope) error {
+	return autoConvert_api_Probe_To_v1_Probe(in, out, s)
 }
 
-func autoconvert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in *api.RBDVolumeSource, out *v1.RBDVolumeSource, s conversion.Scope) error {
+func autoConvert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in *api.RBDVolumeSource, out *v1.RBDVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.RBDVolumeSource))(in)
 	}
@@ -842,9 +859,10 @@ func autoconvert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in *api.RBDVolumeSour
 	out.RBDPool = in.RBDPool
 	out.RadosUser = in.RadosUser
 	out.Keyring = in.Keyring
+	// unable to generate simple pointer conversion for api.LocalObjectReference -> v1.LocalObjectReference
 	if in.SecretRef != nil {
 		out.SecretRef = new(v1.LocalObjectReference)
-		if err := convert_api_LocalObjectReference_To_v1_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
+		if err := Convert_api_LocalObjectReference_To_v1_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
 			return err
 		}
 	} else {
@@ -854,11 +872,11 @@ func autoconvert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in *api.RBDVolumeSour
 	return nil
 }
 
-func convert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in *api.RBDVolumeSource, out *v1.RBDVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in, out, s)
+func Convert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in *api.RBDVolumeSource, out *v1.RBDVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in, out, s)
 }
 
-func autoconvert_api_ResourceRequirements_To_v1_ResourceRequirements(in *api.ResourceRequirements, out *v1.ResourceRequirements, s conversion.Scope) error {
+func autoConvert_api_ResourceRequirements_To_v1_ResourceRequirements(in *api.ResourceRequirements, out *v1.ResourceRequirements, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ResourceRequirements))(in)
 	}
@@ -866,7 +884,7 @@ func autoconvert_api_ResourceRequirements_To_v1_ResourceRequirements(in *api.Res
 		out.Limits = make(v1.ResourceList)
 		for key, val := range in.Limits {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.Limits[v1.ResourceName(key)] = newVal
@@ -878,7 +896,7 @@ func autoconvert_api_ResourceRequirements_To_v1_ResourceRequirements(in *api.Res
 		out.Requests = make(v1.ResourceList)
 		for key, val := range in.Requests {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.Requests[v1.ResourceName(key)] = newVal
@@ -889,11 +907,11 @@ func autoconvert_api_ResourceRequirements_To_v1_ResourceRequirements(in *api.Res
 	return nil
 }
 
-func convert_api_ResourceRequirements_To_v1_ResourceRequirements(in *api.ResourceRequirements, out *v1.ResourceRequirements, s conversion.Scope) error {
-	return autoconvert_api_ResourceRequirements_To_v1_ResourceRequirements(in, out, s)
+func Convert_api_ResourceRequirements_To_v1_ResourceRequirements(in *api.ResourceRequirements, out *v1.ResourceRequirements, s conversion.Scope) error {
+	return autoConvert_api_ResourceRequirements_To_v1_ResourceRequirements(in, out, s)
 }
 
-func autoconvert_api_SELinuxOptions_To_v1_SELinuxOptions(in *api.SELinuxOptions, out *v1.SELinuxOptions, s conversion.Scope) error {
+func autoConvert_api_SELinuxOptions_To_v1_SELinuxOptions(in *api.SELinuxOptions, out *v1.SELinuxOptions, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.SELinuxOptions))(in)
 	}
@@ -904,11 +922,11 @@ func autoconvert_api_SELinuxOptions_To_v1_SELinuxOptions(in *api.SELinuxOptions,
 	return nil
 }
 
-func convert_api_SELinuxOptions_To_v1_SELinuxOptions(in *api.SELinuxOptions, out *v1.SELinuxOptions, s conversion.Scope) error {
-	return autoconvert_api_SELinuxOptions_To_v1_SELinuxOptions(in, out, s)
+func Convert_api_SELinuxOptions_To_v1_SELinuxOptions(in *api.SELinuxOptions, out *v1.SELinuxOptions, s conversion.Scope) error {
+	return autoConvert_api_SELinuxOptions_To_v1_SELinuxOptions(in, out, s)
 }
 
-func autoconvert_api_SecretVolumeSource_To_v1_SecretVolumeSource(in *api.SecretVolumeSource, out *v1.SecretVolumeSource, s conversion.Scope) error {
+func autoConvert_api_SecretVolumeSource_To_v1_SecretVolumeSource(in *api.SecretVolumeSource, out *v1.SecretVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.SecretVolumeSource))(in)
 	}
@@ -916,17 +934,18 @@ func autoconvert_api_SecretVolumeSource_To_v1_SecretVolumeSource(in *api.SecretV
 	return nil
 }
 
-func convert_api_SecretVolumeSource_To_v1_SecretVolumeSource(in *api.SecretVolumeSource, out *v1.SecretVolumeSource, s conversion.Scope) error {
-	return autoconvert_api_SecretVolumeSource_To_v1_SecretVolumeSource(in, out, s)
+func Convert_api_SecretVolumeSource_To_v1_SecretVolumeSource(in *api.SecretVolumeSource, out *v1.SecretVolumeSource, s conversion.Scope) error {
+	return autoConvert_api_SecretVolumeSource_To_v1_SecretVolumeSource(in, out, s)
 }
 
-func autoconvert_api_SecurityContext_To_v1_SecurityContext(in *api.SecurityContext, out *v1.SecurityContext, s conversion.Scope) error {
+func autoConvert_api_SecurityContext_To_v1_SecurityContext(in *api.SecurityContext, out *v1.SecurityContext, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.SecurityContext))(in)
 	}
+	// unable to generate simple pointer conversion for api.Capabilities -> v1.Capabilities
 	if in.Capabilities != nil {
 		out.Capabilities = new(v1.Capabilities)
-		if err := convert_api_Capabilities_To_v1_Capabilities(in.Capabilities, out.Capabilities, s); err != nil {
+		if err := Convert_api_Capabilities_To_v1_Capabilities(in.Capabilities, out.Capabilities, s); err != nil {
 			return err
 		}
 	} else {
@@ -938,9 +957,10 @@ func autoconvert_api_SecurityContext_To_v1_SecurityContext(in *api.SecurityConte
 	} else {
 		out.Privileged = nil
 	}
+	// unable to generate simple pointer conversion for api.SELinuxOptions -> v1.SELinuxOptions
 	if in.SELinuxOptions != nil {
 		out.SELinuxOptions = new(v1.SELinuxOptions)
-		if err := convert_api_SELinuxOptions_To_v1_SELinuxOptions(in.SELinuxOptions, out.SELinuxOptions, s); err != nil {
+		if err := Convert_api_SELinuxOptions_To_v1_SELinuxOptions(in.SELinuxOptions, out.SELinuxOptions, s); err != nil {
 			return err
 		}
 	} else {
@@ -961,40 +981,40 @@ func autoconvert_api_SecurityContext_To_v1_SecurityContext(in *api.SecurityConte
 	return nil
 }
 
-func convert_api_SecurityContext_To_v1_SecurityContext(in *api.SecurityContext, out *v1.SecurityContext, s conversion.Scope) error {
-	return autoconvert_api_SecurityContext_To_v1_SecurityContext(in, out, s)
+func Convert_api_SecurityContext_To_v1_SecurityContext(in *api.SecurityContext, out *v1.SecurityContext, s conversion.Scope) error {
+	return autoConvert_api_SecurityContext_To_v1_SecurityContext(in, out, s)
 }
 
-func autoconvert_api_TCPSocketAction_To_v1_TCPSocketAction(in *api.TCPSocketAction, out *v1.TCPSocketAction, s conversion.Scope) error {
+func autoConvert_api_TCPSocketAction_To_v1_TCPSocketAction(in *api.TCPSocketAction, out *v1.TCPSocketAction, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.TCPSocketAction))(in)
 	}
-	if err := s.Convert(&in.Port, &out.Port, 0); err != nil {
+	if err := api.Convert_intstr_IntOrString_To_intstr_IntOrString(&in.Port, &out.Port, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_api_TCPSocketAction_To_v1_TCPSocketAction(in *api.TCPSocketAction, out *v1.TCPSocketAction, s conversion.Scope) error {
-	return autoconvert_api_TCPSocketAction_To_v1_TCPSocketAction(in, out, s)
+func Convert_api_TCPSocketAction_To_v1_TCPSocketAction(in *api.TCPSocketAction, out *v1.TCPSocketAction, s conversion.Scope) error {
+	return autoConvert_api_TCPSocketAction_To_v1_TCPSocketAction(in, out, s)
 }
 
-func autoconvert_api_Volume_To_v1_Volume(in *api.Volume, out *v1.Volume, s conversion.Scope) error {
+func autoConvert_api_Volume_To_v1_Volume(in *api.Volume, out *v1.Volume, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Volume))(in)
 	}
 	out.Name = in.Name
-	if err := convert_api_VolumeSource_To_v1_VolumeSource(&in.VolumeSource, &out.VolumeSource, s); err != nil {
+	if err := Convert_api_VolumeSource_To_v1_VolumeSource(&in.VolumeSource, &out.VolumeSource, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_api_Volume_To_v1_Volume(in *api.Volume, out *v1.Volume, s conversion.Scope) error {
-	return autoconvert_api_Volume_To_v1_Volume(in, out, s)
+func Convert_api_Volume_To_v1_Volume(in *api.Volume, out *v1.Volume, s conversion.Scope) error {
+	return autoConvert_api_Volume_To_v1_Volume(in, out, s)
 }
 
-func autoconvert_api_VolumeMount_To_v1_VolumeMount(in *api.VolumeMount, out *v1.VolumeMount, s conversion.Scope) error {
+func autoConvert_api_VolumeMount_To_v1_VolumeMount(in *api.VolumeMount, out *v1.VolumeMount, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.VolumeMount))(in)
 	}
@@ -1004,145 +1024,162 @@ func autoconvert_api_VolumeMount_To_v1_VolumeMount(in *api.VolumeMount, out *v1.
 	return nil
 }
 
-func convert_api_VolumeMount_To_v1_VolumeMount(in *api.VolumeMount, out *v1.VolumeMount, s conversion.Scope) error {
-	return autoconvert_api_VolumeMount_To_v1_VolumeMount(in, out, s)
+func Convert_api_VolumeMount_To_v1_VolumeMount(in *api.VolumeMount, out *v1.VolumeMount, s conversion.Scope) error {
+	return autoConvert_api_VolumeMount_To_v1_VolumeMount(in, out, s)
 }
 
-func autoconvert_api_VolumeSource_To_v1_VolumeSource(in *api.VolumeSource, out *v1.VolumeSource, s conversion.Scope) error {
+func autoConvert_api_VolumeSource_To_v1_VolumeSource(in *api.VolumeSource, out *v1.VolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.VolumeSource))(in)
 	}
+	// unable to generate simple pointer conversion for api.HostPathVolumeSource -> v1.HostPathVolumeSource
 	if in.HostPath != nil {
 		out.HostPath = new(v1.HostPathVolumeSource)
-		if err := convert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource(in.HostPath, out.HostPath, s); err != nil {
+		if err := Convert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource(in.HostPath, out.HostPath, s); err != nil {
 			return err
 		}
 	} else {
 		out.HostPath = nil
 	}
+	// unable to generate simple pointer conversion for api.EmptyDirVolumeSource -> v1.EmptyDirVolumeSource
 	if in.EmptyDir != nil {
 		out.EmptyDir = new(v1.EmptyDirVolumeSource)
-		if err := convert_api_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource(in.EmptyDir, out.EmptyDir, s); err != nil {
+		if err := Convert_api_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource(in.EmptyDir, out.EmptyDir, s); err != nil {
 			return err
 		}
 	} else {
 		out.EmptyDir = nil
 	}
+	// unable to generate simple pointer conversion for api.GCEPersistentDiskVolumeSource -> v1.GCEPersistentDiskVolumeSource
 	if in.GCEPersistentDisk != nil {
 		out.GCEPersistentDisk = new(v1.GCEPersistentDiskVolumeSource)
-		if err := convert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSource(in.GCEPersistentDisk, out.GCEPersistentDisk, s); err != nil {
+		if err := Convert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSource(in.GCEPersistentDisk, out.GCEPersistentDisk, s); err != nil {
 			return err
 		}
 	} else {
 		out.GCEPersistentDisk = nil
 	}
+	// unable to generate simple pointer conversion for api.AWSElasticBlockStoreVolumeSource -> v1.AWSElasticBlockStoreVolumeSource
 	if in.AWSElasticBlockStore != nil {
 		out.AWSElasticBlockStore = new(v1.AWSElasticBlockStoreVolumeSource)
-		if err := convert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVolumeSource(in.AWSElasticBlockStore, out.AWSElasticBlockStore, s); err != nil {
+		if err := Convert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVolumeSource(in.AWSElasticBlockStore, out.AWSElasticBlockStore, s); err != nil {
 			return err
 		}
 	} else {
 		out.AWSElasticBlockStore = nil
 	}
+	// unable to generate simple pointer conversion for api.GitRepoVolumeSource -> v1.GitRepoVolumeSource
 	if in.GitRepo != nil {
 		out.GitRepo = new(v1.GitRepoVolumeSource)
-		if err := convert_api_GitRepoVolumeSource_To_v1_GitRepoVolumeSource(in.GitRepo, out.GitRepo, s); err != nil {
+		if err := Convert_api_GitRepoVolumeSource_To_v1_GitRepoVolumeSource(in.GitRepo, out.GitRepo, s); err != nil {
 			return err
 		}
 	} else {
 		out.GitRepo = nil
 	}
+	// unable to generate simple pointer conversion for api.SecretVolumeSource -> v1.SecretVolumeSource
 	if in.Secret != nil {
 		out.Secret = new(v1.SecretVolumeSource)
-		if err := convert_api_SecretVolumeSource_To_v1_SecretVolumeSource(in.Secret, out.Secret, s); err != nil {
+		if err := Convert_api_SecretVolumeSource_To_v1_SecretVolumeSource(in.Secret, out.Secret, s); err != nil {
 			return err
 		}
 	} else {
 		out.Secret = nil
 	}
+	// unable to generate simple pointer conversion for api.NFSVolumeSource -> v1.NFSVolumeSource
 	if in.NFS != nil {
 		out.NFS = new(v1.NFSVolumeSource)
-		if err := convert_api_NFSVolumeSource_To_v1_NFSVolumeSource(in.NFS, out.NFS, s); err != nil {
+		if err := Convert_api_NFSVolumeSource_To_v1_NFSVolumeSource(in.NFS, out.NFS, s); err != nil {
 			return err
 		}
 	} else {
 		out.NFS = nil
 	}
+	// unable to generate simple pointer conversion for api.ISCSIVolumeSource -> v1.ISCSIVolumeSource
 	if in.ISCSI != nil {
 		out.ISCSI = new(v1.ISCSIVolumeSource)
-		if err := convert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource(in.ISCSI, out.ISCSI, s); err != nil {
+		if err := Convert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource(in.ISCSI, out.ISCSI, s); err != nil {
 			return err
 		}
 	} else {
 		out.ISCSI = nil
 	}
+	// unable to generate simple pointer conversion for api.GlusterfsVolumeSource -> v1.GlusterfsVolumeSource
 	if in.Glusterfs != nil {
 		out.Glusterfs = new(v1.GlusterfsVolumeSource)
-		if err := convert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource(in.Glusterfs, out.Glusterfs, s); err != nil {
+		if err := Convert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource(in.Glusterfs, out.Glusterfs, s); err != nil {
 			return err
 		}
 	} else {
 		out.Glusterfs = nil
 	}
+	// unable to generate simple pointer conversion for api.PersistentVolumeClaimVolumeSource -> v1.PersistentVolumeClaimVolumeSource
 	if in.PersistentVolumeClaim != nil {
 		out.PersistentVolumeClaim = new(v1.PersistentVolumeClaimVolumeSource)
-		if err := convert_api_PersistentVolumeClaimVolumeSource_To_v1_PersistentVolumeClaimVolumeSource(in.PersistentVolumeClaim, out.PersistentVolumeClaim, s); err != nil {
+		if err := Convert_api_PersistentVolumeClaimVolumeSource_To_v1_PersistentVolumeClaimVolumeSource(in.PersistentVolumeClaim, out.PersistentVolumeClaim, s); err != nil {
 			return err
 		}
 	} else {
 		out.PersistentVolumeClaim = nil
 	}
+	// unable to generate simple pointer conversion for api.RBDVolumeSource -> v1.RBDVolumeSource
 	if in.RBD != nil {
 		out.RBD = new(v1.RBDVolumeSource)
-		if err := convert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in.RBD, out.RBD, s); err != nil {
+		if err := Convert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in.RBD, out.RBD, s); err != nil {
 			return err
 		}
 	} else {
 		out.RBD = nil
 	}
+	// unable to generate simple pointer conversion for api.FlexVolumeSource -> v1.FlexVolumeSource
 	if in.FlexVolume != nil {
 		out.FlexVolume = new(v1.FlexVolumeSource)
-		if err := convert_api_FlexVolumeSource_To_v1_FlexVolumeSource(in.FlexVolume, out.FlexVolume, s); err != nil {
+		if err := Convert_api_FlexVolumeSource_To_v1_FlexVolumeSource(in.FlexVolume, out.FlexVolume, s); err != nil {
 			return err
 		}
 	} else {
 		out.FlexVolume = nil
 	}
+	// unable to generate simple pointer conversion for api.CinderVolumeSource -> v1.CinderVolumeSource
 	if in.Cinder != nil {
 		out.Cinder = new(v1.CinderVolumeSource)
-		if err := convert_api_CinderVolumeSource_To_v1_CinderVolumeSource(in.Cinder, out.Cinder, s); err != nil {
+		if err := Convert_api_CinderVolumeSource_To_v1_CinderVolumeSource(in.Cinder, out.Cinder, s); err != nil {
 			return err
 		}
 	} else {
 		out.Cinder = nil
 	}
+	// unable to generate simple pointer conversion for api.CephFSVolumeSource -> v1.CephFSVolumeSource
 	if in.CephFS != nil {
 		out.CephFS = new(v1.CephFSVolumeSource)
-		if err := convert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in.CephFS, out.CephFS, s); err != nil {
+		if err := Convert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in.CephFS, out.CephFS, s); err != nil {
 			return err
 		}
 	} else {
 		out.CephFS = nil
 	}
+	// unable to generate simple pointer conversion for api.FlockerVolumeSource -> v1.FlockerVolumeSource
 	if in.Flocker != nil {
 		out.Flocker = new(v1.FlockerVolumeSource)
-		if err := convert_api_FlockerVolumeSource_To_v1_FlockerVolumeSource(in.Flocker, out.Flocker, s); err != nil {
+		if err := Convert_api_FlockerVolumeSource_To_v1_FlockerVolumeSource(in.Flocker, out.Flocker, s); err != nil {
 			return err
 		}
 	} else {
 		out.Flocker = nil
 	}
+	// unable to generate simple pointer conversion for api.DownwardAPIVolumeSource -> v1.DownwardAPIVolumeSource
 	if in.DownwardAPI != nil {
 		out.DownwardAPI = new(v1.DownwardAPIVolumeSource)
-		if err := convert_api_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource(in.DownwardAPI, out.DownwardAPI, s); err != nil {
+		if err := Convert_api_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource(in.DownwardAPI, out.DownwardAPI, s); err != nil {
 			return err
 		}
 	} else {
 		out.DownwardAPI = nil
 	}
+	// unable to generate simple pointer conversion for api.FCVolumeSource -> v1.FCVolumeSource
 	if in.FC != nil {
 		out.FC = new(v1.FCVolumeSource)
-		if err := convert_api_FCVolumeSource_To_v1_FCVolumeSource(in.FC, out.FC, s); err != nil {
+		if err := Convert_api_FCVolumeSource_To_v1_FCVolumeSource(in.FC, out.FC, s); err != nil {
 			return err
 		}
 	} else {
@@ -1151,11 +1188,11 @@ func autoconvert_api_VolumeSource_To_v1_VolumeSource(in *api.VolumeSource, out *
 	return nil
 }
 
-func convert_api_VolumeSource_To_v1_VolumeSource(in *api.VolumeSource, out *v1.VolumeSource, s conversion.Scope) error {
-	return autoconvert_api_VolumeSource_To_v1_VolumeSource(in, out, s)
+func Convert_api_VolumeSource_To_v1_VolumeSource(in *api.VolumeSource, out *v1.VolumeSource, s conversion.Scope) error {
+	return autoConvert_api_VolumeSource_To_v1_VolumeSource(in, out, s)
 }
 
-func autoconvert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource(in *v1.AWSElasticBlockStoreVolumeSource, out *api.AWSElasticBlockStoreVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource(in *v1.AWSElasticBlockStoreVolumeSource, out *api.AWSElasticBlockStoreVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.AWSElasticBlockStoreVolumeSource))(in)
 	}
@@ -1166,11 +1203,11 @@ func autoconvert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStore
 	return nil
 }
 
-func convert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource(in *v1.AWSElasticBlockStoreVolumeSource, out *api.AWSElasticBlockStoreVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource(in, out, s)
+func Convert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource(in *v1.AWSElasticBlockStoreVolumeSource, out *api.AWSElasticBlockStoreVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_Capabilities_To_api_Capabilities(in *v1.Capabilities, out *api.Capabilities, s conversion.Scope) error {
+func autoConvert_v1_Capabilities_To_api_Capabilities(in *v1.Capabilities, out *api.Capabilities, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.Capabilities))(in)
 	}
@@ -1193,11 +1230,11 @@ func autoconvert_v1_Capabilities_To_api_Capabilities(in *v1.Capabilities, out *a
 	return nil
 }
 
-func convert_v1_Capabilities_To_api_Capabilities(in *v1.Capabilities, out *api.Capabilities, s conversion.Scope) error {
-	return autoconvert_v1_Capabilities_To_api_Capabilities(in, out, s)
+func Convert_v1_Capabilities_To_api_Capabilities(in *v1.Capabilities, out *api.Capabilities, s conversion.Scope) error {
+	return autoConvert_v1_Capabilities_To_api_Capabilities(in, out, s)
 }
 
-func autoconvert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in *v1.CephFSVolumeSource, out *api.CephFSVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in *v1.CephFSVolumeSource, out *api.CephFSVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.CephFSVolumeSource))(in)
 	}
@@ -1211,9 +1248,10 @@ func autoconvert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in *v1.CephFSVo
 	}
 	out.User = in.User
 	out.SecretFile = in.SecretFile
+	// unable to generate simple pointer conversion for v1.LocalObjectReference -> api.LocalObjectReference
 	if in.SecretRef != nil {
 		out.SecretRef = new(api.LocalObjectReference)
-		if err := convert_v1_LocalObjectReference_To_api_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
+		if err := Convert_v1_LocalObjectReference_To_api_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
 			return err
 		}
 	} else {
@@ -1223,11 +1261,11 @@ func autoconvert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in *v1.CephFSVo
 	return nil
 }
 
-func convert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in *v1.CephFSVolumeSource, out *api.CephFSVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in, out, s)
+func Convert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in *v1.CephFSVolumeSource, out *api.CephFSVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_CinderVolumeSource_To_api_CinderVolumeSource(in *v1.CinderVolumeSource, out *api.CinderVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_CinderVolumeSource_To_api_CinderVolumeSource(in *v1.CinderVolumeSource, out *api.CinderVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.CinderVolumeSource))(in)
 	}
@@ -1237,11 +1275,11 @@ func autoconvert_v1_CinderVolumeSource_To_api_CinderVolumeSource(in *v1.CinderVo
 	return nil
 }
 
-func convert_v1_CinderVolumeSource_To_api_CinderVolumeSource(in *v1.CinderVolumeSource, out *api.CinderVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_CinderVolumeSource_To_api_CinderVolumeSource(in, out, s)
+func Convert_v1_CinderVolumeSource_To_api_CinderVolumeSource(in *v1.CinderVolumeSource, out *api.CinderVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_CinderVolumeSource_To_api_CinderVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_Container_To_api_Container(in *v1.Container, out *api.Container, s conversion.Scope) error {
+func autoConvert_v1_Container_To_api_Container(in *v1.Container, out *api.Container, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.Container))(in)
 	}
@@ -1267,7 +1305,7 @@ func autoconvert_v1_Container_To_api_Container(in *v1.Container, out *api.Contai
 	if in.Ports != nil {
 		out.Ports = make([]api.ContainerPort, len(in.Ports))
 		for i := range in.Ports {
-			if err := convert_v1_ContainerPort_To_api_ContainerPort(&in.Ports[i], &out.Ports[i], s); err != nil {
+			if err := Convert_v1_ContainerPort_To_api_ContainerPort(&in.Ports[i], &out.Ports[i], s); err != nil {
 				return err
 			}
 		}
@@ -1277,45 +1315,48 @@ func autoconvert_v1_Container_To_api_Container(in *v1.Container, out *api.Contai
 	if in.Env != nil {
 		out.Env = make([]api.EnvVar, len(in.Env))
 		for i := range in.Env {
-			if err := convert_v1_EnvVar_To_api_EnvVar(&in.Env[i], &out.Env[i], s); err != nil {
+			if err := Convert_v1_EnvVar_To_api_EnvVar(&in.Env[i], &out.Env[i], s); err != nil {
 				return err
 			}
 		}
 	} else {
 		out.Env = nil
 	}
-	if err := convert_v1_ResourceRequirements_To_api_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
+	if err := Convert_v1_ResourceRequirements_To_api_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
 		return err
 	}
 	if in.VolumeMounts != nil {
 		out.VolumeMounts = make([]api.VolumeMount, len(in.VolumeMounts))
 		for i := range in.VolumeMounts {
-			if err := convert_v1_VolumeMount_To_api_VolumeMount(&in.VolumeMounts[i], &out.VolumeMounts[i], s); err != nil {
+			if err := Convert_v1_VolumeMount_To_api_VolumeMount(&in.VolumeMounts[i], &out.VolumeMounts[i], s); err != nil {
 				return err
 			}
 		}
 	} else {
 		out.VolumeMounts = nil
 	}
+	// unable to generate simple pointer conversion for v1.Probe -> api.Probe
 	if in.LivenessProbe != nil {
 		out.LivenessProbe = new(api.Probe)
-		if err := convert_v1_Probe_To_api_Probe(in.LivenessProbe, out.LivenessProbe, s); err != nil {
+		if err := Convert_v1_Probe_To_api_Probe(in.LivenessProbe, out.LivenessProbe, s); err != nil {
 			return err
 		}
 	} else {
 		out.LivenessProbe = nil
 	}
+	// unable to generate simple pointer conversion for v1.Probe -> api.Probe
 	if in.ReadinessProbe != nil {
 		out.ReadinessProbe = new(api.Probe)
-		if err := convert_v1_Probe_To_api_Probe(in.ReadinessProbe, out.ReadinessProbe, s); err != nil {
+		if err := Convert_v1_Probe_To_api_Probe(in.ReadinessProbe, out.ReadinessProbe, s); err != nil {
 			return err
 		}
 	} else {
 		out.ReadinessProbe = nil
 	}
+	// unable to generate simple pointer conversion for v1.Lifecycle -> api.Lifecycle
 	if in.Lifecycle != nil {
 		out.Lifecycle = new(api.Lifecycle)
-		if err := convert_v1_Lifecycle_To_api_Lifecycle(in.Lifecycle, out.Lifecycle, s); err != nil {
+		if err := Convert_v1_Lifecycle_To_api_Lifecycle(in.Lifecycle, out.Lifecycle, s); err != nil {
 			return err
 		}
 	} else {
@@ -1323,9 +1364,10 @@ func autoconvert_v1_Container_To_api_Container(in *v1.Container, out *api.Contai
 	}
 	out.TerminationMessagePath = in.TerminationMessagePath
 	out.ImagePullPolicy = api.PullPolicy(in.ImagePullPolicy)
+	// unable to generate simple pointer conversion for v1.SecurityContext -> api.SecurityContext
 	if in.SecurityContext != nil {
 		out.SecurityContext = new(api.SecurityContext)
-		if err := convert_v1_SecurityContext_To_api_SecurityContext(in.SecurityContext, out.SecurityContext, s); err != nil {
+		if err := Convert_v1_SecurityContext_To_api_SecurityContext(in.SecurityContext, out.SecurityContext, s); err != nil {
 			return err
 		}
 	} else {
@@ -1337,11 +1379,11 @@ func autoconvert_v1_Container_To_api_Container(in *v1.Container, out *api.Contai
 	return nil
 }
 
-func convert_v1_Container_To_api_Container(in *v1.Container, out *api.Container, s conversion.Scope) error {
-	return autoconvert_v1_Container_To_api_Container(in, out, s)
+func Convert_v1_Container_To_api_Container(in *v1.Container, out *api.Container, s conversion.Scope) error {
+	return autoConvert_v1_Container_To_api_Container(in, out, s)
 }
 
-func autoconvert_v1_ContainerPort_To_api_ContainerPort(in *v1.ContainerPort, out *api.ContainerPort, s conversion.Scope) error {
+func autoConvert_v1_ContainerPort_To_api_ContainerPort(in *v1.ContainerPort, out *api.ContainerPort, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.ContainerPort))(in)
 	}
@@ -1353,33 +1395,33 @@ func autoconvert_v1_ContainerPort_To_api_ContainerPort(in *v1.ContainerPort, out
 	return nil
 }
 
-func convert_v1_ContainerPort_To_api_ContainerPort(in *v1.ContainerPort, out *api.ContainerPort, s conversion.Scope) error {
-	return autoconvert_v1_ContainerPort_To_api_ContainerPort(in, out, s)
+func Convert_v1_ContainerPort_To_api_ContainerPort(in *v1.ContainerPort, out *api.ContainerPort, s conversion.Scope) error {
+	return autoConvert_v1_ContainerPort_To_api_ContainerPort(in, out, s)
 }
 
-func autoconvert_v1_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile(in *v1.DownwardAPIVolumeFile, out *api.DownwardAPIVolumeFile, s conversion.Scope) error {
+func autoConvert_v1_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile(in *v1.DownwardAPIVolumeFile, out *api.DownwardAPIVolumeFile, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.DownwardAPIVolumeFile))(in)
 	}
 	out.Path = in.Path
-	if err := convert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector(&in.FieldRef, &out.FieldRef, s); err != nil {
+	if err := Convert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector(&in.FieldRef, &out.FieldRef, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile(in *v1.DownwardAPIVolumeFile, out *api.DownwardAPIVolumeFile, s conversion.Scope) error {
-	return autoconvert_v1_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile(in, out, s)
+func Convert_v1_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile(in *v1.DownwardAPIVolumeFile, out *api.DownwardAPIVolumeFile, s conversion.Scope) error {
+	return autoConvert_v1_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile(in, out, s)
 }
 
-func autoconvert_v1_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource(in *v1.DownwardAPIVolumeSource, out *api.DownwardAPIVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource(in *v1.DownwardAPIVolumeSource, out *api.DownwardAPIVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.DownwardAPIVolumeSource))(in)
 	}
 	if in.Items != nil {
 		out.Items = make([]api.DownwardAPIVolumeFile, len(in.Items))
 		for i := range in.Items {
-			if err := convert_v1_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_v1_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -1389,11 +1431,11 @@ func autoconvert_v1_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource(in *v
 	return nil
 }
 
-func convert_v1_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource(in *v1.DownwardAPIVolumeSource, out *api.DownwardAPIVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource(in, out, s)
+func Convert_v1_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource(in *v1.DownwardAPIVolumeSource, out *api.DownwardAPIVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource(in *v1.EmptyDirVolumeSource, out *api.EmptyDirVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource(in *v1.EmptyDirVolumeSource, out *api.EmptyDirVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.EmptyDirVolumeSource))(in)
 	}
@@ -1401,19 +1443,20 @@ func autoconvert_v1_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource(in *v1.Empt
 	return nil
 }
 
-func convert_v1_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource(in *v1.EmptyDirVolumeSource, out *api.EmptyDirVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource(in, out, s)
+func Convert_v1_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource(in *v1.EmptyDirVolumeSource, out *api.EmptyDirVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_EnvVar_To_api_EnvVar(in *v1.EnvVar, out *api.EnvVar, s conversion.Scope) error {
+func autoConvert_v1_EnvVar_To_api_EnvVar(in *v1.EnvVar, out *api.EnvVar, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.EnvVar))(in)
 	}
 	out.Name = in.Name
 	out.Value = in.Value
+	// unable to generate simple pointer conversion for v1.EnvVarSource -> api.EnvVarSource
 	if in.ValueFrom != nil {
 		out.ValueFrom = new(api.EnvVarSource)
-		if err := convert_v1_EnvVarSource_To_api_EnvVarSource(in.ValueFrom, out.ValueFrom, s); err != nil {
+		if err := Convert_v1_EnvVarSource_To_api_EnvVarSource(in.ValueFrom, out.ValueFrom, s); err != nil {
 			return err
 		}
 	} else {
@@ -1422,17 +1465,18 @@ func autoconvert_v1_EnvVar_To_api_EnvVar(in *v1.EnvVar, out *api.EnvVar, s conve
 	return nil
 }
 
-func convert_v1_EnvVar_To_api_EnvVar(in *v1.EnvVar, out *api.EnvVar, s conversion.Scope) error {
-	return autoconvert_v1_EnvVar_To_api_EnvVar(in, out, s)
+func Convert_v1_EnvVar_To_api_EnvVar(in *v1.EnvVar, out *api.EnvVar, s conversion.Scope) error {
+	return autoConvert_v1_EnvVar_To_api_EnvVar(in, out, s)
 }
 
-func autoconvert_v1_EnvVarSource_To_api_EnvVarSource(in *v1.EnvVarSource, out *api.EnvVarSource, s conversion.Scope) error {
+func autoConvert_v1_EnvVarSource_To_api_EnvVarSource(in *v1.EnvVarSource, out *api.EnvVarSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.EnvVarSource))(in)
 	}
+	// unable to generate simple pointer conversion for v1.ObjectFieldSelector -> api.ObjectFieldSelector
 	if in.FieldRef != nil {
 		out.FieldRef = new(api.ObjectFieldSelector)
-		if err := convert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector(in.FieldRef, out.FieldRef, s); err != nil {
+		if err := Convert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector(in.FieldRef, out.FieldRef, s); err != nil {
 			return err
 		}
 	} else {
@@ -1441,11 +1485,11 @@ func autoconvert_v1_EnvVarSource_To_api_EnvVarSource(in *v1.EnvVarSource, out *a
 	return nil
 }
 
-func convert_v1_EnvVarSource_To_api_EnvVarSource(in *v1.EnvVarSource, out *api.EnvVarSource, s conversion.Scope) error {
-	return autoconvert_v1_EnvVarSource_To_api_EnvVarSource(in, out, s)
+func Convert_v1_EnvVarSource_To_api_EnvVarSource(in *v1.EnvVarSource, out *api.EnvVarSource, s conversion.Scope) error {
+	return autoConvert_v1_EnvVarSource_To_api_EnvVarSource(in, out, s)
 }
 
-func autoconvert_v1_ExecAction_To_api_ExecAction(in *v1.ExecAction, out *api.ExecAction, s conversion.Scope) error {
+func autoConvert_v1_ExecAction_To_api_ExecAction(in *v1.ExecAction, out *api.ExecAction, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.ExecAction))(in)
 	}
@@ -1460,11 +1504,11 @@ func autoconvert_v1_ExecAction_To_api_ExecAction(in *v1.ExecAction, out *api.Exe
 	return nil
 }
 
-func convert_v1_ExecAction_To_api_ExecAction(in *v1.ExecAction, out *api.ExecAction, s conversion.Scope) error {
-	return autoconvert_v1_ExecAction_To_api_ExecAction(in, out, s)
+func Convert_v1_ExecAction_To_api_ExecAction(in *v1.ExecAction, out *api.ExecAction, s conversion.Scope) error {
+	return autoConvert_v1_ExecAction_To_api_ExecAction(in, out, s)
 }
 
-func autoconvert_v1_FCVolumeSource_To_api_FCVolumeSource(in *v1.FCVolumeSource, out *api.FCVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_FCVolumeSource_To_api_FCVolumeSource(in *v1.FCVolumeSource, out *api.FCVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.FCVolumeSource))(in)
 	}
@@ -1487,19 +1531,20 @@ func autoconvert_v1_FCVolumeSource_To_api_FCVolumeSource(in *v1.FCVolumeSource, 
 	return nil
 }
 
-func convert_v1_FCVolumeSource_To_api_FCVolumeSource(in *v1.FCVolumeSource, out *api.FCVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_FCVolumeSource_To_api_FCVolumeSource(in, out, s)
+func Convert_v1_FCVolumeSource_To_api_FCVolumeSource(in *v1.FCVolumeSource, out *api.FCVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_FCVolumeSource_To_api_FCVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_FlexVolumeSource_To_api_FlexVolumeSource(in *v1.FlexVolumeSource, out *api.FlexVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_FlexVolumeSource_To_api_FlexVolumeSource(in *v1.FlexVolumeSource, out *api.FlexVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.FlexVolumeSource))(in)
 	}
 	out.Driver = in.Driver
 	out.FSType = in.FSType
+	// unable to generate simple pointer conversion for v1.LocalObjectReference -> api.LocalObjectReference
 	if in.SecretRef != nil {
 		out.SecretRef = new(api.LocalObjectReference)
-		if err := convert_v1_LocalObjectReference_To_api_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
+		if err := Convert_v1_LocalObjectReference_To_api_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
 			return err
 		}
 	} else {
@@ -1517,11 +1562,11 @@ func autoconvert_v1_FlexVolumeSource_To_api_FlexVolumeSource(in *v1.FlexVolumeSo
 	return nil
 }
 
-func convert_v1_FlexVolumeSource_To_api_FlexVolumeSource(in *v1.FlexVolumeSource, out *api.FlexVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_FlexVolumeSource_To_api_FlexVolumeSource(in, out, s)
+func Convert_v1_FlexVolumeSource_To_api_FlexVolumeSource(in *v1.FlexVolumeSource, out *api.FlexVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_FlexVolumeSource_To_api_FlexVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_FlockerVolumeSource_To_api_FlockerVolumeSource(in *v1.FlockerVolumeSource, out *api.FlockerVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_FlockerVolumeSource_To_api_FlockerVolumeSource(in *v1.FlockerVolumeSource, out *api.FlockerVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.FlockerVolumeSource))(in)
 	}
@@ -1529,11 +1574,11 @@ func autoconvert_v1_FlockerVolumeSource_To_api_FlockerVolumeSource(in *v1.Flocke
 	return nil
 }
 
-func convert_v1_FlockerVolumeSource_To_api_FlockerVolumeSource(in *v1.FlockerVolumeSource, out *api.FlockerVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_FlockerVolumeSource_To_api_FlockerVolumeSource(in, out, s)
+func Convert_v1_FlockerVolumeSource_To_api_FlockerVolumeSource(in *v1.FlockerVolumeSource, out *api.FlockerVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_FlockerVolumeSource_To_api_FlockerVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource(in *v1.GCEPersistentDiskVolumeSource, out *api.GCEPersistentDiskVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource(in *v1.GCEPersistentDiskVolumeSource, out *api.GCEPersistentDiskVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.GCEPersistentDiskVolumeSource))(in)
 	}
@@ -1544,11 +1589,11 @@ func autoconvert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolume
 	return nil
 }
 
-func convert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource(in *v1.GCEPersistentDiskVolumeSource, out *api.GCEPersistentDiskVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource(in, out, s)
+func Convert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource(in *v1.GCEPersistentDiskVolumeSource, out *api.GCEPersistentDiskVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_GitRepoVolumeSource_To_api_GitRepoVolumeSource(in *v1.GitRepoVolumeSource, out *api.GitRepoVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_GitRepoVolumeSource_To_api_GitRepoVolumeSource(in *v1.GitRepoVolumeSource, out *api.GitRepoVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.GitRepoVolumeSource))(in)
 	}
@@ -1558,11 +1603,11 @@ func autoconvert_v1_GitRepoVolumeSource_To_api_GitRepoVolumeSource(in *v1.GitRep
 	return nil
 }
 
-func convert_v1_GitRepoVolumeSource_To_api_GitRepoVolumeSource(in *v1.GitRepoVolumeSource, out *api.GitRepoVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_GitRepoVolumeSource_To_api_GitRepoVolumeSource(in, out, s)
+func Convert_v1_GitRepoVolumeSource_To_api_GitRepoVolumeSource(in *v1.GitRepoVolumeSource, out *api.GitRepoVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_GitRepoVolumeSource_To_api_GitRepoVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource(in *v1.GlusterfsVolumeSource, out *api.GlusterfsVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource(in *v1.GlusterfsVolumeSource, out *api.GlusterfsVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.GlusterfsVolumeSource))(in)
 	}
@@ -1572,16 +1617,16 @@ func autoconvert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource(in *v1.Gl
 	return nil
 }
 
-func convert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource(in *v1.GlusterfsVolumeSource, out *api.GlusterfsVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource(in, out, s)
+func Convert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource(in *v1.GlusterfsVolumeSource, out *api.GlusterfsVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_HTTPGetAction_To_api_HTTPGetAction(in *v1.HTTPGetAction, out *api.HTTPGetAction, s conversion.Scope) error {
+func autoConvert_v1_HTTPGetAction_To_api_HTTPGetAction(in *v1.HTTPGetAction, out *api.HTTPGetAction, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.HTTPGetAction))(in)
 	}
 	out.Path = in.Path
-	if err := s.Convert(&in.Port, &out.Port, 0); err != nil {
+	if err := api.Convert_intstr_IntOrString_To_intstr_IntOrString(&in.Port, &out.Port, s); err != nil {
 		return err
 	}
 	out.Host = in.Host
@@ -1589,33 +1634,36 @@ func autoconvert_v1_HTTPGetAction_To_api_HTTPGetAction(in *v1.HTTPGetAction, out
 	return nil
 }
 
-func convert_v1_HTTPGetAction_To_api_HTTPGetAction(in *v1.HTTPGetAction, out *api.HTTPGetAction, s conversion.Scope) error {
-	return autoconvert_v1_HTTPGetAction_To_api_HTTPGetAction(in, out, s)
+func Convert_v1_HTTPGetAction_To_api_HTTPGetAction(in *v1.HTTPGetAction, out *api.HTTPGetAction, s conversion.Scope) error {
+	return autoConvert_v1_HTTPGetAction_To_api_HTTPGetAction(in, out, s)
 }
 
-func autoconvert_v1_Handler_To_api_Handler(in *v1.Handler, out *api.Handler, s conversion.Scope) error {
+func autoConvert_v1_Handler_To_api_Handler(in *v1.Handler, out *api.Handler, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.Handler))(in)
 	}
+	// unable to generate simple pointer conversion for v1.ExecAction -> api.ExecAction
 	if in.Exec != nil {
 		out.Exec = new(api.ExecAction)
-		if err := convert_v1_ExecAction_To_api_ExecAction(in.Exec, out.Exec, s); err != nil {
+		if err := Convert_v1_ExecAction_To_api_ExecAction(in.Exec, out.Exec, s); err != nil {
 			return err
 		}
 	} else {
 		out.Exec = nil
 	}
+	// unable to generate simple pointer conversion for v1.HTTPGetAction -> api.HTTPGetAction
 	if in.HTTPGet != nil {
 		out.HTTPGet = new(api.HTTPGetAction)
-		if err := convert_v1_HTTPGetAction_To_api_HTTPGetAction(in.HTTPGet, out.HTTPGet, s); err != nil {
+		if err := Convert_v1_HTTPGetAction_To_api_HTTPGetAction(in.HTTPGet, out.HTTPGet, s); err != nil {
 			return err
 		}
 	} else {
 		out.HTTPGet = nil
 	}
+	// unable to generate simple pointer conversion for v1.TCPSocketAction -> api.TCPSocketAction
 	if in.TCPSocket != nil {
 		out.TCPSocket = new(api.TCPSocketAction)
-		if err := convert_v1_TCPSocketAction_To_api_TCPSocketAction(in.TCPSocket, out.TCPSocket, s); err != nil {
+		if err := Convert_v1_TCPSocketAction_To_api_TCPSocketAction(in.TCPSocket, out.TCPSocket, s); err != nil {
 			return err
 		}
 	} else {
@@ -1624,11 +1672,11 @@ func autoconvert_v1_Handler_To_api_Handler(in *v1.Handler, out *api.Handler, s c
 	return nil
 }
 
-func convert_v1_Handler_To_api_Handler(in *v1.Handler, out *api.Handler, s conversion.Scope) error {
-	return autoconvert_v1_Handler_To_api_Handler(in, out, s)
+func Convert_v1_Handler_To_api_Handler(in *v1.Handler, out *api.Handler, s conversion.Scope) error {
+	return autoConvert_v1_Handler_To_api_Handler(in, out, s)
 }
 
-func autoconvert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource(in *v1.HostPathVolumeSource, out *api.HostPathVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource(in *v1.HostPathVolumeSource, out *api.HostPathVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.HostPathVolumeSource))(in)
 	}
@@ -1636,11 +1684,11 @@ func autoconvert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource(in *v1.Host
 	return nil
 }
 
-func convert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource(in *v1.HostPathVolumeSource, out *api.HostPathVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource(in, out, s)
+func Convert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource(in *v1.HostPathVolumeSource, out *api.HostPathVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource(in *v1.ISCSIVolumeSource, out *api.ISCSIVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource(in *v1.ISCSIVolumeSource, out *api.ISCSIVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.ISCSIVolumeSource))(in)
 	}
@@ -1653,25 +1701,27 @@ func autoconvert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource(in *v1.ISCSIVolum
 	return nil
 }
 
-func convert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource(in *v1.ISCSIVolumeSource, out *api.ISCSIVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource(in, out, s)
+func Convert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource(in *v1.ISCSIVolumeSource, out *api.ISCSIVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_Lifecycle_To_api_Lifecycle(in *v1.Lifecycle, out *api.Lifecycle, s conversion.Scope) error {
+func autoConvert_v1_Lifecycle_To_api_Lifecycle(in *v1.Lifecycle, out *api.Lifecycle, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.Lifecycle))(in)
 	}
+	// unable to generate simple pointer conversion for v1.Handler -> api.Handler
 	if in.PostStart != nil {
 		out.PostStart = new(api.Handler)
-		if err := convert_v1_Handler_To_api_Handler(in.PostStart, out.PostStart, s); err != nil {
+		if err := Convert_v1_Handler_To_api_Handler(in.PostStart, out.PostStart, s); err != nil {
 			return err
 		}
 	} else {
 		out.PostStart = nil
 	}
+	// unable to generate simple pointer conversion for v1.Handler -> api.Handler
 	if in.PreStop != nil {
 		out.PreStop = new(api.Handler)
-		if err := convert_v1_Handler_To_api_Handler(in.PreStop, out.PreStop, s); err != nil {
+		if err := Convert_v1_Handler_To_api_Handler(in.PreStop, out.PreStop, s); err != nil {
 			return err
 		}
 	} else {
@@ -1680,11 +1730,11 @@ func autoconvert_v1_Lifecycle_To_api_Lifecycle(in *v1.Lifecycle, out *api.Lifecy
 	return nil
 }
 
-func convert_v1_Lifecycle_To_api_Lifecycle(in *v1.Lifecycle, out *api.Lifecycle, s conversion.Scope) error {
-	return autoconvert_v1_Lifecycle_To_api_Lifecycle(in, out, s)
+func Convert_v1_Lifecycle_To_api_Lifecycle(in *v1.Lifecycle, out *api.Lifecycle, s conversion.Scope) error {
+	return autoConvert_v1_Lifecycle_To_api_Lifecycle(in, out, s)
 }
 
-func autoconvert_v1_LoadBalancerIngress_To_api_LoadBalancerIngress(in *v1.LoadBalancerIngress, out *api.LoadBalancerIngress, s conversion.Scope) error {
+func autoConvert_v1_LoadBalancerIngress_To_api_LoadBalancerIngress(in *v1.LoadBalancerIngress, out *api.LoadBalancerIngress, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.LoadBalancerIngress))(in)
 	}
@@ -1693,18 +1743,18 @@ func autoconvert_v1_LoadBalancerIngress_To_api_LoadBalancerIngress(in *v1.LoadBa
 	return nil
 }
 
-func convert_v1_LoadBalancerIngress_To_api_LoadBalancerIngress(in *v1.LoadBalancerIngress, out *api.LoadBalancerIngress, s conversion.Scope) error {
-	return autoconvert_v1_LoadBalancerIngress_To_api_LoadBalancerIngress(in, out, s)
+func Convert_v1_LoadBalancerIngress_To_api_LoadBalancerIngress(in *v1.LoadBalancerIngress, out *api.LoadBalancerIngress, s conversion.Scope) error {
+	return autoConvert_v1_LoadBalancerIngress_To_api_LoadBalancerIngress(in, out, s)
 }
 
-func autoconvert_v1_LoadBalancerStatus_To_api_LoadBalancerStatus(in *v1.LoadBalancerStatus, out *api.LoadBalancerStatus, s conversion.Scope) error {
+func autoConvert_v1_LoadBalancerStatus_To_api_LoadBalancerStatus(in *v1.LoadBalancerStatus, out *api.LoadBalancerStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.LoadBalancerStatus))(in)
 	}
 	if in.Ingress != nil {
 		out.Ingress = make([]api.LoadBalancerIngress, len(in.Ingress))
 		for i := range in.Ingress {
-			if err := convert_v1_LoadBalancerIngress_To_api_LoadBalancerIngress(&in.Ingress[i], &out.Ingress[i], s); err != nil {
+			if err := Convert_v1_LoadBalancerIngress_To_api_LoadBalancerIngress(&in.Ingress[i], &out.Ingress[i], s); err != nil {
 				return err
 			}
 		}
@@ -1714,11 +1764,11 @@ func autoconvert_v1_LoadBalancerStatus_To_api_LoadBalancerStatus(in *v1.LoadBala
 	return nil
 }
 
-func convert_v1_LoadBalancerStatus_To_api_LoadBalancerStatus(in *v1.LoadBalancerStatus, out *api.LoadBalancerStatus, s conversion.Scope) error {
-	return autoconvert_v1_LoadBalancerStatus_To_api_LoadBalancerStatus(in, out, s)
+func Convert_v1_LoadBalancerStatus_To_api_LoadBalancerStatus(in *v1.LoadBalancerStatus, out *api.LoadBalancerStatus, s conversion.Scope) error {
+	return autoConvert_v1_LoadBalancerStatus_To_api_LoadBalancerStatus(in, out, s)
 }
 
-func autoconvert_v1_LocalObjectReference_To_api_LocalObjectReference(in *v1.LocalObjectReference, out *api.LocalObjectReference, s conversion.Scope) error {
+func autoConvert_v1_LocalObjectReference_To_api_LocalObjectReference(in *v1.LocalObjectReference, out *api.LocalObjectReference, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.LocalObjectReference))(in)
 	}
@@ -1726,11 +1776,11 @@ func autoconvert_v1_LocalObjectReference_To_api_LocalObjectReference(in *v1.Loca
 	return nil
 }
 
-func convert_v1_LocalObjectReference_To_api_LocalObjectReference(in *v1.LocalObjectReference, out *api.LocalObjectReference, s conversion.Scope) error {
-	return autoconvert_v1_LocalObjectReference_To_api_LocalObjectReference(in, out, s)
+func Convert_v1_LocalObjectReference_To_api_LocalObjectReference(in *v1.LocalObjectReference, out *api.LocalObjectReference, s conversion.Scope) error {
+	return autoConvert_v1_LocalObjectReference_To_api_LocalObjectReference(in, out, s)
 }
 
-func autoconvert_v1_NFSVolumeSource_To_api_NFSVolumeSource(in *v1.NFSVolumeSource, out *api.NFSVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_NFSVolumeSource_To_api_NFSVolumeSource(in *v1.NFSVolumeSource, out *api.NFSVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.NFSVolumeSource))(in)
 	}
@@ -1740,11 +1790,11 @@ func autoconvert_v1_NFSVolumeSource_To_api_NFSVolumeSource(in *v1.NFSVolumeSourc
 	return nil
 }
 
-func convert_v1_NFSVolumeSource_To_api_NFSVolumeSource(in *v1.NFSVolumeSource, out *api.NFSVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_NFSVolumeSource_To_api_NFSVolumeSource(in, out, s)
+func Convert_v1_NFSVolumeSource_To_api_NFSVolumeSource(in *v1.NFSVolumeSource, out *api.NFSVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_NFSVolumeSource_To_api_NFSVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector(in *v1.ObjectFieldSelector, out *api.ObjectFieldSelector, s conversion.Scope) error {
+func autoConvert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector(in *v1.ObjectFieldSelector, out *api.ObjectFieldSelector, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.ObjectFieldSelector))(in)
 	}
@@ -1753,11 +1803,11 @@ func autoconvert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector(in *v1.Object
 	return nil
 }
 
-func convert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector(in *v1.ObjectFieldSelector, out *api.ObjectFieldSelector, s conversion.Scope) error {
-	return autoconvert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector(in, out, s)
+func Convert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector(in *v1.ObjectFieldSelector, out *api.ObjectFieldSelector, s conversion.Scope) error {
+	return autoConvert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector(in, out, s)
 }
 
-func autoconvert_v1_ObjectMeta_To_api_ObjectMeta(in *v1.ObjectMeta, out *api.ObjectMeta, s conversion.Scope) error {
+func autoConvert_v1_ObjectMeta_To_api_ObjectMeta(in *v1.ObjectMeta, out *api.ObjectMeta, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.ObjectMeta))(in)
 	}
@@ -1768,11 +1818,13 @@ func autoconvert_v1_ObjectMeta_To_api_ObjectMeta(in *v1.ObjectMeta, out *api.Obj
 	out.UID = in.UID
 	out.ResourceVersion = in.ResourceVersion
 	out.Generation = in.Generation
-	if err := s.Convert(&in.CreationTimestamp, &out.CreationTimestamp, 0); err != nil {
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.CreationTimestamp, &out.CreationTimestamp, s); err != nil {
 		return err
 	}
+	// unable to generate simple pointer conversion for unversioned.Time -> unversioned.Time
 	if in.DeletionTimestamp != nil {
-		if err := s.Convert(&in.DeletionTimestamp, &out.DeletionTimestamp, 0); err != nil {
+		out.DeletionTimestamp = new(unversioned.Time)
+		if err := api.Convert_unversioned_Time_To_unversioned_Time(in.DeletionTimestamp, out.DeletionTimestamp, s); err != nil {
 			return err
 		}
 	} else {
@@ -1803,11 +1855,11 @@ func autoconvert_v1_ObjectMeta_To_api_ObjectMeta(in *v1.ObjectMeta, out *api.Obj
 	return nil
 }
 
-func convert_v1_ObjectMeta_To_api_ObjectMeta(in *v1.ObjectMeta, out *api.ObjectMeta, s conversion.Scope) error {
-	return autoconvert_v1_ObjectMeta_To_api_ObjectMeta(in, out, s)
+func Convert_v1_ObjectMeta_To_api_ObjectMeta(in *v1.ObjectMeta, out *api.ObjectMeta, s conversion.Scope) error {
+	return autoConvert_v1_ObjectMeta_To_api_ObjectMeta(in, out, s)
 }
 
-func autoconvert_v1_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeClaimVolumeSource(in *v1.PersistentVolumeClaimVolumeSource, out *api.PersistentVolumeClaimVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeClaimVolumeSource(in *v1.PersistentVolumeClaimVolumeSource, out *api.PersistentVolumeClaimVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.PersistentVolumeClaimVolumeSource))(in)
 	}
@@ -1816,18 +1868,18 @@ func autoconvert_v1_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeCla
 	return nil
 }
 
-func convert_v1_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeClaimVolumeSource(in *v1.PersistentVolumeClaimVolumeSource, out *api.PersistentVolumeClaimVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeClaimVolumeSource(in, out, s)
+func Convert_v1_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeClaimVolumeSource(in *v1.PersistentVolumeClaimVolumeSource, out *api.PersistentVolumeClaimVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeClaimVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_PodSpec_To_api_PodSpec(in *v1.PodSpec, out *api.PodSpec, s conversion.Scope) error {
+func autoConvert_v1_PodSpec_To_api_PodSpec(in *v1.PodSpec, out *api.PodSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.PodSpec))(in)
 	}
 	if in.Volumes != nil {
 		out.Volumes = make([]api.Volume, len(in.Volumes))
 		for i := range in.Volumes {
-			if err := convert_v1_Volume_To_api_Volume(&in.Volumes[i], &out.Volumes[i], s); err != nil {
+			if err := Convert_v1_Volume_To_api_Volume(&in.Volumes[i], &out.Volumes[i], s); err != nil {
 				return err
 			}
 		}
@@ -1837,7 +1889,7 @@ func autoconvert_v1_PodSpec_To_api_PodSpec(in *v1.PodSpec, out *api.PodSpec, s c
 	if in.Containers != nil {
 		out.Containers = make([]api.Container, len(in.Containers))
 		for i := range in.Containers {
-			if err := convert_v1_Container_To_api_Container(&in.Containers[i], &out.Containers[i], s); err != nil {
+			if err := Convert_v1_Container_To_api_Container(&in.Containers[i], &out.Containers[i], s); err != nil {
 				return err
 			}
 		}
@@ -1872,6 +1924,7 @@ func autoconvert_v1_PodSpec_To_api_PodSpec(in *v1.PodSpec, out *api.PodSpec, s c
 	// in.HostNetwork has no peer in out
 	// in.HostPID has no peer in out
 	// in.HostIPC has no peer in out
+	// unable to generate simple pointer conversion for v1.PodSecurityContext -> api.PodSecurityContext
 	if in.SecurityContext != nil {
 		if err := s.Convert(&in.SecurityContext, &out.SecurityContext, 0); err != nil {
 			return err
@@ -1882,7 +1935,7 @@ func autoconvert_v1_PodSpec_To_api_PodSpec(in *v1.PodSpec, out *api.PodSpec, s c
 	if in.ImagePullSecrets != nil {
 		out.ImagePullSecrets = make([]api.LocalObjectReference, len(in.ImagePullSecrets))
 		for i := range in.ImagePullSecrets {
-			if err := convert_v1_LocalObjectReference_To_api_LocalObjectReference(&in.ImagePullSecrets[i], &out.ImagePullSecrets[i], s); err != nil {
+			if err := Convert_v1_LocalObjectReference_To_api_LocalObjectReference(&in.ImagePullSecrets[i], &out.ImagePullSecrets[i], s); err != nil {
 				return err
 			}
 		}
@@ -1892,28 +1945,28 @@ func autoconvert_v1_PodSpec_To_api_PodSpec(in *v1.PodSpec, out *api.PodSpec, s c
 	return nil
 }
 
-func autoconvert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in *v1.PodTemplateSpec, out *api.PodTemplateSpec, s conversion.Scope) error {
+func autoConvert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in *v1.PodTemplateSpec, out *api.PodTemplateSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.PodTemplateSpec))(in)
 	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_PodSpec_To_api_PodSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_v1_PodSpec_To_api_PodSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in *v1.PodTemplateSpec, out *api.PodTemplateSpec, s conversion.Scope) error {
-	return autoconvert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in, out, s)
+func Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in *v1.PodTemplateSpec, out *api.PodTemplateSpec, s conversion.Scope) error {
+	return autoConvert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in, out, s)
 }
 
-func autoconvert_v1_Probe_To_api_Probe(in *v1.Probe, out *api.Probe, s conversion.Scope) error {
+func autoConvert_v1_Probe_To_api_Probe(in *v1.Probe, out *api.Probe, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.Probe))(in)
 	}
-	if err := convert_v1_Handler_To_api_Handler(&in.Handler, &out.Handler, s); err != nil {
+	if err := Convert_v1_Handler_To_api_Handler(&in.Handler, &out.Handler, s); err != nil {
 		return err
 	}
 	out.InitialDelaySeconds = int(in.InitialDelaySeconds)
@@ -1924,11 +1977,11 @@ func autoconvert_v1_Probe_To_api_Probe(in *v1.Probe, out *api.Probe, s conversio
 	return nil
 }
 
-func convert_v1_Probe_To_api_Probe(in *v1.Probe, out *api.Probe, s conversion.Scope) error {
-	return autoconvert_v1_Probe_To_api_Probe(in, out, s)
+func Convert_v1_Probe_To_api_Probe(in *v1.Probe, out *api.Probe, s conversion.Scope) error {
+	return autoConvert_v1_Probe_To_api_Probe(in, out, s)
 }
 
-func autoconvert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in *v1.RBDVolumeSource, out *api.RBDVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in *v1.RBDVolumeSource, out *api.RBDVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.RBDVolumeSource))(in)
 	}
@@ -1945,9 +1998,10 @@ func autoconvert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in *v1.RBDVolumeSourc
 	out.RBDPool = in.RBDPool
 	out.RadosUser = in.RadosUser
 	out.Keyring = in.Keyring
+	// unable to generate simple pointer conversion for v1.LocalObjectReference -> api.LocalObjectReference
 	if in.SecretRef != nil {
 		out.SecretRef = new(api.LocalObjectReference)
-		if err := convert_v1_LocalObjectReference_To_api_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
+		if err := Convert_v1_LocalObjectReference_To_api_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
 			return err
 		}
 	} else {
@@ -1957,11 +2011,11 @@ func autoconvert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in *v1.RBDVolumeSourc
 	return nil
 }
 
-func convert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in *v1.RBDVolumeSource, out *api.RBDVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in, out, s)
+func Convert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in *v1.RBDVolumeSource, out *api.RBDVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_ResourceRequirements_To_api_ResourceRequirements(in *v1.ResourceRequirements, out *api.ResourceRequirements, s conversion.Scope) error {
+func autoConvert_v1_ResourceRequirements_To_api_ResourceRequirements(in *v1.ResourceRequirements, out *api.ResourceRequirements, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.ResourceRequirements))(in)
 	}
@@ -1969,7 +2023,7 @@ func autoconvert_v1_ResourceRequirements_To_api_ResourceRequirements(in *v1.Reso
 		out.Limits = make(api.ResourceList)
 		for key, val := range in.Limits {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.Limits[api.ResourceName(key)] = newVal
@@ -1981,7 +2035,7 @@ func autoconvert_v1_ResourceRequirements_To_api_ResourceRequirements(in *v1.Reso
 		out.Requests = make(api.ResourceList)
 		for key, val := range in.Requests {
 			newVal := resource.Quantity{}
-			if err := s.Convert(&val, &newVal, 0); err != nil {
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
 				return err
 			}
 			out.Requests[api.ResourceName(key)] = newVal
@@ -1992,11 +2046,11 @@ func autoconvert_v1_ResourceRequirements_To_api_ResourceRequirements(in *v1.Reso
 	return nil
 }
 
-func convert_v1_ResourceRequirements_To_api_ResourceRequirements(in *v1.ResourceRequirements, out *api.ResourceRequirements, s conversion.Scope) error {
-	return autoconvert_v1_ResourceRequirements_To_api_ResourceRequirements(in, out, s)
+func Convert_v1_ResourceRequirements_To_api_ResourceRequirements(in *v1.ResourceRequirements, out *api.ResourceRequirements, s conversion.Scope) error {
+	return autoConvert_v1_ResourceRequirements_To_api_ResourceRequirements(in, out, s)
 }
 
-func autoconvert_v1_SELinuxOptions_To_api_SELinuxOptions(in *v1.SELinuxOptions, out *api.SELinuxOptions, s conversion.Scope) error {
+func autoConvert_v1_SELinuxOptions_To_api_SELinuxOptions(in *v1.SELinuxOptions, out *api.SELinuxOptions, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.SELinuxOptions))(in)
 	}
@@ -2007,11 +2061,11 @@ func autoconvert_v1_SELinuxOptions_To_api_SELinuxOptions(in *v1.SELinuxOptions, 
 	return nil
 }
 
-func convert_v1_SELinuxOptions_To_api_SELinuxOptions(in *v1.SELinuxOptions, out *api.SELinuxOptions, s conversion.Scope) error {
-	return autoconvert_v1_SELinuxOptions_To_api_SELinuxOptions(in, out, s)
+func Convert_v1_SELinuxOptions_To_api_SELinuxOptions(in *v1.SELinuxOptions, out *api.SELinuxOptions, s conversion.Scope) error {
+	return autoConvert_v1_SELinuxOptions_To_api_SELinuxOptions(in, out, s)
 }
 
-func autoconvert_v1_SecretVolumeSource_To_api_SecretVolumeSource(in *v1.SecretVolumeSource, out *api.SecretVolumeSource, s conversion.Scope) error {
+func autoConvert_v1_SecretVolumeSource_To_api_SecretVolumeSource(in *v1.SecretVolumeSource, out *api.SecretVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.SecretVolumeSource))(in)
 	}
@@ -2019,17 +2073,18 @@ func autoconvert_v1_SecretVolumeSource_To_api_SecretVolumeSource(in *v1.SecretVo
 	return nil
 }
 
-func convert_v1_SecretVolumeSource_To_api_SecretVolumeSource(in *v1.SecretVolumeSource, out *api.SecretVolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_SecretVolumeSource_To_api_SecretVolumeSource(in, out, s)
+func Convert_v1_SecretVolumeSource_To_api_SecretVolumeSource(in *v1.SecretVolumeSource, out *api.SecretVolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_SecretVolumeSource_To_api_SecretVolumeSource(in, out, s)
 }
 
-func autoconvert_v1_SecurityContext_To_api_SecurityContext(in *v1.SecurityContext, out *api.SecurityContext, s conversion.Scope) error {
+func autoConvert_v1_SecurityContext_To_api_SecurityContext(in *v1.SecurityContext, out *api.SecurityContext, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.SecurityContext))(in)
 	}
+	// unable to generate simple pointer conversion for v1.Capabilities -> api.Capabilities
 	if in.Capabilities != nil {
 		out.Capabilities = new(api.Capabilities)
-		if err := convert_v1_Capabilities_To_api_Capabilities(in.Capabilities, out.Capabilities, s); err != nil {
+		if err := Convert_v1_Capabilities_To_api_Capabilities(in.Capabilities, out.Capabilities, s); err != nil {
 			return err
 		}
 	} else {
@@ -2041,9 +2096,10 @@ func autoconvert_v1_SecurityContext_To_api_SecurityContext(in *v1.SecurityContex
 	} else {
 		out.Privileged = nil
 	}
+	// unable to generate simple pointer conversion for v1.SELinuxOptions -> api.SELinuxOptions
 	if in.SELinuxOptions != nil {
 		out.SELinuxOptions = new(api.SELinuxOptions)
-		if err := convert_v1_SELinuxOptions_To_api_SELinuxOptions(in.SELinuxOptions, out.SELinuxOptions, s); err != nil {
+		if err := Convert_v1_SELinuxOptions_To_api_SELinuxOptions(in.SELinuxOptions, out.SELinuxOptions, s); err != nil {
 			return err
 		}
 	} else {
@@ -2064,40 +2120,40 @@ func autoconvert_v1_SecurityContext_To_api_SecurityContext(in *v1.SecurityContex
 	return nil
 }
 
-func convert_v1_SecurityContext_To_api_SecurityContext(in *v1.SecurityContext, out *api.SecurityContext, s conversion.Scope) error {
-	return autoconvert_v1_SecurityContext_To_api_SecurityContext(in, out, s)
+func Convert_v1_SecurityContext_To_api_SecurityContext(in *v1.SecurityContext, out *api.SecurityContext, s conversion.Scope) error {
+	return autoConvert_v1_SecurityContext_To_api_SecurityContext(in, out, s)
 }
 
-func autoconvert_v1_TCPSocketAction_To_api_TCPSocketAction(in *v1.TCPSocketAction, out *api.TCPSocketAction, s conversion.Scope) error {
+func autoConvert_v1_TCPSocketAction_To_api_TCPSocketAction(in *v1.TCPSocketAction, out *api.TCPSocketAction, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.TCPSocketAction))(in)
 	}
-	if err := s.Convert(&in.Port, &out.Port, 0); err != nil {
+	if err := api.Convert_intstr_IntOrString_To_intstr_IntOrString(&in.Port, &out.Port, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1_TCPSocketAction_To_api_TCPSocketAction(in *v1.TCPSocketAction, out *api.TCPSocketAction, s conversion.Scope) error {
-	return autoconvert_v1_TCPSocketAction_To_api_TCPSocketAction(in, out, s)
+func Convert_v1_TCPSocketAction_To_api_TCPSocketAction(in *v1.TCPSocketAction, out *api.TCPSocketAction, s conversion.Scope) error {
+	return autoConvert_v1_TCPSocketAction_To_api_TCPSocketAction(in, out, s)
 }
 
-func autoconvert_v1_Volume_To_api_Volume(in *v1.Volume, out *api.Volume, s conversion.Scope) error {
+func autoConvert_v1_Volume_To_api_Volume(in *v1.Volume, out *api.Volume, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.Volume))(in)
 	}
 	out.Name = in.Name
-	if err := convert_v1_VolumeSource_To_api_VolumeSource(&in.VolumeSource, &out.VolumeSource, s); err != nil {
+	if err := Convert_v1_VolumeSource_To_api_VolumeSource(&in.VolumeSource, &out.VolumeSource, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1_Volume_To_api_Volume(in *v1.Volume, out *api.Volume, s conversion.Scope) error {
-	return autoconvert_v1_Volume_To_api_Volume(in, out, s)
+func Convert_v1_Volume_To_api_Volume(in *v1.Volume, out *api.Volume, s conversion.Scope) error {
+	return autoConvert_v1_Volume_To_api_Volume(in, out, s)
 }
 
-func autoconvert_v1_VolumeMount_To_api_VolumeMount(in *v1.VolumeMount, out *api.VolumeMount, s conversion.Scope) error {
+func autoConvert_v1_VolumeMount_To_api_VolumeMount(in *v1.VolumeMount, out *api.VolumeMount, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.VolumeMount))(in)
 	}
@@ -2107,145 +2163,162 @@ func autoconvert_v1_VolumeMount_To_api_VolumeMount(in *v1.VolumeMount, out *api.
 	return nil
 }
 
-func convert_v1_VolumeMount_To_api_VolumeMount(in *v1.VolumeMount, out *api.VolumeMount, s conversion.Scope) error {
-	return autoconvert_v1_VolumeMount_To_api_VolumeMount(in, out, s)
+func Convert_v1_VolumeMount_To_api_VolumeMount(in *v1.VolumeMount, out *api.VolumeMount, s conversion.Scope) error {
+	return autoConvert_v1_VolumeMount_To_api_VolumeMount(in, out, s)
 }
 
-func autoconvert_v1_VolumeSource_To_api_VolumeSource(in *v1.VolumeSource, out *api.VolumeSource, s conversion.Scope) error {
+func autoConvert_v1_VolumeSource_To_api_VolumeSource(in *v1.VolumeSource, out *api.VolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.VolumeSource))(in)
 	}
+	// unable to generate simple pointer conversion for v1.HostPathVolumeSource -> api.HostPathVolumeSource
 	if in.HostPath != nil {
 		out.HostPath = new(api.HostPathVolumeSource)
-		if err := convert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource(in.HostPath, out.HostPath, s); err != nil {
+		if err := Convert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource(in.HostPath, out.HostPath, s); err != nil {
 			return err
 		}
 	} else {
 		out.HostPath = nil
 	}
+	// unable to generate simple pointer conversion for v1.EmptyDirVolumeSource -> api.EmptyDirVolumeSource
 	if in.EmptyDir != nil {
 		out.EmptyDir = new(api.EmptyDirVolumeSource)
-		if err := convert_v1_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource(in.EmptyDir, out.EmptyDir, s); err != nil {
+		if err := Convert_v1_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource(in.EmptyDir, out.EmptyDir, s); err != nil {
 			return err
 		}
 	} else {
 		out.EmptyDir = nil
 	}
+	// unable to generate simple pointer conversion for v1.GCEPersistentDiskVolumeSource -> api.GCEPersistentDiskVolumeSource
 	if in.GCEPersistentDisk != nil {
 		out.GCEPersistentDisk = new(api.GCEPersistentDiskVolumeSource)
-		if err := convert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource(in.GCEPersistentDisk, out.GCEPersistentDisk, s); err != nil {
+		if err := Convert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource(in.GCEPersistentDisk, out.GCEPersistentDisk, s); err != nil {
 			return err
 		}
 	} else {
 		out.GCEPersistentDisk = nil
 	}
+	// unable to generate simple pointer conversion for v1.AWSElasticBlockStoreVolumeSource -> api.AWSElasticBlockStoreVolumeSource
 	if in.AWSElasticBlockStore != nil {
 		out.AWSElasticBlockStore = new(api.AWSElasticBlockStoreVolumeSource)
-		if err := convert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource(in.AWSElasticBlockStore, out.AWSElasticBlockStore, s); err != nil {
+		if err := Convert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource(in.AWSElasticBlockStore, out.AWSElasticBlockStore, s); err != nil {
 			return err
 		}
 	} else {
 		out.AWSElasticBlockStore = nil
 	}
+	// unable to generate simple pointer conversion for v1.GitRepoVolumeSource -> api.GitRepoVolumeSource
 	if in.GitRepo != nil {
 		out.GitRepo = new(api.GitRepoVolumeSource)
-		if err := convert_v1_GitRepoVolumeSource_To_api_GitRepoVolumeSource(in.GitRepo, out.GitRepo, s); err != nil {
+		if err := Convert_v1_GitRepoVolumeSource_To_api_GitRepoVolumeSource(in.GitRepo, out.GitRepo, s); err != nil {
 			return err
 		}
 	} else {
 		out.GitRepo = nil
 	}
+	// unable to generate simple pointer conversion for v1.SecretVolumeSource -> api.SecretVolumeSource
 	if in.Secret != nil {
 		out.Secret = new(api.SecretVolumeSource)
-		if err := convert_v1_SecretVolumeSource_To_api_SecretVolumeSource(in.Secret, out.Secret, s); err != nil {
+		if err := Convert_v1_SecretVolumeSource_To_api_SecretVolumeSource(in.Secret, out.Secret, s); err != nil {
 			return err
 		}
 	} else {
 		out.Secret = nil
 	}
+	// unable to generate simple pointer conversion for v1.NFSVolumeSource -> api.NFSVolumeSource
 	if in.NFS != nil {
 		out.NFS = new(api.NFSVolumeSource)
-		if err := convert_v1_NFSVolumeSource_To_api_NFSVolumeSource(in.NFS, out.NFS, s); err != nil {
+		if err := Convert_v1_NFSVolumeSource_To_api_NFSVolumeSource(in.NFS, out.NFS, s); err != nil {
 			return err
 		}
 	} else {
 		out.NFS = nil
 	}
+	// unable to generate simple pointer conversion for v1.ISCSIVolumeSource -> api.ISCSIVolumeSource
 	if in.ISCSI != nil {
 		out.ISCSI = new(api.ISCSIVolumeSource)
-		if err := convert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource(in.ISCSI, out.ISCSI, s); err != nil {
+		if err := Convert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource(in.ISCSI, out.ISCSI, s); err != nil {
 			return err
 		}
 	} else {
 		out.ISCSI = nil
 	}
+	// unable to generate simple pointer conversion for v1.GlusterfsVolumeSource -> api.GlusterfsVolumeSource
 	if in.Glusterfs != nil {
 		out.Glusterfs = new(api.GlusterfsVolumeSource)
-		if err := convert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource(in.Glusterfs, out.Glusterfs, s); err != nil {
+		if err := Convert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource(in.Glusterfs, out.Glusterfs, s); err != nil {
 			return err
 		}
 	} else {
 		out.Glusterfs = nil
 	}
+	// unable to generate simple pointer conversion for v1.PersistentVolumeClaimVolumeSource -> api.PersistentVolumeClaimVolumeSource
 	if in.PersistentVolumeClaim != nil {
 		out.PersistentVolumeClaim = new(api.PersistentVolumeClaimVolumeSource)
-		if err := convert_v1_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeClaimVolumeSource(in.PersistentVolumeClaim, out.PersistentVolumeClaim, s); err != nil {
+		if err := Convert_v1_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeClaimVolumeSource(in.PersistentVolumeClaim, out.PersistentVolumeClaim, s); err != nil {
 			return err
 		}
 	} else {
 		out.PersistentVolumeClaim = nil
 	}
+	// unable to generate simple pointer conversion for v1.RBDVolumeSource -> api.RBDVolumeSource
 	if in.RBD != nil {
 		out.RBD = new(api.RBDVolumeSource)
-		if err := convert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in.RBD, out.RBD, s); err != nil {
+		if err := Convert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in.RBD, out.RBD, s); err != nil {
 			return err
 		}
 	} else {
 		out.RBD = nil
 	}
+	// unable to generate simple pointer conversion for v1.FlexVolumeSource -> api.FlexVolumeSource
 	if in.FlexVolume != nil {
 		out.FlexVolume = new(api.FlexVolumeSource)
-		if err := convert_v1_FlexVolumeSource_To_api_FlexVolumeSource(in.FlexVolume, out.FlexVolume, s); err != nil {
+		if err := Convert_v1_FlexVolumeSource_To_api_FlexVolumeSource(in.FlexVolume, out.FlexVolume, s); err != nil {
 			return err
 		}
 	} else {
 		out.FlexVolume = nil
 	}
+	// unable to generate simple pointer conversion for v1.CinderVolumeSource -> api.CinderVolumeSource
 	if in.Cinder != nil {
 		out.Cinder = new(api.CinderVolumeSource)
-		if err := convert_v1_CinderVolumeSource_To_api_CinderVolumeSource(in.Cinder, out.Cinder, s); err != nil {
+		if err := Convert_v1_CinderVolumeSource_To_api_CinderVolumeSource(in.Cinder, out.Cinder, s); err != nil {
 			return err
 		}
 	} else {
 		out.Cinder = nil
 	}
+	// unable to generate simple pointer conversion for v1.CephFSVolumeSource -> api.CephFSVolumeSource
 	if in.CephFS != nil {
 		out.CephFS = new(api.CephFSVolumeSource)
-		if err := convert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in.CephFS, out.CephFS, s); err != nil {
+		if err := Convert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in.CephFS, out.CephFS, s); err != nil {
 			return err
 		}
 	} else {
 		out.CephFS = nil
 	}
+	// unable to generate simple pointer conversion for v1.FlockerVolumeSource -> api.FlockerVolumeSource
 	if in.Flocker != nil {
 		out.Flocker = new(api.FlockerVolumeSource)
-		if err := convert_v1_FlockerVolumeSource_To_api_FlockerVolumeSource(in.Flocker, out.Flocker, s); err != nil {
+		if err := Convert_v1_FlockerVolumeSource_To_api_FlockerVolumeSource(in.Flocker, out.Flocker, s); err != nil {
 			return err
 		}
 	} else {
 		out.Flocker = nil
 	}
+	// unable to generate simple pointer conversion for v1.DownwardAPIVolumeSource -> api.DownwardAPIVolumeSource
 	if in.DownwardAPI != nil {
 		out.DownwardAPI = new(api.DownwardAPIVolumeSource)
-		if err := convert_v1_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource(in.DownwardAPI, out.DownwardAPI, s); err != nil {
+		if err := Convert_v1_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource(in.DownwardAPI, out.DownwardAPI, s); err != nil {
 			return err
 		}
 	} else {
 		out.DownwardAPI = nil
 	}
+	// unable to generate simple pointer conversion for v1.FCVolumeSource -> api.FCVolumeSource
 	if in.FC != nil {
 		out.FC = new(api.FCVolumeSource)
-		if err := convert_v1_FCVolumeSource_To_api_FCVolumeSource(in.FC, out.FC, s); err != nil {
+		if err := Convert_v1_FCVolumeSource_To_api_FCVolumeSource(in.FC, out.FC, s); err != nil {
 			return err
 		}
 	} else {
@@ -2254,11 +2327,11 @@ func autoconvert_v1_VolumeSource_To_api_VolumeSource(in *v1.VolumeSource, out *a
 	return nil
 }
 
-func convert_v1_VolumeSource_To_api_VolumeSource(in *v1.VolumeSource, out *api.VolumeSource, s conversion.Scope) error {
-	return autoconvert_v1_VolumeSource_To_api_VolumeSource(in, out, s)
+func Convert_v1_VolumeSource_To_api_VolumeSource(in *v1.VolumeSource, out *api.VolumeSource, s conversion.Scope) error {
+	return autoConvert_v1_VolumeSource_To_api_VolumeSource(in, out, s)
 }
 
-func autoconvert_extensions_APIVersion_To_v1beta1_APIVersion(in *extensions.APIVersion, out *APIVersion, s conversion.Scope) error {
+func autoConvert_extensions_APIVersion_To_v1beta1_APIVersion(in *extensions.APIVersion, out *APIVersion, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.APIVersion))(in)
 	}
@@ -2267,11 +2340,11 @@ func autoconvert_extensions_APIVersion_To_v1beta1_APIVersion(in *extensions.APIV
 	return nil
 }
 
-func convert_extensions_APIVersion_To_v1beta1_APIVersion(in *extensions.APIVersion, out *APIVersion, s conversion.Scope) error {
-	return autoconvert_extensions_APIVersion_To_v1beta1_APIVersion(in, out, s)
+func Convert_extensions_APIVersion_To_v1beta1_APIVersion(in *extensions.APIVersion, out *APIVersion, s conversion.Scope) error {
+	return autoConvert_extensions_APIVersion_To_v1beta1_APIVersion(in, out, s)
 }
 
-func autoconvert_extensions_CPUTargetUtilization_To_v1beta1_CPUTargetUtilization(in *extensions.CPUTargetUtilization, out *CPUTargetUtilization, s conversion.Scope) error {
+func autoConvert_extensions_CPUTargetUtilization_To_v1beta1_CPUTargetUtilization(in *extensions.CPUTargetUtilization, out *CPUTargetUtilization, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.CPUTargetUtilization))(in)
 	}
@@ -2279,44 +2352,44 @@ func autoconvert_extensions_CPUTargetUtilization_To_v1beta1_CPUTargetUtilization
 	return nil
 }
 
-func convert_extensions_CPUTargetUtilization_To_v1beta1_CPUTargetUtilization(in *extensions.CPUTargetUtilization, out *CPUTargetUtilization, s conversion.Scope) error {
-	return autoconvert_extensions_CPUTargetUtilization_To_v1beta1_CPUTargetUtilization(in, out, s)
+func Convert_extensions_CPUTargetUtilization_To_v1beta1_CPUTargetUtilization(in *extensions.CPUTargetUtilization, out *CPUTargetUtilization, s conversion.Scope) error {
+	return autoConvert_extensions_CPUTargetUtilization_To_v1beta1_CPUTargetUtilization(in, out, s)
 }
 
-func autoconvert_extensions_ClusterAutoscaler_To_v1beta1_ClusterAutoscaler(in *extensions.ClusterAutoscaler, out *ClusterAutoscaler, s conversion.Scope) error {
+func autoConvert_extensions_ClusterAutoscaler_To_v1beta1_ClusterAutoscaler(in *extensions.ClusterAutoscaler, out *ClusterAutoscaler, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.ClusterAutoscaler))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_extensions_ClusterAutoscalerSpec_To_v1beta1_ClusterAutoscalerSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_extensions_ClusterAutoscalerSpec_To_v1beta1_ClusterAutoscalerSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_extensions_ClusterAutoscaler_To_v1beta1_ClusterAutoscaler(in *extensions.ClusterAutoscaler, out *ClusterAutoscaler, s conversion.Scope) error {
-	return autoconvert_extensions_ClusterAutoscaler_To_v1beta1_ClusterAutoscaler(in, out, s)
+func Convert_extensions_ClusterAutoscaler_To_v1beta1_ClusterAutoscaler(in *extensions.ClusterAutoscaler, out *ClusterAutoscaler, s conversion.Scope) error {
+	return autoConvert_extensions_ClusterAutoscaler_To_v1beta1_ClusterAutoscaler(in, out, s)
 }
 
-func autoconvert_extensions_ClusterAutoscalerList_To_v1beta1_ClusterAutoscalerList(in *extensions.ClusterAutoscalerList, out *ClusterAutoscalerList, s conversion.Scope) error {
+func autoConvert_extensions_ClusterAutoscalerList_To_v1beta1_ClusterAutoscalerList(in *extensions.ClusterAutoscalerList, out *ClusterAutoscalerList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.ClusterAutoscalerList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]ClusterAutoscaler, len(in.Items))
 		for i := range in.Items {
-			if err := convert_extensions_ClusterAutoscaler_To_v1beta1_ClusterAutoscaler(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_extensions_ClusterAutoscaler_To_v1beta1_ClusterAutoscaler(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -2326,11 +2399,11 @@ func autoconvert_extensions_ClusterAutoscalerList_To_v1beta1_ClusterAutoscalerLi
 	return nil
 }
 
-func convert_extensions_ClusterAutoscalerList_To_v1beta1_ClusterAutoscalerList(in *extensions.ClusterAutoscalerList, out *ClusterAutoscalerList, s conversion.Scope) error {
-	return autoconvert_extensions_ClusterAutoscalerList_To_v1beta1_ClusterAutoscalerList(in, out, s)
+func Convert_extensions_ClusterAutoscalerList_To_v1beta1_ClusterAutoscalerList(in *extensions.ClusterAutoscalerList, out *ClusterAutoscalerList, s conversion.Scope) error {
+	return autoConvert_extensions_ClusterAutoscalerList_To_v1beta1_ClusterAutoscalerList(in, out, s)
 }
 
-func autoconvert_extensions_ClusterAutoscalerSpec_To_v1beta1_ClusterAutoscalerSpec(in *extensions.ClusterAutoscalerSpec, out *ClusterAutoscalerSpec, s conversion.Scope) error {
+func autoConvert_extensions_ClusterAutoscalerSpec_To_v1beta1_ClusterAutoscalerSpec(in *extensions.ClusterAutoscalerSpec, out *ClusterAutoscalerSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.ClusterAutoscalerSpec))(in)
 	}
@@ -2339,7 +2412,7 @@ func autoconvert_extensions_ClusterAutoscalerSpec_To_v1beta1_ClusterAutoscalerSp
 	if in.TargetUtilization != nil {
 		out.TargetUtilization = make([]NodeUtilization, len(in.TargetUtilization))
 		for i := range in.TargetUtilization {
-			if err := convert_extensions_NodeUtilization_To_v1beta1_NodeUtilization(&in.TargetUtilization[i], &out.TargetUtilization[i], s); err != nil {
+			if err := Convert_extensions_NodeUtilization_To_v1beta1_NodeUtilization(&in.TargetUtilization[i], &out.TargetUtilization[i], s); err != nil {
 				return err
 			}
 		}
@@ -2349,18 +2422,18 @@ func autoconvert_extensions_ClusterAutoscalerSpec_To_v1beta1_ClusterAutoscalerSp
 	return nil
 }
 
-func convert_extensions_ClusterAutoscalerSpec_To_v1beta1_ClusterAutoscalerSpec(in *extensions.ClusterAutoscalerSpec, out *ClusterAutoscalerSpec, s conversion.Scope) error {
-	return autoconvert_extensions_ClusterAutoscalerSpec_To_v1beta1_ClusterAutoscalerSpec(in, out, s)
+func Convert_extensions_ClusterAutoscalerSpec_To_v1beta1_ClusterAutoscalerSpec(in *extensions.ClusterAutoscalerSpec, out *ClusterAutoscalerSpec, s conversion.Scope) error {
+	return autoConvert_extensions_ClusterAutoscalerSpec_To_v1beta1_ClusterAutoscalerSpec(in, out, s)
 }
 
-func autoconvert_extensions_ConfigMap_To_v1beta1_ConfigMap(in *extensions.ConfigMap, out *ConfigMap, s conversion.Scope) error {
+func autoConvert_extensions_ConfigMap_To_v1beta1_ConfigMap(in *extensions.ConfigMap, out *ConfigMap, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.ConfigMap))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
 	if in.Data != nil {
@@ -2374,24 +2447,24 @@ func autoconvert_extensions_ConfigMap_To_v1beta1_ConfigMap(in *extensions.Config
 	return nil
 }
 
-func convert_extensions_ConfigMap_To_v1beta1_ConfigMap(in *extensions.ConfigMap, out *ConfigMap, s conversion.Scope) error {
-	return autoconvert_extensions_ConfigMap_To_v1beta1_ConfigMap(in, out, s)
+func Convert_extensions_ConfigMap_To_v1beta1_ConfigMap(in *extensions.ConfigMap, out *ConfigMap, s conversion.Scope) error {
+	return autoConvert_extensions_ConfigMap_To_v1beta1_ConfigMap(in, out, s)
 }
 
-func autoconvert_extensions_ConfigMapList_To_v1beta1_ConfigMapList(in *extensions.ConfigMapList, out *ConfigMapList, s conversion.Scope) error {
+func autoConvert_extensions_ConfigMapList_To_v1beta1_ConfigMapList(in *extensions.ConfigMapList, out *ConfigMapList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.ConfigMapList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]ConfigMap, len(in.Items))
 		for i := range in.Items {
-			if err := convert_extensions_ConfigMap_To_v1beta1_ConfigMap(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_extensions_ConfigMap_To_v1beta1_ConfigMap(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -2401,47 +2474,47 @@ func autoconvert_extensions_ConfigMapList_To_v1beta1_ConfigMapList(in *extension
 	return nil
 }
 
-func convert_extensions_ConfigMapList_To_v1beta1_ConfigMapList(in *extensions.ConfigMapList, out *ConfigMapList, s conversion.Scope) error {
-	return autoconvert_extensions_ConfigMapList_To_v1beta1_ConfigMapList(in, out, s)
+func Convert_extensions_ConfigMapList_To_v1beta1_ConfigMapList(in *extensions.ConfigMapList, out *ConfigMapList, s conversion.Scope) error {
+	return autoConvert_extensions_ConfigMapList_To_v1beta1_ConfigMapList(in, out, s)
 }
 
-func autoconvert_extensions_DaemonSet_To_v1beta1_DaemonSet(in *extensions.DaemonSet, out *DaemonSet, s conversion.Scope) error {
+func autoConvert_extensions_DaemonSet_To_v1beta1_DaemonSet(in *extensions.DaemonSet, out *DaemonSet, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.DaemonSet))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_extensions_DaemonSetSpec_To_v1beta1_DaemonSetSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_extensions_DaemonSetSpec_To_v1beta1_DaemonSetSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := convert_extensions_DaemonSetStatus_To_v1beta1_DaemonSetStatus(&in.Status, &out.Status, s); err != nil {
+	if err := Convert_extensions_DaemonSetStatus_To_v1beta1_DaemonSetStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_extensions_DaemonSet_To_v1beta1_DaemonSet(in *extensions.DaemonSet, out *DaemonSet, s conversion.Scope) error {
-	return autoconvert_extensions_DaemonSet_To_v1beta1_DaemonSet(in, out, s)
+func Convert_extensions_DaemonSet_To_v1beta1_DaemonSet(in *extensions.DaemonSet, out *DaemonSet, s conversion.Scope) error {
+	return autoConvert_extensions_DaemonSet_To_v1beta1_DaemonSet(in, out, s)
 }
 
-func autoconvert_extensions_DaemonSetList_To_v1beta1_DaemonSetList(in *extensions.DaemonSetList, out *DaemonSetList, s conversion.Scope) error {
+func autoConvert_extensions_DaemonSetList_To_v1beta1_DaemonSetList(in *extensions.DaemonSetList, out *DaemonSetList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.DaemonSetList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]DaemonSet, len(in.Items))
 		for i := range in.Items {
-			if err := convert_extensions_DaemonSet_To_v1beta1_DaemonSet(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_extensions_DaemonSet_To_v1beta1_DaemonSet(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -2451,25 +2524,27 @@ func autoconvert_extensions_DaemonSetList_To_v1beta1_DaemonSetList(in *extension
 	return nil
 }
 
-func convert_extensions_DaemonSetList_To_v1beta1_DaemonSetList(in *extensions.DaemonSetList, out *DaemonSetList, s conversion.Scope) error {
-	return autoconvert_extensions_DaemonSetList_To_v1beta1_DaemonSetList(in, out, s)
+func Convert_extensions_DaemonSetList_To_v1beta1_DaemonSetList(in *extensions.DaemonSetList, out *DaemonSetList, s conversion.Scope) error {
+	return autoConvert_extensions_DaemonSetList_To_v1beta1_DaemonSetList(in, out, s)
 }
 
-func autoconvert_extensions_DaemonSetSpec_To_v1beta1_DaemonSetSpec(in *extensions.DaemonSetSpec, out *DaemonSetSpec, s conversion.Scope) error {
+func autoConvert_extensions_DaemonSetSpec_To_v1beta1_DaemonSetSpec(in *extensions.DaemonSetSpec, out *DaemonSetSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.DaemonSetSpec))(in)
 	}
+	// unable to generate simple pointer conversion for extensions.LabelSelector -> v1beta1.LabelSelector
 	if in.Selector != nil {
 		out.Selector = new(LabelSelector)
-		if err := convert_extensions_LabelSelector_To_v1beta1_LabelSelector(in.Selector, out.Selector, s); err != nil {
+		if err := Convert_extensions_LabelSelector_To_v1beta1_LabelSelector(in.Selector, out.Selector, s); err != nil {
 			return err
 		}
 	} else {
 		out.Selector = nil
 	}
+	// unable to generate simple pointer conversion for api.PodTemplateSpec -> v1.PodTemplateSpec
 	if in.Template != nil {
 		out.Template = new(v1.PodTemplateSpec)
-		if err := convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in.Template, out.Template, s); err != nil {
+		if err := Convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in.Template, out.Template, s); err != nil {
 			return err
 		}
 	} else {
@@ -2478,11 +2553,11 @@ func autoconvert_extensions_DaemonSetSpec_To_v1beta1_DaemonSetSpec(in *extension
 	return nil
 }
 
-func convert_extensions_DaemonSetSpec_To_v1beta1_DaemonSetSpec(in *extensions.DaemonSetSpec, out *DaemonSetSpec, s conversion.Scope) error {
-	return autoconvert_extensions_DaemonSetSpec_To_v1beta1_DaemonSetSpec(in, out, s)
+func Convert_extensions_DaemonSetSpec_To_v1beta1_DaemonSetSpec(in *extensions.DaemonSetSpec, out *DaemonSetSpec, s conversion.Scope) error {
+	return autoConvert_extensions_DaemonSetSpec_To_v1beta1_DaemonSetSpec(in, out, s)
 }
 
-func autoconvert_extensions_DaemonSetStatus_To_v1beta1_DaemonSetStatus(in *extensions.DaemonSetStatus, out *DaemonSetStatus, s conversion.Scope) error {
+func autoConvert_extensions_DaemonSetStatus_To_v1beta1_DaemonSetStatus(in *extensions.DaemonSetStatus, out *DaemonSetStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.DaemonSetStatus))(in)
 	}
@@ -2492,47 +2567,47 @@ func autoconvert_extensions_DaemonSetStatus_To_v1beta1_DaemonSetStatus(in *exten
 	return nil
 }
 
-func convert_extensions_DaemonSetStatus_To_v1beta1_DaemonSetStatus(in *extensions.DaemonSetStatus, out *DaemonSetStatus, s conversion.Scope) error {
-	return autoconvert_extensions_DaemonSetStatus_To_v1beta1_DaemonSetStatus(in, out, s)
+func Convert_extensions_DaemonSetStatus_To_v1beta1_DaemonSetStatus(in *extensions.DaemonSetStatus, out *DaemonSetStatus, s conversion.Scope) error {
+	return autoConvert_extensions_DaemonSetStatus_To_v1beta1_DaemonSetStatus(in, out, s)
 }
 
-func autoconvert_extensions_Deployment_To_v1beta1_Deployment(in *extensions.Deployment, out *Deployment, s conversion.Scope) error {
+func autoConvert_extensions_Deployment_To_v1beta1_Deployment(in *extensions.Deployment, out *Deployment, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.Deployment))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_extensions_DeploymentSpec_To_v1beta1_DeploymentSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_extensions_DeploymentSpec_To_v1beta1_DeploymentSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := convert_extensions_DeploymentStatus_To_v1beta1_DeploymentStatus(&in.Status, &out.Status, s); err != nil {
+	if err := Convert_extensions_DeploymentStatus_To_v1beta1_DeploymentStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_extensions_Deployment_To_v1beta1_Deployment(in *extensions.Deployment, out *Deployment, s conversion.Scope) error {
-	return autoconvert_extensions_Deployment_To_v1beta1_Deployment(in, out, s)
+func Convert_extensions_Deployment_To_v1beta1_Deployment(in *extensions.Deployment, out *Deployment, s conversion.Scope) error {
+	return autoConvert_extensions_Deployment_To_v1beta1_Deployment(in, out, s)
 }
 
-func autoconvert_extensions_DeploymentList_To_v1beta1_DeploymentList(in *extensions.DeploymentList, out *DeploymentList, s conversion.Scope) error {
+func autoConvert_extensions_DeploymentList_To_v1beta1_DeploymentList(in *extensions.DeploymentList, out *DeploymentList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.DeploymentList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]Deployment, len(in.Items))
 		for i := range in.Items {
-			if err := convert_extensions_Deployment_To_v1beta1_Deployment(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_extensions_Deployment_To_v1beta1_Deployment(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -2542,11 +2617,11 @@ func autoconvert_extensions_DeploymentList_To_v1beta1_DeploymentList(in *extensi
 	return nil
 }
 
-func convert_extensions_DeploymentList_To_v1beta1_DeploymentList(in *extensions.DeploymentList, out *DeploymentList, s conversion.Scope) error {
-	return autoconvert_extensions_DeploymentList_To_v1beta1_DeploymentList(in, out, s)
+func Convert_extensions_DeploymentList_To_v1beta1_DeploymentList(in *extensions.DeploymentList, out *DeploymentList, s conversion.Scope) error {
+	return autoConvert_extensions_DeploymentList_To_v1beta1_DeploymentList(in, out, s)
 }
 
-func autoconvert_extensions_DeploymentSpec_To_v1beta1_DeploymentSpec(in *extensions.DeploymentSpec, out *DeploymentSpec, s conversion.Scope) error {
+func autoConvert_extensions_DeploymentSpec_To_v1beta1_DeploymentSpec(in *extensions.DeploymentSpec, out *DeploymentSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.DeploymentSpec))(in)
 	}
@@ -2561,10 +2636,10 @@ func autoconvert_extensions_DeploymentSpec_To_v1beta1_DeploymentSpec(in *extensi
 	} else {
 		out.Selector = nil
 	}
-	if err := convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
+	if err := Convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
-	if err := convert_extensions_DeploymentStrategy_To_v1beta1_DeploymentStrategy(&in.Strategy, &out.Strategy, s); err != nil {
+	if err := Convert_extensions_DeploymentStrategy_To_v1beta1_DeploymentStrategy(&in.Strategy, &out.Strategy, s); err != nil {
 		return err
 	}
 	if err := s.Convert(&in.UniqueLabelKey, &out.UniqueLabelKey, 0); err != nil {
@@ -2573,7 +2648,7 @@ func autoconvert_extensions_DeploymentSpec_To_v1beta1_DeploymentSpec(in *extensi
 	return nil
 }
 
-func autoconvert_extensions_DeploymentStatus_To_v1beta1_DeploymentStatus(in *extensions.DeploymentStatus, out *DeploymentStatus, s conversion.Scope) error {
+func autoConvert_extensions_DeploymentStatus_To_v1beta1_DeploymentStatus(in *extensions.DeploymentStatus, out *DeploymentStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.DeploymentStatus))(in)
 	}
@@ -2582,18 +2657,19 @@ func autoconvert_extensions_DeploymentStatus_To_v1beta1_DeploymentStatus(in *ext
 	return nil
 }
 
-func convert_extensions_DeploymentStatus_To_v1beta1_DeploymentStatus(in *extensions.DeploymentStatus, out *DeploymentStatus, s conversion.Scope) error {
-	return autoconvert_extensions_DeploymentStatus_To_v1beta1_DeploymentStatus(in, out, s)
+func Convert_extensions_DeploymentStatus_To_v1beta1_DeploymentStatus(in *extensions.DeploymentStatus, out *DeploymentStatus, s conversion.Scope) error {
+	return autoConvert_extensions_DeploymentStatus_To_v1beta1_DeploymentStatus(in, out, s)
 }
 
-func autoconvert_extensions_DeploymentStrategy_To_v1beta1_DeploymentStrategy(in *extensions.DeploymentStrategy, out *DeploymentStrategy, s conversion.Scope) error {
+func autoConvert_extensions_DeploymentStrategy_To_v1beta1_DeploymentStrategy(in *extensions.DeploymentStrategy, out *DeploymentStrategy, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.DeploymentStrategy))(in)
 	}
 	out.Type = DeploymentStrategyType(in.Type)
+	// unable to generate simple pointer conversion for extensions.RollingUpdateDeployment -> v1beta1.RollingUpdateDeployment
 	if in.RollingUpdate != nil {
 		out.RollingUpdate = new(RollingUpdateDeployment)
-		if err := convert_extensions_RollingUpdateDeployment_To_v1beta1_RollingUpdateDeployment(in.RollingUpdate, out.RollingUpdate, s); err != nil {
+		if err := Convert_extensions_RollingUpdateDeployment_To_v1beta1_RollingUpdateDeployment(in.RollingUpdate, out.RollingUpdate, s); err != nil {
 			return err
 		}
 	} else {
@@ -2602,29 +2678,29 @@ func autoconvert_extensions_DeploymentStrategy_To_v1beta1_DeploymentStrategy(in 
 	return nil
 }
 
-func autoconvert_extensions_HTTPIngressPath_To_v1beta1_HTTPIngressPath(in *extensions.HTTPIngressPath, out *HTTPIngressPath, s conversion.Scope) error {
+func autoConvert_extensions_HTTPIngressPath_To_v1beta1_HTTPIngressPath(in *extensions.HTTPIngressPath, out *HTTPIngressPath, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.HTTPIngressPath))(in)
 	}
 	out.Path = in.Path
-	if err := convert_extensions_IngressBackend_To_v1beta1_IngressBackend(&in.Backend, &out.Backend, s); err != nil {
+	if err := Convert_extensions_IngressBackend_To_v1beta1_IngressBackend(&in.Backend, &out.Backend, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_extensions_HTTPIngressPath_To_v1beta1_HTTPIngressPath(in *extensions.HTTPIngressPath, out *HTTPIngressPath, s conversion.Scope) error {
-	return autoconvert_extensions_HTTPIngressPath_To_v1beta1_HTTPIngressPath(in, out, s)
+func Convert_extensions_HTTPIngressPath_To_v1beta1_HTTPIngressPath(in *extensions.HTTPIngressPath, out *HTTPIngressPath, s conversion.Scope) error {
+	return autoConvert_extensions_HTTPIngressPath_To_v1beta1_HTTPIngressPath(in, out, s)
 }
 
-func autoconvert_extensions_HTTPIngressRuleValue_To_v1beta1_HTTPIngressRuleValue(in *extensions.HTTPIngressRuleValue, out *HTTPIngressRuleValue, s conversion.Scope) error {
+func autoConvert_extensions_HTTPIngressRuleValue_To_v1beta1_HTTPIngressRuleValue(in *extensions.HTTPIngressRuleValue, out *HTTPIngressRuleValue, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.HTTPIngressRuleValue))(in)
 	}
 	if in.Paths != nil {
 		out.Paths = make([]HTTPIngressPath, len(in.Paths))
 		for i := range in.Paths {
-			if err := convert_extensions_HTTPIngressPath_To_v1beta1_HTTPIngressPath(&in.Paths[i], &out.Paths[i], s); err != nil {
+			if err := Convert_extensions_HTTPIngressPath_To_v1beta1_HTTPIngressPath(&in.Paths[i], &out.Paths[i], s); err != nil {
 				return err
 			}
 		}
@@ -2634,47 +2710,47 @@ func autoconvert_extensions_HTTPIngressRuleValue_To_v1beta1_HTTPIngressRuleValue
 	return nil
 }
 
-func convert_extensions_HTTPIngressRuleValue_To_v1beta1_HTTPIngressRuleValue(in *extensions.HTTPIngressRuleValue, out *HTTPIngressRuleValue, s conversion.Scope) error {
-	return autoconvert_extensions_HTTPIngressRuleValue_To_v1beta1_HTTPIngressRuleValue(in, out, s)
+func Convert_extensions_HTTPIngressRuleValue_To_v1beta1_HTTPIngressRuleValue(in *extensions.HTTPIngressRuleValue, out *HTTPIngressRuleValue, s conversion.Scope) error {
+	return autoConvert_extensions_HTTPIngressRuleValue_To_v1beta1_HTTPIngressRuleValue(in, out, s)
 }
 
-func autoconvert_extensions_HorizontalPodAutoscaler_To_v1beta1_HorizontalPodAutoscaler(in *extensions.HorizontalPodAutoscaler, out *HorizontalPodAutoscaler, s conversion.Scope) error {
+func autoConvert_extensions_HorizontalPodAutoscaler_To_v1beta1_HorizontalPodAutoscaler(in *extensions.HorizontalPodAutoscaler, out *HorizontalPodAutoscaler, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.HorizontalPodAutoscaler))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_extensions_HorizontalPodAutoscalerSpec_To_v1beta1_HorizontalPodAutoscalerSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_extensions_HorizontalPodAutoscalerSpec_To_v1beta1_HorizontalPodAutoscalerSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := convert_extensions_HorizontalPodAutoscalerStatus_To_v1beta1_HorizontalPodAutoscalerStatus(&in.Status, &out.Status, s); err != nil {
+	if err := Convert_extensions_HorizontalPodAutoscalerStatus_To_v1beta1_HorizontalPodAutoscalerStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_extensions_HorizontalPodAutoscaler_To_v1beta1_HorizontalPodAutoscaler(in *extensions.HorizontalPodAutoscaler, out *HorizontalPodAutoscaler, s conversion.Scope) error {
-	return autoconvert_extensions_HorizontalPodAutoscaler_To_v1beta1_HorizontalPodAutoscaler(in, out, s)
+func Convert_extensions_HorizontalPodAutoscaler_To_v1beta1_HorizontalPodAutoscaler(in *extensions.HorizontalPodAutoscaler, out *HorizontalPodAutoscaler, s conversion.Scope) error {
+	return autoConvert_extensions_HorizontalPodAutoscaler_To_v1beta1_HorizontalPodAutoscaler(in, out, s)
 }
 
-func autoconvert_extensions_HorizontalPodAutoscalerList_To_v1beta1_HorizontalPodAutoscalerList(in *extensions.HorizontalPodAutoscalerList, out *HorizontalPodAutoscalerList, s conversion.Scope) error {
+func autoConvert_extensions_HorizontalPodAutoscalerList_To_v1beta1_HorizontalPodAutoscalerList(in *extensions.HorizontalPodAutoscalerList, out *HorizontalPodAutoscalerList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.HorizontalPodAutoscalerList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]HorizontalPodAutoscaler, len(in.Items))
 		for i := range in.Items {
-			if err := convert_extensions_HorizontalPodAutoscaler_To_v1beta1_HorizontalPodAutoscaler(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_extensions_HorizontalPodAutoscaler_To_v1beta1_HorizontalPodAutoscaler(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -2684,15 +2760,15 @@ func autoconvert_extensions_HorizontalPodAutoscalerList_To_v1beta1_HorizontalPod
 	return nil
 }
 
-func convert_extensions_HorizontalPodAutoscalerList_To_v1beta1_HorizontalPodAutoscalerList(in *extensions.HorizontalPodAutoscalerList, out *HorizontalPodAutoscalerList, s conversion.Scope) error {
-	return autoconvert_extensions_HorizontalPodAutoscalerList_To_v1beta1_HorizontalPodAutoscalerList(in, out, s)
+func Convert_extensions_HorizontalPodAutoscalerList_To_v1beta1_HorizontalPodAutoscalerList(in *extensions.HorizontalPodAutoscalerList, out *HorizontalPodAutoscalerList, s conversion.Scope) error {
+	return autoConvert_extensions_HorizontalPodAutoscalerList_To_v1beta1_HorizontalPodAutoscalerList(in, out, s)
 }
 
-func autoconvert_extensions_HorizontalPodAutoscalerSpec_To_v1beta1_HorizontalPodAutoscalerSpec(in *extensions.HorizontalPodAutoscalerSpec, out *HorizontalPodAutoscalerSpec, s conversion.Scope) error {
+func autoConvert_extensions_HorizontalPodAutoscalerSpec_To_v1beta1_HorizontalPodAutoscalerSpec(in *extensions.HorizontalPodAutoscalerSpec, out *HorizontalPodAutoscalerSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.HorizontalPodAutoscalerSpec))(in)
 	}
-	if err := convert_extensions_SubresourceReference_To_v1beta1_SubresourceReference(&in.ScaleRef, &out.ScaleRef, s); err != nil {
+	if err := Convert_extensions_SubresourceReference_To_v1beta1_SubresourceReference(&in.ScaleRef, &out.ScaleRef, s); err != nil {
 		return err
 	}
 	if in.MinReplicas != nil {
@@ -2702,9 +2778,10 @@ func autoconvert_extensions_HorizontalPodAutoscalerSpec_To_v1beta1_HorizontalPod
 		out.MinReplicas = nil
 	}
 	out.MaxReplicas = int32(in.MaxReplicas)
+	// unable to generate simple pointer conversion for extensions.CPUTargetUtilization -> v1beta1.CPUTargetUtilization
 	if in.CPUUtilization != nil {
 		out.CPUUtilization = new(CPUTargetUtilization)
-		if err := convert_extensions_CPUTargetUtilization_To_v1beta1_CPUTargetUtilization(in.CPUUtilization, out.CPUUtilization, s); err != nil {
+		if err := Convert_extensions_CPUTargetUtilization_To_v1beta1_CPUTargetUtilization(in.CPUUtilization, out.CPUUtilization, s); err != nil {
 			return err
 		}
 	} else {
@@ -2713,11 +2790,11 @@ func autoconvert_extensions_HorizontalPodAutoscalerSpec_To_v1beta1_HorizontalPod
 	return nil
 }
 
-func convert_extensions_HorizontalPodAutoscalerSpec_To_v1beta1_HorizontalPodAutoscalerSpec(in *extensions.HorizontalPodAutoscalerSpec, out *HorizontalPodAutoscalerSpec, s conversion.Scope) error {
-	return autoconvert_extensions_HorizontalPodAutoscalerSpec_To_v1beta1_HorizontalPodAutoscalerSpec(in, out, s)
+func Convert_extensions_HorizontalPodAutoscalerSpec_To_v1beta1_HorizontalPodAutoscalerSpec(in *extensions.HorizontalPodAutoscalerSpec, out *HorizontalPodAutoscalerSpec, s conversion.Scope) error {
+	return autoConvert_extensions_HorizontalPodAutoscalerSpec_To_v1beta1_HorizontalPodAutoscalerSpec(in, out, s)
 }
 
-func autoconvert_extensions_HorizontalPodAutoscalerStatus_To_v1beta1_HorizontalPodAutoscalerStatus(in *extensions.HorizontalPodAutoscalerStatus, out *HorizontalPodAutoscalerStatus, s conversion.Scope) error {
+func autoConvert_extensions_HorizontalPodAutoscalerStatus_To_v1beta1_HorizontalPodAutoscalerStatus(in *extensions.HorizontalPodAutoscalerStatus, out *HorizontalPodAutoscalerStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.HorizontalPodAutoscalerStatus))(in)
 	}
@@ -2727,8 +2804,10 @@ func autoconvert_extensions_HorizontalPodAutoscalerStatus_To_v1beta1_HorizontalP
 	} else {
 		out.ObservedGeneration = nil
 	}
+	// unable to generate simple pointer conversion for unversioned.Time -> unversioned.Time
 	if in.LastScaleTime != nil {
-		if err := s.Convert(&in.LastScaleTime, &out.LastScaleTime, 0); err != nil {
+		out.LastScaleTime = new(unversioned.Time)
+		if err := api.Convert_unversioned_Time_To_unversioned_Time(in.LastScaleTime, out.LastScaleTime, s); err != nil {
 			return err
 		}
 	} else {
@@ -2745,62 +2824,62 @@ func autoconvert_extensions_HorizontalPodAutoscalerStatus_To_v1beta1_HorizontalP
 	return nil
 }
 
-func convert_extensions_HorizontalPodAutoscalerStatus_To_v1beta1_HorizontalPodAutoscalerStatus(in *extensions.HorizontalPodAutoscalerStatus, out *HorizontalPodAutoscalerStatus, s conversion.Scope) error {
-	return autoconvert_extensions_HorizontalPodAutoscalerStatus_To_v1beta1_HorizontalPodAutoscalerStatus(in, out, s)
+func Convert_extensions_HorizontalPodAutoscalerStatus_To_v1beta1_HorizontalPodAutoscalerStatus(in *extensions.HorizontalPodAutoscalerStatus, out *HorizontalPodAutoscalerStatus, s conversion.Scope) error {
+	return autoConvert_extensions_HorizontalPodAutoscalerStatus_To_v1beta1_HorizontalPodAutoscalerStatus(in, out, s)
 }
 
-func autoconvert_extensions_Ingress_To_v1beta1_Ingress(in *extensions.Ingress, out *Ingress, s conversion.Scope) error {
+func autoConvert_extensions_Ingress_To_v1beta1_Ingress(in *extensions.Ingress, out *Ingress, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.Ingress))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_extensions_IngressSpec_To_v1beta1_IngressSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_extensions_IngressSpec_To_v1beta1_IngressSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := convert_extensions_IngressStatus_To_v1beta1_IngressStatus(&in.Status, &out.Status, s); err != nil {
+	if err := Convert_extensions_IngressStatus_To_v1beta1_IngressStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_extensions_Ingress_To_v1beta1_Ingress(in *extensions.Ingress, out *Ingress, s conversion.Scope) error {
-	return autoconvert_extensions_Ingress_To_v1beta1_Ingress(in, out, s)
+func Convert_extensions_Ingress_To_v1beta1_Ingress(in *extensions.Ingress, out *Ingress, s conversion.Scope) error {
+	return autoConvert_extensions_Ingress_To_v1beta1_Ingress(in, out, s)
 }
 
-func autoconvert_extensions_IngressBackend_To_v1beta1_IngressBackend(in *extensions.IngressBackend, out *IngressBackend, s conversion.Scope) error {
+func autoConvert_extensions_IngressBackend_To_v1beta1_IngressBackend(in *extensions.IngressBackend, out *IngressBackend, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.IngressBackend))(in)
 	}
 	out.ServiceName = in.ServiceName
-	if err := s.Convert(&in.ServicePort, &out.ServicePort, 0); err != nil {
+	if err := api.Convert_intstr_IntOrString_To_intstr_IntOrString(&in.ServicePort, &out.ServicePort, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_extensions_IngressBackend_To_v1beta1_IngressBackend(in *extensions.IngressBackend, out *IngressBackend, s conversion.Scope) error {
-	return autoconvert_extensions_IngressBackend_To_v1beta1_IngressBackend(in, out, s)
+func Convert_extensions_IngressBackend_To_v1beta1_IngressBackend(in *extensions.IngressBackend, out *IngressBackend, s conversion.Scope) error {
+	return autoConvert_extensions_IngressBackend_To_v1beta1_IngressBackend(in, out, s)
 }
 
-func autoconvert_extensions_IngressList_To_v1beta1_IngressList(in *extensions.IngressList, out *IngressList, s conversion.Scope) error {
+func autoConvert_extensions_IngressList_To_v1beta1_IngressList(in *extensions.IngressList, out *IngressList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.IngressList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]Ingress, len(in.Items))
 		for i := range in.Items {
-			if err := convert_extensions_Ingress_To_v1beta1_Ingress(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_extensions_Ingress_To_v1beta1_Ingress(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -2810,32 +2889,33 @@ func autoconvert_extensions_IngressList_To_v1beta1_IngressList(in *extensions.In
 	return nil
 }
 
-func convert_extensions_IngressList_To_v1beta1_IngressList(in *extensions.IngressList, out *IngressList, s conversion.Scope) error {
-	return autoconvert_extensions_IngressList_To_v1beta1_IngressList(in, out, s)
+func Convert_extensions_IngressList_To_v1beta1_IngressList(in *extensions.IngressList, out *IngressList, s conversion.Scope) error {
+	return autoConvert_extensions_IngressList_To_v1beta1_IngressList(in, out, s)
 }
 
-func autoconvert_extensions_IngressRule_To_v1beta1_IngressRule(in *extensions.IngressRule, out *IngressRule, s conversion.Scope) error {
+func autoConvert_extensions_IngressRule_To_v1beta1_IngressRule(in *extensions.IngressRule, out *IngressRule, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.IngressRule))(in)
 	}
 	out.Host = in.Host
-	if err := convert_extensions_IngressRuleValue_To_v1beta1_IngressRuleValue(&in.IngressRuleValue, &out.IngressRuleValue, s); err != nil {
+	if err := Convert_extensions_IngressRuleValue_To_v1beta1_IngressRuleValue(&in.IngressRuleValue, &out.IngressRuleValue, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_extensions_IngressRule_To_v1beta1_IngressRule(in *extensions.IngressRule, out *IngressRule, s conversion.Scope) error {
-	return autoconvert_extensions_IngressRule_To_v1beta1_IngressRule(in, out, s)
+func Convert_extensions_IngressRule_To_v1beta1_IngressRule(in *extensions.IngressRule, out *IngressRule, s conversion.Scope) error {
+	return autoConvert_extensions_IngressRule_To_v1beta1_IngressRule(in, out, s)
 }
 
-func autoconvert_extensions_IngressRuleValue_To_v1beta1_IngressRuleValue(in *extensions.IngressRuleValue, out *IngressRuleValue, s conversion.Scope) error {
+func autoConvert_extensions_IngressRuleValue_To_v1beta1_IngressRuleValue(in *extensions.IngressRuleValue, out *IngressRuleValue, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.IngressRuleValue))(in)
 	}
+	// unable to generate simple pointer conversion for extensions.HTTPIngressRuleValue -> v1beta1.HTTPIngressRuleValue
 	if in.HTTP != nil {
 		out.HTTP = new(HTTPIngressRuleValue)
-		if err := convert_extensions_HTTPIngressRuleValue_To_v1beta1_HTTPIngressRuleValue(in.HTTP, out.HTTP, s); err != nil {
+		if err := Convert_extensions_HTTPIngressRuleValue_To_v1beta1_HTTPIngressRuleValue(in.HTTP, out.HTTP, s); err != nil {
 			return err
 		}
 	} else {
@@ -2844,17 +2924,18 @@ func autoconvert_extensions_IngressRuleValue_To_v1beta1_IngressRuleValue(in *ext
 	return nil
 }
 
-func convert_extensions_IngressRuleValue_To_v1beta1_IngressRuleValue(in *extensions.IngressRuleValue, out *IngressRuleValue, s conversion.Scope) error {
-	return autoconvert_extensions_IngressRuleValue_To_v1beta1_IngressRuleValue(in, out, s)
+func Convert_extensions_IngressRuleValue_To_v1beta1_IngressRuleValue(in *extensions.IngressRuleValue, out *IngressRuleValue, s conversion.Scope) error {
+	return autoConvert_extensions_IngressRuleValue_To_v1beta1_IngressRuleValue(in, out, s)
 }
 
-func autoconvert_extensions_IngressSpec_To_v1beta1_IngressSpec(in *extensions.IngressSpec, out *IngressSpec, s conversion.Scope) error {
+func autoConvert_extensions_IngressSpec_To_v1beta1_IngressSpec(in *extensions.IngressSpec, out *IngressSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.IngressSpec))(in)
 	}
+	// unable to generate simple pointer conversion for extensions.IngressBackend -> v1beta1.IngressBackend
 	if in.Backend != nil {
 		out.Backend = new(IngressBackend)
-		if err := convert_extensions_IngressBackend_To_v1beta1_IngressBackend(in.Backend, out.Backend, s); err != nil {
+		if err := Convert_extensions_IngressBackend_To_v1beta1_IngressBackend(in.Backend, out.Backend, s); err != nil {
 			return err
 		}
 	} else {
@@ -2863,7 +2944,7 @@ func autoconvert_extensions_IngressSpec_To_v1beta1_IngressSpec(in *extensions.In
 	if in.Rules != nil {
 		out.Rules = make([]IngressRule, len(in.Rules))
 		for i := range in.Rules {
-			if err := convert_extensions_IngressRule_To_v1beta1_IngressRule(&in.Rules[i], &out.Rules[i], s); err != nil {
+			if err := Convert_extensions_IngressRule_To_v1beta1_IngressRule(&in.Rules[i], &out.Rules[i], s); err != nil {
 				return err
 			}
 		}
@@ -2873,57 +2954,57 @@ func autoconvert_extensions_IngressSpec_To_v1beta1_IngressSpec(in *extensions.In
 	return nil
 }
 
-func convert_extensions_IngressSpec_To_v1beta1_IngressSpec(in *extensions.IngressSpec, out *IngressSpec, s conversion.Scope) error {
-	return autoconvert_extensions_IngressSpec_To_v1beta1_IngressSpec(in, out, s)
+func Convert_extensions_IngressSpec_To_v1beta1_IngressSpec(in *extensions.IngressSpec, out *IngressSpec, s conversion.Scope) error {
+	return autoConvert_extensions_IngressSpec_To_v1beta1_IngressSpec(in, out, s)
 }
 
-func autoconvert_extensions_IngressStatus_To_v1beta1_IngressStatus(in *extensions.IngressStatus, out *IngressStatus, s conversion.Scope) error {
+func autoConvert_extensions_IngressStatus_To_v1beta1_IngressStatus(in *extensions.IngressStatus, out *IngressStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.IngressStatus))(in)
 	}
-	if err := convert_api_LoadBalancerStatus_To_v1_LoadBalancerStatus(&in.LoadBalancer, &out.LoadBalancer, s); err != nil {
+	if err := Convert_api_LoadBalancerStatus_To_v1_LoadBalancerStatus(&in.LoadBalancer, &out.LoadBalancer, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_extensions_IngressStatus_To_v1beta1_IngressStatus(in *extensions.IngressStatus, out *IngressStatus, s conversion.Scope) error {
-	return autoconvert_extensions_IngressStatus_To_v1beta1_IngressStatus(in, out, s)
+func Convert_extensions_IngressStatus_To_v1beta1_IngressStatus(in *extensions.IngressStatus, out *IngressStatus, s conversion.Scope) error {
+	return autoConvert_extensions_IngressStatus_To_v1beta1_IngressStatus(in, out, s)
 }
 
-func autoconvert_extensions_Job_To_v1beta1_Job(in *extensions.Job, out *Job, s conversion.Scope) error {
+func autoConvert_extensions_Job_To_v1beta1_Job(in *extensions.Job, out *Job, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.Job))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_extensions_JobSpec_To_v1beta1_JobSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_extensions_JobSpec_To_v1beta1_JobSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := convert_extensions_JobStatus_To_v1beta1_JobStatus(&in.Status, &out.Status, s); err != nil {
+	if err := Convert_extensions_JobStatus_To_v1beta1_JobStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_extensions_Job_To_v1beta1_Job(in *extensions.Job, out *Job, s conversion.Scope) error {
-	return autoconvert_extensions_Job_To_v1beta1_Job(in, out, s)
+func Convert_extensions_Job_To_v1beta1_Job(in *extensions.Job, out *Job, s conversion.Scope) error {
+	return autoConvert_extensions_Job_To_v1beta1_Job(in, out, s)
 }
 
-func autoconvert_extensions_JobCondition_To_v1beta1_JobCondition(in *extensions.JobCondition, out *JobCondition, s conversion.Scope) error {
+func autoConvert_extensions_JobCondition_To_v1beta1_JobCondition(in *extensions.JobCondition, out *JobCondition, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.JobCondition))(in)
 	}
 	out.Type = JobConditionType(in.Type)
 	out.Status = v1.ConditionStatus(in.Status)
-	if err := s.Convert(&in.LastProbeTime, &out.LastProbeTime, 0); err != nil {
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.LastProbeTime, &out.LastProbeTime, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.LastTransitionTime, &out.LastTransitionTime, 0); err != nil {
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.LastTransitionTime, &out.LastTransitionTime, s); err != nil {
 		return err
 	}
 	out.Reason = in.Reason
@@ -2931,24 +3012,24 @@ func autoconvert_extensions_JobCondition_To_v1beta1_JobCondition(in *extensions.
 	return nil
 }
 
-func convert_extensions_JobCondition_To_v1beta1_JobCondition(in *extensions.JobCondition, out *JobCondition, s conversion.Scope) error {
-	return autoconvert_extensions_JobCondition_To_v1beta1_JobCondition(in, out, s)
+func Convert_extensions_JobCondition_To_v1beta1_JobCondition(in *extensions.JobCondition, out *JobCondition, s conversion.Scope) error {
+	return autoConvert_extensions_JobCondition_To_v1beta1_JobCondition(in, out, s)
 }
 
-func autoconvert_extensions_JobList_To_v1beta1_JobList(in *extensions.JobList, out *JobList, s conversion.Scope) error {
+func autoConvert_extensions_JobList_To_v1beta1_JobList(in *extensions.JobList, out *JobList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.JobList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]Job, len(in.Items))
 		for i := range in.Items {
-			if err := convert_extensions_Job_To_v1beta1_Job(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_extensions_Job_To_v1beta1_Job(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -2958,11 +3039,11 @@ func autoconvert_extensions_JobList_To_v1beta1_JobList(in *extensions.JobList, o
 	return nil
 }
 
-func convert_extensions_JobList_To_v1beta1_JobList(in *extensions.JobList, out *JobList, s conversion.Scope) error {
-	return autoconvert_extensions_JobList_To_v1beta1_JobList(in, out, s)
+func Convert_extensions_JobList_To_v1beta1_JobList(in *extensions.JobList, out *JobList, s conversion.Scope) error {
+	return autoConvert_extensions_JobList_To_v1beta1_JobList(in, out, s)
 }
 
-func autoconvert_extensions_JobSpec_To_v1beta1_JobSpec(in *extensions.JobSpec, out *JobSpec, s conversion.Scope) error {
+func autoConvert_extensions_JobSpec_To_v1beta1_JobSpec(in *extensions.JobSpec, out *JobSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.JobSpec))(in)
 	}
@@ -2984,47 +3065,52 @@ func autoconvert_extensions_JobSpec_To_v1beta1_JobSpec(in *extensions.JobSpec, o
 	} else {
 		out.ActiveDeadlineSeconds = nil
 	}
+	// unable to generate simple pointer conversion for extensions.LabelSelector -> v1beta1.LabelSelector
 	if in.Selector != nil {
 		out.Selector = new(LabelSelector)
-		if err := convert_extensions_LabelSelector_To_v1beta1_LabelSelector(in.Selector, out.Selector, s); err != nil {
+		if err := Convert_extensions_LabelSelector_To_v1beta1_LabelSelector(in.Selector, out.Selector, s); err != nil {
 			return err
 		}
 	} else {
 		out.Selector = nil
 	}
-	if err := convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
+	if err := Convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_extensions_JobSpec_To_v1beta1_JobSpec(in *extensions.JobSpec, out *JobSpec, s conversion.Scope) error {
-	return autoconvert_extensions_JobSpec_To_v1beta1_JobSpec(in, out, s)
+func Convert_extensions_JobSpec_To_v1beta1_JobSpec(in *extensions.JobSpec, out *JobSpec, s conversion.Scope) error {
+	return autoConvert_extensions_JobSpec_To_v1beta1_JobSpec(in, out, s)
 }
 
-func autoconvert_extensions_JobStatus_To_v1beta1_JobStatus(in *extensions.JobStatus, out *JobStatus, s conversion.Scope) error {
+func autoConvert_extensions_JobStatus_To_v1beta1_JobStatus(in *extensions.JobStatus, out *JobStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.JobStatus))(in)
 	}
 	if in.Conditions != nil {
 		out.Conditions = make([]JobCondition, len(in.Conditions))
 		for i := range in.Conditions {
-			if err := convert_extensions_JobCondition_To_v1beta1_JobCondition(&in.Conditions[i], &out.Conditions[i], s); err != nil {
+			if err := Convert_extensions_JobCondition_To_v1beta1_JobCondition(&in.Conditions[i], &out.Conditions[i], s); err != nil {
 				return err
 			}
 		}
 	} else {
 		out.Conditions = nil
 	}
+	// unable to generate simple pointer conversion for unversioned.Time -> unversioned.Time
 	if in.StartTime != nil {
-		if err := s.Convert(&in.StartTime, &out.StartTime, 0); err != nil {
+		out.StartTime = new(unversioned.Time)
+		if err := api.Convert_unversioned_Time_To_unversioned_Time(in.StartTime, out.StartTime, s); err != nil {
 			return err
 		}
 	} else {
 		out.StartTime = nil
 	}
+	// unable to generate simple pointer conversion for unversioned.Time -> unversioned.Time
 	if in.CompletionTime != nil {
-		if err := s.Convert(&in.CompletionTime, &out.CompletionTime, 0); err != nil {
+		out.CompletionTime = new(unversioned.Time)
+		if err := api.Convert_unversioned_Time_To_unversioned_Time(in.CompletionTime, out.CompletionTime, s); err != nil {
 			return err
 		}
 	} else {
@@ -3036,11 +3122,11 @@ func autoconvert_extensions_JobStatus_To_v1beta1_JobStatus(in *extensions.JobSta
 	return nil
 }
 
-func convert_extensions_JobStatus_To_v1beta1_JobStatus(in *extensions.JobStatus, out *JobStatus, s conversion.Scope) error {
-	return autoconvert_extensions_JobStatus_To_v1beta1_JobStatus(in, out, s)
+func Convert_extensions_JobStatus_To_v1beta1_JobStatus(in *extensions.JobStatus, out *JobStatus, s conversion.Scope) error {
+	return autoConvert_extensions_JobStatus_To_v1beta1_JobStatus(in, out, s)
 }
 
-func autoconvert_extensions_LabelSelector_To_v1beta1_LabelSelector(in *extensions.LabelSelector, out *LabelSelector, s conversion.Scope) error {
+func autoConvert_extensions_LabelSelector_To_v1beta1_LabelSelector(in *extensions.LabelSelector, out *LabelSelector, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.LabelSelector))(in)
 	}
@@ -3055,7 +3141,7 @@ func autoconvert_extensions_LabelSelector_To_v1beta1_LabelSelector(in *extension
 	if in.MatchExpressions != nil {
 		out.MatchExpressions = make([]LabelSelectorRequirement, len(in.MatchExpressions))
 		for i := range in.MatchExpressions {
-			if err := convert_extensions_LabelSelectorRequirement_To_v1beta1_LabelSelectorRequirement(&in.MatchExpressions[i], &out.MatchExpressions[i], s); err != nil {
+			if err := Convert_extensions_LabelSelectorRequirement_To_v1beta1_LabelSelectorRequirement(&in.MatchExpressions[i], &out.MatchExpressions[i], s); err != nil {
 				return err
 			}
 		}
@@ -3065,11 +3151,11 @@ func autoconvert_extensions_LabelSelector_To_v1beta1_LabelSelector(in *extension
 	return nil
 }
 
-func convert_extensions_LabelSelector_To_v1beta1_LabelSelector(in *extensions.LabelSelector, out *LabelSelector, s conversion.Scope) error {
-	return autoconvert_extensions_LabelSelector_To_v1beta1_LabelSelector(in, out, s)
+func Convert_extensions_LabelSelector_To_v1beta1_LabelSelector(in *extensions.LabelSelector, out *LabelSelector, s conversion.Scope) error {
+	return autoConvert_extensions_LabelSelector_To_v1beta1_LabelSelector(in, out, s)
 }
 
-func autoconvert_extensions_LabelSelectorRequirement_To_v1beta1_LabelSelectorRequirement(in *extensions.LabelSelectorRequirement, out *LabelSelectorRequirement, s conversion.Scope) error {
+func autoConvert_extensions_LabelSelectorRequirement_To_v1beta1_LabelSelectorRequirement(in *extensions.LabelSelectorRequirement, out *LabelSelectorRequirement, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.LabelSelectorRequirement))(in)
 	}
@@ -3086,11 +3172,11 @@ func autoconvert_extensions_LabelSelectorRequirement_To_v1beta1_LabelSelectorReq
 	return nil
 }
 
-func convert_extensions_LabelSelectorRequirement_To_v1beta1_LabelSelectorRequirement(in *extensions.LabelSelectorRequirement, out *LabelSelectorRequirement, s conversion.Scope) error {
-	return autoconvert_extensions_LabelSelectorRequirement_To_v1beta1_LabelSelectorRequirement(in, out, s)
+func Convert_extensions_LabelSelectorRequirement_To_v1beta1_LabelSelectorRequirement(in *extensions.LabelSelectorRequirement, out *LabelSelectorRequirement, s conversion.Scope) error {
+	return autoConvert_extensions_LabelSelectorRequirement_To_v1beta1_LabelSelectorRequirement(in, out, s)
 }
 
-func autoconvert_extensions_NodeUtilization_To_v1beta1_NodeUtilization(in *extensions.NodeUtilization, out *NodeUtilization, s conversion.Scope) error {
+func autoConvert_extensions_NodeUtilization_To_v1beta1_NodeUtilization(in *extensions.NodeUtilization, out *NodeUtilization, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.NodeUtilization))(in)
 	}
@@ -3099,25 +3185,25 @@ func autoconvert_extensions_NodeUtilization_To_v1beta1_NodeUtilization(in *exten
 	return nil
 }
 
-func convert_extensions_NodeUtilization_To_v1beta1_NodeUtilization(in *extensions.NodeUtilization, out *NodeUtilization, s conversion.Scope) error {
-	return autoconvert_extensions_NodeUtilization_To_v1beta1_NodeUtilization(in, out, s)
+func Convert_extensions_NodeUtilization_To_v1beta1_NodeUtilization(in *extensions.NodeUtilization, out *NodeUtilization, s conversion.Scope) error {
+	return autoConvert_extensions_NodeUtilization_To_v1beta1_NodeUtilization(in, out, s)
 }
 
-func autoconvert_extensions_ReplicationControllerDummy_To_v1beta1_ReplicationControllerDummy(in *extensions.ReplicationControllerDummy, out *ReplicationControllerDummy, s conversion.Scope) error {
+func autoConvert_extensions_ReplicationControllerDummy_To_v1beta1_ReplicationControllerDummy(in *extensions.ReplicationControllerDummy, out *ReplicationControllerDummy, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.ReplicationControllerDummy))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_extensions_ReplicationControllerDummy_To_v1beta1_ReplicationControllerDummy(in *extensions.ReplicationControllerDummy, out *ReplicationControllerDummy, s conversion.Scope) error {
-	return autoconvert_extensions_ReplicationControllerDummy_To_v1beta1_ReplicationControllerDummy(in, out, s)
+func Convert_extensions_ReplicationControllerDummy_To_v1beta1_ReplicationControllerDummy(in *extensions.ReplicationControllerDummy, out *ReplicationControllerDummy, s conversion.Scope) error {
+	return autoConvert_extensions_ReplicationControllerDummy_To_v1beta1_ReplicationControllerDummy(in, out, s)
 }
 
-func autoconvert_extensions_RollingUpdateDeployment_To_v1beta1_RollingUpdateDeployment(in *extensions.RollingUpdateDeployment, out *RollingUpdateDeployment, s conversion.Scope) error {
+func autoConvert_extensions_RollingUpdateDeployment_To_v1beta1_RollingUpdateDeployment(in *extensions.RollingUpdateDeployment, out *RollingUpdateDeployment, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.RollingUpdateDeployment))(in)
 	}
@@ -3131,30 +3217,30 @@ func autoconvert_extensions_RollingUpdateDeployment_To_v1beta1_RollingUpdateDepl
 	return nil
 }
 
-func autoconvert_extensions_Scale_To_v1beta1_Scale(in *extensions.Scale, out *Scale, s conversion.Scope) error {
+func autoConvert_extensions_Scale_To_v1beta1_Scale(in *extensions.Scale, out *Scale, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.Scale))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_extensions_ScaleSpec_To_v1beta1_ScaleSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_extensions_ScaleSpec_To_v1beta1_ScaleSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := convert_extensions_ScaleStatus_To_v1beta1_ScaleStatus(&in.Status, &out.Status, s); err != nil {
+	if err := Convert_extensions_ScaleStatus_To_v1beta1_ScaleStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_extensions_Scale_To_v1beta1_Scale(in *extensions.Scale, out *Scale, s conversion.Scope) error {
-	return autoconvert_extensions_Scale_To_v1beta1_Scale(in, out, s)
+func Convert_extensions_Scale_To_v1beta1_Scale(in *extensions.Scale, out *Scale, s conversion.Scope) error {
+	return autoConvert_extensions_Scale_To_v1beta1_Scale(in, out, s)
 }
 
-func autoconvert_extensions_ScaleSpec_To_v1beta1_ScaleSpec(in *extensions.ScaleSpec, out *ScaleSpec, s conversion.Scope) error {
+func autoConvert_extensions_ScaleSpec_To_v1beta1_ScaleSpec(in *extensions.ScaleSpec, out *ScaleSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.ScaleSpec))(in)
 	}
@@ -3162,11 +3248,11 @@ func autoconvert_extensions_ScaleSpec_To_v1beta1_ScaleSpec(in *extensions.ScaleS
 	return nil
 }
 
-func convert_extensions_ScaleSpec_To_v1beta1_ScaleSpec(in *extensions.ScaleSpec, out *ScaleSpec, s conversion.Scope) error {
-	return autoconvert_extensions_ScaleSpec_To_v1beta1_ScaleSpec(in, out, s)
+func Convert_extensions_ScaleSpec_To_v1beta1_ScaleSpec(in *extensions.ScaleSpec, out *ScaleSpec, s conversion.Scope) error {
+	return autoConvert_extensions_ScaleSpec_To_v1beta1_ScaleSpec(in, out, s)
 }
 
-func autoconvert_extensions_ScaleStatus_To_v1beta1_ScaleStatus(in *extensions.ScaleStatus, out *ScaleStatus, s conversion.Scope) error {
+func autoConvert_extensions_ScaleStatus_To_v1beta1_ScaleStatus(in *extensions.ScaleStatus, out *ScaleStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.ScaleStatus))(in)
 	}
@@ -3182,11 +3268,11 @@ func autoconvert_extensions_ScaleStatus_To_v1beta1_ScaleStatus(in *extensions.Sc
 	return nil
 }
 
-func convert_extensions_ScaleStatus_To_v1beta1_ScaleStatus(in *extensions.ScaleStatus, out *ScaleStatus, s conversion.Scope) error {
-	return autoconvert_extensions_ScaleStatus_To_v1beta1_ScaleStatus(in, out, s)
+func Convert_extensions_ScaleStatus_To_v1beta1_ScaleStatus(in *extensions.ScaleStatus, out *ScaleStatus, s conversion.Scope) error {
+	return autoConvert_extensions_ScaleStatus_To_v1beta1_ScaleStatus(in, out, s)
 }
 
-func autoconvert_extensions_SubresourceReference_To_v1beta1_SubresourceReference(in *extensions.SubresourceReference, out *SubresourceReference, s conversion.Scope) error {
+func autoConvert_extensions_SubresourceReference_To_v1beta1_SubresourceReference(in *extensions.SubresourceReference, out *SubresourceReference, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.SubresourceReference))(in)
 	}
@@ -3197,25 +3283,25 @@ func autoconvert_extensions_SubresourceReference_To_v1beta1_SubresourceReference
 	return nil
 }
 
-func convert_extensions_SubresourceReference_To_v1beta1_SubresourceReference(in *extensions.SubresourceReference, out *SubresourceReference, s conversion.Scope) error {
-	return autoconvert_extensions_SubresourceReference_To_v1beta1_SubresourceReference(in, out, s)
+func Convert_extensions_SubresourceReference_To_v1beta1_SubresourceReference(in *extensions.SubresourceReference, out *SubresourceReference, s conversion.Scope) error {
+	return autoConvert_extensions_SubresourceReference_To_v1beta1_SubresourceReference(in, out, s)
 }
 
-func autoconvert_extensions_ThirdPartyResource_To_v1beta1_ThirdPartyResource(in *extensions.ThirdPartyResource, out *ThirdPartyResource, s conversion.Scope) error {
+func autoConvert_extensions_ThirdPartyResource_To_v1beta1_ThirdPartyResource(in *extensions.ThirdPartyResource, out *ThirdPartyResource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.ThirdPartyResource))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
 	out.Description = in.Description
 	if in.Versions != nil {
 		out.Versions = make([]APIVersion, len(in.Versions))
 		for i := range in.Versions {
-			if err := convert_extensions_APIVersion_To_v1beta1_APIVersion(&in.Versions[i], &out.Versions[i], s); err != nil {
+			if err := Convert_extensions_APIVersion_To_v1beta1_APIVersion(&in.Versions[i], &out.Versions[i], s); err != nil {
 				return err
 			}
 		}
@@ -3225,44 +3311,44 @@ func autoconvert_extensions_ThirdPartyResource_To_v1beta1_ThirdPartyResource(in 
 	return nil
 }
 
-func convert_extensions_ThirdPartyResource_To_v1beta1_ThirdPartyResource(in *extensions.ThirdPartyResource, out *ThirdPartyResource, s conversion.Scope) error {
-	return autoconvert_extensions_ThirdPartyResource_To_v1beta1_ThirdPartyResource(in, out, s)
+func Convert_extensions_ThirdPartyResource_To_v1beta1_ThirdPartyResource(in *extensions.ThirdPartyResource, out *ThirdPartyResource, s conversion.Scope) error {
+	return autoConvert_extensions_ThirdPartyResource_To_v1beta1_ThirdPartyResource(in, out, s)
 }
 
-func autoconvert_extensions_ThirdPartyResourceData_To_v1beta1_ThirdPartyResourceData(in *extensions.ThirdPartyResourceData, out *ThirdPartyResourceData, s conversion.Scope) error {
+func autoConvert_extensions_ThirdPartyResourceData_To_v1beta1_ThirdPartyResourceData(in *extensions.ThirdPartyResourceData, out *ThirdPartyResourceData, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.ThirdPartyResourceData))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.Data, &out.Data, 0); err != nil {
+	if err := conversion.ByteSliceCopy(&in.Data, &out.Data, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_extensions_ThirdPartyResourceData_To_v1beta1_ThirdPartyResourceData(in *extensions.ThirdPartyResourceData, out *ThirdPartyResourceData, s conversion.Scope) error {
-	return autoconvert_extensions_ThirdPartyResourceData_To_v1beta1_ThirdPartyResourceData(in, out, s)
+func Convert_extensions_ThirdPartyResourceData_To_v1beta1_ThirdPartyResourceData(in *extensions.ThirdPartyResourceData, out *ThirdPartyResourceData, s conversion.Scope) error {
+	return autoConvert_extensions_ThirdPartyResourceData_To_v1beta1_ThirdPartyResourceData(in, out, s)
 }
 
-func autoconvert_extensions_ThirdPartyResourceDataList_To_v1beta1_ThirdPartyResourceDataList(in *extensions.ThirdPartyResourceDataList, out *ThirdPartyResourceDataList, s conversion.Scope) error {
+func autoConvert_extensions_ThirdPartyResourceDataList_To_v1beta1_ThirdPartyResourceDataList(in *extensions.ThirdPartyResourceDataList, out *ThirdPartyResourceDataList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.ThirdPartyResourceDataList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]ThirdPartyResourceData, len(in.Items))
 		for i := range in.Items {
-			if err := convert_extensions_ThirdPartyResourceData_To_v1beta1_ThirdPartyResourceData(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_extensions_ThirdPartyResourceData_To_v1beta1_ThirdPartyResourceData(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -3272,24 +3358,24 @@ func autoconvert_extensions_ThirdPartyResourceDataList_To_v1beta1_ThirdPartyReso
 	return nil
 }
 
-func convert_extensions_ThirdPartyResourceDataList_To_v1beta1_ThirdPartyResourceDataList(in *extensions.ThirdPartyResourceDataList, out *ThirdPartyResourceDataList, s conversion.Scope) error {
-	return autoconvert_extensions_ThirdPartyResourceDataList_To_v1beta1_ThirdPartyResourceDataList(in, out, s)
+func Convert_extensions_ThirdPartyResourceDataList_To_v1beta1_ThirdPartyResourceDataList(in *extensions.ThirdPartyResourceDataList, out *ThirdPartyResourceDataList, s conversion.Scope) error {
+	return autoConvert_extensions_ThirdPartyResourceDataList_To_v1beta1_ThirdPartyResourceDataList(in, out, s)
 }
 
-func autoconvert_extensions_ThirdPartyResourceList_To_v1beta1_ThirdPartyResourceList(in *extensions.ThirdPartyResourceList, out *ThirdPartyResourceList, s conversion.Scope) error {
+func autoConvert_extensions_ThirdPartyResourceList_To_v1beta1_ThirdPartyResourceList(in *extensions.ThirdPartyResourceList, out *ThirdPartyResourceList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.ThirdPartyResourceList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]ThirdPartyResource, len(in.Items))
 		for i := range in.Items {
-			if err := convert_extensions_ThirdPartyResource_To_v1beta1_ThirdPartyResource(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_extensions_ThirdPartyResource_To_v1beta1_ThirdPartyResource(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -3299,11 +3385,11 @@ func autoconvert_extensions_ThirdPartyResourceList_To_v1beta1_ThirdPartyResource
 	return nil
 }
 
-func convert_extensions_ThirdPartyResourceList_To_v1beta1_ThirdPartyResourceList(in *extensions.ThirdPartyResourceList, out *ThirdPartyResourceList, s conversion.Scope) error {
-	return autoconvert_extensions_ThirdPartyResourceList_To_v1beta1_ThirdPartyResourceList(in, out, s)
+func Convert_extensions_ThirdPartyResourceList_To_v1beta1_ThirdPartyResourceList(in *extensions.ThirdPartyResourceList, out *ThirdPartyResourceList, s conversion.Scope) error {
+	return autoConvert_extensions_ThirdPartyResourceList_To_v1beta1_ThirdPartyResourceList(in, out, s)
 }
 
-func autoconvert_v1beta1_APIVersion_To_extensions_APIVersion(in *APIVersion, out *extensions.APIVersion, s conversion.Scope) error {
+func autoConvert_v1beta1_APIVersion_To_extensions_APIVersion(in *APIVersion, out *extensions.APIVersion, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*APIVersion))(in)
 	}
@@ -3312,11 +3398,11 @@ func autoconvert_v1beta1_APIVersion_To_extensions_APIVersion(in *APIVersion, out
 	return nil
 }
 
-func convert_v1beta1_APIVersion_To_extensions_APIVersion(in *APIVersion, out *extensions.APIVersion, s conversion.Scope) error {
-	return autoconvert_v1beta1_APIVersion_To_extensions_APIVersion(in, out, s)
+func Convert_v1beta1_APIVersion_To_extensions_APIVersion(in *APIVersion, out *extensions.APIVersion, s conversion.Scope) error {
+	return autoConvert_v1beta1_APIVersion_To_extensions_APIVersion(in, out, s)
 }
 
-func autoconvert_v1beta1_CPUTargetUtilization_To_extensions_CPUTargetUtilization(in *CPUTargetUtilization, out *extensions.CPUTargetUtilization, s conversion.Scope) error {
+func autoConvert_v1beta1_CPUTargetUtilization_To_extensions_CPUTargetUtilization(in *CPUTargetUtilization, out *extensions.CPUTargetUtilization, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*CPUTargetUtilization))(in)
 	}
@@ -3324,44 +3410,44 @@ func autoconvert_v1beta1_CPUTargetUtilization_To_extensions_CPUTargetUtilization
 	return nil
 }
 
-func convert_v1beta1_CPUTargetUtilization_To_extensions_CPUTargetUtilization(in *CPUTargetUtilization, out *extensions.CPUTargetUtilization, s conversion.Scope) error {
-	return autoconvert_v1beta1_CPUTargetUtilization_To_extensions_CPUTargetUtilization(in, out, s)
+func Convert_v1beta1_CPUTargetUtilization_To_extensions_CPUTargetUtilization(in *CPUTargetUtilization, out *extensions.CPUTargetUtilization, s conversion.Scope) error {
+	return autoConvert_v1beta1_CPUTargetUtilization_To_extensions_CPUTargetUtilization(in, out, s)
 }
 
-func autoconvert_v1beta1_ClusterAutoscaler_To_extensions_ClusterAutoscaler(in *ClusterAutoscaler, out *extensions.ClusterAutoscaler, s conversion.Scope) error {
+func autoConvert_v1beta1_ClusterAutoscaler_To_extensions_ClusterAutoscaler(in *ClusterAutoscaler, out *extensions.ClusterAutoscaler, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ClusterAutoscaler))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1beta1_ClusterAutoscalerSpec_To_extensions_ClusterAutoscalerSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_v1beta1_ClusterAutoscalerSpec_To_extensions_ClusterAutoscalerSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1beta1_ClusterAutoscaler_To_extensions_ClusterAutoscaler(in *ClusterAutoscaler, out *extensions.ClusterAutoscaler, s conversion.Scope) error {
-	return autoconvert_v1beta1_ClusterAutoscaler_To_extensions_ClusterAutoscaler(in, out, s)
+func Convert_v1beta1_ClusterAutoscaler_To_extensions_ClusterAutoscaler(in *ClusterAutoscaler, out *extensions.ClusterAutoscaler, s conversion.Scope) error {
+	return autoConvert_v1beta1_ClusterAutoscaler_To_extensions_ClusterAutoscaler(in, out, s)
 }
 
-func autoconvert_v1beta1_ClusterAutoscalerList_To_extensions_ClusterAutoscalerList(in *ClusterAutoscalerList, out *extensions.ClusterAutoscalerList, s conversion.Scope) error {
+func autoConvert_v1beta1_ClusterAutoscalerList_To_extensions_ClusterAutoscalerList(in *ClusterAutoscalerList, out *extensions.ClusterAutoscalerList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ClusterAutoscalerList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]extensions.ClusterAutoscaler, len(in.Items))
 		for i := range in.Items {
-			if err := convert_v1beta1_ClusterAutoscaler_To_extensions_ClusterAutoscaler(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_v1beta1_ClusterAutoscaler_To_extensions_ClusterAutoscaler(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -3371,11 +3457,11 @@ func autoconvert_v1beta1_ClusterAutoscalerList_To_extensions_ClusterAutoscalerLi
 	return nil
 }
 
-func convert_v1beta1_ClusterAutoscalerList_To_extensions_ClusterAutoscalerList(in *ClusterAutoscalerList, out *extensions.ClusterAutoscalerList, s conversion.Scope) error {
-	return autoconvert_v1beta1_ClusterAutoscalerList_To_extensions_ClusterAutoscalerList(in, out, s)
+func Convert_v1beta1_ClusterAutoscalerList_To_extensions_ClusterAutoscalerList(in *ClusterAutoscalerList, out *extensions.ClusterAutoscalerList, s conversion.Scope) error {
+	return autoConvert_v1beta1_ClusterAutoscalerList_To_extensions_ClusterAutoscalerList(in, out, s)
 }
 
-func autoconvert_v1beta1_ClusterAutoscalerSpec_To_extensions_ClusterAutoscalerSpec(in *ClusterAutoscalerSpec, out *extensions.ClusterAutoscalerSpec, s conversion.Scope) error {
+func autoConvert_v1beta1_ClusterAutoscalerSpec_To_extensions_ClusterAutoscalerSpec(in *ClusterAutoscalerSpec, out *extensions.ClusterAutoscalerSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ClusterAutoscalerSpec))(in)
 	}
@@ -3384,7 +3470,7 @@ func autoconvert_v1beta1_ClusterAutoscalerSpec_To_extensions_ClusterAutoscalerSp
 	if in.TargetUtilization != nil {
 		out.TargetUtilization = make([]extensions.NodeUtilization, len(in.TargetUtilization))
 		for i := range in.TargetUtilization {
-			if err := convert_v1beta1_NodeUtilization_To_extensions_NodeUtilization(&in.TargetUtilization[i], &out.TargetUtilization[i], s); err != nil {
+			if err := Convert_v1beta1_NodeUtilization_To_extensions_NodeUtilization(&in.TargetUtilization[i], &out.TargetUtilization[i], s); err != nil {
 				return err
 			}
 		}
@@ -3394,18 +3480,18 @@ func autoconvert_v1beta1_ClusterAutoscalerSpec_To_extensions_ClusterAutoscalerSp
 	return nil
 }
 
-func convert_v1beta1_ClusterAutoscalerSpec_To_extensions_ClusterAutoscalerSpec(in *ClusterAutoscalerSpec, out *extensions.ClusterAutoscalerSpec, s conversion.Scope) error {
-	return autoconvert_v1beta1_ClusterAutoscalerSpec_To_extensions_ClusterAutoscalerSpec(in, out, s)
+func Convert_v1beta1_ClusterAutoscalerSpec_To_extensions_ClusterAutoscalerSpec(in *ClusterAutoscalerSpec, out *extensions.ClusterAutoscalerSpec, s conversion.Scope) error {
+	return autoConvert_v1beta1_ClusterAutoscalerSpec_To_extensions_ClusterAutoscalerSpec(in, out, s)
 }
 
-func autoconvert_v1beta1_ConfigMap_To_extensions_ConfigMap(in *ConfigMap, out *extensions.ConfigMap, s conversion.Scope) error {
+func autoConvert_v1beta1_ConfigMap_To_extensions_ConfigMap(in *ConfigMap, out *extensions.ConfigMap, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ConfigMap))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
 	if in.Data != nil {
@@ -3419,24 +3505,24 @@ func autoconvert_v1beta1_ConfigMap_To_extensions_ConfigMap(in *ConfigMap, out *e
 	return nil
 }
 
-func convert_v1beta1_ConfigMap_To_extensions_ConfigMap(in *ConfigMap, out *extensions.ConfigMap, s conversion.Scope) error {
-	return autoconvert_v1beta1_ConfigMap_To_extensions_ConfigMap(in, out, s)
+func Convert_v1beta1_ConfigMap_To_extensions_ConfigMap(in *ConfigMap, out *extensions.ConfigMap, s conversion.Scope) error {
+	return autoConvert_v1beta1_ConfigMap_To_extensions_ConfigMap(in, out, s)
 }
 
-func autoconvert_v1beta1_ConfigMapList_To_extensions_ConfigMapList(in *ConfigMapList, out *extensions.ConfigMapList, s conversion.Scope) error {
+func autoConvert_v1beta1_ConfigMapList_To_extensions_ConfigMapList(in *ConfigMapList, out *extensions.ConfigMapList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ConfigMapList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]extensions.ConfigMap, len(in.Items))
 		for i := range in.Items {
-			if err := convert_v1beta1_ConfigMap_To_extensions_ConfigMap(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_v1beta1_ConfigMap_To_extensions_ConfigMap(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -3446,47 +3532,47 @@ func autoconvert_v1beta1_ConfigMapList_To_extensions_ConfigMapList(in *ConfigMap
 	return nil
 }
 
-func convert_v1beta1_ConfigMapList_To_extensions_ConfigMapList(in *ConfigMapList, out *extensions.ConfigMapList, s conversion.Scope) error {
-	return autoconvert_v1beta1_ConfigMapList_To_extensions_ConfigMapList(in, out, s)
+func Convert_v1beta1_ConfigMapList_To_extensions_ConfigMapList(in *ConfigMapList, out *extensions.ConfigMapList, s conversion.Scope) error {
+	return autoConvert_v1beta1_ConfigMapList_To_extensions_ConfigMapList(in, out, s)
 }
 
-func autoconvert_v1beta1_DaemonSet_To_extensions_DaemonSet(in *DaemonSet, out *extensions.DaemonSet, s conversion.Scope) error {
+func autoConvert_v1beta1_DaemonSet_To_extensions_DaemonSet(in *DaemonSet, out *extensions.DaemonSet, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*DaemonSet))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1beta1_DaemonSetSpec_To_extensions_DaemonSetSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_v1beta1_DaemonSetSpec_To_extensions_DaemonSetSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := convert_v1beta1_DaemonSetStatus_To_extensions_DaemonSetStatus(&in.Status, &out.Status, s); err != nil {
+	if err := Convert_v1beta1_DaemonSetStatus_To_extensions_DaemonSetStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1beta1_DaemonSet_To_extensions_DaemonSet(in *DaemonSet, out *extensions.DaemonSet, s conversion.Scope) error {
-	return autoconvert_v1beta1_DaemonSet_To_extensions_DaemonSet(in, out, s)
+func Convert_v1beta1_DaemonSet_To_extensions_DaemonSet(in *DaemonSet, out *extensions.DaemonSet, s conversion.Scope) error {
+	return autoConvert_v1beta1_DaemonSet_To_extensions_DaemonSet(in, out, s)
 }
 
-func autoconvert_v1beta1_DaemonSetList_To_extensions_DaemonSetList(in *DaemonSetList, out *extensions.DaemonSetList, s conversion.Scope) error {
+func autoConvert_v1beta1_DaemonSetList_To_extensions_DaemonSetList(in *DaemonSetList, out *extensions.DaemonSetList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*DaemonSetList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]extensions.DaemonSet, len(in.Items))
 		for i := range in.Items {
-			if err := convert_v1beta1_DaemonSet_To_extensions_DaemonSet(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_v1beta1_DaemonSet_To_extensions_DaemonSet(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -3496,25 +3582,27 @@ func autoconvert_v1beta1_DaemonSetList_To_extensions_DaemonSetList(in *DaemonSet
 	return nil
 }
 
-func convert_v1beta1_DaemonSetList_To_extensions_DaemonSetList(in *DaemonSetList, out *extensions.DaemonSetList, s conversion.Scope) error {
-	return autoconvert_v1beta1_DaemonSetList_To_extensions_DaemonSetList(in, out, s)
+func Convert_v1beta1_DaemonSetList_To_extensions_DaemonSetList(in *DaemonSetList, out *extensions.DaemonSetList, s conversion.Scope) error {
+	return autoConvert_v1beta1_DaemonSetList_To_extensions_DaemonSetList(in, out, s)
 }
 
-func autoconvert_v1beta1_DaemonSetSpec_To_extensions_DaemonSetSpec(in *DaemonSetSpec, out *extensions.DaemonSetSpec, s conversion.Scope) error {
+func autoConvert_v1beta1_DaemonSetSpec_To_extensions_DaemonSetSpec(in *DaemonSetSpec, out *extensions.DaemonSetSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*DaemonSetSpec))(in)
 	}
+	// unable to generate simple pointer conversion for v1beta1.LabelSelector -> extensions.LabelSelector
 	if in.Selector != nil {
 		out.Selector = new(extensions.LabelSelector)
-		if err := convert_v1beta1_LabelSelector_To_extensions_LabelSelector(in.Selector, out.Selector, s); err != nil {
+		if err := Convert_v1beta1_LabelSelector_To_extensions_LabelSelector(in.Selector, out.Selector, s); err != nil {
 			return err
 		}
 	} else {
 		out.Selector = nil
 	}
+	// unable to generate simple pointer conversion for v1.PodTemplateSpec -> api.PodTemplateSpec
 	if in.Template != nil {
 		out.Template = new(api.PodTemplateSpec)
-		if err := convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in.Template, out.Template, s); err != nil {
+		if err := Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in.Template, out.Template, s); err != nil {
 			return err
 		}
 	} else {
@@ -3523,11 +3611,11 @@ func autoconvert_v1beta1_DaemonSetSpec_To_extensions_DaemonSetSpec(in *DaemonSet
 	return nil
 }
 
-func convert_v1beta1_DaemonSetSpec_To_extensions_DaemonSetSpec(in *DaemonSetSpec, out *extensions.DaemonSetSpec, s conversion.Scope) error {
-	return autoconvert_v1beta1_DaemonSetSpec_To_extensions_DaemonSetSpec(in, out, s)
+func Convert_v1beta1_DaemonSetSpec_To_extensions_DaemonSetSpec(in *DaemonSetSpec, out *extensions.DaemonSetSpec, s conversion.Scope) error {
+	return autoConvert_v1beta1_DaemonSetSpec_To_extensions_DaemonSetSpec(in, out, s)
 }
 
-func autoconvert_v1beta1_DaemonSetStatus_To_extensions_DaemonSetStatus(in *DaemonSetStatus, out *extensions.DaemonSetStatus, s conversion.Scope) error {
+func autoConvert_v1beta1_DaemonSetStatus_To_extensions_DaemonSetStatus(in *DaemonSetStatus, out *extensions.DaemonSetStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*DaemonSetStatus))(in)
 	}
@@ -3537,47 +3625,47 @@ func autoconvert_v1beta1_DaemonSetStatus_To_extensions_DaemonSetStatus(in *Daemo
 	return nil
 }
 
-func convert_v1beta1_DaemonSetStatus_To_extensions_DaemonSetStatus(in *DaemonSetStatus, out *extensions.DaemonSetStatus, s conversion.Scope) error {
-	return autoconvert_v1beta1_DaemonSetStatus_To_extensions_DaemonSetStatus(in, out, s)
+func Convert_v1beta1_DaemonSetStatus_To_extensions_DaemonSetStatus(in *DaemonSetStatus, out *extensions.DaemonSetStatus, s conversion.Scope) error {
+	return autoConvert_v1beta1_DaemonSetStatus_To_extensions_DaemonSetStatus(in, out, s)
 }
 
-func autoconvert_v1beta1_Deployment_To_extensions_Deployment(in *Deployment, out *extensions.Deployment, s conversion.Scope) error {
+func autoConvert_v1beta1_Deployment_To_extensions_Deployment(in *Deployment, out *extensions.Deployment, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Deployment))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1beta1_DeploymentSpec_To_extensions_DeploymentSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_v1beta1_DeploymentSpec_To_extensions_DeploymentSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := convert_v1beta1_DeploymentStatus_To_extensions_DeploymentStatus(&in.Status, &out.Status, s); err != nil {
+	if err := Convert_v1beta1_DeploymentStatus_To_extensions_DeploymentStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1beta1_Deployment_To_extensions_Deployment(in *Deployment, out *extensions.Deployment, s conversion.Scope) error {
-	return autoconvert_v1beta1_Deployment_To_extensions_Deployment(in, out, s)
+func Convert_v1beta1_Deployment_To_extensions_Deployment(in *Deployment, out *extensions.Deployment, s conversion.Scope) error {
+	return autoConvert_v1beta1_Deployment_To_extensions_Deployment(in, out, s)
 }
 
-func autoconvert_v1beta1_DeploymentList_To_extensions_DeploymentList(in *DeploymentList, out *extensions.DeploymentList, s conversion.Scope) error {
+func autoConvert_v1beta1_DeploymentList_To_extensions_DeploymentList(in *DeploymentList, out *extensions.DeploymentList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*DeploymentList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]extensions.Deployment, len(in.Items))
 		for i := range in.Items {
-			if err := convert_v1beta1_Deployment_To_extensions_Deployment(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_v1beta1_Deployment_To_extensions_Deployment(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -3587,11 +3675,11 @@ func autoconvert_v1beta1_DeploymentList_To_extensions_DeploymentList(in *Deploym
 	return nil
 }
 
-func convert_v1beta1_DeploymentList_To_extensions_DeploymentList(in *DeploymentList, out *extensions.DeploymentList, s conversion.Scope) error {
-	return autoconvert_v1beta1_DeploymentList_To_extensions_DeploymentList(in, out, s)
+func Convert_v1beta1_DeploymentList_To_extensions_DeploymentList(in *DeploymentList, out *extensions.DeploymentList, s conversion.Scope) error {
+	return autoConvert_v1beta1_DeploymentList_To_extensions_DeploymentList(in, out, s)
 }
 
-func autoconvert_v1beta1_DeploymentSpec_To_extensions_DeploymentSpec(in *DeploymentSpec, out *extensions.DeploymentSpec, s conversion.Scope) error {
+func autoConvert_v1beta1_DeploymentSpec_To_extensions_DeploymentSpec(in *DeploymentSpec, out *extensions.DeploymentSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*DeploymentSpec))(in)
 	}
@@ -3604,17 +3692,17 @@ func autoconvert_v1beta1_DeploymentSpec_To_extensions_DeploymentSpec(in *Deploym
 	} else {
 		out.Selector = nil
 	}
-	if err := convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
+	if err := Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
-	if err := convert_v1beta1_DeploymentStrategy_To_extensions_DeploymentStrategy(&in.Strategy, &out.Strategy, s); err != nil {
+	if err := s.Convert(&in.Strategy, &out.Strategy, 0); err != nil {
 		return err
 	}
 	// in.UniqueLabelKey has no peer in out
 	return nil
 }
 
-func autoconvert_v1beta1_DeploymentStatus_To_extensions_DeploymentStatus(in *DeploymentStatus, out *extensions.DeploymentStatus, s conversion.Scope) error {
+func autoConvert_v1beta1_DeploymentStatus_To_extensions_DeploymentStatus(in *DeploymentStatus, out *extensions.DeploymentStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*DeploymentStatus))(in)
 	}
@@ -3623,33 +3711,33 @@ func autoconvert_v1beta1_DeploymentStatus_To_extensions_DeploymentStatus(in *Dep
 	return nil
 }
 
-func convert_v1beta1_DeploymentStatus_To_extensions_DeploymentStatus(in *DeploymentStatus, out *extensions.DeploymentStatus, s conversion.Scope) error {
-	return autoconvert_v1beta1_DeploymentStatus_To_extensions_DeploymentStatus(in, out, s)
+func Convert_v1beta1_DeploymentStatus_To_extensions_DeploymentStatus(in *DeploymentStatus, out *extensions.DeploymentStatus, s conversion.Scope) error {
+	return autoConvert_v1beta1_DeploymentStatus_To_extensions_DeploymentStatus(in, out, s)
 }
 
-func autoconvert_v1beta1_HTTPIngressPath_To_extensions_HTTPIngressPath(in *HTTPIngressPath, out *extensions.HTTPIngressPath, s conversion.Scope) error {
+func autoConvert_v1beta1_HTTPIngressPath_To_extensions_HTTPIngressPath(in *HTTPIngressPath, out *extensions.HTTPIngressPath, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*HTTPIngressPath))(in)
 	}
 	out.Path = in.Path
-	if err := convert_v1beta1_IngressBackend_To_extensions_IngressBackend(&in.Backend, &out.Backend, s); err != nil {
+	if err := Convert_v1beta1_IngressBackend_To_extensions_IngressBackend(&in.Backend, &out.Backend, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1beta1_HTTPIngressPath_To_extensions_HTTPIngressPath(in *HTTPIngressPath, out *extensions.HTTPIngressPath, s conversion.Scope) error {
-	return autoconvert_v1beta1_HTTPIngressPath_To_extensions_HTTPIngressPath(in, out, s)
+func Convert_v1beta1_HTTPIngressPath_To_extensions_HTTPIngressPath(in *HTTPIngressPath, out *extensions.HTTPIngressPath, s conversion.Scope) error {
+	return autoConvert_v1beta1_HTTPIngressPath_To_extensions_HTTPIngressPath(in, out, s)
 }
 
-func autoconvert_v1beta1_HTTPIngressRuleValue_To_extensions_HTTPIngressRuleValue(in *HTTPIngressRuleValue, out *extensions.HTTPIngressRuleValue, s conversion.Scope) error {
+func autoConvert_v1beta1_HTTPIngressRuleValue_To_extensions_HTTPIngressRuleValue(in *HTTPIngressRuleValue, out *extensions.HTTPIngressRuleValue, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*HTTPIngressRuleValue))(in)
 	}
 	if in.Paths != nil {
 		out.Paths = make([]extensions.HTTPIngressPath, len(in.Paths))
 		for i := range in.Paths {
-			if err := convert_v1beta1_HTTPIngressPath_To_extensions_HTTPIngressPath(&in.Paths[i], &out.Paths[i], s); err != nil {
+			if err := Convert_v1beta1_HTTPIngressPath_To_extensions_HTTPIngressPath(&in.Paths[i], &out.Paths[i], s); err != nil {
 				return err
 			}
 		}
@@ -3659,47 +3747,47 @@ func autoconvert_v1beta1_HTTPIngressRuleValue_To_extensions_HTTPIngressRuleValue
 	return nil
 }
 
-func convert_v1beta1_HTTPIngressRuleValue_To_extensions_HTTPIngressRuleValue(in *HTTPIngressRuleValue, out *extensions.HTTPIngressRuleValue, s conversion.Scope) error {
-	return autoconvert_v1beta1_HTTPIngressRuleValue_To_extensions_HTTPIngressRuleValue(in, out, s)
+func Convert_v1beta1_HTTPIngressRuleValue_To_extensions_HTTPIngressRuleValue(in *HTTPIngressRuleValue, out *extensions.HTTPIngressRuleValue, s conversion.Scope) error {
+	return autoConvert_v1beta1_HTTPIngressRuleValue_To_extensions_HTTPIngressRuleValue(in, out, s)
 }
 
-func autoconvert_v1beta1_HorizontalPodAutoscaler_To_extensions_HorizontalPodAutoscaler(in *HorizontalPodAutoscaler, out *extensions.HorizontalPodAutoscaler, s conversion.Scope) error {
+func autoConvert_v1beta1_HorizontalPodAutoscaler_To_extensions_HorizontalPodAutoscaler(in *HorizontalPodAutoscaler, out *extensions.HorizontalPodAutoscaler, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*HorizontalPodAutoscaler))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1beta1_HorizontalPodAutoscalerSpec_To_extensions_HorizontalPodAutoscalerSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_v1beta1_HorizontalPodAutoscalerSpec_To_extensions_HorizontalPodAutoscalerSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := convert_v1beta1_HorizontalPodAutoscalerStatus_To_extensions_HorizontalPodAutoscalerStatus(&in.Status, &out.Status, s); err != nil {
+	if err := Convert_v1beta1_HorizontalPodAutoscalerStatus_To_extensions_HorizontalPodAutoscalerStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1beta1_HorizontalPodAutoscaler_To_extensions_HorizontalPodAutoscaler(in *HorizontalPodAutoscaler, out *extensions.HorizontalPodAutoscaler, s conversion.Scope) error {
-	return autoconvert_v1beta1_HorizontalPodAutoscaler_To_extensions_HorizontalPodAutoscaler(in, out, s)
+func Convert_v1beta1_HorizontalPodAutoscaler_To_extensions_HorizontalPodAutoscaler(in *HorizontalPodAutoscaler, out *extensions.HorizontalPodAutoscaler, s conversion.Scope) error {
+	return autoConvert_v1beta1_HorizontalPodAutoscaler_To_extensions_HorizontalPodAutoscaler(in, out, s)
 }
 
-func autoconvert_v1beta1_HorizontalPodAutoscalerList_To_extensions_HorizontalPodAutoscalerList(in *HorizontalPodAutoscalerList, out *extensions.HorizontalPodAutoscalerList, s conversion.Scope) error {
+func autoConvert_v1beta1_HorizontalPodAutoscalerList_To_extensions_HorizontalPodAutoscalerList(in *HorizontalPodAutoscalerList, out *extensions.HorizontalPodAutoscalerList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*HorizontalPodAutoscalerList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]extensions.HorizontalPodAutoscaler, len(in.Items))
 		for i := range in.Items {
-			if err := convert_v1beta1_HorizontalPodAutoscaler_To_extensions_HorizontalPodAutoscaler(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_v1beta1_HorizontalPodAutoscaler_To_extensions_HorizontalPodAutoscaler(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -3709,15 +3797,15 @@ func autoconvert_v1beta1_HorizontalPodAutoscalerList_To_extensions_HorizontalPod
 	return nil
 }
 
-func convert_v1beta1_HorizontalPodAutoscalerList_To_extensions_HorizontalPodAutoscalerList(in *HorizontalPodAutoscalerList, out *extensions.HorizontalPodAutoscalerList, s conversion.Scope) error {
-	return autoconvert_v1beta1_HorizontalPodAutoscalerList_To_extensions_HorizontalPodAutoscalerList(in, out, s)
+func Convert_v1beta1_HorizontalPodAutoscalerList_To_extensions_HorizontalPodAutoscalerList(in *HorizontalPodAutoscalerList, out *extensions.HorizontalPodAutoscalerList, s conversion.Scope) error {
+	return autoConvert_v1beta1_HorizontalPodAutoscalerList_To_extensions_HorizontalPodAutoscalerList(in, out, s)
 }
 
-func autoconvert_v1beta1_HorizontalPodAutoscalerSpec_To_extensions_HorizontalPodAutoscalerSpec(in *HorizontalPodAutoscalerSpec, out *extensions.HorizontalPodAutoscalerSpec, s conversion.Scope) error {
+func autoConvert_v1beta1_HorizontalPodAutoscalerSpec_To_extensions_HorizontalPodAutoscalerSpec(in *HorizontalPodAutoscalerSpec, out *extensions.HorizontalPodAutoscalerSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*HorizontalPodAutoscalerSpec))(in)
 	}
-	if err := convert_v1beta1_SubresourceReference_To_extensions_SubresourceReference(&in.ScaleRef, &out.ScaleRef, s); err != nil {
+	if err := Convert_v1beta1_SubresourceReference_To_extensions_SubresourceReference(&in.ScaleRef, &out.ScaleRef, s); err != nil {
 		return err
 	}
 	if in.MinReplicas != nil {
@@ -3727,9 +3815,10 @@ func autoconvert_v1beta1_HorizontalPodAutoscalerSpec_To_extensions_HorizontalPod
 		out.MinReplicas = nil
 	}
 	out.MaxReplicas = int(in.MaxReplicas)
+	// unable to generate simple pointer conversion for v1beta1.CPUTargetUtilization -> extensions.CPUTargetUtilization
 	if in.CPUUtilization != nil {
 		out.CPUUtilization = new(extensions.CPUTargetUtilization)
-		if err := convert_v1beta1_CPUTargetUtilization_To_extensions_CPUTargetUtilization(in.CPUUtilization, out.CPUUtilization, s); err != nil {
+		if err := Convert_v1beta1_CPUTargetUtilization_To_extensions_CPUTargetUtilization(in.CPUUtilization, out.CPUUtilization, s); err != nil {
 			return err
 		}
 	} else {
@@ -3738,11 +3827,11 @@ func autoconvert_v1beta1_HorizontalPodAutoscalerSpec_To_extensions_HorizontalPod
 	return nil
 }
 
-func convert_v1beta1_HorizontalPodAutoscalerSpec_To_extensions_HorizontalPodAutoscalerSpec(in *HorizontalPodAutoscalerSpec, out *extensions.HorizontalPodAutoscalerSpec, s conversion.Scope) error {
-	return autoconvert_v1beta1_HorizontalPodAutoscalerSpec_To_extensions_HorizontalPodAutoscalerSpec(in, out, s)
+func Convert_v1beta1_HorizontalPodAutoscalerSpec_To_extensions_HorizontalPodAutoscalerSpec(in *HorizontalPodAutoscalerSpec, out *extensions.HorizontalPodAutoscalerSpec, s conversion.Scope) error {
+	return autoConvert_v1beta1_HorizontalPodAutoscalerSpec_To_extensions_HorizontalPodAutoscalerSpec(in, out, s)
 }
 
-func autoconvert_v1beta1_HorizontalPodAutoscalerStatus_To_extensions_HorizontalPodAutoscalerStatus(in *HorizontalPodAutoscalerStatus, out *extensions.HorizontalPodAutoscalerStatus, s conversion.Scope) error {
+func autoConvert_v1beta1_HorizontalPodAutoscalerStatus_To_extensions_HorizontalPodAutoscalerStatus(in *HorizontalPodAutoscalerStatus, out *extensions.HorizontalPodAutoscalerStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*HorizontalPodAutoscalerStatus))(in)
 	}
@@ -3752,8 +3841,10 @@ func autoconvert_v1beta1_HorizontalPodAutoscalerStatus_To_extensions_HorizontalP
 	} else {
 		out.ObservedGeneration = nil
 	}
+	// unable to generate simple pointer conversion for unversioned.Time -> unversioned.Time
 	if in.LastScaleTime != nil {
-		if err := s.Convert(&in.LastScaleTime, &out.LastScaleTime, 0); err != nil {
+		out.LastScaleTime = new(unversioned.Time)
+		if err := api.Convert_unversioned_Time_To_unversioned_Time(in.LastScaleTime, out.LastScaleTime, s); err != nil {
 			return err
 		}
 	} else {
@@ -3770,62 +3861,62 @@ func autoconvert_v1beta1_HorizontalPodAutoscalerStatus_To_extensions_HorizontalP
 	return nil
 }
 
-func convert_v1beta1_HorizontalPodAutoscalerStatus_To_extensions_HorizontalPodAutoscalerStatus(in *HorizontalPodAutoscalerStatus, out *extensions.HorizontalPodAutoscalerStatus, s conversion.Scope) error {
-	return autoconvert_v1beta1_HorizontalPodAutoscalerStatus_To_extensions_HorizontalPodAutoscalerStatus(in, out, s)
+func Convert_v1beta1_HorizontalPodAutoscalerStatus_To_extensions_HorizontalPodAutoscalerStatus(in *HorizontalPodAutoscalerStatus, out *extensions.HorizontalPodAutoscalerStatus, s conversion.Scope) error {
+	return autoConvert_v1beta1_HorizontalPodAutoscalerStatus_To_extensions_HorizontalPodAutoscalerStatus(in, out, s)
 }
 
-func autoconvert_v1beta1_Ingress_To_extensions_Ingress(in *Ingress, out *extensions.Ingress, s conversion.Scope) error {
+func autoConvert_v1beta1_Ingress_To_extensions_Ingress(in *Ingress, out *extensions.Ingress, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Ingress))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1beta1_IngressSpec_To_extensions_IngressSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_v1beta1_IngressSpec_To_extensions_IngressSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := convert_v1beta1_IngressStatus_To_extensions_IngressStatus(&in.Status, &out.Status, s); err != nil {
+	if err := Convert_v1beta1_IngressStatus_To_extensions_IngressStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1beta1_Ingress_To_extensions_Ingress(in *Ingress, out *extensions.Ingress, s conversion.Scope) error {
-	return autoconvert_v1beta1_Ingress_To_extensions_Ingress(in, out, s)
+func Convert_v1beta1_Ingress_To_extensions_Ingress(in *Ingress, out *extensions.Ingress, s conversion.Scope) error {
+	return autoConvert_v1beta1_Ingress_To_extensions_Ingress(in, out, s)
 }
 
-func autoconvert_v1beta1_IngressBackend_To_extensions_IngressBackend(in *IngressBackend, out *extensions.IngressBackend, s conversion.Scope) error {
+func autoConvert_v1beta1_IngressBackend_To_extensions_IngressBackend(in *IngressBackend, out *extensions.IngressBackend, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*IngressBackend))(in)
 	}
 	out.ServiceName = in.ServiceName
-	if err := s.Convert(&in.ServicePort, &out.ServicePort, 0); err != nil {
+	if err := api.Convert_intstr_IntOrString_To_intstr_IntOrString(&in.ServicePort, &out.ServicePort, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1beta1_IngressBackend_To_extensions_IngressBackend(in *IngressBackend, out *extensions.IngressBackend, s conversion.Scope) error {
-	return autoconvert_v1beta1_IngressBackend_To_extensions_IngressBackend(in, out, s)
+func Convert_v1beta1_IngressBackend_To_extensions_IngressBackend(in *IngressBackend, out *extensions.IngressBackend, s conversion.Scope) error {
+	return autoConvert_v1beta1_IngressBackend_To_extensions_IngressBackend(in, out, s)
 }
 
-func autoconvert_v1beta1_IngressList_To_extensions_IngressList(in *IngressList, out *extensions.IngressList, s conversion.Scope) error {
+func autoConvert_v1beta1_IngressList_To_extensions_IngressList(in *IngressList, out *extensions.IngressList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*IngressList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]extensions.Ingress, len(in.Items))
 		for i := range in.Items {
-			if err := convert_v1beta1_Ingress_To_extensions_Ingress(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_v1beta1_Ingress_To_extensions_Ingress(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -3835,32 +3926,33 @@ func autoconvert_v1beta1_IngressList_To_extensions_IngressList(in *IngressList, 
 	return nil
 }
 
-func convert_v1beta1_IngressList_To_extensions_IngressList(in *IngressList, out *extensions.IngressList, s conversion.Scope) error {
-	return autoconvert_v1beta1_IngressList_To_extensions_IngressList(in, out, s)
+func Convert_v1beta1_IngressList_To_extensions_IngressList(in *IngressList, out *extensions.IngressList, s conversion.Scope) error {
+	return autoConvert_v1beta1_IngressList_To_extensions_IngressList(in, out, s)
 }
 
-func autoconvert_v1beta1_IngressRule_To_extensions_IngressRule(in *IngressRule, out *extensions.IngressRule, s conversion.Scope) error {
+func autoConvert_v1beta1_IngressRule_To_extensions_IngressRule(in *IngressRule, out *extensions.IngressRule, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*IngressRule))(in)
 	}
 	out.Host = in.Host
-	if err := convert_v1beta1_IngressRuleValue_To_extensions_IngressRuleValue(&in.IngressRuleValue, &out.IngressRuleValue, s); err != nil {
+	if err := Convert_v1beta1_IngressRuleValue_To_extensions_IngressRuleValue(&in.IngressRuleValue, &out.IngressRuleValue, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1beta1_IngressRule_To_extensions_IngressRule(in *IngressRule, out *extensions.IngressRule, s conversion.Scope) error {
-	return autoconvert_v1beta1_IngressRule_To_extensions_IngressRule(in, out, s)
+func Convert_v1beta1_IngressRule_To_extensions_IngressRule(in *IngressRule, out *extensions.IngressRule, s conversion.Scope) error {
+	return autoConvert_v1beta1_IngressRule_To_extensions_IngressRule(in, out, s)
 }
 
-func autoconvert_v1beta1_IngressRuleValue_To_extensions_IngressRuleValue(in *IngressRuleValue, out *extensions.IngressRuleValue, s conversion.Scope) error {
+func autoConvert_v1beta1_IngressRuleValue_To_extensions_IngressRuleValue(in *IngressRuleValue, out *extensions.IngressRuleValue, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*IngressRuleValue))(in)
 	}
+	// unable to generate simple pointer conversion for v1beta1.HTTPIngressRuleValue -> extensions.HTTPIngressRuleValue
 	if in.HTTP != nil {
 		out.HTTP = new(extensions.HTTPIngressRuleValue)
-		if err := convert_v1beta1_HTTPIngressRuleValue_To_extensions_HTTPIngressRuleValue(in.HTTP, out.HTTP, s); err != nil {
+		if err := Convert_v1beta1_HTTPIngressRuleValue_To_extensions_HTTPIngressRuleValue(in.HTTP, out.HTTP, s); err != nil {
 			return err
 		}
 	} else {
@@ -3869,17 +3961,18 @@ func autoconvert_v1beta1_IngressRuleValue_To_extensions_IngressRuleValue(in *Ing
 	return nil
 }
 
-func convert_v1beta1_IngressRuleValue_To_extensions_IngressRuleValue(in *IngressRuleValue, out *extensions.IngressRuleValue, s conversion.Scope) error {
-	return autoconvert_v1beta1_IngressRuleValue_To_extensions_IngressRuleValue(in, out, s)
+func Convert_v1beta1_IngressRuleValue_To_extensions_IngressRuleValue(in *IngressRuleValue, out *extensions.IngressRuleValue, s conversion.Scope) error {
+	return autoConvert_v1beta1_IngressRuleValue_To_extensions_IngressRuleValue(in, out, s)
 }
 
-func autoconvert_v1beta1_IngressSpec_To_extensions_IngressSpec(in *IngressSpec, out *extensions.IngressSpec, s conversion.Scope) error {
+func autoConvert_v1beta1_IngressSpec_To_extensions_IngressSpec(in *IngressSpec, out *extensions.IngressSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*IngressSpec))(in)
 	}
+	// unable to generate simple pointer conversion for v1beta1.IngressBackend -> extensions.IngressBackend
 	if in.Backend != nil {
 		out.Backend = new(extensions.IngressBackend)
-		if err := convert_v1beta1_IngressBackend_To_extensions_IngressBackend(in.Backend, out.Backend, s); err != nil {
+		if err := Convert_v1beta1_IngressBackend_To_extensions_IngressBackend(in.Backend, out.Backend, s); err != nil {
 			return err
 		}
 	} else {
@@ -3888,7 +3981,7 @@ func autoconvert_v1beta1_IngressSpec_To_extensions_IngressSpec(in *IngressSpec, 
 	if in.Rules != nil {
 		out.Rules = make([]extensions.IngressRule, len(in.Rules))
 		for i := range in.Rules {
-			if err := convert_v1beta1_IngressRule_To_extensions_IngressRule(&in.Rules[i], &out.Rules[i], s); err != nil {
+			if err := Convert_v1beta1_IngressRule_To_extensions_IngressRule(&in.Rules[i], &out.Rules[i], s); err != nil {
 				return err
 			}
 		}
@@ -3898,57 +3991,57 @@ func autoconvert_v1beta1_IngressSpec_To_extensions_IngressSpec(in *IngressSpec, 
 	return nil
 }
 
-func convert_v1beta1_IngressSpec_To_extensions_IngressSpec(in *IngressSpec, out *extensions.IngressSpec, s conversion.Scope) error {
-	return autoconvert_v1beta1_IngressSpec_To_extensions_IngressSpec(in, out, s)
+func Convert_v1beta1_IngressSpec_To_extensions_IngressSpec(in *IngressSpec, out *extensions.IngressSpec, s conversion.Scope) error {
+	return autoConvert_v1beta1_IngressSpec_To_extensions_IngressSpec(in, out, s)
 }
 
-func autoconvert_v1beta1_IngressStatus_To_extensions_IngressStatus(in *IngressStatus, out *extensions.IngressStatus, s conversion.Scope) error {
+func autoConvert_v1beta1_IngressStatus_To_extensions_IngressStatus(in *IngressStatus, out *extensions.IngressStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*IngressStatus))(in)
 	}
-	if err := convert_v1_LoadBalancerStatus_To_api_LoadBalancerStatus(&in.LoadBalancer, &out.LoadBalancer, s); err != nil {
+	if err := Convert_v1_LoadBalancerStatus_To_api_LoadBalancerStatus(&in.LoadBalancer, &out.LoadBalancer, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1beta1_IngressStatus_To_extensions_IngressStatus(in *IngressStatus, out *extensions.IngressStatus, s conversion.Scope) error {
-	return autoconvert_v1beta1_IngressStatus_To_extensions_IngressStatus(in, out, s)
+func Convert_v1beta1_IngressStatus_To_extensions_IngressStatus(in *IngressStatus, out *extensions.IngressStatus, s conversion.Scope) error {
+	return autoConvert_v1beta1_IngressStatus_To_extensions_IngressStatus(in, out, s)
 }
 
-func autoconvert_v1beta1_Job_To_extensions_Job(in *Job, out *extensions.Job, s conversion.Scope) error {
+func autoConvert_v1beta1_Job_To_extensions_Job(in *Job, out *extensions.Job, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Job))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1beta1_JobSpec_To_extensions_JobSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_v1beta1_JobSpec_To_extensions_JobSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := convert_v1beta1_JobStatus_To_extensions_JobStatus(&in.Status, &out.Status, s); err != nil {
+	if err := Convert_v1beta1_JobStatus_To_extensions_JobStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1beta1_Job_To_extensions_Job(in *Job, out *extensions.Job, s conversion.Scope) error {
-	return autoconvert_v1beta1_Job_To_extensions_Job(in, out, s)
+func Convert_v1beta1_Job_To_extensions_Job(in *Job, out *extensions.Job, s conversion.Scope) error {
+	return autoConvert_v1beta1_Job_To_extensions_Job(in, out, s)
 }
 
-func autoconvert_v1beta1_JobCondition_To_extensions_JobCondition(in *JobCondition, out *extensions.JobCondition, s conversion.Scope) error {
+func autoConvert_v1beta1_JobCondition_To_extensions_JobCondition(in *JobCondition, out *extensions.JobCondition, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*JobCondition))(in)
 	}
 	out.Type = extensions.JobConditionType(in.Type)
 	out.Status = api.ConditionStatus(in.Status)
-	if err := s.Convert(&in.LastProbeTime, &out.LastProbeTime, 0); err != nil {
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.LastProbeTime, &out.LastProbeTime, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.LastTransitionTime, &out.LastTransitionTime, 0); err != nil {
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.LastTransitionTime, &out.LastTransitionTime, s); err != nil {
 		return err
 	}
 	out.Reason = in.Reason
@@ -3956,24 +4049,24 @@ func autoconvert_v1beta1_JobCondition_To_extensions_JobCondition(in *JobConditio
 	return nil
 }
 
-func convert_v1beta1_JobCondition_To_extensions_JobCondition(in *JobCondition, out *extensions.JobCondition, s conversion.Scope) error {
-	return autoconvert_v1beta1_JobCondition_To_extensions_JobCondition(in, out, s)
+func Convert_v1beta1_JobCondition_To_extensions_JobCondition(in *JobCondition, out *extensions.JobCondition, s conversion.Scope) error {
+	return autoConvert_v1beta1_JobCondition_To_extensions_JobCondition(in, out, s)
 }
 
-func autoconvert_v1beta1_JobList_To_extensions_JobList(in *JobList, out *extensions.JobList, s conversion.Scope) error {
+func autoConvert_v1beta1_JobList_To_extensions_JobList(in *JobList, out *extensions.JobList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*JobList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]extensions.Job, len(in.Items))
 		for i := range in.Items {
-			if err := convert_v1beta1_Job_To_extensions_Job(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_v1beta1_Job_To_extensions_Job(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -3983,11 +4076,11 @@ func autoconvert_v1beta1_JobList_To_extensions_JobList(in *JobList, out *extensi
 	return nil
 }
 
-func convert_v1beta1_JobList_To_extensions_JobList(in *JobList, out *extensions.JobList, s conversion.Scope) error {
-	return autoconvert_v1beta1_JobList_To_extensions_JobList(in, out, s)
+func Convert_v1beta1_JobList_To_extensions_JobList(in *JobList, out *extensions.JobList, s conversion.Scope) error {
+	return autoConvert_v1beta1_JobList_To_extensions_JobList(in, out, s)
 }
 
-func autoconvert_v1beta1_JobSpec_To_extensions_JobSpec(in *JobSpec, out *extensions.JobSpec, s conversion.Scope) error {
+func autoConvert_v1beta1_JobSpec_To_extensions_JobSpec(in *JobSpec, out *extensions.JobSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*JobSpec))(in)
 	}
@@ -4009,47 +4102,52 @@ func autoconvert_v1beta1_JobSpec_To_extensions_JobSpec(in *JobSpec, out *extensi
 	} else {
 		out.ActiveDeadlineSeconds = nil
 	}
+	// unable to generate simple pointer conversion for v1beta1.LabelSelector -> extensions.LabelSelector
 	if in.Selector != nil {
 		out.Selector = new(extensions.LabelSelector)
-		if err := convert_v1beta1_LabelSelector_To_extensions_LabelSelector(in.Selector, out.Selector, s); err != nil {
+		if err := Convert_v1beta1_LabelSelector_To_extensions_LabelSelector(in.Selector, out.Selector, s); err != nil {
 			return err
 		}
 	} else {
 		out.Selector = nil
 	}
-	if err := convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
+	if err := Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1beta1_JobSpec_To_extensions_JobSpec(in *JobSpec, out *extensions.JobSpec, s conversion.Scope) error {
-	return autoconvert_v1beta1_JobSpec_To_extensions_JobSpec(in, out, s)
+func Convert_v1beta1_JobSpec_To_extensions_JobSpec(in *JobSpec, out *extensions.JobSpec, s conversion.Scope) error {
+	return autoConvert_v1beta1_JobSpec_To_extensions_JobSpec(in, out, s)
 }
 
-func autoconvert_v1beta1_JobStatus_To_extensions_JobStatus(in *JobStatus, out *extensions.JobStatus, s conversion.Scope) error {
+func autoConvert_v1beta1_JobStatus_To_extensions_JobStatus(in *JobStatus, out *extensions.JobStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*JobStatus))(in)
 	}
 	if in.Conditions != nil {
 		out.Conditions = make([]extensions.JobCondition, len(in.Conditions))
 		for i := range in.Conditions {
-			if err := convert_v1beta1_JobCondition_To_extensions_JobCondition(&in.Conditions[i], &out.Conditions[i], s); err != nil {
+			if err := Convert_v1beta1_JobCondition_To_extensions_JobCondition(&in.Conditions[i], &out.Conditions[i], s); err != nil {
 				return err
 			}
 		}
 	} else {
 		out.Conditions = nil
 	}
+	// unable to generate simple pointer conversion for unversioned.Time -> unversioned.Time
 	if in.StartTime != nil {
-		if err := s.Convert(&in.StartTime, &out.StartTime, 0); err != nil {
+		out.StartTime = new(unversioned.Time)
+		if err := api.Convert_unversioned_Time_To_unversioned_Time(in.StartTime, out.StartTime, s); err != nil {
 			return err
 		}
 	} else {
 		out.StartTime = nil
 	}
+	// unable to generate simple pointer conversion for unversioned.Time -> unversioned.Time
 	if in.CompletionTime != nil {
-		if err := s.Convert(&in.CompletionTime, &out.CompletionTime, 0); err != nil {
+		out.CompletionTime = new(unversioned.Time)
+		if err := api.Convert_unversioned_Time_To_unversioned_Time(in.CompletionTime, out.CompletionTime, s); err != nil {
 			return err
 		}
 	} else {
@@ -4061,11 +4159,11 @@ func autoconvert_v1beta1_JobStatus_To_extensions_JobStatus(in *JobStatus, out *e
 	return nil
 }
 
-func convert_v1beta1_JobStatus_To_extensions_JobStatus(in *JobStatus, out *extensions.JobStatus, s conversion.Scope) error {
-	return autoconvert_v1beta1_JobStatus_To_extensions_JobStatus(in, out, s)
+func Convert_v1beta1_JobStatus_To_extensions_JobStatus(in *JobStatus, out *extensions.JobStatus, s conversion.Scope) error {
+	return autoConvert_v1beta1_JobStatus_To_extensions_JobStatus(in, out, s)
 }
 
-func autoconvert_v1beta1_LabelSelector_To_extensions_LabelSelector(in *LabelSelector, out *extensions.LabelSelector, s conversion.Scope) error {
+func autoConvert_v1beta1_LabelSelector_To_extensions_LabelSelector(in *LabelSelector, out *extensions.LabelSelector, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*LabelSelector))(in)
 	}
@@ -4080,7 +4178,7 @@ func autoconvert_v1beta1_LabelSelector_To_extensions_LabelSelector(in *LabelSele
 	if in.MatchExpressions != nil {
 		out.MatchExpressions = make([]extensions.LabelSelectorRequirement, len(in.MatchExpressions))
 		for i := range in.MatchExpressions {
-			if err := convert_v1beta1_LabelSelectorRequirement_To_extensions_LabelSelectorRequirement(&in.MatchExpressions[i], &out.MatchExpressions[i], s); err != nil {
+			if err := Convert_v1beta1_LabelSelectorRequirement_To_extensions_LabelSelectorRequirement(&in.MatchExpressions[i], &out.MatchExpressions[i], s); err != nil {
 				return err
 			}
 		}
@@ -4090,11 +4188,11 @@ func autoconvert_v1beta1_LabelSelector_To_extensions_LabelSelector(in *LabelSele
 	return nil
 }
 
-func convert_v1beta1_LabelSelector_To_extensions_LabelSelector(in *LabelSelector, out *extensions.LabelSelector, s conversion.Scope) error {
-	return autoconvert_v1beta1_LabelSelector_To_extensions_LabelSelector(in, out, s)
+func Convert_v1beta1_LabelSelector_To_extensions_LabelSelector(in *LabelSelector, out *extensions.LabelSelector, s conversion.Scope) error {
+	return autoConvert_v1beta1_LabelSelector_To_extensions_LabelSelector(in, out, s)
 }
 
-func autoconvert_v1beta1_LabelSelectorRequirement_To_extensions_LabelSelectorRequirement(in *LabelSelectorRequirement, out *extensions.LabelSelectorRequirement, s conversion.Scope) error {
+func autoConvert_v1beta1_LabelSelectorRequirement_To_extensions_LabelSelectorRequirement(in *LabelSelectorRequirement, out *extensions.LabelSelectorRequirement, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*LabelSelectorRequirement))(in)
 	}
@@ -4111,21 +4209,21 @@ func autoconvert_v1beta1_LabelSelectorRequirement_To_extensions_LabelSelectorReq
 	return nil
 }
 
-func convert_v1beta1_LabelSelectorRequirement_To_extensions_LabelSelectorRequirement(in *LabelSelectorRequirement, out *extensions.LabelSelectorRequirement, s conversion.Scope) error {
-	return autoconvert_v1beta1_LabelSelectorRequirement_To_extensions_LabelSelectorRequirement(in, out, s)
+func Convert_v1beta1_LabelSelectorRequirement_To_extensions_LabelSelectorRequirement(in *LabelSelectorRequirement, out *extensions.LabelSelectorRequirement, s conversion.Scope) error {
+	return autoConvert_v1beta1_LabelSelectorRequirement_To_extensions_LabelSelectorRequirement(in, out, s)
 }
 
-func autoconvert_v1beta1_ListOptions_To_api_ListOptions(in *ListOptions, out *api.ListOptions, s conversion.Scope) error {
+func autoConvert_v1beta1_ListOptions_To_api_ListOptions(in *ListOptions, out *api.ListOptions, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ListOptions))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.LabelSelector, &out.LabelSelector, 0); err != nil {
+	if err := api.Convert_string_To_labels_Selector(&in.LabelSelector, &out.LabelSelector, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.FieldSelector, &out.FieldSelector, 0); err != nil {
+	if err := api.Convert_string_To_fields_Selector(&in.FieldSelector, &out.FieldSelector, s); err != nil {
 		return err
 	}
 	out.Watch = in.Watch
@@ -4139,11 +4237,11 @@ func autoconvert_v1beta1_ListOptions_To_api_ListOptions(in *ListOptions, out *ap
 	return nil
 }
 
-func convert_v1beta1_ListOptions_To_api_ListOptions(in *ListOptions, out *api.ListOptions, s conversion.Scope) error {
-	return autoconvert_v1beta1_ListOptions_To_api_ListOptions(in, out, s)
+func Convert_v1beta1_ListOptions_To_api_ListOptions(in *ListOptions, out *api.ListOptions, s conversion.Scope) error {
+	return autoConvert_v1beta1_ListOptions_To_api_ListOptions(in, out, s)
 }
 
-func autoconvert_v1beta1_NodeUtilization_To_extensions_NodeUtilization(in *NodeUtilization, out *extensions.NodeUtilization, s conversion.Scope) error {
+func autoConvert_v1beta1_NodeUtilization_To_extensions_NodeUtilization(in *NodeUtilization, out *extensions.NodeUtilization, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*NodeUtilization))(in)
 	}
@@ -4152,25 +4250,25 @@ func autoconvert_v1beta1_NodeUtilization_To_extensions_NodeUtilization(in *NodeU
 	return nil
 }
 
-func convert_v1beta1_NodeUtilization_To_extensions_NodeUtilization(in *NodeUtilization, out *extensions.NodeUtilization, s conversion.Scope) error {
-	return autoconvert_v1beta1_NodeUtilization_To_extensions_NodeUtilization(in, out, s)
+func Convert_v1beta1_NodeUtilization_To_extensions_NodeUtilization(in *NodeUtilization, out *extensions.NodeUtilization, s conversion.Scope) error {
+	return autoConvert_v1beta1_NodeUtilization_To_extensions_NodeUtilization(in, out, s)
 }
 
-func autoconvert_v1beta1_ReplicationControllerDummy_To_extensions_ReplicationControllerDummy(in *ReplicationControllerDummy, out *extensions.ReplicationControllerDummy, s conversion.Scope) error {
+func autoConvert_v1beta1_ReplicationControllerDummy_To_extensions_ReplicationControllerDummy(in *ReplicationControllerDummy, out *extensions.ReplicationControllerDummy, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ReplicationControllerDummy))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1beta1_ReplicationControllerDummy_To_extensions_ReplicationControllerDummy(in *ReplicationControllerDummy, out *extensions.ReplicationControllerDummy, s conversion.Scope) error {
-	return autoconvert_v1beta1_ReplicationControllerDummy_To_extensions_ReplicationControllerDummy(in, out, s)
+func Convert_v1beta1_ReplicationControllerDummy_To_extensions_ReplicationControllerDummy(in *ReplicationControllerDummy, out *extensions.ReplicationControllerDummy, s conversion.Scope) error {
+	return autoConvert_v1beta1_ReplicationControllerDummy_To_extensions_ReplicationControllerDummy(in, out, s)
 }
 
-func autoconvert_v1beta1_RollingUpdateDeployment_To_extensions_RollingUpdateDeployment(in *RollingUpdateDeployment, out *extensions.RollingUpdateDeployment, s conversion.Scope) error {
+func autoConvert_v1beta1_RollingUpdateDeployment_To_extensions_RollingUpdateDeployment(in *RollingUpdateDeployment, out *extensions.RollingUpdateDeployment, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*RollingUpdateDeployment))(in)
 	}
@@ -4180,30 +4278,30 @@ func autoconvert_v1beta1_RollingUpdateDeployment_To_extensions_RollingUpdateDepl
 	return nil
 }
 
-func autoconvert_v1beta1_Scale_To_extensions_Scale(in *Scale, out *extensions.Scale, s conversion.Scope) error {
+func autoConvert_v1beta1_Scale_To_extensions_Scale(in *Scale, out *extensions.Scale, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*Scale))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1beta1_ScaleSpec_To_extensions_ScaleSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := Convert_v1beta1_ScaleSpec_To_extensions_ScaleSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := convert_v1beta1_ScaleStatus_To_extensions_ScaleStatus(&in.Status, &out.Status, s); err != nil {
+	if err := Convert_v1beta1_ScaleStatus_To_extensions_ScaleStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1beta1_Scale_To_extensions_Scale(in *Scale, out *extensions.Scale, s conversion.Scope) error {
-	return autoconvert_v1beta1_Scale_To_extensions_Scale(in, out, s)
+func Convert_v1beta1_Scale_To_extensions_Scale(in *Scale, out *extensions.Scale, s conversion.Scope) error {
+	return autoConvert_v1beta1_Scale_To_extensions_Scale(in, out, s)
 }
 
-func autoconvert_v1beta1_ScaleSpec_To_extensions_ScaleSpec(in *ScaleSpec, out *extensions.ScaleSpec, s conversion.Scope) error {
+func autoConvert_v1beta1_ScaleSpec_To_extensions_ScaleSpec(in *ScaleSpec, out *extensions.ScaleSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ScaleSpec))(in)
 	}
@@ -4211,11 +4309,11 @@ func autoconvert_v1beta1_ScaleSpec_To_extensions_ScaleSpec(in *ScaleSpec, out *e
 	return nil
 }
 
-func convert_v1beta1_ScaleSpec_To_extensions_ScaleSpec(in *ScaleSpec, out *extensions.ScaleSpec, s conversion.Scope) error {
-	return autoconvert_v1beta1_ScaleSpec_To_extensions_ScaleSpec(in, out, s)
+func Convert_v1beta1_ScaleSpec_To_extensions_ScaleSpec(in *ScaleSpec, out *extensions.ScaleSpec, s conversion.Scope) error {
+	return autoConvert_v1beta1_ScaleSpec_To_extensions_ScaleSpec(in, out, s)
 }
 
-func autoconvert_v1beta1_ScaleStatus_To_extensions_ScaleStatus(in *ScaleStatus, out *extensions.ScaleStatus, s conversion.Scope) error {
+func autoConvert_v1beta1_ScaleStatus_To_extensions_ScaleStatus(in *ScaleStatus, out *extensions.ScaleStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ScaleStatus))(in)
 	}
@@ -4231,11 +4329,11 @@ func autoconvert_v1beta1_ScaleStatus_To_extensions_ScaleStatus(in *ScaleStatus, 
 	return nil
 }
 
-func convert_v1beta1_ScaleStatus_To_extensions_ScaleStatus(in *ScaleStatus, out *extensions.ScaleStatus, s conversion.Scope) error {
-	return autoconvert_v1beta1_ScaleStatus_To_extensions_ScaleStatus(in, out, s)
+func Convert_v1beta1_ScaleStatus_To_extensions_ScaleStatus(in *ScaleStatus, out *extensions.ScaleStatus, s conversion.Scope) error {
+	return autoConvert_v1beta1_ScaleStatus_To_extensions_ScaleStatus(in, out, s)
 }
 
-func autoconvert_v1beta1_SubresourceReference_To_extensions_SubresourceReference(in *SubresourceReference, out *extensions.SubresourceReference, s conversion.Scope) error {
+func autoConvert_v1beta1_SubresourceReference_To_extensions_SubresourceReference(in *SubresourceReference, out *extensions.SubresourceReference, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*SubresourceReference))(in)
 	}
@@ -4246,25 +4344,25 @@ func autoconvert_v1beta1_SubresourceReference_To_extensions_SubresourceReference
 	return nil
 }
 
-func convert_v1beta1_SubresourceReference_To_extensions_SubresourceReference(in *SubresourceReference, out *extensions.SubresourceReference, s conversion.Scope) error {
-	return autoconvert_v1beta1_SubresourceReference_To_extensions_SubresourceReference(in, out, s)
+func Convert_v1beta1_SubresourceReference_To_extensions_SubresourceReference(in *SubresourceReference, out *extensions.SubresourceReference, s conversion.Scope) error {
+	return autoConvert_v1beta1_SubresourceReference_To_extensions_SubresourceReference(in, out, s)
 }
 
-func autoconvert_v1beta1_ThirdPartyResource_To_extensions_ThirdPartyResource(in *ThirdPartyResource, out *extensions.ThirdPartyResource, s conversion.Scope) error {
+func autoConvert_v1beta1_ThirdPartyResource_To_extensions_ThirdPartyResource(in *ThirdPartyResource, out *extensions.ThirdPartyResource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ThirdPartyResource))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
 	out.Description = in.Description
 	if in.Versions != nil {
 		out.Versions = make([]extensions.APIVersion, len(in.Versions))
 		for i := range in.Versions {
-			if err := convert_v1beta1_APIVersion_To_extensions_APIVersion(&in.Versions[i], &out.Versions[i], s); err != nil {
+			if err := Convert_v1beta1_APIVersion_To_extensions_APIVersion(&in.Versions[i], &out.Versions[i], s); err != nil {
 				return err
 			}
 		}
@@ -4274,44 +4372,44 @@ func autoconvert_v1beta1_ThirdPartyResource_To_extensions_ThirdPartyResource(in 
 	return nil
 }
 
-func convert_v1beta1_ThirdPartyResource_To_extensions_ThirdPartyResource(in *ThirdPartyResource, out *extensions.ThirdPartyResource, s conversion.Scope) error {
-	return autoconvert_v1beta1_ThirdPartyResource_To_extensions_ThirdPartyResource(in, out, s)
+func Convert_v1beta1_ThirdPartyResource_To_extensions_ThirdPartyResource(in *ThirdPartyResource, out *extensions.ThirdPartyResource, s conversion.Scope) error {
+	return autoConvert_v1beta1_ThirdPartyResource_To_extensions_ThirdPartyResource(in, out, s)
 }
 
-func autoconvert_v1beta1_ThirdPartyResourceData_To_extensions_ThirdPartyResourceData(in *ThirdPartyResourceData, out *extensions.ThirdPartyResourceData, s conversion.Scope) error {
+func autoConvert_v1beta1_ThirdPartyResourceData_To_extensions_ThirdPartyResourceData(in *ThirdPartyResourceData, out *extensions.ThirdPartyResourceData, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ThirdPartyResourceData))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.Data, &out.Data, 0); err != nil {
+	if err := conversion.ByteSliceCopy(&in.Data, &out.Data, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1beta1_ThirdPartyResourceData_To_extensions_ThirdPartyResourceData(in *ThirdPartyResourceData, out *extensions.ThirdPartyResourceData, s conversion.Scope) error {
-	return autoconvert_v1beta1_ThirdPartyResourceData_To_extensions_ThirdPartyResourceData(in, out, s)
+func Convert_v1beta1_ThirdPartyResourceData_To_extensions_ThirdPartyResourceData(in *ThirdPartyResourceData, out *extensions.ThirdPartyResourceData, s conversion.Scope) error {
+	return autoConvert_v1beta1_ThirdPartyResourceData_To_extensions_ThirdPartyResourceData(in, out, s)
 }
 
-func autoconvert_v1beta1_ThirdPartyResourceDataList_To_extensions_ThirdPartyResourceDataList(in *ThirdPartyResourceDataList, out *extensions.ThirdPartyResourceDataList, s conversion.Scope) error {
+func autoConvert_v1beta1_ThirdPartyResourceDataList_To_extensions_ThirdPartyResourceDataList(in *ThirdPartyResourceDataList, out *extensions.ThirdPartyResourceDataList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ThirdPartyResourceDataList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]extensions.ThirdPartyResourceData, len(in.Items))
 		for i := range in.Items {
-			if err := convert_v1beta1_ThirdPartyResourceData_To_extensions_ThirdPartyResourceData(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_v1beta1_ThirdPartyResourceData_To_extensions_ThirdPartyResourceData(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -4321,24 +4419,24 @@ func autoconvert_v1beta1_ThirdPartyResourceDataList_To_extensions_ThirdPartyReso
 	return nil
 }
 
-func convert_v1beta1_ThirdPartyResourceDataList_To_extensions_ThirdPartyResourceDataList(in *ThirdPartyResourceDataList, out *extensions.ThirdPartyResourceDataList, s conversion.Scope) error {
-	return autoconvert_v1beta1_ThirdPartyResourceDataList_To_extensions_ThirdPartyResourceDataList(in, out, s)
+func Convert_v1beta1_ThirdPartyResourceDataList_To_extensions_ThirdPartyResourceDataList(in *ThirdPartyResourceDataList, out *extensions.ThirdPartyResourceDataList, s conversion.Scope) error {
+	return autoConvert_v1beta1_ThirdPartyResourceDataList_To_extensions_ThirdPartyResourceDataList(in, out, s)
 }
 
-func autoconvert_v1beta1_ThirdPartyResourceList_To_extensions_ThirdPartyResourceList(in *ThirdPartyResourceList, out *extensions.ThirdPartyResourceList, s conversion.Scope) error {
+func autoConvert_v1beta1_ThirdPartyResourceList_To_extensions_ThirdPartyResourceList(in *ThirdPartyResourceList, out *extensions.ThirdPartyResourceList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ThirdPartyResourceList))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.ListMeta, &out.ListMeta, 0); err != nil {
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
 		return err
 	}
 	if in.Items != nil {
 		out.Items = make([]extensions.ThirdPartyResource, len(in.Items))
 		for i := range in.Items {
-			if err := convert_v1beta1_ThirdPartyResource_To_extensions_ThirdPartyResource(&in.Items[i], &out.Items[i], s); err != nil {
+			if err := Convert_v1beta1_ThirdPartyResource_To_extensions_ThirdPartyResource(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -4348,191 +4446,191 @@ func autoconvert_v1beta1_ThirdPartyResourceList_To_extensions_ThirdPartyResource
 	return nil
 }
 
-func convert_v1beta1_ThirdPartyResourceList_To_extensions_ThirdPartyResourceList(in *ThirdPartyResourceList, out *extensions.ThirdPartyResourceList, s conversion.Scope) error {
-	return autoconvert_v1beta1_ThirdPartyResourceList_To_extensions_ThirdPartyResourceList(in, out, s)
+func Convert_v1beta1_ThirdPartyResourceList_To_extensions_ThirdPartyResourceList(in *ThirdPartyResourceList, out *extensions.ThirdPartyResourceList, s conversion.Scope) error {
+	return autoConvert_v1beta1_ThirdPartyResourceList_To_extensions_ThirdPartyResourceList(in, out, s)
 }
 
 func init() {
 	err := api.Scheme.AddGeneratedConversionFuncs(
-		autoconvert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVolumeSource,
-		autoconvert_api_Capabilities_To_v1_Capabilities,
-		autoconvert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource,
-		autoconvert_api_CinderVolumeSource_To_v1_CinderVolumeSource,
-		autoconvert_api_ContainerPort_To_v1_ContainerPort,
-		autoconvert_api_Container_To_v1_Container,
-		autoconvert_api_DownwardAPIVolumeFile_To_v1_DownwardAPIVolumeFile,
-		autoconvert_api_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource,
-		autoconvert_api_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource,
-		autoconvert_api_EnvVarSource_To_v1_EnvVarSource,
-		autoconvert_api_EnvVar_To_v1_EnvVar,
-		autoconvert_api_ExecAction_To_v1_ExecAction,
-		autoconvert_api_FCVolumeSource_To_v1_FCVolumeSource,
-		autoconvert_api_FlexVolumeSource_To_v1_FlexVolumeSource,
-		autoconvert_api_FlockerVolumeSource_To_v1_FlockerVolumeSource,
-		autoconvert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSource,
-		autoconvert_api_GitRepoVolumeSource_To_v1_GitRepoVolumeSource,
-		autoconvert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource,
-		autoconvert_api_HTTPGetAction_To_v1_HTTPGetAction,
-		autoconvert_api_Handler_To_v1_Handler,
-		autoconvert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource,
-		autoconvert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource,
-		autoconvert_api_Lifecycle_To_v1_Lifecycle,
-		autoconvert_api_ListOptions_To_v1beta1_ListOptions,
-		autoconvert_api_LoadBalancerIngress_To_v1_LoadBalancerIngress,
-		autoconvert_api_LoadBalancerStatus_To_v1_LoadBalancerStatus,
-		autoconvert_api_LocalObjectReference_To_v1_LocalObjectReference,
-		autoconvert_api_NFSVolumeSource_To_v1_NFSVolumeSource,
-		autoconvert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector,
-		autoconvert_api_ObjectMeta_To_v1_ObjectMeta,
-		autoconvert_api_PersistentVolumeClaimVolumeSource_To_v1_PersistentVolumeClaimVolumeSource,
-		autoconvert_api_PodSpec_To_v1_PodSpec,
-		autoconvert_api_PodTemplateSpec_To_v1_PodTemplateSpec,
-		autoconvert_api_Probe_To_v1_Probe,
-		autoconvert_api_RBDVolumeSource_To_v1_RBDVolumeSource,
-		autoconvert_api_ResourceRequirements_To_v1_ResourceRequirements,
-		autoconvert_api_SELinuxOptions_To_v1_SELinuxOptions,
-		autoconvert_api_SecretVolumeSource_To_v1_SecretVolumeSource,
-		autoconvert_api_SecurityContext_To_v1_SecurityContext,
-		autoconvert_api_TCPSocketAction_To_v1_TCPSocketAction,
-		autoconvert_api_VolumeMount_To_v1_VolumeMount,
-		autoconvert_api_VolumeSource_To_v1_VolumeSource,
-		autoconvert_api_Volume_To_v1_Volume,
-		autoconvert_extensions_APIVersion_To_v1beta1_APIVersion,
-		autoconvert_extensions_CPUTargetUtilization_To_v1beta1_CPUTargetUtilization,
-		autoconvert_extensions_ClusterAutoscalerList_To_v1beta1_ClusterAutoscalerList,
-		autoconvert_extensions_ClusterAutoscalerSpec_To_v1beta1_ClusterAutoscalerSpec,
-		autoconvert_extensions_ClusterAutoscaler_To_v1beta1_ClusterAutoscaler,
-		autoconvert_extensions_ConfigMapList_To_v1beta1_ConfigMapList,
-		autoconvert_extensions_ConfigMap_To_v1beta1_ConfigMap,
-		autoconvert_extensions_DaemonSetList_To_v1beta1_DaemonSetList,
-		autoconvert_extensions_DaemonSetSpec_To_v1beta1_DaemonSetSpec,
-		autoconvert_extensions_DaemonSetStatus_To_v1beta1_DaemonSetStatus,
-		autoconvert_extensions_DaemonSet_To_v1beta1_DaemonSet,
-		autoconvert_extensions_DeploymentList_To_v1beta1_DeploymentList,
-		autoconvert_extensions_DeploymentSpec_To_v1beta1_DeploymentSpec,
-		autoconvert_extensions_DeploymentStatus_To_v1beta1_DeploymentStatus,
-		autoconvert_extensions_DeploymentStrategy_To_v1beta1_DeploymentStrategy,
-		autoconvert_extensions_Deployment_To_v1beta1_Deployment,
-		autoconvert_extensions_HTTPIngressPath_To_v1beta1_HTTPIngressPath,
-		autoconvert_extensions_HTTPIngressRuleValue_To_v1beta1_HTTPIngressRuleValue,
-		autoconvert_extensions_HorizontalPodAutoscalerList_To_v1beta1_HorizontalPodAutoscalerList,
-		autoconvert_extensions_HorizontalPodAutoscalerSpec_To_v1beta1_HorizontalPodAutoscalerSpec,
-		autoconvert_extensions_HorizontalPodAutoscalerStatus_To_v1beta1_HorizontalPodAutoscalerStatus,
-		autoconvert_extensions_HorizontalPodAutoscaler_To_v1beta1_HorizontalPodAutoscaler,
-		autoconvert_extensions_IngressBackend_To_v1beta1_IngressBackend,
-		autoconvert_extensions_IngressList_To_v1beta1_IngressList,
-		autoconvert_extensions_IngressRuleValue_To_v1beta1_IngressRuleValue,
-		autoconvert_extensions_IngressRule_To_v1beta1_IngressRule,
-		autoconvert_extensions_IngressSpec_To_v1beta1_IngressSpec,
-		autoconvert_extensions_IngressStatus_To_v1beta1_IngressStatus,
-		autoconvert_extensions_Ingress_To_v1beta1_Ingress,
-		autoconvert_extensions_JobCondition_To_v1beta1_JobCondition,
-		autoconvert_extensions_JobList_To_v1beta1_JobList,
-		autoconvert_extensions_JobSpec_To_v1beta1_JobSpec,
-		autoconvert_extensions_JobStatus_To_v1beta1_JobStatus,
-		autoconvert_extensions_Job_To_v1beta1_Job,
-		autoconvert_extensions_LabelSelectorRequirement_To_v1beta1_LabelSelectorRequirement,
-		autoconvert_extensions_LabelSelector_To_v1beta1_LabelSelector,
-		autoconvert_extensions_NodeUtilization_To_v1beta1_NodeUtilization,
-		autoconvert_extensions_ReplicationControllerDummy_To_v1beta1_ReplicationControllerDummy,
-		autoconvert_extensions_RollingUpdateDeployment_To_v1beta1_RollingUpdateDeployment,
-		autoconvert_extensions_ScaleSpec_To_v1beta1_ScaleSpec,
-		autoconvert_extensions_ScaleStatus_To_v1beta1_ScaleStatus,
-		autoconvert_extensions_Scale_To_v1beta1_Scale,
-		autoconvert_extensions_SubresourceReference_To_v1beta1_SubresourceReference,
-		autoconvert_extensions_ThirdPartyResourceDataList_To_v1beta1_ThirdPartyResourceDataList,
-		autoconvert_extensions_ThirdPartyResourceData_To_v1beta1_ThirdPartyResourceData,
-		autoconvert_extensions_ThirdPartyResourceList_To_v1beta1_ThirdPartyResourceList,
-		autoconvert_extensions_ThirdPartyResource_To_v1beta1_ThirdPartyResource,
-		autoconvert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource,
-		autoconvert_v1_Capabilities_To_api_Capabilities,
-		autoconvert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource,
-		autoconvert_v1_CinderVolumeSource_To_api_CinderVolumeSource,
-		autoconvert_v1_ContainerPort_To_api_ContainerPort,
-		autoconvert_v1_Container_To_api_Container,
-		autoconvert_v1_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile,
-		autoconvert_v1_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource,
-		autoconvert_v1_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource,
-		autoconvert_v1_EnvVarSource_To_api_EnvVarSource,
-		autoconvert_v1_EnvVar_To_api_EnvVar,
-		autoconvert_v1_ExecAction_To_api_ExecAction,
-		autoconvert_v1_FCVolumeSource_To_api_FCVolumeSource,
-		autoconvert_v1_FlexVolumeSource_To_api_FlexVolumeSource,
-		autoconvert_v1_FlockerVolumeSource_To_api_FlockerVolumeSource,
-		autoconvert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource,
-		autoconvert_v1_GitRepoVolumeSource_To_api_GitRepoVolumeSource,
-		autoconvert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource,
-		autoconvert_v1_HTTPGetAction_To_api_HTTPGetAction,
-		autoconvert_v1_Handler_To_api_Handler,
-		autoconvert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource,
-		autoconvert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource,
-		autoconvert_v1_Lifecycle_To_api_Lifecycle,
-		autoconvert_v1_LoadBalancerIngress_To_api_LoadBalancerIngress,
-		autoconvert_v1_LoadBalancerStatus_To_api_LoadBalancerStatus,
-		autoconvert_v1_LocalObjectReference_To_api_LocalObjectReference,
-		autoconvert_v1_NFSVolumeSource_To_api_NFSVolumeSource,
-		autoconvert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector,
-		autoconvert_v1_ObjectMeta_To_api_ObjectMeta,
-		autoconvert_v1_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeClaimVolumeSource,
-		autoconvert_v1_PodSpec_To_api_PodSpec,
-		autoconvert_v1_PodTemplateSpec_To_api_PodTemplateSpec,
-		autoconvert_v1_Probe_To_api_Probe,
-		autoconvert_v1_RBDVolumeSource_To_api_RBDVolumeSource,
-		autoconvert_v1_ResourceRequirements_To_api_ResourceRequirements,
-		autoconvert_v1_SELinuxOptions_To_api_SELinuxOptions,
-		autoconvert_v1_SecretVolumeSource_To_api_SecretVolumeSource,
-		autoconvert_v1_SecurityContext_To_api_SecurityContext,
-		autoconvert_v1_TCPSocketAction_To_api_TCPSocketAction,
-		autoconvert_v1_VolumeMount_To_api_VolumeMount,
-		autoconvert_v1_VolumeSource_To_api_VolumeSource,
-		autoconvert_v1_Volume_To_api_Volume,
-		autoconvert_v1beta1_APIVersion_To_extensions_APIVersion,
-		autoconvert_v1beta1_CPUTargetUtilization_To_extensions_CPUTargetUtilization,
-		autoconvert_v1beta1_ClusterAutoscalerList_To_extensions_ClusterAutoscalerList,
-		autoconvert_v1beta1_ClusterAutoscalerSpec_To_extensions_ClusterAutoscalerSpec,
-		autoconvert_v1beta1_ClusterAutoscaler_To_extensions_ClusterAutoscaler,
-		autoconvert_v1beta1_ConfigMapList_To_extensions_ConfigMapList,
-		autoconvert_v1beta1_ConfigMap_To_extensions_ConfigMap,
-		autoconvert_v1beta1_DaemonSetList_To_extensions_DaemonSetList,
-		autoconvert_v1beta1_DaemonSetSpec_To_extensions_DaemonSetSpec,
-		autoconvert_v1beta1_DaemonSetStatus_To_extensions_DaemonSetStatus,
-		autoconvert_v1beta1_DaemonSet_To_extensions_DaemonSet,
-		autoconvert_v1beta1_DeploymentList_To_extensions_DeploymentList,
-		autoconvert_v1beta1_DeploymentSpec_To_extensions_DeploymentSpec,
-		autoconvert_v1beta1_DeploymentStatus_To_extensions_DeploymentStatus,
-		autoconvert_v1beta1_Deployment_To_extensions_Deployment,
-		autoconvert_v1beta1_HTTPIngressPath_To_extensions_HTTPIngressPath,
-		autoconvert_v1beta1_HTTPIngressRuleValue_To_extensions_HTTPIngressRuleValue,
-		autoconvert_v1beta1_HorizontalPodAutoscalerList_To_extensions_HorizontalPodAutoscalerList,
-		autoconvert_v1beta1_HorizontalPodAutoscalerSpec_To_extensions_HorizontalPodAutoscalerSpec,
-		autoconvert_v1beta1_HorizontalPodAutoscalerStatus_To_extensions_HorizontalPodAutoscalerStatus,
-		autoconvert_v1beta1_HorizontalPodAutoscaler_To_extensions_HorizontalPodAutoscaler,
-		autoconvert_v1beta1_IngressBackend_To_extensions_IngressBackend,
-		autoconvert_v1beta1_IngressList_To_extensions_IngressList,
-		autoconvert_v1beta1_IngressRuleValue_To_extensions_IngressRuleValue,
-		autoconvert_v1beta1_IngressRule_To_extensions_IngressRule,
-		autoconvert_v1beta1_IngressSpec_To_extensions_IngressSpec,
-		autoconvert_v1beta1_IngressStatus_To_extensions_IngressStatus,
-		autoconvert_v1beta1_Ingress_To_extensions_Ingress,
-		autoconvert_v1beta1_JobCondition_To_extensions_JobCondition,
-		autoconvert_v1beta1_JobList_To_extensions_JobList,
-		autoconvert_v1beta1_JobSpec_To_extensions_JobSpec,
-		autoconvert_v1beta1_JobStatus_To_extensions_JobStatus,
-		autoconvert_v1beta1_Job_To_extensions_Job,
-		autoconvert_v1beta1_LabelSelectorRequirement_To_extensions_LabelSelectorRequirement,
-		autoconvert_v1beta1_LabelSelector_To_extensions_LabelSelector,
-		autoconvert_v1beta1_ListOptions_To_api_ListOptions,
-		autoconvert_v1beta1_NodeUtilization_To_extensions_NodeUtilization,
-		autoconvert_v1beta1_ReplicationControllerDummy_To_extensions_ReplicationControllerDummy,
-		autoconvert_v1beta1_RollingUpdateDeployment_To_extensions_RollingUpdateDeployment,
-		autoconvert_v1beta1_ScaleSpec_To_extensions_ScaleSpec,
-		autoconvert_v1beta1_ScaleStatus_To_extensions_ScaleStatus,
-		autoconvert_v1beta1_Scale_To_extensions_Scale,
-		autoconvert_v1beta1_SubresourceReference_To_extensions_SubresourceReference,
-		autoconvert_v1beta1_ThirdPartyResourceDataList_To_extensions_ThirdPartyResourceDataList,
-		autoconvert_v1beta1_ThirdPartyResourceData_To_extensions_ThirdPartyResourceData,
-		autoconvert_v1beta1_ThirdPartyResourceList_To_extensions_ThirdPartyResourceList,
-		autoconvert_v1beta1_ThirdPartyResource_To_extensions_ThirdPartyResource,
+		autoConvert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVolumeSource,
+		autoConvert_api_Capabilities_To_v1_Capabilities,
+		autoConvert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource,
+		autoConvert_api_CinderVolumeSource_To_v1_CinderVolumeSource,
+		autoConvert_api_ContainerPort_To_v1_ContainerPort,
+		autoConvert_api_Container_To_v1_Container,
+		autoConvert_api_DownwardAPIVolumeFile_To_v1_DownwardAPIVolumeFile,
+		autoConvert_api_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource,
+		autoConvert_api_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource,
+		autoConvert_api_EnvVarSource_To_v1_EnvVarSource,
+		autoConvert_api_EnvVar_To_v1_EnvVar,
+		autoConvert_api_ExecAction_To_v1_ExecAction,
+		autoConvert_api_FCVolumeSource_To_v1_FCVolumeSource,
+		autoConvert_api_FlexVolumeSource_To_v1_FlexVolumeSource,
+		autoConvert_api_FlockerVolumeSource_To_v1_FlockerVolumeSource,
+		autoConvert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSource,
+		autoConvert_api_GitRepoVolumeSource_To_v1_GitRepoVolumeSource,
+		autoConvert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource,
+		autoConvert_api_HTTPGetAction_To_v1_HTTPGetAction,
+		autoConvert_api_Handler_To_v1_Handler,
+		autoConvert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource,
+		autoConvert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource,
+		autoConvert_api_Lifecycle_To_v1_Lifecycle,
+		autoConvert_api_ListOptions_To_v1beta1_ListOptions,
+		autoConvert_api_LoadBalancerIngress_To_v1_LoadBalancerIngress,
+		autoConvert_api_LoadBalancerStatus_To_v1_LoadBalancerStatus,
+		autoConvert_api_LocalObjectReference_To_v1_LocalObjectReference,
+		autoConvert_api_NFSVolumeSource_To_v1_NFSVolumeSource,
+		autoConvert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector,
+		autoConvert_api_ObjectMeta_To_v1_ObjectMeta,
+		autoConvert_api_PersistentVolumeClaimVolumeSource_To_v1_PersistentVolumeClaimVolumeSource,
+		autoConvert_api_PodSpec_To_v1_PodSpec,
+		autoConvert_api_PodTemplateSpec_To_v1_PodTemplateSpec,
+		autoConvert_api_Probe_To_v1_Probe,
+		autoConvert_api_RBDVolumeSource_To_v1_RBDVolumeSource,
+		autoConvert_api_ResourceRequirements_To_v1_ResourceRequirements,
+		autoConvert_api_SELinuxOptions_To_v1_SELinuxOptions,
+		autoConvert_api_SecretVolumeSource_To_v1_SecretVolumeSource,
+		autoConvert_api_SecurityContext_To_v1_SecurityContext,
+		autoConvert_api_TCPSocketAction_To_v1_TCPSocketAction,
+		autoConvert_api_VolumeMount_To_v1_VolumeMount,
+		autoConvert_api_VolumeSource_To_v1_VolumeSource,
+		autoConvert_api_Volume_To_v1_Volume,
+		autoConvert_extensions_APIVersion_To_v1beta1_APIVersion,
+		autoConvert_extensions_CPUTargetUtilization_To_v1beta1_CPUTargetUtilization,
+		autoConvert_extensions_ClusterAutoscalerList_To_v1beta1_ClusterAutoscalerList,
+		autoConvert_extensions_ClusterAutoscalerSpec_To_v1beta1_ClusterAutoscalerSpec,
+		autoConvert_extensions_ClusterAutoscaler_To_v1beta1_ClusterAutoscaler,
+		autoConvert_extensions_ConfigMapList_To_v1beta1_ConfigMapList,
+		autoConvert_extensions_ConfigMap_To_v1beta1_ConfigMap,
+		autoConvert_extensions_DaemonSetList_To_v1beta1_DaemonSetList,
+		autoConvert_extensions_DaemonSetSpec_To_v1beta1_DaemonSetSpec,
+		autoConvert_extensions_DaemonSetStatus_To_v1beta1_DaemonSetStatus,
+		autoConvert_extensions_DaemonSet_To_v1beta1_DaemonSet,
+		autoConvert_extensions_DeploymentList_To_v1beta1_DeploymentList,
+		autoConvert_extensions_DeploymentSpec_To_v1beta1_DeploymentSpec,
+		autoConvert_extensions_DeploymentStatus_To_v1beta1_DeploymentStatus,
+		autoConvert_extensions_DeploymentStrategy_To_v1beta1_DeploymentStrategy,
+		autoConvert_extensions_Deployment_To_v1beta1_Deployment,
+		autoConvert_extensions_HTTPIngressPath_To_v1beta1_HTTPIngressPath,
+		autoConvert_extensions_HTTPIngressRuleValue_To_v1beta1_HTTPIngressRuleValue,
+		autoConvert_extensions_HorizontalPodAutoscalerList_To_v1beta1_HorizontalPodAutoscalerList,
+		autoConvert_extensions_HorizontalPodAutoscalerSpec_To_v1beta1_HorizontalPodAutoscalerSpec,
+		autoConvert_extensions_HorizontalPodAutoscalerStatus_To_v1beta1_HorizontalPodAutoscalerStatus,
+		autoConvert_extensions_HorizontalPodAutoscaler_To_v1beta1_HorizontalPodAutoscaler,
+		autoConvert_extensions_IngressBackend_To_v1beta1_IngressBackend,
+		autoConvert_extensions_IngressList_To_v1beta1_IngressList,
+		autoConvert_extensions_IngressRuleValue_To_v1beta1_IngressRuleValue,
+		autoConvert_extensions_IngressRule_To_v1beta1_IngressRule,
+		autoConvert_extensions_IngressSpec_To_v1beta1_IngressSpec,
+		autoConvert_extensions_IngressStatus_To_v1beta1_IngressStatus,
+		autoConvert_extensions_Ingress_To_v1beta1_Ingress,
+		autoConvert_extensions_JobCondition_To_v1beta1_JobCondition,
+		autoConvert_extensions_JobList_To_v1beta1_JobList,
+		autoConvert_extensions_JobSpec_To_v1beta1_JobSpec,
+		autoConvert_extensions_JobStatus_To_v1beta1_JobStatus,
+		autoConvert_extensions_Job_To_v1beta1_Job,
+		autoConvert_extensions_LabelSelectorRequirement_To_v1beta1_LabelSelectorRequirement,
+		autoConvert_extensions_LabelSelector_To_v1beta1_LabelSelector,
+		autoConvert_extensions_NodeUtilization_To_v1beta1_NodeUtilization,
+		autoConvert_extensions_ReplicationControllerDummy_To_v1beta1_ReplicationControllerDummy,
+		autoConvert_extensions_RollingUpdateDeployment_To_v1beta1_RollingUpdateDeployment,
+		autoConvert_extensions_ScaleSpec_To_v1beta1_ScaleSpec,
+		autoConvert_extensions_ScaleStatus_To_v1beta1_ScaleStatus,
+		autoConvert_extensions_Scale_To_v1beta1_Scale,
+		autoConvert_extensions_SubresourceReference_To_v1beta1_SubresourceReference,
+		autoConvert_extensions_ThirdPartyResourceDataList_To_v1beta1_ThirdPartyResourceDataList,
+		autoConvert_extensions_ThirdPartyResourceData_To_v1beta1_ThirdPartyResourceData,
+		autoConvert_extensions_ThirdPartyResourceList_To_v1beta1_ThirdPartyResourceList,
+		autoConvert_extensions_ThirdPartyResource_To_v1beta1_ThirdPartyResource,
+		autoConvert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource,
+		autoConvert_v1_Capabilities_To_api_Capabilities,
+		autoConvert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource,
+		autoConvert_v1_CinderVolumeSource_To_api_CinderVolumeSource,
+		autoConvert_v1_ContainerPort_To_api_ContainerPort,
+		autoConvert_v1_Container_To_api_Container,
+		autoConvert_v1_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile,
+		autoConvert_v1_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource,
+		autoConvert_v1_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource,
+		autoConvert_v1_EnvVarSource_To_api_EnvVarSource,
+		autoConvert_v1_EnvVar_To_api_EnvVar,
+		autoConvert_v1_ExecAction_To_api_ExecAction,
+		autoConvert_v1_FCVolumeSource_To_api_FCVolumeSource,
+		autoConvert_v1_FlexVolumeSource_To_api_FlexVolumeSource,
+		autoConvert_v1_FlockerVolumeSource_To_api_FlockerVolumeSource,
+		autoConvert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource,
+		autoConvert_v1_GitRepoVolumeSource_To_api_GitRepoVolumeSource,
+		autoConvert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource,
+		autoConvert_v1_HTTPGetAction_To_api_HTTPGetAction,
+		autoConvert_v1_Handler_To_api_Handler,
+		autoConvert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource,
+		autoConvert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource,
+		autoConvert_v1_Lifecycle_To_api_Lifecycle,
+		autoConvert_v1_LoadBalancerIngress_To_api_LoadBalancerIngress,
+		autoConvert_v1_LoadBalancerStatus_To_api_LoadBalancerStatus,
+		autoConvert_v1_LocalObjectReference_To_api_LocalObjectReference,
+		autoConvert_v1_NFSVolumeSource_To_api_NFSVolumeSource,
+		autoConvert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector,
+		autoConvert_v1_ObjectMeta_To_api_ObjectMeta,
+		autoConvert_v1_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeClaimVolumeSource,
+		autoConvert_v1_PodSpec_To_api_PodSpec,
+		autoConvert_v1_PodTemplateSpec_To_api_PodTemplateSpec,
+		autoConvert_v1_Probe_To_api_Probe,
+		autoConvert_v1_RBDVolumeSource_To_api_RBDVolumeSource,
+		autoConvert_v1_ResourceRequirements_To_api_ResourceRequirements,
+		autoConvert_v1_SELinuxOptions_To_api_SELinuxOptions,
+		autoConvert_v1_SecretVolumeSource_To_api_SecretVolumeSource,
+		autoConvert_v1_SecurityContext_To_api_SecurityContext,
+		autoConvert_v1_TCPSocketAction_To_api_TCPSocketAction,
+		autoConvert_v1_VolumeMount_To_api_VolumeMount,
+		autoConvert_v1_VolumeSource_To_api_VolumeSource,
+		autoConvert_v1_Volume_To_api_Volume,
+		autoConvert_v1beta1_APIVersion_To_extensions_APIVersion,
+		autoConvert_v1beta1_CPUTargetUtilization_To_extensions_CPUTargetUtilization,
+		autoConvert_v1beta1_ClusterAutoscalerList_To_extensions_ClusterAutoscalerList,
+		autoConvert_v1beta1_ClusterAutoscalerSpec_To_extensions_ClusterAutoscalerSpec,
+		autoConvert_v1beta1_ClusterAutoscaler_To_extensions_ClusterAutoscaler,
+		autoConvert_v1beta1_ConfigMapList_To_extensions_ConfigMapList,
+		autoConvert_v1beta1_ConfigMap_To_extensions_ConfigMap,
+		autoConvert_v1beta1_DaemonSetList_To_extensions_DaemonSetList,
+		autoConvert_v1beta1_DaemonSetSpec_To_extensions_DaemonSetSpec,
+		autoConvert_v1beta1_DaemonSetStatus_To_extensions_DaemonSetStatus,
+		autoConvert_v1beta1_DaemonSet_To_extensions_DaemonSet,
+		autoConvert_v1beta1_DeploymentList_To_extensions_DeploymentList,
+		autoConvert_v1beta1_DeploymentSpec_To_extensions_DeploymentSpec,
+		autoConvert_v1beta1_DeploymentStatus_To_extensions_DeploymentStatus,
+		autoConvert_v1beta1_Deployment_To_extensions_Deployment,
+		autoConvert_v1beta1_HTTPIngressPath_To_extensions_HTTPIngressPath,
+		autoConvert_v1beta1_HTTPIngressRuleValue_To_extensions_HTTPIngressRuleValue,
+		autoConvert_v1beta1_HorizontalPodAutoscalerList_To_extensions_HorizontalPodAutoscalerList,
+		autoConvert_v1beta1_HorizontalPodAutoscalerSpec_To_extensions_HorizontalPodAutoscalerSpec,
+		autoConvert_v1beta1_HorizontalPodAutoscalerStatus_To_extensions_HorizontalPodAutoscalerStatus,
+		autoConvert_v1beta1_HorizontalPodAutoscaler_To_extensions_HorizontalPodAutoscaler,
+		autoConvert_v1beta1_IngressBackend_To_extensions_IngressBackend,
+		autoConvert_v1beta1_IngressList_To_extensions_IngressList,
+		autoConvert_v1beta1_IngressRuleValue_To_extensions_IngressRuleValue,
+		autoConvert_v1beta1_IngressRule_To_extensions_IngressRule,
+		autoConvert_v1beta1_IngressSpec_To_extensions_IngressSpec,
+		autoConvert_v1beta1_IngressStatus_To_extensions_IngressStatus,
+		autoConvert_v1beta1_Ingress_To_extensions_Ingress,
+		autoConvert_v1beta1_JobCondition_To_extensions_JobCondition,
+		autoConvert_v1beta1_JobList_To_extensions_JobList,
+		autoConvert_v1beta1_JobSpec_To_extensions_JobSpec,
+		autoConvert_v1beta1_JobStatus_To_extensions_JobStatus,
+		autoConvert_v1beta1_Job_To_extensions_Job,
+		autoConvert_v1beta1_LabelSelectorRequirement_To_extensions_LabelSelectorRequirement,
+		autoConvert_v1beta1_LabelSelector_To_extensions_LabelSelector,
+		autoConvert_v1beta1_ListOptions_To_api_ListOptions,
+		autoConvert_v1beta1_NodeUtilization_To_extensions_NodeUtilization,
+		autoConvert_v1beta1_ReplicationControllerDummy_To_extensions_ReplicationControllerDummy,
+		autoConvert_v1beta1_RollingUpdateDeployment_To_extensions_RollingUpdateDeployment,
+		autoConvert_v1beta1_ScaleSpec_To_extensions_ScaleSpec,
+		autoConvert_v1beta1_ScaleStatus_To_extensions_ScaleStatus,
+		autoConvert_v1beta1_Scale_To_extensions_Scale,
+		autoConvert_v1beta1_SubresourceReference_To_extensions_SubresourceReference,
+		autoConvert_v1beta1_ThirdPartyResourceDataList_To_extensions_ThirdPartyResourceDataList,
+		autoConvert_v1beta1_ThirdPartyResourceData_To_extensions_ThirdPartyResourceData,
+		autoConvert_v1beta1_ThirdPartyResourceList_To_extensions_ThirdPartyResourceList,
+		autoConvert_v1beta1_ThirdPartyResource_To_extensions_ThirdPartyResource,
 	)
 	if err != nil {
 		// If one of the conversion functions is malformed, detect it immediately.

--- a/pkg/apis/metrics/v1alpha1/conversion_generated.go
+++ b/pkg/apis/metrics/v1alpha1/conversion_generated.go
@@ -26,68 +26,68 @@ import (
 	conversion "k8s.io/kubernetes/pkg/conversion"
 )
 
-func autoconvert_metrics_RawNode_To_v1alpha1_RawNode(in *metrics.RawNode, out *RawNode, s conversion.Scope) error {
+func autoConvert_metrics_RawNode_To_v1alpha1_RawNode(in *metrics.RawNode, out *RawNode, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*metrics.RawNode))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_metrics_RawNode_To_v1alpha1_RawNode(in *metrics.RawNode, out *RawNode, s conversion.Scope) error {
-	return autoconvert_metrics_RawNode_To_v1alpha1_RawNode(in, out, s)
+func Convert_metrics_RawNode_To_v1alpha1_RawNode(in *metrics.RawNode, out *RawNode, s conversion.Scope) error {
+	return autoConvert_metrics_RawNode_To_v1alpha1_RawNode(in, out, s)
 }
 
-func autoconvert_metrics_RawPod_To_v1alpha1_RawPod(in *metrics.RawPod, out *RawPod, s conversion.Scope) error {
+func autoConvert_metrics_RawPod_To_v1alpha1_RawPod(in *metrics.RawPod, out *RawPod, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*metrics.RawPod))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_metrics_RawPod_To_v1alpha1_RawPod(in *metrics.RawPod, out *RawPod, s conversion.Scope) error {
-	return autoconvert_metrics_RawPod_To_v1alpha1_RawPod(in, out, s)
+func Convert_metrics_RawPod_To_v1alpha1_RawPod(in *metrics.RawPod, out *RawPod, s conversion.Scope) error {
+	return autoConvert_metrics_RawPod_To_v1alpha1_RawPod(in, out, s)
 }
 
-func autoconvert_v1alpha1_RawNode_To_metrics_RawNode(in *RawNode, out *metrics.RawNode, s conversion.Scope) error {
+func autoConvert_v1alpha1_RawNode_To_metrics_RawNode(in *RawNode, out *metrics.RawNode, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*RawNode))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1alpha1_RawNode_To_metrics_RawNode(in *RawNode, out *metrics.RawNode, s conversion.Scope) error {
-	return autoconvert_v1alpha1_RawNode_To_metrics_RawNode(in, out, s)
+func Convert_v1alpha1_RawNode_To_metrics_RawNode(in *RawNode, out *metrics.RawNode, s conversion.Scope) error {
+	return autoConvert_v1alpha1_RawNode_To_metrics_RawNode(in, out, s)
 }
 
-func autoconvert_v1alpha1_RawPod_To_metrics_RawPod(in *RawPod, out *metrics.RawPod, s conversion.Scope) error {
+func autoConvert_v1alpha1_RawPod_To_metrics_RawPod(in *RawPod, out *metrics.RawPod, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*RawPod))(in)
 	}
-	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1alpha1_RawPod_To_metrics_RawPod(in *RawPod, out *metrics.RawPod, s conversion.Scope) error {
-	return autoconvert_v1alpha1_RawPod_To_metrics_RawPod(in, out, s)
+func Convert_v1alpha1_RawPod_To_metrics_RawPod(in *RawPod, out *metrics.RawPod, s conversion.Scope) error {
+	return autoConvert_v1alpha1_RawPod_To_metrics_RawPod(in, out, s)
 }
 
 func init() {
 	err := api.Scheme.AddGeneratedConversionFuncs(
-		autoconvert_metrics_RawNode_To_v1alpha1_RawNode,
-		autoconvert_metrics_RawPod_To_v1alpha1_RawPod,
-		autoconvert_v1alpha1_RawNode_To_metrics_RawNode,
-		autoconvert_v1alpha1_RawPod_To_metrics_RawPod,
+		autoConvert_metrics_RawNode_To_v1alpha1_RawNode,
+		autoConvert_metrics_RawPod_To_v1alpha1_RawPod,
+		autoConvert_v1alpha1_RawNode_To_metrics_RawNode,
+		autoConvert_v1alpha1_RawPod_To_metrics_RawPod,
 	)
 	if err != nil {
 		// If one of the conversion functions is malformed, detect it immediately.

--- a/pkg/conversion/converter.go
+++ b/pkg/conversion/converter.go
@@ -87,12 +87,12 @@ func NewConverter() *Converter {
 		inputFieldMappingFuncs: map[reflect.Type]FieldMappingFunc{},
 		inputDefaultFlags:      map[reflect.Type]FieldMatchingFlags{},
 	}
-	c.RegisterConversionFunc(byteSliceCopy)
+	c.RegisterConversionFunc(ByteSliceCopy)
 	return c
 }
 
-// Prevent recursing into every byte...
-func byteSliceCopy(in *[]byte, out *[]byte, s Scope) error {
+// ByteSliceCopy prevents recursing into every byte
+func ByteSliceCopy(in *[]byte, out *[]byte, s Scope) error {
 	*out = make([]byte, len(*in))
 	copy(*out, *in)
 	return nil
@@ -320,6 +320,11 @@ func (c *Converter) RegisterGeneratedConversionFunc(conversionFunc interface{}) 
 func (c *Converter) HasConversionFunc(inType, outType reflect.Type) bool {
 	_, found := c.conversionFuncs[typePair{inType, outType}]
 	return found
+}
+
+func (c *Converter) ConversionFuncValue(inType, outType reflect.Type) (reflect.Value, bool) {
+	value, found := c.conversionFuncs[typePair{inType, outType}]
+	return value, found
 }
 
 // SetStructFieldCopy registers a correspondence. Whenever a struct field is encountered

--- a/pkg/runtime/conversion_generator.go
+++ b/pkg/runtime/conversion_generator.go
@@ -19,8 +19,10 @@ package runtime
 import (
 	"fmt"
 	"io"
+	"log"
 	"path"
 	"reflect"
+	goruntime "runtime"
 	"sort"
 	"strings"
 
@@ -42,8 +44,13 @@ type ConversionGenerator interface {
 
 func NewConversionGenerator(scheme *conversion.Scheme, targetPkg string) ConversionGenerator {
 	g := &conversionGenerator{
-		scheme:        scheme,
-		targetPkg:     targetPkg,
+		scheme: scheme,
+
+		nameFormat:          "Convert_%s_%s_To_%s_%s",
+		generatedNamePrefix: "auto",
+		targetPkg:           targetPkg,
+
+		publicFuncs:   make(map[typePair]string),
 		convertibles:  make(map[reflect.Type]reflect.Type),
 		overridden:    make(map[reflect.Type]bool),
 		pkgOverwrites: make(map[string]string),
@@ -59,8 +66,13 @@ func NewConversionGenerator(scheme *conversion.Scheme, targetPkg string) Convers
 var complexTypes []reflect.Kind = []reflect.Kind{reflect.Map, reflect.Ptr, reflect.Slice, reflect.Interface, reflect.Struct}
 
 type conversionGenerator struct {
-	scheme       *conversion.Scheme
-	targetPkg    string
+	scheme *conversion.Scheme
+
+	nameFormat          string
+	generatedNamePrefix string
+	targetPkg           string
+
+	publicFuncs  map[typePair]string
 	convertibles map[reflect.Type]reflect.Type
 	overridden   map[reflect.Type]bool
 	// If pkgOverwrites is set for a given package name, that package name
@@ -138,6 +150,14 @@ func (g *conversionGenerator) generateConversionsBetween(inType, outType reflect
 		return nil
 	}
 	if inType == outType {
+		switch inType.Kind() {
+		case reflect.Ptr:
+			return g.generateConversionsBetween(inType.Elem(), inType.Elem())
+		case reflect.Struct:
+			// pointers to structs invoke new(inType)
+			g.addImportByPath(inType.PkgPath())
+		}
+		g.rememberConversionFunction(inType, inType, false)
 		// Don't generate conversion methods for the same type.
 		return nil
 	}
@@ -148,6 +168,8 @@ func (g *conversionGenerator) generateConversionsBetween(inType, outType reflect
 
 	if inType.Kind() != outType.Kind() {
 		if existingConversion {
+			g.rememberConversionFunction(inType, outType, false)
+			g.rememberConversionFunction(outType, inType, false)
 			return nil
 		}
 		return fmt.Errorf("cannot convert types of different kinds: %v %v", inType, outType)
@@ -194,6 +216,7 @@ func (g *conversionGenerator) generateConversionsBetween(inType, outType reflect
 		if !existingConversion && (inErr != nil || outErr != nil) {
 			return inErr
 		}
+		g.rememberConversionFunction(inType, outType, true)
 		if existingConversion {
 			g.overridden[inType] = true
 		}
@@ -212,6 +235,42 @@ func isComplexType(reflection reflect.Type) bool {
 		}
 	}
 	return false
+}
+
+func (g *conversionGenerator) rememberConversionFunction(inType, outType reflect.Type, willGenerate bool) {
+	if _, ok := g.publicFuncs[typePair{inType, outType}]; ok {
+		return
+	}
+
+	if v, ok := g.scheme.Converter().ConversionFuncValue(inType, outType); ok {
+		if fn := goruntime.FuncForPC(v.Pointer()); fn != nil {
+			name := fn.Name()
+			var p, n string
+			if last := strings.LastIndex(name, "."); last != -1 {
+				p = name[:last]
+				n = name[last+1:]
+				p = g.imports[p]
+				if len(p) > 0 {
+					p = p + "."
+				}
+			} else {
+				n = name
+			}
+			if isPublic(n) {
+				g.publicFuncs[typePair{inType, outType}] = p + n
+			} else {
+				log.Printf("WARNING: Cannot generate conversion %v -> %v, method %q is private", inType, outType, fn.Name())
+			}
+		} else {
+			log.Printf("WARNING: Cannot generate conversion %v -> %v, method is not accessible", inType, outType)
+		}
+	} else if willGenerate {
+		g.publicFuncs[typePair{inType, outType}] = g.conversionFunctionName(inType, outType)
+	}
+}
+
+func isPublic(name string) bool {
+	return strings.ToUpper(name[:1]) == name[:1]
 }
 
 func (g *conversionGenerator) generateConversionsForMap(inType, outType reflect.Type) error {
@@ -507,15 +566,24 @@ func packageForName(inType reflect.Type) string {
 }
 
 func (g *conversionGenerator) conversionFunctionName(inType, outType reflect.Type) string {
-	funcNameFormat := "convert_%s_%s_To_%s_%s"
+	funcNameFormat := g.nameFormat
 	inPkg := packageForName(inType)
 	outPkg := packageForName(outType)
 	funcName := fmt.Sprintf(funcNameFormat, inPkg, inType.Name(), outPkg, outType.Name())
 	return funcName
 }
 
+func (g *conversionGenerator) conversionFunctionCall(inType, outType reflect.Type, scopeName string, args ...string) string {
+	if named, ok := g.publicFuncs[typePair{inType, outType}]; ok {
+		args[len(args)-1] = scopeName
+		return fmt.Sprintf("%s(%s)", named, strings.Join(args, ", "))
+	}
+	log.Printf("WARNING: Using reflection to convert %v -> %v (no public conversion)", inType, outType)
+	return fmt.Sprintf("%s.Convert(%s)", scopeName, strings.Join(args, ", "))
+}
+
 func (g *conversionGenerator) generatedFunctionName(inType, outType reflect.Type) string {
-	return "auto" + g.conversionFunctionName(inType, outType)
+	return g.generatedNamePrefix + g.conversionFunctionName(inType, outType)
 }
 
 func (g *conversionGenerator) writeHeader(b *buffer, name, inType, outType string, indent int) {
@@ -547,7 +615,8 @@ func (g *conversionGenerator) writeConversionForMap(b *buffer, inField, outField
 		newFormat := "newVal := %s{}\n"
 		newStmt := fmt.Sprintf(newFormat, g.typeName(outField.Type.Elem()))
 		b.addLine(newStmt, indent+2)
-		convertStmt := "if err := s.Convert(&val, &newVal, 0); err != nil {\n"
+		call := g.conversionFunctionCall(inField.Type.Elem(), outField.Type.Elem(), "s", "&val", "&newVal", "0")
+		convertStmt := fmt.Sprintf("if err := %s; err != nil {\n", call)
 		b.addLine(convertStmt, indent+2)
 		b.addLine("return err\n", indent+3)
 		b.addLine("}\n", indent+2)
@@ -607,15 +676,8 @@ func (g *conversionGenerator) writeConversionForSlice(b *buffer, inField, outFie
 		}
 	}
 	if !assigned {
-		assignStmt := ""
-		if g.existsDedicatedConversionFunction(inField.Type.Elem(), outField.Type.Elem()) {
-			assignFormat := "if err := %s(&in.%s[i], &out.%s[i], s); err != nil {\n"
-			funcName := g.conversionFunctionName(inField.Type.Elem(), outField.Type.Elem())
-			assignStmt = fmt.Sprintf(assignFormat, funcName, inField.Name, outField.Name)
-		} else {
-			assignFormat := "if err := s.Convert(&in.%s[i], &out.%s[i], 0); err != nil {\n"
-			assignStmt = fmt.Sprintf(assignFormat, inField.Name, outField.Name)
-		}
+		call := g.conversionFunctionCall(inField.Type.Elem(), outField.Type.Elem(), "s", "&in."+inField.Name+"[i]", "&out."+outField.Name+"[i]", "0")
+		assignStmt := fmt.Sprintf("if err := %s; err != nil {\n", call)
 		b.addLine(assignStmt, indent+2)
 		b.addLine("return err\n", indent+3)
 		b.addLine("}\n", indent+2)
@@ -664,20 +726,20 @@ func (g *conversionGenerator) writeConversionForPtr(b *buffer, inField, outField
 		}
 	}
 
+	b.addLine(fmt.Sprintf("// unable to generate simple pointer conversion for %v -> %v\n", inField.Type.Elem(), outField.Type.Elem()), indent)
 	ifFormat := "if in.%s != nil {\n"
 	ifStmt := fmt.Sprintf(ifFormat, inField.Name)
 	b.addLine(ifStmt, indent)
 	assignStmt := ""
-	if g.existsDedicatedConversionFunction(inField.Type.Elem(), outField.Type.Elem()) {
+	if _, ok := g.publicFuncs[typePair{inField.Type.Elem(), outField.Type.Elem()}]; ok {
 		newFormat := "out.%s = new(%s)\n"
 		newStmt := fmt.Sprintf(newFormat, outField.Name, g.typeName(outField.Type.Elem()))
 		b.addLine(newStmt, indent+1)
-		assignFormat := "if err := %s(in.%s, out.%s, s); err != nil {\n"
-		funcName := g.conversionFunctionName(inField.Type.Elem(), outField.Type.Elem())
-		assignStmt = fmt.Sprintf(assignFormat, funcName, inField.Name, outField.Name)
+		call := g.conversionFunctionCall(inField.Type.Elem(), outField.Type.Elem(), "s", "in."+inField.Name, "out."+outField.Name, "0")
+		assignStmt = fmt.Sprintf("if err := %s; err != nil {\n", call)
 	} else {
-		assignFormat := "if err := s.Convert(&in.%s, &out.%s, 0); err != nil {\n"
-		assignStmt = fmt.Sprintf(assignFormat, inField.Name, outField.Name)
+		call := g.conversionFunctionCall(inField.Type.Elem(), outField.Type.Elem(), "s", "&in."+inField.Name, "&out."+outField.Name, "0")
+		assignStmt = fmt.Sprintf("if err := %s; err != nil {\n", call)
 	}
 	b.addLine(assignStmt, indent+1)
 	b.addLine("return err\n", indent+2)
@@ -714,10 +776,14 @@ func (g *conversionGenerator) writeConversionForStruct(b *buffer, inType, outTyp
 		}
 
 		existsConversion := g.scheme.Converter().HasConversionFunc(inField.Type, outField.Type)
-		if existsConversion && !g.existsDedicatedConversionFunction(inField.Type, outField.Type) {
+		_, hasPublicConversion := g.publicFuncs[typePair{inField.Type, outField.Type}]
+		// TODO: This allows a private conversion for a slice to take precedence over a public
+		// conversion for the field, even though that is technically slower. We should report when
+		// we generate an inefficient conversion.
+		if existsConversion || hasPublicConversion {
 			// Use the conversion method that is already defined.
-			assignFormat := "if err := s.Convert(&in.%s, &out.%s, 0); err != nil {\n"
-			assignStmt := fmt.Sprintf(assignFormat, inField.Name, outField.Name)
+			call := g.conversionFunctionCall(inField.Type, outField.Type, "s", "&in."+inField.Name, "&out."+outField.Name, "0")
+			assignStmt := fmt.Sprintf("if err := %s; err != nil {\n", call)
 			b.addLine(assignStmt, indent)
 			b.addLine("return err\n", indent+1)
 			b.addLine("}\n", indent)
@@ -773,15 +839,8 @@ func (g *conversionGenerator) writeConversionForStruct(b *buffer, inType, outTyp
 			}
 		}
 
-		assignStmt := ""
-		if g.existsDedicatedConversionFunction(inField.Type, outField.Type) {
-			assignFormat := "if err := %s(&in.%s, &out.%s, s); err != nil {\n"
-			funcName := g.conversionFunctionName(inField.Type, outField.Type)
-			assignStmt = fmt.Sprintf(assignFormat, funcName, inField.Name, outField.Name)
-		} else {
-			assignFormat := "if err := s.Convert(&in.%s, &out.%s, 0); err != nil {\n"
-			assignStmt = fmt.Sprintf(assignFormat, inField.Name, outField.Name)
-		}
+		call := g.conversionFunctionCall(inField.Type, outField.Type, "s", "&in."+inField.Name, "&out."+outField.Name, "0")
+		assignStmt := fmt.Sprintf("if err := %s; err != nil {\n", call)
 		b.addLine(assignStmt, indent)
 		b.addLine("return err\n", indent+1)
 		b.addLine("}\n", indent)
@@ -841,33 +900,6 @@ var defaultConversions []typePair = []typePair{
 	{reflect.TypeOf([]Object{}), reflect.TypeOf([]RawExtension{})},
 	{reflect.TypeOf(RawExtension{}), reflect.TypeOf(EmbeddedObject{})},
 	{reflect.TypeOf(EmbeddedObject{}), reflect.TypeOf(RawExtension{})},
-}
-
-func (g *conversionGenerator) existsDedicatedConversionFunction(inType, outType reflect.Type) bool {
-	if inType == outType {
-		// Assume that conversion are not defined for "deep copies".
-		return false
-	}
-
-	if g.existsConversionFunction(inType, outType) {
-		return true
-	}
-
-	for _, conv := range defaultConversions {
-		if conv.inType == inType && conv.outType == outType {
-			return false
-		}
-	}
-	if inType.Kind() != outType.Kind() {
-		// TODO(wojtek-t): Currently all conversions between types of different kinds are
-		// unnamed. Thus we return false here.
-		return false
-	}
-	// TODO: no way to handle private conversions in different packages
-	if g.assumePrivateConversions {
-		return false
-	}
-	return g.scheme.Converter().HasConversionFunc(inType, outType)
 }
 
 func (g *conversionGenerator) OverwritePackage(pkg, overwrite string) {


### PR DESCRIPTION
Replace many of the remaining s.Convert() invocations with direct
execution, and make generated methods public. Removes 10% of the
allocations during decode of a pod and ~20-40% of the total CPU time.
