### PR TITLE
Push server docker images during the release (attempt 2)

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -703,6 +703,7 @@ function kube::release::package_server_tarballs() {
   local platform
   for platform in "${KUBE_SERVER_PLATFORMS[@]}" ; do
     local platform_tag=${platform/\//-} # Replace a "/" for a "-"
+    local arch=$(basename ${platform})
     kube::log::status "Building tarball: server $platform_tag"
 
     local release_stage="${RELEASE_STAGE}/server/${platform_tag}/kubernetes"
@@ -716,7 +717,7 @@ function kube::release::package_server_tarballs() {
     cp "${KUBE_SERVER_BINARIES[@]/#/${LOCAL_OUTPUT_BINPATH}/${platform}/}" \
       "${release_stage}/server/bin/"
 
-    kube::release::create_docker_images_for_server "${release_stage}/server/bin";
+    kube::release::create_docker_images_for_server "${release_stage}/server/bin" "${arch}"
     kube::release::write_addon_docker_images_for_server "${release_stage}/addons"
 
     # Include the client binaries here too as they are useful debugging tools.
@@ -754,12 +755,14 @@ function kube::release::sha1() {
 # that wrap the binary in them. (One docker image per binary)
 # Args:
 #  $1 - binary_dir, the directory to save the tared images to.
+#  $2 - arch, architecture for which we are building docker images.
 # Globals:
 #   KUBE_DOCKER_WRAPPED_BINARIES
 function kube::release::create_docker_images_for_server() {
   # Create a sub-shell so that we don't pollute the outer environment
   (
     local binary_dir="$1"
+    local arch="$2"
     local binary_name
     for wrappable in "${KUBE_DOCKER_WRAPPED_BINARIES[@]}"; do
 
@@ -787,11 +790,19 @@ function kube::release::create_docker_images_for_server() {
         printf " FROM ${base_image} \n ADD ${binary_name} /usr/local/bin/${binary_name}\n" > ${docker_file_path}
 
         local docker_image_tag=gcr.io/google_containers/$binary_name:$md5_sum
-        docker build -q -t "${docker_image_tag}" ${docker_build_path} >/dev/null
-        docker save ${docker_image_tag} > ${binary_dir}/${binary_name}.tar
+        "${DOCKER[@]}" build -q -t "${docker_image_tag}" ${docker_build_path} >/dev/null
+        "${DOCKER[@]}" save ${docker_image_tag} > ${binary_dir}/${binary_name}.tar
         echo $md5_sum > ${binary_dir}/${binary_name}.docker_tag
 
         rm -rf ${docker_build_path}
+
+        # If we are building an official/alpha/beta release we want to keep docker images
+        # and tag them appropriately.
+        if [[ -n "${KUBE_DOCKER_IMAGE_TAG-}" && -n "${KUBE_DOCKER_REGISTRY-}" ]]; then
+          local release_docker_image_tag="${KUBE_DOCKER_REGISTRY}/${binary_name}-${arch}:${KUBE_DOCKER_IMAGE_TAG}"
+          kube::log::status "Tagging docker image ${docker_image_tag} as ${release_docker_image_tag}"
+          "${DOCKER[@]}" tag -f "${docker_image_tag}" "${release_docker_image_tag}" 2>/dev/null
+        fi
 
         kube::log::status "Deleting docker image ${docker_image_tag}"
         "${DOCKER[@]}" rmi ${docker_image_tag} 2>/dev/null || true
@@ -1426,4 +1437,42 @@ function kube::release::gcs::publish() {
     kube::log::error "Expected contents of file to be ${KUBE_GCS_PUBLISH_VERSION}, but got ${contents}"
     return 1
   fi
+}
+
+# ---------------------------------------------------------------------------
+# Docker Release
+
+# Releases all docker images to a docker registry specified by KUBE_DOCKER_REGISTRY
+# using tag KUBE_DOCKER_IMAGE_TAG.
+#
+# Globals:
+#   KUBE_DOCKER_REGISTRY
+#   KUBE_DOCKER_IMAGE_TAG
+# Returns:
+#   If new pushing docker images was successful.
+function kube::release::docker::release() {
+  local binaries=(
+    "kube-apiserver"
+    "kube-controller-manager"
+    "kube-scheduler"
+    "kube-proxy"
+    "hyperkube"
+  )
+
+  local archs=(
+    "amd64"
+  )
+
+  local docker_push_cmd=("docker")
+  if [[ "${KUBE_DOCKER_REGISTRY}" == "gcr.io/"* ]]; then
+    docker_push_cmd=("gcloud" "docker")
+  fi
+
+  for arch in "${archs[@]}"; do
+    for binary in "${binaries[@]}"; do
+      local docker_target="${KUBE_DOCKER_REGISTRY}/${binary}-${arch}:${KUBE_DOCKER_IMAGE_TAG}"
+      kube::log::status "Pushing ${binary} to ${docker_target}"
+      "${docker_push_cmd[@]}" push "${docker_target}"
+    done
+  done
 }

--- a/build/push-official-release.sh
+++ b/build/push-official-release.sh
@@ -34,6 +34,9 @@ KUBE_GCS_RELEASE_BUCKET='kubernetes-release'
 KUBE_GCS_RELEASE_PREFIX="release/${KUBE_RELEASE_VERSION}"
 KUBE_GCS_PUBLISH_VERSION="${KUBE_RELEASE_VERSION}"
 
+KUBE_DOCKER_REGISTRY="gcr.io/google_containers"
+KUBE_DOCKER_IMAGE_TAG="${KUBE_RELEASE_VERSION}"
+
 KUBE_ROOT="$(dirname "${BASH_SOURCE}")/.."
 source "${KUBE_ROOT}/build/common.sh"
 
@@ -44,4 +47,5 @@ fi
 
 kube::release::parse_and_validate_release_version "${KUBE_RELEASE_VERSION}"
 kube::release::gcs::release
+kube::release::docker::release
 kube::release::gcs::publish_official 'latest'

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -1,6 +1,9 @@
-# build the hyperkube image.
+# Build the hyperkube image.
+#
+# Usage:
+#   VERSION=v1.1.2 [REGISTRY="gcr.io/google_containers"] make build
 
-VERSION=v1.1.2
+REGISTRY?="gcr.io/google_containers"
 ARCH=amd64
 BASEIMAGE=debian:jessie
 TEMP_DIR:=$(shell mktemp -d)
@@ -13,6 +16,9 @@ TEMP_DIR:=$(shell mktemp -d)
 all: build
 
 build:
+ifndef VERSION
+    $(error VERSION is undefined)
+endif
 	cp ./* ${TEMP_DIR}
 	cp ../../saltbase/salt/helpers/safe_format_and_mount ${TEMP_DIR}
 	cp ../../saltbase/salt/generate-cert/make-ca-cert.sh ${TEMP_DIR}
@@ -20,19 +26,16 @@ build:
 	cd ${TEMP_DIR} && sed -i "s/VERSION/${VERSION}/g" master-multi.json master.json kube-proxy.json
 	cd ${TEMP_DIR} && sed -i "s/ARCH/${ARCH}/g" master-multi.json master.json kube-proxy.json
 	cd ${TEMP_DIR} && sed -i "s/BASEIMAGE/${BASEIMAGE}/g" Dockerfile
-	docker build -t gcr.io/google_containers/hyperkube-${ARCH}:${VERSION} ${TEMP_DIR}
+	docker build -t ${REGISTRY}/hyperkube-${ARCH}:${VERSION} ${TEMP_DIR}
 	# Backward compatability.  TODO: deprecate this image tag
 ifeq ($(ARCH),amd64)
-	docker tag -f gcr.io/google_containers/hyperkube-${ARCH}:${VERSION} gcr.io/google_containers/hyperkube:${VERSION}
+	docker tag -f ${REGISTRY}/hyperkube-${ARCH}:${VERSION} ${REGISTRY}/hyperkube:${VERSION}
 endif
 
 push: build
-	gcloud docker push gcr.io/google_containers/hyperkube-${ARCH}:${VERSION}
+	gcloud docker push ${REGISTRY}/hyperkube-${ARCH}:${VERSION}
 ifeq ($(ARCH),amd64)
-	gcloud docker push gcr.io/google_containers/hyperkube:${VERSION}
+	gcloud docker push ${REGISTRY}/hyperkube:${VERSION}
 endif
-
-clean:
-	rm -f safe_format_and_mount make-ca-cert.sh hyperkube
 
 .PHONY: all

--- a/release/build-official-release.sh
+++ b/release/build-official-release.sh
@@ -82,9 +82,17 @@ echo "Cloned, building release."
 echo
 
 cd "${KUBE_BUILD_DIR}"
+
 export KUBE_RELEASE_RUN_TESTS=n
 export KUBE_SKIP_CONFIRMATIONS=y
+# In order to build docker images for a release and tag them appropriately we need
+# to set these two variables.
+export KUBE_DOCKER_REGISTRY="gcr.io/google_containers"
+export KUBE_DOCKER_IMAGE_TAG="${KUBE_RELEASE_VERSION}"
+
 make release
+# We don't want to include this in 'make release' as it'd slow down every day development cycle.
+REGISTRY="${KUBE_DOCKER_REGISTRY}" VERSION="${KUBE_DOCKER_IMAGE_TAG}" make -C cluster/images/hyperkube/ build
 
 if ${KUBE_BUILD_DIR}/cluster/kubectl.sh version | grep Client | grep dirty; then
   echo "!!! Tag at invalid point, or something else is bad. Build is dirty. Don't push this build." >&2


### PR DESCRIPTION
This will release the following images:

```
gcr.io/google_containers/kube-apiserver-amd64            v1.2                581627bd855f        2 minutes ago        54.09 MB
gcr.io/google_containers/kube-controller-manager-amd64   v1.2                90ea7e237fd8        2 minutes ago        48.17 MB
gcr.io/google_containers/kube-proxy-amd64                v1.2                028858138a94        2 minutes ago        162.4 MB
gcr.io/google_containers/kube-scheduler-amd64            v1.2                75aae7f75086        2 minutes ago        33.5 MB
gcr.io/google_containers/hyperkube-amd64                 v1.2                b962b62aa778        3 minutes ago        297.1 MB
```

Fixes #11751

@ihmccreery @mikedanese @quinton-hoole 
