### PR TITLE
Run kubelet in dockerized clusters via nsenter.

### DIFF
--- a/cluster/get-kube-local.sh
+++ b/cluster/get-kube-local.sh
@@ -57,7 +57,6 @@ function create_cluster {
   echo "Creating a local cluster:"
   echo -e -n "\tStarting kubelet..."
   run "docker run \
-  --volume=/:/rootfs:ro \
   --volume=/sys:/sys:ro \
   --volume=/dev:/dev \
   --volume=/var/lib/docker/:/var/lib/docker:rw \
@@ -68,12 +67,11 @@ function create_cluster {
   --privileged=true \
   -d \
   gcr.io/google_containers/hyperkube-${arch}:${release} \
-    /hyperkube kubelet \
-      --containerized \
+    /kubelet-runner.sh \
       --hostname-override="127.0.0.1" \
       --address="0.0.0.0" \
       --api-servers=http://localhost:8080 \
-      --config=/etc/kubernetes/manifests \
+      --config=etc/kubernetes/manifests \
       --allow-privileged=true \
       --cluster-dns=10.0.0.10 \
       --cluster-domain=cluster.local \

--- a/cluster/images/hyperkube/Dockerfile
+++ b/cluster/images/hyperkube/Dockerfile
@@ -32,6 +32,9 @@ RUN cp /usr/bin/nsenter /nsenter
 COPY hyperkube /hyperkube
 RUN chmod a+rx /hyperkube
 
+COPY kubelet-runner.sh /kubelet-runner.sh
+RUN chmod a+rx /kubelet-runner.sh
+
 COPY master-multi.json /etc/kubernetes/manifests-multi/master.json
 COPY kube-proxy.json /etc/kubernetes/manifests-multi/kube-proxy.json
 

--- a/cluster/images/hyperkube/kubelet-runner.sh
+++ b/cluster/images/hyperkube/kubelet-runner.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This will run kubelet outside of the container (in host namespaces) and will
+# exit when kubelet exits with the same error code.
+# TODO: This script is used to workaround lack of namespace propagation flag in docker
+#       (see https://github.com/docker/docker/issues/14630). This got fixed in PR
+#       https://github.com/docker/docker/pull/17034 and will be released in docker 1.10.
+#       As long as we support docker versions older than 1.10 we should run kubelet
+#       via nsenter.
+nsenter --target=1 --mount --wd=. -- ./hyperkube kubelet $@

--- a/cluster/images/hyperkube/turnup.sh
+++ b/cluster/images/hyperkube/turnup.sh
@@ -33,12 +33,11 @@ docker run \
   --pid=host \
   --privileged=true \
   -d gcr.io/google_containers/hyperkube:v${K8S_VERSION} \
-  /hyperkube kubelet \
-    --containerized \
+  /kubelet-runner.sh \
     --hostname-override="127.0.0.1" \
     --address="0.0.0.0" \
     --api-servers=http://localhost:8080 \
-    --config=/etc/kubernetes/manifests \
+    --config=etc/kubernetes/manifests \
     --cluster-dns=10.0.0.10 \
     --cluster-domain=cluster.local \
-    --allow-privileged=true --v=10
+    --allow-privileged=true --v=2

--- a/docs/getting-started-guides/docker-multinode/master.sh
+++ b/docs/getting-started-guides/docker-multinode/master.sh
@@ -204,20 +204,18 @@ start_k8s(){
         -d \
         -v /sys:/sys:ro \
         -v /var/run:/var/run:rw \
-        -v /:/rootfs:ro \
         -v /dev:/dev \
         -v /var/lib/docker/:/var/lib/docker:rw \
         -v /var/lib/kubelet/:/var/lib/kubelet:rw \
         gcr.io/google_containers/hyperkube-${ARCH}:v${K8S_VERSION} \
-        /hyperkube kubelet \
+        /kubelet-runner.sh \
             --address=0.0.0.0 \
             --allow-privileged=true \
             --enable-server \
             --api-servers=http://localhost:8080 \
-            --config=/etc/kubernetes/manifests-multi \
+            --config=etc/kubernetes/manifests-multi \
             --cluster-dns=10.0.0.10 \
             --cluster-domain=cluster.local \
-            --containerized \
             --v=2
 
 }

--- a/docs/getting-started-guides/docker-multinode/worker.sh
+++ b/docs/getting-started-guides/docker-multinode/worker.sh
@@ -184,19 +184,17 @@ start_k8s() {
         -d \
         -v /sys:/sys:ro \
         -v /var/run:/var/run:rw  \
-        -v /:/rootfs:ro \
         -v /dev:/dev \
         -v /var/lib/docker/:/var/lib/docker:rw \
         -v /var/lib/kubelet/:/var/lib/kubelet:rw \
         gcr.io/google_containers/hyperkube-${ARCH}:v${K8S_VERSION} \
-        /hyperkube kubelet \
+        /kubelet-runner.sh \
             --allow-privileged=true \
             --api-servers=http://${MASTER_IP}:8080 \
-            --address=0.0.0.0 \
+            --address=0.0.0.0
             --enable-server \
             --cluster-dns=10.0.0.10 \
             --cluster-domain=cluster.local \
-            --containerized \
             --v=2
     
     docker run \

--- a/docs/getting-started-guides/docker.md
+++ b/docs/getting-started-guides/docker.md
@@ -64,7 +64,6 @@ Here's a diagram of what the final result will look like:
 
 ```sh
 docker run \
-    --volume=/:/rootfs:ro \
     --volume=/sys:/sys:ro \
     --volume=/dev:/dev \
     --volume=/var/lib/docker/:/var/lib/docker:rw \
@@ -75,15 +74,14 @@ docker run \
     --privileged=true \
     -d \
     gcr.io/google_containers/hyperkube-amd64:v${K8S_VERSION} \
-    /hyperkube kubelet \
-        --containerized \
+    /kubelet-runner.sh \
         --hostname-override="127.0.0.1" \
         --address="0.0.0.0" \
         --api-servers=http://localhost:8080 \
-        --config=/etc/kubernetes/manifests \
+        --config=etc/kubernetes/manifests \
         --cluster-dns=10.0.0.10 \
         --cluster-domain=cluster.local \
-        --allow-privileged=true --v=10
+        --allow-privileged=true --v=2
 ```
 
 > Note that `--cluster-dns` and `--cluster-domain` is used to deploy dns, feel free to discard them if dns is not needed.


### PR DESCRIPTION
Run `kubelet` in `hyperkube` via `nsenter` to workaround problems with namespace propagation.

Fixes #18239 #16055 #14403 #13987 #13627 #11984
Ref #4869

@resouer @dalanlan @luxas @brendandburns (as this changes dockerized setups)
@vishh @dchen1107 (as this changes how we run kubelet)
