### PR TITLE
Use Allocatable to replace Capacity

### DIFF
--- a/plugin/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/predicates.go
@@ -305,7 +305,6 @@ func (r *ResourceFit) PodFitsResources(pod *api.Pod, existingPods []*api.Pod, no
 	}
 
 	allocatable := info.Status.Allocatable
-
 	if int64(len(existingPods))+1 > allocatable.Pods().Value() {
 		glog.V(10).Infof("Cannot schedule Pod %+v, because Node %+v is full, running %v out of %v Pods.", podName(pod), node, len(existingPods), allocatable.Pods().Value())
 		return false, ErrExceededMaxPodNumber

--- a/plugin/pkg/scheduler/algorithm/priorities/priorities.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/priorities.go
@@ -76,8 +76,8 @@ func getNonzeroRequests(requests *api.ResourceList) (int64, int64) {
 func calculateResourceOccupancy(pod *api.Pod, node api.Node, pods []*api.Pod) schedulerapi.HostPriority {
 	totalMilliCPU := int64(0)
 	totalMemory := int64(0)
-	capacityMilliCPU := node.Status.Capacity.Cpu().MilliValue()
-	capacityMemory := node.Status.Capacity.Memory().Value()
+	capacityMilliCPU := node.Status.Allocatable.Cpu().MilliValue()
+	capacityMemory := node.Status.Allocatable.Memory().Value()
 
 	for _, existingPod := range pods {
 		for _, container := range existingPod.Spec.Containers {
@@ -208,8 +208,8 @@ func calculateBalancedResourceAllocation(pod *api.Pod, node api.Node, pods []*ap
 		totalMemory += memory
 	}
 
-	capacityMilliCPU := node.Status.Capacity.Cpu().MilliValue()
-	capacityMemory := node.Status.Capacity.Memory().Value()
+	capacityMilliCPU := node.Status.Allocatable.Cpu().MilliValue()
+	capacityMemory := node.Status.Allocatable.Memory().Value()
 
 	cpuFraction := fractionOfCapacity(totalMilliCPU, capacityMilliCPU)
 	memoryFraction := fractionOfCapacity(totalMemory, capacityMemory)

--- a/plugin/pkg/scheduler/algorithm/priorities/priorities_test.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/priorities_test.go
@@ -38,6 +38,10 @@ func makeNode(node string, milliCPU, memory int64) api.Node {
 				"cpu":    *resource.NewMilliQuantity(milliCPU, resource.DecimalSI),
 				"memory": *resource.NewQuantity(memory, resource.BinarySI),
 			},
+			Allocatable: api.ResourceList{
+				"cpu":    *resource.NewMilliQuantity(milliCPU, resource.DecimalSI),
+				"memory": *resource.NewQuantity(memory, resource.BinarySI),
+			},
 		},
 	}
 }


### PR DESCRIPTION
Fixes: #18848

Scheduler should use Allocatable instead of Capacity to make decision. But the general behavior does not need to change.

We should also make sure older kubelet can also work well with this code (use Capacity instead in this case).
