### PR TITLE
authn.go doesn't belong in pkg/apiserver

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/validation"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/apiserver"
+	"k8s.io/kubernetes/pkg/apiserver/authenticator"
 	"k8s.io/kubernetes/pkg/capabilities"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/cloudprovider"
@@ -485,13 +486,13 @@ func (s *APIServer) Run(_ []string) error {
 
 	// Default to the private server key for service account token signing
 	if s.ServiceAccountKeyFile == "" && s.TLSPrivateKeyFile != "" {
-		if apiserver.IsValidServiceAccountKeyFile(s.TLSPrivateKeyFile) {
+		if authenticator.IsValidServiceAccountKeyFile(s.TLSPrivateKeyFile) {
 			s.ServiceAccountKeyFile = s.TLSPrivateKeyFile
 		} else {
 			glog.Warning("No RSA key provided, service account token authentication disabled")
 		}
 	}
-	authenticator, err := apiserver.NewAuthenticator(apiserver.AuthenticatorConfig{
+	authenticator, err := authenticator.New(authenticator.AuthenticatorConfig{
 		BasicAuthFile:         s.BasicAuthFile,
 		ClientCAFile:          s.ClientCAFile,
 		TokenAuthFile:         s.TokenAuthFile,

--- a/pkg/apiserver/authenticator/authn.go
+++ b/pkg/apiserver/authenticator/authn.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package apiserver
+package authenticator
 
 import (
 	"crypto/rsa"
@@ -47,8 +47,9 @@ type AuthenticatorConfig struct {
 	KeystoneURL           string
 }
 
-// NewAuthenticator returns an authenticator.Request or an error
-func NewAuthenticator(config AuthenticatorConfig) (authenticator.Request, error) {
+// New returns an authenticator.Request or an error that supports the standard
+// Kubernetes authentication mechanisms.
+func New(config AuthenticatorConfig) (authenticator.Request, error) {
 	var authenticators []authenticator.Request
 
 	if len(config.BasicAuthFile) > 0 {


### PR DESCRIPTION
apiserver does not need to know about specific authentication
mechanisms, and does not need to take dependencies on all the
authentication packages.
