### PR TITLE
scheduler cache: Node level aggregated pods' resource summary

### DIFF
--- a/plugin/pkg/scheduler/schedulercache/interface.go
+++ b/plugin/pkg/scheduler/schedulercache/interface.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schedulercache
+
+import "k8s.io/kubernetes/pkg/api"
+
+// NodeInfoCache collects pods' information and provides node-level aggregated information.
+// It's intended to supplant system modeler in some cases for efficient lookup.
+// NodeInfoCache's operations are pod centric. It incrementally updates itself based on pod event.
+// Pod events are sent via network. We don't have guaranteed delivery of all events except last seen.
+// Thus, we organized the state machine flow of a pod's events and handle it clearly.
+//
+// State Machine (life cycle) of a pod in scheduler's cache:
+//
+//                                                +-------+
+//                                                |       |
+//                                                |       | Update
+//           Assume                Add            +       |
+// Initial +--------> Assumed +----------------> Added <--+
+//                      +                         +
+//                      |                         |
+//                      |                         |
+//                      | Remove                  | Remove
+//                      |                         v
+//                      +------------------->  Deleted
+//
+// Depending on the implementation, it might choose to manage the expiration of assumed pod.
+// Thus, a new state "Expired" could be added to the diagram:
+//
+//                                                     +--------+
+//                                                     |        |
+//                                                     |        | Update
+//                                       Add           +        |
+//                        +---------------+------->  Added <----+
+//                        |               |            +
+//                        |               |            |
+//                        |               |            |
+//           Assume       +    expire     +            |
+// Initial +-------> Assumed +--------> Expired        |
+//                        +               +            |Remove
+//                        |               |            |
+//                        |               |            v
+//                        +---------------+------> Deleted
+//                                      Remove
+//
+// Note:
+// - Both "Initial" and "Deleted" pods do not actually exist in cache.
+//   In order to differentiate them, we need external request to guarantee
+//   no same pod will be created twice.
+type NodeInfoCache interface {
+	// GetNodeInfo returns aggregated node information for given node name.
+	// If no pod has been added on the node, it returns nil.
+	// For better concurrency control, we use a callback to serve the result.
+	// Depending on the implementation, it might acquire a lock. So don't do anything time consuming inside.
+	GetNodeInfo(nodeName string, callback func(*NodeInfo))
+	// AssumePod assumes a pod to be scheduled. The pod's information is aggregated into assigned node.
+	// The implementation might decide the policy to expire/remove the assumed pod before it is confirmed to be scheduled.
+	// After expiration, its information would be subtracted.
+	AssumePod(pod *api.Pod) error
+	// AddPod will confirms a pod if it's assumed, or adds back if it's expired.
+	// If added back, the pod's information would be added again.
+	AddPod(pod *api.Pod) error
+	// UpdatePod removes oldPod's information and adds newPod's information.
+	UpdatePod(oldPod, newPod *api.Pod) error
+	// RemovePod removes a pod. The pod's information would be subtracted from assigned node.
+	RemovePod(pod *api.Pod) error
+}

--- a/plugin/pkg/scheduler/schedulercache/interface.go
+++ b/plugin/pkg/scheduler/schedulercache/interface.go
@@ -67,10 +67,10 @@ type NodeInfoCache interface {
 	// For better concurrency control, we use a callback to serve the result.
 	// Depending on the implementation, it might acquire a lock. So don't do anything time consuming inside.
 	GetNodeInfo(nodeName string, callback func(*NodeInfo))
-	// AssumePod assumes a pod to be scheduled. The pod's information is aggregated into assigned node.
+	// AssumePodScheduled assumes a pod to be scheduled. The pod's information is aggregated into assigned node.
 	// The implementation might decide the policy to expire/remove the assumed pod before it is confirmed to be scheduled.
 	// After expiration, its information would be subtracted.
-	AssumePod(pod *api.Pod) error
+	AssumePodScheduled(pod *api.Pod) error
 	// AddPod will confirms a pod if it's assumed, or adds back if it's expired.
 	// If added back, the pod's information would be added again.
 	AddPod(pod *api.Pod) error

--- a/plugin/pkg/scheduler/schedulercache/node_info.go
+++ b/plugin/pkg/scheduler/schedulercache/node_info.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schedulercache
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/api"
+)
+
+// NodeInfo is node level aggregated information.
+// Note: if change fields, also change String() method
+type NodeInfo struct {
+	PodNum int
+	// Total requested resource of all pods (including assumed ones) on this node
+	RequestedResource *Resource
+}
+
+// Resource is a collection of compute resource .
+type Resource struct {
+	MilliCPU int64
+	Memory   int64
+}
+
+// PodInfo is *internal* struct used to collect and transfer pod's information to NodeInfo.
+// It's also used by assumedPod struct to keep local copy of information.
+type PodInfo struct {
+	RequestedResource Resource
+}
+
+// ParsePodInfo will parse an api.Pod struct to PodInfo.
+func ParsePodInfo(pod *api.Pod) PodInfo {
+	var cpu, mem int64
+	for _, c := range pod.Spec.Containers {
+		req := c.Resources.Requests
+		cpu += req.Cpu().MilliValue()
+		mem += req.Memory().Value()
+	}
+	return PodInfo{
+		RequestedResource: Resource{
+			MilliCPU: cpu,
+			Memory:   mem,
+		},
+	}
+}
+
+// NewNodeInfo returns a ready to use NodeInfo object.
+func NewNodeInfo() *NodeInfo {
+	return &NodeInfo{
+		RequestedResource: &Resource{},
+		PodNum:            0,
+	}
+}
+
+// AddPodInfo adds pod information to this NodeInfo.
+func (n *NodeInfo) AddPodInfo(pi PodInfo) {
+	n.RequestedResource.MilliCPU += pi.RequestedResource.MilliCPU
+	n.RequestedResource.Memory += pi.RequestedResource.Memory
+	n.PodNum++
+}
+
+// RemovePodInfo subtracts pod information to this NodeInfo.
+func (n *NodeInfo) RemovePodInfo(pi PodInfo) {
+	n.RequestedResource.MilliCPU -= pi.RequestedResource.MilliCPU
+	n.RequestedResource.Memory -= pi.RequestedResource.Memory
+	n.PodNum--
+}
+
+// String returns representation of human readable format of this NodeInfo.
+func (n *NodeInfo) String() string {
+	return fmt.Sprintf("&NodeInfo{PodNum:%v, RequestedResource:%#v}", n.PodNum, n.RequestedResource)
+}

--- a/plugin/pkg/scheduler/schedulercache/nodeinfocache/node_info_cache.go
+++ b/plugin/pkg/scheduler/schedulercache/nodeinfocache/node_info_cache.go
@@ -110,12 +110,12 @@ func (cache *nodeInfoCache) getNodeInfo(nodeName string) *schedulercache.NodeInf
 	return n
 }
 
-func (cache *nodeInfoCache) AssumePod(pod *api.Pod) error {
-	return cache.assumePod(pod, time.Now())
+func (cache *nodeInfoCache) AssumePodScheduled(pod *api.Pod) error {
+	return cache.assumePodScheduled(pod, time.Now())
 }
 
-// assumePod exists for making test deterministic by taking time as input argument.
-func (cache *nodeInfoCache) assumePod(pod *api.Pod, now time.Time) error {
+// assumePodScheduled exists for making test deterministic by taking time as input argument.
+func (cache *nodeInfoCache) assumePodScheduled(pod *api.Pod, now time.Time) error {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 

--- a/plugin/pkg/scheduler/schedulercache/nodeinfocache/node_info_cache.go
+++ b/plugin/pkg/scheduler/schedulercache/nodeinfocache/node_info_cache.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeinfocache
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/api"
+	clientcache "k8s.io/kubernetes/pkg/client/cache"
+	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
+)
+
+// New returns a NodeInfoCache implementation.
+// It automatically starts a go routine that manages expiration of assumed pods.
+// "ttl" is how long the assumed pod will get expired.
+// "period" is how long the background goroutine should wait before cleaning up expired pods periodically.
+// "stop" is the channel that signals stopping and we would close background goroutines.
+func New(ttl, period time.Duration, stop chan struct{}) schedulercache.NodeInfoCache {
+	cache := newNodeInfoCache(ttl, period, stop)
+	cache.run()
+	return cache
+}
+
+// mustGetPodKey returns the string key of a pod.
+// A pod is ensured to have accessor. We don't want to check the error everytime.
+// TODO: We should consider adding a Key() method to api.Pod
+func mustGetPodKey(pod *api.Pod) string {
+	key, err := clientcache.MetaNamespaceKeyFunc(pod)
+	if err != nil {
+		panic("api.Pod should have key func: " + err.Error())
+	}
+	return key
+}
+
+type nodeInfoCache struct {
+	stop chan struct{}
+
+	// This mutex guards all fields within this cache struct
+	mu          sync.Mutex
+	ttl         time.Duration
+	period      time.Duration
+	assumedPods map[string]assumedPod
+	podStates   map[string]podState
+	// TODO: we should also watch node deletion and clean up node entries
+	nodes map[string]*schedulercache.NodeInfo
+}
+
+type podState int
+
+const (
+	podAsummed podState = iota + 1
+	podAdded
+	podExpired
+)
+
+type assumedPod struct {
+	nodeName string
+	podInfo  schedulercache.PodInfo
+	deadline time.Time
+}
+
+func newNodeInfoCache(ttl, period time.Duration, stop chan struct{}) *nodeInfoCache {
+	return &nodeInfoCache{
+		ttl:    ttl,
+		period: period,
+		stop:   stop,
+
+		nodes:       make(map[string]*schedulercache.NodeInfo),
+		podStates:   make(map[string]podState),
+		assumedPods: make(map[string]assumedPod),
+	}
+}
+
+func (cache *nodeInfoCache) run() {
+	go util.Until(cache.cleanupExpiredAssumedPods, cache.period, cache.stop)
+}
+
+func (cache *nodeInfoCache) GetNodeInfo(nodeName string, cb func(*schedulercache.NodeInfo)) {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	n := cache.getNodeInfo(nodeName)
+	cb(n)
+}
+
+// GetNodeInfo returns cached NodeInfo. It returns nil if no such node if found for given node name.
+func (cache *nodeInfoCache) getNodeInfo(nodeName string) *schedulercache.NodeInfo {
+	n, ok := cache.nodes[nodeName]
+	if !ok || n.PodNum == 0 {
+		return nil
+	}
+	return n
+}
+
+func (cache *nodeInfoCache) AssumePod(pod *api.Pod) error {
+	return cache.assumePod(pod, time.Now())
+}
+
+// assumePod exists for making test deterministic by taking time as input argument.
+func (cache *nodeInfoCache) assumePod(pod *api.Pod, now time.Time) error {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	key := mustGetPodKey(pod)
+	if _, ok := cache.podStates[key]; ok {
+		return fmt.Errorf("pod state wasn't initial but get assumed. Pod key: %v", key)
+	}
+
+	cache.addPod(pod)
+	cache.podStates[key] = podAsummed
+	aPod := assumedPod{
+		nodeName: pod.Spec.NodeName,
+		podInfo:  schedulercache.ParsePodInfo(pod),
+		deadline: now.Add(cache.ttl),
+	}
+	cache.assumedPods[key] = aPod
+	return nil
+}
+
+func (cache *nodeInfoCache) AddPod(pod *api.Pod) error {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	key := mustGetPodKey(pod)
+	state, ok := cache.podStates[key]
+	switch {
+	case ok && state == podAsummed:
+		delete(cache.assumedPods, key)
+	case ok && state == podExpired:
+		// Pod was expired and deleted. We should add it back.
+		cache.addPod(pod)
+	default:
+		return fmt.Errorf("pod state wasn't assumed or expired but get added. Pod key: %v", key)
+	}
+	cache.podStates[key] = podAdded
+	return nil
+}
+
+func (cache *nodeInfoCache) UpdatePod(oldPod, newPod *api.Pod) error {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	key := mustGetPodKey(oldPod)
+	state, ok := cache.podStates[key]
+	switch {
+	case ok && state == podAdded:
+		cache.updatePod(oldPod, newPod, key)
+	default:
+		return fmt.Errorf("pod state wasn't added but get updated. Pod key: %v", key)
+	}
+	return nil
+}
+
+func (cache *nodeInfoCache) updatePod(oldPod, newPod *api.Pod, key string) {
+	cache.deletePod(oldPod)
+	cache.addPod(newPod)
+}
+
+func (cache *nodeInfoCache) addPod(pod *api.Pod) {
+	n, ok := cache.nodes[pod.Spec.NodeName]
+	if !ok {
+		n = schedulercache.NewNodeInfo()
+		cache.nodes[pod.Spec.NodeName] = n
+	}
+	n.AddPodInfo(schedulercache.ParsePodInfo(pod))
+}
+
+func (cache *nodeInfoCache) deletePod(pod *api.Pod) {
+	n := cache.nodes[pod.Spec.NodeName]
+	n.RemovePodInfo(schedulercache.ParsePodInfo(pod))
+}
+
+func (cache *nodeInfoCache) RemovePod(pod *api.Pod) error {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	key := mustGetPodKey(pod)
+	state, ok := cache.podStates[key]
+	switch {
+	case ok && state == podExpired:
+	case ok && state == podAsummed:
+		delete(cache.assumedPods, key)
+		fallthrough
+	case ok && state == podAdded:
+		cache.deletePod(pod)
+	default:
+		return fmt.Errorf("pod state wasn't assumed, expired, or added but get removed. Pod key: %v", key)
+	}
+	delete(cache.podStates, key)
+	return nil
+}
+
+func (cache *nodeInfoCache) cleanupExpiredAssumedPods() {
+	cache.cleanupAssumedPods(time.Now())
+}
+
+// cleanupAssumedPods exists for making test deterministic by taking time as input argument.
+func (cache *nodeInfoCache) cleanupAssumedPods(now time.Time) {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	// the size of assumedPods should be small
+	for key, aPod := range cache.assumedPods {
+		if now.After(aPod.deadline) {
+			err := cache.expirePod(key, aPod)
+			if err != nil {
+				glog.Errorf("cache.expirePod failed: %v", err)
+			}
+		}
+	}
+}
+
+func (cache *nodeInfoCache) expirePod(key string, aPod assumedPod) error {
+	state, ok := cache.podStates[key]
+	switch {
+	case ok && state == podAsummed:
+		delete(cache.assumedPods, key)
+		// This is the same logic as deletePod but we don't keep the api.Pod pointer.
+		// Instead we keep and use a local copy of information.
+		n := cache.nodes[aPod.nodeName]
+		n.RemovePodInfo(aPod.podInfo)
+		cache.podStates[key] = podExpired
+		return nil
+	default:
+		return fmt.Errorf("pod state wasn't assumed but get expired. Pod key: %v", key)
+	}
+}

--- a/plugin/pkg/scheduler/schedulercache/nodeinfocache/node_info_cache_test.go
+++ b/plugin/pkg/scheduler/schedulercache/nodeinfocache/node_info_cache_test.go
@@ -1,0 +1,410 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeinfocache
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
+)
+
+// TestAssumePod tests that after a pod is assumed, its information is aggregated
+// on node level.
+func TestAssumePod(t *testing.T) {
+	nodeName := "node"
+	tests := []struct {
+		pods []*api.Pod
+
+		wNodeInfo *schedulercache.NodeInfo
+	}{{
+		pods: []*api.Pod{makeBasePod(nodeName, "test", "100m", "500", []api.ContainerPort{{HostPort: 80}})},
+		wNodeInfo: &schedulercache.NodeInfo{
+			RequestedResource: &schedulercache.Resource{
+				MilliCPU: 100,
+				Memory:   500,
+			},
+			PodNum: 1,
+		},
+	}, {
+		pods: []*api.Pod{
+			makeBasePod(nodeName, "test-1", "100m", "500", []api.ContainerPort{{HostPort: 80}}),
+			makeBasePod(nodeName, "test-2", "200m", "1Ki", []api.ContainerPort{{HostPort: 8080}})},
+		wNodeInfo: &schedulercache.NodeInfo{
+			RequestedResource: &schedulercache.Resource{
+				MilliCPU: 300,
+				Memory:   1524,
+			},
+			PodNum: 2,
+		},
+	}}
+
+	for i, tt := range tests {
+		cache := newNodeInfoCache(time.Second, time.Second, nil)
+		for _, pod := range tt.pods {
+			err := cache.AssumePod(pod)
+			if err != nil {
+				t.Fatalf("AssumePod failed: %v", err)
+			}
+		}
+		n := cache.getNodeInfo(nodeName)
+		if !reflect.DeepEqual(n, tt.wNodeInfo) {
+			t.Errorf("#%d: node info get=%s, want=%s", i, n, tt.wNodeInfo)
+		}
+	}
+}
+
+// TestExpirePod tests that assumed pods will be removed if expired.
+// The removal will be reflected in node info.
+func TestExpirePod(t *testing.T) {
+	nodeName := "node"
+	now := time.Now()
+	ttl := 10 * time.Second
+	tests := []struct {
+		pods        []*api.Pod
+		assumedTime []time.Time // assume time for individual pods
+		cleanupTime time.Time
+
+		wNodeInfo *schedulercache.NodeInfo
+	}{{ // assumed pod would expires
+		pods:        []*api.Pod{makeBasePod(nodeName, "test", "100m", "500", []api.ContainerPort{{HostPort: 80}})},
+		assumedTime: []time.Time{now},
+		cleanupTime: now.Add(2 * ttl),
+		wNodeInfo:   nil,
+	}, { // first one would expire, second one would not.
+		pods: []*api.Pod{
+			makeBasePod(nodeName, "test-1", "100m", "500", []api.ContainerPort{{HostPort: 80}}),
+			makeBasePod(nodeName, "test-2", "200m", "1Ki", []api.ContainerPort{{HostPort: 8080}})},
+		assumedTime: []time.Time{now, now.Add(3 * ttl / 2)},
+		cleanupTime: now.Add(2 * ttl),
+		wNodeInfo: &schedulercache.NodeInfo{
+			RequestedResource: &schedulercache.Resource{
+				MilliCPU: 200,
+				Memory:   1024,
+			},
+			PodNum: 1,
+		},
+	}}
+
+	for i, tt := range tests {
+		cache := newNodeInfoCache(ttl, time.Second, nil)
+
+		for j, pod := range tt.pods {
+			err := cache.assumePod(pod, tt.assumedTime[j])
+			if err != nil {
+				t.Fatalf("assumePod failed: %v", err)
+			}
+		}
+		// pods that have assumedTime + ttl < cleanupTime will get expired and removed
+		cache.cleanupAssumedPods(tt.cleanupTime)
+		n := cache.getNodeInfo(nodeName)
+		if !reflect.DeepEqual(n, tt.wNodeInfo) {
+			t.Errorf("#%d: node info get=%s, want=%s", i, n, tt.wNodeInfo)
+		}
+	}
+}
+
+// TestAddPodWillConfirm tests that a pod being Add()ed will be confirmed if binded.
+// The pod info should still exist after manually expiring unconfirmed pods.
+func TestAddPodWillConfirm(t *testing.T) {
+	nodeName := "node"
+	ttl := 10 * time.Second
+	basePod := makeBasePod(nodeName, "test", "100m", "500", []api.ContainerPort{{HostPort: 80}})
+	tests := []struct {
+		podToAssume *api.Pod
+		podToAdd    *api.Pod
+
+		wNodeInfo *schedulercache.NodeInfo
+	}{{ // Pod is binded. It should be confirmed.
+		podToAssume: basePod,
+		podToAdd:    basePod,
+		wNodeInfo: &schedulercache.NodeInfo{
+			RequestedResource: &schedulercache.Resource{
+				MilliCPU: 100,
+				Memory:   500,
+			},
+			PodNum: 1,
+		},
+	}}
+
+	now := time.Now()
+	for i, tt := range tests {
+		cache := newNodeInfoCache(ttl, time.Second, nil)
+		err := cache.assumePod(tt.podToAssume, now)
+		if err != nil {
+			t.Fatalf("assumePod failed: %v", err)
+		}
+		err = cache.AddPod(tt.podToAdd)
+		if err != nil {
+			t.Fatalf("AddPod failed: %v", err)
+		}
+		cache.cleanupAssumedPods(now.Add(2 * ttl))
+		// check after expiration. confirmed pods shouldn't be expired.
+		n := cache.getNodeInfo(nodeName)
+		if !reflect.DeepEqual(n, tt.wNodeInfo) {
+			t.Errorf("#%d: node info get=%s, want=%s", i, n, tt.wNodeInfo)
+		}
+	}
+}
+
+// TestAddPodAfterExpiration tests that a pod being Add()ed will be added back if expired.
+func TestAddPodAfterExpiration(t *testing.T) {
+	nodeName := "node"
+	ttl := 10 * time.Second
+	basePod := makeBasePod(nodeName, "test", "100m", "500", []api.ContainerPort{{HostPort: 80}})
+	tests := []struct {
+		podToAssume *api.Pod
+		podToAdd    *api.Pod
+
+		wNodeInfo *schedulercache.NodeInfo
+	}{{
+		podToAssume: basePod,
+		podToAdd:    basePod,
+		wNodeInfo: &schedulercache.NodeInfo{
+			RequestedResource: &schedulercache.Resource{
+				MilliCPU: 100,
+				Memory:   500,
+			},
+			PodNum: 1,
+		},
+	}}
+
+	now := time.Now()
+	for i, tt := range tests {
+		cache := newNodeInfoCache(ttl, time.Second, nil)
+		err := cache.assumePod(tt.podToAssume, now)
+		if err != nil {
+			t.Fatalf("assumePod failed: %v", err)
+		}
+		cache.cleanupAssumedPods(now.Add(2 * ttl))
+		// It should be expired and removed.
+		n := cache.getNodeInfo(nodeName)
+		if n != nil {
+			t.Errorf("#%d: expecting nil node info, but get=%v", i, n)
+		}
+		err = cache.AddPod(tt.podToAdd)
+		if err != nil {
+			t.Fatalf("AddPod failed: %v", err)
+		}
+		// check after expiration. confirmed pods shouldn't be expired.
+		n = cache.getNodeInfo(nodeName)
+		if !reflect.DeepEqual(n, tt.wNodeInfo) {
+			t.Errorf("#%d: node info get=%s, want=%s", i, n, tt.wNodeInfo)
+		}
+	}
+}
+
+// TestUpdatePod tests that a pod will be updated if added before.
+func TestUpdatePod(t *testing.T) {
+	nodeName := "node"
+	ttl := 10 * time.Second
+	basePod := makeBasePod(nodeName, "test", "100m", "500", []api.ContainerPort{{HostPort: 80}})
+	tests := []struct {
+		podToAssume *api.Pod
+		podToAdd    *api.Pod
+		podToUpdate *api.Pod
+
+		wNodeInfo *schedulercache.NodeInfo
+	}{{ // Pod is binded. It should be confirmed.
+		podToAssume: basePod,
+		podToAdd:    basePod,
+		podToUpdate: makeBasePod(nodeName, "test", "200m", "1Ki", []api.ContainerPort{{HostPort: 8080}}),
+		wNodeInfo: &schedulercache.NodeInfo{
+			RequestedResource: &schedulercache.Resource{
+				MilliCPU: 200,
+				Memory:   1024,
+			},
+			PodNum: 1,
+		},
+	}}
+
+	now := time.Now()
+	for i, tt := range tests {
+		cache := newNodeInfoCache(ttl, time.Second, nil)
+		err := cache.assumePod(tt.podToAssume, now)
+		if err != nil {
+			t.Fatalf("assumePod failed: %v", err)
+		}
+		err = cache.AddPod(tt.podToAdd)
+		if err != nil {
+			t.Fatalf("AddPod failed: %v", err)
+		}
+		err = cache.UpdatePod(tt.podToAdd, tt.podToUpdate)
+		if err != nil {
+			t.Fatalf("UpdatePod failed: %v", err)
+		}
+		// check after expiration. confirmed pods shouldn't be expired.
+		n := cache.getNodeInfo(nodeName)
+		if !reflect.DeepEqual(n, tt.wNodeInfo) {
+			t.Errorf("#%d: node info get=%s, want=%s", i, n, tt.wNodeInfo)
+		}
+	}
+}
+
+// TestRemoveBindedPod tests after binded pod is removed, its information should also be subtracted.
+func TestRemoveBindedPod(t *testing.T) {
+	nodeName := "node"
+	basePod := makeBasePod(nodeName, "test", "100m", "500", []api.ContainerPort{{HostPort: 80}})
+	tests := []struct {
+		pod *api.Pod
+
+		wNodeInfo *schedulercache.NodeInfo
+	}{{
+		pod: basePod,
+		wNodeInfo: &schedulercache.NodeInfo{
+			RequestedResource: &schedulercache.Resource{
+				MilliCPU: 100,
+				Memory:   500,
+			},
+			PodNum: 1,
+		},
+	}}
+
+	for i, tt := range tests {
+		cache := newNodeInfoCache(time.Second, time.Second, nil)
+		err := cache.AssumePod(tt.pod)
+		if err != nil {
+			t.Fatalf("assumePod failed: %v", err)
+		}
+		n := cache.getNodeInfo(nodeName)
+		if !reflect.DeepEqual(n, tt.wNodeInfo) {
+			t.Errorf("#%d: node info get=%s, want=%s", i, n, tt.wNodeInfo)
+		}
+
+		err = cache.RemovePod(tt.pod)
+		if err != nil {
+			t.Fatalf("RemovePod failed: %v", err)
+		}
+
+		n = cache.getNodeInfo(nodeName)
+		if n != nil {
+			t.Errorf("#%d: expecting pod deleted and nil node info, get=%s", i, n)
+		}
+	}
+}
+
+// TestRemoveBindedPod tests after added pod is removed, its information should also be subtracted.
+func TestRemoveAddedPod(t *testing.T) {
+	nodeName := "node"
+	basePod := makeBasePod(nodeName, "test", "100m", "500", []api.ContainerPort{{HostPort: 80}})
+	tests := []struct {
+		pod *api.Pod
+
+		wNodeInfo *schedulercache.NodeInfo
+	}{{
+		pod: basePod,
+		wNodeInfo: &schedulercache.NodeInfo{
+			RequestedResource: &schedulercache.Resource{
+				MilliCPU: 100,
+				Memory:   500,
+			},
+			PodNum: 1,
+		},
+	}}
+
+	for i, tt := range tests {
+		cache := newNodeInfoCache(time.Second, time.Second, nil)
+		err := cache.AssumePod(tt.pod)
+		if err != nil {
+			t.Fatalf("assumePod failed: %v", err)
+		}
+		err = cache.AddPod(tt.pod)
+		if err != nil {
+			t.Fatalf("AddPod failed: %v", err)
+		}
+		n := cache.getNodeInfo(nodeName)
+		if !reflect.DeepEqual(n, tt.wNodeInfo) {
+			t.Errorf("#%d: node info get=%s, want=%s", i, n, tt.wNodeInfo)
+		}
+
+		err = cache.RemovePod(tt.pod)
+		if err != nil {
+			t.Fatalf("RemovePod failed: %v", err)
+		}
+
+		n = cache.getNodeInfo(nodeName)
+		if n != nil {
+			t.Errorf("#%d: expecting pod deleted and nil node info, get=%s", i, n)
+		}
+	}
+}
+
+// TestRemoveExpiredPod tests that removing expired pod shouldn't have any error.
+func TestRemoveExpiredPod(t *testing.T) {
+	nodeName := "node"
+	ttl := 10 * time.Second
+	basePod := makeBasePod(nodeName, "test", "100m", "500", []api.ContainerPort{{HostPort: 80}})
+	tests := []struct {
+		pod       *api.Pod
+		wNodeInfo *schedulercache.NodeInfo
+	}{{
+		pod: basePod,
+		wNodeInfo: &schedulercache.NodeInfo{
+			RequestedResource: &schedulercache.Resource{
+				MilliCPU: 100,
+				Memory:   500,
+			},
+			PodNum: 1,
+		},
+	}}
+
+	now := time.Now()
+	for i, tt := range tests {
+		cache := newNodeInfoCache(ttl, time.Second, nil)
+		err := cache.assumePod(tt.pod, now)
+		if err != nil {
+			t.Fatalf("assumePod failed: %v", err)
+		}
+		cache.cleanupAssumedPods(now.Add(2 * ttl))
+
+		n := cache.getNodeInfo(nodeName)
+		if n != nil {
+			t.Errorf("#%d: expecting pod expired and nil node info, get=%s", i, n)
+			continue
+		}
+
+		// no error should happen
+		err = cache.RemovePod(tt.pod)
+		if err != nil {
+			t.Fatalf("RemovePod failed: %v", err)
+		}
+	}
+}
+
+func makeBasePod(nodeName, objName, cpu, mem string, ports []api.ContainerPort) *api.Pod {
+	return &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Namespace: "node_info_cache_test",
+			Name:      objName,
+		},
+		Spec: api.PodSpec{
+			Containers: []api.Container{{
+				Resources: api.ResourceRequirements{
+					Requests: api.ResourceList{
+						api.ResourceCPU:    resource.MustParse(cpu),
+						api.ResourceMemory: resource.MustParse(mem),
+					},
+				},
+				Ports: ports,
+			}},
+			NodeName: nodeName,
+		},
+	}
+}

--- a/plugin/pkg/scheduler/schedulercache/nodeinfocache/node_info_cache_test.go
+++ b/plugin/pkg/scheduler/schedulercache/nodeinfocache/node_info_cache_test.go
@@ -26,9 +26,9 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
 )
 
-// TestAssumePod tests that after a pod is assumed, its information is aggregated
+// TestAssumePodScheduled tests that after a pod is assumed, its information is aggregated
 // on node level.
-func TestAssumePod(t *testing.T) {
+func TestAssumePodScheduled(t *testing.T) {
 	nodeName := "node"
 	tests := []struct {
 		pods []*api.Pod
@@ -59,9 +59,9 @@ func TestAssumePod(t *testing.T) {
 	for i, tt := range tests {
 		cache := newNodeInfoCache(time.Second, time.Second, nil)
 		for _, pod := range tt.pods {
-			err := cache.AssumePod(pod)
+			err := cache.AssumePodScheduled(pod)
 			if err != nil {
-				t.Fatalf("AssumePod failed: %v", err)
+				t.Fatalf("AssumePodScheduled failed: %v", err)
 			}
 		}
 		n := cache.getNodeInfo(nodeName)
@@ -107,7 +107,7 @@ func TestExpirePod(t *testing.T) {
 		cache := newNodeInfoCache(ttl, time.Second, nil)
 
 		for j, pod := range tt.pods {
-			err := cache.assumePod(pod, tt.assumedTime[j])
+			err := cache.assumePodScheduled(pod, tt.assumedTime[j])
 			if err != nil {
 				t.Fatalf("assumePod failed: %v", err)
 			}
@@ -147,7 +147,7 @@ func TestAddPodWillConfirm(t *testing.T) {
 	now := time.Now()
 	for i, tt := range tests {
 		cache := newNodeInfoCache(ttl, time.Second, nil)
-		err := cache.assumePod(tt.podToAssume, now)
+		err := cache.assumePodScheduled(tt.podToAssume, now)
 		if err != nil {
 			t.Fatalf("assumePod failed: %v", err)
 		}
@@ -189,7 +189,7 @@ func TestAddPodAfterExpiration(t *testing.T) {
 	now := time.Now()
 	for i, tt := range tests {
 		cache := newNodeInfoCache(ttl, time.Second, nil)
-		err := cache.assumePod(tt.podToAssume, now)
+		err := cache.assumePodScheduled(tt.podToAssume, now)
 		if err != nil {
 			t.Fatalf("assumePod failed: %v", err)
 		}
@@ -238,7 +238,7 @@ func TestUpdatePod(t *testing.T) {
 	now := time.Now()
 	for i, tt := range tests {
 		cache := newNodeInfoCache(ttl, time.Second, nil)
-		err := cache.assumePod(tt.podToAssume, now)
+		err := cache.assumePodScheduled(tt.podToAssume, now)
 		if err != nil {
 			t.Fatalf("assumePod failed: %v", err)
 		}
@@ -279,7 +279,7 @@ func TestRemoveBindedPod(t *testing.T) {
 
 	for i, tt := range tests {
 		cache := newNodeInfoCache(time.Second, time.Second, nil)
-		err := cache.AssumePod(tt.pod)
+		err := cache.AssumePodScheduled(tt.pod)
 		if err != nil {
 			t.Fatalf("assumePod failed: %v", err)
 		}
@@ -321,7 +321,7 @@ func TestRemoveAddedPod(t *testing.T) {
 
 	for i, tt := range tests {
 		cache := newNodeInfoCache(time.Second, time.Second, nil)
-		err := cache.AssumePod(tt.pod)
+		err := cache.AssumePodScheduled(tt.pod)
 		if err != nil {
 			t.Fatalf("assumePod failed: %v", err)
 		}
@@ -368,7 +368,7 @@ func TestRemoveExpiredPod(t *testing.T) {
 	now := time.Now()
 	for i, tt := range tests {
 		cache := newNodeInfoCache(ttl, time.Second, nil)
-		err := cache.assumePod(tt.pod, now)
+		err := cache.assumePodScheduled(tt.pod, now)
 		if err != nil {
 			t.Fatalf("assumePod failed: %v", err)
 		}


### PR DESCRIPTION
This PR provides NodeInfoCache which aggregates pods' resource request and provides node-level resource summary. It's intended to supplant system modeler for efficient lookup in `PodFitsResource`. As we indicated in #18831 that it is the most time-consuming code path and optimizing it would result in 10x improvement. 

The interface defined in the cache is similar to system modeler and its pod lister. Additionally, we also need Update() and GetNodeInfo(). 

We have drawn the state machine explicitly to show the workflow and how it interacts with pod events. 

It would be pretty straight-forward to use this cache into related hooks when state changes happen. That say, when pod is assumed, added, updated, removed. Then we can use the cache to optimize scheduler predicates `PodFitsResources`.
