### PR TITLE
Split proxy and scheduler arguments

### DIFF
--- a/cmd/hyperkube/kube-proxy.go
+++ b/cmd/hyperkube/kube-proxy.go
@@ -19,13 +19,14 @@ limitations under the License.
 package main
 
 import (
-	kubeproxy "k8s.io/kubernetes/cmd/kube-proxy/app"
+	"k8s.io/kubernetes/cmd/kube-proxy/app"
+	"k8s.io/kubernetes/cmd/kube-proxy/app/options"
 )
 
 // NewKubeProxy creates a new hyperkube Server object that includes the
 // description and flags.
 func NewKubeProxy() *Server {
-	config := kubeproxy.NewProxyConfig()
+	config := options.NewProxyConfig()
 
 	hks := Server{
 		SimpleUsage: "proxy",
@@ -37,13 +38,13 @@ func NewKubeProxy() *Server {
 
 	config.AddFlags(hks.Flags())
 
-	hks.Run = func(_ *Server, args []string) error {
-		s, err := kubeproxy.NewProxyServerDefault(config)
+	hks.Run = func(_ *Server, _ []string) error {
+		s, err := app.NewProxyServerDefault(config)
 		if err != nil {
 			return err
 		}
 
-		return s.Run(args)
+		return s.Run()
 	}
 
 	return &hks

--- a/cmd/hyperkube/kube-scheduler.go
+++ b/cmd/hyperkube/kube-scheduler.go
@@ -19,19 +19,20 @@ limitations under the License.
 package main
 
 import (
-	scheduler "k8s.io/kubernetes/plugin/cmd/kube-scheduler/app"
+	"k8s.io/kubernetes/plugin/cmd/kube-scheduler/app"
+	"k8s.io/kubernetes/plugin/cmd/kube-scheduler/app/options"
 )
 
 // NewScheduler creates a new hyperkube Server object that includes the
 // description and flags.
 func NewScheduler() *Server {
-	s := scheduler.NewSchedulerServer()
+	s := options.NewSchedulerServer()
 
 	hks := Server{
 		SimpleUsage: "scheduler",
 		Long:        "Implements a Kubernetes scheduler.  This will assign pods to kubelets based on capacity and constraints.",
-		Run: func(_ *Server, args []string) error {
-			return s.Run(args)
+		Run: func(_ *Server, _ []string) error {
+			return app.Run(s)
 		},
 	}
 	s.AddFlags(hks.Flags())

--- a/cmd/kube-proxy/app/options/options.go
+++ b/cmd/kube-proxy/app/options/options.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package options contains flags for initializing a proxy.
+package options
+
+import (
+	"net"
+	_ "net/http/pprof"
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/kubelet/qos"
+	"k8s.io/kubernetes/pkg/util"
+
+	"github.com/spf13/pflag"
+)
+
+const (
+	ExperimentalProxyModeAnnotation = "net.experimental.kubernetes.io/proxy-mode"
+)
+
+// ProxyServerConfig contains configurations for a Kubernetes proxy server
+type ProxyServerConfig struct {
+	BindAddress                    net.IP
+	HealthzPort                    int
+	HealthzBindAddress             net.IP
+	OOMScoreAdj                    int
+	ResourceContainer              string
+	Master                         string
+	Kubeconfig                     string
+	PortRange                      util.PortRange
+	HostnameOverride               string
+	ProxyMode                      string
+	IptablesSyncPeriod             time.Duration
+	ConfigSyncPeriod               time.Duration
+	NodeRef                        *api.ObjectReference // Reference to this node.
+	MasqueradeAll                  bool
+	CleanupAndExit                 bool
+	KubeAPIQPS                     float32
+	KubeAPIBurst                   int
+	UDPIdleTimeout                 time.Duration
+	ConntrackMax                   int
+	ConntrackTCPTimeoutEstablished int // seconds
+}
+
+func NewProxyConfig() *ProxyServerConfig {
+	return &ProxyServerConfig{
+		BindAddress:                    net.ParseIP("0.0.0.0"),
+		HealthzPort:                    10249,
+		HealthzBindAddress:             net.ParseIP("127.0.0.1"),
+		OOMScoreAdj:                    qos.KubeProxyOOMScoreAdj,
+		ResourceContainer:              "/kube-proxy",
+		IptablesSyncPeriod:             30 * time.Second,
+		ConfigSyncPeriod:               15 * time.Minute,
+		KubeAPIQPS:                     5.0,
+		KubeAPIBurst:                   10,
+		UDPIdleTimeout:                 250 * time.Millisecond,
+		ConntrackMax:                   256 * 1024, // 4x default (64k)
+		ConntrackTCPTimeoutEstablished: 86400,      // 1 day (1/5 default)
+	}
+}
+
+// AddFlags adds flags for a specific ProxyServer to the specified FlagSet
+func (s *ProxyServerConfig) AddFlags(fs *pflag.FlagSet) {
+	fs.IPVar(&s.BindAddress, "bind-address", s.BindAddress, "The IP address for the proxy server to serve on (set to 0.0.0.0 for all interfaces)")
+	fs.StringVar(&s.Master, "master", s.Master, "The address of the Kubernetes API server (overrides any value in kubeconfig)")
+	fs.IntVar(&s.HealthzPort, "healthz-port", s.HealthzPort, "The port to bind the health check server. Use 0 to disable.")
+	fs.IPVar(&s.HealthzBindAddress, "healthz-bind-address", s.HealthzBindAddress, "The IP address for the health check server to serve on, defaulting to 127.0.0.1 (set to 0.0.0.0 for all interfaces)")
+	fs.IntVar(&s.OOMScoreAdj, "oom-score-adj", s.OOMScoreAdj, "The oom-score-adj value for kube-proxy process. Values must be within the range [-1000, 1000]")
+	fs.StringVar(&s.ResourceContainer, "resource-container", s.ResourceContainer, "Absolute name of the resource-only container to create and run the Kube-proxy in (Default: /kube-proxy).")
+	fs.MarkDeprecated("resource-container", "This feature will be removed in a later release.")
+	fs.StringVar(&s.Kubeconfig, "kubeconfig", s.Kubeconfig, "Path to kubeconfig file with authorization information (the master location is set by the master flag).")
+	fs.Var(&s.PortRange, "proxy-port-range", "Range of host ports (beginPort-endPort, inclusive) that may be consumed in order to proxy service traffic. If unspecified (0-0) then ports will be randomly chosen.")
+	fs.StringVar(&s.HostnameOverride, "hostname-override", s.HostnameOverride, "If non-empty, will use this string as identification instead of the actual hostname.")
+	fs.StringVar(&s.ProxyMode, "proxy-mode", "", "Which proxy mode to use: 'userspace' (older) or 'iptables' (faster). If blank, look at the Node object on the Kubernetes API and respect the '"+ExperimentalProxyModeAnnotation+"' annotation if provided.  Otherwise use the best-available proxy (currently iptables).  If the iptables proxy is selected, regardless of how, but the system's kernel or iptables versions are insufficient, this always falls back to the userspace proxy.")
+	fs.DurationVar(&s.IptablesSyncPeriod, "iptables-sync-period", s.IptablesSyncPeriod, "How often iptables rules are refreshed (e.g. '5s', '1m', '2h22m').  Must be greater than 0.")
+	fs.DurationVar(&s.ConfigSyncPeriod, "config-sync-period", s.ConfigSyncPeriod, "How often configuration from the apiserver is refreshed.  Must be greater than 0.")
+	fs.BoolVar(&s.MasqueradeAll, "masquerade-all", false, "If using the pure iptables proxy, SNAT everything")
+	fs.BoolVar(&s.CleanupAndExit, "cleanup-iptables", false, "If true cleanup iptables rules and exit.")
+	fs.Float32Var(&s.KubeAPIQPS, "kube-api-qps", s.KubeAPIQPS, "QPS to use while talking with kubernetes apiserver")
+	fs.IntVar(&s.KubeAPIBurst, "kube-api-burst", s.KubeAPIBurst, "Burst to use while talking with kubernetes apiserver")
+	fs.DurationVar(&s.UDPIdleTimeout, "udp-timeout", s.UDPIdleTimeout, "How long an idle UDP connection will be kept open (e.g. '250ms', '2s').  Must be greater than 0. Only applicable for proxy-mode=userspace")
+	fs.IntVar(&s.ConntrackMax, "conntrack-max", s.ConntrackMax, "Maximum number of NAT connections to track (0 to leave as-is)")
+	fs.IntVar(&s.ConntrackTCPTimeoutEstablished, "conntrack-tcp-timeout-established", s.ConntrackTCPTimeoutEstablished, "Idle timeout for established TCP connections (0 to leave as-is)")
+}

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -20,18 +20,17 @@ package app
 
 import (
 	"errors"
-	"net"
 	"net/http"
 	_ "net/http/pprof"
 	"strconv"
 	"time"
 
+	"k8s.io/kubernetes/cmd/kube-proxy/app/options"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/record"
 	kubeclient "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
-	"k8s.io/kubernetes/pkg/kubelet/qos"
 	"k8s.io/kubernetes/pkg/proxy"
 	proxyconfig "k8s.io/kubernetes/pkg/proxy/config"
 	"k8s.io/kubernetes/pkg/proxy/iptables"
@@ -49,33 +48,9 @@ import (
 	"github.com/spf13/pflag"
 )
 
-// ProxyServerConfig contains configures and runs a Kubernetes proxy server
-type ProxyServerConfig struct {
-	BindAddress                    net.IP
-	HealthzPort                    int
-	HealthzBindAddress             net.IP
-	OOMScoreAdj                    int
-	ResourceContainer              string
-	Master                         string
-	Kubeconfig                     string
-	PortRange                      util.PortRange
-	HostnameOverride               string
-	ProxyMode                      string
-	IptablesSyncPeriod             time.Duration
-	ConfigSyncPeriod               time.Duration
-	NodeRef                        *api.ObjectReference // Reference to this node.
-	MasqueradeAll                  bool
-	CleanupAndExit                 bool
-	KubeAPIQPS                     float32
-	KubeAPIBurst                   int
-	UDPIdleTimeout                 time.Duration
-	ConntrackMax                   int
-	ConntrackTCPTimeoutEstablished int // seconds
-}
-
 type ProxyServer struct {
 	Client       *kubeclient.Client
-	Config       *ProxyServerConfig
+	Config       *options.ProxyServerConfig
 	IptInterface utiliptables.Interface
 	Proxier      proxy.ProxyProvider
 	Broadcaster  record.EventBroadcaster
@@ -83,34 +58,10 @@ type ProxyServer struct {
 	Conntracker  Conntracker // if nil, ignored
 }
 
-// AddFlags adds flags for a specific ProxyServer to the specified FlagSet
-func (s *ProxyServerConfig) AddFlags(fs *pflag.FlagSet) {
-	fs.IPVar(&s.BindAddress, "bind-address", s.BindAddress, "The IP address for the proxy server to serve on (set to 0.0.0.0 for all interfaces)")
-	fs.StringVar(&s.Master, "master", s.Master, "The address of the Kubernetes API server (overrides any value in kubeconfig)")
-	fs.IntVar(&s.HealthzPort, "healthz-port", s.HealthzPort, "The port to bind the health check server. Use 0 to disable.")
-	fs.IPVar(&s.HealthzBindAddress, "healthz-bind-address", s.HealthzBindAddress, "The IP address for the health check server to serve on, defaulting to 127.0.0.1 (set to 0.0.0.0 for all interfaces)")
-	fs.IntVar(&s.OOMScoreAdj, "oom-score-adj", s.OOMScoreAdj, "The oom-score-adj value for kube-proxy process. Values must be within the range [-1000, 1000]")
-	fs.StringVar(&s.ResourceContainer, "resource-container", s.ResourceContainer, "Absolute name of the resource-only container to create and run the Kube-proxy in (Default: /kube-proxy).")
-	fs.MarkDeprecated("resource-container", "This feature will be removed in a later release.")
-	fs.StringVar(&s.Kubeconfig, "kubeconfig", s.Kubeconfig, "Path to kubeconfig file with authorization information (the master location is set by the master flag).")
-	fs.Var(&s.PortRange, "proxy-port-range", "Range of host ports (beginPort-endPort, inclusive) that may be consumed in order to proxy service traffic. If unspecified (0-0) then ports will be randomly chosen.")
-	fs.StringVar(&s.HostnameOverride, "hostname-override", s.HostnameOverride, "If non-empty, will use this string as identification instead of the actual hostname.")
-	fs.StringVar(&s.ProxyMode, "proxy-mode", "", "Which proxy mode to use: 'userspace' (older) or 'iptables' (faster). If blank, look at the Node object on the Kubernetes API and respect the '"+experimentalProxyModeAnnotation+"' annotation if provided.  Otherwise use the best-available proxy (currently iptables).  If the iptables proxy is selected, regardless of how, but the system's kernel or iptables versions are insufficient, this always falls back to the userspace proxy.")
-	fs.DurationVar(&s.IptablesSyncPeriod, "iptables-sync-period", s.IptablesSyncPeriod, "How often iptables rules are refreshed (e.g. '5s', '1m', '2h22m').  Must be greater than 0.")
-	fs.DurationVar(&s.ConfigSyncPeriod, "config-sync-period", s.ConfigSyncPeriod, "How often configuration from the apiserver is refreshed.  Must be greater than 0.")
-	fs.BoolVar(&s.MasqueradeAll, "masquerade-all", false, "If using the pure iptables proxy, SNAT everything")
-	fs.BoolVar(&s.CleanupAndExit, "cleanup-iptables", false, "If true cleanup iptables rules and exit.")
-	fs.Float32Var(&s.KubeAPIQPS, "kube-api-qps", s.KubeAPIQPS, "QPS to use while talking with kubernetes apiserver")
-	fs.IntVar(&s.KubeAPIBurst, "kube-api-burst", s.KubeAPIBurst, "Burst to use while talking with kubernetes apiserver")
-	fs.DurationVar(&s.UDPIdleTimeout, "udp-timeout", s.UDPIdleTimeout, "How long an idle UDP connection will be kept open (e.g. '250ms', '2s').  Must be greater than 0. Only applicable for proxy-mode=userspace")
-	fs.IntVar(&s.ConntrackMax, "conntrack-max", s.ConntrackMax, "Maximum number of NAT connections to track (0 to leave as-is)")
-	fs.IntVar(&s.ConntrackTCPTimeoutEstablished, "conntrack-tcp-timeout-established", s.ConntrackTCPTimeoutEstablished, "Idle timeout for established TCP connections (0 to leave as-is)")
-}
-
 const (
 	proxyModeUserspace              = "userspace"
 	proxyModeIptables               = "iptables"
-	experimentalProxyModeAnnotation = "net.experimental.kubernetes.io/proxy-mode"
+	experimentalProxyModeAnnotation = options.ExperimentalProxyModeAnnotation
 	betaProxyModeAnnotation         = "net.beta.kubernetes.io/proxy-mode"
 )
 
@@ -122,26 +73,9 @@ func checkKnownProxyMode(proxyMode string) bool {
 	return false
 }
 
-func NewProxyConfig() *ProxyServerConfig {
-	return &ProxyServerConfig{
-		BindAddress:                    net.ParseIP("0.0.0.0"),
-		HealthzPort:                    10249,
-		HealthzBindAddress:             net.ParseIP("127.0.0.1"),
-		OOMScoreAdj:                    qos.KubeProxyOOMScoreAdj,
-		ResourceContainer:              "/kube-proxy",
-		IptablesSyncPeriod:             30 * time.Second,
-		ConfigSyncPeriod:               15 * time.Minute,
-		KubeAPIQPS:                     5.0,
-		KubeAPIBurst:                   10,
-		UDPIdleTimeout:                 250 * time.Millisecond,
-		ConntrackMax:                   256 * 1024, // 4x default (64k)
-		ConntrackTCPTimeoutEstablished: 86400,      // 1 day (1/5 default)
-	}
-}
-
 func NewProxyServer(
 	client *kubeclient.Client,
-	config *ProxyServerConfig,
+	config *options.ProxyServerConfig,
 	iptInterface utiliptables.Interface,
 	proxier proxy.ProxyProvider,
 	broadcaster record.EventBroadcaster,
@@ -161,7 +95,7 @@ func NewProxyServer(
 
 // NewProxyCommand creates a *cobra.Command object with default parameters
 func NewProxyCommand() *cobra.Command {
-	s := NewProxyConfig()
+	s := options.NewProxyConfig()
 	s.AddFlags(pflag.CommandLine)
 	cmd := &cobra.Command{
 		Use: "kube-proxy",
@@ -180,7 +114,7 @@ with the apiserver API to configure the proxy.`,
 }
 
 // NewProxyServerDefault creates a new ProxyServer object with default parameters.
-func NewProxyServerDefault(config *ProxyServerConfig) (*ProxyServer, error) {
+func NewProxyServerDefault(config *options.ProxyServerConfig) (*ProxyServer, error) {
 	protocol := utiliptables.ProtocolIpv4
 	if config.BindAddress.To4() == nil {
 		protocol = utiliptables.ProtocolIpv6
@@ -309,7 +243,7 @@ func NewProxyServerDefault(config *ProxyServerConfig) (*ProxyServer, error) {
 }
 
 // Run runs the specified ProxyServer.  This should never exit (unless CleanupAndExit is set).
-func (s *ProxyServer) Run(_ []string) error {
+func (s *ProxyServer) Run() error {
 	// remove iptables rules and exit
 	if s.Config.CleanupAndExit {
 		encounteredError := userspace.CleanupLeftovers(s.IptInterface)

--- a/cmd/kube-proxy/app/server_test.go
+++ b/cmd/kube-proxy/app/server_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"k8s.io/kubernetes/cmd/kube-proxy/app/options"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/util/iptables"
 )
@@ -213,7 +215,7 @@ func Test_getProxyMode(t *testing.T) {
 func TestProxyServerWithCleanupAndExit(t *testing.T) {
 
 	//creates default config
-	config := NewProxyConfig()
+	config := options.NewProxyConfig()
 
 	//sets CleanupAndExit manually
 	config.CleanupAndExit = true

--- a/cmd/kube-proxy/proxy.go
+++ b/cmd/kube-proxy/proxy.go
@@ -22,6 +22,7 @@ import (
 	"runtime"
 
 	"k8s.io/kubernetes/cmd/kube-proxy/app"
+	"k8s.io/kubernetes/cmd/kube-proxy/app/options"
 	"k8s.io/kubernetes/pkg/healthz"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/version/verflag"
@@ -35,7 +36,7 @@ func init() {
 
 func main() {
 	runtime.GOMAXPROCS(runtime.NumCPU())
-	config := app.NewProxyConfig()
+	config := options.NewProxyConfig()
 	config.AddFlags(pflag.CommandLine)
 
 	util.InitFlags()
@@ -50,7 +51,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = s.Run(pflag.CommandLine.Args()); err != nil {
+	if err = s.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}

--- a/contrib/mesos/cmd/km/kube-proxy.go
+++ b/contrib/mesos/cmd/km/kube-proxy.go
@@ -18,7 +18,8 @@ limitations under the License.
 package main
 
 import (
-	kubeproxy "k8s.io/kubernetes/cmd/kube-proxy/app"
+	"k8s.io/kubernetes/cmd/kube-proxy/app"
+	"k8s.io/kubernetes/cmd/kube-proxy/app/options"
 	"k8s.io/kubernetes/contrib/mesos/pkg/hyperkube"
 )
 
@@ -26,7 +27,7 @@ import (
 // description and flags.
 
 func NewKubeProxy() *Server {
-	config := kubeproxy.NewProxyConfig()
+	config := options.NewProxyConfig()
 
 	hks := Server{
 		SimpleUsage: hyperkube.CommandProxy,
@@ -38,13 +39,13 @@ func NewKubeProxy() *Server {
 
 	config.AddFlags(hks.Flags())
 
-	hks.Run = func(_ *Server, args []string) error {
-		s, err := kubeproxy.NewProxyServerDefault(config)
+	hks.Run = func(_ *Server, _ []string) error {
+		s, err := app.NewProxyServerDefault(config)
 		if err != nil {
 			return err
 		}
 
-		return s.Run(args)
+		return s.Run()
 	}
 
 	return &hks

--- a/pkg/kubemark/hollow_proxy.go
+++ b/pkg/kubemark/hollow_proxy.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	proxyapp "k8s.io/kubernetes/cmd/kube-proxy/app"
+	"k8s.io/kubernetes/cmd/kube-proxy/app/options"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/record"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
@@ -57,7 +58,7 @@ func NewHollowProxyOrDie(
 	recorder record.EventRecorder,
 ) *HollowProxy {
 	// Create and start Hollow Proxy
-	config := proxyapp.NewProxyConfig()
+	config := options.NewProxyConfig()
 	config.OOMScoreAdj = 0
 	config.ResourceContainer = ""
 	config.NodeRef = &api.ObjectReference{
@@ -83,7 +84,7 @@ func NewHollowProxyOrDie(
 }
 
 func (hp *HollowProxy) Run() {
-	if err := hp.ProxyServer.Run(make([]string, 0)); err != nil {
+	if err := hp.ProxyServer.Run(); err != nil {
 		glog.Fatalf("Error while running proxy: %v\n", err)
 	}
 }

--- a/plugin/cmd/kube-scheduler/app/options/options.go
+++ b/plugin/cmd/kube-scheduler/app/options/options.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package options provides the scheduler flags
+package options
+
+import (
+	"net"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/master/ports"
+	"k8s.io/kubernetes/plugin/pkg/scheduler/factory"
+
+	"github.com/spf13/pflag"
+)
+
+// SchedulerServer has all the context and params needed to run a Scheduler
+type SchedulerServer struct {
+	Port              int
+	Address           net.IP
+	AlgorithmProvider string
+	PolicyConfigFile  string
+	EnableProfiling   bool
+	Master            string
+	Kubeconfig        string
+	BindPodsQPS       float32
+	BindPodsBurst     int
+	KubeAPIQPS        float32
+	KubeAPIBurst      int
+	SchedulerName     string
+}
+
+// NewSchedulerServer creates a new SchedulerServer with default parameters
+func NewSchedulerServer() *SchedulerServer {
+	s := SchedulerServer{
+		Port:              ports.SchedulerPort,
+		Address:           net.ParseIP("0.0.0.0"),
+		AlgorithmProvider: factory.DefaultProvider,
+		BindPodsQPS:       50.0,
+		BindPodsBurst:     100,
+		KubeAPIQPS:        50.0,
+		KubeAPIBurst:      100,
+		SchedulerName:     api.DefaultSchedulerName,
+	}
+	return &s
+}
+
+// AddFlags adds flags for a specific SchedulerServer to the specified FlagSet
+func (s *SchedulerServer) AddFlags(fs *pflag.FlagSet) {
+	fs.IntVar(&s.Port, "port", s.Port, "The port that the scheduler's http service runs on")
+	fs.IPVar(&s.Address, "address", s.Address, "The IP address to serve on (set to 0.0.0.0 for all interfaces)")
+	fs.StringVar(&s.AlgorithmProvider, "algorithm-provider", s.AlgorithmProvider, "The scheduling algorithm provider to use, one of: "+factory.ListAlgorithmProviders())
+	fs.StringVar(&s.PolicyConfigFile, "policy-config-file", s.PolicyConfigFile, "File with scheduler policy configuration")
+	fs.BoolVar(&s.EnableProfiling, "profiling", true, "Enable profiling via web interface host:port/debug/pprof/")
+	fs.StringVar(&s.Master, "master", s.Master, "The address of the Kubernetes API server (overrides any value in kubeconfig)")
+	fs.StringVar(&s.Kubeconfig, "kubeconfig", s.Kubeconfig, "Path to kubeconfig file with authorization and master location information.")
+	fs.Float32Var(&s.BindPodsQPS, "bind-pods-qps", s.BindPodsQPS, "Number of bindings per second scheduler is allowed to continuously make")
+	fs.IntVar(&s.BindPodsBurst, "bind-pods-burst", s.BindPodsBurst, "Number of bindings per second scheduler is allowed to make during bursts")
+	fs.Float32Var(&s.KubeAPIQPS, "kube-api-qps", s.KubeAPIQPS, "QPS to use while talking with kubernetes apiserver")
+	fs.IntVar(&s.KubeAPIBurst, "kube-api-burst", s.KubeAPIBurst, "Burst to use while talking with kubernetes apiserver")
+	fs.StringVar(&s.SchedulerName, "scheduler-name", s.SchedulerName, "Name of the scheduler, used to select which pods will be processed by this scheduler, based on pod's annotation with key 'scheduler.alpha.kubernetes.io/name'")
+}

--- a/plugin/cmd/kube-scheduler/app/server.go
+++ b/plugin/cmd/kube-scheduler/app/server.go
@@ -31,8 +31,8 @@ import (
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	"k8s.io/kubernetes/pkg/healthz"
-	"k8s.io/kubernetes/pkg/master/ports"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/plugin/cmd/kube-scheduler/app/options"
 	"k8s.io/kubernetes/plugin/pkg/scheduler"
 	_ "k8s.io/kubernetes/plugin/pkg/scheduler/algorithmprovider"
 	schedulerapi "k8s.io/kubernetes/plugin/pkg/scheduler/api"
@@ -45,40 +45,9 @@ import (
 	"github.com/spf13/pflag"
 )
 
-// SchedulerServer has all the context and params needed to run a Scheduler
-type SchedulerServer struct {
-	Port              int
-	Address           net.IP
-	AlgorithmProvider string
-	PolicyConfigFile  string
-	EnableProfiling   bool
-	Master            string
-	Kubeconfig        string
-	BindPodsQPS       float32
-	BindPodsBurst     int
-	KubeAPIQPS        float32
-	KubeAPIBurst      int
-	SchedulerName     string
-}
-
-// NewSchedulerServer creates a new SchedulerServer with default parameters
-func NewSchedulerServer() *SchedulerServer {
-	s := SchedulerServer{
-		Port:              ports.SchedulerPort,
-		Address:           net.ParseIP("0.0.0.0"),
-		AlgorithmProvider: factory.DefaultProvider,
-		BindPodsQPS:       50.0,
-		BindPodsBurst:     100,
-		KubeAPIQPS:        50.0,
-		KubeAPIBurst:      100,
-		SchedulerName:     api.DefaultSchedulerName,
-	}
-	return &s
-}
-
 // NewSchedulerCommand creates a *cobra.Command object with default parameters
 func NewSchedulerCommand() *cobra.Command {
-	s := NewSchedulerServer()
+	s := options.NewSchedulerServer()
 	s.AddFlags(pflag.CommandLine)
 	cmd := &cobra.Command{
 		Use: "kube-scheduler",
@@ -96,24 +65,8 @@ through the API as necessary.`,
 	return cmd
 }
 
-// AddFlags adds flags for a specific SchedulerServer to the specified FlagSet
-func (s *SchedulerServer) AddFlags(fs *pflag.FlagSet) {
-	fs.IntVar(&s.Port, "port", s.Port, "The port that the scheduler's http service runs on")
-	fs.IPVar(&s.Address, "address", s.Address, "The IP address to serve on (set to 0.0.0.0 for all interfaces)")
-	fs.StringVar(&s.AlgorithmProvider, "algorithm-provider", s.AlgorithmProvider, "The scheduling algorithm provider to use, one of: "+factory.ListAlgorithmProviders())
-	fs.StringVar(&s.PolicyConfigFile, "policy-config-file", s.PolicyConfigFile, "File with scheduler policy configuration")
-	fs.BoolVar(&s.EnableProfiling, "profiling", true, "Enable profiling via web interface host:port/debug/pprof/")
-	fs.StringVar(&s.Master, "master", s.Master, "The address of the Kubernetes API server (overrides any value in kubeconfig)")
-	fs.StringVar(&s.Kubeconfig, "kubeconfig", s.Kubeconfig, "Path to kubeconfig file with authorization and master location information.")
-	fs.Float32Var(&s.BindPodsQPS, "bind-pods-qps", s.BindPodsQPS, "Number of bindings per second scheduler is allowed to continuously make")
-	fs.IntVar(&s.BindPodsBurst, "bind-pods-burst", s.BindPodsBurst, "Number of bindings per second scheduler is allowed to make during bursts")
-	fs.Float32Var(&s.KubeAPIQPS, "kube-api-qps", s.KubeAPIQPS, "QPS to use while talking with kubernetes apiserver")
-	fs.IntVar(&s.KubeAPIBurst, "kube-api-burst", s.KubeAPIBurst, "Burst to use while talking with kubernetes apiserver")
-	fs.StringVar(&s.SchedulerName, "scheduler-name", s.SchedulerName, "Name of the scheduler, used to select which pods will be processed by this scheduler, based on pod's annotation with key 'scheduler.alpha.kubernetes.io/name'")
-}
-
 // Run runs the specified SchedulerServer.  This should never exit.
-func (s *SchedulerServer) Run(_ []string) error {
+func Run(s *options.SchedulerServer) error {
 	kubeconfig, err := clientcmd.BuildConfigFromFlags(s.Master, s.Kubeconfig)
 	if err != nil {
 		return err
@@ -146,7 +99,7 @@ func (s *SchedulerServer) Run(_ []string) error {
 	}()
 
 	configFactory := factory.NewConfigFactory(kubeClient, util.NewTokenBucketRateLimiter(s.BindPodsQPS, s.BindPodsBurst), s.SchedulerName)
-	config, err := s.createConfig(configFactory)
+	config, err := createConfig(s, configFactory)
 	if err != nil {
 		glog.Fatalf("Failed to create scheduler configuration: %v", err)
 	}
@@ -162,7 +115,7 @@ func (s *SchedulerServer) Run(_ []string) error {
 	select {}
 }
 
-func (s *SchedulerServer) createConfig(configFactory *factory.ConfigFactory) (*scheduler.Config, error) {
+func createConfig(s *options.SchedulerServer, configFactory *factory.ConfigFactory) (*scheduler.Config, error) {
 	var policy schedulerapi.Policy
 	var configData []byte
 

--- a/plugin/cmd/kube-scheduler/scheduler.go
+++ b/plugin/cmd/kube-scheduler/scheduler.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/version/verflag"
 	"k8s.io/kubernetes/plugin/cmd/kube-scheduler/app"
+	"k8s.io/kubernetes/plugin/cmd/kube-scheduler/app/options"
 
 	"github.com/spf13/pflag"
 )
@@ -33,7 +34,7 @@ func init() {
 
 func main() {
 	runtime.GOMAXPROCS(runtime.NumCPU())
-	s := app.NewSchedulerServer()
+	s := options.NewSchedulerServer()
 	s.AddFlags(pflag.CommandLine)
 
 	util.InitFlags()
@@ -42,5 +43,5 @@ func main() {
 
 	verflag.PrintAndExitIfRequested()
 
-	s.Run(pflag.CommandLine.Args())
+	app.Run(s)
 }


### PR DESCRIPTION
Keep options and flags distinct from initialization

Related to #19089, #19091, and #19092
