### PR TITLE
Preload camlistore godep in verify-godeps

### DIFF
--- a/hack/verify-godeps.sh
+++ b/hack/verify-godeps.sh
@@ -74,6 +74,9 @@ echo "Starting to download all kubernetes godeps. This takes a while"
 # Remove once either godep works properly or we bump docker version
 preload-dep github.com/docker docker 0f5c9d301b9b1cca66b3ea0f9dec3b5317d3686d
 
+# Remove once either godep works properly or we bump camlistore deps
+preload-dep github.com/camlistore camlistore 9868aa0f8d8a93ff0b30ff0de46cc351b6b88b30
+
 "${GODEP}" restore
 echo "Download finished"
 


### PR DESCRIPTION
Similar to 62eb82d6fc5ead89f07cf4e61ada8db439aeb015, this works around
package refactoring and godep incompatibility

As noted in https://github.com/kubernetes/kubernetes/pull/18798#issuecomment-167193621
/cc @smarterclayton
