### PR TITLE
WIP: Add pod/commit subsource to support user to commit their container

### DIFF
--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -80,6 +80,7 @@ func AddToScheme(scheme *runtime.Scheme) {
 		&PodLogOptions{},
 		&PodExecOptions{},
 		&PodProxyOptions{},
+		&PodCommitOptions{},
 		&ComponentStatus{},
 		&ComponentStatusList{},
 		&SerializedReference{},
@@ -149,6 +150,7 @@ func (obj *PodAttachOptions) GetObjectKind() unversioned.ObjectKind          { r
 func (obj *PodLogOptions) GetObjectKind() unversioned.ObjectKind             { return &obj.TypeMeta }
 func (obj *PodExecOptions) GetObjectKind() unversioned.ObjectKind            { return &obj.TypeMeta }
 func (obj *PodProxyOptions) GetObjectKind() unversioned.ObjectKind           { return &obj.TypeMeta }
+func (obj *PodCommitOptions) GetObjectKind() unversioned.ObjectKind          { return &obj.TypeMeta }
 func (obj *ComponentStatus) GetObjectMeta() meta.Object                      { return &obj.ObjectMeta }
 func (obj *ComponentStatus) GetObjectKind() unversioned.ObjectKind           { return &obj.TypeMeta }
 func (obj *ComponentStatusList) GetObjectKind() unversioned.ObjectKind       { return &obj.TypeMeta }

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1799,6 +1799,26 @@ type PodProxyOptions struct {
 	Path string
 }
 
+// PodCommitOptions is the query options to a Pod's commit call
+type PodCommitOptions struct {
+	unversioned.TypeMeta
+
+	// Container which to commit.
+	Container string
+
+	// Author(e.g.,"foo, <foo@bar.com>)
+	Author string
+
+	// Commit Message
+	Message string
+
+	// Pause container during commit
+	Pause bool
+
+	// Apply Dockerfile instruction to the created image
+	Change []string
+}
+
 // ObjectReference contains enough information to let you inspect or modify the referred object.
 type ObjectReference struct {
 	Kind            string    `json:"kind,omitempty"`

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -307,6 +307,7 @@ func (m *Master) initV1ResourcesStorage(c *Config) {
 		"pods/exec":        podStorage.Exec,
 		"pods/portforward": podStorage.PortForward,
 		"pods/proxy":       podStorage.Proxy,
+		"pods/commit":      podStorage.Commit,
 		"pods/binding":     podStorage.Binding,
 		"bindings":         podStorage.Binding,
 

--- a/pkg/registry/pod/etcd/etcd.go
+++ b/pkg/registry/pod/etcd/etcd.go
@@ -48,6 +48,7 @@ type PodStorage struct {
 	Exec        *podrest.ExecREST
 	Attach      *podrest.AttachREST
 	PortForward *podrest.PortForwardREST
+	Commit      *podrest.CommitREST
 }
 
 // REST implements a RESTStorage for pods against etcd
@@ -106,6 +107,7 @@ func NewStorage(
 		Exec:        &podrest.ExecREST{Store: store, KubeletConn: k},
 		Attach:      &podrest.AttachREST{Store: store, KubeletConn: k},
 		PortForward: &podrest.PortForwardREST{Store: store, KubeletConn: k},
+		Commit:      &podrest.CommitREST{Store: store, KubeletConn: k},
 	}
 }
 

--- a/pkg/registry/pod/strategy.go
+++ b/pkg/registry/pod/strategy.go
@@ -369,6 +369,18 @@ func ExecLocation(
 	return streamLocation(getter, connInfo, ctx, name, opts, opts.Container, "exec")
 }
 
+// CommmitLocation returns the exec URL for a pod container. If opts.Container is blank
+// and only one container is present in the pod, that container is used.
+func CommitLocation(
+	getter ResourceGetter,
+	connInfo client.ConnectionInfoGetter,
+	ctx api.Context,
+	name string,
+	opts *api.PodExecOptions,
+) (*url.URL, http.RoundTripper, error) {
+	return streamLocation(getter, connInfo, ctx, name, opts, opts.Container, "commit")
+}
+
 func streamLocation(
 	getter ResourceGetter,
 	connInfo client.ConnectionInfoGetter,


### PR DESCRIPTION
This PR add pod/commit subsource to support user to commit their image.

I didn't try to fully implement this(I even not update the auto generated files) since some discussion may needed. 

If this looks good, I will implement the kubelet&kubectl part and implement the `pod/push` subsource to support user to push their container to registry.

Kubelet will support the commit/push functionality by some abstraction mediating the runtime(docker and rkt by now), so that it's runtime-agnostic. 

It seems that rkt doesn't support commit&push by now(correct me if I am wrong), we can return a error message(indicating that the command is not supported) to user until rkt support commit/push.

Any comment are welcomed.
