### PR TITLE
pkg/controller/node: heap.Fix instead of Remove, Push

### DIFF
--- a/pkg/controller/node/rate_limited_queue.go
+++ b/pkg/controller/node/rate_limited_queue.go
@@ -87,8 +87,8 @@ func (q *UniqueQueue) Replace(value TimedValue) bool {
 		if q.queue[i].Value != value.Value {
 			continue
 		}
-		heap.Remove(&q.queue, i)
-		heap.Push(&q.queue, &value)
+		*(q.queue[i]) = value
+		heap.Fix(&q.queue, i)
 		return true
 	}
 	return false


### PR DESCRIPTION
This calls heap.Fix, which is O(log(n)) where n = h.Len(),
only once, instead of calling O(log(n)) operation Remove and
Push, which is 2 \* O(log(n)).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/19108)

<!-- Reviewable:end -->
