### PR TITLE
Deployment should support DaemonSet update

### DIFF
--- a/pkg/apis/extensions/types.go
+++ b/pkg/apis/extensions/types.go
@@ -202,10 +202,22 @@ type Deployment struct {
 	Status DeploymentStatus `json:"status,omitempty"`
 }
 
+type DeploymentTarget string
+
+const(
+	// the Deployment is ReplicationController-oriented
+	DeploymentTargetController DeploymentTarget  = "ReplicationController"
+	// the Deployment is DaemonSet-oriented
+	DeploymentTargetDaemonSet  DeploymentTarget  = "DaemonSet"
+)
+
 type DeploymentSpec struct {
 	// Number of desired pods. This is a pointer to distinguish between explicit
 	// zero and not specified. Defaults to 1.
 	Replicas int `json:"replicas,omitempty"`
+
+	// The target of the deployment(ReplicationController/Daemonset by now)
+	Target DeploymentTarget `json:"target,omitempty"`
 
 	// Label selector for pods. Existing ReplicationControllers whose pods are
 	// selected by this will be the ones affected by this deployment.


### PR DESCRIPTION
@davidopp 

Current, we can use deployment to update replication controller. Deployment should support updating  DaemonSet, too. This PR add a field `Target` to `Deployment.Spec`, indicating the deployment is rc-oriented or daemonset-oriented. If the deployment is rc-oriented, DeploymentController will update replicationcontroller, otherwise it will update daemonset. (in the future, it may support more API which could create pods, such as ReplicaSet)

I will update the auto-generated files and implement the DeploymentController part if this looks good.
