### PR TITLE
Don't limit `go test` to only 2 cores

### DIFF
--- a/hack/jenkins/test-dockerized.sh
+++ b/hack/jenkins/test-dockerized.sh
@@ -49,7 +49,7 @@ godep go install ./...
 
 ./hack/verify-all.sh -v
 
-./hack/test-go.sh -- -p=2
+./hack/test-go.sh
 ./hack/test-cmd.sh
 ./hack/test-integration.sh
 ./hack/test-update-storage-objects.sh


### PR DESCRIPTION
Removing `-p=2` to see if this helps with the increasingly long test times we're seeing in #18980.

@kubernetes/goog-testing 
