### PR TITLE
RFC: Adding a new ImageManager package to kubelet

### DIFF
--- a/pkg/kubelet/images/doc.go
+++ b/pkg/kubelet/images/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package images is responsible for managing lifecycle of container images.
+package images

--- a/pkg/kubelet/images/types.go
+++ b/pkg/kubelet/images/types.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package images
+
+import "k8s.io/kubernetes/pkg/api"
+
+// ImageSpec contains an image and all the metadata required for managing that image.
+type ImageSpec struct {
+	Name        string
+	PullPolicy  api.PullPolicy
+	PullSecrets []api.Secret
+}
+
+// ImageManager provides an interface to manage the lifecycle of images.
+// Implementations of this interface are expected to deal with pulling (downloading),
+// managing, and deleting container images.
+// Implementations are expected to abstract the underlying runtimes.
+// Implementations are expected to be thread safe.
+type ImageManager interface {
+	// EnsureImageExists will ensure that image specified in `imageSpec` exists.
+	// TODO: Consider failing when conflicting PullPolicy is provided for the same image.
+	EnsureImageExists(imageSpec ImageSpec) error
+	// IncImageUsage increases the usage count of the image specified in `imageSpec`.
+	// This is useful for reference counting images.
+	IncImageUsage(imageSpec ImageSpec) error
+	// DecImageUsage decreases the usage count of the image specified in `imageSpec`.
+	// This is useful for reference counting images.
+	DecImageUsage(imageSpec ImageSpec) error
+	// DeleteImages attempts to free up `bytesToBeFreed` by deleting images that are curretly unused.
+	// It will return the number of bytes freed on success, an appropriate error otherwise.
+	DeleteImages(bytesToBeFreed uint64) (uint64, error)
+}


### PR DESCRIPTION
This will eventually abstract out image management from Kubelet core.

@yujuhong: Based on our offline discussion I created this PR to facilitate design discussion before we move on with the overall refactoring.

Primary goals as of now are:
1. Make Image GC synchronous.
2. Reduce the overhead on runtimes for image GC by closely integrating with kubelet's existing pod (and container) lifecycle management.
3. Pave way for separating out Image management from runtime management inside kubelet.
4. Enable centralized Out of Resource eviction based on various policies. As of now each resource is managed separately. This will cause issues once kubelet starts to evict pods in the future.
