### PR TITLE
Refactor hyperkube Makefile to avoid changing local files

### DIFF
--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -3,6 +3,7 @@
 VERSION=v1.1.2
 ARCH=amd64
 BASEIMAGE=debian:jessie
+TEMP_DIR:=$(shell mktemp -d)
 
 ## Comment in for arm builds, must be run on an arm machine
 # ARCH=arm
@@ -12,13 +13,14 @@ BASEIMAGE=debian:jessie
 all: build
 
 build:
-	cp ../../saltbase/salt/helpers/safe_format_and_mount .
-	cp ../../saltbase/salt/generate-cert/make-ca-cert.sh  .
-	curl -O https://storage.googleapis.com/kubernetes-release/release/${VERSION}/bin/linux/${ARCH}/hyperkube
-	sed -i "s/VERSION/${VERSION}/g" master-multi.json master.json kube-proxy.json
-	sed -i "s/ARCH/${ARCH}/g" master-multi.json master.json kube-proxy.json
-	sed -i "s/BASEIMAGE/${BASEIMAGE}/g" Dockerfile
-	docker build -t gcr.io/google_containers/hyperkube-${ARCH}:${VERSION} .
+	cp ./* ${TEMP_DIR}
+	cp ../../saltbase/salt/helpers/safe_format_and_mount ${TEMP_DIR}
+	cp ../../saltbase/salt/generate-cert/make-ca-cert.sh ${TEMP_DIR}
+	cp ../../../_output/dockerized/bin/linux/${ARCH}/hyperkube ${TEMP_DIR}
+	cd ${TEMP_DIR} && sed -i "s/VERSION/${VERSION}/g" master-multi.json master.json kube-proxy.json
+	cd ${TEMP_DIR} && sed -i "s/ARCH/${ARCH}/g" master-multi.json master.json kube-proxy.json
+	cd ${TEMP_DIR} && sed -i "s/BASEIMAGE/${BASEIMAGE}/g" Dockerfile
+	docker build -t gcr.io/google_containers/hyperkube-${ARCH}:${VERSION} ${TEMP_DIR}
 	# Backward compatability.  TODO: deprecate this image tag
 ifeq ($(ARCH),amd64)
 	docker tag -f gcr.io/google_containers/hyperkube-${ARCH}:${VERSION} gcr.io/google_containers/hyperkube:${VERSION}


### PR DESCRIPTION
Previously this Makefile was modifying local files (e.g. master.json). Now we'll use temporary directory during the build process so that we can build hyperkube image without polluting current working directory.

After this PR it will be required to run `make release` before running this `Makefile`. This is not a problem as build hyperkube image will part of the official release.

Ref #11751

@ihmccreery (release process)
@brendandburns (local docker setup)
