### PR TITLE
Skip monitoring e2e tests until new Heapster release

### DIFF
--- a/test/e2e/monitoring.go
+++ b/test/e2e/monitoring.go
@@ -30,7 +30,7 @@ import (
 )
 
 // TODO: quinton: debug issue #6541 and then remove Pending flag here.
-var _ = Describe("Monitoring", func() {
+var _ = Describe("[Flaky] Monitoring", func() {
 	var c *client.Client
 
 	BeforeEach(func() {


### PR DESCRIPTION
With 0.19.1 Influxdb problems should be fixed.
