### PR TITLE
Increase limit for elasticsearch logs amount in scalability tests

### DIFF
--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -79,7 +79,7 @@ func density30AddonResourceVerifier() map[string]resourceConstraint {
 	constraints["elasticsearch-logging"] = resourceConstraint{
 		cpuConstraint: 2,
 		// TODO: bring it down to 750MB again, when we lower Kubelet verbosity level. I.e. revert #19164
-		memoryConstraint: 2000 * (1024 * 1024),
+		memoryConstraint: 5000 * (1024 * 1024),
 	}
 	constraints["heapster"] = resourceConstraint{
 		cpuConstraint:    2,


### PR DESCRIPTION
Will fix this failure:
http://kubekins.dls.corp.google.com/view/Critical%20Builds/job/kubernetes-e2e-gce-scalability/3713/
