### PR TITLE
Add docker images for kubelet and kubelet-checker.

### DIFF
--- a/cluster/images/kubelet-checker/Dockerfile
+++ b/cluster/images/kubelet-checker/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine
+
+COPY kubelet-checker.sh /kubelet-checker.sh
+RUN chmod a+rx /kubelet-checker.sh
+

--- a/cluster/images/kubelet-checker/Makefile
+++ b/cluster/images/kubelet-checker/Makefile
@@ -1,0 +1,15 @@
+# Build the kubelet-checker image.
+#
+# Usage:
+#   VERSION=v1.1.2 [REGISTRY="gcr.io/google_containers"] make build
+
+REGISTRY?="gcr.io/google_containers"
+ARCH=amd64
+
+build:
+ifndef VERSION
+    $(error VERSION is undefined)
+endif
+	docker build -t ${REGISTRY}/kubelet-checker-${ARCH}:${VERSION} .
+
+.PHONY: release

--- a/cluster/images/kubelet-checker/kubelet-checker.sh
+++ b/cluster/images/kubelet-checker/kubelet-checker.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is intended to watch kubelet health and restart it when
+# it detects a failure.
+#
+# Usage:
+#  kubelet-checker.sh <kubelet_container_id> [<kubelet_url>]
+
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
+	echo "Usage:"
+	echo "  kubelet-checker.sh <kubelet_container_id> [<kubelet_url>]"
+	exit 1
+fi
+
+max_seconds=10
+container_id="${1}"
+kubelet_url="${2:-https://127.0.0.1:10250}"
+
+echo "Watching kubelet on ${kubelet_url} (container_id=${container_id})"
+echo ""
+echo "Waiting a minute for kubelet startup"
+sleep 60
+while true; do
+  if ! curl --insecure -m ${max_seconds} -f -s ${kubelet_url}/healthz > /dev/null; then
+    echo "Kubelet failed!"
+    sudo docker restart $1
+    echo "Waiting a minute for kubelet startup"
+	sleep 60
+  else
+	sleep 10
+  fi
+done
+

--- a/cluster/images/kubelet/Dockerfile
+++ b/cluster/images/kubelet/Dockerfile
@@ -1,8 +1,21 @@
-FROM centos
-ADD kubelet /kubelet
-RUN chmod a+rx /kubelet
-RUN cp /usr/bin/nsenter /nsenter
+FROM debian:jessie
 
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get -yy -q \
+    install \
+    iptables \
+    ethtool \
+    && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY kubelet /kubelet
+RUN chmod a+rx /kubelet
+
+COPY kubelet-runner.sh /kubelet-runner.sh
+RUN chmod a+rx /kubelet-runner.sh
+
+VOLUME /sys
+VOLUME /dev
 VOLUME /var/lib/docker
 VOLUME /var/lib/kubelet
-CMD [ "/kubelet" ]
+VOLUME /var/run

--- a/cluster/images/kubelet/Makefile
+++ b/cluster/images/kubelet/Makefile
@@ -1,21 +1,20 @@
-# build the kubelet image.
-
+# Build the kubelet image.
+#
+# Usage:
+#   VERSION=v1.1.2 [REGISTRY="gcr.io/google_containers"] make build
+#
 # TODO: figure out the best base image
-# TODO: figure out how to best source the nsenter binary, if necessary
-# TODO: figure out how to make a single source of version info for these
-#       images
-VERSION=v0.16
-BIN_DIR=bin/linux/amd64
-LOCAL_OUTPUT_DIR=../../../_output/local
 
-release: clean
-	curl -O https://storage.googleapis.com/kubernetes-release/release/${VERSION}/${BIN_DIR}/kubelet
-	docker build -t gcr.io/google_containers/kubelet:${VERSION} .
-	gcloud docker push gcr.io/google_containers/kubelet:${VERSION}
+REGISTRY?="gcr.io/google_containers"
+ARCH=amd64
 
-local: clean
-	cp ${LOCAL_OUTPUT_DIR}/${BIN_DIR}/kubelet .
-	docker build -t gcr.io/google_containers/kubelet .
+build:
+ifndef VERSION
+    $(error VERSION is undefined)
+endif
+	cp ../../../_output/dockerized/bin/linux/${ARCH}/kubelet .
+	docker build -t ${REGISTRY}/kubelet-${ARCH}:${VERSION} .
+	rm -f kubelet
 
 clean:
 	rm -f kubelet

--- a/cluster/images/kubelet/kubelet-runner.sh
+++ b/cluster/images/kubelet/kubelet-runner.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This will run kubelet outside of the container (in host namespaces) and will
+# exit when kubelet exits with the same error code.
+# TODO: This script is used to workaround lack of namespace propagation flag in docker
+#       (see https://github.com/docker/docker/issues/14630). This got fixed in PR
+#       https://github.com/docker/docker/pull/17034 and will be released in docker 1.10.
+#       As long as we support docker versions older than 1.10 we should run kubelet
+#       via nsenter.
+nsenter --target=1 --mount --wd=. -- ./kubelet $@


### PR DESCRIPTION
Add two docker images:
- `kubelet` - run kubelet via nsenter to workaround problems with namespace propagation.
- `kubelet-checker` - script to monitor kubelet running in docker image; similar to https://github.com/kubernetes/kubernetes/blob/master/cluster/saltbase/salt/supervisor/kubelet-checker.sh

I'll send a followup PR to build and release those images.

This has similar changes to #19069.

In the long term I'd like to use those images by default in most cluster deployments (ref #18287)

@dchen1107 @vishh @roberthbailey @mikedanese 

Ref #4869
