### PR TITLE
Build kubectl statically

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -131,6 +131,7 @@ readonly KUBE_STATIC_LIBRARIES=(
   kube-controller-manager
   kube-scheduler
   kube-proxy
+  kubectl
 )
 
 kube::golang::is_statically_linked_library() {


### PR DESCRIPTION
Ref: #19109

What do you think?
I can't see it would break something to make `kubectl` statically linked.

@thockin @brendandburns @janetkuo @bgrant0607 @gmarek 
