### PR TITLE
Increase apiserver timeout in tests

### DIFF
--- a/hack/test-update-storage-objects.sh
+++ b/hack/test-update-storage-objects.sh
@@ -57,7 +57,7 @@ function startApiServer() {
   APISERVER_PID=$!
 
   # url, prefix, wait, times
-  kube::util::wait_for_url "http://127.0.0.1:${API_PORT}/healthz" "apiserver: " 1 45
+  kube::util::wait_for_url "http://127.0.0.1:${API_PORT}/healthz" "apiserver: " 1 120
 }
 
 function killApiServer() {


### PR DESCRIPTION
Increasing it from 10s to 45s solved almost all failures, but I've still seen one or two. Increasing it a bit more should solve those issues too.
