### PR TITLE
examples/elasticsearch/es-rc.yaml file was not compatible with the schema

### DIFF
--- a/examples/elasticsearch/es-rc.yaml
+++ b/examples/elasticsearch/es-rc.yaml
@@ -48,5 +48,4 @@ spec:
           name: storage
       volumes:
       - name: storage
-        source:
-          emptyDir: {}
+        emptyDir: {}

--- a/examples/elasticsearch/production_cluster/es-master-rc.yaml
+++ b/examples/elasticsearch/production_cluster/es-master-rc.yaml
@@ -45,5 +45,4 @@ spec:
           name: storage
       volumes:
       - name: storage
-        source:
-          emptyDir: {}
+        emptyDir: {}


### PR DESCRIPTION
there is no "source" field in the volume type.
