### PR TITLE
Make the etcd image cross-platform

### DIFF
--- a/cluster/images/etcd/.gitignore
+++ b/cluster/images/etcd/.gitignore
@@ -1,4 +1,0 @@
-etcd
-etcdctl
-etcd-*-linux-amd64.tar.gz
-etcd-*-linux-amd64/

--- a/cluster/images/etcd/Dockerfile
+++ b/cluster/images/etcd/Dockerfile
@@ -1,5 +1,5 @@
-FROM busybox
+FROM BASEIMAGE
 MAINTAINER  Dawn Chen <dawnchen@google.com>
 
-ADD ./etcd /usr/local/bin/etcd
-ADD ./etcdctl /usr/local/bin/etcdctl
+COPY ./etcd /usr/local/bin/etcd
+COPY ./etcdctl /usr/local/bin/etcdctl

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -1,21 +1,48 @@
-.PHONY:	clean build push
+# Build the etcd image
+#
+# Usage:
+# 	[TAG=2.2.1] [REGISTRY=gcr.io/google_containers] [ARCH=amd64] [BASEIMAGE=busybox] make (build|push)
 
-IMAGE = etcd
-TAG = 2.2.1
-ETCD_VERSION = 2.2.1
-OUTPUT_DIR = $(IMAGE)-v$(ETCD_VERSION)-linux-amd64
+TAG?=2.2.1
+ARCH?=amd64
+REGISTRY?=gcr.io/google_containers
+TEMP_DIR:=$(shell mktemp -d)
 
-clean:
-	rm -rf $(OUTPUT_DIR) $(IMAGE)-v$(ETCD_VERSION)-linux-amd64.tar.gz etcd etcdctl
+# Default base images for different architectures
+# '/' in images has to be written as '\\/'
+ifeq ($(ARCH),amd64)
+	BASEIMAGE?=busybox
+endif
+ifeq ($(ARCH),arm)
+	BASEIMAGE?=hypriot\\/armhf-busybox
+endif
 
-build: clean
-	curl -L -O https://github.com/coreos/etcd/releases/download/v$(ETCD_VERSION)/$(IMAGE)-v$(ETCD_VERSION)-linux-amd64.tar.gz
-	tar xzvf $(IMAGE)-v$(ETCD_VERSION)-linux-amd64.tar.gz
-	cp $(OUTPUT_DIR)/etcd .
-	cp $(OUTPUT_DIR)/etcdctl .
-	docker build -t gcr.io/google_containers/$(IMAGE):$(TAG) .
+build:
+	# Download etcd source in a golang container and cross-compile it statically
+	# or download official binaries if the ARCH is amd64
+	./build-etcd.sh ${TAG} ${ARCH} ${TEMP_DIR}
+
+	# Copy the content in this dir to the temp dir
+	cp ./* ${TEMP_DIR}
+
+	# Replace BASEIMAGE with the real base image
+	cd ${TEMP_DIR} && sed -i "s/BASEIMAGE/${BASEIMAGE}/g" Dockerfile
+
+	# And build the image
+	docker build -t ${REGISTRY}/etcd-${ARCH}:${TAG} ${TEMP_DIR}
+
+ifeq ($(ARCH),amd64)
+	# Backward compatability. TODO: deprecate this image tag
+	docker tag -f ${REGISTRY}/etcd-${ARCH}:${TAG} ${REGISTRY}/etcd:${TAG}
+endif
 
 push: build
-	gcloud docker push gcr.io/google_containers/$(IMAGE):$(TAG)
+	gcloud docker push ${REGISTRY}/etcd-${ARCH}:${TAG}
 
-all:	push
+	# Backward compatability. TODO: deprecate this image tag
+ifeq ($(ARCH),amd64)
+	gcloud docker push ${REGISTRY}/etcd:${TAG}
+endif
+
+all: build
+.PHONY:	build push

--- a/cluster/images/etcd/build-etcd.sh
+++ b/cluster/images/etcd/build-etcd.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build etcd from source in a docker container
+
+# Require three arguments
+if [[ $# != 3 ]]; then
+	echo "Usage: ./build-etcd.sh TAG ARCH TARGET_DIR"
+	exit
+fi
+
+# Example tag should be 2.2.1, not v2.2.1
+TAG=$1
+ARCH=$2
+TARGET_DIR=$3
+
+GOLANG_VERSION=${GOLANG_VERSION:-1.5.2}
+GOARM=6
+
+# Create the ${TARGET_DIR} directory, if it doesn't exist
+mkdir -p ${TARGET_DIR}
+
+# Do not compile if we should make an image for amd64, use the "official" etcd binaries instead
+if [[ ${ARCH} == "amd64" ]]; then
+
+	# Just download the binaries to ${TARGET_DIR}
+	curl -sSL https://github.com/coreos/etcd/releases/download/v${TAG}/etcd-v${TAG}-linux-amd64.tar.gz | tar -xz -C ${TARGET_DIR} --strip-components=1
+else
+	# Download etcd in a golang container and cross-compile it statically
+	CID=$(docker run -d golang:${GOLANG_VERSION} /bin/sh -c \
+		"mkdir /etcd \
+		&& curl -sSL https://github.com/coreos/etcd/archive/v${TAG}.tar.gz | tar -C /etcd -xz --strip-components=1 \
+		&& cd /etcd \
+		&& GOARM=${GOARM} GOARCH=${ARCH} ./build")
+	
+	# Wait until etcd has compiled
+	docker wait ${CID}
+
+	# Copy out the bin folder to ${TARGET_DIR}
+	docker cp ${CID}:/etcd/bin ${TARGET_DIR}
+
+	# Move the contents in bin to the target directory
+	mv ${TARGET_DIR}/bin/* ${TARGET_DIR}
+fi


### PR DESCRIPTION
ARM tracking issue: #17981 

If building for `amd64`, download the release as earlier.
If building for another arch, cross-compile `etcd` statically.

Harmonize the `Makefile` with `hyperkube` `Makefile`

This patch fixes partially this issue: #19185
Usage: `ARCH=ppc64le BASEIMAGE=scratch make`
Of course, if you have a `ppc64le` busybox image, use that instead.
One caveat, `etcd` doesn't compile on `ppc64le` right now:

```
# github.com/coreos/etcd/Godeps/_workspace/src/github.com/boltdb/bolt
gopath/src/github.com/coreos/etcd/Godeps/_workspace/src/github.com/boltdb/bolt/db.go:85: undefined: maxMapSize
gopath/src/github.com/coreos/etcd/Godeps/_workspace/src/github.com/boltdb/bolt/db.go:85: invalid array bound maxMapSize
```

But when that is fixed, `ppc64le` is also supported.

@brendandburns @dchen1107 @ArtfulCoder @thockin @fgrzadkowski @qq511700505
