### PR TITLE
Refactor cluster/gce scripts to separate logical steps of cluster deployment

### DIFF
--- a/cluster/gce/addons.sh
+++ b/cluster/gce/addons.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A library with any addon related operations during kube-up, kube-down etc.
+
+# Deploys addons to the kubernetes clusters.
+function addons::deploy() {
+  # Report logging choice (if any).
+  if [[ "${ENABLE_NODE_LOGGING-}" == "true" ]]; then
+    echo "+++ Logging using Fluentd to ${LOGGING_DESTINATION:-unknown}"
+  fi
+
+  # Create autoscaler for nodes if requested
+  if [[ "${ENABLE_NODE_AUTOSCALER}" == "true" ]]; then
+    METRICS=""
+    # Current usage
+    METRICS+="--custom-metric-utilization metric=custom.cloudmonitoring.googleapis.com/kubernetes.io/cpu/node_utilization,"
+    METRICS+="utilization-target=${TARGET_NODE_UTILIZATION},utilization-target-type=GAUGE "
+    METRICS+="--custom-metric-utilization metric=custom.cloudmonitoring.googleapis.com/kubernetes.io/memory/node_utilization,"
+    METRICS+="utilization-target=${TARGET_NODE_UTILIZATION},utilization-target-type=GAUGE "
+
+    # Reservation
+    METRICS+="--custom-metric-utilization metric=custom.cloudmonitoring.googleapis.com/kubernetes.io/cpu/node_reservation,"
+    METRICS+="utilization-target=${TARGET_NODE_UTILIZATION},utilization-target-type=GAUGE "
+    METRICS+="--custom-metric-utilization metric=custom.cloudmonitoring.googleapis.com/kubernetes.io/memory/node_reservation,"
+    METRICS+="utilization-target=${TARGET_NODE_UTILIZATION},utilization-target-type=GAUGE "
+
+    echo "Creating node autoscalers."
+
+    local max_instances_per_mig=$(((${AUTOSCALER_MAX_NODES} + ${num_migs} - 1) / ${num_migs}))
+    local last_max_instances=$((${AUTOSCALER_MAX_NODES} - (${num_migs} - 1) * ${max_instances_per_mig}))
+    local min_instances_per_mig=$(((${AUTOSCALER_MIN_NODES} + ${num_migs} - 1) / ${num_migs}))
+    local last_min_instances=$((${AUTOSCALER_MIN_NODES} - (${num_migs} - 1) * ${min_instances_per_mig}))
+
+    for i in $(seq $((${num_migs} - 1))); do
+      gcloud compute instance-groups managed set-autoscaling "${NODE_INSTANCE_PREFIX}-group-$i" --zone "${ZONE}" --project "${PROJECT}" \
+        --min-num-replicas "${min_instances_per_mig}" --max-num-replicas "${max_instances_per_mig}" ${METRICS} || true
+    done
+    gcloud compute instance-groups managed set-autoscaling "${NODE_INSTANCE_PREFIX}-group" --zone "${ZONE}" --project "${PROJECT}" \
+    --min-num-replicas "${last_min_instances}" --max-num-replicas "${last_max_instances}" ${METRICS} || true
+  fi
+}

--- a/cluster/gce/cluster.sh
+++ b/cluster/gce/cluster.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A library with any cluster level operations during kube-up, kube-down etc.
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${KUBE_ROOT}/cluster/gce/common.sh"
+
+# Provisions cluster level resources such as network and firewall rules.
+function cluster::provision() {
+  detect-project
+
+  if ! gcloud compute networks --project "${PROJECT}" describe "${NETWORK}" &>/dev/null; then
+    echo "Creating new network: ${NETWORK}"
+    # The network needs to be created synchronously or we have a race. The
+    # firewalls can be added concurrent with instance creation.
+    gcloud compute networks create --project "${PROJECT}" "${NETWORK}" --range "10.240.0.0/16"
+  fi
+
+  if ! gcloud compute firewall-rules --project "${PROJECT}" describe "${NETWORK}-default-internal" &>/dev/null; then
+    echo "Creating firewall rule for internal traffic"
+    gcloud compute firewall-rules create "${NETWORK}-default-internal" \
+      --project "${PROJECT}" \
+      --network "${NETWORK}" \
+      --source-ranges "10.0.0.0/8" \
+      --allow "tcp:1-65535,udp:1-65535,icmp" &
+  fi
+
+  if ! gcloud compute firewall-rules describe --project "${PROJECT}" "${NETWORK}-default-ssh" &>/dev/null; then
+    echo "Creating firewall rule for ssh"
+    gcloud compute firewall-rules create "${NETWORK}-default-ssh" \
+      --project "${PROJECT}" \
+      --network "${NETWORK}" \
+      --source-ranges "0.0.0.0/0" \
+      --allow "tcp:22" &
+  fi
+}

--- a/cluster/gce/common.sh
+++ b/cluster/gce/common.sh
@@ -1,0 +1,267 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use the gcloud defaults to find the project.  If it is already set in the
+# environment then go with that.
+#
+# Vars set:
+#   PROJECT
+#   PROJECT_REPORTED
+function detect-project () {
+  if [[ -z "${PROJECT-}" ]]; then
+    PROJECT=$(gcloud config list project | tail -n 1 | cut -f 3 -d ' ')
+  fi
+
+  if [[ -z "${PROJECT-}" ]]; then
+    echo "Could not detect Google Cloud Platform project.  Set the default project using " >&2
+    echo "'gcloud config set project <PROJECT>'" >&2
+    exit 1
+  fi
+  if [[ -z "${PROJECT_REPORTED-}" ]]; then
+    echo "Project: ${PROJECT}" >&2
+    echo "Zone: ${ZONE}" >&2
+    PROJECT_REPORTED=true
+  fi
+}
+
+# Wait for background jobs to finish. Exit with
+# an error status if any of the jobs failed.
+function wait-for-jobs {
+  local fail=0
+  local job
+  for job in $(jobs -p); do
+    wait "${job}" || fail=$((fail + 1))
+  done
+  if (( fail != 0 )); then
+    echo -e "${color_red}${fail} commands failed.  Exiting.${color_norm}" >&2
+    # Ignore failures for now.
+    # exit 2
+  fi
+}
+
+# Robustly try to create a firewall rule.
+# $1: The name of firewall rule.
+# $2: IP ranges.
+# $3: Target tags for this firewall rule.
+function create-firewall-rule {
+  detect-project
+
+  local attempt=0
+  while true; do
+    if ! gcloud compute firewall-rules create "$1" \
+      --project "${PROJECT}" \
+      --network "${NETWORK}" \
+      --source-ranges "$2" \
+      --target-tags "$3" \
+      --allow tcp,udp,icmp,esp,ah,sctp; then
+      if (( attempt > 4 )); then
+        echo -e "${color_red}Failed to create firewall rule $1 ${color_norm}" >&2
+        exit 2
+      fi
+      echo -e "${color_yellow}Attempt $(($attempt+1)) failed to create firewall rule $1. Retrying.${color_norm}" >&2
+      attempt=$(($attempt+1))
+      sleep $(($attempt * 5))
+    else
+      break
+    fi
+  done
+}
+
+# Quote something appropriate for a yaml string.
+#
+# TODO(zmerlynn): Note that this function doesn't so much "quote" as
+# "strip out quotes", and we really should be using a YAML library for
+# this, but PyYAML isn't shipped by default, and *rant rant rant ... SIGH*
+function yaml-quote {
+  echo "'$(echo "${@}" | sed -e "s/'/''/g")'"
+}
+
+function write-node-env {
+  build-kube-env false "${KUBE_TEMP}/node-kube-env.yaml"
+}
+
+# TODO: Move this to master.sh once all the master related code is there.
+function write-master-env {
+  # If the user requested that the master be part of the cluster, set the
+  # environment variable to program the master kubelet to register itself.
+  if [[ "${REGISTER_MASTER_KUBELET:-}" == "true" ]]; then
+    KUBELET_APISERVER="${MASTER_NAME}"
+  fi
+
+  build-kube-env true "${KUBE_TEMP}/master-kube-env.yaml"
+}
+
+# $1: if 'true', we're building a master yaml, else a node
+function build-kube-env {
+  local master=$1
+  local file=$2
+
+  build-runtime-config
+
+  rm -f ${file}
+  cat >$file <<EOF
+ENV_TIMESTAMP: $(yaml-quote $(date -u +%Y-%m-%dT%T%z))
+INSTANCE_PREFIX: $(yaml-quote ${INSTANCE_PREFIX})
+NODE_INSTANCE_PREFIX: $(yaml-quote ${NODE_INSTANCE_PREFIX})
+CLUSTER_IP_RANGE: $(yaml-quote ${CLUSTER_IP_RANGE:-10.244.0.0/16})
+SERVER_BINARY_TAR_URL: $(yaml-quote ${SERVER_BINARY_TAR_URL})
+SERVER_BINARY_TAR_HASH: $(yaml-quote ${SERVER_BINARY_TAR_HASH})
+SALT_TAR_URL: $(yaml-quote ${SALT_TAR_URL})
+SALT_TAR_HASH: $(yaml-quote ${SALT_TAR_HASH})
+SERVICE_CLUSTER_IP_RANGE: $(yaml-quote ${SERVICE_CLUSTER_IP_RANGE})
+KUBERNETES_MASTER_NAME: $(yaml-quote ${MASTER_NAME})
+ALLOCATE_NODE_CIDRS: $(yaml-quote ${ALLOCATE_NODE_CIDRS:-false})
+ENABLE_CLUSTER_MONITORING: $(yaml-quote ${ENABLE_CLUSTER_MONITORING:-none})
+ENABLE_L7_LOADBALANCING: $(yaml-quote ${ENABLE_L7_LOADBALANCING:-none})
+ENABLE_CLUSTER_LOGGING: $(yaml-quote ${ENABLE_CLUSTER_LOGGING:-false})
+ENABLE_CLUSTER_UI: $(yaml-quote ${ENABLE_CLUSTER_UI:-false})
+ENABLE_NODE_LOGGING: $(yaml-quote ${ENABLE_NODE_LOGGING:-false})
+LOGGING_DESTINATION: $(yaml-quote ${LOGGING_DESTINATION:-})
+ELASTICSEARCH_LOGGING_REPLICAS: $(yaml-quote ${ELASTICSEARCH_LOGGING_REPLICAS:-})
+ENABLE_CLUSTER_DNS: $(yaml-quote ${ENABLE_CLUSTER_DNS:-false})
+ENABLE_CLUSTER_REGISTRY: $(yaml-quote ${ENABLE_CLUSTER_REGISTRY:-false})
+CLUSTER_REGISTRY_DISK: $(yaml-quote ${CLUSTER_REGISTRY_DISK})
+CLUSTER_REGISTRY_DISK_SIZE: $(yaml-quote ${CLUSTER_REGISTRY_DISK_SIZE})
+DNS_REPLICAS: $(yaml-quote ${DNS_REPLICAS:-})
+DNS_SERVER_IP: $(yaml-quote ${DNS_SERVER_IP:-})
+DNS_DOMAIN: $(yaml-quote ${DNS_DOMAIN:-})
+KUBELET_TOKEN: $(yaml-quote ${KUBELET_TOKEN:-})
+KUBE_PROXY_TOKEN: $(yaml-quote ${KUBE_PROXY_TOKEN:-})
+ADMISSION_CONTROL: $(yaml-quote ${ADMISSION_CONTROL:-})
+MASTER_IP_RANGE: $(yaml-quote ${MASTER_IP_RANGE})
+RUNTIME_CONFIG: $(yaml-quote ${RUNTIME_CONFIG})
+CA_CERT: $(yaml-quote ${CA_CERT_BASE64:-})
+KUBELET_CERT: $(yaml-quote ${KUBELET_CERT_BASE64:-})
+KUBELET_KEY: $(yaml-quote ${KUBELET_KEY_BASE64:-})
+NETWORK_PROVIDER: $(yaml-quote ${NETWORK_PROVIDER:-})
+OPENCONTRAIL_TAG: $(yaml-quote ${OPENCONTRAIL_TAG:-})
+OPENCONTRAIL_KUBERNETES_TAG: $(yaml-quote ${OPENCONTRAIL_KUBERNETES_TAG:-})
+OPENCONTRAIL_PUBLIC_SUBNET: $(yaml-quote ${OPENCONTRAIL_PUBLIC_SUBNET:-})
+E2E_STORAGE_TEST_ENVIRONMENT: $(yaml-quote ${E2E_STORAGE_TEST_ENVIRONMENT:-})
+KUBE_IMAGE_TAG: $(yaml-quote ${KUBE_IMAGE_TAG:-})
+KUBE_DOCKER_REGISTRY: $(yaml-quote ${KUBE_DOCKER_REGISTRY:-})
+EOF
+  if [ -n "${KUBELET_PORT:-}" ]; then
+    cat >>$file <<EOF
+KUBELET_PORT: $(yaml-quote ${KUBELET_PORT})
+EOF
+  fi
+  if [ -n "${KUBE_APISERVER_REQUEST_TIMEOUT:-}" ]; then
+    cat >>$file <<EOF
+KUBE_APISERVER_REQUEST_TIMEOUT: $(yaml-quote ${KUBE_APISERVER_REQUEST_TIMEOUT})
+EOF
+  fi
+  if [ -n "${TERMINATED_POD_GC_THRESHOLD:-}" ]; then
+    cat >>$file <<EOF
+TERMINATED_POD_GC_THRESHOLD: $(yaml-quote ${TERMINATED_POD_GC_THRESHOLD})
+EOF
+  fi
+  if [[ "${OS_DISTRIBUTION}" == "trusty" ]]; then
+    cat >>$file <<EOF
+KUBE_MANIFESTS_TAR_URL: $(yaml-quote ${KUBE_MANIFESTS_TAR_URL})
+KUBE_MANIFESTS_TAR_HASH: $(yaml-quote ${KUBE_MANIFESTS_TAR_HASH})
+EOF
+  fi
+  if [ -n "${TEST_CLUSTER:-}" ]; then
+    cat >>$file <<EOF
+TEST_CLUSTER: $(yaml-quote ${TEST_CLUSTER})
+EOF
+  fi
+  if [ -n "${KUBELET_TEST_ARGS:-}" ]; then
+      cat >>$file <<EOF
+KUBELET_TEST_ARGS: $(yaml-quote ${KUBELET_TEST_ARGS})
+EOF
+  fi
+  if [ -n "${KUBELET_TEST_LOG_LEVEL:-}" ]; then
+      cat >>$file <<EOF
+KUBELET_TEST_LOG_LEVEL: $(yaml-quote ${KUBELET_TEST_LOG_LEVEL})
+EOF
+  fi
+  if [[ "${master}" == "true" ]]; then
+    # Master-only env vars.
+    cat >>$file <<EOF
+KUBERNETES_MASTER: $(yaml-quote "true")
+KUBE_USER: $(yaml-quote ${KUBE_USER})
+KUBE_PASSWORD: $(yaml-quote ${KUBE_PASSWORD})
+KUBE_BEARER_TOKEN: $(yaml-quote ${KUBE_BEARER_TOKEN})
+MASTER_CERT: $(yaml-quote ${MASTER_CERT_BASE64:-})
+MASTER_KEY: $(yaml-quote ${MASTER_KEY_BASE64:-})
+KUBECFG_CERT: $(yaml-quote ${KUBECFG_CERT_BASE64:-})
+KUBECFG_KEY: $(yaml-quote ${KUBECFG_KEY_BASE64:-})
+KUBELET_APISERVER: $(yaml-quote ${KUBELET_APISERVER:-})
+ENABLE_MANIFEST_URL: $(yaml-quote ${ENABLE_MANIFEST_URL:-false})
+MANIFEST_URL: $(yaml-quote ${MANIFEST_URL:-})
+MANIFEST_URL_HEADER: $(yaml-quote ${MANIFEST_URL_HEADER:-})
+NUM_NODES: $(yaml-quote ${NUM_NODES})
+EOF
+    if [ -n "${APISERVER_TEST_ARGS:-}" ]; then
+      cat >>$file <<EOF
+APISERVER_TEST_ARGS: $(yaml-quote ${APISERVER_TEST_ARGS})
+EOF
+    fi
+    if [ -n "${APISERVER_TEST_LOG_LEVEL:-}" ]; then
+      cat >>$file <<EOF
+APISERVER_TEST_LOG_LEVEL: $(yaml-quote ${APISERVER_TEST_LOG_LEVEL})
+EOF
+    fi
+    if [ -n "${CONTROLLER_MANAGER_TEST_ARGS:-}" ]; then
+      cat >>$file <<EOF
+CONTROLLER_MANAGER_TEST_ARGS: $(yaml-quote ${CONTROLLER_MANAGER_TEST_ARGS})
+EOF
+    fi
+    if [ -n "${CONTROLLER_MANAGER_TEST_LOG_LEVEL:-}" ]; then
+      cat >>$file <<EOF
+CONTROLLER_MANAGER_TEST_LOG_LEVEL: $(yaml-quote ${CONTROLLER_MANAGER_TEST_LOG_LEVEL})
+EOF
+    fi
+    if [ -n "${SCHEDULER_TEST_ARGS:-}" ]; then
+      cat >>$file <<EOF
+SCHEDULER_TEST_ARGS: $(yaml-quote ${SCHEDULER_TEST_ARGS})
+EOF
+    fi
+    if [ -n "${SCHEDULER_TEST_LOG_LEVEL:-}" ]; then
+      cat >>$file <<EOF
+SCHEDULER_TEST_LOG_LEVEL: $(yaml-quote ${SCHEDULER_TEST_LOG_LEVEL})
+EOF
+    fi
+  else
+    # Node-only env vars.
+    cat >>$file <<EOF
+KUBERNETES_MASTER: $(yaml-quote "false")
+ZONE: $(yaml-quote ${ZONE})
+EXTRA_DOCKER_OPTS: $(yaml-quote ${EXTRA_DOCKER_OPTS:-})
+EOF
+    if [ -n "${KUBEPROXY_TEST_ARGS:-}" ]; then
+      cat >>$file <<EOF
+KUBEPROXY_TEST_ARGS: $(yaml-quote ${KUBEPROXY_TEST_ARGS})
+EOF
+    fi
+    if [ -n "${KUBEPROXY_TEST_LOG_LEVEL:-}" ]; then
+      cat >>$file <<EOF
+KUBEPROXY_TEST_LOG_LEVEL: $(yaml-quote ${KUBEPROXY_TEST_LOG_LEVEL})
+EOF
+    fi
+  fi
+  if [[ "${OS_DISTRIBUTION}" == "coreos" ]]; then
+    # CoreOS-only env vars. TODO(yifan): Make them available on other distros.
+    cat >>$file <<EOF
+KUBERNETES_CONTAINER_RUNTIME: $(yaml-quote ${CONTAINER_RUNTIME:-docker})
+RKT_VERSION: $(yaml-quote ${RKT_VERSION:-})
+RKT_PATH: $(yaml-quote ${RKT_PATH:-})
+KUBERNETES_CONFIGURE_CBR0: $(yaml-quote ${KUBERNETES_CONFIGURE_CBR0:-true})
+EOF
+  fi
+}

--- a/cluster/gce/coreos/helper.sh
+++ b/cluster/gce/coreos/helper.sh
@@ -16,15 +16,10 @@
 
 # A library of helper functions and constant for coreos os distro
 
-# By sourcing debian's helper.sh, we use the same create-master-instance
-# functions as debian. But we overwrite the create-node-instance-template
-# function to use coreos.
-source "${KUBE_ROOT}/cluster/gce/debian/helper.sh"
-
 # TODO(dawnchen): Check $CONTAINER_RUNTIME to decide which
 # cloud_config yaml file should be passed
 # $1: template name (required)
-function create-node-instance-template {
+function nodes::create-instance-template {
   local template_name="$1"
   create-node-template "$template_name" "${scope_flags}" \
     "kube-env=${KUBE_TEMP}/node-kube-env.yaml" \

--- a/cluster/gce/debian/helper.sh
+++ b/cluster/gce/debian/helper.sh
@@ -16,43 +16,8 @@
 
 # A library of helper functions and constant for debian os distro
 
-
-# create-master-instance creates the master instance. If called with
-# an argument, the argument is used as the name to a reserved IP
-# address for the master. (In the case of upgrade/repair, we re-use
-# the same IP.)
-#
-# It requires a whole slew of assumed variables, partially due to to
-# the call to write-master-env. Listing them would be rather
-# futile. Instead, we list the required calls to ensure any additional
-# variables are set:
-#   ensure-temp-dir
-#   detect-project
-#   get-bearer-token
-#
-function create-master-instance {
-  local address_opt=""
-  [[ -n ${1:-} ]] && address_opt="--address ${1}"
-
-  write-master-env
-  gcloud compute instances create "${MASTER_NAME}" \
-    ${address_opt} \
-    --project "${PROJECT}" \
-    --zone "${ZONE}" \
-    --machine-type "${MASTER_SIZE}" \
-    --image-project="${MASTER_IMAGE_PROJECT}" \
-    --image "${MASTER_IMAGE}" \
-    --tags "${MASTER_TAG}" \
-    --network "${NETWORK}" \
-    --scopes "storage-ro,compute-rw,monitoring,logging-write" \
-    --can-ip-forward \
-    --metadata-from-file \
-      "startup-script=${KUBE_ROOT}/cluster/gce/configure-vm.sh,kube-env=${KUBE_TEMP}/master-kube-env.yaml" \
-    --disk "name=${MASTER_NAME}-pd,device-name=master-pd,mode=rw,boot=no,auto-delete=no"
-}
-
 # $1: template name (required)
-function create-node-instance-template {
+function nodes::create-instance-template {
   local template_name="$1"
   create-node-template "$template_name" "${scope_flags}" \
     "startup-script=${KUBE_ROOT}/cluster/gce/configure-vm.sh" \

--- a/cluster/gce/master.sh
+++ b/cluster/gce/master.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A library with any master related operations during kube-up, kube-down etc.
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${KUBE_ROOT}/cluster/gce/common.sh"
+
+# Provision master machine and configures network to give access to it over HTTPS.
+function master::provision {
+  master::configure-network
+  master::create
+
+  # Wait for last batch of jobs
+  wait-for-jobs
+}
+
+# Configures network to give access to master machine over HTTPS.
+function master::configure-network {
+  detect-project
+
+  echo "Creating firewall rule for HTTPS traffic to ${MASTER_NAME}"
+  gcloud compute firewall-rules create "${MASTER_NAME}-https" \
+    --project "${PROJECT}" \
+    --network "${NETWORK}" \
+    --target-tags "${MASTER_TAG}" \
+    --allow tcp:443 &
+}
+
+# Creates master machine with a static IP and persistent disk.
+function master::create {
+  KUBE_MASTER=${MASTER_NAME}
+  master::create-disk
+  master::create-ip
+  master::create-instance "${KUBE_MASTER_IP}" &
+}
+
+# Creates persistent disk for master machine.
+function master::create-disk {
+  detect-project
+
+  # We have to make sure the disk is created before creating the master VM, so
+  # run this in the foreground.
+  gcloud compute disks create "${MASTER_NAME}-pd" \
+    --project "${PROJECT}" \
+    --zone "${ZONE}" \
+    --type "${MASTER_DISK_TYPE}" \
+    --size "${MASTER_DISK_SIZE}"  
+}
+
+# Creates static IP address for master machine.
+function master::create-ip {
+  detect-project
+
+  # Reserve the master's IP so that it can later be transferred to another VM
+  # without disrupting the kubelets. IPs are associated with regions, not zones,
+  # so extract the region name, which is the same as the zone but with the final
+  # dash and characters trailing the dash removed.
+  local REGION=${ZONE%-*}
+
+  local attempt=0
+  while true; do
+    if ! gcloud compute addresses create "${MASTER_NAME}-ip" \
+      --project "${PROJECT}" \
+      --region "${REGION}" -q > /dev/null; then
+      if (( attempt > 4 )); then
+        echo -e "${color_red}Failed to create static ip $1 ${color_norm}" >&2
+        exit 2
+      fi
+      attempt=$(($attempt+1)) 
+      echo -e "${color_yellow}Attempt $attempt failed to create static ip $1. Retrying.${color_norm}" >&2
+      sleep $(($attempt * 5))
+    else
+      break
+    fi
+  done
+
+  KUBE_MASTER_IP=$(gcloud compute addresses describe "${MASTER_NAME}-ip" \
+    --project "${PROJECT}" \
+    --region "${REGION}" -q --format yaml | awk '/^address:/ { print $2 }')
+}
+
+# Creates the master instance. If called with an argument, the argument is
+# used as the name to a reserved IP address for the master. (In the case of
+# upgrade/repair, we re-use the same IP.)
+#
+# It requires a whole slew of assumed variables, partially due to to
+# the call to write-master-env. Listing them would be rather
+# futile. Instead, we list the required calls to ensure any additional
+# variables are set:
+#   ensure-temp-dir
+#   detect-project
+#   get-bearer-token
+#
+function master::create-instance {
+  detect-project
+  local address_opt=""
+  [[ -n ${1:-} ]] && address_opt="--address ${1}"
+
+  gcloud compute instances create "${MASTER_NAME}" \
+    ${address_opt} \
+    --project "${PROJECT}" \
+    --zone "${ZONE}" \
+    --machine-type "${MASTER_SIZE}" \
+    --image-project="${MASTER_IMAGE_PROJECT}" \
+    --image "${MASTER_IMAGE}" \
+    --tags "${MASTER_TAG}" \
+    --network "${NETWORK}" \
+    --scopes "storage-ro,compute-rw,monitoring,logging-write" \
+    --can-ip-forward \
+    --disk "name=${MASTER_NAME}-pd,device-name=master-pd,mode=rw,boot=no,auto-delete=no"
+}
+
+# Deploys kubernetes on master machine by setting startup script and restarting the machine.
+function master::deploy {
+  write-master-env
+  gcloud compute instances add-metadata "${MASTER_NAME}" \
+    --project "${PROJECT}" \
+    --zone "${ZONE}" \
+    --metadata-from-file \
+      "startup-script=${KUBE_ROOT}/cluster/gce/configure-vm.sh,kube-env=${KUBE_TEMP}/master-kube-env.yaml"
+  gcloud compute instances reset "${MASTER_NAME}" \
+    --project "${PROJECT}" \
+    --zone "${ZONE}"
+}

--- a/cluster/gce/nodes.sh
+++ b/cluster/gce/nodes.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A library with any node related operations during kube-up, kube-down etc.
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${KUBE_ROOT}/cluster/gce/common.sh"
+
+if [[ "${OS_DISTRIBUTION}" == "debian" || "${OS_DISTRIBUTION}" == "coreos" || "${OS_DISTRIBUTION}" == "trusty" ]]; then
+  source "${KUBE_ROOT}/cluster/gce/${OS_DISTRIBUTION}/helper.sh"
+else
+  echo "Cannot operate on cluster using os distro: ${OS_DISTRIBUTION}" >&2
+  exit 1
+fi
+
+# Provisions nodes together with appropriate network configuration. This will also deploy kubernetes
+# binaries and start them.
+# TODO: We should refactor this to keep provisioning and deploying separate.
+function nodes::provision {
+  nodes::configure-network
+
+  echo "Creating nodes."
+
+  # TODO(zmerlynn): Refactor setting scope flags.
+  local scope_flags=
+  if [ -n "${NODE_SCOPES}" ]; then
+    scope_flags="--scopes ${NODE_SCOPES}"
+  else
+    scope_flags="--no-scopes"
+  fi
+
+  write-node-env
+
+  local template_name="${NODE_INSTANCE_PREFIX}-template"
+
+  nodes::create-instance-template $template_name
+
+  local defaulted_max_instances_per_mig=${MAX_INSTANCES_PER_MIG:-500}
+
+  if [[ ${defaulted_max_instances_per_mig} -le "0" ]]; then
+    echo "MAX_INSTANCES_PER_MIG cannot be negative. Assuming default 500"
+    defaulted_max_instances_per_mig=500
+  fi
+  local num_migs=$(((${NUM_NODES} + ${defaulted_max_instances_per_mig} - 1) / ${defaulted_max_instances_per_mig}))
+  local instances_per_mig=$(((${NUM_NODES} + ${num_migs} - 1) / ${num_migs}))
+  local last_mig_size=$((${NUM_NODES} - (${num_migs} - 1) * ${instances_per_mig}))
+
+  #TODO: parallelize this loop to speed up the process
+  for i in $(seq $((${num_migs} - 1))); do
+    gcloud compute instance-groups managed \
+      create "${NODE_INSTANCE_PREFIX}-group-$i" \
+      --project "${PROJECT}" \
+      --zone "${ZONE}" \
+      --base-instance-name "${NODE_INSTANCE_PREFIX}" \
+      --size "${instances_per_mig}" \
+      --template "$template_name" || true;
+    gcloud compute instance-groups managed wait-until-stable \
+      "${NODE_INSTANCE_PREFIX}-group-$i" \
+      --zone "${ZONE}" \
+      --project "${PROJECT}" || true;
+  done
+
+  # TODO: We don't add a suffix for the last group to keep backward compatibility when there's only one MIG.
+  # We should change it at some point, but note #18545 when changing this.
+  gcloud compute instance-groups managed \
+    create "${NODE_INSTANCE_PREFIX}-group" \
+    --project "${PROJECT}" \
+    --zone "${ZONE}" \
+    --base-instance-name "${NODE_INSTANCE_PREFIX}" \
+    --size "${last_mig_size}" \
+    --template "$template_name" || true;
+  gcloud compute instance-groups managed wait-until-stable \
+    "${NODE_INSTANCE_PREFIX}-group" \
+    --zone "${ZONE}" \
+    --project "${PROJECT}" || true;
+}
+
+
+function nodes::configure-network {
+  detect-project
+
+  echo "Creating firewall rule for inter-cluster communication between all nodes"
+  create-firewall-rule "${NODE_TAG}-all" "${CLUSTER_IP_RANGE}" "${NODE_TAG}" &
+}

--- a/cluster/gce/trusty/helper.sh
+++ b/cluster/gce/trusty/helper.sh
@@ -22,13 +22,8 @@
 # replaced upstart with systemd as the init system. Consequently, the
 # configuration cannot work on these images.
 
-# By sourcing debian's helper.sh, we use the same  create-master-instance
-# functions as debian. But we overwrite the create-node-instance-template
-# function to use Ubuntu.
-source "${KUBE_ROOT}/cluster/gce/debian/helper.sh"
-
 # $1: template name (required)
-function create-node-instance-template {
+function nodes::create-instance-template {
   local template_name="$1"
   create-node-template "$template_name" "${scope_flags[*]}" \
     "kube-env=${KUBE_TEMP}/node-kube-env.yaml" \

--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -84,7 +84,8 @@ function upgrade-master() {
     --zone "${ZONE}" \
     "${MASTER_NAME}"
 
-  create-master-instance "${MASTER_NAME}-ip"
+  master::create-instance "${MASTER_NAME}-ip"
+  master::deploy
   wait-for-master
 }
 
@@ -209,9 +210,9 @@ function prepare-node-upgrade() {
   write-node-env
 
   # TODO(zmerlynn): Get configure-vm script from ${version}. (Must plumb this
-  #                 through all create-node-instance-template implementations).
+  #                 through all nodes::create-instance-template implementations).
   local template_name=$(get-template-name-from-version ${SANITIZED_VERSION})
-  create-node-instance-template "${template_name}"
+  nodes::create-instance-template "${template_name}"
   # The following is echo'd so that callers can get the template name.
   echo $template_name
   echo "== Finished preparing node upgrade (to ${KUBE_VERSION}). ==" >&2

--- a/cluster/kube-down.sh
+++ b/cluster/kube-down.sh
@@ -23,7 +23,7 @@ set -o pipefail
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 if [ -f "${KUBE_ROOT}/cluster/env.sh" ]; then
-    source "${KUBE_ROOT}/cluster/env.sh"
+  source "${KUBE_ROOT}/cluster/env.sh"
 fi
 
 source "${KUBE_ROOT}/cluster/kube-env.sh"

--- a/cluster/kube-util.sh
+++ b/cluster/kube-util.sh
@@ -20,81 +20,81 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 # Must ensure that the following ENV vars are set
 function detect-master {
-	echo "KUBE_MASTER_IP: $KUBE_MASTER_IP" 1>&2
-	echo "KUBE_MASTER: $KUBE_MASTER" 1>&2
+  echo "KUBE_MASTER_IP: $KUBE_MASTER_IP" 1>&2
+  echo "KUBE_MASTER: $KUBE_MASTER" 1>&2
 }
 
 # Get node names if they are not static.
 function detect-node-names {
-	echo "NODE_NAMES: [${NODE_NAMES[*]}]" 1>&2
+  echo "NODE_NAMES: [${NODE_NAMES[*]}]" 1>&2
 }
 
 # Get node IP addresses and store in KUBE_NODE_IP_ADDRESSES[]
 function detect-nodes {
-	echo "KUBE_NODE_IP_ADDRESSES: [${KUBE_NODE_IP_ADDRESSES[*]}]" 1>&2
+  echo "KUBE_NODE_IP_ADDRESSES: [${KUBE_NODE_IP_ADDRESSES[*]}]" 1>&2
 }
 
 # Verify prereqs on host machine
 function verify-prereqs {
-	echo "TODO: verify-prereqs" 1>&2
+  echo "TODO: verify-prereqs" 1>&2
 }
 
 # Validate a kubernetes cluster
 function validate-cluster {
-	# by default call the generic validate-cluster.sh script, customizable by
-	# any cluster provider if this does not fit.
-	"${KUBE_ROOT}/cluster/validate-cluster.sh"
+  # by default call the generic validate-cluster.sh script, customizable by
+  # any cluster provider if this does not fit.
+  "${KUBE_ROOT}/cluster/validate-cluster.sh"
 }
 
 # Instantiate a kubernetes cluster
 function kube-up {
-	echo "TODO: kube-up" 1>&2
+  echo "TODO: kube-up" 1>&2
 }
 
 # Delete a kubernetes cluster
 function kube-down {
-	echo "TODO: kube-down" 1>&2
+  echo "TODO: kube-down" 1>&2
 }
 
 # Update a kubernetes cluster
 function kube-push {
-	echo "TODO: kube-push" 1>&2
+  echo "TODO: kube-push" 1>&2
 }
 
 # Prepare update a kubernetes component
 function prepare-push {
-	echo "TODO: prepare-push" 1>&2
+  echo "TODO: prepare-push" 1>&2
 }
 
 # Update a kubernetes master
 function push-master {
-	echo "TODO: push-master" 1>&2
+  echo "TODO: push-master" 1>&2
 }
 
 # Update a kubernetes node
 function push-node {
-	echo "TODO: push-node" 1>&2
+  echo "TODO: push-node" 1>&2
 }
 
 # Execute prior to running tests to build a release if required for env
 function test-build-release {
-	echo "TODO: test-build-release" 1>&2
+  echo "TODO: test-build-release" 1>&2
 }
 
 # Execute prior to running tests to initialize required structure
 function test-setup {
-	echo "TODO: test-setup" 1>&2
+  echo "TODO: test-setup" 1>&2
 }
 
 # Execute after running tests to perform any required clean-up
 function test-teardown {
-	echo "TODO: test-teardown" 1>&2
+  echo "TODO: test-teardown" 1>&2
 }
 
 # Providers util.sh scripts should define functions that override the above default functions impls
 if [ -n "${KUBERNETES_PROVIDER}" ]; then
-	PROVIDER_UTILS="${KUBE_ROOT}/cluster/${KUBERNETES_PROVIDER}/util.sh"
-	if [ -f ${PROVIDER_UTILS} ]; then
-		source "${PROVIDER_UTILS}"
-	fi
+  PROVIDER_UTILS="${KUBE_ROOT}/cluster/${KUBERNETES_PROVIDER}/util.sh"
+  if [ -f ${PROVIDER_UTILS} ]; then
+    source "${PROVIDER_UTILS}"
+  fi
 fi


### PR DESCRIPTION
This is the first step in refactoring how we deploy kubernetes cluster. I want to first refactor GCE script and then move other cloud providers to reuse as much as possible (e.g. deploying master/nodes).

This PR divides kube-up into the following steps:
- provision cluster
- provision master
- generates certificates
- deploy master
- provision and deploy nodes

There should be only one semantic change, i.e. how we deploy master. I have split creating master machine from installing and running kubernetes. This is done by setting startup script separately and restarting master machine to invoke it.

Assigning to @zmerlynn as I believe he knows those scripts pretty well :)

@roberthbailey @mikedanese 
