### PR TITLE
FIX : replace publicIP (deprecated) for clusterIP

### DIFF
--- a/cluster/libvirt-coreos/skydns-svc.yaml
+++ b/cluster/libvirt-coreos/skydns-svc.yaml
@@ -6,7 +6,7 @@ metadata:
   name: skydns
   namespace: kube-system
 spec:
-  portalIP: ${DNS_SERVER_IP}
+  clusterIP: ${DNS_SERVER_IP}
   ports:
   - port: 53
     protocol: UDP


### PR DESCRIPTION
It fix this bug :
https://stackoverflow.com/questions/34255601/kube-addons-service-failed-on-coreos-libvirt-installation

Some documentation that explain why clusterIP is better :
https://github.com/kubernetes/kubernetes/blob/master/docs/api.md
