### PR TITLE
Change -o go-template to --template in user-guide

### DIFF
--- a/docs/user-guide/compute-resources.md
+++ b/docs/user-guide/compute-resources.md
@@ -264,10 +264,10 @@ Events:
 
 The `Restart Count:  5` indicates that the `simmemleak` container in this pod was terminated and restarted 5 times.
 
-You can call `get pod` with the `-o go-template=...` option to fetch the status of previously terminated containers:
+You can call `get pod` with the `--template=...` option to fetch the status of previously terminated containers:
 
 ```console
-[13:59:01] $ ./cluster/kubectl.sh  get pod -o go-template='{{range.status.containerStatuses}}{{"Container Name: "}}{{.name}}{{"\r\nLastState: "}}{{.lastState}}{{end}}'  simmemleak-60xbc
+[13:59:01] $ ./cluster/kubectl.sh  get pod --template='{{range.status.containerStatuses}}{{"Container Name: "}}{{.name}}{{"\r\nLastState: "}}{{.lastState}}{{end}}'  simmemleak-60xbc
 Container Name: simmemleak
 LastState: map[terminated:map[exitCode:137 reason:OOM Killed startedAt:2015-07-07T20:58:43Z finishedAt:2015-07-07T20:58:43Z containerID:docker://0e4095bba1feccdfe7ef9fb6ebffe972b4b14285d5acdec6f0d3ae8a22fad8b2]][13:59:03] clusterScaleDoc ~/go/src/github.com/kubernetes/kubernetes $
 ```

--- a/docs/user-guide/production-pods.md
+++ b/docs/user-guide/production-pods.md
@@ -378,9 +378,9 @@ The message is recorded along with the other state of the last (i.e., most recen
 $ kubectl create -f ./pod.yaml
 pods/pod-w-message
 $ sleep 70
-$ kubectl get pods/pod-w-message -o go-template="{{range .status.containerStatuses}}{{.lastState.terminated.message}}{{end}}"
+$ kubectl get pods/pod-w-message --template="{{range .status.containerStatuses}}{{.lastState.terminated.message}}{{end}}"
 Sleep expired
-$ kubectl get pods/pod-w-message -o go-template="{{range .status.containerStatuses}}{{.lastState.terminated.exitCode}}{{end}}"
+$ kubectl get pods/pod-w-message --template="{{range .status.containerStatuses}}{{.lastState.terminated.exitCode}}{{end}}"
 0
 ```
 

--- a/docs/user-guide/walkthrough/k8s201.md
+++ b/docs/user-guide/walkthrough/k8s201.md
@@ -218,8 +218,8 @@ On most providers, the service IPs are not externally accessible. The easiest wa
 Provided the service IP is accessible, you should be able to access its http endpoint with curl on port 80:
 
 ```console
-$ export SERVICE_IP=$(kubectl get service nginx-service -o go-template={{.spec.clusterIP}})
-$ export SERVICE_PORT=$(kubectl get service nginx-service -o go-template'={{(index .spec.ports 0).port}}')
+$ export SERVICE_IP=$(kubectl get service nginx-service --template={{.spec.clusterIP}})
+$ export SERVICE_PORT=$(kubectl get service nginx-service --template'={{(index .spec.ports 0).port}}')
 $ curl http://${SERVICE_IP}:${SERVICE_PORT}
 ```
 


### PR DESCRIPTION
Same as #19100 for other user-guide docs.

The user-guide has references to `kubectl get pod -o go-template` that should use the `--template` flag instead.

The same issue exists in `./user-guide/kubectl/kubectl_*.md` but those docs are generated from the kubectl source.
