### PR TITLE
Add Scala to client library list

### DIFF
--- a/docs/devel/client-libraries.md
+++ b/docs/devel/client-libraries.md
@@ -50,6 +50,7 @@ Documentation for other releases can be found at
    * [Node.js](https://github.com/tenxcloud/node-kubernetes-client)
    * [Perl](https://metacpan.org/pod/Net::Kubernetes)
    * [Clojure](https://github.com/yanatan16/clj-kubernetes-api)
+   * [Scala](https://github.com/doriordan/skuber)
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->


### PR DESCRIPTION
I've created a Scala client library for Kubernetes, this patch adds it into the client libraries list
