### PR TITLE
Update Docker getting started versions to 1.1.x

### DIFF
--- a/docs/getting-started-guides/docker.md
+++ b/docs/getting-started-guides/docker.md
@@ -75,7 +75,7 @@ docker run \
     --pid=host \
     --privileged=true \
     -d \
-    gcr.io/google_containers/hyperkube:v1.0.1 \
+    gcr.io/google_containers/hyperkube:v1.1.3 \
     /hyperkube kubelet --containerized --hostname-override="127.0.0.1" --address="0.0.0.0" --api-servers=http://localhost:8080 --config=/etc/kubernetes/manifests
 ```
 
@@ -84,15 +84,15 @@ This actually runs the kubelet, which in turn runs a [pod](../user-guide/pods.md
 ### Step Three: Run the service proxy
 
 ```sh
-docker run -d --net=host --privileged gcr.io/google_containers/hyperkube:v1.0.1 /hyperkube proxy --master=http://127.0.0.1:8080 --v=2
+docker run -d --net=host --privileged gcr.io/google_containers/hyperkube:v1.1.3 /hyperkube proxy --master=http://127.0.0.1:8080 --v=2
 ```
 
 ### Test it out
 
 At this point you should have a running Kubernetes cluster.  You can test this by downloading the kubectl
 binary
-([OS X](https://storage.googleapis.com/kubernetes-release/release/v1.0.1/bin/darwin/amd64/kubectl))
-([linux](https://storage.googleapis.com/kubernetes-release/release/v1.0.1/bin/linux/amd64/kubectl))
+([OS X](https://storage.googleapis.com/kubernetes-release/release/v1.1.3/bin/darwin/amd64/kubectl))
+([linux](https://storage.googleapis.com/kubernetes-release/release/v1.1.3/bin/linux/amd64/kubectl))
 
 *Note:*
 On OS/X you will need to set up port forwarding via ssh:


### PR DESCRIPTION
The Docker getting started guide points to 1.0.1 versions of the `hyperkube` images and `kubectl` binary.

This incongruity implies that some `kubectl` examples are wrong (e.g.: the documentation instructs to use `kubectl get ... -o go-template` but 1.0.1 uses `--template` creating situations like #19232 or #19100).

This PR updates the guide to download the latest (at the time of writing 1.1.3) release version.
