### PR TITLE
Automated cherry pick of #19238 upstream release 1.1

### DIFF
--- a/pkg/util/bandwidth/linux.go
+++ b/pkg/util/bandwidth/linux.go
@@ -226,7 +226,7 @@ func (t *tcShaper) interfaceExists() (bool, string, error) {
 	}
 	// Newer versions of tc and/or the kernel return the following instead of nothing:
 	// qdisc noqueue 0: root refcnt 2
-	fields := strings.Split(value, " ")
+	fields := strings.Fields(value)
 	if len(fields) > 1 && fields[1] == "noqueue" {
 		return false, "", nil
 	}

--- a/pkg/util/bandwidth/linux.go
+++ b/pkg/util/bandwidth/linux.go
@@ -224,6 +224,12 @@ func (t *tcShaper) interfaceExists() (bool, string, error) {
 	if len(value) == 0 {
 		return false, "", nil
 	}
+	// Newer versions of tc and/or the kernel return the following instead of nothing:
+	// qdisc noqueue 0: root refcnt 2
+	fields := strings.Split(value, " ")
+	if len(fields) > 1 && fields[1] == "noqueue" {
+		return false, "", nil
+	}
 	return true, value, nil
 }
 

--- a/pkg/util/bandwidth/linux_test.go
+++ b/pkg/util/bandwidth/linux_test.go
@@ -490,11 +490,11 @@ func TestReconcileInterfaceExists(t *testing.T) {
 	}
 }
 
-func TestReconcileInterfaceDoesntExist(t *testing.T) {
+func testReconcileInterfaceHasNoData(t *testing.T, output string) {
 	fcmd := exec.FakeCmd{
 		CombinedOutputScript: []exec.FakeCombinedOutputAction{
-			func() ([]byte, error) { return []byte("\n"), nil },
-			func() ([]byte, error) { return []byte("\n"), nil },
+			func() ([]byte, error) { return []byte(output), nil },
+			func() ([]byte, error) { return []byte(output), nil },
 		},
 	}
 
@@ -545,6 +545,16 @@ func TestReconcileInterfaceDoesntExist(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestReconcileInterfaceDoesntExist(t *testing.T) {
+	testReconcileInterfaceHasNoData(t, "\n")
+}
+
+var tcQdiscNoqueue = "qdisc noqueue 0: root refcnt 2 \n"
+
+func TestReconcileInterfaceExistsWithNoqueue(t *testing.T) {
+	testReconcileInterfaceHasNoData(t, tcQdiscNoqueue)
 }
 
 var tcQdiscWrong = []string{


### PR DESCRIPTION
Deal properly with tc qdisc show returning "noqueue" (e.g. newer CoreOS)
