### PR TITLE
Concerto provider implementation

### DIFF
--- a/pkg/cloudprovider/providers/concerto/api_service.go
+++ b/pkg/cloudprovider/providers/concerto/api_service.go
@@ -1,0 +1,368 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package concerto_cloud
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/cloudprovider"
+)
+
+// ConcertoAPIService is an abstraction for Flexiant Concerto API.
+type ConcertoAPIService interface {
+	// Retrieves the info related to the instance which name is passed
+	GetInstanceByName(name string) (ConcertoInstance, error)
+	// Retrieves all instances
+	GetInstanceList() ([]ConcertoInstance, error)
+	// Creates a LB with the specified name
+	CreateLoadBalancer(name string, port int, nodePort int) (*ConcertoLoadBalancer, error)
+	// Retrieves a LB with the specified name
+	GetLoadBalancerByName(name string) (*ConcertoLoadBalancer, error)
+	// Deletes Load Balancer with given Id
+	DeleteLoadBalancerById(id string) error
+	// Gets the nodes registered with the load balancer
+	GetLoadBalancerNodes(loadBalancerId string) ([]ConcertoLoadBalancerNode, error)
+	// Gets the IPs of the nodes registered with the load balancer
+	GetLoadBalancerNodesAsIPs(loadBalancerId string) ([]string, error)
+	// Registers the instances with the load balancer
+	RegisterInstancesWithLoadBalancer(loadBalancerId string, nodesIPs []string) error
+	// Deregisters the instances from the load balancer
+	DeregisterInstancesFromLoadBalancer(loadBalancerId string, nodesIPs []string) error
+}
+
+// ConcertoInstance is an abstraction for a Concerto cloud instance
+type ConcertoInstance struct {
+	Id       string  // Unique identifier for the instance in Concerto
+	Name     string  // Hostname for the instance
+	PublicIP string  // Public IP for the instance
+	CPUs     float64 // Number of cores
+	Memory   int64   // Amount of RAM (in MiB)
+	Storage  int64   // Amount of disk (in GiB)
+}
+
+// Ship is used for deserializing
+type Ship struct {
+	Id             string
+	Fqdn           string
+	Public_ip      string
+	Server_plan_id string
+	Cpus           float64 // Number of cores
+	Memory         int64   // Amount of RAM (in MB)
+	Storage        int64   // Amount of disk (in GiB)
+}
+
+// ConcertoLoadBalancer abstracts a Concerto Load Balancer
+type ConcertoLoadBalancer struct {
+	Id       string `json:"id"`   // Unique identifier for the LB in Concerto
+	Name     string `json:"name"` // Name of the LB in concerto
+	FQDN     string `json:"fqdn"` // Fully Qualified domain name
+	Port     int    `json:"port"`
+	NodePort int    `json:"nodeport"`
+	Protocol string `json:"protocol"`
+}
+
+// ConcertoLoadBalancer abstracts a Concerto Load Balancer
+type ConcertoLoadBalancerNode struct {
+	ID string
+	IP string `json:"public_ip"`
+	// Port int    `json:"port"`
+}
+
+// Concerto REST API client implementation
+type concertoAPIServiceREST struct {
+	// Pre-configured HTTP client
+	client concertoRESTService
+}
+
+type concertoRESTService interface {
+	// Get resource at 'path', returning body, status code, and error if any
+	Get(path string) ([]byte, int, error)
+	// Post resource to 'path', returning body, status code, and error if any
+	Post(path string, json []byte) ([]byte, int, error)
+	// Delete resource at 'path', returning body, status code, and error if any
+	Delete(path string) ([]byte, int, error)
+}
+
+// BuildConcertoRESTClient Factory for 'concertoAPIServiceREST' objects
+func buildConcertoRESTClient(config ConcertoConfig) (ConcertoAPIService, error) {
+	rs, err := newRestService(config)
+	if err != nil {
+		return nil, fmt.Errorf("error building Concerto REST client: %v", err)
+	}
+
+	return &concertoAPIServiceREST{client: rs}, nil
+}
+
+func (c *concertoAPIServiceREST) GetInstanceList() ([]ConcertoInstance, error) {
+	var ships []Ship
+	instances := []ConcertoInstance{}
+
+	data, status, err := c.client.Get("/kaas/ships")
+	if err != nil {
+		return nil, fmt.Errorf("error on 'GET /kaas/ships' http request: %v", err)
+	}
+
+	if status == 404 {
+		return instances, nil
+	}
+
+	err = json.Unmarshal(data, &ships)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling http response: %v (received data was: %s)", err, string(data))
+	}
+
+	for _, s := range ships {
+		concertoInstance := ConcertoInstance{
+			Id:       s.Id,
+			Name:     s.Fqdn,
+			PublicIP: s.Public_ip,
+			CPUs:     s.Cpus,
+			Memory:   s.Memory,
+			Storage:  s.Storage,
+		}
+		instances = append(instances, concertoInstance)
+	}
+
+	return instances, nil
+}
+
+func (c *concertoAPIServiceREST) GetInstanceByName(name string) (ConcertoInstance, error) {
+	concertoInstances, err := c.GetInstanceList()
+	if err != nil {
+		return ConcertoInstance{}, fmt.Errorf("error getting list of instances from Concerto: %v", err)
+	}
+
+	for _, instance := range concertoInstances {
+		if instance.Name == name {
+			return instance, nil
+		}
+	}
+
+	return ConcertoInstance{}, cloudprovider.InstanceNotFound
+}
+
+func (c *concertoAPIServiceREST) GetLoadBalancerList() ([]ConcertoLoadBalancer, error) {
+	var lbs []ConcertoLoadBalancer
+
+	data, status, err := c.client.Get("/kaas/load_balancers")
+	if err != nil {
+		return nil, fmt.Errorf("error on 'GET /kaas/load_balancers' http request: %v", err)
+	}
+
+	if status >= 400 {
+		return nil, fmt.Errorf("HTTP status %v when getting '/kaas/load_balancers'", status)
+	}
+
+	err = json.Unmarshal(data, &lbs)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling http response: %v (received data was: %s)", err, string(data))
+	}
+
+	return lbs, nil
+}
+
+func (c *concertoAPIServiceREST) GetLoadBalancerByName(name string) (*ConcertoLoadBalancer, error) {
+	concertoLBs, err := c.GetLoadBalancerList()
+	if err != nil {
+		return nil, fmt.Errorf("error getting load balancer list from Concerto: %v", err)
+	}
+
+	for _, lb := range concertoLBs {
+		if lb.Name == name {
+			return &lb, nil
+		}
+	}
+
+	glog.Warningf("Could not find load balancer '%s' on Concerto", name)
+	return nil, nil
+}
+
+func (c *concertoAPIServiceREST) DeleteLoadBalancerById(id string) error {
+	_, status, err := c.client.Delete("/kaas/load_balancers/" + id)
+	if err != nil {
+		return fmt.Errorf("error on http request 'DELETE /kaas/load_balancers/%s': %v", id, err)
+	}
+	if status != 200 && status != 204 {
+		return fmt.Errorf("http status %v on request 'DELETE /kaas/load_balancers/%s' (expected 204 or 200)", status, id)
+	}
+	return nil
+}
+
+func (c *concertoAPIServiceREST) RegisterInstancesWithLoadBalancer(loadBalancerId string, ips []string) error {
+	for _, ip := range ips {
+		err := c.registerInstanceWithLoadBalancer(loadBalancerId, ip)
+		if err != nil {
+			return fmt.Errorf("error registering instance '%s' with load balancer '%s': %v", ip, loadBalancerId, err)
+		}
+	}
+	return nil
+}
+
+func (c *concertoAPIServiceREST) registerInstanceWithLoadBalancer(loadBalancerId string, ip string) error {
+	instance, err := c.GetInstanceByIP(ip)
+	if err != nil {
+		return fmt.Errorf("error getting Concerto instance by IP '%s': %v", ip, err)
+	}
+	jsonNode := instance.toNode().toJson()
+	url := fmt.Sprintf("/kaas/load_balancers/%s/nodes", loadBalancerId)
+	_, status, err := c.client.Post(url, jsonNode)
+	if err != nil {
+		return fmt.Errorf("error on http request 'POST %s': %v", url, err)
+	}
+	if status != 201 {
+		return fmt.Errorf("http status %v on request 'POST %s' (expected 201)", status, url)
+	}
+	return nil
+}
+
+func (c *concertoAPIServiceREST) DeregisterInstancesFromLoadBalancer(loadBalancerId string, ips []string) error {
+	for _, ip := range ips {
+		err := c.deregisterInstanceFromLoadBalancer(loadBalancerId, ip)
+		if err != nil {
+			return fmt.Errorf("error deregistering instance '%s' from load balancer '%s': %v", ip, loadBalancerId, err)
+		}
+	}
+	return nil
+}
+
+func (c *concertoAPIServiceREST) deregisterInstanceFromLoadBalancer(loadBalancerId string, ip string) error {
+	node, err := c.GetNodeByIP(loadBalancerId, ip)
+	if err != nil {
+		return fmt.Errorf("error getting node by ip '%s' from load balancer '%s': %v", ip, loadBalancerId, err)
+	}
+	path := fmt.Sprintf("/kaas/load_balancers/%s/nodes/%s", loadBalancerId, node.ID)
+	_, status, err := c.client.Delete(path)
+	if err != nil {
+		return fmt.Errorf("error on http request 'DELETE %s': %v", path, err)
+	}
+	if status != 200 && status != 204 {
+		return fmt.Errorf("http status %v on request 'DELETE %s' (expected 204 or 200)", status, path)
+	}
+	return nil
+}
+
+func (c *concertoAPIServiceREST) GetLoadBalancerNodes(loadBalancerId string) ([]ConcertoLoadBalancerNode, error) {
+	var nodes []ConcertoLoadBalancerNode
+
+	path := fmt.Sprintf("/kaas/load_balancers/%s/nodes", loadBalancerId)
+	data, status, err := c.client.Get(path)
+	if err != nil {
+		return nil, fmt.Errorf("error on http request 'GET %s': %v", path, err)
+	}
+
+	if status == 404 {
+		return nil, fmt.Errorf("load balancer not found: %v", loadBalancerId)
+	}
+
+	err = json.Unmarshal(data, &nodes)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling http response: %v (received data was: %s)", err, string(data))
+	}
+
+	return nodes, nil
+}
+
+func (c *concertoAPIServiceREST) GetLoadBalancerNodesAsIPs(loadBalancerId string) (nodeips []string, e error) {
+	nodes, err := c.GetLoadBalancerNodes(loadBalancerId)
+	if err != nil {
+		return nil, fmt.Errorf("error getting nodes from load balancer '%s' : %v", loadBalancerId, err)
+	}
+
+	for _, node := range nodes {
+		nodeips = append(nodeips, node.IP)
+	}
+
+	return nodeips, nil
+}
+
+func (c *concertoAPIServiceREST) CreateLoadBalancer(name string, port int, nodePort int) (*ConcertoLoadBalancer, error) {
+	lb := ConcertoLoadBalancer{
+		Name:     name,
+		FQDN:     name,
+		Port:     port,
+		NodePort: nodePort,
+		Protocol: "tcp",
+	}
+	data, status, err := c.client.Post("/kaas/load_balancers", lb.toJson())
+	if err != nil {
+		return nil, fmt.Errorf("error on http request 'POST /kaas/load_balancers': %v", err)
+	}
+	if status != 201 {
+		return nil, fmt.Errorf("HTTP %v when creating load balancer %s", status, name)
+	}
+
+	err = json.Unmarshal(data, &lb) // So that we get the Id
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling http response: %v (received data was: %s)", err, string(data))
+	}
+
+	return &lb, nil
+}
+
+func (c *concertoAPIServiceREST) GetInstanceByIP(ip string) (ConcertoInstance, error) {
+	concertoInstances, err := c.GetInstanceList()
+	if err != nil {
+		return ConcertoInstance{}, fmt.Errorf("error getting instance list from Concerto: %v", err)
+	}
+
+	for _, instance := range concertoInstances {
+		if instance.PublicIP == ip {
+			return instance, nil
+		}
+	}
+
+	return ConcertoInstance{}, cloudprovider.InstanceNotFound
+}
+
+func (c *concertoAPIServiceREST) GetNodeByIP(loadBalancerId, ip string) (ConcertoLoadBalancerNode, error) {
+	lbNodes, err := c.GetLoadBalancerNodes(loadBalancerId)
+	if err != nil {
+		return ConcertoLoadBalancerNode{}, fmt.Errorf("error getting nodes from load balancer '%s' : %v", loadBalancerId, err)
+	}
+
+	for _, node := range lbNodes {
+		if node.IP == ip {
+			return node, nil
+		}
+	}
+
+	return ConcertoLoadBalancerNode{}, fmt.Errorf("Node '%s' not found in load balancer '%s'", ip, loadBalancerId)
+}
+
+func (ci ConcertoInstance) toNode() ConcertoLoadBalancerNode {
+	var node ConcertoLoadBalancerNode
+	node.IP = ci.PublicIP
+	return node
+}
+
+func (cn ConcertoLoadBalancerNode) toJson() []byte {
+	b, err := json.Marshal(cn)
+	if err != nil {
+		return nil
+	}
+	return b
+}
+
+func (lb ConcertoLoadBalancer) toJson() []byte {
+	b, err := json.Marshal(lb)
+	if err != nil {
+		return nil
+	}
+	return b
+}

--- a/pkg/cloudprovider/providers/concerto/api_service_mock_for_test.go
+++ b/pkg/cloudprovider/providers/concerto/api_service_mock_for_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package concerto_cloud
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+
+	"k8s.io/kubernetes/pkg/cloudprovider"
+)
+
+// ConcertoAPIService mock implementation
+type ConcertoAPIServiceMock struct {
+	instances         []ConcertoInstance
+	balancers         []ConcertoLoadBalancer
+	balancedInstances map[string][]string // key is LB id, value is a list of nodes ids
+}
+
+func (mock *ConcertoAPIServiceMock) GetInstanceByName(name string) (ConcertoInstance, error) {
+	for _, ci := range mock.instances {
+		if ci.Name == name {
+			return ci, nil
+		}
+	}
+	return ConcertoInstance{}, cloudprovider.InstanceNotFound
+}
+
+func (mock *ConcertoAPIServiceMock) GetInstanceList() ([]ConcertoInstance, error) {
+	return mock.instances, nil
+}
+
+func (mock *ConcertoAPIServiceMock) GetLoadBalancerByName(name string) (*ConcertoLoadBalancer, error) {
+	if name == "GiveMeAnError" {
+		return nil, fmt.Errorf("Take this!")
+	}
+	for _, lb := range mock.balancers {
+		if lb.Name == name {
+			return &lb, nil
+		}
+	}
+	return nil, nil
+}
+
+func (mock *ConcertoAPIServiceMock) DeleteLoadBalancerById(id string) error {
+	for i, lb := range mock.balancers {
+		if lb.Id == id {
+			if i == len(mock.balancers)-1 {
+				mock.balancers = mock.balancers[:i]
+			} else {
+				mock.balancers = append(mock.balancers[:i], mock.balancers[i+1:]...)
+			}
+			return nil
+		}
+	}
+	return errors.New("load balancer delete error")
+}
+
+func (mock *ConcertoAPIServiceMock) GetLoadBalancerNodes(loadBalancerId string) ([]ConcertoLoadBalancerNode, error) {
+	var nodes []ConcertoLoadBalancerNode
+
+	ips, err := mock.GetLoadBalancerNodesAsIPs(loadBalancerId)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, ip := range ips {
+		nodes = append(nodes, ConcertoLoadBalancerNode{ip, ip})
+	}
+
+	return nodes, nil
+}
+
+func (mock *ConcertoAPIServiceMock) GetLoadBalancerNodesAsIPs(loadBalancerId string) ([]string, error) {
+	return mock.balancedInstances[loadBalancerId], nil
+}
+
+func (mock *ConcertoAPIServiceMock) RegisterInstancesWithLoadBalancer(loadBalancerId string, instancesIds []string) error {
+	nodes := mock.balancedInstances[loadBalancerId]
+	mock.balancedInstances[loadBalancerId] = append(nodes, instancesIds...)
+	return nil
+}
+
+func (mock *ConcertoAPIServiceMock) DeregisterInstancesFromLoadBalancer(loadBalancerId string, instancesIds []string) error {
+	mock.balancedInstances[loadBalancerId] = subtractStringArrays(mock.balancedInstances[loadBalancerId], instancesIds)
+	return nil
+}
+
+func (mock *ConcertoAPIServiceMock) CreateLoadBalancer(name string, port int, nodePort int) (*ConcertoLoadBalancer, error) {
+	lb := ConcertoLoadBalancer{
+		Id:   string(rand.Int63()),
+		Name: name,
+		Port: port,
+	}
+	mock.balancers = append(mock.balancers, lb)
+	return &lb, nil
+}

--- a/pkg/cloudprovider/providers/concerto/api_service_mock_for_test.go
+++ b/pkg/cloudprovider/providers/concerto/api_service_mock_for_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"regexp"
 
 	"k8s.io/kubernetes/pkg/cloudprovider"
 )
@@ -45,7 +46,8 @@ func (mock *ConcertoAPIServiceMock) GetInstanceList() ([]ConcertoInstance, error
 }
 
 func (mock *ConcertoAPIServiceMock) GetLoadBalancerByName(name string) (*ConcertoLoadBalancer, error) {
-	if name == "GiveMeAnError" {
+	matchError, _ := regexp.MatchString("Error", name)
+	if matchError {
 		return nil, fmt.Errorf("Take this!")
 	}
 	for _, lb := range mock.balancers {

--- a/pkg/cloudprovider/providers/concerto/api_service_test.go
+++ b/pkg/cloudprovider/providers/concerto/api_service_test.go
@@ -1,0 +1,375 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package concerto_cloud
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/cloudprovider"
+)
+
+func Test_GetInstanceList_Success(t *testing.T) {
+	jsonList := "[{\"Id\":\"0001\"},{\"Id\":\"0002\"}]"
+	restMock := buildConcertoRESTMockClient(jsonList, 200, nil)
+	apiService := concertoAPIServiceREST{client: restMock}
+	instances, err := apiService.GetInstanceList()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	} else if instances == nil {
+		t.Errorf("Unexpected nil return value")
+	} else if len(instances) != 2 {
+		t.Errorf("Unexpected slice size: was %v but expected 2", len(instances))
+	}
+	if len(restMock.receivedCalls) != 1 || restMock.receivedCalls[0] != "GET /kaas/ships" {
+		t.Errorf("Expected exactly one 'GET /kaas/ships' but received: %v", restMock.receivedCalls)
+	}
+}
+
+func Test_GetInstanceList_NoInstances(t *testing.T) {
+	restMock := buildConcertoRESTMockClient("", 404, nil)
+	apiService := concertoAPIServiceREST{client: restMock}
+	instances, err := apiService.GetInstanceList()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if instances == nil {
+		t.Errorf("Should return an empty slice but got nil")
+	}
+	if len(instances) != 0 {
+		t.Errorf("Should return an empty slice but got some instances: %v", instances)
+	}
+}
+
+func Test_GetInstanceByName_Success(t *testing.T) {
+	jsonList := "[{\"id\":\"0001\",\"fqdn\":\"myinstance\"},{\"Id\":\"0002\",\"fqdn\":\"anotherinstance\"}]"
+	restMock := buildConcertoRESTMockClient(jsonList, 200, nil)
+	apiService := concertoAPIServiceREST{client: restMock}
+	instance, err := apiService.GetInstanceByName("myinstance")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if instance.Id != "0001" {
+		t.Errorf("Incorrect instance: expected Id '0001' but was '%v'", instance.Id)
+	}
+}
+
+func Test_GetInstanceByName_NotFound(t *testing.T) {
+	jsonList := "[{\"id\":\"0003\",\"fqdn\":\"someinstance\"}]"
+	restMock := buildConcertoRESTMockClient(jsonList, 200, nil)
+	apiService := concertoAPIServiceREST{client: restMock}
+	_, err := apiService.GetInstanceByName("anotherinstance")
+	if err == nil {
+		t.Errorf("Expected to receive an error but didn't")
+	} else if err != cloudprovider.InstanceNotFound {
+		t.Errorf("Expected error: %v , but was %v", cloudprovider.InstanceNotFound, err)
+	}
+}
+
+func Test_GetLoadBalancerList_Success(t *testing.T) {
+	jsonList := "[{\"Id\":\"0001\"},{\"Id\":\"0002\"}]"
+	restMock := buildConcertoRESTMockClient(jsonList, 200, nil)
+	apiService := concertoAPIServiceREST{client: restMock}
+	lbs, err := apiService.GetLoadBalancerList()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	} else if lbs == nil {
+		t.Errorf("Unexpected nil return value")
+	} else if len(lbs) != 2 {
+		t.Errorf("Unexpected slice size: was %v but expected 2", len(lbs))
+	}
+	if len(restMock.receivedCalls) != 1 || restMock.receivedCalls[0] != "GET /kaas/load_balancers" {
+		t.Errorf("Expected exactly one 'GET /kaas/load_balancers' but received: %v", restMock.receivedCalls)
+	}
+}
+
+func Test_GetLoadBalancerList_NoInstances(t *testing.T) {
+	jsonList := "[]"
+	restMock := buildConcertoRESTMockClient(jsonList, 200, nil)
+	apiService := concertoAPIServiceREST{client: restMock}
+	lbs, err := apiService.GetLoadBalancerList()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	} else if lbs == nil {
+		t.Errorf("Unexpected nil return value")
+	} else if len(lbs) != 0 {
+		t.Errorf("Unexpected slice size: was %v but expected 0", len(lbs))
+	}
+	if len(restMock.receivedCalls) != 1 || restMock.receivedCalls[0] != "GET /kaas/load_balancers" {
+		t.Errorf("Expected exactly one 'GET /kaas/load_balancers' but received: %v", restMock.receivedCalls)
+	}
+}
+
+func Test_GetLoadBalancerList_UnexpectedHTTPStatus(t *testing.T) {
+	jsonList := "[]"
+	restMock := buildConcertoRESTMockClient(jsonList, 500, nil)
+	apiService := concertoAPIServiceREST{client: restMock}
+	_, err := apiService.GetLoadBalancerList()
+	if err == nil {
+		t.Errorf("Expected error but none was returned")
+	}
+	if len(restMock.receivedCalls) != 1 || restMock.receivedCalls[0] != "GET /kaas/load_balancers" {
+		t.Errorf("Expected exactly one 'GET /kaas/load_balancers' but received: %v", restMock.receivedCalls)
+	}
+}
+
+func Test_GetLoadBalancerByName_Success(t *testing.T) {
+	jsonList := "[{\"id\":\"0001\",\"name\":\"myLB\"},{\"Id\":\"0002\",\"name\":\"anotherLB\"}]"
+	restMock := buildConcertoRESTMockClient(jsonList, 200, nil)
+	apiService := concertoAPIServiceREST{client: restMock}
+	instance, err := apiService.GetLoadBalancerByName("myLB")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if instance.Id != "0001" {
+		t.Errorf("Incorrect instance: expected Id '0001' but was '%v'", instance.Id)
+	}
+}
+
+func Test_GetLoadBalancerByName_NotFound(t *testing.T) {
+	jsonList := "[{\"id\":\"0003\",\"name\":\"someLB\"}]"
+	restMock := buildConcertoRESTMockClient(jsonList, 200, nil)
+	apiService := concertoAPIServiceREST{client: restMock}
+	lb, err := apiService.GetLoadBalancerByName("anotherLB")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if lb != nil {
+		t.Errorf("Expected nil but got: %v", lb)
+	}
+}
+
+func Test_DeleteLoadBalancerById_Success_HTTP204(t *testing.T) {
+	restMock := buildConcertoRESTMockClient("", 204, nil)
+	apiService := concertoAPIServiceREST{client: restMock}
+	err := apiService.DeleteLoadBalancerById("0001")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func Test_DeleteLoadBalancerById_Success_HTTP200(t *testing.T) {
+	restMock := buildConcertoRESTMockClient("", 200, nil)
+	apiService := concertoAPIServiceREST{client: restMock}
+	err := apiService.DeleteLoadBalancerById("0001")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func Test_DeleteLoadBalancerById_UnexpectedHTTPStatus(t *testing.T) {
+	restMock := buildConcertoRESTMockClient("", 500, nil)
+	apiService := concertoAPIServiceREST{client: restMock}
+	err := apiService.DeleteLoadBalancerById("0001")
+	if err == nil {
+		t.Errorf("Expected error but got none")
+	}
+}
+
+func Test_RegisterInstancesWithLoadBalancer(t *testing.T) {
+	jsonList := "[{\"id\":\"1234\",\"public_ip\":\"1.2.3.4\"},{\"id\":\"5678\",\"public_ip\":\"5.6.7.8\"},{\"id\":\"0000\",\"public_ip\":\"0.0.0.0\"}]"
+	restMock := buildConcertoRESTMockClient(jsonList, 201, nil)
+	apiService := concertoAPIServiceREST{client: restMock}
+	err := apiService.RegisterInstancesWithLoadBalancer("someLB", []string{"1.2.3.4", "5.6.7.8"})
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	expectedCalls := []string{
+		"GET /kaas/ships",
+		"POST /kaas/load_balancers/someLB/nodes {\"ID\":\"\",\"public_ip\":\"1.2.3.4\"}",
+		"GET /kaas/ships",
+		"POST /kaas/load_balancers/someLB/nodes {\"ID\":\"\",\"public_ip\":\"5.6.7.8\"}",
+	}
+	if len(restMock.receivedCalls) != 4 ||
+		restMock.receivedCalls[0] != expectedCalls[0] ||
+		restMock.receivedCalls[1] != expectedCalls[1] ||
+		restMock.receivedCalls[2] != expectedCalls[2] ||
+		restMock.receivedCalls[3] != expectedCalls[3] {
+		t.Errorf("Received this sequence of calls: '%v' but expected: '%v'", restMock.receivedCalls, expectedCalls)
+	}
+}
+
+func TestDeregisterInstancesFromLoadBalancer(t *testing.T) {
+	jsonList := "[{\"id\":\"1234\",\"public_ip\":\"1.2.3.4\"},{\"id\":\"5678\",\"public_ip\":\"5.6.7.8\"},{\"id\":\"0000\",\"public_ip\":\"0.0.0.0\"}]"
+	restMock := buildConcertoRESTMockClient(jsonList, 204, nil)
+	apiService := concertoAPIServiceREST{client: restMock}
+	err := apiService.DeregisterInstancesFromLoadBalancer("someLB", []string{"1.2.3.4", "5.6.7.8"})
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	expectedCalls := []string{
+		"GET /kaas/load_balancers/someLB/nodes",
+		"DELETE /kaas/load_balancers/someLB/nodes/1234",
+		"GET /kaas/load_balancers/someLB/nodes",
+		"DELETE /kaas/load_balancers/someLB/nodes/5678",
+	}
+	if len(restMock.receivedCalls) != 4 ||
+		restMock.receivedCalls[0] != expectedCalls[0] ||
+		restMock.receivedCalls[1] != expectedCalls[1] ||
+		restMock.receivedCalls[2] != expectedCalls[2] ||
+		restMock.receivedCalls[3] != expectedCalls[3] {
+		t.Errorf("Received this sequence of calls: '%v' but expected: '%v'", restMock.receivedCalls, expectedCalls)
+	}
+}
+
+func TestGetLoadBalancerNodes(t *testing.T) {
+	jsonList := "[{\"id\":\"1234\",\"public_ip\":\"1.2.3.4\"}]"
+	restMock := buildConcertoRESTMockClient(jsonList, 204, nil)
+	apiService := concertoAPIServiceREST{client: restMock}
+	nodes, err := apiService.GetLoadBalancerNodes("someLB")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	expectedCall := "GET /kaas/load_balancers/someLB/nodes"
+	if len(restMock.receivedCalls) != 1 ||
+		restMock.receivedCalls[0] != expectedCall {
+		t.Errorf("Received this sequence of calls: '%v' but expected: '%v'", restMock.receivedCalls, expectedCall)
+	}
+	if len(nodes) != 1 {
+		t.Errorf("Received %v nodes but expected 1", len(nodes))
+	}
+	if nodes[0].ID != "1234" {
+		t.Errorf("Received node with id '%v' but expected '1234'", nodes[0].ID)
+	}
+}
+
+func TestGetLoadBalancerNodesAsIPs(t *testing.T) {
+	jsonList := "[{\"id\":\"1234\",\"public_ip\":\"1.2.3.4\"}]"
+	restMock := buildConcertoRESTMockClient(jsonList, 204, nil)
+	apiService := concertoAPIServiceREST{client: restMock}
+	nodes, err := apiService.GetLoadBalancerNodesAsIPs("someLB")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	expectedCall := "GET /kaas/load_balancers/someLB/nodes"
+	if len(restMock.receivedCalls) != 1 ||
+		restMock.receivedCalls[0] != expectedCall {
+		t.Errorf("Received this sequence of calls: '%v' but expected: '%v'", restMock.receivedCalls, expectedCall)
+	}
+	if len(nodes) != 1 {
+		t.Errorf("Received %v nodes but expected 1", len(nodes))
+	}
+	if nodes[0] != "1.2.3.4" {
+		t.Errorf("Received ip '%v' but expected '1.2.3.4'", nodes[0])
+	}
+}
+
+func Test_CreateLoadBalancer_Success(t *testing.T) {
+	name := "myLB"
+	port := 4567
+	nodePort := 5678
+	jsonList := fmt.Sprintf("{\"id\":\"1234\",\"name\":\"%s\",\"fqdn\":\"%s\",\"port\":%v,\"nodeport\":%v,\"protocol\":\"tcp\"}", name, name, port, nodePort)
+	restMock := buildConcertoRESTMockClient(jsonList, 201, nil)
+	apiService := concertoAPIServiceREST{client: restMock}
+	lb, err := apiService.CreateLoadBalancer(name, port, nodePort)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	expectedCallBody := fmt.Sprintf("{\"id\":\"\",\"name\":\"%s\",\"fqdn\":\"%s\",\"port\":%v,\"nodeport\":%v,\"protocol\":\"tcp\"}", name, name, port, nodePort)
+	expectedCall := fmt.Sprintf("POST /kaas/load_balancers %s", expectedCallBody)
+	if len(restMock.receivedCalls) != 1 ||
+		restMock.receivedCalls[0] != expectedCall {
+		t.Errorf("Received this sequence of calls: '%v' but expected: '%v'", restMock.receivedCalls, expectedCall)
+	}
+	if lb.Id != "1234" {
+		t.Errorf("Unexpected load balancer id: '%v'", lb.Id)
+	}
+	if lb.Name != name {
+		t.Errorf("Unexpected load balancer name: '%v'", lb.Name)
+	}
+	if lb.FQDN != name {
+		t.Errorf("Unexpected load balancer FQDN: '%v'", lb.FQDN)
+	}
+	if lb.Port != port {
+		t.Errorf("Unexpected load balancer port: '%v'", lb.Port)
+	}
+	if lb.NodePort != nodePort {
+		t.Errorf("Unexpected load balancer node port: '%v'", lb.NodePort)
+	}
+	if lb.Protocol != "tcp" {
+		t.Errorf("Unexpected load balancer protocol: '%v'", lb.Protocol)
+	}
+}
+
+func Test_CreateLoadBalancer_UnexpectedHTTPStatus(t *testing.T) {
+	name := "myLB"
+	port := 4567
+	nodePort := 5678
+	jsonList := fmt.Sprintf("{\"id\":\"1234\",\"name\":\"%s\",\"fqdn\":\"%s\",\"port\":%v,\"nodeport\":%v,\"protocol\":\"tcp\"}", name, name, port, nodePort)
+	restMock := buildConcertoRESTMockClient(jsonList, 500, nil)
+	apiService := concertoAPIServiceREST{client: restMock}
+	_, err := apiService.CreateLoadBalancer(name, port, nodePort)
+	if err == nil {
+		t.Errorf("Expected error but got none")
+	}
+}
+
+func Test_CreateLoadBalancer_UnmarshalError(t *testing.T) {
+	name := "myLB"
+	port := 4567
+	nodePort := 5678
+	jsonList := "notvalidjson"
+	restMock := buildConcertoRESTMockClient(jsonList, 201, nil)
+	apiService := concertoAPIServiceREST{client: restMock}
+	_, err := apiService.CreateLoadBalancer(name, port, nodePort)
+	if err == nil {
+		t.Errorf("Expected error but got none")
+	}
+}
+
+func Test_CreateLoadBalancer_HTTPClientError(t *testing.T) {
+	name := "myLB"
+	port := 4567
+	nodePort := 5678
+	jsonList := fmt.Sprintf("{\"id\":\"1234\",\"name\":\"%s\",\"fqdn\":\"%s\",\"port\":%v,\"nodeport\":%v,\"protocol\":\"tcp\"}", name, name, port, nodePort)
+	somerror := errors.New("some error")
+	restMock := buildConcertoRESTMockClient(jsonList, 201, somerror)
+	apiService := concertoAPIServiceREST{client: restMock}
+	_, err := apiService.CreateLoadBalancer(name, port, nodePort)
+	if err == nil {
+		t.Errorf("Expected error but got none")
+	}
+}
+
+// Mock implementation of rest service
+
+type RESTMock struct {
+	receivedCalls []string
+	body          []byte
+	status        int
+	err           error
+}
+
+func (mock *RESTMock) Get(path string) ([]byte, int, error) {
+	mock.receivedCalls = append(mock.receivedCalls, "GET "+path)
+	return mock.body, mock.status, mock.err
+}
+
+func (mock *RESTMock) Post(path string, body []byte) ([]byte, int, error) {
+	mock.receivedCalls = append(mock.receivedCalls, fmt.Sprintf("POST %s %s", path, string(body)))
+	return mock.body, mock.status, mock.err
+}
+
+func (mock *RESTMock) Delete(path string) ([]byte, int, error) {
+	mock.receivedCalls = append(mock.receivedCalls, "DELETE "+path)
+	return mock.body, mock.status, mock.err
+}
+
+func buildConcertoRESTMockClient(body string, status int, err error) *RESTMock {
+	return &RESTMock{body: []byte(body), status: status, err: err}
+}

--- a/pkg/cloudprovider/providers/concerto/concerto.go
+++ b/pkg/cloudprovider/providers/concerto/concerto.go
@@ -19,7 +19,7 @@ package concerto_cloud
 import (
 	"io"
 
-	"github.com/scalingdata/gcfg"
+	"gopkg.in/gcfg.v1"
 
 	"k8s.io/kubernetes/pkg/cloudprovider"
 )

--- a/pkg/cloudprovider/providers/concerto/concerto.go
+++ b/pkg/cloudprovider/providers/concerto/concerto.go
@@ -27,7 +27,7 @@ import (
 // ProviderName is the name under which Concerto cloud provider is registered
 const ProviderName = "concerto"
 
-// ConcertoCloud is an implementation of Interface, TCPLoadBalancer, and Instances
+// ConcertoCloud is an implementation of Interface, LoadBalancer, and Instances
 // for Flexiant Concerto.
 type ConcertoCloud struct {
 	// Abstracting access to Concerto API

--- a/pkg/cloudprovider/providers/concerto/concerto.go
+++ b/pkg/cloudprovider/providers/concerto/concerto.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package concerto_cloud
+
+import (
+	"io"
+
+	"github.com/scalingdata/gcfg"
+
+	"k8s.io/kubernetes/pkg/cloudprovider"
+)
+
+// ProviderName is the name under which Concerto cloud provider is registered
+const ProviderName = "concerto"
+
+// ConcertoCloud is an implementation of Interface, TCPLoadBalancer, and Instances
+// for Flexiant Concerto.
+type ConcertoCloud struct {
+	// Abstracting access to Concerto API
+	service ConcertoAPIService
+}
+
+// ConcertoConfig holds the Concerto cloud provider configuration.
+// Example config file contents :
+//
+//	# concerto-cloud.conf
+//	[connection]
+//	apiendpoint = https://localhost:8443/
+//	cert = /etc/concerto/api/cert.pem
+//	key = /etc/concerto/api/private/key.pem
+//
+type ConcertoConfig struct {
+	Connection struct {
+		APIEndpoint string `gcfg:"apiendpoint"`
+		CACert      string `gcfg:"cacert"`
+		Cert        string `gcfg:"cert"`
+		Key         string `gcfg:"key"`
+	}
+}
+
+func init() {
+	cloudprovider.RegisterCloudProvider(
+		ProviderName,
+		func(config io.Reader) (cloudprovider.Interface, error) {
+			cc, err := newConcertoCloud(config)
+			return cc, err
+		})
+}
+
+// newConcertoCloud creates a new instance of ConcertoCloud.
+func newConcertoCloud(config io.Reader) (*ConcertoCloud, error) {
+	concertoConfig := ConcertoConfig{}
+
+	err := gcfg.ReadInto(&concertoConfig, config)
+	if err != nil {
+		return nil, err
+	}
+
+	apiService, err := buildConcertoRESTClient(concertoConfig)
+	if err != nil {
+		return nil, err
+	}
+	return &ConcertoCloud{service: apiService}, nil
+}

--- a/pkg/cloudprovider/providers/concerto/instances.go
+++ b/pkg/cloudprovider/providers/concerto/instances.go
@@ -90,6 +90,10 @@ func (concerto *ConcertoCloud) CurrentNodeName(hostname string) (string, error) 
 	return hostname, nil
 }
 
+func (concerto *ConcertoCloud) InstanceType(hostname string) (string, error) {
+	return "", nil
+}
+
 // NOT SUPPORTED in Concerto Cloud
 func (concerto *ConcertoCloud) AddSSHKeyToAllInstances(user string, keyData []byte) error {
 	return fmt.Errorf("Unsupported operation")

--- a/pkg/cloudprovider/providers/concerto/instances.go
+++ b/pkg/cloudprovider/providers/concerto/instances.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package concerto_cloud
+
+import (
+	"fmt"
+	"net"
+	"regexp"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/cloudprovider"
+)
+
+// NodeAddresses returns the addresses of the specified instance.
+func (concerto *ConcertoCloud) NodeAddresses(name string) ([]api.NodeAddress, error) {
+	ci, err := concerto.service.GetInstanceByName(name)
+	if err != nil {
+		return nil, fmt.Errorf("error getting Concerto instance by name '%s' : %v", name, err)
+	}
+	publicAddress := api.NodeAddress{
+		Type:    api.NodeExternalIP,
+		Address: net.ParseIP(ci.PublicIP).String(),
+	}
+	return []api.NodeAddress{publicAddress}, nil
+}
+
+// ExternalID returns the cloud provider ID of the specified instance (deprecated).
+func (concerto *ConcertoCloud) ExternalID(name string) (string, error) {
+	return concerto.InstanceID(name)
+}
+
+// InstanceID returns the cloud provider ID of the specified instance.
+// Note that if the instance does not exist or is no longer running, we must return ("", cloudprovider.InstanceNotFound)
+func (concerto *ConcertoCloud) InstanceID(name string) (string, error) {
+	ci, err := concerto.service.GetInstanceByName(name)
+	if err == cloudprovider.InstanceNotFound {
+		return "", cloudprovider.InstanceNotFound
+	}
+	if err != nil {
+		return "", fmt.Errorf("error getting Concerto instance by name '%s' : %v", name, err)
+	}
+	return ci.Id, nil
+}
+
+// List lists instances that match 'filter' which is a regular expression which must match the entire instance name (fqdn)
+func (concerto *ConcertoCloud) List(filter string) ([]string, error) {
+	regexp, err := regexp.Compile(filter)
+	if err != nil {
+		return nil, fmt.Errorf("error compiling regular expression '%s' : %v", filter, err)
+	}
+	instances, err := concerto.service.GetInstanceList()
+	if err != nil {
+		return nil, fmt.Errorf("error getting Concerto instance list : %v", err)
+	}
+	names := make([]string, 0)
+	for _, instance := range instances {
+		if regexp.MatchString(instance.Name) {
+			names = append(names, instance.Name)
+		}
+	}
+	return names, nil
+}
+
+// GetNodeResources gets the resources for a particular node
+func (concerto *ConcertoCloud) GetNodeResources(name string) (*api.NodeResources, error) {
+	ci, err := concerto.service.GetInstanceByName(name)
+	if err != nil {
+		return nil, fmt.Errorf("error getting Concerto instance by name '%s' : %v", name, err)
+	}
+	return makeNodeResources(ci.CPUs, ci.Memory), nil
+}
+
+// Returns the name of the node we are currently running on
+func (concerto *ConcertoCloud) CurrentNodeName(hostname string) (string, error) {
+	return hostname, nil
+}
+
+// NOT SUPPORTED in Concerto Cloud
+func (concerto *ConcertoCloud) AddSSHKeyToAllInstances(user string, keyData []byte) error {
+	return fmt.Errorf("Unsupported operation")
+}
+
+// Builds an api.NodeResources
+// cpu is in cores, memory is in MiB
+func makeNodeResources(cpu float64, memory int64) *api.NodeResources {
+	return &api.NodeResources{
+		Capacity: api.ResourceList{
+			api.ResourceCPU:    *resource.NewMilliQuantity(int64(cpu*1000), resource.DecimalSI),
+			api.ResourceMemory: *resource.NewQuantity(int64(memory*1024*1024), resource.BinarySI),
+		},
+	}
+}

--- a/pkg/cloudprovider/providers/concerto/instances_test.go
+++ b/pkg/cloudprovider/providers/concerto/instances_test.go
@@ -1,0 +1,237 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package concerto_cloud
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/cloudprovider"
+)
+
+func TestAddSSHKeyToAllInstancesNotSupported(t *testing.T) {
+	concerto := &ConcertoCloud{}
+	err := concerto.AddSSHKeyToAllInstances("user", nil)
+	if err == nil {
+		t.Errorf("Expected 'AddSSHKeyToAllInstances' to not be supported")
+	}
+}
+
+func TestNodeAddresses(t *testing.T) {
+	concerto := &ConcertoCloud{
+		service: &ConcertoAPIServiceMock{
+			instances: []ConcertoInstance{
+				{
+					Name:     "myinstance",
+					Id:       "11235813",
+					PublicIP: "123.123.123.123"}}}}
+	na, err := concerto.NodeAddresses("myinstance") // ([]api.NodeAddress, error)
+	if err != nil {
+		t.Errorf("NodeAddresses: Should have found instance 'myinstance'")
+	}
+	if len(na) != 1 {
+		t.Errorf("NodeAddresses: Should have found just one address")
+		t.FailNow()
+	}
+	// api.NodeAddress = {Type: api.NodeExternalIP, Address: externalIP}
+	// ip := net.ParseIP(ipAddress)
+	if na[0].Type != api.NodeExternalIP {
+		t.Errorf("NodeAddresses: Should have found an external address")
+	}
+	if na[0].Address != "123.123.123.123" {
+		t.Errorf("NodeAddresses: Should have found the correct address")
+	}
+}
+
+func TestNodeAddresses_InstanceNotFound(t *testing.T) {
+	concerto := &ConcertoCloud{
+		service: &ConcertoAPIServiceMock{
+			instances: []ConcertoInstance{
+				{
+					Name:     "someinstance",
+					Id:       "11235813",
+					PublicIP: "123.123.123.123"}}}}
+	na, err := concerto.NodeAddresses("myinstance") // ([]api.NodeAddress, error)
+	if err == nil {
+		t.Errorf("NodeAddresses: Should have returned error")
+	}
+	if len(na) != 0 {
+		t.Errorf("NodeAddresses: Should have not found any address")
+		t.FailNow()
+	}
+}
+
+func TestInstanceID(t *testing.T) {
+	concerto := &ConcertoCloud{
+		service: &ConcertoAPIServiceMock{
+			instances: []ConcertoInstance{
+				{
+					Name:     "myinstance",
+					Id:       "11235813",
+					PublicIP: "123.123.123.123"}}}}
+	id, err := concerto.InstanceID("myinstance")
+	if err != nil {
+		t.Errorf("InstanceID: Should have found instance 'myinstance'")
+	}
+	if id != "11235813" {
+		t.Errorf("InstanceID: Should have returned the correct ID")
+	}
+}
+
+func TestInstanceID_InstanceNotFound(t *testing.T) {
+	concerto := &ConcertoCloud{
+		service: &ConcertoAPIServiceMock{
+			instances: []ConcertoInstance{
+				{
+					Name:     "someinstance",
+					Id:       "11235813",
+					PublicIP: "123.123.123.123"}}}}
+	id, err := concerto.InstanceID("myinstance")
+	if err != cloudprovider.InstanceNotFound {
+		t.Errorf("InstanceID: Should have returned error")
+	}
+	if id != "" {
+		t.Errorf("InstanceID: Should not have returned any ID")
+	}
+}
+
+func TestExternalID(t *testing.T) {
+	concerto := &ConcertoCloud{
+		service: &ConcertoAPIServiceMock{
+			instances: []ConcertoInstance{
+				{
+					Name:     "myinstance",
+					Id:       "11235813",
+					PublicIP: "123.123.123.123"}}}}
+	id, err := concerto.ExternalID("myinstance")
+	if err != nil {
+		t.Errorf("ExternalID: Should have found instance 'myinstance'")
+	}
+	if id != "11235813" {
+		t.Errorf("ExternalID: Should have returned the correct ID")
+	}
+}
+
+func TestExternalID_InstanceNotFound(t *testing.T) {
+	concerto := &ConcertoCloud{
+		service: &ConcertoAPIServiceMock{
+			instances: []ConcertoInstance{
+				{
+					Name:     "someinstance",
+					Id:       "11235813",
+					PublicIP: "123.123.123.123"}}}}
+	id, err := concerto.ExternalID("myinstance")
+	if err != cloudprovider.InstanceNotFound {
+		t.Errorf("ExternalID: Should have returned error")
+	}
+	if id != "" {
+		t.Errorf("ExternalID: Should not have returned any ID")
+	}
+}
+
+func TestList(t *testing.T) {
+	concerto := &ConcertoCloud{
+		service: &ConcertoAPIServiceMock{
+			instances: []ConcertoInstance{
+				{
+					Name:     "myinstance.acme.concerto.io",
+					Id:       "11235813",
+					PublicIP: "123.123.123.123",
+					CPUs:     2,
+					Memory:   4},
+				{
+					Name:     "otherinstance.acme.concerto.io",
+					Id:       "9876543",
+					PublicIP: "1.1.1.1",
+					CPUs:     2,
+					Memory:   4},
+			}}}
+	list, err := concerto.List(".*my.*")
+	if err != nil {
+		t.Errorf("List: Should not have returned error: %v", err)
+	}
+	if len(list) != 1 {
+		t.Errorf("List: Should have found exactly one instance")
+		t.FailNow()
+	}
+	if list[0] != "myinstance.acme.concerto.io" {
+		t.Errorf("List: Should have found instance 'myinstance'")
+	}
+}
+
+func TestGetNodeResources(t *testing.T) {
+	concerto := &ConcertoCloud{
+		service: &ConcertoAPIServiceMock{
+			instances: []ConcertoInstance{
+				{
+					Name:     "myinstance",
+					Id:       "11235813",
+					PublicIP: "123.123.123.123",
+					CPUs:     2,
+					Memory:   4 * 1024,
+				}}}}
+	nr, err := concerto.GetNodeResources("myinstance") // (*api.NodeResources, error)
+	if err != nil {
+		t.Errorf("GetNodeResources: Should have found instance 'myinstance'")
+	}
+	aux := nr.Capacity[api.ResourceCPU]
+	returnedCPUs := (&aux).Value()
+	expectedCPUs := int64(2)
+	if returnedCPUs != expectedCPUs {
+		t.Errorf("GetNodeResources: Should have returned the correct CPU resources")
+		t.Errorf("GetNodeResources: Expected %v but was %v", expectedCPUs, returnedCPUs)
+	}
+	aux = nr.Capacity[api.ResourceMemory]
+	returnedMemory := (&aux).Value()
+	expectedMemory := int64(4 * 1024 * 1024 * 1024)
+	if returnedMemory != expectedMemory {
+		t.Errorf("GetNodeResources: Should have returned the correct Memory resources")
+		t.Errorf("GetNodeResources: Expected %v but was %v", expectedMemory, returnedMemory)
+	}
+}
+
+func TestGetNodeResources_InstanceNotFound(t *testing.T) {
+	concerto := &ConcertoCloud{
+		service: &ConcertoAPIServiceMock{
+			instances: []ConcertoInstance{
+				{
+					Name:     "someinstance",
+					Id:       "11235813",
+					PublicIP: "123.123.123.123",
+					CPUs:     2,
+					Memory:   4,
+				}}}}
+	nr, err := concerto.GetNodeResources("myinstance")
+	if err == nil {
+		t.Errorf("GetNodeResources: Should have returned error")
+	}
+	if nr != nil {
+		t.Errorf("GetNodeResources: Should not have returned any resources")
+	}
+}
+
+func TestCurrentNodeName(t *testing.T) {
+	concerto := &ConcertoCloud{}
+	nodename, err := concerto.CurrentNodeName("something")
+	if err != nil {
+		t.Errorf("GetNodeName: Should not have returned error: %v", err)
+		t.FailNow()
+	}
+	if nodename != "something" {
+		t.Errorf("GetNodeName: Should have returned correct name")
+	}
+}

--- a/pkg/cloudprovider/providers/concerto/interface.go
+++ b/pkg/cloudprovider/providers/concerto/interface.go
@@ -30,8 +30,8 @@ func (concerto *ConcertoCloud) Instances() (cloudprovider.Instances, bool) {
 	return concerto, true
 }
 
-// TCPLoadBalancer returns an implementation of TCPLoadBalancer for Concerto.
-func (concerto *ConcertoCloud) TCPLoadBalancer() (cloudprovider.TCPLoadBalancer, bool) {
+// LoadBalancer returns an implementation of LoadBalancer for Concerto.
+func (concerto *ConcertoCloud) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 	return concerto, true
 }
 

--- a/pkg/cloudprovider/providers/concerto/interface.go
+++ b/pkg/cloudprovider/providers/concerto/interface.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package concerto_cloud
+
+import (
+	"k8s.io/kubernetes/pkg/cloudprovider"
+)
+
+// ProviderName returns the cloud provider ID.
+func (f *ConcertoCloud) ProviderName() string {
+	return ProviderName
+}
+
+// Instances returns an implementation of Instances for Concerto.
+func (concerto *ConcertoCloud) Instances() (cloudprovider.Instances, bool) {
+	return concerto, true
+}
+
+// TCPLoadBalancer returns an implementation of TCPLoadBalancer for Concerto.
+func (concerto *ConcertoCloud) TCPLoadBalancer() (cloudprovider.TCPLoadBalancer, bool) {
+	return concerto, true
+}
+
+// Clusters not supported.
+func (concerto *ConcertoCloud) Clusters() (cloudprovider.Clusters, bool) {
+	return nil, false
+}
+
+// Routes not supported.
+func (concerto *ConcertoCloud) Routes() (cloudprovider.Routes, bool) {
+	return nil, false
+}
+
+// Zones returns an implementation of Zones for Concerto.
+func (concerto *ConcertoCloud) Zones() (cloudprovider.Zones, bool) {
+	return concerto, true
+}
+
+// ScrubDNS filters DNS settings for pods.
+func (concerto *ConcertoCloud) ScrubDNS(nameservers, searches []string) (nsOut, srchOut []string) {
+	return nameservers, searches
+}

--- a/pkg/cloudprovider/providers/concerto/interface_test.go
+++ b/pkg/cloudprovider/providers/concerto/interface_test.go
@@ -39,14 +39,14 @@ func TestInstances(t *testing.T) {
 	}
 }
 
-func TestTCPLoadBalancer(t *testing.T) {
+func TestLoadBalancer(t *testing.T) {
 	concerto := &ConcertoCloud{}
-	loadbalancers, ok := concerto.TCPLoadBalancer()
+	loadbalancers, ok := concerto.LoadBalancer()
 	if !ok {
-		t.Errorf("Unexpected error fetching Concerto 'TCPLoadBalancer' component")
+		t.Errorf("Unexpected error fetching Concerto 'LoadBalancer' component")
 	}
 	if loadbalancers != concerto {
-		t.Errorf("Unexpected error fetching Concerto 'TCPLoadBalancer' component")
+		t.Errorf("Unexpected error fetching Concerto 'LoadBalancer' component")
 	}
 }
 

--- a/pkg/cloudprovider/providers/concerto/interface_test.go
+++ b/pkg/cloudprovider/providers/concerto/interface_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package concerto_cloud
+
+import (
+	"testing"
+)
+
+func TestProviderName(t *testing.T) {
+	concerto := &ConcertoCloud{}
+	name := concerto.ProviderName()
+	if name != "concerto" {
+		t.Errorf("Unexpected provider name: '%v' (expecting 'concerto')", name)
+	}
+}
+
+func TestInstances(t *testing.T) {
+	concerto := &ConcertoCloud{}
+	instances, ok := concerto.Instances()
+	if !ok {
+		t.Errorf("Unexpected error fetching Concerto 'Instances' component")
+	}
+	if instances != concerto {
+		t.Errorf("Unexpected error fetching Concerto 'Instances' component")
+	}
+}
+
+func TestTCPLoadBalancer(t *testing.T) {
+	concerto := &ConcertoCloud{}
+	loadbalancers, ok := concerto.TCPLoadBalancer()
+	if !ok {
+		t.Errorf("Unexpected error fetching Concerto 'TCPLoadBalancer' component")
+	}
+	if loadbalancers != concerto {
+		t.Errorf("Unexpected error fetching Concerto 'TCPLoadBalancer' component")
+	}
+}
+
+func TestZones(t *testing.T) {
+	concerto := &ConcertoCloud{}
+	zones, ok := concerto.Zones()
+	if !ok {
+		t.Errorf("Unexpected error fetching Concerto 'Zones' component")
+	}
+	if zones != concerto {
+		t.Errorf("Unexpected error fetching Concerto 'Zones' component")
+	}
+}
+
+func TestClusters(t *testing.T) {
+	concerto := &ConcertoCloud{}
+	clusters, supported := concerto.Clusters()
+	if supported {
+		t.Errorf("'Clusters' interface is suppossed to be unsupported")
+	}
+	if clusters != nil {
+		t.Errorf("'Clusters' interface is suppossed to be unsupported")
+	}
+}
+
+func TestRoutes(t *testing.T) {
+	concerto := &ConcertoCloud{}
+	routes, supported := concerto.Routes()
+	if supported {
+		t.Errorf("'Routes' interface is suppossed to be unsupported")
+	}
+	if routes != nil {
+		t.Errorf("'Routes' interface is suppossed to be unsupported")
+	}
+}
+
+func TestScrubDNS(t *testing.T) {
+	concerto := &ConcertoCloud{}
+	nsIn := []string{"ns1"}
+	srchIn := []string{"*"}
+	nsOut, srchOut := concerto.ScrubDNS(nsIn, srchIn)
+	if len(nsOut) != len(nsIn) || nsOut[0] != nsIn[0] {
+		t.Errorf("'ScrubDNS' : returned 'nameservers' should equal received 'nameservers'")
+	}
+	if len(srchOut) != len(srchIn) || srchOut[0] != srchIn[0] {
+		t.Errorf("'ScrubDNS' : returned 'searches' should equal received 'searches'")
+	}
+}

--- a/pkg/cloudprovider/providers/concerto/load_balancer.go
+++ b/pkg/cloudprovider/providers/concerto/load_balancer.go
@@ -21,6 +21,7 @@ import (
 	"net"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/types"
 )
 
 // GetLoadBalancer implementation for Flexiant Concerto.
@@ -49,7 +50,7 @@ func toStatus(lb *ConcertoLoadBalancer) *api.LoadBalancerStatus {
 }
 
 // EnsureLoadBalancer implementation for Flexiant Concerto.
-func (c *ConcertoCloud) EnsureLoadBalancer(name, region string, loadBalancerIP net.IP, ports []*api.ServicePort, hosts []string, affinityType api.ServiceAffinity) (*api.LoadBalancerStatus, error) {
+func (c *ConcertoCloud) EnsureLoadBalancer(name, region string, loadBalancerIP net.IP, ports []*api.ServicePort, hosts []string, serviceName types.NamespacedName, affinityType api.ServiceAffinity, annotations map[string]string) (*api.LoadBalancerStatus, error) {
 	// Concerto LB does not support session affinity
 	if affinityType != api.ServiceAffinityNone {
 		return nil, fmt.Errorf("Unsupported load balancer affinity: %v", affinityType)

--- a/pkg/cloudprovider/providers/concerto/load_balancer.go
+++ b/pkg/cloudprovider/providers/concerto/load_balancer.go
@@ -23,8 +23,8 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 )
 
-// GetTCPLoadBalancer implementation for Flexiant Concerto.
-func (c *ConcertoCloud) GetTCPLoadBalancer(name, _region string) (status *api.LoadBalancerStatus, exists bool, err error) {
+// GetLoadBalancer implementation for Flexiant Concerto.
+func (c *ConcertoCloud) GetLoadBalancer(name, _region string) (status *api.LoadBalancerStatus, exists bool, err error) {
 	lb, err := c.service.GetLoadBalancerByName(name)
 	if err != nil {
 		return nil, false, fmt.Errorf("error getting Concerto load balancer by name '%s' : %v", name, err)
@@ -48,8 +48,8 @@ func toStatus(lb *ConcertoLoadBalancer) *api.LoadBalancerStatus {
 	return status
 }
 
-// EnsureTCPLoadBalancer implementation for Flexiant Concerto.
-func (c *ConcertoCloud) EnsureTCPLoadBalancer(name, region string, loadBalancerIP net.IP, ports []*api.ServicePort, hosts []string, affinityType api.ServiceAffinity) (*api.LoadBalancerStatus, error) {
+// EnsureLoadBalancer implementation for Flexiant Concerto.
+func (c *ConcertoCloud) EnsureLoadBalancer(name, region string, loadBalancerIP net.IP, ports []*api.ServicePort, hosts []string, affinityType api.ServiceAffinity) (*api.LoadBalancerStatus, error) {
 	// Concerto LB does not support session affinity
 	if affinityType != api.ServiceAffinityNone {
 		return nil, fmt.Errorf("Unsupported load balancer affinity: %v", affinityType)
@@ -71,13 +71,13 @@ func (c *ConcertoCloud) EnsureTCPLoadBalancer(name, region string, loadBalancerI
 
 	if lb == nil {
 		// It does not exist: create it
-		lb, err = c.createTCPLoadBalancer(name, ports, hosts)
+		lb, err = c.createLoadBalancer(name, ports, hosts)
 		if err != nil {
 			return nil, fmt.Errorf("error creating load balancer '%s' in Concerto: %v", name, err)
 		}
 	} else {
 		// It already exists: update it
-		err = c.UpdateTCPLoadBalancer(name, region, hosts)
+		err = c.UpdateLoadBalancer(name, region, hosts)
 		if err != nil {
 			return nil, fmt.Errorf("error updating load balancer '%s' in Concerto: %v", name, err)
 		}
@@ -86,7 +86,7 @@ func (c *ConcertoCloud) EnsureTCPLoadBalancer(name, region string, loadBalancerI
 	return toStatus(lb), nil
 }
 
-func (c *ConcertoCloud) createTCPLoadBalancer(name string, ports []*api.ServicePort, hosts []string) (*ConcertoLoadBalancer, error) {
+func (c *ConcertoCloud) createLoadBalancer(name string, ports []*api.ServicePort, hosts []string) (*ConcertoLoadBalancer, error) {
 	// Create the LB
 	port := ports[0].Port // The port that will be exposed on the service.
 	// targetPort := ports[0].TargetPort // Optional: The target port on pods selected by this service
@@ -111,8 +111,8 @@ func (c *ConcertoCloud) createTCPLoadBalancer(name string, ports []*api.ServiceP
 	return lb, nil
 }
 
-// UpdateTCPLoadBalancer implementation for Flexiant Concerto.
-func (c *ConcertoCloud) UpdateTCPLoadBalancer(name, region string, hosts []string) error {
+// UpdateLoadBalancer implementation for Flexiant Concerto.
+func (c *ConcertoCloud) UpdateLoadBalancer(name, region string, hosts []string) error {
 	// Get the load balancer
 	lb, err := c.service.GetLoadBalancerByName(name)
 	if err != nil {
@@ -145,8 +145,8 @@ func (c *ConcertoCloud) UpdateTCPLoadBalancer(name, region string, hosts []strin
 	return nil
 }
 
-// EnsureTCPLoadBalancerDeleted implementation for Flexiant Concerto.
-func (c *ConcertoCloud) EnsureTCPLoadBalancerDeleted(name, region string) error {
+// EnsureLoadBalancerDeleted implementation for Flexiant Concerto.
+func (c *ConcertoCloud) EnsureLoadBalancerDeleted(name, region string) error {
 	// Get the LB
 	lb, err := c.service.GetLoadBalancerByName(name)
 	if err != nil {

--- a/pkg/cloudprovider/providers/concerto/load_balancer.go
+++ b/pkg/cloudprovider/providers/concerto/load_balancer.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package concerto_cloud
+
+import (
+	"fmt"
+	"net"
+
+	"k8s.io/kubernetes/pkg/api"
+)
+
+// GetTCPLoadBalancer implementation for Flexiant Concerto.
+func (c *ConcertoCloud) GetTCPLoadBalancer(name, _region string) (status *api.LoadBalancerStatus, exists bool, err error) {
+	lb, err := c.service.GetLoadBalancerByName(name)
+	if err != nil {
+		return nil, false, fmt.Errorf("error getting Concerto load balancer by name '%s' : %v", name, err)
+	}
+
+	if lb == nil {
+		return nil, false, nil
+	}
+
+	status = toStatus(lb)
+	return status, true, nil
+}
+
+func toStatus(lb *ConcertoLoadBalancer) *api.LoadBalancerStatus {
+	status := &api.LoadBalancerStatus{}
+
+	var ingress api.LoadBalancerIngress
+	ingress.Hostname = lb.FQDN
+	status.Ingress = []api.LoadBalancerIngress{ingress}
+
+	return status
+}
+
+// EnsureTCPLoadBalancer implementation for Flexiant Concerto.
+func (c *ConcertoCloud) EnsureTCPLoadBalancer(name, region string, loadBalancerIP net.IP, ports []*api.ServicePort, hosts []string, affinityType api.ServiceAffinity) (*api.LoadBalancerStatus, error) {
+	// Concerto LB does not support session affinity
+	if affinityType != api.ServiceAffinityNone {
+		return nil, fmt.Errorf("Unsupported load balancer affinity: %v", affinityType)
+	}
+	// Can not specify a public IP for the LB
+	if loadBalancerIP != nil {
+		return nil, fmt.Errorf("can not specify an IP address for a Concerto load balancer")
+	}
+	// Dont support multi-port
+	if len(ports) != 1 {
+		return nil, fmt.Errorf("Concerto load balancer only supports one single port")
+	}
+
+	// Check previous existence
+	lb, err := c.service.GetLoadBalancerByName(name)
+	if err != nil {
+		return nil, fmt.Errorf("error checking existence of load balancer '%s' in Concerto: %v", name, err)
+	}
+
+	if lb == nil {
+		// It does not exist: create it
+		lb, err = c.createTCPLoadBalancer(name, ports, hosts)
+		if err != nil {
+			return nil, fmt.Errorf("error creating load balancer '%s' in Concerto: %v", name, err)
+		}
+	} else {
+		// It already exists: update it
+		err = c.UpdateTCPLoadBalancer(name, region, hosts)
+		if err != nil {
+			return nil, fmt.Errorf("error updating load balancer '%s' in Concerto: %v", name, err)
+		}
+	}
+
+	return toStatus(lb), nil
+}
+
+func (c *ConcertoCloud) createTCPLoadBalancer(name string, ports []*api.ServicePort, hosts []string) (*ConcertoLoadBalancer, error) {
+	// Create the LB
+	port := ports[0].Port // The port that will be exposed on the service.
+	// targetPort := ports[0].TargetPort // Optional: The target port on pods selected by this service
+	nodePort := ports[0].NodePort // The port on each node on which this service is exposed.
+	lb, err := c.service.CreateLoadBalancer(name, port, nodePort)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Concerto load balancer (%v/%v/%v): %v", name, port, nodePort, err)
+	}
+
+	// Add the corresponding nodes
+	if len(hosts) > 0 {
+		ipAddresses, err := c.hostsNamesToIPs(hosts)
+		if err != nil {
+			return nil, fmt.Errorf("error converting hostnames to IP addresses: %v", err)
+		}
+		err = c.service.RegisterInstancesWithLoadBalancer(lb.Id, ipAddresses)
+		if err != nil {
+			return nil, fmt.Errorf("error registering instances with load balancer: %v", err)
+		}
+	}
+
+	return lb, nil
+}
+
+// UpdateTCPLoadBalancer implementation for Flexiant Concerto.
+func (c *ConcertoCloud) UpdateTCPLoadBalancer(name, region string, hosts []string) error {
+	// Get the load balancer
+	lb, err := c.service.GetLoadBalancerByName(name)
+	if err != nil {
+		return fmt.Errorf("error getting Concerto load balancer by name '%s': %v", name, err)
+	}
+	// Get the LB nodes
+	currentNodes, err := c.service.GetLoadBalancerNodesAsIPs(lb.Id)
+	if err != nil {
+		return fmt.Errorf("error getting nodes (as IP addresses) of Concerto load balancer '%s': %v", lb.Id, err)
+	}
+
+	// Calculate nodes to deregister
+	wantedNodes, err := c.hostsNamesToIPs(hosts)
+	if err != nil {
+		return fmt.Errorf("error converting hostnames to IP addresses: %v", err)
+	}
+	nodesToRemove := subtractStringArrays(currentNodes, wantedNodes)
+	// Calculate nodes to be registered
+	nodesToAdd := subtractStringArrays(wantedNodes, currentNodes)
+	// Do the thing
+	err = c.service.DeregisterInstancesFromLoadBalancer(lb.Id, nodesToRemove)
+	if err != nil {
+		return fmt.Errorf("error deregistering instances (%v) from load balancer (%v) : %v", nodesToRemove, lb.Id, err)
+	}
+	err = c.service.RegisterInstancesWithLoadBalancer(lb.Id, nodesToAdd)
+	if err != nil {
+		return fmt.Errorf("error registering instances (%v) with load balancer (%v) : %v", nodesToAdd, lb.Id, err)
+	}
+
+	return nil
+}
+
+// EnsureTCPLoadBalancerDeleted implementation for Flexiant Concerto.
+func (c *ConcertoCloud) EnsureTCPLoadBalancerDeleted(name, region string) error {
+	// Get the LB
+	lb, err := c.service.GetLoadBalancerByName(name)
+	if err != nil {
+		return fmt.Errorf("error getting Concerto load balancer by name '%s': %v", name, err)
+	}
+	if lb == nil {
+		return nil
+	}
+	return c.service.DeleteLoadBalancerById(lb.Id)
+}
+
+func (c *ConcertoCloud) hostsNamesToIPs(hosts []string) ([]string, error) {
+	var ips []string
+	instances, err := c.service.GetInstanceList()
+	if err != nil {
+		return nil, fmt.Errorf("error getting Concerto instance list : %v", err)
+	}
+	for _, name := range hosts {
+		found := false
+		for _, instance := range instances {
+			if instance.Name == name {
+				ips = append(ips, instance.PublicIP)
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, fmt.Errorf("could not find instance: %s", name)
+		}
+	}
+	return ips, nil
+}

--- a/pkg/cloudprovider/providers/concerto/load_balancer_test.go
+++ b/pkg/cloudprovider/providers/concerto/load_balancer_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/types"
 )
 
 func TestGetLoadBalancer(t *testing.T) {
@@ -72,7 +73,10 @@ func TestEnsureLoadBalancer_CreatesTheLBInConcerto(t *testing.T) {
 		nil,   // external ip
 		ports, // ports
 		[]string{"host1", "host2"},
-		api.ServiceAffinityNone)
+		types.NamespacedName{}, // namespaced name
+		api.ServiceAffinityNone,
+		nil, // annotations
+	)
 	if len(apiMock.balancers) != 1 {
 		t.Errorf("EnsureLoadBalancer: should have created the LB")
 	} else {
@@ -101,7 +105,10 @@ func TestEnsureLoadBalancerAddsTheNodes(t *testing.T) {
 		nil,   // external ip
 		ports, // ports
 		[]string{"host1", "host2"},
-		api.ServiceAffinityNone)
+		types.NamespacedName{}, // namespaced name
+		api.ServiceAffinityNone,
+		nil, // annotations
+	)
 	if err != nil {
 		t.Errorf("EnsureLoadBalancer: should not have returned any errors")
 	}
@@ -121,7 +128,10 @@ func TestEnsureLoadBalancerWithUnsupportedAffinity(t *testing.T) {
 		nil,   // external ip
 		ports, // ports
 		[]string{"host1", "host2"},
-		api.ServiceAffinityClientIP)
+		types.NamespacedName{}, // namespaced name
+		api.ServiceAffinityClientIP,
+		nil, // annotations
+	)
 	if err == nil {
 		t.Errorf("EnsureLoadBalancer: should not support ServiceAffinity")
 	}
@@ -135,7 +145,10 @@ func TestEnsureLoadBalancerWithNoPort(t *testing.T) {
 		nil,   // external ip
 		ports, // ports
 		[]string{"host1", "host2"},
-		api.ServiceAffinityNone)
+		types.NamespacedName{}, // namespaced name
+		api.ServiceAffinityNone,
+		nil, // annotations
+	)
 	if err == nil {
 		t.Errorf("EnsureLoadBalancer: should return error if no port specified")
 	}
@@ -152,7 +165,10 @@ func TestEnsureLoadBalancerWithMultiplePorts(t *testing.T) {
 		nil,   // external ip
 		ports, // ports
 		[]string{"host1", "host2"},
-		api.ServiceAffinityNone)
+		types.NamespacedName{}, // namespaced name
+		api.ServiceAffinityNone,
+		nil, // annotations
+	)
 	if err == nil {
 		t.Errorf("EnsureLoadBalancer: should return error if no port specified")
 	}
@@ -168,7 +184,10 @@ func TestEnsureLoadBalancerWithExternalIP(t *testing.T) {
 		net.IP{}, // external ip
 		ports,    // ports
 		[]string{"host1", "host2"},
-		api.ServiceAffinityNone)
+		types.NamespacedName{}, // namespaced name
+		api.ServiceAffinityNone,
+		nil, // annotations
+	)
 	if err == nil {
 		t.Errorf("EnsureLoadBalancer: should not support ExternalIP specification")
 	}
@@ -197,7 +216,10 @@ func TestEnsureLoadBalancer_UpdatesTheLBInConcerto(t *testing.T) {
 		nil,   // external ip
 		ports, // ports
 		[]string{"host1", "host3"},
-		api.ServiceAffinityNone)
+		types.NamespacedName{}, // namespaced name
+		api.ServiceAffinityNone,
+		nil, // annotations
+	)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}

--- a/pkg/cloudprovider/providers/concerto/load_balancer_test.go
+++ b/pkg/cloudprovider/providers/concerto/load_balancer_test.go
@@ -23,42 +23,42 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 )
 
-func TestGetTCPLoadBalancer(t *testing.T) {
+func TestGetLoadBalancer(t *testing.T) {
 	apiMock := &ConcertoAPIServiceMock{
 		balancers: []ConcertoLoadBalancer{
 			{Id: "123456", Name: "mybalancer", FQDN: "mybalancer.concerto.mock"},
 		},
 	}
 	concerto := ConcertoCloud{service: apiMock}
-	status, exists, err := concerto.GetTCPLoadBalancer("mybalancer", "whatever region")
+	status, exists, err := concerto.GetLoadBalancer("mybalancer", "whatever region")
 	if err != nil {
-		t.Errorf("GetTCPLoadBalancer: should not have returned error")
+		t.Errorf("GetLoadBalancer: should not have returned error")
 	}
 	if !exists {
-		t.Errorf("GetTCPLoadBalancer: should have found the LB")
+		t.Errorf("GetLoadBalancer: should have found the LB")
 	}
 	if status.Ingress[0].Hostname != "mybalancer.concerto.mock" {
-		t.Errorf("GetTCPLoadBalancer: should have returned the correct status")
+		t.Errorf("GetLoadBalancer: should have returned the correct status")
 	}
 }
 
-func TestGetTCPLoadBalancer_NonExisting(t *testing.T) {
+func TestGetLoadBalancer_NonExisting(t *testing.T) {
 	apiMock := &ConcertoAPIServiceMock{
 		balancers: []ConcertoLoadBalancer{
 			{Id: "123456", Name: "mybalancer", FQDN: "mybalancer.concerto.mock"},
 		},
 	}
 	concerto := ConcertoCloud{service: apiMock}
-	_, exists, err := concerto.GetTCPLoadBalancer("otherbalancer", "whatever region")
+	_, exists, err := concerto.GetLoadBalancer("otherbalancer", "whatever region")
 	if err != nil {
-		t.Errorf("GetTCPLoadBalancer: should not have returned error")
+		t.Errorf("GetLoadBalancer: should not have returned error")
 	}
 	if exists {
-		t.Errorf("GetTCPLoadBalancer: should not have found the LB")
+		t.Errorf("GetLoadBalancer: should not have found the LB")
 	}
 }
 
-func TestEnsureTCPLoadBalancer_CreatesTheLBInConcerto(t *testing.T) {
+func TestEnsureLoadBalancer_CreatesTheLBInConcerto(t *testing.T) {
 	apiMock := &ConcertoAPIServiceMock{
 		balancers:         []ConcertoLoadBalancer{},
 		balancedInstances: map[string][]string{},
@@ -67,23 +67,23 @@ func TestEnsureTCPLoadBalancer_CreatesTheLBInConcerto(t *testing.T) {
 		{Port: 1234},
 	}
 	concerto := ConcertoCloud{service: apiMock}
-	concerto.EnsureTCPLoadBalancer("myloadbalancer",
+	concerto.EnsureLoadBalancer("myloadbalancer",
 		"region",
 		nil,   // external ip
 		ports, // ports
 		[]string{"host1", "host2"},
 		api.ServiceAffinityNone)
 	if len(apiMock.balancers) != 1 {
-		t.Errorf("EnsureTCPLoadBalancer: should have created the LB")
+		t.Errorf("EnsureLoadBalancer: should have created the LB")
 	} else {
 		lb := apiMock.balancers[0]
 		if lb.Name != "myloadbalancer" || lb.Port != 1234 {
-			t.Errorf("EnsureTCPLoadBalancer: should have created the LB with correct data")
+			t.Errorf("EnsureLoadBalancer: should have created the LB with correct data")
 		}
 	}
 }
 
-func TestEnsureTCPLoadBalancerAddsTheNodes(t *testing.T) {
+func TestEnsureLoadBalancerAddsTheNodes(t *testing.T) {
 	apiMock := &ConcertoAPIServiceMock{
 		balancers:         []ConcertoLoadBalancer{},
 		balancedInstances: map[string][]string{},
@@ -96,85 +96,85 @@ func TestEnsureTCPLoadBalancerAddsTheNodes(t *testing.T) {
 		{Port: 1234},
 	}
 	concerto := ConcertoCloud{service: apiMock}
-	_, err := concerto.EnsureTCPLoadBalancer("myloadbalancer",
+	_, err := concerto.EnsureLoadBalancer("myloadbalancer",
 		"region",
 		nil,   // external ip
 		ports, // ports
 		[]string{"host1", "host2"},
 		api.ServiceAffinityNone)
 	if err != nil {
-		t.Errorf("EnsureTCPLoadBalancer: should not have returned any errors")
+		t.Errorf("EnsureLoadBalancer: should not have returned any errors")
 	}
 	lb, _ := apiMock.GetLoadBalancerByName("myloadbalancer")
 	if len(apiMock.balancedInstances[lb.Id]) != 2 {
-		t.Errorf("EnsureTCPLoadBalancer: should have registered the nodes with the LB")
+		t.Errorf("EnsureLoadBalancer: should have registered the nodes with the LB")
 	}
 }
 
-func TestEnsureTCPLoadBalancerWithUnsupportedAffinity(t *testing.T) {
+func TestEnsureLoadBalancerWithUnsupportedAffinity(t *testing.T) {
 	concerto := ConcertoCloud{}
 	ports := []*api.ServicePort{
 		{},
 	}
-	_, err := concerto.EnsureTCPLoadBalancer("name",
+	_, err := concerto.EnsureLoadBalancer("name",
 		"region",
 		nil,   // external ip
 		ports, // ports
 		[]string{"host1", "host2"},
 		api.ServiceAffinityClientIP)
 	if err == nil {
-		t.Errorf("EnsureTCPLoadBalancer: should not support ServiceAffinity")
+		t.Errorf("EnsureLoadBalancer: should not support ServiceAffinity")
 	}
 }
 
-func TestEnsureTCPLoadBalancerWithNoPort(t *testing.T) {
+func TestEnsureLoadBalancerWithNoPort(t *testing.T) {
 	concerto := ConcertoCloud{}
 	ports := []*api.ServicePort{}
-	_, err := concerto.EnsureTCPLoadBalancer("name",
+	_, err := concerto.EnsureLoadBalancer("name",
 		"region",
 		nil,   // external ip
 		ports, // ports
 		[]string{"host1", "host2"},
 		api.ServiceAffinityNone)
 	if err == nil {
-		t.Errorf("EnsureTCPLoadBalancer: should return error if no port specified")
+		t.Errorf("EnsureLoadBalancer: should return error if no port specified")
 	}
 }
 
-func TestEnsureTCPLoadBalancerWithMultiplePorts(t *testing.T) {
+func TestEnsureLoadBalancerWithMultiplePorts(t *testing.T) {
 	concerto := ConcertoCloud{}
 	ports := []*api.ServicePort{
 		{},
 		{},
 	}
-	_, err := concerto.EnsureTCPLoadBalancer("name",
+	_, err := concerto.EnsureLoadBalancer("name",
 		"region",
 		nil,   // external ip
 		ports, // ports
 		[]string{"host1", "host2"},
 		api.ServiceAffinityNone)
 	if err == nil {
-		t.Errorf("EnsureTCPLoadBalancer: should return error if no port specified")
+		t.Errorf("EnsureLoadBalancer: should return error if no port specified")
 	}
 }
 
-func TestEnsureTCPLoadBalancerWithExternalIP(t *testing.T) {
+func TestEnsureLoadBalancerWithExternalIP(t *testing.T) {
 	concerto := ConcertoCloud{}
 	ports := []*api.ServicePort{
 		{},
 	}
-	_, err := concerto.EnsureTCPLoadBalancer("name",
+	_, err := concerto.EnsureLoadBalancer("name",
 		"region",
 		net.IP{}, // external ip
 		ports,    // ports
 		[]string{"host1", "host2"},
 		api.ServiceAffinityNone)
 	if err == nil {
-		t.Errorf("EnsureTCPLoadBalancer: should not support ExternalIP specification")
+		t.Errorf("EnsureLoadBalancer: should not support ExternalIP specification")
 	}
 }
 
-func TestEnsureTCPLoadBalancer_UpdatesTheLBInConcerto(t *testing.T) {
+func TestEnsureLoadBalancer_UpdatesTheLBInConcerto(t *testing.T) {
 	apiMock := &ConcertoAPIServiceMock{
 		balancers: []ConcertoLoadBalancer{
 			{Id: "LB1", Name: "mybalancer"},
@@ -192,7 +192,7 @@ func TestEnsureTCPLoadBalancer_UpdatesTheLBInConcerto(t *testing.T) {
 		{Port: 1234},
 	}
 	concerto := ConcertoCloud{service: apiMock}
-	_, err := concerto.EnsureTCPLoadBalancer("mybalancer",
+	_, err := concerto.EnsureLoadBalancer("mybalancer",
 		"region",
 		nil,   // external ip
 		ports, // ports
@@ -202,17 +202,17 @@ func TestEnsureTCPLoadBalancer_UpdatesTheLBInConcerto(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	if len(apiMock.balancers) > 1 {
-		t.Errorf("EnsureTCPLoadBalancer: should not have created the LB")
+		t.Errorf("EnsureLoadBalancer: should not have created the LB")
 	} else if len(apiMock.balancers) < 1 {
-		t.Errorf("EnsureTCPLoadBalancer: should not have deleted the LB")
+		t.Errorf("EnsureLoadBalancer: should not have deleted the LB")
 	} else {
 		if apiMock.balancedInstances["LB1"][0] != "123.123.123.123" || apiMock.balancedInstances["LB1"][1] != "123.123.123.125" {
-			t.Errorf("EnsureTCPLoadBalancer: should have updated the load balancer: %v", apiMock.balancedInstances["LB1"])
+			t.Errorf("EnsureLoadBalancer: should have updated the load balancer: %v", apiMock.balancedInstances["LB1"])
 		}
 	}
 }
 
-func TestUpdateTCPLoadBalancer(t *testing.T) {
+func TestUpdateLoadBalancer(t *testing.T) {
 	apiMock := &ConcertoAPIServiceMock{
 		balancers: []ConcertoLoadBalancer{
 			{Id: "LB1", Name: "mybalancer"},
@@ -227,55 +227,55 @@ func TestUpdateTCPLoadBalancer(t *testing.T) {
 		},
 	}
 	concerto := ConcertoCloud{service: apiMock}
-	err := concerto.UpdateTCPLoadBalancer("mybalancer", "noregion", []string{"host1", "host3"})
+	err := concerto.UpdateLoadBalancer("mybalancer", "noregion", []string{"host1", "host3"})
 	if err != nil {
-		t.Errorf("UpdateTCPLoadBalancer: should not have returned error")
+		t.Errorf("UpdateLoadBalancer: should not have returned error")
 	}
 	if apiMock.balancedInstances["LB1"][0] != "123.123.123.123" || apiMock.balancedInstances["LB1"][1] != "123.123.123.125" {
-		t.Errorf("UpdateTCPLoadBalancer: should have updated the load balancer: %v", apiMock.balancedInstances["LB1"])
+		t.Errorf("UpdateLoadBalancer: should have updated the load balancer: %v", apiMock.balancedInstances["LB1"])
 	}
 }
 
-func TestEnsureTCPLoadBalancerDeleted(t *testing.T) {
+func TestEnsureLoadBalancerDeleted(t *testing.T) {
 	apiMock := &ConcertoAPIServiceMock{
 		balancers: []ConcertoLoadBalancer{
 			{Id: "123456", Name: "mybalancer"},
 		},
 	}
 	concerto := ConcertoCloud{service: apiMock}
-	err := concerto.EnsureTCPLoadBalancerDeleted("mybalancer", "whatever region")
+	err := concerto.EnsureLoadBalancerDeleted("mybalancer", "whatever region")
 	if err != nil {
-		t.Errorf("EnsureTCPLoadBalancerDeleted: should not have returned error")
+		t.Errorf("EnsureLoadBalancerDeleted: should not have returned error")
 	}
 	if len(apiMock.balancers) > 0 {
-		t.Errorf("EnsureTCPLoadBalancerDeleted: should have deleted the load balancer")
+		t.Errorf("EnsureLoadBalancerDeleted: should have deleted the load balancer")
 	}
 }
 
-func Test_EnsureTCPLoadBalancerDeleted_NonExisting(t *testing.T) {
+func Test_EnsureLoadBalancerDeleted_NonExisting(t *testing.T) {
 	apiMock := &ConcertoAPIServiceMock{
 		balancers: []ConcertoLoadBalancer{
 			{Id: "123456", Name: "mybalancer"},
 		},
 	}
 	concerto := ConcertoCloud{service: apiMock}
-	err := concerto.EnsureTCPLoadBalancerDeleted("anotherbalancer", "whatever region")
+	err := concerto.EnsureLoadBalancerDeleted("anotherbalancer", "whatever region")
 	if err != nil {
-		t.Errorf("EnsureTCPLoadBalancerDeleted: should not have returned error")
+		t.Errorf("EnsureLoadBalancerDeleted: should not have returned error")
 	}
 	if len(apiMock.balancers) == 0 {
-		t.Errorf("EnsureTCPLoadBalancerDeleted: should not have deleted any load balancer")
+		t.Errorf("EnsureLoadBalancerDeleted: should not have deleted any load balancer")
 	}
 }
 
-func Test_EnsureTCPLoadBalancerDeleted_Error(t *testing.T) {
+func Test_EnsureLoadBalancerDeleted_Error(t *testing.T) {
 	apiMock := &ConcertoAPIServiceMock{
 		balancers: []ConcertoLoadBalancer{
 			{Id: "123456", Name: "mybalancer"},
 		},
 	}
 	concerto := ConcertoCloud{service: apiMock}
-	err := concerto.EnsureTCPLoadBalancerDeleted("GiveMeAnError", "whatever region")
+	err := concerto.EnsureLoadBalancerDeleted("GiveMeAnError", "whatever region")
 	if err == nil {
 		t.Errorf("Error was expected but got none")
 	}

--- a/pkg/cloudprovider/providers/concerto/load_balancer_test.go
+++ b/pkg/cloudprovider/providers/concerto/load_balancer_test.go
@@ -1,0 +1,282 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package concerto_cloud
+
+import (
+	"net"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+)
+
+func TestGetTCPLoadBalancer(t *testing.T) {
+	apiMock := &ConcertoAPIServiceMock{
+		balancers: []ConcertoLoadBalancer{
+			{Id: "123456", Name: "mybalancer", FQDN: "mybalancer.concerto.mock"},
+		},
+	}
+	concerto := ConcertoCloud{service: apiMock}
+	status, exists, err := concerto.GetTCPLoadBalancer("mybalancer", "whatever region")
+	if err != nil {
+		t.Errorf("GetTCPLoadBalancer: should not have returned error")
+	}
+	if !exists {
+		t.Errorf("GetTCPLoadBalancer: should have found the LB")
+	}
+	if status.Ingress[0].Hostname != "mybalancer.concerto.mock" {
+		t.Errorf("GetTCPLoadBalancer: should have returned the correct status")
+	}
+}
+
+func TestGetTCPLoadBalancer_NonExisting(t *testing.T) {
+	apiMock := &ConcertoAPIServiceMock{
+		balancers: []ConcertoLoadBalancer{
+			{Id: "123456", Name: "mybalancer", FQDN: "mybalancer.concerto.mock"},
+		},
+	}
+	concerto := ConcertoCloud{service: apiMock}
+	_, exists, err := concerto.GetTCPLoadBalancer("otherbalancer", "whatever region")
+	if err != nil {
+		t.Errorf("GetTCPLoadBalancer: should not have returned error")
+	}
+	if exists {
+		t.Errorf("GetTCPLoadBalancer: should not have found the LB")
+	}
+}
+
+func TestEnsureTCPLoadBalancer_CreatesTheLBInConcerto(t *testing.T) {
+	apiMock := &ConcertoAPIServiceMock{
+		balancers:         []ConcertoLoadBalancer{},
+		balancedInstances: map[string][]string{},
+	}
+	ports := []*api.ServicePort{
+		{Port: 1234},
+	}
+	concerto := ConcertoCloud{service: apiMock}
+	concerto.EnsureTCPLoadBalancer("myloadbalancer",
+		"region",
+		nil,   // external ip
+		ports, // ports
+		[]string{"host1", "host2"},
+		api.ServiceAffinityNone)
+	if len(apiMock.balancers) != 1 {
+		t.Errorf("EnsureTCPLoadBalancer: should have created the LB")
+	} else {
+		lb := apiMock.balancers[0]
+		if lb.Name != "myloadbalancer" || lb.Port != 1234 {
+			t.Errorf("EnsureTCPLoadBalancer: should have created the LB with correct data")
+		}
+	}
+}
+
+func TestEnsureTCPLoadBalancerAddsTheNodes(t *testing.T) {
+	apiMock := &ConcertoAPIServiceMock{
+		balancers:         []ConcertoLoadBalancer{},
+		balancedInstances: map[string][]string{},
+		instances: []ConcertoInstance{
+			{Name: "host1", Id: "11235813", PublicIP: "123.123.123.123"},
+			{Name: "host2", Id: "11235815", PublicIP: "123.123.123.124"},
+		},
+	}
+	ports := []*api.ServicePort{
+		{Port: 1234},
+	}
+	concerto := ConcertoCloud{service: apiMock}
+	_, err := concerto.EnsureTCPLoadBalancer("myloadbalancer",
+		"region",
+		nil,   // external ip
+		ports, // ports
+		[]string{"host1", "host2"},
+		api.ServiceAffinityNone)
+	if err != nil {
+		t.Errorf("EnsureTCPLoadBalancer: should not have returned any errors")
+	}
+	lb, _ := apiMock.GetLoadBalancerByName("myloadbalancer")
+	if len(apiMock.balancedInstances[lb.Id]) != 2 {
+		t.Errorf("EnsureTCPLoadBalancer: should have registered the nodes with the LB")
+	}
+}
+
+func TestEnsureTCPLoadBalancerWithUnsupportedAffinity(t *testing.T) {
+	concerto := ConcertoCloud{}
+	ports := []*api.ServicePort{
+		{},
+	}
+	_, err := concerto.EnsureTCPLoadBalancer("name",
+		"region",
+		nil,   // external ip
+		ports, // ports
+		[]string{"host1", "host2"},
+		api.ServiceAffinityClientIP)
+	if err == nil {
+		t.Errorf("EnsureTCPLoadBalancer: should not support ServiceAffinity")
+	}
+}
+
+func TestEnsureTCPLoadBalancerWithNoPort(t *testing.T) {
+	concerto := ConcertoCloud{}
+	ports := []*api.ServicePort{}
+	_, err := concerto.EnsureTCPLoadBalancer("name",
+		"region",
+		nil,   // external ip
+		ports, // ports
+		[]string{"host1", "host2"},
+		api.ServiceAffinityNone)
+	if err == nil {
+		t.Errorf("EnsureTCPLoadBalancer: should return error if no port specified")
+	}
+}
+
+func TestEnsureTCPLoadBalancerWithMultiplePorts(t *testing.T) {
+	concerto := ConcertoCloud{}
+	ports := []*api.ServicePort{
+		{},
+		{},
+	}
+	_, err := concerto.EnsureTCPLoadBalancer("name",
+		"region",
+		nil,   // external ip
+		ports, // ports
+		[]string{"host1", "host2"},
+		api.ServiceAffinityNone)
+	if err == nil {
+		t.Errorf("EnsureTCPLoadBalancer: should return error if no port specified")
+	}
+}
+
+func TestEnsureTCPLoadBalancerWithExternalIP(t *testing.T) {
+	concerto := ConcertoCloud{}
+	ports := []*api.ServicePort{
+		{},
+	}
+	_, err := concerto.EnsureTCPLoadBalancer("name",
+		"region",
+		net.IP{}, // external ip
+		ports,    // ports
+		[]string{"host1", "host2"},
+		api.ServiceAffinityNone)
+	if err == nil {
+		t.Errorf("EnsureTCPLoadBalancer: should not support ExternalIP specification")
+	}
+}
+
+func TestEnsureTCPLoadBalancer_UpdatesTheLBInConcerto(t *testing.T) {
+	apiMock := &ConcertoAPIServiceMock{
+		balancers: []ConcertoLoadBalancer{
+			{Id: "LB1", Name: "mybalancer"},
+		},
+		balancedInstances: map[string][]string{
+			"LB1": {"123.123.123.123", "123.123.123.124"},
+		},
+		instances: []ConcertoInstance{
+			{Name: "host1", Id: "11235813", PublicIP: "123.123.123.123"},
+			{Name: "host2", Id: "11235815", PublicIP: "123.123.123.124"},
+			{Name: "host3", Id: "11235817", PublicIP: "123.123.123.125"},
+		},
+	}
+	ports := []*api.ServicePort{
+		{Port: 1234},
+	}
+	concerto := ConcertoCloud{service: apiMock}
+	_, err := concerto.EnsureTCPLoadBalancer("mybalancer",
+		"region",
+		nil,   // external ip
+		ports, // ports
+		[]string{"host1", "host3"},
+		api.ServiceAffinityNone)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if len(apiMock.balancers) > 1 {
+		t.Errorf("EnsureTCPLoadBalancer: should not have created the LB")
+	} else if len(apiMock.balancers) < 1 {
+		t.Errorf("EnsureTCPLoadBalancer: should not have deleted the LB")
+	} else {
+		if apiMock.balancedInstances["LB1"][0] != "123.123.123.123" || apiMock.balancedInstances["LB1"][1] != "123.123.123.125" {
+			t.Errorf("EnsureTCPLoadBalancer: should have updated the load balancer: %v", apiMock.balancedInstances["LB1"])
+		}
+	}
+}
+
+func TestUpdateTCPLoadBalancer(t *testing.T) {
+	apiMock := &ConcertoAPIServiceMock{
+		balancers: []ConcertoLoadBalancer{
+			{Id: "LB1", Name: "mybalancer"},
+		},
+		balancedInstances: map[string][]string{
+			"LB1": {"123.123.123.123", "123.123.123.124"},
+		},
+		instances: []ConcertoInstance{
+			{Name: "host1", Id: "11235813", PublicIP: "123.123.123.123"},
+			{Name: "host2", Id: "11235815", PublicIP: "123.123.123.124"},
+			{Name: "host3", Id: "11235817", PublicIP: "123.123.123.125"},
+		},
+	}
+	concerto := ConcertoCloud{service: apiMock}
+	err := concerto.UpdateTCPLoadBalancer("mybalancer", "noregion", []string{"host1", "host3"})
+	if err != nil {
+		t.Errorf("UpdateTCPLoadBalancer: should not have returned error")
+	}
+	if apiMock.balancedInstances["LB1"][0] != "123.123.123.123" || apiMock.balancedInstances["LB1"][1] != "123.123.123.125" {
+		t.Errorf("UpdateTCPLoadBalancer: should have updated the load balancer: %v", apiMock.balancedInstances["LB1"])
+	}
+}
+
+func TestEnsureTCPLoadBalancerDeleted(t *testing.T) {
+	apiMock := &ConcertoAPIServiceMock{
+		balancers: []ConcertoLoadBalancer{
+			{Id: "123456", Name: "mybalancer"},
+		},
+	}
+	concerto := ConcertoCloud{service: apiMock}
+	err := concerto.EnsureTCPLoadBalancerDeleted("mybalancer", "whatever region")
+	if err != nil {
+		t.Errorf("EnsureTCPLoadBalancerDeleted: should not have returned error")
+	}
+	if len(apiMock.balancers) > 0 {
+		t.Errorf("EnsureTCPLoadBalancerDeleted: should have deleted the load balancer")
+	}
+}
+
+func Test_EnsureTCPLoadBalancerDeleted_NonExisting(t *testing.T) {
+	apiMock := &ConcertoAPIServiceMock{
+		balancers: []ConcertoLoadBalancer{
+			{Id: "123456", Name: "mybalancer"},
+		},
+	}
+	concerto := ConcertoCloud{service: apiMock}
+	err := concerto.EnsureTCPLoadBalancerDeleted("anotherbalancer", "whatever region")
+	if err != nil {
+		t.Errorf("EnsureTCPLoadBalancerDeleted: should not have returned error")
+	}
+	if len(apiMock.balancers) == 0 {
+		t.Errorf("EnsureTCPLoadBalancerDeleted: should not have deleted any load balancer")
+	}
+}
+
+func Test_EnsureTCPLoadBalancerDeleted_Error(t *testing.T) {
+	apiMock := &ConcertoAPIServiceMock{
+		balancers: []ConcertoLoadBalancer{
+			{Id: "123456", Name: "mybalancer"},
+		},
+	}
+	concerto := ConcertoCloud{service: apiMock}
+	err := concerto.EnsureTCPLoadBalancerDeleted("GiveMeAnError", "whatever region")
+	if err == nil {
+		t.Errorf("Error was expected but got none")
+	}
+}

--- a/pkg/cloudprovider/providers/concerto/rest.go
+++ b/pkg/cloudprovider/providers/concerto/rest.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package concerto_cloud
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+type restService struct {
+	config ConcertoConfig
+	client *http.Client
+}
+
+func newRestService(config ConcertoConfig) (concertoRESTService, error) {
+	client, err := httpClient(config)
+	if err != nil {
+		return nil, fmt.Errorf("error creating HTTP client: %v", err)
+	}
+	return &restService{config, client}, nil
+}
+
+func httpClient(config ConcertoConfig) (*http.Client, error) {
+	// load client certificate
+	cert, err := tls.LoadX509KeyPair(config.Connection.Cert, config.Connection.Key)
+	if err != nil {
+		return nil, fmt.Errorf("error loading X509 key pair: %v", err)
+	}
+	// load CA file to verify server
+	CA_Pool := x509.NewCertPool()
+	severCert, err := ioutil.ReadFile(config.Connection.CACert)
+	if err != nil {
+		return nil, fmt.Errorf("could not load CA file: %v", err)
+	}
+	CA_Pool.AppendCertsFromPEM(severCert)
+	// create a client with specific transport configurations
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs:      CA_Pool,
+			Certificates: []tls.Certificate{cert},
+		},
+	}
+	client := &http.Client{Transport: transport}
+
+	return client, nil
+}
+
+func (r *restService) Post(path string, json []byte) ([]byte, int, error) {
+	output := strings.NewReader(string(json))
+	response, err := r.client.Post(r.config.Connection.APIEndpoint+path, "application/json", output)
+	if err != nil {
+		return nil, -1, fmt.Errorf("error on http request (POST %v): %v", r.config.Connection.APIEndpoint+path, err)
+	}
+	defer response.Body.Close()
+
+	body, _ := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, -1, fmt.Errorf("error reading http request body: %v", err)
+	}
+
+	return body, response.StatusCode, err
+}
+
+func (r *restService) Delete(path string) ([]byte, int, error) {
+	request, err := http.NewRequest("DELETE", r.config.Connection.APIEndpoint+path, nil)
+	if err != nil {
+		return nil, -1, fmt.Errorf("error creating http request (DELETE %v): %v", r.config.Connection.APIEndpoint+path, err)
+	}
+	response, err := r.client.Do(request)
+	if err != nil {
+		return nil, -1, fmt.Errorf("error executing http request (DELETE %v): %v", r.config.Connection.APIEndpoint+path, err)
+	}
+	defer response.Body.Close()
+
+	body, _ := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, -1, fmt.Errorf("error reading http request body: %v", err)
+	}
+
+	return body, response.StatusCode, nil
+}
+
+func (r *restService) Get(path string) ([]byte, int, error) {
+	response, err := r.client.Get(r.config.Connection.APIEndpoint + path)
+	if err != nil {
+		return nil, -1, fmt.Errorf("error on http request (GET %v): %v", r.config.Connection.APIEndpoint+path, err)
+	}
+	defer response.Body.Close()
+
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, -1, fmt.Errorf("error reading http request body: %v", err)
+	}
+
+	return body, response.StatusCode, nil
+}

--- a/pkg/cloudprovider/providers/concerto/utils.go
+++ b/pkg/cloudprovider/providers/concerto/utils.go
@@ -14,15 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cloudprovider
+package concerto_cloud
 
-import (
-	// Cloud providers
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/aws"
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/concerto"
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/mesos"
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/openstack"
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/ovirt"
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/rackspace"
-)
+func subtractStringArrays(a, b []string) []string {
+	var result []string
+	for _, s := range a {
+		toBeRemoved := false
+		for _, t := range b {
+			if s == t {
+				toBeRemoved = true
+			}
+		}
+		if !toBeRemoved {
+			result = append(result, s)
+		}
+	}
+	return result
+}

--- a/pkg/cloudprovider/providers/concerto/zones.go
+++ b/pkg/cloudprovider/providers/concerto/zones.go
@@ -14,15 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cloudprovider
+package concerto_cloud
 
 import (
-	// Cloud providers
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/aws"
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/concerto"
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/mesos"
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/openstack"
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/ovirt"
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/rackspace"
+	"k8s.io/kubernetes/pkg/cloudprovider"
 )
+
+// GetZone returns the Zone containing the current failure zone and locality
+// region that the program is running in
+func (concerto *ConcertoCloud) GetZone() (cloudprovider.Zone, error) {
+	return cloudprovider.Zone{"concerto", "concerto"}, nil
+}

--- a/pkg/cloudprovider/providers/concerto/zones_test.go
+++ b/pkg/cloudprovider/providers/concerto/zones_test.go
@@ -14,15 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cloudprovider
+package concerto_cloud
 
 import (
-	// Cloud providers
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/aws"
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/concerto"
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/mesos"
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/openstack"
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/ovirt"
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/rackspace"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/cloudprovider"
 )
+
+func TestGetZone(t *testing.T) {
+	concerto := &ConcertoCloud{}
+	zone, err := concerto.GetZone()
+	expectedZone := cloudprovider.Zone{"concerto", "concerto"}
+	if expectedZone != zone {
+		t.Errorf("Unexpected zone: '%v'", zone)
+	}
+	if err != nil {
+		t.Errorf("Unexpected error: '%v'", err)
+	}
+}


### PR DESCRIPTION
Add a new ‘cloud provider’ implementation for Flexiant Concerto. 

This pull request adds a 'concerto_cloud’ package which implements some of the interfaces in the “cloudprovider” package as part of our solution for orchestration of multi-cloud Kubernetes clusters using Flexiant's Concerto system - see https://www.flexiant.com/2015/12/10/flexiant-kubernetes-orchestration-as-a-service-demonstrated/ . This new provider implementation was necessary in order to achieve automatic creation of Concerto load balancers for services that requested them.

We would like to contribute this code upstream. Aside from being useful in itself, it should also be useful as a further example of a cloud provider implementation.

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/19260)

<!-- Reviewable:end -->
