### PR TITLE
scheduler metrics should only observe successful ops

### DIFF
--- a/plugin/pkg/scheduler/metrics/metrics.go
+++ b/plugin/pkg/scheduler/metrics/metrics.go
@@ -28,28 +28,28 @@ const schedulerSubsystem = "scheduler"
 var BindingSaturationReportInterval = 1 * time.Second
 
 var (
-	E2eSchedulingLatency = prometheus.NewSummary(
-		prometheus.SummaryOpts{
+	E2eSchedulingLatency = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
 			Subsystem: schedulerSubsystem,
 			Name:      "e2e_scheduling_latency_microseconds",
 			Help:      "E2e scheduling latency (scheduling algorithm + binding)",
-			MaxAge:    time.Hour,
+			Buckets:   prometheus.ExponentialBuckets(1000, 2, 15),
 		},
 	)
-	SchedulingAlgorithmLatency = prometheus.NewSummary(
-		prometheus.SummaryOpts{
+	SchedulingAlgorithmLatency = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
 			Subsystem: schedulerSubsystem,
 			Name:      "scheduling_algorithm_latency_microseconds",
 			Help:      "Scheduling algorithm latency",
-			MaxAge:    time.Hour,
+			Buckets:   prometheus.ExponentialBuckets(1000, 2, 15),
 		},
 	)
-	BindingLatency = prometheus.NewSummary(
-		prometheus.SummaryOpts{
+	BindingLatency = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
 			Subsystem: schedulerSubsystem,
 			Name:      "binding_latency_microseconds",
 			Help:      "Binding latency",
-			MaxAge:    time.Hour,
+			Buckets:   prometheus.ExponentialBuckets(1000, 2, 15),
 		},
 	)
 	BindingRateLimiterSaturation = prometheus.NewGauge(


### PR DESCRIPTION
This resolves #19246 
We should record metrics for successful ops only without interference from failure cases. I'm not sure if we should separately record failure cases as well? At least for here?

@gmarek 
