### PR TITLE
Fix small dns readme error

### DIFF
--- a/cluster/addons/dns/README.md
+++ b/cluster/addons/dns/README.md
@@ -144,7 +144,7 @@ kubectl get pods busybox
 
 You should see:
 ```
-NAME      READY     REASON    RESTARTS   AGE
+NAME      READY     STATUS    RESTARTS   AGE
 busybox   1/1       Running   0          <some-time>
 ```
 


### PR DESCRIPTION
`kubectl get pods` output: `REASON` -> `STATUS`
