### PR TITLE
Do not delete text that fails preformat-balance

### DIFF
--- a/cmd/mungedocs/mungedocs.go
+++ b/cmd/mungedocs/mungedocs.go
@@ -119,8 +119,12 @@ func (f fileProcessor) visit(path string) error {
 			}
 			fmt.Printf("%s:\n", munge.name)
 			if *verbose {
-				fmt.Printf("INPUT: <<<%v>>>\n", mungeLines)
-				fmt.Printf("MUNGED: <<<%v>>>\n", after)
+				if len(mungeLines) <= 20 {
+					fmt.Printf("INPUT: <<<%v>>>\n", mungeLines)
+					fmt.Printf("MUNGED: <<<%v>>>\n", after)
+				} else {
+					fmt.Printf("not printing failed chunk: too many lines\n")
+				}
 			}
 			if err != nil {
 				fmt.Println(err)

--- a/cmd/mungedocs/preformatted.go
+++ b/cmd/mungedocs/preformatted.go
@@ -45,7 +45,7 @@ func updatePreformatted(filePath string, mlines mungeLines) (mungeLines, error) 
 // If the file ends on a preformatted line, there must have been an imbalance.
 func checkPreformatBalance(filePath string, mlines mungeLines) (mungeLines, error) {
 	if len(mlines) > 0 && mlines[len(mlines)-1].preformatted {
-		return nil, fmt.Errorf("file ends in preformatted block")
+		return mlines, fmt.Errorf("unbalanced triple backtick delimiters")
 	}
 	return mlines, nil
 }

--- a/cmd/mungedocs/preformatted_test.go
+++ b/cmd/mungedocs/preformatted_test.go
@@ -69,12 +69,29 @@ func TestPreformattedImbalance(t *testing.T) {
 	}
 	for i, c := range cases {
 		in := getMungeLines(c.in)
-		_, err := checkPreformatBalance("filename.md", in)
+		out, err := checkPreformatBalance("filename.md", in)
 		if err != nil && c.ok {
 			t.Errorf("case[%d]: expected success", i)
 		}
 		if err == nil && !c.ok {
 			t.Errorf("case[%d]: expected failure", i)
 		}
+		// Even in case of misformat, return all the text,
+		// so that the user's work is not lost.
+		if !equalMungeLines(out, in) {
+			t.Errorf("case[%d]: expected munged text to be identical to input text", i)
+		}
 	}
+}
+
+func equalMungeLines(a, b mungeLines) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
If preformat lines are unbalanced, do not delete all the lines from there to
end of file.  That might be the only copy of edits made by the user.
