### PR TITLE
insert space after comment character in cmd folder

### DIFF
--- a/cmd/genbashcomp/gen_kubectl_bash_comp.go
+++ b/cmd/genbashcomp/gen_kubectl_bash_comp.go
@@ -43,7 +43,7 @@ func main() {
 	}
 	outFile := outDir + "kubectl"
 
-	//TODO os.Stdin should really be something like ioutil.Discard, but a Reader
+	// TODO os.Stdin should really be something like ioutil.Discard, but a Reader
 	kubectl := cmd.NewKubectlCommand(cmdutil.NewFactory(nil), os.Stdin, ioutil.Discard, ioutil.Discard)
 	kubectl.GenBashCompletionFile(outFile)
 }

--- a/cmd/gendocs/gen_kubectl_docs.go
+++ b/cmd/gendocs/gen_kubectl_docs.go
@@ -46,7 +46,7 @@ func main() {
 	// Set environment variables used by kubectl so the output is consistent,
 	// regardless of where we run.
 	os.Setenv("HOME", "/home/username")
-	//TODO os.Stdin should really be something like ioutil.Discard, but a Reader
+	// TODO os.Stdin should really be something like ioutil.Discard, but a Reader
 	kubectl := cmd.NewKubectlCommand(cmdutil.NewFactory(nil), os.Stdin, ioutil.Discard, ioutil.Discard)
 	cobra.GenMarkdownTree(kubectl, outDir)
 }

--- a/cmd/genman/gen_kubectl_man.go
+++ b/cmd/genman/gen_kubectl_man.go
@@ -50,7 +50,7 @@ func main() {
 	// Set environment variables used by kubectl so the output is consistent,
 	// regardless of where we run.
 	os.Setenv("HOME", "/home/username")
-	//TODO os.Stdin should really be something like ioutil.Discard, but a Reader
+	// TODO os.Stdin should really be something like ioutil.Discard, but a Reader
 	kubectl := cmd.NewKubectlCommand(cmdutil.NewFactory(nil), os.Stdin, ioutil.Discard, ioutil.Discard)
 	genMarkdown(kubectl, "", outDir)
 	for _, c := range kubectl.Commands() {

--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -39,7 +39,7 @@ const (
 	// Maximum duration before timing out read/write requests
 	// Set to a value larger than the timeouts in each watch server.
 	ReadWriteTimeout = time.Minute * 60
-	//TODO: This can be tightened up. It still matches objects named watch or proxy.
+	// TODO: This can be tightened up. It still matches objects named watch or proxy.
 	defaultLongRunningRequestRE = "(/|^)((watch|proxy)(/|$)|(logs?|portforward|exec|attach)/?$)"
 )
 
@@ -225,7 +225,7 @@ func (s *APIServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.KubeletConfig.CertFile, "kubelet-client-certificate", s.KubeletConfig.CertFile, "Path to a client cert file for TLS.")
 	fs.StringVar(&s.KubeletConfig.KeyFile, "kubelet-client-key", s.KubeletConfig.KeyFile, "Path to a client key file for TLS.")
 	fs.StringVar(&s.KubeletConfig.CAFile, "kubelet-certificate-authority", s.KubeletConfig.CAFile, "Path to a cert. file for the certificate authority.")
-	//See #14282 for details on how to test/try this option out.  TODO remove this comment once this option is tested in CI.
+	// See #14282 for details on how to test/try this option out.  TODO remove this comment once this option is tested in CI.
 	fs.IntVar(&s.KubernetesServiceNodePort, "kubernetes-service-node-port", 0, "If non-zero, the Kubernetes master service (which apiserver creates/maintains) will be of type NodePort, using this as the value of the port. If zero, the Kubernetes master service will be of type ClusterIP.")
 	// TODO: delete this flag as soon as we identify and fix all clients that send malformed updates, like #14126.
 	fs.BoolVar(&validation.RepairMalformedUpdates, "repair-malformed-updates", true, "If true, server will do its best to fix the update request to pass the validation, e.g., setting empty UID in update request to its existing value. This flag can be turned off after we fix all the clients that send malformed updates.")

--- a/cmd/kube-controller-manager/app/plugins.go
+++ b/cmd/kube-controller-manager/app/plugins.go
@@ -25,7 +25,7 @@ import (
 
 	"k8s.io/kubernetes/cmd/kube-controller-manager/app/options"
 
-	//Cloud providers
+	// Cloud providers
 	_ "k8s.io/kubernetes/pkg/cloudprovider/providers"
 
 	// Volume plugins

--- a/cmd/kube-proxy/app/server_test.go
+++ b/cmd/kube-proxy/app/server_test.go
@@ -209,21 +209,21 @@ func Test_getProxyMode(t *testing.T) {
 	}
 }
 
-//This test verifies that Proxy Server does not crash that means
-//Config and iptinterface are not nil when CleanupAndExit is true.
-//To avoid proxy crash: https://github.com/kubernetes/kubernetes/pull/14736
+// This test verifies that Proxy Server does not crash that means
+// Config and iptinterface are not nil when CleanupAndExit is true.
+// To avoid proxy crash: https://github.com/kubernetes/kubernetes/pull/14736
 func TestProxyServerWithCleanupAndExit(t *testing.T) {
 
-	//creates default config
+	// creates default config
 	config := options.NewProxyConfig()
 
-	//sets CleanupAndExit manually
+	// sets CleanupAndExit manually
 	config.CleanupAndExit = true
 
-	//creates new proxy server
+	// creates new proxy server
 	proxyserver, err := NewProxyServerDefault(config)
 
-	//verifies that nothing is nill except error
+	// verifies that nothing is nill except error
 	assert.Nil(t, err)
 	assert.NotNil(t, proxyserver)
 	assert.NotNil(t, proxyserver.Config)

--- a/cmd/kubelet/app/plugins.go
+++ b/cmd/kubelet/app/plugins.go
@@ -43,7 +43,7 @@ import (
 	"k8s.io/kubernetes/pkg/volume/persistent_claim"
 	"k8s.io/kubernetes/pkg/volume/rbd"
 	"k8s.io/kubernetes/pkg/volume/secret"
-	//Cloud providers
+	// Cloud providers
 	_ "k8s.io/kubernetes/pkg/cloudprovider/providers"
 )
 

--- a/cmd/linkcheck/links.go
+++ b/cmd/linkcheck/links.go
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//This command checks if the hyperlinks in files are valid. It checks the files
-//with 'fileSuffix' in 'rootDir' for URLs that match 'prefix'. It trims the
-//'prefix' from the URL, uses what's left as the relative path to repoRoot to
-//verify if the link is valid. For example:
-//$ linkcheck --root-dir=${TYPEROOT} --repo-root=${KUBE_ROOT} \
-//  --file-suffix=types.go --prefix=http://releases.k8s.io/HEAD
+// This command checks if the hyperlinks in files are valid. It checks the files
+// with 'fileSuffix' in 'rootDir' for URLs that match 'prefix'. It trims the
+// 'prefix' from the URL, uses what's left as the relative path to repoRoot to
+// verify if the link is valid. For example:
+// $ linkcheck --root-dir=${TYPEROOT} --repo-root=${KUBE_ROOT} \
+// --file-suffix=types.go --prefix=http://releases.k8s.io/HEAD
 
 package main
 
@@ -56,7 +56,7 @@ func newWalkFunc(invalidLink *bool) filepath.WalkFunc {
 		foundInvalid := false
 		matches := httpRE.FindAllSubmatch(fileBytes, -1)
 		for _, match := range matches {
-			//match[1] should look like docs/devel/api-conventions.md
+			// match[1] should look like docs/devel/api-conventions.md
 			if _, err := os.Stat(path.Join(*repoRoot, string(match[1]))); err != nil {
 				fmt.Fprintf(os.Stderr, "Link is not valid: %s\n", string(match[0]))
 				foundInvalid = true


### PR DESCRIPTION
Patch which inserts space after the comment character(as per golang conventions in kubernetes) in the cmd folder.
