### PR TITLE
command should in code block

### DIFF
--- a/docs/user-guide/kubectl/kubectl_proxy.md
+++ b/docs/user-guide/kubectl/kubectl_proxy.md
@@ -38,26 +38,19 @@ Run a proxy to the Kubernetes API server
 
 ### Synopsis
 
-
-To proxy all of the kubernetes api and nothing else, use:
-
-kubectl proxy --api-prefix=/
-
-To proxy only part of the kubernetes api and also some static files:
-
-kubectl proxy --www=/my/files --www-prefix=/static/ --api-prefix=/api/
-
-The above lets you 'curl localhost:8001/api/v1/pods'.
-
-To proxy the entire kubernetes api at a different root, use:
-
-kubectl proxy --api-prefix=/custom/
-
-The above lets you 'curl localhost:8001/custom/api/v1/pods'
-
-
 ```
-kubectl proxy [--port=PORT] [--www=static-dir] [--www-prefix=prefix] [--api-prefix=prefix]
+$ kubectl proxy [--port=PORT] [--www=static-dir] [--www-prefix=prefix] [--api-prefix=prefix]
+
+# To proxy all of the kubernetes api and nothing else
+$ kubectl proxy --api-prefix=/
+
+# To proxy only part of the kubernetes api and also some static files
+# This lets you 'curl localhost:8001/api/v1/pods'.
+$ kubectl proxy --www=/my/files --www-prefix=/static/ --api-prefix=/api/
+
+# To proxy the entire kubernetes api at a different root
+# This lets you 'curl localhost:8001/custom/api/v1/pods'.
+$ kubectl proxy --api-prefix=/custom/
 ```
 
 ### Examples


### PR DESCRIPTION
I think those commands should in code block.

**Before:**
<img width="910" alt="kubectl_proxy" src="https://cloud.githubusercontent.com/assets/1023347/12118043/479ebb82-b3ff-11e5-8883-e4a75e210530.png">

**After:**

<img width="899" alt="kubernetes_kubectl_proxy_md_at_0d619e6c5835e7729bb89db50f1cce975f0efa11_ _tooooolong_kubernetes" src="https://cloud.githubusercontent.com/assets/1023347/12118063/6d36aaf8-b3ff-11e5-9bcb-d002134d90b7.png">
