### PR TITLE
WIP/MESOS: test harness fixes for 724

### DIFF
--- a/cmd/kube-proxy/app/conntrack.go
+++ b/cmd/kube-proxy/app/conntrack.go
@@ -39,7 +39,13 @@ func (realConntracker) SetMax(max int) error {
 	}
 	// TODO: generify this and sysctl to a new sysfs.WriteInt()
 	glog.Infof("Setting conntrack hashsize to %d", max/4)
-	return ioutil.WriteFile("/sys/module/nf_conntrack/parameters/hashsize", []byte(strconv.Itoa(max/4)), 0640)
+
+	//TODO(jdef) debugging, don't return this error (for now)
+	err := ioutil.WriteFile("/sys/module/nf_conntrack/parameters/hashsize", []byte(strconv.Itoa(max/4)), 0640)
+	if err != nil {
+		glog.Errorf("Failed to set conntrack hashsize: %+v", err)
+	}
+	return nil
 }
 
 func (realConntracker) SetTCPEstablishedTimeout(seconds int) error {

--- a/contrib/mesos/ci/run-with-cluster.sh
+++ b/contrib/mesos/ci/run-with-cluster.sh
@@ -58,6 +58,7 @@ echo "${DOCKER_BIN_PATH}"
 cd "${KUBE_ROOT}"
 exec docker run \
   --rm \
+  --privileged \
   -v "${KUBE_ROOT}:/go/src/github.com/GoogleCloudPlatform/kubernetes" \
   -v "/var/run/docker.sock:/var/run/docker.sock" \
   -v "${DOCKER_BIN_PATH}:/usr/bin/docker" \

--- a/contrib/mesos/ci/run-with-cluster.sh
+++ b/contrib/mesos/ci/run-with-cluster.sh
@@ -83,6 +83,9 @@ exec docker run \
   -t $(tty &>/dev/null && echo "-i") \
   mesosphere/kubernetes-mesos-test \
   -ceux "\
+    cat /proc/self/mounts && \
+    stat /sys/module/nf_conntrack && \
+    stat /proc/sys/net/netfilter/nf_conntrack_max && \
     make clean all && \
     trap 'timeout 5m ./cluster/kube-down.sh' EXIT && \
     ./cluster/kube-down.sh && \

--- a/contrib/mesos/ci/run-with-cluster.sh
+++ b/contrib/mesos/ci/run-with-cluster.sh
@@ -54,6 +54,11 @@ else
 fi
 echo "${DOCKER_BIN_PATH}"
 
+if which lsmod; then
+  echo "Listing loaded linux kernel modules"
+  lsmod | sort
+fi
+
 # Clean (k8s output & images), Build, Kube-Up, Test, Kube-Down
 cd "${KUBE_ROOT}"
 exec docker run \

--- a/contrib/mesos/pkg/minion/server.go
+++ b/contrib/mesos/pkg/minion/server.go
@@ -139,11 +139,13 @@ func (ms *MinionServer) launchProxyServer() {
 		"--logtostderr=true",
 		"--resource-container=" + path.Join("/", ms.mesosCgroup, "kube-proxy"),
 		"--proxy-mode=" + ms.proxyMode,
-		// TODO(jdef) this is a temporary hack to fix failing smoke tests. a following PR
-		// will more properly fix the smoke tests as well as make these flags configrable
-		// at the framework level (as opposed to hardcoded here)
-		"--conntrack-max=0",
-		"--conntrack-tcp-timeout-established=0",
+		/*
+			// TODO(jdef) this is a temporary hack to fix failing smoke tests. a following PR
+			// will more properly fix the smoke tests as well as make these flags configrable
+			// at the framework level (as opposed to hardcoded here)
+			"--conntrack-max=0",
+			"--conntrack-tcp-timeout-established=0",
+		*/
 	}
 
 	if ms.clientConfig.Host != "" {

--- a/contrib/mesos/pkg/minion/server.go
+++ b/contrib/mesos/pkg/minion/server.go
@@ -139,12 +139,12 @@ func (ms *MinionServer) launchProxyServer() {
 		"--logtostderr=true",
 		"--resource-container=" + path.Join("/", ms.mesosCgroup, "kube-proxy"),
 		"--proxy-mode=" + ms.proxyMode,
-		"--conntrack-max=0",
+		"--conntrack-tcp-timeout-established=0",
 		/*
 			// TODO(jdef) this is a temporary hack to fix failing smoke tests. a following PR
 			// will more properly fix the smoke tests as well as make these flags configrable
 			// at the framework level (as opposed to hardcoded here)
-			"--conntrack-tcp-timeout-established=0",
+			"--conntrack-max=0", // this appears to smoke-test OK on its own
 		*/
 	}
 

--- a/contrib/mesos/pkg/minion/server.go
+++ b/contrib/mesos/pkg/minion/server.go
@@ -139,12 +139,12 @@ func (ms *MinionServer) launchProxyServer() {
 		"--logtostderr=true",
 		"--resource-container=" + path.Join("/", ms.mesosCgroup, "kube-proxy"),
 		"--proxy-mode=" + ms.proxyMode,
-		"--conntrack-tcp-timeout-established=0",
 		/*
 			// TODO(jdef) this is a temporary hack to fix failing smoke tests. a following PR
 			// will more properly fix the smoke tests as well as make these flags configrable
 			// at the framework level (as opposed to hardcoded here)
-			"--conntrack-max=0", // this appears to smoke-test OK on its own
+			"--conntrack-max=0", // problematic when non-zero, testing a change in cmd/proxy/app/conntrack.go to ignore sysfs-module errors
+			"--conntrack-tcp-timeout-established=0", // this is fine when it's non-zero
 		*/
 	}
 

--- a/contrib/mesos/pkg/minion/server.go
+++ b/contrib/mesos/pkg/minion/server.go
@@ -139,11 +139,11 @@ func (ms *MinionServer) launchProxyServer() {
 		"--logtostderr=true",
 		"--resource-container=" + path.Join("/", ms.mesosCgroup, "kube-proxy"),
 		"--proxy-mode=" + ms.proxyMode,
+		"--conntrack-max=0",
 		/*
 			// TODO(jdef) this is a temporary hack to fix failing smoke tests. a following PR
 			// will more properly fix the smoke tests as well as make these flags configrable
 			// at the framework level (as opposed to hardcoded here)
-			"--conntrack-max=0",
 			"--conntrack-tcp-timeout-established=0",
 		*/
 	}


### PR DESCRIPTION
xref https://github.com/mesosphere/kubernetes-mesos/issues/724

there are couple of changes that may fix the nf_conntracking problem:
1. it's likely that our test harness used for CI isn't setting up a security context w/ the linux capabilities required for kernel module config/management (conntrack configuration is partially managed via the sysfs-modules pseudo-filesystem)
2. the nf_conntrack may not be loaded by default in our test environment

I've created this PR as a playground to see how our CI system reacts as I make changes to the harness.
