### PR TITLE
add hostname DNS A record based on pod annotation

### DIFF
--- a/cluster/addons/dns/kube2sky/Changelog
+++ b/cluster/addons/dns/kube2sky/Changelog
@@ -1,3 +1,11 @@
+## Version 1.13 (Jan 22, 2015 Abhishek Shah <abshah@google.com>)
+- Add hostname DNS A record based on pod annotation
+  If the pod spec has the following two annotations,
+  i. net.beta.kubernetes.io/hostName
+  ii. net.beta.kubernetes.io/setName,
+  DNS A Record will be created with the following format:
+  <hostName>.<setName>.<pod namespace>.set.cluster.local
+
 ## Version 1.12 (Dec 15 2015 Abhishek Shah <abshah@google.com>)
 - Gave pods their own cache store. (034ecbd)
 - Allow pods to have dns. (717660a)

--- a/cluster/addons/dns/kube2sky/Makefile
+++ b/cluster/addons/dns/kube2sky/Makefile
@@ -4,7 +4,7 @@
 
 .PHONY: all kube2sky container push clean test
 
-TAG = 1.12
+TAG = 1.13
 PREFIX = gcr.io/google_containers
 
 all: container

--- a/cluster/addons/dns/kube2sky/kube2sky.go
+++ b/cluster/addons/dns/kube2sky/kube2sky.go
@@ -43,6 +43,7 @@ import (
 	kselector "k8s.io/kubernetes/pkg/fields"
 	etcdutil "k8s.io/kubernetes/pkg/storage/etcd/util"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/validation"
 	"k8s.io/kubernetes/pkg/util/wait"
 )
 
@@ -63,7 +64,11 @@ const (
 	// A subdomain added to the user specified domain for all services.
 	serviceSubdomain = "svc"
 	// A subdomain added to the user specified dmoain for all pods.
-	podSubdomain = "pod"
+	podSubdomain       = "pod"
+	setSubdomain       = "set"
+	ptrRecordSuffix    = "in-addr.arpa"
+	hostNameAnnotation = "net.beta.kubernetes.io/hostName"
+	setNameAnnotation  = "net.beta.kubernetes.io/setName"
 )
 
 type etcdClient interface {
@@ -155,11 +160,10 @@ func getSkyMsg(ip string, port int) *skymsg.Service {
 func (ks *kube2sky) generateRecordsForHeadlessService(subdomain string, e *kapi.Endpoints, svc *kapi.Service) error {
 	for idx := range e.Subsets {
 		for subIdx := range e.Subsets[idx].Addresses {
-			b, err := json.Marshal(getSkyMsg(e.Subsets[idx].Addresses[subIdx].IP, 0))
+			recordValue, err := generateDNSRecordValue(e.Subsets[idx].Addresses[subIdx].IP, 0)
 			if err != nil {
 				return err
 			}
-			recordValue := string(b)
 			recordLabel := getHash(recordValue)
 			recordKey := buildDNSNameString(subdomain, recordLabel)
 
@@ -228,13 +232,52 @@ func (ks *kube2sky) handleEndpointAdd(obj interface{}) {
 }
 
 func (ks *kube2sky) handlePodCreate(obj interface{}) {
-	if e, ok := obj.(*kapi.Pod); ok {
-		// If the pod ip is not yet available, do not attempt to create.
-		if e.Status.PodIP != "" {
-			name := buildDNSNameString(ks.domain, podSubdomain, e.Namespace, santizeIP(e.Status.PodIP))
-			ks.mutateEtcdOrDie(func() error { return ks.generateRecordsForPod(name, e) })
-		}
+	if p, ok := obj.(*kapi.Pod); ok {
+		ks.createIPBasedPodRecords(p)
+		ks.createSetBasedPodRecords(p)
 	}
+}
+
+func (ks *kube2sky) createIPBasedPodRecords(e *kapi.Pod) {
+	// If the pod ip is not yet available, do not attempt to create.
+	if e.Status.PodIP != "" {
+		name := buildDNSNameString(ks.domain, podSubdomain, e.Namespace, santizeIP(e.Status.PodIP))
+		ks.mutateEtcdOrDie(func() error { return ks.generateRecordsForPod(name, e) })
+	}
+}
+
+func (ks *kube2sky) createSetBasedPodRecords(pod *kapi.Pod) {
+	hostName := ks.getPodFQDN(pod)
+	if len(hostName) <= 0 {
+		return
+	}
+
+	glog.V(4).Infof("Writing A record: %s", hostName)
+	ks.mutateEtcdOrDie(func() error {
+		// Create A Record
+		recordValue, err := generateDNSRecordValue(pod.Status.PodIP, 0)
+		if err != nil {
+			return err
+		}
+		recordLabel := getHash(pod.Name)
+		recordKey := buildDNSNameString(hostName, recordLabel)
+		glog.V(2).Infof("Setting DNS record: %v -> %q, with recordKey: %v\n", hostName, recordValue, recordKey)
+		if err := ks.writeSkyRecord(recordKey, recordValue); err != nil {
+			return err
+		}
+
+		// Create PTR Record
+		ptrRecordKey := generatePTRRecordKey(pod.Status.PodIP)
+		ptrRecordValue, err := generateDNSRecordValue(hostName, 0)
+		if err != nil {
+			return err
+		}
+		glog.V(2).Infof("Writing PTR record: %v -> %q\n", ptrRecordKey, ptrRecordValue)
+		if err := ks.writeSkyRecord(ptrRecordKey, ptrRecordValue); err != nil {
+			return err
+		}
+		return nil
+	})
 }
 
 func (ks *kube2sky) handlePodUpdate(old interface{}, new interface{}) {
@@ -244,8 +287,12 @@ func (ks *kube2sky) handlePodUpdate(old interface{}, new interface{}) {
 	// Validate that the objects are good
 	if okOld && okNew {
 		if oldPod.Status.PodIP != newPod.Status.PodIP {
-			ks.handlePodDelete(oldPod)
-			ks.handlePodCreate(newPod)
+			ks.deleteIPBasedPodRecords(oldPod)
+			ks.createIPBasedPodRecords(newPod)
+		}
+		if ks.getPodFQDN(oldPod) != ks.getPodFQDN(newPod) {
+			ks.deleteSetBasedPodRecords(oldPod)
+			ks.createSetBasedPodRecords(newPod)
 		}
 	} else if okNew {
 		ks.handlePodCreate(newPod)
@@ -256,19 +303,57 @@ func (ks *kube2sky) handlePodUpdate(old interface{}, new interface{}) {
 
 func (ks *kube2sky) handlePodDelete(obj interface{}) {
 	if e, ok := obj.(*kapi.Pod); ok {
-		if e.Status.PodIP != "" {
-			name := buildDNSNameString(ks.domain, podSubdomain, e.Namespace, santizeIP(e.Status.PodIP))
-			ks.mutateEtcdOrDie(func() error { return ks.removeDNS(name) })
-		}
+		ks.deleteIPBasedPodRecords(e)
+		ks.deleteSetBasedPodRecords(e)
 	}
 }
 
+func (ks *kube2sky) deleteIPBasedPodRecords(e *kapi.Pod) {
+	if e.Status.PodIP != "" {
+		name := buildDNSNameString(ks.domain, podSubdomain, e.Namespace, santizeIP(e.Status.PodIP))
+		ks.mutateEtcdOrDie(func() error { return ks.removeDNS(name) })
+	}
+}
+
+func (ks *kube2sky) deleteSetBasedPodRecords(pod *kapi.Pod) {
+	hostName := ks.getPodFQDN(pod)
+	if len(hostName) > 0 {
+		recordLabel := getHash(pod.Name)
+		recordKey := buildDNSNameString(hostName, recordLabel)
+		ptrRecordKey := generatePTRRecordKey(pod.Status.PodIP)
+		ks.mutateEtcdOrDie(func() error {
+			glog.V(2).Infof("Deleting A record: %v, with recordKey: %v\n", hostName, recordKey)
+			err := ks.removeDNS(recordKey)
+			if err != nil {
+				return err
+			}
+			glog.V(2).Infof("Deleting PTR record: %v\n", ptrRecordKey)
+			return ks.removeDNS(ptrRecordKey)
+		})
+	}
+}
+
+func (ks *kube2sky) getPodFQDN(e *kapi.Pod) string {
+	hostLabel := e.Annotations[hostNameAnnotation]
+	if !validation.IsDNS1123Label(hostLabel) {
+		glog.Errorf("annotation-based hostname not created for pod. hostLabel is not valid:%s", hostLabel)
+		return ""
+	}
+
+	setLabel := e.Annotations[setNameAnnotation]
+	if !validation.IsDNS1123Label(setLabel) {
+		glog.Errorf("annotation-based hostname not created for pod. setLabel is not valid:%s", setLabel)
+		return ""
+	}
+
+	return buildDNSNameString(ks.domain, setSubdomain, e.Namespace, setLabel, hostLabel)
+}
+
 func (ks *kube2sky) generateRecordsForPod(subdomain string, service *kapi.Pod) error {
-	b, err := json.Marshal(getSkyMsg(service.Status.PodIP, 0))
+	recordValue, err := generateDNSRecordValue(service.Status.PodIP, 0)
 	if err != nil {
 		return err
 	}
-	recordValue := string(b)
 	recordLabel := getHash(recordValue)
 	recordKey := buildDNSNameString(subdomain, recordLabel)
 
@@ -281,11 +366,10 @@ func (ks *kube2sky) generateRecordsForPod(subdomain string, service *kapi.Pod) e
 }
 
 func (ks *kube2sky) generateRecordsForPortalService(subdomain string, service *kapi.Service) error {
-	b, err := json.Marshal(getSkyMsg(service.Spec.ClusterIP, 0))
+	recordValue, err := generateDNSRecordValue(service.Spec.ClusterIP, 0)
 	if err != nil {
 		return err
 	}
-	recordValue := string(b)
 	recordLabel := getHash(recordValue)
 	recordKey := buildDNSNameString(subdomain, recordLabel)
 
@@ -305,6 +389,21 @@ func (ks *kube2sky) generateRecordsForPortalService(subdomain string, service *k
 		}
 	}
 	return nil
+}
+
+func generatePTRRecordKey(podIP string) string {
+	// Create PTR Record
+	ipPath := buildDNSNameString(strings.Split(podIP, ".")...)
+	return buildDNSNameString(ptrRecordSuffix, ipPath)
+}
+
+func generateDNSRecordValue(ip string, port int) (string, error) {
+	b, err := json.Marshal(getSkyMsg(ip, port))
+	if err != nil {
+		return "", err
+	}
+	recordValue := string(b)
+	return recordValue, nil
 }
 
 func santizeIP(ip string) string {
@@ -327,11 +426,11 @@ func buildPortSegmentString(portName string, portProtocol kapi.Protocol) string 
 
 func (ks *kube2sky) generateSRVRecord(subdomain, portSegment, recordName, cName string, portNumber int) error {
 	recordKey := buildDNSNameString(subdomain, portSegment, recordName)
-	srv_rec, err := json.Marshal(getSkyMsg(cName, portNumber))
+	srv_rec, err := generateDNSRecordValue(cName, portNumber)
 	if err != nil {
 		return err
 	}
-	if err := ks.writeSkyRecord(recordKey, string(srv_rec)); err != nil {
+	if err := ks.writeSkyRecord(recordKey, srv_rec); err != nil {
 		return err
 	}
 	return nil

--- a/test/e2e/dns.go
+++ b/test/e2e/dns.go
@@ -33,6 +33,9 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+const DNSPodHostName = "dns-querier-1"
+const DNSPodSetName = "dns-set"
+
 var dnsServiceLableSelector = labels.Set{
 	"k8s-app":                       "kube-dns",
 	"kubernetes.io/cluster-service": "true",
@@ -40,6 +43,7 @@ var dnsServiceLableSelector = labels.Set{
 
 func createDNSPod(namespace, wheezyProbeCmd, jessieProbeCmd string) *api.Pod {
 	pod := &api.Pod{
+
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Pod",
 			APIVersion: latest.GroupOrDie(api.GroupName).GroupVersion.String(),
@@ -47,6 +51,10 @@ func createDNSPod(namespace, wheezyProbeCmd, jessieProbeCmd string) *api.Pod {
 		ObjectMeta: api.ObjectMeta{
 			Name:      "dns-test-" + string(util.NewUUID()),
 			Namespace: namespace,
+			Annotations: map[string]string{
+				"net.beta.kubernetes.io/hostName": DNSPodHostName,
+				"net.beta.kubernetes.io/setName":  DNSPodSetName,
+			},
 		},
 		Spec: api.PodSpec{
 			Volumes: []api.Volume{
@@ -76,7 +84,7 @@ func createDNSPod(namespace, wheezyProbeCmd, jessieProbeCmd string) *api.Pod {
 					},
 				},
 				{
-					Name:    "querier",
+					Name:    "wheezy-querier",
 					Image:   "gcr.io/google_containers/dnsutils",
 					Command: []string{"sh", "-c", wheezyProbeCmd},
 					VolumeMounts: []api.VolumeMount{
@@ -105,7 +113,7 @@ func createDNSPod(namespace, wheezyProbeCmd, jessieProbeCmd string) *api.Pod {
 
 func createProbeCommand(namesToResolve []string, fileNamePrefix string) (string, []string) {
 	fileNames := make([]string, 0, len(namesToResolve)*2)
-	probeCmd := "for i in `seq 1 600`; do "
+	probeCmd := "for j in `seq 1 600`; do "
 	for _, name := range namesToResolve {
 		// Resolve by TCP and UDP DNS.  Use $$(...) because $(...) is
 		// expanded by kubernetes (though this won't expand so should
@@ -116,11 +124,14 @@ func createProbeCommand(namesToResolve []string, fileNamePrefix string) (string,
 		}
 		fileName := fmt.Sprintf("%s_udp@%s", fileNamePrefix, name)
 		fileNames = append(fileNames, fileName)
-		probeCmd += fmt.Sprintf(`test -n "$$(dig +notcp +noall +answer +search %s %s)" && echo OK > /results/%s;`, name, lookup, fileName)
+		probeCmd += fmt.Sprintf(`test -n "$(dig +notcp +noall +answer +search %s %s)" && echo OK > /results/%s;`, name, lookup, fileName)
 		fileName = fmt.Sprintf("%s_tcp@%s", fileNamePrefix, name)
 		fileNames = append(fileNames, fileName)
-		probeCmd += fmt.Sprintf(`test -n "$$(dig +tcp +noall +answer +search %s %s)" && echo OK > /results/%s;`, name, lookup, fileName)
+		probeCmd += fmt.Sprintf(`test -n "$(dig +tcp +noall +answer +search %s %s)" && echo OK > /results/%s;`, name, lookup, fileName)
 	}
+	probeCmd += fmt.Sprintf(`test -n "$(dig +tcp +noall +answer +search -x $(hostname -i))" && echo OK > /results/PTR_TCP;`)
+	probeCmd += fmt.Sprintf(`test -n "$(dig +notcp +noall +answer +search -x $(hostname -i))" && echo OK > /results/PTR_UDP;`)
+
 	probeCmd += "sleep 1; done"
 	return probeCmd, fileNames
 }
@@ -222,6 +233,7 @@ var _ = Describe("DNS", func() {
 			"kubernetes.default.svc",
 			"kubernetes.default.svc.cluster.local",
 			"google.com",
+			fmt.Sprintf("%s.%s.%s.set.cluster.local", DNSPodHostName, DNSPodSetName, f.Namespace.Name),
 		}
 		// Added due to #8512. This is critical for GCE and GKE deployments.
 		if providerIs("gce", "gke") {
@@ -230,6 +242,8 @@ var _ = Describe("DNS", func() {
 
 		wheezyProbeCmd, wheezyFileNames := createProbeCommand(namesToResolve, "wheezy")
 		jessieProbeCmd, jessieFileNames := createProbeCommand(namesToResolve, "jessie")
+		By("Running these commands on wheezy:" + wheezyProbeCmd + "\n")
+		By("Running these commands on jessie:" + jessieProbeCmd + "\n")
 
 		// Run a pod which probes DNS and exposes the results by HTTP.
 		By("creating a pod to probe DNS")
@@ -313,12 +327,13 @@ var _ = Describe("DNS", func() {
 
 		wheezyProbeCmd, wheezyFileNames := createProbeCommand(namesToResolve, "wheezy")
 		jessieProbeCmd, jessieFileNames := createProbeCommand(namesToResolve, "jessie")
+		By("Running these commands on wheezy:" + wheezyProbeCmd + "\n")
+		By("Running these commands on jessie:" + jessieProbeCmd + "\n")
 
 		// Run a pod which probes DNS and exposes the results by HTTP.
 		By("creating a pod to probe DNS")
 		pod := createDNSPod(f.Namespace.Name, wheezyProbeCmd, jessieProbeCmd)
 		pod.ObjectMeta.Labels = testServiceSelector
-
 		validateDNSResults(f, pod, append(wheezyFileNames, jessieFileNames...))
 	})
 


### PR DESCRIPTION
Add hostname DNS A record based on pod annotation
   If the pod spec has the following two annotations,
   i. net.beta.kubernetes.io/hostName
   ii. net.beta.kubernetes.io/setName,
   DNS A Record will be created with the following format:
   `<hostName>.<setName>.<pod namespace>.set.cluster.local`
