### PR TITLE
Label [Skipped] tests appropriately

### DIFF
--- a/test/e2e/ingress.go
+++ b/test/e2e/ingress.go
@@ -376,6 +376,11 @@ func (cont *IngressController) Cleanup(del bool) error {
 	return fmt.Errorf(errMsg)
 }
 
+// Before enabling this loadbalancer test in any other test list you must
+// make sure the associated project has enough quota. At the time of this
+// writing a GCE project is allowed 3 backend services by default. This
+// test requires at least 5.
+//
 // Slow by design (10 min)
 // Flaky issue #17518
 var _ = Describe("GCE L7 LoadBalancer Controller [Serial] [Slow] [Flaky]", func() {

--- a/test/e2e/restart.go
+++ b/test/e2e/restart.go
@@ -48,7 +48,9 @@ const (
 	restartPodReadyAgainTimeout = 5 * time.Minute
 )
 
-var _ = Describe("Restart", func() {
+// TODO(ihmccreery): This is skipped because it was previously in
+// REBOOT_SKIP_TESTS, dates back before version control (#10078)
+var _ = Describe("Restart [Skipped]", func() {
 	var c *client.Client
 	var ps *podStore
 	var skipped bool

--- a/test/e2e/serviceloadbalancers.go
+++ b/test/e2e/serviceloadbalancers.go
@@ -203,7 +203,9 @@ func (s *ingManager) test(path string) error {
 	})
 }
 
-var _ = Describe("ServiceLoadBalancer", func() {
+// TODO(ihmccreery) Skipped originally in #14988, never sent follow-up PR, as
+// far as I can tell.
+var _ = Describe("ServiceLoadBalancer [Skipped]", func() {
 	// These variables are initialized after framework's beforeEach.
 	var ns string
 	var repoRoot string


### PR DESCRIPTION
I completely removed `GCE_SOAK_CONTINUOUS_SKIP_TESTS`, as they were redundant and/or just wrong:
- "Density.*30\spods" # Skipped, also table-driven and [Performance]
- "Elasticsearch" # Flaky
- "identically\snamed\sservices" # Flaky
- "GCE\sL7\sLoadBalancer\sController" # issue: #17119 # serial, slow, flaky
- "${DISRUPTIVE_TESTS[@]}"       # avoid component restarts, moved into skip list in soak tests
- "network\spartition" # Disruptive
- "external\sload\sbalancer" # doesn't match anything
- "Services.*Type\sgoes\sfrom" # matches nothing, perhaps meant to match "should be able to change the type and nodeport settings of a service"?

I believe "Reboot" was accidentally, redundantly added to `GCE_DEFAULT_SKIP_TESTS` in #13863, so I removed it.

(I also fixed a comment I messed up in an earlier PR.)
