### PR TITLE
move ServerVersion to DiscoveryClient

### DIFF
--- a/pkg/client/unversioned/client.go
+++ b/pkg/client/unversioned/client.go
@@ -27,7 +27,6 @@ import (
 
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/api/v1"
-	"k8s.io/kubernetes/pkg/version"
 )
 
 // Interface holds the methods for clients of Kubernetes,
@@ -38,7 +37,6 @@ type Interface interface {
 	ReplicationControllersNamespacer
 	ServicesNamespacer
 	EndpointsNamespacer
-	VersionInterface
 	NodesInterface
 	EventNamespacer
 	LimitRangesNamespacer
@@ -113,31 +111,12 @@ func (c *Client) ComponentStatuses() ComponentStatusInterface {
 	return newComponentStatuses(c)
 }
 
-// VersionInterface has a method to retrieve the server version.
-type VersionInterface interface {
-	ServerVersion() (*version.Info, error)
-}
-
 // Client is the implementation of a Kubernetes client.
 type Client struct {
 	*RESTClient
 	*ExtensionsClient
 	// TODO: remove this when we re-structure pkg/client.
 	*DiscoveryClient
-}
-
-// ServerVersion retrieves and parses the server's version.
-func (c *Client) ServerVersion() (*version.Info, error) {
-	body, err := c.Get().AbsPath("/version").Do().Raw()
-	if err != nil {
-		return nil, err
-	}
-	var info version.Info
-	err = json.Unmarshal(body, &info)
-	if err != nil {
-		return nil, fmt.Errorf("got '%s': %v", string(body), err)
-	}
-	return &info, nil
 }
 
 // SwaggerSchemaInterface has a method to retrieve the swagger schema. Used in

--- a/pkg/client/unversioned/client_test.go
+++ b/pkg/client/unversioned/client_test.go
@@ -48,7 +48,7 @@ func TestGetServerVersion(t *testing.T) {
 	}))
 	client := NewOrDie(&Config{Host: server.URL})
 
-	got, err := client.ServerVersion()
+	got, err := client.Discovery().ServerVersion()
 	if err != nil {
 		t.Fatalf("unexpected encoding error: %v", err)
 	}

--- a/pkg/client/unversioned/extensions.go
+++ b/pkg/client/unversioned/extensions.go
@@ -17,12 +17,10 @@ limitations under the License.
 package unversioned
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/apis/extensions"
-	"k8s.io/kubernetes/pkg/version"
 )
 
 // Interface holds the experimental methods for clients of Kubernetes
@@ -30,7 +28,6 @@ import (
 // Features of Extensions group are not supported and may be changed or removed in
 // incompatible ways at any time.
 type ExtensionsInterface interface {
-	VersionInterface
 	HorizontalPodAutoscalersNamespacer
 	ScaleNamespacer
 	DaemonSetsNamespacer
@@ -46,20 +43,6 @@ type ExtensionsInterface interface {
 // incompatible ways at any time.
 type ExtensionsClient struct {
 	*RESTClient
-}
-
-// ServerVersion retrieves and parses the server's version.
-func (c *ExtensionsClient) ServerVersion() (*version.Info, error) {
-	body, err := c.Get().AbsPath("/version").Do().Raw()
-	if err != nil {
-		return nil, err
-	}
-	var info version.Info
-	err = json.Unmarshal(body, &info)
-	if err != nil {
-		return nil, fmt.Errorf("got '%s': %v", string(body), err)
-	}
-	return &info, nil
 }
 
 func (c *ExtensionsClient) HorizontalPodAutoscalers(namespace string) HorizontalPodAutoscalerInterface {

--- a/pkg/client/unversioned/helper.go
+++ b/pkg/client/unversioned/helper.go
@@ -157,7 +157,7 @@ func MatchesServerVersion(client *Client, c *Config) error {
 		}
 	}
 	clientVersion := version.Get()
-	serverVersion, err := client.ServerVersion()
+	serverVersion, err := client.Discovery().ServerVersion()
 	if err != nil {
 		return fmt.Errorf("couldn't read version from server: %v\n", err)
 	}

--- a/pkg/client/unversioned/testclient/testclient.go
+++ b/pkg/client/unversioned/testclient/testclient.go
@@ -279,16 +279,7 @@ func (c *Fake) Discovery() client.DiscoveryInterface {
 	return &FakeDiscovery{c}
 }
 
-func (c *Fake) ServerVersion() (*version.Info, error) {
-	action := ActionImpl{}
-	action.Verb = "get"
-	action.Resource = "version"
-
-	c.Invokes(action, nil)
-	versionInfo := version.Get()
-	return &versionInfo, nil
-}
-
+// TODO: this should be removed
 func (c *Fake) ServerAPIVersions() (*unversioned.APIVersions, error) {
 	action := ActionImpl{}
 	action.Verb = "get"
@@ -385,4 +376,14 @@ func (c *FakeDiscovery) ServerResources() (map[string]*unversioned.APIResourceLi
 
 func (c *FakeDiscovery) ServerGroups() (*unversioned.APIGroupList, error) {
 	return nil, nil
+}
+
+func (c *FakeDiscovery) ServerVersion() (*version.Info, error) {
+	action := ActionImpl{}
+	action.Verb = "get"
+	action.Resource = "version"
+
+	c.Invokes(action, nil)
+	versionInfo := version.Get()
+	return &versionInfo, nil
 }

--- a/pkg/kubectl/version.go
+++ b/pkg/kubectl/version.go
@@ -26,7 +26,7 @@ import (
 )
 
 func GetServerVersion(w io.Writer, kubeClient client.Interface) {
-	serverVersion, err := kubeClient.ServerVersion()
+	serverVersion, err := kubeClient.Discovery().ServerVersion()
 	if err != nil {
 		fmt.Printf("Couldn't read server version from server: %v\n", err)
 		os.Exit(1)

--- a/test/e2e/cluster_upgrade.go
+++ b/test/e2e/cluster_upgrade.go
@@ -326,7 +326,7 @@ func testMasterUpgrade(ip, v string, mUp func(v string) error) {
 }
 
 func checkMasterVersion(c *client.Client, want string) error {
-	v, err := c.ServerVersion()
+	v, err := c.Discovery().ServerVersion()
 	if err != nil {
 		return fmt.Errorf("checkMasterVersion() couldn't get the master version: %v", err)
 	}

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -972,7 +972,7 @@ func (r podResponseChecker) checkAllResponses() (done bool, err error) {
 // version.
 //
 // TODO(18726): This should be incorporated into client.VersionInterface.
-func serverVersionGTE(v semver.Version, c client.VersionInterface) (bool, error) {
+func serverVersionGTE(v semver.Version, c client.DiscoveryInterface) (bool, error) {
 	serverVersion, err := c.ServerVersion()
 	if err != nil {
 		return false, fmt.Errorf("Unable to get server version: %v", err)

--- a/test/images/network-tester/webserver.go
+++ b/test/images/network-tester/webserver.go
@@ -220,7 +220,7 @@ func contactOthers(state *State) {
 		log.Fatalf("Unable to create client; error: %v\n", err)
 	}
 	// Double check that that worked by getting the server version.
-	if v, err := client.ServerVersion(); err != nil {
+	if v, err := client.Discovery().ServerVersion(); err != nil {
 		log.Fatalf("Unable to get server version: %v\n", err)
 	} else {
 		log.Printf("Server version: %#v\n", v)

--- a/test/integration/client_test.go
+++ b/test/integration/client_test.go
@@ -45,7 +45,7 @@ func TestClient(t *testing.T) {
 	framework.DeleteAllEtcdKeys()
 	client := client.NewOrDie(&client.Config{Host: s.URL, GroupVersion: testapi.Default.GroupVersion()})
 
-	info, err := client.ServerVersion()
+	info, err := client.Discovery().ServerVersion()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
Background: In order to generate the [clientset](https://github.com/kubernetes/kubernetes/blob/master/docs/proposals/client-package-structure.md#high-level-client-sets), I'm moving the methods of [unversioned.Client](https://github.com/kubernetes/kubernetes/blob/master/pkg/client/unversioned/client.go#L122) to its handwritten member clients (e.g. `DiscoveryClient`). When generating `clientset`, the generator just needs to include the handwritten clients.

This PR moves the ServerVersion method to DiscoveryClient.
