### PR TITLE
[Client-gen] Remove the use of namespaceifscoped from typed clients

### DIFF
--- a/cmd/libs/go2idl/client-gen/generators/generator-for-type.go
+++ b/cmd/libs/go2idl/client-gen/generators/generator-for-type.go
@@ -158,7 +158,7 @@ var deleteCollectionTemplate = `
 // DeleteCollection deletes a collection of objects.
 func (c *$.type|privatePlural$) DeleteCollection(options *$.apiDeleteOptions|raw$, listOptions $.apiListOptions|raw$) error {
 	return c.client.Delete().
-		NamespaceIfScoped(c.ns, len(c.ns) > 0).
+		Namespace(c.ns).
 		Resource("$.type|privatePlural$").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).

--- a/cmd/libs/go2idl/client-gen/testoutput/testgroup/unversioned/testtype.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/testgroup/unversioned/testtype.go
@@ -91,7 +91,7 @@ func (c *testTypes) Delete(name string, options *api.DeleteOptions) error {
 // DeleteCollection deletes a collection of objects.
 func (c *testTypes) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
-		NamespaceIfScoped(c.ns, len(c.ns) > 0).
+		Namespace(c.ns).
 		Resource("testTypes").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).

--- a/pkg/client/typed/generated/extensions/unversioned/daemonset.go
+++ b/pkg/client/typed/generated/extensions/unversioned/daemonset.go
@@ -91,7 +91,7 @@ func (c *daemonSets) Delete(name string, options *api.DeleteOptions) error {
 // DeleteCollection deletes a collection of objects.
 func (c *daemonSets) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
-		NamespaceIfScoped(c.ns, len(c.ns) > 0).
+		Namespace(c.ns).
 		Resource("daemonSets").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).

--- a/pkg/client/typed/generated/extensions/unversioned/deployment.go
+++ b/pkg/client/typed/generated/extensions/unversioned/deployment.go
@@ -91,7 +91,7 @@ func (c *deployments) Delete(name string, options *api.DeleteOptions) error {
 // DeleteCollection deletes a collection of objects.
 func (c *deployments) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
-		NamespaceIfScoped(c.ns, len(c.ns) > 0).
+		Namespace(c.ns).
 		Resource("deployments").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).

--- a/pkg/client/typed/generated/extensions/unversioned/horizontalpodautoscaler.go
+++ b/pkg/client/typed/generated/extensions/unversioned/horizontalpodautoscaler.go
@@ -91,7 +91,7 @@ func (c *horizontalPodAutoscalers) Delete(name string, options *api.DeleteOption
 // DeleteCollection deletes a collection of objects.
 func (c *horizontalPodAutoscalers) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
-		NamespaceIfScoped(c.ns, len(c.ns) > 0).
+		Namespace(c.ns).
 		Resource("horizontalPodAutoscalers").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).

--- a/pkg/client/typed/generated/extensions/unversioned/ingress.go
+++ b/pkg/client/typed/generated/extensions/unversioned/ingress.go
@@ -91,7 +91,7 @@ func (c *ingresses) Delete(name string, options *api.DeleteOptions) error {
 // DeleteCollection deletes a collection of objects.
 func (c *ingresses) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
-		NamespaceIfScoped(c.ns, len(c.ns) > 0).
+		Namespace(c.ns).
 		Resource("ingresses").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).

--- a/pkg/client/typed/generated/extensions/unversioned/job.go
+++ b/pkg/client/typed/generated/extensions/unversioned/job.go
@@ -91,7 +91,7 @@ func (c *jobs) Delete(name string, options *api.DeleteOptions) error {
 // DeleteCollection deletes a collection of objects.
 func (c *jobs) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
-		NamespaceIfScoped(c.ns, len(c.ns) > 0).
+		Namespace(c.ns).
 		Resource("jobs").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).

--- a/pkg/client/typed/generated/extensions/unversioned/thirdpartyresource.go
+++ b/pkg/client/typed/generated/extensions/unversioned/thirdpartyresource.go
@@ -91,7 +91,7 @@ func (c *thirdPartyResources) Delete(name string, options *api.DeleteOptions) er
 // DeleteCollection deletes a collection of objects.
 func (c *thirdPartyResources) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
-		NamespaceIfScoped(c.ns, len(c.ns) > 0).
+		Namespace(c.ns).
 		Resource("thirdPartyResources").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).

--- a/pkg/client/typed/generated/legacy/unversioned/componentstatus.go
+++ b/pkg/client/typed/generated/legacy/unversioned/componentstatus.go
@@ -90,7 +90,7 @@ func (c *componentStatus) Delete(name string, options *api.DeleteOptions) error 
 // DeleteCollection deletes a collection of objects.
 func (c *componentStatus) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
-		NamespaceIfScoped(c.ns, len(c.ns) > 0).
+		Namespace(c.ns).
 		Resource("componentStatus").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).

--- a/pkg/client/typed/generated/legacy/unversioned/endpoints.go
+++ b/pkg/client/typed/generated/legacy/unversioned/endpoints.go
@@ -90,7 +90,7 @@ func (c *endpoints) Delete(name string, options *api.DeleteOptions) error {
 // DeleteCollection deletes a collection of objects.
 func (c *endpoints) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
-		NamespaceIfScoped(c.ns, len(c.ns) > 0).
+		Namespace(c.ns).
 		Resource("endpoints").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).

--- a/pkg/client/typed/generated/legacy/unversioned/event.go
+++ b/pkg/client/typed/generated/legacy/unversioned/event.go
@@ -90,7 +90,7 @@ func (c *events) Delete(name string, options *api.DeleteOptions) error {
 // DeleteCollection deletes a collection of objects.
 func (c *events) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
-		NamespaceIfScoped(c.ns, len(c.ns) > 0).
+		Namespace(c.ns).
 		Resource("events").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).

--- a/pkg/client/typed/generated/legacy/unversioned/limitrange.go
+++ b/pkg/client/typed/generated/legacy/unversioned/limitrange.go
@@ -90,7 +90,7 @@ func (c *limitRanges) Delete(name string, options *api.DeleteOptions) error {
 // DeleteCollection deletes a collection of objects.
 func (c *limitRanges) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
-		NamespaceIfScoped(c.ns, len(c.ns) > 0).
+		Namespace(c.ns).
 		Resource("limitRanges").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).

--- a/pkg/client/typed/generated/legacy/unversioned/namespace.go
+++ b/pkg/client/typed/generated/legacy/unversioned/namespace.go
@@ -90,7 +90,7 @@ func (c *namespaces) Delete(name string, options *api.DeleteOptions) error {
 // DeleteCollection deletes a collection of objects.
 func (c *namespaces) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
-		NamespaceIfScoped(c.ns, len(c.ns) > 0).
+		Namespace(c.ns).
 		Resource("namespaces").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).

--- a/pkg/client/typed/generated/legacy/unversioned/node.go
+++ b/pkg/client/typed/generated/legacy/unversioned/node.go
@@ -90,7 +90,7 @@ func (c *nodes) Delete(name string, options *api.DeleteOptions) error {
 // DeleteCollection deletes a collection of objects.
 func (c *nodes) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
-		NamespaceIfScoped(c.ns, len(c.ns) > 0).
+		Namespace(c.ns).
 		Resource("nodes").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).

--- a/pkg/client/typed/generated/legacy/unversioned/persistentvolume.go
+++ b/pkg/client/typed/generated/legacy/unversioned/persistentvolume.go
@@ -90,7 +90,7 @@ func (c *persistentVolumes) Delete(name string, options *api.DeleteOptions) erro
 // DeleteCollection deletes a collection of objects.
 func (c *persistentVolumes) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
-		NamespaceIfScoped(c.ns, len(c.ns) > 0).
+		Namespace(c.ns).
 		Resource("persistentVolumes").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).

--- a/pkg/client/typed/generated/legacy/unversioned/persistentvolumeclaim.go
+++ b/pkg/client/typed/generated/legacy/unversioned/persistentvolumeclaim.go
@@ -90,7 +90,7 @@ func (c *persistentVolumeClaims) Delete(name string, options *api.DeleteOptions)
 // DeleteCollection deletes a collection of objects.
 func (c *persistentVolumeClaims) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
-		NamespaceIfScoped(c.ns, len(c.ns) > 0).
+		Namespace(c.ns).
 		Resource("persistentVolumeClaims").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).

--- a/pkg/client/typed/generated/legacy/unversioned/pod.go
+++ b/pkg/client/typed/generated/legacy/unversioned/pod.go
@@ -90,7 +90,7 @@ func (c *pods) Delete(name string, options *api.DeleteOptions) error {
 // DeleteCollection deletes a collection of objects.
 func (c *pods) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
-		NamespaceIfScoped(c.ns, len(c.ns) > 0).
+		Namespace(c.ns).
 		Resource("pods").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).

--- a/pkg/client/typed/generated/legacy/unversioned/podtemplate.go
+++ b/pkg/client/typed/generated/legacy/unversioned/podtemplate.go
@@ -90,7 +90,7 @@ func (c *podTemplates) Delete(name string, options *api.DeleteOptions) error {
 // DeleteCollection deletes a collection of objects.
 func (c *podTemplates) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
-		NamespaceIfScoped(c.ns, len(c.ns) > 0).
+		Namespace(c.ns).
 		Resource("podTemplates").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).

--- a/pkg/client/typed/generated/legacy/unversioned/replicationcontroller.go
+++ b/pkg/client/typed/generated/legacy/unversioned/replicationcontroller.go
@@ -90,7 +90,7 @@ func (c *replicationControllers) Delete(name string, options *api.DeleteOptions)
 // DeleteCollection deletes a collection of objects.
 func (c *replicationControllers) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
-		NamespaceIfScoped(c.ns, len(c.ns) > 0).
+		Namespace(c.ns).
 		Resource("replicationControllers").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).

--- a/pkg/client/typed/generated/legacy/unversioned/resourcequota.go
+++ b/pkg/client/typed/generated/legacy/unversioned/resourcequota.go
@@ -90,7 +90,7 @@ func (c *resourceQuotas) Delete(name string, options *api.DeleteOptions) error {
 // DeleteCollection deletes a collection of objects.
 func (c *resourceQuotas) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
-		NamespaceIfScoped(c.ns, len(c.ns) > 0).
+		Namespace(c.ns).
 		Resource("resourceQuotas").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).

--- a/pkg/client/typed/generated/legacy/unversioned/secret.go
+++ b/pkg/client/typed/generated/legacy/unversioned/secret.go
@@ -90,7 +90,7 @@ func (c *secrets) Delete(name string, options *api.DeleteOptions) error {
 // DeleteCollection deletes a collection of objects.
 func (c *secrets) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
-		NamespaceIfScoped(c.ns, len(c.ns) > 0).
+		Namespace(c.ns).
 		Resource("secrets").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).

--- a/pkg/client/typed/generated/legacy/unversioned/service.go
+++ b/pkg/client/typed/generated/legacy/unversioned/service.go
@@ -90,7 +90,7 @@ func (c *services) Delete(name string, options *api.DeleteOptions) error {
 // DeleteCollection deletes a collection of objects.
 func (c *services) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
-		NamespaceIfScoped(c.ns, len(c.ns) > 0).
+		Namespace(c.ns).
 		Resource("services").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).

--- a/pkg/client/typed/generated/legacy/unversioned/serviceaccount.go
+++ b/pkg/client/typed/generated/legacy/unversioned/serviceaccount.go
@@ -90,7 +90,7 @@ func (c *serviceAccounts) Delete(name string, options *api.DeleteOptions) error 
 // DeleteCollection deletes a collection of objects.
 func (c *serviceAccounts) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
-		NamespaceIfScoped(c.ns, len(c.ns) > 0).
+		Namespace(c.ns).
 		Resource("serviceAccounts").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).

--- a/pkg/client/unversioned/events.go
+++ b/pkg/client/unversioned/events.go
@@ -72,7 +72,7 @@ func (e *events) Create(event *api.Event) (*api.Event, error) {
 	}
 	result := &api.Event{}
 	err := e.client.Post().
-		NamespaceIfScoped(event.Namespace, len(event.Namespace) > 0).
+		Namespace(event.Namespace).
 		Resource("events").
 		Body(event).
 		Do().
@@ -91,7 +91,7 @@ func (e *events) Update(event *api.Event) (*api.Event, error) {
 	}
 	result := &api.Event{}
 	err := e.client.Put().
-		NamespaceIfScoped(event.Namespace, len(event.Namespace) > 0).
+		Namespace(event.Namespace).
 		Resource("events").
 		Name(event.Name).
 		Body(event).
@@ -107,7 +107,7 @@ func (e *events) Update(event *api.Event) (*api.Event, error) {
 func (e *events) Patch(incompleteEvent *api.Event, data []byte) (*api.Event, error) {
 	result := &api.Event{}
 	err := e.client.Patch(api.StrategicMergePatchType).
-		NamespaceIfScoped(incompleteEvent.Namespace, len(incompleteEvent.Namespace) > 0).
+		Namespace(incompleteEvent.Namespace).
 		Resource("events").
 		Name(incompleteEvent.Name).
 		Body(data).
@@ -120,7 +120,7 @@ func (e *events) Patch(incompleteEvent *api.Event, data []byte) (*api.Event, err
 func (e *events) List(opts api.ListOptions) (*api.EventList, error) {
 	result := &api.EventList{}
 	err := e.client.Get().
-		NamespaceIfScoped(e.namespace, len(e.namespace) > 0).
+		Namespace(e.namespace).
 		Resource("events").
 		VersionedParams(&opts, api.Scheme).
 		Do().
@@ -132,7 +132,7 @@ func (e *events) List(opts api.ListOptions) (*api.EventList, error) {
 func (e *events) Get(name string) (*api.Event, error) {
 	result := &api.Event{}
 	err := e.client.Get().
-		NamespaceIfScoped(e.namespace, len(e.namespace) > 0).
+		Namespace(e.namespace).
 		Resource("events").
 		Name(name).
 		Do().
@@ -144,7 +144,7 @@ func (e *events) Get(name string) (*api.Event, error) {
 func (e *events) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return e.client.Get().
 		Prefix("watch").
-		NamespaceIfScoped(e.namespace, len(e.namespace) > 0).
+		Namespace(e.namespace).
 		Resource("events").
 		VersionedParams(&opts, api.Scheme).
 		Watch()
@@ -178,7 +178,7 @@ func (e *events) Search(objOrRef runtime.Object) (*api.EventList, error) {
 // Delete deletes an existing event.
 func (e *events) Delete(name string) error {
 	return e.client.Delete().
-		NamespaceIfScoped(e.namespace, len(e.namespace) > 0).
+		Namespace(e.namespace).
 		Resource("events").
 		Name(name).
 		Do().
@@ -188,7 +188,7 @@ func (e *events) Delete(name string) error {
 // DeleteCollection deletes a collection of objects.
 func (e *events) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return e.client.Delete().
-		NamespaceIfScoped(e.namespace, len(e.namespace) > 0).
+		Namespace(e.namespace).
 		Resource("events").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).


### PR DESCRIPTION
pkg/client/unversioned/events.go unnecessarily uses NamespaceIfScoped many times, I removed those usage so events.go looks more similar to the generated clients.

I also remove the use of NamespaceIfScoped from the client-gen template.

Note: the Create and Update methods in events.go are still unique, the request is scoped to namespace of the passed in API object rather than the event client's namesapce, so they still have to be manually written.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/19307)

<!-- Reviewable:end -->
