### PR TITLE
Added --allow-privileged flag to kubelet and apiserver init command for Juju provider

### DIFF
--- a/cluster/juju/charms/trusty/kubernetes-master/files/apiserver.upstart.tmpl
+++ b/cluster/juju/charms/trusty/kubernetes-master/files/apiserver.upstart.tmpl
@@ -8,6 +8,7 @@ limit nofile 20000 20000
 kill timeout 30 # wait 30s between SIGTERM and SIGKILL.
 
 exec /usr/local/bin/apiserver \
+     --allow-privileged=true \
      --basic-auth-file=/srv/kubernetes/basic-auth.csv \
      --bind-address=%(api_private_address)s \
      --etcd-servers=%(etcd_servers)s \

--- a/cluster/juju/charms/trusty/kubernetes/files/kubelet.upstart.tmpl
+++ b/cluster/juju/charms/trusty/kubernetes/files/kubelet.upstart.tmpl
@@ -9,6 +9,7 @@ kill timeout 60 # wait 60s between SIGTERM and SIGKILL.
 
 exec /usr/local/bin/kubelet \
      --address=%(kubelet_bind_addr)s \
+     --allow-privileged=true \
      --api-servers=%(kubeapi_server)s \
      --hostname-override=%(kubelet_bind_addr)s \
      --cadvisor-port=4193 \


### PR DESCRIPTION
Closes #18931

As described in https://github.com/kubernetes/kubernetes/issues/391 this patch adds the --allow-privileged flag to the apiserver and kubelet upstart templates for the Juju provider.

Thanks,
