### PR TITLE
AWS: Provide newly required initialization arguments

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -260,7 +260,7 @@ func (p *awsSDKProvider) Autoscaling(regionName string) (ASG, error) {
 }
 
 func (p *awsSDKProvider) Metadata() (EC2Metadata, error) {
-	client := ec2metadata.New(nil)
+	client := ec2metadata.New(session.New(&aws.Config{}))
 	return client, nil
 }
 
@@ -439,7 +439,9 @@ func init() {
 		creds := credentials.NewChainCredentials(
 			[]credentials.Provider{
 				&credentials.EnvProvider{},
-				&ec2rolecreds.EC2RoleProvider{},
+				&ec2rolecreds.EC2RoleProvider{
+					Client: ec2metadata.New(session.New(&aws.Config{})),
+				},
 				&credentials.SharedCredentialsProvider{},
 			})
 		aws := &awsSDKProvider{creds: creds}


### PR DESCRIPTION
It seems that some formerly optional arguments are now required in the
latest aws-sdk-go, see e.g.
https://github.com/aws/aws-sdk-go/issues/452.
