### PR TITLE
Skip gcloud update checks for Jenkins jobs.

### DIFF
--- a/hack/jenkins/build.sh
+++ b/hack/jenkins/build.sh
@@ -33,6 +33,9 @@ export HOME=${WORKSPACE} # Nothing should want Jenkins $HOME
 export PATH=$PATH:/usr/local/go/bin
 export KUBE_SKIP_CONFIRMATIONS=y
 
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+
 : ${KUBE_RELEASE_RUN_TESTS:="n"}
 export KUBE_RELEASE_RUN_TESTS
 

--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -1034,6 +1034,9 @@ case ${JOB_NAME} in
     ;;
 esac
 
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+
 # AWS variables
 export KUBE_AWS_INSTANCE_PREFIX=${E2E_CLUSTER_NAME}
 export KUBE_AWS_ZONE=${E2E_ZONE}


### PR DESCRIPTION
We update every day in a Jenkins job as of #18846. For builds and E2E tests, skip update checking with this environment variable. If we're trying to parse gcloud outputs, that check might break something (#19350).

@ixdy Is it necessary to do this in build.sh, or is just e2e.sh enough? Eventually this can be set from Jenkins environment plugin once all the jobs are in source control.
