### PR TITLE
Make kube2sky and skydns docker images cross-platform

### DIFF
--- a/cluster/addons/dns/kube2sky/Changelog
+++ b/cluster/addons/dns/kube2sky/Changelog
@@ -1,3 +1,10 @@
+## Version 1.15 (Apr 7 2016 Lucas Käldström <lucas.kaldstrom@hotmail.co.uk>)
+ - No code changes since 1.14
+ - Built in a dockerized env instead of using go on host to make it more reliable. `1.15` was built with `go1.6`
+ - Made it possible to compile this image for multiple architectures, so the main naming of this image is 
+   now `gcr.io/google_containers/kube2sky-arch:tag`. `arch` may be one of `amd64`, `arm`, `arm64` or `ppc64le`.
+   `gcr.io/google_containers/kube2sky:tag` is still pushed for backward compability
+
 ## Version 1.14 (Mar 4 2016 Abhishek Shah <abshah@google.com>)
 - If Endpoint has hostnames-map annotation (endpoints.net.beta.kubernetes.io/hostnames-map),
   the hostnames supplied via the annotation will be used to generate A Records for Headless Service.

--- a/cluster/addons/dns/kube2sky/Dockerfile
+++ b/cluster/addons/dns/kube2sky/Dockerfile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM busybox
+FROM BASEIMAGE
 MAINTAINER Tim Hockin <thockin@google.com>
-ADD kube2sky kube2sky
-ADD kube2sky.go kube2sky.go
+ADD kube2sky /
+ADD kube2sky.go /
 ENTRYPOINT ["/kube2sky"]

--- a/cluster/addons/dns/kube2sky/Makefile
+++ b/cluster/addons/dns/kube2sky/Makefile
@@ -15,25 +15,72 @@
 # Makefile for the Docker image gcr.io/google_containers/kube2sky
 # MAINTAINER: Tim Hockin <thockin@google.com>
 # If you update this image please bump the tag value before pushing.
+#
+# Usage:
+#   [ARCH=amd64] [TAG=1.14] [REGISTRY=gcr.io/google_containers] [BASEIMAGE=busybox] make (build|push)
 
-.PHONY: all kube2sky container push clean test
+# Default registry, arch and tag. This can be overwritten by arguments to make
+ARCH?=amd64
+TAG?=1.15
+REGISTRY?=gcr.io/google_containers
+GOLANG_VERSION=1.6
+GOARM=6
+KUBE_ROOT=$(shell pwd)/../../../..
+TEMP_DIR:=$(shell mktemp -d)
 
-TAG = 1.14
-PREFIX = gcr.io/google_containers
+ifeq ($(ARCH),amd64)
+	BASEIMAGE?=busybox
+endif
+ifeq ($(ARCH),arm)
+	BASEIMAGE?=armel/busybox
+endif
+ifeq ($(ARCH),arm64)
+	BASEIMAGE?=aarch64/busybox
+endif
+ifeq ($(ARCH),ppc64le)
+	BASEIMAGE?=ppc64le/busybox
+endif
+
 
 all: container
 
 kube2sky: kube2sky.go
-	GOOS=linux CGO_ENABLED=0 godep go build -a -installsuffix cgo --ldflags '-w' ./kube2sky.go
+	# Only build kube2sky. This requires go and godep in PATH
+	CGO_ENABLED=0 GOARCH=$(ARCH) GOARM=$(GOARM) godep go build -a -installsuffix cgo --ldflags '-w' ./kube2sky.go
 
-container: kube2sky
-	docker build -t $(PREFIX)/kube2sky:$(TAG) .
+container:
+	# Copy the content in this dir to the temp dir
+	cp ./* $(TEMP_DIR)
 
-push:
-	gcloud docker push $(PREFIX)/kube2sky:$(TAG)
+	# Build the binary dockerized. Mount the whole Kubernetes source first, and then the temporary dir to kube2sky source.
+	# It runs "make kube2sky" inside the docker container, and the binary is put in the temporary dir.
+	docker run -it \
+		-v $(KUBE_ROOT):/go/src/k8s.io/kubernetes \
+		-v $(TEMP_DIR):/go/src/k8s.io/kubernetes/cluster/addons/dns/kube2sky \
+		golang:$(GOLANG_VERSION) /bin/bash -c \
+		"go get github.com/tools/godep \
+		&& make -C /go/src/k8s.io/kubernetes/cluster/addons/dns/kube2sky kube2sky ARCH=$(ARCH)"
+
+	# Replace BASEIMAGE with the real base image
+	cd $(TEMP_DIR) && sed -i "s|BASEIMAGE|$(BASEIMAGE)|g" Dockerfile
+
+	# And build the image
+	docker build -t $(REGISTRY)/kube2sky-$(ARCH):$(TAG) $(TEMP_DIR)
+
+push: container
+	gcloud docker push $(REGISTRY)/kube2sky-$(ARCH):$(TAG)
+
+ifeq ($(ARCH),amd64)
+	# Backward compatability. TODO: deprecate this image tag
+	docker tag -f $(REGISTRY)/kube2sky-$(ARCH):$(TAG) $(REGISTRY)/kube2sky:$(TAG)
+	gcloud docker push $(REGISTRY)/kube2sky:$(TAG)
+endif
 
 clean:
 	rm -f kube2sky
 
 test: clean
 	godep go test -v --vmodule=*=4
+
+
+.PHONY: all kube2sky container push clean test

--- a/cluster/addons/dns/kube2sky/RELEASES.md
+++ b/cluster/addons/dns/kube2sky/RELEASES.md
@@ -1,7 +1,7 @@
 # Cutting a release
 
 Until we have a proper setup for building this automatically with every binary
-release, here are the steps for making a release.  We make releases when they
+release, here are the steps for making a release. We make releases when they
 are ready, not on every PR.
 
 1. Build the container for testing: `make container PREFIX=<your-docker-hub> TAG=rc`
@@ -11,19 +11,33 @@ are ready, not on every PR.
 
 3. Verify it works.
 
-4. Update the TAG version in `Makefile` and update the `Changelog`.  Update the
-   `*.yaml.in` to point to the new tag.  Send a PR but mark it as "DO NOT MERGE".
+4. Update the TAG version in `Makefile` and update the `Changelog`. Update the
+   `*.yaml.in` to point to the new tag. Send a PR but mark it as "DO NOT MERGE".
 
-5. Once the PR is approved, build the container for real: `make container`.
+5. Once the PR is approved, build and push the container for real for all architectures:
 
-6. Push the container: `make push`.
+	```console
+	# Build for linux/amd64 (default)
+	$ make push ARCH=amd64
+	# ---> gcr.io/google_containers/kube2sky-amd64:TAG
+	# ---> gcr.io/google_containers/kube2sky:TAG (image with backwards-compatible naming)
 
-7. Manually deploy this to your own cluster by updating the replication
+	$ make push ARCH=arm
+	# ---> gcr.io/google_containers/kube2sky-arm:TAG
+
+	$ make push ARCH=arm64
+	# ---> gcr.io/google_containers/kube2sky-arm64:TAG
+
+	$ make push ARCH=ppc64le
+	# ---> gcr.io/google_containers/kube2sky-ppc64le:TAG
+	```
+
+6. Manually deploy this to your own cluster by updating the replication
    controller and deleting the running pod(s).
 
-8. Verify it works.
+7. Verify it works.
 
-9. Allow the PR to be merged.
+8. Allow the PR to be merged.
 
 
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/cluster/addons/dns/kube2sky/RELEASES.md?pixel)]()

--- a/cluster/addons/dns/skydns/Dockerfile
+++ b/cluster/addons/dns/skydns/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM busybox
+FROM BASEIMAGE
 MAINTAINER Tim Hockin <thockin@google.com>
-ADD skydns skydns
+ADD skydns /
 ENTRYPOINT ["/skydns"]

--- a/cluster/addons/dns/skydns/Makefile
+++ b/cluster/addons/dns/skydns/Makefile
@@ -12,16 +12,67 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Build skydns
+#
+# Usage:
+#   [ARCH=amd64] [TAG=1.0] [REGISTRY=gcr.io/google_containers] [BASEIMAGE=busybox] make (build|push)
+
+# Default registry and arch. This can be overwritten by arguments to make
+ARCH?=amd64
+
+# Version of this image, not the version of skydns
+TAG=1.0
+REGISTRY?=gcr.io/google_containers
+GOLANG_VERSION=1.6
+GOARM=6
+TEMP_DIR:=$(shell mktemp -d)
+
+ifeq ($(ARCH),amd64)
+	BASEIMAGE?=busybox
+	GOBIN_DIR=/go/bin/
+else
+	# If not the GOARCH == the host arch, the binary directory is here
+	GOBIN_DIR=/go/bin/linux_$(ARCH)
+endif
+
+ifeq ($(ARCH),arm)
+	BASEIMAGE?=armel/busybox
+endif
+ifeq ($(ARCH),arm64)
+	BASEIMAGE?=aarch64/busybox
+endif
+ifeq ($(ARCH),ppc64le)
+	BASEIMAGE?=ppc64le/busybox
+endif
+
+# Do not change this default value
 all: skydns
 
 skydns:
-	CGO_ENABLED=0 go build -a -installsuffix cgo --ldflags '-w' github.com/skynetservices/skydns
+	# Only build skydns. This requires go in PATH
+	CGO_ENABLED=0 GOARCH=$(ARCH) GOARM=$(GOARM) go get -a -installsuffix cgo --ldflags '-w' github.com/skynetservices/skydns
 
-container: skydns
-	sudo docker build -t gcr.io/google_containers/skydns .
+container:
+	# Copy the content in this dir to the temp dir
+	cp ./* $(TEMP_DIR)
 
-push:
-	sudo gcloud docker push gcr.io/google_containers/skydns
+	# Build skydns in a container. We mount the temporary dir
+	docker run -it -v $(TEMP_DIR):$(GOBIN_DIR) golang:$(GOLANG_VERSION) /bin/bash -c "make -C $(GOBIN_DIR) skydns ARCH=$(ARCH)"
+
+	# Replace BASEIMAGE with the real base image
+	cd $(TEMP_DIR) && sed -i "s|BASEIMAGE|$(BASEIMAGE)|g" Dockerfile
+
+	# And build the image
+	docker build -t $(REGISTRY)/skydns-$(ARCH):$(TAG) $(TEMP_DIR)
+
+push: container
+	gcloud docker push $(REGISTRY)/skydns-$(ARCH):$(TAG)
+
+ifeq ($(ARCH),amd64)
+	# Backward compatability. TODO: deprecate this image tag
+	docker tag -f $(REGISTRY)/skydns-$(ARCH):$(TAG) $(REGISTRY)/skydns:$(TAG)
+	gcloud docker push $(REGISTRY)/skydns:$(TAG)
+endif
 
 clean:
 	rm -f skydns

--- a/cluster/addons/dns/skydns/README.md
+++ b/cluster/addons/dns/skydns/README.md
@@ -1,8 +1,30 @@
 # skydns for kubernetes
 =======================
 
-This container only exists until skydns itself is reduced in some way.  At the
+This container only exists until skydns itself is reduced in some way. At the
 time of this writing, it is over 600 MB large.
 
+#### How to release
+
+This image is compiled for multiple architectures.
+If you're rebuilding the image, please bump the `TAG` in the Makefile.
+
+```console
+# Build for linux/amd64 (default)
+$ make push ARCH=amd64
+# ---> gcr.io/google_containers/skydns-amd64:TAG
+# ---> gcr.io/google_containers/skydns:TAG (image with backwards-compatible naming)
+
+$ make push ARCH=arm
+# ---> gcr.io/google_containers/skydns-arm:TAG
+
+$ make push ARCH=arm64
+# ---> gcr.io/google_containers/skydns-arm64:TAG
+
+$ make push ARCH=ppc64le
+# ---> gcr.io/google_containers/skydns-ppc64le:TAG
+```
+
+If you don't want to push the images, run `make` or `make build` instead
 
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/cluster/addons/dns/skydns/README.md?pixel)]()


### PR DESCRIPTION
ARM tracking issue: #17981
Continues on: #19216

Make it possible to create `kube2sky` and `skydns` docker images for ARM and other architectures too
Build in a container, so `golang` isn't a dependency
I've preserved the original default behaviour:
- `skydns`: It just compiles with go on host
- `kube2sky`: Build an image

@brendandburns @dchen1107 @ArtfulCoder @thockin @fgrzadkowski
