### PR TITLE
Update verify-jenkins-jobs, check in job config.

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-verify-jenkins-jobs.yaml
+++ b/hack/jenkins/job-configs/kubernetes-verify-jenkins-jobs.yaml
@@ -1,0 +1,23 @@
+- job:
+    name: 'kubernetes-verify-jenkins-jobs'
+    description: 'Verify that tests in e2e.sh are running on Jenkins and vice versa. Test owner: spxtr'
+    logrotate:
+        numToKeep: 200
+    builders:
+        - shell: |
+            curl -fsS --retry 3 "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/e2e.sh" > "e2e.sh"
+            curl -fsS --retry 3 "https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.1/hack/jenkins/e2e.sh" >> "e2e.sh"
+            curl -fsS --retry 3 "https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.0/hack/jenkins/e2e.sh" >> "e2e.sh"
+
+            export E2E="e2e.sh"
+            export JENKINS=localhost:8080
+            curl -fsS --retry 3 "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/verify-jenkins-jobs.sh" | bash -
+    triggers:
+        - timed: '@daily'
+    publishers:
+        - email-ext:
+            recipients: 'spxtr@google.com'
+    wrappers:
+        - timeout:
+            timeout: 3
+            fail: true

--- a/hack/jenkins/verify-jenkins-jobs.sh
+++ b/hack/jenkins/verify-jenkins-jobs.sh
@@ -33,8 +33,10 @@ kubernetes-build-1.0
 kubernetes-build-1.1
 kubernetes-check-links
 kubernetes-test-go
+kubernetes-test-go-release-1.1
 kubernetes-pull-build-test-e2e-gce
 kubernetes-pull-test-unit-integration
+kubernetes-update-jenkins-jobs
 kubernetes-verify-jenkins-jobs
 '
 
@@ -72,5 +74,11 @@ e2e_builds=$(grep "^  kubernetes-.*)$" "${E2E}" | tr -d " )")
 jenkins_builds=$(curl -sg "${JENKINS}/api/json?tree=jobs[name]&pretty=true" \
   | grep -Po '(?<="name" : ")[^"]*')
 
-search_build "${e2e_builds}" "${jenkins_builds}" "Jenkins" \
-  || search_build "${jenkins_builds}" "${e2e_builds}" "e2e.sh"
+exit_code=0
+if ! search_build "${e2e_builds}" "${jenkins_builds}" "Jenkins"; then
+  exit_code=1
+fi
+if ! search_build "${jenkins_builds}" "${e2e_builds}" "e2e.sh"; then
+  exit_code=1
+fi
+exit ${exit_code}


### PR DESCRIPTION
This job is almost green. @ihmccreery , the only things keeping this red are these:

```
- Builds not found in Jenkins:
kubernetes-upgrade-gce-step1-deploy
kubernetes-upgrade-gce-step2-upgrade-master
kubernetes-upgrade-gce-step3-e2e-old
kubernetes-upgrade-gce-step4-upgrade-cluster
kubernetes-upgrade-gce-step5-e2e-old
kubernetes-upgrade-gce-step6-e2e-new
```

We won't keep this job around forever, but it's still useful for now.
