### PR TITLE
client-gen: generate an interface which allows user to expand typed client's methods

### DIFF
--- a/cmd/libs/go2idl/client-gen/generators/generator-for-expansion.go
+++ b/cmd/libs/go2idl/client-gen/generators/generator-for-expansion.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generators
+
+import (
+	"io"
+
+	"k8s.io/kubernetes/cmd/libs/go2idl/generator"
+	"k8s.io/kubernetes/cmd/libs/go2idl/types"
+)
+
+// genExpansion produces a file for a group client, e.g. ExtensionsClient for the extension group.
+type genExpansion struct {
+	generator.DefaultGen
+	// types in a group
+	types []*types.Type
+}
+
+// We only want to call GenerateType() once per group.
+func (g *genExpansion) Filter(c *generator.Context, t *types.Type) bool {
+	return t == g.types[0]
+}
+
+func (g *genExpansion) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {
+	sw := generator.NewSnippetWriter(w, c, "$", "$")
+	for _, t := range g.types {
+		sw.Do(expansionInterfaceTemplate, t)
+	}
+	return sw.Error()
+}
+
+var expansionInterfaceTemplate = `
+type $.|public$Expansion interface {}
+`

--- a/cmd/libs/go2idl/client-gen/generators/generator-for-type.go
+++ b/cmd/libs/go2idl/client-gen/generators/generator-for-type.go
@@ -94,6 +94,7 @@ type $.type|public$Interface interface {
 	Get(name string) (*$.type|raw$, error)
 	List(opts $.apiListOptions|raw$) (*$.type|raw$List, error)
 	Watch(opts $.apiListOptions|raw$) ($.watchInterface|raw$, error)
+	$.type|public$Expansion
 }
 `
 

--- a/cmd/libs/go2idl/client-gen/testoutput/testgroup/unversioned/generated_expansion.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/testgroup/unversioned/generated_expansion.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned

--- a/cmd/libs/go2idl/client-gen/testoutput/testgroup/unversioned/testgroup_test.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/testgroup/unversioned/testgroup_test.go
@@ -214,3 +214,10 @@ func TestListTestTypesLabels(t *testing.T) {
 	receivedTestTypeList, err := c.TestTypes(ns).List(options)
 	c.simpleClient.Validate(t, receivedTestTypeList, err)
 }
+
+func TestExpansionInterface(t *testing.T) {
+	c := New(nil)
+	if e, a := "hello!", c.TestTypes("").Hello(); e != a {
+		t.Errorf("expansion failed")
+	}
+}

--- a/cmd/libs/go2idl/client-gen/testoutput/testgroup/unversioned/testtype.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/testgroup/unversioned/testtype.go
@@ -36,6 +36,7 @@ type TestTypeInterface interface {
 	Get(name string) (*testgroup.TestType, error)
 	List(opts api.ListOptions) (*testgroup.TestTypeList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	TestTypeExpansion
 }
 
 // testTypes implements TestTypeInterface

--- a/cmd/libs/go2idl/client-gen/testoutput/testgroup/unversioned/testtype_expansion.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/testgroup/unversioned/testtype_expansion.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+type TestTypeExpansion interface {
+	Hello() string
+}
+
+func (c *testTypes) Hello() string {
+	return "hello!"
+}

--- a/pkg/client/typed/generated/extensions/unversioned/daemonset.go
+++ b/pkg/client/typed/generated/extensions/unversioned/daemonset.go
@@ -36,6 +36,7 @@ type DaemonSetInterface interface {
 	Get(name string) (*extensions.DaemonSet, error)
 	List(opts api.ListOptions) (*extensions.DaemonSetList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	DaemonSetExpansion
 }
 
 // daemonSets implements DaemonSetInterface

--- a/pkg/client/typed/generated/extensions/unversioned/deployment.go
+++ b/pkg/client/typed/generated/extensions/unversioned/deployment.go
@@ -36,6 +36,7 @@ type DeploymentInterface interface {
 	Get(name string) (*extensions.Deployment, error)
 	List(opts api.ListOptions) (*extensions.DeploymentList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	DeploymentExpansion
 }
 
 // deployments implements DeploymentInterface

--- a/pkg/client/typed/generated/extensions/unversioned/generated_expansion.go
+++ b/pkg/client/typed/generated/extensions/unversioned/generated_expansion.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+type DaemonSetExpansion interface{}
+
+type DeploymentExpansion interface{}
+
+type HorizontalPodAutoscalerExpansion interface{}
+
+type IngressExpansion interface{}
+
+type JobExpansion interface{}
+
+type ThirdPartyResourceExpansion interface{}

--- a/pkg/client/typed/generated/extensions/unversioned/horizontalpodautoscaler.go
+++ b/pkg/client/typed/generated/extensions/unversioned/horizontalpodautoscaler.go
@@ -36,6 +36,7 @@ type HorizontalPodAutoscalerInterface interface {
 	Get(name string) (*extensions.HorizontalPodAutoscaler, error)
 	List(opts api.ListOptions) (*extensions.HorizontalPodAutoscalerList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	HorizontalPodAutoscalerExpansion
 }
 
 // horizontalPodAutoscalers implements HorizontalPodAutoscalerInterface

--- a/pkg/client/typed/generated/extensions/unversioned/ingress.go
+++ b/pkg/client/typed/generated/extensions/unversioned/ingress.go
@@ -36,6 +36,7 @@ type IngressInterface interface {
 	Get(name string) (*extensions.Ingress, error)
 	List(opts api.ListOptions) (*extensions.IngressList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	IngressExpansion
 }
 
 // ingresses implements IngressInterface

--- a/pkg/client/typed/generated/extensions/unversioned/job.go
+++ b/pkg/client/typed/generated/extensions/unversioned/job.go
@@ -36,6 +36,7 @@ type JobInterface interface {
 	Get(name string) (*extensions.Job, error)
 	List(opts api.ListOptions) (*extensions.JobList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	JobExpansion
 }
 
 // jobs implements JobInterface

--- a/pkg/client/typed/generated/extensions/unversioned/thirdpartyresource.go
+++ b/pkg/client/typed/generated/extensions/unversioned/thirdpartyresource.go
@@ -36,6 +36,7 @@ type ThirdPartyResourceInterface interface {
 	Get(name string) (*extensions.ThirdPartyResource, error)
 	List(opts api.ListOptions) (*extensions.ThirdPartyResourceList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	ThirdPartyResourceExpansion
 }
 
 // thirdPartyResources implements ThirdPartyResourceInterface

--- a/pkg/client/typed/generated/legacy/unversioned/componentstatus.go
+++ b/pkg/client/typed/generated/legacy/unversioned/componentstatus.go
@@ -35,6 +35,7 @@ type ComponentStatusInterface interface {
 	Get(name string) (*api.ComponentStatus, error)
 	List(opts api.ListOptions) (*api.ComponentStatusList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	ComponentStatusExpansion
 }
 
 // componentStatus implements ComponentStatusInterface

--- a/pkg/client/typed/generated/legacy/unversioned/endpoints.go
+++ b/pkg/client/typed/generated/legacy/unversioned/endpoints.go
@@ -35,6 +35,7 @@ type EndpointsInterface interface {
 	Get(name string) (*api.Endpoints, error)
 	List(opts api.ListOptions) (*api.EndpointsList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	EndpointsExpansion
 }
 
 // endpoints implements EndpointsInterface

--- a/pkg/client/typed/generated/legacy/unversioned/event.go
+++ b/pkg/client/typed/generated/legacy/unversioned/event.go
@@ -35,6 +35,7 @@ type EventInterface interface {
 	Get(name string) (*api.Event, error)
 	List(opts api.ListOptions) (*api.EventList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	EventExpansion
 }
 
 // events implements EventInterface

--- a/pkg/client/typed/generated/legacy/unversioned/generated_expansion.go
+++ b/pkg/client/typed/generated/legacy/unversioned/generated_expansion.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+type ComponentStatusExpansion interface{}
+
+type EndpointsExpansion interface{}
+
+type EventExpansion interface{}
+
+type LimitRangeExpansion interface{}
+
+type NamespaceExpansion interface{}
+
+type NodeExpansion interface{}
+
+type PersistentVolumeExpansion interface{}
+
+type PersistentVolumeClaimExpansion interface{}
+
+type PodExpansion interface{}
+
+type PodTemplateExpansion interface{}
+
+type ReplicationControllerExpansion interface{}
+
+type ResourceQuotaExpansion interface{}
+
+type SecretExpansion interface{}
+
+type ServiceExpansion interface{}
+
+type ServiceAccountExpansion interface{}

--- a/pkg/client/typed/generated/legacy/unversioned/limitrange.go
+++ b/pkg/client/typed/generated/legacy/unversioned/limitrange.go
@@ -35,6 +35,7 @@ type LimitRangeInterface interface {
 	Get(name string) (*api.LimitRange, error)
 	List(opts api.ListOptions) (*api.LimitRangeList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	LimitRangeExpansion
 }
 
 // limitRanges implements LimitRangeInterface

--- a/pkg/client/typed/generated/legacy/unversioned/namespace.go
+++ b/pkg/client/typed/generated/legacy/unversioned/namespace.go
@@ -35,6 +35,7 @@ type NamespaceInterface interface {
 	Get(name string) (*api.Namespace, error)
 	List(opts api.ListOptions) (*api.NamespaceList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	NamespaceExpansion
 }
 
 // namespaces implements NamespaceInterface

--- a/pkg/client/typed/generated/legacy/unversioned/node.go
+++ b/pkg/client/typed/generated/legacy/unversioned/node.go
@@ -35,6 +35,7 @@ type NodeInterface interface {
 	Get(name string) (*api.Node, error)
 	List(opts api.ListOptions) (*api.NodeList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	NodeExpansion
 }
 
 // nodes implements NodeInterface

--- a/pkg/client/typed/generated/legacy/unversioned/persistentvolume.go
+++ b/pkg/client/typed/generated/legacy/unversioned/persistentvolume.go
@@ -35,6 +35,7 @@ type PersistentVolumeInterface interface {
 	Get(name string) (*api.PersistentVolume, error)
 	List(opts api.ListOptions) (*api.PersistentVolumeList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	PersistentVolumeExpansion
 }
 
 // persistentVolumes implements PersistentVolumeInterface

--- a/pkg/client/typed/generated/legacy/unversioned/persistentvolumeclaim.go
+++ b/pkg/client/typed/generated/legacy/unversioned/persistentvolumeclaim.go
@@ -35,6 +35,7 @@ type PersistentVolumeClaimInterface interface {
 	Get(name string) (*api.PersistentVolumeClaim, error)
 	List(opts api.ListOptions) (*api.PersistentVolumeClaimList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	PersistentVolumeClaimExpansion
 }
 
 // persistentVolumeClaims implements PersistentVolumeClaimInterface

--- a/pkg/client/typed/generated/legacy/unversioned/pod.go
+++ b/pkg/client/typed/generated/legacy/unversioned/pod.go
@@ -35,6 +35,7 @@ type PodInterface interface {
 	Get(name string) (*api.Pod, error)
 	List(opts api.ListOptions) (*api.PodList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	PodExpansion
 }
 
 // pods implements PodInterface

--- a/pkg/client/typed/generated/legacy/unversioned/podtemplate.go
+++ b/pkg/client/typed/generated/legacy/unversioned/podtemplate.go
@@ -35,6 +35,7 @@ type PodTemplateInterface interface {
 	Get(name string) (*api.PodTemplate, error)
 	List(opts api.ListOptions) (*api.PodTemplateList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	PodTemplateExpansion
 }
 
 // podTemplates implements PodTemplateInterface

--- a/pkg/client/typed/generated/legacy/unversioned/replicationcontroller.go
+++ b/pkg/client/typed/generated/legacy/unversioned/replicationcontroller.go
@@ -35,6 +35,7 @@ type ReplicationControllerInterface interface {
 	Get(name string) (*api.ReplicationController, error)
 	List(opts api.ListOptions) (*api.ReplicationControllerList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	ReplicationControllerExpansion
 }
 
 // replicationControllers implements ReplicationControllerInterface

--- a/pkg/client/typed/generated/legacy/unversioned/resourcequota.go
+++ b/pkg/client/typed/generated/legacy/unversioned/resourcequota.go
@@ -35,6 +35,7 @@ type ResourceQuotaInterface interface {
 	Get(name string) (*api.ResourceQuota, error)
 	List(opts api.ListOptions) (*api.ResourceQuotaList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	ResourceQuotaExpansion
 }
 
 // resourceQuotas implements ResourceQuotaInterface

--- a/pkg/client/typed/generated/legacy/unversioned/secret.go
+++ b/pkg/client/typed/generated/legacy/unversioned/secret.go
@@ -35,6 +35,7 @@ type SecretInterface interface {
 	Get(name string) (*api.Secret, error)
 	List(opts api.ListOptions) (*api.SecretList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	SecretExpansion
 }
 
 // secrets implements SecretInterface

--- a/pkg/client/typed/generated/legacy/unversioned/service.go
+++ b/pkg/client/typed/generated/legacy/unversioned/service.go
@@ -35,6 +35,7 @@ type ServiceInterface interface {
 	Get(name string) (*api.Service, error)
 	List(opts api.ListOptions) (*api.ServiceList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	ServiceExpansion
 }
 
 // services implements ServiceInterface

--- a/pkg/client/typed/generated/legacy/unversioned/serviceaccount.go
+++ b/pkg/client/typed/generated/legacy/unversioned/serviceaccount.go
@@ -35,6 +35,7 @@ type ServiceAccountInterface interface {
 	Get(name string) (*api.ServiceAccount, error)
 	List(opts api.ListOptions) (*api.ServiceAccountList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	ServiceAccountExpansion
 }
 
 // serviceAccounts implements ServiceAccountInterface


### PR DESCRIPTION
Client-gen adds an expansion interface to each typed clients' interface, so user can later expand the interface and add handwritten methods (e.g. [c.Pods().GetLogs()](https://github.com/kubernetes/kubernetes/blob/master/pkg/client/unversioned/pods.go#L112)).

To make the code compile, the added expansion interfaces need to be declared. Client-gen will generate `generated_expansion.go` which includes the declarations of all the expansion interfaces, if the file doesn't exist already.
