### PR TITLE
Treat pod NotFound errors as permanent

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -525,6 +525,10 @@ func waitForPodCondition(c *client.Client, ns, podName, desc string, timeout tim
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(poll) {
 		pod, err := c.Pods(ns).Get(podName)
 		if err != nil {
+			if apierrs.IsNotFound(err) {
+				Logf("Pod %q in namespace %q disappeared. Error: %v", podName, ns, err)
+				return err
+			}
 			// Aligning this text makes it much more readable
 			Logf("Get pod %[1]s in namespace '%[2]s' failed, ignoring for %[3]v. Error: %[4]v",
 				podName, ns, poll, err)


### PR DESCRIPTION
When waiting for a pod to become running, a NotFound error should be
treated a permanent, and report the NotFound error rather than a timeout
error.

Relates to: https://github.com/kubernetes/kubernetes/issues/17931, https://github.com/kubernetes/kubernetes/issues/19387
