### PR TITLE
Update get-kube.sh to not re-download the kubernetes archive

### DIFF
--- a/cluster/get-kube.sh
+++ b/cluster/get-kube.sh
@@ -120,9 +120,9 @@ if [[ -n "${KUBERNETES_SKIP_CONFIRM-}" ]]; then
 fi
 
 if [[ $(which wget) ]]; then
-  wget -O ${file} ${release_url}
+  wget -N ${release_url}
 elif [[ $(which curl) ]]; then
-  curl -L -o ${file} ${release_url}
+  curl -L -z ${file} ${release_url} -o ${file}
 else
   echo "Couldn't find curl or wget.  Bailing out."
   exit 1
@@ -130,6 +130,5 @@ fi
 
 echo "Unpacking kubernetes release ${release}"
 tar -xzf ${file}
-rm ${file}
 
 create_cluster


### PR DESCRIPTION
Currently, get-kube.sh unconditionally downloads 'kubernetes.tar.gz'. It would be a nice optimization to skip re-downloading the file if it already exists locally with the same version/timestamp.

Issue number: 15197
Fixes https://github.com/kubernetes/kubernetes/issues/15197
