### PR TITLE
AWS: don't rely on salt for kube-node-unpacker on AWS

### DIFF
--- a/cluster/saltbase/salt/kube-node-unpacker/init.sls
+++ b/cluster/saltbase/salt/kube-node-unpacker/init.sls
@@ -25,7 +25,8 @@ kube-proxy-tar:
 # Super annoying, the salt version on GCE is old enough that 'salt.cmd.run'
 # isn't supported
 {% if grains.cloud is defined and grains.cloud == 'aws' %}
-   {% set is_helium = salt.cmd.run('salt --version | grep -c Helium') %}
+   # Salt has terrible problems with systemd on AWS too
+   {% set is_helium = '0' %}
 {% endif %}
 # Salt Helium doesn't support systemd modules for service running
 {% if pillar.get('is_systemd') and is_helium == '0' %}


### PR DESCRIPTION
We've had a lot of salt problems with systemd on AWS; we have a
workaround in place that we use everywhere else, we should use that for
kube-node-unpacker too.

Fixes #19386
Issue #19388
