### PR TITLE
Automated cherry pick of #19350 upstream release 1.1

### DIFF
--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -284,6 +284,10 @@ func (eic execInContainer) CombinedOutput() ([]byte, error) {
 	return eic.run()
 }
 
+func (eic execInContainer) Output() ([]byte, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+
 func (eic execInContainer) SetDir(dir string) {
 	//unimplemented
 }

--- a/pkg/probe/exec/exec_test.go
+++ b/pkg/probe/exec/exec_test.go
@@ -24,12 +24,17 @@ import (
 )
 
 type FakeCmd struct {
-	out []byte
-	err error
+	out    []byte
+	stdout []byte
+	err    error
 }
 
 func (f *FakeCmd) CombinedOutput() ([]byte, error) {
 	return f.out, f.err
+}
+
+func (f *FakeCmd) Output() ([]byte, error) {
+	return f.stdout, f.err
 }
 
 func (f *FakeCmd) SetDir(dir string) {}

--- a/pkg/util/exec/exec.go
+++ b/pkg/util/exec/exec.go
@@ -39,6 +39,8 @@ type Cmd interface {
 	// CombinedOutput runs the command and returns its combined standard output
 	// and standard error.  This follows the pattern of package os/exec.
 	CombinedOutput() ([]byte, error)
+	// Output runs the command and returns standard output, but not standard err
+	Output() ([]byte, error)
 	SetDir(dir string)
 }
 
@@ -81,15 +83,31 @@ func (cmd *cmdWrapper) SetDir(dir string) {
 func (cmd *cmdWrapper) CombinedOutput() ([]byte, error) {
 	out, err := (*osexec.Cmd)(cmd).CombinedOutput()
 	if err != nil {
-		ee, ok := err.(*osexec.ExitError)
-		if !ok {
-			return out, err
-		}
-		// Force a compile fail if exitErrorWrapper can't convert to ExitError.
-		var x ExitError = &exitErrorWrapper{ee}
-		return out, x
+		return out, handleError(err)
 	}
 	return out, nil
+}
+
+func (cmd *cmdWrapper) Output() ([]byte, error) {
+	out, err := (*osexec.Cmd)(cmd).Output()
+	if err != nil {
+		return out, handleError(err)
+	}
+	return out, nil
+}
+
+func handleError(err error) error {
+	if ee, ok := err.(*osexec.ExitError); ok {
+		// Force a compile fail if exitErrorWrapper can't convert to ExitError.
+		var x ExitError = &exitErrorWrapper{ee}
+		return x
+	}
+	if ee, ok := err.(*osexec.Error); ok {
+		if ee.Err == osexec.ErrNotFound {
+			return ErrExecutableNotFound
+		}
+	}
+	return err
 }
 
 // exitErrorWrapper is an implementation of ExitError in terms of os/exec ExitError.

--- a/pkg/util/exec/fake_exec.go
+++ b/pkg/util/exec/fake_exec.go
@@ -75,6 +75,10 @@ func (fake *FakeCmd) CombinedOutput() ([]byte, error) {
 	return fake.CombinedOutputScript[i]()
 }
 
+func (fake *FakeCmd) Output() ([]byte, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+
 // A simple fake ExitError type.
 type FakeExitError struct {
 	Status int

--- a/test/e2e/ingress.go
+++ b/test/e2e/ingress.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/util"
+	utilexec "k8s.io/kubernetes/pkg/util/exec"
 	"k8s.io/kubernetes/pkg/util/wait"
 
 	. "github.com/onsi/ginkgo"
@@ -187,15 +188,21 @@ func createApp(c *client.Client, ns string, i int) {
 
 // gcloudUnmarshal unmarshals json output of gcloud into given out interface.
 func gcloudUnmarshal(resource, regex string, out interface{}) {
-	args := []string{
+	// gcloud prints a message to stderr if it has an available update
+	// so we only look at stdout.
+	command := []string{
 		"compute", resource, "list",
 		fmt.Sprintf("--regex=%v", regex),
 		fmt.Sprintf("--project=%v", testContext.CloudConfig.ProjectID),
 		"-q", "--format=json",
 	}
-	output, err := exec.Command("gcloud", args...).CombinedOutput()
+	output, err := exec.Command("gcloud", command...).Output()
 	if err != nil {
-		Failf("Error unmarshalling gcloud output: %v", err)
+		errCode := -1
+		if exitErr, ok := err.(utilexec.ExitError); ok {
+			errCode = exitErr.ExitStatus()
+		}
+		Logf("Error running gcloud command 'gcloud %s': err: %v, output: %v, status: %d", strings.Join(command, " "), err, string(output), errCode)
 	}
 	if err := json.Unmarshal([]byte(output), out); err != nil {
 		Failf("Error unmarshalling gcloud output for %v: %v, output: %v, command: gcloud %s", resource, err, string(output), strings.Join(args, " "))


### PR DESCRIPTION
Improve error reporting a little in ingress e2e. Also add Output() to the util/exec Cmd interface.

Fixes #19394.

This cherry pick was _not_ clean; please review with skepticism.
