### PR TITLE
Label [Skipped] tests apprpriately

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -265,19 +265,13 @@ fi
 # When 1.2.0-beta.0 comes out, e.g., this will become "ci/latest-1.2"
 CURRENT_RELEASE_PUBLISHED_VERSION="ci/latest-1.1"
 
-# Specialized to skip when running reboot tests.
-REBOOT_SKIP_TESTS=(
-    "Restart\sshould\srestart\sall\snodes"
-    "\[Example\]"
-    )
-
 # Specialized tests which should be skipped by default for projects.
 GCE_DEFAULT_SKIP_TESTS=(
-    "${REBOOT_SKIP_TESTS[@]}"
+    "\[Example\]" # previously in REBOOT_SKIP_TESTS..., dates back before version control (#10078)
     "\[Skipped\]"
-    "Reboot"
-    "ServiceLoadBalancer"
     )
+
+# PROVIDER SKIPS --------------------------------------
 
 # Tests which cannot be run on GKE, e.g. because they require
 # master ssh access.
@@ -307,6 +301,7 @@ AWS_REQUIRED_SKIP_TESTS=(
     "GCE\sL7\sLoadBalancer\sController" # GCE L7 loadbalancing
 )
 
+# END PROVIDER SKIPS --------------------------------------
 
 # Tests which kills or restarts components and/or nodes.
 DISRUPTIVE_TESTS=(
@@ -326,10 +321,6 @@ GCE_FLAKY_TESTS=(
 # comments below, and for poorly implemented tests, please quote the
 # issue number tracking speed improvements.
 GCE_SLOW_TESTS=(
-    # Before enabling this loadbalancer test in any other test list you must
-    # make sure the associated project has enough quota. At the time of this
-    # writing a GCE project is allowed 3 backend services by default. This
-    # test requires at least 5.
     "\[Slow\]"
     )
 
@@ -340,21 +331,6 @@ GCE_PARALLEL_SKIP_TESTS=(
     "\[Serial\]"
     "\[Disruptive\]"
 )
-
-# Tests that should not run on soak cluster.
-GCE_SOAK_CONTINUOUS_SKIP_TESTS=(
-    "GCE\sL7\sLoadBalancer\sController" # issue: #17119
-    "Density.*30\spods"
-    "Elasticsearch"
-    "external\sload\sbalancer"
-    "identically\snamed\sservices"
-    "network\spartition"
-    "Services.*Type\sgoes\sfrom"
-    "${DISRUPTIVE_TESTS[@]}"       # avoid component restarts.
-    )
-
-GCE_RELEASE_SKIP_TESTS=(
-    )
 
 # Define environment variables based on the Jenkins project name.
 # NOTE: Not all jobs are defined here. The hack/jenkins/e2e.sh in master and
@@ -616,10 +592,13 @@ case ${JOB_NAME} in
     : ${E2E_UP:="false"}
     # Clear out any orphaned namespaces in case previous run was interrupted.
     : ${E2E_CLEAN_START:="true"}
+    # We should be testing the reliability of a long-running cluster. The
+    # DISRUPTIVE_TESTS kill/restart components or nodes in the cluster,
+    # defeating the purpose of a soak cluster. (#15722)
     : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
           ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
           ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-          ${GCE_SOAK_CONTINUOUS_SKIP_TESTS[@]:+${GCE_SOAK_CONTINUOUS_SKIP_TESTS[@]}} \
+          ${DISRUPTIVE_TESTS[@]:+${DISRUPTIVE_TESTS[@]}} \
           )"}
     : ${KUBE_GCE_INSTANCE_PREFIX:="gce-soak-weekly"}
     : ${PROJECT:="kubernetes-jenkins"}
@@ -647,7 +626,6 @@ case ${JOB_NAME} in
     : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
           "\[Skipped\]" \
           ${GKE_DEFAULT_SKIP_TESTS[@]:+${GKE_DEFAULT_SKIP_TESTS[@]}} \
-          ${REBOOT_SKIP_TESTS[@]:+${REBOOT_SKIP_TESTS[@]}} \
           ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
           ${GCE_SLOW_TESTS[@]:+${GCE_SLOW_TESTS[@]}} \
           )"}
@@ -690,11 +668,14 @@ case ${JOB_NAME} in
     : ${E2E_CLEAN_START:="true"}
     : ${PROJECT:="kubernetes-jenkins"}
     : ${E2E_OPT:="--check_version_skew=false"}
+    # We should be testing the reliability of a long-running cluster. The
+    # DISRUPTIVE_TESTS kill/restart components or nodes in the cluster,
+    # defeating the purpose of a soak cluster. (#15722)
     : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
           ${GKE_REQUIRED_SKIP_TESTS[@]:+${GKE_REQUIRED_SKIP_TESTS[@]}} \
           ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
           ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-          ${GCE_SOAK_CONTINUOUS_SKIP_TESTS[@]:+${GCE_SOAK_CONTINUOUS_SKIP_TESTS[@]}} \
+          ${DISRUPTIVE_TESTS[@]:+${DISRUPTIVE_TESTS[@]}} \
           )"}
     ;;
 

--- a/test/e2e/ingress.go
+++ b/test/e2e/ingress.go
@@ -390,6 +390,11 @@ func (cont *IngressController) Cleanup(del bool) error {
 	return fmt.Errorf(errMsg)
 }
 
+// Before enabling this loadbalancer test in any other test list you must
+// make sure the associated project has enough quota. At the time of this
+// writing a GCE project is allowed 3 backend services by default. This
+// test requires at least 5.
+//
 // Slow by design (10 min)
 // Flaky issue #17518
 var _ = Describe("GCE L7 LoadBalancer Controller [Serial] [Slow] [Flaky]", func() {

--- a/test/e2e/restart.go
+++ b/test/e2e/restart.go
@@ -48,7 +48,9 @@ const (
 	restartPodReadyAgainTimeout = 5 * time.Minute
 )
 
-var _ = Describe("Restart", func() {
+// TODO(ihmccreery): This is skipped because it was previously in
+// REBOOT_SKIP_TESTS, dates back before version control (#10078)
+var _ = Describe("Restart [Skipped]", func() {
 	var c *client.Client
 	var ps *podStore
 	var skipped bool

--- a/test/e2e/serviceloadbalancers.go
+++ b/test/e2e/serviceloadbalancers.go
@@ -203,7 +203,9 @@ func (s *ingManager) test(path string) error {
 	})
 }
 
-var _ = Describe("ServiceLoadBalancer", func() {
+// TODO(ihmccreery) Skipped originally in #14988, never sent follow-up PR, as
+// far as I can tell.
+var _ = Describe("ServiceLoadBalancer [Skipped]", func() {
 	// These variables are initialized after framework's beforeEach.
 	var ns string
 	var repoRoot string


### PR DESCRIPTION
Collapse REBOOT_SKIP_TESTS into GCE_DEFAULT_SKIP_TESTS, and remove GCE_SOAK_CONTINUOUS_SKIP_TESTS as redundant.

Redo of #19297.

@k8s-oncall This will break the soak test because the skip list that's currently running is tightly coupled to  the names of the tests.  This PR begins to help clarify that by enforcing a proper interface rather than an ad-hoc skip list, but we can't get around breaking the soak tests in a way that's at all reasonable.
