### PR TITLE
api server library: Extracting out code to run a http server

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -35,90 +35,67 @@ import (
 	"github.com/spf13/pflag"
 )
 
-const (
-	// Maximum duration before timing out read/write requests
-	// Set to a value larger than the timeouts in each watch server.
-	ReadWriteTimeout = time.Minute * 60
-	// TODO: This can be tightened up. It still matches objects named watch or proxy.
-	defaultLongRunningRequestRE = "(/|^)((watch|proxy)(/|$)|(logs?|portforward|exec|attach)/?$)"
-)
-
 // APIServer runs a kubernetes api server.
 type APIServer struct {
-	InsecureBindAddress        net.IP
-	InsecurePort               int
-	BindAddress                net.IP
-	AdvertiseAddress           net.IP
-	SecurePort                 int
-	ExternalHost               string
-	TLSCertFile                string
-	TLSPrivateKeyFile          string
-	CertDirectory              string
-	APIPrefix                  string
+	*genericapiserver.ServerRunOptions
 	APIGroupPrefix             string
-	DeprecatedStorageVersion   string
-	StorageVersions            string
-	CloudProvider              string
-	CloudConfigFile            string
-	EventTTL                   time.Duration
-	BasicAuthFile              string
-	ClientCAFile               string
-	TokenAuthFile              string
-	OIDCIssuerURL              string
-	OIDCClientID               string
-	OIDCCAFile                 string
-	OIDCUsernameClaim          string
-	ServiceAccountKeyFile      string
-	ServiceAccountLookup       bool
-	KeystoneURL                string
-	AuthorizationMode          string
-	AuthorizationPolicyFile    string
+	APIPrefix                  string
 	AdmissionControl           string
 	AdmissionControlConfigFile string
-	EtcdServerList             []string
-	EtcdServersOverrides       []string
-	EtcdPathPrefix             string
-	CorsAllowedOriginList      []string
+	AdvertiseAddress           net.IP
 	AllowPrivileged            bool
-	ServiceClusterIPRange      net.IPNet // TODO: make this a list
-	ServiceNodePortRange       util.PortRange
+	AuthorizationMode          string
+	AuthorizationPolicyFile    string
+	BasicAuthFile              string
+	CloudConfigFile            string
+	CloudProvider              string
+	CorsAllowedOriginList      []string
+	DeprecatedStorageVersion   string
 	EnableLogsSupport          bool
-	MasterServiceNamespace     string
-	MasterCount                int
-	RuntimeConfig              util.ConfigurationMap
-	KubeletConfig              kubeletclient.KubeletClientConfig
 	EnableProfiling            bool
 	EnableWatchCache           bool
-	MaxRequestsInFlight        int
-	MinRequestTimeout          int
-	LongRunningRequestRE       string
-	SSHUser                    string
-	SSHKeyfile                 string
-	MaxConnectionBytesPerSec   int64
+	EtcdPathPrefix             string
+	EtcdServerList             []string
+	EtcdServersOverrides       []string
+	EventTTL                   time.Duration
+	ExternalHost               string
+	KeystoneURL                string
+	KubeletConfig              kubeletclient.KubeletClientConfig
 	KubernetesServiceNodePort  int
+	MasterCount                int
+	MasterServiceNamespace     string
+	MaxConnectionBytesPerSec   int64
+	MinRequestTimeout          int
+	OIDCCAFile                 string
+	OIDCClientID               string
+	OIDCIssuerURL              string
+	OIDCUsernameClaim          string
+	RuntimeConfig              util.ConfigurationMap
+	SSHKeyfile                 string
+	SSHUser                    string
+	ServiceAccountKeyFile      string
+	ServiceAccountLookup       bool
+	ServiceClusterIPRange      net.IPNet // TODO: make this a list
+	ServiceNodePortRange       util.PortRange
+	StorageVersions            string
+	TokenAuthFile              string
 }
 
 // NewAPIServer creates a new APIServer object with default parameters
 func NewAPIServer() *APIServer {
 	s := APIServer{
-		InsecurePort:           8080,
-		InsecureBindAddress:    net.ParseIP("127.0.0.1"),
-		BindAddress:            net.ParseIP("0.0.0.0"),
-		SecurePort:             6443,
-		APIPrefix:              "/api",
+		ServerRunOptions:       genericapiserver.NewServerRunOptions(),
 		APIGroupPrefix:         "/apis",
-		EventTTL:               1 * time.Hour,
-		AuthorizationMode:      "AlwaysAllow",
+		APIPrefix:              "/api",
 		AdmissionControl:       "AlwaysAdmit",
-		EtcdPathPrefix:         genericapiserver.DefaultEtcdPathPrefix,
+		AuthorizationMode:      "AlwaysAllow",
 		EnableLogsSupport:      true,
-		MasterServiceNamespace: api.NamespaceDefault,
+		EtcdPathPrefix:         genericapiserver.DefaultEtcdPathPrefix,
+		EventTTL:               1 * time.Hour,
 		MasterCount:            1,
-		CertDirectory:          "/var/run/kubernetes",
+		MasterServiceNamespace: api.NamespaceDefault,
+		RuntimeConfig:          make(util.ConfigurationMap),
 		StorageVersions:        latest.AllPreferredGroupVersions(),
-		LongRunningRequestRE:   defaultLongRunningRequestRE,
-
-		RuntimeConfig: make(util.ConfigurationMap),
 		KubeletConfig: kubeletclient.KubeletClientConfig{
 			Port:        ports.KubeletPort,
 			EnableHttps: true,

--- a/pkg/genericapiserver/server_run_options.go
+++ b/pkg/genericapiserver/server_run_options.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genericapiserver
+
+import (
+	"net"
+)
+
+const (
+	// TODO: This can be tightened up. It still matches objects named watch or proxy.
+	defaultLongRunningRequestRE = "(/|^)((watch|proxy)(/|$)|(logs?|portforward|exec|attach)/?$)"
+)
+
+// ServerRunOptions contains the options while running a generic api server.
+type ServerRunOptions struct {
+	BindAddress          net.IP
+	CertDirectory        string
+	ClientCAFile         string
+	InsecureBindAddress  net.IP
+	InsecurePort         int
+	LongRunningRequestRE string
+	MaxRequestsInFlight  int
+	SecurePort           int
+	TLSCertFile          string
+	TLSPrivateKeyFile    string
+}
+
+func NewServerRunOptions() *ServerRunOptions {
+	return &ServerRunOptions{
+		BindAddress:          net.ParseIP("0.0.0.0"),
+		CertDirectory:        "/var/run/kubernetes",
+		InsecureBindAddress:  net.ParseIP("127.0.0.1"),
+		InsecurePort:         8080,
+		LongRunningRequestRE: defaultLongRunningRequestRE,
+		SecurePort:           6443,
+	}
+}


### PR DESCRIPTION
Follow up to https://github.com/kubernetes/kubernetes/pull/19040

Extracting out the code to run an api server and moving it to genericapiserver.

With this change, I can run the following code to start an API server:

```
import (
    "github.com/nikhiljindal/kubernetes/pkg/genericapiserver"
)

func main() {
    config := genericapiserver.Config{
        EnableIndex: true,
    }
    s := genericapiserver.New(&config)
    s.Run(genericapiserver.NewServerRunOptions())
}
```

cc @krousey @smarterclayton @lavalamp @kubernetes/sig-api-machinery @kubernetes/goog-csi 
