### PR TITLE
ignore STDOUT of cd command when setting POOL_PATH in cluster/libvirt…

### DIFF
--- a/cluster/libvirt-coreos/util.sh
+++ b/cluster/libvirt-coreos/util.sh
@@ -25,7 +25,7 @@ export LIBVIRT_DEFAULT_URI=qemu:///system
 export SERVICE_ACCOUNT_LOOKUP=${SERVICE_ACCOUNT_LOOKUP:-false}
 export ADMISSION_CONTROL=${ADMISSION_CONTROL:-NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota}
 readonly POOL=kubernetes
-readonly POOL_PATH="$(cd $ROOT && pwd)/libvirt_storage_pool"
+readonly POOL_PATH="$(cd $ROOT > /dev/null && pwd)/libvirt_storage_pool"
 
 # join <delim> <list...>
 # Concatenates the list elements with the delimiter passed as first parameter


### PR DESCRIPTION
This is a real corner case but gave me 20 minutes of hassle :-) if you happen to have the Bash environmental variable CDPATH set to certain values, POOL_PATH in cluster/libvirt-coreos/util.sh will get set wrong since the cd command will print the directory name. Redirecting STDOUT of the cd command fixes this. For example adding one line of debugging after POOL_PATH is set:

+echo POOL_PATH="|$POOL_PATH|"
+exit 0

$ export CDPATH=.

kmcounts@jabba:~/dev/countdigi/kubernetes
$ KUBERNETES_PROVIDER=libvirt-coreos cluster/kube-up.sh 

POOL_PATH=|/home/kmcounts/dev/countdigi/kubernetes/cluster/libvirt-coreos
/home/kmcounts/dev/countdigi/kubernetes/cluster/libvirt-coreos/libvirt_storage_pool|
