### PR TITLE
unset CDPATH before command substitutions using cd command

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -667,7 +667,7 @@ function kube::release::package_tarballs() {
 function kube::release::package_client_tarballs() {
    # Find all of the built client binaries
   local platform platforms
-  platforms=($(cd "${LOCAL_OUTPUT_BINPATH}" ; echo */*))
+  platforms=($(CDPATH="" cd "${LOCAL_OUTPUT_BINPATH}" ; echo */*))
   for platform in "${platforms[@]}"; do
     local platform_tag=${platform/\//-} # Replace a "/" for a "-"
     kube::log::status "Starting tarball: client $platform_tag"
@@ -852,7 +852,7 @@ function kube::release::package_salt_tarball() {
   # them into kube-addons, where we expect them. (This pipeline is a
   # fancy copy, stripping anything but the files we don't want.)
   local objects
-  objects=$(cd "${KUBE_ROOT}/cluster/addons" && find . \( -name \*.yaml -or -name \*.yaml.in -or -name \*.json \) | grep -v demo)
+  objects=$(CDPATH="" cd "${KUBE_ROOT}/cluster/addons" && find . \( -name \*.yaml -or -name \*.yaml.in -or -name \*.json \) | grep -v demo)
   tar c -C "${KUBE_ROOT}/cluster/addons" ${objects} | tar x -C "${release_stage}/saltbase/salt/kube-addons"
 
   kube::release::clean_cruft
@@ -1084,7 +1084,7 @@ function kube::release::gcs::copy_release_artifacts() {
   # Upload the "naked" binaries to GCS.  This is useful for install scripts that
   # download the binaries directly and don't need tars.
   local platform platforms
-  platforms=($(cd "${RELEASE_STAGE}/client" ; echo *))
+  platforms=($(CDPATH="" cd "${RELEASE_STAGE}/client" ; echo *))
   for platform in "${platforms[@]}"; do
     local src="${RELEASE_STAGE}/client/${platform}/kubernetes/client/bin/*"
     local dst="bin/${platform/-//}/"

--- a/cluster/centos/build.sh
+++ b/cluster/centos/build.sh
@@ -29,10 +29,10 @@ source ${ROOT}/config-build.sh
 
 # ensure $RELEASES_DIR is an absolute file path
 mkdir -p ${RELEASES_DIR}
-RELEASES_DIR=$(cd ${RELEASES_DIR}; pwd)
+RELEASES_DIR=$(CDPATH="" cd ${RELEASES_DIR}; pwd)
 
 # get absolute file path of binaries
-BINARY_DIR=$(cd ${ROOT}; pwd)/binaries
+BINARY_DIR=$(CDPATH="" cd ${ROOT}; pwd)/binaries
 
 function clean-up() {
   rm -rf ${RELEASES_DIR}

--- a/cluster/kubectl.sh
+++ b/cluster/kubectl.sh
@@ -37,7 +37,7 @@ source "${KUBE_ROOT}/cluster/kube-util.sh"
 # Get the absolute path of the directory component of a file, i.e. the
 # absolute path of the dirname of $1.
 get_absolute_dirname() {
-  echo "$(cd "$(dirname "$1")" && pwd)"
+  echo "$(CDPATH="" cd "$(dirname "$1")" && pwd)"
 }
 
 # Detect the OS name/arch so that we can find our binary

--- a/cluster/libvirt-coreos/util.sh
+++ b/cluster/libvirt-coreos/util.sh
@@ -25,7 +25,7 @@ export LIBVIRT_DEFAULT_URI=qemu:///system
 export SERVICE_ACCOUNT_LOOKUP=${SERVICE_ACCOUNT_LOOKUP:-false}
 export ADMISSION_CONTROL=${ADMISSION_CONTROL:-NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota}
 readonly POOL=kubernetes
-readonly POOL_PATH="$(cd $ROOT && pwd)/libvirt_storage_pool"
+readonly POOL_PATH="$(CDPATH="" cd $ROOT && pwd)/libvirt_storage_pool"
 
 # join <delim> <list...>
 # Concatenates the list elements with the delimiter passed as first parameter

--- a/cluster/mesos/docker/common/bin/await-health-check
+++ b/cluster/mesos/docker/common/bin/await-health-check
@@ -33,7 +33,7 @@ fi
 address=${1:-}
 [ -z "${address}" ] && echo "No address supplied" && exit 1
 
-bin=$(cd "$(dirname ${BASH_SOURCE})" && pwd -P)
+bin=$(CDPATH="" cd "$(dirname ${BASH_SOURCE})" && pwd -P)
 
 echo "Waiting (up to ${duration}s) for ${address} to be healthy"
 if ! timeout "${duration}" bash -c "while ! ${bin}/health-check ${address}; do sleep 0.5; done"; then

--- a/cluster/mesos/docker/common/bin/util-ssl.sh
+++ b/cluster/mesos/docker/common/bin/util-ssl.sh
@@ -21,7 +21,7 @@ set -o nounset
 set -o pipefail
 set -o errtrace
 
-bin="$(cd "$(dirname "${BASH_SOURCE}")" && pwd -P)"
+bin="$(CDPATH="" cd "$(dirname "${BASH_SOURCE}")" && pwd -P)"
 source "${bin}/util-temp-dir.sh"
 
 function cluster::mesos::docker::find_openssl_config {

--- a/cluster/mesos/docker/deploy-addons.sh
+++ b/cluster/mesos/docker/deploy-addons.sh
@@ -25,7 +25,7 @@ set -o nounset
 set -o pipefail
 set -o errtrace
 
-KUBE_ROOT=$(cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
+KUBE_ROOT=$(CDPATH="" cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
 source "${KUBE_ROOT}/cluster/${KUBERNETES_PROVIDER}/${KUBE_CONFIG_FILE-"config-default.sh"}"
 source "${KUBE_ROOT}/cluster/${KUBERNETES_PROVIDER}/common/bin/util-temp-dir.sh"
 kubectl="${KUBE_ROOT}/cluster/kubectl.sh"

--- a/cluster/mesos/docker/keygen/build.sh
+++ b/cluster/mesos/docker/keygen/build.sh
@@ -23,9 +23,9 @@ set -o pipefail
 IMAGE_REPO=${IMAGE_REPO:-mesosphere/kubernetes-mesos-keygen}
 IMAGE_TAG=${IMAGE_TAG:-latest}
 
-script_dir=$(cd $(dirname "${BASH_SOURCE}") && pwd -P)
-common_bin_path=$(cd ${script_dir}/../common/bin && pwd -P)
-KUBE_ROOT=$(cd ${script_dir}/../../../.. && pwd -P)
+script_dir=$(CDPATH="" cd $(dirname "${BASH_SOURCE}") && pwd -P)
+common_bin_path=$(CDPATH="" cd ${script_dir}/../common/bin && pwd -P)
+KUBE_ROOT=$(CDPATH="" cd ${script_dir}/../../../.. && pwd -P)
 
 source "${common_bin_path}/util-temp-dir.sh"
 

--- a/cluster/mesos/docker/km/build.sh
+++ b/cluster/mesos/docker/km/build.sh
@@ -23,8 +23,8 @@ set -o pipefail
 IMAGE_REPO=${IMAGE_REPO:-mesosphere/kubernetes-mesos}
 IMAGE_TAG=${IMAGE_TAG:-latest}
 
-script_dir=$(cd $(dirname "${BASH_SOURCE}") && pwd -P)
-KUBE_ROOT=$(cd ${script_dir}/../../../.. && pwd -P)
+script_dir=$(CDPATH="" cd $(dirname "${BASH_SOURCE}") && pwd -P)
+KUBE_ROOT=$(CDPATH="" cd ${script_dir}/../../../.. && pwd -P)
 
 # Find a platform specific binary, whether it was cross compiled, locally built, or downloaded.
 find-binary() {
@@ -48,7 +48,7 @@ if [ -z "$km_path" ]; then
   fi
 fi
 kube_bin_path=$(dirname ${km_path})
-common_bin_path=$(cd ${script_dir}/../common/bin && pwd -P)
+common_bin_path=$(CDPATH="" cd ${script_dir}/../common/bin && pwd -P)
 
 # download nsenter and socat
 overlay_dir=${MESOS_DOCKER_OVERLAY_DIR:-${script_dir}/overlay}

--- a/cluster/mesos/docker/socat/build.sh
+++ b/cluster/mesos/docker/socat/build.sh
@@ -18,7 +18,7 @@
 
 set -o errexit
 set -o nounset
-set -o pipefailscript_dir=$(cd $(dirname "${BASH_SOURCE}") && pwd -P)
+set -o pipefailscript_dir=$(CDPATH="" cd $(dirname "${BASH_SOURCE}") && pwd -P)
 
 cd "${script_dir}"
 

--- a/cluster/mesos/docker/test/build.sh
+++ b/cluster/mesos/docker/test/build.sh
@@ -21,9 +21,9 @@ set -o pipefail
 IMAGE_REPO=${IMAGE_REPO:-mesosphere/kubernetes-mesos-test}
 IMAGE_TAG=${IMAGE_TAG:-latest}
 
-script_dir=$(cd $(dirname "${BASH_SOURCE}") && pwd -P)
-common_bin_path=$(cd ${script_dir}/../common/bin && pwd -P)
-KUBE_ROOT=$(cd ${script_dir}/../../../.. && pwd -P)
+script_dir=$(CDPATH="" cd $(dirname "${BASH_SOURCE}") && pwd -P)
+common_bin_path=$(CDPATH="" cd ${script_dir}/../common/bin && pwd -P)
+KUBE_ROOT=$(CDPATH="" cd ${script_dir}/../../../.. && pwd -P)
 
 cd "${KUBE_ROOT}"
 

--- a/cluster/mesos/docker/util.sh
+++ b/cluster/mesos/docker/util.sh
@@ -25,7 +25,7 @@ set -o nounset
 set -o pipefail
 set -o errtrace
 
-KUBE_ROOT=$(cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
+KUBE_ROOT=$(CDPATH="" cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
 provider_root="${KUBE_ROOT}/cluster/${KUBERNETES_PROVIDER}"
 
 source "${provider_root}/${KUBE_CONFIG_FILE-"config-default.sh"}"

--- a/contrib/mesos/ci/build-release.sh
+++ b/contrib/mesos/ci/build-release.sh
@@ -27,7 +27,7 @@ set -o nounset
 set -o pipefail
 set -o errtrace
 
-KUBE_ROOT=$(cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
+KUBE_ROOT=$(CDPATH="" cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
 
 "${KUBE_ROOT}/contrib/mesos/ci/run.sh" make clean
 

--- a/contrib/mesos/ci/build.sh
+++ b/contrib/mesos/ci/build.sh
@@ -29,7 +29,7 @@ set -o errtrace
 
 TEST_ARGS="$@"
 
-KUBE_ROOT=$(cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
+KUBE_ROOT=$(CDPATH="" cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
 
 export KUBERNETES_CONTRIB=mesos
 

--- a/contrib/mesos/ci/run-with-cluster.sh
+++ b/contrib/mesos/ci/run-with-cluster.sh
@@ -36,7 +36,7 @@ KUBERNETES_PROVIDER="mesos/docker"
 
 MESOS_DOCKER_WORK_DIR="${MESOS_DOCKER_WORK_DIR:-${HOME}/tmp/kubernetes}"
 
-KUBE_ROOT=$(cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
+KUBE_ROOT=$(CDPATH="" cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
 
 # Clean (test artifacts)
 echo "Cleaning work dir"

--- a/contrib/mesos/ci/run.sh
+++ b/contrib/mesos/ci/run.sh
@@ -30,7 +30,7 @@ set -o errtrace
 RUN_CMD="$@"
 [ -z "${RUN_CMD:-}" ] && echo "No command supplied" && exit 1
 
-KUBE_ROOT=$(cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
+KUBE_ROOT=$(CDPATH="" cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
 
 echo "Detecting docker client"
 # Mount docker client binary to avoid client/compose/daemon version conflicts

--- a/contrib/mesos/ci/test-conformance.sh
+++ b/contrib/mesos/ci/test-conformance.sh
@@ -29,7 +29,7 @@ set -o errtrace
 
 TEST_ARGS="$@"
 
-KUBE_ROOT=$(cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
+KUBE_ROOT=$(CDPATH="" cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
 
 TEST_CMD="KUBECONFIG=~/.kube/config hack/conformance-test.sh"
 if [ -n "${CONFORMANCE_BRANCH}" ]; then

--- a/contrib/mesos/ci/test-e2e.sh
+++ b/contrib/mesos/ci/test-e2e.sh
@@ -29,6 +29,6 @@ set -o errtrace
 
 TEST_ARGS="$@"
 
-KUBE_ROOT=$(cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
+KUBE_ROOT=$(CDPATH="" cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
 
 "${KUBE_ROOT}/contrib/mesos/ci/run-with-cluster.sh" ./cluster/test-e2e.sh ${TEST_ARGS}

--- a/contrib/mesos/ci/test-integration.sh
+++ b/contrib/mesos/ci/test-integration.sh
@@ -29,6 +29,6 @@ set -o errtrace
 
 TEST_ARGS="$@"
 
-KUBE_ROOT=$(cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
+KUBE_ROOT=$(CDPATH="" cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
 
 "${KUBE_ROOT}/contrib/mesos/ci/run.sh" make clean test_integration ${TEST_ARGS}

--- a/contrib/mesos/ci/test-smoke.sh
+++ b/contrib/mesos/ci/test-smoke.sh
@@ -29,6 +29,6 @@ set -o errtrace
 
 TEST_ARGS="$@"
 
-KUBE_ROOT=$(cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
+KUBE_ROOT=$(CDPATH="" cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
 
 "${KUBE_ROOT}/contrib/mesos/ci/run-with-cluster.sh" ./cluster/test-smoke.sh ${TEST_ARGS}

--- a/contrib/mesos/ci/test-unit.sh
+++ b/contrib/mesos/ci/test-unit.sh
@@ -29,6 +29,6 @@ set -o errtrace
 
 TEST_ARGS="$@"
 
-KUBE_ROOT=$(cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
+KUBE_ROOT=$(CDPATH="" cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)
 
 "${KUBE_ROOT}/contrib/mesos/ci/run.sh" make clean test ${TEST_ARGS}

--- a/examples/guestbook-go/_src/script/release.sh
+++ b/examples/guestbook-go/_src/script/release.sh
@@ -21,7 +21,7 @@ set -o nounset
 set -o pipefail
 
 base_dir=$(dirname "$0")
-base_dir=$(cd "${base_dir}" && pwd)
+base_dir=$(CDPATH="" cd "${base_dir}" && pwd)
 
 guestbook_version=${1:-latest}
 

--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -49,7 +49,7 @@ function readlinkdashf {
     path="$(readlink $path)"
   done 
   # Convert to canonical path.
-  path=$(cd "$(dirname "${path}")" && pwd -P)
+  path=$(CDPATH="" cd "$(dirname "${path}")" && pwd -P)
   echo "$path"
 }
 


### PR DESCRIPTION
## Summary

Added guards in multiple Bash scripts to prevent a corner case when cd is used in a command substitution. I ran into this issue when using the libvirt-coreos provider and my path was set wrong because cd was emitting a path when run which was captured unintentionally.

The guard was already present in the rackspace provider : https://github.com/kubernetes/kubernetes/blob/master/cluster/rackspace/util.sh#L262
## Example of corner case

`$POOL_PATH` (https://github.com/kubernetes/kubernetes/blob/master/cluster/libvirt-coreos/util.sh#L28) will get set wrong since the cd command will print the directory name. Setting CDPATH  to empty fixes this.

For example adding one line of debugging after POOL_PATH is set:

```
+echo POOL_PATH="|$POOL_PATH|"
+exit 0

$ export CDPATH=.

kmcounts@jabba:~/dev/countdigi/kubernetes
$ KUBERNETES_PROVIDER=libvirt-coreos cluster/kube-up.sh

POOL_PATH=|/home/kmcounts/dev/countdigi/kubernetes/cluster/libvirt-coreos
/home/kmcounts/dev/countdigi/kubernetes/cluster/libvirt-coreos/libvirt_storage_pool|
```
