### PR TITLE
Salt: mode for tar file should be 644, not 755

### DIFF
--- a/cluster/saltbase/salt/kube-node-unpacker/init.sls
+++ b/cluster/saltbase/salt/kube-node-unpacker/init.sls
@@ -18,7 +18,7 @@ kube-proxy-tar:
     - makedirs: True
     - user: root
     - group: root
-    - mode: 755
+    - mode: 644
 {% endif %}
 
 {% set is_helium = '0' %}


### PR DESCRIPTION
Probably harmless, but it doesn't make sense to have it be executable.
