### PR TITLE
Comment out calls to httptest.Server.Close() to work around https://github.com/golang/go/issues/12262

### DIFF
--- a/contrib/mesos/pkg/executor/executor_test.go
+++ b/contrib/mesos/pkg/executor/executor_test.go
@@ -128,7 +128,8 @@ func TestExecutorLaunchAndKillTask(t *testing.T) {
 
 	// create fake apiserver
 	testApiServer := NewTestServer(t, api.NamespaceDefault, &podListWatch.list)
-	defer testApiServer.server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testApiServer.server.Close()
 
 	mockDriver := &MockExecutorDriver{}
 	updates := make(chan kubetypes.PodUpdate, 1024)
@@ -342,7 +343,8 @@ func TestExecutorFrameworkMessage(t *testing.T) {
 	// create fake apiserver
 	podListWatch := NewMockPodsListWatch(api.PodList{})
 	testApiServer := NewTestServer(t, api.NamespaceDefault, &podListWatch.list)
-	defer testApiServer.server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testApiServer.server.Close()
 
 	// create and start executor
 	mockDriver := &MockExecutorDriver{}

--- a/contrib/mesos/pkg/scheduler/integration/integration_test.go
+++ b/contrib/mesos/pkg/scheduler/integration/integration_test.go
@@ -602,7 +602,8 @@ func (lt lifecycleTest) Start() <-chan LaunchedTask {
 }
 
 func (lt lifecycleTest) Close() {
-	lt.apiServer.server.Close()
+	// TODO: Uncomment when fix #19254
+	// lt.apiServer.server.Close()
 }
 
 func (lt lifecycleTest) End() <-chan struct{} {

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -732,7 +732,8 @@ func TestNotFound(t *testing.T) {
 		"simpleroots": &SimpleRESTStorage{},
 	})
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	client := http.Client{}
 	for k, v := range cases {
 		request, err := http.NewRequest(v.Method, server.URL+v.Path, nil)
@@ -794,7 +795,8 @@ func TestUnimplementedRESTStorage(t *testing.T) {
 		"foo": UnimplementedRESTStorage{},
 	})
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	client := http.Client{}
 	for k, v := range cases {
 		request, err := http.NewRequest(v.Method, server.URL+v.Path, bytes.NewReader([]byte(`{"kind":"Simple","apiVersion":"version"}`)))
@@ -821,7 +823,8 @@ func TestUnimplementedRESTStorage(t *testing.T) {
 func TestVersion(t *testing.T) {
 	handler := handle(map[string]rest.Storage{})
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	client := http.Client{}
 
 	request, err := http.NewRequest("GET", server.URL+"/version", nil)
@@ -1017,7 +1020,8 @@ func TestList(t *testing.T) {
 		}
 		var handler = handleInternal(storage, admissionControl, selfLinker)
 		server := httptest.NewServer(handler)
-		defer server.Close()
+		// TODO: Uncomment when fix #19254
+		// defer server.Close()
 
 		resp, err := http.Get(server.URL + testCase.url)
 		if err != nil {
@@ -1061,7 +1065,8 @@ func TestErrorList(t *testing.T) {
 	storage["simple"] = &simpleStorage
 	handler := handle(storage)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	resp, err := http.Get(server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/simple")
 	if err != nil {
@@ -1086,7 +1091,8 @@ func TestNonEmptyList(t *testing.T) {
 	storage["simple"] = &simpleStorage
 	handler := handle(storage)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	resp, err := http.Get(server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/simple")
 	if err != nil {
@@ -1137,7 +1143,8 @@ func TestSelfLinkSkipsEmptyName(t *testing.T) {
 	storage["simple"] = &simpleStorage
 	handler := handle(storage)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	resp, err := http.Get(server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/simple")
 	if err != nil {
@@ -1214,7 +1221,8 @@ func TestExport(t *testing.T) {
 	storage["simple"] = &simpleStorage
 	handler := handleLinker(storage, selfLinker)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	resp, err := http.Get(server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple/id?export=true")
 	if err != nil {
@@ -1259,7 +1267,8 @@ func TestGet(t *testing.T) {
 	storage["simple"] = &simpleStorage
 	handler := handleLinker(storage, selfLinker)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	resp, err := http.Get(server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple/id")
 	if err != nil {
@@ -1291,7 +1300,8 @@ func TestGetBinary(t *testing.T) {
 	}
 	stream := simpleStorage.stream
 	server := httptest.NewServer(handle(map[string]rest.Storage{"simple": &simpleStorage}))
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	req, err := http.NewRequest("GET", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/binary", nil)
 	if err != nil {
@@ -1368,7 +1378,8 @@ func TestGetWithOptions(t *testing.T) {
 	storage["simple"] = &simpleStorage
 	handler := handle(storage)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	resp, err := http.Get(server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple/id?param1=test1&param2=test2")
 	if err != nil {
@@ -1410,7 +1421,8 @@ func TestGetWithOptionsAndPath(t *testing.T) {
 	storage["simple"] = &simpleStorage
 	handler := handle(storage)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	resp, err := http.Get(server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple/id/a/different/path?param1=test1&param2=test2&atAPath=not")
 	if err != nil {
@@ -1454,7 +1466,8 @@ func TestGetAlternateSelfLink(t *testing.T) {
 	storage["simple"] = &simpleStorage
 	handler := handleLinker(storage, selfLinker)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	resp, err := http.Get(server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/test/simple/id")
 	if err != nil {
@@ -1492,7 +1505,8 @@ func TestGetNamespaceSelfLink(t *testing.T) {
 	storage["simple"] = &simpleStorage
 	handler := handleInternal(storage, admissionControl, selfLinker)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	resp, err := http.Get(server.URL + "/" + prefix + "/" + newGroupVersion.Group + "/" + newGroupVersion.Version + "/namespaces/foo/simple/id")
 	if err != nil {
@@ -1521,7 +1535,8 @@ func TestGetMissing(t *testing.T) {
 	storage["simple"] = &simpleStorage
 	handler := handle(storage)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	resp, err := http.Get(server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/simple/id")
 	if err != nil {
@@ -1547,7 +1562,8 @@ func TestConnect(t *testing.T) {
 	}
 	handler := handle(storage)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	resp, err := http.Get(server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple/" + itemID + "/connect")
 
@@ -1585,7 +1601,8 @@ func TestConnectResponderObject(t *testing.T) {
 	}
 	handler := handle(storage)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	resp, err := http.Get(server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple/" + itemID + "/connect")
 
@@ -1626,7 +1643,8 @@ func TestConnectResponderError(t *testing.T) {
 	}
 	handler := handle(storage)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	resp, err := http.Get(server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple/" + itemID + "/connect")
 
@@ -1695,7 +1713,8 @@ func TestConnectWithOptions(t *testing.T) {
 	}
 	handler := handle(storage)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	resp, err := http.Get(server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple/" + itemID + "/connect?param1=value1&param2=value2")
 
@@ -1745,7 +1764,8 @@ func TestConnectWithOptionsAndPath(t *testing.T) {
 	}
 	handler := handle(storage)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	resp, err := http.Get(server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/default/simple/" + itemID + "/connect/" + testPath + "?param1=value1&param2=value2")
 
@@ -1785,7 +1805,8 @@ func TestDelete(t *testing.T) {
 	storage["simple"] = &simpleStorage
 	handler := handle(storage)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	client := http.Client{}
 	request, err := http.NewRequest("DELETE", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, nil)
@@ -1808,7 +1829,8 @@ func TestDeleteWithOptions(t *testing.T) {
 	storage["simple"] = &simpleStorage
 	handler := handle(storage)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	grace := int64(300)
 	item := &api.DeleteOptions{
@@ -1849,7 +1871,8 @@ func TestLegacyDelete(t *testing.T) {
 	var _ rest.Deleter = storage["simple"].(LegacyRESTStorage)
 	handler := handle(storage)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	client := http.Client{}
 	request, err := http.NewRequest("DELETE", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, nil)
@@ -1875,7 +1898,8 @@ func TestLegacyDeleteIgnoresOptions(t *testing.T) {
 	storage["simple"] = LegacyRESTStorage{&simpleStorage}
 	handler := handle(storage)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	item := api.NewDeleteOptions(300)
 	body, err := runtime.Encode(codec, item)
@@ -1907,7 +1931,8 @@ func TestDeleteInvokesAdmissionControl(t *testing.T) {
 	storage["simple"] = &simpleStorage
 	handler := handleDeny(storage)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	client := http.Client{}
 	request, err := http.NewRequest("DELETE", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, nil)
@@ -1929,7 +1954,8 @@ func TestDeleteMissing(t *testing.T) {
 	storage["simple"] = &simpleStorage
 	handler := handle(storage)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	client := http.Client{}
 	request, err := http.NewRequest("DELETE", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, nil)
@@ -1963,7 +1989,8 @@ func TestPatch(t *testing.T) {
 	}
 	handler := handleLinker(storage, selfLinker)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	client := http.Client{}
 	request, err := http.NewRequest("PATCH", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader([]byte(`{"labels":{"foo":"bar"}}`)))
@@ -1995,7 +2022,8 @@ func TestPatchRequiresMatchingName(t *testing.T) {
 	storage["simple"] = &simpleStorage
 	handler := handle(storage)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	client := http.Client{}
 	request, err := http.NewRequest("PATCH", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, bytes.NewReader([]byte(`{"metadata":{"name":"idbar"}}`)))
@@ -2022,7 +2050,8 @@ func TestUpdate(t *testing.T) {
 	}
 	handler := handleLinker(storage, selfLinker)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	item := &apiservertesting.Simple{
 		ObjectMeta: api.ObjectMeta{
@@ -2059,7 +2088,8 @@ func TestUpdateInvokesAdmissionControl(t *testing.T) {
 	storage["simple"] = &simpleStorage
 	handler := handleDeny(storage)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	item := &apiservertesting.Simple{
 		ObjectMeta: api.ObjectMeta{
@@ -2092,7 +2122,8 @@ func TestUpdateRequiresMatchingName(t *testing.T) {
 	storage["simple"] = &simpleStorage
 	handler := handleDeny(storage)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	item := &apiservertesting.Simple{
 		Other: "bar",
@@ -2121,7 +2152,8 @@ func TestUpdateAllowsMissingNamespace(t *testing.T) {
 	storage["simple"] = &simpleStorage
 	handler := handle(storage)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	item := &apiservertesting.Simple{
 		ObjectMeta: api.ObjectMeta{
@@ -2158,7 +2190,8 @@ func TestUpdateAllowsMismatchedNamespaceOnError(t *testing.T) {
 	}
 	handler := handleLinker(storage, selfLinker)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	item := &apiservertesting.Simple{
 		ObjectMeta: api.ObjectMeta{
@@ -2195,7 +2228,8 @@ func TestUpdatePreventsMismatchedNamespace(t *testing.T) {
 	storage["simple"] = &simpleStorage
 	handler := handle(storage)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	item := &apiservertesting.Simple{
 		ObjectMeta: api.ObjectMeta{
@@ -2230,7 +2264,8 @@ func TestUpdateMissing(t *testing.T) {
 	storage["simple"] = &simpleStorage
 	handler := handle(storage)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	item := &apiservertesting.Simple{
 		ObjectMeta: api.ObjectMeta{
@@ -2264,7 +2299,8 @@ func TestCreateNotFound(t *testing.T) {
 		},
 	})
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	client := http.Client{}
 
 	simple := &apiservertesting.Simple{Other: "foo"}
@@ -2290,7 +2326,8 @@ func TestCreateNotFound(t *testing.T) {
 func TestCreateChecksDecode(t *testing.T) {
 	handler := handle(map[string]rest.Storage{"simple": &SimpleRESTStorage{}})
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	client := http.Client{}
 
 	simple := &api.Pod{}
@@ -2480,7 +2517,8 @@ func TestCreateWithName(t *testing.T) {
 		"simple/sub": storage,
 	})
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	client := http.Client{}
 
 	simple := &apiservertesting.Simple{Other: "foo"}
@@ -2507,7 +2545,8 @@ func TestCreateWithName(t *testing.T) {
 func TestUpdateChecksDecode(t *testing.T) {
 	handler := handle(map[string]rest.Storage{"simple": &SimpleRESTStorage{}})
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	client := http.Client{}
 
 	simple := &api.Pod{}
@@ -2581,7 +2620,8 @@ func TestCreate(t *testing.T) {
 	}
 	handler := handleLinker(map[string]rest.Storage{"foo": &storage}, selfLinker)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	client := http.Client{}
 
 	simple := &apiservertesting.Simple{
@@ -2640,7 +2680,8 @@ func TestCreateInNamespace(t *testing.T) {
 	}
 	handler := handleLinker(map[string]rest.Storage{"foo": &storage}, selfLinker)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	client := http.Client{}
 
 	simple := &apiservertesting.Simple{
@@ -2699,7 +2740,8 @@ func TestCreateInvokesAdmissionControl(t *testing.T) {
 	}
 	handler := handleInternal(map[string]rest.Storage{"foo": &storage}, deny.NewAlwaysDeny(), selfLinker)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	client := http.Client{}
 
 	simple := &apiservertesting.Simple{
@@ -2761,7 +2803,8 @@ func TestDelayReturnsError(t *testing.T) {
 	}
 	handler := handle(map[string]rest.Storage{"foo": &storage})
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	status := expectApiStatus(t, "DELETE", fmt.Sprintf("%s/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/foo/bar", server.URL), nil, http.StatusConflict)
 	if status.Status != unversioned.StatusFailure || status.Message == "" || status.Details == nil || status.Reason != unversioned.StatusReasonAlreadyExists {
@@ -2781,7 +2824,8 @@ func TestWriteJSONDecodeError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		writeJSON(http.StatusOK, codec, &UnregisteredAPIObject{"Undecodable"}, w, false)
 	}))
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	// We send a 200 status code before we encode the object, so we expect OK, but there will
 	// still be an error object.  This seems ok, the alternative is to validate the object before
 	// encoding, but this really should never happen, so it's wasted compute for every API request.
@@ -2806,7 +2850,8 @@ func TestWriteRAWJSONMarshalError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		writeRawJSON(http.StatusOK, &marshalError{errors.New("Undecodable")}, w)
 	}))
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	client := http.Client{}
 	resp, err := client.Get(server.URL)
 	if err != nil {
@@ -2832,7 +2877,8 @@ func TestCreateTimeout(t *testing.T) {
 		"foo": &storage,
 	})
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	simple := &apiservertesting.Simple{Other: "foo"}
 	data, err := runtime.Encode(codec, simple)
@@ -2869,7 +2915,8 @@ func TestCORSAllowedOrigins(t *testing.T) {
 			allowedOriginRegexps, nil, nil, "true",
 		)
 		server := httptest.NewServer(handler)
-		defer server.Close()
+		// TODO: Uncomment when fix #19254
+		// defer server.Close()
 		client := http.Client{}
 
 		request, err := http.NewRequest("GET", server.URL+"/version", nil)
@@ -2922,7 +2969,8 @@ func TestCORSAllowedOrigins(t *testing.T) {
 func TestCreateChecksAPIVersion(t *testing.T) {
 	handler := handle(map[string]rest.Storage{"simple": &SimpleRESTStorage{}})
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	client := http.Client{}
 
 	simple := &apiservertesting.Simple{}
@@ -2953,7 +3001,8 @@ func TestCreateChecksAPIVersion(t *testing.T) {
 func TestCreateDefaultsAPIVersion(t *testing.T) {
 	handler := handle(map[string]rest.Storage{"simple": &SimpleRESTStorage{}})
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	client := http.Client{}
 
 	simple := &apiservertesting.Simple{}
@@ -2988,7 +3037,8 @@ func TestCreateDefaultsAPIVersion(t *testing.T) {
 func TestUpdateChecksAPIVersion(t *testing.T) {
 	handler := handle(map[string]rest.Storage{"simple": &SimpleRESTStorage{}})
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	client := http.Client{}
 
 	simple := &apiservertesting.Simple{ObjectMeta: api.ObjectMeta{Name: "bar"}}

--- a/pkg/apiserver/handlers_test.go
+++ b/pkg/apiserver/handlers_test.go
@@ -111,7 +111,8 @@ func TestMaxInFlight(t *testing.T) {
 			}),
 		),
 	)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	// These should hang, but not affect accounting.
 	for i := 0; i < AllowedInflightRequestsNo; i++ {
@@ -173,7 +174,8 @@ func TestReadOnly(t *testing.T) {
 			}
 		},
 	)))
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	for _, verb := range []string{"GET", "POST", "PUT", "DELETE", "CREATE"} {
 		req, err := http.NewRequest(verb, server.URL, nil)
 		if err != nil {
@@ -199,7 +201,8 @@ func TestTimeout(t *testing.T) {
 		func(*http.Request) (<-chan time.Time, string) {
 			return timeout, timeoutResp
 		}))
-	defer ts.Close()
+	// TODO: Uncomment when fix #19254
+	// defer ts.Close()
 
 	// No timeouts
 	sendResponse <- struct{}{}

--- a/pkg/apiserver/proxy_test.go
+++ b/pkg/apiserver/proxy_test.go
@@ -193,7 +193,8 @@ func TestProxyRequestContentLengthAndTransferEncoding(t *testing.T) {
 			// Write successful response
 			w.Write([]byte(successfulResponse))
 		}))
-		defer downstreamServer.Close()
+		// TODO: Uncomment when fix #19254
+		// defer downstreamServer.Close()
 
 		// Start the proxy server
 		serverURL, _ := url.Parse(downstreamServer.URL)
@@ -204,7 +205,8 @@ func TestProxyRequestContentLengthAndTransferEncoding(t *testing.T) {
 		}
 		namespaceHandler := handleNamespaced(map[string]rest.Storage{"foo": simpleStorage})
 		server := httptest.NewServer(namespaceHandler)
-		defer server.Close()
+		// TODO: Uncomment when fix #19254
+		// defer server.Close()
 
 		// Dial the proxy server
 		conn, err := net.Dial(server.Listener.Addr().Network(), server.Listener.Addr().String())
@@ -299,7 +301,8 @@ func TestProxy(t *testing.T) {
 			}
 			fmt.Fprint(out, item.respBody)
 		}))
-		defer downstreamServer.Close()
+		// TODO: Uncomment when fix #19254
+		// defer downstreamServer.Close()
 
 		serverURL, _ := url.Parse(downstreamServer.URL)
 		simpleStorage := &SimpleRESTStorage{
@@ -310,7 +313,8 @@ func TestProxy(t *testing.T) {
 
 		namespaceHandler := handleNamespaced(map[string]rest.Storage{"foo": simpleStorage})
 		namespaceServer := httptest.NewServer(namespaceHandler)
-		defer namespaceServer.Close()
+		// TODO: Uncomment when fix #19254
+		// defer namespaceServer.Close()
 
 		// test each supported URL pattern for finding the redirection resource in the proxy in a particular namespace
 		serverPatterns := []struct {
@@ -419,7 +423,8 @@ func TestProxyUpgrade(t *testing.T) {
 			ws.Read(body)
 			ws.Write([]byte("hello " + string(body)))
 		}))
-		defer backendServer.Close()
+		// TODO: Uncomment when fix #19254
+		// defer backendServer.Close()
 
 		serverURL, _ := url.Parse(backendServer.URL)
 		simpleStorage := &SimpleRESTStorage{
@@ -432,7 +437,8 @@ func TestProxyUpgrade(t *testing.T) {
 		namespaceHandler := handleNamespaced(map[string]rest.Storage{"foo": simpleStorage})
 
 		server := httptest.NewServer(namespaceHandler)
-		defer server.Close()
+		// TODO: Uncomment when fix #19254
+		// defer server.Close()
 
 		ws, err := websocket.Dial("ws://"+server.Listener.Addr().String()+"/"+prefix+"/"+newGroupVersion.Group+"/"+newGroupVersion.Version+"/proxy/namespaces/myns/foo/123", "", "http://127.0.0.1/")
 		if err != nil {
@@ -485,7 +491,8 @@ func TestRedirectOnMissingTrailingSlash(t *testing.T) {
 				t.Errorf("Unexpected query on url: %s, expected: %s", req.URL.RawQuery, item.query)
 			}
 		}))
-		defer downstreamServer.Close()
+		// TODO: Uncomment when fix #19254
+		// defer downstreamServer.Close()
 
 		serverURL, _ := url.Parse(downstreamServer.URL)
 		simpleStorage := &SimpleRESTStorage{
@@ -496,7 +503,8 @@ func TestRedirectOnMissingTrailingSlash(t *testing.T) {
 
 		handler := handleNamespaced(map[string]rest.Storage{"foo": simpleStorage})
 		server := httptest.NewServer(handler)
-		defer server.Close()
+		// TODO: Uncomment when fix #19254
+		// defer server.Close()
 
 		proxyTestPattern := "/" + prefix + "/" + newGroupVersion.Group + "/" + newGroupVersion.Version + "/proxy/namespaces/ns/foo/id" + item.path
 		req, err := http.NewRequest(

--- a/pkg/apiserver/watch_test.go
+++ b/pkg/apiserver/watch_test.go
@@ -58,7 +58,8 @@ func TestWatchWebsocket(t *testing.T) {
 	_ = rest.Watcher(simpleStorage) // Give compile error if this doesn't work.
 	handler := handle(map[string]rest.Storage{"simples": simpleStorage})
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	dest, _ := url.Parse(server.URL)
 	dest.Scheme = "ws" // Required by websocket, though the server never sees it.
@@ -110,7 +111,8 @@ func TestWatchHTTP(t *testing.T) {
 	simpleStorage := &SimpleRESTStorage{}
 	handler := handle(map[string]rest.Storage{"simples": simpleStorage})
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	client := http.Client{}
 
 	dest, _ := url.Parse(server.URL)
@@ -174,7 +176,8 @@ func TestWatchParamParsing(t *testing.T) {
 		"simpleroots": simpleStorage,
 	})
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	dest, _ := url.Parse(server.URL)
 
@@ -281,7 +284,8 @@ func TestWatchProtocolSelection(t *testing.T) {
 	simpleStorage := &SimpleRESTStorage{}
 	handler := handle(map[string]rest.Storage{"simples": simpleStorage})
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	defer server.CloseClientConnections()
 	client := http.Client{}
 
@@ -354,7 +358,8 @@ func TestWatchHTTPTimeout(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		watchServer.ServeHTTP(w, req)
 	}))
-	defer s.Close()
+	// TODO: Uncomment when fix #19254
+	// defer s.Close()
 
 	// Setup a client
 	dest, _ := url.Parse(s.URL)

--- a/pkg/client/cache/listwatch_test.go
+++ b/pkg/client/cache/listwatch_test.go
@@ -95,7 +95,8 @@ func TestListWatchesCanList(t *testing.T) {
 			T:            t,
 		}
 		server := httptest.NewServer(&handler)
-		defer server.Close()
+		// TODO: Uncomment when fix #19254
+		// defer server.Close()
 		client := client.NewOrDie(&client.Config{Host: server.URL, GroupVersion: testapi.Default.GroupVersion()})
 		lw := NewListWatchFromClient(client, item.resource, item.namespace, item.fieldSelector)
 		// This test merely tests that the correct request is made.
@@ -161,7 +162,8 @@ func TestListWatchesCanWatch(t *testing.T) {
 			T:            t,
 		}
 		server := httptest.NewServer(&handler)
-		defer server.Close()
+		// TODO: Uncomment when fix #19254
+		// defer server.Close()
 		client := client.NewOrDie(&client.Config{Host: server.URL, GroupVersion: testapi.Default.GroupVersion()})
 		lw := NewListWatchFromClient(client, item.resource, item.namespace, item.fieldSelector)
 		// This test merely tests that the correct request is made.

--- a/pkg/client/chaosclient/chaosclient_test.go
+++ b/pkg/client/chaosclient/chaosclient_test.go
@@ -42,7 +42,8 @@ func TestChaos(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	client := http.Client{
 		Transport: NewChaosRoundTripper(http.DefaultTransport, TestLogChaos{t}, ErrSimulatedConnectionResetByPeer),
 	}
@@ -59,7 +60,8 @@ func TestPartialChaos(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	seed := NewSeed(1)
 	client := http.Client{
 		Transport: NewChaosRoundTripper(

--- a/pkg/client/unversioned/client_test.go
+++ b/pkg/client/unversioned/client_test.go
@@ -46,7 +46,8 @@ func TestGetServerVersion(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		w.Write(output)
 	}))
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	client := NewOrDie(&Config{Host: server.URL})
 
 	got, err := client.ServerVersion()
@@ -81,7 +82,8 @@ func TestGetServerGroupsWithV1Server(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		w.Write(output)
 	}))
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	client := NewOrDie(&Config{Host: server.URL})
 	// ServerGroups should not return an error even if server returns error at /api and /apis
 	apiGroupList, err := client.Discovery().ServerGroups()
@@ -117,7 +119,8 @@ func TestGetServerResourcesWithV1Server(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		w.Write(output)
 	}))
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	client := NewOrDie(&Config{Host: server.URL})
 	// ServerResources should not return an error even if server returns error at /api/v1.
 	resourceMap, err := client.Discovery().ServerResources()
@@ -209,7 +212,8 @@ func TestGetServerResources(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		w.Write(output)
 	}))
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	client := NewOrDie(&Config{Host: server.URL})
 	for _, test := range tests {
 		got, err := client.Discovery().ServerResourcesForGroupVersion(test.request)
@@ -270,7 +274,8 @@ func TestGetSwaggerSchema(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected encoding error: %v", err)
 	}
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	client := NewOrDie(&Config{Host: server.URL})
 	got, err := client.SwaggerSchema(v1.SchemeGroupVersion)
@@ -289,7 +294,8 @@ func TestGetSwaggerSchemaFail(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected encoding error: %v", err)
 	}
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	client := NewOrDie(&Config{Host: server.URL})
 	got, err := client.SwaggerSchema(unversioned.GroupVersion{Group: "api.group", Version: "v4"})

--- a/pkg/client/unversioned/containerinfo_test.go
+++ b/pkg/client/unversioned/containerinfo_test.go
@@ -70,7 +70,8 @@ func testHTTPContainerInfoGetter(
 			t.Fatal(err)
 		}
 	}))
-	defer ts.Close()
+	// TODO: Uncomment when fix #19254
+	// defer ts.Close()
 	hostURL, err := url.Parse(ts.URL)
 	if err != nil {
 		t.Fatal(err)
@@ -171,7 +172,8 @@ func TestHTTPGetMachineInfo(t *testing.T) {
 			t.Fatal(err)
 		}
 	}))
-	defer ts.Close()
+	// TODO: Uncomment when fix #19254
+	// defer ts.Close()
 	hostURL, err := url.Parse(ts.URL)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/client/unversioned/helper_test.go
+++ b/pkg/client/unversioned/helper_test.go
@@ -185,7 +185,8 @@ func TestHelperGetServerAPIVersions(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		w.Write(output)
 	}))
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	got, err := ServerAPIVersions(&Config{Host: server.URL, GroupVersion: &unversioned.GroupVersion{Group: "invalid version", Version: "one"}, Codec: testapi.Default.Codec()})
 	if err != nil {
 		t.Fatalf("unexpected encoding error: %v", err)

--- a/pkg/client/unversioned/portforward/portforward_test.go
+++ b/pkg/client/unversioned/portforward/portforward_test.go
@@ -320,7 +320,8 @@ func TestForwardPorts(t *testing.T) {
 			clientConn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", port))
 			if err != nil {
 				t.Errorf("%s: error dialing %d: %s", testName, port, err)
-				server.Close()
+				// TODO: Uncomment when fix #19254
+				// server.Close()
 				continue
 			}
 			defer clientConn.Close()
@@ -328,24 +329,28 @@ func TestForwardPorts(t *testing.T) {
 			n, err := clientConn.Write([]byte(data))
 			if err != nil && err != io.EOF {
 				t.Errorf("%s: Error sending data '%s': %s", testName, data, err)
-				server.Close()
+				// TODO: Uncomment when fix #19254
+				// server.Close()
 				continue
 			}
 			if n == 0 {
 				t.Errorf("%s: unexpected write of 0 bytes", testName)
-				server.Close()
+				// TODO: Uncomment when fix #19254
+				// server.Close()
 				continue
 			}
 			b := make([]byte, 4)
 			n, err = clientConn.Read(b)
 			if err != nil && err != io.EOF {
 				t.Errorf("%s: Error reading data: %s", testName, err)
-				server.Close()
+				// TODO: Uncomment when fix #19254
+				// server.Close()
 				continue
 			}
 			if !bytes.Equal([]byte(test.serverSends[port]), b) {
 				t.Errorf("%s: expected to read '%s', got '%s'", testName, test.serverSends[port], b)
-				server.Close()
+				// TODO: Uncomment when fix #19254
+				// server.Close()
 				continue
 			}
 		}
@@ -357,14 +362,16 @@ func TestForwardPorts(t *testing.T) {
 		if err != nil {
 			t.Errorf("%s: unexpected error: %s", testName, err)
 		}
-		server.Close()
+		// TODO: Uncomment when fix #19254
+		// server.Close()
 	}
 
 }
 
 func TestForwardPortsReturnsErrorWhenAllBindsFailed(t *testing.T) {
 	server := httptest.NewServer(fakePortForwardServer(t, "allBindsFailed", nil, nil))
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	url, _ := url.Parse(server.URL)
 	exec, err := remotecommand.NewExecutor(&client.Config{}, "POST", url)

--- a/pkg/client/unversioned/remotecommand/remotecommand_test.go
+++ b/pkg/client/unversioned/remotecommand/remotecommand_test.go
@@ -215,13 +215,15 @@ func TestRequestExecuteRemoteCommand(t *testing.T) {
 				}
 			}
 
-			server.Close()
+			// TODO: Uncomment when fix #19254
+			// server.Close()
 			continue
 		}
 
 		if hasErr {
 			t.Errorf("%d: unexpected error: %v", i, err)
-			server.Close()
+			// TODO: Uncomment when fix #19254
+			// server.Close()
 			continue
 		}
 
@@ -237,7 +239,8 @@ func TestRequestExecuteRemoteCommand(t *testing.T) {
 			}
 		}
 
-		server.Close()
+		// TODO: Uncomment when fix #19254
+		// server.Close()
 	}
 }
 
@@ -295,13 +298,15 @@ func TestRequestAttachRemoteCommand(t *testing.T) {
 				}
 			}
 
-			server.Close()
+			// TODO: Uncomment when fix #19254
+			// server.Close()
 			continue
 		}
 
 		if hasErr {
 			t.Errorf("%d: unexpected error: %v", i, err)
-			server.Close()
+			// TODO: Uncomment when fix #19254
+			// server.Close()
 			continue
 		}
 
@@ -317,7 +322,8 @@ func TestRequestAttachRemoteCommand(t *testing.T) {
 			}
 		}
 
-		server.Close()
+		// TODO: Uncomment when fix #19254
+		// server.Close()
 	}
 }
 

--- a/pkg/client/unversioned/request_test.go
+++ b/pkg/client/unversioned/request_test.go
@@ -704,7 +704,8 @@ func TestDoRequestNewWay(t *testing.T) {
 		T:            t,
 	}
 	testServer := httptest.NewServer(&fakeHandler)
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 	c := testRESTClient(t, testServer)
 	obj, err := c.Verb("POST").
 		Prefix("foo", "bar").
@@ -740,7 +741,8 @@ func TestBackoffLifecycle(t *testing.T) {
 			return
 		}
 	}))
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 	c := testRESTClient(t, testServer)
 
 	// Test backoff recovery and increase.  This correlates to the constants
@@ -776,7 +778,8 @@ func TestCheckRetryClosesBody(t *testing.T) {
 		w.Header().Set("Retry-After", "0")
 		w.WriteHeader(apierrors.StatusTooManyRequests)
 	}))
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 
 	c := testRESTClient(t, testServer)
 	_, err := c.Verb("POST").
@@ -808,7 +811,8 @@ func TestCheckRetryHandles429And5xx(t *testing.T) {
 		w.WriteHeader([]int{apierrors.StatusTooManyRequests, 500, 501, 504}[count])
 		count++
 	}))
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 
 	c := testRESTClient(t, testServer)
 	_, err := c.Verb("POST").
@@ -837,7 +841,8 @@ func BenchmarkCheckRetryClosesBody(b *testing.B) {
 		w.Header().Set("Retry-After", "0")
 		w.WriteHeader(apierrors.StatusTooManyRequests)
 	}))
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 
 	c := testRESTClient(b, testServer)
 	r := c.Verb("POST").
@@ -868,7 +873,8 @@ func TestDoRequestNewWayReader(t *testing.T) {
 		T:            t,
 	}
 	testServer := httptest.NewServer(&fakeHandler)
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 	c := testRESTClient(t, testServer)
 	obj, err := c.Verb("POST").
 		Resource("bar").
@@ -908,7 +914,8 @@ func TestDoRequestNewWayObj(t *testing.T) {
 		T:            t,
 	}
 	testServer := httptest.NewServer(&fakeHandler)
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 	c := testRESTClient(t, testServer)
 	obj, err := c.Verb("POST").
 		Suffix("baz").
@@ -963,7 +970,8 @@ func TestDoRequestNewWayFile(t *testing.T) {
 		T:            t,
 	}
 	testServer := httptest.NewServer(&fakeHandler)
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 	c := testRESTClient(t, testServer)
 	wasCreated := true
 	obj, err := c.Verb("POST").
@@ -1008,7 +1016,8 @@ func TestWasCreated(t *testing.T) {
 		T:            t,
 	}
 	testServer := httptest.NewServer(&fakeHandler)
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 	c := testRESTClient(t, testServer)
 	wasCreated := false
 	obj, err := c.Verb("PUT").
@@ -1177,7 +1186,8 @@ func TestWatch(t *testing.T) {
 			flusher.Flush()
 		}
 	}))
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 
 	s := testRESTClient(t, testServer)
 	watching, err := s.Get().Prefix("path/to/watch/thing").Watch()
@@ -1217,7 +1227,8 @@ func TestStream(t *testing.T) {
 		w.Write([]byte(expectedBody))
 		flusher.Flush()
 	}))
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 
 	s := testRESTClient(t, testServer)
 	readCloser, err := s.Get().Prefix("path/to/stream/thing").Stream()

--- a/pkg/client/unversioned/restclient_test.go
+++ b/pkg/client/unversioned/restclient_test.go
@@ -40,7 +40,8 @@ func TestDoRequestSuccess(t *testing.T) {
 		T:            t,
 	}
 	testServer := httptest.NewServer(&fakeHandler)
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 	c, err := RESTClientFor(&Config{
 		Host:         testServer.URL,
 		GroupVersion: testapi.Default.GroupVersion(),
@@ -83,7 +84,8 @@ func TestDoRequestFailed(t *testing.T) {
 		T:            t,
 	}
 	testServer := httptest.NewServer(&fakeHandler)
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 	c, err := RESTClientFor(&Config{
 		Host:         testServer.URL,
 		GroupVersion: testapi.Default.GroupVersion(),
@@ -115,7 +117,8 @@ func TestDoRequestCreated(t *testing.T) {
 		T:            t,
 	}
 	testServer := httptest.NewServer(&fakeHandler)
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 	c, err := RESTClientFor(&Config{
 		Host:         testServer.URL,
 		GroupVersion: testapi.Default.GroupVersion(),

--- a/pkg/client/unversioned/testclient/simple/simple_testclient.go
+++ b/pkg/client/unversioned/testclient/simple/simple_testclient.go
@@ -93,7 +93,8 @@ func (c *Client) Setup(t *testing.T) *Client {
 
 func (c *Client) Close() {
 	if c.server != nil {
-		c.server.Close()
+		// TODO: Uncomment when fix #19254
+		// c.server.Close()
 	}
 }
 

--- a/pkg/cloudprovider/providers/mesos/client_test.go
+++ b/pkg/cloudprovider/providers/mesos/client_test.go
@@ -212,8 +212,11 @@ func Test_parseMesosState(t *testing.T) {
 func Test_listSlaves(t *testing.T) {
 	defer log.Flush()
 	md := FakeMasterDetector{}
-	httpServer, httpClient, httpTransport := makeHttpMocks()
-	defer httpServer.Close()
+	// TODO: Uncomment next two lines and remove third line when fix #19254
+	// defer httpServer.Close()
+	// httpServer, httpClient, httpTransport := makeHttpMocks()
+	_, httpClient, httpTransport := makeHttpMocks()
+
 	cacheTTL := 500 * time.Millisecond
 	mesosClient, err := createMesosClient(md, httpClient, httpTransport, cacheTTL)
 
@@ -250,8 +253,10 @@ func Test_listSlaves(t *testing.T) {
 func Test_clusterName(t *testing.T) {
 	defer log.Flush()
 	md := FakeMasterDetector{}
-	httpServer, httpClient, httpTransport := makeHttpMocks()
-	defer httpServer.Close()
+	// TODO: Uncomment next two lines and remove third line when fix #19254
+	// defer httpServer.Close()
+	// httpServer, httpClient, httpTransport := makeHttpMocks()
+	_, httpClient, httpTransport := makeHttpMocks()
 	cacheTTL := 500 * time.Millisecond
 	mesosClient, err := createMesosClient(md, httpClient, httpTransport, cacheTTL)
 

--- a/pkg/controller/controller_utils_test.go
+++ b/pkg/controller/controller_utils_test.go
@@ -189,7 +189,8 @@ func TestCreatePods(t *testing.T) {
 		ResponseBody: string(body),
 	}
 	testServer := httptest.NewServer(&fakeHandler)
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 	client := client.NewOrDie(&client.Config{Host: testServer.URL, GroupVersion: testapi.Default.GroupVersion()})
 
 	podControl := RealPodControl{

--- a/pkg/controller/endpoint/endpoints_controller_test.go
+++ b/pkg/controller/endpoint/endpoints_controller_test.go
@@ -102,7 +102,8 @@ func TestSyncEndpointsItemsPreserveNoSelector(t *testing.T) {
 				Ports:     []api.EndpointPort{{Port: 1000}},
 			}},
 		}})
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 	client := client.NewOrDie(&client.Config{Host: testServer.URL, GroupVersion: testapi.Default.GroupVersion()})
 	endpoints := NewEndpointController(client, controller.NoResyncPeriodFunc)
 	endpoints.serviceStore.Store.Add(&api.Service{
@@ -134,7 +135,8 @@ func TestCheckLeftoverEndpoints(t *testing.T) {
 				}},
 			}},
 		}})
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 	client := client.NewOrDie(&client.Config{Host: testServer.URL, GroupVersion: testapi.Default.GroupVersion()})
 	endpoints := NewEndpointController(client, controller.NoResyncPeriodFunc)
 	endpoints.checkLeftoverEndpoints()
@@ -162,7 +164,8 @@ func TestSyncEndpointsProtocolTCP(t *testing.T) {
 				Ports:     []api.EndpointPort{{Port: 1000, Protocol: "TCP"}},
 			}},
 		}})
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 	client := client.NewOrDie(&client.Config{Host: testServer.URL, GroupVersion: testapi.Default.GroupVersion()})
 	endpoints := NewEndpointController(client, controller.NoResyncPeriodFunc)
 	endpoints.serviceStore.Store.Add(&api.Service{
@@ -190,7 +193,8 @@ func TestSyncEndpointsProtocolUDP(t *testing.T) {
 				Ports:     []api.EndpointPort{{Port: 1000, Protocol: "UDP"}},
 			}},
 		}})
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 	client := client.NewOrDie(&client.Config{Host: testServer.URL, GroupVersion: testapi.Default.GroupVersion()})
 	endpoints := NewEndpointController(client, controller.NoResyncPeriodFunc)
 	endpoints.serviceStore.Store.Add(&api.Service{
@@ -215,7 +219,8 @@ func TestSyncEndpointsItemsEmptySelectorSelectsAll(t *testing.T) {
 			},
 			Subsets: []api.EndpointSubset{},
 		}})
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 	client := client.NewOrDie(&client.Config{Host: testServer.URL, GroupVersion: testapi.Default.GroupVersion()})
 	endpoints := NewEndpointController(client, controller.NoResyncPeriodFunc)
 	addPods(endpoints.podStore.Store, ns, 1, 1, 0)
@@ -252,7 +257,8 @@ func TestSyncEndpointsItemsEmptySelectorSelectsAllNotReady(t *testing.T) {
 			},
 			Subsets: []api.EndpointSubset{},
 		}})
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 	client := client.NewOrDie(&client.Config{Host: testServer.URL, GroupVersion: testapi.Default.GroupVersion()})
 	endpoints := NewEndpointController(client, controller.NoResyncPeriodFunc)
 	addPods(endpoints.podStore.Store, ns, 0, 1, 1)
@@ -289,7 +295,8 @@ func TestSyncEndpointsItemsEmptySelectorSelectsAllMixed(t *testing.T) {
 			},
 			Subsets: []api.EndpointSubset{},
 		}})
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 	client := client.NewOrDie(&client.Config{Host: testServer.URL, GroupVersion: testapi.Default.GroupVersion()})
 	endpoints := NewEndpointController(client, controller.NoResyncPeriodFunc)
 	addPods(endpoints.podStore.Store, ns, 1, 1, 1)
@@ -330,7 +337,8 @@ func TestSyncEndpointsItemsPreexisting(t *testing.T) {
 				Ports:     []api.EndpointPort{{Port: 1000}},
 			}},
 		}})
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 	client := client.NewOrDie(&client.Config{Host: testServer.URL, GroupVersion: testapi.Default.GroupVersion()})
 	endpoints := NewEndpointController(client, controller.NoResyncPeriodFunc)
 	addPods(endpoints.podStore.Store, ns, 1, 1, 0)
@@ -370,7 +378,8 @@ func TestSyncEndpointsItemsPreexistingIdentical(t *testing.T) {
 				Ports:     []api.EndpointPort{{Port: 8080, Protocol: "TCP"}},
 			}},
 		}})
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 	client := client.NewOrDie(&client.Config{Host: testServer.URL, GroupVersion: testapi.Default.GroupVersion()})
 	endpoints := NewEndpointController(client, controller.NoResyncPeriodFunc)
 	addPods(endpoints.podStore.Store, api.NamespaceDefault, 1, 1, 0)
@@ -389,7 +398,8 @@ func TestSyncEndpointsItems(t *testing.T) {
 	ns := "other"
 	testServer, endpointsHandler := makeTestServer(t, ns,
 		serverResponse{http.StatusOK, &api.Endpoints{}})
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 	client := client.NewOrDie(&client.Config{Host: testServer.URL, GroupVersion: testapi.Default.GroupVersion()})
 	endpoints := NewEndpointController(client, controller.NoResyncPeriodFunc)
 	addPods(endpoints.podStore.Store, ns, 3, 2, 0)
@@ -431,7 +441,8 @@ func TestSyncEndpointsItemsWithLabels(t *testing.T) {
 	ns := "other"
 	testServer, endpointsHandler := makeTestServer(t, ns,
 		serverResponse{http.StatusOK, &api.Endpoints{}})
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 	client := client.NewOrDie(&client.Config{Host: testServer.URL, GroupVersion: testapi.Default.GroupVersion()})
 	endpoints := NewEndpointController(client, controller.NoResyncPeriodFunc)
 	addPods(endpoints.podStore.Store, ns, 3, 2, 0)
@@ -491,7 +502,8 @@ func TestSyncEndpointsItemsPreexistingLabelsChange(t *testing.T) {
 				Ports:     []api.EndpointPort{{Port: 1000}},
 			}},
 		}})
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 	client := client.NewOrDie(&client.Config{Host: testServer.URL, GroupVersion: testapi.Default.GroupVersion()})
 	endpoints := NewEndpointController(client, controller.NoResyncPeriodFunc)
 	addPods(endpoints.podStore.Store, ns, 1, 1, 0)

--- a/pkg/controller/replication/replication_controller_test.go
+++ b/pkg/controller/replication/replication_controller_test.go
@@ -215,7 +215,8 @@ func TestStatusUpdatesWithoutReplicasChange(t *testing.T) {
 		ResponseBody: "",
 	}
 	testServer := httptest.NewServer(&fakeHandler)
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 	client := client.NewOrDie(&client.Config{Host: testServer.URL, GroupVersion: testapi.Default.GroupVersion()})
 	manager := NewReplicationManager(client, controller.NoResyncPeriodFunc, BurstReplicas)
 	manager.podStoreSynced = alwaysReady
@@ -256,7 +257,8 @@ func TestControllerUpdateReplicas(t *testing.T) {
 		ResponseBody: "",
 	}
 	testServer := httptest.NewServer(&fakeHandler)
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 
 	client := client.NewOrDie(&client.Config{Host: testServer.URL, GroupVersion: testapi.Default.GroupVersion()})
 	manager := NewReplicationManager(client, controller.NoResyncPeriodFunc, BurstReplicas)
@@ -295,7 +297,8 @@ func TestSyncReplicationControllerDormancy(t *testing.T) {
 		ResponseBody: "",
 	}
 	testServer := httptest.NewServer(&fakeHandler)
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 	client := client.NewOrDie(&client.Config{Host: testServer.URL, GroupVersion: testapi.Default.GroupVersion()})
 
 	fakePodControl := controller.FakePodControl{}
@@ -554,7 +557,8 @@ func TestControllerUpdateRequeue(t *testing.T) {
 		ResponseBody: "",
 	}
 	testServer := httptest.NewServer(&fakeHandler)
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 
 	client := client.NewOrDie(&client.Config{Host: testServer.URL, GroupVersion: testapi.Default.GroupVersion()})
 	manager := NewReplicationManager(client, controller.NoResyncPeriodFunc, BurstReplicas)

--- a/pkg/credentialprovider/gcp/jwt_test.go
+++ b/pkg/credentialprovider/gcp/jwt_test.go
@@ -77,7 +77,8 @@ func TestJwtProvider(t *testing.T) {
 			"expires_in": 3600
 		}`, token)))
 	}))
-	defer ts.Close()
+	// TODO: Uncomment when fix #19254
+	// defer ts.Close()
 
 	file, err := ioutil.TempFile(os.TempDir(), "temp")
 	if err != nil {

--- a/pkg/credentialprovider/gcp/metadata_test.go
+++ b/pkg/credentialprovider/gcp/metadata_test.go
@@ -56,7 +56,8 @@ func TestDockerKeyringFromGoogleDockerConfigMetadata(t *testing.T) {
 			w.WriteHeader(http.StatusNotFound)
 		}
 	}))
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	// Make a transport that reroutes all traffic to the example server
 	transport := &http.Transport{
@@ -128,7 +129,8 @@ func TestDockerKeyringFromGoogleDockerConfigMetadataUrl(t *testing.T) {
 			w.WriteHeader(http.StatusNotFound)
 		}
 	}))
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	// Make a transport that reroutes all traffic to the example server
 	transport := &http.Transport{
@@ -201,7 +203,8 @@ func TestContainerRegistryBasics(t *testing.T) {
 			w.WriteHeader(http.StatusNotFound)
 		}
 	}))
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	// Make a transport that reroutes all traffic to the example server
 	transport := &http.Transport{
@@ -257,7 +260,8 @@ func TestContainerRegistryNoStorageScope(t *testing.T) {
 			w.WriteHeader(http.StatusNotFound)
 		}
 	}))
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	// Make a transport that reroutes all traffic to the example server
 	transport := &http.Transport{
@@ -290,7 +294,8 @@ func TestComputePlatformScopeSubstitutesStorageScope(t *testing.T) {
 			w.WriteHeader(http.StatusNotFound)
 		}
 	}))
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	// Make a transport that reroutes all traffic to the example server
 	transport := &http.Transport{
@@ -312,7 +317,8 @@ func TestAllProvidersNoMetadata(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	// Make a transport that reroutes all traffic to the example server
 	transport := &http.Transport{

--- a/pkg/genericapiserver/genericapiserver_test.go
+++ b/pkg/genericapiserver/genericapiserver_test.go
@@ -114,6 +114,7 @@ func TestInstallAPIGroups(t *testing.T) {
 	}
 	s.InstallAPIGroups(apiGroupsInfo)
 
+	// TODO: Close() this server when fix #19254
 	server := httptest.NewServer(s.HandlerContainer.ServeMux)
 	validPaths := []string{
 		// "/api"

--- a/pkg/kubectl/cmd/util/helpers_test.go
+++ b/pkg/kubectl/cmd/util/helpers_test.go
@@ -212,6 +212,7 @@ func (f *fileHandler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 
 func TestReadConfigData(t *testing.T) {
 	httpData := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	// TODO: Close() this server when fix #19254
 	server := httptest.NewServer(&fileHandler{data: httpData})
 
 	fileData := []byte{11, 12, 13, 14, 15, 16, 17, 18, 19}

--- a/pkg/kubectl/proxy_server_test.go
+++ b/pkg/kubectl/proxy_server_test.go
@@ -205,7 +205,8 @@ func TestFileServing(t *testing.T) {
 	const prefix = "/foo/"
 	handler := newFileHandler(prefix, dir)
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 
 	url := server.URL + prefix + fname
 	res, err := http.Get(url)
@@ -235,7 +236,8 @@ func TestAPIRequests(t *testing.T) {
 		}
 		fmt.Fprintf(w, "%s %s %s", r.Method, r.RequestURI, string(b))
 	}))
-	defer ts.Close()
+	// TODO: Uncomment when fix #19254
+	// defer ts.Close()
 
 	// httptest.NewServer should always generate a valid URL.
 	target, _ := url.Parse(ts.URL)
@@ -271,7 +273,8 @@ func TestPathHandling(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, r.URL.Path)
 	}))
-	defer ts.Close()
+	// TODO: Uncomment when fix #19254
+	// defer ts.Close()
 
 	table := []struct {
 		prefix     string
@@ -301,7 +304,8 @@ func TestPathHandling(t *testing.T) {
 				t.Fatalf("%#v: %v", item, err)
 			}
 			pts := httptest.NewServer(p.handler)
-			defer pts.Close()
+			// TODO: Uncomment when fix #19254
+			// defer pts.Close()
 
 			r, err := http.Get(pts.URL + item.reqPath)
 			if err != nil {

--- a/pkg/kubectl/resource/builder_test.go
+++ b/pkg/kubectl/resource/builder_test.go
@@ -280,7 +280,8 @@ func TestNamespaceOverride(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(runtime.EncodeOrDie(testapi.Default.Codec(), &api.Pod{ObjectMeta: api.ObjectMeta{Namespace: "foo", Name: "test"}})))
 	}))
-	defer s.Close()
+	// TODO: Uncomment when fix #19254
+	// defer s.Close()
 
 	b := NewBuilder(testapi.Default.RESTMapper(), api.Scheme, fakeClient()).
 		FilenameParam(false, s.URL).
@@ -310,7 +311,8 @@ func TestURLBuilder(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(runtime.EncodeOrDie(testapi.Default.Codec(), &api.Pod{ObjectMeta: api.ObjectMeta{Namespace: "foo", Name: "test"}})))
 	}))
-	defer s.Close()
+	// TODO: Uncomment when fix #19254
+	// defer s.Close()
 
 	b := NewBuilder(testapi.Default.RESTMapper(), api.Scheme, fakeClient()).
 		FilenameParam(false, s.URL).
@@ -334,7 +336,8 @@ func TestURLBuilderRequireNamespace(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(runtime.EncodeOrDie(testapi.Default.Codec(), &api.Pod{ObjectMeta: api.ObjectMeta{Namespace: "foo", Name: "test"}})))
 	}))
-	defer s.Close()
+	// TODO: Uncomment when fix #19254
+	// defer s.Close()
 
 	b := NewBuilder(testapi.Default.RESTMapper(), api.Scheme, fakeClient()).
 		FilenameParam(false, s.URL).

--- a/pkg/kubelet/client/kubelet_client_test.go
+++ b/pkg/kubelet/client/kubelet_client_test.go
@@ -39,7 +39,8 @@ func TestHTTPKubeletClient(t *testing.T) {
 		ResponseBody: string(body),
 	}
 	testServer := httptest.NewServer(&fakeHandler)
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 
 	if _, err := url.Parse(testServer.URL); err != nil {
 		t.Errorf("unexpected error: %v", err)

--- a/pkg/kubelet/config/http_test.go
+++ b/pkg/kubelet/config/http_test.go
@@ -111,7 +111,8 @@ func TestExtractInvalidPods(t *testing.T) {
 			ResponseBody: string(data),
 		}
 		testServer := httptest.NewServer(&fakeHandler)
-		defer testServer.Close()
+		// TODO: Uncomment when fix #19254
+		// defer testServer.Close()
 		ch := make(chan interface{}, 1)
 		c := sourceURL{testServer.URL, http.Header{}, "localhost", ch, nil, 0}
 		if err := c.extractFromURL(); err == nil {
@@ -271,7 +272,8 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 			ResponseBody: string(data),
 		}
 		testServer := httptest.NewServer(&fakeHandler)
-		defer testServer.Close()
+		// TODO: Uncomment when fix #19254
+		// defer testServer.Close()
 		ch := make(chan interface{}, 1)
 		c := sourceURL{testServer.URL, http.Header{}, hostname, ch, nil, 0}
 		if err := c.extractFromURL(); err != nil {
@@ -316,7 +318,8 @@ func TestURLWithHeader(t *testing.T) {
 		ResponseBody: string(data),
 	}
 	testServer := httptest.NewServer(&fakeHandler)
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 	ch := make(chan interface{}, 1)
 	header := make(http.Header)
 	header.Set("Metadata-Flavor", "Google")

--- a/pkg/kubelet/server/server_test.go
+++ b/pkg/kubelet/server/server_test.go
@@ -180,6 +180,7 @@ func newServerTest() *serverTestFramework {
 	}
 	server := NewServer(fw.fakeKubelet, fw.fakeAuth, true)
 	fw.serverUnderTest = &server
+	// TODO: Close() this when fix #19254
 	fw.testHTTPServer = httptest.NewServer(fw.serverUnderTest)
 	return fw
 }

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -400,7 +400,8 @@ func testInstallThirdPartyAPIListVersion(t *testing.T, version string) {
 	for _, test := range tests {
 		func() {
 			master, etcdserver, server, assert := initThirdParty(t, version)
-			defer server.Close()
+			// TODO: Uncomment when fix #19254
+			// defer server.Close()
 			defer etcdserver.Terminate(t)
 
 			if test.items != nil {
@@ -509,7 +510,8 @@ func TestInstallThirdPartyAPIGet(t *testing.T) {
 
 func testInstallThirdPartyAPIGetVersion(t *testing.T, version string) {
 	master, etcdserver, server, assert := initThirdParty(t, version)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	defer etcdserver.Terminate(t)
 
 	expectedObj := Foo{
@@ -556,7 +558,8 @@ func TestInstallThirdPartyAPIPost(t *testing.T) {
 
 func testInstallThirdPartyAPIPostForVersion(t *testing.T, version string) {
 	master, etcdserver, server, assert := initThirdParty(t, version)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	defer etcdserver.Terminate(t)
 
 	inputObj := Foo{
@@ -621,7 +624,8 @@ func TestInstallThirdPartyAPIDelete(t *testing.T) {
 
 func testInstallThirdPartyAPIDeleteVersion(t *testing.T, version string) {
 	master, etcdserver, server, assert := initThirdParty(t, version)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	defer etcdserver.Terminate(t)
 
 	expectedObj := Foo{
@@ -698,7 +702,8 @@ func TestInstallThirdPartyResourceRemove(t *testing.T) {
 
 func testInstallThirdPartyResourceRemove(t *testing.T, version string) {
 	master, etcdserver, server, assert := initThirdParty(t, version)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	defer etcdserver.Terminate(t)
 
 	expectedObj := Foo{

--- a/pkg/probe/http/http_test.go
+++ b/pkg/probe/http/http_test.go
@@ -80,6 +80,7 @@ func TestHTTPProbeChecker(t *testing.T) {
 		},
 	}
 	for _, test := range testCases {
+		// TODO: Close() this when fix #19254
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			test.handler(w)
 		}))

--- a/pkg/probe/tcp/tcp_test.go
+++ b/pkg/probe/tcp/tcp_test.go
@@ -42,7 +42,8 @@ func TestTcpHealthChecker(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	tHost, tPortStr, err := net.SplitHostPort(server.Listener.Addr().String())
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)

--- a/pkg/proxy/userspace/proxier_test.go
+++ b/pkg/proxy/userspace/proxier_test.go
@@ -90,6 +90,7 @@ func init() {
 	util.ReallyCrash = true
 
 	// TCP setup.
+	// TODO: Close() this when fix #19254
 	tcp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(r.URL.Path[1:]))

--- a/pkg/registry/generic/rest/proxy_test.go
+++ b/pkg/registry/generic/rest/proxy_test.go
@@ -207,7 +207,8 @@ func TestServeHTTP(t *testing.T) {
 				responseHeader: backendResponseHeader,
 			}
 			backendServer := httptest.NewServer(backendHandler)
-			defer backendServer.Close()
+			// TODO: Uncomment when fix #19254
+			// defer backendServer.Close()
 
 			responder := &fakeResponder{}
 			backendURL, _ := url.Parse(backendServer.URL)
@@ -218,7 +219,8 @@ func TestServeHTTP(t *testing.T) {
 				UpgradeRequired: test.upgradeRequired,
 			}
 			proxyServer := httptest.NewServer(proxyHandler)
-			defer proxyServer.Close()
+			// TODO: Uncomment when fix #19254
+			// defer proxyServer.Close()
 			proxyURL, _ := url.Parse(proxyServer.URL)
 			proxyURL.Path = test.requestPath
 			paramValues := url.Values{}
@@ -374,7 +376,8 @@ func TestProxyUpgrade(t *testing.T) {
 			ws.Read(body)
 			ws.Write([]byte("hello " + string(body)))
 		}))
-		defer backendServer.Close()
+		// TODO: Uncomment when fix #19254
+		// defer backendServer.Close()
 
 		serverURL, _ := url.Parse(backendServer.URL)
 		proxyHandler := &UpgradeAwareProxyHandler{
@@ -382,7 +385,8 @@ func TestProxyUpgrade(t *testing.T) {
 			Transport: tc.ProxyTransport,
 		}
 		proxy := httptest.NewServer(proxyHandler)
-		defer proxy.Close()
+		// TODO: Uncomment when fix #19254
+		// defer proxy.Close()
 
 		ws, err := websocket.Dial("ws://"+proxy.Listener.Addr().String()+"/some/path", "", "http://127.0.0.1/")
 		if err != nil {
@@ -616,7 +620,8 @@ func TestProxyRequestContentLengthAndTransferEncoding(t *testing.T) {
 			// Write successful response
 			w.Write([]byte(successfulResponse))
 		}))
-		defer downstreamServer.Close()
+		// TODO: Uncomment when fix #19254
+		// defer downstreamServer.Close()
 
 		responder := &fakeResponder{}
 		backendURL, _ := url.Parse(downstreamServer.URL)
@@ -626,7 +631,8 @@ func TestProxyRequestContentLengthAndTransferEncoding(t *testing.T) {
 			UpgradeRequired: false,
 		}
 		proxyServer := httptest.NewServer(proxyHandler)
-		defer proxyServer.Close()
+		// TODO: Uncomment when fix #19254
+		// defer proxyServer.Close()
 
 		// Dial the proxy server
 		conn, err := net.Dial(proxyServer.Listener.Addr().Network(), proxyServer.Listener.Addr().String())

--- a/pkg/registry/generic/rest/streamer_test.go
+++ b/pkg/registry/generic/rest/streamer_test.go
@@ -36,7 +36,8 @@ func TestInputStreamReader(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.Write([]byte(resultString))
 	}))
-	defer s.Close()
+	// TODO: Uncomment when fix #19254
+	// defer s.Close()
 	u, err := url.Parse(s.URL)
 	if err != nil {
 		t.Errorf("Error parsing server URL: %v", err)

--- a/pkg/storage/etcd/util/etcd_util_test.go
+++ b/pkg/storage/etcd/util/etcd_util_test.go
@@ -47,7 +47,8 @@ func TestGetEtcdVersion_ValidVersion(t *testing.T) {
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, validEtcdVersion)
 	}))
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 
 	var version string
 	var err error
@@ -62,7 +63,8 @@ func TestGetEtcdVersion_ErrorStatus(t *testing.T) {
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
 	}))
-	defer testServer.Close()
+	// TODO: Uncomment when fix #19254
+	// defer testServer.Close()
 
 	_, err := GetEtcdVersion(testServer.URL)
 	assert.NotNil(t, err)

--- a/pkg/util/fake_handler_test.go
+++ b/pkg/util/fake_handler_test.go
@@ -26,7 +26,8 @@ import (
 func TestFakeHandlerPath(t *testing.T) {
 	handler := FakeHandler{}
 	server := httptest.NewServer(&handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	method := "GET"
 	path := "/foo/bar"
 	body := "somebody"
@@ -48,7 +49,8 @@ func TestFakeHandlerPath(t *testing.T) {
 func TestFakeHandlerPathNoBody(t *testing.T) {
 	handler := FakeHandler{}
 	server := httptest.NewServer(&handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	method := "GET"
 	path := "/foo/bar"
 
@@ -79,7 +81,8 @@ func (f *fakeError) Logf(format string, args ...interface{}) {}
 func TestFakeHandlerWrongPath(t *testing.T) {
 	handler := FakeHandler{}
 	server := httptest.NewServer(&handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	method := "GET"
 	path := "/foo/bar"
 	fakeT := fakeError{}
@@ -104,7 +107,8 @@ func TestFakeHandlerWrongPath(t *testing.T) {
 func TestFakeHandlerWrongMethod(t *testing.T) {
 	handler := FakeHandler{}
 	server := httptest.NewServer(&handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	method := "GET"
 	path := "/foo/bar"
 	fakeT := fakeError{}
@@ -129,7 +133,8 @@ func TestFakeHandlerWrongMethod(t *testing.T) {
 func TestFakeHandlerWrongBody(t *testing.T) {
 	handler := FakeHandler{}
 	server := httptest.NewServer(&handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	method := "GET"
 	path := "/foo/bar"
 	body := "somebody"
@@ -156,7 +161,8 @@ func TestFakeHandlerWrongBody(t *testing.T) {
 func TestFakeHandlerNilBody(t *testing.T) {
 	handler := FakeHandler{}
 	server := httptest.NewServer(&handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	method := "GET"
 	path := "/foo/bar"
 	body := "somebody"

--- a/pkg/util/httpstream/spdy/roundtripper_test.go
+++ b/pkg/util/httpstream/spdy/roundtripper_test.go
@@ -146,7 +146,8 @@ func TestRoundTripAndNewConnection(t *testing.T) {
 			stream := <-streamCh
 			io.Copy(stream, stream)
 		}))
-		defer server.Close()
+		// TODO: Uncomment when fix #19254
+		// defer server.Close()
 
 		req, err := http.NewRequest("GET", server.URL, nil)
 		if err != nil {

--- a/pkg/util/httpstream/spdy/upgrade_test.go
+++ b/pkg/util/httpstream/spdy/upgrade_test.go
@@ -66,7 +66,8 @@ func TestUpgradeResponse(t *testing.T) {
 			}
 			defer conn.Close()
 		}))
-		defer server.Close()
+		// TODO: Uncomment when fix #19254
+		// defer server.Close()
 
 		req, err := http.NewRequest("GET", server.URL, nil)
 		if err != nil {

--- a/pkg/util/proxy/transport_test.go
+++ b/pkg/util/proxy/transport_test.go
@@ -219,7 +219,8 @@ func TestProxyTransport(t *testing.T) {
 			w.Header().Set("Content-Type", item.contentType)
 			fmt.Fprint(w, item.input)
 		}))
-		defer server.Close()
+		// TODO: Uncomment when fix #19254
+		// defer server.Close()
 
 		// Replace source URL with our test server address.
 		sourceURL := parseURLOrDie(item.sourceURL)

--- a/pkg/util/wsstream/conn_test.go
+++ b/pkg/util/wsstream/conn_test.go
@@ -36,8 +36,10 @@ func newServer(handler websocket.Handler) (*httptest.Server, string) {
 
 func TestRawConn(t *testing.T) {
 	conn := NewConn(ReadWriteChannel, ReadWriteChannel, IgnoreChannel, ReadChannel, WriteChannel)
-	s, addr := newServer(conn.handle)
-	defer s.Close()
+	// TODO: Uncomment next two lines and remove third line when fix #19254
+	// s, addr := newServer(conn.handle)
+	// defer s.Close()
+	_, addr := newServer(conn.handle)
 
 	client, err := websocket.Dial("ws://"+addr, "", "http://localhost/")
 	if err != nil {
@@ -113,8 +115,10 @@ func TestRawConn(t *testing.T) {
 
 func TestBase64Conn(t *testing.T) {
 	conn := NewConn(ReadWriteChannel, ReadWriteChannel)
-	s, addr := newServer(conn.handle)
-	defer s.Close()
+	// TODO: Uncomment next two lines and remove third line when fix #19254
+	// s, addr := newServer(conn.handle)
+	// defer s.Close()
+	_, addr := newServer(conn.handle)
 
 	config, err := websocket.NewConfig("ws://"+addr, "http://localhost/")
 	if err != nil {

--- a/plugin/pkg/auth/authenticator/token/oidc/oidc_test.go
+++ b/plugin/pkg/auth/authenticator/token/oidc/oidc_test.go
@@ -237,7 +237,8 @@ func TestOIDCDiscoverySecureConnection(t *testing.T) {
 	// Verify that plain HTTP issuer URL is forbidden.
 	op := newOIDCProvider(t)
 	srv := httptest.NewServer(op.mux)
-	defer srv.Close()
+	// TODO: Uncomment when fix #19254
+	// defer srv.Close()
 
 	op.pcfg = oidc.ProviderConfig{
 		Issuer:       srv.URL,

--- a/plugin/pkg/scheduler/factory/factory_test.go
+++ b/plugin/pkg/scheduler/factory/factory_test.go
@@ -43,7 +43,8 @@ func TestCreate(t *testing.T) {
 		T:            t,
 	}
 	server := httptest.NewServer(&handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	client := client.NewOrDie(&client.Config{Host: server.URL, GroupVersion: testapi.Default.GroupVersion()})
 	factory := NewConfigFactory(client, nil, api.DefaultSchedulerName)
 	factory.Create()
@@ -61,7 +62,8 @@ func TestCreateFromConfig(t *testing.T) {
 		T:            t,
 	}
 	server := httptest.NewServer(&handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	client := client.NewOrDie(&client.Config{Host: server.URL, GroupVersion: testapi.Default.GroupVersion()})
 	factory := NewConfigFactory(client, nil, api.DefaultSchedulerName)
 
@@ -103,7 +105,8 @@ func TestCreateFromEmptyConfig(t *testing.T) {
 		T:            t,
 	}
 	server := httptest.NewServer(&handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	client := client.NewOrDie(&client.Config{Host: server.URL, GroupVersion: testapi.Default.GroupVersion()})
 	factory := NewConfigFactory(client, nil, api.DefaultSchedulerName)
 
@@ -147,7 +150,8 @@ func TestDefaultErrorFunc(t *testing.T) {
 	// FakeHandler musn't be sent requests other than the one you want to test.
 	mux.Handle(testapi.Default.ResourcePath("pods", "bar", "foo"), &handler)
 	server := httptest.NewServer(mux)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	factory := NewConfigFactory(client.NewOrDie(&client.Config{Host: server.URL, GroupVersion: testapi.Default.GroupVersion()}), nil, api.DefaultSchedulerName)
 	queue := cache.NewFIFO(cache.MetaNamespaceKeyFunc)
 	podBackoff := podBackoff{
@@ -230,7 +234,8 @@ func TestBind(t *testing.T) {
 			T:            t,
 		}
 		server := httptest.NewServer(&handler)
-		defer server.Close()
+		// TODO: Uncomment when fix #19254
+		// defer server.Close()
 		client := client.NewOrDie(&client.Config{Host: server.URL, GroupVersion: testapi.Default.GroupVersion()})
 		b := binder{client}
 
@@ -315,7 +320,8 @@ func TestResponsibleForPod(t *testing.T) {
 		T:            t,
 	}
 	server := httptest.NewServer(&handler)
-	defer server.Close()
+	// TODO: Uncomment when fix #19254
+	// defer server.Close()
 	client := client.NewOrDie(&client.Config{Host: server.URL, GroupVersion: testapi.Default.GroupVersion()})
 	// factory of "default-scheduler"
 	factoryDefaultScheduler := NewConfigFactory(client, nil, api.DefaultSchedulerName)

--- a/test/component/scheduler/perf/util.go
+++ b/test/component/scheduler/perf/util.go
@@ -71,7 +71,8 @@ func mustSetupScheduler() (schedulerConfigFactory *factory.ConfigFactory, destro
 	destroyFunc = func() {
 		glog.Infof("destroying")
 		close(schedulerConfig.StopEverything)
-		s.Close()
+		// TODO: Uncomment when fix #19254
+		// s.Close()
 		glog.Infof("destroyed")
 	}
 	return

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -390,7 +390,8 @@ func TestAuthModeAlwaysAllow(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		m.Handler.ServeHTTP(w, req)
 	}))
-	defer s.Close()
+	// TODO: Uncomment when fix #19254
+	// defer s.Close()
 
 	masterConfig := framework.NewIntegrationTestMasterConfig()
 	m = master.New(masterConfig)
@@ -492,7 +493,8 @@ func TestAuthModeAlwaysDeny(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		m.Handler.ServeHTTP(w, req)
 	}))
-	defer s.Close()
+	// TODO: Uncomment when fix #19254
+	// defer s.Close()
 
 	masterConfig := framework.NewIntegrationTestMasterConfig()
 	masterConfig.Authorizer = apiserver.NewAlwaysDenyAuthorizer()
@@ -546,7 +548,8 @@ func TestAliceNotForbiddenOrUnauthorized(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		m.Handler.ServeHTTP(w, req)
 	}))
-	defer s.Close()
+	// TODO: Uncomment when fix #19254
+	// defer s.Close()
 
 	masterConfig := framework.NewIntegrationTestMasterConfig()
 	masterConfig.Authenticator = getTestTokenAuth()
@@ -621,7 +624,8 @@ func TestBobIsForbidden(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		m.Handler.ServeHTTP(w, req)
 	}))
-	defer s.Close()
+	// TODO: Uncomment when fix #19254
+	// defer s.Close()
 
 	masterConfig := framework.NewIntegrationTestMasterConfig()
 	masterConfig.Authenticator = getTestTokenAuth()
@@ -669,7 +673,8 @@ func TestUnknownUserIsUnauthorized(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		m.Handler.ServeHTTP(w, req)
 	}))
-	defer s.Close()
+	// TODO: Uncomment when fix #19254
+	// defer s.Close()
 
 	masterConfig := framework.NewIntegrationTestMasterConfig()
 	masterConfig.Authenticator = getTestTokenAuth()
@@ -742,7 +747,8 @@ func TestAuthorizationAttributeDetermination(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		m.Handler.ServeHTTP(w, req)
 	}))
-	defer s.Close()
+	// TODO: Uncomment when fix #19254
+	// defer s.Close()
 
 	masterConfig := framework.NewIntegrationTestMasterConfig()
 	masterConfig.Authenticator = getTestTokenAuth()
@@ -810,7 +816,8 @@ func TestNamespaceAuthorization(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		m.Handler.ServeHTTP(w, req)
 	}))
-	defer s.Close()
+	// TODO: Uncomment when fix #19254
+	// defer s.Close()
 
 	masterConfig := framework.NewIntegrationTestMasterConfig()
 	masterConfig.Authenticator = getTestTokenAuth()
@@ -912,7 +919,8 @@ func TestKindAuthorization(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		m.Handler.ServeHTTP(w, req)
 	}))
-	defer s.Close()
+	// TODO: Uncomment when fix #19254
+	// defer s.Close()
 
 	masterConfig := framework.NewIntegrationTestMasterConfig()
 	masterConfig.Authenticator = getTestTokenAuth()
@@ -1001,7 +1009,8 @@ func TestReadOnlyAuthorization(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		m.Handler.ServeHTTP(w, req)
 	}))
-	defer s.Close()
+	// TODO: Uncomment when fix #19254
+	// defer s.Close()
 
 	masterConfig := framework.NewIntegrationTestMasterConfig()
 	masterConfig.Authenticator = getTestTokenAuth()

--- a/test/integration/extender_test.go
+++ b/test/integration/extender_test.go
@@ -191,7 +191,8 @@ func TestSchedulerExtender(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		m.Handler.ServeHTTP(w, req)
 	}))
-	defer s.Close()
+	// TODO: Uncomment when fix #19254
+	// defer s.Close()
 
 	masterConfig := framework.NewIntegrationTestMasterConfig()
 	m = master.New(masterConfig)
@@ -206,7 +207,8 @@ func TestSchedulerExtender(t *testing.T) {
 	es1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		extender1.serveHTTP(t, w, req)
 	}))
-	defer es1.Close()
+	// TODO: Uncomment when fix #19254
+	// defer es1.Close()
 
 	extender2 := &Extender{
 		name:         "extender2",
@@ -216,7 +218,8 @@ func TestSchedulerExtender(t *testing.T) {
 	es2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		extender2.serveHTTP(t, w, req)
 	}))
-	defer es2.Close()
+	// TODO: Uncomment when fix #19254
+	// defer es2.Close()
 
 	policy := schedulerapi.Policy{
 		ExtenderConfigs: []schedulerapi.ExtenderConfig{

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -183,7 +183,8 @@ func (m *MasterComponents) Stop(apiServer, rcManager bool) {
 		m.once.Do(m.stopRCManager)
 	}
 	if apiServer {
-		m.ApiServer.Close()
+		// TODO: Uncomment when fix #19254
+		// m.ApiServer.Close()
 	}
 }
 

--- a/test/integration/scheduler_test.go
+++ b/test/integration/scheduler_test.go
@@ -58,7 +58,8 @@ func TestUnschedulableNodes(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		m.Handler.ServeHTTP(w, req)
 	}))
-	defer s.Close()
+	// TODO: Uncomment when fix #19254
+	// defer s.Close()
 
 	masterConfig := framework.NewIntegrationTestMasterConfig()
 	m = master.New(masterConfig)
@@ -281,7 +282,8 @@ func TestMultiScheduler(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		m.Handler.ServeHTTP(w, req)
 	}))
-	defer s.Close()
+	// TODO: Uncomment when fix #19254
+	// defer s.Close()
 
 	masterConfig := framework.NewIntegrationTestMasterConfig()
 	m = master.New(masterConfig)

--- a/test/integration/secret_test.go
+++ b/test/integration/secret_test.go
@@ -49,7 +49,8 @@ func TestSecrets(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		m.Handler.ServeHTTP(w, req)
 	}))
-	defer s.Close()
+	// TODO: Uncomment when fix #19254
+	// defer s.Close()
 
 	masterConfig := framework.NewIntegrationTestMasterConfig()
 	m = master.New(masterConfig)

--- a/test/integration/service_account_test.go
+++ b/test/integration/service_account_test.go
@@ -422,7 +422,8 @@ func startServiceAccountTestServer(t *testing.T) (*client.Client, client.Config,
 		tokenController.Stop()
 		serviceAccountController.Stop()
 		serviceAccountAdmission.Stop()
-		apiServer.Close()
+		// TODO: Uncomment when fix #19254
+		// apiServer.Close()
 	}
 
 	return rootClient, clientConfig, stop


### PR DESCRIPTION
See #19254 for more details. This change should be reverted when we upgrade to Go 1.6.

@mikedanese @quinton-hoole 
