### PR TITLE
Run test for grabbing metrics from Kubelet only on GCE

### DIFF
--- a/test/e2e/metrics_grabber_test.go
+++ b/test/e2e/metrics_grabber_test.go
@@ -92,15 +92,18 @@ var _ = Describe("MetricsGrabber", func() {
 	})
 
 	It("should grab all metrics from a Kubelet.", func() {
-		By("Connecting proxying to Node through the API server")
-		nodes := ListSchedulableNodesOrDie(c)
-		Expect(nodes.Items).NotTo(BeEmpty())
-		unknownMetrics := sets.NewString()
-		response, err := grabber.GrabFromKubelet(nodes.Items[0].Name, unknownMetrics)
-		expectNoError(err)
-		Expect(unknownMetrics).To(BeEmpty())
+		// We run this test only on GCE, as for some reason it flakes in GKE #19468
+		if providerIs("gce") {
+			By("Connecting proxying to Node through the API server")
+			nodes := ListSchedulableNodesOrDie(c)
+			Expect(nodes.Items).NotTo(BeEmpty())
+			unknownMetrics := sets.NewString()
+			response, err := grabber.GrabFromKubelet(nodes.Items[0].Name, unknownMetrics)
+			expectNoError(err)
+			Expect(unknownMetrics).To(BeEmpty())
 
-		checkMetrics(metrics.Metrics(response), metrics.KnownKubeletMetrics)
+			checkMetrics(metrics.Metrics(response), metrics.KnownKubeletMetrics)
+		}
 	})
 
 	It("should grab all metrics from a Scheduler.", func() {


### PR DESCRIPTION
Ref. #19468

cc @roberthbailey
