### PR TITLE
Don't print hairpin_mode error when not using Linux bridges

### DIFF
--- a/pkg/kubelet/network/hairpin/hairpin.go
+++ b/pkg/kubelet/network/hairpin/hairpin.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"os"
 	"path"
 	"regexp"
 	"strconv"
@@ -30,7 +31,8 @@ import (
 
 const (
 	sysfsNetPath            = "/sys/devices/virtual/net"
-	hairpinModeRelativePath = "brport/hairpin_mode"
+	brportRelativePath      = "brport"
+	hairpinModeRelativePath = "hairpin_mode"
 	hairpinEnable           = "1"
 )
 
@@ -95,6 +97,15 @@ func setUpAllInterfaces() error {
 
 func setUpInterface(ifName string) error {
 	glog.V(3).Infof("Enabling hairpin on interface %s", ifName)
-	hairpinModeFile := path.Join(sysfsNetPath, ifName, hairpinModeRelativePath)
+	ifPath := path.Join(sysfsNetPath, ifName)
+	if _, err := os.Stat(ifPath); err != nil {
+		return err
+	}
+	brportPath := path.Join(ifPath, brportRelativePath)
+	if _, err := os.Stat(brportPath); err != nil && os.IsNotExist(err) {
+		// Device is not on a bridge, so doesn't need hairpin mode
+		return nil
+	}
+	hairpinModeFile := path.Join(brportPath, hairpinModeRelativePath)
 	return ioutil.WriteFile(hairpinModeFile, []byte(hairpinEnable), 0644)
 }

--- a/pkg/kubelet/network/hairpin/hairpin_test.go
+++ b/pkg/kubelet/network/hairpin/hairpin_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 	"testing"
 
@@ -84,13 +85,23 @@ func TestFindPairInterfaceOfContainerInterface(t *testing.T) {
 	}
 }
 
-func TestSetUpInterface(t *testing.T) {
+func TestSetUpInterfaceNonExistent(t *testing.T) {
 	err := setUpInterface("non-existent")
 	if err == nil {
 		t.Errorf("unexpected non-error")
 	}
-	hairpinModeFile := fmt.Sprintf("%s/%s/%s", sysfsNetPath, "non-existent", hairpinModeRelativePath)
-	if !strings.Contains(fmt.Sprintf("%v", err), hairpinModeFile) {
-		t.Errorf("should have tried to open %s", hairpinModeFile)
+	deviceDir := fmt.Sprintf("%s/%s", sysfsNetPath, "non-existent")
+	if !strings.Contains(fmt.Sprintf("%v", err), deviceDir) {
+		t.Errorf("should have tried to open %s", deviceDir)
+	}
+}
+
+func TestSetUpInterfaceNotBridged(t *testing.T) {
+	err := setUpInterface("lo")
+	if err != nil {
+		if os.IsNotExist(err) {
+			t.Skipf("'lo' device does not exist??? (%v)", err)
+		}
+		t.Errorf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
#13628 made kubernetes log a warning if it could not set hairpin_mode on a container interface, which is wrong if you're using a plugin that doesn't use linux bridges (ie, if you're using ovs).

This patch fixes it so that if the container interface exists, but is not attached to a linux bridge, then you don't get an error message. (Under the assumption that if the interface isn't attached to a bridge at this point, then that's because it's not supposed to be, because if the network plugin had tried to attach it to a bridge and failed, then it would have returned an error from SetUpPod().)
