### PR TITLE
[Client-gen] Generated client: add expansion methods

### DIFF
--- a/pkg/client/typed/generated/legacy/unversioned/event_expansion.go
+++ b/pkg/client/typed/generated/legacy/unversioned/event_expansion.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+type EventExpansion interface {
+	// CreateWithEventNamespace is the same as a Create, except that it sends the request to the event.Namespace.
+	CreateWithEventNamespace(event *api.Event) (*api.Event, error)
+	// UpdateWithEventNamespace is the same as a Update, except that it sends the request to the event.Namespace.
+	UpdateWithEventNamespace(event *api.Event) (*api.Event, error)
+	Patch(event *api.Event, data []byte) (*api.Event, error)
+	// Search finds events about the specified object
+	Search(objOrRef runtime.Object) (*api.EventList, error)
+	// Returns the appropriate field selector based on the API version being used to communicate with the server.
+	// The returned field selector can be used with List and Watch to filter desired events.
+	GetFieldSelector(involvedObjectName, involvedObjectNamespace, involvedObjectKind, involvedObjectUID *string) fields.Selector
+}
+
+// CreateWithEventNamespace makes a new event. Returns the copy of the event the server returns,
+// or an error. The namespace to create the event within is deduced from the
+// event; it must either match this event client's namespace, or this event
+// client must have been created with the "" namespace.
+func (e *events) CreateWithEventNamespace(event *api.Event) (*api.Event, error) {
+	if e.ns != "" && event.Namespace != e.ns {
+		return nil, fmt.Errorf("can't create an event with namespace '%v' in namespace '%v'", event.Namespace, e.ns)
+	}
+	result := &api.Event{}
+	err := e.client.Post().
+		NamespaceIfScoped(event.Namespace, len(event.Namespace) > 0).
+		Resource("events").
+		Body(event).
+		Do().
+		Into(result)
+	return result, err
+}
+
+// UpdateWithEventNamespace modifies an existing event. It returns the copy of the event that the server returns,
+// or an error. The namespace and key to update the event within is deduced from the event. The
+// namespace must either match this event client's namespace, or this event client must have been
+// created with the "" namespace. Update also requires the ResourceVersion to be set in the event
+// object.
+func (e *events) UpdateWithEventNamespace(event *api.Event) (*api.Event, error) {
+	result := &api.Event{}
+	err := e.client.Put().
+		NamespaceIfScoped(event.Namespace, len(event.Namespace) > 0).
+		Resource("events").
+		Name(event.Name).
+		Body(event).
+		Do().
+		Into(result)
+	return result, err
+}
+
+// Patch modifies an existing event. It returns the copy of the event that the server returns, or an
+// error. The namespace and name of the target event is deduced from the incompleteEvent. The
+// namespace must either match this event client's namespace, or this event client must have been
+// created with the "" namespace.
+func (e *events) Patch(incompleteEvent *api.Event, data []byte) (*api.Event, error) {
+	result := &api.Event{}
+	err := e.client.Patch(api.StrategicMergePatchType).
+		NamespaceIfScoped(incompleteEvent.Namespace, len(incompleteEvent.Namespace) > 0).
+		Resource("events").
+		Name(incompleteEvent.Name).
+		Body(data).
+		Do().
+		Into(result)
+	return result, err
+}
+
+// Search finds events about the specified object. The namespace of the
+// object must match this event's client namespace unless the event client
+// was made with the "" namespace.
+func (e *events) Search(objOrRef runtime.Object) (*api.EventList, error) {
+	ref, err := api.GetReference(objOrRef)
+	if err != nil {
+		return nil, err
+	}
+	if e.ns != "" && ref.Namespace != e.ns {
+		return nil, fmt.Errorf("won't be able to find any events of namespace '%v' in namespace '%v'", ref.Namespace, e.ns)
+	}
+	stringRefKind := string(ref.Kind)
+	var refKind *string
+	if stringRefKind != "" {
+		refKind = &stringRefKind
+	}
+	stringRefUID := string(ref.UID)
+	var refUID *string
+	if stringRefUID != "" {
+		refUID = &stringRefUID
+	}
+	fieldSelector := e.GetFieldSelector(&ref.Name, &ref.Namespace, refKind, refUID)
+	return e.List(api.ListOptions{FieldSelector: fieldSelector})
+}
+
+// Returns the appropriate field selector based on the API version being used to communicate with the server.
+// The returned field selector can be used with List and Watch to filter desired events.
+func (e *events) GetFieldSelector(involvedObjectName, involvedObjectNamespace, involvedObjectKind, involvedObjectUID *string) fields.Selector {
+	apiVersion := e.client.APIVersion().String()
+	field := fields.Set{}
+	if involvedObjectName != nil {
+		field[GetInvolvedObjectNameFieldLabel(apiVersion)] = *involvedObjectName
+	}
+	if involvedObjectNamespace != nil {
+		field["involvedObject.namespace"] = *involvedObjectNamespace
+	}
+	if involvedObjectKind != nil {
+		field["involvedObject.kind"] = *involvedObjectKind
+	}
+	if involvedObjectUID != nil {
+		field["involvedObject.uid"] = *involvedObjectUID
+	}
+	return field.AsSelector()
+}
+
+// Returns the appropriate field label to use for name of the involved object as per the given API version.
+func GetInvolvedObjectNameFieldLabel(version string) string {
+	return "involvedObject.name"
+}

--- a/pkg/client/typed/generated/legacy/unversioned/namespace_expansion.go
+++ b/pkg/client/typed/generated/legacy/unversioned/namespace_expansion.go
@@ -16,26 +16,15 @@ limitations under the License.
 
 package unversioned
 
-type ComponentStatusExpansion interface{}
+import "k8s.io/kubernetes/pkg/api"
 
-type EndpointsExpansion interface{}
+type NamespaceExpansion interface {
+	Finalize(item *api.Namespace) (*api.Namespace, error)
+}
 
-type LimitRangeExpansion interface{}
-
-type NodeExpansion interface{}
-
-type PersistentVolumeExpansion interface{}
-
-type PersistentVolumeClaimExpansion interface{}
-
-type PodTemplateExpansion interface{}
-
-type ReplicationControllerExpansion interface{}
-
-type ResourceQuotaExpansion interface{}
-
-type SecretExpansion interface{}
-
-type ServiceExpansion interface{}
-
-type ServiceAccountExpansion interface{}
+// Finalize takes the representation of a namespace to update.  Returns the server's representation of the namespace, and an error, if it occurs.
+func (c *namespaces) Finalize(namespace *api.Namespace) (result *api.Namespace, err error) {
+	result = &api.Namespace{}
+	err = c.client.Put().Resource("namespaces").Name(namespace.Name).SubResource("finalize").Body(namespace).Do().Into(result)
+	return
+}

--- a/pkg/client/typed/generated/legacy/unversioned/pod_expansion.go
+++ b/pkg/client/typed/generated/legacy/unversioned/pod_expansion.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	unversioned "k8s.io/kubernetes/pkg/client/unversioned"
+)
+
+type PodExpansion interface {
+	Bind(binding *api.Binding) error
+	GetLogs(name string, opts *api.PodLogOptions) *unversioned.Request
+}
+
+// Bind applies the provided binding to the named pod in the current namespace (binding.Namespace is ignored).
+func (c *pods) Bind(binding *api.Binding) error {
+	return c.client.Post().Namespace(c.ns).Resource("pods").Name(binding.Name).SubResource("binding").Body(binding).Do().Error()
+}
+
+// Get constructs a request for getting the logs for a pod
+func (c *pods) GetLogs(name string, opts *api.PodLogOptions) *unversioned.Request {
+	return c.client.Get().Namespace(c.ns).Name(name).Resource("pods").SubResource("log").VersionedParams(opts, api.Scheme)
+}


### PR DESCRIPTION
A follow up of #19379, this PR copies the extra methods from pkg/client/unversioned/ to the generated client.

The first commit is #19379, please take a look at the second one.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/19492)

<!-- Reviewable:end -->
