### PR TITLE
Errors in network setup should prevent pod creation

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2683,12 +2683,14 @@ func (kl *Kubelet) syncNetworkStatus() {
 		if err := ensureIPTablesMasqRule(); err != nil {
 			err = fmt.Errorf("Error on adding ip table rules: %v", err)
 			glog.Error(err)
+			kl.runtimeState.setNetworkState(err)
+			return
 		}
 		podCIDR := kl.runtimeState.podCIDR()
 		if len(podCIDR) == 0 {
 			err = fmt.Errorf("ConfigureCBR0 requested, but PodCIDR not set. Will not configure CBR0 right now")
 			glog.Warning(err)
-		} else if err := kl.reconcileCBR0(podCIDR); err != nil {
+		} else if err = kl.reconcileCBR0(podCIDR); err != nil {
 			err = fmt.Errorf("Error configuring cbr0: %v", err)
 			glog.Error(err)
 		}


### PR DESCRIPTION
Unittesting requires a larger refactor (https://github.com/bprashanth/kubernetes/commit/0e4a593ee884fab410a53d9a596e1a763e06f341), which I'm not going to invest in right now unless someone from @kubernetes/goog-node thinks it's worthwhile.
