### PR TITLE
client-gen: typed client with only the expansion interface

### DIFF
--- a/cmd/libs/go2idl/client-gen/generators/generator-for-type.go
+++ b/cmd/libs/go2idl/client-gen/generators/generator-for-type.go
@@ -84,12 +84,19 @@ func (g *genClientForType) GenerateType(c *generator.Context, t *types.Type, w i
 	} else {
 		sw.Do(getterNonNamesapced, m)
 	}
+	noMethods := types.ExtractCommentTags("+", t.SecondClosestCommentLines)["noMethods"] == "true"
+
 	sw.Do(interfaceTemplate1, m)
-	// Include the UpdateStatus method if the type has a status
-	if hasStatus(t) {
-		sw.Do(interfaceUpdateStatusTemplate, m)
+	if !noMethods {
+		sw.Do(interfaceTemplate2, m)
+		// Include the UpdateStatus method if the type has a status
+		if hasStatus(t) {
+			sw.Do(interfaceUpdateStatusTemplate, m)
+		}
+		sw.Do(interfaceTemplate3, m)
 	}
-	sw.Do(interfaceTemplate2, m)
+	sw.Do(interfaceTemplate4, m)
+
 	if namespaced {
 		sw.Do(structNamespaced, m)
 		sw.Do(newStructNamespaced, m)
@@ -97,17 +104,20 @@ func (g *genClientForType) GenerateType(c *generator.Context, t *types.Type, w i
 		sw.Do(structNonNamespaced, m)
 		sw.Do(newStructNonNamespaced, m)
 	}
-	sw.Do(createTemplate, m)
-	sw.Do(updateTemplate, m)
-	// Generate the UpdateStatus method if the type has a status
-	if hasStatus(t) {
-		sw.Do(updateStatusTemplate, m)
+
+	if !noMethods {
+		sw.Do(createTemplate, m)
+		sw.Do(updateTemplate, m)
+		// Generate the UpdateStatus method if the type has a status
+		if hasStatus(t) {
+			sw.Do(updateStatusTemplate, m)
+		}
+		sw.Do(deleteTemplate, m)
+		sw.Do(deleteCollectionTemplate, m)
+		sw.Do(getTemplate, m)
+		sw.Do(listTemplate, m)
+		sw.Do(watchTemplate, m)
 	}
-	sw.Do(deleteTemplate, m)
-	sw.Do(deleteCollectionTemplate, m)
-	sw.Do(getTemplate, m)
-	sw.Do(listTemplate, m)
-	sw.Do(watchTemplate, m)
 
 	return sw.Error()
 }
@@ -132,7 +142,9 @@ type $.type|publicPlural$Getter interface {
 // this type's interface, typed client will implement this interface.
 var interfaceTemplate1 = `
 // $.type|public$Interface has methods to work with $.type|public$ resources.
-type $.type|public$Interface interface {
+type $.type|public$Interface interface {`
+
+var interfaceTemplate2 = `
 	Create(*$.type|raw$) (*$.type|raw$, error)
 	Update(*$.type|raw$) (*$.type|raw$, error)`
 
@@ -140,12 +152,14 @@ var interfaceUpdateStatusTemplate = `
 	UpdateStatus(*$.type|raw$) (*$.type|raw$, error)`
 
 // template for the Interface
-var interfaceTemplate2 = `
+var interfaceTemplate3 = `
 	Delete(name string, options *$.apiDeleteOptions|raw$) error
 	DeleteCollection(options *$.apiDeleteOptions|raw$, listOptions $.apiListOptions|raw$) error
 	Get(name string) (*$.type|raw$, error)
 	List(opts $.apiListOptions|raw$) (*$.type|raw$List, error)
-	Watch(opts $.apiListOptions|raw$) ($.watchInterface|raw$, error)
+	Watch(opts $.apiListOptions|raw$) ($.watchInterface|raw$, error)`
+
+var interfaceTemplate4 = `
 	$.type|public$Expansion
 }
 `

--- a/pkg/apis/extensions/types.go
+++ b/pkg/apis/extensions/types.go
@@ -49,6 +49,8 @@ type ScaleStatus struct {
 	Selector map[string]string `json:"selector,omitempty"`
 }
 
+// +genclient=true,noMethods=true
+
 // represents a scaling request for a resource.
 type Scale struct {
 	unversioned.TypeMeta `json:",inline"`

--- a/pkg/client/typed/generated/extensions/unversioned/extensions_client.go
+++ b/pkg/client/typed/generated/extensions/unversioned/extensions_client.go
@@ -28,6 +28,7 @@ type ExtensionsInterface interface {
 	HorizontalPodAutoscalersGetter
 	IngressesGetter
 	JobsGetter
+	ScalesGetter
 	ThirdPartyResourcesGetter
 }
 
@@ -54,6 +55,10 @@ func (c *ExtensionsClient) Ingresses(namespace string) IngressInterface {
 
 func (c *ExtensionsClient) Jobs(namespace string) JobInterface {
 	return newJobs(c, namespace)
+}
+
+func (c *ExtensionsClient) Scales(namespace string) ScaleInterface {
+	return newScales(c, namespace)
 }
 
 func (c *ExtensionsClient) ThirdPartyResources(namespace string) ThirdPartyResourceInterface {

--- a/pkg/client/typed/generated/extensions/unversioned/scale.go
+++ b/pkg/client/typed/generated/extensions/unversioned/scale.go
@@ -16,16 +16,27 @@ limitations under the License.
 
 package unversioned
 
-type DaemonSetExpansion interface{}
+// ScalesGetter has a method to return a ScaleInterface.
+// A group's client should implement this interface.
+type ScalesGetter interface {
+	Scales(namespace string) ScaleInterface
+}
 
-type DeploymentExpansion interface{}
+// ScaleInterface has methods to work with Scale resources.
+type ScaleInterface interface {
+	ScaleExpansion
+}
 
-type HorizontalPodAutoscalerExpansion interface{}
+// scales implements ScaleInterface
+type scales struct {
+	client *ExtensionsClient
+	ns     string
+}
 
-type IngressExpansion interface{}
-
-type JobExpansion interface{}
-
-type ScaleExpansion interface{}
-
-type ThirdPartyResourceExpansion interface{}
+// newScales returns a Scales
+func newScales(c *ExtensionsClient, namespace string) *scales {
+	return &scales{
+		client: c,
+		ns:     namespace,
+	}
+}


### PR DESCRIPTION
Add comment tag "noMethods=true", which will instruct the client-gen to generate a typed client with only the expansion interface. This is useful for irregular typed client, like the one for subresource [`Scale`](https://github.com/kubernetes/kubernetes/blob/master/pkg/client/unversioned/scale.go).

~~This depends on #19267 and #19379. First two commit are the dependencies.~~
