### PR TITLE
Add documentation for labels

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -269,6 +269,7 @@ CURRENT_RELEASE_PUBLISHED_VERSION="ci/latest-1.1"
 GCE_DEFAULT_SKIP_TESTS=(
     "\[Example\]" # previously in REBOOT_SKIP_TESTS..., dates back before version control (#10078)
     "\[Skipped\]"
+    "\[Feature:.+\]"
     )
 
 # PROVIDER SKIPS --------------------------------------

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -147,7 +147,8 @@ func TestE2E(t *testing.T) {
 
 	// Disable skipped tests unless they are explicitly requested.
 	if config.GinkgoConfig.FocusString == "" && config.GinkgoConfig.SkipString == "" {
-		config.GinkgoConfig.SkipString = `\[Skipped\]`
+		// TODO(ihmccreery) Remove [Skipped] once all [Skipped] labels have been reclassified.
+		config.GinkgoConfig.SkipString = `\[Flaky\]|\[Skipped\]|\[Feature\]`
 	}
 	gomega.RegisterFailHandler(ginkgo.Fail)
 


### PR DESCRIPTION
Add doc for partitioning tests, and collapse `[Serial]` into `[Disruptive]`.

Progress toward #10548.

cc @kubernetes/goog-testing
