### PR TITLE
Don't run git clean in kubernetes-test-go.

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-test-go.yaml
+++ b/hack/jenkins/job-configs/kubernetes-test-go.yaml
@@ -38,9 +38,6 @@
             browser-url: https://github.com/kubernetes/kubernetes
             wipe-workspace: false
             skip-tag: true
-            clean:
-                after: true
-                before: false
     triggers:
         - pollscm:
             cron: 'H/2 * * * *'
@@ -52,6 +49,19 @@
             timeout: 30
             fail: true
         - timestamps
+        - raw:
+            xml: |
+                <hudson.plugins.ws__cleanup.PreBuildCleanup plugin="ws-cleanup@0.28">
+                    <patterns>
+                        <hudson.plugins.ws__cleanup.Pattern>
+                            <pattern>*</pattern>
+                            <type>INCLUDE</type>
+                        </hudson.plugins.ws__cleanup.Pattern>
+                    </patterns>
+                    <deleteDirs>true</deleteDirs>
+                    <cleanupParameter/>
+                    <externalDelete>sudo rm -rf %s</externalDelete>
+                </hudson.plugins.ws__cleanup.PreBuildCleanup>
 
 - project:
     name: kubernetes-test-go


### PR DESCRIPTION
#19430  broke the two jobs because they failed to clean Godeps, so we got a red light and this error:

```
 > git clean -fdx # timeout=10
FATAL: Command "git clean -fdx" returned status code 1:
stdout: Removing Godeps/_workspace/bin/
Removing Godeps/_workspace/pkg/
Removing _artifacts/
Removing _output/
Removing generatedJUnitFiles/
Removing third_party/etcd
Removing third_party/etcd-v2.0.0-linux-amd64/

stderr: warning: failed to remove Godeps/_workspace/bin/
warning: failed to remove Godeps/_workspace/pkg/
warning: failed to remove _artifacts/
warning: failed to remove _output/
warning: failed to remove third_party/etcd-v2.0.0-linux-amd64/

hudson.plugins.git.GitException: Command "git clean -fdx" returned status code 1:
stdout: Removing Godeps/_workspace/bin/
Removing Godeps/_workspace/pkg/
Removing _artifacts/
Removing _output/
Removing generatedJUnitFiles/
Removing third_party/etcd
Removing third_party/etcd-v2.0.0-linux-amd64/

stderr: warning: failed to remove Godeps/_workspace/bin/
warning: failed to remove Godeps/_workspace/pkg/
warning: failed to remove _artifacts/
warning: failed to remove _output/
warning: failed to remove third_party/etcd-v2.0.0-linux-amd64/

    at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandIn(CliGitAPIImpl.java:1640)
    at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandIn(CliGitAPIImpl.java:1616)
    at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandIn(CliGitAPIImpl.java:1612)
    at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommand(CliGitAPIImpl.java:1254)
    at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommand(CliGitAPIImpl.java:1266)
    at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.clean(CliGitAPIImpl.java:621)
    at hudson.plugins.git.GitAPI.clean(GitAPI.java:311)
    at sun.reflect.GeneratedMethodAccessor56.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
    at hudson.remoting.RemoteInvocationHandler$RPCRequest.perform(RemoteInvocationHandler.java:608)
    at hudson.remoting.RemoteInvocationHandler$RPCRequest.call(RemoteInvocationHandler.java:583)
    at hudson.remoting.RemoteInvocationHandler$RPCRequest.call(RemoteInvocationHandler.java:542)
    at hudson.remoting.UserRequest.perform(UserRequest.java:120)
    at hudson.remoting.UserRequest.perform(UserRequest.java:48)
    at hudson.remoting.Request$2.run(Request.java:326)
    at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:68)
    at java.util.concurrent.FutureTask.run(FutureTask.java:262)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    at java.lang.Thread.run(Thread.java:745)
    at ......remote call to jenkins-builder-1(Native Method)
    at hudson.remoting.Channel.attachCallSiteStackTrace(Channel.java:1416)
    at hudson.remoting.UserResponse.retrieve(UserRequest.java:220)
    at hudson.remoting.Channel.call(Channel.java:781)
    at hudson.remoting.RemoteInvocationHandler.invoke(RemoteInvocationHandler.java:250)
    at com.sun.proxy.$Proxy51.clean(Unknown Source)
    at org.jenkinsci.plugins.gitclient.RemoteGitImpl.clean(RemoteGitImpl.java:444)
    at hudson.plugins.git.extensions.impl.CleanCheckout.onCheckoutCompleted(CleanCheckout.java:28)
    at hudson.plugins.git.GitSCM.checkout(GitSCM.java:1074)
    at hudson.scm.SCM.checkout(SCM.java:485)
    at hudson.model.AbstractProject.checkout(AbstractProject.java:1276)
    at hudson.model.AbstractBuild$AbstractBuildExecution.defaultCheckout(AbstractBuild.java:607)
    at jenkins.scm.SCMCheckoutStrategy.checkout(SCMCheckoutStrategy.java:86)
    at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:529)
    at hudson.model.Run.execute(Run.java:1738)
    at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
    at hudson.model.ResourceController.execute(ResourceController.java:98)
    at hudson.model.Executor.run(Executor.java:410)
```

I've already made this change on Jenkins in order to fix the jobs.
