### PR TITLE
Remove FailedResourceType and return custom error

### DIFF
--- a/plugin/pkg/scheduler/algorithm/predicates/error.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/error.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicates
+
+import "fmt"
+
+var (
+	ErrExceededMaxPodNumber   = newInsufficientResourceError("PodCount")
+	ErrInsufficientFreeCPU    = newInsufficientResourceError("CPU")
+	ErrInsufficientFreeMemory = newInsufficientResourceError("Memory")
+)
+
+// InsufficientResourceError is an error type that indicates what kind of resource limit is
+// hit and caused the unfitting failure.
+type InsufficientResourceError struct {
+	// ResourceName tells the name of the resource that is insufficient
+	ResourceName string
+}
+
+func newInsufficientResourceError(resourceName string) *InsufficientResourceError {
+	return &InsufficientResourceError{resourceName}
+}
+
+func (e *InsufficientResourceError) Error() string {
+	return fmt.Sprintf("Node didn't have enough resource: %s", e.ResourceName)
+}

--- a/plugin/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/predicates.go
@@ -256,8 +256,6 @@ type resourceRequest struct {
 	memory   int64
 }
 
-var FailedResourceType string
-
 func getResourceRequest(pod *api.Pod) resourceRequest {
 	result := resourceRequest{}
 	for _, container := range pod.Spec.Containers {
@@ -308,8 +306,7 @@ func (r *ResourceFit) PodFitsResources(pod *api.Pod, existingPods []*api.Pod, no
 
 	if int64(len(existingPods))+1 > info.Status.Capacity.Pods().Value() {
 		glog.V(10).Infof("Cannot schedule Pod %+v, because Node %+v is full, running %v out of %v Pods.", podName(pod), node, len(existingPods), info.Status.Capacity.Pods().Value())
-		FailedResourceType = "PodExceedsMaxPodNumber"
-		return false, nil
+		return false, ErrExceededMaxPodNumber
 	}
 
 	podRequest := getResourceRequest(pod)
@@ -321,13 +318,11 @@ func (r *ResourceFit) PodFitsResources(pod *api.Pod, existingPods []*api.Pod, no
 	_, exceedingCPU, exceedingMemory := CheckPodsExceedingFreeResources(pods, info.Status.Capacity)
 	if len(exceedingCPU) > 0 {
 		glog.V(10).Infof("Cannot schedule Pod %+v, because Node %v does not have sufficient CPU", podName(pod), node)
-		FailedResourceType = "PodExceedsFreeCPU"
-		return false, nil
+		return false, ErrInsufficientFreeCPU
 	}
 	if len(exceedingMemory) > 0 {
 		glog.V(10).Infof("Cannot schedule Pod %+v, because Node %v does not have sufficient Memory", podName(pod), node)
-		FailedResourceType = "PodExceedsFreeMemory"
-		return false, nil
+		return false, ErrInsufficientFreeMemory
 	}
 	glog.V(10).Infof("Schedule Pod %+v on Node %+v is allowed, Node is running only %v out of %v Pods.", podName(pod), node, len(pods)-1, info.Status.Capacity.Pods().Value())
 	return true, nil

--- a/plugin/pkg/scheduler/generic_scheduler.go
+++ b/plugin/pkg/scheduler/generic_scheduler.go
@@ -129,8 +129,12 @@ func findNodesThatFit(pod *api.Pod, machineToPods map[string][]*api.Pod, predica
 		for name, predicate := range predicateFuncs {
 			fit, err := predicate(pod, machineToPods[node.Name], node.Name)
 			if err != nil {
-				switch err.(type) {
+				switch e := err.(type) {
 				case *predicates.InsufficientResourceError:
+					if fit {
+						err := fmt.Errorf("got InsufficientResourceError: %v, but also fit='true' which is unexpected", e)
+						return api.NodeList{}, FailedPredicateMap{}, err
+					}
 				default:
 					return api.NodeList{}, FailedPredicateMap{}, err
 				}

--- a/plugin/pkg/scheduler/generic_scheduler.go
+++ b/plugin/pkg/scheduler/generic_scheduler.go
@@ -127,18 +127,21 @@ func findNodesThatFit(pod *api.Pod, machineToPods map[string][]*api.Pod, predica
 	for _, node := range nodes.Items {
 		fits := true
 		for name, predicate := range predicateFuncs {
-			predicates.FailedResourceType = ""
 			fit, err := predicate(pod, machineToPods[node.Name], node.Name)
 			if err != nil {
-				return api.NodeList{}, FailedPredicateMap{}, err
+				switch err.(type) {
+				case *predicates.InsufficientResourceError:
+				default:
+					return api.NodeList{}, FailedPredicateMap{}, err
+				}
 			}
 			if !fit {
 				fits = false
 				if _, found := failedPredicateMap[node.Name]; !found {
 					failedPredicateMap[node.Name] = sets.String{}
 				}
-				if predicates.FailedResourceType != "" {
-					failedPredicateMap[node.Name].Insert(predicates.FailedResourceType)
+				if re, ok := err.(*predicates.InsufficientResourceError); ok {
+					failedPredicateMap[node.Name].Insert(re.ResourceName)
 					break
 				}
 				failedPredicateMap[node.Name].Insert(name)


### PR DESCRIPTION
To continue our discussion and work in #19487 and #19296.
The previous commit in #19296 didn't check the custom error from predicate() which caused failure cases.

Please let me know what you think. Highly appreciate it! @saad-ali @gmarek @lavalamp 
