### PR TITLE
Fix job status conditions bloat

### DIFF
--- a/pkg/controller/job/controller.go
+++ b/pkg/controller/job/controller.go
@@ -330,11 +330,11 @@ func (jm *JobController) syncJob(key string) error {
 		now := unversioned.Now()
 		job.Status.StartTime = &now
 	}
+	// if job was finished previously, we don't want to redo the termination
+	if isJobFinished(&job) {
+		return nil
+	}
 	if pastActiveDeadline(&job) {
-		// if job was finished previously, we don't want to redo the termination
-		if isJobFinished(&job) {
-			return nil
-		}
 		// TODO: below code should be replaced with pod termination resulting in
 		// pod failures, rather than killing pods. Unfortunately none such solution
 		// exists ATM. There's an open discussion in the topic in


### PR DESCRIPTION
When a job is complete, the controller will indefinitely update its conditions
with a Complete condition. This change makes the controller exit the
reconcilation as soon as the job is already found to be marked as complete.

@soltysh @erictune @deads2k 

Reported by @gravis
