### PR TITLE
Add the facility for AdmissionControllers to return warnings

### DIFF
--- a/pkg/admission/chain.go
+++ b/pkg/admission/chain.go
@@ -18,6 +18,7 @@ package admission
 
 import (
 	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/util/errors"
 )
 
 // chainAdmissionHandler is an instance of admission.Interface that performs admission control using a chain of admission handlers
@@ -42,17 +43,27 @@ func NewChainHandler(handlers ...Interface) Interface {
 }
 
 // Admit performs an admission control check using a chain of handlers, and returns immediately on first error
-func (admissionHandler chainAdmissionHandler) Admit(a Attributes) error {
+func (admissionHandler chainAdmissionHandler) Admit(a Attributes) (Warning, error) {
+	var errs []error
 	for _, handler := range admissionHandler {
 		if !handler.Handles(a.GetOperation()) {
 			continue
 		}
-		err := handler.Admit(a)
+		warning, err := handler.Admit(a)
+		if warning != nil {
+			aggregate, ok := warning.(errors.Aggregate)
+			if ok {
+				errs = append(errs, aggregate.Errors()...)
+			} else {
+				errs = append(errs, warning)
+			}
+		}
 		if err != nil {
-			return err
+			return errors.NewAggregate(errs), err
 		}
 	}
-	return nil
+
+	return errors.NewAggregate(errs), nil
 }
 
 // Handles will return true if any of the handlers handles the given operation

--- a/pkg/admission/chain_test.go
+++ b/pkg/admission/chain_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/util/errors"
 )
 
 type FakeHandler struct {
@@ -28,14 +29,15 @@ type FakeHandler struct {
 	name        string
 	admit       bool
 	admitCalled bool
+	warning     Warning
 }
 
-func (h *FakeHandler) Admit(a Attributes) (err error) {
+func (h *FakeHandler) Admit(a Attributes) (warn Warning, err error) {
 	h.admitCalled = true
 	if h.admit {
-		return nil
+		return h.warning, nil
 	}
-	return fmt.Errorf("Don't admit")
+	return h.warning, fmt.Errorf("Don't admit")
 }
 
 func makeHandler(name string, admit bool, ops ...Operation) Interface {
@@ -46,12 +48,31 @@ func makeHandler(name string, admit bool, ops ...Operation) Interface {
 	}
 }
 
+func makeHandlerWithWarning(name string, admit bool, warn Warning, ops ...Operation) Interface {
+	return &FakeHandler{
+		name:    name,
+		admit:   admit,
+		Handler: NewHandler(ops...),
+		warning: warn,
+	}
+}
+
+func containsWarning(warning Warning, warnings []error) bool {
+	for ix := range warnings {
+		if warning.Error() == warnings[ix].Error() {
+			return true
+		}
+	}
+	return false
+}
+
 func TestAdmit(t *testing.T) {
 	tests := []struct {
 		name      string
 		operation Operation
 		chain     chainAdmissionHandler
 		accept    bool
+		warnings  bool
 		calls     map[string]bool
 	}{
 		{
@@ -98,19 +119,47 @@ func TestAdmit(t *testing.T) {
 			calls:  map[string]bool{"a": true, "b": true},
 			accept: false,
 		},
+		{
+			name:      "warnings one",
+			operation: Create,
+			chain: []Interface{
+				makeHandlerWithWarning("a", true, Warning(fmt.Errorf("fake warning")), Update, Delete, Create),
+				makeHandler("b", true, Create),
+				makeHandlerWithWarning("c", true, Warning(fmt.Errorf("fake warning 2")), Create),
+			},
+			calls:    map[string]bool{"a": true, "b": true, "c": true},
+			accept:   true,
+			warnings: true,
+		},
 	}
 	for _, test := range tests {
-		err := test.chain.Admit(NewAttributesRecord(nil, unversioned.GroupKind{}, "", "", unversioned.GroupResource{}, "", test.operation, nil))
+		warn, err := test.chain.Admit(NewAttributesRecord(nil, unversioned.GroupKind{}, "", "", unversioned.GroupResource{}, "", test.operation, nil))
 		accepted := (err == nil)
 		if accepted != test.accept {
 			t.Errorf("%s: unexpected result of admit call: %v\n", test.name, accepted)
 		}
+		if test.warnings && warn == nil {
+			t.Errorf("unexpected non-warning")
+		}
+		var warnings []error
+		if warn != nil {
+			aggregate, ok := warn.(errors.Aggregate)
+			if !ok {
+				t.Errorf("unexpected warning: %v", warn)
+			} else {
+				warnings = aggregate.Errors()
+			}
+		}
+
 		for _, h := range test.chain {
 			fake := h.(*FakeHandler)
 			_, shouldBeCalled := test.calls[fake.name]
 			if shouldBeCalled != fake.admitCalled {
 				t.Errorf("%s: handler %s not called as expected: %v", test.name, fake.name, fake.admitCalled)
 				continue
+			}
+			if fake.warning != nil && !containsWarning(fake.warning, warnings) {
+				t.Errorf("%s: failed to find expected warning: %v (%v)", test.name, fake.warning, warnings)
 			}
 		}
 	}

--- a/pkg/admission/interfaces.go
+++ b/pkg/admission/interfaces.go
@@ -22,6 +22,12 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
+// Warning describes a warning to a user about an activity that they are taking.
+// A warning could be a deprecation message, it could be advice about an object, etc.
+type Warning interface {
+	error
+}
+
 // Attributes is an interface used by AdmissionController to get information about a request
 // that is used to make an admission decision.
 type Attributes interface {
@@ -50,7 +56,7 @@ type Attributes interface {
 // Interface is an abstract, pluggable interface for Admission Control decisions.
 type Interface interface {
 	// Admit makes an admission decision based on the request attributes
-	Admit(a Attributes) (err error)
+	Admit(a Attributes) (warning Warning, err error)
 
 	// Handles returns true if this admission controller can handle the given operation
 	// where operation can be one of CREATE, UPDATE, DELETE, or CONNECT

--- a/pkg/api/rest/resttest/resttest.go
+++ b/pkg/api/rest/resttest/resttest.go
@@ -18,6 +18,7 @@ package resttest
 
 import (
 	"fmt"
+	"net/http"
 	"reflect"
 	"strings"
 	"testing"
@@ -42,6 +43,9 @@ type Tester struct {
 	createOnUpdate      bool
 	generatesName       bool
 	returnDeletedObject bool
+
+	methods []string
+	handler http.Handler
 }
 
 func New(t *testing.T, storage rest.Storage) *Tester {
@@ -49,6 +53,18 @@ func New(t *testing.T, storage rest.Storage) *Tester {
 		T:       t,
 		storage: storage,
 	}
+}
+
+func (t *Tester) Connect(ctx api.Context, id string, options runtime.Object, r rest.Responder) (http.Handler, error) {
+	return t.handler, nil
+}
+
+func (t *Tester) NewConnectOptions() (runtime.Object, bool, string) {
+	return nil, false, ""
+}
+
+func (t *Tester) ConnectMethods() []string {
+	return t.methods
 }
 
 func (t *Tester) ClusterScope() *Tester {

--- a/pkg/apiserver/resthandler_test.go
+++ b/pkg/apiserver/resthandler_test.go
@@ -19,6 +19,7 @@ package apiserver
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"reflect"
 	"testing"
 	"time"
@@ -26,14 +27,64 @@ import (
 	"github.com/emicklei/go-restful"
 	"github.com/evanphx/json-patch"
 
+	"k8s.io/kubernetes/pkg/admission"
 	"k8s.io/kubernetes/pkg/api"
 	apierrors "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/strategicpatch"
 )
+
+type fakeWriter struct {
+	headers http.Header
+}
+
+func (f *fakeWriter) Write([]byte) (int, error) { return 0, fmt.Errorf("unimplemented") }
+func (f *fakeWriter) Header() http.Header       { return f.headers }
+func (f *fakeWriter) WriteHeader(int)           {}
+
+func TestAddWarnings(t *testing.T) {
+	tests := []struct {
+		name             string
+		warning          admission.Warning
+		expectedWarnings []string
+		source           string
+	}{
+		{
+			name:             "simple",
+			warning:          admission.Warning(fmt.Errorf("test warning")),
+			source:           "PodValidator",
+			expectedWarnings: []string{"199 PodValidator test warning"},
+		},
+		{
+			name: "aggregate",
+			warning: admission.Warning(utilerrors.NewAggregate([]error{
+				fmt.Errorf("test warning"),
+				fmt.Errorf("test warning 2"),
+			})),
+			source: "PodValidator",
+			expectedWarnings: []string{
+				"199 PodValidator test warning",
+				"199 PodValidator test warning 2",
+			},
+		},
+	}
+	for _, test := range tests {
+		res := &restful.Response{}
+		fakeWriter := &fakeWriter{
+			headers: http.Header{},
+		}
+		res.ResponseWriter = fakeWriter
+		addWarningHeaders(test.warning, test.source, res)
+		values := fakeWriter.headers["Warning"]
+		if !reflect.DeepEqual(values, test.expectedWarnings) {
+			t.Errorf("unexpected headers: %v expected: %v", values, test.expectedWarnings)
+		}
+	}
+}
 
 type testPatchType struct {
 	unversioned.TypeMeta `json:",inline"`

--- a/plugin/pkg/admission/admit/admission.go
+++ b/plugin/pkg/admission/admit/admission.go
@@ -33,8 +33,8 @@ func init() {
 // It is useful in tests and when using kubernetes in an open manner.
 type alwaysAdmit struct{}
 
-func (alwaysAdmit) Admit(a admission.Attributes) (err error) {
-	return nil
+func (alwaysAdmit) Admit(a admission.Attributes) (warn admission.Warning, err error) {
+	return nil, nil
 }
 
 func (alwaysAdmit) Handles(operation admission.Operation) bool {

--- a/plugin/pkg/admission/alwayspullimages/admission.go
+++ b/plugin/pkg/admission/alwayspullimages/admission.go
@@ -45,21 +45,21 @@ type alwaysPullImages struct {
 	*admission.Handler
 }
 
-func (a *alwaysPullImages) Admit(attributes admission.Attributes) (err error) {
+func (a *alwaysPullImages) Admit(attributes admission.Attributes) (warn admission.Warning, err error) {
 	// Ignore all calls to subresources or resources other than pods.
 	if len(attributes.GetSubresource()) != 0 || attributes.GetResource() != api.Resource("pods") {
-		return nil
+		return nil, nil
 	}
 	pod, ok := attributes.GetObject().(*api.Pod)
 	if !ok {
-		return apierrors.NewBadRequest("Resource was marked with kind Pod but was unable to be converted")
+		return nil, apierrors.NewBadRequest("Resource was marked with kind Pod but was unable to be converted")
 	}
 
 	for i := range pod.Spec.Containers {
 		pod.Spec.Containers[i].ImagePullPolicy = api.PullAlways
 	}
 
-	return nil
+	return nil, nil
 }
 
 // NewAlwaysPullImages creates a new always pull images admission control handler

--- a/plugin/pkg/admission/deny/admission.go
+++ b/plugin/pkg/admission/deny/admission.go
@@ -34,8 +34,8 @@ func init() {
 // It is useful in unit tests to force an operation to be forbidden.
 type alwaysDeny struct{}
 
-func (alwaysDeny) Admit(a admission.Attributes) (err error) {
-	return admission.NewForbidden(a, errors.New("Admission control is denying all modifications"))
+func (alwaysDeny) Admit(a admission.Attributes) (warn admission.Warning, err error) {
+	return nil, admission.NewForbidden(a, errors.New("Admission control is denying all modifications"))
 }
 
 func (alwaysDeny) Handles(operation admission.Operation) bool {

--- a/plugin/pkg/admission/exec/admission.go
+++ b/plugin/pkg/admission/exec/admission.go
@@ -76,33 +76,33 @@ func NewDenyExecOnPrivileged(client client.Interface) admission.Interface {
 	}
 }
 
-func (d *denyExec) Admit(a admission.Attributes) (err error) {
+func (d *denyExec) Admit(a admission.Attributes) (warn admission.Warning, err error) {
 	connectRequest, ok := a.GetObject().(*rest.ConnectRequest)
 	if !ok {
-		return errors.NewBadRequest("a connect request was received, but could not convert the request object.")
+		return nil, errors.NewBadRequest("a connect request was received, but could not convert the request object.")
 	}
 	// Only handle exec or attach requests on pods
 	if connectRequest.ResourcePath != "pods/exec" && connectRequest.ResourcePath != "pods/attach" {
-		return nil
+		return nil, nil
 	}
 	pod, err := d.client.Pods(a.GetNamespace()).Get(connectRequest.Name)
 	if err != nil {
-		return admission.NewForbidden(a, err)
+		return nil, admission.NewForbidden(a, err)
 	}
 
 	if d.hostPID && pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.HostPID {
-		return admission.NewForbidden(a, fmt.Errorf("Cannot exec into or attach to a container using host pid"))
+		return nil, admission.NewForbidden(a, fmt.Errorf("Cannot exec into or attach to a container using host pid"))
 	}
 
 	if d.hostIPC && pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.HostIPC {
-		return admission.NewForbidden(a, fmt.Errorf("Cannot exec into or attach to a container using host ipc"))
+		return nil, admission.NewForbidden(a, fmt.Errorf("Cannot exec into or attach to a container using host ipc"))
 	}
 
 	if d.privileged && isPrivileged(pod) {
-		return admission.NewForbidden(a, fmt.Errorf("Cannot exec into or attach to a privileged container"))
+		return nil, admission.NewForbidden(a, fmt.Errorf("Cannot exec into or attach to a privileged container"))
 	}
 
-	return nil
+	return nil, nil
 }
 
 // isPrivileged will return true a pod has any privileged containers

--- a/plugin/pkg/admission/initialresources/admission.go
+++ b/plugin/pkg/admission/initialresources/admission.go
@@ -71,18 +71,18 @@ func newInitialResources(source dataSource, percentile int64, nsOnly bool) admis
 	}
 }
 
-func (ir initialResources) Admit(a admission.Attributes) (err error) {
+func (ir initialResources) Admit(a admission.Attributes) (warn admission.Warning, err error) {
 	// Ignore all calls to subresources or resources other than pods.
 	if a.GetSubresource() != "" || a.GetResource() != api.Resource("pods") {
-		return nil
+		return nil, nil
 	}
 	pod, ok := a.GetObject().(*api.Pod)
 	if !ok {
-		return apierrors.NewBadRequest("Resource was marked with kind Pod but was unable to be converted")
+		return nil, apierrors.NewBadRequest("Resource was marked with kind Pod but was unable to be converted")
 	}
 
 	ir.estimateAndFillResourcesIfNotSet(pod)
-	return nil
+	return nil, nil
 }
 
 // The method veryfies whether resources should be set for the given pod and

--- a/plugin/pkg/admission/namespace/exists/admission.go
+++ b/plugin/pkg/admission/namespace/exists/admission.go
@@ -44,12 +44,12 @@ type exists struct {
 	store  cache.Store
 }
 
-func (e *exists) Admit(a admission.Attributes) (err error) {
+func (e *exists) Admit(a admission.Attributes) (warn admission.Warning, err error) {
 	// if we're here, then we've already passed authentication, so we're allowed to do what we're trying to do
 	// if we're here, then the API server has found a route, which means that if we have a non-empty namespace
 	// its a namespaced resource.
 	if len(a.GetNamespace()) == 0 || a.GetKind() == api.Kind("Namespace") {
-		return nil
+		return nil, nil
 	}
 
 	namespace := &api.Namespace{
@@ -61,22 +61,22 @@ func (e *exists) Admit(a admission.Attributes) (err error) {
 	}
 	_, exists, err := e.store.Get(namespace)
 	if err != nil {
-		return errors.NewInternalError(err)
+		return nil, errors.NewInternalError(err)
 	}
 	if exists {
-		return nil
+		return nil, nil
 	}
 
 	// in case of latency in our caches, make a call direct to storage to verify that it truly exists or not
 	_, err = e.client.Namespaces().Get(a.GetNamespace())
 	if err != nil {
 		if errors.IsNotFound(err) {
-			return err
+			return nil, err
 		}
-		return errors.NewInternalError(err)
+		return nil, errors.NewInternalError(err)
 	}
 
-	return nil
+	return nil, nil
 }
 
 // NewExists creates a new namespace exists admission control handler

--- a/plugin/pkg/admission/securitycontext/scdeny/admission.go
+++ b/plugin/pkg/admission/securitycontext/scdeny/admission.go
@@ -47,41 +47,41 @@ func NewSecurityContextDeny(client client.Interface) admission.Interface {
 }
 
 // Admit will deny any pod that defines SELinuxOptions or RunAsUser.
-func (p *plugin) Admit(a admission.Attributes) (err error) {
+func (p *plugin) Admit(a admission.Attributes) (warn admission.Warning, err error) {
 	if a.GetResource() != api.Resource("pods") {
-		return nil
+		return nil, nil
 	}
 
 	pod, ok := a.GetObject().(*api.Pod)
 	if !ok {
-		return apierrors.NewBadRequest("Resource was marked with kind Pod but was unable to be converted")
+		return nil, apierrors.NewBadRequest("Resource was marked with kind Pod but was unable to be converted")
 	}
 
 	if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.SupplementalGroups != nil {
-		return apierrors.NewForbidden(a.GetResource(), pod.Name, fmt.Errorf("SecurityContext.SupplementalGroups is forbidden"))
+		return nil, apierrors.NewForbidden(a.GetResource(), pod.Name, fmt.Errorf("SecurityContext.SupplementalGroups is forbidden"))
 	}
 	if pod.Spec.SecurityContext != nil {
 		if pod.Spec.SecurityContext.SELinuxOptions != nil {
-			return apierrors.NewForbidden(a.GetResource(), pod.Name, fmt.Errorf("pod.Spec.SecurityContext.SELinuxOptions is forbidden"))
+			return nil, apierrors.NewForbidden(a.GetResource(), pod.Name, fmt.Errorf("pod.Spec.SecurityContext.SELinuxOptions is forbidden"))
 		}
 		if pod.Spec.SecurityContext.RunAsUser != nil {
-			return apierrors.NewForbidden(a.GetResource(), pod.Name, fmt.Errorf("pod.Spec.SecurityContext.RunAsUser is forbidden"))
+			return nil, apierrors.NewForbidden(a.GetResource(), pod.Name, fmt.Errorf("pod.Spec.SecurityContext.RunAsUser is forbidden"))
 		}
 	}
 
 	if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.FSGroup != nil {
-		return apierrors.NewForbidden(a.GetResource(), pod.Name, fmt.Errorf("SecurityContext.FSGroup is forbidden"))
+		return nil, apierrors.NewForbidden(a.GetResource(), pod.Name, fmt.Errorf("SecurityContext.FSGroup is forbidden"))
 	}
 
 	for _, v := range pod.Spec.Containers {
 		if v.SecurityContext != nil {
 			if v.SecurityContext.SELinuxOptions != nil {
-				return apierrors.NewForbidden(a.GetResource(), pod.Name, fmt.Errorf("SecurityContext.SELinuxOptions is forbidden"))
+				return nil, apierrors.NewForbidden(a.GetResource(), pod.Name, fmt.Errorf("SecurityContext.SELinuxOptions is forbidden"))
 			}
 			if v.SecurityContext.RunAsUser != nil {
-				return apierrors.NewForbidden(a.GetResource(), pod.Name, fmt.Errorf("SecurityContext.RunAsUser is forbidden"))
+				return nil, apierrors.NewForbidden(a.GetResource(), pod.Name, fmt.Errorf("SecurityContext.RunAsUser is forbidden"))
 			}
 		}
 	}
-	return nil
+	return nil, nil
 }


### PR DESCRIPTION
@bgrant0607 @smarterclayton @lavalamp @deads2k @liggitt 

This adds the ability for `AdmissionControllers` to pass back warnings as well as errors.

These warnings are returned as an HTTP `Warning` header.

The use cases include:
- Advisorial admission controllers ("if you give that JVM only 10Mb of memory, you're going to have a bad time")
- Deprecation warnings (when we eventually deprecate `v11)
- Typos/nonsensical requests: (e.g. "No pods match the selector for that service", "Did you really mean to specify empty string for that secret?" )
  etc.

I plan on adding warning printing to kubectl in a follow on CL.

I know the unit tests don't compile (and there are no tests of the new behavior) I will add them once the rest of this LGTM.

Eventually, we can add a `warningsAsErrors` parameter to the request that will turn these into errors (similar to gcc `-Werror`), that way kubectl can dry-run things, see if there are errors, and then prompty "are you sure"
