### PR TITLE
ADDing to a dir should suffix the dir with /

### DIFF
--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -55,4 +55,4 @@ ENV KUBE_GIT_VERSION_FILE /kube-version-defs
 ENV KUBE_OUTPUT_SUBPATH _output/dockerized
 
 # Upload Kubernetes source
-ADD kube-source.tar.gz /go/src/k8s.io/kubernetes
+ADD kube-source.tar.gz /go/src/k8s.io/kubernetes/


### PR DESCRIPTION
When using ADD in a Dockerfile, if the target is a directory then it should end in `/`

Fixes the following:

``` sh
$ KUBERNETES_CONTRIB=mesos build/run.sh hack/build-cross.sh
+++ [0112 17:28:44] Verifying Prerequisites....
+++ [0112 17:28:45] Building Docker image kube-build:cross.
+++ [0112 17:28:47] Building Docker image kube-build:build-5f2e2cc586.
+++ [0112 17:28:55] Running build command....
Error response from daemon: Cannot start container ac7b5ac6f2dbdf0d41763e0d303525b95224e51e195ba849978735ea47a45176: Cannot mkdir: /go/src/k8s.io/kubernetes is not a directory
!!! Error in build/../build/common.sh:578
  '"${docker_cmd[@]}" "$@"' exited with status 1
Call stack:
  1: build/../build/common.sh:578 kube::build::run_build_command(...)
  2: build/run.sh:30 main(...)
Exiting with status 1
```

My docker version:

```
$ docker version
Client:
 Version:      1.8.3
 API version:  1.20
 Go version:   go1.4.2
 Git commit:   f4bf5c7
 Built:        Mon Oct 12 05:37:18 UTC 2015
 OS/Arch:      linux/amd64

Server:
 Version:      1.8.3
 API version:  1.20
 Go version:   go1.4.2
 Git commit:   f4bf5c7
 Built:        Mon Oct 12 05:37:18 UTC 2015
 OS/Arch:      linux/amd64
```

Docker info:

``` sh
$ docker info
Containers: 11
Images: 241
Storage Driver: overlay
 Backing Filesystem: extfs
Execution Driver: native-0.2
Logging Driver: json-file
Kernel Version: 3.19.0-30-generic
Operating System: Ubuntu 14.04 LTS
CPUs: 2
Total Memory: 4.844 GiB
Name: node-1
ID: 5P3G:6A7R:SWTX:D7YZ:QCLB:3WIU:QIZ2:J3VJ:2W7X:J2TV:KSXO:HWPB
Username: jdef
Registry: https://index.docker.io/v1/
WARNING: No swap limit support
```
