### PR TITLE
Make [Autoscaling] [Feature:Autoscaling]

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -289,7 +289,6 @@ GKE_REQUIRED_SKIP_TESTS=(
 
 # Specialized tests which should be skipped by default for GKE.
 GKE_DEFAULT_SKIP_TESTS=(
-    "Autoscaling\sSuite"
     # Perf test, slow by design
     "resource\susage\stracking"
     "${GKE_REQUIRED_SKIP_TESTS[@]}"
@@ -389,7 +388,7 @@ case ${JOB_NAME} in
   kubernetes-e2e-gce-autoscaling)
     : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-autoscaling"}
     : ${E2E_NETWORK:="e2e-autoscaling"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Autoscaling\]"}
+    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Feature:Autoscaling\]"}
     : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-autoscaling"}
     : ${PROJECT:="k8s-jnks-e2e-gce-autoscaling"}
     : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}

--- a/test/e2e/cluster_size_autoscaling.go
+++ b/test/e2e/cluster_size_autoscaling.go
@@ -32,7 +32,7 @@ const (
 	scaleDownTimeout = 30 * time.Minute
 )
 
-var _ = Describe("[Autoscaling] [Skipped]", func() {
+var _ = Describe("Autoscaling [Feature:Autoscaling]", func() {
 	f := NewFramework("autoscaling")
 	var nodeCount int
 	var coresPerNode int

--- a/test/e2e/horizontal_pod_autoscaling.go
+++ b/test/e2e/horizontal_pod_autoscaling.go
@@ -48,7 +48,7 @@ var _ = Describe("Horizontal pod autoscaling (scale resource: CPU) [Skipped]", f
 		})
 	})
 
-	Describe("[Autoscaling] ReplicationController", func() {
+	Describe("ReplicationController [Feature:Autoscaling]", func() {
 		// CPU tests via replication controllers
 		It(titleUp, func() {
 			scaleUp("rc", kindRC, rc, f)


### PR DESCRIPTION
Per #19505, make `[Autoscaling]` a `[Feature:...]`, so it's skipped by default.

This shouldn't be merged until #19505 is merged.

This is work toward #10548.
