### PR TITLE
Reclassify [Example] and [Feature:Example]

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -267,7 +267,6 @@ CURRENT_RELEASE_PUBLISHED_VERSION="ci/latest-1.1"
 
 # Specialized tests which should be skipped by default for projects.
 GCE_DEFAULT_SKIP_TESTS=(
-    "\[Example\]" # previously in REBOOT_SKIP_TESTS..., dates back before version control (#10078)
     "\[Skipped\]"
     )
 
@@ -380,7 +379,7 @@ case ${JOB_NAME} in
   kubernetes-e2e-gce-examples)
     : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-examples"}
     : ${E2E_NETWORK:="e2e-examples"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Example\]"}
+    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Feature:Example\]"}
     : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-examples"}
     : ${PROJECT:="kubernetes-jenkins"}
     ;;

--- a/test/e2e/example_cluster_dns.go
+++ b/test/e2e/example_cluster_dns.go
@@ -41,7 +41,7 @@ try:
 except:
 	print 'err'`
 
-var _ = Describe("[Example] ClusterDns", func() {
+var _ = Describe("ClusterDns [Feature:Example]", func() {
 	framework := NewFramework("cluster-dns")
 
 	var c *client.Client

--- a/test/e2e/example_k8petstore.go
+++ b/test/e2e/example_k8petstore.go
@@ -150,7 +150,7 @@ T:
 	Ω(totalTransactions).Should(BeNumerically(">", minExpected))
 }
 
-var _ = Describe("[Example] Pet Store [Skipped]", func() {
+var _ = Describe("Pet Store [Feature:Example]", func() {
 
 	// The number of nodes dictates total number of generators/transaction expectations.
 	var nodeCount int

--- a/test/e2e/examples.go
+++ b/test/e2e/examples.go
@@ -37,7 +37,7 @@ const (
 	serverStartTimeout = podStartTimeout + 3*time.Minute
 )
 
-var _ = Describe("[Example] [Skipped]", func() {
+var _ = Describe("[Feature:Example]", func() {
 	framework := NewFramework("examples")
 	var c *client.Client
 	var ns string


### PR DESCRIPTION
Per #19505, make `[Example]` a `[Feature:...]`, so it's skipped by default.

This shouldn't be merged until #19505 is merged.

This is work toward #10548.
