### PR TITLE
Relabel Restart tests as [Feature:Restart]

### DIFF
--- a/test/e2e/restart.go
+++ b/test/e2e/restart.go
@@ -48,9 +48,9 @@ const (
 	restartPodReadyAgainTimeout = 5 * time.Minute
 )
 
-// TODO(ihmccreery): This is skipped because it was previously in
-// REBOOT_SKIP_TESTS, dates back before version control (#10078)
-var _ = Describe("Restart [Skipped]", func() {
+// TODO(ihmccreery): These tests haven't been run for a while, so until they're
+// known stable, consider them a non-core feature.
+var _ = Describe("Restart [Feature:Restart]", func() {
 	var c *client.Client
 	var ps *podStore
 	var skipped bool


### PR DESCRIPTION
Per #19505, "Restart" tests shouldn't be `[Skipped]`, just `[Disruptive]`.

This shouldn't be merged until #19505 is merged.

This is work toward #10548.
