### PR TITLE
client-gen: add a nonNamespaced comment tag

### DIFF
--- a/cmd/libs/go2idl/client-gen/testoutput/testgroup/unversioned/testgroup_client.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/testgroup/unversioned/testgroup_client.go
@@ -23,7 +23,7 @@ import (
 )
 
 type TestgroupInterface interface {
-	TestTypeNamespacer
+	TestTypesGetter
 }
 
 // TestgroupClient is used to interact with features provided by the Testgroup group.

--- a/cmd/libs/go2idl/client-gen/testoutput/testgroup/unversioned/testtype.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/testgroup/unversioned/testtype.go
@@ -22,8 +22,9 @@ import (
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
-// TestTypeNamespacer has methods to work with TestType resources in a namespace
-type TestTypeNamespacer interface {
+// TestTypesGetter has a method to return a TestTypeInterface.
+// A group's client should implement this interface.
+type TestTypesGetter interface {
 	TestTypes(namespace string) TestTypeInterface
 }
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -261,7 +261,7 @@ type PersistentVolumeClaimVolumeSource struct {
 	ReadOnly bool `json:"readOnly,omitempty"`
 }
 
-// +genclient=true
+// +genclient=true,nonNamespaced=true
 
 type PersistentVolume struct {
 	unversioned.TypeMeta `json:",inline"`
@@ -1629,7 +1629,7 @@ const (
 // ResourceList is a set of (resource name, quantity) pairs.
 type ResourceList map[ResourceName]resource.Quantity
 
-// +genclient=true
+// +genclient=true,nonNamespaced=true
 
 // Node is a worker node in Kubernetes
 // The name of the node according to etcd is in ObjectMeta.Name.
@@ -1681,7 +1681,7 @@ const (
 	NamespaceTerminating NamespacePhase = "Terminating"
 )
 
-// +genclient=true
+// +genclient=true,nonNamespaced=true
 
 // A namespace provides a scope for Names.
 // Use of multiple namespaces is optional
@@ -2174,7 +2174,7 @@ type ComponentCondition struct {
 	Error   string                 `json:"error,omitempty"`
 }
 
-// +genclient=true
+// +genclient=true,nonNamespaced=true
 
 // ComponentStatus (and ComponentStatusList) holds the cluster validation info.
 type ComponentStatus struct {

--- a/pkg/client/typed/generated/extensions/unversioned/daemonset.go
+++ b/pkg/client/typed/generated/extensions/unversioned/daemonset.go
@@ -22,8 +22,9 @@ import (
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
-// DaemonSetNamespacer has methods to work with DaemonSet resources in a namespace
-type DaemonSetNamespacer interface {
+// DaemonSetsGetter has a method to return a DaemonSetInterface.
+// A group's client should implement this interface.
+type DaemonSetsGetter interface {
 	DaemonSets(namespace string) DaemonSetInterface
 }
 

--- a/pkg/client/typed/generated/extensions/unversioned/deployment.go
+++ b/pkg/client/typed/generated/extensions/unversioned/deployment.go
@@ -22,8 +22,9 @@ import (
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
-// DeploymentNamespacer has methods to work with Deployment resources in a namespace
-type DeploymentNamespacer interface {
+// DeploymentsGetter has a method to return a DeploymentInterface.
+// A group's client should implement this interface.
+type DeploymentsGetter interface {
 	Deployments(namespace string) DeploymentInterface
 }
 

--- a/pkg/client/typed/generated/extensions/unversioned/extensions_client.go
+++ b/pkg/client/typed/generated/extensions/unversioned/extensions_client.go
@@ -23,12 +23,12 @@ import (
 )
 
 type ExtensionsInterface interface {
-	DaemonSetNamespacer
-	DeploymentNamespacer
-	HorizontalPodAutoscalerNamespacer
-	IngressNamespacer
-	JobNamespacer
-	ThirdPartyResourceNamespacer
+	DaemonSetsGetter
+	DeploymentsGetter
+	HorizontalPodAutoscalersGetter
+	IngressesGetter
+	JobsGetter
+	ThirdPartyResourcesGetter
 }
 
 // ExtensionsClient is used to interact with features provided by the Extensions group.

--- a/pkg/client/typed/generated/extensions/unversioned/horizontalpodautoscaler.go
+++ b/pkg/client/typed/generated/extensions/unversioned/horizontalpodautoscaler.go
@@ -22,8 +22,9 @@ import (
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
-// HorizontalPodAutoscalerNamespacer has methods to work with HorizontalPodAutoscaler resources in a namespace
-type HorizontalPodAutoscalerNamespacer interface {
+// HorizontalPodAutoscalersGetter has a method to return a HorizontalPodAutoscalerInterface.
+// A group's client should implement this interface.
+type HorizontalPodAutoscalersGetter interface {
 	HorizontalPodAutoscalers(namespace string) HorizontalPodAutoscalerInterface
 }
 

--- a/pkg/client/typed/generated/extensions/unversioned/ingress.go
+++ b/pkg/client/typed/generated/extensions/unversioned/ingress.go
@@ -22,8 +22,9 @@ import (
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
-// IngressNamespacer has methods to work with Ingress resources in a namespace
-type IngressNamespacer interface {
+// IngressesGetter has a method to return a IngressInterface.
+// A group's client should implement this interface.
+type IngressesGetter interface {
 	Ingresses(namespace string) IngressInterface
 }
 

--- a/pkg/client/typed/generated/extensions/unversioned/job.go
+++ b/pkg/client/typed/generated/extensions/unversioned/job.go
@@ -22,8 +22,9 @@ import (
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
-// JobNamespacer has methods to work with Job resources in a namespace
-type JobNamespacer interface {
+// JobsGetter has a method to return a JobInterface.
+// A group's client should implement this interface.
+type JobsGetter interface {
 	Jobs(namespace string) JobInterface
 }
 

--- a/pkg/client/typed/generated/extensions/unversioned/thirdpartyresource.go
+++ b/pkg/client/typed/generated/extensions/unversioned/thirdpartyresource.go
@@ -22,8 +22,9 @@ import (
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
-// ThirdPartyResourceNamespacer has methods to work with ThirdPartyResource resources in a namespace
-type ThirdPartyResourceNamespacer interface {
+// ThirdPartyResourcesGetter has a method to return a ThirdPartyResourceInterface.
+// A group's client should implement this interface.
+type ThirdPartyResourcesGetter interface {
 	ThirdPartyResources(namespace string) ThirdPartyResourceInterface
 }
 

--- a/pkg/client/typed/generated/legacy/unversioned/componentstatus.go
+++ b/pkg/client/typed/generated/legacy/unversioned/componentstatus.go
@@ -21,9 +21,10 @@ import (
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
-// ComponentStatusNamespacer has methods to work with ComponentStatus resources in a namespace
-type ComponentStatusNamespacer interface {
-	ComponentStatus(namespace string) ComponentStatusInterface
+// ComponentStatusGetter has a method to return a ComponentStatusInterface.
+// A group's client should implement this interface.
+type ComponentStatusGetter interface {
+	ComponentStatus() ComponentStatusInterface
 }
 
 // ComponentStatusInterface has methods to work with ComponentStatus resources.
@@ -41,14 +42,12 @@ type ComponentStatusInterface interface {
 // componentStatus implements ComponentStatusInterface
 type componentStatus struct {
 	client *LegacyClient
-	ns     string
 }
 
 // newComponentStatus returns a ComponentStatus
-func newComponentStatus(c *LegacyClient, namespace string) *componentStatus {
+func newComponentStatus(c *LegacyClient) *componentStatus {
 	return &componentStatus{
 		client: c,
-		ns:     namespace,
 	}
 }
 
@@ -56,7 +55,6 @@ func newComponentStatus(c *LegacyClient, namespace string) *componentStatus {
 func (c *componentStatus) Create(componentStatus *api.ComponentStatus) (result *api.ComponentStatus, err error) {
 	result = &api.ComponentStatus{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("componentStatus").
 		Body(componentStatus).
 		Do().
@@ -68,7 +66,6 @@ func (c *componentStatus) Create(componentStatus *api.ComponentStatus) (result *
 func (c *componentStatus) Update(componentStatus *api.ComponentStatus) (result *api.ComponentStatus, err error) {
 	result = &api.ComponentStatus{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("componentStatus").
 		Name(componentStatus.Name).
 		Body(componentStatus).
@@ -80,7 +77,6 @@ func (c *componentStatus) Update(componentStatus *api.ComponentStatus) (result *
 // Delete takes name of the componentStatus and deletes it. Returns an error if one occurs.
 func (c *componentStatus) Delete(name string, options *api.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("componentStatus").
 		Name(name).
 		Body(options).
@@ -91,7 +87,6 @@ func (c *componentStatus) Delete(name string, options *api.DeleteOptions) error 
 // DeleteCollection deletes a collection of objects.
 func (c *componentStatus) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("componentStatus").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).
@@ -103,7 +98,6 @@ func (c *componentStatus) DeleteCollection(options *api.DeleteOptions, listOptio
 func (c *componentStatus) Get(name string) (result *api.ComponentStatus, err error) {
 	result = &api.ComponentStatus{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("componentStatus").
 		Name(name).
 		Do().
@@ -115,7 +109,6 @@ func (c *componentStatus) Get(name string) (result *api.ComponentStatus, err err
 func (c *componentStatus) List(opts api.ListOptions) (result *api.ComponentStatusList, err error) {
 	result = &api.ComponentStatusList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("componentStatus").
 		VersionedParams(&opts, api.Scheme).
 		Do().
@@ -127,7 +120,6 @@ func (c *componentStatus) List(opts api.ListOptions) (result *api.ComponentStatu
 func (c *componentStatus) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.client.Get().
 		Prefix("watch").
-		Namespace(c.ns).
 		Resource("componentStatus").
 		VersionedParams(&opts, api.Scheme).
 		Watch()

--- a/pkg/client/typed/generated/legacy/unversioned/endpoints.go
+++ b/pkg/client/typed/generated/legacy/unversioned/endpoints.go
@@ -21,8 +21,9 @@ import (
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
-// EndpointsNamespacer has methods to work with Endpoints resources in a namespace
-type EndpointsNamespacer interface {
+// EndpointsGetter has a method to return a EndpointsInterface.
+// A group's client should implement this interface.
+type EndpointsGetter interface {
 	Endpoints(namespace string) EndpointsInterface
 }
 

--- a/pkg/client/typed/generated/legacy/unversioned/event.go
+++ b/pkg/client/typed/generated/legacy/unversioned/event.go
@@ -21,8 +21,9 @@ import (
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
-// EventNamespacer has methods to work with Event resources in a namespace
-type EventNamespacer interface {
+// EventsGetter has a method to return a EventInterface.
+// A group's client should implement this interface.
+type EventsGetter interface {
 	Events(namespace string) EventInterface
 }
 

--- a/pkg/client/typed/generated/legacy/unversioned/legacy_client.go
+++ b/pkg/client/typed/generated/legacy/unversioned/legacy_client.go
@@ -23,21 +23,21 @@ import (
 )
 
 type LegacyInterface interface {
-	ComponentStatusNamespacer
-	EndpointsNamespacer
-	EventNamespacer
-	LimitRangeNamespacer
-	NamespaceNamespacer
-	NodeNamespacer
-	PersistentVolumeNamespacer
-	PersistentVolumeClaimNamespacer
-	PodNamespacer
-	PodTemplateNamespacer
-	ReplicationControllerNamespacer
-	ResourceQuotaNamespacer
-	SecretNamespacer
-	ServiceNamespacer
-	ServiceAccountNamespacer
+	ComponentStatusGetter
+	EndpointsGetter
+	EventsGetter
+	LimitRangesGetter
+	NamespacesGetter
+	NodesGetter
+	PersistentVolumesGetter
+	PersistentVolumeClaimsGetter
+	PodsGetter
+	PodTemplatesGetter
+	ReplicationControllersGetter
+	ResourceQuotasGetter
+	SecretsGetter
+	ServicesGetter
+	ServiceAccountsGetter
 }
 
 // LegacyClient is used to interact with features provided by the Legacy group.
@@ -45,8 +45,8 @@ type LegacyClient struct {
 	*unversioned.RESTClient
 }
 
-func (c *LegacyClient) ComponentStatus(namespace string) ComponentStatusInterface {
-	return newComponentStatus(c, namespace)
+func (c *LegacyClient) ComponentStatus() ComponentStatusInterface {
+	return newComponentStatus(c)
 }
 
 func (c *LegacyClient) Endpoints(namespace string) EndpointsInterface {
@@ -61,16 +61,16 @@ func (c *LegacyClient) LimitRanges(namespace string) LimitRangeInterface {
 	return newLimitRanges(c, namespace)
 }
 
-func (c *LegacyClient) Namespaces(namespace string) NamespaceInterface {
-	return newNamespaces(c, namespace)
+func (c *LegacyClient) Namespaces() NamespaceInterface {
+	return newNamespaces(c)
 }
 
-func (c *LegacyClient) Nodes(namespace string) NodeInterface {
-	return newNodes(c, namespace)
+func (c *LegacyClient) Nodes() NodeInterface {
+	return newNodes(c)
 }
 
-func (c *LegacyClient) PersistentVolumes(namespace string) PersistentVolumeInterface {
-	return newPersistentVolumes(c, namespace)
+func (c *LegacyClient) PersistentVolumes() PersistentVolumeInterface {
+	return newPersistentVolumes(c)
 }
 
 func (c *LegacyClient) PersistentVolumeClaims(namespace string) PersistentVolumeClaimInterface {

--- a/pkg/client/typed/generated/legacy/unversioned/limitrange.go
+++ b/pkg/client/typed/generated/legacy/unversioned/limitrange.go
@@ -21,8 +21,9 @@ import (
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
-// LimitRangeNamespacer has methods to work with LimitRange resources in a namespace
-type LimitRangeNamespacer interface {
+// LimitRangesGetter has a method to return a LimitRangeInterface.
+// A group's client should implement this interface.
+type LimitRangesGetter interface {
 	LimitRanges(namespace string) LimitRangeInterface
 }
 

--- a/pkg/client/typed/generated/legacy/unversioned/namespace.go
+++ b/pkg/client/typed/generated/legacy/unversioned/namespace.go
@@ -21,9 +21,10 @@ import (
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
-// NamespaceNamespacer has methods to work with Namespace resources in a namespace
-type NamespaceNamespacer interface {
-	Namespaces(namespace string) NamespaceInterface
+// NamespacesGetter has a method to return a NamespaceInterface.
+// A group's client should implement this interface.
+type NamespacesGetter interface {
+	Namespaces() NamespaceInterface
 }
 
 // NamespaceInterface has methods to work with Namespace resources.
@@ -42,14 +43,12 @@ type NamespaceInterface interface {
 // namespaces implements NamespaceInterface
 type namespaces struct {
 	client *LegacyClient
-	ns     string
 }
 
 // newNamespaces returns a Namespaces
-func newNamespaces(c *LegacyClient, namespace string) *namespaces {
+func newNamespaces(c *LegacyClient) *namespaces {
 	return &namespaces{
 		client: c,
-		ns:     namespace,
 	}
 }
 
@@ -57,7 +56,6 @@ func newNamespaces(c *LegacyClient, namespace string) *namespaces {
 func (c *namespaces) Create(namespace *api.Namespace) (result *api.Namespace, err error) {
 	result = &api.Namespace{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("namespaces").
 		Body(namespace).
 		Do().
@@ -69,7 +67,6 @@ func (c *namespaces) Create(namespace *api.Namespace) (result *api.Namespace, er
 func (c *namespaces) Update(namespace *api.Namespace) (result *api.Namespace, err error) {
 	result = &api.Namespace{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("namespaces").
 		Name(namespace.Name).
 		Body(namespace).
@@ -87,7 +84,6 @@ func (c *namespaces) UpdateStatus(namespace *api.Namespace) (*api.Namespace, err
 // Delete takes name of the namespace and deletes it. Returns an error if one occurs.
 func (c *namespaces) Delete(name string, options *api.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("namespaces").
 		Name(name).
 		Body(options).
@@ -98,7 +94,6 @@ func (c *namespaces) Delete(name string, options *api.DeleteOptions) error {
 // DeleteCollection deletes a collection of objects.
 func (c *namespaces) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("namespaces").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).
@@ -110,7 +105,6 @@ func (c *namespaces) DeleteCollection(options *api.DeleteOptions, listOptions ap
 func (c *namespaces) Get(name string) (result *api.Namespace, err error) {
 	result = &api.Namespace{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("namespaces").
 		Name(name).
 		Do().
@@ -122,7 +116,6 @@ func (c *namespaces) Get(name string) (result *api.Namespace, err error) {
 func (c *namespaces) List(opts api.ListOptions) (result *api.NamespaceList, err error) {
 	result = &api.NamespaceList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("namespaces").
 		VersionedParams(&opts, api.Scheme).
 		Do().
@@ -134,7 +127,6 @@ func (c *namespaces) List(opts api.ListOptions) (result *api.NamespaceList, err 
 func (c *namespaces) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.client.Get().
 		Prefix("watch").
-		Namespace(c.ns).
 		Resource("namespaces").
 		VersionedParams(&opts, api.Scheme).
 		Watch()

--- a/pkg/client/typed/generated/legacy/unversioned/node.go
+++ b/pkg/client/typed/generated/legacy/unversioned/node.go
@@ -21,9 +21,10 @@ import (
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
-// NodeNamespacer has methods to work with Node resources in a namespace
-type NodeNamespacer interface {
-	Nodes(namespace string) NodeInterface
+// NodesGetter has a method to return a NodeInterface.
+// A group's client should implement this interface.
+type NodesGetter interface {
+	Nodes() NodeInterface
 }
 
 // NodeInterface has methods to work with Node resources.
@@ -42,14 +43,12 @@ type NodeInterface interface {
 // nodes implements NodeInterface
 type nodes struct {
 	client *LegacyClient
-	ns     string
 }
 
 // newNodes returns a Nodes
-func newNodes(c *LegacyClient, namespace string) *nodes {
+func newNodes(c *LegacyClient) *nodes {
 	return &nodes{
 		client: c,
-		ns:     namespace,
 	}
 }
 
@@ -57,7 +56,6 @@ func newNodes(c *LegacyClient, namespace string) *nodes {
 func (c *nodes) Create(node *api.Node) (result *api.Node, err error) {
 	result = &api.Node{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("nodes").
 		Body(node).
 		Do().
@@ -69,7 +67,6 @@ func (c *nodes) Create(node *api.Node) (result *api.Node, err error) {
 func (c *nodes) Update(node *api.Node) (result *api.Node, err error) {
 	result = &api.Node{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("nodes").
 		Name(node.Name).
 		Body(node).
@@ -87,7 +84,6 @@ func (c *nodes) UpdateStatus(node *api.Node) (*api.Node, error) {
 // Delete takes name of the node and deletes it. Returns an error if one occurs.
 func (c *nodes) Delete(name string, options *api.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("nodes").
 		Name(name).
 		Body(options).
@@ -98,7 +94,6 @@ func (c *nodes) Delete(name string, options *api.DeleteOptions) error {
 // DeleteCollection deletes a collection of objects.
 func (c *nodes) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("nodes").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).
@@ -110,7 +105,6 @@ func (c *nodes) DeleteCollection(options *api.DeleteOptions, listOptions api.Lis
 func (c *nodes) Get(name string) (result *api.Node, err error) {
 	result = &api.Node{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("nodes").
 		Name(name).
 		Do().
@@ -122,7 +116,6 @@ func (c *nodes) Get(name string) (result *api.Node, err error) {
 func (c *nodes) List(opts api.ListOptions) (result *api.NodeList, err error) {
 	result = &api.NodeList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("nodes").
 		VersionedParams(&opts, api.Scheme).
 		Do().
@@ -134,7 +127,6 @@ func (c *nodes) List(opts api.ListOptions) (result *api.NodeList, err error) {
 func (c *nodes) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.client.Get().
 		Prefix("watch").
-		Namespace(c.ns).
 		Resource("nodes").
 		VersionedParams(&opts, api.Scheme).
 		Watch()

--- a/pkg/client/typed/generated/legacy/unversioned/persistentvolume.go
+++ b/pkg/client/typed/generated/legacy/unversioned/persistentvolume.go
@@ -21,9 +21,10 @@ import (
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
-// PersistentVolumeNamespacer has methods to work with PersistentVolume resources in a namespace
-type PersistentVolumeNamespacer interface {
-	PersistentVolumes(namespace string) PersistentVolumeInterface
+// PersistentVolumesGetter has a method to return a PersistentVolumeInterface.
+// A group's client should implement this interface.
+type PersistentVolumesGetter interface {
+	PersistentVolumes() PersistentVolumeInterface
 }
 
 // PersistentVolumeInterface has methods to work with PersistentVolume resources.
@@ -42,14 +43,12 @@ type PersistentVolumeInterface interface {
 // persistentVolumes implements PersistentVolumeInterface
 type persistentVolumes struct {
 	client *LegacyClient
-	ns     string
 }
 
 // newPersistentVolumes returns a PersistentVolumes
-func newPersistentVolumes(c *LegacyClient, namespace string) *persistentVolumes {
+func newPersistentVolumes(c *LegacyClient) *persistentVolumes {
 	return &persistentVolumes{
 		client: c,
-		ns:     namespace,
 	}
 }
 
@@ -57,7 +56,6 @@ func newPersistentVolumes(c *LegacyClient, namespace string) *persistentVolumes 
 func (c *persistentVolumes) Create(persistentVolume *api.PersistentVolume) (result *api.PersistentVolume, err error) {
 	result = &api.PersistentVolume{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("persistentVolumes").
 		Body(persistentVolume).
 		Do().
@@ -69,7 +67,6 @@ func (c *persistentVolumes) Create(persistentVolume *api.PersistentVolume) (resu
 func (c *persistentVolumes) Update(persistentVolume *api.PersistentVolume) (result *api.PersistentVolume, err error) {
 	result = &api.PersistentVolume{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("persistentVolumes").
 		Name(persistentVolume.Name).
 		Body(persistentVolume).
@@ -87,7 +84,6 @@ func (c *persistentVolumes) UpdateStatus(persistentVolume *api.PersistentVolume)
 // Delete takes name of the persistentVolume and deletes it. Returns an error if one occurs.
 func (c *persistentVolumes) Delete(name string, options *api.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("persistentVolumes").
 		Name(name).
 		Body(options).
@@ -98,7 +94,6 @@ func (c *persistentVolumes) Delete(name string, options *api.DeleteOptions) erro
 // DeleteCollection deletes a collection of objects.
 func (c *persistentVolumes) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("persistentVolumes").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).
@@ -110,7 +105,6 @@ func (c *persistentVolumes) DeleteCollection(options *api.DeleteOptions, listOpt
 func (c *persistentVolumes) Get(name string) (result *api.PersistentVolume, err error) {
 	result = &api.PersistentVolume{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("persistentVolumes").
 		Name(name).
 		Do().
@@ -122,7 +116,6 @@ func (c *persistentVolumes) Get(name string) (result *api.PersistentVolume, err 
 func (c *persistentVolumes) List(opts api.ListOptions) (result *api.PersistentVolumeList, err error) {
 	result = &api.PersistentVolumeList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("persistentVolumes").
 		VersionedParams(&opts, api.Scheme).
 		Do().
@@ -134,7 +127,6 @@ func (c *persistentVolumes) List(opts api.ListOptions) (result *api.PersistentVo
 func (c *persistentVolumes) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.client.Get().
 		Prefix("watch").
-		Namespace(c.ns).
 		Resource("persistentVolumes").
 		VersionedParams(&opts, api.Scheme).
 		Watch()

--- a/pkg/client/typed/generated/legacy/unversioned/persistentvolumeclaim.go
+++ b/pkg/client/typed/generated/legacy/unversioned/persistentvolumeclaim.go
@@ -21,8 +21,9 @@ import (
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
-// PersistentVolumeClaimNamespacer has methods to work with PersistentVolumeClaim resources in a namespace
-type PersistentVolumeClaimNamespacer interface {
+// PersistentVolumeClaimsGetter has a method to return a PersistentVolumeClaimInterface.
+// A group's client should implement this interface.
+type PersistentVolumeClaimsGetter interface {
 	PersistentVolumeClaims(namespace string) PersistentVolumeClaimInterface
 }
 

--- a/pkg/client/typed/generated/legacy/unversioned/pod.go
+++ b/pkg/client/typed/generated/legacy/unversioned/pod.go
@@ -21,8 +21,9 @@ import (
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
-// PodNamespacer has methods to work with Pod resources in a namespace
-type PodNamespacer interface {
+// PodsGetter has a method to return a PodInterface.
+// A group's client should implement this interface.
+type PodsGetter interface {
 	Pods(namespace string) PodInterface
 }
 

--- a/pkg/client/typed/generated/legacy/unversioned/podtemplate.go
+++ b/pkg/client/typed/generated/legacy/unversioned/podtemplate.go
@@ -21,8 +21,9 @@ import (
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
-// PodTemplateNamespacer has methods to work with PodTemplate resources in a namespace
-type PodTemplateNamespacer interface {
+// PodTemplatesGetter has a method to return a PodTemplateInterface.
+// A group's client should implement this interface.
+type PodTemplatesGetter interface {
 	PodTemplates(namespace string) PodTemplateInterface
 }
 

--- a/pkg/client/typed/generated/legacy/unversioned/replicationcontroller.go
+++ b/pkg/client/typed/generated/legacy/unversioned/replicationcontroller.go
@@ -21,8 +21,9 @@ import (
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
-// ReplicationControllerNamespacer has methods to work with ReplicationController resources in a namespace
-type ReplicationControllerNamespacer interface {
+// ReplicationControllersGetter has a method to return a ReplicationControllerInterface.
+// A group's client should implement this interface.
+type ReplicationControllersGetter interface {
 	ReplicationControllers(namespace string) ReplicationControllerInterface
 }
 

--- a/pkg/client/typed/generated/legacy/unversioned/resourcequota.go
+++ b/pkg/client/typed/generated/legacy/unversioned/resourcequota.go
@@ -21,8 +21,9 @@ import (
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
-// ResourceQuotaNamespacer has methods to work with ResourceQuota resources in a namespace
-type ResourceQuotaNamespacer interface {
+// ResourceQuotasGetter has a method to return a ResourceQuotaInterface.
+// A group's client should implement this interface.
+type ResourceQuotasGetter interface {
 	ResourceQuotas(namespace string) ResourceQuotaInterface
 }
 

--- a/pkg/client/typed/generated/legacy/unversioned/secret.go
+++ b/pkg/client/typed/generated/legacy/unversioned/secret.go
@@ -21,8 +21,9 @@ import (
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
-// SecretNamespacer has methods to work with Secret resources in a namespace
-type SecretNamespacer interface {
+// SecretsGetter has a method to return a SecretInterface.
+// A group's client should implement this interface.
+type SecretsGetter interface {
 	Secrets(namespace string) SecretInterface
 }
 

--- a/pkg/client/typed/generated/legacy/unversioned/service.go
+++ b/pkg/client/typed/generated/legacy/unversioned/service.go
@@ -21,8 +21,9 @@ import (
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
-// ServiceNamespacer has methods to work with Service resources in a namespace
-type ServiceNamespacer interface {
+// ServicesGetter has a method to return a ServiceInterface.
+// A group's client should implement this interface.
+type ServicesGetter interface {
 	Services(namespace string) ServiceInterface
 }
 

--- a/pkg/client/typed/generated/legacy/unversioned/serviceaccount.go
+++ b/pkg/client/typed/generated/legacy/unversioned/serviceaccount.go
@@ -21,8 +21,9 @@ import (
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
-// ServiceAccountNamespacer has methods to work with ServiceAccount resources in a namespace
-type ServiceAccountNamespacer interface {
+// ServiceAccountsGetter has a method to return a ServiceAccountInterface.
+// A group's client should implement this interface.
+type ServiceAccountsGetter interface {
 	ServiceAccounts(namespace string) ServiceAccountInterface
 }
 


### PR DESCRIPTION
User can add a `nonNamespaced` tag in the comment in types.go to indicate the type is nonNamespaced. client-gen will generate the typed client differently based on if the type is namespaced or not.

~~First commit is #19267.~~
