### PR TITLE
Move pod template hash and label adding util functions to their packages.

### DIFF
--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -34,6 +34,8 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
 	deploymentutil "k8s.io/kubernetes/pkg/util/deployment"
+	labelsutil "k8s.io/kubernetes/pkg/util/labels"
+	podutil "k8s.io/kubernetes/pkg/util/pod"
 	"k8s.io/kubernetes/pkg/util/workqueue"
 	"k8s.io/kubernetes/pkg/watch"
 )
@@ -477,10 +479,10 @@ func (dc *DeploymentController) getNewRC(deployment extensions.Deployment) (*api
 	}
 	// new RC does not exist, create one.
 	namespace := deployment.ObjectMeta.Namespace
-	podTemplateSpecHash := deploymentutil.GetPodTemplateSpecHash(deployment.Spec.Template)
+	podTemplateSpecHash := podutil.GetPodTemplateSpecHash(deployment.Spec.Template)
 	newRCTemplate := deploymentutil.GetNewRCTemplate(deployment)
 	// Add podTemplateHash label to selector.
-	newRCSelector := deploymentutil.CloneAndAddLabel(deployment.Spec.Selector, deployment.Spec.UniqueLabelKey, podTemplateSpecHash)
+	newRCSelector := labelsutil.CloneAndAddLabel(deployment.Spec.Selector, deployment.Spec.UniqueLabelKey, podTemplateSpecHash)
 
 	newRC := api.ReplicationController{
 		ObjectMeta: api.ObjectMeta{

--- a/pkg/util/labels/doc.go
+++ b/pkg/util/labels/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package labels provides utilities to work with Kubernetes labels.
+package labels

--- a/pkg/util/labels/labels.go
+++ b/pkg/util/labels/labels.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package labels
+
+import (
+	"fmt"
+)
+
+// Clones the given map and returns a new map with the given key and value added.
+// Returns the given map, if labelKey is empty.
+func CloneAndAddLabel(labels map[string]string, labelKey string, labelValue uint32) map[string]string {
+	if labelKey == "" {
+		// Dont need to add a label.
+		return labels
+	}
+	// Clone.
+	newLabels := map[string]string{}
+	for key, value := range labels {
+		newLabels[key] = value
+	}
+	newLabels[labelKey] = fmt.Sprintf("%d", labelValue)
+	return newLabels
+}

--- a/pkg/util/labels/labels_test.go
+++ b/pkg/util/labels/labels_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package labels
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCloneAndAddLabel(t *testing.T) {
+	labels := map[string]string{
+		"foo1": "bar1",
+		"foo2": "bar2",
+		"foo3": "bar3",
+	}
+
+	cases := []struct {
+		labels     map[string]string
+		labelKey   string
+		labelValue uint32
+		want       map[string]string
+	}{
+		{
+			labels: labels,
+			want:   labels,
+		},
+		{
+			labels:     labels,
+			labelKey:   "foo4",
+			labelValue: uint32(42),
+			want: map[string]string{
+				"foo1": "bar1",
+				"foo2": "bar2",
+				"foo3": "bar3",
+				"foo4": "42",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		got := CloneAndAddLabel(tc.labels, tc.labelKey, tc.labelValue)
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("got %v, want %v", got, tc.want)
+		}
+	}
+}

--- a/pkg/util/pod/doc.go
+++ b/pkg/util/pod/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package pod provides utilities to work with Kubernetes pod and pod templates.
+package pod

--- a/pkg/util/pod/pod.go
+++ b/pkg/util/pod/pod.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	"hash/adler32"
+
+	"k8s.io/kubernetes/pkg/api"
+	hashutil "k8s.io/kubernetes/pkg/util/hash"
+)
+
+func GetPodTemplateSpecHash(template api.PodTemplateSpec) uint32 {
+	podTemplateSpecHasher := adler32.New()
+	hashutil.DeepHashObject(podTemplateSpecHasher, template)
+	return podTemplateSpecHasher.Sum32()
+}


### PR DESCRIPTION
These utilities are useful outside Deployments as well, for example
in DaemonSets for DaemonSet updates. So move them to their own util
packages.
