### PR TITLE
Add benchmarks for watch over websocket and http

### DIFF
--- a/docs/devel/development.md
+++ b/docs/devel/development.md
@@ -374,6 +374,15 @@ See [conformance-test.sh](http://releases.k8s.io/HEAD/hack/conformance-test.sh).
 
 [Instructions here](flaky-tests.md)
 
+## Benchmarking
+
+To run benchmark tests, you'll typically use something like:
+
+    $ godep go test ./pkg/apiserver -benchmem -run=XXX -bench=BenchmarkWatch
+
+The `-run=XXX` prevents normal unit tests for running, while `-bench` is a regexp for selecting which benchmarks to run.
+See `go test -h` for more instructions on generating profiles from benchmarks.
+
 ## Regenerating the CLI documentation
 
 ```sh

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/rest"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/v1"
 	apiservertesting "k8s.io/kubernetes/pkg/apiserver/testing"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -158,6 +159,7 @@ func addNewTestTypes() {
 	api.Scheme.AddKnownTypes(newGroupVersion,
 		&apiservertesting.Simple{}, &apiservertesting.SimpleList{}, &ListOptions{},
 		&api.DeleteOptions{}, &apiservertesting.SimpleGetOptions{}, &apiservertesting.SimpleRoot{})
+	api.Scheme.AddKnownTypes(newGroupVersion, &v1.Pod{})
 }
 
 func init() {


### PR DESCRIPTION
```
$ godep go test ./pkg/apiserver -benchmem -run=XXX -bench=BenchmarkWatch
PASS
BenchmarkWatchHTTP-8           20000         97169 ns/op       15126 B/op        197 allocs/op
BenchmarkWatchWebsocket-8      10000        102608 ns/op       18509 B/op        205 allocs/op
```

@kubernetes/sig-api-machinery
