### PR TITLE
jenkins: Add the ability to specify ginkgo parallel nodes number.

### DIFF
--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -81,8 +81,10 @@ if [[ -n "${CONFORMANCE_TEST_SKIP_REGEX:-}" ]]; then
   ginkgo_args+=("--skip=${CONFORMANCE_TEST_SKIP_REGEX}")
   ginkgo_args+=("--seed=1436380640")
 fi
-if [[ ${GINKGO_PARALLEL} =~ ^[yY]$ ]]; then
-  ginkgo_args+=("-p")
+if [[ -n "${GINKGO_PARALLEL_NODES:-}" ]]; then
+  ginkgo_args+=("--nodes=${GINKGO_PARALLEL_NODES}")
+elif [[ ${GINKGO_PARALLEL} =~ ^[yY]$ ]]; then
+  ginkgo_args+=("--nodes=30") # By default, set --nodes=30.
 fi
 
 

--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -1101,6 +1101,7 @@ export E2E_DOWN="${E2E_DOWN:-true}"
 export E2E_CLEAN_START="${E2E_CLEAN_START:-}"
 # Used by hack/ginkgo-e2e.sh to enable ginkgo's parallel test runner.
 export GINKGO_PARALLEL=${GINKGO_PARALLEL:-}
+export GINKGO_PARALLEL_NODES=${GINKGO_PARALLEL_NODES:-}
 export GINKGO_TEST_ARGS="${GINKGO_TEST_ARGS:-}"
 
 # If we are on PR Jenkins merging into master, use the local e2e.sh. Otherwise, use the latest on github.


### PR DESCRIPTION
This PR introduces the `GINKGO_PARALLEL_NODES` environment variable. If it's specified, then the ginkgo test will be launched with the flag `-nodes=${GINKGO_PARALLEL_NODES}` for parallel running ginkgo tests.

Previously, when `GINKGO_PARALLEL` is true, then ginkgo will run the tests with `-p`. According to [ginkgo's doc](http://onsi.github.io/ginkgo/#parallel-specs). `-p` will set the `-nodes` according to the number of cpu cores on the machine. As a result, this will slow down the test a lot on nodes that has very few cpu cores. This is also proved unnecessary as I observed that during the test, the CPU usage is pretty low (< 10%).

I tested this change on my internal jenkins cluster (with a GCE slave node of type n1-standard-1 (1 vCPU, 3.75 GB memory) ) with `GINKGO_PARALLEL_NODES=10`. It reduced the test time from 1hr (previous logs [here](https://console.developers.google.com/storage/browser/kubernetes-coreos-jenkin/pr-log/kubernetes-pull-build-test-e2e-gce/76/)) to 14mins. (logs [here](https://console.developers.google.com/storage/browser/kubernetes-coreos-jenkin/pr-log/kubernetes-pull-build-test-e2e-gce/77/))

cc @yujuhong @ixdy 
