### PR TITLE
hack: ignore cluster/env.sh in boilerplate check

### DIFF
--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -95,7 +95,7 @@ def file_passes(filename, refs, regexs):
 def file_extension(filename):
     return os.path.splitext(filename)[1].split(".")[-1].lower()
 
-skipped_dirs = ['Godeps', 'third_party', '_gopath', '_output', '.git']
+skipped_dirs = ['Godeps', 'third_party', '_gopath', '_output', '.git', 'cluster/env.sh']
 def normalize_files(files):
     newfiles = []
     for pathname in files:


### PR DESCRIPTION
This is used for user configuration overrides in cluster/. We should not
enforce the boilerplate headers in this file.
