### PR TITLE
use param indices for `NewThreadSafeStore` func

### DIFF
--- a/pkg/client/cache/thread_safe_store.go
+++ b/pkg/client/cache/thread_safe_store.go
@@ -243,6 +243,6 @@ func NewThreadSafeStore(indexers Indexers, indices Indices) ThreadSafeStore {
 	return &threadSafeMap{
 		items:    map[string]interface{}{},
 		indexers: indexers,
-		indices:  Indices{},
+		indices:  indices,
 	}
 }


### PR DESCRIPTION
Fix #19583
/cc @mikedanese @HardySimpson
