### PR TITLE
Fix panic when sort-by is used with kubectl get.

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -1341,6 +1341,16 @@ __EOF__
     [[ "$(grep "Watch for changes to the described resources" "${file}")" ]]
   fi
 
+  #####################
+  # Kubectl --sort-by #
+  #####################
+
+  ### sort-by should not panic if no pod exists
+  # Pre-condition: no POD exists
+  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
+  # Command
+  kubectl get pods --sort-by="{metadata.name}"
+
   kube::test::clear_all
 }
 

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -243,7 +243,7 @@ func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string
 
 	sorting, err := cmd.Flags().GetString("sort-by")
 	var sorter *kubectl.RuntimeSort
-	if err == nil && len(sorting) > 0 {
+	if err == nil && len(sorting) > 0 && len(objs) > 1 {
 		// TODO: questionable
 		if sorter, err = kubectl.SortObjects(f.Decoder(true), objs, sorting); err != nil {
 			return err


### PR DESCRIPTION
For example, if there is no rc or pod created in the cluster, kubectl get rc --sort-by=.metadata.name panics as below and also there is no point in sorting just one object.

panic: runtime error: index out of range

goroutine 1 [running]:
k8s.io/kubernetes/pkg/kubectl.SortObjects(0x1c88640, 0x0, 0x0, 0xc8202b2a40, 0xe, 0x0, 0x0, 0x0)
    /root/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubectl/sorting_printer.go:106 +0x6bd
k8s.io/kubernetes/pkg/kubectl/cmd.RunGet(0xc820216000, 0x7fb098a474d0, 0xc82002a010, 0xc82020e600, 0xc820238980, 0x1, 0x2, 0xc82020a4c0, 0x0, 0x0)
    /root/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubectl/cmd/get.go:247 +0xf87
k8s.io/kubernetes/pkg/kubectl/cmd.NewCmdGet.func1(0xc82020e600, 0xc820238980, 0x1, 0x2)
    /root/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubectl/cmd/get.go:93 +0x7d
github.com/spf13/cobra.(_Command).execute(0xc82020e600, 0xc820238860, 0x2, 0x2, 0x0, 0x0)
    /root/kubernetes/Godeps/_workspace/src/github.com/spf13/cobra/command.go:572 +0x869
github.com/spf13/cobra.(_Command).ExecuteC(0xc82020e200, 0xc82020e600, 0x0, 0x0)
    /root/kubernetes/Godeps/_workspace/src/github.com/spf13/cobra/command.go:662 +0x54e
github.com/spf13/cobra.(*Command).Execute(0xc82020e200, 0x0, 0x0)
    /root/kubernetes/Godeps/_workspace/src/github.com/spf13/cobra/command.go:618 +0x2d
k8s.io/kubernetes/cmd/kubectl/app.Run(0x0, 0x0)
    /root/kubernetes/_output/local/go/src/k8s.io/kubernetes/cmd/kubectl/app/kubectl.go:28 +0xf0
main.main()
    /root/kubernetes/_output/local/go/src/k8s.io/kubernetes/cmd/kubectl/kubectl.go:28 +0x28

goroutine 6 [chan receive]:
github.com/golang/glog.(*loggingT).flushDaemon(0x1c5ef40)
    /root/kubernetes/Godeps/_workspace/src/github.com/golang/glog/glog.go:879 +0x67
created by github.com/golang/glog.init.1
    /root/kubernetes/Godeps/_workspace/src/github.com/golang/glog/glog.go:410 +0x297

goroutine 14 [syscall]:
os/signal.loop()
    /usr/lib/golang/src/os/signal/signal_unix.go:22 +0x18
created by os/signal.init.1
    /usr/lib/golang/src/os/signal/signal_unix.go:28 +0x37

goroutine 16 [IO wait]:
net.runtime_pollWait(0x7fb098a50450, 0x72, 0xc820010180)
    /usr/lib/golang/src/runtime/netpoll.go:157 +0x60
net.(_pollDesc).Wait(0xc820285330, 0x72, 0x0, 0x0)
    /usr/lib/golang/src/net/fd_poll_runtime.go:73 +0x3a
net.(_pollDesc).WaitRead(0xc820285330, 0x0, 0x0)
    /usr/lib/golang/src/net/fd_poll_runtime.go:78 +0x36
net.(_netFD).Read(0xc8202852d0, 0xc8202a6000, 0x1000, 0x1000, 0x0, 0x7fb098a43050, 0xc820010180)
    /usr/lib/golang/src/net/fd_unix.go:232 +0x23a
net.(_conn).Read(0xc82002a6f8, 0xc8202a6000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
    /usr/lib/golang/src/net/net.go:172 +0xe4
net/http.noteEOFReader.Read(0x7fb098a50510, 0xc82002a6f8, 0xc820217448, 0xc8202a6000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
    /usr/lib/golang/src/net/http/transport.go:1370 +0x67
net/http.(_noteEOFReader).Read(0xc820293b20, 0xc8202a6000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
    <autogenerated>:126 +0xd0
bufio.(_Reader).fill(0xc820294780)
    /usr/lib/golang/src/bufio/bufio.go:97 +0x1e9
bufio.(_Reader).Peek(0xc820294780, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0)
    /usr/lib/golang/src/bufio/bufio.go:132 +0xcc
net/http.(_persistConn).readLoop(0xc8202173f0)
    /usr/lib/golang/src/net/http/transport.go:876 +0xf7
created by net/http.(*Transport).dialConn
    /usr/lib/golang/src/net/http/transport.go:685 +0xc78

goroutine 33 [select]:
net/http.(_persistConn).writeLoop(0xc8202173f0)
    /usr/lib/golang/src/net/http/transport.go:1009 +0x40c
created by net/http.(_Transport).dialConn
    /usr/lib/golang/src/net/http/transport.go:686 +0xc9d
