### PR TITLE
Skip kubectl tests that don't work before v1.1 when running against a pre-v1.1 cluster

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -290,6 +290,16 @@ func providerIs(providers ...string) bool {
 	return false
 }
 
+func SkipUnlessServerVersionGTE(v semver.Version, c client.ServerVersionInterface) {
+	gte, err := serverVersionGTE(v, c)
+	if err != nil {
+		Failf("Failed to get server version: %v", err)
+	}
+	if !gte {
+		Skipf("Not supported for server versions before %q", v)
+	}
+}
+
 // providersWithSSH are those providers where each node is accessible with SSH
 var providersWithSSH = []string{"gce", "gke", "aws"}
 


### PR DESCRIPTION
Fixes #18581.

We want signal when a newer Kubectl isn't working properly against an older cluster, but these tests make use of functionality that didn't exist pre-v1.1, so they aren't expected to work.  Skip them if we're running against a server that is pre-v1.1.

Some precedent in #18773.

cc @kubernetes/goog-csi for how I'm doing this, in case you hate it.
