### PR TITLE
dns: don't die when a headless service declares no ports

### DIFF
--- a/cluster/addons/dns/kube2sky/kube2sky.go
+++ b/cluster/addons/dns/kube2sky/kube2sky.go
@@ -338,12 +338,12 @@ func (ks *kube2sky) generateSRVRecord(subdomain, portSegment, recordName, cName 
 }
 
 func (ks *kube2sky) addDNS(subdomain string, service *kapi.Service) error {
-	if len(service.Spec.Ports) == 0 {
-		glog.Fatalf("Unexpected service with no ports: %v", service)
-	}
 	// if ClusterIP is not set, a DNS entry should not be created
 	if !kapi.IsServiceIPSet(service) {
 		return ks.newHeadlessService(subdomain, service)
+	}
+	if len(service.Spec.Ports) == 0 {
+		glog.Info("Unexpected service with no ports, this should not have happend: %v", service)
 	}
 	return ks.generateRecordsForPortalService(subdomain, service)
 }


### PR DESCRIPTION
Headless services are not required to declare ports.
cc @thockin @ArtfulCoder 
