### PR TITLE
test: make ValidateCount throw an error instead of a log

### DIFF
--- a/pkg/controller/replication/replication_controller_test.go
+++ b/pkg/controller/replication/replication_controller_test.go
@@ -295,7 +295,7 @@ func TestSyncReplicationControllerDormancy(t *testing.T) {
 	// Setup a test server so we can lie about the current state of pods
 	fakeHandler := utiltesting.FakeHandler{
 		StatusCode:   200,
-		ResponseBody: "",
+		ResponseBody: "{}",
 	}
 	testServer := httptest.NewServer(&fakeHandler)
 	// TODO: Uncomment when fix #19254

--- a/pkg/util/testing/fake_handler.go
+++ b/pkg/util/testing/fake_handler.go
@@ -79,7 +79,7 @@ func (f *FakeHandler) ValidateRequestCount(t TestInterface, count int) bool {
 	defer f.lock.Unlock()
 	if f.requestCount != count {
 		ok = false
-		t.Logf("Expected %d call, but got %d. Only the last call is recorded and checked.", count, f.requestCount)
+		t.Errorf("Expected %d call, but got %d. Only the last call is recorded and checked.", count, f.requestCount)
 	}
 	f.hasBeenChecked = true
 	return ok


### PR DESCRIPTION
We can either fix it here or at every callsite. Every callsite is
currently using this method incorrectly.

```
pkg/controller/controller_utils_test.go
213:    fakeHandler.ValidateRequest(t, testapi.Default.ResourcePath("pods", api.NamespaceDefault, ""), "POST", nil)

pkg/controller/replication/replication_controller_test.go
250:    fakeHandler.ValidateRequest(t, testapi.Default.ResourcePath(replicationControllerResourceName(), rc.Namespace, rc.Name)+"/status", "PUT", &updatedRc)
289:    fakeHandler.ValidateRequest(t, testapi.Default.ResourcePath(replicationControllerResourceName(), rc.Namespace, rc.Name)+"/status", "PUT", &decRc)
347:    fakeHandler.ValidateRequestCount(t, 1)
593:    fakeHandler.ValidateRequestCount(t, 2)

pkg/controller/endpoint/endpoints_controller_test.go
114:    endpointsHandler.ValidateRequestCount(t, 0)
179:    endpointsHandler.ValidateRequestCount(t, 0)
208:    endpointsHandler.ValidateRequestCount(t, 0)
246:    endpointsHandler.ValidateRequest(t, testapi.Default.ResourcePath("endpoints", ns, "foo"), "PUT", &data)
284:    endpointsHandler.ValidateRequest(t, testapi.Default.ResourcePath("endpoints", ns, "foo"), "PUT", &data)
323:    endpointsHandler.ValidateRequest(t, testapi.Default.ResourcePath("endpoints", ns, "foo"), "PUT", &data)
364:    endpointsHandler.ValidateRequest(t, testapi.Default.ResourcePath("endpoints", ns, "foo"), "PUT", &data)
394:    endpointsHandler.ValidateRequest(t, testapi.Default.ResourcePath("endpoints", api.NamespaceDefault, "foo"), "GET", nil)
436:    endpointsHandler.ValidateRequestCount(t, 2)
437:    endpointsHandler.ValidateRequest(t, testapi.Default.ResourcePath("endpoints", ns, ""), "POST", &data)
484:    endpointsHandler.ValidateRequestCount(t, 2)
485:    endpointsHandler.ValidateRequest(t, testapi.Default.ResourcePath("endpoints", ns, ""), "POST", &data)
535:    endpointsHandler.ValidateRequest(t, testapi.Default.ResourcePath("endpoints", ns, "foo"), "PUT", &data)

pkg/client/unversioned/restclient_test.go
69:     fakeHandler.ValidateRequest(t, "/"+testapi.Default.GroupVersion().String()+"/test", "GET", nil)
147:    fakeHandler.ValidateRequest(t, "/"+testapi.Default.GroupVersion().String()+"/test", "GET", nil)

pkg/client/unversioned/testclient/simple/simple_testclient.go
141:    // We check the query manually, so blank it out so that FakeHandler.ValidateRequest
144:    c.handler.ValidateRequest(t, path.Join(c.Request.Path), c.Request.Method, requestBody)

pkg/client/unversioned/request_test.go
727:    fakeHandler.ValidateRequest(t, requestURL, "POST", &reqBody)
899:    fakeHandler.ValidateRequest(t, requestURL, "POST", &tmpStr)
940:    fakeHandler.ValidateRequest(t, requestURL, "POST", &tmpStr)
997:    fakeHandler.ValidateRequest(t, requestURL, "POST", &tmpStr)
1044:   fakeHandler.ValidateRequest(t, requestURL, "PUT", &tmpStr)

pkg/client/cache/listwatch_test.go
104:            handler.ValidateRequest(t, item.location, "GET", nil)
171:            handler.ValidateRequest(t, item.location, "GET", nil)

pkg/util/fake_handler_test.go
46:     handler.ValidateRequest(t, path, method, &body)
68:     handler.ValidateRequest(t, path, method, nil)
101:    handler.ValidateRequest(&fakeT, path, method, nil)
127:    handler.ValidateRequest(&fakeT, path, method, nil)
155:    handler.ValidateRequest(&fakeT, path, method, &otherbody)
182:    handler.ValidateRequest(&fakeT, path, method, &body)

pkg/util/fake_handler.go
76:func (f *FakeHandler) ValidateRequestCount(t TestInterface, count int) bool {
88:// ValidateRequest verifies that FakeHandler received a request with expected path, method, and body.
89:func (f *FakeHandler) ValidateRequest(t TestInterface, expectedPath, expectedMethod string, body *string) {

plugin/pkg/scheduler/factory/factory_test.go
175:            handler.ValidateRequest(t, testapi.Default.ResourcePath("pods", "bar", "foo"), "GET", nil)
247:            handler.ValidateRequest(t, testapi.Default.ResourcePath("bindings", api.NamespaceDefault, ""), "POST", &expectedBody)
```

cc @lavalamp 
