### PR TITLE
Remove provider skip lists

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -54,7 +54,6 @@ function join_regex_no_empty() {
 # Assumes globals:
 #   $JOB_NAME
 #   $KUBERNETES_PROVIDER
-#   $GKE_REQUIRED_SKIP_TESTS
 #   $GCE_DEFAULT_SKIP_TESTS
 #   $GCE_FLAKY_TESTS
 #   $GCE_SLOW_TESTS
@@ -87,7 +86,6 @@ function configure_upgrade_step() {
         ${GCE_SLOW_TESTS[@]:+${GCE_SLOW_TESTS[@]}} \
         )"
   local -r gke_test_args="--ginkgo.skip=$(join_regex_allow_empty \
-        ${GKE_REQUIRED_SKIP_TESTS[@]:+${GKE_REQUIRED_SKIP_TESTS[@]}} \
         ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
         ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
         ${GCE_SLOW_TESTS[@]:+${GCE_SLOW_TESTS[@]}} \
@@ -272,30 +270,6 @@ GCE_DEFAULT_SKIP_TESTS=(
     "\[Feature:.+\]"
     )
 
-# PROVIDER SKIPS --------------------------------------
-
-# Tests which cannot be run on GKE, e.g. because they require
-# master ssh access.
-GKE_REQUIRED_SKIP_TESTS=(
-    "Nodes"
-    "Etcd\sFailure"
-    "MasterCerts"
-    "experimental\sresource\susage\stracking" # Expect --max-pods=110
-    "ServiceLoadBalancer" # issue: #16602
-    "Shell"
-    # Alpha features, remove from skip when these move to beta
-    "Daemon\sset"
-    "Deployment"
-    )
-
-# Tests which cannot be run on AWS.
-AWS_REQUIRED_SKIP_TESTS=(
-    "experimental\sresource\susage\stracking" # Expect --max-pods=110
-    "GCE\sL7\sLoadBalancer\sController" # GCE L7 loadbalancing
-)
-
-# END PROVIDER SKIPS --------------------------------------
-
 # Tests which kills or restarts components and/or nodes.
 DISRUPTIVE_TESTS=(
     "\[Disruptive\]"
@@ -357,7 +331,6 @@ case ${JOB_NAME} in
           ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
           ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
           ${GCE_SLOW_TESTS[@]:+${GCE_SLOW_TESTS[@]}} \
-          ${AWS_REQUIRED_SKIP_TESTS[@]:+${AWS_REQUIRED_SKIP_TESTS[@]}} \
 	  )"}
     : ${KUBE_GCE_INSTANCE_PREFIX="e2e-aws"}
     : ${PROJECT:="k8s-jkns-e2e-aws"}
@@ -465,7 +438,6 @@ case ${JOB_NAME} in
           ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
           ${GCE_PARALLEL_SKIP_TESTS[@]:+${GCE_PARALLEL_SKIP_TESTS[@]}} \
           ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-          ${AWS_REQUIRED_SKIP_TESTS[@]:+${AWS_REQUIRED_SKIP_TESTS[@]}} \
           )"}
     : ${ENABLE_DEPLOYMENTS:=true}
     # Override AWS defaults.
@@ -626,7 +598,6 @@ case ${JOB_NAME} in
     : ${PROJECT:="k8s-jkns-e2e-gke-ci"}
     : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
     : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
-          ${GKE_REQUIRED_SKIP_TESTS[@]:+${GKE_REQUIRED_SKIP_TESTS[@]}} \
           ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
           ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
           ${GCE_SLOW_TESTS[@]:+${GCE_SLOW_TESTS[@]}} \
@@ -645,7 +616,6 @@ case ${JOB_NAME} in
           ) --ginkgo.skip=$(join_regex_no_empty \
           ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
           ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-          ${GKE_REQUIRED_SKIP_TESTS[@]:+${GKE_REQUIRED_SKIP_TESTS[@]}} \
           )"}
     ;;
 
@@ -655,9 +625,7 @@ case ${JOB_NAME} in
     : ${E2E_SET_CLUSTER_API_VERSION:=y}
     : ${PROJECT:="k8s-jkns-e2e-gke-ci-flaky"}
     : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
-          ${GKE_REQUIRED_SKIP_TESTS[@]:+${GKE_REQUIRED_SKIP_TESTS[@]}}) \
-          --ginkgo.focus=$(join_regex_no_empty \
+    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=$(join_regex_no_empty \
           ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
           )"}
     ;;
@@ -690,7 +658,6 @@ case ${JOB_NAME} in
     # DISRUPTIVE_TESTS kill/restart components or nodes in the cluster,
     # defeating the purpose of a soak cluster. (#15722)
     : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
-          ${GKE_REQUIRED_SKIP_TESTS[@]:+${GKE_REQUIRED_SKIP_TESTS[@]}} \
           ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
           ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
           ${DISRUPTIVE_TESTS[@]:+${DISRUPTIVE_TESTS[@]}} \

--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -54,7 +54,7 @@ function join_regex_no_empty() {
 # Assumes globals:
 #   $JOB_NAME
 #   $KUBERNETES_PROVIDER
-#   $GKE_DEFAULT_SKIP_TESTS
+#   $GKE_REQUIRED_SKIP_TESTS
 #   $GCE_DEFAULT_SKIP_TESTS
 #   $GCE_FLAKY_TESTS
 #   $GCE_SLOW_TESTS
@@ -87,7 +87,7 @@ function configure_upgrade_step() {
         ${GCE_SLOW_TESTS[@]:+${GCE_SLOW_TESTS[@]}} \
         )"
   local -r gke_test_args="--ginkgo.skip=$(join_regex_allow_empty \
-        ${GKE_DEFAULT_SKIP_TESTS[@]:+${GKE_DEFAULT_SKIP_TESTS[@]}} \
+        ${GKE_REQUIRED_SKIP_TESTS[@]:+${GKE_REQUIRED_SKIP_TESTS[@]}} \
         ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
         ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
         ${GCE_SLOW_TESTS[@]:+${GCE_SLOW_TESTS[@]}} \
@@ -286,13 +286,6 @@ GKE_REQUIRED_SKIP_TESTS=(
     # Alpha features, remove from skip when these move to beta
     "Daemon\sset"
     "Deployment"
-    )
-
-# Specialized tests which should be skipped by default for GKE.
-GKE_DEFAULT_SKIP_TESTS=(
-    # Perf test, slow by design
-    "resource\susage\stracking"
-    "${GKE_REQUIRED_SKIP_TESTS[@]}"
     )
 
 # Tests which cannot be run on AWS.
@@ -633,9 +626,10 @@ case ${JOB_NAME} in
     : ${PROJECT:="k8s-jkns-e2e-gke-ci"}
     : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
     : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
-          ${GKE_DEFAULT_SKIP_TESTS[@]:+${GKE_DEFAULT_SKIP_TESTS[@]}} \
+          ${GKE_REQUIRED_SKIP_TESTS[@]:+${GKE_REQUIRED_SKIP_TESTS[@]}} \
           ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
           ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
+          ${GCE_SLOW_TESTS[@]:+${GCE_SLOW_TESTS[@]}} \
           )"}
     ;;
 
@@ -651,7 +645,7 @@ case ${JOB_NAME} in
           ) --ginkgo.skip=$(join_regex_no_empty \
           ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
           ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-          ${GKE_DEFAULT_SKIP_TESTS[@]:+${GKE_DEFAULT_SKIP_TESTS[@]}} \
+          ${GKE_REQUIRED_SKIP_TESTS[@]:+${GKE_REQUIRED_SKIP_TESTS[@]}} \
           )"}
     ;;
 

--- a/test/e2e/daemon_set.go
+++ b/test/e2e/daemon_set.go
@@ -48,7 +48,7 @@ const (
 	daemonsetColorLabel  = daemonsetLabelPrefix + "color"
 )
 
-var _ = Describe("Daemon set", func() {
+var _ = Describe("Daemon set [Feature:DaemonSet]", func() {
 	var f *Framework
 
 	AfterEach(func() {

--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -30,7 +30,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Deployment", func() {
+var _ = Describe("Deployment [Feature:Deployment]", func() {
 	f := NewFramework("deployment")
 
 	It("deployment should create new pods", func() {

--- a/test/e2e/horizontal_pod_autoscaling.go
+++ b/test/e2e/horizontal_pod_autoscaling.go
@@ -38,7 +38,7 @@ var _ = Describe("Horizontal pod autoscaling (scale resource: CPU) [Skipped]", f
 	titleUp := "Should scale from 1 pod to 3 pods and from 3 to 5"
 	titleDown := "Should scale from 5 pods to 3 pods and from 3 to 1"
 
-	Describe("Deployment", func() {
+	Describe("Deployment [Feature:Deployment]", func() {
 		// CPU tests via deployments
 		It(titleUp, func() {
 			scaleUp("deployment", kindDeployment, rc, f)

--- a/test/e2e/horizontal_pod_autoscaling.go
+++ b/test/e2e/horizontal_pod_autoscaling.go
@@ -31,14 +31,14 @@ const (
 	subresource    = "scale"
 )
 
-var _ = Describe("Horizontal pod autoscaling (scale resource: CPU) [Skipped]", func() {
+var _ = Describe("Horizontal pod autoscaling (scale resource: CPU) [Feature:Autoscaling]", func() {
 	var rc *ResourceConsumer
 	f := NewFramework("horizontal-pod-autoscaling")
 
 	titleUp := "Should scale from 1 pod to 3 pods and from 3 to 5"
 	titleDown := "Should scale from 5 pods to 3 pods and from 3 to 1"
 
-	Describe("Deployment [Feature:Deployment]", func() {
+	Describe("Deployment", func() {
 		// CPU tests via deployments
 		It(titleUp, func() {
 			scaleUp("deployment", kindDeployment, rc, f)
@@ -48,7 +48,7 @@ var _ = Describe("Horizontal pod autoscaling (scale resource: CPU) [Skipped]", f
 		})
 	})
 
-	Describe("ReplicationController [Feature:Autoscaling]", func() {
+	Describe("ReplicationController", func() {
 		// CPU tests via replication controllers
 		It(titleUp, func() {
 			scaleUp("rc", kindRC, rc, f)

--- a/test/e2e/kubelet_perf.go
+++ b/test/e2e/kubelet_perf.go
@@ -184,7 +184,7 @@ var _ = Describe("Kubelet [Serial] [Slow]", func() {
 			})
 		}
 	})
-	Describe("experimental resource usage tracking", func() {
+	Describe("experimental resource usage tracking [Feature:ExperimentalResourceUsageTracking]", func() {
 		density := []int{100}
 		for i := range density {
 			podsPerNode := density[i]


### PR DESCRIPTION
Toward #10548, remove provider-specific skip lists, instead relying on `SkipIfProviderIs` and `SkipUnlessProviderIs`.

These were largely erroneous anyway:

`GKE_DEFAULT_SKIP_TESTS`:
- "Autoscaling\sSuite": doesn't exist
  -: Perf test, slow by design
- "resource\susage\stracking": [Serial] and [Slow]

`GKE_REQUIRED_SKIP_TESTS`, "Tests which cannot be run on GKE, e.g. because they require master ssh access":
- "Nodes": `[Disruptive]`, shouldn't actually be skipped; works in GKE
- "Etcd\sFailure": Doesn't exist, but "Etcd failure" is `SkipUnlessProviderIs("gce")`
- "MasterCerts": Doesn't exist
- "experimental\sresource\susage\stracking": now [Feature:ExperimentalResourceUsageTracking]
- "ServiceLoadBalancer": `[Skipped]`, issue:19552
- "Shell": does not exist
- "Daemon\sset": now `[Feature:DaemonSet]`
- "Deployment": most `Deployment` tests are `[Flaky]`, now `[Feature:Deployment]`
