### PR TITLE
Fix bug in needsReconcile

### DIFF
--- a/pkg/kubelet/status/manager.go
+++ b/pkg/kubelet/status/manager.go
@@ -410,8 +410,7 @@ func (m *manager) needsReconcile(uid types.UID, status api.PodStatus) bool {
 	// The pod could be a static pod, so we should translate first.
 	pod, ok := m.podManager.GetPodByUID(uid)
 	if !ok {
-		// Although we get uid from pod manager in syncBatch, it still could be deleted before here.
-		glog.V(4).Infof("Pod %q has been deleted, no need to reconcile", format.Pod(pod))
+		glog.V(4).Infof("Pod %q has been deleted, no need to reconcile", string(uid))
 		return false
 	}
 	// If the pod is a static pod, we should check its mirror pod, because only status in mirror pod is meaningful to us.


### PR DESCRIPTION
For issue #19666

Hope we could merge this soon.
if `pod` is deleted, we should not print it with `format.Pod()`, because that will access the content of a nil pointer.

@yujuhong @bprashanth 
