### PR TITLE
Jenkins: reenable cadvisor related tests for Trusty and Trusty-dev

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -410,20 +410,10 @@ TRUSTY_DEFAULT_SKIP_TESTS=(
 
 TRUSTY_SKIP_TESTS=(
     "${TRUSTY_DEFAULT_SKIP_TESTS[@]}"
-    # These tests rely on cadvisor, which doesn't quite work with Trusty and
-    # Trusty dev images yet. An internal issue has been filed to track the fix.
-    # TODO(wonderfly): Remove this once the internal issue is fixed.
-    "Monitoring\sshould\sverify\smonitoring\spods\sand\sall\scluster\snodes\sare\savailable\son\sinfluxdb\susing\sheapster"
-    "Horizontal\spod\sautoscaling"
 )
 
 TRUSTY_DEV_SKIP_TESTS=(
     "${TRUSTY_DEFAULT_SKIP_TESTS[@]}"
-    # These tests rely on cadvisor, which doesn't quite work with Trusty and
-    # Trusty dev images yet. An internal issue has been filed to track the fix.
-    # TODO(wonderfly): Remove this once the internal issue is fixed.
-    "Monitoring\sshould\sverify\smonitoring\spods\sand\sall\scluster\snodes\sare\savailable\son\sinfluxdb\susing\sheapster"
-    "Horizontal\spod\sautoscaling"
 )
 
 TRUSTY_BETA_SKIP_TESTS=(


### PR DESCRIPTION
Tested in internal Jenkins.
@ixdy @andyzheng0831 @roberthbailey 
