### PR TITLE
Add rollback subresource; add rollback logic to deployment controller

### DIFF
--- a/pkg/apis/extensions/register.go
+++ b/pkg/apis/extensions/register.go
@@ -51,6 +51,7 @@ func addKnownTypes(scheme *runtime.Scheme) {
 		&ClusterAutoscalerList{},
 		&Deployment{},
 		&DeploymentList{},
+		&DeploymentRollback{},
 		&HorizontalPodAutoscaler{},
 		&HorizontalPodAutoscalerList{},
 		&Job{},
@@ -76,6 +77,7 @@ func (obj *ClusterAutoscaler) GetObjectKind() unversioned.ObjectKind           {
 func (obj *ClusterAutoscalerList) GetObjectKind() unversioned.ObjectKind       { return &obj.TypeMeta }
 func (obj *Deployment) GetObjectKind() unversioned.ObjectKind                  { return &obj.TypeMeta }
 func (obj *DeploymentList) GetObjectKind() unversioned.ObjectKind              { return &obj.TypeMeta }
+func (obj *DeploymentRollback) GetObjectKind() unversioned.ObjectKind          { return &obj.TypeMeta }
 func (obj *HorizontalPodAutoscaler) GetObjectKind() unversioned.ObjectKind     { return &obj.TypeMeta }
 func (obj *HorizontalPodAutoscalerList) GetObjectKind() unversioned.ObjectKind { return &obj.TypeMeta }
 func (obj *Job) GetObjectKind() unversioned.ObjectKind                         { return &obj.TypeMeta }

--- a/pkg/apis/extensions/types.generated.go
+++ b/pkg/apis/extensions/types.generated.go
@@ -4604,7 +4604,7 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 		} else {
 			yysep387 := !z.EncBinary()
 			yy2arr387 := z.EncBasicHandle().StructToArray
-			var yyq387 [7]bool
+			var yyq387 [8]bool
 			_, _, _ = yysep387, yyq387, yy2arr387
 			const yyr387 bool = false
 			yyq387[0] = x.Replicas != 0
@@ -4613,9 +4613,10 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq387[4] = x.RevisionHistoryLimit != nil
 			yyq387[5] = x.UniqueLabelKey != ""
 			yyq387[6] = x.Paused != false
+			yyq387[7] = x.RollbackTo != nil
 			var yynn387 int
 			if yyr387 || yy2arr387 {
-				r.EncodeArrayStart(7)
+				r.EncodeArrayStart(8)
 			} else {
 				yynn387 = 1
 				for _, b := range yyq387 {
@@ -4798,6 +4799,29 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr387 || yy2arr387 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq387[7] {
+					if x.RollbackTo == nil {
+						r.EncodeNil()
+					} else {
+						x.RollbackTo.CodecEncodeSelf(e)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq387[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("rollbackTo"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if x.RollbackTo == nil {
+						r.EncodeNil()
+					} else {
+						x.RollbackTo.CodecEncodeSelf(e)
+					}
+				}
+			}
+			if yyr387 || yy2arr387 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -4810,25 +4834,25 @@ func (x *DeploymentSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym411 := z.DecBinary()
-	_ = yym411
+	yym412 := z.DecBinary()
+	_ = yym412
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct412 := r.ContainerType()
-		if yyct412 == codecSelferValueTypeMap1234 {
-			yyl412 := r.ReadMapStart()
-			if yyl412 == 0 {
+		yyct413 := r.ContainerType()
+		if yyct413 == codecSelferValueTypeMap1234 {
+			yyl413 := r.ReadMapStart()
+			if yyl413 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl412, d)
+				x.codecDecodeSelfFromMap(yyl413, d)
 			}
-		} else if yyct412 == codecSelferValueTypeArray1234 {
-			yyl412 := r.ReadArrayStart()
-			if yyl412 == 0 {
+		} else if yyct413 == codecSelferValueTypeArray1234 {
+			yyl413 := r.ReadArrayStart()
+			if yyl413 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl412, d)
+				x.codecDecodeSelfFromArray(yyl413, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4840,12 +4864,12 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys413Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys413Slc
-	var yyhl413 bool = l >= 0
-	for yyj413 := 0; ; yyj413++ {
-		if yyhl413 {
-			if yyj413 >= l {
+	var yys414Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys414Slc
+	var yyhl414 bool = l >= 0
+	for yyj414 := 0; ; yyj414++ {
+		if yyhl414 {
+			if yyj414 >= l {
 				break
 			}
 		} else {
@@ -4854,10 +4878,10 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys413Slc = r.DecodeBytes(yys413Slc, true, true)
-		yys413 := string(yys413Slc)
+		yys414Slc = r.DecodeBytes(yys414Slc, true, true)
+		yys414 := string(yys414Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys413 {
+		switch yys414 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
 				x.Replicas = 0
@@ -4868,27 +4892,27 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Selector = nil
 			} else {
-				yyv415 := &x.Selector
-				yym416 := z.DecBinary()
-				_ = yym416
+				yyv416 := &x.Selector
+				yym417 := z.DecBinary()
+				_ = yym417
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv415, false, d)
+					z.F.DecMapStringStringX(yyv416, false, d)
 				}
 			}
 		case "template":
 			if r.TryDecodeAsNil() {
 				x.Template = pkg2_api.PodTemplateSpec{}
 			} else {
-				yyv417 := &x.Template
-				yyv417.CodecDecodeSelf(d)
+				yyv418 := &x.Template
+				yyv418.CodecDecodeSelf(d)
 			}
 		case "strategy":
 			if r.TryDecodeAsNil() {
 				x.Strategy = DeploymentStrategy{}
 			} else {
-				yyv418 := &x.Strategy
-				yyv418.CodecDecodeSelf(d)
+				yyv419 := &x.Strategy
+				yyv419.CodecDecodeSelf(d)
 			}
 		case "revisionHistoryLimit":
 			if r.TryDecodeAsNil() {
@@ -4899,8 +4923,8 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.RevisionHistoryLimit == nil {
 					x.RevisionHistoryLimit = new(int)
 				}
-				yym420 := z.DecBinary()
-				_ = yym420
+				yym421 := z.DecBinary()
+				_ = yym421
 				if false {
 				} else {
 					*((*int)(x.RevisionHistoryLimit)) = int(r.DecodeInt(codecSelferBitsize1234))
@@ -4918,10 +4942,21 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			} else {
 				x.Paused = bool(r.DecodeBool())
 			}
+		case "rollbackTo":
+			if r.TryDecodeAsNil() {
+				if x.RollbackTo != nil {
+					x.RollbackTo = nil
+				}
+			} else {
+				if x.RollbackTo == nil {
+					x.RollbackTo = new(RollbackConfig)
+				}
+				x.RollbackTo.CodecDecodeSelf(d)
+			}
 		default:
-			z.DecStructFieldNotFound(-1, yys413)
-		} // end switch yys413
-	} // end for yyj413
+			z.DecStructFieldNotFound(-1, yys414)
+		} // end switch yys414
+	} // end for yyj414
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -4929,16 +4964,16 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj423 int
-	var yyb423 bool
-	var yyhl423 bool = l >= 0
-	yyj423++
-	if yyhl423 {
-		yyb423 = yyj423 > l
+	var yyj425 int
+	var yyb425 bool
+	var yyhl425 bool = l >= 0
+	yyj425++
+	if yyhl425 {
+		yyb425 = yyj425 > l
 	} else {
-		yyb423 = r.CheckBreak()
+		yyb425 = r.CheckBreak()
 	}
-	if yyb423 {
+	if yyb425 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4948,13 +4983,13 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj423++
-	if yyhl423 {
-		yyb423 = yyj423 > l
+	yyj425++
+	if yyhl425 {
+		yyb425 = yyj425 > l
 	} else {
-		yyb423 = r.CheckBreak()
+		yyb425 = r.CheckBreak()
 	}
-	if yyb423 {
+	if yyb425 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4962,21 +4997,21 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Selector = nil
 	} else {
-		yyv425 := &x.Selector
-		yym426 := z.DecBinary()
-		_ = yym426
+		yyv427 := &x.Selector
+		yym428 := z.DecBinary()
+		_ = yym428
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv425, false, d)
+			z.F.DecMapStringStringX(yyv427, false, d)
 		}
 	}
-	yyj423++
-	if yyhl423 {
-		yyb423 = yyj423 > l
+	yyj425++
+	if yyhl425 {
+		yyb425 = yyj425 > l
 	} else {
-		yyb423 = r.CheckBreak()
+		yyb425 = r.CheckBreak()
 	}
-	if yyb423 {
+	if yyb425 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4984,16 +5019,16 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Template = pkg2_api.PodTemplateSpec{}
 	} else {
-		yyv427 := &x.Template
-		yyv427.CodecDecodeSelf(d)
+		yyv429 := &x.Template
+		yyv429.CodecDecodeSelf(d)
 	}
-	yyj423++
-	if yyhl423 {
-		yyb423 = yyj423 > l
+	yyj425++
+	if yyhl425 {
+		yyb425 = yyj425 > l
 	} else {
-		yyb423 = r.CheckBreak()
+		yyb425 = r.CheckBreak()
 	}
-	if yyb423 {
+	if yyb425 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5001,16 +5036,16 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Strategy = DeploymentStrategy{}
 	} else {
-		yyv428 := &x.Strategy
-		yyv428.CodecDecodeSelf(d)
+		yyv430 := &x.Strategy
+		yyv430.CodecDecodeSelf(d)
 	}
-	yyj423++
-	if yyhl423 {
-		yyb423 = yyj423 > l
+	yyj425++
+	if yyhl425 {
+		yyb425 = yyj425 > l
 	} else {
-		yyb423 = r.CheckBreak()
+		yyb425 = r.CheckBreak()
 	}
-	if yyb423 {
+	if yyb425 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5023,20 +5058,20 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.RevisionHistoryLimit == nil {
 			x.RevisionHistoryLimit = new(int)
 		}
-		yym430 := z.DecBinary()
-		_ = yym430
+		yym432 := z.DecBinary()
+		_ = yym432
 		if false {
 		} else {
 			*((*int)(x.RevisionHistoryLimit)) = int(r.DecodeInt(codecSelferBitsize1234))
 		}
 	}
-	yyj423++
-	if yyhl423 {
-		yyb423 = yyj423 > l
+	yyj425++
+	if yyhl425 {
+		yyb425 = yyj425 > l
 	} else {
-		yyb423 = r.CheckBreak()
+		yyb425 = r.CheckBreak()
 	}
-	if yyb423 {
+	if yyb425 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5046,13 +5081,13 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.UniqueLabelKey = string(r.DecodeString())
 	}
-	yyj423++
-	if yyhl423 {
-		yyb423 = yyj423 > l
+	yyj425++
+	if yyhl425 {
+		yyb425 = yyj425 > l
 	} else {
-		yyb423 = r.CheckBreak()
+		yyb425 = r.CheckBreak()
 	}
-	if yyb423 {
+	if yyb425 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5062,18 +5097,569 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Paused = bool(r.DecodeBool())
 	}
-	for {
-		yyj423++
-		if yyhl423 {
-			yyb423 = yyj423 > l
-		} else {
-			yyb423 = r.CheckBreak()
+	yyj425++
+	if yyhl425 {
+		yyb425 = yyj425 > l
+	} else {
+		yyb425 = r.CheckBreak()
+	}
+	if yyb425 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		if x.RollbackTo != nil {
+			x.RollbackTo = nil
 		}
-		if yyb423 {
+	} else {
+		if x.RollbackTo == nil {
+			x.RollbackTo = new(RollbackConfig)
+		}
+		x.RollbackTo.CodecDecodeSelf(d)
+	}
+	for {
+		yyj425++
+		if yyhl425 {
+			yyb425 = yyj425 > l
+		} else {
+			yyb425 = r.CheckBreak()
+		}
+		if yyb425 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj423-1, "")
+		z.DecStructFieldNotFound(yyj425-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x *DeploymentRollback) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym436 := z.EncBinary()
+		_ = yym436
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep437 := !z.EncBinary()
+			yy2arr437 := z.EncBasicHandle().StructToArray
+			var yyq437 [5]bool
+			_, _, _ = yysep437, yyq437, yy2arr437
+			const yyr437 bool = false
+			yyq437[0] = x.Kind != ""
+			yyq437[1] = x.APIVersion != ""
+			yyq437[3] = len(x.UpdatedAnnotations) != 0
+			var yynn437 int
+			if yyr437 || yy2arr437 {
+				r.EncodeArrayStart(5)
+			} else {
+				yynn437 = 2
+				for _, b := range yyq437 {
+					if b {
+						yynn437++
+					}
+				}
+				r.EncodeMapStart(yynn437)
+				yynn437 = 0
+			}
+			if yyr437 || yy2arr437 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq437[0] {
+					yym439 := z.EncBinary()
+					_ = yym439
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq437[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym440 := z.EncBinary()
+					_ = yym440
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr437 || yy2arr437 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq437[1] {
+					yym442 := z.EncBinary()
+					_ = yym442
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq437[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym443 := z.EncBinary()
+					_ = yym443
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr437 || yy2arr437 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym445 := z.EncBinary()
+				_ = yym445
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("name"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym446 := z.EncBinary()
+				_ = yym446
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+				}
+			}
+			if yyr437 || yy2arr437 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq437[3] {
+					if x.UpdatedAnnotations == nil {
+						r.EncodeNil()
+					} else {
+						yym448 := z.EncBinary()
+						_ = yym448
+						if false {
+						} else {
+							z.F.EncMapStringStringV(x.UpdatedAnnotations, false, e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq437[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("updatedAnnotations"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if x.UpdatedAnnotations == nil {
+						r.EncodeNil()
+					} else {
+						yym449 := z.EncBinary()
+						_ = yym449
+						if false {
+						} else {
+							z.F.EncMapStringStringV(x.UpdatedAnnotations, false, e)
+						}
+					}
+				}
+			}
+			if yyr437 || yy2arr437 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yy451 := &x.RollbackTo
+				yy451.CodecEncodeSelf(e)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("rollbackTo"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yy452 := &x.RollbackTo
+				yy452.CodecEncodeSelf(e)
+			}
+			if yyr437 || yy2arr437 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *DeploymentRollback) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym453 := z.DecBinary()
+	_ = yym453
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct454 := r.ContainerType()
+		if yyct454 == codecSelferValueTypeMap1234 {
+			yyl454 := r.ReadMapStart()
+			if yyl454 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl454, d)
+			}
+		} else if yyct454 == codecSelferValueTypeArray1234 {
+			yyl454 := r.ReadArrayStart()
+			if yyl454 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl454, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *DeploymentRollback) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys455Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys455Slc
+	var yyhl455 bool = l >= 0
+	for yyj455 := 0; ; yyj455++ {
+		if yyhl455 {
+			if yyj455 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys455Slc = r.DecodeBytes(yys455Slc, true, true)
+		yys455 := string(yys455Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys455 {
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
+			}
+		case "name":
+			if r.TryDecodeAsNil() {
+				x.Name = ""
+			} else {
+				x.Name = string(r.DecodeString())
+			}
+		case "updatedAnnotations":
+			if r.TryDecodeAsNil() {
+				x.UpdatedAnnotations = nil
+			} else {
+				yyv459 := &x.UpdatedAnnotations
+				yym460 := z.DecBinary()
+				_ = yym460
+				if false {
+				} else {
+					z.F.DecMapStringStringX(yyv459, false, d)
+				}
+			}
+		case "rollbackTo":
+			if r.TryDecodeAsNil() {
+				x.RollbackTo = RollbackConfig{}
+			} else {
+				yyv461 := &x.RollbackTo
+				yyv461.CodecDecodeSelf(d)
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys455)
+		} // end switch yys455
+	} // end for yyj455
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *DeploymentRollback) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj462 int
+	var yyb462 bool
+	var yyhl462 bool = l >= 0
+	yyj462++
+	if yyhl462 {
+		yyb462 = yyj462 > l
+	} else {
+		yyb462 = r.CheckBreak()
+	}
+	if yyb462 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj462++
+	if yyhl462 {
+		yyb462 = yyj462 > l
+	} else {
+		yyb462 = r.CheckBreak()
+	}
+	if yyb462 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
+	}
+	yyj462++
+	if yyhl462 {
+		yyb462 = yyj462 > l
+	} else {
+		yyb462 = r.CheckBreak()
+	}
+	if yyb462 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Name = ""
+	} else {
+		x.Name = string(r.DecodeString())
+	}
+	yyj462++
+	if yyhl462 {
+		yyb462 = yyj462 > l
+	} else {
+		yyb462 = r.CheckBreak()
+	}
+	if yyb462 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.UpdatedAnnotations = nil
+	} else {
+		yyv466 := &x.UpdatedAnnotations
+		yym467 := z.DecBinary()
+		_ = yym467
+		if false {
+		} else {
+			z.F.DecMapStringStringX(yyv466, false, d)
+		}
+	}
+	yyj462++
+	if yyhl462 {
+		yyb462 = yyj462 > l
+	} else {
+		yyb462 = r.CheckBreak()
+	}
+	if yyb462 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.RollbackTo = RollbackConfig{}
+	} else {
+		yyv468 := &x.RollbackTo
+		yyv468.CodecDecodeSelf(d)
+	}
+	for {
+		yyj462++
+		if yyhl462 {
+			yyb462 = yyj462 > l
+		} else {
+			yyb462 = r.CheckBreak()
+		}
+		if yyb462 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj462-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x *RollbackConfig) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym469 := z.EncBinary()
+		_ = yym469
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep470 := !z.EncBinary()
+			yy2arr470 := z.EncBasicHandle().StructToArray
+			var yyq470 [1]bool
+			_, _, _ = yysep470, yyq470, yy2arr470
+			const yyr470 bool = false
+			yyq470[0] = x.Revision != 0
+			var yynn470 int
+			if yyr470 || yy2arr470 {
+				r.EncodeArrayStart(1)
+			} else {
+				yynn470 = 0
+				for _, b := range yyq470 {
+					if b {
+						yynn470++
+					}
+				}
+				r.EncodeMapStart(yynn470)
+				yynn470 = 0
+			}
+			if yyr470 || yy2arr470 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq470[0] {
+					yym472 := z.EncBinary()
+					_ = yym472
+					if false {
+					} else {
+						r.EncodeInt(int64(x.Revision))
+					}
+				} else {
+					r.EncodeInt(0)
+				}
+			} else {
+				if yyq470[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("revision"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym473 := z.EncBinary()
+					_ = yym473
+					if false {
+					} else {
+						r.EncodeInt(int64(x.Revision))
+					}
+				}
+			}
+			if yyr470 || yy2arr470 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *RollbackConfig) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym474 := z.DecBinary()
+	_ = yym474
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct475 := r.ContainerType()
+		if yyct475 == codecSelferValueTypeMap1234 {
+			yyl475 := r.ReadMapStart()
+			if yyl475 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl475, d)
+			}
+		} else if yyct475 == codecSelferValueTypeArray1234 {
+			yyl475 := r.ReadArrayStart()
+			if yyl475 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl475, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *RollbackConfig) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys476Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys476Slc
+	var yyhl476 bool = l >= 0
+	for yyj476 := 0; ; yyj476++ {
+		if yyhl476 {
+			if yyj476 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys476Slc = r.DecodeBytes(yys476Slc, true, true)
+		yys476 := string(yys476Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys476 {
+		case "revision":
+			if r.TryDecodeAsNil() {
+				x.Revision = 0
+			} else {
+				x.Revision = int64(r.DecodeInt(64))
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys476)
+		} // end switch yys476
+	} // end for yyj476
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *RollbackConfig) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj478 int
+	var yyb478 bool
+	var yyhl478 bool = l >= 0
+	yyj478++
+	if yyhl478 {
+		yyb478 = yyj478 > l
+	} else {
+		yyb478 = r.CheckBreak()
+	}
+	if yyb478 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Revision = 0
+	} else {
+		x.Revision = int64(r.DecodeInt(64))
+	}
+	for {
+		yyj478++
+		if yyhl478 {
+			yyb478 = yyj478 > l
+		} else {
+			yyb478 = r.CheckBreak()
+		}
+		if yyb478 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj478-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -5085,49 +5671,49 @@ func (x *DeploymentStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym433 := z.EncBinary()
-		_ = yym433
+		yym480 := z.EncBinary()
+		_ = yym480
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep434 := !z.EncBinary()
-			yy2arr434 := z.EncBasicHandle().StructToArray
-			var yyq434 [2]bool
-			_, _, _ = yysep434, yyq434, yy2arr434
-			const yyr434 bool = false
-			yyq434[0] = x.Type != ""
-			yyq434[1] = x.RollingUpdate != nil
-			var yynn434 int
-			if yyr434 || yy2arr434 {
+			yysep481 := !z.EncBinary()
+			yy2arr481 := z.EncBasicHandle().StructToArray
+			var yyq481 [2]bool
+			_, _, _ = yysep481, yyq481, yy2arr481
+			const yyr481 bool = false
+			yyq481[0] = x.Type != ""
+			yyq481[1] = x.RollingUpdate != nil
+			var yynn481 int
+			if yyr481 || yy2arr481 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn434 = 0
-				for _, b := range yyq434 {
+				yynn481 = 0
+				for _, b := range yyq481 {
 					if b {
-						yynn434++
+						yynn481++
 					}
 				}
-				r.EncodeMapStart(yynn434)
-				yynn434 = 0
+				r.EncodeMapStart(yynn481)
+				yynn481 = 0
 			}
-			if yyr434 || yy2arr434 {
+			if yyr481 || yy2arr481 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq434[0] {
+				if yyq481[0] {
 					x.Type.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq434[0] {
+				if yyq481[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("type"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.Type.CodecEncodeSelf(e)
 				}
 			}
-			if yyr434 || yy2arr434 {
+			if yyr481 || yy2arr481 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq434[1] {
+				if yyq481[1] {
 					if x.RollingUpdate == nil {
 						r.EncodeNil()
 					} else {
@@ -5137,7 +5723,7 @@ func (x *DeploymentStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq434[1] {
+				if yyq481[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("rollingUpdate"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
@@ -5148,7 +5734,7 @@ func (x *DeploymentStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr434 || yy2arr434 {
+			if yyr481 || yy2arr481 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -5161,25 +5747,25 @@ func (x *DeploymentStrategy) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym437 := z.DecBinary()
-	_ = yym437
+	yym484 := z.DecBinary()
+	_ = yym484
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct438 := r.ContainerType()
-		if yyct438 == codecSelferValueTypeMap1234 {
-			yyl438 := r.ReadMapStart()
-			if yyl438 == 0 {
+		yyct485 := r.ContainerType()
+		if yyct485 == codecSelferValueTypeMap1234 {
+			yyl485 := r.ReadMapStart()
+			if yyl485 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl438, d)
+				x.codecDecodeSelfFromMap(yyl485, d)
 			}
-		} else if yyct438 == codecSelferValueTypeArray1234 {
-			yyl438 := r.ReadArrayStart()
-			if yyl438 == 0 {
+		} else if yyct485 == codecSelferValueTypeArray1234 {
+			yyl485 := r.ReadArrayStart()
+			if yyl485 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl438, d)
+				x.codecDecodeSelfFromArray(yyl485, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -5191,12 +5777,12 @@ func (x *DeploymentStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys439Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys439Slc
-	var yyhl439 bool = l >= 0
-	for yyj439 := 0; ; yyj439++ {
-		if yyhl439 {
-			if yyj439 >= l {
+	var yys486Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys486Slc
+	var yyhl486 bool = l >= 0
+	for yyj486 := 0; ; yyj486++ {
+		if yyhl486 {
+			if yyj486 >= l {
 				break
 			}
 		} else {
@@ -5205,10 +5791,10 @@ func (x *DeploymentStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys439Slc = r.DecodeBytes(yys439Slc, true, true)
-		yys439 := string(yys439Slc)
+		yys486Slc = r.DecodeBytes(yys486Slc, true, true)
+		yys486 := string(yys486Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys439 {
+		switch yys486 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -5227,9 +5813,9 @@ func (x *DeploymentStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				x.RollingUpdate.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys439)
-		} // end switch yys439
-	} // end for yyj439
+			z.DecStructFieldNotFound(-1, yys486)
+		} // end switch yys486
+	} // end for yyj486
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -5237,16 +5823,16 @@ func (x *DeploymentStrategy) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj442 int
-	var yyb442 bool
-	var yyhl442 bool = l >= 0
-	yyj442++
-	if yyhl442 {
-		yyb442 = yyj442 > l
+	var yyj489 int
+	var yyb489 bool
+	var yyhl489 bool = l >= 0
+	yyj489++
+	if yyhl489 {
+		yyb489 = yyj489 > l
 	} else {
-		yyb442 = r.CheckBreak()
+		yyb489 = r.CheckBreak()
 	}
-	if yyb442 {
+	if yyb489 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5256,13 +5842,13 @@ func (x *DeploymentStrategy) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.Type = DeploymentStrategyType(r.DecodeString())
 	}
-	yyj442++
-	if yyhl442 {
-		yyb442 = yyj442 > l
+	yyj489++
+	if yyhl489 {
+		yyb489 = yyj489 > l
 	} else {
-		yyb442 = r.CheckBreak()
+		yyb489 = r.CheckBreak()
 	}
-	if yyb442 {
+	if yyb489 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5278,17 +5864,17 @@ func (x *DeploymentStrategy) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		x.RollingUpdate.CodecDecodeSelf(d)
 	}
 	for {
-		yyj442++
-		if yyhl442 {
-			yyb442 = yyj442 > l
+		yyj489++
+		if yyhl489 {
+			yyb489 = yyj489 > l
 		} else {
-			yyb442 = r.CheckBreak()
+			yyb489 = r.CheckBreak()
 		}
-		if yyb442 {
+		if yyb489 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj442-1, "")
+		z.DecStructFieldNotFound(yyj489-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -5297,8 +5883,8 @@ func (x DeploymentStrategyType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym445 := z.EncBinary()
-	_ = yym445
+	yym492 := z.EncBinary()
+	_ = yym492
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -5310,8 +5896,8 @@ func (x *DeploymentStrategyType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym446 := z.DecBinary()
-	_ = yym446
+	yym493 := z.DecBinary()
+	_ = yym493
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -5326,103 +5912,103 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym447 := z.EncBinary()
-		_ = yym447
+		yym494 := z.EncBinary()
+		_ = yym494
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep448 := !z.EncBinary()
-			yy2arr448 := z.EncBasicHandle().StructToArray
-			var yyq448 [3]bool
-			_, _, _ = yysep448, yyq448, yy2arr448
-			const yyr448 bool = false
-			yyq448[0] = true
-			yyq448[1] = true
-			yyq448[2] = x.MinReadySeconds != 0
-			var yynn448 int
-			if yyr448 || yy2arr448 {
+			yysep495 := !z.EncBinary()
+			yy2arr495 := z.EncBasicHandle().StructToArray
+			var yyq495 [3]bool
+			_, _, _ = yysep495, yyq495, yy2arr495
+			const yyr495 bool = false
+			yyq495[0] = true
+			yyq495[1] = true
+			yyq495[2] = x.MinReadySeconds != 0
+			var yynn495 int
+			if yyr495 || yy2arr495 {
 				r.EncodeArrayStart(3)
 			} else {
-				yynn448 = 0
-				for _, b := range yyq448 {
+				yynn495 = 0
+				for _, b := range yyq495 {
 					if b {
-						yynn448++
+						yynn495++
 					}
 				}
-				r.EncodeMapStart(yynn448)
-				yynn448 = 0
+				r.EncodeMapStart(yynn495)
+				yynn495 = 0
 			}
-			if yyr448 || yy2arr448 {
+			if yyr495 || yy2arr495 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq448[0] {
-					yy450 := &x.MaxUnavailable
-					yym451 := z.EncBinary()
-					_ = yym451
+				if yyq495[0] {
+					yy497 := &x.MaxUnavailable
+					yym498 := z.EncBinary()
+					_ = yym498
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy450) {
-					} else if !yym451 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy450)
+					} else if z.HasExtensions() && z.EncExt(yy497) {
+					} else if !yym498 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy497)
 					} else {
-						z.EncFallback(yy450)
+						z.EncFallback(yy497)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq448[0] {
+				if yyq495[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("maxUnavailable"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy452 := &x.MaxUnavailable
-					yym453 := z.EncBinary()
-					_ = yym453
+					yy499 := &x.MaxUnavailable
+					yym500 := z.EncBinary()
+					_ = yym500
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy452) {
-					} else if !yym453 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy452)
+					} else if z.HasExtensions() && z.EncExt(yy499) {
+					} else if !yym500 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy499)
 					} else {
-						z.EncFallback(yy452)
+						z.EncFallback(yy499)
 					}
 				}
 			}
-			if yyr448 || yy2arr448 {
+			if yyr495 || yy2arr495 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq448[1] {
-					yy455 := &x.MaxSurge
-					yym456 := z.EncBinary()
-					_ = yym456
+				if yyq495[1] {
+					yy502 := &x.MaxSurge
+					yym503 := z.EncBinary()
+					_ = yym503
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy455) {
-					} else if !yym456 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy455)
+					} else if z.HasExtensions() && z.EncExt(yy502) {
+					} else if !yym503 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy502)
 					} else {
-						z.EncFallback(yy455)
+						z.EncFallback(yy502)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq448[1] {
+				if yyq495[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("maxSurge"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy457 := &x.MaxSurge
-					yym458 := z.EncBinary()
-					_ = yym458
+					yy504 := &x.MaxSurge
+					yym505 := z.EncBinary()
+					_ = yym505
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy457) {
-					} else if !yym458 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy457)
+					} else if z.HasExtensions() && z.EncExt(yy504) {
+					} else if !yym505 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy504)
 					} else {
-						z.EncFallback(yy457)
+						z.EncFallback(yy504)
 					}
 				}
 			}
-			if yyr448 || yy2arr448 {
+			if yyr495 || yy2arr495 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq448[2] {
-					yym460 := z.EncBinary()
-					_ = yym460
+				if yyq495[2] {
+					yym507 := z.EncBinary()
+					_ = yym507
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MinReadySeconds))
@@ -5431,19 +6017,19 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq448[2] {
+				if yyq495[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("minReadySeconds"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym461 := z.EncBinary()
-					_ = yym461
+					yym508 := z.EncBinary()
+					_ = yym508
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MinReadySeconds))
 					}
 				}
 			}
-			if yyr448 || yy2arr448 {
+			if yyr495 || yy2arr495 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -5456,25 +6042,25 @@ func (x *RollingUpdateDeployment) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym462 := z.DecBinary()
-	_ = yym462
+	yym509 := z.DecBinary()
+	_ = yym509
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct463 := r.ContainerType()
-		if yyct463 == codecSelferValueTypeMap1234 {
-			yyl463 := r.ReadMapStart()
-			if yyl463 == 0 {
+		yyct510 := r.ContainerType()
+		if yyct510 == codecSelferValueTypeMap1234 {
+			yyl510 := r.ReadMapStart()
+			if yyl510 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl463, d)
+				x.codecDecodeSelfFromMap(yyl510, d)
 			}
-		} else if yyct463 == codecSelferValueTypeArray1234 {
-			yyl463 := r.ReadArrayStart()
-			if yyl463 == 0 {
+		} else if yyct510 == codecSelferValueTypeArray1234 {
+			yyl510 := r.ReadArrayStart()
+			if yyl510 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl463, d)
+				x.codecDecodeSelfFromArray(yyl510, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -5486,12 +6072,12 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys464Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys464Slc
-	var yyhl464 bool = l >= 0
-	for yyj464 := 0; ; yyj464++ {
-		if yyhl464 {
-			if yyj464 >= l {
+	var yys511Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys511Slc
+	var yyhl511 bool = l >= 0
+	for yyj511 := 0; ; yyj511++ {
+		if yyhl511 {
+			if yyj511 >= l {
 				break
 			}
 		} else {
@@ -5500,38 +6086,38 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys464Slc = r.DecodeBytes(yys464Slc, true, true)
-		yys464 := string(yys464Slc)
+		yys511Slc = r.DecodeBytes(yys511Slc, true, true)
+		yys511 := string(yys511Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys464 {
+		switch yys511 {
 		case "maxUnavailable":
 			if r.TryDecodeAsNil() {
 				x.MaxUnavailable = pkg6_intstr.IntOrString{}
 			} else {
-				yyv465 := &x.MaxUnavailable
-				yym466 := z.DecBinary()
-				_ = yym466
+				yyv512 := &x.MaxUnavailable
+				yym513 := z.DecBinary()
+				_ = yym513
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv465) {
-				} else if !yym466 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv465)
+				} else if z.HasExtensions() && z.DecExt(yyv512) {
+				} else if !yym513 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv512)
 				} else {
-					z.DecFallback(yyv465, false)
+					z.DecFallback(yyv512, false)
 				}
 			}
 		case "maxSurge":
 			if r.TryDecodeAsNil() {
 				x.MaxSurge = pkg6_intstr.IntOrString{}
 			} else {
-				yyv467 := &x.MaxSurge
-				yym468 := z.DecBinary()
-				_ = yym468
+				yyv514 := &x.MaxSurge
+				yym515 := z.DecBinary()
+				_ = yym515
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv467) {
-				} else if !yym468 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv467)
+				} else if z.HasExtensions() && z.DecExt(yyv514) {
+				} else if !yym515 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv514)
 				} else {
-					z.DecFallback(yyv467, false)
+					z.DecFallback(yyv514, false)
 				}
 			}
 		case "minReadySeconds":
@@ -5541,9 +6127,9 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				x.MinReadySeconds = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys464)
-		} // end switch yys464
-	} // end for yyj464
+			z.DecStructFieldNotFound(-1, yys511)
+		} // end switch yys511
+	} // end for yyj511
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -5551,16 +6137,16 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromArray(l int, d *codec1978.D
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj470 int
-	var yyb470 bool
-	var yyhl470 bool = l >= 0
-	yyj470++
-	if yyhl470 {
-		yyb470 = yyj470 > l
+	var yyj517 int
+	var yyb517 bool
+	var yyhl517 bool = l >= 0
+	yyj517++
+	if yyhl517 {
+		yyb517 = yyj517 > l
 	} else {
-		yyb470 = r.CheckBreak()
+		yyb517 = r.CheckBreak()
 	}
-	if yyb470 {
+	if yyb517 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5568,24 +6154,24 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromArray(l int, d *codec1978.D
 	if r.TryDecodeAsNil() {
 		x.MaxUnavailable = pkg6_intstr.IntOrString{}
 	} else {
-		yyv471 := &x.MaxUnavailable
-		yym472 := z.DecBinary()
-		_ = yym472
+		yyv518 := &x.MaxUnavailable
+		yym519 := z.DecBinary()
+		_ = yym519
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv471) {
-		} else if !yym472 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv471)
+		} else if z.HasExtensions() && z.DecExt(yyv518) {
+		} else if !yym519 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv518)
 		} else {
-			z.DecFallback(yyv471, false)
+			z.DecFallback(yyv518, false)
 		}
 	}
-	yyj470++
-	if yyhl470 {
-		yyb470 = yyj470 > l
+	yyj517++
+	if yyhl517 {
+		yyb517 = yyj517 > l
 	} else {
-		yyb470 = r.CheckBreak()
+		yyb517 = r.CheckBreak()
 	}
-	if yyb470 {
+	if yyb517 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5593,24 +6179,24 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromArray(l int, d *codec1978.D
 	if r.TryDecodeAsNil() {
 		x.MaxSurge = pkg6_intstr.IntOrString{}
 	} else {
-		yyv473 := &x.MaxSurge
-		yym474 := z.DecBinary()
-		_ = yym474
+		yyv520 := &x.MaxSurge
+		yym521 := z.DecBinary()
+		_ = yym521
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv473) {
-		} else if !yym474 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv473)
+		} else if z.HasExtensions() && z.DecExt(yyv520) {
+		} else if !yym521 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv520)
 		} else {
-			z.DecFallback(yyv473, false)
+			z.DecFallback(yyv520, false)
 		}
 	}
-	yyj470++
-	if yyhl470 {
-		yyb470 = yyj470 > l
+	yyj517++
+	if yyhl517 {
+		yyb517 = yyj517 > l
 	} else {
-		yyb470 = r.CheckBreak()
+		yyb517 = r.CheckBreak()
 	}
-	if yyb470 {
+	if yyb517 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5621,17 +6207,17 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromArray(l int, d *codec1978.D
 		x.MinReadySeconds = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj470++
-		if yyhl470 {
-			yyb470 = yyj470 > l
+		yyj517++
+		if yyhl517 {
+			yyb517 = yyj517 > l
 		} else {
-			yyb470 = r.CheckBreak()
+			yyb517 = r.CheckBreak()
 		}
-		if yyb470 {
+		if yyb517 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj470-1, "")
+		z.DecStructFieldNotFound(yyj517-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -5643,38 +6229,38 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym476 := z.EncBinary()
-		_ = yym476
+		yym523 := z.EncBinary()
+		_ = yym523
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep477 := !z.EncBinary()
-			yy2arr477 := z.EncBasicHandle().StructToArray
-			var yyq477 [4]bool
-			_, _, _ = yysep477, yyq477, yy2arr477
-			const yyr477 bool = false
-			yyq477[0] = x.Replicas != 0
-			yyq477[1] = x.UpdatedReplicas != 0
-			yyq477[2] = x.AvailableReplicas != 0
-			yyq477[3] = x.UnavailableReplicas != 0
-			var yynn477 int
-			if yyr477 || yy2arr477 {
+			yysep524 := !z.EncBinary()
+			yy2arr524 := z.EncBasicHandle().StructToArray
+			var yyq524 [4]bool
+			_, _, _ = yysep524, yyq524, yy2arr524
+			const yyr524 bool = false
+			yyq524[0] = x.Replicas != 0
+			yyq524[1] = x.UpdatedReplicas != 0
+			yyq524[2] = x.AvailableReplicas != 0
+			yyq524[3] = x.UnavailableReplicas != 0
+			var yynn524 int
+			if yyr524 || yy2arr524 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn477 = 0
-				for _, b := range yyq477 {
+				yynn524 = 0
+				for _, b := range yyq524 {
 					if b {
-						yynn477++
+						yynn524++
 					}
 				}
-				r.EncodeMapStart(yynn477)
-				yynn477 = 0
+				r.EncodeMapStart(yynn524)
+				yynn524 = 0
 			}
-			if yyr477 || yy2arr477 {
+			if yyr524 || yy2arr524 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq477[0] {
-					yym479 := z.EncBinary()
-					_ = yym479
+				if yyq524[0] {
+					yym526 := z.EncBinary()
+					_ = yym526
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Replicas))
@@ -5683,23 +6269,23 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq477[0] {
+				if yyq524[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("replicas"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym480 := z.EncBinary()
-					_ = yym480
+					yym527 := z.EncBinary()
+					_ = yym527
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Replicas))
 					}
 				}
 			}
-			if yyr477 || yy2arr477 {
+			if yyr524 || yy2arr524 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq477[1] {
-					yym482 := z.EncBinary()
-					_ = yym482
+				if yyq524[1] {
+					yym529 := z.EncBinary()
+					_ = yym529
 					if false {
 					} else {
 						r.EncodeInt(int64(x.UpdatedReplicas))
@@ -5708,23 +6294,23 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq477[1] {
+				if yyq524[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("updatedReplicas"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym483 := z.EncBinary()
-					_ = yym483
+					yym530 := z.EncBinary()
+					_ = yym530
 					if false {
 					} else {
 						r.EncodeInt(int64(x.UpdatedReplicas))
 					}
 				}
 			}
-			if yyr477 || yy2arr477 {
+			if yyr524 || yy2arr524 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq477[2] {
-					yym485 := z.EncBinary()
-					_ = yym485
+				if yyq524[2] {
+					yym532 := z.EncBinary()
+					_ = yym532
 					if false {
 					} else {
 						r.EncodeInt(int64(x.AvailableReplicas))
@@ -5733,23 +6319,23 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq477[2] {
+				if yyq524[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("availableReplicas"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym486 := z.EncBinary()
-					_ = yym486
+					yym533 := z.EncBinary()
+					_ = yym533
 					if false {
 					} else {
 						r.EncodeInt(int64(x.AvailableReplicas))
 					}
 				}
 			}
-			if yyr477 || yy2arr477 {
+			if yyr524 || yy2arr524 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq477[3] {
-					yym488 := z.EncBinary()
-					_ = yym488
+				if yyq524[3] {
+					yym535 := z.EncBinary()
+					_ = yym535
 					if false {
 					} else {
 						r.EncodeInt(int64(x.UnavailableReplicas))
@@ -5758,19 +6344,19 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq477[3] {
+				if yyq524[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("unavailableReplicas"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym489 := z.EncBinary()
-					_ = yym489
+					yym536 := z.EncBinary()
+					_ = yym536
 					if false {
 					} else {
 						r.EncodeInt(int64(x.UnavailableReplicas))
 					}
 				}
 			}
-			if yyr477 || yy2arr477 {
+			if yyr524 || yy2arr524 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -5783,25 +6369,25 @@ func (x *DeploymentStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym490 := z.DecBinary()
-	_ = yym490
+	yym537 := z.DecBinary()
+	_ = yym537
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct491 := r.ContainerType()
-		if yyct491 == codecSelferValueTypeMap1234 {
-			yyl491 := r.ReadMapStart()
-			if yyl491 == 0 {
+		yyct538 := r.ContainerType()
+		if yyct538 == codecSelferValueTypeMap1234 {
+			yyl538 := r.ReadMapStart()
+			if yyl538 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl491, d)
+				x.codecDecodeSelfFromMap(yyl538, d)
 			}
-		} else if yyct491 == codecSelferValueTypeArray1234 {
-			yyl491 := r.ReadArrayStart()
-			if yyl491 == 0 {
+		} else if yyct538 == codecSelferValueTypeArray1234 {
+			yyl538 := r.ReadArrayStart()
+			if yyl538 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl491, d)
+				x.codecDecodeSelfFromArray(yyl538, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -5813,12 +6399,12 @@ func (x *DeploymentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys492Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys492Slc
-	var yyhl492 bool = l >= 0
-	for yyj492 := 0; ; yyj492++ {
-		if yyhl492 {
-			if yyj492 >= l {
+	var yys539Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys539Slc
+	var yyhl539 bool = l >= 0
+	for yyj539 := 0; ; yyj539++ {
+		if yyhl539 {
+			if yyj539 >= l {
 				break
 			}
 		} else {
@@ -5827,10 +6413,10 @@ func (x *DeploymentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys492Slc = r.DecodeBytes(yys492Slc, true, true)
-		yys492 := string(yys492Slc)
+		yys539Slc = r.DecodeBytes(yys539Slc, true, true)
+		yys539 := string(yys539Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys492 {
+		switch yys539 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
 				x.Replicas = 0
@@ -5856,9 +6442,9 @@ func (x *DeploymentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.UnavailableReplicas = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys492)
-		} // end switch yys492
-	} // end for yyj492
+			z.DecStructFieldNotFound(-1, yys539)
+		} // end switch yys539
+	} // end for yyj539
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -5866,16 +6452,16 @@ func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj497 int
-	var yyb497 bool
-	var yyhl497 bool = l >= 0
-	yyj497++
-	if yyhl497 {
-		yyb497 = yyj497 > l
+	var yyj544 int
+	var yyb544 bool
+	var yyhl544 bool = l >= 0
+	yyj544++
+	if yyhl544 {
+		yyb544 = yyj544 > l
 	} else {
-		yyb497 = r.CheckBreak()
+		yyb544 = r.CheckBreak()
 	}
-	if yyb497 {
+	if yyb544 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5885,13 +6471,13 @@ func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj497++
-	if yyhl497 {
-		yyb497 = yyj497 > l
+	yyj544++
+	if yyhl544 {
+		yyb544 = yyj544 > l
 	} else {
-		yyb497 = r.CheckBreak()
+		yyb544 = r.CheckBreak()
 	}
-	if yyb497 {
+	if yyb544 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5901,13 +6487,13 @@ func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.UpdatedReplicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj497++
-	if yyhl497 {
-		yyb497 = yyj497 > l
+	yyj544++
+	if yyhl544 {
+		yyb544 = yyj544 > l
 	} else {
-		yyb497 = r.CheckBreak()
+		yyb544 = r.CheckBreak()
 	}
-	if yyb497 {
+	if yyb544 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5917,13 +6503,13 @@ func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.AvailableReplicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj497++
-	if yyhl497 {
-		yyb497 = yyj497 > l
+	yyj544++
+	if yyhl544 {
+		yyb544 = yyj544 > l
 	} else {
-		yyb497 = r.CheckBreak()
+		yyb544 = r.CheckBreak()
 	}
-	if yyb497 {
+	if yyb544 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5934,17 +6520,17 @@ func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		x.UnavailableReplicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj497++
-		if yyhl497 {
-			yyb497 = yyj497 > l
+		yyj544++
+		if yyhl544 {
+			yyb544 = yyj544 > l
 		} else {
-			yyb497 = r.CheckBreak()
+			yyb544 = r.CheckBreak()
 		}
-		if yyb497 {
+		if yyb544 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj497-1, "")
+		z.DecStructFieldNotFound(yyj544-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -5956,37 +6542,37 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym502 := z.EncBinary()
-		_ = yym502
+		yym549 := z.EncBinary()
+		_ = yym549
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep503 := !z.EncBinary()
-			yy2arr503 := z.EncBasicHandle().StructToArray
-			var yyq503 [4]bool
-			_, _, _ = yysep503, yyq503, yy2arr503
-			const yyr503 bool = false
-			yyq503[0] = x.Kind != ""
-			yyq503[1] = x.APIVersion != ""
-			yyq503[2] = true
-			var yynn503 int
-			if yyr503 || yy2arr503 {
+			yysep550 := !z.EncBinary()
+			yy2arr550 := z.EncBasicHandle().StructToArray
+			var yyq550 [4]bool
+			_, _, _ = yysep550, yyq550, yy2arr550
+			const yyr550 bool = false
+			yyq550[0] = x.Kind != ""
+			yyq550[1] = x.APIVersion != ""
+			yyq550[2] = true
+			var yynn550 int
+			if yyr550 || yy2arr550 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn503 = 1
-				for _, b := range yyq503 {
+				yynn550 = 1
+				for _, b := range yyq550 {
 					if b {
-						yynn503++
+						yynn550++
 					}
 				}
-				r.EncodeMapStart(yynn503)
-				yynn503 = 0
+				r.EncodeMapStart(yynn550)
+				yynn550 = 0
 			}
-			if yyr503 || yy2arr503 {
+			if yyr550 || yy2arr550 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq503[0] {
-					yym505 := z.EncBinary()
-					_ = yym505
+				if yyq550[0] {
+					yym552 := z.EncBinary()
+					_ = yym552
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -5995,23 +6581,23 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq503[0] {
+				if yyq550[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym506 := z.EncBinary()
-					_ = yym506
+					yym553 := z.EncBinary()
+					_ = yym553
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr503 || yy2arr503 {
+			if yyr550 || yy2arr550 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq503[1] {
-					yym508 := z.EncBinary()
-					_ = yym508
+				if yyq550[1] {
+					yym555 := z.EncBinary()
+					_ = yym555
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -6020,54 +6606,54 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq503[1] {
+				if yyq550[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym509 := z.EncBinary()
-					_ = yym509
+					yym556 := z.EncBinary()
+					_ = yym556
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr503 || yy2arr503 {
+			if yyr550 || yy2arr550 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq503[2] {
-					yy511 := &x.ListMeta
-					yym512 := z.EncBinary()
-					_ = yym512
+				if yyq550[2] {
+					yy558 := &x.ListMeta
+					yym559 := z.EncBinary()
+					_ = yym559
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy511) {
+					} else if z.HasExtensions() && z.EncExt(yy558) {
 					} else {
-						z.EncFallback(yy511)
+						z.EncFallback(yy558)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq503[2] {
+				if yyq550[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy513 := &x.ListMeta
-					yym514 := z.EncBinary()
-					_ = yym514
+					yy560 := &x.ListMeta
+					yym561 := z.EncBinary()
+					_ = yym561
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy513) {
+					} else if z.HasExtensions() && z.EncExt(yy560) {
 					} else {
-						z.EncFallback(yy513)
+						z.EncFallback(yy560)
 					}
 				}
 			}
-			if yyr503 || yy2arr503 {
+			if yyr550 || yy2arr550 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym516 := z.EncBinary()
-					_ = yym516
+					yym563 := z.EncBinary()
+					_ = yym563
 					if false {
 					} else {
 						h.encSliceDeployment(([]Deployment)(x.Items), e)
@@ -6080,15 +6666,15 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym517 := z.EncBinary()
-					_ = yym517
+					yym564 := z.EncBinary()
+					_ = yym564
 					if false {
 					} else {
 						h.encSliceDeployment(([]Deployment)(x.Items), e)
 					}
 				}
 			}
-			if yyr503 || yy2arr503 {
+			if yyr550 || yy2arr550 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -6101,25 +6687,25 @@ func (x *DeploymentList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym518 := z.DecBinary()
-	_ = yym518
+	yym565 := z.DecBinary()
+	_ = yym565
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct519 := r.ContainerType()
-		if yyct519 == codecSelferValueTypeMap1234 {
-			yyl519 := r.ReadMapStart()
-			if yyl519 == 0 {
+		yyct566 := r.ContainerType()
+		if yyct566 == codecSelferValueTypeMap1234 {
+			yyl566 := r.ReadMapStart()
+			if yyl566 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl519, d)
+				x.codecDecodeSelfFromMap(yyl566, d)
 			}
-		} else if yyct519 == codecSelferValueTypeArray1234 {
-			yyl519 := r.ReadArrayStart()
-			if yyl519 == 0 {
+		} else if yyct566 == codecSelferValueTypeArray1234 {
+			yyl566 := r.ReadArrayStart()
+			if yyl566 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl519, d)
+				x.codecDecodeSelfFromArray(yyl566, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -6131,12 +6717,12 @@ func (x *DeploymentList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys520Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys520Slc
-	var yyhl520 bool = l >= 0
-	for yyj520 := 0; ; yyj520++ {
-		if yyhl520 {
-			if yyj520 >= l {
+	var yys567Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys567Slc
+	var yyhl567 bool = l >= 0
+	for yyj567 := 0; ; yyj567++ {
+		if yyhl567 {
+			if yyj567 >= l {
 				break
 			}
 		} else {
@@ -6145,10 +6731,10 @@ func (x *DeploymentList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys520Slc = r.DecodeBytes(yys520Slc, true, true)
-		yys520 := string(yys520Slc)
+		yys567Slc = r.DecodeBytes(yys567Slc, true, true)
+		yys567 := string(yys567Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys520 {
+		switch yys567 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -6165,31 +6751,31 @@ func (x *DeploymentList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv523 := &x.ListMeta
-				yym524 := z.DecBinary()
-				_ = yym524
+				yyv570 := &x.ListMeta
+				yym571 := z.DecBinary()
+				_ = yym571
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv523) {
+				} else if z.HasExtensions() && z.DecExt(yyv570) {
 				} else {
-					z.DecFallback(yyv523, false)
+					z.DecFallback(yyv570, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv525 := &x.Items
-				yym526 := z.DecBinary()
-				_ = yym526
+				yyv572 := &x.Items
+				yym573 := z.DecBinary()
+				_ = yym573
 				if false {
 				} else {
-					h.decSliceDeployment((*[]Deployment)(yyv525), d)
+					h.decSliceDeployment((*[]Deployment)(yyv572), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys520)
-		} // end switch yys520
-	} // end for yyj520
+			z.DecStructFieldNotFound(-1, yys567)
+		} // end switch yys567
+	} // end for yyj567
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -6197,16 +6783,16 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj527 int
-	var yyb527 bool
-	var yyhl527 bool = l >= 0
-	yyj527++
-	if yyhl527 {
-		yyb527 = yyj527 > l
+	var yyj574 int
+	var yyb574 bool
+	var yyhl574 bool = l >= 0
+	yyj574++
+	if yyhl574 {
+		yyb574 = yyj574 > l
 	} else {
-		yyb527 = r.CheckBreak()
+		yyb574 = r.CheckBreak()
 	}
-	if yyb527 {
+	if yyb574 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6216,13 +6802,13 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj527++
-	if yyhl527 {
-		yyb527 = yyj527 > l
+	yyj574++
+	if yyhl574 {
+		yyb574 = yyj574 > l
 	} else {
-		yyb527 = r.CheckBreak()
+		yyb574 = r.CheckBreak()
 	}
-	if yyb527 {
+	if yyb574 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6232,13 +6818,13 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj527++
-	if yyhl527 {
-		yyb527 = yyj527 > l
+	yyj574++
+	if yyhl574 {
+		yyb574 = yyj574 > l
 	} else {
-		yyb527 = r.CheckBreak()
+		yyb574 = r.CheckBreak()
 	}
-	if yyb527 {
+	if yyb574 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6246,22 +6832,22 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv530 := &x.ListMeta
-		yym531 := z.DecBinary()
-		_ = yym531
+		yyv577 := &x.ListMeta
+		yym578 := z.DecBinary()
+		_ = yym578
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv530) {
+		} else if z.HasExtensions() && z.DecExt(yyv577) {
 		} else {
-			z.DecFallback(yyv530, false)
+			z.DecFallback(yyv577, false)
 		}
 	}
-	yyj527++
-	if yyhl527 {
-		yyb527 = yyj527 > l
+	yyj574++
+	if yyhl574 {
+		yyb574 = yyj574 > l
 	} else {
-		yyb527 = r.CheckBreak()
+		yyb574 = r.CheckBreak()
 	}
-	if yyb527 {
+	if yyb574 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6269,26 +6855,26 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv532 := &x.Items
-		yym533 := z.DecBinary()
-		_ = yym533
+		yyv579 := &x.Items
+		yym580 := z.DecBinary()
+		_ = yym580
 		if false {
 		} else {
-			h.decSliceDeployment((*[]Deployment)(yyv532), d)
+			h.decSliceDeployment((*[]Deployment)(yyv579), d)
 		}
 	}
 	for {
-		yyj527++
-		if yyhl527 {
-			yyb527 = yyj527 > l
+		yyj574++
+		if yyhl574 {
+			yyb574 = yyj574 > l
 		} else {
-			yyb527 = r.CheckBreak()
+			yyb574 = r.CheckBreak()
 		}
-		if yyb527 {
+		if yyb574 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj527-1, "")
+		z.DecStructFieldNotFound(yyj574-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -6300,49 +6886,49 @@ func (x *DaemonSetUpdateStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym534 := z.EncBinary()
-		_ = yym534
+		yym581 := z.EncBinary()
+		_ = yym581
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep535 := !z.EncBinary()
-			yy2arr535 := z.EncBasicHandle().StructToArray
-			var yyq535 [2]bool
-			_, _, _ = yysep535, yyq535, yy2arr535
-			const yyr535 bool = false
-			yyq535[0] = x.Type != ""
-			yyq535[1] = x.RollingUpdate != nil
-			var yynn535 int
-			if yyr535 || yy2arr535 {
+			yysep582 := !z.EncBinary()
+			yy2arr582 := z.EncBasicHandle().StructToArray
+			var yyq582 [2]bool
+			_, _, _ = yysep582, yyq582, yy2arr582
+			const yyr582 bool = false
+			yyq582[0] = x.Type != ""
+			yyq582[1] = x.RollingUpdate != nil
+			var yynn582 int
+			if yyr582 || yy2arr582 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn535 = 0
-				for _, b := range yyq535 {
+				yynn582 = 0
+				for _, b := range yyq582 {
 					if b {
-						yynn535++
+						yynn582++
 					}
 				}
-				r.EncodeMapStart(yynn535)
-				yynn535 = 0
+				r.EncodeMapStart(yynn582)
+				yynn582 = 0
 			}
-			if yyr535 || yy2arr535 {
+			if yyr582 || yy2arr582 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq535[0] {
+				if yyq582[0] {
 					x.Type.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq535[0] {
+				if yyq582[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("type"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.Type.CodecEncodeSelf(e)
 				}
 			}
-			if yyr535 || yy2arr535 {
+			if yyr582 || yy2arr582 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq535[1] {
+				if yyq582[1] {
 					if x.RollingUpdate == nil {
 						r.EncodeNil()
 					} else {
@@ -6352,7 +6938,7 @@ func (x *DaemonSetUpdateStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq535[1] {
+				if yyq582[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("rollingUpdate"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
@@ -6363,7 +6949,7 @@ func (x *DaemonSetUpdateStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr535 || yy2arr535 {
+			if yyr582 || yy2arr582 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -6376,25 +6962,25 @@ func (x *DaemonSetUpdateStrategy) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym538 := z.DecBinary()
-	_ = yym538
+	yym585 := z.DecBinary()
+	_ = yym585
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct539 := r.ContainerType()
-		if yyct539 == codecSelferValueTypeMap1234 {
-			yyl539 := r.ReadMapStart()
-			if yyl539 == 0 {
+		yyct586 := r.ContainerType()
+		if yyct586 == codecSelferValueTypeMap1234 {
+			yyl586 := r.ReadMapStart()
+			if yyl586 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl539, d)
+				x.codecDecodeSelfFromMap(yyl586, d)
 			}
-		} else if yyct539 == codecSelferValueTypeArray1234 {
-			yyl539 := r.ReadArrayStart()
-			if yyl539 == 0 {
+		} else if yyct586 == codecSelferValueTypeArray1234 {
+			yyl586 := r.ReadArrayStart()
+			if yyl586 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl539, d)
+				x.codecDecodeSelfFromArray(yyl586, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -6406,12 +6992,12 @@ func (x *DaemonSetUpdateStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys540Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys540Slc
-	var yyhl540 bool = l >= 0
-	for yyj540 := 0; ; yyj540++ {
-		if yyhl540 {
-			if yyj540 >= l {
+	var yys587Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys587Slc
+	var yyhl587 bool = l >= 0
+	for yyj587 := 0; ; yyj587++ {
+		if yyhl587 {
+			if yyj587 >= l {
 				break
 			}
 		} else {
@@ -6420,10 +7006,10 @@ func (x *DaemonSetUpdateStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys540Slc = r.DecodeBytes(yys540Slc, true, true)
-		yys540 := string(yys540Slc)
+		yys587Slc = r.DecodeBytes(yys587Slc, true, true)
+		yys587 := string(yys587Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys540 {
+		switch yys587 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -6442,9 +7028,9 @@ func (x *DaemonSetUpdateStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				x.RollingUpdate.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys540)
-		} // end switch yys540
-	} // end for yyj540
+			z.DecStructFieldNotFound(-1, yys587)
+		} // end switch yys587
+	} // end for yyj587
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -6452,16 +7038,16 @@ func (x *DaemonSetUpdateStrategy) codecDecodeSelfFromArray(l int, d *codec1978.D
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj543 int
-	var yyb543 bool
-	var yyhl543 bool = l >= 0
-	yyj543++
-	if yyhl543 {
-		yyb543 = yyj543 > l
+	var yyj590 int
+	var yyb590 bool
+	var yyhl590 bool = l >= 0
+	yyj590++
+	if yyhl590 {
+		yyb590 = yyj590 > l
 	} else {
-		yyb543 = r.CheckBreak()
+		yyb590 = r.CheckBreak()
 	}
-	if yyb543 {
+	if yyb590 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6471,13 +7057,13 @@ func (x *DaemonSetUpdateStrategy) codecDecodeSelfFromArray(l int, d *codec1978.D
 	} else {
 		x.Type = DaemonSetUpdateStrategyType(r.DecodeString())
 	}
-	yyj543++
-	if yyhl543 {
-		yyb543 = yyj543 > l
+	yyj590++
+	if yyhl590 {
+		yyb590 = yyj590 > l
 	} else {
-		yyb543 = r.CheckBreak()
+		yyb590 = r.CheckBreak()
 	}
-	if yyb543 {
+	if yyb590 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6493,17 +7079,17 @@ func (x *DaemonSetUpdateStrategy) codecDecodeSelfFromArray(l int, d *codec1978.D
 		x.RollingUpdate.CodecDecodeSelf(d)
 	}
 	for {
-		yyj543++
-		if yyhl543 {
-			yyb543 = yyj543 > l
+		yyj590++
+		if yyhl590 {
+			yyb590 = yyj590 > l
 		} else {
-			yyb543 = r.CheckBreak()
+			yyb590 = r.CheckBreak()
 		}
-		if yyb543 {
+		if yyb590 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj543-1, "")
+		z.DecStructFieldNotFound(yyj590-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -6512,8 +7098,8 @@ func (x DaemonSetUpdateStrategyType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym546 := z.EncBinary()
-	_ = yym546
+	yym593 := z.EncBinary()
+	_ = yym593
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -6525,8 +7111,8 @@ func (x *DaemonSetUpdateStrategyType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym547 := z.DecBinary()
-	_ = yym547
+	yym594 := z.DecBinary()
+	_ = yym594
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -6541,69 +7127,69 @@ func (x *RollingUpdateDaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym548 := z.EncBinary()
-		_ = yym548
+		yym595 := z.EncBinary()
+		_ = yym595
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep549 := !z.EncBinary()
-			yy2arr549 := z.EncBasicHandle().StructToArray
-			var yyq549 [2]bool
-			_, _, _ = yysep549, yyq549, yy2arr549
-			const yyr549 bool = false
-			yyq549[0] = true
-			yyq549[1] = x.MinReadySeconds != 0
-			var yynn549 int
-			if yyr549 || yy2arr549 {
+			yysep596 := !z.EncBinary()
+			yy2arr596 := z.EncBasicHandle().StructToArray
+			var yyq596 [2]bool
+			_, _, _ = yysep596, yyq596, yy2arr596
+			const yyr596 bool = false
+			yyq596[0] = true
+			yyq596[1] = x.MinReadySeconds != 0
+			var yynn596 int
+			if yyr596 || yy2arr596 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn549 = 0
-				for _, b := range yyq549 {
+				yynn596 = 0
+				for _, b := range yyq596 {
 					if b {
-						yynn549++
+						yynn596++
 					}
 				}
-				r.EncodeMapStart(yynn549)
-				yynn549 = 0
+				r.EncodeMapStart(yynn596)
+				yynn596 = 0
 			}
-			if yyr549 || yy2arr549 {
+			if yyr596 || yy2arr596 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq549[0] {
-					yy551 := &x.MaxUnavailable
-					yym552 := z.EncBinary()
-					_ = yym552
+				if yyq596[0] {
+					yy598 := &x.MaxUnavailable
+					yym599 := z.EncBinary()
+					_ = yym599
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy551) {
-					} else if !yym552 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy551)
+					} else if z.HasExtensions() && z.EncExt(yy598) {
+					} else if !yym599 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy598)
 					} else {
-						z.EncFallback(yy551)
+						z.EncFallback(yy598)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq549[0] {
+				if yyq596[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("maxUnavailable"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy553 := &x.MaxUnavailable
-					yym554 := z.EncBinary()
-					_ = yym554
+					yy600 := &x.MaxUnavailable
+					yym601 := z.EncBinary()
+					_ = yym601
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy553) {
-					} else if !yym554 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy553)
+					} else if z.HasExtensions() && z.EncExt(yy600) {
+					} else if !yym601 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy600)
 					} else {
-						z.EncFallback(yy553)
+						z.EncFallback(yy600)
 					}
 				}
 			}
-			if yyr549 || yy2arr549 {
+			if yyr596 || yy2arr596 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq549[1] {
-					yym556 := z.EncBinary()
-					_ = yym556
+				if yyq596[1] {
+					yym603 := z.EncBinary()
+					_ = yym603
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MinReadySeconds))
@@ -6612,19 +7198,19 @@ func (x *RollingUpdateDaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq549[1] {
+				if yyq596[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("minReadySeconds"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym557 := z.EncBinary()
-					_ = yym557
+					yym604 := z.EncBinary()
+					_ = yym604
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MinReadySeconds))
 					}
 				}
 			}
-			if yyr549 || yy2arr549 {
+			if yyr596 || yy2arr596 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -6637,25 +7223,25 @@ func (x *RollingUpdateDaemonSet) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym558 := z.DecBinary()
-	_ = yym558
+	yym605 := z.DecBinary()
+	_ = yym605
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct559 := r.ContainerType()
-		if yyct559 == codecSelferValueTypeMap1234 {
-			yyl559 := r.ReadMapStart()
-			if yyl559 == 0 {
+		yyct606 := r.ContainerType()
+		if yyct606 == codecSelferValueTypeMap1234 {
+			yyl606 := r.ReadMapStart()
+			if yyl606 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl559, d)
+				x.codecDecodeSelfFromMap(yyl606, d)
 			}
-		} else if yyct559 == codecSelferValueTypeArray1234 {
-			yyl559 := r.ReadArrayStart()
-			if yyl559 == 0 {
+		} else if yyct606 == codecSelferValueTypeArray1234 {
+			yyl606 := r.ReadArrayStart()
+			if yyl606 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl559, d)
+				x.codecDecodeSelfFromArray(yyl606, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -6667,12 +7253,12 @@ func (x *RollingUpdateDaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys560Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys560Slc
-	var yyhl560 bool = l >= 0
-	for yyj560 := 0; ; yyj560++ {
-		if yyhl560 {
-			if yyj560 >= l {
+	var yys607Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys607Slc
+	var yyhl607 bool = l >= 0
+	for yyj607 := 0; ; yyj607++ {
+		if yyhl607 {
+			if yyj607 >= l {
 				break
 			}
 		} else {
@@ -6681,23 +7267,23 @@ func (x *RollingUpdateDaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys560Slc = r.DecodeBytes(yys560Slc, true, true)
-		yys560 := string(yys560Slc)
+		yys607Slc = r.DecodeBytes(yys607Slc, true, true)
+		yys607 := string(yys607Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys560 {
+		switch yys607 {
 		case "maxUnavailable":
 			if r.TryDecodeAsNil() {
 				x.MaxUnavailable = pkg6_intstr.IntOrString{}
 			} else {
-				yyv561 := &x.MaxUnavailable
-				yym562 := z.DecBinary()
-				_ = yym562
+				yyv608 := &x.MaxUnavailable
+				yym609 := z.DecBinary()
+				_ = yym609
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv561) {
-				} else if !yym562 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv561)
+				} else if z.HasExtensions() && z.DecExt(yyv608) {
+				} else if !yym609 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv608)
 				} else {
-					z.DecFallback(yyv561, false)
+					z.DecFallback(yyv608, false)
 				}
 			}
 		case "minReadySeconds":
@@ -6707,9 +7293,9 @@ func (x *RollingUpdateDaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				x.MinReadySeconds = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys560)
-		} // end switch yys560
-	} // end for yyj560
+			z.DecStructFieldNotFound(-1, yys607)
+		} // end switch yys607
+	} // end for yyj607
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -6717,16 +7303,16 @@ func (x *RollingUpdateDaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.De
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj564 int
-	var yyb564 bool
-	var yyhl564 bool = l >= 0
-	yyj564++
-	if yyhl564 {
-		yyb564 = yyj564 > l
+	var yyj611 int
+	var yyb611 bool
+	var yyhl611 bool = l >= 0
+	yyj611++
+	if yyhl611 {
+		yyb611 = yyj611 > l
 	} else {
-		yyb564 = r.CheckBreak()
+		yyb611 = r.CheckBreak()
 	}
-	if yyb564 {
+	if yyb611 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6734,24 +7320,24 @@ func (x *RollingUpdateDaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.De
 	if r.TryDecodeAsNil() {
 		x.MaxUnavailable = pkg6_intstr.IntOrString{}
 	} else {
-		yyv565 := &x.MaxUnavailable
-		yym566 := z.DecBinary()
-		_ = yym566
+		yyv612 := &x.MaxUnavailable
+		yym613 := z.DecBinary()
+		_ = yym613
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv565) {
-		} else if !yym566 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv565)
+		} else if z.HasExtensions() && z.DecExt(yyv612) {
+		} else if !yym613 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv612)
 		} else {
-			z.DecFallback(yyv565, false)
+			z.DecFallback(yyv612, false)
 		}
 	}
-	yyj564++
-	if yyhl564 {
-		yyb564 = yyj564 > l
+	yyj611++
+	if yyhl611 {
+		yyb611 = yyj611 > l
 	} else {
-		yyb564 = r.CheckBreak()
+		yyb611 = r.CheckBreak()
 	}
-	if yyb564 {
+	if yyb611 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6762,17 +7348,17 @@ func (x *RollingUpdateDaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.De
 		x.MinReadySeconds = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj564++
-		if yyhl564 {
-			yyb564 = yyj564 > l
+		yyj611++
+		if yyhl611 {
+			yyb611 = yyj611 > l
 		} else {
-			yyb564 = r.CheckBreak()
+			yyb611 = r.CheckBreak()
 		}
-		if yyb564 {
+		if yyb611 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj564-1, "")
+		z.DecStructFieldNotFound(yyj611-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -6784,35 +7370,35 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym568 := z.EncBinary()
-		_ = yym568
+		yym615 := z.EncBinary()
+		_ = yym615
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep569 := !z.EncBinary()
-			yy2arr569 := z.EncBasicHandle().StructToArray
-			var yyq569 [4]bool
-			_, _, _ = yysep569, yyq569, yy2arr569
-			const yyr569 bool = false
-			yyq569[0] = x.Selector != nil
-			yyq569[2] = true
-			yyq569[3] = x.UniqueLabelKey != ""
-			var yynn569 int
-			if yyr569 || yy2arr569 {
+			yysep616 := !z.EncBinary()
+			yy2arr616 := z.EncBasicHandle().StructToArray
+			var yyq616 [4]bool
+			_, _, _ = yysep616, yyq616, yy2arr616
+			const yyr616 bool = false
+			yyq616[0] = x.Selector != nil
+			yyq616[2] = true
+			yyq616[3] = x.UniqueLabelKey != ""
+			var yynn616 int
+			if yyr616 || yy2arr616 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn569 = 1
-				for _, b := range yyq569 {
+				yynn616 = 1
+				for _, b := range yyq616 {
 					if b {
-						yynn569++
+						yynn616++
 					}
 				}
-				r.EncodeMapStart(yynn569)
-				yynn569 = 0
+				r.EncodeMapStart(yynn616)
+				yynn616 = 0
 			}
-			if yyr569 || yy2arr569 {
+			if yyr616 || yy2arr616 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq569[0] {
+				if yyq616[0] {
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
@@ -6822,7 +7408,7 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq569[0] {
+				if yyq616[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
@@ -6833,39 +7419,39 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr569 || yy2arr569 {
+			if yyr616 || yy2arr616 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy572 := &x.Template
-				yy572.CodecEncodeSelf(e)
+				yy619 := &x.Template
+				yy619.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("template"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy573 := &x.Template
-				yy573.CodecEncodeSelf(e)
+				yy620 := &x.Template
+				yy620.CodecEncodeSelf(e)
 			}
-			if yyr569 || yy2arr569 {
+			if yyr616 || yy2arr616 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq569[2] {
-					yy575 := &x.UpdateStrategy
-					yy575.CodecEncodeSelf(e)
+				if yyq616[2] {
+					yy622 := &x.UpdateStrategy
+					yy622.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq569[2] {
+				if yyq616[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("updateStrategy"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy576 := &x.UpdateStrategy
-					yy576.CodecEncodeSelf(e)
+					yy623 := &x.UpdateStrategy
+					yy623.CodecEncodeSelf(e)
 				}
 			}
-			if yyr569 || yy2arr569 {
+			if yyr616 || yy2arr616 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq569[3] {
-					yym578 := z.EncBinary()
-					_ = yym578
+				if yyq616[3] {
+					yym625 := z.EncBinary()
+					_ = yym625
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.UniqueLabelKey))
@@ -6874,19 +7460,19 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq569[3] {
+				if yyq616[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("uniqueLabelKey"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym579 := z.EncBinary()
-					_ = yym579
+					yym626 := z.EncBinary()
+					_ = yym626
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.UniqueLabelKey))
 					}
 				}
 			}
-			if yyr569 || yy2arr569 {
+			if yyr616 || yy2arr616 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -6899,25 +7485,25 @@ func (x *DaemonSetSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym580 := z.DecBinary()
-	_ = yym580
+	yym627 := z.DecBinary()
+	_ = yym627
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct581 := r.ContainerType()
-		if yyct581 == codecSelferValueTypeMap1234 {
-			yyl581 := r.ReadMapStart()
-			if yyl581 == 0 {
+		yyct628 := r.ContainerType()
+		if yyct628 == codecSelferValueTypeMap1234 {
+			yyl628 := r.ReadMapStart()
+			if yyl628 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl581, d)
+				x.codecDecodeSelfFromMap(yyl628, d)
 			}
-		} else if yyct581 == codecSelferValueTypeArray1234 {
-			yyl581 := r.ReadArrayStart()
-			if yyl581 == 0 {
+		} else if yyct628 == codecSelferValueTypeArray1234 {
+			yyl628 := r.ReadArrayStart()
+			if yyl628 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl581, d)
+				x.codecDecodeSelfFromArray(yyl628, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -6929,12 +7515,12 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys582Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys582Slc
-	var yyhl582 bool = l >= 0
-	for yyj582 := 0; ; yyj582++ {
-		if yyhl582 {
-			if yyj582 >= l {
+	var yys629Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys629Slc
+	var yyhl629 bool = l >= 0
+	for yyj629 := 0; ; yyj629++ {
+		if yyhl629 {
+			if yyj629 >= l {
 				break
 			}
 		} else {
@@ -6943,10 +7529,10 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys582Slc = r.DecodeBytes(yys582Slc, true, true)
-		yys582 := string(yys582Slc)
+		yys629Slc = r.DecodeBytes(yys629Slc, true, true)
+		yys629 := string(yys629Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys582 {
+		switch yys629 {
 		case "selector":
 			if r.TryDecodeAsNil() {
 				if x.Selector != nil {
@@ -6962,15 +7548,15 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Template = pkg2_api.PodTemplateSpec{}
 			} else {
-				yyv584 := &x.Template
-				yyv584.CodecDecodeSelf(d)
+				yyv631 := &x.Template
+				yyv631.CodecDecodeSelf(d)
 			}
 		case "updateStrategy":
 			if r.TryDecodeAsNil() {
 				x.UpdateStrategy = DaemonSetUpdateStrategy{}
 			} else {
-				yyv585 := &x.UpdateStrategy
-				yyv585.CodecDecodeSelf(d)
+				yyv632 := &x.UpdateStrategy
+				yyv632.CodecDecodeSelf(d)
 			}
 		case "uniqueLabelKey":
 			if r.TryDecodeAsNil() {
@@ -6979,9 +7565,9 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.UniqueLabelKey = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys582)
-		} // end switch yys582
-	} // end for yyj582
+			z.DecStructFieldNotFound(-1, yys629)
+		} // end switch yys629
+	} // end for yyj629
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -6989,16 +7575,16 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj587 int
-	var yyb587 bool
-	var yyhl587 bool = l >= 0
-	yyj587++
-	if yyhl587 {
-		yyb587 = yyj587 > l
+	var yyj634 int
+	var yyb634 bool
+	var yyhl634 bool = l >= 0
+	yyj634++
+	if yyhl634 {
+		yyb634 = yyj634 > l
 	} else {
-		yyb587 = r.CheckBreak()
+		yyb634 = r.CheckBreak()
 	}
-	if yyb587 {
+	if yyb634 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7013,13 +7599,13 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Selector.CodecDecodeSelf(d)
 	}
-	yyj587++
-	if yyhl587 {
-		yyb587 = yyj587 > l
+	yyj634++
+	if yyhl634 {
+		yyb634 = yyj634 > l
 	} else {
-		yyb587 = r.CheckBreak()
+		yyb634 = r.CheckBreak()
 	}
-	if yyb587 {
+	if yyb634 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7027,16 +7613,16 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Template = pkg2_api.PodTemplateSpec{}
 	} else {
-		yyv589 := &x.Template
-		yyv589.CodecDecodeSelf(d)
+		yyv636 := &x.Template
+		yyv636.CodecDecodeSelf(d)
 	}
-	yyj587++
-	if yyhl587 {
-		yyb587 = yyj587 > l
+	yyj634++
+	if yyhl634 {
+		yyb634 = yyj634 > l
 	} else {
-		yyb587 = r.CheckBreak()
+		yyb634 = r.CheckBreak()
 	}
-	if yyb587 {
+	if yyb634 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7044,16 +7630,16 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.UpdateStrategy = DaemonSetUpdateStrategy{}
 	} else {
-		yyv590 := &x.UpdateStrategy
-		yyv590.CodecDecodeSelf(d)
+		yyv637 := &x.UpdateStrategy
+		yyv637.CodecDecodeSelf(d)
 	}
-	yyj587++
-	if yyhl587 {
-		yyb587 = yyj587 > l
+	yyj634++
+	if yyhl634 {
+		yyb634 = yyj634 > l
 	} else {
-		yyb587 = r.CheckBreak()
+		yyb634 = r.CheckBreak()
 	}
-	if yyb587 {
+	if yyb634 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7064,17 +7650,17 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.UniqueLabelKey = string(r.DecodeString())
 	}
 	for {
-		yyj587++
-		if yyhl587 {
-			yyb587 = yyj587 > l
+		yyj634++
+		if yyhl634 {
+			yyb634 = yyj634 > l
 		} else {
-			yyb587 = r.CheckBreak()
+			yyb634 = r.CheckBreak()
 		}
-		if yyb587 {
+		if yyb634 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj587-1, "")
+		z.DecStructFieldNotFound(yyj634-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -7086,33 +7672,33 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym592 := z.EncBinary()
-		_ = yym592
+		yym639 := z.EncBinary()
+		_ = yym639
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep593 := !z.EncBinary()
-			yy2arr593 := z.EncBasicHandle().StructToArray
-			var yyq593 [3]bool
-			_, _, _ = yysep593, yyq593, yy2arr593
-			const yyr593 bool = false
-			var yynn593 int
-			if yyr593 || yy2arr593 {
+			yysep640 := !z.EncBinary()
+			yy2arr640 := z.EncBasicHandle().StructToArray
+			var yyq640 [3]bool
+			_, _, _ = yysep640, yyq640, yy2arr640
+			const yyr640 bool = false
+			var yynn640 int
+			if yyr640 || yy2arr640 {
 				r.EncodeArrayStart(3)
 			} else {
-				yynn593 = 3
-				for _, b := range yyq593 {
+				yynn640 = 3
+				for _, b := range yyq640 {
 					if b {
-						yynn593++
+						yynn640++
 					}
 				}
-				r.EncodeMapStart(yynn593)
-				yynn593 = 0
+				r.EncodeMapStart(yynn640)
+				yynn640 = 0
 			}
-			if yyr593 || yy2arr593 {
+			if yyr640 || yy2arr640 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym595 := z.EncBinary()
-				_ = yym595
+				yym642 := z.EncBinary()
+				_ = yym642
 				if false {
 				} else {
 					r.EncodeInt(int64(x.CurrentNumberScheduled))
@@ -7121,17 +7707,17 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("currentNumberScheduled"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym596 := z.EncBinary()
-				_ = yym596
+				yym643 := z.EncBinary()
+				_ = yym643
 				if false {
 				} else {
 					r.EncodeInt(int64(x.CurrentNumberScheduled))
 				}
 			}
-			if yyr593 || yy2arr593 {
+			if yyr640 || yy2arr640 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym598 := z.EncBinary()
-				_ = yym598
+				yym645 := z.EncBinary()
+				_ = yym645
 				if false {
 				} else {
 					r.EncodeInt(int64(x.NumberMisscheduled))
@@ -7140,17 +7726,17 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("numberMisscheduled"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym599 := z.EncBinary()
-				_ = yym599
+				yym646 := z.EncBinary()
+				_ = yym646
 				if false {
 				} else {
 					r.EncodeInt(int64(x.NumberMisscheduled))
 				}
 			}
-			if yyr593 || yy2arr593 {
+			if yyr640 || yy2arr640 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym601 := z.EncBinary()
-				_ = yym601
+				yym648 := z.EncBinary()
+				_ = yym648
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DesiredNumberScheduled))
@@ -7159,14 +7745,14 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("desiredNumberScheduled"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym602 := z.EncBinary()
-				_ = yym602
+				yym649 := z.EncBinary()
+				_ = yym649
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DesiredNumberScheduled))
 				}
 			}
-			if yyr593 || yy2arr593 {
+			if yyr640 || yy2arr640 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -7179,25 +7765,25 @@ func (x *DaemonSetStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym603 := z.DecBinary()
-	_ = yym603
+	yym650 := z.DecBinary()
+	_ = yym650
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct604 := r.ContainerType()
-		if yyct604 == codecSelferValueTypeMap1234 {
-			yyl604 := r.ReadMapStart()
-			if yyl604 == 0 {
+		yyct651 := r.ContainerType()
+		if yyct651 == codecSelferValueTypeMap1234 {
+			yyl651 := r.ReadMapStart()
+			if yyl651 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl604, d)
+				x.codecDecodeSelfFromMap(yyl651, d)
 			}
-		} else if yyct604 == codecSelferValueTypeArray1234 {
-			yyl604 := r.ReadArrayStart()
-			if yyl604 == 0 {
+		} else if yyct651 == codecSelferValueTypeArray1234 {
+			yyl651 := r.ReadArrayStart()
+			if yyl651 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl604, d)
+				x.codecDecodeSelfFromArray(yyl651, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -7209,12 +7795,12 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys605Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys605Slc
-	var yyhl605 bool = l >= 0
-	for yyj605 := 0; ; yyj605++ {
-		if yyhl605 {
-			if yyj605 >= l {
+	var yys652Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys652Slc
+	var yyhl652 bool = l >= 0
+	for yyj652 := 0; ; yyj652++ {
+		if yyhl652 {
+			if yyj652 >= l {
 				break
 			}
 		} else {
@@ -7223,10 +7809,10 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys605Slc = r.DecodeBytes(yys605Slc, true, true)
-		yys605 := string(yys605Slc)
+		yys652Slc = r.DecodeBytes(yys652Slc, true, true)
+		yys652 := string(yys652Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys605 {
+		switch yys652 {
 		case "currentNumberScheduled":
 			if r.TryDecodeAsNil() {
 				x.CurrentNumberScheduled = 0
@@ -7246,9 +7832,9 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.DesiredNumberScheduled = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys605)
-		} // end switch yys605
-	} // end for yyj605
+			z.DecStructFieldNotFound(-1, yys652)
+		} // end switch yys652
+	} // end for yyj652
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -7256,16 +7842,16 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj609 int
-	var yyb609 bool
-	var yyhl609 bool = l >= 0
-	yyj609++
-	if yyhl609 {
-		yyb609 = yyj609 > l
+	var yyj656 int
+	var yyb656 bool
+	var yyhl656 bool = l >= 0
+	yyj656++
+	if yyhl656 {
+		yyb656 = yyj656 > l
 	} else {
-		yyb609 = r.CheckBreak()
+		yyb656 = r.CheckBreak()
 	}
-	if yyb609 {
+	if yyb656 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7275,13 +7861,13 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.CurrentNumberScheduled = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj609++
-	if yyhl609 {
-		yyb609 = yyj609 > l
+	yyj656++
+	if yyhl656 {
+		yyb656 = yyj656 > l
 	} else {
-		yyb609 = r.CheckBreak()
+		yyb656 = r.CheckBreak()
 	}
-	if yyb609 {
+	if yyb656 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7291,13 +7877,13 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.NumberMisscheduled = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj609++
-	if yyhl609 {
-		yyb609 = yyj609 > l
+	yyj656++
+	if yyhl656 {
+		yyb656 = yyj656 > l
 	} else {
-		yyb609 = r.CheckBreak()
+		yyb656 = r.CheckBreak()
 	}
-	if yyb609 {
+	if yyb656 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7308,17 +7894,17 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.DesiredNumberScheduled = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj609++
-		if yyhl609 {
-			yyb609 = yyj609 > l
+		yyj656++
+		if yyhl656 {
+			yyb656 = yyj656 > l
 		} else {
-			yyb609 = r.CheckBreak()
+			yyb656 = r.CheckBreak()
 		}
-		if yyb609 {
+		if yyb656 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj609-1, "")
+		z.DecStructFieldNotFound(yyj656-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -7330,39 +7916,39 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym613 := z.EncBinary()
-		_ = yym613
+		yym660 := z.EncBinary()
+		_ = yym660
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep614 := !z.EncBinary()
-			yy2arr614 := z.EncBasicHandle().StructToArray
-			var yyq614 [5]bool
-			_, _, _ = yysep614, yyq614, yy2arr614
-			const yyr614 bool = false
-			yyq614[0] = x.Kind != ""
-			yyq614[1] = x.APIVersion != ""
-			yyq614[2] = true
-			yyq614[3] = true
-			yyq614[4] = true
-			var yynn614 int
-			if yyr614 || yy2arr614 {
+			yysep661 := !z.EncBinary()
+			yy2arr661 := z.EncBasicHandle().StructToArray
+			var yyq661 [5]bool
+			_, _, _ = yysep661, yyq661, yy2arr661
+			const yyr661 bool = false
+			yyq661[0] = x.Kind != ""
+			yyq661[1] = x.APIVersion != ""
+			yyq661[2] = true
+			yyq661[3] = true
+			yyq661[4] = true
+			var yynn661 int
+			if yyr661 || yy2arr661 {
 				r.EncodeArrayStart(5)
 			} else {
-				yynn614 = 0
-				for _, b := range yyq614 {
+				yynn661 = 0
+				for _, b := range yyq661 {
 					if b {
-						yynn614++
+						yynn661++
 					}
 				}
-				r.EncodeMapStart(yynn614)
-				yynn614 = 0
+				r.EncodeMapStart(yynn661)
+				yynn661 = 0
 			}
-			if yyr614 || yy2arr614 {
+			if yyr661 || yy2arr661 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq614[0] {
-					yym616 := z.EncBinary()
-					_ = yym616
+				if yyq661[0] {
+					yym663 := z.EncBinary()
+					_ = yym663
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -7371,23 +7957,23 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq614[0] {
+				if yyq661[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym617 := z.EncBinary()
-					_ = yym617
+					yym664 := z.EncBinary()
+					_ = yym664
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr614 || yy2arr614 {
+			if yyr661 || yy2arr661 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq614[1] {
-					yym619 := z.EncBinary()
-					_ = yym619
+				if yyq661[1] {
+					yym666 := z.EncBinary()
+					_ = yym666
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -7396,70 +7982,70 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq614[1] {
+				if yyq661[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym620 := z.EncBinary()
-					_ = yym620
+					yym667 := z.EncBinary()
+					_ = yym667
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr614 || yy2arr614 {
+			if yyr661 || yy2arr661 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq614[2] {
-					yy622 := &x.ObjectMeta
-					yy622.CodecEncodeSelf(e)
+				if yyq661[2] {
+					yy669 := &x.ObjectMeta
+					yy669.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq614[2] {
+				if yyq661[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy623 := &x.ObjectMeta
-					yy623.CodecEncodeSelf(e)
+					yy670 := &x.ObjectMeta
+					yy670.CodecEncodeSelf(e)
 				}
 			}
-			if yyr614 || yy2arr614 {
+			if yyr661 || yy2arr661 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq614[3] {
-					yy625 := &x.Spec
-					yy625.CodecEncodeSelf(e)
+				if yyq661[3] {
+					yy672 := &x.Spec
+					yy672.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq614[3] {
+				if yyq661[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy626 := &x.Spec
-					yy626.CodecEncodeSelf(e)
+					yy673 := &x.Spec
+					yy673.CodecEncodeSelf(e)
 				}
 			}
-			if yyr614 || yy2arr614 {
+			if yyr661 || yy2arr661 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq614[4] {
-					yy628 := &x.Status
-					yy628.CodecEncodeSelf(e)
+				if yyq661[4] {
+					yy675 := &x.Status
+					yy675.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq614[4] {
+				if yyq661[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy629 := &x.Status
-					yy629.CodecEncodeSelf(e)
+					yy676 := &x.Status
+					yy676.CodecEncodeSelf(e)
 				}
 			}
-			if yyr614 || yy2arr614 {
+			if yyr661 || yy2arr661 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -7472,25 +8058,25 @@ func (x *DaemonSet) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym630 := z.DecBinary()
-	_ = yym630
+	yym677 := z.DecBinary()
+	_ = yym677
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct631 := r.ContainerType()
-		if yyct631 == codecSelferValueTypeMap1234 {
-			yyl631 := r.ReadMapStart()
-			if yyl631 == 0 {
+		yyct678 := r.ContainerType()
+		if yyct678 == codecSelferValueTypeMap1234 {
+			yyl678 := r.ReadMapStart()
+			if yyl678 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl631, d)
+				x.codecDecodeSelfFromMap(yyl678, d)
 			}
-		} else if yyct631 == codecSelferValueTypeArray1234 {
-			yyl631 := r.ReadArrayStart()
-			if yyl631 == 0 {
+		} else if yyct678 == codecSelferValueTypeArray1234 {
+			yyl678 := r.ReadArrayStart()
+			if yyl678 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl631, d)
+				x.codecDecodeSelfFromArray(yyl678, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -7502,12 +8088,12 @@ func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys632Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys632Slc
-	var yyhl632 bool = l >= 0
-	for yyj632 := 0; ; yyj632++ {
-		if yyhl632 {
-			if yyj632 >= l {
+	var yys679Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys679Slc
+	var yyhl679 bool = l >= 0
+	for yyj679 := 0; ; yyj679++ {
+		if yyhl679 {
+			if yyj679 >= l {
 				break
 			}
 		} else {
@@ -7516,10 +8102,10 @@ func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys632Slc = r.DecodeBytes(yys632Slc, true, true)
-		yys632 := string(yys632Slc)
+		yys679Slc = r.DecodeBytes(yys679Slc, true, true)
+		yys679 := string(yys679Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys632 {
+		switch yys679 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -7536,27 +8122,27 @@ func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv635 := &x.ObjectMeta
-				yyv635.CodecDecodeSelf(d)
+				yyv682 := &x.ObjectMeta
+				yyv682.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = DaemonSetSpec{}
 			} else {
-				yyv636 := &x.Spec
-				yyv636.CodecDecodeSelf(d)
+				yyv683 := &x.Spec
+				yyv683.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = DaemonSetStatus{}
 			} else {
-				yyv637 := &x.Status
-				yyv637.CodecDecodeSelf(d)
+				yyv684 := &x.Status
+				yyv684.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys632)
-		} // end switch yys632
-	} // end for yyj632
+			z.DecStructFieldNotFound(-1, yys679)
+		} // end switch yys679
+	} // end for yyj679
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -7564,16 +8150,16 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj638 int
-	var yyb638 bool
-	var yyhl638 bool = l >= 0
-	yyj638++
-	if yyhl638 {
-		yyb638 = yyj638 > l
+	var yyj685 int
+	var yyb685 bool
+	var yyhl685 bool = l >= 0
+	yyj685++
+	if yyhl685 {
+		yyb685 = yyj685 > l
 	} else {
-		yyb638 = r.CheckBreak()
+		yyb685 = r.CheckBreak()
 	}
-	if yyb638 {
+	if yyb685 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7583,13 +8169,13 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj638++
-	if yyhl638 {
-		yyb638 = yyj638 > l
+	yyj685++
+	if yyhl685 {
+		yyb685 = yyj685 > l
 	} else {
-		yyb638 = r.CheckBreak()
+		yyb685 = r.CheckBreak()
 	}
-	if yyb638 {
+	if yyb685 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7599,13 +8185,13 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj638++
-	if yyhl638 {
-		yyb638 = yyj638 > l
+	yyj685++
+	if yyhl685 {
+		yyb685 = yyj685 > l
 	} else {
-		yyb638 = r.CheckBreak()
+		yyb685 = r.CheckBreak()
 	}
-	if yyb638 {
+	if yyb685 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7613,16 +8199,16 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv641 := &x.ObjectMeta
-		yyv641.CodecDecodeSelf(d)
+		yyv688 := &x.ObjectMeta
+		yyv688.CodecDecodeSelf(d)
 	}
-	yyj638++
-	if yyhl638 {
-		yyb638 = yyj638 > l
+	yyj685++
+	if yyhl685 {
+		yyb685 = yyj685 > l
 	} else {
-		yyb638 = r.CheckBreak()
+		yyb685 = r.CheckBreak()
 	}
-	if yyb638 {
+	if yyb685 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7630,16 +8216,16 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Spec = DaemonSetSpec{}
 	} else {
-		yyv642 := &x.Spec
-		yyv642.CodecDecodeSelf(d)
+		yyv689 := &x.Spec
+		yyv689.CodecDecodeSelf(d)
 	}
-	yyj638++
-	if yyhl638 {
-		yyb638 = yyj638 > l
+	yyj685++
+	if yyhl685 {
+		yyb685 = yyj685 > l
 	} else {
-		yyb638 = r.CheckBreak()
+		yyb685 = r.CheckBreak()
 	}
-	if yyb638 {
+	if yyb685 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7647,21 +8233,21 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Status = DaemonSetStatus{}
 	} else {
-		yyv643 := &x.Status
-		yyv643.CodecDecodeSelf(d)
+		yyv690 := &x.Status
+		yyv690.CodecDecodeSelf(d)
 	}
 	for {
-		yyj638++
-		if yyhl638 {
-			yyb638 = yyj638 > l
+		yyj685++
+		if yyhl685 {
+			yyb685 = yyj685 > l
 		} else {
-			yyb638 = r.CheckBreak()
+			yyb685 = r.CheckBreak()
 		}
-		if yyb638 {
+		if yyb685 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj638-1, "")
+		z.DecStructFieldNotFound(yyj685-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -7673,37 +8259,37 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym644 := z.EncBinary()
-		_ = yym644
+		yym691 := z.EncBinary()
+		_ = yym691
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep645 := !z.EncBinary()
-			yy2arr645 := z.EncBasicHandle().StructToArray
-			var yyq645 [4]bool
-			_, _, _ = yysep645, yyq645, yy2arr645
-			const yyr645 bool = false
-			yyq645[0] = x.Kind != ""
-			yyq645[1] = x.APIVersion != ""
-			yyq645[2] = true
-			var yynn645 int
-			if yyr645 || yy2arr645 {
+			yysep692 := !z.EncBinary()
+			yy2arr692 := z.EncBasicHandle().StructToArray
+			var yyq692 [4]bool
+			_, _, _ = yysep692, yyq692, yy2arr692
+			const yyr692 bool = false
+			yyq692[0] = x.Kind != ""
+			yyq692[1] = x.APIVersion != ""
+			yyq692[2] = true
+			var yynn692 int
+			if yyr692 || yy2arr692 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn645 = 1
-				for _, b := range yyq645 {
+				yynn692 = 1
+				for _, b := range yyq692 {
 					if b {
-						yynn645++
+						yynn692++
 					}
 				}
-				r.EncodeMapStart(yynn645)
-				yynn645 = 0
+				r.EncodeMapStart(yynn692)
+				yynn692 = 0
 			}
-			if yyr645 || yy2arr645 {
+			if yyr692 || yy2arr692 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq645[0] {
-					yym647 := z.EncBinary()
-					_ = yym647
+				if yyq692[0] {
+					yym694 := z.EncBinary()
+					_ = yym694
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -7712,23 +8298,23 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq645[0] {
+				if yyq692[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym648 := z.EncBinary()
-					_ = yym648
+					yym695 := z.EncBinary()
+					_ = yym695
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr645 || yy2arr645 {
+			if yyr692 || yy2arr692 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq645[1] {
-					yym650 := z.EncBinary()
-					_ = yym650
+				if yyq692[1] {
+					yym697 := z.EncBinary()
+					_ = yym697
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -7737,54 +8323,54 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq645[1] {
+				if yyq692[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym651 := z.EncBinary()
-					_ = yym651
+					yym698 := z.EncBinary()
+					_ = yym698
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr645 || yy2arr645 {
+			if yyr692 || yy2arr692 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq645[2] {
-					yy653 := &x.ListMeta
-					yym654 := z.EncBinary()
-					_ = yym654
+				if yyq692[2] {
+					yy700 := &x.ListMeta
+					yym701 := z.EncBinary()
+					_ = yym701
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy653) {
+					} else if z.HasExtensions() && z.EncExt(yy700) {
 					} else {
-						z.EncFallback(yy653)
+						z.EncFallback(yy700)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq645[2] {
+				if yyq692[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy655 := &x.ListMeta
-					yym656 := z.EncBinary()
-					_ = yym656
+					yy702 := &x.ListMeta
+					yym703 := z.EncBinary()
+					_ = yym703
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy655) {
+					} else if z.HasExtensions() && z.EncExt(yy702) {
 					} else {
-						z.EncFallback(yy655)
+						z.EncFallback(yy702)
 					}
 				}
 			}
-			if yyr645 || yy2arr645 {
+			if yyr692 || yy2arr692 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym658 := z.EncBinary()
-					_ = yym658
+					yym705 := z.EncBinary()
+					_ = yym705
 					if false {
 					} else {
 						h.encSliceDaemonSet(([]DaemonSet)(x.Items), e)
@@ -7797,15 +8383,15 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym659 := z.EncBinary()
-					_ = yym659
+					yym706 := z.EncBinary()
+					_ = yym706
 					if false {
 					} else {
 						h.encSliceDaemonSet(([]DaemonSet)(x.Items), e)
 					}
 				}
 			}
-			if yyr645 || yy2arr645 {
+			if yyr692 || yy2arr692 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -7818,25 +8404,25 @@ func (x *DaemonSetList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym660 := z.DecBinary()
-	_ = yym660
+	yym707 := z.DecBinary()
+	_ = yym707
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct661 := r.ContainerType()
-		if yyct661 == codecSelferValueTypeMap1234 {
-			yyl661 := r.ReadMapStart()
-			if yyl661 == 0 {
+		yyct708 := r.ContainerType()
+		if yyct708 == codecSelferValueTypeMap1234 {
+			yyl708 := r.ReadMapStart()
+			if yyl708 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl661, d)
+				x.codecDecodeSelfFromMap(yyl708, d)
 			}
-		} else if yyct661 == codecSelferValueTypeArray1234 {
-			yyl661 := r.ReadArrayStart()
-			if yyl661 == 0 {
+		} else if yyct708 == codecSelferValueTypeArray1234 {
+			yyl708 := r.ReadArrayStart()
+			if yyl708 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl661, d)
+				x.codecDecodeSelfFromArray(yyl708, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -7848,12 +8434,12 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys662Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys662Slc
-	var yyhl662 bool = l >= 0
-	for yyj662 := 0; ; yyj662++ {
-		if yyhl662 {
-			if yyj662 >= l {
+	var yys709Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys709Slc
+	var yyhl709 bool = l >= 0
+	for yyj709 := 0; ; yyj709++ {
+		if yyhl709 {
+			if yyj709 >= l {
 				break
 			}
 		} else {
@@ -7862,10 +8448,10 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys662Slc = r.DecodeBytes(yys662Slc, true, true)
-		yys662 := string(yys662Slc)
+		yys709Slc = r.DecodeBytes(yys709Slc, true, true)
+		yys709 := string(yys709Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys662 {
+		switch yys709 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -7882,31 +8468,31 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv665 := &x.ListMeta
-				yym666 := z.DecBinary()
-				_ = yym666
+				yyv712 := &x.ListMeta
+				yym713 := z.DecBinary()
+				_ = yym713
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv665) {
+				} else if z.HasExtensions() && z.DecExt(yyv712) {
 				} else {
-					z.DecFallback(yyv665, false)
+					z.DecFallback(yyv712, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv667 := &x.Items
-				yym668 := z.DecBinary()
-				_ = yym668
+				yyv714 := &x.Items
+				yym715 := z.DecBinary()
+				_ = yym715
 				if false {
 				} else {
-					h.decSliceDaemonSet((*[]DaemonSet)(yyv667), d)
+					h.decSliceDaemonSet((*[]DaemonSet)(yyv714), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys662)
-		} // end switch yys662
-	} // end for yyj662
+			z.DecStructFieldNotFound(-1, yys709)
+		} // end switch yys709
+	} // end for yyj709
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -7914,16 +8500,16 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj669 int
-	var yyb669 bool
-	var yyhl669 bool = l >= 0
-	yyj669++
-	if yyhl669 {
-		yyb669 = yyj669 > l
+	var yyj716 int
+	var yyb716 bool
+	var yyhl716 bool = l >= 0
+	yyj716++
+	if yyhl716 {
+		yyb716 = yyj716 > l
 	} else {
-		yyb669 = r.CheckBreak()
+		yyb716 = r.CheckBreak()
 	}
-	if yyb669 {
+	if yyb716 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7933,13 +8519,13 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj669++
-	if yyhl669 {
-		yyb669 = yyj669 > l
+	yyj716++
+	if yyhl716 {
+		yyb716 = yyj716 > l
 	} else {
-		yyb669 = r.CheckBreak()
+		yyb716 = r.CheckBreak()
 	}
-	if yyb669 {
+	if yyb716 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7949,13 +8535,13 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj669++
-	if yyhl669 {
-		yyb669 = yyj669 > l
+	yyj716++
+	if yyhl716 {
+		yyb716 = yyj716 > l
 	} else {
-		yyb669 = r.CheckBreak()
+		yyb716 = r.CheckBreak()
 	}
-	if yyb669 {
+	if yyb716 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7963,22 +8549,22 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv672 := &x.ListMeta
-		yym673 := z.DecBinary()
-		_ = yym673
+		yyv719 := &x.ListMeta
+		yym720 := z.DecBinary()
+		_ = yym720
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv672) {
+		} else if z.HasExtensions() && z.DecExt(yyv719) {
 		} else {
-			z.DecFallback(yyv672, false)
+			z.DecFallback(yyv719, false)
 		}
 	}
-	yyj669++
-	if yyhl669 {
-		yyb669 = yyj669 > l
+	yyj716++
+	if yyhl716 {
+		yyb716 = yyj716 > l
 	} else {
-		yyb669 = r.CheckBreak()
+		yyb716 = r.CheckBreak()
 	}
-	if yyb669 {
+	if yyb716 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7986,26 +8572,26 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv674 := &x.Items
-		yym675 := z.DecBinary()
-		_ = yym675
+		yyv721 := &x.Items
+		yym722 := z.DecBinary()
+		_ = yym722
 		if false {
 		} else {
-			h.decSliceDaemonSet((*[]DaemonSet)(yyv674), d)
+			h.decSliceDaemonSet((*[]DaemonSet)(yyv721), d)
 		}
 	}
 	for {
-		yyj669++
-		if yyhl669 {
-			yyb669 = yyj669 > l
+		yyj716++
+		if yyhl716 {
+			yyb716 = yyj716 > l
 		} else {
-			yyb669 = r.CheckBreak()
+			yyb716 = r.CheckBreak()
 		}
-		if yyb669 {
+		if yyb716 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj669-1, "")
+		z.DecStructFieldNotFound(yyj716-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -8017,37 +8603,37 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym676 := z.EncBinary()
-		_ = yym676
+		yym723 := z.EncBinary()
+		_ = yym723
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep677 := !z.EncBinary()
-			yy2arr677 := z.EncBasicHandle().StructToArray
-			var yyq677 [4]bool
-			_, _, _ = yysep677, yyq677, yy2arr677
-			const yyr677 bool = false
-			yyq677[0] = x.Kind != ""
-			yyq677[1] = x.APIVersion != ""
-			yyq677[2] = true
-			var yynn677 int
-			if yyr677 || yy2arr677 {
+			yysep724 := !z.EncBinary()
+			yy2arr724 := z.EncBasicHandle().StructToArray
+			var yyq724 [4]bool
+			_, _, _ = yysep724, yyq724, yy2arr724
+			const yyr724 bool = false
+			yyq724[0] = x.Kind != ""
+			yyq724[1] = x.APIVersion != ""
+			yyq724[2] = true
+			var yynn724 int
+			if yyr724 || yy2arr724 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn677 = 1
-				for _, b := range yyq677 {
+				yynn724 = 1
+				for _, b := range yyq724 {
 					if b {
-						yynn677++
+						yynn724++
 					}
 				}
-				r.EncodeMapStart(yynn677)
-				yynn677 = 0
+				r.EncodeMapStart(yynn724)
+				yynn724 = 0
 			}
-			if yyr677 || yy2arr677 {
+			if yyr724 || yy2arr724 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq677[0] {
-					yym679 := z.EncBinary()
-					_ = yym679
+				if yyq724[0] {
+					yym726 := z.EncBinary()
+					_ = yym726
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -8056,23 +8642,23 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq677[0] {
+				if yyq724[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym680 := z.EncBinary()
-					_ = yym680
+					yym727 := z.EncBinary()
+					_ = yym727
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr677 || yy2arr677 {
+			if yyr724 || yy2arr724 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq677[1] {
-					yym682 := z.EncBinary()
-					_ = yym682
+				if yyq724[1] {
+					yym729 := z.EncBinary()
+					_ = yym729
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -8081,54 +8667,54 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq677[1] {
+				if yyq724[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym683 := z.EncBinary()
-					_ = yym683
+					yym730 := z.EncBinary()
+					_ = yym730
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr677 || yy2arr677 {
+			if yyr724 || yy2arr724 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq677[2] {
-					yy685 := &x.ListMeta
-					yym686 := z.EncBinary()
-					_ = yym686
+				if yyq724[2] {
+					yy732 := &x.ListMeta
+					yym733 := z.EncBinary()
+					_ = yym733
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy685) {
+					} else if z.HasExtensions() && z.EncExt(yy732) {
 					} else {
-						z.EncFallback(yy685)
+						z.EncFallback(yy732)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq677[2] {
+				if yyq724[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy687 := &x.ListMeta
-					yym688 := z.EncBinary()
-					_ = yym688
+					yy734 := &x.ListMeta
+					yym735 := z.EncBinary()
+					_ = yym735
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy687) {
+					} else if z.HasExtensions() && z.EncExt(yy734) {
 					} else {
-						z.EncFallback(yy687)
+						z.EncFallback(yy734)
 					}
 				}
 			}
-			if yyr677 || yy2arr677 {
+			if yyr724 || yy2arr724 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym690 := z.EncBinary()
-					_ = yym690
+					yym737 := z.EncBinary()
+					_ = yym737
 					if false {
 					} else {
 						h.encSliceThirdPartyResourceData(([]ThirdPartyResourceData)(x.Items), e)
@@ -8141,15 +8727,15 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym691 := z.EncBinary()
-					_ = yym691
+					yym738 := z.EncBinary()
+					_ = yym738
 					if false {
 					} else {
 						h.encSliceThirdPartyResourceData(([]ThirdPartyResourceData)(x.Items), e)
 					}
 				}
 			}
-			if yyr677 || yy2arr677 {
+			if yyr724 || yy2arr724 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -8162,25 +8748,25 @@ func (x *ThirdPartyResourceDataList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym692 := z.DecBinary()
-	_ = yym692
+	yym739 := z.DecBinary()
+	_ = yym739
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct693 := r.ContainerType()
-		if yyct693 == codecSelferValueTypeMap1234 {
-			yyl693 := r.ReadMapStart()
-			if yyl693 == 0 {
+		yyct740 := r.ContainerType()
+		if yyct740 == codecSelferValueTypeMap1234 {
+			yyl740 := r.ReadMapStart()
+			if yyl740 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl693, d)
+				x.codecDecodeSelfFromMap(yyl740, d)
 			}
-		} else if yyct693 == codecSelferValueTypeArray1234 {
-			yyl693 := r.ReadArrayStart()
-			if yyl693 == 0 {
+		} else if yyct740 == codecSelferValueTypeArray1234 {
+			yyl740 := r.ReadArrayStart()
+			if yyl740 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl693, d)
+				x.codecDecodeSelfFromArray(yyl740, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -8192,12 +8778,12 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys694Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys694Slc
-	var yyhl694 bool = l >= 0
-	for yyj694 := 0; ; yyj694++ {
-		if yyhl694 {
-			if yyj694 >= l {
+	var yys741Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys741Slc
+	var yyhl741 bool = l >= 0
+	for yyj741 := 0; ; yyj741++ {
+		if yyhl741 {
+			if yyj741 >= l {
 				break
 			}
 		} else {
@@ -8206,10 +8792,10 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys694Slc = r.DecodeBytes(yys694Slc, true, true)
-		yys694 := string(yys694Slc)
+		yys741Slc = r.DecodeBytes(yys741Slc, true, true)
+		yys741 := string(yys741Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys694 {
+		switch yys741 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -8226,31 +8812,31 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv697 := &x.ListMeta
-				yym698 := z.DecBinary()
-				_ = yym698
+				yyv744 := &x.ListMeta
+				yym745 := z.DecBinary()
+				_ = yym745
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv697) {
+				} else if z.HasExtensions() && z.DecExt(yyv744) {
 				} else {
-					z.DecFallback(yyv697, false)
+					z.DecFallback(yyv744, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv699 := &x.Items
-				yym700 := z.DecBinary()
-				_ = yym700
+				yyv746 := &x.Items
+				yym747 := z.DecBinary()
+				_ = yym747
 				if false {
 				} else {
-					h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv699), d)
+					h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv746), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys694)
-		} // end switch yys694
-	} // end for yyj694
+			z.DecStructFieldNotFound(-1, yys741)
+		} // end switch yys741
+	} // end for yyj741
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -8258,16 +8844,16 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj701 int
-	var yyb701 bool
-	var yyhl701 bool = l >= 0
-	yyj701++
-	if yyhl701 {
-		yyb701 = yyj701 > l
+	var yyj748 int
+	var yyb748 bool
+	var yyhl748 bool = l >= 0
+	yyj748++
+	if yyhl748 {
+		yyb748 = yyj748 > l
 	} else {
-		yyb701 = r.CheckBreak()
+		yyb748 = r.CheckBreak()
 	}
-	if yyb701 {
+	if yyb748 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8277,13 +8863,13 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj701++
-	if yyhl701 {
-		yyb701 = yyj701 > l
+	yyj748++
+	if yyhl748 {
+		yyb748 = yyj748 > l
 	} else {
-		yyb701 = r.CheckBreak()
+		yyb748 = r.CheckBreak()
 	}
-	if yyb701 {
+	if yyb748 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8293,13 +8879,13 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj701++
-	if yyhl701 {
-		yyb701 = yyj701 > l
+	yyj748++
+	if yyhl748 {
+		yyb748 = yyj748 > l
 	} else {
-		yyb701 = r.CheckBreak()
+		yyb748 = r.CheckBreak()
 	}
-	if yyb701 {
+	if yyb748 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8307,22 +8893,22 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv704 := &x.ListMeta
-		yym705 := z.DecBinary()
-		_ = yym705
+		yyv751 := &x.ListMeta
+		yym752 := z.DecBinary()
+		_ = yym752
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv704) {
+		} else if z.HasExtensions() && z.DecExt(yyv751) {
 		} else {
-			z.DecFallback(yyv704, false)
+			z.DecFallback(yyv751, false)
 		}
 	}
-	yyj701++
-	if yyhl701 {
-		yyb701 = yyj701 > l
+	yyj748++
+	if yyhl748 {
+		yyb748 = yyj748 > l
 	} else {
-		yyb701 = r.CheckBreak()
+		yyb748 = r.CheckBreak()
 	}
-	if yyb701 {
+	if yyb748 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8330,26 +8916,26 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv706 := &x.Items
-		yym707 := z.DecBinary()
-		_ = yym707
+		yyv753 := &x.Items
+		yym754 := z.DecBinary()
+		_ = yym754
 		if false {
 		} else {
-			h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv706), d)
+			h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv753), d)
 		}
 	}
 	for {
-		yyj701++
-		if yyhl701 {
-			yyb701 = yyj701 > l
+		yyj748++
+		if yyhl748 {
+			yyb748 = yyj748 > l
 		} else {
-			yyb701 = r.CheckBreak()
+			yyb748 = r.CheckBreak()
 		}
-		if yyb701 {
+		if yyb748 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj701-1, "")
+		z.DecStructFieldNotFound(yyj748-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -8361,39 +8947,39 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym708 := z.EncBinary()
-		_ = yym708
+		yym755 := z.EncBinary()
+		_ = yym755
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep709 := !z.EncBinary()
-			yy2arr709 := z.EncBasicHandle().StructToArray
-			var yyq709 [5]bool
-			_, _, _ = yysep709, yyq709, yy2arr709
-			const yyr709 bool = false
-			yyq709[0] = x.Kind != ""
-			yyq709[1] = x.APIVersion != ""
-			yyq709[2] = true
-			yyq709[3] = true
-			yyq709[4] = true
-			var yynn709 int
-			if yyr709 || yy2arr709 {
+			yysep756 := !z.EncBinary()
+			yy2arr756 := z.EncBasicHandle().StructToArray
+			var yyq756 [5]bool
+			_, _, _ = yysep756, yyq756, yy2arr756
+			const yyr756 bool = false
+			yyq756[0] = x.Kind != ""
+			yyq756[1] = x.APIVersion != ""
+			yyq756[2] = true
+			yyq756[3] = true
+			yyq756[4] = true
+			var yynn756 int
+			if yyr756 || yy2arr756 {
 				r.EncodeArrayStart(5)
 			} else {
-				yynn709 = 0
-				for _, b := range yyq709 {
+				yynn756 = 0
+				for _, b := range yyq756 {
 					if b {
-						yynn709++
+						yynn756++
 					}
 				}
-				r.EncodeMapStart(yynn709)
-				yynn709 = 0
+				r.EncodeMapStart(yynn756)
+				yynn756 = 0
 			}
-			if yyr709 || yy2arr709 {
+			if yyr756 || yy2arr756 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq709[0] {
-					yym711 := z.EncBinary()
-					_ = yym711
+				if yyq756[0] {
+					yym758 := z.EncBinary()
+					_ = yym758
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -8402,23 +8988,23 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq709[0] {
+				if yyq756[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym712 := z.EncBinary()
-					_ = yym712
+					yym759 := z.EncBinary()
+					_ = yym759
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr709 || yy2arr709 {
+			if yyr756 || yy2arr756 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq709[1] {
-					yym714 := z.EncBinary()
-					_ = yym714
+				if yyq756[1] {
+					yym761 := z.EncBinary()
+					_ = yym761
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -8427,70 +9013,70 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq709[1] {
+				if yyq756[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym715 := z.EncBinary()
-					_ = yym715
+					yym762 := z.EncBinary()
+					_ = yym762
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr709 || yy2arr709 {
+			if yyr756 || yy2arr756 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq709[2] {
-					yy717 := &x.ObjectMeta
-					yy717.CodecEncodeSelf(e)
+				if yyq756[2] {
+					yy764 := &x.ObjectMeta
+					yy764.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq709[2] {
+				if yyq756[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy718 := &x.ObjectMeta
-					yy718.CodecEncodeSelf(e)
+					yy765 := &x.ObjectMeta
+					yy765.CodecEncodeSelf(e)
 				}
 			}
-			if yyr709 || yy2arr709 {
+			if yyr756 || yy2arr756 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq709[3] {
-					yy720 := &x.Spec
-					yy720.CodecEncodeSelf(e)
+				if yyq756[3] {
+					yy767 := &x.Spec
+					yy767.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq709[3] {
+				if yyq756[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy721 := &x.Spec
-					yy721.CodecEncodeSelf(e)
+					yy768 := &x.Spec
+					yy768.CodecEncodeSelf(e)
 				}
 			}
-			if yyr709 || yy2arr709 {
+			if yyr756 || yy2arr756 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq709[4] {
-					yy723 := &x.Status
-					yy723.CodecEncodeSelf(e)
+				if yyq756[4] {
+					yy770 := &x.Status
+					yy770.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq709[4] {
+				if yyq756[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy724 := &x.Status
-					yy724.CodecEncodeSelf(e)
+					yy771 := &x.Status
+					yy771.CodecEncodeSelf(e)
 				}
 			}
-			if yyr709 || yy2arr709 {
+			if yyr756 || yy2arr756 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -8503,25 +9089,25 @@ func (x *Job) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym725 := z.DecBinary()
-	_ = yym725
+	yym772 := z.DecBinary()
+	_ = yym772
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct726 := r.ContainerType()
-		if yyct726 == codecSelferValueTypeMap1234 {
-			yyl726 := r.ReadMapStart()
-			if yyl726 == 0 {
+		yyct773 := r.ContainerType()
+		if yyct773 == codecSelferValueTypeMap1234 {
+			yyl773 := r.ReadMapStart()
+			if yyl773 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl726, d)
+				x.codecDecodeSelfFromMap(yyl773, d)
 			}
-		} else if yyct726 == codecSelferValueTypeArray1234 {
-			yyl726 := r.ReadArrayStart()
-			if yyl726 == 0 {
+		} else if yyct773 == codecSelferValueTypeArray1234 {
+			yyl773 := r.ReadArrayStart()
+			if yyl773 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl726, d)
+				x.codecDecodeSelfFromArray(yyl773, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -8533,12 +9119,12 @@ func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys727Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys727Slc
-	var yyhl727 bool = l >= 0
-	for yyj727 := 0; ; yyj727++ {
-		if yyhl727 {
-			if yyj727 >= l {
+	var yys774Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys774Slc
+	var yyhl774 bool = l >= 0
+	for yyj774 := 0; ; yyj774++ {
+		if yyhl774 {
+			if yyj774 >= l {
 				break
 			}
 		} else {
@@ -8547,10 +9133,10 @@ func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys727Slc = r.DecodeBytes(yys727Slc, true, true)
-		yys727 := string(yys727Slc)
+		yys774Slc = r.DecodeBytes(yys774Slc, true, true)
+		yys774 := string(yys774Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys727 {
+		switch yys774 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -8567,27 +9153,27 @@ func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv730 := &x.ObjectMeta
-				yyv730.CodecDecodeSelf(d)
+				yyv777 := &x.ObjectMeta
+				yyv777.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = JobSpec{}
 			} else {
-				yyv731 := &x.Spec
-				yyv731.CodecDecodeSelf(d)
+				yyv778 := &x.Spec
+				yyv778.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = JobStatus{}
 			} else {
-				yyv732 := &x.Status
-				yyv732.CodecDecodeSelf(d)
+				yyv779 := &x.Status
+				yyv779.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys727)
-		} // end switch yys727
-	} // end for yyj727
+			z.DecStructFieldNotFound(-1, yys774)
+		} // end switch yys774
+	} // end for yyj774
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -8595,16 +9181,16 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj733 int
-	var yyb733 bool
-	var yyhl733 bool = l >= 0
-	yyj733++
-	if yyhl733 {
-		yyb733 = yyj733 > l
+	var yyj780 int
+	var yyb780 bool
+	var yyhl780 bool = l >= 0
+	yyj780++
+	if yyhl780 {
+		yyb780 = yyj780 > l
 	} else {
-		yyb733 = r.CheckBreak()
+		yyb780 = r.CheckBreak()
 	}
-	if yyb733 {
+	if yyb780 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8614,13 +9200,13 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj733++
-	if yyhl733 {
-		yyb733 = yyj733 > l
+	yyj780++
+	if yyhl780 {
+		yyb780 = yyj780 > l
 	} else {
-		yyb733 = r.CheckBreak()
+		yyb780 = r.CheckBreak()
 	}
-	if yyb733 {
+	if yyb780 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8630,13 +9216,13 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj733++
-	if yyhl733 {
-		yyb733 = yyj733 > l
+	yyj780++
+	if yyhl780 {
+		yyb780 = yyj780 > l
 	} else {
-		yyb733 = r.CheckBreak()
+		yyb780 = r.CheckBreak()
 	}
-	if yyb733 {
+	if yyb780 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8644,16 +9230,16 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv736 := &x.ObjectMeta
-		yyv736.CodecDecodeSelf(d)
+		yyv783 := &x.ObjectMeta
+		yyv783.CodecDecodeSelf(d)
 	}
-	yyj733++
-	if yyhl733 {
-		yyb733 = yyj733 > l
+	yyj780++
+	if yyhl780 {
+		yyb780 = yyj780 > l
 	} else {
-		yyb733 = r.CheckBreak()
+		yyb780 = r.CheckBreak()
 	}
-	if yyb733 {
+	if yyb780 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8661,16 +9247,16 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Spec = JobSpec{}
 	} else {
-		yyv737 := &x.Spec
-		yyv737.CodecDecodeSelf(d)
+		yyv784 := &x.Spec
+		yyv784.CodecDecodeSelf(d)
 	}
-	yyj733++
-	if yyhl733 {
-		yyb733 = yyj733 > l
+	yyj780++
+	if yyhl780 {
+		yyb780 = yyj780 > l
 	} else {
-		yyb733 = r.CheckBreak()
+		yyb780 = r.CheckBreak()
 	}
-	if yyb733 {
+	if yyb780 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8678,21 +9264,21 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Status = JobStatus{}
 	} else {
-		yyv738 := &x.Status
-		yyv738.CodecDecodeSelf(d)
+		yyv785 := &x.Status
+		yyv785.CodecDecodeSelf(d)
 	}
 	for {
-		yyj733++
-		if yyhl733 {
-			yyb733 = yyj733 > l
+		yyj780++
+		if yyhl780 {
+			yyb780 = yyj780 > l
 		} else {
-			yyb733 = r.CheckBreak()
+			yyb780 = r.CheckBreak()
 		}
-		if yyb733 {
+		if yyb780 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj733-1, "")
+		z.DecStructFieldNotFound(yyj780-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -8704,37 +9290,37 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym739 := z.EncBinary()
-		_ = yym739
+		yym786 := z.EncBinary()
+		_ = yym786
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep740 := !z.EncBinary()
-			yy2arr740 := z.EncBasicHandle().StructToArray
-			var yyq740 [4]bool
-			_, _, _ = yysep740, yyq740, yy2arr740
-			const yyr740 bool = false
-			yyq740[0] = x.Kind != ""
-			yyq740[1] = x.APIVersion != ""
-			yyq740[2] = true
-			var yynn740 int
-			if yyr740 || yy2arr740 {
+			yysep787 := !z.EncBinary()
+			yy2arr787 := z.EncBasicHandle().StructToArray
+			var yyq787 [4]bool
+			_, _, _ = yysep787, yyq787, yy2arr787
+			const yyr787 bool = false
+			yyq787[0] = x.Kind != ""
+			yyq787[1] = x.APIVersion != ""
+			yyq787[2] = true
+			var yynn787 int
+			if yyr787 || yy2arr787 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn740 = 1
-				for _, b := range yyq740 {
+				yynn787 = 1
+				for _, b := range yyq787 {
 					if b {
-						yynn740++
+						yynn787++
 					}
 				}
-				r.EncodeMapStart(yynn740)
-				yynn740 = 0
+				r.EncodeMapStart(yynn787)
+				yynn787 = 0
 			}
-			if yyr740 || yy2arr740 {
+			if yyr787 || yy2arr787 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq740[0] {
-					yym742 := z.EncBinary()
-					_ = yym742
+				if yyq787[0] {
+					yym789 := z.EncBinary()
+					_ = yym789
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -8743,23 +9329,23 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq740[0] {
+				if yyq787[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym743 := z.EncBinary()
-					_ = yym743
+					yym790 := z.EncBinary()
+					_ = yym790
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr740 || yy2arr740 {
+			if yyr787 || yy2arr787 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq740[1] {
-					yym745 := z.EncBinary()
-					_ = yym745
+				if yyq787[1] {
+					yym792 := z.EncBinary()
+					_ = yym792
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -8768,54 +9354,54 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq740[1] {
+				if yyq787[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym746 := z.EncBinary()
-					_ = yym746
+					yym793 := z.EncBinary()
+					_ = yym793
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr740 || yy2arr740 {
+			if yyr787 || yy2arr787 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq740[2] {
-					yy748 := &x.ListMeta
-					yym749 := z.EncBinary()
-					_ = yym749
+				if yyq787[2] {
+					yy795 := &x.ListMeta
+					yym796 := z.EncBinary()
+					_ = yym796
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy748) {
+					} else if z.HasExtensions() && z.EncExt(yy795) {
 					} else {
-						z.EncFallback(yy748)
+						z.EncFallback(yy795)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq740[2] {
+				if yyq787[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy750 := &x.ListMeta
-					yym751 := z.EncBinary()
-					_ = yym751
+					yy797 := &x.ListMeta
+					yym798 := z.EncBinary()
+					_ = yym798
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy750) {
+					} else if z.HasExtensions() && z.EncExt(yy797) {
 					} else {
-						z.EncFallback(yy750)
+						z.EncFallback(yy797)
 					}
 				}
 			}
-			if yyr740 || yy2arr740 {
+			if yyr787 || yy2arr787 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym753 := z.EncBinary()
-					_ = yym753
+					yym800 := z.EncBinary()
+					_ = yym800
 					if false {
 					} else {
 						h.encSliceJob(([]Job)(x.Items), e)
@@ -8828,15 +9414,15 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym754 := z.EncBinary()
-					_ = yym754
+					yym801 := z.EncBinary()
+					_ = yym801
 					if false {
 					} else {
 						h.encSliceJob(([]Job)(x.Items), e)
 					}
 				}
 			}
-			if yyr740 || yy2arr740 {
+			if yyr787 || yy2arr787 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -8849,25 +9435,25 @@ func (x *JobList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym755 := z.DecBinary()
-	_ = yym755
+	yym802 := z.DecBinary()
+	_ = yym802
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct756 := r.ContainerType()
-		if yyct756 == codecSelferValueTypeMap1234 {
-			yyl756 := r.ReadMapStart()
-			if yyl756 == 0 {
+		yyct803 := r.ContainerType()
+		if yyct803 == codecSelferValueTypeMap1234 {
+			yyl803 := r.ReadMapStart()
+			if yyl803 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl756, d)
+				x.codecDecodeSelfFromMap(yyl803, d)
 			}
-		} else if yyct756 == codecSelferValueTypeArray1234 {
-			yyl756 := r.ReadArrayStart()
-			if yyl756 == 0 {
+		} else if yyct803 == codecSelferValueTypeArray1234 {
+			yyl803 := r.ReadArrayStart()
+			if yyl803 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl756, d)
+				x.codecDecodeSelfFromArray(yyl803, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -8879,12 +9465,12 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys757Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys757Slc
-	var yyhl757 bool = l >= 0
-	for yyj757 := 0; ; yyj757++ {
-		if yyhl757 {
-			if yyj757 >= l {
+	var yys804Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys804Slc
+	var yyhl804 bool = l >= 0
+	for yyj804 := 0; ; yyj804++ {
+		if yyhl804 {
+			if yyj804 >= l {
 				break
 			}
 		} else {
@@ -8893,10 +9479,10 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys757Slc = r.DecodeBytes(yys757Slc, true, true)
-		yys757 := string(yys757Slc)
+		yys804Slc = r.DecodeBytes(yys804Slc, true, true)
+		yys804 := string(yys804Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys757 {
+		switch yys804 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -8913,31 +9499,31 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv760 := &x.ListMeta
-				yym761 := z.DecBinary()
-				_ = yym761
+				yyv807 := &x.ListMeta
+				yym808 := z.DecBinary()
+				_ = yym808
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv760) {
+				} else if z.HasExtensions() && z.DecExt(yyv807) {
 				} else {
-					z.DecFallback(yyv760, false)
+					z.DecFallback(yyv807, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv762 := &x.Items
-				yym763 := z.DecBinary()
-				_ = yym763
+				yyv809 := &x.Items
+				yym810 := z.DecBinary()
+				_ = yym810
 				if false {
 				} else {
-					h.decSliceJob((*[]Job)(yyv762), d)
+					h.decSliceJob((*[]Job)(yyv809), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys757)
-		} // end switch yys757
-	} // end for yyj757
+			z.DecStructFieldNotFound(-1, yys804)
+		} // end switch yys804
+	} // end for yyj804
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -8945,16 +9531,16 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj764 int
-	var yyb764 bool
-	var yyhl764 bool = l >= 0
-	yyj764++
-	if yyhl764 {
-		yyb764 = yyj764 > l
+	var yyj811 int
+	var yyb811 bool
+	var yyhl811 bool = l >= 0
+	yyj811++
+	if yyhl811 {
+		yyb811 = yyj811 > l
 	} else {
-		yyb764 = r.CheckBreak()
+		yyb811 = r.CheckBreak()
 	}
-	if yyb764 {
+	if yyb811 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8964,13 +9550,13 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj764++
-	if yyhl764 {
-		yyb764 = yyj764 > l
+	yyj811++
+	if yyhl811 {
+		yyb811 = yyj811 > l
 	} else {
-		yyb764 = r.CheckBreak()
+		yyb811 = r.CheckBreak()
 	}
-	if yyb764 {
+	if yyb811 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8980,13 +9566,13 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj764++
-	if yyhl764 {
-		yyb764 = yyj764 > l
+	yyj811++
+	if yyhl811 {
+		yyb811 = yyj811 > l
 	} else {
-		yyb764 = r.CheckBreak()
+		yyb811 = r.CheckBreak()
 	}
-	if yyb764 {
+	if yyb811 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8994,22 +9580,22 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv767 := &x.ListMeta
-		yym768 := z.DecBinary()
-		_ = yym768
+		yyv814 := &x.ListMeta
+		yym815 := z.DecBinary()
+		_ = yym815
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv767) {
+		} else if z.HasExtensions() && z.DecExt(yyv814) {
 		} else {
-			z.DecFallback(yyv767, false)
+			z.DecFallback(yyv814, false)
 		}
 	}
-	yyj764++
-	if yyhl764 {
-		yyb764 = yyj764 > l
+	yyj811++
+	if yyhl811 {
+		yyb811 = yyj811 > l
 	} else {
-		yyb764 = r.CheckBreak()
+		yyb811 = r.CheckBreak()
 	}
-	if yyb764 {
+	if yyb811 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9017,26 +9603,26 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv769 := &x.Items
-		yym770 := z.DecBinary()
-		_ = yym770
+		yyv816 := &x.Items
+		yym817 := z.DecBinary()
+		_ = yym817
 		if false {
 		} else {
-			h.decSliceJob((*[]Job)(yyv769), d)
+			h.decSliceJob((*[]Job)(yyv816), d)
 		}
 	}
 	for {
-		yyj764++
-		if yyhl764 {
-			yyb764 = yyj764 > l
+		yyj811++
+		if yyhl811 {
+			yyb811 = yyj811 > l
 		} else {
-			yyb764 = r.CheckBreak()
+			yyb811 = r.CheckBreak()
 		}
-		if yyb764 {
+		if yyb811 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj764-1, "")
+		z.DecStructFieldNotFound(yyj811-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -9048,141 +9634,141 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym771 := z.EncBinary()
-		_ = yym771
+		yym818 := z.EncBinary()
+		_ = yym818
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep772 := !z.EncBinary()
-			yy2arr772 := z.EncBasicHandle().StructToArray
-			var yyq772 [5]bool
-			_, _, _ = yysep772, yyq772, yy2arr772
-			const yyr772 bool = false
-			yyq772[0] = x.Parallelism != nil
-			yyq772[1] = x.Completions != nil
-			yyq772[2] = x.ActiveDeadlineSeconds != nil
-			yyq772[3] = x.Selector != nil
-			var yynn772 int
-			if yyr772 || yy2arr772 {
+			yysep819 := !z.EncBinary()
+			yy2arr819 := z.EncBasicHandle().StructToArray
+			var yyq819 [5]bool
+			_, _, _ = yysep819, yyq819, yy2arr819
+			const yyr819 bool = false
+			yyq819[0] = x.Parallelism != nil
+			yyq819[1] = x.Completions != nil
+			yyq819[2] = x.ActiveDeadlineSeconds != nil
+			yyq819[3] = x.Selector != nil
+			var yynn819 int
+			if yyr819 || yy2arr819 {
 				r.EncodeArrayStart(5)
 			} else {
-				yynn772 = 1
-				for _, b := range yyq772 {
+				yynn819 = 1
+				for _, b := range yyq819 {
 					if b {
-						yynn772++
+						yynn819++
 					}
 				}
-				r.EncodeMapStart(yynn772)
-				yynn772 = 0
+				r.EncodeMapStart(yynn819)
+				yynn819 = 0
 			}
-			if yyr772 || yy2arr772 {
+			if yyr819 || yy2arr819 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq772[0] {
+				if yyq819[0] {
 					if x.Parallelism == nil {
 						r.EncodeNil()
 					} else {
-						yy774 := *x.Parallelism
-						yym775 := z.EncBinary()
-						_ = yym775
+						yy821 := *x.Parallelism
+						yym822 := z.EncBinary()
+						_ = yym822
 						if false {
 						} else {
-							r.EncodeInt(int64(yy774))
+							r.EncodeInt(int64(yy821))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq772[0] {
+				if yyq819[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("parallelism"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Parallelism == nil {
 						r.EncodeNil()
 					} else {
-						yy776 := *x.Parallelism
-						yym777 := z.EncBinary()
-						_ = yym777
+						yy823 := *x.Parallelism
+						yym824 := z.EncBinary()
+						_ = yym824
 						if false {
 						} else {
-							r.EncodeInt(int64(yy776))
+							r.EncodeInt(int64(yy823))
 						}
 					}
 				}
 			}
-			if yyr772 || yy2arr772 {
+			if yyr819 || yy2arr819 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq772[1] {
+				if yyq819[1] {
 					if x.Completions == nil {
 						r.EncodeNil()
 					} else {
-						yy779 := *x.Completions
-						yym780 := z.EncBinary()
-						_ = yym780
+						yy826 := *x.Completions
+						yym827 := z.EncBinary()
+						_ = yym827
 						if false {
 						} else {
-							r.EncodeInt(int64(yy779))
+							r.EncodeInt(int64(yy826))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq772[1] {
+				if yyq819[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("completions"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Completions == nil {
 						r.EncodeNil()
 					} else {
-						yy781 := *x.Completions
-						yym782 := z.EncBinary()
-						_ = yym782
+						yy828 := *x.Completions
+						yym829 := z.EncBinary()
+						_ = yym829
 						if false {
 						} else {
-							r.EncodeInt(int64(yy781))
+							r.EncodeInt(int64(yy828))
 						}
 					}
 				}
 			}
-			if yyr772 || yy2arr772 {
+			if yyr819 || yy2arr819 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq772[2] {
+				if yyq819[2] {
 					if x.ActiveDeadlineSeconds == nil {
 						r.EncodeNil()
 					} else {
-						yy784 := *x.ActiveDeadlineSeconds
-						yym785 := z.EncBinary()
-						_ = yym785
+						yy831 := *x.ActiveDeadlineSeconds
+						yym832 := z.EncBinary()
+						_ = yym832
 						if false {
 						} else {
-							r.EncodeInt(int64(yy784))
+							r.EncodeInt(int64(yy831))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq772[2] {
+				if yyq819[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("activeDeadlineSeconds"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.ActiveDeadlineSeconds == nil {
 						r.EncodeNil()
 					} else {
-						yy786 := *x.ActiveDeadlineSeconds
-						yym787 := z.EncBinary()
-						_ = yym787
+						yy833 := *x.ActiveDeadlineSeconds
+						yym834 := z.EncBinary()
+						_ = yym834
 						if false {
 						} else {
-							r.EncodeInt(int64(yy786))
+							r.EncodeInt(int64(yy833))
 						}
 					}
 				}
 			}
-			if yyr772 || yy2arr772 {
+			if yyr819 || yy2arr819 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq772[3] {
+				if yyq819[3] {
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
@@ -9192,7 +9778,7 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq772[3] {
+				if yyq819[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
@@ -9203,18 +9789,18 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr772 || yy2arr772 {
+			if yyr819 || yy2arr819 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy790 := &x.Template
-				yy790.CodecEncodeSelf(e)
+				yy837 := &x.Template
+				yy837.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("template"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy791 := &x.Template
-				yy791.CodecEncodeSelf(e)
+				yy838 := &x.Template
+				yy838.CodecEncodeSelf(e)
 			}
-			if yyr772 || yy2arr772 {
+			if yyr819 || yy2arr819 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -9227,25 +9813,25 @@ func (x *JobSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym792 := z.DecBinary()
-	_ = yym792
+	yym839 := z.DecBinary()
+	_ = yym839
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct793 := r.ContainerType()
-		if yyct793 == codecSelferValueTypeMap1234 {
-			yyl793 := r.ReadMapStart()
-			if yyl793 == 0 {
+		yyct840 := r.ContainerType()
+		if yyct840 == codecSelferValueTypeMap1234 {
+			yyl840 := r.ReadMapStart()
+			if yyl840 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl793, d)
+				x.codecDecodeSelfFromMap(yyl840, d)
 			}
-		} else if yyct793 == codecSelferValueTypeArray1234 {
-			yyl793 := r.ReadArrayStart()
-			if yyl793 == 0 {
+		} else if yyct840 == codecSelferValueTypeArray1234 {
+			yyl840 := r.ReadArrayStart()
+			if yyl840 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl793, d)
+				x.codecDecodeSelfFromArray(yyl840, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -9257,12 +9843,12 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys794Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys794Slc
-	var yyhl794 bool = l >= 0
-	for yyj794 := 0; ; yyj794++ {
-		if yyhl794 {
-			if yyj794 >= l {
+	var yys841Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys841Slc
+	var yyhl841 bool = l >= 0
+	for yyj841 := 0; ; yyj841++ {
+		if yyhl841 {
+			if yyj841 >= l {
 				break
 			}
 		} else {
@@ -9271,10 +9857,10 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys794Slc = r.DecodeBytes(yys794Slc, true, true)
-		yys794 := string(yys794Slc)
+		yys841Slc = r.DecodeBytes(yys841Slc, true, true)
+		yys841 := string(yys841Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys794 {
+		switch yys841 {
 		case "parallelism":
 			if r.TryDecodeAsNil() {
 				if x.Parallelism != nil {
@@ -9284,8 +9870,8 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Parallelism == nil {
 					x.Parallelism = new(int)
 				}
-				yym796 := z.DecBinary()
-				_ = yym796
+				yym843 := z.DecBinary()
+				_ = yym843
 				if false {
 				} else {
 					*((*int)(x.Parallelism)) = int(r.DecodeInt(codecSelferBitsize1234))
@@ -9300,8 +9886,8 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Completions == nil {
 					x.Completions = new(int)
 				}
-				yym798 := z.DecBinary()
-				_ = yym798
+				yym845 := z.DecBinary()
+				_ = yym845
 				if false {
 				} else {
 					*((*int)(x.Completions)) = int(r.DecodeInt(codecSelferBitsize1234))
@@ -9316,8 +9902,8 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.ActiveDeadlineSeconds == nil {
 					x.ActiveDeadlineSeconds = new(int64)
 				}
-				yym800 := z.DecBinary()
-				_ = yym800
+				yym847 := z.DecBinary()
+				_ = yym847
 				if false {
 				} else {
 					*((*int64)(x.ActiveDeadlineSeconds)) = int64(r.DecodeInt(64))
@@ -9338,13 +9924,13 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Template = pkg2_api.PodTemplateSpec{}
 			} else {
-				yyv802 := &x.Template
-				yyv802.CodecDecodeSelf(d)
+				yyv849 := &x.Template
+				yyv849.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys794)
-		} // end switch yys794
-	} // end for yyj794
+			z.DecStructFieldNotFound(-1, yys841)
+		} // end switch yys841
+	} // end for yyj841
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -9352,16 +9938,16 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj803 int
-	var yyb803 bool
-	var yyhl803 bool = l >= 0
-	yyj803++
-	if yyhl803 {
-		yyb803 = yyj803 > l
+	var yyj850 int
+	var yyb850 bool
+	var yyhl850 bool = l >= 0
+	yyj850++
+	if yyhl850 {
+		yyb850 = yyj850 > l
 	} else {
-		yyb803 = r.CheckBreak()
+		yyb850 = r.CheckBreak()
 	}
-	if yyb803 {
+	if yyb850 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9374,20 +9960,20 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.Parallelism == nil {
 			x.Parallelism = new(int)
 		}
-		yym805 := z.DecBinary()
-		_ = yym805
+		yym852 := z.DecBinary()
+		_ = yym852
 		if false {
 		} else {
 			*((*int)(x.Parallelism)) = int(r.DecodeInt(codecSelferBitsize1234))
 		}
 	}
-	yyj803++
-	if yyhl803 {
-		yyb803 = yyj803 > l
+	yyj850++
+	if yyhl850 {
+		yyb850 = yyj850 > l
 	} else {
-		yyb803 = r.CheckBreak()
+		yyb850 = r.CheckBreak()
 	}
-	if yyb803 {
+	if yyb850 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9400,20 +9986,20 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.Completions == nil {
 			x.Completions = new(int)
 		}
-		yym807 := z.DecBinary()
-		_ = yym807
+		yym854 := z.DecBinary()
+		_ = yym854
 		if false {
 		} else {
 			*((*int)(x.Completions)) = int(r.DecodeInt(codecSelferBitsize1234))
 		}
 	}
-	yyj803++
-	if yyhl803 {
-		yyb803 = yyj803 > l
+	yyj850++
+	if yyhl850 {
+		yyb850 = yyj850 > l
 	} else {
-		yyb803 = r.CheckBreak()
+		yyb850 = r.CheckBreak()
 	}
-	if yyb803 {
+	if yyb850 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9426,20 +10012,20 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.ActiveDeadlineSeconds == nil {
 			x.ActiveDeadlineSeconds = new(int64)
 		}
-		yym809 := z.DecBinary()
-		_ = yym809
+		yym856 := z.DecBinary()
+		_ = yym856
 		if false {
 		} else {
 			*((*int64)(x.ActiveDeadlineSeconds)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj803++
-	if yyhl803 {
-		yyb803 = yyj803 > l
+	yyj850++
+	if yyhl850 {
+		yyb850 = yyj850 > l
 	} else {
-		yyb803 = r.CheckBreak()
+		yyb850 = r.CheckBreak()
 	}
-	if yyb803 {
+	if yyb850 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9454,13 +10040,13 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Selector.CodecDecodeSelf(d)
 	}
-	yyj803++
-	if yyhl803 {
-		yyb803 = yyj803 > l
+	yyj850++
+	if yyhl850 {
+		yyb850 = yyj850 > l
 	} else {
-		yyb803 = r.CheckBreak()
+		yyb850 = r.CheckBreak()
 	}
-	if yyb803 {
+	if yyb850 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9468,21 +10054,21 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Template = pkg2_api.PodTemplateSpec{}
 	} else {
-		yyv811 := &x.Template
-		yyv811.CodecDecodeSelf(d)
+		yyv858 := &x.Template
+		yyv858.CodecDecodeSelf(d)
 	}
 	for {
-		yyj803++
-		if yyhl803 {
-			yyb803 = yyj803 > l
+		yyj850++
+		if yyhl850 {
+			yyb850 = yyj850 > l
 		} else {
-			yyb803 = r.CheckBreak()
+			yyb850 = r.CheckBreak()
 		}
-		if yyb803 {
+		if yyb850 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj803-1, "")
+		z.DecStructFieldNotFound(yyj850-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -9494,43 +10080,43 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym812 := z.EncBinary()
-		_ = yym812
+		yym859 := z.EncBinary()
+		_ = yym859
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep813 := !z.EncBinary()
-			yy2arr813 := z.EncBasicHandle().StructToArray
-			var yyq813 [6]bool
-			_, _, _ = yysep813, yyq813, yy2arr813
-			const yyr813 bool = false
-			yyq813[0] = len(x.Conditions) != 0
-			yyq813[1] = x.StartTime != nil
-			yyq813[2] = x.CompletionTime != nil
-			yyq813[3] = x.Active != 0
-			yyq813[4] = x.Succeeded != 0
-			yyq813[5] = x.Failed != 0
-			var yynn813 int
-			if yyr813 || yy2arr813 {
+			yysep860 := !z.EncBinary()
+			yy2arr860 := z.EncBasicHandle().StructToArray
+			var yyq860 [6]bool
+			_, _, _ = yysep860, yyq860, yy2arr860
+			const yyr860 bool = false
+			yyq860[0] = len(x.Conditions) != 0
+			yyq860[1] = x.StartTime != nil
+			yyq860[2] = x.CompletionTime != nil
+			yyq860[3] = x.Active != 0
+			yyq860[4] = x.Succeeded != 0
+			yyq860[5] = x.Failed != 0
+			var yynn860 int
+			if yyr860 || yy2arr860 {
 				r.EncodeArrayStart(6)
 			} else {
-				yynn813 = 0
-				for _, b := range yyq813 {
+				yynn860 = 0
+				for _, b := range yyq860 {
 					if b {
-						yynn813++
+						yynn860++
 					}
 				}
-				r.EncodeMapStart(yynn813)
-				yynn813 = 0
+				r.EncodeMapStart(yynn860)
+				yynn860 = 0
 			}
-			if yyr813 || yy2arr813 {
+			if yyr860 || yy2arr860 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq813[0] {
+				if yyq860[0] {
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym815 := z.EncBinary()
-						_ = yym815
+						yym862 := z.EncBinary()
+						_ = yym862
 						if false {
 						} else {
 							h.encSliceJobCondition(([]JobCondition)(x.Conditions), e)
@@ -9540,15 +10126,15 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq813[0] {
+				if yyq860[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("conditions"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym816 := z.EncBinary()
-						_ = yym816
+						yym863 := z.EncBinary()
+						_ = yym863
 						if false {
 						} else {
 							h.encSliceJobCondition(([]JobCondition)(x.Conditions), e)
@@ -9556,19 +10142,19 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr813 || yy2arr813 {
+			if yyr860 || yy2arr860 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq813[1] {
+				if yyq860[1] {
 					if x.StartTime == nil {
 						r.EncodeNil()
 					} else {
-						yym818 := z.EncBinary()
-						_ = yym818
+						yym865 := z.EncBinary()
+						_ = yym865
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
-						} else if yym818 {
+						} else if yym865 {
 							z.EncBinaryMarshal(x.StartTime)
-						} else if !yym818 && z.IsJSONHandle() {
+						} else if !yym865 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.StartTime)
 						} else {
 							z.EncFallback(x.StartTime)
@@ -9578,20 +10164,20 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq813[1] {
+				if yyq860[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("startTime"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.StartTime == nil {
 						r.EncodeNil()
 					} else {
-						yym819 := z.EncBinary()
-						_ = yym819
+						yym866 := z.EncBinary()
+						_ = yym866
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
-						} else if yym819 {
+						} else if yym866 {
 							z.EncBinaryMarshal(x.StartTime)
-						} else if !yym819 && z.IsJSONHandle() {
+						} else if !yym866 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.StartTime)
 						} else {
 							z.EncFallback(x.StartTime)
@@ -9599,19 +10185,19 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr813 || yy2arr813 {
+			if yyr860 || yy2arr860 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq813[2] {
+				if yyq860[2] {
 					if x.CompletionTime == nil {
 						r.EncodeNil()
 					} else {
-						yym821 := z.EncBinary()
-						_ = yym821
+						yym868 := z.EncBinary()
+						_ = yym868
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.CompletionTime) {
-						} else if yym821 {
+						} else if yym868 {
 							z.EncBinaryMarshal(x.CompletionTime)
-						} else if !yym821 && z.IsJSONHandle() {
+						} else if !yym868 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.CompletionTime)
 						} else {
 							z.EncFallback(x.CompletionTime)
@@ -9621,20 +10207,20 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq813[2] {
+				if yyq860[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("completionTime"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.CompletionTime == nil {
 						r.EncodeNil()
 					} else {
-						yym822 := z.EncBinary()
-						_ = yym822
+						yym869 := z.EncBinary()
+						_ = yym869
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.CompletionTime) {
-						} else if yym822 {
+						} else if yym869 {
 							z.EncBinaryMarshal(x.CompletionTime)
-						} else if !yym822 && z.IsJSONHandle() {
+						} else if !yym869 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.CompletionTime)
 						} else {
 							z.EncFallback(x.CompletionTime)
@@ -9642,11 +10228,11 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr813 || yy2arr813 {
+			if yyr860 || yy2arr860 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq813[3] {
-					yym824 := z.EncBinary()
-					_ = yym824
+				if yyq860[3] {
+					yym871 := z.EncBinary()
+					_ = yym871
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Active))
@@ -9655,23 +10241,23 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq813[3] {
+				if yyq860[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("active"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym825 := z.EncBinary()
-					_ = yym825
+					yym872 := z.EncBinary()
+					_ = yym872
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Active))
 					}
 				}
 			}
-			if yyr813 || yy2arr813 {
+			if yyr860 || yy2arr860 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq813[4] {
-					yym827 := z.EncBinary()
-					_ = yym827
+				if yyq860[4] {
+					yym874 := z.EncBinary()
+					_ = yym874
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Succeeded))
@@ -9680,23 +10266,23 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq813[4] {
+				if yyq860[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("succeeded"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym828 := z.EncBinary()
-					_ = yym828
+					yym875 := z.EncBinary()
+					_ = yym875
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Succeeded))
 					}
 				}
 			}
-			if yyr813 || yy2arr813 {
+			if yyr860 || yy2arr860 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq813[5] {
-					yym830 := z.EncBinary()
-					_ = yym830
+				if yyq860[5] {
+					yym877 := z.EncBinary()
+					_ = yym877
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Failed))
@@ -9705,19 +10291,19 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq813[5] {
+				if yyq860[5] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("failed"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym831 := z.EncBinary()
-					_ = yym831
+					yym878 := z.EncBinary()
+					_ = yym878
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Failed))
 					}
 				}
 			}
-			if yyr813 || yy2arr813 {
+			if yyr860 || yy2arr860 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -9730,25 +10316,25 @@ func (x *JobStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym832 := z.DecBinary()
-	_ = yym832
+	yym879 := z.DecBinary()
+	_ = yym879
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct833 := r.ContainerType()
-		if yyct833 == codecSelferValueTypeMap1234 {
-			yyl833 := r.ReadMapStart()
-			if yyl833 == 0 {
+		yyct880 := r.ContainerType()
+		if yyct880 == codecSelferValueTypeMap1234 {
+			yyl880 := r.ReadMapStart()
+			if yyl880 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl833, d)
+				x.codecDecodeSelfFromMap(yyl880, d)
 			}
-		} else if yyct833 == codecSelferValueTypeArray1234 {
-			yyl833 := r.ReadArrayStart()
-			if yyl833 == 0 {
+		} else if yyct880 == codecSelferValueTypeArray1234 {
+			yyl880 := r.ReadArrayStart()
+			if yyl880 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl833, d)
+				x.codecDecodeSelfFromArray(yyl880, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -9760,12 +10346,12 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys834Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys834Slc
-	var yyhl834 bool = l >= 0
-	for yyj834 := 0; ; yyj834++ {
-		if yyhl834 {
-			if yyj834 >= l {
+	var yys881Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys881Slc
+	var yyhl881 bool = l >= 0
+	for yyj881 := 0; ; yyj881++ {
+		if yyhl881 {
+			if yyj881 >= l {
 				break
 			}
 		} else {
@@ -9774,20 +10360,20 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys834Slc = r.DecodeBytes(yys834Slc, true, true)
-		yys834 := string(yys834Slc)
+		yys881Slc = r.DecodeBytes(yys881Slc, true, true)
+		yys881 := string(yys881Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys834 {
+		switch yys881 {
 		case "conditions":
 			if r.TryDecodeAsNil() {
 				x.Conditions = nil
 			} else {
-				yyv835 := &x.Conditions
-				yym836 := z.DecBinary()
-				_ = yym836
+				yyv882 := &x.Conditions
+				yym883 := z.DecBinary()
+				_ = yym883
 				if false {
 				} else {
-					h.decSliceJobCondition((*[]JobCondition)(yyv835), d)
+					h.decSliceJobCondition((*[]JobCondition)(yyv882), d)
 				}
 			}
 		case "startTime":
@@ -9799,13 +10385,13 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.StartTime == nil {
 					x.StartTime = new(pkg1_unversioned.Time)
 				}
-				yym838 := z.DecBinary()
-				_ = yym838
+				yym885 := z.DecBinary()
+				_ = yym885
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.StartTime) {
-				} else if yym838 {
+				} else if yym885 {
 					z.DecBinaryUnmarshal(x.StartTime)
-				} else if !yym838 && z.IsJSONHandle() {
+				} else if !yym885 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.StartTime)
 				} else {
 					z.DecFallback(x.StartTime, false)
@@ -9820,13 +10406,13 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.CompletionTime == nil {
 					x.CompletionTime = new(pkg1_unversioned.Time)
 				}
-				yym840 := z.DecBinary()
-				_ = yym840
+				yym887 := z.DecBinary()
+				_ = yym887
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.CompletionTime) {
-				} else if yym840 {
+				} else if yym887 {
 					z.DecBinaryUnmarshal(x.CompletionTime)
-				} else if !yym840 && z.IsJSONHandle() {
+				} else if !yym887 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.CompletionTime)
 				} else {
 					z.DecFallback(x.CompletionTime, false)
@@ -9851,9 +10437,9 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Failed = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys834)
-		} // end switch yys834
-	} // end for yyj834
+			z.DecStructFieldNotFound(-1, yys881)
+		} // end switch yys881
+	} // end for yyj881
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -9861,16 +10447,16 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj844 int
-	var yyb844 bool
-	var yyhl844 bool = l >= 0
-	yyj844++
-	if yyhl844 {
-		yyb844 = yyj844 > l
+	var yyj891 int
+	var yyb891 bool
+	var yyhl891 bool = l >= 0
+	yyj891++
+	if yyhl891 {
+		yyb891 = yyj891 > l
 	} else {
-		yyb844 = r.CheckBreak()
+		yyb891 = r.CheckBreak()
 	}
-	if yyb844 {
+	if yyb891 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9878,21 +10464,21 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Conditions = nil
 	} else {
-		yyv845 := &x.Conditions
-		yym846 := z.DecBinary()
-		_ = yym846
+		yyv892 := &x.Conditions
+		yym893 := z.DecBinary()
+		_ = yym893
 		if false {
 		} else {
-			h.decSliceJobCondition((*[]JobCondition)(yyv845), d)
+			h.decSliceJobCondition((*[]JobCondition)(yyv892), d)
 		}
 	}
-	yyj844++
-	if yyhl844 {
-		yyb844 = yyj844 > l
+	yyj891++
+	if yyhl891 {
+		yyb891 = yyj891 > l
 	} else {
-		yyb844 = r.CheckBreak()
+		yyb891 = r.CheckBreak()
 	}
-	if yyb844 {
+	if yyb891 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9905,25 +10491,25 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.StartTime == nil {
 			x.StartTime = new(pkg1_unversioned.Time)
 		}
-		yym848 := z.DecBinary()
-		_ = yym848
+		yym895 := z.DecBinary()
+		_ = yym895
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.StartTime) {
-		} else if yym848 {
+		} else if yym895 {
 			z.DecBinaryUnmarshal(x.StartTime)
-		} else if !yym848 && z.IsJSONHandle() {
+		} else if !yym895 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.StartTime)
 		} else {
 			z.DecFallback(x.StartTime, false)
 		}
 	}
-	yyj844++
-	if yyhl844 {
-		yyb844 = yyj844 > l
+	yyj891++
+	if yyhl891 {
+		yyb891 = yyj891 > l
 	} else {
-		yyb844 = r.CheckBreak()
+		yyb891 = r.CheckBreak()
 	}
-	if yyb844 {
+	if yyb891 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9936,25 +10522,25 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.CompletionTime == nil {
 			x.CompletionTime = new(pkg1_unversioned.Time)
 		}
-		yym850 := z.DecBinary()
-		_ = yym850
+		yym897 := z.DecBinary()
+		_ = yym897
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.CompletionTime) {
-		} else if yym850 {
+		} else if yym897 {
 			z.DecBinaryUnmarshal(x.CompletionTime)
-		} else if !yym850 && z.IsJSONHandle() {
+		} else if !yym897 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.CompletionTime)
 		} else {
 			z.DecFallback(x.CompletionTime, false)
 		}
 	}
-	yyj844++
-	if yyhl844 {
-		yyb844 = yyj844 > l
+	yyj891++
+	if yyhl891 {
+		yyb891 = yyj891 > l
 	} else {
-		yyb844 = r.CheckBreak()
+		yyb891 = r.CheckBreak()
 	}
-	if yyb844 {
+	if yyb891 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9964,13 +10550,13 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Active = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj844++
-	if yyhl844 {
-		yyb844 = yyj844 > l
+	yyj891++
+	if yyhl891 {
+		yyb891 = yyj891 > l
 	} else {
-		yyb844 = r.CheckBreak()
+		yyb891 = r.CheckBreak()
 	}
-	if yyb844 {
+	if yyb891 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9980,13 +10566,13 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Succeeded = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj844++
-	if yyhl844 {
-		yyb844 = yyj844 > l
+	yyj891++
+	if yyhl891 {
+		yyb891 = yyj891 > l
 	} else {
-		yyb844 = r.CheckBreak()
+		yyb891 = r.CheckBreak()
 	}
-	if yyb844 {
+	if yyb891 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9997,17 +10583,17 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Failed = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj844++
-		if yyhl844 {
-			yyb844 = yyj844 > l
+		yyj891++
+		if yyhl891 {
+			yyb891 = yyj891 > l
 		} else {
-			yyb844 = r.CheckBreak()
+			yyb891 = r.CheckBreak()
 		}
-		if yyb844 {
+		if yyb891 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj844-1, "")
+		z.DecStructFieldNotFound(yyj891-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -10016,8 +10602,8 @@ func (x JobConditionType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym854 := z.EncBinary()
-	_ = yym854
+	yym901 := z.EncBinary()
+	_ = yym901
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -10029,8 +10615,8 @@ func (x *JobConditionType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym855 := z.DecBinary()
-	_ = yym855
+	yym902 := z.DecBinary()
+	_ = yym902
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -10045,34 +10631,34 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym856 := z.EncBinary()
-		_ = yym856
+		yym903 := z.EncBinary()
+		_ = yym903
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep857 := !z.EncBinary()
-			yy2arr857 := z.EncBasicHandle().StructToArray
-			var yyq857 [6]bool
-			_, _, _ = yysep857, yyq857, yy2arr857
-			const yyr857 bool = false
-			yyq857[2] = true
-			yyq857[3] = true
-			yyq857[4] = x.Reason != ""
-			yyq857[5] = x.Message != ""
-			var yynn857 int
-			if yyr857 || yy2arr857 {
+			yysep904 := !z.EncBinary()
+			yy2arr904 := z.EncBasicHandle().StructToArray
+			var yyq904 [6]bool
+			_, _, _ = yysep904, yyq904, yy2arr904
+			const yyr904 bool = false
+			yyq904[2] = true
+			yyq904[3] = true
+			yyq904[4] = x.Reason != ""
+			yyq904[5] = x.Message != ""
+			var yynn904 int
+			if yyr904 || yy2arr904 {
 				r.EncodeArrayStart(6)
 			} else {
-				yynn857 = 2
-				for _, b := range yyq857 {
+				yynn904 = 2
+				for _, b := range yyq904 {
 					if b {
-						yynn857++
+						yynn904++
 					}
 				}
-				r.EncodeMapStart(yynn857)
-				yynn857 = 0
+				r.EncodeMapStart(yynn904)
+				yynn904 = 0
 			}
-			if yyr857 || yy2arr857 {
+			if yyr904 || yy2arr904 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Type.CodecEncodeSelf(e)
 			} else {
@@ -10081,10 +10667,10 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Type.CodecEncodeSelf(e)
 			}
-			if yyr857 || yy2arr857 {
+			if yyr904 || yy2arr904 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym860 := z.EncBinary()
-				_ = yym860
+				yym907 := z.EncBinary()
+				_ = yym907
 				if false {
 				} else if z.HasExtensions() && z.EncExt(x.Status) {
 				} else {
@@ -10094,93 +10680,93 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("status"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym861 := z.EncBinary()
-				_ = yym861
+				yym908 := z.EncBinary()
+				_ = yym908
 				if false {
 				} else if z.HasExtensions() && z.EncExt(x.Status) {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Status))
 				}
 			}
-			if yyr857 || yy2arr857 {
+			if yyr904 || yy2arr904 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq857[2] {
-					yy863 := &x.LastProbeTime
-					yym864 := z.EncBinary()
-					_ = yym864
+				if yyq904[2] {
+					yy910 := &x.LastProbeTime
+					yym911 := z.EncBinary()
+					_ = yym911
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy863) {
-					} else if yym864 {
-						z.EncBinaryMarshal(yy863)
-					} else if !yym864 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy863)
+					} else if z.HasExtensions() && z.EncExt(yy910) {
+					} else if yym911 {
+						z.EncBinaryMarshal(yy910)
+					} else if !yym911 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy910)
 					} else {
-						z.EncFallback(yy863)
+						z.EncFallback(yy910)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq857[2] {
+				if yyq904[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("lastProbeTime"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy865 := &x.LastProbeTime
-					yym866 := z.EncBinary()
-					_ = yym866
+					yy912 := &x.LastProbeTime
+					yym913 := z.EncBinary()
+					_ = yym913
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy865) {
-					} else if yym866 {
-						z.EncBinaryMarshal(yy865)
-					} else if !yym866 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy865)
+					} else if z.HasExtensions() && z.EncExt(yy912) {
+					} else if yym913 {
+						z.EncBinaryMarshal(yy912)
+					} else if !yym913 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy912)
 					} else {
-						z.EncFallback(yy865)
+						z.EncFallback(yy912)
 					}
 				}
 			}
-			if yyr857 || yy2arr857 {
+			if yyr904 || yy2arr904 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq857[3] {
-					yy868 := &x.LastTransitionTime
-					yym869 := z.EncBinary()
-					_ = yym869
+				if yyq904[3] {
+					yy915 := &x.LastTransitionTime
+					yym916 := z.EncBinary()
+					_ = yym916
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy868) {
-					} else if yym869 {
-						z.EncBinaryMarshal(yy868)
-					} else if !yym869 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy868)
+					} else if z.HasExtensions() && z.EncExt(yy915) {
+					} else if yym916 {
+						z.EncBinaryMarshal(yy915)
+					} else if !yym916 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy915)
 					} else {
-						z.EncFallback(yy868)
+						z.EncFallback(yy915)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq857[3] {
+				if yyq904[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("lastTransitionTime"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy870 := &x.LastTransitionTime
-					yym871 := z.EncBinary()
-					_ = yym871
+					yy917 := &x.LastTransitionTime
+					yym918 := z.EncBinary()
+					_ = yym918
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy870) {
-					} else if yym871 {
-						z.EncBinaryMarshal(yy870)
-					} else if !yym871 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy870)
+					} else if z.HasExtensions() && z.EncExt(yy917) {
+					} else if yym918 {
+						z.EncBinaryMarshal(yy917)
+					} else if !yym918 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy917)
 					} else {
-						z.EncFallback(yy870)
+						z.EncFallback(yy917)
 					}
 				}
 			}
-			if yyr857 || yy2arr857 {
+			if yyr904 || yy2arr904 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq857[4] {
-					yym873 := z.EncBinary()
-					_ = yym873
+				if yyq904[4] {
+					yym920 := z.EncBinary()
+					_ = yym920
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
@@ -10189,23 +10775,23 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq857[4] {
+				if yyq904[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("reason"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym874 := z.EncBinary()
-					_ = yym874
+					yym921 := z.EncBinary()
+					_ = yym921
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
 					}
 				}
 			}
-			if yyr857 || yy2arr857 {
+			if yyr904 || yy2arr904 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq857[5] {
-					yym876 := z.EncBinary()
-					_ = yym876
+				if yyq904[5] {
+					yym923 := z.EncBinary()
+					_ = yym923
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
@@ -10214,19 +10800,19 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq857[5] {
+				if yyq904[5] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym877 := z.EncBinary()
-					_ = yym877
+					yym924 := z.EncBinary()
+					_ = yym924
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
 					}
 				}
 			}
-			if yyr857 || yy2arr857 {
+			if yyr904 || yy2arr904 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -10239,25 +10825,25 @@ func (x *JobCondition) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym878 := z.DecBinary()
-	_ = yym878
+	yym925 := z.DecBinary()
+	_ = yym925
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct879 := r.ContainerType()
-		if yyct879 == codecSelferValueTypeMap1234 {
-			yyl879 := r.ReadMapStart()
-			if yyl879 == 0 {
+		yyct926 := r.ContainerType()
+		if yyct926 == codecSelferValueTypeMap1234 {
+			yyl926 := r.ReadMapStart()
+			if yyl926 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl879, d)
+				x.codecDecodeSelfFromMap(yyl926, d)
 			}
-		} else if yyct879 == codecSelferValueTypeArray1234 {
-			yyl879 := r.ReadArrayStart()
-			if yyl879 == 0 {
+		} else if yyct926 == codecSelferValueTypeArray1234 {
+			yyl926 := r.ReadArrayStart()
+			if yyl926 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl879, d)
+				x.codecDecodeSelfFromArray(yyl926, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10269,12 +10855,12 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys880Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys880Slc
-	var yyhl880 bool = l >= 0
-	for yyj880 := 0; ; yyj880++ {
-		if yyhl880 {
-			if yyj880 >= l {
+	var yys927Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys927Slc
+	var yyhl927 bool = l >= 0
+	for yyj927 := 0; ; yyj927++ {
+		if yyhl927 {
+			if yyj927 >= l {
 				break
 			}
 		} else {
@@ -10283,10 +10869,10 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys880Slc = r.DecodeBytes(yys880Slc, true, true)
-		yys880 := string(yys880Slc)
+		yys927Slc = r.DecodeBytes(yys927Slc, true, true)
+		yys927 := string(yys927Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys880 {
+		switch yys927 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -10303,34 +10889,34 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.LastProbeTime = pkg1_unversioned.Time{}
 			} else {
-				yyv883 := &x.LastProbeTime
-				yym884 := z.DecBinary()
-				_ = yym884
+				yyv930 := &x.LastProbeTime
+				yym931 := z.DecBinary()
+				_ = yym931
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv883) {
-				} else if yym884 {
-					z.DecBinaryUnmarshal(yyv883)
-				} else if !yym884 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv883)
+				} else if z.HasExtensions() && z.DecExt(yyv930) {
+				} else if yym931 {
+					z.DecBinaryUnmarshal(yyv930)
+				} else if !yym931 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv930)
 				} else {
-					z.DecFallback(yyv883, false)
+					z.DecFallback(yyv930, false)
 				}
 			}
 		case "lastTransitionTime":
 			if r.TryDecodeAsNil() {
 				x.LastTransitionTime = pkg1_unversioned.Time{}
 			} else {
-				yyv885 := &x.LastTransitionTime
-				yym886 := z.DecBinary()
-				_ = yym886
+				yyv932 := &x.LastTransitionTime
+				yym933 := z.DecBinary()
+				_ = yym933
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv885) {
-				} else if yym886 {
-					z.DecBinaryUnmarshal(yyv885)
-				} else if !yym886 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv885)
+				} else if z.HasExtensions() && z.DecExt(yyv932) {
+				} else if yym933 {
+					z.DecBinaryUnmarshal(yyv932)
+				} else if !yym933 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv932)
 				} else {
-					z.DecFallback(yyv885, false)
+					z.DecFallback(yyv932, false)
 				}
 			}
 		case "reason":
@@ -10346,9 +10932,9 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Message = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys880)
-		} // end switch yys880
-	} // end for yyj880
+			z.DecStructFieldNotFound(-1, yys927)
+		} // end switch yys927
+	} // end for yyj927
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -10356,16 +10942,16 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj889 int
-	var yyb889 bool
-	var yyhl889 bool = l >= 0
-	yyj889++
-	if yyhl889 {
-		yyb889 = yyj889 > l
+	var yyj936 int
+	var yyb936 bool
+	var yyhl936 bool = l >= 0
+	yyj936++
+	if yyhl936 {
+		yyb936 = yyj936 > l
 	} else {
-		yyb889 = r.CheckBreak()
+		yyb936 = r.CheckBreak()
 	}
-	if yyb889 {
+	if yyb936 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10375,13 +10961,13 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Type = JobConditionType(r.DecodeString())
 	}
-	yyj889++
-	if yyhl889 {
-		yyb889 = yyj889 > l
+	yyj936++
+	if yyhl936 {
+		yyb936 = yyj936 > l
 	} else {
-		yyb889 = r.CheckBreak()
+		yyb936 = r.CheckBreak()
 	}
-	if yyb889 {
+	if yyb936 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10391,13 +10977,13 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Status = pkg2_api.ConditionStatus(r.DecodeString())
 	}
-	yyj889++
-	if yyhl889 {
-		yyb889 = yyj889 > l
+	yyj936++
+	if yyhl936 {
+		yyb936 = yyj936 > l
 	} else {
-		yyb889 = r.CheckBreak()
+		yyb936 = r.CheckBreak()
 	}
-	if yyb889 {
+	if yyb936 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10405,26 +10991,26 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.LastProbeTime = pkg1_unversioned.Time{}
 	} else {
-		yyv892 := &x.LastProbeTime
-		yym893 := z.DecBinary()
-		_ = yym893
+		yyv939 := &x.LastProbeTime
+		yym940 := z.DecBinary()
+		_ = yym940
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv892) {
-		} else if yym893 {
-			z.DecBinaryUnmarshal(yyv892)
-		} else if !yym893 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv892)
+		} else if z.HasExtensions() && z.DecExt(yyv939) {
+		} else if yym940 {
+			z.DecBinaryUnmarshal(yyv939)
+		} else if !yym940 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv939)
 		} else {
-			z.DecFallback(yyv892, false)
+			z.DecFallback(yyv939, false)
 		}
 	}
-	yyj889++
-	if yyhl889 {
-		yyb889 = yyj889 > l
+	yyj936++
+	if yyhl936 {
+		yyb936 = yyj936 > l
 	} else {
-		yyb889 = r.CheckBreak()
+		yyb936 = r.CheckBreak()
 	}
-	if yyb889 {
+	if yyb936 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10432,26 +11018,26 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.LastTransitionTime = pkg1_unversioned.Time{}
 	} else {
-		yyv894 := &x.LastTransitionTime
-		yym895 := z.DecBinary()
-		_ = yym895
+		yyv941 := &x.LastTransitionTime
+		yym942 := z.DecBinary()
+		_ = yym942
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv894) {
-		} else if yym895 {
-			z.DecBinaryUnmarshal(yyv894)
-		} else if !yym895 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv894)
+		} else if z.HasExtensions() && z.DecExt(yyv941) {
+		} else if yym942 {
+			z.DecBinaryUnmarshal(yyv941)
+		} else if !yym942 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv941)
 		} else {
-			z.DecFallback(yyv894, false)
+			z.DecFallback(yyv941, false)
 		}
 	}
-	yyj889++
-	if yyhl889 {
-		yyb889 = yyj889 > l
+	yyj936++
+	if yyhl936 {
+		yyb936 = yyj936 > l
 	} else {
-		yyb889 = r.CheckBreak()
+		yyb936 = r.CheckBreak()
 	}
-	if yyb889 {
+	if yyb936 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10461,13 +11047,13 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Reason = string(r.DecodeString())
 	}
-	yyj889++
-	if yyhl889 {
-		yyb889 = yyj889 > l
+	yyj936++
+	if yyhl936 {
+		yyb936 = yyj936 > l
 	} else {
-		yyb889 = r.CheckBreak()
+		yyb936 = r.CheckBreak()
 	}
-	if yyb889 {
+	if yyb936 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10478,17 +11064,17 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Message = string(r.DecodeString())
 	}
 	for {
-		yyj889++
-		if yyhl889 {
-			yyb889 = yyj889 > l
+		yyj936++
+		if yyhl936 {
+			yyb936 = yyj936 > l
 		} else {
-			yyb889 = r.CheckBreak()
+			yyb936 = r.CheckBreak()
 		}
-		if yyb889 {
+		if yyb936 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj889-1, "")
+		z.DecStructFieldNotFound(yyj936-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -10500,39 +11086,39 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym898 := z.EncBinary()
-		_ = yym898
+		yym945 := z.EncBinary()
+		_ = yym945
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep899 := !z.EncBinary()
-			yy2arr899 := z.EncBasicHandle().StructToArray
-			var yyq899 [5]bool
-			_, _, _ = yysep899, yyq899, yy2arr899
-			const yyr899 bool = false
-			yyq899[0] = x.Kind != ""
-			yyq899[1] = x.APIVersion != ""
-			yyq899[2] = true
-			yyq899[3] = true
-			yyq899[4] = true
-			var yynn899 int
-			if yyr899 || yy2arr899 {
+			yysep946 := !z.EncBinary()
+			yy2arr946 := z.EncBasicHandle().StructToArray
+			var yyq946 [5]bool
+			_, _, _ = yysep946, yyq946, yy2arr946
+			const yyr946 bool = false
+			yyq946[0] = x.Kind != ""
+			yyq946[1] = x.APIVersion != ""
+			yyq946[2] = true
+			yyq946[3] = true
+			yyq946[4] = true
+			var yynn946 int
+			if yyr946 || yy2arr946 {
 				r.EncodeArrayStart(5)
 			} else {
-				yynn899 = 0
-				for _, b := range yyq899 {
+				yynn946 = 0
+				for _, b := range yyq946 {
 					if b {
-						yynn899++
+						yynn946++
 					}
 				}
-				r.EncodeMapStart(yynn899)
-				yynn899 = 0
+				r.EncodeMapStart(yynn946)
+				yynn946 = 0
 			}
-			if yyr899 || yy2arr899 {
+			if yyr946 || yy2arr946 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq899[0] {
-					yym901 := z.EncBinary()
-					_ = yym901
+				if yyq946[0] {
+					yym948 := z.EncBinary()
+					_ = yym948
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -10541,23 +11127,23 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq899[0] {
+				if yyq946[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym902 := z.EncBinary()
-					_ = yym902
+					yym949 := z.EncBinary()
+					_ = yym949
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr899 || yy2arr899 {
+			if yyr946 || yy2arr946 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq899[1] {
-					yym904 := z.EncBinary()
-					_ = yym904
+				if yyq946[1] {
+					yym951 := z.EncBinary()
+					_ = yym951
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -10566,70 +11152,70 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq899[1] {
+				if yyq946[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym905 := z.EncBinary()
-					_ = yym905
+					yym952 := z.EncBinary()
+					_ = yym952
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr899 || yy2arr899 {
+			if yyr946 || yy2arr946 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq899[2] {
-					yy907 := &x.ObjectMeta
-					yy907.CodecEncodeSelf(e)
+				if yyq946[2] {
+					yy954 := &x.ObjectMeta
+					yy954.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq899[2] {
+				if yyq946[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy908 := &x.ObjectMeta
-					yy908.CodecEncodeSelf(e)
+					yy955 := &x.ObjectMeta
+					yy955.CodecEncodeSelf(e)
 				}
 			}
-			if yyr899 || yy2arr899 {
+			if yyr946 || yy2arr946 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq899[3] {
-					yy910 := &x.Spec
-					yy910.CodecEncodeSelf(e)
+				if yyq946[3] {
+					yy957 := &x.Spec
+					yy957.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq899[3] {
+				if yyq946[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy911 := &x.Spec
-					yy911.CodecEncodeSelf(e)
+					yy958 := &x.Spec
+					yy958.CodecEncodeSelf(e)
 				}
 			}
-			if yyr899 || yy2arr899 {
+			if yyr946 || yy2arr946 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq899[4] {
-					yy913 := &x.Status
-					yy913.CodecEncodeSelf(e)
+				if yyq946[4] {
+					yy960 := &x.Status
+					yy960.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq899[4] {
+				if yyq946[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy914 := &x.Status
-					yy914.CodecEncodeSelf(e)
+					yy961 := &x.Status
+					yy961.CodecEncodeSelf(e)
 				}
 			}
-			if yyr899 || yy2arr899 {
+			if yyr946 || yy2arr946 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -10642,25 +11228,25 @@ func (x *Ingress) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym915 := z.DecBinary()
-	_ = yym915
+	yym962 := z.DecBinary()
+	_ = yym962
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct916 := r.ContainerType()
-		if yyct916 == codecSelferValueTypeMap1234 {
-			yyl916 := r.ReadMapStart()
-			if yyl916 == 0 {
+		yyct963 := r.ContainerType()
+		if yyct963 == codecSelferValueTypeMap1234 {
+			yyl963 := r.ReadMapStart()
+			if yyl963 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl916, d)
+				x.codecDecodeSelfFromMap(yyl963, d)
 			}
-		} else if yyct916 == codecSelferValueTypeArray1234 {
-			yyl916 := r.ReadArrayStart()
-			if yyl916 == 0 {
+		} else if yyct963 == codecSelferValueTypeArray1234 {
+			yyl963 := r.ReadArrayStart()
+			if yyl963 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl916, d)
+				x.codecDecodeSelfFromArray(yyl963, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10672,12 +11258,12 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys917Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys917Slc
-	var yyhl917 bool = l >= 0
-	for yyj917 := 0; ; yyj917++ {
-		if yyhl917 {
-			if yyj917 >= l {
+	var yys964Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys964Slc
+	var yyhl964 bool = l >= 0
+	for yyj964 := 0; ; yyj964++ {
+		if yyhl964 {
+			if yyj964 >= l {
 				break
 			}
 		} else {
@@ -10686,10 +11272,10 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys917Slc = r.DecodeBytes(yys917Slc, true, true)
-		yys917 := string(yys917Slc)
+		yys964Slc = r.DecodeBytes(yys964Slc, true, true)
+		yys964 := string(yys964Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys917 {
+		switch yys964 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -10706,27 +11292,27 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv920 := &x.ObjectMeta
-				yyv920.CodecDecodeSelf(d)
+				yyv967 := &x.ObjectMeta
+				yyv967.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = IngressSpec{}
 			} else {
-				yyv921 := &x.Spec
-				yyv921.CodecDecodeSelf(d)
+				yyv968 := &x.Spec
+				yyv968.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = IngressStatus{}
 			} else {
-				yyv922 := &x.Status
-				yyv922.CodecDecodeSelf(d)
+				yyv969 := &x.Status
+				yyv969.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys917)
-		} // end switch yys917
-	} // end for yyj917
+			z.DecStructFieldNotFound(-1, yys964)
+		} // end switch yys964
+	} // end for yyj964
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -10734,16 +11320,16 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj923 int
-	var yyb923 bool
-	var yyhl923 bool = l >= 0
-	yyj923++
-	if yyhl923 {
-		yyb923 = yyj923 > l
+	var yyj970 int
+	var yyb970 bool
+	var yyhl970 bool = l >= 0
+	yyj970++
+	if yyhl970 {
+		yyb970 = yyj970 > l
 	} else {
-		yyb923 = r.CheckBreak()
+		yyb970 = r.CheckBreak()
 	}
-	if yyb923 {
+	if yyb970 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10753,13 +11339,13 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj923++
-	if yyhl923 {
-		yyb923 = yyj923 > l
+	yyj970++
+	if yyhl970 {
+		yyb970 = yyj970 > l
 	} else {
-		yyb923 = r.CheckBreak()
+		yyb970 = r.CheckBreak()
 	}
-	if yyb923 {
+	if yyb970 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10769,13 +11355,13 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj923++
-	if yyhl923 {
-		yyb923 = yyj923 > l
+	yyj970++
+	if yyhl970 {
+		yyb970 = yyj970 > l
 	} else {
-		yyb923 = r.CheckBreak()
+		yyb970 = r.CheckBreak()
 	}
-	if yyb923 {
+	if yyb970 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10783,16 +11369,16 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv926 := &x.ObjectMeta
-		yyv926.CodecDecodeSelf(d)
+		yyv973 := &x.ObjectMeta
+		yyv973.CodecDecodeSelf(d)
 	}
-	yyj923++
-	if yyhl923 {
-		yyb923 = yyj923 > l
+	yyj970++
+	if yyhl970 {
+		yyb970 = yyj970 > l
 	} else {
-		yyb923 = r.CheckBreak()
+		yyb970 = r.CheckBreak()
 	}
-	if yyb923 {
+	if yyb970 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10800,16 +11386,16 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Spec = IngressSpec{}
 	} else {
-		yyv927 := &x.Spec
-		yyv927.CodecDecodeSelf(d)
+		yyv974 := &x.Spec
+		yyv974.CodecDecodeSelf(d)
 	}
-	yyj923++
-	if yyhl923 {
-		yyb923 = yyj923 > l
+	yyj970++
+	if yyhl970 {
+		yyb970 = yyj970 > l
 	} else {
-		yyb923 = r.CheckBreak()
+		yyb970 = r.CheckBreak()
 	}
-	if yyb923 {
+	if yyb970 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10817,21 +11403,21 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Status = IngressStatus{}
 	} else {
-		yyv928 := &x.Status
-		yyv928.CodecDecodeSelf(d)
+		yyv975 := &x.Status
+		yyv975.CodecDecodeSelf(d)
 	}
 	for {
-		yyj923++
-		if yyhl923 {
-			yyb923 = yyj923 > l
+		yyj970++
+		if yyhl970 {
+			yyb970 = yyj970 > l
 		} else {
-			yyb923 = r.CheckBreak()
+			yyb970 = r.CheckBreak()
 		}
-		if yyb923 {
+		if yyb970 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj923-1, "")
+		z.DecStructFieldNotFound(yyj970-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -10843,37 +11429,37 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym929 := z.EncBinary()
-		_ = yym929
+		yym976 := z.EncBinary()
+		_ = yym976
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep930 := !z.EncBinary()
-			yy2arr930 := z.EncBasicHandle().StructToArray
-			var yyq930 [4]bool
-			_, _, _ = yysep930, yyq930, yy2arr930
-			const yyr930 bool = false
-			yyq930[0] = x.Kind != ""
-			yyq930[1] = x.APIVersion != ""
-			yyq930[2] = true
-			var yynn930 int
-			if yyr930 || yy2arr930 {
+			yysep977 := !z.EncBinary()
+			yy2arr977 := z.EncBasicHandle().StructToArray
+			var yyq977 [4]bool
+			_, _, _ = yysep977, yyq977, yy2arr977
+			const yyr977 bool = false
+			yyq977[0] = x.Kind != ""
+			yyq977[1] = x.APIVersion != ""
+			yyq977[2] = true
+			var yynn977 int
+			if yyr977 || yy2arr977 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn930 = 1
-				for _, b := range yyq930 {
+				yynn977 = 1
+				for _, b := range yyq977 {
 					if b {
-						yynn930++
+						yynn977++
 					}
 				}
-				r.EncodeMapStart(yynn930)
-				yynn930 = 0
+				r.EncodeMapStart(yynn977)
+				yynn977 = 0
 			}
-			if yyr930 || yy2arr930 {
+			if yyr977 || yy2arr977 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq930[0] {
-					yym932 := z.EncBinary()
-					_ = yym932
+				if yyq977[0] {
+					yym979 := z.EncBinary()
+					_ = yym979
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -10882,23 +11468,23 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq930[0] {
+				if yyq977[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym933 := z.EncBinary()
-					_ = yym933
+					yym980 := z.EncBinary()
+					_ = yym980
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr930 || yy2arr930 {
+			if yyr977 || yy2arr977 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq930[1] {
-					yym935 := z.EncBinary()
-					_ = yym935
+				if yyq977[1] {
+					yym982 := z.EncBinary()
+					_ = yym982
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -10907,54 +11493,54 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq930[1] {
+				if yyq977[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym936 := z.EncBinary()
-					_ = yym936
+					yym983 := z.EncBinary()
+					_ = yym983
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr930 || yy2arr930 {
+			if yyr977 || yy2arr977 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq930[2] {
-					yy938 := &x.ListMeta
-					yym939 := z.EncBinary()
-					_ = yym939
+				if yyq977[2] {
+					yy985 := &x.ListMeta
+					yym986 := z.EncBinary()
+					_ = yym986
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy938) {
+					} else if z.HasExtensions() && z.EncExt(yy985) {
 					} else {
-						z.EncFallback(yy938)
+						z.EncFallback(yy985)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq930[2] {
+				if yyq977[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy940 := &x.ListMeta
-					yym941 := z.EncBinary()
-					_ = yym941
+					yy987 := &x.ListMeta
+					yym988 := z.EncBinary()
+					_ = yym988
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy940) {
+					} else if z.HasExtensions() && z.EncExt(yy987) {
 					} else {
-						z.EncFallback(yy940)
+						z.EncFallback(yy987)
 					}
 				}
 			}
-			if yyr930 || yy2arr930 {
+			if yyr977 || yy2arr977 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym943 := z.EncBinary()
-					_ = yym943
+					yym990 := z.EncBinary()
+					_ = yym990
 					if false {
 					} else {
 						h.encSliceIngress(([]Ingress)(x.Items), e)
@@ -10967,15 +11553,15 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym944 := z.EncBinary()
-					_ = yym944
+					yym991 := z.EncBinary()
+					_ = yym991
 					if false {
 					} else {
 						h.encSliceIngress(([]Ingress)(x.Items), e)
 					}
 				}
 			}
-			if yyr930 || yy2arr930 {
+			if yyr977 || yy2arr977 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -10988,25 +11574,25 @@ func (x *IngressList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym945 := z.DecBinary()
-	_ = yym945
+	yym992 := z.DecBinary()
+	_ = yym992
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct946 := r.ContainerType()
-		if yyct946 == codecSelferValueTypeMap1234 {
-			yyl946 := r.ReadMapStart()
-			if yyl946 == 0 {
+		yyct993 := r.ContainerType()
+		if yyct993 == codecSelferValueTypeMap1234 {
+			yyl993 := r.ReadMapStart()
+			if yyl993 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl946, d)
+				x.codecDecodeSelfFromMap(yyl993, d)
 			}
-		} else if yyct946 == codecSelferValueTypeArray1234 {
-			yyl946 := r.ReadArrayStart()
-			if yyl946 == 0 {
+		} else if yyct993 == codecSelferValueTypeArray1234 {
+			yyl993 := r.ReadArrayStart()
+			if yyl993 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl946, d)
+				x.codecDecodeSelfFromArray(yyl993, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -11018,12 +11604,12 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys947Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys947Slc
-	var yyhl947 bool = l >= 0
-	for yyj947 := 0; ; yyj947++ {
-		if yyhl947 {
-			if yyj947 >= l {
+	var yys994Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys994Slc
+	var yyhl994 bool = l >= 0
+	for yyj994 := 0; ; yyj994++ {
+		if yyhl994 {
+			if yyj994 >= l {
 				break
 			}
 		} else {
@@ -11032,10 +11618,10 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys947Slc = r.DecodeBytes(yys947Slc, true, true)
-		yys947 := string(yys947Slc)
+		yys994Slc = r.DecodeBytes(yys994Slc, true, true)
+		yys994 := string(yys994Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys947 {
+		switch yys994 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -11052,31 +11638,31 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv950 := &x.ListMeta
-				yym951 := z.DecBinary()
-				_ = yym951
+				yyv997 := &x.ListMeta
+				yym998 := z.DecBinary()
+				_ = yym998
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv950) {
+				} else if z.HasExtensions() && z.DecExt(yyv997) {
 				} else {
-					z.DecFallback(yyv950, false)
+					z.DecFallback(yyv997, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv952 := &x.Items
-				yym953 := z.DecBinary()
-				_ = yym953
+				yyv999 := &x.Items
+				yym1000 := z.DecBinary()
+				_ = yym1000
 				if false {
 				} else {
-					h.decSliceIngress((*[]Ingress)(yyv952), d)
+					h.decSliceIngress((*[]Ingress)(yyv999), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys947)
-		} // end switch yys947
-	} // end for yyj947
+			z.DecStructFieldNotFound(-1, yys994)
+		} // end switch yys994
+	} // end for yyj994
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -11084,16 +11670,16 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj954 int
-	var yyb954 bool
-	var yyhl954 bool = l >= 0
-	yyj954++
-	if yyhl954 {
-		yyb954 = yyj954 > l
+	var yyj1001 int
+	var yyb1001 bool
+	var yyhl1001 bool = l >= 0
+	yyj1001++
+	if yyhl1001 {
+		yyb1001 = yyj1001 > l
 	} else {
-		yyb954 = r.CheckBreak()
+		yyb1001 = r.CheckBreak()
 	}
-	if yyb954 {
+	if yyb1001 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11103,13 +11689,13 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj954++
-	if yyhl954 {
-		yyb954 = yyj954 > l
+	yyj1001++
+	if yyhl1001 {
+		yyb1001 = yyj1001 > l
 	} else {
-		yyb954 = r.CheckBreak()
+		yyb1001 = r.CheckBreak()
 	}
-	if yyb954 {
+	if yyb1001 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11119,13 +11705,13 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj954++
-	if yyhl954 {
-		yyb954 = yyj954 > l
+	yyj1001++
+	if yyhl1001 {
+		yyb1001 = yyj1001 > l
 	} else {
-		yyb954 = r.CheckBreak()
+		yyb1001 = r.CheckBreak()
 	}
-	if yyb954 {
+	if yyb1001 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11133,22 +11719,22 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv957 := &x.ListMeta
-		yym958 := z.DecBinary()
-		_ = yym958
+		yyv1004 := &x.ListMeta
+		yym1005 := z.DecBinary()
+		_ = yym1005
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv957) {
+		} else if z.HasExtensions() && z.DecExt(yyv1004) {
 		} else {
-			z.DecFallback(yyv957, false)
+			z.DecFallback(yyv1004, false)
 		}
 	}
-	yyj954++
-	if yyhl954 {
-		yyb954 = yyj954 > l
+	yyj1001++
+	if yyhl1001 {
+		yyb1001 = yyj1001 > l
 	} else {
-		yyb954 = r.CheckBreak()
+		yyb1001 = r.CheckBreak()
 	}
-	if yyb954 {
+	if yyb1001 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11156,26 +11742,26 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv959 := &x.Items
-		yym960 := z.DecBinary()
-		_ = yym960
+		yyv1006 := &x.Items
+		yym1007 := z.DecBinary()
+		_ = yym1007
 		if false {
 		} else {
-			h.decSliceIngress((*[]Ingress)(yyv959), d)
+			h.decSliceIngress((*[]Ingress)(yyv1006), d)
 		}
 	}
 	for {
-		yyj954++
-		if yyhl954 {
-			yyb954 = yyj954 > l
+		yyj1001++
+		if yyhl1001 {
+			yyb1001 = yyj1001 > l
 		} else {
-			yyb954 = r.CheckBreak()
+			yyb1001 = r.CheckBreak()
 		}
-		if yyb954 {
+		if yyb1001 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj954-1, "")
+		z.DecStructFieldNotFound(yyj1001-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -11187,34 +11773,34 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym961 := z.EncBinary()
-		_ = yym961
+		yym1008 := z.EncBinary()
+		_ = yym1008
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep962 := !z.EncBinary()
-			yy2arr962 := z.EncBasicHandle().StructToArray
-			var yyq962 [2]bool
-			_, _, _ = yysep962, yyq962, yy2arr962
-			const yyr962 bool = false
-			yyq962[0] = x.Backend != nil
-			yyq962[1] = len(x.Rules) != 0
-			var yynn962 int
-			if yyr962 || yy2arr962 {
+			yysep1009 := !z.EncBinary()
+			yy2arr1009 := z.EncBasicHandle().StructToArray
+			var yyq1009 [2]bool
+			_, _, _ = yysep1009, yyq1009, yy2arr1009
+			const yyr1009 bool = false
+			yyq1009[0] = x.Backend != nil
+			yyq1009[1] = len(x.Rules) != 0
+			var yynn1009 int
+			if yyr1009 || yy2arr1009 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn962 = 0
-				for _, b := range yyq962 {
+				yynn1009 = 0
+				for _, b := range yyq1009 {
 					if b {
-						yynn962++
+						yynn1009++
 					}
 				}
-				r.EncodeMapStart(yynn962)
-				yynn962 = 0
+				r.EncodeMapStart(yynn1009)
+				yynn1009 = 0
 			}
-			if yyr962 || yy2arr962 {
+			if yyr1009 || yy2arr1009 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq962[0] {
+				if yyq1009[0] {
 					if x.Backend == nil {
 						r.EncodeNil()
 					} else {
@@ -11224,7 +11810,7 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq962[0] {
+				if yyq1009[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("backend"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
@@ -11235,14 +11821,14 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr962 || yy2arr962 {
+			if yyr1009 || yy2arr1009 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq962[1] {
+				if yyq1009[1] {
 					if x.Rules == nil {
 						r.EncodeNil()
 					} else {
-						yym965 := z.EncBinary()
-						_ = yym965
+						yym1012 := z.EncBinary()
+						_ = yym1012
 						if false {
 						} else {
 							h.encSliceIngressRule(([]IngressRule)(x.Rules), e)
@@ -11252,15 +11838,15 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq962[1] {
+				if yyq1009[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("rules"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Rules == nil {
 						r.EncodeNil()
 					} else {
-						yym966 := z.EncBinary()
-						_ = yym966
+						yym1013 := z.EncBinary()
+						_ = yym1013
 						if false {
 						} else {
 							h.encSliceIngressRule(([]IngressRule)(x.Rules), e)
@@ -11268,7 +11854,7 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr962 || yy2arr962 {
+			if yyr1009 || yy2arr1009 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -11281,25 +11867,25 @@ func (x *IngressSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym967 := z.DecBinary()
-	_ = yym967
+	yym1014 := z.DecBinary()
+	_ = yym1014
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct968 := r.ContainerType()
-		if yyct968 == codecSelferValueTypeMap1234 {
-			yyl968 := r.ReadMapStart()
-			if yyl968 == 0 {
+		yyct1015 := r.ContainerType()
+		if yyct1015 == codecSelferValueTypeMap1234 {
+			yyl1015 := r.ReadMapStart()
+			if yyl1015 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl968, d)
+				x.codecDecodeSelfFromMap(yyl1015, d)
 			}
-		} else if yyct968 == codecSelferValueTypeArray1234 {
-			yyl968 := r.ReadArrayStart()
-			if yyl968 == 0 {
+		} else if yyct1015 == codecSelferValueTypeArray1234 {
+			yyl1015 := r.ReadArrayStart()
+			if yyl1015 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl968, d)
+				x.codecDecodeSelfFromArray(yyl1015, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -11311,12 +11897,12 @@ func (x *IngressSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys969Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys969Slc
-	var yyhl969 bool = l >= 0
-	for yyj969 := 0; ; yyj969++ {
-		if yyhl969 {
-			if yyj969 >= l {
+	var yys1016Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1016Slc
+	var yyhl1016 bool = l >= 0
+	for yyj1016 := 0; ; yyj1016++ {
+		if yyhl1016 {
+			if yyj1016 >= l {
 				break
 			}
 		} else {
@@ -11325,10 +11911,10 @@ func (x *IngressSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys969Slc = r.DecodeBytes(yys969Slc, true, true)
-		yys969 := string(yys969Slc)
+		yys1016Slc = r.DecodeBytes(yys1016Slc, true, true)
+		yys1016 := string(yys1016Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys969 {
+		switch yys1016 {
 		case "backend":
 			if r.TryDecodeAsNil() {
 				if x.Backend != nil {
@@ -11344,18 +11930,18 @@ func (x *IngressSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Rules = nil
 			} else {
-				yyv971 := &x.Rules
-				yym972 := z.DecBinary()
-				_ = yym972
+				yyv1018 := &x.Rules
+				yym1019 := z.DecBinary()
+				_ = yym1019
 				if false {
 				} else {
-					h.decSliceIngressRule((*[]IngressRule)(yyv971), d)
+					h.decSliceIngressRule((*[]IngressRule)(yyv1018), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys969)
-		} // end switch yys969
-	} // end for yyj969
+			z.DecStructFieldNotFound(-1, yys1016)
+		} // end switch yys1016
+	} // end for yyj1016
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -11363,16 +11949,16 @@ func (x *IngressSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj973 int
-	var yyb973 bool
-	var yyhl973 bool = l >= 0
-	yyj973++
-	if yyhl973 {
-		yyb973 = yyj973 > l
+	var yyj1020 int
+	var yyb1020 bool
+	var yyhl1020 bool = l >= 0
+	yyj1020++
+	if yyhl1020 {
+		yyb1020 = yyj1020 > l
 	} else {
-		yyb973 = r.CheckBreak()
+		yyb1020 = r.CheckBreak()
 	}
-	if yyb973 {
+	if yyb1020 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11387,13 +11973,13 @@ func (x *IngressSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Backend.CodecDecodeSelf(d)
 	}
-	yyj973++
-	if yyhl973 {
-		yyb973 = yyj973 > l
+	yyj1020++
+	if yyhl1020 {
+		yyb1020 = yyj1020 > l
 	} else {
-		yyb973 = r.CheckBreak()
+		yyb1020 = r.CheckBreak()
 	}
-	if yyb973 {
+	if yyb1020 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11401,26 +11987,26 @@ func (x *IngressSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Rules = nil
 	} else {
-		yyv975 := &x.Rules
-		yym976 := z.DecBinary()
-		_ = yym976
+		yyv1022 := &x.Rules
+		yym1023 := z.DecBinary()
+		_ = yym1023
 		if false {
 		} else {
-			h.decSliceIngressRule((*[]IngressRule)(yyv975), d)
+			h.decSliceIngressRule((*[]IngressRule)(yyv1022), d)
 		}
 	}
 	for {
-		yyj973++
-		if yyhl973 {
-			yyb973 = yyj973 > l
+		yyj1020++
+		if yyhl1020 {
+			yyb1020 = yyj1020 > l
 		} else {
-			yyb973 = r.CheckBreak()
+			yyb1020 = r.CheckBreak()
 		}
-		if yyb973 {
+		if yyb1020 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj973-1, "")
+		z.DecStructFieldNotFound(yyj1020-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -11432,48 +12018,48 @@ func (x *IngressStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym977 := z.EncBinary()
-		_ = yym977
+		yym1024 := z.EncBinary()
+		_ = yym1024
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep978 := !z.EncBinary()
-			yy2arr978 := z.EncBasicHandle().StructToArray
-			var yyq978 [1]bool
-			_, _, _ = yysep978, yyq978, yy2arr978
-			const yyr978 bool = false
-			yyq978[0] = true
-			var yynn978 int
-			if yyr978 || yy2arr978 {
+			yysep1025 := !z.EncBinary()
+			yy2arr1025 := z.EncBasicHandle().StructToArray
+			var yyq1025 [1]bool
+			_, _, _ = yysep1025, yyq1025, yy2arr1025
+			const yyr1025 bool = false
+			yyq1025[0] = true
+			var yynn1025 int
+			if yyr1025 || yy2arr1025 {
 				r.EncodeArrayStart(1)
 			} else {
-				yynn978 = 0
-				for _, b := range yyq978 {
+				yynn1025 = 0
+				for _, b := range yyq1025 {
 					if b {
-						yynn978++
+						yynn1025++
 					}
 				}
-				r.EncodeMapStart(yynn978)
-				yynn978 = 0
+				r.EncodeMapStart(yynn1025)
+				yynn1025 = 0
 			}
-			if yyr978 || yy2arr978 {
+			if yyr1025 || yy2arr1025 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq978[0] {
-					yy980 := &x.LoadBalancer
-					yy980.CodecEncodeSelf(e)
+				if yyq1025[0] {
+					yy1027 := &x.LoadBalancer
+					yy1027.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq978[0] {
+				if yyq1025[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("loadBalancer"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy981 := &x.LoadBalancer
-					yy981.CodecEncodeSelf(e)
+					yy1028 := &x.LoadBalancer
+					yy1028.CodecEncodeSelf(e)
 				}
 			}
-			if yyr978 || yy2arr978 {
+			if yyr1025 || yy2arr1025 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -11486,25 +12072,25 @@ func (x *IngressStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym982 := z.DecBinary()
-	_ = yym982
+	yym1029 := z.DecBinary()
+	_ = yym1029
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct983 := r.ContainerType()
-		if yyct983 == codecSelferValueTypeMap1234 {
-			yyl983 := r.ReadMapStart()
-			if yyl983 == 0 {
+		yyct1030 := r.ContainerType()
+		if yyct1030 == codecSelferValueTypeMap1234 {
+			yyl1030 := r.ReadMapStart()
+			if yyl1030 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl983, d)
+				x.codecDecodeSelfFromMap(yyl1030, d)
 			}
-		} else if yyct983 == codecSelferValueTypeArray1234 {
-			yyl983 := r.ReadArrayStart()
-			if yyl983 == 0 {
+		} else if yyct1030 == codecSelferValueTypeArray1234 {
+			yyl1030 := r.ReadArrayStart()
+			if yyl1030 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl983, d)
+				x.codecDecodeSelfFromArray(yyl1030, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -11516,12 +12102,12 @@ func (x *IngressStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys984Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys984Slc
-	var yyhl984 bool = l >= 0
-	for yyj984 := 0; ; yyj984++ {
-		if yyhl984 {
-			if yyj984 >= l {
+	var yys1031Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1031Slc
+	var yyhl1031 bool = l >= 0
+	for yyj1031 := 0; ; yyj1031++ {
+		if yyhl1031 {
+			if yyj1031 >= l {
 				break
 			}
 		} else {
@@ -11530,21 +12116,21 @@ func (x *IngressStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys984Slc = r.DecodeBytes(yys984Slc, true, true)
-		yys984 := string(yys984Slc)
+		yys1031Slc = r.DecodeBytes(yys1031Slc, true, true)
+		yys1031 := string(yys1031Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys984 {
+		switch yys1031 {
 		case "loadBalancer":
 			if r.TryDecodeAsNil() {
 				x.LoadBalancer = pkg2_api.LoadBalancerStatus{}
 			} else {
-				yyv985 := &x.LoadBalancer
-				yyv985.CodecDecodeSelf(d)
+				yyv1032 := &x.LoadBalancer
+				yyv1032.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys984)
-		} // end switch yys984
-	} // end for yyj984
+			z.DecStructFieldNotFound(-1, yys1031)
+		} // end switch yys1031
+	} // end for yyj1031
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -11552,16 +12138,16 @@ func (x *IngressStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj986 int
-	var yyb986 bool
-	var yyhl986 bool = l >= 0
-	yyj986++
-	if yyhl986 {
-		yyb986 = yyj986 > l
+	var yyj1033 int
+	var yyb1033 bool
+	var yyhl1033 bool = l >= 0
+	yyj1033++
+	if yyhl1033 {
+		yyb1033 = yyj1033 > l
 	} else {
-		yyb986 = r.CheckBreak()
+		yyb1033 = r.CheckBreak()
 	}
-	if yyb986 {
+	if yyb1033 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11569,21 +12155,21 @@ func (x *IngressStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.LoadBalancer = pkg2_api.LoadBalancerStatus{}
 	} else {
-		yyv987 := &x.LoadBalancer
-		yyv987.CodecDecodeSelf(d)
+		yyv1034 := &x.LoadBalancer
+		yyv1034.CodecDecodeSelf(d)
 	}
 	for {
-		yyj986++
-		if yyhl986 {
-			yyb986 = yyj986 > l
+		yyj1033++
+		if yyhl1033 {
+			yyb1033 = yyj1033 > l
 		} else {
-			yyb986 = r.CheckBreak()
+			yyb1033 = r.CheckBreak()
 		}
-		if yyb986 {
+		if yyb1033 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj986-1, "")
+		z.DecStructFieldNotFound(yyj1033-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -11595,36 +12181,36 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym988 := z.EncBinary()
-		_ = yym988
+		yym1035 := z.EncBinary()
+		_ = yym1035
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep989 := !z.EncBinary()
-			yy2arr989 := z.EncBasicHandle().StructToArray
-			var yyq989 [2]bool
-			_, _, _ = yysep989, yyq989, yy2arr989
-			const yyr989 bool = false
-			yyq989[0] = x.Host != ""
-			yyq989[1] = x.IngressRuleValue.HTTP != nil && x.HTTP != nil
-			var yynn989 int
-			if yyr989 || yy2arr989 {
+			yysep1036 := !z.EncBinary()
+			yy2arr1036 := z.EncBasicHandle().StructToArray
+			var yyq1036 [2]bool
+			_, _, _ = yysep1036, yyq1036, yy2arr1036
+			const yyr1036 bool = false
+			yyq1036[0] = x.Host != ""
+			yyq1036[1] = x.IngressRuleValue.HTTP != nil && x.HTTP != nil
+			var yynn1036 int
+			if yyr1036 || yy2arr1036 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn989 = 0
-				for _, b := range yyq989 {
+				yynn1036 = 0
+				for _, b := range yyq1036 {
 					if b {
-						yynn989++
+						yynn1036++
 					}
 				}
-				r.EncodeMapStart(yynn989)
-				yynn989 = 0
+				r.EncodeMapStart(yynn1036)
+				yynn1036 = 0
 			}
-			if yyr989 || yy2arr989 {
+			if yyr1036 || yy2arr1036 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq989[0] {
-					yym991 := z.EncBinary()
-					_ = yym991
+				if yyq1036[0] {
+					yym1038 := z.EncBinary()
+					_ = yym1038
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Host))
@@ -11633,30 +12219,30 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq989[0] {
+				if yyq1036[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("host"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym992 := z.EncBinary()
-					_ = yym992
+					yym1039 := z.EncBinary()
+					_ = yym1039
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Host))
 					}
 				}
 			}
-			var yyn993 bool
+			var yyn1040 bool
 			if x.IngressRuleValue.HTTP == nil {
-				yyn993 = true
-				goto LABEL993
+				yyn1040 = true
+				goto LABEL1040
 			}
-		LABEL993:
-			if yyr989 || yy2arr989 {
-				if yyn993 {
+		LABEL1040:
+			if yyr1036 || yy2arr1036 {
+				if yyn1040 {
 					r.EncodeNil()
 				} else {
 					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq989[1] {
+					if yyq1036[1] {
 						if x.HTTP == nil {
 							r.EncodeNil()
 						} else {
@@ -11667,11 +12253,11 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
-				if yyq989[1] {
+				if yyq1036[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("http"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn993 {
+					if yyn1040 {
 						r.EncodeNil()
 					} else {
 						if x.HTTP == nil {
@@ -11682,7 +12268,7 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr989 || yy2arr989 {
+			if yyr1036 || yy2arr1036 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -11695,25 +12281,25 @@ func (x *IngressRule) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym994 := z.DecBinary()
-	_ = yym994
+	yym1041 := z.DecBinary()
+	_ = yym1041
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct995 := r.ContainerType()
-		if yyct995 == codecSelferValueTypeMap1234 {
-			yyl995 := r.ReadMapStart()
-			if yyl995 == 0 {
+		yyct1042 := r.ContainerType()
+		if yyct1042 == codecSelferValueTypeMap1234 {
+			yyl1042 := r.ReadMapStart()
+			if yyl1042 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl995, d)
+				x.codecDecodeSelfFromMap(yyl1042, d)
 			}
-		} else if yyct995 == codecSelferValueTypeArray1234 {
-			yyl995 := r.ReadArrayStart()
-			if yyl995 == 0 {
+		} else if yyct1042 == codecSelferValueTypeArray1234 {
+			yyl1042 := r.ReadArrayStart()
+			if yyl1042 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl995, d)
+				x.codecDecodeSelfFromArray(yyl1042, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -11725,12 +12311,12 @@ func (x *IngressRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys996Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys996Slc
-	var yyhl996 bool = l >= 0
-	for yyj996 := 0; ; yyj996++ {
-		if yyhl996 {
-			if yyj996 >= l {
+	var yys1043Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1043Slc
+	var yyhl1043 bool = l >= 0
+	for yyj1043 := 0; ; yyj1043++ {
+		if yyhl1043 {
+			if yyj1043 >= l {
 				break
 			}
 		} else {
@@ -11739,10 +12325,10 @@ func (x *IngressRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys996Slc = r.DecodeBytes(yys996Slc, true, true)
-		yys996 := string(yys996Slc)
+		yys1043Slc = r.DecodeBytes(yys1043Slc, true, true)
+		yys1043 := string(yys1043Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys996 {
+		switch yys1043 {
 		case "host":
 			if r.TryDecodeAsNil() {
 				x.Host = ""
@@ -11764,9 +12350,9 @@ func (x *IngressRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.HTTP.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys996)
-		} // end switch yys996
-	} // end for yyj996
+			z.DecStructFieldNotFound(-1, yys1043)
+		} // end switch yys1043
+	} // end for yyj1043
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -11774,16 +12360,16 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj999 int
-	var yyb999 bool
-	var yyhl999 bool = l >= 0
-	yyj999++
-	if yyhl999 {
-		yyb999 = yyj999 > l
+	var yyj1046 int
+	var yyb1046 bool
+	var yyhl1046 bool = l >= 0
+	yyj1046++
+	if yyhl1046 {
+		yyb1046 = yyj1046 > l
 	} else {
-		yyb999 = r.CheckBreak()
+		yyb1046 = r.CheckBreak()
 	}
-	if yyb999 {
+	if yyb1046 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11796,13 +12382,13 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if x.IngressRuleValue.HTTP == nil {
 		x.IngressRuleValue.HTTP = new(HTTPIngressRuleValue)
 	}
-	yyj999++
-	if yyhl999 {
-		yyb999 = yyj999 > l
+	yyj1046++
+	if yyhl1046 {
+		yyb1046 = yyj1046 > l
 	} else {
-		yyb999 = r.CheckBreak()
+		yyb1046 = r.CheckBreak()
 	}
-	if yyb999 {
+	if yyb1046 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11818,17 +12404,17 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.HTTP.CodecDecodeSelf(d)
 	}
 	for {
-		yyj999++
-		if yyhl999 {
-			yyb999 = yyj999 > l
+		yyj1046++
+		if yyhl1046 {
+			yyb1046 = yyj1046 > l
 		} else {
-			yyb999 = r.CheckBreak()
+			yyb1046 = r.CheckBreak()
 		}
-		if yyb999 {
+		if yyb1046 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj999-1, "")
+		z.DecStructFieldNotFound(yyj1046-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -11840,33 +12426,33 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1002 := z.EncBinary()
-		_ = yym1002
+		yym1049 := z.EncBinary()
+		_ = yym1049
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1003 := !z.EncBinary()
-			yy2arr1003 := z.EncBasicHandle().StructToArray
-			var yyq1003 [1]bool
-			_, _, _ = yysep1003, yyq1003, yy2arr1003
-			const yyr1003 bool = false
-			yyq1003[0] = x.HTTP != nil
-			var yynn1003 int
-			if yyr1003 || yy2arr1003 {
+			yysep1050 := !z.EncBinary()
+			yy2arr1050 := z.EncBasicHandle().StructToArray
+			var yyq1050 [1]bool
+			_, _, _ = yysep1050, yyq1050, yy2arr1050
+			const yyr1050 bool = false
+			yyq1050[0] = x.HTTP != nil
+			var yynn1050 int
+			if yyr1050 || yy2arr1050 {
 				r.EncodeArrayStart(1)
 			} else {
-				yynn1003 = 0
-				for _, b := range yyq1003 {
+				yynn1050 = 0
+				for _, b := range yyq1050 {
 					if b {
-						yynn1003++
+						yynn1050++
 					}
 				}
-				r.EncodeMapStart(yynn1003)
-				yynn1003 = 0
+				r.EncodeMapStart(yynn1050)
+				yynn1050 = 0
 			}
-			if yyr1003 || yy2arr1003 {
+			if yyr1050 || yy2arr1050 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1003[0] {
+				if yyq1050[0] {
 					if x.HTTP == nil {
 						r.EncodeNil()
 					} else {
@@ -11876,7 +12462,7 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1003[0] {
+				if yyq1050[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("http"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
@@ -11887,7 +12473,7 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1003 || yy2arr1003 {
+			if yyr1050 || yy2arr1050 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -11900,25 +12486,25 @@ func (x *IngressRuleValue) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1005 := z.DecBinary()
-	_ = yym1005
+	yym1052 := z.DecBinary()
+	_ = yym1052
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1006 := r.ContainerType()
-		if yyct1006 == codecSelferValueTypeMap1234 {
-			yyl1006 := r.ReadMapStart()
-			if yyl1006 == 0 {
+		yyct1053 := r.ContainerType()
+		if yyct1053 == codecSelferValueTypeMap1234 {
+			yyl1053 := r.ReadMapStart()
+			if yyl1053 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1006, d)
+				x.codecDecodeSelfFromMap(yyl1053, d)
 			}
-		} else if yyct1006 == codecSelferValueTypeArray1234 {
-			yyl1006 := r.ReadArrayStart()
-			if yyl1006 == 0 {
+		} else if yyct1053 == codecSelferValueTypeArray1234 {
+			yyl1053 := r.ReadArrayStart()
+			if yyl1053 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1006, d)
+				x.codecDecodeSelfFromArray(yyl1053, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -11930,12 +12516,12 @@ func (x *IngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1007Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1007Slc
-	var yyhl1007 bool = l >= 0
-	for yyj1007 := 0; ; yyj1007++ {
-		if yyhl1007 {
-			if yyj1007 >= l {
+	var yys1054Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1054Slc
+	var yyhl1054 bool = l >= 0
+	for yyj1054 := 0; ; yyj1054++ {
+		if yyhl1054 {
+			if yyj1054 >= l {
 				break
 			}
 		} else {
@@ -11944,10 +12530,10 @@ func (x *IngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1007Slc = r.DecodeBytes(yys1007Slc, true, true)
-		yys1007 := string(yys1007Slc)
+		yys1054Slc = r.DecodeBytes(yys1054Slc, true, true)
+		yys1054 := string(yys1054Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1007 {
+		switch yys1054 {
 		case "http":
 			if r.TryDecodeAsNil() {
 				if x.HTTP != nil {
@@ -11960,608 +12546,13 @@ func (x *IngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.HTTP.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1007)
-		} // end switch yys1007
-	} // end for yyj1007
+			z.DecStructFieldNotFound(-1, yys1054)
+		} // end switch yys1054
+	} // end for yyj1054
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *IngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj1009 int
-	var yyb1009 bool
-	var yyhl1009 bool = l >= 0
-	yyj1009++
-	if yyhl1009 {
-		yyb1009 = yyj1009 > l
-	} else {
-		yyb1009 = r.CheckBreak()
-	}
-	if yyb1009 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		if x.HTTP != nil {
-			x.HTTP = nil
-		}
-	} else {
-		if x.HTTP == nil {
-			x.HTTP = new(HTTPIngressRuleValue)
-		}
-		x.HTTP.CodecDecodeSelf(d)
-	}
-	for {
-		yyj1009++
-		if yyhl1009 {
-			yyb1009 = yyj1009 > l
-		} else {
-			yyb1009 = r.CheckBreak()
-		}
-		if yyb1009 {
-			break
-		}
-		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1009-1, "")
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x *HTTPIngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym1011 := z.EncBinary()
-		_ = yym1011
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep1012 := !z.EncBinary()
-			yy2arr1012 := z.EncBasicHandle().StructToArray
-			var yyq1012 [1]bool
-			_, _, _ = yysep1012, yyq1012, yy2arr1012
-			const yyr1012 bool = false
-			var yynn1012 int
-			if yyr1012 || yy2arr1012 {
-				r.EncodeArrayStart(1)
-			} else {
-				yynn1012 = 1
-				for _, b := range yyq1012 {
-					if b {
-						yynn1012++
-					}
-				}
-				r.EncodeMapStart(yynn1012)
-				yynn1012 = 0
-			}
-			if yyr1012 || yy2arr1012 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if x.Paths == nil {
-					r.EncodeNil()
-				} else {
-					yym1014 := z.EncBinary()
-					_ = yym1014
-					if false {
-					} else {
-						h.encSliceHTTPIngressPath(([]HTTPIngressPath)(x.Paths), e)
-					}
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("paths"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				if x.Paths == nil {
-					r.EncodeNil()
-				} else {
-					yym1015 := z.EncBinary()
-					_ = yym1015
-					if false {
-					} else {
-						h.encSliceHTTPIngressPath(([]HTTPIngressPath)(x.Paths), e)
-					}
-				}
-			}
-			if yyr1012 || yy2arr1012 {
-				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
-			}
-		}
-	}
-}
-
-func (x *HTTPIngressRuleValue) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym1016 := z.DecBinary()
-	_ = yym1016
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		yyct1017 := r.ContainerType()
-		if yyct1017 == codecSelferValueTypeMap1234 {
-			yyl1017 := r.ReadMapStart()
-			if yyl1017 == 0 {
-				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-			} else {
-				x.codecDecodeSelfFromMap(yyl1017, d)
-			}
-		} else if yyct1017 == codecSelferValueTypeArray1234 {
-			yyl1017 := r.ReadArrayStart()
-			if yyl1017 == 0 {
-				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				x.codecDecodeSelfFromArray(yyl1017, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *HTTPIngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys1018Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1018Slc
-	var yyhl1018 bool = l >= 0
-	for yyj1018 := 0; ; yyj1018++ {
-		if yyhl1018 {
-			if yyj1018 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1018Slc = r.DecodeBytes(yys1018Slc, true, true)
-		yys1018 := string(yys1018Slc)
-		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1018 {
-		case "paths":
-			if r.TryDecodeAsNil() {
-				x.Paths = nil
-			} else {
-				yyv1019 := &x.Paths
-				yym1020 := z.DecBinary()
-				_ = yym1020
-				if false {
-				} else {
-					h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv1019), d)
-				}
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys1018)
-		} // end switch yys1018
-	} // end for yyj1018
-	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-}
-
-func (x *HTTPIngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj1021 int
-	var yyb1021 bool
-	var yyhl1021 bool = l >= 0
-	yyj1021++
-	if yyhl1021 {
-		yyb1021 = yyj1021 > l
-	} else {
-		yyb1021 = r.CheckBreak()
-	}
-	if yyb1021 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Paths = nil
-	} else {
-		yyv1022 := &x.Paths
-		yym1023 := z.DecBinary()
-		_ = yym1023
-		if false {
-		} else {
-			h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv1022), d)
-		}
-	}
-	for {
-		yyj1021++
-		if yyhl1021 {
-			yyb1021 = yyj1021 > l
-		} else {
-			yyb1021 = r.CheckBreak()
-		}
-		if yyb1021 {
-			break
-		}
-		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1021-1, "")
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x *HTTPIngressPath) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym1024 := z.EncBinary()
-		_ = yym1024
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep1025 := !z.EncBinary()
-			yy2arr1025 := z.EncBasicHandle().StructToArray
-			var yyq1025 [2]bool
-			_, _, _ = yysep1025, yyq1025, yy2arr1025
-			const yyr1025 bool = false
-			yyq1025[0] = x.Path != ""
-			var yynn1025 int
-			if yyr1025 || yy2arr1025 {
-				r.EncodeArrayStart(2)
-			} else {
-				yynn1025 = 1
-				for _, b := range yyq1025 {
-					if b {
-						yynn1025++
-					}
-				}
-				r.EncodeMapStart(yynn1025)
-				yynn1025 = 0
-			}
-			if yyr1025 || yy2arr1025 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1025[0] {
-					yym1027 := z.EncBinary()
-					_ = yym1027
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Path))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1025[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("path"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1028 := z.EncBinary()
-					_ = yym1028
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Path))
-					}
-				}
-			}
-			if yyr1025 || yy2arr1025 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy1030 := &x.Backend
-				yy1030.CodecEncodeSelf(e)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("backend"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy1031 := &x.Backend
-				yy1031.CodecEncodeSelf(e)
-			}
-			if yyr1025 || yy2arr1025 {
-				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
-			}
-		}
-	}
-}
-
-func (x *HTTPIngressPath) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym1032 := z.DecBinary()
-	_ = yym1032
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		yyct1033 := r.ContainerType()
-		if yyct1033 == codecSelferValueTypeMap1234 {
-			yyl1033 := r.ReadMapStart()
-			if yyl1033 == 0 {
-				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-			} else {
-				x.codecDecodeSelfFromMap(yyl1033, d)
-			}
-		} else if yyct1033 == codecSelferValueTypeArray1234 {
-			yyl1033 := r.ReadArrayStart()
-			if yyl1033 == 0 {
-				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				x.codecDecodeSelfFromArray(yyl1033, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *HTTPIngressPath) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys1034Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1034Slc
-	var yyhl1034 bool = l >= 0
-	for yyj1034 := 0; ; yyj1034++ {
-		if yyhl1034 {
-			if yyj1034 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1034Slc = r.DecodeBytes(yys1034Slc, true, true)
-		yys1034 := string(yys1034Slc)
-		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1034 {
-		case "path":
-			if r.TryDecodeAsNil() {
-				x.Path = ""
-			} else {
-				x.Path = string(r.DecodeString())
-			}
-		case "backend":
-			if r.TryDecodeAsNil() {
-				x.Backend = IngressBackend{}
-			} else {
-				yyv1036 := &x.Backend
-				yyv1036.CodecDecodeSelf(d)
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys1034)
-		} // end switch yys1034
-	} // end for yyj1034
-	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-}
-
-func (x *HTTPIngressPath) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj1037 int
-	var yyb1037 bool
-	var yyhl1037 bool = l >= 0
-	yyj1037++
-	if yyhl1037 {
-		yyb1037 = yyj1037 > l
-	} else {
-		yyb1037 = r.CheckBreak()
-	}
-	if yyb1037 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Path = ""
-	} else {
-		x.Path = string(r.DecodeString())
-	}
-	yyj1037++
-	if yyhl1037 {
-		yyb1037 = yyj1037 > l
-	} else {
-		yyb1037 = r.CheckBreak()
-	}
-	if yyb1037 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Backend = IngressBackend{}
-	} else {
-		yyv1039 := &x.Backend
-		yyv1039.CodecDecodeSelf(d)
-	}
-	for {
-		yyj1037++
-		if yyhl1037 {
-			yyb1037 = yyj1037 > l
-		} else {
-			yyb1037 = r.CheckBreak()
-		}
-		if yyb1037 {
-			break
-		}
-		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1037-1, "")
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x *IngressBackend) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym1040 := z.EncBinary()
-		_ = yym1040
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep1041 := !z.EncBinary()
-			yy2arr1041 := z.EncBasicHandle().StructToArray
-			var yyq1041 [2]bool
-			_, _, _ = yysep1041, yyq1041, yy2arr1041
-			const yyr1041 bool = false
-			var yynn1041 int
-			if yyr1041 || yy2arr1041 {
-				r.EncodeArrayStart(2)
-			} else {
-				yynn1041 = 2
-				for _, b := range yyq1041 {
-					if b {
-						yynn1041++
-					}
-				}
-				r.EncodeMapStart(yynn1041)
-				yynn1041 = 0
-			}
-			if yyr1041 || yy2arr1041 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1043 := z.EncBinary()
-				_ = yym1043
-				if false {
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceName))
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("serviceName"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1044 := z.EncBinary()
-				_ = yym1044
-				if false {
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceName))
-				}
-			}
-			if yyr1041 || yy2arr1041 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy1046 := &x.ServicePort
-				yym1047 := z.EncBinary()
-				_ = yym1047
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy1046) {
-				} else if !yym1047 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy1046)
-				} else {
-					z.EncFallback(yy1046)
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("servicePort"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy1048 := &x.ServicePort
-				yym1049 := z.EncBinary()
-				_ = yym1049
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy1048) {
-				} else if !yym1049 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy1048)
-				} else {
-					z.EncFallback(yy1048)
-				}
-			}
-			if yyr1041 || yy2arr1041 {
-				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
-			}
-		}
-	}
-}
-
-func (x *IngressBackend) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym1050 := z.DecBinary()
-	_ = yym1050
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		yyct1051 := r.ContainerType()
-		if yyct1051 == codecSelferValueTypeMap1234 {
-			yyl1051 := r.ReadMapStart()
-			if yyl1051 == 0 {
-				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-			} else {
-				x.codecDecodeSelfFromMap(yyl1051, d)
-			}
-		} else if yyct1051 == codecSelferValueTypeArray1234 {
-			yyl1051 := r.ReadArrayStart()
-			if yyl1051 == 0 {
-				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				x.codecDecodeSelfFromArray(yyl1051, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *IngressBackend) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys1052Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1052Slc
-	var yyhl1052 bool = l >= 0
-	for yyj1052 := 0; ; yyj1052++ {
-		if yyhl1052 {
-			if yyj1052 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1052Slc = r.DecodeBytes(yys1052Slc, true, true)
-		yys1052 := string(yys1052Slc)
-		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1052 {
-		case "serviceName":
-			if r.TryDecodeAsNil() {
-				x.ServiceName = ""
-			} else {
-				x.ServiceName = string(r.DecodeString())
-			}
-		case "servicePort":
-			if r.TryDecodeAsNil() {
-				x.ServicePort = pkg6_intstr.IntOrString{}
-			} else {
-				yyv1054 := &x.ServicePort
-				yym1055 := z.DecBinary()
-				_ = yym1055
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1054) {
-				} else if !yym1055 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1054)
-				} else {
-					z.DecFallback(yyv1054, false)
-				}
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys1052)
-		} // end switch yys1052
-	} // end for yyj1052
-	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-}
-
-func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -12580,34 +12571,14 @@ func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.ServiceName = ""
-	} else {
-		x.ServiceName = string(r.DecodeString())
-	}
-	yyj1056++
-	if yyhl1056 {
-		yyb1056 = yyj1056 > l
-	} else {
-		yyb1056 = r.CheckBreak()
-	}
-	if yyb1056 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ServicePort = pkg6_intstr.IntOrString{}
-	} else {
-		yyv1058 := &x.ServicePort
-		yym1059 := z.DecBinary()
-		_ = yym1059
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1058) {
-		} else if !yym1059 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1058)
-		} else {
-			z.DecFallback(yyv1058, false)
+		if x.HTTP != nil {
+			x.HTTP = nil
 		}
+	} else {
+		if x.HTTP == nil {
+			x.HTTP = new(HTTPIngressRuleValue)
+		}
+		x.HTTP.CodecDecodeSelf(d)
 	}
 	for {
 		yyj1056++
@@ -12625,12 +12596,627 @@ func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
+func (x *HTTPIngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym1058 := z.EncBinary()
+		_ = yym1058
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep1059 := !z.EncBinary()
+			yy2arr1059 := z.EncBasicHandle().StructToArray
+			var yyq1059 [1]bool
+			_, _, _ = yysep1059, yyq1059, yy2arr1059
+			const yyr1059 bool = false
+			var yynn1059 int
+			if yyr1059 || yy2arr1059 {
+				r.EncodeArrayStart(1)
+			} else {
+				yynn1059 = 1
+				for _, b := range yyq1059 {
+					if b {
+						yynn1059++
+					}
+				}
+				r.EncodeMapStart(yynn1059)
+				yynn1059 = 0
+			}
+			if yyr1059 || yy2arr1059 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if x.Paths == nil {
+					r.EncodeNil()
+				} else {
+					yym1061 := z.EncBinary()
+					_ = yym1061
+					if false {
+					} else {
+						h.encSliceHTTPIngressPath(([]HTTPIngressPath)(x.Paths), e)
+					}
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("paths"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				if x.Paths == nil {
+					r.EncodeNil()
+				} else {
+					yym1062 := z.EncBinary()
+					_ = yym1062
+					if false {
+					} else {
+						h.encSliceHTTPIngressPath(([]HTTPIngressPath)(x.Paths), e)
+					}
+				}
+			}
+			if yyr1059 || yy2arr1059 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *HTTPIngressRuleValue) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym1063 := z.DecBinary()
+	_ = yym1063
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct1064 := r.ContainerType()
+		if yyct1064 == codecSelferValueTypeMap1234 {
+			yyl1064 := r.ReadMapStart()
+			if yyl1064 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl1064, d)
+			}
+		} else if yyct1064 == codecSelferValueTypeArray1234 {
+			yyl1064 := r.ReadArrayStart()
+			if yyl1064 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl1064, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *HTTPIngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys1065Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1065Slc
+	var yyhl1065 bool = l >= 0
+	for yyj1065 := 0; ; yyj1065++ {
+		if yyhl1065 {
+			if yyj1065 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys1065Slc = r.DecodeBytes(yys1065Slc, true, true)
+		yys1065 := string(yys1065Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys1065 {
+		case "paths":
+			if r.TryDecodeAsNil() {
+				x.Paths = nil
+			} else {
+				yyv1066 := &x.Paths
+				yym1067 := z.DecBinary()
+				_ = yym1067
+				if false {
+				} else {
+					h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv1066), d)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys1065)
+		} // end switch yys1065
+	} // end for yyj1065
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *HTTPIngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj1068 int
+	var yyb1068 bool
+	var yyhl1068 bool = l >= 0
+	yyj1068++
+	if yyhl1068 {
+		yyb1068 = yyj1068 > l
+	} else {
+		yyb1068 = r.CheckBreak()
+	}
+	if yyb1068 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Paths = nil
+	} else {
+		yyv1069 := &x.Paths
+		yym1070 := z.DecBinary()
+		_ = yym1070
+		if false {
+		} else {
+			h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv1069), d)
+		}
+	}
+	for {
+		yyj1068++
+		if yyhl1068 {
+			yyb1068 = yyj1068 > l
+		} else {
+			yyb1068 = r.CheckBreak()
+		}
+		if yyb1068 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj1068-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x *HTTPIngressPath) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym1071 := z.EncBinary()
+		_ = yym1071
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep1072 := !z.EncBinary()
+			yy2arr1072 := z.EncBasicHandle().StructToArray
+			var yyq1072 [2]bool
+			_, _, _ = yysep1072, yyq1072, yy2arr1072
+			const yyr1072 bool = false
+			yyq1072[0] = x.Path != ""
+			var yynn1072 int
+			if yyr1072 || yy2arr1072 {
+				r.EncodeArrayStart(2)
+			} else {
+				yynn1072 = 1
+				for _, b := range yyq1072 {
+					if b {
+						yynn1072++
+					}
+				}
+				r.EncodeMapStart(yynn1072)
+				yynn1072 = 0
+			}
+			if yyr1072 || yy2arr1072 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1072[0] {
+					yym1074 := z.EncBinary()
+					_ = yym1074
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Path))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1072[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("path"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1075 := z.EncBinary()
+					_ = yym1075
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Path))
+					}
+				}
+			}
+			if yyr1072 || yy2arr1072 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yy1077 := &x.Backend
+				yy1077.CodecEncodeSelf(e)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("backend"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yy1078 := &x.Backend
+				yy1078.CodecEncodeSelf(e)
+			}
+			if yyr1072 || yy2arr1072 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *HTTPIngressPath) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym1079 := z.DecBinary()
+	_ = yym1079
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct1080 := r.ContainerType()
+		if yyct1080 == codecSelferValueTypeMap1234 {
+			yyl1080 := r.ReadMapStart()
+			if yyl1080 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl1080, d)
+			}
+		} else if yyct1080 == codecSelferValueTypeArray1234 {
+			yyl1080 := r.ReadArrayStart()
+			if yyl1080 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl1080, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *HTTPIngressPath) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys1081Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1081Slc
+	var yyhl1081 bool = l >= 0
+	for yyj1081 := 0; ; yyj1081++ {
+		if yyhl1081 {
+			if yyj1081 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys1081Slc = r.DecodeBytes(yys1081Slc, true, true)
+		yys1081 := string(yys1081Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys1081 {
+		case "path":
+			if r.TryDecodeAsNil() {
+				x.Path = ""
+			} else {
+				x.Path = string(r.DecodeString())
+			}
+		case "backend":
+			if r.TryDecodeAsNil() {
+				x.Backend = IngressBackend{}
+			} else {
+				yyv1083 := &x.Backend
+				yyv1083.CodecDecodeSelf(d)
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys1081)
+		} // end switch yys1081
+	} // end for yyj1081
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *HTTPIngressPath) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj1084 int
+	var yyb1084 bool
+	var yyhl1084 bool = l >= 0
+	yyj1084++
+	if yyhl1084 {
+		yyb1084 = yyj1084 > l
+	} else {
+		yyb1084 = r.CheckBreak()
+	}
+	if yyb1084 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Path = ""
+	} else {
+		x.Path = string(r.DecodeString())
+	}
+	yyj1084++
+	if yyhl1084 {
+		yyb1084 = yyj1084 > l
+	} else {
+		yyb1084 = r.CheckBreak()
+	}
+	if yyb1084 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Backend = IngressBackend{}
+	} else {
+		yyv1086 := &x.Backend
+		yyv1086.CodecDecodeSelf(d)
+	}
+	for {
+		yyj1084++
+		if yyhl1084 {
+			yyb1084 = yyj1084 > l
+		} else {
+			yyb1084 = r.CheckBreak()
+		}
+		if yyb1084 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj1084-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x *IngressBackend) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym1087 := z.EncBinary()
+		_ = yym1087
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep1088 := !z.EncBinary()
+			yy2arr1088 := z.EncBasicHandle().StructToArray
+			var yyq1088 [2]bool
+			_, _, _ = yysep1088, yyq1088, yy2arr1088
+			const yyr1088 bool = false
+			var yynn1088 int
+			if yyr1088 || yy2arr1088 {
+				r.EncodeArrayStart(2)
+			} else {
+				yynn1088 = 2
+				for _, b := range yyq1088 {
+					if b {
+						yynn1088++
+					}
+				}
+				r.EncodeMapStart(yynn1088)
+				yynn1088 = 0
+			}
+			if yyr1088 || yy2arr1088 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym1090 := z.EncBinary()
+				_ = yym1090
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceName))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("serviceName"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym1091 := z.EncBinary()
+				_ = yym1091
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceName))
+				}
+			}
+			if yyr1088 || yy2arr1088 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yy1093 := &x.ServicePort
+				yym1094 := z.EncBinary()
+				_ = yym1094
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy1093) {
+				} else if !yym1094 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy1093)
+				} else {
+					z.EncFallback(yy1093)
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("servicePort"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yy1095 := &x.ServicePort
+				yym1096 := z.EncBinary()
+				_ = yym1096
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy1095) {
+				} else if !yym1096 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy1095)
+				} else {
+					z.EncFallback(yy1095)
+				}
+			}
+			if yyr1088 || yy2arr1088 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *IngressBackend) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym1097 := z.DecBinary()
+	_ = yym1097
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct1098 := r.ContainerType()
+		if yyct1098 == codecSelferValueTypeMap1234 {
+			yyl1098 := r.ReadMapStart()
+			if yyl1098 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl1098, d)
+			}
+		} else if yyct1098 == codecSelferValueTypeArray1234 {
+			yyl1098 := r.ReadArrayStart()
+			if yyl1098 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl1098, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *IngressBackend) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys1099Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1099Slc
+	var yyhl1099 bool = l >= 0
+	for yyj1099 := 0; ; yyj1099++ {
+		if yyhl1099 {
+			if yyj1099 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys1099Slc = r.DecodeBytes(yys1099Slc, true, true)
+		yys1099 := string(yys1099Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys1099 {
+		case "serviceName":
+			if r.TryDecodeAsNil() {
+				x.ServiceName = ""
+			} else {
+				x.ServiceName = string(r.DecodeString())
+			}
+		case "servicePort":
+			if r.TryDecodeAsNil() {
+				x.ServicePort = pkg6_intstr.IntOrString{}
+			} else {
+				yyv1101 := &x.ServicePort
+				yym1102 := z.DecBinary()
+				_ = yym1102
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv1101) {
+				} else if !yym1102 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1101)
+				} else {
+					z.DecFallback(yyv1101, false)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys1099)
+		} // end switch yys1099
+	} // end for yyj1099
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj1103 int
+	var yyb1103 bool
+	var yyhl1103 bool = l >= 0
+	yyj1103++
+	if yyhl1103 {
+		yyb1103 = yyj1103 > l
+	} else {
+		yyb1103 = r.CheckBreak()
+	}
+	if yyb1103 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ServiceName = ""
+	} else {
+		x.ServiceName = string(r.DecodeString())
+	}
+	yyj1103++
+	if yyhl1103 {
+		yyb1103 = yyj1103 > l
+	} else {
+		yyb1103 = r.CheckBreak()
+	}
+	if yyb1103 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ServicePort = pkg6_intstr.IntOrString{}
+	} else {
+		yyv1105 := &x.ServicePort
+		yym1106 := z.DecBinary()
+		_ = yym1106
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1105) {
+		} else if !yym1106 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv1105)
+		} else {
+			z.DecFallback(yyv1105, false)
+		}
+	}
+	for {
+		yyj1103++
+		if yyhl1103 {
+			yyb1103 = yyj1103 > l
+		} else {
+			yyb1103 = r.CheckBreak()
+		}
+		if yyb1103 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj1103-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
 func (x NodeResource) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym1060 := z.EncBinary()
-	_ = yym1060
+	yym1107 := z.EncBinary()
+	_ = yym1107
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -12642,8 +13228,8 @@ func (x *NodeResource) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1061 := z.DecBinary()
-	_ = yym1061
+	yym1108 := z.DecBinary()
+	_ = yym1108
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -12658,30 +13244,30 @@ func (x *NodeUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1062 := z.EncBinary()
-		_ = yym1062
+		yym1109 := z.EncBinary()
+		_ = yym1109
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1063 := !z.EncBinary()
-			yy2arr1063 := z.EncBasicHandle().StructToArray
-			var yyq1063 [2]bool
-			_, _, _ = yysep1063, yyq1063, yy2arr1063
-			const yyr1063 bool = false
-			var yynn1063 int
-			if yyr1063 || yy2arr1063 {
+			yysep1110 := !z.EncBinary()
+			yy2arr1110 := z.EncBasicHandle().StructToArray
+			var yyq1110 [2]bool
+			_, _, _ = yysep1110, yyq1110, yy2arr1110
+			const yyr1110 bool = false
+			var yynn1110 int
+			if yyr1110 || yy2arr1110 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn1063 = 2
-				for _, b := range yyq1063 {
+				yynn1110 = 2
+				for _, b := range yyq1110 {
 					if b {
-						yynn1063++
+						yynn1110++
 					}
 				}
-				r.EncodeMapStart(yynn1063)
-				yynn1063 = 0
+				r.EncodeMapStart(yynn1110)
+				yynn1110 = 0
 			}
-			if yyr1063 || yy2arr1063 {
+			if yyr1110 || yy2arr1110 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Resource.CodecEncodeSelf(e)
 			} else {
@@ -12690,10 +13276,10 @@ func (x *NodeUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Resource.CodecEncodeSelf(e)
 			}
-			if yyr1063 || yy2arr1063 {
+			if yyr1110 || yy2arr1110 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1066 := z.EncBinary()
-				_ = yym1066
+				yym1113 := z.EncBinary()
+				_ = yym1113
 				if false {
 				} else {
 					r.EncodeFloat64(float64(x.Value))
@@ -12702,14 +13288,14 @@ func (x *NodeUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("value"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1067 := z.EncBinary()
-				_ = yym1067
+				yym1114 := z.EncBinary()
+				_ = yym1114
 				if false {
 				} else {
 					r.EncodeFloat64(float64(x.Value))
 				}
 			}
-			if yyr1063 || yy2arr1063 {
+			if yyr1110 || yy2arr1110 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -12722,25 +13308,25 @@ func (x *NodeUtilization) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1068 := z.DecBinary()
-	_ = yym1068
+	yym1115 := z.DecBinary()
+	_ = yym1115
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1069 := r.ContainerType()
-		if yyct1069 == codecSelferValueTypeMap1234 {
-			yyl1069 := r.ReadMapStart()
-			if yyl1069 == 0 {
+		yyct1116 := r.ContainerType()
+		if yyct1116 == codecSelferValueTypeMap1234 {
+			yyl1116 := r.ReadMapStart()
+			if yyl1116 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1069, d)
+				x.codecDecodeSelfFromMap(yyl1116, d)
 			}
-		} else if yyct1069 == codecSelferValueTypeArray1234 {
-			yyl1069 := r.ReadArrayStart()
-			if yyl1069 == 0 {
+		} else if yyct1116 == codecSelferValueTypeArray1234 {
+			yyl1116 := r.ReadArrayStart()
+			if yyl1116 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1069, d)
+				x.codecDecodeSelfFromArray(yyl1116, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -12752,12 +13338,12 @@ func (x *NodeUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1070Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1070Slc
-	var yyhl1070 bool = l >= 0
-	for yyj1070 := 0; ; yyj1070++ {
-		if yyhl1070 {
-			if yyj1070 >= l {
+	var yys1117Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1117Slc
+	var yyhl1117 bool = l >= 0
+	for yyj1117 := 0; ; yyj1117++ {
+		if yyhl1117 {
+			if yyj1117 >= l {
 				break
 			}
 		} else {
@@ -12766,10 +13352,10 @@ func (x *NodeUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1070Slc = r.DecodeBytes(yys1070Slc, true, true)
-		yys1070 := string(yys1070Slc)
+		yys1117Slc = r.DecodeBytes(yys1117Slc, true, true)
+		yys1117 := string(yys1117Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1070 {
+		switch yys1117 {
 		case "resource":
 			if r.TryDecodeAsNil() {
 				x.Resource = ""
@@ -12783,544 +13369,13 @@ func (x *NodeUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Value = float64(r.DecodeFloat(false))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1070)
-		} // end switch yys1070
-	} // end for yyj1070
+			z.DecStructFieldNotFound(-1, yys1117)
+		} // end switch yys1117
+	} // end for yyj1117
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *NodeUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj1073 int
-	var yyb1073 bool
-	var yyhl1073 bool = l >= 0
-	yyj1073++
-	if yyhl1073 {
-		yyb1073 = yyj1073 > l
-	} else {
-		yyb1073 = r.CheckBreak()
-	}
-	if yyb1073 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Resource = ""
-	} else {
-		x.Resource = NodeResource(r.DecodeString())
-	}
-	yyj1073++
-	if yyhl1073 {
-		yyb1073 = yyj1073 > l
-	} else {
-		yyb1073 = r.CheckBreak()
-	}
-	if yyb1073 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Value = 0
-	} else {
-		x.Value = float64(r.DecodeFloat(false))
-	}
-	for {
-		yyj1073++
-		if yyhl1073 {
-			yyb1073 = yyj1073 > l
-		} else {
-			yyb1073 = r.CheckBreak()
-		}
-		if yyb1073 {
-			break
-		}
-		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1073-1, "")
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym1076 := z.EncBinary()
-		_ = yym1076
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep1077 := !z.EncBinary()
-			yy2arr1077 := z.EncBasicHandle().StructToArray
-			var yyq1077 [3]bool
-			_, _, _ = yysep1077, yyq1077, yy2arr1077
-			const yyr1077 bool = false
-			var yynn1077 int
-			if yyr1077 || yy2arr1077 {
-				r.EncodeArrayStart(3)
-			} else {
-				yynn1077 = 3
-				for _, b := range yyq1077 {
-					if b {
-						yynn1077++
-					}
-				}
-				r.EncodeMapStart(yynn1077)
-				yynn1077 = 0
-			}
-			if yyr1077 || yy2arr1077 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1079 := z.EncBinary()
-				_ = yym1079
-				if false {
-				} else {
-					r.EncodeInt(int64(x.MinNodes))
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("minNodes"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1080 := z.EncBinary()
-				_ = yym1080
-				if false {
-				} else {
-					r.EncodeInt(int64(x.MinNodes))
-				}
-			}
-			if yyr1077 || yy2arr1077 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1082 := z.EncBinary()
-				_ = yym1082
-				if false {
-				} else {
-					r.EncodeInt(int64(x.MaxNodes))
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("maxNodes"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1083 := z.EncBinary()
-				_ = yym1083
-				if false {
-				} else {
-					r.EncodeInt(int64(x.MaxNodes))
-				}
-			}
-			if yyr1077 || yy2arr1077 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if x.TargetUtilization == nil {
-					r.EncodeNil()
-				} else {
-					yym1085 := z.EncBinary()
-					_ = yym1085
-					if false {
-					} else {
-						h.encSliceNodeUtilization(([]NodeUtilization)(x.TargetUtilization), e)
-					}
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("target"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				if x.TargetUtilization == nil {
-					r.EncodeNil()
-				} else {
-					yym1086 := z.EncBinary()
-					_ = yym1086
-					if false {
-					} else {
-						h.encSliceNodeUtilization(([]NodeUtilization)(x.TargetUtilization), e)
-					}
-				}
-			}
-			if yyr1077 || yy2arr1077 {
-				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
-			}
-		}
-	}
-}
-
-func (x *ClusterAutoscalerSpec) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym1087 := z.DecBinary()
-	_ = yym1087
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		yyct1088 := r.ContainerType()
-		if yyct1088 == codecSelferValueTypeMap1234 {
-			yyl1088 := r.ReadMapStart()
-			if yyl1088 == 0 {
-				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-			} else {
-				x.codecDecodeSelfFromMap(yyl1088, d)
-			}
-		} else if yyct1088 == codecSelferValueTypeArray1234 {
-			yyl1088 := r.ReadArrayStart()
-			if yyl1088 == 0 {
-				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				x.codecDecodeSelfFromArray(yyl1088, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *ClusterAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys1089Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1089Slc
-	var yyhl1089 bool = l >= 0
-	for yyj1089 := 0; ; yyj1089++ {
-		if yyhl1089 {
-			if yyj1089 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1089Slc = r.DecodeBytes(yys1089Slc, true, true)
-		yys1089 := string(yys1089Slc)
-		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1089 {
-		case "minNodes":
-			if r.TryDecodeAsNil() {
-				x.MinNodes = 0
-			} else {
-				x.MinNodes = int(r.DecodeInt(codecSelferBitsize1234))
-			}
-		case "maxNodes":
-			if r.TryDecodeAsNil() {
-				x.MaxNodes = 0
-			} else {
-				x.MaxNodes = int(r.DecodeInt(codecSelferBitsize1234))
-			}
-		case "target":
-			if r.TryDecodeAsNil() {
-				x.TargetUtilization = nil
-			} else {
-				yyv1092 := &x.TargetUtilization
-				yym1093 := z.DecBinary()
-				_ = yym1093
-				if false {
-				} else {
-					h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1092), d)
-				}
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys1089)
-		} // end switch yys1089
-	} // end for yyj1089
-	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-}
-
-func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj1094 int
-	var yyb1094 bool
-	var yyhl1094 bool = l >= 0
-	yyj1094++
-	if yyhl1094 {
-		yyb1094 = yyj1094 > l
-	} else {
-		yyb1094 = r.CheckBreak()
-	}
-	if yyb1094 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.MinNodes = 0
-	} else {
-		x.MinNodes = int(r.DecodeInt(codecSelferBitsize1234))
-	}
-	yyj1094++
-	if yyhl1094 {
-		yyb1094 = yyj1094 > l
-	} else {
-		yyb1094 = r.CheckBreak()
-	}
-	if yyb1094 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.MaxNodes = 0
-	} else {
-		x.MaxNodes = int(r.DecodeInt(codecSelferBitsize1234))
-	}
-	yyj1094++
-	if yyhl1094 {
-		yyb1094 = yyj1094 > l
-	} else {
-		yyb1094 = r.CheckBreak()
-	}
-	if yyb1094 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.TargetUtilization = nil
-	} else {
-		yyv1097 := &x.TargetUtilization
-		yym1098 := z.DecBinary()
-		_ = yym1098
-		if false {
-		} else {
-			h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1097), d)
-		}
-	}
-	for {
-		yyj1094++
-		if yyhl1094 {
-			yyb1094 = yyj1094 > l
-		} else {
-			yyb1094 = r.CheckBreak()
-		}
-		if yyb1094 {
-			break
-		}
-		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1094-1, "")
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym1099 := z.EncBinary()
-		_ = yym1099
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep1100 := !z.EncBinary()
-			yy2arr1100 := z.EncBasicHandle().StructToArray
-			var yyq1100 [4]bool
-			_, _, _ = yysep1100, yyq1100, yy2arr1100
-			const yyr1100 bool = false
-			yyq1100[0] = x.Kind != ""
-			yyq1100[1] = x.APIVersion != ""
-			yyq1100[2] = true
-			yyq1100[3] = true
-			var yynn1100 int
-			if yyr1100 || yy2arr1100 {
-				r.EncodeArrayStart(4)
-			} else {
-				yynn1100 = 0
-				for _, b := range yyq1100 {
-					if b {
-						yynn1100++
-					}
-				}
-				r.EncodeMapStart(yynn1100)
-				yynn1100 = 0
-			}
-			if yyr1100 || yy2arr1100 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1100[0] {
-					yym1102 := z.EncBinary()
-					_ = yym1102
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1100[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1103 := z.EncBinary()
-					_ = yym1103
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr1100 || yy2arr1100 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1100[1] {
-					yym1105 := z.EncBinary()
-					_ = yym1105
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1100[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1106 := z.EncBinary()
-					_ = yym1106
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr1100 || yy2arr1100 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1100[2] {
-					yy1108 := &x.ObjectMeta
-					yy1108.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1100[2] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1109 := &x.ObjectMeta
-					yy1109.CodecEncodeSelf(e)
-				}
-			}
-			if yyr1100 || yy2arr1100 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1100[3] {
-					yy1111 := &x.Spec
-					yy1111.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1100[3] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1112 := &x.Spec
-					yy1112.CodecEncodeSelf(e)
-				}
-			}
-			if yyr1100 || yy2arr1100 {
-				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
-			}
-		}
-	}
-}
-
-func (x *ClusterAutoscaler) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym1113 := z.DecBinary()
-	_ = yym1113
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		yyct1114 := r.ContainerType()
-		if yyct1114 == codecSelferValueTypeMap1234 {
-			yyl1114 := r.ReadMapStart()
-			if yyl1114 == 0 {
-				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-			} else {
-				x.codecDecodeSelfFromMap(yyl1114, d)
-			}
-		} else if yyct1114 == codecSelferValueTypeArray1234 {
-			yyl1114 := r.ReadArrayStart()
-			if yyl1114 == 0 {
-				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				x.codecDecodeSelfFromArray(yyl1114, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys1115Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1115Slc
-	var yyhl1115 bool = l >= 0
-	for yyj1115 := 0; ; yyj1115++ {
-		if yyhl1115 {
-			if yyj1115 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1115Slc = r.DecodeBytes(yys1115Slc, true, true)
-		yys1115 := string(yys1115Slc)
-		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1115 {
-		case "kind":
-			if r.TryDecodeAsNil() {
-				x.Kind = ""
-			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = pkg2_api.ObjectMeta{}
-			} else {
-				yyv1118 := &x.ObjectMeta
-				yyv1118.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = ClusterAutoscalerSpec{}
-			} else {
-				yyv1119 := &x.Spec
-				yyv1119.CodecDecodeSelf(d)
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys1115)
-		} // end switch yys1115
-	} // end for yyj1115
-	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-}
-
-func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -13339,9 +13394,9 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.Kind = ""
+		x.Resource = ""
 	} else {
-		x.Kind = string(r.DecodeString())
+		x.Resource = NodeResource(r.DecodeString())
 	}
 	yyj1120++
 	if yyhl1120 {
@@ -13355,43 +13410,9 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
+		x.Value = 0
 	} else {
-		x.APIVersion = string(r.DecodeString())
-	}
-	yyj1120++
-	if yyhl1120 {
-		yyb1120 = yyj1120 > l
-	} else {
-		yyb1120 = r.CheckBreak()
-	}
-	if yyb1120 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = pkg2_api.ObjectMeta{}
-	} else {
-		yyv1123 := &x.ObjectMeta
-		yyv1123.CodecDecodeSelf(d)
-	}
-	yyj1120++
-	if yyhl1120 {
-		yyb1120 = yyj1120 > l
-	} else {
-		yyb1120 = r.CheckBreak()
-	}
-	if yyb1120 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = ClusterAutoscalerSpec{}
-	} else {
-		yyv1124 := &x.Spec
-		yyv1124.CodecDecodeSelf(d)
+		x.Value = float64(r.DecodeFloat(false))
 	}
 	for {
 		yyj1120++
@@ -13409,146 +13430,102 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
-func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
+func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1125 := z.EncBinary()
-		_ = yym1125
+		yym1123 := z.EncBinary()
+		_ = yym1123
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1126 := !z.EncBinary()
-			yy2arr1126 := z.EncBasicHandle().StructToArray
-			var yyq1126 [4]bool
-			_, _, _ = yysep1126, yyq1126, yy2arr1126
-			const yyr1126 bool = false
-			yyq1126[0] = x.Kind != ""
-			yyq1126[1] = x.APIVersion != ""
-			yyq1126[2] = true
-			var yynn1126 int
-			if yyr1126 || yy2arr1126 {
-				r.EncodeArrayStart(4)
+			yysep1124 := !z.EncBinary()
+			yy2arr1124 := z.EncBasicHandle().StructToArray
+			var yyq1124 [3]bool
+			_, _, _ = yysep1124, yyq1124, yy2arr1124
+			const yyr1124 bool = false
+			var yynn1124 int
+			if yyr1124 || yy2arr1124 {
+				r.EncodeArrayStart(3)
 			} else {
-				yynn1126 = 1
-				for _, b := range yyq1126 {
+				yynn1124 = 3
+				for _, b := range yyq1124 {
 					if b {
-						yynn1126++
+						yynn1124++
 					}
 				}
-				r.EncodeMapStart(yynn1126)
-				yynn1126 = 0
+				r.EncodeMapStart(yynn1124)
+				yynn1124 = 0
 			}
-			if yyr1126 || yy2arr1126 {
+			if yyr1124 || yy2arr1124 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1126[0] {
-					yym1128 := z.EncBinary()
-					_ = yym1128
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+				yym1126 := z.EncBinary()
+				_ = yym1126
+				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeInt(int64(x.MinNodes))
 				}
 			} else {
-				if yyq1126[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1129 := z.EncBinary()
-					_ = yym1129
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("minNodes"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym1127 := z.EncBinary()
+				_ = yym1127
+				if false {
+				} else {
+					r.EncodeInt(int64(x.MinNodes))
 				}
 			}
-			if yyr1126 || yy2arr1126 {
+			if yyr1124 || yy2arr1124 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1126[1] {
-					yym1131 := z.EncBinary()
-					_ = yym1131
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+				yym1129 := z.EncBinary()
+				_ = yym1129
+				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeInt(int64(x.MaxNodes))
 				}
 			} else {
-				if yyq1126[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("maxNodes"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym1130 := z.EncBinary()
+				_ = yym1130
+				if false {
+				} else {
+					r.EncodeInt(int64(x.MaxNodes))
+				}
+			}
+			if yyr1124 || yy2arr1124 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if x.TargetUtilization == nil {
+					r.EncodeNil()
+				} else {
 					yym1132 := z.EncBinary()
 					_ = yym1132
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr1126 || yy2arr1126 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1126[2] {
-					yy1134 := &x.ListMeta
-					yym1135 := z.EncBinary()
-					_ = yym1135
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1134) {
-					} else {
-						z.EncFallback(yy1134)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1126[2] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1136 := &x.ListMeta
-					yym1137 := z.EncBinary()
-					_ = yym1137
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1136) {
-					} else {
-						z.EncFallback(yy1136)
-					}
-				}
-			}
-			if yyr1126 || yy2arr1126 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if x.Items == nil {
-					r.EncodeNil()
-				} else {
-					yym1139 := z.EncBinary()
-					_ = yym1139
-					if false {
-					} else {
-						h.encSliceClusterAutoscaler(([]ClusterAutoscaler)(x.Items), e)
+						h.encSliceNodeUtilization(([]NodeUtilization)(x.TargetUtilization), e)
 					}
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				r.EncodeString(codecSelferC_UTF81234, string("target"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				if x.Items == nil {
+				if x.TargetUtilization == nil {
 					r.EncodeNil()
 				} else {
-					yym1140 := z.EncBinary()
-					_ = yym1140
+					yym1133 := z.EncBinary()
+					_ = yym1133
 					if false {
 					} else {
-						h.encSliceClusterAutoscaler(([]ClusterAutoscaler)(x.Items), e)
+						h.encSliceNodeUtilization(([]NodeUtilization)(x.TargetUtilization), e)
 					}
 				}
 			}
-			if yyr1126 || yy2arr1126 {
+			if yyr1124 || yy2arr1124 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -13557,29 +13534,29 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 	}
 }
 
-func (x *ClusterAutoscalerList) CodecDecodeSelf(d *codec1978.Decoder) {
+func (x *ClusterAutoscalerSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1141 := z.DecBinary()
-	_ = yym1141
+	yym1134 := z.DecBinary()
+	_ = yym1134
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1142 := r.ContainerType()
-		if yyct1142 == codecSelferValueTypeMap1234 {
-			yyl1142 := r.ReadMapStart()
-			if yyl1142 == 0 {
+		yyct1135 := r.ContainerType()
+		if yyct1135 == codecSelferValueTypeMap1234 {
+			yyl1135 := r.ReadMapStart()
+			if yyl1135 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1142, d)
+				x.codecDecodeSelfFromMap(yyl1135, d)
 			}
-		} else if yyct1142 == codecSelferValueTypeArray1234 {
-			yyl1142 := r.ReadArrayStart()
-			if yyl1142 == 0 {
+		} else if yyct1135 == codecSelferValueTypeArray1234 {
+			yyl1135 := r.ReadArrayStart()
+			if yyl1135 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1142, d)
+				x.codecDecodeSelfFromArray(yyl1135, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -13587,16 +13564,16 @@ func (x *ClusterAutoscalerList) CodecDecodeSelf(d *codec1978.Decoder) {
 	}
 }
 
-func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+func (x *ClusterAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1143Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1143Slc
-	var yyhl1143 bool = l >= 0
-	for yyj1143 := 0; ; yyj1143++ {
-		if yyhl1143 {
-			if yyj1143 >= l {
+	var yys1136Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1136Slc
+	var yyhl1136 bool = l >= 0
+	for yyj1136 := 0; ; yyj1136++ {
+		if yyhl1136 {
+			if yyj1136 >= l {
 				break
 			}
 		} else {
@@ -13605,738 +13582,157 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1143Slc = r.DecodeBytes(yys1143Slc, true, true)
-		yys1143 := string(yys1143Slc)
+		yys1136Slc = r.DecodeBytes(yys1136Slc, true, true)
+		yys1136 := string(yys1136Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1143 {
-		case "kind":
+		switch yys1136 {
+		case "minNodes":
 			if r.TryDecodeAsNil() {
-				x.Kind = ""
+				x.MinNodes = 0
 			} else {
-				x.Kind = string(r.DecodeString())
+				x.MinNodes = int(r.DecodeInt(codecSelferBitsize1234))
 			}
-		case "apiVersion":
+		case "maxNodes":
 			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
+				x.MaxNodes = 0
 			} else {
-				x.APIVersion = string(r.DecodeString())
+				x.MaxNodes = int(r.DecodeInt(codecSelferBitsize1234))
 			}
-		case "metadata":
+		case "target":
 			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg1_unversioned.ListMeta{}
+				x.TargetUtilization = nil
 			} else {
-				yyv1146 := &x.ListMeta
-				yym1147 := z.DecBinary()
-				_ = yym1147
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1146) {
-				} else {
-					z.DecFallback(yyv1146, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv1148 := &x.Items
-				yym1149 := z.DecBinary()
-				_ = yym1149
+				yyv1139 := &x.TargetUtilization
+				yym1140 := z.DecBinary()
+				_ = yym1140
 				if false {
 				} else {
-					h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1148), d)
+					h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1139), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1143)
-		} // end switch yys1143
-	} // end for yyj1143
+			z.DecStructFieldNotFound(-1, yys1136)
+		} // end switch yys1136
+	} // end for yyj1136
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
-func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1150 int
-	var yyb1150 bool
-	var yyhl1150 bool = l >= 0
-	yyj1150++
-	if yyhl1150 {
-		yyb1150 = yyj1150 > l
+	var yyj1141 int
+	var yyb1141 bool
+	var yyhl1141 bool = l >= 0
+	yyj1141++
+	if yyhl1141 {
+		yyb1141 = yyj1141 > l
 	} else {
-		yyb1150 = r.CheckBreak()
+		yyb1141 = r.CheckBreak()
 	}
-	if yyb1150 {
+	if yyb1141 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.Kind = ""
+		x.MinNodes = 0
 	} else {
-		x.Kind = string(r.DecodeString())
+		x.MinNodes = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj1150++
-	if yyhl1150 {
-		yyb1150 = yyj1150 > l
+	yyj1141++
+	if yyhl1141 {
+		yyb1141 = yyj1141 > l
 	} else {
-		yyb1150 = r.CheckBreak()
+		yyb1141 = r.CheckBreak()
 	}
-	if yyb1150 {
+	if yyb1141 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
+		x.MaxNodes = 0
 	} else {
-		x.APIVersion = string(r.DecodeString())
+		x.MaxNodes = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj1150++
-	if yyhl1150 {
-		yyb1150 = yyj1150 > l
+	yyj1141++
+	if yyhl1141 {
+		yyb1141 = yyj1141 > l
 	} else {
-		yyb1150 = r.CheckBreak()
+		yyb1141 = r.CheckBreak()
 	}
-	if yyb1150 {
+	if yyb1141 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg1_unversioned.ListMeta{}
+		x.TargetUtilization = nil
 	} else {
-		yyv1153 := &x.ListMeta
-		yym1154 := z.DecBinary()
-		_ = yym1154
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1153) {
-		} else {
-			z.DecFallback(yyv1153, false)
-		}
-	}
-	yyj1150++
-	if yyhl1150 {
-		yyb1150 = yyj1150 > l
-	} else {
-		yyb1150 = r.CheckBreak()
-	}
-	if yyb1150 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv1155 := &x.Items
-		yym1156 := z.DecBinary()
-		_ = yym1156
+		yyv1144 := &x.TargetUtilization
+		yym1145 := z.DecBinary()
+		_ = yym1145
 		if false {
 		} else {
-			h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1155), d)
+			h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1144), d)
 		}
 	}
 	for {
-		yyj1150++
-		if yyhl1150 {
-			yyb1150 = yyj1150 > l
+		yyj1141++
+		if yyhl1141 {
+			yyb1141 = yyj1141 > l
 		} else {
-			yyb1150 = r.CheckBreak()
+			yyb1141 = r.CheckBreak()
 		}
-		if yyb1150 {
+		if yyb1141 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1150-1, "")
+		z.DecStructFieldNotFound(yyj1141-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
-func (x *LabelSelector) CodecEncodeSelf(e *codec1978.Encoder) {
+func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1157 := z.EncBinary()
-		_ = yym1157
+		yym1146 := z.EncBinary()
+		_ = yym1146
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1158 := !z.EncBinary()
-			yy2arr1158 := z.EncBasicHandle().StructToArray
-			var yyq1158 [2]bool
-			_, _, _ = yysep1158, yyq1158, yy2arr1158
-			const yyr1158 bool = false
-			yyq1158[0] = len(x.MatchLabels) != 0
-			yyq1158[1] = len(x.MatchExpressions) != 0
-			var yynn1158 int
-			if yyr1158 || yy2arr1158 {
-				r.EncodeArrayStart(2)
+			yysep1147 := !z.EncBinary()
+			yy2arr1147 := z.EncBasicHandle().StructToArray
+			var yyq1147 [4]bool
+			_, _, _ = yysep1147, yyq1147, yy2arr1147
+			const yyr1147 bool = false
+			yyq1147[0] = x.Kind != ""
+			yyq1147[1] = x.APIVersion != ""
+			yyq1147[2] = true
+			yyq1147[3] = true
+			var yynn1147 int
+			if yyr1147 || yy2arr1147 {
+				r.EncodeArrayStart(4)
 			} else {
-				yynn1158 = 0
-				for _, b := range yyq1158 {
+				yynn1147 = 0
+				for _, b := range yyq1147 {
 					if b {
-						yynn1158++
+						yynn1147++
 					}
 				}
-				r.EncodeMapStart(yynn1158)
-				yynn1158 = 0
+				r.EncodeMapStart(yynn1147)
+				yynn1147 = 0
 			}
-			if yyr1158 || yy2arr1158 {
+			if yyr1147 || yy2arr1147 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1158[0] {
-					if x.MatchLabels == nil {
-						r.EncodeNil()
-					} else {
-						yym1160 := z.EncBinary()
-						_ = yym1160
-						if false {
-						} else {
-							z.F.EncMapStringStringV(x.MatchLabels, false, e)
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1158[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("matchLabels"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if x.MatchLabels == nil {
-						r.EncodeNil()
-					} else {
-						yym1161 := z.EncBinary()
-						_ = yym1161
-						if false {
-						} else {
-							z.F.EncMapStringStringV(x.MatchLabels, false, e)
-						}
-					}
-				}
-			}
-			if yyr1158 || yy2arr1158 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1158[1] {
-					if x.MatchExpressions == nil {
-						r.EncodeNil()
-					} else {
-						yym1163 := z.EncBinary()
-						_ = yym1163
-						if false {
-						} else {
-							h.encSliceLabelSelectorRequirement(([]LabelSelectorRequirement)(x.MatchExpressions), e)
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1158[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("matchExpressions"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if x.MatchExpressions == nil {
-						r.EncodeNil()
-					} else {
-						yym1164 := z.EncBinary()
-						_ = yym1164
-						if false {
-						} else {
-							h.encSliceLabelSelectorRequirement(([]LabelSelectorRequirement)(x.MatchExpressions), e)
-						}
-					}
-				}
-			}
-			if yyr1158 || yy2arr1158 {
-				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
-			}
-		}
-	}
-}
-
-func (x *LabelSelector) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym1165 := z.DecBinary()
-	_ = yym1165
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		yyct1166 := r.ContainerType()
-		if yyct1166 == codecSelferValueTypeMap1234 {
-			yyl1166 := r.ReadMapStart()
-			if yyl1166 == 0 {
-				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-			} else {
-				x.codecDecodeSelfFromMap(yyl1166, d)
-			}
-		} else if yyct1166 == codecSelferValueTypeArray1234 {
-			yyl1166 := r.ReadArrayStart()
-			if yyl1166 == 0 {
-				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				x.codecDecodeSelfFromArray(yyl1166, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *LabelSelector) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys1167Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1167Slc
-	var yyhl1167 bool = l >= 0
-	for yyj1167 := 0; ; yyj1167++ {
-		if yyhl1167 {
-			if yyj1167 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1167Slc = r.DecodeBytes(yys1167Slc, true, true)
-		yys1167 := string(yys1167Slc)
-		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1167 {
-		case "matchLabels":
-			if r.TryDecodeAsNil() {
-				x.MatchLabels = nil
-			} else {
-				yyv1168 := &x.MatchLabels
-				yym1169 := z.DecBinary()
-				_ = yym1169
-				if false {
-				} else {
-					z.F.DecMapStringStringX(yyv1168, false, d)
-				}
-			}
-		case "matchExpressions":
-			if r.TryDecodeAsNil() {
-				x.MatchExpressions = nil
-			} else {
-				yyv1170 := &x.MatchExpressions
-				yym1171 := z.DecBinary()
-				_ = yym1171
-				if false {
-				} else {
-					h.decSliceLabelSelectorRequirement((*[]LabelSelectorRequirement)(yyv1170), d)
-				}
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys1167)
-		} // end switch yys1167
-	} // end for yyj1167
-	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-}
-
-func (x *LabelSelector) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj1172 int
-	var yyb1172 bool
-	var yyhl1172 bool = l >= 0
-	yyj1172++
-	if yyhl1172 {
-		yyb1172 = yyj1172 > l
-	} else {
-		yyb1172 = r.CheckBreak()
-	}
-	if yyb1172 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.MatchLabels = nil
-	} else {
-		yyv1173 := &x.MatchLabels
-		yym1174 := z.DecBinary()
-		_ = yym1174
-		if false {
-		} else {
-			z.F.DecMapStringStringX(yyv1173, false, d)
-		}
-	}
-	yyj1172++
-	if yyhl1172 {
-		yyb1172 = yyj1172 > l
-	} else {
-		yyb1172 = r.CheckBreak()
-	}
-	if yyb1172 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.MatchExpressions = nil
-	} else {
-		yyv1175 := &x.MatchExpressions
-		yym1176 := z.DecBinary()
-		_ = yym1176
-		if false {
-		} else {
-			h.decSliceLabelSelectorRequirement((*[]LabelSelectorRequirement)(yyv1175), d)
-		}
-	}
-	for {
-		yyj1172++
-		if yyhl1172 {
-			yyb1172 = yyj1172 > l
-		} else {
-			yyb1172 = r.CheckBreak()
-		}
-		if yyb1172 {
-			break
-		}
-		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1172-1, "")
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x *LabelSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym1177 := z.EncBinary()
-		_ = yym1177
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep1178 := !z.EncBinary()
-			yy2arr1178 := z.EncBasicHandle().StructToArray
-			var yyq1178 [3]bool
-			_, _, _ = yysep1178, yyq1178, yy2arr1178
-			const yyr1178 bool = false
-			yyq1178[2] = len(x.Values) != 0
-			var yynn1178 int
-			if yyr1178 || yy2arr1178 {
-				r.EncodeArrayStart(3)
-			} else {
-				yynn1178 = 2
-				for _, b := range yyq1178 {
-					if b {
-						yynn1178++
-					}
-				}
-				r.EncodeMapStart(yynn1178)
-				yynn1178 = 0
-			}
-			if yyr1178 || yy2arr1178 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1180 := z.EncBinary()
-				_ = yym1180
-				if false {
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("key"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1181 := z.EncBinary()
-				_ = yym1181
-				if false {
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
-				}
-			}
-			if yyr1178 || yy2arr1178 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				x.Operator.CodecEncodeSelf(e)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("operator"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				x.Operator.CodecEncodeSelf(e)
-			}
-			if yyr1178 || yy2arr1178 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1178[2] {
-					if x.Values == nil {
-						r.EncodeNil()
-					} else {
-						yym1184 := z.EncBinary()
-						_ = yym1184
-						if false {
-						} else {
-							z.F.EncSliceStringV(x.Values, false, e)
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1178[2] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("values"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if x.Values == nil {
-						r.EncodeNil()
-					} else {
-						yym1185 := z.EncBinary()
-						_ = yym1185
-						if false {
-						} else {
-							z.F.EncSliceStringV(x.Values, false, e)
-						}
-					}
-				}
-			}
-			if yyr1178 || yy2arr1178 {
-				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
-			}
-		}
-	}
-}
-
-func (x *LabelSelectorRequirement) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym1186 := z.DecBinary()
-	_ = yym1186
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		yyct1187 := r.ContainerType()
-		if yyct1187 == codecSelferValueTypeMap1234 {
-			yyl1187 := r.ReadMapStart()
-			if yyl1187 == 0 {
-				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-			} else {
-				x.codecDecodeSelfFromMap(yyl1187, d)
-			}
-		} else if yyct1187 == codecSelferValueTypeArray1234 {
-			yyl1187 := r.ReadArrayStart()
-			if yyl1187 == 0 {
-				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				x.codecDecodeSelfFromArray(yyl1187, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *LabelSelectorRequirement) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys1188Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1188Slc
-	var yyhl1188 bool = l >= 0
-	for yyj1188 := 0; ; yyj1188++ {
-		if yyhl1188 {
-			if yyj1188 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1188Slc = r.DecodeBytes(yys1188Slc, true, true)
-		yys1188 := string(yys1188Slc)
-		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1188 {
-		case "key":
-			if r.TryDecodeAsNil() {
-				x.Key = ""
-			} else {
-				x.Key = string(r.DecodeString())
-			}
-		case "operator":
-			if r.TryDecodeAsNil() {
-				x.Operator = ""
-			} else {
-				x.Operator = LabelSelectorOperator(r.DecodeString())
-			}
-		case "values":
-			if r.TryDecodeAsNil() {
-				x.Values = nil
-			} else {
-				yyv1191 := &x.Values
-				yym1192 := z.DecBinary()
-				_ = yym1192
-				if false {
-				} else {
-					z.F.DecSliceStringX(yyv1191, false, d)
-				}
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys1188)
-		} // end switch yys1188
-	} // end for yyj1188
-	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-}
-
-func (x *LabelSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj1193 int
-	var yyb1193 bool
-	var yyhl1193 bool = l >= 0
-	yyj1193++
-	if yyhl1193 {
-		yyb1193 = yyj1193 > l
-	} else {
-		yyb1193 = r.CheckBreak()
-	}
-	if yyb1193 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Key = ""
-	} else {
-		x.Key = string(r.DecodeString())
-	}
-	yyj1193++
-	if yyhl1193 {
-		yyb1193 = yyj1193 > l
-	} else {
-		yyb1193 = r.CheckBreak()
-	}
-	if yyb1193 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Operator = ""
-	} else {
-		x.Operator = LabelSelectorOperator(r.DecodeString())
-	}
-	yyj1193++
-	if yyhl1193 {
-		yyb1193 = yyj1193 > l
-	} else {
-		yyb1193 = r.CheckBreak()
-	}
-	if yyb1193 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Values = nil
-	} else {
-		yyv1196 := &x.Values
-		yym1197 := z.DecBinary()
-		_ = yym1197
-		if false {
-		} else {
-			z.F.DecSliceStringX(yyv1196, false, d)
-		}
-	}
-	for {
-		yyj1193++
-		if yyhl1193 {
-			yyb1193 = yyj1193 > l
-		} else {
-			yyb1193 = r.CheckBreak()
-		}
-		if yyb1193 {
-			break
-		}
-		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1193-1, "")
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x LabelSelectorOperator) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	yym1198 := z.EncBinary()
-	_ = yym1198
-	if false {
-	} else if z.HasExtensions() && z.EncExt(x) {
-	} else {
-		r.EncodeString(codecSelferC_UTF81234, string(x))
-	}
-}
-
-func (x *LabelSelectorOperator) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym1199 := z.DecBinary()
-	_ = yym1199
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		*((*string)(x)) = r.DecodeString()
-	}
-}
-
-func (x *ReplicaSet) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym1200 := z.EncBinary()
-		_ = yym1200
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep1201 := !z.EncBinary()
-			yy2arr1201 := z.EncBasicHandle().StructToArray
-			var yyq1201 [5]bool
-			_, _, _ = yysep1201, yyq1201, yy2arr1201
-			const yyr1201 bool = false
-			yyq1201[0] = x.Kind != ""
-			yyq1201[1] = x.APIVersion != ""
-			yyq1201[2] = true
-			yyq1201[3] = true
-			yyq1201[4] = true
-			var yynn1201 int
-			if yyr1201 || yy2arr1201 {
-				r.EncodeArrayStart(5)
-			} else {
-				yynn1201 = 0
-				for _, b := range yyq1201 {
-					if b {
-						yynn1201++
-					}
-				}
-				r.EncodeMapStart(yynn1201)
-				yynn1201 = 0
-			}
-			if yyr1201 || yy2arr1201 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1201[0] {
-					yym1203 := z.EncBinary()
-					_ = yym1203
+				if yyq1147[0] {
+					yym1149 := z.EncBinary()
+					_ = yym1149
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -14345,23 +13741,23 @@ func (x *ReplicaSet) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1201[0] {
+				if yyq1147[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1204 := z.EncBinary()
-					_ = yym1204
+					yym1150 := z.EncBinary()
+					_ = yym1150
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1201 || yy2arr1201 {
+			if yyr1147 || yy2arr1147 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1201[1] {
-					yym1206 := z.EncBinary()
-					_ = yym1206
+				if yyq1147[1] {
+					yym1152 := z.EncBinary()
+					_ = yym1152
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -14370,70 +13766,53 @@ func (x *ReplicaSet) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1201[1] {
+				if yyq1147[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1207 := z.EncBinary()
-					_ = yym1207
+					yym1153 := z.EncBinary()
+					_ = yym1153
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1201 || yy2arr1201 {
+			if yyr1147 || yy2arr1147 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1201[2] {
-					yy1209 := &x.ObjectMeta
-					yy1209.CodecEncodeSelf(e)
+				if yyq1147[2] {
+					yy1155 := &x.ObjectMeta
+					yy1155.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1201[2] {
+				if yyq1147[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1210 := &x.ObjectMeta
-					yy1210.CodecEncodeSelf(e)
+					yy1156 := &x.ObjectMeta
+					yy1156.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1201 || yy2arr1201 {
+			if yyr1147 || yy2arr1147 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1201[3] {
-					yy1212 := &x.Spec
-					yy1212.CodecEncodeSelf(e)
+				if yyq1147[3] {
+					yy1158 := &x.Spec
+					yy1158.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1201[3] {
+				if yyq1147[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1213 := &x.Spec
-					yy1213.CodecEncodeSelf(e)
+					yy1159 := &x.Spec
+					yy1159.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1201 || yy2arr1201 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1201[4] {
-					yy1215 := &x.Status
-					yy1215.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1201[4] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1216 := &x.Status
-					yy1216.CodecEncodeSelf(e)
-				}
-			}
-			if yyr1201 || yy2arr1201 {
+			if yyr1147 || yy2arr1147 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -14442,29 +13821,29 @@ func (x *ReplicaSet) CodecEncodeSelf(e *codec1978.Encoder) {
 	}
 }
 
-func (x *ReplicaSet) CodecDecodeSelf(d *codec1978.Decoder) {
+func (x *ClusterAutoscaler) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1217 := z.DecBinary()
-	_ = yym1217
+	yym1160 := z.DecBinary()
+	_ = yym1160
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1218 := r.ContainerType()
-		if yyct1218 == codecSelferValueTypeMap1234 {
-			yyl1218 := r.ReadMapStart()
-			if yyl1218 == 0 {
+		yyct1161 := r.ContainerType()
+		if yyct1161 == codecSelferValueTypeMap1234 {
+			yyl1161 := r.ReadMapStart()
+			if yyl1161 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1218, d)
+				x.codecDecodeSelfFromMap(yyl1161, d)
 			}
-		} else if yyct1218 == codecSelferValueTypeArray1234 {
-			yyl1218 := r.ReadArrayStart()
-			if yyl1218 == 0 {
+		} else if yyct1161 == codecSelferValueTypeArray1234 {
+			yyl1161 := r.ReadArrayStart()
+			if yyl1161 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1218, d)
+				x.codecDecodeSelfFromArray(yyl1161, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -14472,16 +13851,16 @@ func (x *ReplicaSet) CodecDecodeSelf(d *codec1978.Decoder) {
 	}
 }
 
-func (x *ReplicaSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1219Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1219Slc
-	var yyhl1219 bool = l >= 0
-	for yyj1219 := 0; ; yyj1219++ {
-		if yyhl1219 {
-			if yyj1219 >= l {
+	var yys1162Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1162Slc
+	var yyhl1162 bool = l >= 0
+	for yyj1162 := 0; ; yyj1162++ {
+		if yyhl1162 {
+			if yyj1162 >= l {
 				break
 			}
 		} else {
@@ -14490,10 +13869,10 @@ func (x *ReplicaSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1219Slc = r.DecodeBytes(yys1219Slc, true, true)
-		yys1219 := string(yys1219Slc)
+		yys1162Slc = r.DecodeBytes(yys1162Slc, true, true)
+		yys1162 := string(yys1162Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1219 {
+		switch yys1162 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -14510,44 +13889,37 @@ func (x *ReplicaSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv1222 := &x.ObjectMeta
-				yyv1222.CodecDecodeSelf(d)
+				yyv1165 := &x.ObjectMeta
+				yyv1165.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
-				x.Spec = ReplicaSetSpec{}
+				x.Spec = ClusterAutoscalerSpec{}
 			} else {
-				yyv1223 := &x.Spec
-				yyv1223.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = ReplicaSetStatus{}
-			} else {
-				yyv1224 := &x.Status
-				yyv1224.CodecDecodeSelf(d)
+				yyv1166 := &x.Spec
+				yyv1166.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1219)
-		} // end switch yys1219
-	} // end for yyj1219
+			z.DecStructFieldNotFound(-1, yys1162)
+		} // end switch yys1162
+	} // end for yyj1162
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
-func (x *ReplicaSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1225 int
-	var yyb1225 bool
-	var yyhl1225 bool = l >= 0
-	yyj1225++
-	if yyhl1225 {
-		yyb1225 = yyj1225 > l
+	var yyj1167 int
+	var yyb1167 bool
+	var yyhl1167 bool = l >= 0
+	yyj1167++
+	if yyhl1167 {
+		yyb1167 = yyj1167 > l
 	} else {
-		yyb1225 = r.CheckBreak()
+		yyb1167 = r.CheckBreak()
 	}
-	if yyb1225 {
+	if yyb1167 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14557,13 +13929,13 @@ func (x *ReplicaSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1225++
-	if yyhl1225 {
-		yyb1225 = yyj1225 > l
+	yyj1167++
+	if yyhl1167 {
+		yyb1167 = yyj1167 > l
 	} else {
-		yyb1225 = r.CheckBreak()
+		yyb1167 = r.CheckBreak()
 	}
-	if yyb1225 {
+	if yyb1167 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14573,13 +13945,13 @@ func (x *ReplicaSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1225++
-	if yyhl1225 {
-		yyb1225 = yyj1225 > l
+	yyj1167++
+	if yyhl1167 {
+		yyb1167 = yyj1167 > l
 	} else {
-		yyb1225 = r.CheckBreak()
+		yyb1167 = r.CheckBreak()
 	}
-	if yyb1225 {
+	if yyb1167 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14587,97 +13959,80 @@ func (x *ReplicaSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv1228 := &x.ObjectMeta
-		yyv1228.CodecDecodeSelf(d)
+		yyv1170 := &x.ObjectMeta
+		yyv1170.CodecDecodeSelf(d)
 	}
-	yyj1225++
-	if yyhl1225 {
-		yyb1225 = yyj1225 > l
+	yyj1167++
+	if yyhl1167 {
+		yyb1167 = yyj1167 > l
 	} else {
-		yyb1225 = r.CheckBreak()
+		yyb1167 = r.CheckBreak()
 	}
-	if yyb1225 {
+	if yyb1167 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.Spec = ReplicaSetSpec{}
+		x.Spec = ClusterAutoscalerSpec{}
 	} else {
-		yyv1229 := &x.Spec
-		yyv1229.CodecDecodeSelf(d)
-	}
-	yyj1225++
-	if yyhl1225 {
-		yyb1225 = yyj1225 > l
-	} else {
-		yyb1225 = r.CheckBreak()
-	}
-	if yyb1225 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = ReplicaSetStatus{}
-	} else {
-		yyv1230 := &x.Status
-		yyv1230.CodecDecodeSelf(d)
+		yyv1171 := &x.Spec
+		yyv1171.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1225++
-		if yyhl1225 {
-			yyb1225 = yyj1225 > l
+		yyj1167++
+		if yyhl1167 {
+			yyb1167 = yyj1167 > l
 		} else {
-			yyb1225 = r.CheckBreak()
+			yyb1167 = r.CheckBreak()
 		}
-		if yyb1225 {
+		if yyb1167 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1225-1, "")
+		z.DecStructFieldNotFound(yyj1167-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
-func (x *ReplicaSetList) CodecEncodeSelf(e *codec1978.Encoder) {
+func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1231 := z.EncBinary()
-		_ = yym1231
+		yym1172 := z.EncBinary()
+		_ = yym1172
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1232 := !z.EncBinary()
-			yy2arr1232 := z.EncBasicHandle().StructToArray
-			var yyq1232 [4]bool
-			_, _, _ = yysep1232, yyq1232, yy2arr1232
-			const yyr1232 bool = false
-			yyq1232[0] = x.Kind != ""
-			yyq1232[1] = x.APIVersion != ""
-			yyq1232[2] = true
-			var yynn1232 int
-			if yyr1232 || yy2arr1232 {
+			yysep1173 := !z.EncBinary()
+			yy2arr1173 := z.EncBasicHandle().StructToArray
+			var yyq1173 [4]bool
+			_, _, _ = yysep1173, yyq1173, yy2arr1173
+			const yyr1173 bool = false
+			yyq1173[0] = x.Kind != ""
+			yyq1173[1] = x.APIVersion != ""
+			yyq1173[2] = true
+			var yynn1173 int
+			if yyr1173 || yy2arr1173 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn1232 = 1
-				for _, b := range yyq1232 {
+				yynn1173 = 1
+				for _, b := range yyq1173 {
 					if b {
-						yynn1232++
+						yynn1173++
 					}
 				}
-				r.EncodeMapStart(yynn1232)
-				yynn1232 = 0
+				r.EncodeMapStart(yynn1173)
+				yynn1173 = 0
 			}
-			if yyr1232 || yy2arr1232 {
+			if yyr1173 || yy2arr1173 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1232[0] {
-					yym1234 := z.EncBinary()
-					_ = yym1234
+				if yyq1173[0] {
+					yym1175 := z.EncBinary()
+					_ = yym1175
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -14686,23 +14041,23 @@ func (x *ReplicaSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1232[0] {
+				if yyq1173[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1235 := z.EncBinary()
-					_ = yym1235
+					yym1176 := z.EncBinary()
+					_ = yym1176
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1232 || yy2arr1232 {
+			if yyr1173 || yy2arr1173 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1232[1] {
-					yym1237 := z.EncBinary()
-					_ = yym1237
+				if yyq1173[1] {
+					yym1178 := z.EncBinary()
+					_ = yym1178
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -14711,57 +14066,57 @@ func (x *ReplicaSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1232[1] {
+				if yyq1173[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1238 := z.EncBinary()
-					_ = yym1238
+					yym1179 := z.EncBinary()
+					_ = yym1179
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1232 || yy2arr1232 {
+			if yyr1173 || yy2arr1173 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1232[2] {
-					yy1240 := &x.ListMeta
-					yym1241 := z.EncBinary()
-					_ = yym1241
+				if yyq1173[2] {
+					yy1181 := &x.ListMeta
+					yym1182 := z.EncBinary()
+					_ = yym1182
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1240) {
+					} else if z.HasExtensions() && z.EncExt(yy1181) {
 					} else {
-						z.EncFallback(yy1240)
+						z.EncFallback(yy1181)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1232[2] {
+				if yyq1173[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1242 := &x.ListMeta
-					yym1243 := z.EncBinary()
-					_ = yym1243
+					yy1183 := &x.ListMeta
+					yym1184 := z.EncBinary()
+					_ = yym1184
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1242) {
+					} else if z.HasExtensions() && z.EncExt(yy1183) {
 					} else {
-						z.EncFallback(yy1242)
+						z.EncFallback(yy1183)
 					}
 				}
 			}
-			if yyr1232 || yy2arr1232 {
+			if yyr1173 || yy2arr1173 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1245 := z.EncBinary()
-					_ = yym1245
+					yym1186 := z.EncBinary()
+					_ = yym1186
 					if false {
 					} else {
-						h.encSliceReplicaSet(([]ReplicaSet)(x.Items), e)
+						h.encSliceClusterAutoscaler(([]ClusterAutoscaler)(x.Items), e)
 					}
 				}
 			} else {
@@ -14771,15 +14126,15 @@ func (x *ReplicaSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1246 := z.EncBinary()
-					_ = yym1246
+					yym1187 := z.EncBinary()
+					_ = yym1187
 					if false {
 					} else {
-						h.encSliceReplicaSet(([]ReplicaSet)(x.Items), e)
+						h.encSliceClusterAutoscaler(([]ClusterAutoscaler)(x.Items), e)
 					}
 				}
 			}
-			if yyr1232 || yy2arr1232 {
+			if yyr1173 || yy2arr1173 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -14788,29 +14143,29 @@ func (x *ReplicaSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 	}
 }
 
-func (x *ReplicaSetList) CodecDecodeSelf(d *codec1978.Decoder) {
+func (x *ClusterAutoscalerList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1247 := z.DecBinary()
-	_ = yym1247
+	yym1188 := z.DecBinary()
+	_ = yym1188
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1248 := r.ContainerType()
-		if yyct1248 == codecSelferValueTypeMap1234 {
-			yyl1248 := r.ReadMapStart()
-			if yyl1248 == 0 {
+		yyct1189 := r.ContainerType()
+		if yyct1189 == codecSelferValueTypeMap1234 {
+			yyl1189 := r.ReadMapStart()
+			if yyl1189 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1248, d)
+				x.codecDecodeSelfFromMap(yyl1189, d)
 			}
-		} else if yyct1248 == codecSelferValueTypeArray1234 {
-			yyl1248 := r.ReadArrayStart()
-			if yyl1248 == 0 {
+		} else if yyct1189 == codecSelferValueTypeArray1234 {
+			yyl1189 := r.ReadArrayStart()
+			if yyl1189 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1248, d)
+				x.codecDecodeSelfFromArray(yyl1189, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -14818,16 +14173,16 @@ func (x *ReplicaSetList) CodecDecodeSelf(d *codec1978.Decoder) {
 	}
 }
 
-func (x *ReplicaSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1249Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1249Slc
-	var yyhl1249 bool = l >= 0
-	for yyj1249 := 0; ; yyj1249++ {
-		if yyhl1249 {
-			if yyj1249 >= l {
+	var yys1190Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1190Slc
+	var yyhl1190 bool = l >= 0
+	for yyj1190 := 0; ; yyj1190++ {
+		if yyhl1190 {
+			if yyj1190 >= l {
 				break
 			}
 		} else {
@@ -14836,10 +14191,10 @@ func (x *ReplicaSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1249Slc = r.DecodeBytes(yys1249Slc, true, true)
-		yys1249 := string(yys1249Slc)
+		yys1190Slc = r.DecodeBytes(yys1190Slc, true, true)
+		yys1190 := string(yys1190Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1249 {
+		switch yys1190 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -14856,48 +14211,48 @@ func (x *ReplicaSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv1252 := &x.ListMeta
-				yym1253 := z.DecBinary()
-				_ = yym1253
+				yyv1193 := &x.ListMeta
+				yym1194 := z.DecBinary()
+				_ = yym1194
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1252) {
+				} else if z.HasExtensions() && z.DecExt(yyv1193) {
 				} else {
-					z.DecFallback(yyv1252, false)
+					z.DecFallback(yyv1193, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv1254 := &x.Items
-				yym1255 := z.DecBinary()
-				_ = yym1255
+				yyv1195 := &x.Items
+				yym1196 := z.DecBinary()
+				_ = yym1196
 				if false {
 				} else {
-					h.decSliceReplicaSet((*[]ReplicaSet)(yyv1254), d)
+					h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1195), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1249)
-		} // end switch yys1249
-	} // end for yyj1249
+			z.DecStructFieldNotFound(-1, yys1190)
+		} // end switch yys1190
+	} // end for yyj1190
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
-func (x *ReplicaSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1256 int
-	var yyb1256 bool
-	var yyhl1256 bool = l >= 0
-	yyj1256++
-	if yyhl1256 {
-		yyb1256 = yyj1256 > l
+	var yyj1197 int
+	var yyb1197 bool
+	var yyhl1197 bool = l >= 0
+	yyj1197++
+	if yyhl1197 {
+		yyb1197 = yyj1197 > l
 	} else {
-		yyb1256 = r.CheckBreak()
+		yyb1197 = r.CheckBreak()
 	}
-	if yyb1256 {
+	if yyb1197 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14907,13 +14262,13 @@ func (x *ReplicaSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1256++
-	if yyhl1256 {
-		yyb1256 = yyj1256 > l
+	yyj1197++
+	if yyhl1197 {
+		yyb1197 = yyj1197 > l
 	} else {
-		yyb1256 = r.CheckBreak()
+		yyb1197 = r.CheckBreak()
 	}
-	if yyb1256 {
+	if yyb1197 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14923,13 +14278,13 @@ func (x *ReplicaSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1256++
-	if yyhl1256 {
-		yyb1256 = yyj1256 > l
+	yyj1197++
+	if yyhl1197 {
+		yyb1197 = yyj1197 > l
 	} else {
-		yyb1256 = r.CheckBreak()
+		yyb1197 = r.CheckBreak()
 	}
-	if yyb1256 {
+	if yyb1197 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14937,22 +14292,22 @@ func (x *ReplicaSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv1259 := &x.ListMeta
-		yym1260 := z.DecBinary()
-		_ = yym1260
+		yyv1200 := &x.ListMeta
+		yym1201 := z.DecBinary()
+		_ = yym1201
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1259) {
+		} else if z.HasExtensions() && z.DecExt(yyv1200) {
 		} else {
-			z.DecFallback(yyv1259, false)
+			z.DecFallback(yyv1200, false)
 		}
 	}
-	yyj1256++
-	if yyhl1256 {
-		yyb1256 = yyj1256 > l
+	yyj1197++
+	if yyhl1197 {
+		yyb1197 = yyj1197 > l
 	} else {
-		yyb1256 = r.CheckBreak()
+		yyb1197 = r.CheckBreak()
 	}
-	if yyb1256 {
+	if yyb1197 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14960,26 +14315,1257 @@ func (x *ReplicaSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv1261 := &x.Items
-		yym1262 := z.DecBinary()
-		_ = yym1262
+		yyv1202 := &x.Items
+		yym1203 := z.DecBinary()
+		_ = yym1203
 		if false {
 		} else {
-			h.decSliceReplicaSet((*[]ReplicaSet)(yyv1261), d)
+			h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1202), d)
 		}
 	}
 	for {
-		yyj1256++
-		if yyhl1256 {
-			yyb1256 = yyj1256 > l
+		yyj1197++
+		if yyhl1197 {
+			yyb1197 = yyj1197 > l
 		} else {
-			yyb1256 = r.CheckBreak()
+			yyb1197 = r.CheckBreak()
 		}
-		if yyb1256 {
+		if yyb1197 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1256-1, "")
+		z.DecStructFieldNotFound(yyj1197-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x *LabelSelector) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym1204 := z.EncBinary()
+		_ = yym1204
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep1205 := !z.EncBinary()
+			yy2arr1205 := z.EncBasicHandle().StructToArray
+			var yyq1205 [2]bool
+			_, _, _ = yysep1205, yyq1205, yy2arr1205
+			const yyr1205 bool = false
+			yyq1205[0] = len(x.MatchLabels) != 0
+			yyq1205[1] = len(x.MatchExpressions) != 0
+			var yynn1205 int
+			if yyr1205 || yy2arr1205 {
+				r.EncodeArrayStart(2)
+			} else {
+				yynn1205 = 0
+				for _, b := range yyq1205 {
+					if b {
+						yynn1205++
+					}
+				}
+				r.EncodeMapStart(yynn1205)
+				yynn1205 = 0
+			}
+			if yyr1205 || yy2arr1205 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1205[0] {
+					if x.MatchLabels == nil {
+						r.EncodeNil()
+					} else {
+						yym1207 := z.EncBinary()
+						_ = yym1207
+						if false {
+						} else {
+							z.F.EncMapStringStringV(x.MatchLabels, false, e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1205[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("matchLabels"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if x.MatchLabels == nil {
+						r.EncodeNil()
+					} else {
+						yym1208 := z.EncBinary()
+						_ = yym1208
+						if false {
+						} else {
+							z.F.EncMapStringStringV(x.MatchLabels, false, e)
+						}
+					}
+				}
+			}
+			if yyr1205 || yy2arr1205 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1205[1] {
+					if x.MatchExpressions == nil {
+						r.EncodeNil()
+					} else {
+						yym1210 := z.EncBinary()
+						_ = yym1210
+						if false {
+						} else {
+							h.encSliceLabelSelectorRequirement(([]LabelSelectorRequirement)(x.MatchExpressions), e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1205[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("matchExpressions"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if x.MatchExpressions == nil {
+						r.EncodeNil()
+					} else {
+						yym1211 := z.EncBinary()
+						_ = yym1211
+						if false {
+						} else {
+							h.encSliceLabelSelectorRequirement(([]LabelSelectorRequirement)(x.MatchExpressions), e)
+						}
+					}
+				}
+			}
+			if yyr1205 || yy2arr1205 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *LabelSelector) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym1212 := z.DecBinary()
+	_ = yym1212
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct1213 := r.ContainerType()
+		if yyct1213 == codecSelferValueTypeMap1234 {
+			yyl1213 := r.ReadMapStart()
+			if yyl1213 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl1213, d)
+			}
+		} else if yyct1213 == codecSelferValueTypeArray1234 {
+			yyl1213 := r.ReadArrayStart()
+			if yyl1213 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl1213, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *LabelSelector) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys1214Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1214Slc
+	var yyhl1214 bool = l >= 0
+	for yyj1214 := 0; ; yyj1214++ {
+		if yyhl1214 {
+			if yyj1214 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys1214Slc = r.DecodeBytes(yys1214Slc, true, true)
+		yys1214 := string(yys1214Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys1214 {
+		case "matchLabels":
+			if r.TryDecodeAsNil() {
+				x.MatchLabels = nil
+			} else {
+				yyv1215 := &x.MatchLabels
+				yym1216 := z.DecBinary()
+				_ = yym1216
+				if false {
+				} else {
+					z.F.DecMapStringStringX(yyv1215, false, d)
+				}
+			}
+		case "matchExpressions":
+			if r.TryDecodeAsNil() {
+				x.MatchExpressions = nil
+			} else {
+				yyv1217 := &x.MatchExpressions
+				yym1218 := z.DecBinary()
+				_ = yym1218
+				if false {
+				} else {
+					h.decSliceLabelSelectorRequirement((*[]LabelSelectorRequirement)(yyv1217), d)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys1214)
+		} // end switch yys1214
+	} // end for yyj1214
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *LabelSelector) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj1219 int
+	var yyb1219 bool
+	var yyhl1219 bool = l >= 0
+	yyj1219++
+	if yyhl1219 {
+		yyb1219 = yyj1219 > l
+	} else {
+		yyb1219 = r.CheckBreak()
+	}
+	if yyb1219 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.MatchLabels = nil
+	} else {
+		yyv1220 := &x.MatchLabels
+		yym1221 := z.DecBinary()
+		_ = yym1221
+		if false {
+		} else {
+			z.F.DecMapStringStringX(yyv1220, false, d)
+		}
+	}
+	yyj1219++
+	if yyhl1219 {
+		yyb1219 = yyj1219 > l
+	} else {
+		yyb1219 = r.CheckBreak()
+	}
+	if yyb1219 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.MatchExpressions = nil
+	} else {
+		yyv1222 := &x.MatchExpressions
+		yym1223 := z.DecBinary()
+		_ = yym1223
+		if false {
+		} else {
+			h.decSliceLabelSelectorRequirement((*[]LabelSelectorRequirement)(yyv1222), d)
+		}
+	}
+	for {
+		yyj1219++
+		if yyhl1219 {
+			yyb1219 = yyj1219 > l
+		} else {
+			yyb1219 = r.CheckBreak()
+		}
+		if yyb1219 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj1219-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x *LabelSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym1224 := z.EncBinary()
+		_ = yym1224
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep1225 := !z.EncBinary()
+			yy2arr1225 := z.EncBasicHandle().StructToArray
+			var yyq1225 [3]bool
+			_, _, _ = yysep1225, yyq1225, yy2arr1225
+			const yyr1225 bool = false
+			yyq1225[2] = len(x.Values) != 0
+			var yynn1225 int
+			if yyr1225 || yy2arr1225 {
+				r.EncodeArrayStart(3)
+			} else {
+				yynn1225 = 2
+				for _, b := range yyq1225 {
+					if b {
+						yynn1225++
+					}
+				}
+				r.EncodeMapStart(yynn1225)
+				yynn1225 = 0
+			}
+			if yyr1225 || yy2arr1225 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym1227 := z.EncBinary()
+				_ = yym1227
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("key"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym1228 := z.EncBinary()
+				_ = yym1228
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
+				}
+			}
+			if yyr1225 || yy2arr1225 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				x.Operator.CodecEncodeSelf(e)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("operator"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				x.Operator.CodecEncodeSelf(e)
+			}
+			if yyr1225 || yy2arr1225 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1225[2] {
+					if x.Values == nil {
+						r.EncodeNil()
+					} else {
+						yym1231 := z.EncBinary()
+						_ = yym1231
+						if false {
+						} else {
+							z.F.EncSliceStringV(x.Values, false, e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1225[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("values"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if x.Values == nil {
+						r.EncodeNil()
+					} else {
+						yym1232 := z.EncBinary()
+						_ = yym1232
+						if false {
+						} else {
+							z.F.EncSliceStringV(x.Values, false, e)
+						}
+					}
+				}
+			}
+			if yyr1225 || yy2arr1225 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *LabelSelectorRequirement) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym1233 := z.DecBinary()
+	_ = yym1233
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct1234 := r.ContainerType()
+		if yyct1234 == codecSelferValueTypeMap1234 {
+			yyl1234 := r.ReadMapStart()
+			if yyl1234 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl1234, d)
+			}
+		} else if yyct1234 == codecSelferValueTypeArray1234 {
+			yyl1234 := r.ReadArrayStart()
+			if yyl1234 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl1234, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *LabelSelectorRequirement) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys1235Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1235Slc
+	var yyhl1235 bool = l >= 0
+	for yyj1235 := 0; ; yyj1235++ {
+		if yyhl1235 {
+			if yyj1235 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys1235Slc = r.DecodeBytes(yys1235Slc, true, true)
+		yys1235 := string(yys1235Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys1235 {
+		case "key":
+			if r.TryDecodeAsNil() {
+				x.Key = ""
+			} else {
+				x.Key = string(r.DecodeString())
+			}
+		case "operator":
+			if r.TryDecodeAsNil() {
+				x.Operator = ""
+			} else {
+				x.Operator = LabelSelectorOperator(r.DecodeString())
+			}
+		case "values":
+			if r.TryDecodeAsNil() {
+				x.Values = nil
+			} else {
+				yyv1238 := &x.Values
+				yym1239 := z.DecBinary()
+				_ = yym1239
+				if false {
+				} else {
+					z.F.DecSliceStringX(yyv1238, false, d)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys1235)
+		} // end switch yys1235
+	} // end for yyj1235
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *LabelSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj1240 int
+	var yyb1240 bool
+	var yyhl1240 bool = l >= 0
+	yyj1240++
+	if yyhl1240 {
+		yyb1240 = yyj1240 > l
+	} else {
+		yyb1240 = r.CheckBreak()
+	}
+	if yyb1240 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Key = ""
+	} else {
+		x.Key = string(r.DecodeString())
+	}
+	yyj1240++
+	if yyhl1240 {
+		yyb1240 = yyj1240 > l
+	} else {
+		yyb1240 = r.CheckBreak()
+	}
+	if yyb1240 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Operator = ""
+	} else {
+		x.Operator = LabelSelectorOperator(r.DecodeString())
+	}
+	yyj1240++
+	if yyhl1240 {
+		yyb1240 = yyj1240 > l
+	} else {
+		yyb1240 = r.CheckBreak()
+	}
+	if yyb1240 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Values = nil
+	} else {
+		yyv1243 := &x.Values
+		yym1244 := z.DecBinary()
+		_ = yym1244
+		if false {
+		} else {
+			z.F.DecSliceStringX(yyv1243, false, d)
+		}
+	}
+	for {
+		yyj1240++
+		if yyhl1240 {
+			yyb1240 = yyj1240 > l
+		} else {
+			yyb1240 = r.CheckBreak()
+		}
+		if yyb1240 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj1240-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x LabelSelectorOperator) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	yym1245 := z.EncBinary()
+	_ = yym1245
+	if false {
+	} else if z.HasExtensions() && z.EncExt(x) {
+	} else {
+		r.EncodeString(codecSelferC_UTF81234, string(x))
+	}
+}
+
+func (x *LabelSelectorOperator) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym1246 := z.DecBinary()
+	_ = yym1246
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		*((*string)(x)) = r.DecodeString()
+	}
+}
+
+func (x *ReplicaSet) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym1247 := z.EncBinary()
+		_ = yym1247
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep1248 := !z.EncBinary()
+			yy2arr1248 := z.EncBasicHandle().StructToArray
+			var yyq1248 [5]bool
+			_, _, _ = yysep1248, yyq1248, yy2arr1248
+			const yyr1248 bool = false
+			yyq1248[0] = x.Kind != ""
+			yyq1248[1] = x.APIVersion != ""
+			yyq1248[2] = true
+			yyq1248[3] = true
+			yyq1248[4] = true
+			var yynn1248 int
+			if yyr1248 || yy2arr1248 {
+				r.EncodeArrayStart(5)
+			} else {
+				yynn1248 = 0
+				for _, b := range yyq1248 {
+					if b {
+						yynn1248++
+					}
+				}
+				r.EncodeMapStart(yynn1248)
+				yynn1248 = 0
+			}
+			if yyr1248 || yy2arr1248 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1248[0] {
+					yym1250 := z.EncBinary()
+					_ = yym1250
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1248[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1251 := z.EncBinary()
+					_ = yym1251
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr1248 || yy2arr1248 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1248[1] {
+					yym1253 := z.EncBinary()
+					_ = yym1253
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1248[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1254 := z.EncBinary()
+					_ = yym1254
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr1248 || yy2arr1248 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1248[2] {
+					yy1256 := &x.ObjectMeta
+					yy1256.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1248[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1257 := &x.ObjectMeta
+					yy1257.CodecEncodeSelf(e)
+				}
+			}
+			if yyr1248 || yy2arr1248 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1248[3] {
+					yy1259 := &x.Spec
+					yy1259.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1248[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1260 := &x.Spec
+					yy1260.CodecEncodeSelf(e)
+				}
+			}
+			if yyr1248 || yy2arr1248 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1248[4] {
+					yy1262 := &x.Status
+					yy1262.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1248[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1263 := &x.Status
+					yy1263.CodecEncodeSelf(e)
+				}
+			}
+			if yyr1248 || yy2arr1248 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *ReplicaSet) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym1264 := z.DecBinary()
+	_ = yym1264
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct1265 := r.ContainerType()
+		if yyct1265 == codecSelferValueTypeMap1234 {
+			yyl1265 := r.ReadMapStart()
+			if yyl1265 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl1265, d)
+			}
+		} else if yyct1265 == codecSelferValueTypeArray1234 {
+			yyl1265 := r.ReadArrayStart()
+			if yyl1265 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl1265, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *ReplicaSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys1266Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1266Slc
+	var yyhl1266 bool = l >= 0
+	for yyj1266 := 0; ; yyj1266++ {
+		if yyhl1266 {
+			if yyj1266 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys1266Slc = r.DecodeBytes(yys1266Slc, true, true)
+		yys1266 := string(yys1266Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys1266 {
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
+			}
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_api.ObjectMeta{}
+			} else {
+				yyv1269 := &x.ObjectMeta
+				yyv1269.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = ReplicaSetSpec{}
+			} else {
+				yyv1270 := &x.Spec
+				yyv1270.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = ReplicaSetStatus{}
+			} else {
+				yyv1271 := &x.Status
+				yyv1271.CodecDecodeSelf(d)
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys1266)
+		} // end switch yys1266
+	} // end for yyj1266
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *ReplicaSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj1272 int
+	var yyb1272 bool
+	var yyhl1272 bool = l >= 0
+	yyj1272++
+	if yyhl1272 {
+		yyb1272 = yyj1272 > l
+	} else {
+		yyb1272 = r.CheckBreak()
+	}
+	if yyb1272 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj1272++
+	if yyhl1272 {
+		yyb1272 = yyj1272 > l
+	} else {
+		yyb1272 = r.CheckBreak()
+	}
+	if yyb1272 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
+	}
+	yyj1272++
+	if yyhl1272 {
+		yyb1272 = yyj1272 > l
+	} else {
+		yyb1272 = r.CheckBreak()
+	}
+	if yyb1272 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_api.ObjectMeta{}
+	} else {
+		yyv1275 := &x.ObjectMeta
+		yyv1275.CodecDecodeSelf(d)
+	}
+	yyj1272++
+	if yyhl1272 {
+		yyb1272 = yyj1272 > l
+	} else {
+		yyb1272 = r.CheckBreak()
+	}
+	if yyb1272 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = ReplicaSetSpec{}
+	} else {
+		yyv1276 := &x.Spec
+		yyv1276.CodecDecodeSelf(d)
+	}
+	yyj1272++
+	if yyhl1272 {
+		yyb1272 = yyj1272 > l
+	} else {
+		yyb1272 = r.CheckBreak()
+	}
+	if yyb1272 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = ReplicaSetStatus{}
+	} else {
+		yyv1277 := &x.Status
+		yyv1277.CodecDecodeSelf(d)
+	}
+	for {
+		yyj1272++
+		if yyhl1272 {
+			yyb1272 = yyj1272 > l
+		} else {
+			yyb1272 = r.CheckBreak()
+		}
+		if yyb1272 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj1272-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x *ReplicaSetList) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym1278 := z.EncBinary()
+		_ = yym1278
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep1279 := !z.EncBinary()
+			yy2arr1279 := z.EncBasicHandle().StructToArray
+			var yyq1279 [4]bool
+			_, _, _ = yysep1279, yyq1279, yy2arr1279
+			const yyr1279 bool = false
+			yyq1279[0] = x.Kind != ""
+			yyq1279[1] = x.APIVersion != ""
+			yyq1279[2] = true
+			var yynn1279 int
+			if yyr1279 || yy2arr1279 {
+				r.EncodeArrayStart(4)
+			} else {
+				yynn1279 = 1
+				for _, b := range yyq1279 {
+					if b {
+						yynn1279++
+					}
+				}
+				r.EncodeMapStart(yynn1279)
+				yynn1279 = 0
+			}
+			if yyr1279 || yy2arr1279 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1279[0] {
+					yym1281 := z.EncBinary()
+					_ = yym1281
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1279[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1282 := z.EncBinary()
+					_ = yym1282
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr1279 || yy2arr1279 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1279[1] {
+					yym1284 := z.EncBinary()
+					_ = yym1284
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1279[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1285 := z.EncBinary()
+					_ = yym1285
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr1279 || yy2arr1279 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1279[2] {
+					yy1287 := &x.ListMeta
+					yym1288 := z.EncBinary()
+					_ = yym1288
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1287) {
+					} else {
+						z.EncFallback(yy1287)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1279[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1289 := &x.ListMeta
+					yym1290 := z.EncBinary()
+					_ = yym1290
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1289) {
+					} else {
+						z.EncFallback(yy1289)
+					}
+				}
+			}
+			if yyr1279 || yy2arr1279 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if x.Items == nil {
+					r.EncodeNil()
+				} else {
+					yym1292 := z.EncBinary()
+					_ = yym1292
+					if false {
+					} else {
+						h.encSliceReplicaSet(([]ReplicaSet)(x.Items), e)
+					}
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				if x.Items == nil {
+					r.EncodeNil()
+				} else {
+					yym1293 := z.EncBinary()
+					_ = yym1293
+					if false {
+					} else {
+						h.encSliceReplicaSet(([]ReplicaSet)(x.Items), e)
+					}
+				}
+			}
+			if yyr1279 || yy2arr1279 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *ReplicaSetList) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym1294 := z.DecBinary()
+	_ = yym1294
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct1295 := r.ContainerType()
+		if yyct1295 == codecSelferValueTypeMap1234 {
+			yyl1295 := r.ReadMapStart()
+			if yyl1295 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl1295, d)
+			}
+		} else if yyct1295 == codecSelferValueTypeArray1234 {
+			yyl1295 := r.ReadArrayStart()
+			if yyl1295 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl1295, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *ReplicaSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys1296Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1296Slc
+	var yyhl1296 bool = l >= 0
+	for yyj1296 := 0; ; yyj1296++ {
+		if yyhl1296 {
+			if yyj1296 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys1296Slc = r.DecodeBytes(yys1296Slc, true, true)
+		yys1296 := string(yys1296Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys1296 {
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
+			}
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv1299 := &x.ListMeta
+				yym1300 := z.DecBinary()
+				_ = yym1300
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv1299) {
+				} else {
+					z.DecFallback(yyv1299, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv1301 := &x.Items
+				yym1302 := z.DecBinary()
+				_ = yym1302
+				if false {
+				} else {
+					h.decSliceReplicaSet((*[]ReplicaSet)(yyv1301), d)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys1296)
+		} // end switch yys1296
+	} // end for yyj1296
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *ReplicaSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj1303 int
+	var yyb1303 bool
+	var yyhl1303 bool = l >= 0
+	yyj1303++
+	if yyhl1303 {
+		yyb1303 = yyj1303 > l
+	} else {
+		yyb1303 = r.CheckBreak()
+	}
+	if yyb1303 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj1303++
+	if yyhl1303 {
+		yyb1303 = yyj1303 > l
+	} else {
+		yyb1303 = r.CheckBreak()
+	}
+	if yyb1303 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
+	}
+	yyj1303++
+	if yyhl1303 {
+		yyb1303 = yyj1303 > l
+	} else {
+		yyb1303 = r.CheckBreak()
+	}
+	if yyb1303 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv1306 := &x.ListMeta
+		yym1307 := z.DecBinary()
+		_ = yym1307
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1306) {
+		} else {
+			z.DecFallback(yyv1306, false)
+		}
+	}
+	yyj1303++
+	if yyhl1303 {
+		yyb1303 = yyj1303 > l
+	} else {
+		yyb1303 = r.CheckBreak()
+	}
+	if yyb1303 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv1308 := &x.Items
+		yym1309 := z.DecBinary()
+		_ = yym1309
+		if false {
+		} else {
+			h.decSliceReplicaSet((*[]ReplicaSet)(yyv1308), d)
+		}
+	}
+	for {
+		yyj1303++
+		if yyhl1303 {
+			yyb1303 = yyj1303 > l
+		} else {
+			yyb1303 = r.CheckBreak()
+		}
+		if yyb1303 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj1303-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -14991,35 +15577,35 @@ func (x *ReplicaSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1263 := z.EncBinary()
-		_ = yym1263
+		yym1310 := z.EncBinary()
+		_ = yym1310
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1264 := !z.EncBinary()
-			yy2arr1264 := z.EncBasicHandle().StructToArray
-			var yyq1264 [3]bool
-			_, _, _ = yysep1264, yyq1264, yy2arr1264
-			const yyr1264 bool = false
-			yyq1264[1] = x.Selector != nil
-			yyq1264[2] = x.Template != nil
-			var yynn1264 int
-			if yyr1264 || yy2arr1264 {
+			yysep1311 := !z.EncBinary()
+			yy2arr1311 := z.EncBasicHandle().StructToArray
+			var yyq1311 [3]bool
+			_, _, _ = yysep1311, yyq1311, yy2arr1311
+			const yyr1311 bool = false
+			yyq1311[1] = x.Selector != nil
+			yyq1311[2] = x.Template != nil
+			var yynn1311 int
+			if yyr1311 || yy2arr1311 {
 				r.EncodeArrayStart(3)
 			} else {
-				yynn1264 = 1
-				for _, b := range yyq1264 {
+				yynn1311 = 1
+				for _, b := range yyq1311 {
 					if b {
-						yynn1264++
+						yynn1311++
 					}
 				}
-				r.EncodeMapStart(yynn1264)
-				yynn1264 = 0
+				r.EncodeMapStart(yynn1311)
+				yynn1311 = 0
 			}
-			if yyr1264 || yy2arr1264 {
+			if yyr1311 || yy2arr1311 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1266 := z.EncBinary()
-				_ = yym1266
+				yym1313 := z.EncBinary()
+				_ = yym1313
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Replicas))
@@ -15028,16 +15614,16 @@ func (x *ReplicaSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("replicas"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1267 := z.EncBinary()
-				_ = yym1267
+				yym1314 := z.EncBinary()
+				_ = yym1314
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Replicas))
 				}
 			}
-			if yyr1264 || yy2arr1264 {
+			if yyr1311 || yy2arr1311 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1264[1] {
+				if yyq1311[1] {
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
@@ -15047,7 +15633,7 @@ func (x *ReplicaSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1264[1] {
+				if yyq1311[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
@@ -15058,9 +15644,9 @@ func (x *ReplicaSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1264 || yy2arr1264 {
+			if yyr1311 || yy2arr1311 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1264[2] {
+				if yyq1311[2] {
 					if x.Template == nil {
 						r.EncodeNil()
 					} else {
@@ -15070,7 +15656,7 @@ func (x *ReplicaSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1264[2] {
+				if yyq1311[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("template"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
@@ -15081,7 +15667,7 @@ func (x *ReplicaSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1264 || yy2arr1264 {
+			if yyr1311 || yy2arr1311 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -15094,25 +15680,25 @@ func (x *ReplicaSetSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1270 := z.DecBinary()
-	_ = yym1270
+	yym1317 := z.DecBinary()
+	_ = yym1317
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1271 := r.ContainerType()
-		if yyct1271 == codecSelferValueTypeMap1234 {
-			yyl1271 := r.ReadMapStart()
-			if yyl1271 == 0 {
+		yyct1318 := r.ContainerType()
+		if yyct1318 == codecSelferValueTypeMap1234 {
+			yyl1318 := r.ReadMapStart()
+			if yyl1318 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1271, d)
+				x.codecDecodeSelfFromMap(yyl1318, d)
 			}
-		} else if yyct1271 == codecSelferValueTypeArray1234 {
-			yyl1271 := r.ReadArrayStart()
-			if yyl1271 == 0 {
+		} else if yyct1318 == codecSelferValueTypeArray1234 {
+			yyl1318 := r.ReadArrayStart()
+			if yyl1318 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1271, d)
+				x.codecDecodeSelfFromArray(yyl1318, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -15124,12 +15710,12 @@ func (x *ReplicaSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1272Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1272Slc
-	var yyhl1272 bool = l >= 0
-	for yyj1272 := 0; ; yyj1272++ {
-		if yyhl1272 {
-			if yyj1272 >= l {
+	var yys1319Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1319Slc
+	var yyhl1319 bool = l >= 0
+	for yyj1319 := 0; ; yyj1319++ {
+		if yyhl1319 {
+			if yyj1319 >= l {
 				break
 			}
 		} else {
@@ -15138,10 +15724,10 @@ func (x *ReplicaSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1272Slc = r.DecodeBytes(yys1272Slc, true, true)
-		yys1272 := string(yys1272Slc)
+		yys1319Slc = r.DecodeBytes(yys1319Slc, true, true)
+		yys1319 := string(yys1319Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1272 {
+		switch yys1319 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
 				x.Replicas = 0
@@ -15171,9 +15757,9 @@ func (x *ReplicaSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Template.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1272)
-		} // end switch yys1272
-	} // end for yyj1272
+			z.DecStructFieldNotFound(-1, yys1319)
+		} // end switch yys1319
+	} // end for yyj1319
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -15181,16 +15767,16 @@ func (x *ReplicaSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1276 int
-	var yyb1276 bool
-	var yyhl1276 bool = l >= 0
-	yyj1276++
-	if yyhl1276 {
-		yyb1276 = yyj1276 > l
+	var yyj1323 int
+	var yyb1323 bool
+	var yyhl1323 bool = l >= 0
+	yyj1323++
+	if yyhl1323 {
+		yyb1323 = yyj1323 > l
 	} else {
-		yyb1276 = r.CheckBreak()
+		yyb1323 = r.CheckBreak()
 	}
-	if yyb1276 {
+	if yyb1323 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15200,13 +15786,13 @@ func (x *ReplicaSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj1276++
-	if yyhl1276 {
-		yyb1276 = yyj1276 > l
+	yyj1323++
+	if yyhl1323 {
+		yyb1323 = yyj1323 > l
 	} else {
-		yyb1276 = r.CheckBreak()
+		yyb1323 = r.CheckBreak()
 	}
-	if yyb1276 {
+	if yyb1323 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15221,13 +15807,13 @@ func (x *ReplicaSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Selector.CodecDecodeSelf(d)
 	}
-	yyj1276++
-	if yyhl1276 {
-		yyb1276 = yyj1276 > l
+	yyj1323++
+	if yyhl1323 {
+		yyb1323 = yyj1323 > l
 	} else {
-		yyb1276 = r.CheckBreak()
+		yyb1323 = r.CheckBreak()
 	}
-	if yyb1276 {
+	if yyb1323 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15243,17 +15829,17 @@ func (x *ReplicaSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Template.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1276++
-		if yyhl1276 {
-			yyb1276 = yyj1276 > l
+		yyj1323++
+		if yyhl1323 {
+			yyb1323 = yyj1323 > l
 		} else {
-			yyb1276 = r.CheckBreak()
+			yyb1323 = r.CheckBreak()
 		}
-		if yyb1276 {
+		if yyb1323 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1276-1, "")
+		z.DecStructFieldNotFound(yyj1323-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -15265,34 +15851,34 @@ func (x *ReplicaSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1280 := z.EncBinary()
-		_ = yym1280
+		yym1327 := z.EncBinary()
+		_ = yym1327
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1281 := !z.EncBinary()
-			yy2arr1281 := z.EncBasicHandle().StructToArray
-			var yyq1281 [2]bool
-			_, _, _ = yysep1281, yyq1281, yy2arr1281
-			const yyr1281 bool = false
-			yyq1281[1] = x.ObservedGeneration != 0
-			var yynn1281 int
-			if yyr1281 || yy2arr1281 {
+			yysep1328 := !z.EncBinary()
+			yy2arr1328 := z.EncBasicHandle().StructToArray
+			var yyq1328 [2]bool
+			_, _, _ = yysep1328, yyq1328, yy2arr1328
+			const yyr1328 bool = false
+			yyq1328[1] = x.ObservedGeneration != 0
+			var yynn1328 int
+			if yyr1328 || yy2arr1328 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn1281 = 1
-				for _, b := range yyq1281 {
+				yynn1328 = 1
+				for _, b := range yyq1328 {
 					if b {
-						yynn1281++
+						yynn1328++
 					}
 				}
-				r.EncodeMapStart(yynn1281)
-				yynn1281 = 0
+				r.EncodeMapStart(yynn1328)
+				yynn1328 = 0
 			}
-			if yyr1281 || yy2arr1281 {
+			if yyr1328 || yy2arr1328 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1283 := z.EncBinary()
-				_ = yym1283
+				yym1330 := z.EncBinary()
+				_ = yym1330
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Replicas))
@@ -15301,18 +15887,18 @@ func (x *ReplicaSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("replicas"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1284 := z.EncBinary()
-				_ = yym1284
+				yym1331 := z.EncBinary()
+				_ = yym1331
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Replicas))
 				}
 			}
-			if yyr1281 || yy2arr1281 {
+			if yyr1328 || yy2arr1328 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1281[1] {
-					yym1286 := z.EncBinary()
-					_ = yym1286
+				if yyq1328[1] {
+					yym1333 := z.EncBinary()
+					_ = yym1333
 					if false {
 					} else {
 						r.EncodeInt(int64(x.ObservedGeneration))
@@ -15321,19 +15907,19 @@ func (x *ReplicaSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq1281[1] {
+				if yyq1328[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("observedGeneration"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1287 := z.EncBinary()
-					_ = yym1287
+					yym1334 := z.EncBinary()
+					_ = yym1334
 					if false {
 					} else {
 						r.EncodeInt(int64(x.ObservedGeneration))
 					}
 				}
 			}
-			if yyr1281 || yy2arr1281 {
+			if yyr1328 || yy2arr1328 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -15346,25 +15932,25 @@ func (x *ReplicaSetStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1288 := z.DecBinary()
-	_ = yym1288
+	yym1335 := z.DecBinary()
+	_ = yym1335
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1289 := r.ContainerType()
-		if yyct1289 == codecSelferValueTypeMap1234 {
-			yyl1289 := r.ReadMapStart()
-			if yyl1289 == 0 {
+		yyct1336 := r.ContainerType()
+		if yyct1336 == codecSelferValueTypeMap1234 {
+			yyl1336 := r.ReadMapStart()
+			if yyl1336 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1289, d)
+				x.codecDecodeSelfFromMap(yyl1336, d)
 			}
-		} else if yyct1289 == codecSelferValueTypeArray1234 {
-			yyl1289 := r.ReadArrayStart()
-			if yyl1289 == 0 {
+		} else if yyct1336 == codecSelferValueTypeArray1234 {
+			yyl1336 := r.ReadArrayStart()
+			if yyl1336 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1289, d)
+				x.codecDecodeSelfFromArray(yyl1336, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -15376,12 +15962,12 @@ func (x *ReplicaSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1290Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1290Slc
-	var yyhl1290 bool = l >= 0
-	for yyj1290 := 0; ; yyj1290++ {
-		if yyhl1290 {
-			if yyj1290 >= l {
+	var yys1337Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1337Slc
+	var yyhl1337 bool = l >= 0
+	for yyj1337 := 0; ; yyj1337++ {
+		if yyhl1337 {
+			if yyj1337 >= l {
 				break
 			}
 		} else {
@@ -15390,10 +15976,10 @@ func (x *ReplicaSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1290Slc = r.DecodeBytes(yys1290Slc, true, true)
-		yys1290 := string(yys1290Slc)
+		yys1337Slc = r.DecodeBytes(yys1337Slc, true, true)
+		yys1337 := string(yys1337Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1290 {
+		switch yys1337 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
 				x.Replicas = 0
@@ -15407,9 +15993,9 @@ func (x *ReplicaSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.ObservedGeneration = int64(r.DecodeInt(64))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1290)
-		} // end switch yys1290
-	} // end for yyj1290
+			z.DecStructFieldNotFound(-1, yys1337)
+		} // end switch yys1337
+	} // end for yyj1337
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -15417,16 +16003,16 @@ func (x *ReplicaSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1293 int
-	var yyb1293 bool
-	var yyhl1293 bool = l >= 0
-	yyj1293++
-	if yyhl1293 {
-		yyb1293 = yyj1293 > l
+	var yyj1340 int
+	var yyb1340 bool
+	var yyhl1340 bool = l >= 0
+	yyj1340++
+	if yyhl1340 {
+		yyb1340 = yyj1340 > l
 	} else {
-		yyb1293 = r.CheckBreak()
+		yyb1340 = r.CheckBreak()
 	}
-	if yyb1293 {
+	if yyb1340 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15436,13 +16022,13 @@ func (x *ReplicaSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj1293++
-	if yyhl1293 {
-		yyb1293 = yyj1293 > l
+	yyj1340++
+	if yyhl1340 {
+		yyb1340 = yyj1340 > l
 	} else {
-		yyb1293 = r.CheckBreak()
+		yyb1340 = r.CheckBreak()
 	}
-	if yyb1293 {
+	if yyb1340 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15453,17 +16039,17 @@ func (x *ReplicaSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		x.ObservedGeneration = int64(r.DecodeInt(64))
 	}
 	for {
-		yyj1293++
-		if yyhl1293 {
-			yyb1293 = yyj1293 > l
+		yyj1340++
+		if yyhl1340 {
+			yyb1340 = yyj1340 > l
 		} else {
-			yyb1293 = r.CheckBreak()
+			yyb1340 = r.CheckBreak()
 		}
-		if yyb1293 {
+		if yyb1340 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1293-1, "")
+		z.DecStructFieldNotFound(yyj1340-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -15473,10 +16059,10 @@ func (x codecSelfer1234) encSliceHorizontalPodAutoscaler(v []HorizontalPodAutosc
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1296 := range v {
+	for _, yyv1343 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1297 := &yyv1296
-		yy1297.CodecEncodeSelf(e)
+		yy1344 := &yyv1343
+		yy1344.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -15486,83 +16072,83 @@ func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutos
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1298 := *v
-	yyh1298, yyl1298 := z.DecSliceHelperStart()
-	var yyc1298 bool
-	if yyl1298 == 0 {
-		if yyv1298 == nil {
-			yyv1298 = []HorizontalPodAutoscaler{}
-			yyc1298 = true
-		} else if len(yyv1298) != 0 {
-			yyv1298 = yyv1298[:0]
-			yyc1298 = true
+	yyv1345 := *v
+	yyh1345, yyl1345 := z.DecSliceHelperStart()
+	var yyc1345 bool
+	if yyl1345 == 0 {
+		if yyv1345 == nil {
+			yyv1345 = []HorizontalPodAutoscaler{}
+			yyc1345 = true
+		} else if len(yyv1345) != 0 {
+			yyv1345 = yyv1345[:0]
+			yyc1345 = true
 		}
-	} else if yyl1298 > 0 {
-		var yyrr1298, yyrl1298 int
-		var yyrt1298 bool
-		if yyl1298 > cap(yyv1298) {
+	} else if yyl1345 > 0 {
+		var yyrr1345, yyrl1345 int
+		var yyrt1345 bool
+		if yyl1345 > cap(yyv1345) {
 
-			yyrg1298 := len(yyv1298) > 0
-			yyv21298 := yyv1298
-			yyrl1298, yyrt1298 = z.DecInferLen(yyl1298, z.DecBasicHandle().MaxInitLen, 320)
-			if yyrt1298 {
-				if yyrl1298 <= cap(yyv1298) {
-					yyv1298 = yyv1298[:yyrl1298]
+			yyrg1345 := len(yyv1345) > 0
+			yyv21345 := yyv1345
+			yyrl1345, yyrt1345 = z.DecInferLen(yyl1345, z.DecBasicHandle().MaxInitLen, 320)
+			if yyrt1345 {
+				if yyrl1345 <= cap(yyv1345) {
+					yyv1345 = yyv1345[:yyrl1345]
 				} else {
-					yyv1298 = make([]HorizontalPodAutoscaler, yyrl1298)
+					yyv1345 = make([]HorizontalPodAutoscaler, yyrl1345)
 				}
 			} else {
-				yyv1298 = make([]HorizontalPodAutoscaler, yyrl1298)
+				yyv1345 = make([]HorizontalPodAutoscaler, yyrl1345)
 			}
-			yyc1298 = true
-			yyrr1298 = len(yyv1298)
-			if yyrg1298 {
-				copy(yyv1298, yyv21298)
+			yyc1345 = true
+			yyrr1345 = len(yyv1345)
+			if yyrg1345 {
+				copy(yyv1345, yyv21345)
 			}
-		} else if yyl1298 != len(yyv1298) {
-			yyv1298 = yyv1298[:yyl1298]
-			yyc1298 = true
+		} else if yyl1345 != len(yyv1345) {
+			yyv1345 = yyv1345[:yyl1345]
+			yyc1345 = true
 		}
-		yyj1298 := 0
-		for ; yyj1298 < yyrr1298; yyj1298++ {
-			yyh1298.ElemContainerState(yyj1298)
+		yyj1345 := 0
+		for ; yyj1345 < yyrr1345; yyj1345++ {
+			yyh1345.ElemContainerState(yyj1345)
 			if r.TryDecodeAsNil() {
-				yyv1298[yyj1298] = HorizontalPodAutoscaler{}
+				yyv1345[yyj1345] = HorizontalPodAutoscaler{}
 			} else {
-				yyv1299 := &yyv1298[yyj1298]
-				yyv1299.CodecDecodeSelf(d)
+				yyv1346 := &yyv1345[yyj1345]
+				yyv1346.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1298 {
-			for ; yyj1298 < yyl1298; yyj1298++ {
-				yyv1298 = append(yyv1298, HorizontalPodAutoscaler{})
-				yyh1298.ElemContainerState(yyj1298)
+		if yyrt1345 {
+			for ; yyj1345 < yyl1345; yyj1345++ {
+				yyv1345 = append(yyv1345, HorizontalPodAutoscaler{})
+				yyh1345.ElemContainerState(yyj1345)
 				if r.TryDecodeAsNil() {
-					yyv1298[yyj1298] = HorizontalPodAutoscaler{}
+					yyv1345[yyj1345] = HorizontalPodAutoscaler{}
 				} else {
-					yyv1300 := &yyv1298[yyj1298]
-					yyv1300.CodecDecodeSelf(d)
+					yyv1347 := &yyv1345[yyj1345]
+					yyv1347.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1298 := 0
-		for ; !r.CheckBreak(); yyj1298++ {
+		yyj1345 := 0
+		for ; !r.CheckBreak(); yyj1345++ {
 
-			if yyj1298 >= len(yyv1298) {
-				yyv1298 = append(yyv1298, HorizontalPodAutoscaler{}) // var yyz1298 HorizontalPodAutoscaler
-				yyc1298 = true
+			if yyj1345 >= len(yyv1345) {
+				yyv1345 = append(yyv1345, HorizontalPodAutoscaler{}) // var yyz1345 HorizontalPodAutoscaler
+				yyc1345 = true
 			}
-			yyh1298.ElemContainerState(yyj1298)
-			if yyj1298 < len(yyv1298) {
+			yyh1345.ElemContainerState(yyj1345)
+			if yyj1345 < len(yyv1345) {
 				if r.TryDecodeAsNil() {
-					yyv1298[yyj1298] = HorizontalPodAutoscaler{}
+					yyv1345[yyj1345] = HorizontalPodAutoscaler{}
 				} else {
-					yyv1301 := &yyv1298[yyj1298]
-					yyv1301.CodecDecodeSelf(d)
+					yyv1348 := &yyv1345[yyj1345]
+					yyv1348.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -15570,17 +16156,17 @@ func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutos
 			}
 
 		}
-		if yyj1298 < len(yyv1298) {
-			yyv1298 = yyv1298[:yyj1298]
-			yyc1298 = true
-		} else if yyj1298 == 0 && yyv1298 == nil {
-			yyv1298 = []HorizontalPodAutoscaler{}
-			yyc1298 = true
+		if yyj1345 < len(yyv1345) {
+			yyv1345 = yyv1345[:yyj1345]
+			yyc1345 = true
+		} else if yyj1345 == 0 && yyv1345 == nil {
+			yyv1345 = []HorizontalPodAutoscaler{}
+			yyc1345 = true
 		}
 	}
-	yyh1298.End()
-	if yyc1298 {
-		*v = yyv1298
+	yyh1345.End()
+	if yyc1345 {
+		*v = yyv1345
 	}
 }
 
@@ -15589,10 +16175,10 @@ func (x codecSelfer1234) encSliceAPIVersion(v []APIVersion, e *codec1978.Encoder
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1302 := range v {
+	for _, yyv1349 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1303 := &yyv1302
-		yy1303.CodecEncodeSelf(e)
+		yy1350 := &yyv1349
+		yy1350.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -15602,83 +16188,83 @@ func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decode
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1304 := *v
-	yyh1304, yyl1304 := z.DecSliceHelperStart()
-	var yyc1304 bool
-	if yyl1304 == 0 {
-		if yyv1304 == nil {
-			yyv1304 = []APIVersion{}
-			yyc1304 = true
-		} else if len(yyv1304) != 0 {
-			yyv1304 = yyv1304[:0]
-			yyc1304 = true
+	yyv1351 := *v
+	yyh1351, yyl1351 := z.DecSliceHelperStart()
+	var yyc1351 bool
+	if yyl1351 == 0 {
+		if yyv1351 == nil {
+			yyv1351 = []APIVersion{}
+			yyc1351 = true
+		} else if len(yyv1351) != 0 {
+			yyv1351 = yyv1351[:0]
+			yyc1351 = true
 		}
-	} else if yyl1304 > 0 {
-		var yyrr1304, yyrl1304 int
-		var yyrt1304 bool
-		if yyl1304 > cap(yyv1304) {
+	} else if yyl1351 > 0 {
+		var yyrr1351, yyrl1351 int
+		var yyrt1351 bool
+		if yyl1351 > cap(yyv1351) {
 
-			yyrg1304 := len(yyv1304) > 0
-			yyv21304 := yyv1304
-			yyrl1304, yyrt1304 = z.DecInferLen(yyl1304, z.DecBasicHandle().MaxInitLen, 32)
-			if yyrt1304 {
-				if yyrl1304 <= cap(yyv1304) {
-					yyv1304 = yyv1304[:yyrl1304]
+			yyrg1351 := len(yyv1351) > 0
+			yyv21351 := yyv1351
+			yyrl1351, yyrt1351 = z.DecInferLen(yyl1351, z.DecBasicHandle().MaxInitLen, 32)
+			if yyrt1351 {
+				if yyrl1351 <= cap(yyv1351) {
+					yyv1351 = yyv1351[:yyrl1351]
 				} else {
-					yyv1304 = make([]APIVersion, yyrl1304)
+					yyv1351 = make([]APIVersion, yyrl1351)
 				}
 			} else {
-				yyv1304 = make([]APIVersion, yyrl1304)
+				yyv1351 = make([]APIVersion, yyrl1351)
 			}
-			yyc1304 = true
-			yyrr1304 = len(yyv1304)
-			if yyrg1304 {
-				copy(yyv1304, yyv21304)
+			yyc1351 = true
+			yyrr1351 = len(yyv1351)
+			if yyrg1351 {
+				copy(yyv1351, yyv21351)
 			}
-		} else if yyl1304 != len(yyv1304) {
-			yyv1304 = yyv1304[:yyl1304]
-			yyc1304 = true
+		} else if yyl1351 != len(yyv1351) {
+			yyv1351 = yyv1351[:yyl1351]
+			yyc1351 = true
 		}
-		yyj1304 := 0
-		for ; yyj1304 < yyrr1304; yyj1304++ {
-			yyh1304.ElemContainerState(yyj1304)
+		yyj1351 := 0
+		for ; yyj1351 < yyrr1351; yyj1351++ {
+			yyh1351.ElemContainerState(yyj1351)
 			if r.TryDecodeAsNil() {
-				yyv1304[yyj1304] = APIVersion{}
+				yyv1351[yyj1351] = APIVersion{}
 			} else {
-				yyv1305 := &yyv1304[yyj1304]
-				yyv1305.CodecDecodeSelf(d)
+				yyv1352 := &yyv1351[yyj1351]
+				yyv1352.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1304 {
-			for ; yyj1304 < yyl1304; yyj1304++ {
-				yyv1304 = append(yyv1304, APIVersion{})
-				yyh1304.ElemContainerState(yyj1304)
+		if yyrt1351 {
+			for ; yyj1351 < yyl1351; yyj1351++ {
+				yyv1351 = append(yyv1351, APIVersion{})
+				yyh1351.ElemContainerState(yyj1351)
 				if r.TryDecodeAsNil() {
-					yyv1304[yyj1304] = APIVersion{}
+					yyv1351[yyj1351] = APIVersion{}
 				} else {
-					yyv1306 := &yyv1304[yyj1304]
-					yyv1306.CodecDecodeSelf(d)
+					yyv1353 := &yyv1351[yyj1351]
+					yyv1353.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1304 := 0
-		for ; !r.CheckBreak(); yyj1304++ {
+		yyj1351 := 0
+		for ; !r.CheckBreak(); yyj1351++ {
 
-			if yyj1304 >= len(yyv1304) {
-				yyv1304 = append(yyv1304, APIVersion{}) // var yyz1304 APIVersion
-				yyc1304 = true
+			if yyj1351 >= len(yyv1351) {
+				yyv1351 = append(yyv1351, APIVersion{}) // var yyz1351 APIVersion
+				yyc1351 = true
 			}
-			yyh1304.ElemContainerState(yyj1304)
-			if yyj1304 < len(yyv1304) {
+			yyh1351.ElemContainerState(yyj1351)
+			if yyj1351 < len(yyv1351) {
 				if r.TryDecodeAsNil() {
-					yyv1304[yyj1304] = APIVersion{}
+					yyv1351[yyj1351] = APIVersion{}
 				} else {
-					yyv1307 := &yyv1304[yyj1304]
-					yyv1307.CodecDecodeSelf(d)
+					yyv1354 := &yyv1351[yyj1351]
+					yyv1354.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -15686,17 +16272,17 @@ func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decode
 			}
 
 		}
-		if yyj1304 < len(yyv1304) {
-			yyv1304 = yyv1304[:yyj1304]
-			yyc1304 = true
-		} else if yyj1304 == 0 && yyv1304 == nil {
-			yyv1304 = []APIVersion{}
-			yyc1304 = true
+		if yyj1351 < len(yyv1351) {
+			yyv1351 = yyv1351[:yyj1351]
+			yyc1351 = true
+		} else if yyj1351 == 0 && yyv1351 == nil {
+			yyv1351 = []APIVersion{}
+			yyc1351 = true
 		}
 	}
-	yyh1304.End()
-	if yyc1304 {
-		*v = yyv1304
+	yyh1351.End()
+	if yyc1351 {
+		*v = yyv1351
 	}
 }
 
@@ -15705,10 +16291,10 @@ func (x codecSelfer1234) encSliceThirdPartyResource(v []ThirdPartyResource, e *c
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1308 := range v {
+	for _, yyv1355 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1309 := &yyv1308
-		yy1309.CodecEncodeSelf(e)
+		yy1356 := &yyv1355
+		yy1356.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -15718,83 +16304,83 @@ func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1310 := *v
-	yyh1310, yyl1310 := z.DecSliceHelperStart()
-	var yyc1310 bool
-	if yyl1310 == 0 {
-		if yyv1310 == nil {
-			yyv1310 = []ThirdPartyResource{}
-			yyc1310 = true
-		} else if len(yyv1310) != 0 {
-			yyv1310 = yyv1310[:0]
-			yyc1310 = true
+	yyv1357 := *v
+	yyh1357, yyl1357 := z.DecSliceHelperStart()
+	var yyc1357 bool
+	if yyl1357 == 0 {
+		if yyv1357 == nil {
+			yyv1357 = []ThirdPartyResource{}
+			yyc1357 = true
+		} else if len(yyv1357) != 0 {
+			yyv1357 = yyv1357[:0]
+			yyc1357 = true
 		}
-	} else if yyl1310 > 0 {
-		var yyrr1310, yyrl1310 int
-		var yyrt1310 bool
-		if yyl1310 > cap(yyv1310) {
+	} else if yyl1357 > 0 {
+		var yyrr1357, yyrl1357 int
+		var yyrt1357 bool
+		if yyl1357 > cap(yyv1357) {
 
-			yyrg1310 := len(yyv1310) > 0
-			yyv21310 := yyv1310
-			yyrl1310, yyrt1310 = z.DecInferLen(yyl1310, z.DecBasicHandle().MaxInitLen, 232)
-			if yyrt1310 {
-				if yyrl1310 <= cap(yyv1310) {
-					yyv1310 = yyv1310[:yyrl1310]
+			yyrg1357 := len(yyv1357) > 0
+			yyv21357 := yyv1357
+			yyrl1357, yyrt1357 = z.DecInferLen(yyl1357, z.DecBasicHandle().MaxInitLen, 232)
+			if yyrt1357 {
+				if yyrl1357 <= cap(yyv1357) {
+					yyv1357 = yyv1357[:yyrl1357]
 				} else {
-					yyv1310 = make([]ThirdPartyResource, yyrl1310)
+					yyv1357 = make([]ThirdPartyResource, yyrl1357)
 				}
 			} else {
-				yyv1310 = make([]ThirdPartyResource, yyrl1310)
+				yyv1357 = make([]ThirdPartyResource, yyrl1357)
 			}
-			yyc1310 = true
-			yyrr1310 = len(yyv1310)
-			if yyrg1310 {
-				copy(yyv1310, yyv21310)
+			yyc1357 = true
+			yyrr1357 = len(yyv1357)
+			if yyrg1357 {
+				copy(yyv1357, yyv21357)
 			}
-		} else if yyl1310 != len(yyv1310) {
-			yyv1310 = yyv1310[:yyl1310]
-			yyc1310 = true
+		} else if yyl1357 != len(yyv1357) {
+			yyv1357 = yyv1357[:yyl1357]
+			yyc1357 = true
 		}
-		yyj1310 := 0
-		for ; yyj1310 < yyrr1310; yyj1310++ {
-			yyh1310.ElemContainerState(yyj1310)
+		yyj1357 := 0
+		for ; yyj1357 < yyrr1357; yyj1357++ {
+			yyh1357.ElemContainerState(yyj1357)
 			if r.TryDecodeAsNil() {
-				yyv1310[yyj1310] = ThirdPartyResource{}
+				yyv1357[yyj1357] = ThirdPartyResource{}
 			} else {
-				yyv1311 := &yyv1310[yyj1310]
-				yyv1311.CodecDecodeSelf(d)
+				yyv1358 := &yyv1357[yyj1357]
+				yyv1358.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1310 {
-			for ; yyj1310 < yyl1310; yyj1310++ {
-				yyv1310 = append(yyv1310, ThirdPartyResource{})
-				yyh1310.ElemContainerState(yyj1310)
+		if yyrt1357 {
+			for ; yyj1357 < yyl1357; yyj1357++ {
+				yyv1357 = append(yyv1357, ThirdPartyResource{})
+				yyh1357.ElemContainerState(yyj1357)
 				if r.TryDecodeAsNil() {
-					yyv1310[yyj1310] = ThirdPartyResource{}
+					yyv1357[yyj1357] = ThirdPartyResource{}
 				} else {
-					yyv1312 := &yyv1310[yyj1310]
-					yyv1312.CodecDecodeSelf(d)
+					yyv1359 := &yyv1357[yyj1357]
+					yyv1359.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1310 := 0
-		for ; !r.CheckBreak(); yyj1310++ {
+		yyj1357 := 0
+		for ; !r.CheckBreak(); yyj1357++ {
 
-			if yyj1310 >= len(yyv1310) {
-				yyv1310 = append(yyv1310, ThirdPartyResource{}) // var yyz1310 ThirdPartyResource
-				yyc1310 = true
+			if yyj1357 >= len(yyv1357) {
+				yyv1357 = append(yyv1357, ThirdPartyResource{}) // var yyz1357 ThirdPartyResource
+				yyc1357 = true
 			}
-			yyh1310.ElemContainerState(yyj1310)
-			if yyj1310 < len(yyv1310) {
+			yyh1357.ElemContainerState(yyj1357)
+			if yyj1357 < len(yyv1357) {
 				if r.TryDecodeAsNil() {
-					yyv1310[yyj1310] = ThirdPartyResource{}
+					yyv1357[yyj1357] = ThirdPartyResource{}
 				} else {
-					yyv1313 := &yyv1310[yyj1310]
-					yyv1313.CodecDecodeSelf(d)
+					yyv1360 := &yyv1357[yyj1357]
+					yyv1360.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -15802,17 +16388,17 @@ func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *
 			}
 
 		}
-		if yyj1310 < len(yyv1310) {
-			yyv1310 = yyv1310[:yyj1310]
-			yyc1310 = true
-		} else if yyj1310 == 0 && yyv1310 == nil {
-			yyv1310 = []ThirdPartyResource{}
-			yyc1310 = true
+		if yyj1357 < len(yyv1357) {
+			yyv1357 = yyv1357[:yyj1357]
+			yyc1357 = true
+		} else if yyj1357 == 0 && yyv1357 == nil {
+			yyv1357 = []ThirdPartyResource{}
+			yyc1357 = true
 		}
 	}
-	yyh1310.End()
-	if yyc1310 {
-		*v = yyv1310
+	yyh1357.End()
+	if yyc1357 {
+		*v = yyv1357
 	}
 }
 
@@ -15821,10 +16407,10 @@ func (x codecSelfer1234) encSliceDeployment(v []Deployment, e *codec1978.Encoder
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1314 := range v {
+	for _, yyv1361 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1315 := &yyv1314
-		yy1315.CodecEncodeSelf(e)
+		yy1362 := &yyv1361
+		yy1362.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -15834,83 +16420,83 @@ func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decode
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1316 := *v
-	yyh1316, yyl1316 := z.DecSliceHelperStart()
-	var yyc1316 bool
-	if yyl1316 == 0 {
-		if yyv1316 == nil {
-			yyv1316 = []Deployment{}
-			yyc1316 = true
-		} else if len(yyv1316) != 0 {
-			yyv1316 = yyv1316[:0]
-			yyc1316 = true
+	yyv1363 := *v
+	yyh1363, yyl1363 := z.DecSliceHelperStart()
+	var yyc1363 bool
+	if yyl1363 == 0 {
+		if yyv1363 == nil {
+			yyv1363 = []Deployment{}
+			yyc1363 = true
+		} else if len(yyv1363) != 0 {
+			yyv1363 = yyv1363[:0]
+			yyc1363 = true
 		}
-	} else if yyl1316 > 0 {
-		var yyrr1316, yyrl1316 int
-		var yyrt1316 bool
-		if yyl1316 > cap(yyv1316) {
+	} else if yyl1363 > 0 {
+		var yyrr1363, yyrl1363 int
+		var yyrt1363 bool
+		if yyl1363 > cap(yyv1363) {
 
-			yyrg1316 := len(yyv1316) > 0
-			yyv21316 := yyv1316
-			yyrl1316, yyrt1316 = z.DecInferLen(yyl1316, z.DecBasicHandle().MaxInitLen, 624)
-			if yyrt1316 {
-				if yyrl1316 <= cap(yyv1316) {
-					yyv1316 = yyv1316[:yyrl1316]
+			yyrg1363 := len(yyv1363) > 0
+			yyv21363 := yyv1363
+			yyrl1363, yyrt1363 = z.DecInferLen(yyl1363, z.DecBasicHandle().MaxInitLen, 632)
+			if yyrt1363 {
+				if yyrl1363 <= cap(yyv1363) {
+					yyv1363 = yyv1363[:yyrl1363]
 				} else {
-					yyv1316 = make([]Deployment, yyrl1316)
+					yyv1363 = make([]Deployment, yyrl1363)
 				}
 			} else {
-				yyv1316 = make([]Deployment, yyrl1316)
+				yyv1363 = make([]Deployment, yyrl1363)
 			}
-			yyc1316 = true
-			yyrr1316 = len(yyv1316)
-			if yyrg1316 {
-				copy(yyv1316, yyv21316)
+			yyc1363 = true
+			yyrr1363 = len(yyv1363)
+			if yyrg1363 {
+				copy(yyv1363, yyv21363)
 			}
-		} else if yyl1316 != len(yyv1316) {
-			yyv1316 = yyv1316[:yyl1316]
-			yyc1316 = true
+		} else if yyl1363 != len(yyv1363) {
+			yyv1363 = yyv1363[:yyl1363]
+			yyc1363 = true
 		}
-		yyj1316 := 0
-		for ; yyj1316 < yyrr1316; yyj1316++ {
-			yyh1316.ElemContainerState(yyj1316)
+		yyj1363 := 0
+		for ; yyj1363 < yyrr1363; yyj1363++ {
+			yyh1363.ElemContainerState(yyj1363)
 			if r.TryDecodeAsNil() {
-				yyv1316[yyj1316] = Deployment{}
+				yyv1363[yyj1363] = Deployment{}
 			} else {
-				yyv1317 := &yyv1316[yyj1316]
-				yyv1317.CodecDecodeSelf(d)
+				yyv1364 := &yyv1363[yyj1363]
+				yyv1364.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1316 {
-			for ; yyj1316 < yyl1316; yyj1316++ {
-				yyv1316 = append(yyv1316, Deployment{})
-				yyh1316.ElemContainerState(yyj1316)
+		if yyrt1363 {
+			for ; yyj1363 < yyl1363; yyj1363++ {
+				yyv1363 = append(yyv1363, Deployment{})
+				yyh1363.ElemContainerState(yyj1363)
 				if r.TryDecodeAsNil() {
-					yyv1316[yyj1316] = Deployment{}
+					yyv1363[yyj1363] = Deployment{}
 				} else {
-					yyv1318 := &yyv1316[yyj1316]
-					yyv1318.CodecDecodeSelf(d)
+					yyv1365 := &yyv1363[yyj1363]
+					yyv1365.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1316 := 0
-		for ; !r.CheckBreak(); yyj1316++ {
+		yyj1363 := 0
+		for ; !r.CheckBreak(); yyj1363++ {
 
-			if yyj1316 >= len(yyv1316) {
-				yyv1316 = append(yyv1316, Deployment{}) // var yyz1316 Deployment
-				yyc1316 = true
+			if yyj1363 >= len(yyv1363) {
+				yyv1363 = append(yyv1363, Deployment{}) // var yyz1363 Deployment
+				yyc1363 = true
 			}
-			yyh1316.ElemContainerState(yyj1316)
-			if yyj1316 < len(yyv1316) {
+			yyh1363.ElemContainerState(yyj1363)
+			if yyj1363 < len(yyv1363) {
 				if r.TryDecodeAsNil() {
-					yyv1316[yyj1316] = Deployment{}
+					yyv1363[yyj1363] = Deployment{}
 				} else {
-					yyv1319 := &yyv1316[yyj1316]
-					yyv1319.CodecDecodeSelf(d)
+					yyv1366 := &yyv1363[yyj1363]
+					yyv1366.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -15918,17 +16504,17 @@ func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decode
 			}
 
 		}
-		if yyj1316 < len(yyv1316) {
-			yyv1316 = yyv1316[:yyj1316]
-			yyc1316 = true
-		} else if yyj1316 == 0 && yyv1316 == nil {
-			yyv1316 = []Deployment{}
-			yyc1316 = true
+		if yyj1363 < len(yyv1363) {
+			yyv1363 = yyv1363[:yyj1363]
+			yyc1363 = true
+		} else if yyj1363 == 0 && yyv1363 == nil {
+			yyv1363 = []Deployment{}
+			yyc1363 = true
 		}
 	}
-	yyh1316.End()
-	if yyc1316 {
-		*v = yyv1316
+	yyh1363.End()
+	if yyc1363 {
+		*v = yyv1363
 	}
 }
 
@@ -15937,10 +16523,10 @@ func (x codecSelfer1234) encSliceDaemonSet(v []DaemonSet, e *codec1978.Encoder) 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1320 := range v {
+	for _, yyv1367 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1321 := &yyv1320
-		yy1321.CodecEncodeSelf(e)
+		yy1368 := &yyv1367
+		yy1368.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -15950,83 +16536,83 @@ func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder)
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1322 := *v
-	yyh1322, yyl1322 := z.DecSliceHelperStart()
-	var yyc1322 bool
-	if yyl1322 == 0 {
-		if yyv1322 == nil {
-			yyv1322 = []DaemonSet{}
-			yyc1322 = true
-		} else if len(yyv1322) != 0 {
-			yyv1322 = yyv1322[:0]
-			yyc1322 = true
+	yyv1369 := *v
+	yyh1369, yyl1369 := z.DecSliceHelperStart()
+	var yyc1369 bool
+	if yyl1369 == 0 {
+		if yyv1369 == nil {
+			yyv1369 = []DaemonSet{}
+			yyc1369 = true
+		} else if len(yyv1369) != 0 {
+			yyv1369 = yyv1369[:0]
+			yyc1369 = true
 		}
-	} else if yyl1322 > 0 {
-		var yyrr1322, yyrl1322 int
-		var yyrt1322 bool
-		if yyl1322 > cap(yyv1322) {
+	} else if yyl1369 > 0 {
+		var yyrr1369, yyrl1369 int
+		var yyrt1369 bool
+		if yyl1369 > cap(yyv1369) {
 
-			yyrg1322 := len(yyv1322) > 0
-			yyv21322 := yyv1322
-			yyrl1322, yyrt1322 = z.DecInferLen(yyl1322, z.DecBasicHandle().MaxInitLen, 592)
-			if yyrt1322 {
-				if yyrl1322 <= cap(yyv1322) {
-					yyv1322 = yyv1322[:yyrl1322]
+			yyrg1369 := len(yyv1369) > 0
+			yyv21369 := yyv1369
+			yyrl1369, yyrt1369 = z.DecInferLen(yyl1369, z.DecBasicHandle().MaxInitLen, 592)
+			if yyrt1369 {
+				if yyrl1369 <= cap(yyv1369) {
+					yyv1369 = yyv1369[:yyrl1369]
 				} else {
-					yyv1322 = make([]DaemonSet, yyrl1322)
+					yyv1369 = make([]DaemonSet, yyrl1369)
 				}
 			} else {
-				yyv1322 = make([]DaemonSet, yyrl1322)
+				yyv1369 = make([]DaemonSet, yyrl1369)
 			}
-			yyc1322 = true
-			yyrr1322 = len(yyv1322)
-			if yyrg1322 {
-				copy(yyv1322, yyv21322)
+			yyc1369 = true
+			yyrr1369 = len(yyv1369)
+			if yyrg1369 {
+				copy(yyv1369, yyv21369)
 			}
-		} else if yyl1322 != len(yyv1322) {
-			yyv1322 = yyv1322[:yyl1322]
-			yyc1322 = true
+		} else if yyl1369 != len(yyv1369) {
+			yyv1369 = yyv1369[:yyl1369]
+			yyc1369 = true
 		}
-		yyj1322 := 0
-		for ; yyj1322 < yyrr1322; yyj1322++ {
-			yyh1322.ElemContainerState(yyj1322)
+		yyj1369 := 0
+		for ; yyj1369 < yyrr1369; yyj1369++ {
+			yyh1369.ElemContainerState(yyj1369)
 			if r.TryDecodeAsNil() {
-				yyv1322[yyj1322] = DaemonSet{}
+				yyv1369[yyj1369] = DaemonSet{}
 			} else {
-				yyv1323 := &yyv1322[yyj1322]
-				yyv1323.CodecDecodeSelf(d)
+				yyv1370 := &yyv1369[yyj1369]
+				yyv1370.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1322 {
-			for ; yyj1322 < yyl1322; yyj1322++ {
-				yyv1322 = append(yyv1322, DaemonSet{})
-				yyh1322.ElemContainerState(yyj1322)
+		if yyrt1369 {
+			for ; yyj1369 < yyl1369; yyj1369++ {
+				yyv1369 = append(yyv1369, DaemonSet{})
+				yyh1369.ElemContainerState(yyj1369)
 				if r.TryDecodeAsNil() {
-					yyv1322[yyj1322] = DaemonSet{}
+					yyv1369[yyj1369] = DaemonSet{}
 				} else {
-					yyv1324 := &yyv1322[yyj1322]
-					yyv1324.CodecDecodeSelf(d)
+					yyv1371 := &yyv1369[yyj1369]
+					yyv1371.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1322 := 0
-		for ; !r.CheckBreak(); yyj1322++ {
+		yyj1369 := 0
+		for ; !r.CheckBreak(); yyj1369++ {
 
-			if yyj1322 >= len(yyv1322) {
-				yyv1322 = append(yyv1322, DaemonSet{}) // var yyz1322 DaemonSet
-				yyc1322 = true
+			if yyj1369 >= len(yyv1369) {
+				yyv1369 = append(yyv1369, DaemonSet{}) // var yyz1369 DaemonSet
+				yyc1369 = true
 			}
-			yyh1322.ElemContainerState(yyj1322)
-			if yyj1322 < len(yyv1322) {
+			yyh1369.ElemContainerState(yyj1369)
+			if yyj1369 < len(yyv1369) {
 				if r.TryDecodeAsNil() {
-					yyv1322[yyj1322] = DaemonSet{}
+					yyv1369[yyj1369] = DaemonSet{}
 				} else {
-					yyv1325 := &yyv1322[yyj1322]
-					yyv1325.CodecDecodeSelf(d)
+					yyv1372 := &yyv1369[yyj1369]
+					yyv1372.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -16034,17 +16620,17 @@ func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder)
 			}
 
 		}
-		if yyj1322 < len(yyv1322) {
-			yyv1322 = yyv1322[:yyj1322]
-			yyc1322 = true
-		} else if yyj1322 == 0 && yyv1322 == nil {
-			yyv1322 = []DaemonSet{}
-			yyc1322 = true
+		if yyj1369 < len(yyv1369) {
+			yyv1369 = yyv1369[:yyj1369]
+			yyc1369 = true
+		} else if yyj1369 == 0 && yyv1369 == nil {
+			yyv1369 = []DaemonSet{}
+			yyc1369 = true
 		}
 	}
-	yyh1322.End()
-	if yyc1322 {
-		*v = yyv1322
+	yyh1369.End()
+	if yyc1369 {
+		*v = yyv1369
 	}
 }
 
@@ -16053,10 +16639,10 @@ func (x codecSelfer1234) encSliceThirdPartyResourceData(v []ThirdPartyResourceDa
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1326 := range v {
+	for _, yyv1373 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1327 := &yyv1326
-		yy1327.CodecEncodeSelf(e)
+		yy1374 := &yyv1373
+		yy1374.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -16066,83 +16652,83 @@ func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceD
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1328 := *v
-	yyh1328, yyl1328 := z.DecSliceHelperStart()
-	var yyc1328 bool
-	if yyl1328 == 0 {
-		if yyv1328 == nil {
-			yyv1328 = []ThirdPartyResourceData{}
-			yyc1328 = true
-		} else if len(yyv1328) != 0 {
-			yyv1328 = yyv1328[:0]
-			yyc1328 = true
+	yyv1375 := *v
+	yyh1375, yyl1375 := z.DecSliceHelperStart()
+	var yyc1375 bool
+	if yyl1375 == 0 {
+		if yyv1375 == nil {
+			yyv1375 = []ThirdPartyResourceData{}
+			yyc1375 = true
+		} else if len(yyv1375) != 0 {
+			yyv1375 = yyv1375[:0]
+			yyc1375 = true
 		}
-	} else if yyl1328 > 0 {
-		var yyrr1328, yyrl1328 int
-		var yyrt1328 bool
-		if yyl1328 > cap(yyv1328) {
+	} else if yyl1375 > 0 {
+		var yyrr1375, yyrl1375 int
+		var yyrt1375 bool
+		if yyl1375 > cap(yyv1375) {
 
-			yyrg1328 := len(yyv1328) > 0
-			yyv21328 := yyv1328
-			yyrl1328, yyrt1328 = z.DecInferLen(yyl1328, z.DecBasicHandle().MaxInitLen, 216)
-			if yyrt1328 {
-				if yyrl1328 <= cap(yyv1328) {
-					yyv1328 = yyv1328[:yyrl1328]
+			yyrg1375 := len(yyv1375) > 0
+			yyv21375 := yyv1375
+			yyrl1375, yyrt1375 = z.DecInferLen(yyl1375, z.DecBasicHandle().MaxInitLen, 216)
+			if yyrt1375 {
+				if yyrl1375 <= cap(yyv1375) {
+					yyv1375 = yyv1375[:yyrl1375]
 				} else {
-					yyv1328 = make([]ThirdPartyResourceData, yyrl1328)
+					yyv1375 = make([]ThirdPartyResourceData, yyrl1375)
 				}
 			} else {
-				yyv1328 = make([]ThirdPartyResourceData, yyrl1328)
+				yyv1375 = make([]ThirdPartyResourceData, yyrl1375)
 			}
-			yyc1328 = true
-			yyrr1328 = len(yyv1328)
-			if yyrg1328 {
-				copy(yyv1328, yyv21328)
+			yyc1375 = true
+			yyrr1375 = len(yyv1375)
+			if yyrg1375 {
+				copy(yyv1375, yyv21375)
 			}
-		} else if yyl1328 != len(yyv1328) {
-			yyv1328 = yyv1328[:yyl1328]
-			yyc1328 = true
+		} else if yyl1375 != len(yyv1375) {
+			yyv1375 = yyv1375[:yyl1375]
+			yyc1375 = true
 		}
-		yyj1328 := 0
-		for ; yyj1328 < yyrr1328; yyj1328++ {
-			yyh1328.ElemContainerState(yyj1328)
+		yyj1375 := 0
+		for ; yyj1375 < yyrr1375; yyj1375++ {
+			yyh1375.ElemContainerState(yyj1375)
 			if r.TryDecodeAsNil() {
-				yyv1328[yyj1328] = ThirdPartyResourceData{}
+				yyv1375[yyj1375] = ThirdPartyResourceData{}
 			} else {
-				yyv1329 := &yyv1328[yyj1328]
-				yyv1329.CodecDecodeSelf(d)
+				yyv1376 := &yyv1375[yyj1375]
+				yyv1376.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1328 {
-			for ; yyj1328 < yyl1328; yyj1328++ {
-				yyv1328 = append(yyv1328, ThirdPartyResourceData{})
-				yyh1328.ElemContainerState(yyj1328)
+		if yyrt1375 {
+			for ; yyj1375 < yyl1375; yyj1375++ {
+				yyv1375 = append(yyv1375, ThirdPartyResourceData{})
+				yyh1375.ElemContainerState(yyj1375)
 				if r.TryDecodeAsNil() {
-					yyv1328[yyj1328] = ThirdPartyResourceData{}
+					yyv1375[yyj1375] = ThirdPartyResourceData{}
 				} else {
-					yyv1330 := &yyv1328[yyj1328]
-					yyv1330.CodecDecodeSelf(d)
+					yyv1377 := &yyv1375[yyj1375]
+					yyv1377.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1328 := 0
-		for ; !r.CheckBreak(); yyj1328++ {
+		yyj1375 := 0
+		for ; !r.CheckBreak(); yyj1375++ {
 
-			if yyj1328 >= len(yyv1328) {
-				yyv1328 = append(yyv1328, ThirdPartyResourceData{}) // var yyz1328 ThirdPartyResourceData
-				yyc1328 = true
+			if yyj1375 >= len(yyv1375) {
+				yyv1375 = append(yyv1375, ThirdPartyResourceData{}) // var yyz1375 ThirdPartyResourceData
+				yyc1375 = true
 			}
-			yyh1328.ElemContainerState(yyj1328)
-			if yyj1328 < len(yyv1328) {
+			yyh1375.ElemContainerState(yyj1375)
+			if yyj1375 < len(yyv1375) {
 				if r.TryDecodeAsNil() {
-					yyv1328[yyj1328] = ThirdPartyResourceData{}
+					yyv1375[yyj1375] = ThirdPartyResourceData{}
 				} else {
-					yyv1331 := &yyv1328[yyj1328]
-					yyv1331.CodecDecodeSelf(d)
+					yyv1378 := &yyv1375[yyj1375]
+					yyv1378.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -16150,17 +16736,17 @@ func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceD
 			}
 
 		}
-		if yyj1328 < len(yyv1328) {
-			yyv1328 = yyv1328[:yyj1328]
-			yyc1328 = true
-		} else if yyj1328 == 0 && yyv1328 == nil {
-			yyv1328 = []ThirdPartyResourceData{}
-			yyc1328 = true
+		if yyj1375 < len(yyv1375) {
+			yyv1375 = yyv1375[:yyj1375]
+			yyc1375 = true
+		} else if yyj1375 == 0 && yyv1375 == nil {
+			yyv1375 = []ThirdPartyResourceData{}
+			yyc1375 = true
 		}
 	}
-	yyh1328.End()
-	if yyc1328 {
-		*v = yyv1328
+	yyh1375.End()
+	if yyc1375 {
+		*v = yyv1375
 	}
 }
 
@@ -16169,10 +16755,10 @@ func (x codecSelfer1234) encSliceJob(v []Job, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1332 := range v {
+	for _, yyv1379 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1333 := &yyv1332
-		yy1333.CodecEncodeSelf(e)
+		yy1380 := &yyv1379
+		yy1380.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -16182,83 +16768,83 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1334 := *v
-	yyh1334, yyl1334 := z.DecSliceHelperStart()
-	var yyc1334 bool
-	if yyl1334 == 0 {
-		if yyv1334 == nil {
-			yyv1334 = []Job{}
-			yyc1334 = true
-		} else if len(yyv1334) != 0 {
-			yyv1334 = yyv1334[:0]
-			yyc1334 = true
+	yyv1381 := *v
+	yyh1381, yyl1381 := z.DecSliceHelperStart()
+	var yyc1381 bool
+	if yyl1381 == 0 {
+		if yyv1381 == nil {
+			yyv1381 = []Job{}
+			yyc1381 = true
+		} else if len(yyv1381) != 0 {
+			yyv1381 = yyv1381[:0]
+			yyc1381 = true
 		}
-	} else if yyl1334 > 0 {
-		var yyrr1334, yyrl1334 int
-		var yyrt1334 bool
-		if yyl1334 > cap(yyv1334) {
+	} else if yyl1381 > 0 {
+		var yyrr1381, yyrl1381 int
+		var yyrt1381 bool
+		if yyl1381 > cap(yyv1381) {
 
-			yyrg1334 := len(yyv1334) > 0
-			yyv21334 := yyv1334
-			yyrl1334, yyrt1334 = z.DecInferLen(yyl1334, z.DecBasicHandle().MaxInitLen, 616)
-			if yyrt1334 {
-				if yyrl1334 <= cap(yyv1334) {
-					yyv1334 = yyv1334[:yyrl1334]
+			yyrg1381 := len(yyv1381) > 0
+			yyv21381 := yyv1381
+			yyrl1381, yyrt1381 = z.DecInferLen(yyl1381, z.DecBasicHandle().MaxInitLen, 616)
+			if yyrt1381 {
+				if yyrl1381 <= cap(yyv1381) {
+					yyv1381 = yyv1381[:yyrl1381]
 				} else {
-					yyv1334 = make([]Job, yyrl1334)
+					yyv1381 = make([]Job, yyrl1381)
 				}
 			} else {
-				yyv1334 = make([]Job, yyrl1334)
+				yyv1381 = make([]Job, yyrl1381)
 			}
-			yyc1334 = true
-			yyrr1334 = len(yyv1334)
-			if yyrg1334 {
-				copy(yyv1334, yyv21334)
+			yyc1381 = true
+			yyrr1381 = len(yyv1381)
+			if yyrg1381 {
+				copy(yyv1381, yyv21381)
 			}
-		} else if yyl1334 != len(yyv1334) {
-			yyv1334 = yyv1334[:yyl1334]
-			yyc1334 = true
+		} else if yyl1381 != len(yyv1381) {
+			yyv1381 = yyv1381[:yyl1381]
+			yyc1381 = true
 		}
-		yyj1334 := 0
-		for ; yyj1334 < yyrr1334; yyj1334++ {
-			yyh1334.ElemContainerState(yyj1334)
+		yyj1381 := 0
+		for ; yyj1381 < yyrr1381; yyj1381++ {
+			yyh1381.ElemContainerState(yyj1381)
 			if r.TryDecodeAsNil() {
-				yyv1334[yyj1334] = Job{}
+				yyv1381[yyj1381] = Job{}
 			} else {
-				yyv1335 := &yyv1334[yyj1334]
-				yyv1335.CodecDecodeSelf(d)
+				yyv1382 := &yyv1381[yyj1381]
+				yyv1382.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1334 {
-			for ; yyj1334 < yyl1334; yyj1334++ {
-				yyv1334 = append(yyv1334, Job{})
-				yyh1334.ElemContainerState(yyj1334)
+		if yyrt1381 {
+			for ; yyj1381 < yyl1381; yyj1381++ {
+				yyv1381 = append(yyv1381, Job{})
+				yyh1381.ElemContainerState(yyj1381)
 				if r.TryDecodeAsNil() {
-					yyv1334[yyj1334] = Job{}
+					yyv1381[yyj1381] = Job{}
 				} else {
-					yyv1336 := &yyv1334[yyj1334]
-					yyv1336.CodecDecodeSelf(d)
+					yyv1383 := &yyv1381[yyj1381]
+					yyv1383.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1334 := 0
-		for ; !r.CheckBreak(); yyj1334++ {
+		yyj1381 := 0
+		for ; !r.CheckBreak(); yyj1381++ {
 
-			if yyj1334 >= len(yyv1334) {
-				yyv1334 = append(yyv1334, Job{}) // var yyz1334 Job
-				yyc1334 = true
+			if yyj1381 >= len(yyv1381) {
+				yyv1381 = append(yyv1381, Job{}) // var yyz1381 Job
+				yyc1381 = true
 			}
-			yyh1334.ElemContainerState(yyj1334)
-			if yyj1334 < len(yyv1334) {
+			yyh1381.ElemContainerState(yyj1381)
+			if yyj1381 < len(yyv1381) {
 				if r.TryDecodeAsNil() {
-					yyv1334[yyj1334] = Job{}
+					yyv1381[yyj1381] = Job{}
 				} else {
-					yyv1337 := &yyv1334[yyj1334]
-					yyv1337.CodecDecodeSelf(d)
+					yyv1384 := &yyv1381[yyj1381]
+					yyv1384.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -16266,17 +16852,17 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 			}
 
 		}
-		if yyj1334 < len(yyv1334) {
-			yyv1334 = yyv1334[:yyj1334]
-			yyc1334 = true
-		} else if yyj1334 == 0 && yyv1334 == nil {
-			yyv1334 = []Job{}
-			yyc1334 = true
+		if yyj1381 < len(yyv1381) {
+			yyv1381 = yyv1381[:yyj1381]
+			yyc1381 = true
+		} else if yyj1381 == 0 && yyv1381 == nil {
+			yyv1381 = []Job{}
+			yyc1381 = true
 		}
 	}
-	yyh1334.End()
-	if yyc1334 {
-		*v = yyv1334
+	yyh1381.End()
+	if yyc1381 {
+		*v = yyv1381
 	}
 }
 
@@ -16285,10 +16871,10 @@ func (x codecSelfer1234) encSliceJobCondition(v []JobCondition, e *codec1978.Enc
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1338 := range v {
+	for _, yyv1385 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1339 := &yyv1338
-		yy1339.CodecEncodeSelf(e)
+		yy1386 := &yyv1385
+		yy1386.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -16298,83 +16884,83 @@ func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.De
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1340 := *v
-	yyh1340, yyl1340 := z.DecSliceHelperStart()
-	var yyc1340 bool
-	if yyl1340 == 0 {
-		if yyv1340 == nil {
-			yyv1340 = []JobCondition{}
-			yyc1340 = true
-		} else if len(yyv1340) != 0 {
-			yyv1340 = yyv1340[:0]
-			yyc1340 = true
+	yyv1387 := *v
+	yyh1387, yyl1387 := z.DecSliceHelperStart()
+	var yyc1387 bool
+	if yyl1387 == 0 {
+		if yyv1387 == nil {
+			yyv1387 = []JobCondition{}
+			yyc1387 = true
+		} else if len(yyv1387) != 0 {
+			yyv1387 = yyv1387[:0]
+			yyc1387 = true
 		}
-	} else if yyl1340 > 0 {
-		var yyrr1340, yyrl1340 int
-		var yyrt1340 bool
-		if yyl1340 > cap(yyv1340) {
+	} else if yyl1387 > 0 {
+		var yyrr1387, yyrl1387 int
+		var yyrt1387 bool
+		if yyl1387 > cap(yyv1387) {
 
-			yyrg1340 := len(yyv1340) > 0
-			yyv21340 := yyv1340
-			yyrl1340, yyrt1340 = z.DecInferLen(yyl1340, z.DecBasicHandle().MaxInitLen, 112)
-			if yyrt1340 {
-				if yyrl1340 <= cap(yyv1340) {
-					yyv1340 = yyv1340[:yyrl1340]
+			yyrg1387 := len(yyv1387) > 0
+			yyv21387 := yyv1387
+			yyrl1387, yyrt1387 = z.DecInferLen(yyl1387, z.DecBasicHandle().MaxInitLen, 112)
+			if yyrt1387 {
+				if yyrl1387 <= cap(yyv1387) {
+					yyv1387 = yyv1387[:yyrl1387]
 				} else {
-					yyv1340 = make([]JobCondition, yyrl1340)
+					yyv1387 = make([]JobCondition, yyrl1387)
 				}
 			} else {
-				yyv1340 = make([]JobCondition, yyrl1340)
+				yyv1387 = make([]JobCondition, yyrl1387)
 			}
-			yyc1340 = true
-			yyrr1340 = len(yyv1340)
-			if yyrg1340 {
-				copy(yyv1340, yyv21340)
+			yyc1387 = true
+			yyrr1387 = len(yyv1387)
+			if yyrg1387 {
+				copy(yyv1387, yyv21387)
 			}
-		} else if yyl1340 != len(yyv1340) {
-			yyv1340 = yyv1340[:yyl1340]
-			yyc1340 = true
+		} else if yyl1387 != len(yyv1387) {
+			yyv1387 = yyv1387[:yyl1387]
+			yyc1387 = true
 		}
-		yyj1340 := 0
-		for ; yyj1340 < yyrr1340; yyj1340++ {
-			yyh1340.ElemContainerState(yyj1340)
+		yyj1387 := 0
+		for ; yyj1387 < yyrr1387; yyj1387++ {
+			yyh1387.ElemContainerState(yyj1387)
 			if r.TryDecodeAsNil() {
-				yyv1340[yyj1340] = JobCondition{}
+				yyv1387[yyj1387] = JobCondition{}
 			} else {
-				yyv1341 := &yyv1340[yyj1340]
-				yyv1341.CodecDecodeSelf(d)
+				yyv1388 := &yyv1387[yyj1387]
+				yyv1388.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1340 {
-			for ; yyj1340 < yyl1340; yyj1340++ {
-				yyv1340 = append(yyv1340, JobCondition{})
-				yyh1340.ElemContainerState(yyj1340)
+		if yyrt1387 {
+			for ; yyj1387 < yyl1387; yyj1387++ {
+				yyv1387 = append(yyv1387, JobCondition{})
+				yyh1387.ElemContainerState(yyj1387)
 				if r.TryDecodeAsNil() {
-					yyv1340[yyj1340] = JobCondition{}
+					yyv1387[yyj1387] = JobCondition{}
 				} else {
-					yyv1342 := &yyv1340[yyj1340]
-					yyv1342.CodecDecodeSelf(d)
+					yyv1389 := &yyv1387[yyj1387]
+					yyv1389.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1340 := 0
-		for ; !r.CheckBreak(); yyj1340++ {
+		yyj1387 := 0
+		for ; !r.CheckBreak(); yyj1387++ {
 
-			if yyj1340 >= len(yyv1340) {
-				yyv1340 = append(yyv1340, JobCondition{}) // var yyz1340 JobCondition
-				yyc1340 = true
+			if yyj1387 >= len(yyv1387) {
+				yyv1387 = append(yyv1387, JobCondition{}) // var yyz1387 JobCondition
+				yyc1387 = true
 			}
-			yyh1340.ElemContainerState(yyj1340)
-			if yyj1340 < len(yyv1340) {
+			yyh1387.ElemContainerState(yyj1387)
+			if yyj1387 < len(yyv1387) {
 				if r.TryDecodeAsNil() {
-					yyv1340[yyj1340] = JobCondition{}
+					yyv1387[yyj1387] = JobCondition{}
 				} else {
-					yyv1343 := &yyv1340[yyj1340]
-					yyv1343.CodecDecodeSelf(d)
+					yyv1390 := &yyv1387[yyj1387]
+					yyv1390.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -16382,17 +16968,17 @@ func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.De
 			}
 
 		}
-		if yyj1340 < len(yyv1340) {
-			yyv1340 = yyv1340[:yyj1340]
-			yyc1340 = true
-		} else if yyj1340 == 0 && yyv1340 == nil {
-			yyv1340 = []JobCondition{}
-			yyc1340 = true
+		if yyj1387 < len(yyv1387) {
+			yyv1387 = yyv1387[:yyj1387]
+			yyc1387 = true
+		} else if yyj1387 == 0 && yyv1387 == nil {
+			yyv1387 = []JobCondition{}
+			yyc1387 = true
 		}
 	}
-	yyh1340.End()
-	if yyc1340 {
-		*v = yyv1340
+	yyh1387.End()
+	if yyc1387 {
+		*v = yyv1387
 	}
 }
 
@@ -16401,10 +16987,10 @@ func (x codecSelfer1234) encSliceIngress(v []Ingress, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1344 := range v {
+	for _, yyv1391 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1345 := &yyv1344
-		yy1345.CodecEncodeSelf(e)
+		yy1392 := &yyv1391
+		yy1392.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -16414,83 +17000,83 @@ func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1346 := *v
-	yyh1346, yyl1346 := z.DecSliceHelperStart()
-	var yyc1346 bool
-	if yyl1346 == 0 {
-		if yyv1346 == nil {
-			yyv1346 = []Ingress{}
-			yyc1346 = true
-		} else if len(yyv1346) != 0 {
-			yyv1346 = yyv1346[:0]
-			yyc1346 = true
+	yyv1393 := *v
+	yyh1393, yyl1393 := z.DecSliceHelperStart()
+	var yyc1393 bool
+	if yyl1393 == 0 {
+		if yyv1393 == nil {
+			yyv1393 = []Ingress{}
+			yyc1393 = true
+		} else if len(yyv1393) != 0 {
+			yyv1393 = yyv1393[:0]
+			yyc1393 = true
 		}
-	} else if yyl1346 > 0 {
-		var yyrr1346, yyrl1346 int
-		var yyrt1346 bool
-		if yyl1346 > cap(yyv1346) {
+	} else if yyl1393 > 0 {
+		var yyrr1393, yyrl1393 int
+		var yyrt1393 bool
+		if yyl1393 > cap(yyv1393) {
 
-			yyrg1346 := len(yyv1346) > 0
-			yyv21346 := yyv1346
-			yyrl1346, yyrt1346 = z.DecInferLen(yyl1346, z.DecBasicHandle().MaxInitLen, 248)
-			if yyrt1346 {
-				if yyrl1346 <= cap(yyv1346) {
-					yyv1346 = yyv1346[:yyrl1346]
+			yyrg1393 := len(yyv1393) > 0
+			yyv21393 := yyv1393
+			yyrl1393, yyrt1393 = z.DecInferLen(yyl1393, z.DecBasicHandle().MaxInitLen, 248)
+			if yyrt1393 {
+				if yyrl1393 <= cap(yyv1393) {
+					yyv1393 = yyv1393[:yyrl1393]
 				} else {
-					yyv1346 = make([]Ingress, yyrl1346)
+					yyv1393 = make([]Ingress, yyrl1393)
 				}
 			} else {
-				yyv1346 = make([]Ingress, yyrl1346)
+				yyv1393 = make([]Ingress, yyrl1393)
 			}
-			yyc1346 = true
-			yyrr1346 = len(yyv1346)
-			if yyrg1346 {
-				copy(yyv1346, yyv21346)
+			yyc1393 = true
+			yyrr1393 = len(yyv1393)
+			if yyrg1393 {
+				copy(yyv1393, yyv21393)
 			}
-		} else if yyl1346 != len(yyv1346) {
-			yyv1346 = yyv1346[:yyl1346]
-			yyc1346 = true
+		} else if yyl1393 != len(yyv1393) {
+			yyv1393 = yyv1393[:yyl1393]
+			yyc1393 = true
 		}
-		yyj1346 := 0
-		for ; yyj1346 < yyrr1346; yyj1346++ {
-			yyh1346.ElemContainerState(yyj1346)
+		yyj1393 := 0
+		for ; yyj1393 < yyrr1393; yyj1393++ {
+			yyh1393.ElemContainerState(yyj1393)
 			if r.TryDecodeAsNil() {
-				yyv1346[yyj1346] = Ingress{}
+				yyv1393[yyj1393] = Ingress{}
 			} else {
-				yyv1347 := &yyv1346[yyj1346]
-				yyv1347.CodecDecodeSelf(d)
+				yyv1394 := &yyv1393[yyj1393]
+				yyv1394.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1346 {
-			for ; yyj1346 < yyl1346; yyj1346++ {
-				yyv1346 = append(yyv1346, Ingress{})
-				yyh1346.ElemContainerState(yyj1346)
+		if yyrt1393 {
+			for ; yyj1393 < yyl1393; yyj1393++ {
+				yyv1393 = append(yyv1393, Ingress{})
+				yyh1393.ElemContainerState(yyj1393)
 				if r.TryDecodeAsNil() {
-					yyv1346[yyj1346] = Ingress{}
+					yyv1393[yyj1393] = Ingress{}
 				} else {
-					yyv1348 := &yyv1346[yyj1346]
-					yyv1348.CodecDecodeSelf(d)
+					yyv1395 := &yyv1393[yyj1393]
+					yyv1395.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1346 := 0
-		for ; !r.CheckBreak(); yyj1346++ {
+		yyj1393 := 0
+		for ; !r.CheckBreak(); yyj1393++ {
 
-			if yyj1346 >= len(yyv1346) {
-				yyv1346 = append(yyv1346, Ingress{}) // var yyz1346 Ingress
-				yyc1346 = true
+			if yyj1393 >= len(yyv1393) {
+				yyv1393 = append(yyv1393, Ingress{}) // var yyz1393 Ingress
+				yyc1393 = true
 			}
-			yyh1346.ElemContainerState(yyj1346)
-			if yyj1346 < len(yyv1346) {
+			yyh1393.ElemContainerState(yyj1393)
+			if yyj1393 < len(yyv1393) {
 				if r.TryDecodeAsNil() {
-					yyv1346[yyj1346] = Ingress{}
+					yyv1393[yyj1393] = Ingress{}
 				} else {
-					yyv1349 := &yyv1346[yyj1346]
-					yyv1349.CodecDecodeSelf(d)
+					yyv1396 := &yyv1393[yyj1393]
+					yyv1396.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -16498,17 +17084,17 @@ func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
 			}
 
 		}
-		if yyj1346 < len(yyv1346) {
-			yyv1346 = yyv1346[:yyj1346]
-			yyc1346 = true
-		} else if yyj1346 == 0 && yyv1346 == nil {
-			yyv1346 = []Ingress{}
-			yyc1346 = true
+		if yyj1393 < len(yyv1393) {
+			yyv1393 = yyv1393[:yyj1393]
+			yyc1393 = true
+		} else if yyj1393 == 0 && yyv1393 == nil {
+			yyv1393 = []Ingress{}
+			yyc1393 = true
 		}
 	}
-	yyh1346.End()
-	if yyc1346 {
-		*v = yyv1346
+	yyh1393.End()
+	if yyc1393 {
+		*v = yyv1393
 	}
 }
 
@@ -16517,10 +17103,10 @@ func (x codecSelfer1234) encSliceIngressRule(v []IngressRule, e *codec1978.Encod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1350 := range v {
+	for _, yyv1397 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1351 := &yyv1350
-		yy1351.CodecEncodeSelf(e)
+		yy1398 := &yyv1397
+		yy1398.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -16530,83 +17116,83 @@ func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Deco
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1352 := *v
-	yyh1352, yyl1352 := z.DecSliceHelperStart()
-	var yyc1352 bool
-	if yyl1352 == 0 {
-		if yyv1352 == nil {
-			yyv1352 = []IngressRule{}
-			yyc1352 = true
-		} else if len(yyv1352) != 0 {
-			yyv1352 = yyv1352[:0]
-			yyc1352 = true
+	yyv1399 := *v
+	yyh1399, yyl1399 := z.DecSliceHelperStart()
+	var yyc1399 bool
+	if yyl1399 == 0 {
+		if yyv1399 == nil {
+			yyv1399 = []IngressRule{}
+			yyc1399 = true
+		} else if len(yyv1399) != 0 {
+			yyv1399 = yyv1399[:0]
+			yyc1399 = true
 		}
-	} else if yyl1352 > 0 {
-		var yyrr1352, yyrl1352 int
-		var yyrt1352 bool
-		if yyl1352 > cap(yyv1352) {
+	} else if yyl1399 > 0 {
+		var yyrr1399, yyrl1399 int
+		var yyrt1399 bool
+		if yyl1399 > cap(yyv1399) {
 
-			yyrg1352 := len(yyv1352) > 0
-			yyv21352 := yyv1352
-			yyrl1352, yyrt1352 = z.DecInferLen(yyl1352, z.DecBasicHandle().MaxInitLen, 24)
-			if yyrt1352 {
-				if yyrl1352 <= cap(yyv1352) {
-					yyv1352 = yyv1352[:yyrl1352]
+			yyrg1399 := len(yyv1399) > 0
+			yyv21399 := yyv1399
+			yyrl1399, yyrt1399 = z.DecInferLen(yyl1399, z.DecBasicHandle().MaxInitLen, 24)
+			if yyrt1399 {
+				if yyrl1399 <= cap(yyv1399) {
+					yyv1399 = yyv1399[:yyrl1399]
 				} else {
-					yyv1352 = make([]IngressRule, yyrl1352)
+					yyv1399 = make([]IngressRule, yyrl1399)
 				}
 			} else {
-				yyv1352 = make([]IngressRule, yyrl1352)
+				yyv1399 = make([]IngressRule, yyrl1399)
 			}
-			yyc1352 = true
-			yyrr1352 = len(yyv1352)
-			if yyrg1352 {
-				copy(yyv1352, yyv21352)
+			yyc1399 = true
+			yyrr1399 = len(yyv1399)
+			if yyrg1399 {
+				copy(yyv1399, yyv21399)
 			}
-		} else if yyl1352 != len(yyv1352) {
-			yyv1352 = yyv1352[:yyl1352]
-			yyc1352 = true
+		} else if yyl1399 != len(yyv1399) {
+			yyv1399 = yyv1399[:yyl1399]
+			yyc1399 = true
 		}
-		yyj1352 := 0
-		for ; yyj1352 < yyrr1352; yyj1352++ {
-			yyh1352.ElemContainerState(yyj1352)
+		yyj1399 := 0
+		for ; yyj1399 < yyrr1399; yyj1399++ {
+			yyh1399.ElemContainerState(yyj1399)
 			if r.TryDecodeAsNil() {
-				yyv1352[yyj1352] = IngressRule{}
+				yyv1399[yyj1399] = IngressRule{}
 			} else {
-				yyv1353 := &yyv1352[yyj1352]
-				yyv1353.CodecDecodeSelf(d)
+				yyv1400 := &yyv1399[yyj1399]
+				yyv1400.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1352 {
-			for ; yyj1352 < yyl1352; yyj1352++ {
-				yyv1352 = append(yyv1352, IngressRule{})
-				yyh1352.ElemContainerState(yyj1352)
+		if yyrt1399 {
+			for ; yyj1399 < yyl1399; yyj1399++ {
+				yyv1399 = append(yyv1399, IngressRule{})
+				yyh1399.ElemContainerState(yyj1399)
 				if r.TryDecodeAsNil() {
-					yyv1352[yyj1352] = IngressRule{}
+					yyv1399[yyj1399] = IngressRule{}
 				} else {
-					yyv1354 := &yyv1352[yyj1352]
-					yyv1354.CodecDecodeSelf(d)
+					yyv1401 := &yyv1399[yyj1399]
+					yyv1401.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1352 := 0
-		for ; !r.CheckBreak(); yyj1352++ {
+		yyj1399 := 0
+		for ; !r.CheckBreak(); yyj1399++ {
 
-			if yyj1352 >= len(yyv1352) {
-				yyv1352 = append(yyv1352, IngressRule{}) // var yyz1352 IngressRule
-				yyc1352 = true
+			if yyj1399 >= len(yyv1399) {
+				yyv1399 = append(yyv1399, IngressRule{}) // var yyz1399 IngressRule
+				yyc1399 = true
 			}
-			yyh1352.ElemContainerState(yyj1352)
-			if yyj1352 < len(yyv1352) {
+			yyh1399.ElemContainerState(yyj1399)
+			if yyj1399 < len(yyv1399) {
 				if r.TryDecodeAsNil() {
-					yyv1352[yyj1352] = IngressRule{}
+					yyv1399[yyj1399] = IngressRule{}
 				} else {
-					yyv1355 := &yyv1352[yyj1352]
-					yyv1355.CodecDecodeSelf(d)
+					yyv1402 := &yyv1399[yyj1399]
+					yyv1402.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -16614,17 +17200,17 @@ func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Deco
 			}
 
 		}
-		if yyj1352 < len(yyv1352) {
-			yyv1352 = yyv1352[:yyj1352]
-			yyc1352 = true
-		} else if yyj1352 == 0 && yyv1352 == nil {
-			yyv1352 = []IngressRule{}
-			yyc1352 = true
+		if yyj1399 < len(yyv1399) {
+			yyv1399 = yyv1399[:yyj1399]
+			yyc1399 = true
+		} else if yyj1399 == 0 && yyv1399 == nil {
+			yyv1399 = []IngressRule{}
+			yyc1399 = true
 		}
 	}
-	yyh1352.End()
-	if yyc1352 {
-		*v = yyv1352
+	yyh1399.End()
+	if yyc1399 {
+		*v = yyv1399
 	}
 }
 
@@ -16633,10 +17219,10 @@ func (x codecSelfer1234) encSliceHTTPIngressPath(v []HTTPIngressPath, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1356 := range v {
+	for _, yyv1403 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1357 := &yyv1356
-		yy1357.CodecEncodeSelf(e)
+		yy1404 := &yyv1403
+		yy1404.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -16646,83 +17232,83 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1358 := *v
-	yyh1358, yyl1358 := z.DecSliceHelperStart()
-	var yyc1358 bool
-	if yyl1358 == 0 {
-		if yyv1358 == nil {
-			yyv1358 = []HTTPIngressPath{}
-			yyc1358 = true
-		} else if len(yyv1358) != 0 {
-			yyv1358 = yyv1358[:0]
-			yyc1358 = true
+	yyv1405 := *v
+	yyh1405, yyl1405 := z.DecSliceHelperStart()
+	var yyc1405 bool
+	if yyl1405 == 0 {
+		if yyv1405 == nil {
+			yyv1405 = []HTTPIngressPath{}
+			yyc1405 = true
+		} else if len(yyv1405) != 0 {
+			yyv1405 = yyv1405[:0]
+			yyc1405 = true
 		}
-	} else if yyl1358 > 0 {
-		var yyrr1358, yyrl1358 int
-		var yyrt1358 bool
-		if yyl1358 > cap(yyv1358) {
+	} else if yyl1405 > 0 {
+		var yyrr1405, yyrl1405 int
+		var yyrt1405 bool
+		if yyl1405 > cap(yyv1405) {
 
-			yyrg1358 := len(yyv1358) > 0
-			yyv21358 := yyv1358
-			yyrl1358, yyrt1358 = z.DecInferLen(yyl1358, z.DecBasicHandle().MaxInitLen, 64)
-			if yyrt1358 {
-				if yyrl1358 <= cap(yyv1358) {
-					yyv1358 = yyv1358[:yyrl1358]
+			yyrg1405 := len(yyv1405) > 0
+			yyv21405 := yyv1405
+			yyrl1405, yyrt1405 = z.DecInferLen(yyl1405, z.DecBasicHandle().MaxInitLen, 64)
+			if yyrt1405 {
+				if yyrl1405 <= cap(yyv1405) {
+					yyv1405 = yyv1405[:yyrl1405]
 				} else {
-					yyv1358 = make([]HTTPIngressPath, yyrl1358)
+					yyv1405 = make([]HTTPIngressPath, yyrl1405)
 				}
 			} else {
-				yyv1358 = make([]HTTPIngressPath, yyrl1358)
+				yyv1405 = make([]HTTPIngressPath, yyrl1405)
 			}
-			yyc1358 = true
-			yyrr1358 = len(yyv1358)
-			if yyrg1358 {
-				copy(yyv1358, yyv21358)
+			yyc1405 = true
+			yyrr1405 = len(yyv1405)
+			if yyrg1405 {
+				copy(yyv1405, yyv21405)
 			}
-		} else if yyl1358 != len(yyv1358) {
-			yyv1358 = yyv1358[:yyl1358]
-			yyc1358 = true
+		} else if yyl1405 != len(yyv1405) {
+			yyv1405 = yyv1405[:yyl1405]
+			yyc1405 = true
 		}
-		yyj1358 := 0
-		for ; yyj1358 < yyrr1358; yyj1358++ {
-			yyh1358.ElemContainerState(yyj1358)
+		yyj1405 := 0
+		for ; yyj1405 < yyrr1405; yyj1405++ {
+			yyh1405.ElemContainerState(yyj1405)
 			if r.TryDecodeAsNil() {
-				yyv1358[yyj1358] = HTTPIngressPath{}
+				yyv1405[yyj1405] = HTTPIngressPath{}
 			} else {
-				yyv1359 := &yyv1358[yyj1358]
-				yyv1359.CodecDecodeSelf(d)
+				yyv1406 := &yyv1405[yyj1405]
+				yyv1406.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1358 {
-			for ; yyj1358 < yyl1358; yyj1358++ {
-				yyv1358 = append(yyv1358, HTTPIngressPath{})
-				yyh1358.ElemContainerState(yyj1358)
+		if yyrt1405 {
+			for ; yyj1405 < yyl1405; yyj1405++ {
+				yyv1405 = append(yyv1405, HTTPIngressPath{})
+				yyh1405.ElemContainerState(yyj1405)
 				if r.TryDecodeAsNil() {
-					yyv1358[yyj1358] = HTTPIngressPath{}
+					yyv1405[yyj1405] = HTTPIngressPath{}
 				} else {
-					yyv1360 := &yyv1358[yyj1358]
-					yyv1360.CodecDecodeSelf(d)
+					yyv1407 := &yyv1405[yyj1405]
+					yyv1407.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1358 := 0
-		for ; !r.CheckBreak(); yyj1358++ {
+		yyj1405 := 0
+		for ; !r.CheckBreak(); yyj1405++ {
 
-			if yyj1358 >= len(yyv1358) {
-				yyv1358 = append(yyv1358, HTTPIngressPath{}) // var yyz1358 HTTPIngressPath
-				yyc1358 = true
+			if yyj1405 >= len(yyv1405) {
+				yyv1405 = append(yyv1405, HTTPIngressPath{}) // var yyz1405 HTTPIngressPath
+				yyc1405 = true
 			}
-			yyh1358.ElemContainerState(yyj1358)
-			if yyj1358 < len(yyv1358) {
+			yyh1405.ElemContainerState(yyj1405)
+			if yyj1405 < len(yyv1405) {
 				if r.TryDecodeAsNil() {
-					yyv1358[yyj1358] = HTTPIngressPath{}
+					yyv1405[yyj1405] = HTTPIngressPath{}
 				} else {
-					yyv1361 := &yyv1358[yyj1358]
-					yyv1361.CodecDecodeSelf(d)
+					yyv1408 := &yyv1405[yyj1405]
+					yyv1408.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -16730,17 +17316,17 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 			}
 
 		}
-		if yyj1358 < len(yyv1358) {
-			yyv1358 = yyv1358[:yyj1358]
-			yyc1358 = true
-		} else if yyj1358 == 0 && yyv1358 == nil {
-			yyv1358 = []HTTPIngressPath{}
-			yyc1358 = true
+		if yyj1405 < len(yyv1405) {
+			yyv1405 = yyv1405[:yyj1405]
+			yyc1405 = true
+		} else if yyj1405 == 0 && yyv1405 == nil {
+			yyv1405 = []HTTPIngressPath{}
+			yyc1405 = true
 		}
 	}
-	yyh1358.End()
-	if yyc1358 {
-		*v = yyv1358
+	yyh1405.End()
+	if yyc1405 {
+		*v = yyv1405
 	}
 }
 
@@ -16749,10 +17335,10 @@ func (x codecSelfer1234) encSliceNodeUtilization(v []NodeUtilization, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1362 := range v {
+	for _, yyv1409 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1363 := &yyv1362
-		yy1363.CodecEncodeSelf(e)
+		yy1410 := &yyv1409
+		yy1410.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -16762,83 +17348,83 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1364 := *v
-	yyh1364, yyl1364 := z.DecSliceHelperStart()
-	var yyc1364 bool
-	if yyl1364 == 0 {
-		if yyv1364 == nil {
-			yyv1364 = []NodeUtilization{}
-			yyc1364 = true
-		} else if len(yyv1364) != 0 {
-			yyv1364 = yyv1364[:0]
-			yyc1364 = true
+	yyv1411 := *v
+	yyh1411, yyl1411 := z.DecSliceHelperStart()
+	var yyc1411 bool
+	if yyl1411 == 0 {
+		if yyv1411 == nil {
+			yyv1411 = []NodeUtilization{}
+			yyc1411 = true
+		} else if len(yyv1411) != 0 {
+			yyv1411 = yyv1411[:0]
+			yyc1411 = true
 		}
-	} else if yyl1364 > 0 {
-		var yyrr1364, yyrl1364 int
-		var yyrt1364 bool
-		if yyl1364 > cap(yyv1364) {
+	} else if yyl1411 > 0 {
+		var yyrr1411, yyrl1411 int
+		var yyrt1411 bool
+		if yyl1411 > cap(yyv1411) {
 
-			yyrg1364 := len(yyv1364) > 0
-			yyv21364 := yyv1364
-			yyrl1364, yyrt1364 = z.DecInferLen(yyl1364, z.DecBasicHandle().MaxInitLen, 24)
-			if yyrt1364 {
-				if yyrl1364 <= cap(yyv1364) {
-					yyv1364 = yyv1364[:yyrl1364]
+			yyrg1411 := len(yyv1411) > 0
+			yyv21411 := yyv1411
+			yyrl1411, yyrt1411 = z.DecInferLen(yyl1411, z.DecBasicHandle().MaxInitLen, 24)
+			if yyrt1411 {
+				if yyrl1411 <= cap(yyv1411) {
+					yyv1411 = yyv1411[:yyrl1411]
 				} else {
-					yyv1364 = make([]NodeUtilization, yyrl1364)
+					yyv1411 = make([]NodeUtilization, yyrl1411)
 				}
 			} else {
-				yyv1364 = make([]NodeUtilization, yyrl1364)
+				yyv1411 = make([]NodeUtilization, yyrl1411)
 			}
-			yyc1364 = true
-			yyrr1364 = len(yyv1364)
-			if yyrg1364 {
-				copy(yyv1364, yyv21364)
+			yyc1411 = true
+			yyrr1411 = len(yyv1411)
+			if yyrg1411 {
+				copy(yyv1411, yyv21411)
 			}
-		} else if yyl1364 != len(yyv1364) {
-			yyv1364 = yyv1364[:yyl1364]
-			yyc1364 = true
+		} else if yyl1411 != len(yyv1411) {
+			yyv1411 = yyv1411[:yyl1411]
+			yyc1411 = true
 		}
-		yyj1364 := 0
-		for ; yyj1364 < yyrr1364; yyj1364++ {
-			yyh1364.ElemContainerState(yyj1364)
+		yyj1411 := 0
+		for ; yyj1411 < yyrr1411; yyj1411++ {
+			yyh1411.ElemContainerState(yyj1411)
 			if r.TryDecodeAsNil() {
-				yyv1364[yyj1364] = NodeUtilization{}
+				yyv1411[yyj1411] = NodeUtilization{}
 			} else {
-				yyv1365 := &yyv1364[yyj1364]
-				yyv1365.CodecDecodeSelf(d)
+				yyv1412 := &yyv1411[yyj1411]
+				yyv1412.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1364 {
-			for ; yyj1364 < yyl1364; yyj1364++ {
-				yyv1364 = append(yyv1364, NodeUtilization{})
-				yyh1364.ElemContainerState(yyj1364)
+		if yyrt1411 {
+			for ; yyj1411 < yyl1411; yyj1411++ {
+				yyv1411 = append(yyv1411, NodeUtilization{})
+				yyh1411.ElemContainerState(yyj1411)
 				if r.TryDecodeAsNil() {
-					yyv1364[yyj1364] = NodeUtilization{}
+					yyv1411[yyj1411] = NodeUtilization{}
 				} else {
-					yyv1366 := &yyv1364[yyj1364]
-					yyv1366.CodecDecodeSelf(d)
+					yyv1413 := &yyv1411[yyj1411]
+					yyv1413.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1364 := 0
-		for ; !r.CheckBreak(); yyj1364++ {
+		yyj1411 := 0
+		for ; !r.CheckBreak(); yyj1411++ {
 
-			if yyj1364 >= len(yyv1364) {
-				yyv1364 = append(yyv1364, NodeUtilization{}) // var yyz1364 NodeUtilization
-				yyc1364 = true
+			if yyj1411 >= len(yyv1411) {
+				yyv1411 = append(yyv1411, NodeUtilization{}) // var yyz1411 NodeUtilization
+				yyc1411 = true
 			}
-			yyh1364.ElemContainerState(yyj1364)
-			if yyj1364 < len(yyv1364) {
+			yyh1411.ElemContainerState(yyj1411)
+			if yyj1411 < len(yyv1411) {
 				if r.TryDecodeAsNil() {
-					yyv1364[yyj1364] = NodeUtilization{}
+					yyv1411[yyj1411] = NodeUtilization{}
 				} else {
-					yyv1367 := &yyv1364[yyj1364]
-					yyv1367.CodecDecodeSelf(d)
+					yyv1414 := &yyv1411[yyj1411]
+					yyv1414.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -16846,17 +17432,17 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 			}
 
 		}
-		if yyj1364 < len(yyv1364) {
-			yyv1364 = yyv1364[:yyj1364]
-			yyc1364 = true
-		} else if yyj1364 == 0 && yyv1364 == nil {
-			yyv1364 = []NodeUtilization{}
-			yyc1364 = true
+		if yyj1411 < len(yyv1411) {
+			yyv1411 = yyv1411[:yyj1411]
+			yyc1411 = true
+		} else if yyj1411 == 0 && yyv1411 == nil {
+			yyv1411 = []NodeUtilization{}
+			yyc1411 = true
 		}
 	}
-	yyh1364.End()
-	if yyc1364 {
-		*v = yyv1364
+	yyh1411.End()
+	if yyc1411 {
+		*v = yyv1411
 	}
 }
 
@@ -16865,10 +17451,10 @@ func (x codecSelfer1234) encSliceClusterAutoscaler(v []ClusterAutoscaler, e *cod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1368 := range v {
+	for _, yyv1415 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1369 := &yyv1368
-		yy1369.CodecEncodeSelf(e)
+		yy1416 := &yyv1415
+		yy1416.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -16878,83 +17464,83 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1370 := *v
-	yyh1370, yyl1370 := z.DecSliceHelperStart()
-	var yyc1370 bool
-	if yyl1370 == 0 {
-		if yyv1370 == nil {
-			yyv1370 = []ClusterAutoscaler{}
-			yyc1370 = true
-		} else if len(yyv1370) != 0 {
-			yyv1370 = yyv1370[:0]
-			yyc1370 = true
+	yyv1417 := *v
+	yyh1417, yyl1417 := z.DecSliceHelperStart()
+	var yyc1417 bool
+	if yyl1417 == 0 {
+		if yyv1417 == nil {
+			yyv1417 = []ClusterAutoscaler{}
+			yyc1417 = true
+		} else if len(yyv1417) != 0 {
+			yyv1417 = yyv1417[:0]
+			yyc1417 = true
 		}
-	} else if yyl1370 > 0 {
-		var yyrr1370, yyrl1370 int
-		var yyrt1370 bool
-		if yyl1370 > cap(yyv1370) {
+	} else if yyl1417 > 0 {
+		var yyrr1417, yyrl1417 int
+		var yyrt1417 bool
+		if yyl1417 > cap(yyv1417) {
 
-			yyrg1370 := len(yyv1370) > 0
-			yyv21370 := yyv1370
-			yyrl1370, yyrt1370 = z.DecInferLen(yyl1370, z.DecBasicHandle().MaxInitLen, 232)
-			if yyrt1370 {
-				if yyrl1370 <= cap(yyv1370) {
-					yyv1370 = yyv1370[:yyrl1370]
+			yyrg1417 := len(yyv1417) > 0
+			yyv21417 := yyv1417
+			yyrl1417, yyrt1417 = z.DecInferLen(yyl1417, z.DecBasicHandle().MaxInitLen, 232)
+			if yyrt1417 {
+				if yyrl1417 <= cap(yyv1417) {
+					yyv1417 = yyv1417[:yyrl1417]
 				} else {
-					yyv1370 = make([]ClusterAutoscaler, yyrl1370)
+					yyv1417 = make([]ClusterAutoscaler, yyrl1417)
 				}
 			} else {
-				yyv1370 = make([]ClusterAutoscaler, yyrl1370)
+				yyv1417 = make([]ClusterAutoscaler, yyrl1417)
 			}
-			yyc1370 = true
-			yyrr1370 = len(yyv1370)
-			if yyrg1370 {
-				copy(yyv1370, yyv21370)
+			yyc1417 = true
+			yyrr1417 = len(yyv1417)
+			if yyrg1417 {
+				copy(yyv1417, yyv21417)
 			}
-		} else if yyl1370 != len(yyv1370) {
-			yyv1370 = yyv1370[:yyl1370]
-			yyc1370 = true
+		} else if yyl1417 != len(yyv1417) {
+			yyv1417 = yyv1417[:yyl1417]
+			yyc1417 = true
 		}
-		yyj1370 := 0
-		for ; yyj1370 < yyrr1370; yyj1370++ {
-			yyh1370.ElemContainerState(yyj1370)
+		yyj1417 := 0
+		for ; yyj1417 < yyrr1417; yyj1417++ {
+			yyh1417.ElemContainerState(yyj1417)
 			if r.TryDecodeAsNil() {
-				yyv1370[yyj1370] = ClusterAutoscaler{}
+				yyv1417[yyj1417] = ClusterAutoscaler{}
 			} else {
-				yyv1371 := &yyv1370[yyj1370]
-				yyv1371.CodecDecodeSelf(d)
+				yyv1418 := &yyv1417[yyj1417]
+				yyv1418.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1370 {
-			for ; yyj1370 < yyl1370; yyj1370++ {
-				yyv1370 = append(yyv1370, ClusterAutoscaler{})
-				yyh1370.ElemContainerState(yyj1370)
+		if yyrt1417 {
+			for ; yyj1417 < yyl1417; yyj1417++ {
+				yyv1417 = append(yyv1417, ClusterAutoscaler{})
+				yyh1417.ElemContainerState(yyj1417)
 				if r.TryDecodeAsNil() {
-					yyv1370[yyj1370] = ClusterAutoscaler{}
+					yyv1417[yyj1417] = ClusterAutoscaler{}
 				} else {
-					yyv1372 := &yyv1370[yyj1370]
-					yyv1372.CodecDecodeSelf(d)
+					yyv1419 := &yyv1417[yyj1417]
+					yyv1419.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1370 := 0
-		for ; !r.CheckBreak(); yyj1370++ {
+		yyj1417 := 0
+		for ; !r.CheckBreak(); yyj1417++ {
 
-			if yyj1370 >= len(yyv1370) {
-				yyv1370 = append(yyv1370, ClusterAutoscaler{}) // var yyz1370 ClusterAutoscaler
-				yyc1370 = true
+			if yyj1417 >= len(yyv1417) {
+				yyv1417 = append(yyv1417, ClusterAutoscaler{}) // var yyz1417 ClusterAutoscaler
+				yyc1417 = true
 			}
-			yyh1370.ElemContainerState(yyj1370)
-			if yyj1370 < len(yyv1370) {
+			yyh1417.ElemContainerState(yyj1417)
+			if yyj1417 < len(yyv1417) {
 				if r.TryDecodeAsNil() {
-					yyv1370[yyj1370] = ClusterAutoscaler{}
+					yyv1417[yyj1417] = ClusterAutoscaler{}
 				} else {
-					yyv1373 := &yyv1370[yyj1370]
-					yyv1373.CodecDecodeSelf(d)
+					yyv1420 := &yyv1417[yyj1417]
+					yyv1420.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -16962,17 +17548,17 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 			}
 
 		}
-		if yyj1370 < len(yyv1370) {
-			yyv1370 = yyv1370[:yyj1370]
-			yyc1370 = true
-		} else if yyj1370 == 0 && yyv1370 == nil {
-			yyv1370 = []ClusterAutoscaler{}
-			yyc1370 = true
+		if yyj1417 < len(yyv1417) {
+			yyv1417 = yyv1417[:yyj1417]
+			yyc1417 = true
+		} else if yyj1417 == 0 && yyv1417 == nil {
+			yyv1417 = []ClusterAutoscaler{}
+			yyc1417 = true
 		}
 	}
-	yyh1370.End()
-	if yyc1370 {
-		*v = yyv1370
+	yyh1417.End()
+	if yyc1417 {
+		*v = yyv1417
 	}
 }
 
@@ -16981,10 +17567,10 @@ func (x codecSelfer1234) encSliceLabelSelectorRequirement(v []LabelSelectorRequi
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1374 := range v {
+	for _, yyv1421 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1375 := &yyv1374
-		yy1375.CodecEncodeSelf(e)
+		yy1422 := &yyv1421
+		yy1422.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -16994,83 +17580,83 @@ func (x codecSelfer1234) decSliceLabelSelectorRequirement(v *[]LabelSelectorRequ
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1376 := *v
-	yyh1376, yyl1376 := z.DecSliceHelperStart()
-	var yyc1376 bool
-	if yyl1376 == 0 {
-		if yyv1376 == nil {
-			yyv1376 = []LabelSelectorRequirement{}
-			yyc1376 = true
-		} else if len(yyv1376) != 0 {
-			yyv1376 = yyv1376[:0]
-			yyc1376 = true
+	yyv1423 := *v
+	yyh1423, yyl1423 := z.DecSliceHelperStart()
+	var yyc1423 bool
+	if yyl1423 == 0 {
+		if yyv1423 == nil {
+			yyv1423 = []LabelSelectorRequirement{}
+			yyc1423 = true
+		} else if len(yyv1423) != 0 {
+			yyv1423 = yyv1423[:0]
+			yyc1423 = true
 		}
-	} else if yyl1376 > 0 {
-		var yyrr1376, yyrl1376 int
-		var yyrt1376 bool
-		if yyl1376 > cap(yyv1376) {
+	} else if yyl1423 > 0 {
+		var yyrr1423, yyrl1423 int
+		var yyrt1423 bool
+		if yyl1423 > cap(yyv1423) {
 
-			yyrg1376 := len(yyv1376) > 0
-			yyv21376 := yyv1376
-			yyrl1376, yyrt1376 = z.DecInferLen(yyl1376, z.DecBasicHandle().MaxInitLen, 56)
-			if yyrt1376 {
-				if yyrl1376 <= cap(yyv1376) {
-					yyv1376 = yyv1376[:yyrl1376]
+			yyrg1423 := len(yyv1423) > 0
+			yyv21423 := yyv1423
+			yyrl1423, yyrt1423 = z.DecInferLen(yyl1423, z.DecBasicHandle().MaxInitLen, 56)
+			if yyrt1423 {
+				if yyrl1423 <= cap(yyv1423) {
+					yyv1423 = yyv1423[:yyrl1423]
 				} else {
-					yyv1376 = make([]LabelSelectorRequirement, yyrl1376)
+					yyv1423 = make([]LabelSelectorRequirement, yyrl1423)
 				}
 			} else {
-				yyv1376 = make([]LabelSelectorRequirement, yyrl1376)
+				yyv1423 = make([]LabelSelectorRequirement, yyrl1423)
 			}
-			yyc1376 = true
-			yyrr1376 = len(yyv1376)
-			if yyrg1376 {
-				copy(yyv1376, yyv21376)
+			yyc1423 = true
+			yyrr1423 = len(yyv1423)
+			if yyrg1423 {
+				copy(yyv1423, yyv21423)
 			}
-		} else if yyl1376 != len(yyv1376) {
-			yyv1376 = yyv1376[:yyl1376]
-			yyc1376 = true
+		} else if yyl1423 != len(yyv1423) {
+			yyv1423 = yyv1423[:yyl1423]
+			yyc1423 = true
 		}
-		yyj1376 := 0
-		for ; yyj1376 < yyrr1376; yyj1376++ {
-			yyh1376.ElemContainerState(yyj1376)
+		yyj1423 := 0
+		for ; yyj1423 < yyrr1423; yyj1423++ {
+			yyh1423.ElemContainerState(yyj1423)
 			if r.TryDecodeAsNil() {
-				yyv1376[yyj1376] = LabelSelectorRequirement{}
+				yyv1423[yyj1423] = LabelSelectorRequirement{}
 			} else {
-				yyv1377 := &yyv1376[yyj1376]
-				yyv1377.CodecDecodeSelf(d)
+				yyv1424 := &yyv1423[yyj1423]
+				yyv1424.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1376 {
-			for ; yyj1376 < yyl1376; yyj1376++ {
-				yyv1376 = append(yyv1376, LabelSelectorRequirement{})
-				yyh1376.ElemContainerState(yyj1376)
+		if yyrt1423 {
+			for ; yyj1423 < yyl1423; yyj1423++ {
+				yyv1423 = append(yyv1423, LabelSelectorRequirement{})
+				yyh1423.ElemContainerState(yyj1423)
 				if r.TryDecodeAsNil() {
-					yyv1376[yyj1376] = LabelSelectorRequirement{}
+					yyv1423[yyj1423] = LabelSelectorRequirement{}
 				} else {
-					yyv1378 := &yyv1376[yyj1376]
-					yyv1378.CodecDecodeSelf(d)
+					yyv1425 := &yyv1423[yyj1423]
+					yyv1425.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1376 := 0
-		for ; !r.CheckBreak(); yyj1376++ {
+		yyj1423 := 0
+		for ; !r.CheckBreak(); yyj1423++ {
 
-			if yyj1376 >= len(yyv1376) {
-				yyv1376 = append(yyv1376, LabelSelectorRequirement{}) // var yyz1376 LabelSelectorRequirement
-				yyc1376 = true
+			if yyj1423 >= len(yyv1423) {
+				yyv1423 = append(yyv1423, LabelSelectorRequirement{}) // var yyz1423 LabelSelectorRequirement
+				yyc1423 = true
 			}
-			yyh1376.ElemContainerState(yyj1376)
-			if yyj1376 < len(yyv1376) {
+			yyh1423.ElemContainerState(yyj1423)
+			if yyj1423 < len(yyv1423) {
 				if r.TryDecodeAsNil() {
-					yyv1376[yyj1376] = LabelSelectorRequirement{}
+					yyv1423[yyj1423] = LabelSelectorRequirement{}
 				} else {
-					yyv1379 := &yyv1376[yyj1376]
-					yyv1379.CodecDecodeSelf(d)
+					yyv1426 := &yyv1423[yyj1423]
+					yyv1426.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -17078,17 +17664,17 @@ func (x codecSelfer1234) decSliceLabelSelectorRequirement(v *[]LabelSelectorRequ
 			}
 
 		}
-		if yyj1376 < len(yyv1376) {
-			yyv1376 = yyv1376[:yyj1376]
-			yyc1376 = true
-		} else if yyj1376 == 0 && yyv1376 == nil {
-			yyv1376 = []LabelSelectorRequirement{}
-			yyc1376 = true
+		if yyj1423 < len(yyv1423) {
+			yyv1423 = yyv1423[:yyj1423]
+			yyc1423 = true
+		} else if yyj1423 == 0 && yyv1423 == nil {
+			yyv1423 = []LabelSelectorRequirement{}
+			yyc1423 = true
 		}
 	}
-	yyh1376.End()
-	if yyc1376 {
-		*v = yyv1376
+	yyh1423.End()
+	if yyc1423 {
+		*v = yyv1423
 	}
 }
 
@@ -17097,10 +17683,10 @@ func (x codecSelfer1234) encSliceReplicaSet(v []ReplicaSet, e *codec1978.Encoder
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1380 := range v {
+	for _, yyv1427 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1381 := &yyv1380
-		yy1381.CodecEncodeSelf(e)
+		yy1428 := &yyv1427
+		yy1428.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -17110,83 +17696,83 @@ func (x codecSelfer1234) decSliceReplicaSet(v *[]ReplicaSet, d *codec1978.Decode
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1382 := *v
-	yyh1382, yyl1382 := z.DecSliceHelperStart()
-	var yyc1382 bool
-	if yyl1382 == 0 {
-		if yyv1382 == nil {
-			yyv1382 = []ReplicaSet{}
-			yyc1382 = true
-		} else if len(yyv1382) != 0 {
-			yyv1382 = yyv1382[:0]
-			yyc1382 = true
+	yyv1429 := *v
+	yyh1429, yyl1429 := z.DecSliceHelperStart()
+	var yyc1429 bool
+	if yyl1429 == 0 {
+		if yyv1429 == nil {
+			yyv1429 = []ReplicaSet{}
+			yyc1429 = true
+		} else if len(yyv1429) != 0 {
+			yyv1429 = yyv1429[:0]
+			yyc1429 = true
 		}
-	} else if yyl1382 > 0 {
-		var yyrr1382, yyrl1382 int
-		var yyrt1382 bool
-		if yyl1382 > cap(yyv1382) {
+	} else if yyl1429 > 0 {
+		var yyrr1429, yyrl1429 int
+		var yyrt1429 bool
+		if yyl1429 > cap(yyv1429) {
 
-			yyrg1382 := len(yyv1382) > 0
-			yyv21382 := yyv1382
-			yyrl1382, yyrt1382 = z.DecInferLen(yyl1382, z.DecBasicHandle().MaxInitLen, 232)
-			if yyrt1382 {
-				if yyrl1382 <= cap(yyv1382) {
-					yyv1382 = yyv1382[:yyrl1382]
+			yyrg1429 := len(yyv1429) > 0
+			yyv21429 := yyv1429
+			yyrl1429, yyrt1429 = z.DecInferLen(yyl1429, z.DecBasicHandle().MaxInitLen, 232)
+			if yyrt1429 {
+				if yyrl1429 <= cap(yyv1429) {
+					yyv1429 = yyv1429[:yyrl1429]
 				} else {
-					yyv1382 = make([]ReplicaSet, yyrl1382)
+					yyv1429 = make([]ReplicaSet, yyrl1429)
 				}
 			} else {
-				yyv1382 = make([]ReplicaSet, yyrl1382)
+				yyv1429 = make([]ReplicaSet, yyrl1429)
 			}
-			yyc1382 = true
-			yyrr1382 = len(yyv1382)
-			if yyrg1382 {
-				copy(yyv1382, yyv21382)
+			yyc1429 = true
+			yyrr1429 = len(yyv1429)
+			if yyrg1429 {
+				copy(yyv1429, yyv21429)
 			}
-		} else if yyl1382 != len(yyv1382) {
-			yyv1382 = yyv1382[:yyl1382]
-			yyc1382 = true
+		} else if yyl1429 != len(yyv1429) {
+			yyv1429 = yyv1429[:yyl1429]
+			yyc1429 = true
 		}
-		yyj1382 := 0
-		for ; yyj1382 < yyrr1382; yyj1382++ {
-			yyh1382.ElemContainerState(yyj1382)
+		yyj1429 := 0
+		for ; yyj1429 < yyrr1429; yyj1429++ {
+			yyh1429.ElemContainerState(yyj1429)
 			if r.TryDecodeAsNil() {
-				yyv1382[yyj1382] = ReplicaSet{}
+				yyv1429[yyj1429] = ReplicaSet{}
 			} else {
-				yyv1383 := &yyv1382[yyj1382]
-				yyv1383.CodecDecodeSelf(d)
+				yyv1430 := &yyv1429[yyj1429]
+				yyv1430.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1382 {
-			for ; yyj1382 < yyl1382; yyj1382++ {
-				yyv1382 = append(yyv1382, ReplicaSet{})
-				yyh1382.ElemContainerState(yyj1382)
+		if yyrt1429 {
+			for ; yyj1429 < yyl1429; yyj1429++ {
+				yyv1429 = append(yyv1429, ReplicaSet{})
+				yyh1429.ElemContainerState(yyj1429)
 				if r.TryDecodeAsNil() {
-					yyv1382[yyj1382] = ReplicaSet{}
+					yyv1429[yyj1429] = ReplicaSet{}
 				} else {
-					yyv1384 := &yyv1382[yyj1382]
-					yyv1384.CodecDecodeSelf(d)
+					yyv1431 := &yyv1429[yyj1429]
+					yyv1431.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1382 := 0
-		for ; !r.CheckBreak(); yyj1382++ {
+		yyj1429 := 0
+		for ; !r.CheckBreak(); yyj1429++ {
 
-			if yyj1382 >= len(yyv1382) {
-				yyv1382 = append(yyv1382, ReplicaSet{}) // var yyz1382 ReplicaSet
-				yyc1382 = true
+			if yyj1429 >= len(yyv1429) {
+				yyv1429 = append(yyv1429, ReplicaSet{}) // var yyz1429 ReplicaSet
+				yyc1429 = true
 			}
-			yyh1382.ElemContainerState(yyj1382)
-			if yyj1382 < len(yyv1382) {
+			yyh1429.ElemContainerState(yyj1429)
+			if yyj1429 < len(yyv1429) {
 				if r.TryDecodeAsNil() {
-					yyv1382[yyj1382] = ReplicaSet{}
+					yyv1429[yyj1429] = ReplicaSet{}
 				} else {
-					yyv1385 := &yyv1382[yyj1382]
-					yyv1385.CodecDecodeSelf(d)
+					yyv1432 := &yyv1429[yyj1429]
+					yyv1432.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -17194,16 +17780,16 @@ func (x codecSelfer1234) decSliceReplicaSet(v *[]ReplicaSet, d *codec1978.Decode
 			}
 
 		}
-		if yyj1382 < len(yyv1382) {
-			yyv1382 = yyv1382[:yyj1382]
-			yyc1382 = true
-		} else if yyj1382 == 0 && yyv1382 == nil {
-			yyv1382 = []ReplicaSet{}
-			yyc1382 = true
+		if yyj1429 < len(yyv1429) {
+			yyv1429 = yyv1429[:yyj1429]
+			yyc1429 = true
+		} else if yyj1429 == 0 && yyv1429 == nil {
+			yyv1429 = []ReplicaSet{}
+			yyc1429 = true
 		}
 	}
-	yyh1382.End()
-	if yyc1382 {
-		*v = yyv1382
+	yyh1429.End()
+	if yyc1429 {
+		*v = yyv1429
 	}
 }

--- a/pkg/apis/extensions/types.go
+++ b/pkg/apis/extensions/types.go
@@ -236,6 +236,24 @@ type DeploymentSpec struct {
 	// Indicates that the deployment is paused and will not be processed by the
 	// deployment controller.
 	Paused bool `json:"paused,omitempty"`
+	// The config this deployment is rolling back to. Will be cleared after rollback is done.
+	RollbackTo *RollbackConfig `json:"rollbackTo,omitempty"`
+}
+
+// DeploymentRollback stores the information required to rollback a deployment.
+type DeploymentRollback struct {
+	unversioned.TypeMeta `json:",inline"`
+	// Required: This must match the Name of a deployment.
+	Name string `json:"name"`
+	// The annotations to be updated to a deployment
+	UpdatedAnnotations map[string]string `json:"updatedAnnotations,omitempty"`
+	// The config of this deployment rollback.
+	RollbackTo RollbackConfig `json:"rollbackTo"`
+}
+
+type RollbackConfig struct {
+	// The revision to rollback to. If set to 0, rollbck to the last revision.
+	Revision int64 `json:"revision,omitempty"`
 }
 
 const (

--- a/pkg/apis/extensions/v1beta1/conversion.go
+++ b/pkg/apis/extensions/v1beta1/conversion.go
@@ -267,6 +267,12 @@ func Convert_extensions_DeploymentSpec_To_v1beta1_DeploymentSpec(in *extensions.
 	out.UniqueLabelKey = new(string)
 	*out.UniqueLabelKey = in.UniqueLabelKey
 	out.Paused = in.Paused
+	if in.RollbackTo != nil {
+		out.RollbackTo = new(RollbackConfig)
+		out.RollbackTo.Revision = int64(in.RollbackTo.Revision)
+	} else {
+		out.RollbackTo = nil
+	}
 	return nil
 }
 
@@ -299,6 +305,12 @@ func Convert_v1beta1_DeploymentSpec_To_extensions_DeploymentSpec(in *DeploymentS
 		out.UniqueLabelKey = *in.UniqueLabelKey
 	}
 	out.Paused = in.Paused
+	if in.RollbackTo != nil {
+		out.RollbackTo = new(extensions.RollbackConfig)
+		out.RollbackTo.Revision = in.RollbackTo.Revision
+	} else {
+		out.RollbackTo = nil
+	}
 	return nil
 }
 

--- a/pkg/apis/extensions/v1beta1/conversion_generated.go
+++ b/pkg/apis/extensions/v1beta1/conversion_generated.go
@@ -2678,6 +2678,32 @@ func Convert_extensions_DeploymentList_To_v1beta1_DeploymentList(in *extensions.
 	return autoConvert_extensions_DeploymentList_To_v1beta1_DeploymentList(in, out, s)
 }
 
+func autoConvert_extensions_DeploymentRollback_To_v1beta1_DeploymentRollback(in *extensions.DeploymentRollback, out *DeploymentRollback, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*extensions.DeploymentRollback))(in)
+	}
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	out.Name = in.Name
+	if in.UpdatedAnnotations != nil {
+		out.UpdatedAnnotations = make(map[string]string)
+		for key, val := range in.UpdatedAnnotations {
+			out.UpdatedAnnotations[key] = val
+		}
+	} else {
+		out.UpdatedAnnotations = nil
+	}
+	if err := Convert_extensions_RollbackConfig_To_v1beta1_RollbackConfig(&in.RollbackTo, &out.RollbackTo, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Convert_extensions_DeploymentRollback_To_v1beta1_DeploymentRollback(in *extensions.DeploymentRollback, out *DeploymentRollback, s conversion.Scope) error {
+	return autoConvert_extensions_DeploymentRollback_To_v1beta1_DeploymentRollback(in, out, s)
+}
+
 func autoConvert_extensions_DeploymentSpec_To_v1beta1_DeploymentSpec(in *extensions.DeploymentSpec, out *DeploymentSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.DeploymentSpec))(in)
@@ -2709,6 +2735,15 @@ func autoConvert_extensions_DeploymentSpec_To_v1beta1_DeploymentSpec(in *extensi
 		return err
 	}
 	out.Paused = in.Paused
+	// unable to generate simple pointer conversion for extensions.RollbackConfig -> v1beta1.RollbackConfig
+	if in.RollbackTo != nil {
+		out.RollbackTo = new(RollbackConfig)
+		if err := Convert_extensions_RollbackConfig_To_v1beta1_RollbackConfig(in.RollbackTo, out.RollbackTo, s); err != nil {
+			return err
+		}
+	} else {
+		out.RollbackTo = nil
+	}
 	return nil
 }
 
@@ -3360,6 +3395,18 @@ func Convert_extensions_ReplicationControllerDummy_To_v1beta1_ReplicationControl
 	return autoConvert_extensions_ReplicationControllerDummy_To_v1beta1_ReplicationControllerDummy(in, out, s)
 }
 
+func autoConvert_extensions_RollbackConfig_To_v1beta1_RollbackConfig(in *extensions.RollbackConfig, out *RollbackConfig, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*extensions.RollbackConfig))(in)
+	}
+	out.Revision = in.Revision
+	return nil
+}
+
+func Convert_extensions_RollbackConfig_To_v1beta1_RollbackConfig(in *extensions.RollbackConfig, out *RollbackConfig, s conversion.Scope) error {
+	return autoConvert_extensions_RollbackConfig_To_v1beta1_RollbackConfig(in, out, s)
+}
+
 func autoConvert_extensions_RollingUpdateDaemonSet_To_v1beta1_RollingUpdateDaemonSet(in *extensions.RollingUpdateDaemonSet, out *RollingUpdateDaemonSet, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.RollingUpdateDaemonSet))(in)
@@ -3806,6 +3853,32 @@ func Convert_v1beta1_DeploymentList_To_extensions_DeploymentList(in *DeploymentL
 	return autoConvert_v1beta1_DeploymentList_To_extensions_DeploymentList(in, out, s)
 }
 
+func autoConvert_v1beta1_DeploymentRollback_To_extensions_DeploymentRollback(in *DeploymentRollback, out *extensions.DeploymentRollback, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*DeploymentRollback))(in)
+	}
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	out.Name = in.Name
+	if in.UpdatedAnnotations != nil {
+		out.UpdatedAnnotations = make(map[string]string)
+		for key, val := range in.UpdatedAnnotations {
+			out.UpdatedAnnotations[key] = val
+		}
+	} else {
+		out.UpdatedAnnotations = nil
+	}
+	if err := Convert_v1beta1_RollbackConfig_To_extensions_RollbackConfig(&in.RollbackTo, &out.RollbackTo, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Convert_v1beta1_DeploymentRollback_To_extensions_DeploymentRollback(in *DeploymentRollback, out *extensions.DeploymentRollback, s conversion.Scope) error {
+	return autoConvert_v1beta1_DeploymentRollback_To_extensions_DeploymentRollback(in, out, s)
+}
+
 func autoConvert_v1beta1_DeploymentSpec_To_extensions_DeploymentSpec(in *DeploymentSpec, out *extensions.DeploymentSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*DeploymentSpec))(in)
@@ -3833,6 +3906,15 @@ func autoConvert_v1beta1_DeploymentSpec_To_extensions_DeploymentSpec(in *Deploym
 	}
 	// in.UniqueLabelKey has no peer in out
 	out.Paused = in.Paused
+	// unable to generate simple pointer conversion for v1beta1.RollbackConfig -> extensions.RollbackConfig
+	if in.RollbackTo != nil {
+		out.RollbackTo = new(extensions.RollbackConfig)
+		if err := Convert_v1beta1_RollbackConfig_To_extensions_RollbackConfig(in.RollbackTo, out.RollbackTo, s); err != nil {
+			return err
+		}
+	} else {
+		out.RollbackTo = nil
+	}
 	return nil
 }
 
@@ -4493,6 +4575,18 @@ func Convert_v1beta1_ReplicationControllerDummy_To_extensions_ReplicationControl
 	return autoConvert_v1beta1_ReplicationControllerDummy_To_extensions_ReplicationControllerDummy(in, out, s)
 }
 
+func autoConvert_v1beta1_RollbackConfig_To_extensions_RollbackConfig(in *RollbackConfig, out *extensions.RollbackConfig, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*RollbackConfig))(in)
+	}
+	out.Revision = in.Revision
+	return nil
+}
+
+func Convert_v1beta1_RollbackConfig_To_extensions_RollbackConfig(in *RollbackConfig, out *extensions.RollbackConfig, s conversion.Scope) error {
+	return autoConvert_v1beta1_RollbackConfig_To_extensions_RollbackConfig(in, out, s)
+}
+
 func autoConvert_v1beta1_RollingUpdateDaemonSet_To_extensions_RollingUpdateDaemonSet(in *RollingUpdateDaemonSet, out *extensions.RollingUpdateDaemonSet, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*RollingUpdateDaemonSet))(in)
@@ -4742,6 +4836,7 @@ func init() {
 		autoConvert_extensions_DaemonSetUpdateStrategy_To_v1beta1_DaemonSetUpdateStrategy,
 		autoConvert_extensions_DaemonSet_To_v1beta1_DaemonSet,
 		autoConvert_extensions_DeploymentList_To_v1beta1_DeploymentList,
+		autoConvert_extensions_DeploymentRollback_To_v1beta1_DeploymentRollback,
 		autoConvert_extensions_DeploymentSpec_To_v1beta1_DeploymentSpec,
 		autoConvert_extensions_DeploymentStatus_To_v1beta1_DeploymentStatus,
 		autoConvert_extensions_DeploymentStrategy_To_v1beta1_DeploymentStrategy,
@@ -4772,6 +4867,7 @@ func init() {
 		autoConvert_extensions_ReplicaSetStatus_To_v1beta1_ReplicaSetStatus,
 		autoConvert_extensions_ReplicaSet_To_v1beta1_ReplicaSet,
 		autoConvert_extensions_ReplicationControllerDummy_To_v1beta1_ReplicationControllerDummy,
+		autoConvert_extensions_RollbackConfig_To_v1beta1_RollbackConfig,
 		autoConvert_extensions_RollingUpdateDaemonSet_To_v1beta1_RollingUpdateDaemonSet,
 		autoConvert_extensions_RollingUpdateDeployment_To_v1beta1_RollingUpdateDeployment,
 		autoConvert_extensions_ScaleSpec_To_v1beta1_ScaleSpec,
@@ -4837,6 +4933,7 @@ func init() {
 		autoConvert_v1beta1_DaemonSetUpdateStrategy_To_extensions_DaemonSetUpdateStrategy,
 		autoConvert_v1beta1_DaemonSet_To_extensions_DaemonSet,
 		autoConvert_v1beta1_DeploymentList_To_extensions_DeploymentList,
+		autoConvert_v1beta1_DeploymentRollback_To_extensions_DeploymentRollback,
 		autoConvert_v1beta1_DeploymentSpec_To_extensions_DeploymentSpec,
 		autoConvert_v1beta1_DeploymentStatus_To_extensions_DeploymentStatus,
 		autoConvert_v1beta1_Deployment_To_extensions_Deployment,
@@ -4867,6 +4964,7 @@ func init() {
 		autoConvert_v1beta1_ReplicaSetStatus_To_extensions_ReplicaSetStatus,
 		autoConvert_v1beta1_ReplicaSet_To_extensions_ReplicaSet,
 		autoConvert_v1beta1_ReplicationControllerDummy_To_extensions_ReplicationControllerDummy,
+		autoConvert_v1beta1_RollbackConfig_To_extensions_RollbackConfig,
 		autoConvert_v1beta1_RollingUpdateDaemonSet_To_extensions_RollingUpdateDaemonSet,
 		autoConvert_v1beta1_RollingUpdateDeployment_To_extensions_RollingUpdateDeployment,
 		autoConvert_v1beta1_ScaleSpec_To_extensions_ScaleSpec,

--- a/pkg/apis/extensions/v1beta1/deep_copy_generated.go
+++ b/pkg/apis/extensions/v1beta1/deep_copy_generated.go
@@ -1126,6 +1126,25 @@ func deepCopy_v1beta1_DeploymentList(in DeploymentList, out *DeploymentList, c *
 	return nil
 }
 
+func deepCopy_v1beta1_DeploymentRollback(in DeploymentRollback, out *DeploymentRollback, c *conversion.Cloner) error {
+	if err := deepCopy_unversioned_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	out.Name = in.Name
+	if in.UpdatedAnnotations != nil {
+		out.UpdatedAnnotations = make(map[string]string)
+		for key, val := range in.UpdatedAnnotations {
+			out.UpdatedAnnotations[key] = val
+		}
+	} else {
+		out.UpdatedAnnotations = nil
+	}
+	if err := deepCopy_v1beta1_RollbackConfig(in.RollbackTo, &out.RollbackTo, c); err != nil {
+		return err
+	}
+	return nil
+}
+
 func deepCopy_v1beta1_DeploymentSpec(in DeploymentSpec, out *DeploymentSpec, c *conversion.Cloner) error {
 	if in.Replicas != nil {
 		out.Replicas = new(int32)
@@ -1160,6 +1179,14 @@ func deepCopy_v1beta1_DeploymentSpec(in DeploymentSpec, out *DeploymentSpec, c *
 		out.UniqueLabelKey = nil
 	}
 	out.Paused = in.Paused
+	if in.RollbackTo != nil {
+		out.RollbackTo = new(RollbackConfig)
+		if err := deepCopy_v1beta1_RollbackConfig(*in.RollbackTo, out.RollbackTo, c); err != nil {
+			return err
+		}
+	} else {
+		out.RollbackTo = nil
+	}
 	return nil
 }
 
@@ -1633,6 +1660,11 @@ func deepCopy_v1beta1_ReplicationControllerDummy(in ReplicationControllerDummy, 
 	return nil
 }
 
+func deepCopy_v1beta1_RollbackConfig(in RollbackConfig, out *RollbackConfig, c *conversion.Cloner) error {
+	out.Revision = in.Revision
+	return nil
+}
+
 func deepCopy_v1beta1_RollingUpdateDaemonSet(in RollingUpdateDaemonSet, out *RollingUpdateDaemonSet, c *conversion.Cloner) error {
 	if in.MaxUnavailable != nil {
 		out.MaxUnavailable = new(intstr.IntOrString)
@@ -1858,6 +1890,7 @@ func init() {
 		deepCopy_v1beta1_DaemonSetUpdateStrategy,
 		deepCopy_v1beta1_Deployment,
 		deepCopy_v1beta1_DeploymentList,
+		deepCopy_v1beta1_DeploymentRollback,
 		deepCopy_v1beta1_DeploymentSpec,
 		deepCopy_v1beta1_DeploymentStatus,
 		deepCopy_v1beta1_DeploymentStrategy,
@@ -1888,6 +1921,7 @@ func init() {
 		deepCopy_v1beta1_ReplicaSetSpec,
 		deepCopy_v1beta1_ReplicaSetStatus,
 		deepCopy_v1beta1_ReplicationControllerDummy,
+		deepCopy_v1beta1_RollbackConfig,
 		deepCopy_v1beta1_RollingUpdateDaemonSet,
 		deepCopy_v1beta1_RollingUpdateDeployment,
 		deepCopy_v1beta1_Scale,

--- a/pkg/apis/extensions/v1beta1/register.go
+++ b/pkg/apis/extensions/v1beta1/register.go
@@ -41,6 +41,7 @@ func addKnownTypes(scheme *runtime.Scheme) {
 		&ClusterAutoscalerList{},
 		&Deployment{},
 		&DeploymentList{},
+		&DeploymentRollback{},
 		&HorizontalPodAutoscaler{},
 		&HorizontalPodAutoscalerList{},
 		&Job{},
@@ -66,6 +67,7 @@ func (obj *ClusterAutoscaler) GetObjectKind() unversioned.ObjectKind           {
 func (obj *ClusterAutoscalerList) GetObjectKind() unversioned.ObjectKind       { return &obj.TypeMeta }
 func (obj *Deployment) GetObjectKind() unversioned.ObjectKind                  { return &obj.TypeMeta }
 func (obj *DeploymentList) GetObjectKind() unversioned.ObjectKind              { return &obj.TypeMeta }
+func (obj *DeploymentRollback) GetObjectKind() unversioned.ObjectKind          { return &obj.TypeMeta }
 func (obj *HorizontalPodAutoscaler) GetObjectKind() unversioned.ObjectKind     { return &obj.TypeMeta }
 func (obj *HorizontalPodAutoscalerList) GetObjectKind() unversioned.ObjectKind { return &obj.TypeMeta }
 func (obj *Job) GetObjectKind() unversioned.ObjectKind                         { return &obj.TypeMeta }

--- a/pkg/apis/extensions/v1beta1/types.generated.go
+++ b/pkg/apis/extensions/v1beta1/types.generated.go
@@ -4604,7 +4604,7 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 		} else {
 			yysep387 := !z.EncBinary()
 			yy2arr387 := z.EncBasicHandle().StructToArray
-			var yyq387 [7]bool
+			var yyq387 [8]bool
 			_, _, _ = yysep387, yyq387, yy2arr387
 			const yyr387 bool = false
 			yyq387[0] = x.Replicas != nil
@@ -4613,9 +4613,10 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq387[4] = x.RevisionHistoryLimit != nil
 			yyq387[5] = x.UniqueLabelKey != nil
 			yyq387[6] = x.Paused != false
+			yyq387[7] = x.RollbackTo != nil
 			var yynn387 int
 			if yyr387 || yy2arr387 {
-				r.EncodeArrayStart(7)
+				r.EncodeArrayStart(8)
 			} else {
 				yynn387 = 1
 				for _, b := range yyq387 {
@@ -4818,6 +4819,29 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr387 || yy2arr387 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq387[7] {
+					if x.RollbackTo == nil {
+						r.EncodeNil()
+					} else {
+						x.RollbackTo.CodecEncodeSelf(e)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq387[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("rollbackTo"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if x.RollbackTo == nil {
+						r.EncodeNil()
+					} else {
+						x.RollbackTo.CodecEncodeSelf(e)
+					}
+				}
+			}
+			if yyr387 || yy2arr387 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -4830,25 +4854,25 @@ func (x *DeploymentSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym415 := z.DecBinary()
-	_ = yym415
+	yym416 := z.DecBinary()
+	_ = yym416
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct416 := r.ContainerType()
-		if yyct416 == codecSelferValueTypeMap1234 {
-			yyl416 := r.ReadMapStart()
-			if yyl416 == 0 {
+		yyct417 := r.ContainerType()
+		if yyct417 == codecSelferValueTypeMap1234 {
+			yyl417 := r.ReadMapStart()
+			if yyl417 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl416, d)
+				x.codecDecodeSelfFromMap(yyl417, d)
 			}
-		} else if yyct416 == codecSelferValueTypeArray1234 {
-			yyl416 := r.ReadArrayStart()
-			if yyl416 == 0 {
+		} else if yyct417 == codecSelferValueTypeArray1234 {
+			yyl417 := r.ReadArrayStart()
+			if yyl417 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl416, d)
+				x.codecDecodeSelfFromArray(yyl417, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4860,12 +4884,12 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys417Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys417Slc
-	var yyhl417 bool = l >= 0
-	for yyj417 := 0; ; yyj417++ {
-		if yyhl417 {
-			if yyj417 >= l {
+	var yys418Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys418Slc
+	var yyhl418 bool = l >= 0
+	for yyj418 := 0; ; yyj418++ {
+		if yyhl418 {
+			if yyj418 >= l {
 				break
 			}
 		} else {
@@ -4874,10 +4898,10 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys417Slc = r.DecodeBytes(yys417Slc, true, true)
-		yys417 := string(yys417Slc)
+		yys418Slc = r.DecodeBytes(yys418Slc, true, true)
+		yys418 := string(yys418Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys417 {
+		switch yys418 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
 				if x.Replicas != nil {
@@ -4887,8 +4911,8 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Replicas == nil {
 					x.Replicas = new(int32)
 				}
-				yym419 := z.DecBinary()
-				_ = yym419
+				yym420 := z.DecBinary()
+				_ = yym420
 				if false {
 				} else {
 					*((*int32)(x.Replicas)) = int32(r.DecodeInt(32))
@@ -4898,27 +4922,27 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Selector = nil
 			} else {
-				yyv420 := &x.Selector
-				yym421 := z.DecBinary()
-				_ = yym421
+				yyv421 := &x.Selector
+				yym422 := z.DecBinary()
+				_ = yym422
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv420, false, d)
+					z.F.DecMapStringStringX(yyv421, false, d)
 				}
 			}
 		case "template":
 			if r.TryDecodeAsNil() {
 				x.Template = pkg2_v1.PodTemplateSpec{}
 			} else {
-				yyv422 := &x.Template
-				yyv422.CodecDecodeSelf(d)
+				yyv423 := &x.Template
+				yyv423.CodecDecodeSelf(d)
 			}
 		case "strategy":
 			if r.TryDecodeAsNil() {
 				x.Strategy = DeploymentStrategy{}
 			} else {
-				yyv423 := &x.Strategy
-				yyv423.CodecDecodeSelf(d)
+				yyv424 := &x.Strategy
+				yyv424.CodecDecodeSelf(d)
 			}
 		case "revisionHistoryLimit":
 			if r.TryDecodeAsNil() {
@@ -4929,8 +4953,8 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.RevisionHistoryLimit == nil {
 					x.RevisionHistoryLimit = new(int32)
 				}
-				yym425 := z.DecBinary()
-				_ = yym425
+				yym426 := z.DecBinary()
+				_ = yym426
 				if false {
 				} else {
 					*((*int32)(x.RevisionHistoryLimit)) = int32(r.DecodeInt(32))
@@ -4945,8 +4969,8 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.UniqueLabelKey == nil {
 					x.UniqueLabelKey = new(string)
 				}
-				yym427 := z.DecBinary()
-				_ = yym427
+				yym428 := z.DecBinary()
+				_ = yym428
 				if false {
 				} else {
 					*((*string)(x.UniqueLabelKey)) = r.DecodeString()
@@ -4958,10 +4982,21 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			} else {
 				x.Paused = bool(r.DecodeBool())
 			}
+		case "rollbackTo":
+			if r.TryDecodeAsNil() {
+				if x.RollbackTo != nil {
+					x.RollbackTo = nil
+				}
+			} else {
+				if x.RollbackTo == nil {
+					x.RollbackTo = new(RollbackConfig)
+				}
+				x.RollbackTo.CodecDecodeSelf(d)
+			}
 		default:
-			z.DecStructFieldNotFound(-1, yys417)
-		} // end switch yys417
-	} // end for yyj417
+			z.DecStructFieldNotFound(-1, yys418)
+		} // end switch yys418
+	} // end for yyj418
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -4969,16 +5004,16 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj429 int
-	var yyb429 bool
-	var yyhl429 bool = l >= 0
-	yyj429++
-	if yyhl429 {
-		yyb429 = yyj429 > l
+	var yyj431 int
+	var yyb431 bool
+	var yyhl431 bool = l >= 0
+	yyj431++
+	if yyhl431 {
+		yyb431 = yyj431 > l
 	} else {
-		yyb429 = r.CheckBreak()
+		yyb431 = r.CheckBreak()
 	}
-	if yyb429 {
+	if yyb431 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4991,20 +5026,20 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.Replicas == nil {
 			x.Replicas = new(int32)
 		}
-		yym431 := z.DecBinary()
-		_ = yym431
+		yym433 := z.DecBinary()
+		_ = yym433
 		if false {
 		} else {
 			*((*int32)(x.Replicas)) = int32(r.DecodeInt(32))
 		}
 	}
-	yyj429++
-	if yyhl429 {
-		yyb429 = yyj429 > l
+	yyj431++
+	if yyhl431 {
+		yyb431 = yyj431 > l
 	} else {
-		yyb429 = r.CheckBreak()
+		yyb431 = r.CheckBreak()
 	}
-	if yyb429 {
+	if yyb431 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5012,21 +5047,21 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Selector = nil
 	} else {
-		yyv432 := &x.Selector
-		yym433 := z.DecBinary()
-		_ = yym433
+		yyv434 := &x.Selector
+		yym435 := z.DecBinary()
+		_ = yym435
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv432, false, d)
+			z.F.DecMapStringStringX(yyv434, false, d)
 		}
 	}
-	yyj429++
-	if yyhl429 {
-		yyb429 = yyj429 > l
+	yyj431++
+	if yyhl431 {
+		yyb431 = yyj431 > l
 	} else {
-		yyb429 = r.CheckBreak()
+		yyb431 = r.CheckBreak()
 	}
-	if yyb429 {
+	if yyb431 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5034,16 +5069,16 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Template = pkg2_v1.PodTemplateSpec{}
 	} else {
-		yyv434 := &x.Template
-		yyv434.CodecDecodeSelf(d)
+		yyv436 := &x.Template
+		yyv436.CodecDecodeSelf(d)
 	}
-	yyj429++
-	if yyhl429 {
-		yyb429 = yyj429 > l
+	yyj431++
+	if yyhl431 {
+		yyb431 = yyj431 > l
 	} else {
-		yyb429 = r.CheckBreak()
+		yyb431 = r.CheckBreak()
 	}
-	if yyb429 {
+	if yyb431 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5051,16 +5086,16 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Strategy = DeploymentStrategy{}
 	} else {
-		yyv435 := &x.Strategy
-		yyv435.CodecDecodeSelf(d)
+		yyv437 := &x.Strategy
+		yyv437.CodecDecodeSelf(d)
 	}
-	yyj429++
-	if yyhl429 {
-		yyb429 = yyj429 > l
+	yyj431++
+	if yyhl431 {
+		yyb431 = yyj431 > l
 	} else {
-		yyb429 = r.CheckBreak()
+		yyb431 = r.CheckBreak()
 	}
-	if yyb429 {
+	if yyb431 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5073,20 +5108,20 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.RevisionHistoryLimit == nil {
 			x.RevisionHistoryLimit = new(int32)
 		}
-		yym437 := z.DecBinary()
-		_ = yym437
+		yym439 := z.DecBinary()
+		_ = yym439
 		if false {
 		} else {
 			*((*int32)(x.RevisionHistoryLimit)) = int32(r.DecodeInt(32))
 		}
 	}
-	yyj429++
-	if yyhl429 {
-		yyb429 = yyj429 > l
+	yyj431++
+	if yyhl431 {
+		yyb431 = yyj431 > l
 	} else {
-		yyb429 = r.CheckBreak()
+		yyb431 = r.CheckBreak()
 	}
-	if yyb429 {
+	if yyb431 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5099,20 +5134,20 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.UniqueLabelKey == nil {
 			x.UniqueLabelKey = new(string)
 		}
-		yym439 := z.DecBinary()
-		_ = yym439
+		yym441 := z.DecBinary()
+		_ = yym441
 		if false {
 		} else {
 			*((*string)(x.UniqueLabelKey)) = r.DecodeString()
 		}
 	}
-	yyj429++
-	if yyhl429 {
-		yyb429 = yyj429 > l
+	yyj431++
+	if yyhl431 {
+		yyb431 = yyj431 > l
 	} else {
-		yyb429 = r.CheckBreak()
+		yyb431 = r.CheckBreak()
 	}
-	if yyb429 {
+	if yyb431 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5122,18 +5157,569 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Paused = bool(r.DecodeBool())
 	}
-	for {
-		yyj429++
-		if yyhl429 {
-			yyb429 = yyj429 > l
-		} else {
-			yyb429 = r.CheckBreak()
+	yyj431++
+	if yyhl431 {
+		yyb431 = yyj431 > l
+	} else {
+		yyb431 = r.CheckBreak()
+	}
+	if yyb431 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		if x.RollbackTo != nil {
+			x.RollbackTo = nil
 		}
-		if yyb429 {
+	} else {
+		if x.RollbackTo == nil {
+			x.RollbackTo = new(RollbackConfig)
+		}
+		x.RollbackTo.CodecDecodeSelf(d)
+	}
+	for {
+		yyj431++
+		if yyhl431 {
+			yyb431 = yyj431 > l
+		} else {
+			yyb431 = r.CheckBreak()
+		}
+		if yyb431 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj429-1, "")
+		z.DecStructFieldNotFound(yyj431-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x *DeploymentRollback) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym444 := z.EncBinary()
+		_ = yym444
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep445 := !z.EncBinary()
+			yy2arr445 := z.EncBasicHandle().StructToArray
+			var yyq445 [5]bool
+			_, _, _ = yysep445, yyq445, yy2arr445
+			const yyr445 bool = false
+			yyq445[0] = x.Kind != ""
+			yyq445[1] = x.APIVersion != ""
+			yyq445[3] = len(x.UpdatedAnnotations) != 0
+			var yynn445 int
+			if yyr445 || yy2arr445 {
+				r.EncodeArrayStart(5)
+			} else {
+				yynn445 = 2
+				for _, b := range yyq445 {
+					if b {
+						yynn445++
+					}
+				}
+				r.EncodeMapStart(yynn445)
+				yynn445 = 0
+			}
+			if yyr445 || yy2arr445 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq445[0] {
+					yym447 := z.EncBinary()
+					_ = yym447
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq445[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym448 := z.EncBinary()
+					_ = yym448
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr445 || yy2arr445 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq445[1] {
+					yym450 := z.EncBinary()
+					_ = yym450
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq445[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym451 := z.EncBinary()
+					_ = yym451
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr445 || yy2arr445 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym453 := z.EncBinary()
+				_ = yym453
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("name"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym454 := z.EncBinary()
+				_ = yym454
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+				}
+			}
+			if yyr445 || yy2arr445 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq445[3] {
+					if x.UpdatedAnnotations == nil {
+						r.EncodeNil()
+					} else {
+						yym456 := z.EncBinary()
+						_ = yym456
+						if false {
+						} else {
+							z.F.EncMapStringStringV(x.UpdatedAnnotations, false, e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq445[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("updatedAnnotations"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if x.UpdatedAnnotations == nil {
+						r.EncodeNil()
+					} else {
+						yym457 := z.EncBinary()
+						_ = yym457
+						if false {
+						} else {
+							z.F.EncMapStringStringV(x.UpdatedAnnotations, false, e)
+						}
+					}
+				}
+			}
+			if yyr445 || yy2arr445 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yy459 := &x.RollbackTo
+				yy459.CodecEncodeSelf(e)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("rollbackTo"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yy460 := &x.RollbackTo
+				yy460.CodecEncodeSelf(e)
+			}
+			if yyr445 || yy2arr445 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *DeploymentRollback) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym461 := z.DecBinary()
+	_ = yym461
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct462 := r.ContainerType()
+		if yyct462 == codecSelferValueTypeMap1234 {
+			yyl462 := r.ReadMapStart()
+			if yyl462 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl462, d)
+			}
+		} else if yyct462 == codecSelferValueTypeArray1234 {
+			yyl462 := r.ReadArrayStart()
+			if yyl462 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl462, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *DeploymentRollback) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys463Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys463Slc
+	var yyhl463 bool = l >= 0
+	for yyj463 := 0; ; yyj463++ {
+		if yyhl463 {
+			if yyj463 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys463Slc = r.DecodeBytes(yys463Slc, true, true)
+		yys463 := string(yys463Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys463 {
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
+			}
+		case "name":
+			if r.TryDecodeAsNil() {
+				x.Name = ""
+			} else {
+				x.Name = string(r.DecodeString())
+			}
+		case "updatedAnnotations":
+			if r.TryDecodeAsNil() {
+				x.UpdatedAnnotations = nil
+			} else {
+				yyv467 := &x.UpdatedAnnotations
+				yym468 := z.DecBinary()
+				_ = yym468
+				if false {
+				} else {
+					z.F.DecMapStringStringX(yyv467, false, d)
+				}
+			}
+		case "rollbackTo":
+			if r.TryDecodeAsNil() {
+				x.RollbackTo = RollbackConfig{}
+			} else {
+				yyv469 := &x.RollbackTo
+				yyv469.CodecDecodeSelf(d)
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys463)
+		} // end switch yys463
+	} // end for yyj463
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *DeploymentRollback) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj470 int
+	var yyb470 bool
+	var yyhl470 bool = l >= 0
+	yyj470++
+	if yyhl470 {
+		yyb470 = yyj470 > l
+	} else {
+		yyb470 = r.CheckBreak()
+	}
+	if yyb470 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj470++
+	if yyhl470 {
+		yyb470 = yyj470 > l
+	} else {
+		yyb470 = r.CheckBreak()
+	}
+	if yyb470 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
+	}
+	yyj470++
+	if yyhl470 {
+		yyb470 = yyj470 > l
+	} else {
+		yyb470 = r.CheckBreak()
+	}
+	if yyb470 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Name = ""
+	} else {
+		x.Name = string(r.DecodeString())
+	}
+	yyj470++
+	if yyhl470 {
+		yyb470 = yyj470 > l
+	} else {
+		yyb470 = r.CheckBreak()
+	}
+	if yyb470 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.UpdatedAnnotations = nil
+	} else {
+		yyv474 := &x.UpdatedAnnotations
+		yym475 := z.DecBinary()
+		_ = yym475
+		if false {
+		} else {
+			z.F.DecMapStringStringX(yyv474, false, d)
+		}
+	}
+	yyj470++
+	if yyhl470 {
+		yyb470 = yyj470 > l
+	} else {
+		yyb470 = r.CheckBreak()
+	}
+	if yyb470 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.RollbackTo = RollbackConfig{}
+	} else {
+		yyv476 := &x.RollbackTo
+		yyv476.CodecDecodeSelf(d)
+	}
+	for {
+		yyj470++
+		if yyhl470 {
+			yyb470 = yyj470 > l
+		} else {
+			yyb470 = r.CheckBreak()
+		}
+		if yyb470 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj470-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x *RollbackConfig) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym477 := z.EncBinary()
+		_ = yym477
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep478 := !z.EncBinary()
+			yy2arr478 := z.EncBasicHandle().StructToArray
+			var yyq478 [1]bool
+			_, _, _ = yysep478, yyq478, yy2arr478
+			const yyr478 bool = false
+			yyq478[0] = x.Revision != 0
+			var yynn478 int
+			if yyr478 || yy2arr478 {
+				r.EncodeArrayStart(1)
+			} else {
+				yynn478 = 0
+				for _, b := range yyq478 {
+					if b {
+						yynn478++
+					}
+				}
+				r.EncodeMapStart(yynn478)
+				yynn478 = 0
+			}
+			if yyr478 || yy2arr478 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq478[0] {
+					yym480 := z.EncBinary()
+					_ = yym480
+					if false {
+					} else {
+						r.EncodeInt(int64(x.Revision))
+					}
+				} else {
+					r.EncodeInt(0)
+				}
+			} else {
+				if yyq478[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("revision"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym481 := z.EncBinary()
+					_ = yym481
+					if false {
+					} else {
+						r.EncodeInt(int64(x.Revision))
+					}
+				}
+			}
+			if yyr478 || yy2arr478 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *RollbackConfig) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym482 := z.DecBinary()
+	_ = yym482
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct483 := r.ContainerType()
+		if yyct483 == codecSelferValueTypeMap1234 {
+			yyl483 := r.ReadMapStart()
+			if yyl483 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl483, d)
+			}
+		} else if yyct483 == codecSelferValueTypeArray1234 {
+			yyl483 := r.ReadArrayStart()
+			if yyl483 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl483, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *RollbackConfig) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys484Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys484Slc
+	var yyhl484 bool = l >= 0
+	for yyj484 := 0; ; yyj484++ {
+		if yyhl484 {
+			if yyj484 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys484Slc = r.DecodeBytes(yys484Slc, true, true)
+		yys484 := string(yys484Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys484 {
+		case "revision":
+			if r.TryDecodeAsNil() {
+				x.Revision = 0
+			} else {
+				x.Revision = int64(r.DecodeInt(64))
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys484)
+		} // end switch yys484
+	} // end for yyj484
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *RollbackConfig) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj486 int
+	var yyb486 bool
+	var yyhl486 bool = l >= 0
+	yyj486++
+	if yyhl486 {
+		yyb486 = yyj486 > l
+	} else {
+		yyb486 = r.CheckBreak()
+	}
+	if yyb486 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Revision = 0
+	} else {
+		x.Revision = int64(r.DecodeInt(64))
+	}
+	for {
+		yyj486++
+		if yyhl486 {
+			yyb486 = yyj486 > l
+		} else {
+			yyb486 = r.CheckBreak()
+		}
+		if yyb486 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj486-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -5145,49 +5731,49 @@ func (x *DeploymentStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym441 := z.EncBinary()
-		_ = yym441
+		yym488 := z.EncBinary()
+		_ = yym488
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep442 := !z.EncBinary()
-			yy2arr442 := z.EncBasicHandle().StructToArray
-			var yyq442 [2]bool
-			_, _, _ = yysep442, yyq442, yy2arr442
-			const yyr442 bool = false
-			yyq442[0] = x.Type != ""
-			yyq442[1] = x.RollingUpdate != nil
-			var yynn442 int
-			if yyr442 || yy2arr442 {
+			yysep489 := !z.EncBinary()
+			yy2arr489 := z.EncBasicHandle().StructToArray
+			var yyq489 [2]bool
+			_, _, _ = yysep489, yyq489, yy2arr489
+			const yyr489 bool = false
+			yyq489[0] = x.Type != ""
+			yyq489[1] = x.RollingUpdate != nil
+			var yynn489 int
+			if yyr489 || yy2arr489 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn442 = 0
-				for _, b := range yyq442 {
+				yynn489 = 0
+				for _, b := range yyq489 {
 					if b {
-						yynn442++
+						yynn489++
 					}
 				}
-				r.EncodeMapStart(yynn442)
-				yynn442 = 0
+				r.EncodeMapStart(yynn489)
+				yynn489 = 0
 			}
-			if yyr442 || yy2arr442 {
+			if yyr489 || yy2arr489 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq442[0] {
+				if yyq489[0] {
 					x.Type.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq442[0] {
+				if yyq489[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("type"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.Type.CodecEncodeSelf(e)
 				}
 			}
-			if yyr442 || yy2arr442 {
+			if yyr489 || yy2arr489 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq442[1] {
+				if yyq489[1] {
 					if x.RollingUpdate == nil {
 						r.EncodeNil()
 					} else {
@@ -5197,7 +5783,7 @@ func (x *DeploymentStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq442[1] {
+				if yyq489[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("rollingUpdate"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
@@ -5208,7 +5794,7 @@ func (x *DeploymentStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr442 || yy2arr442 {
+			if yyr489 || yy2arr489 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -5221,25 +5807,25 @@ func (x *DeploymentStrategy) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym445 := z.DecBinary()
-	_ = yym445
+	yym492 := z.DecBinary()
+	_ = yym492
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct446 := r.ContainerType()
-		if yyct446 == codecSelferValueTypeMap1234 {
-			yyl446 := r.ReadMapStart()
-			if yyl446 == 0 {
+		yyct493 := r.ContainerType()
+		if yyct493 == codecSelferValueTypeMap1234 {
+			yyl493 := r.ReadMapStart()
+			if yyl493 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl446, d)
+				x.codecDecodeSelfFromMap(yyl493, d)
 			}
-		} else if yyct446 == codecSelferValueTypeArray1234 {
-			yyl446 := r.ReadArrayStart()
-			if yyl446 == 0 {
+		} else if yyct493 == codecSelferValueTypeArray1234 {
+			yyl493 := r.ReadArrayStart()
+			if yyl493 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl446, d)
+				x.codecDecodeSelfFromArray(yyl493, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -5251,12 +5837,12 @@ func (x *DeploymentStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys447Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys447Slc
-	var yyhl447 bool = l >= 0
-	for yyj447 := 0; ; yyj447++ {
-		if yyhl447 {
-			if yyj447 >= l {
+	var yys494Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys494Slc
+	var yyhl494 bool = l >= 0
+	for yyj494 := 0; ; yyj494++ {
+		if yyhl494 {
+			if yyj494 >= l {
 				break
 			}
 		} else {
@@ -5265,10 +5851,10 @@ func (x *DeploymentStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys447Slc = r.DecodeBytes(yys447Slc, true, true)
-		yys447 := string(yys447Slc)
+		yys494Slc = r.DecodeBytes(yys494Slc, true, true)
+		yys494 := string(yys494Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys447 {
+		switch yys494 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -5287,9 +5873,9 @@ func (x *DeploymentStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				x.RollingUpdate.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys447)
-		} // end switch yys447
-	} // end for yyj447
+			z.DecStructFieldNotFound(-1, yys494)
+		} // end switch yys494
+	} // end for yyj494
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -5297,16 +5883,16 @@ func (x *DeploymentStrategy) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj450 int
-	var yyb450 bool
-	var yyhl450 bool = l >= 0
-	yyj450++
-	if yyhl450 {
-		yyb450 = yyj450 > l
+	var yyj497 int
+	var yyb497 bool
+	var yyhl497 bool = l >= 0
+	yyj497++
+	if yyhl497 {
+		yyb497 = yyj497 > l
 	} else {
-		yyb450 = r.CheckBreak()
+		yyb497 = r.CheckBreak()
 	}
-	if yyb450 {
+	if yyb497 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5316,13 +5902,13 @@ func (x *DeploymentStrategy) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.Type = DeploymentStrategyType(r.DecodeString())
 	}
-	yyj450++
-	if yyhl450 {
-		yyb450 = yyj450 > l
+	yyj497++
+	if yyhl497 {
+		yyb497 = yyj497 > l
 	} else {
-		yyb450 = r.CheckBreak()
+		yyb497 = r.CheckBreak()
 	}
-	if yyb450 {
+	if yyb497 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5338,17 +5924,17 @@ func (x *DeploymentStrategy) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		x.RollingUpdate.CodecDecodeSelf(d)
 	}
 	for {
-		yyj450++
-		if yyhl450 {
-			yyb450 = yyj450 > l
+		yyj497++
+		if yyhl497 {
+			yyb497 = yyj497 > l
 		} else {
-			yyb450 = r.CheckBreak()
+			yyb497 = r.CheckBreak()
 		}
-		if yyb450 {
+		if yyb497 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj450-1, "")
+		z.DecStructFieldNotFound(yyj497-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -5357,8 +5943,8 @@ func (x DeploymentStrategyType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym453 := z.EncBinary()
-	_ = yym453
+	yym500 := z.EncBinary()
+	_ = yym500
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -5370,8 +5956,8 @@ func (x *DeploymentStrategyType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym454 := z.DecBinary()
-	_ = yym454
+	yym501 := z.DecBinary()
+	_ = yym501
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -5386,43 +5972,43 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym455 := z.EncBinary()
-		_ = yym455
+		yym502 := z.EncBinary()
+		_ = yym502
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep456 := !z.EncBinary()
-			yy2arr456 := z.EncBasicHandle().StructToArray
-			var yyq456 [3]bool
-			_, _, _ = yysep456, yyq456, yy2arr456
-			const yyr456 bool = false
-			yyq456[0] = x.MaxUnavailable != nil
-			yyq456[1] = x.MaxSurge != nil
-			yyq456[2] = x.MinReadySeconds != 0
-			var yynn456 int
-			if yyr456 || yy2arr456 {
+			yysep503 := !z.EncBinary()
+			yy2arr503 := z.EncBasicHandle().StructToArray
+			var yyq503 [3]bool
+			_, _, _ = yysep503, yyq503, yy2arr503
+			const yyr503 bool = false
+			yyq503[0] = x.MaxUnavailable != nil
+			yyq503[1] = x.MaxSurge != nil
+			yyq503[2] = x.MinReadySeconds != 0
+			var yynn503 int
+			if yyr503 || yy2arr503 {
 				r.EncodeArrayStart(3)
 			} else {
-				yynn456 = 0
-				for _, b := range yyq456 {
+				yynn503 = 0
+				for _, b := range yyq503 {
 					if b {
-						yynn456++
+						yynn503++
 					}
 				}
-				r.EncodeMapStart(yynn456)
-				yynn456 = 0
+				r.EncodeMapStart(yynn503)
+				yynn503 = 0
 			}
-			if yyr456 || yy2arr456 {
+			if yyr503 || yy2arr503 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq456[0] {
+				if yyq503[0] {
 					if x.MaxUnavailable == nil {
 						r.EncodeNil()
 					} else {
-						yym458 := z.EncBinary()
-						_ = yym458
+						yym505 := z.EncBinary()
+						_ = yym505
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.MaxUnavailable) {
-						} else if !yym458 && z.IsJSONHandle() {
+						} else if !yym505 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.MaxUnavailable)
 						} else {
 							z.EncFallback(x.MaxUnavailable)
@@ -5432,18 +6018,18 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq456[0] {
+				if yyq503[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("maxUnavailable"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.MaxUnavailable == nil {
 						r.EncodeNil()
 					} else {
-						yym459 := z.EncBinary()
-						_ = yym459
+						yym506 := z.EncBinary()
+						_ = yym506
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.MaxUnavailable) {
-						} else if !yym459 && z.IsJSONHandle() {
+						} else if !yym506 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.MaxUnavailable)
 						} else {
 							z.EncFallback(x.MaxUnavailable)
@@ -5451,17 +6037,17 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr456 || yy2arr456 {
+			if yyr503 || yy2arr503 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq456[1] {
+				if yyq503[1] {
 					if x.MaxSurge == nil {
 						r.EncodeNil()
 					} else {
-						yym461 := z.EncBinary()
-						_ = yym461
+						yym508 := z.EncBinary()
+						_ = yym508
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.MaxSurge) {
-						} else if !yym461 && z.IsJSONHandle() {
+						} else if !yym508 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.MaxSurge)
 						} else {
 							z.EncFallback(x.MaxSurge)
@@ -5471,18 +6057,18 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq456[1] {
+				if yyq503[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("maxSurge"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.MaxSurge == nil {
 						r.EncodeNil()
 					} else {
-						yym462 := z.EncBinary()
-						_ = yym462
+						yym509 := z.EncBinary()
+						_ = yym509
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.MaxSurge) {
-						} else if !yym462 && z.IsJSONHandle() {
+						} else if !yym509 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.MaxSurge)
 						} else {
 							z.EncFallback(x.MaxSurge)
@@ -5490,11 +6076,11 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr456 || yy2arr456 {
+			if yyr503 || yy2arr503 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq456[2] {
-					yym464 := z.EncBinary()
-					_ = yym464
+				if yyq503[2] {
+					yym511 := z.EncBinary()
+					_ = yym511
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MinReadySeconds))
@@ -5503,19 +6089,19 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq456[2] {
+				if yyq503[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("minReadySeconds"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym465 := z.EncBinary()
-					_ = yym465
+					yym512 := z.EncBinary()
+					_ = yym512
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MinReadySeconds))
 					}
 				}
 			}
-			if yyr456 || yy2arr456 {
+			if yyr503 || yy2arr503 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -5528,25 +6114,25 @@ func (x *RollingUpdateDeployment) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym466 := z.DecBinary()
-	_ = yym466
+	yym513 := z.DecBinary()
+	_ = yym513
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct467 := r.ContainerType()
-		if yyct467 == codecSelferValueTypeMap1234 {
-			yyl467 := r.ReadMapStart()
-			if yyl467 == 0 {
+		yyct514 := r.ContainerType()
+		if yyct514 == codecSelferValueTypeMap1234 {
+			yyl514 := r.ReadMapStart()
+			if yyl514 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl467, d)
+				x.codecDecodeSelfFromMap(yyl514, d)
 			}
-		} else if yyct467 == codecSelferValueTypeArray1234 {
-			yyl467 := r.ReadArrayStart()
-			if yyl467 == 0 {
+		} else if yyct514 == codecSelferValueTypeArray1234 {
+			yyl514 := r.ReadArrayStart()
+			if yyl514 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl467, d)
+				x.codecDecodeSelfFromArray(yyl514, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -5558,12 +6144,12 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys468Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys468Slc
-	var yyhl468 bool = l >= 0
-	for yyj468 := 0; ; yyj468++ {
-		if yyhl468 {
-			if yyj468 >= l {
+	var yys515Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys515Slc
+	var yyhl515 bool = l >= 0
+	for yyj515 := 0; ; yyj515++ {
+		if yyhl515 {
+			if yyj515 >= l {
 				break
 			}
 		} else {
@@ -5572,10 +6158,10 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys468Slc = r.DecodeBytes(yys468Slc, true, true)
-		yys468 := string(yys468Slc)
+		yys515Slc = r.DecodeBytes(yys515Slc, true, true)
+		yys515 := string(yys515Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys468 {
+		switch yys515 {
 		case "maxUnavailable":
 			if r.TryDecodeAsNil() {
 				if x.MaxUnavailable != nil {
@@ -5585,11 +6171,11 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				if x.MaxUnavailable == nil {
 					x.MaxUnavailable = new(pkg6_intstr.IntOrString)
 				}
-				yym470 := z.DecBinary()
-				_ = yym470
+				yym517 := z.DecBinary()
+				_ = yym517
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.MaxUnavailable) {
-				} else if !yym470 && z.IsJSONHandle() {
+				} else if !yym517 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.MaxUnavailable)
 				} else {
 					z.DecFallback(x.MaxUnavailable, false)
@@ -5604,11 +6190,11 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				if x.MaxSurge == nil {
 					x.MaxSurge = new(pkg6_intstr.IntOrString)
 				}
-				yym472 := z.DecBinary()
-				_ = yym472
+				yym519 := z.DecBinary()
+				_ = yym519
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.MaxSurge) {
-				} else if !yym472 && z.IsJSONHandle() {
+				} else if !yym519 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.MaxSurge)
 				} else {
 					z.DecFallback(x.MaxSurge, false)
@@ -5621,9 +6207,9 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				x.MinReadySeconds = int32(r.DecodeInt(32))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys468)
-		} // end switch yys468
-	} // end for yyj468
+			z.DecStructFieldNotFound(-1, yys515)
+		} // end switch yys515
+	} // end for yyj515
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -5631,16 +6217,16 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromArray(l int, d *codec1978.D
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj474 int
-	var yyb474 bool
-	var yyhl474 bool = l >= 0
-	yyj474++
-	if yyhl474 {
-		yyb474 = yyj474 > l
+	var yyj521 int
+	var yyb521 bool
+	var yyhl521 bool = l >= 0
+	yyj521++
+	if yyhl521 {
+		yyb521 = yyj521 > l
 	} else {
-		yyb474 = r.CheckBreak()
+		yyb521 = r.CheckBreak()
 	}
-	if yyb474 {
+	if yyb521 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5653,23 +6239,23 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromArray(l int, d *codec1978.D
 		if x.MaxUnavailable == nil {
 			x.MaxUnavailable = new(pkg6_intstr.IntOrString)
 		}
-		yym476 := z.DecBinary()
-		_ = yym476
+		yym523 := z.DecBinary()
+		_ = yym523
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.MaxUnavailable) {
-		} else if !yym476 && z.IsJSONHandle() {
+		} else if !yym523 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.MaxUnavailable)
 		} else {
 			z.DecFallback(x.MaxUnavailable, false)
 		}
 	}
-	yyj474++
-	if yyhl474 {
-		yyb474 = yyj474 > l
+	yyj521++
+	if yyhl521 {
+		yyb521 = yyj521 > l
 	} else {
-		yyb474 = r.CheckBreak()
+		yyb521 = r.CheckBreak()
 	}
-	if yyb474 {
+	if yyb521 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5682,23 +6268,23 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromArray(l int, d *codec1978.D
 		if x.MaxSurge == nil {
 			x.MaxSurge = new(pkg6_intstr.IntOrString)
 		}
-		yym478 := z.DecBinary()
-		_ = yym478
+		yym525 := z.DecBinary()
+		_ = yym525
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.MaxSurge) {
-		} else if !yym478 && z.IsJSONHandle() {
+		} else if !yym525 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.MaxSurge)
 		} else {
 			z.DecFallback(x.MaxSurge, false)
 		}
 	}
-	yyj474++
-	if yyhl474 {
-		yyb474 = yyj474 > l
+	yyj521++
+	if yyhl521 {
+		yyb521 = yyj521 > l
 	} else {
-		yyb474 = r.CheckBreak()
+		yyb521 = r.CheckBreak()
 	}
-	if yyb474 {
+	if yyb521 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5709,17 +6295,17 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromArray(l int, d *codec1978.D
 		x.MinReadySeconds = int32(r.DecodeInt(32))
 	}
 	for {
-		yyj474++
-		if yyhl474 {
-			yyb474 = yyj474 > l
+		yyj521++
+		if yyhl521 {
+			yyb521 = yyj521 > l
 		} else {
-			yyb474 = r.CheckBreak()
+			yyb521 = r.CheckBreak()
 		}
-		if yyb474 {
+		if yyb521 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj474-1, "")
+		z.DecStructFieldNotFound(yyj521-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -5731,38 +6317,38 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym480 := z.EncBinary()
-		_ = yym480
+		yym527 := z.EncBinary()
+		_ = yym527
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep481 := !z.EncBinary()
-			yy2arr481 := z.EncBasicHandle().StructToArray
-			var yyq481 [4]bool
-			_, _, _ = yysep481, yyq481, yy2arr481
-			const yyr481 bool = false
-			yyq481[0] = x.Replicas != 0
-			yyq481[1] = x.UpdatedReplicas != 0
-			yyq481[2] = x.AvailableReplicas != 0
-			yyq481[3] = x.UnavailableReplicas != 0
-			var yynn481 int
-			if yyr481 || yy2arr481 {
+			yysep528 := !z.EncBinary()
+			yy2arr528 := z.EncBasicHandle().StructToArray
+			var yyq528 [4]bool
+			_, _, _ = yysep528, yyq528, yy2arr528
+			const yyr528 bool = false
+			yyq528[0] = x.Replicas != 0
+			yyq528[1] = x.UpdatedReplicas != 0
+			yyq528[2] = x.AvailableReplicas != 0
+			yyq528[3] = x.UnavailableReplicas != 0
+			var yynn528 int
+			if yyr528 || yy2arr528 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn481 = 0
-				for _, b := range yyq481 {
+				yynn528 = 0
+				for _, b := range yyq528 {
 					if b {
-						yynn481++
+						yynn528++
 					}
 				}
-				r.EncodeMapStart(yynn481)
-				yynn481 = 0
+				r.EncodeMapStart(yynn528)
+				yynn528 = 0
 			}
-			if yyr481 || yy2arr481 {
+			if yyr528 || yy2arr528 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq481[0] {
-					yym483 := z.EncBinary()
-					_ = yym483
+				if yyq528[0] {
+					yym530 := z.EncBinary()
+					_ = yym530
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Replicas))
@@ -5771,23 +6357,23 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq481[0] {
+				if yyq528[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("replicas"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym484 := z.EncBinary()
-					_ = yym484
+					yym531 := z.EncBinary()
+					_ = yym531
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Replicas))
 					}
 				}
 			}
-			if yyr481 || yy2arr481 {
+			if yyr528 || yy2arr528 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq481[1] {
-					yym486 := z.EncBinary()
-					_ = yym486
+				if yyq528[1] {
+					yym533 := z.EncBinary()
+					_ = yym533
 					if false {
 					} else {
 						r.EncodeInt(int64(x.UpdatedReplicas))
@@ -5796,23 +6382,23 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq481[1] {
+				if yyq528[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("updatedReplicas"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym487 := z.EncBinary()
-					_ = yym487
+					yym534 := z.EncBinary()
+					_ = yym534
 					if false {
 					} else {
 						r.EncodeInt(int64(x.UpdatedReplicas))
 					}
 				}
 			}
-			if yyr481 || yy2arr481 {
+			if yyr528 || yy2arr528 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq481[2] {
-					yym489 := z.EncBinary()
-					_ = yym489
+				if yyq528[2] {
+					yym536 := z.EncBinary()
+					_ = yym536
 					if false {
 					} else {
 						r.EncodeInt(int64(x.AvailableReplicas))
@@ -5821,23 +6407,23 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq481[2] {
+				if yyq528[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("availableReplicas"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym490 := z.EncBinary()
-					_ = yym490
+					yym537 := z.EncBinary()
+					_ = yym537
 					if false {
 					} else {
 						r.EncodeInt(int64(x.AvailableReplicas))
 					}
 				}
 			}
-			if yyr481 || yy2arr481 {
+			if yyr528 || yy2arr528 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq481[3] {
-					yym492 := z.EncBinary()
-					_ = yym492
+				if yyq528[3] {
+					yym539 := z.EncBinary()
+					_ = yym539
 					if false {
 					} else {
 						r.EncodeInt(int64(x.UnavailableReplicas))
@@ -5846,19 +6432,19 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq481[3] {
+				if yyq528[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("unavailableReplicas"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym493 := z.EncBinary()
-					_ = yym493
+					yym540 := z.EncBinary()
+					_ = yym540
 					if false {
 					} else {
 						r.EncodeInt(int64(x.UnavailableReplicas))
 					}
 				}
 			}
-			if yyr481 || yy2arr481 {
+			if yyr528 || yy2arr528 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -5871,25 +6457,25 @@ func (x *DeploymentStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym494 := z.DecBinary()
-	_ = yym494
+	yym541 := z.DecBinary()
+	_ = yym541
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct495 := r.ContainerType()
-		if yyct495 == codecSelferValueTypeMap1234 {
-			yyl495 := r.ReadMapStart()
-			if yyl495 == 0 {
+		yyct542 := r.ContainerType()
+		if yyct542 == codecSelferValueTypeMap1234 {
+			yyl542 := r.ReadMapStart()
+			if yyl542 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl495, d)
+				x.codecDecodeSelfFromMap(yyl542, d)
 			}
-		} else if yyct495 == codecSelferValueTypeArray1234 {
-			yyl495 := r.ReadArrayStart()
-			if yyl495 == 0 {
+		} else if yyct542 == codecSelferValueTypeArray1234 {
+			yyl542 := r.ReadArrayStart()
+			if yyl542 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl495, d)
+				x.codecDecodeSelfFromArray(yyl542, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -5901,12 +6487,12 @@ func (x *DeploymentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys496Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys496Slc
-	var yyhl496 bool = l >= 0
-	for yyj496 := 0; ; yyj496++ {
-		if yyhl496 {
-			if yyj496 >= l {
+	var yys543Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys543Slc
+	var yyhl543 bool = l >= 0
+	for yyj543 := 0; ; yyj543++ {
+		if yyhl543 {
+			if yyj543 >= l {
 				break
 			}
 		} else {
@@ -5915,10 +6501,10 @@ func (x *DeploymentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys496Slc = r.DecodeBytes(yys496Slc, true, true)
-		yys496 := string(yys496Slc)
+		yys543Slc = r.DecodeBytes(yys543Slc, true, true)
+		yys543 := string(yys543Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys496 {
+		switch yys543 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
 				x.Replicas = 0
@@ -5944,9 +6530,9 @@ func (x *DeploymentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.UnavailableReplicas = int32(r.DecodeInt(32))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys496)
-		} // end switch yys496
-	} // end for yyj496
+			z.DecStructFieldNotFound(-1, yys543)
+		} // end switch yys543
+	} // end for yyj543
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -5954,16 +6540,16 @@ func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj501 int
-	var yyb501 bool
-	var yyhl501 bool = l >= 0
-	yyj501++
-	if yyhl501 {
-		yyb501 = yyj501 > l
+	var yyj548 int
+	var yyb548 bool
+	var yyhl548 bool = l >= 0
+	yyj548++
+	if yyhl548 {
+		yyb548 = yyj548 > l
 	} else {
-		yyb501 = r.CheckBreak()
+		yyb548 = r.CheckBreak()
 	}
-	if yyb501 {
+	if yyb548 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5973,13 +6559,13 @@ func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Replicas = int32(r.DecodeInt(32))
 	}
-	yyj501++
-	if yyhl501 {
-		yyb501 = yyj501 > l
+	yyj548++
+	if yyhl548 {
+		yyb548 = yyj548 > l
 	} else {
-		yyb501 = r.CheckBreak()
+		yyb548 = r.CheckBreak()
 	}
-	if yyb501 {
+	if yyb548 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -5989,13 +6575,13 @@ func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.UpdatedReplicas = int32(r.DecodeInt(32))
 	}
-	yyj501++
-	if yyhl501 {
-		yyb501 = yyj501 > l
+	yyj548++
+	if yyhl548 {
+		yyb548 = yyj548 > l
 	} else {
-		yyb501 = r.CheckBreak()
+		yyb548 = r.CheckBreak()
 	}
-	if yyb501 {
+	if yyb548 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6005,13 +6591,13 @@ func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.AvailableReplicas = int32(r.DecodeInt(32))
 	}
-	yyj501++
-	if yyhl501 {
-		yyb501 = yyj501 > l
+	yyj548++
+	if yyhl548 {
+		yyb548 = yyj548 > l
 	} else {
-		yyb501 = r.CheckBreak()
+		yyb548 = r.CheckBreak()
 	}
-	if yyb501 {
+	if yyb548 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6022,17 +6608,17 @@ func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		x.UnavailableReplicas = int32(r.DecodeInt(32))
 	}
 	for {
-		yyj501++
-		if yyhl501 {
-			yyb501 = yyj501 > l
+		yyj548++
+		if yyhl548 {
+			yyb548 = yyj548 > l
 		} else {
-			yyb501 = r.CheckBreak()
+			yyb548 = r.CheckBreak()
 		}
-		if yyb501 {
+		if yyb548 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj501-1, "")
+		z.DecStructFieldNotFound(yyj548-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -6044,37 +6630,37 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym506 := z.EncBinary()
-		_ = yym506
+		yym553 := z.EncBinary()
+		_ = yym553
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep507 := !z.EncBinary()
-			yy2arr507 := z.EncBasicHandle().StructToArray
-			var yyq507 [4]bool
-			_, _, _ = yysep507, yyq507, yy2arr507
-			const yyr507 bool = false
-			yyq507[0] = x.Kind != ""
-			yyq507[1] = x.APIVersion != ""
-			yyq507[2] = true
-			var yynn507 int
-			if yyr507 || yy2arr507 {
+			yysep554 := !z.EncBinary()
+			yy2arr554 := z.EncBasicHandle().StructToArray
+			var yyq554 [4]bool
+			_, _, _ = yysep554, yyq554, yy2arr554
+			const yyr554 bool = false
+			yyq554[0] = x.Kind != ""
+			yyq554[1] = x.APIVersion != ""
+			yyq554[2] = true
+			var yynn554 int
+			if yyr554 || yy2arr554 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn507 = 1
-				for _, b := range yyq507 {
+				yynn554 = 1
+				for _, b := range yyq554 {
 					if b {
-						yynn507++
+						yynn554++
 					}
 				}
-				r.EncodeMapStart(yynn507)
-				yynn507 = 0
+				r.EncodeMapStart(yynn554)
+				yynn554 = 0
 			}
-			if yyr507 || yy2arr507 {
+			if yyr554 || yy2arr554 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq507[0] {
-					yym509 := z.EncBinary()
-					_ = yym509
+				if yyq554[0] {
+					yym556 := z.EncBinary()
+					_ = yym556
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -6083,23 +6669,23 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq507[0] {
+				if yyq554[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym510 := z.EncBinary()
-					_ = yym510
+					yym557 := z.EncBinary()
+					_ = yym557
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr507 || yy2arr507 {
+			if yyr554 || yy2arr554 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq507[1] {
-					yym512 := z.EncBinary()
-					_ = yym512
+				if yyq554[1] {
+					yym559 := z.EncBinary()
+					_ = yym559
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -6108,54 +6694,54 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq507[1] {
+				if yyq554[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym513 := z.EncBinary()
-					_ = yym513
+					yym560 := z.EncBinary()
+					_ = yym560
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr507 || yy2arr507 {
+			if yyr554 || yy2arr554 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq507[2] {
-					yy515 := &x.ListMeta
-					yym516 := z.EncBinary()
-					_ = yym516
+				if yyq554[2] {
+					yy562 := &x.ListMeta
+					yym563 := z.EncBinary()
+					_ = yym563
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy515) {
+					} else if z.HasExtensions() && z.EncExt(yy562) {
 					} else {
-						z.EncFallback(yy515)
+						z.EncFallback(yy562)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq507[2] {
+				if yyq554[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy517 := &x.ListMeta
-					yym518 := z.EncBinary()
-					_ = yym518
+					yy564 := &x.ListMeta
+					yym565 := z.EncBinary()
+					_ = yym565
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy517) {
+					} else if z.HasExtensions() && z.EncExt(yy564) {
 					} else {
-						z.EncFallback(yy517)
+						z.EncFallback(yy564)
 					}
 				}
 			}
-			if yyr507 || yy2arr507 {
+			if yyr554 || yy2arr554 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym520 := z.EncBinary()
-					_ = yym520
+					yym567 := z.EncBinary()
+					_ = yym567
 					if false {
 					} else {
 						h.encSliceDeployment(([]Deployment)(x.Items), e)
@@ -6168,15 +6754,15 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym521 := z.EncBinary()
-					_ = yym521
+					yym568 := z.EncBinary()
+					_ = yym568
 					if false {
 					} else {
 						h.encSliceDeployment(([]Deployment)(x.Items), e)
 					}
 				}
 			}
-			if yyr507 || yy2arr507 {
+			if yyr554 || yy2arr554 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -6189,25 +6775,25 @@ func (x *DeploymentList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym522 := z.DecBinary()
-	_ = yym522
+	yym569 := z.DecBinary()
+	_ = yym569
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct523 := r.ContainerType()
-		if yyct523 == codecSelferValueTypeMap1234 {
-			yyl523 := r.ReadMapStart()
-			if yyl523 == 0 {
+		yyct570 := r.ContainerType()
+		if yyct570 == codecSelferValueTypeMap1234 {
+			yyl570 := r.ReadMapStart()
+			if yyl570 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl523, d)
+				x.codecDecodeSelfFromMap(yyl570, d)
 			}
-		} else if yyct523 == codecSelferValueTypeArray1234 {
-			yyl523 := r.ReadArrayStart()
-			if yyl523 == 0 {
+		} else if yyct570 == codecSelferValueTypeArray1234 {
+			yyl570 := r.ReadArrayStart()
+			if yyl570 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl523, d)
+				x.codecDecodeSelfFromArray(yyl570, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -6219,12 +6805,12 @@ func (x *DeploymentList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys524Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys524Slc
-	var yyhl524 bool = l >= 0
-	for yyj524 := 0; ; yyj524++ {
-		if yyhl524 {
-			if yyj524 >= l {
+	var yys571Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys571Slc
+	var yyhl571 bool = l >= 0
+	for yyj571 := 0; ; yyj571++ {
+		if yyhl571 {
+			if yyj571 >= l {
 				break
 			}
 		} else {
@@ -6233,10 +6819,10 @@ func (x *DeploymentList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys524Slc = r.DecodeBytes(yys524Slc, true, true)
-		yys524 := string(yys524Slc)
+		yys571Slc = r.DecodeBytes(yys571Slc, true, true)
+		yys571 := string(yys571Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys524 {
+		switch yys571 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -6253,31 +6839,31 @@ func (x *DeploymentList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv527 := &x.ListMeta
-				yym528 := z.DecBinary()
-				_ = yym528
+				yyv574 := &x.ListMeta
+				yym575 := z.DecBinary()
+				_ = yym575
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv527) {
+				} else if z.HasExtensions() && z.DecExt(yyv574) {
 				} else {
-					z.DecFallback(yyv527, false)
+					z.DecFallback(yyv574, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv529 := &x.Items
-				yym530 := z.DecBinary()
-				_ = yym530
+				yyv576 := &x.Items
+				yym577 := z.DecBinary()
+				_ = yym577
 				if false {
 				} else {
-					h.decSliceDeployment((*[]Deployment)(yyv529), d)
+					h.decSliceDeployment((*[]Deployment)(yyv576), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys524)
-		} // end switch yys524
-	} // end for yyj524
+			z.DecStructFieldNotFound(-1, yys571)
+		} // end switch yys571
+	} // end for yyj571
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -6285,16 +6871,16 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj531 int
-	var yyb531 bool
-	var yyhl531 bool = l >= 0
-	yyj531++
-	if yyhl531 {
-		yyb531 = yyj531 > l
+	var yyj578 int
+	var yyb578 bool
+	var yyhl578 bool = l >= 0
+	yyj578++
+	if yyhl578 {
+		yyb578 = yyj578 > l
 	} else {
-		yyb531 = r.CheckBreak()
+		yyb578 = r.CheckBreak()
 	}
-	if yyb531 {
+	if yyb578 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6304,13 +6890,13 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj531++
-	if yyhl531 {
-		yyb531 = yyj531 > l
+	yyj578++
+	if yyhl578 {
+		yyb578 = yyj578 > l
 	} else {
-		yyb531 = r.CheckBreak()
+		yyb578 = r.CheckBreak()
 	}
-	if yyb531 {
+	if yyb578 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6320,13 +6906,13 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj531++
-	if yyhl531 {
-		yyb531 = yyj531 > l
+	yyj578++
+	if yyhl578 {
+		yyb578 = yyj578 > l
 	} else {
-		yyb531 = r.CheckBreak()
+		yyb578 = r.CheckBreak()
 	}
-	if yyb531 {
+	if yyb578 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6334,22 +6920,22 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv534 := &x.ListMeta
-		yym535 := z.DecBinary()
-		_ = yym535
+		yyv581 := &x.ListMeta
+		yym582 := z.DecBinary()
+		_ = yym582
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv534) {
+		} else if z.HasExtensions() && z.DecExt(yyv581) {
 		} else {
-			z.DecFallback(yyv534, false)
+			z.DecFallback(yyv581, false)
 		}
 	}
-	yyj531++
-	if yyhl531 {
-		yyb531 = yyj531 > l
+	yyj578++
+	if yyhl578 {
+		yyb578 = yyj578 > l
 	} else {
-		yyb531 = r.CheckBreak()
+		yyb578 = r.CheckBreak()
 	}
-	if yyb531 {
+	if yyb578 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6357,26 +6943,26 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv536 := &x.Items
-		yym537 := z.DecBinary()
-		_ = yym537
+		yyv583 := &x.Items
+		yym584 := z.DecBinary()
+		_ = yym584
 		if false {
 		} else {
-			h.decSliceDeployment((*[]Deployment)(yyv536), d)
+			h.decSliceDeployment((*[]Deployment)(yyv583), d)
 		}
 	}
 	for {
-		yyj531++
-		if yyhl531 {
-			yyb531 = yyj531 > l
+		yyj578++
+		if yyhl578 {
+			yyb578 = yyj578 > l
 		} else {
-			yyb531 = r.CheckBreak()
+			yyb578 = r.CheckBreak()
 		}
-		if yyb531 {
+		if yyb578 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj531-1, "")
+		z.DecStructFieldNotFound(yyj578-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -6388,49 +6974,49 @@ func (x *DaemonSetUpdateStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym538 := z.EncBinary()
-		_ = yym538
+		yym585 := z.EncBinary()
+		_ = yym585
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep539 := !z.EncBinary()
-			yy2arr539 := z.EncBasicHandle().StructToArray
-			var yyq539 [2]bool
-			_, _, _ = yysep539, yyq539, yy2arr539
-			const yyr539 bool = false
-			yyq539[0] = x.Type != ""
-			yyq539[1] = x.RollingUpdate != nil
-			var yynn539 int
-			if yyr539 || yy2arr539 {
+			yysep586 := !z.EncBinary()
+			yy2arr586 := z.EncBasicHandle().StructToArray
+			var yyq586 [2]bool
+			_, _, _ = yysep586, yyq586, yy2arr586
+			const yyr586 bool = false
+			yyq586[0] = x.Type != ""
+			yyq586[1] = x.RollingUpdate != nil
+			var yynn586 int
+			if yyr586 || yy2arr586 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn539 = 0
-				for _, b := range yyq539 {
+				yynn586 = 0
+				for _, b := range yyq586 {
 					if b {
-						yynn539++
+						yynn586++
 					}
 				}
-				r.EncodeMapStart(yynn539)
-				yynn539 = 0
+				r.EncodeMapStart(yynn586)
+				yynn586 = 0
 			}
-			if yyr539 || yy2arr539 {
+			if yyr586 || yy2arr586 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq539[0] {
+				if yyq586[0] {
 					x.Type.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq539[0] {
+				if yyq586[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("type"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.Type.CodecEncodeSelf(e)
 				}
 			}
-			if yyr539 || yy2arr539 {
+			if yyr586 || yy2arr586 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq539[1] {
+				if yyq586[1] {
 					if x.RollingUpdate == nil {
 						r.EncodeNil()
 					} else {
@@ -6440,7 +7026,7 @@ func (x *DaemonSetUpdateStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq539[1] {
+				if yyq586[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("rollingUpdate"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
@@ -6451,7 +7037,7 @@ func (x *DaemonSetUpdateStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr539 || yy2arr539 {
+			if yyr586 || yy2arr586 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -6464,25 +7050,25 @@ func (x *DaemonSetUpdateStrategy) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym542 := z.DecBinary()
-	_ = yym542
+	yym589 := z.DecBinary()
+	_ = yym589
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct543 := r.ContainerType()
-		if yyct543 == codecSelferValueTypeMap1234 {
-			yyl543 := r.ReadMapStart()
-			if yyl543 == 0 {
+		yyct590 := r.ContainerType()
+		if yyct590 == codecSelferValueTypeMap1234 {
+			yyl590 := r.ReadMapStart()
+			if yyl590 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl543, d)
+				x.codecDecodeSelfFromMap(yyl590, d)
 			}
-		} else if yyct543 == codecSelferValueTypeArray1234 {
-			yyl543 := r.ReadArrayStart()
-			if yyl543 == 0 {
+		} else if yyct590 == codecSelferValueTypeArray1234 {
+			yyl590 := r.ReadArrayStart()
+			if yyl590 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl543, d)
+				x.codecDecodeSelfFromArray(yyl590, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -6494,12 +7080,12 @@ func (x *DaemonSetUpdateStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys544Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys544Slc
-	var yyhl544 bool = l >= 0
-	for yyj544 := 0; ; yyj544++ {
-		if yyhl544 {
-			if yyj544 >= l {
+	var yys591Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys591Slc
+	var yyhl591 bool = l >= 0
+	for yyj591 := 0; ; yyj591++ {
+		if yyhl591 {
+			if yyj591 >= l {
 				break
 			}
 		} else {
@@ -6508,10 +7094,10 @@ func (x *DaemonSetUpdateStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys544Slc = r.DecodeBytes(yys544Slc, true, true)
-		yys544 := string(yys544Slc)
+		yys591Slc = r.DecodeBytes(yys591Slc, true, true)
+		yys591 := string(yys591Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys544 {
+		switch yys591 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -6530,9 +7116,9 @@ func (x *DaemonSetUpdateStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				x.RollingUpdate.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys544)
-		} // end switch yys544
-	} // end for yyj544
+			z.DecStructFieldNotFound(-1, yys591)
+		} // end switch yys591
+	} // end for yyj591
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -6540,16 +7126,16 @@ func (x *DaemonSetUpdateStrategy) codecDecodeSelfFromArray(l int, d *codec1978.D
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj547 int
-	var yyb547 bool
-	var yyhl547 bool = l >= 0
-	yyj547++
-	if yyhl547 {
-		yyb547 = yyj547 > l
+	var yyj594 int
+	var yyb594 bool
+	var yyhl594 bool = l >= 0
+	yyj594++
+	if yyhl594 {
+		yyb594 = yyj594 > l
 	} else {
-		yyb547 = r.CheckBreak()
+		yyb594 = r.CheckBreak()
 	}
-	if yyb547 {
+	if yyb594 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6559,13 +7145,13 @@ func (x *DaemonSetUpdateStrategy) codecDecodeSelfFromArray(l int, d *codec1978.D
 	} else {
 		x.Type = DaemonSetUpdateStrategyType(r.DecodeString())
 	}
-	yyj547++
-	if yyhl547 {
-		yyb547 = yyj547 > l
+	yyj594++
+	if yyhl594 {
+		yyb594 = yyj594 > l
 	} else {
-		yyb547 = r.CheckBreak()
+		yyb594 = r.CheckBreak()
 	}
-	if yyb547 {
+	if yyb594 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6581,17 +7167,17 @@ func (x *DaemonSetUpdateStrategy) codecDecodeSelfFromArray(l int, d *codec1978.D
 		x.RollingUpdate.CodecDecodeSelf(d)
 	}
 	for {
-		yyj547++
-		if yyhl547 {
-			yyb547 = yyj547 > l
+		yyj594++
+		if yyhl594 {
+			yyb594 = yyj594 > l
 		} else {
-			yyb547 = r.CheckBreak()
+			yyb594 = r.CheckBreak()
 		}
-		if yyb547 {
+		if yyb594 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj547-1, "")
+		z.DecStructFieldNotFound(yyj594-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -6600,8 +7186,8 @@ func (x DaemonSetUpdateStrategyType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym550 := z.EncBinary()
-	_ = yym550
+	yym597 := z.EncBinary()
+	_ = yym597
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -6613,8 +7199,8 @@ func (x *DaemonSetUpdateStrategyType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym551 := z.DecBinary()
-	_ = yym551
+	yym598 := z.DecBinary()
+	_ = yym598
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -6629,42 +7215,42 @@ func (x *RollingUpdateDaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym552 := z.EncBinary()
-		_ = yym552
+		yym599 := z.EncBinary()
+		_ = yym599
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep553 := !z.EncBinary()
-			yy2arr553 := z.EncBasicHandle().StructToArray
-			var yyq553 [2]bool
-			_, _, _ = yysep553, yyq553, yy2arr553
-			const yyr553 bool = false
-			yyq553[0] = x.MaxUnavailable != nil
-			yyq553[1] = x.MinReadySeconds != 0
-			var yynn553 int
-			if yyr553 || yy2arr553 {
+			yysep600 := !z.EncBinary()
+			yy2arr600 := z.EncBasicHandle().StructToArray
+			var yyq600 [2]bool
+			_, _, _ = yysep600, yyq600, yy2arr600
+			const yyr600 bool = false
+			yyq600[0] = x.MaxUnavailable != nil
+			yyq600[1] = x.MinReadySeconds != 0
+			var yynn600 int
+			if yyr600 || yy2arr600 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn553 = 0
-				for _, b := range yyq553 {
+				yynn600 = 0
+				for _, b := range yyq600 {
 					if b {
-						yynn553++
+						yynn600++
 					}
 				}
-				r.EncodeMapStart(yynn553)
-				yynn553 = 0
+				r.EncodeMapStart(yynn600)
+				yynn600 = 0
 			}
-			if yyr553 || yy2arr553 {
+			if yyr600 || yy2arr600 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq553[0] {
+				if yyq600[0] {
 					if x.MaxUnavailable == nil {
 						r.EncodeNil()
 					} else {
-						yym555 := z.EncBinary()
-						_ = yym555
+						yym602 := z.EncBinary()
+						_ = yym602
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.MaxUnavailable) {
-						} else if !yym555 && z.IsJSONHandle() {
+						} else if !yym602 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.MaxUnavailable)
 						} else {
 							z.EncFallback(x.MaxUnavailable)
@@ -6674,18 +7260,18 @@ func (x *RollingUpdateDaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq553[0] {
+				if yyq600[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("maxUnavailable"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.MaxUnavailable == nil {
 						r.EncodeNil()
 					} else {
-						yym556 := z.EncBinary()
-						_ = yym556
+						yym603 := z.EncBinary()
+						_ = yym603
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.MaxUnavailable) {
-						} else if !yym556 && z.IsJSONHandle() {
+						} else if !yym603 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.MaxUnavailable)
 						} else {
 							z.EncFallback(x.MaxUnavailable)
@@ -6693,11 +7279,11 @@ func (x *RollingUpdateDaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr553 || yy2arr553 {
+			if yyr600 || yy2arr600 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq553[1] {
-					yym558 := z.EncBinary()
-					_ = yym558
+				if yyq600[1] {
+					yym605 := z.EncBinary()
+					_ = yym605
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MinReadySeconds))
@@ -6706,19 +7292,19 @@ func (x *RollingUpdateDaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq553[1] {
+				if yyq600[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("minReadySeconds"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym559 := z.EncBinary()
-					_ = yym559
+					yym606 := z.EncBinary()
+					_ = yym606
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MinReadySeconds))
 					}
 				}
 			}
-			if yyr553 || yy2arr553 {
+			if yyr600 || yy2arr600 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -6731,25 +7317,25 @@ func (x *RollingUpdateDaemonSet) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym560 := z.DecBinary()
-	_ = yym560
+	yym607 := z.DecBinary()
+	_ = yym607
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct561 := r.ContainerType()
-		if yyct561 == codecSelferValueTypeMap1234 {
-			yyl561 := r.ReadMapStart()
-			if yyl561 == 0 {
+		yyct608 := r.ContainerType()
+		if yyct608 == codecSelferValueTypeMap1234 {
+			yyl608 := r.ReadMapStart()
+			if yyl608 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl561, d)
+				x.codecDecodeSelfFromMap(yyl608, d)
 			}
-		} else if yyct561 == codecSelferValueTypeArray1234 {
-			yyl561 := r.ReadArrayStart()
-			if yyl561 == 0 {
+		} else if yyct608 == codecSelferValueTypeArray1234 {
+			yyl608 := r.ReadArrayStart()
+			if yyl608 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl561, d)
+				x.codecDecodeSelfFromArray(yyl608, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -6761,12 +7347,12 @@ func (x *RollingUpdateDaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys562Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys562Slc
-	var yyhl562 bool = l >= 0
-	for yyj562 := 0; ; yyj562++ {
-		if yyhl562 {
-			if yyj562 >= l {
+	var yys609Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys609Slc
+	var yyhl609 bool = l >= 0
+	for yyj609 := 0; ; yyj609++ {
+		if yyhl609 {
+			if yyj609 >= l {
 				break
 			}
 		} else {
@@ -6775,10 +7361,10 @@ func (x *RollingUpdateDaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys562Slc = r.DecodeBytes(yys562Slc, true, true)
-		yys562 := string(yys562Slc)
+		yys609Slc = r.DecodeBytes(yys609Slc, true, true)
+		yys609 := string(yys609Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys562 {
+		switch yys609 {
 		case "maxUnavailable":
 			if r.TryDecodeAsNil() {
 				if x.MaxUnavailable != nil {
@@ -6788,11 +7374,11 @@ func (x *RollingUpdateDaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				if x.MaxUnavailable == nil {
 					x.MaxUnavailable = new(pkg6_intstr.IntOrString)
 				}
-				yym564 := z.DecBinary()
-				_ = yym564
+				yym611 := z.DecBinary()
+				_ = yym611
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.MaxUnavailable) {
-				} else if !yym564 && z.IsJSONHandle() {
+				} else if !yym611 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.MaxUnavailable)
 				} else {
 					z.DecFallback(x.MaxUnavailable, false)
@@ -6805,9 +7391,9 @@ func (x *RollingUpdateDaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				x.MinReadySeconds = int32(r.DecodeInt(32))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys562)
-		} // end switch yys562
-	} // end for yyj562
+			z.DecStructFieldNotFound(-1, yys609)
+		} // end switch yys609
+	} // end for yyj609
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -6815,16 +7401,16 @@ func (x *RollingUpdateDaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.De
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj566 int
-	var yyb566 bool
-	var yyhl566 bool = l >= 0
-	yyj566++
-	if yyhl566 {
-		yyb566 = yyj566 > l
+	var yyj613 int
+	var yyb613 bool
+	var yyhl613 bool = l >= 0
+	yyj613++
+	if yyhl613 {
+		yyb613 = yyj613 > l
 	} else {
-		yyb566 = r.CheckBreak()
+		yyb613 = r.CheckBreak()
 	}
-	if yyb566 {
+	if yyb613 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6837,23 +7423,23 @@ func (x *RollingUpdateDaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.De
 		if x.MaxUnavailable == nil {
 			x.MaxUnavailable = new(pkg6_intstr.IntOrString)
 		}
-		yym568 := z.DecBinary()
-		_ = yym568
+		yym615 := z.DecBinary()
+		_ = yym615
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.MaxUnavailable) {
-		} else if !yym568 && z.IsJSONHandle() {
+		} else if !yym615 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.MaxUnavailable)
 		} else {
 			z.DecFallback(x.MaxUnavailable, false)
 		}
 	}
-	yyj566++
-	if yyhl566 {
-		yyb566 = yyj566 > l
+	yyj613++
+	if yyhl613 {
+		yyb613 = yyj613 > l
 	} else {
-		yyb566 = r.CheckBreak()
+		yyb613 = r.CheckBreak()
 	}
-	if yyb566 {
+	if yyb613 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -6864,17 +7450,17 @@ func (x *RollingUpdateDaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.De
 		x.MinReadySeconds = int32(r.DecodeInt(32))
 	}
 	for {
-		yyj566++
-		if yyhl566 {
-			yyb566 = yyj566 > l
+		yyj613++
+		if yyhl613 {
+			yyb613 = yyj613 > l
 		} else {
-			yyb566 = r.CheckBreak()
+			yyb613 = r.CheckBreak()
 		}
-		if yyb566 {
+		if yyb613 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj566-1, "")
+		z.DecStructFieldNotFound(yyj613-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -6886,35 +7472,35 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym570 := z.EncBinary()
-		_ = yym570
+		yym617 := z.EncBinary()
+		_ = yym617
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep571 := !z.EncBinary()
-			yy2arr571 := z.EncBasicHandle().StructToArray
-			var yyq571 [4]bool
-			_, _, _ = yysep571, yyq571, yy2arr571
-			const yyr571 bool = false
-			yyq571[0] = x.Selector != nil
-			yyq571[2] = true
-			yyq571[3] = x.UniqueLabelKey != nil
-			var yynn571 int
-			if yyr571 || yy2arr571 {
+			yysep618 := !z.EncBinary()
+			yy2arr618 := z.EncBasicHandle().StructToArray
+			var yyq618 [4]bool
+			_, _, _ = yysep618, yyq618, yy2arr618
+			const yyr618 bool = false
+			yyq618[0] = x.Selector != nil
+			yyq618[2] = true
+			yyq618[3] = x.UniqueLabelKey != nil
+			var yynn618 int
+			if yyr618 || yy2arr618 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn571 = 1
-				for _, b := range yyq571 {
+				yynn618 = 1
+				for _, b := range yyq618 {
 					if b {
-						yynn571++
+						yynn618++
 					}
 				}
-				r.EncodeMapStart(yynn571)
-				yynn571 = 0
+				r.EncodeMapStart(yynn618)
+				yynn618 = 0
 			}
-			if yyr571 || yy2arr571 {
+			if yyr618 || yy2arr618 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq571[0] {
+				if yyq618[0] {
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
@@ -6924,7 +7510,7 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq571[0] {
+				if yyq618[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
@@ -6935,70 +7521,70 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr571 || yy2arr571 {
+			if yyr618 || yy2arr618 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy574 := &x.Template
-				yy574.CodecEncodeSelf(e)
+				yy621 := &x.Template
+				yy621.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("template"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy575 := &x.Template
-				yy575.CodecEncodeSelf(e)
+				yy622 := &x.Template
+				yy622.CodecEncodeSelf(e)
 			}
-			if yyr571 || yy2arr571 {
+			if yyr618 || yy2arr618 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq571[2] {
-					yy577 := &x.UpdateStrategy
-					yy577.CodecEncodeSelf(e)
+				if yyq618[2] {
+					yy624 := &x.UpdateStrategy
+					yy624.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq571[2] {
+				if yyq618[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("updateStrategy"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy578 := &x.UpdateStrategy
-					yy578.CodecEncodeSelf(e)
+					yy625 := &x.UpdateStrategy
+					yy625.CodecEncodeSelf(e)
 				}
 			}
-			if yyr571 || yy2arr571 {
+			if yyr618 || yy2arr618 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq571[3] {
+				if yyq618[3] {
 					if x.UniqueLabelKey == nil {
 						r.EncodeNil()
 					} else {
-						yy580 := *x.UniqueLabelKey
-						yym581 := z.EncBinary()
-						_ = yym581
+						yy627 := *x.UniqueLabelKey
+						yym628 := z.EncBinary()
+						_ = yym628
 						if false {
 						} else {
-							r.EncodeString(codecSelferC_UTF81234, string(yy580))
+							r.EncodeString(codecSelferC_UTF81234, string(yy627))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq571[3] {
+				if yyq618[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("uniqueLabelKey"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.UniqueLabelKey == nil {
 						r.EncodeNil()
 					} else {
-						yy582 := *x.UniqueLabelKey
-						yym583 := z.EncBinary()
-						_ = yym583
+						yy629 := *x.UniqueLabelKey
+						yym630 := z.EncBinary()
+						_ = yym630
 						if false {
 						} else {
-							r.EncodeString(codecSelferC_UTF81234, string(yy582))
+							r.EncodeString(codecSelferC_UTF81234, string(yy629))
 						}
 					}
 				}
 			}
-			if yyr571 || yy2arr571 {
+			if yyr618 || yy2arr618 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -7011,25 +7597,25 @@ func (x *DaemonSetSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym584 := z.DecBinary()
-	_ = yym584
+	yym631 := z.DecBinary()
+	_ = yym631
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct585 := r.ContainerType()
-		if yyct585 == codecSelferValueTypeMap1234 {
-			yyl585 := r.ReadMapStart()
-			if yyl585 == 0 {
+		yyct632 := r.ContainerType()
+		if yyct632 == codecSelferValueTypeMap1234 {
+			yyl632 := r.ReadMapStart()
+			if yyl632 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl585, d)
+				x.codecDecodeSelfFromMap(yyl632, d)
 			}
-		} else if yyct585 == codecSelferValueTypeArray1234 {
-			yyl585 := r.ReadArrayStart()
-			if yyl585 == 0 {
+		} else if yyct632 == codecSelferValueTypeArray1234 {
+			yyl632 := r.ReadArrayStart()
+			if yyl632 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl585, d)
+				x.codecDecodeSelfFromArray(yyl632, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -7041,12 +7627,12 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys586Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys586Slc
-	var yyhl586 bool = l >= 0
-	for yyj586 := 0; ; yyj586++ {
-		if yyhl586 {
-			if yyj586 >= l {
+	var yys633Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys633Slc
+	var yyhl633 bool = l >= 0
+	for yyj633 := 0; ; yyj633++ {
+		if yyhl633 {
+			if yyj633 >= l {
 				break
 			}
 		} else {
@@ -7055,10 +7641,10 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys586Slc = r.DecodeBytes(yys586Slc, true, true)
-		yys586 := string(yys586Slc)
+		yys633Slc = r.DecodeBytes(yys633Slc, true, true)
+		yys633 := string(yys633Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys586 {
+		switch yys633 {
 		case "selector":
 			if r.TryDecodeAsNil() {
 				if x.Selector != nil {
@@ -7074,15 +7660,15 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Template = pkg2_v1.PodTemplateSpec{}
 			} else {
-				yyv588 := &x.Template
-				yyv588.CodecDecodeSelf(d)
+				yyv635 := &x.Template
+				yyv635.CodecDecodeSelf(d)
 			}
 		case "updateStrategy":
 			if r.TryDecodeAsNil() {
 				x.UpdateStrategy = DaemonSetUpdateStrategy{}
 			} else {
-				yyv589 := &x.UpdateStrategy
-				yyv589.CodecDecodeSelf(d)
+				yyv636 := &x.UpdateStrategy
+				yyv636.CodecDecodeSelf(d)
 			}
 		case "uniqueLabelKey":
 			if r.TryDecodeAsNil() {
@@ -7093,17 +7679,17 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.UniqueLabelKey == nil {
 					x.UniqueLabelKey = new(string)
 				}
-				yym591 := z.DecBinary()
-				_ = yym591
+				yym638 := z.DecBinary()
+				_ = yym638
 				if false {
 				} else {
 					*((*string)(x.UniqueLabelKey)) = r.DecodeString()
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys586)
-		} // end switch yys586
-	} // end for yyj586
+			z.DecStructFieldNotFound(-1, yys633)
+		} // end switch yys633
+	} // end for yyj633
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -7111,16 +7697,16 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj592 int
-	var yyb592 bool
-	var yyhl592 bool = l >= 0
-	yyj592++
-	if yyhl592 {
-		yyb592 = yyj592 > l
+	var yyj639 int
+	var yyb639 bool
+	var yyhl639 bool = l >= 0
+	yyj639++
+	if yyhl639 {
+		yyb639 = yyj639 > l
 	} else {
-		yyb592 = r.CheckBreak()
+		yyb639 = r.CheckBreak()
 	}
-	if yyb592 {
+	if yyb639 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7135,13 +7721,13 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Selector.CodecDecodeSelf(d)
 	}
-	yyj592++
-	if yyhl592 {
-		yyb592 = yyj592 > l
+	yyj639++
+	if yyhl639 {
+		yyb639 = yyj639 > l
 	} else {
-		yyb592 = r.CheckBreak()
+		yyb639 = r.CheckBreak()
 	}
-	if yyb592 {
+	if yyb639 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7149,16 +7735,16 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Template = pkg2_v1.PodTemplateSpec{}
 	} else {
-		yyv594 := &x.Template
-		yyv594.CodecDecodeSelf(d)
+		yyv641 := &x.Template
+		yyv641.CodecDecodeSelf(d)
 	}
-	yyj592++
-	if yyhl592 {
-		yyb592 = yyj592 > l
+	yyj639++
+	if yyhl639 {
+		yyb639 = yyj639 > l
 	} else {
-		yyb592 = r.CheckBreak()
+		yyb639 = r.CheckBreak()
 	}
-	if yyb592 {
+	if yyb639 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7166,16 +7752,16 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.UpdateStrategy = DaemonSetUpdateStrategy{}
 	} else {
-		yyv595 := &x.UpdateStrategy
-		yyv595.CodecDecodeSelf(d)
+		yyv642 := &x.UpdateStrategy
+		yyv642.CodecDecodeSelf(d)
 	}
-	yyj592++
-	if yyhl592 {
-		yyb592 = yyj592 > l
+	yyj639++
+	if yyhl639 {
+		yyb639 = yyj639 > l
 	} else {
-		yyb592 = r.CheckBreak()
+		yyb639 = r.CheckBreak()
 	}
-	if yyb592 {
+	if yyb639 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7188,25 +7774,25 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.UniqueLabelKey == nil {
 			x.UniqueLabelKey = new(string)
 		}
-		yym597 := z.DecBinary()
-		_ = yym597
+		yym644 := z.DecBinary()
+		_ = yym644
 		if false {
 		} else {
 			*((*string)(x.UniqueLabelKey)) = r.DecodeString()
 		}
 	}
 	for {
-		yyj592++
-		if yyhl592 {
-			yyb592 = yyj592 > l
+		yyj639++
+		if yyhl639 {
+			yyb639 = yyj639 > l
 		} else {
-			yyb592 = r.CheckBreak()
+			yyb639 = r.CheckBreak()
 		}
-		if yyb592 {
+		if yyb639 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj592-1, "")
+		z.DecStructFieldNotFound(yyj639-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -7218,33 +7804,33 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym598 := z.EncBinary()
-		_ = yym598
+		yym645 := z.EncBinary()
+		_ = yym645
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep599 := !z.EncBinary()
-			yy2arr599 := z.EncBasicHandle().StructToArray
-			var yyq599 [3]bool
-			_, _, _ = yysep599, yyq599, yy2arr599
-			const yyr599 bool = false
-			var yynn599 int
-			if yyr599 || yy2arr599 {
+			yysep646 := !z.EncBinary()
+			yy2arr646 := z.EncBasicHandle().StructToArray
+			var yyq646 [3]bool
+			_, _, _ = yysep646, yyq646, yy2arr646
+			const yyr646 bool = false
+			var yynn646 int
+			if yyr646 || yy2arr646 {
 				r.EncodeArrayStart(3)
 			} else {
-				yynn599 = 3
-				for _, b := range yyq599 {
+				yynn646 = 3
+				for _, b := range yyq646 {
 					if b {
-						yynn599++
+						yynn646++
 					}
 				}
-				r.EncodeMapStart(yynn599)
-				yynn599 = 0
+				r.EncodeMapStart(yynn646)
+				yynn646 = 0
 			}
-			if yyr599 || yy2arr599 {
+			if yyr646 || yy2arr646 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym601 := z.EncBinary()
-				_ = yym601
+				yym648 := z.EncBinary()
+				_ = yym648
 				if false {
 				} else {
 					r.EncodeInt(int64(x.CurrentNumberScheduled))
@@ -7253,17 +7839,17 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("currentNumberScheduled"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym602 := z.EncBinary()
-				_ = yym602
+				yym649 := z.EncBinary()
+				_ = yym649
 				if false {
 				} else {
 					r.EncodeInt(int64(x.CurrentNumberScheduled))
 				}
 			}
-			if yyr599 || yy2arr599 {
+			if yyr646 || yy2arr646 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym604 := z.EncBinary()
-				_ = yym604
+				yym651 := z.EncBinary()
+				_ = yym651
 				if false {
 				} else {
 					r.EncodeInt(int64(x.NumberMisscheduled))
@@ -7272,17 +7858,17 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("numberMisscheduled"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym605 := z.EncBinary()
-				_ = yym605
+				yym652 := z.EncBinary()
+				_ = yym652
 				if false {
 				} else {
 					r.EncodeInt(int64(x.NumberMisscheduled))
 				}
 			}
-			if yyr599 || yy2arr599 {
+			if yyr646 || yy2arr646 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym607 := z.EncBinary()
-				_ = yym607
+				yym654 := z.EncBinary()
+				_ = yym654
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DesiredNumberScheduled))
@@ -7291,14 +7877,14 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("desiredNumberScheduled"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym608 := z.EncBinary()
-				_ = yym608
+				yym655 := z.EncBinary()
+				_ = yym655
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DesiredNumberScheduled))
 				}
 			}
-			if yyr599 || yy2arr599 {
+			if yyr646 || yy2arr646 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -7311,25 +7897,25 @@ func (x *DaemonSetStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym609 := z.DecBinary()
-	_ = yym609
+	yym656 := z.DecBinary()
+	_ = yym656
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct610 := r.ContainerType()
-		if yyct610 == codecSelferValueTypeMap1234 {
-			yyl610 := r.ReadMapStart()
-			if yyl610 == 0 {
+		yyct657 := r.ContainerType()
+		if yyct657 == codecSelferValueTypeMap1234 {
+			yyl657 := r.ReadMapStart()
+			if yyl657 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl610, d)
+				x.codecDecodeSelfFromMap(yyl657, d)
 			}
-		} else if yyct610 == codecSelferValueTypeArray1234 {
-			yyl610 := r.ReadArrayStart()
-			if yyl610 == 0 {
+		} else if yyct657 == codecSelferValueTypeArray1234 {
+			yyl657 := r.ReadArrayStart()
+			if yyl657 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl610, d)
+				x.codecDecodeSelfFromArray(yyl657, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -7341,12 +7927,12 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys611Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys611Slc
-	var yyhl611 bool = l >= 0
-	for yyj611 := 0; ; yyj611++ {
-		if yyhl611 {
-			if yyj611 >= l {
+	var yys658Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys658Slc
+	var yyhl658 bool = l >= 0
+	for yyj658 := 0; ; yyj658++ {
+		if yyhl658 {
+			if yyj658 >= l {
 				break
 			}
 		} else {
@@ -7355,10 +7941,10 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys611Slc = r.DecodeBytes(yys611Slc, true, true)
-		yys611 := string(yys611Slc)
+		yys658Slc = r.DecodeBytes(yys658Slc, true, true)
+		yys658 := string(yys658Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys611 {
+		switch yys658 {
 		case "currentNumberScheduled":
 			if r.TryDecodeAsNil() {
 				x.CurrentNumberScheduled = 0
@@ -7378,9 +7964,9 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.DesiredNumberScheduled = int32(r.DecodeInt(32))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys611)
-		} // end switch yys611
-	} // end for yyj611
+			z.DecStructFieldNotFound(-1, yys658)
+		} // end switch yys658
+	} // end for yyj658
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -7388,16 +7974,16 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj615 int
-	var yyb615 bool
-	var yyhl615 bool = l >= 0
-	yyj615++
-	if yyhl615 {
-		yyb615 = yyj615 > l
+	var yyj662 int
+	var yyb662 bool
+	var yyhl662 bool = l >= 0
+	yyj662++
+	if yyhl662 {
+		yyb662 = yyj662 > l
 	} else {
-		yyb615 = r.CheckBreak()
+		yyb662 = r.CheckBreak()
 	}
-	if yyb615 {
+	if yyb662 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7407,13 +7993,13 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.CurrentNumberScheduled = int32(r.DecodeInt(32))
 	}
-	yyj615++
-	if yyhl615 {
-		yyb615 = yyj615 > l
+	yyj662++
+	if yyhl662 {
+		yyb662 = yyj662 > l
 	} else {
-		yyb615 = r.CheckBreak()
+		yyb662 = r.CheckBreak()
 	}
-	if yyb615 {
+	if yyb662 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7423,13 +8009,13 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.NumberMisscheduled = int32(r.DecodeInt(32))
 	}
-	yyj615++
-	if yyhl615 {
-		yyb615 = yyj615 > l
+	yyj662++
+	if yyhl662 {
+		yyb662 = yyj662 > l
 	} else {
-		yyb615 = r.CheckBreak()
+		yyb662 = r.CheckBreak()
 	}
-	if yyb615 {
+	if yyb662 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7440,17 +8026,17 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.DesiredNumberScheduled = int32(r.DecodeInt(32))
 	}
 	for {
-		yyj615++
-		if yyhl615 {
-			yyb615 = yyj615 > l
+		yyj662++
+		if yyhl662 {
+			yyb662 = yyj662 > l
 		} else {
-			yyb615 = r.CheckBreak()
+			yyb662 = r.CheckBreak()
 		}
-		if yyb615 {
+		if yyb662 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj615-1, "")
+		z.DecStructFieldNotFound(yyj662-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -7462,39 +8048,39 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym619 := z.EncBinary()
-		_ = yym619
+		yym666 := z.EncBinary()
+		_ = yym666
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep620 := !z.EncBinary()
-			yy2arr620 := z.EncBasicHandle().StructToArray
-			var yyq620 [5]bool
-			_, _, _ = yysep620, yyq620, yy2arr620
-			const yyr620 bool = false
-			yyq620[0] = x.Kind != ""
-			yyq620[1] = x.APIVersion != ""
-			yyq620[2] = true
-			yyq620[3] = true
-			yyq620[4] = true
-			var yynn620 int
-			if yyr620 || yy2arr620 {
+			yysep667 := !z.EncBinary()
+			yy2arr667 := z.EncBasicHandle().StructToArray
+			var yyq667 [5]bool
+			_, _, _ = yysep667, yyq667, yy2arr667
+			const yyr667 bool = false
+			yyq667[0] = x.Kind != ""
+			yyq667[1] = x.APIVersion != ""
+			yyq667[2] = true
+			yyq667[3] = true
+			yyq667[4] = true
+			var yynn667 int
+			if yyr667 || yy2arr667 {
 				r.EncodeArrayStart(5)
 			} else {
-				yynn620 = 0
-				for _, b := range yyq620 {
+				yynn667 = 0
+				for _, b := range yyq667 {
 					if b {
-						yynn620++
+						yynn667++
 					}
 				}
-				r.EncodeMapStart(yynn620)
-				yynn620 = 0
+				r.EncodeMapStart(yynn667)
+				yynn667 = 0
 			}
-			if yyr620 || yy2arr620 {
+			if yyr667 || yy2arr667 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq620[0] {
-					yym622 := z.EncBinary()
-					_ = yym622
+				if yyq667[0] {
+					yym669 := z.EncBinary()
+					_ = yym669
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -7503,23 +8089,23 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq620[0] {
+				if yyq667[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym623 := z.EncBinary()
-					_ = yym623
+					yym670 := z.EncBinary()
+					_ = yym670
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr620 || yy2arr620 {
+			if yyr667 || yy2arr667 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq620[1] {
-					yym625 := z.EncBinary()
-					_ = yym625
+				if yyq667[1] {
+					yym672 := z.EncBinary()
+					_ = yym672
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -7528,70 +8114,70 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq620[1] {
+				if yyq667[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym626 := z.EncBinary()
-					_ = yym626
+					yym673 := z.EncBinary()
+					_ = yym673
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr620 || yy2arr620 {
+			if yyr667 || yy2arr667 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq620[2] {
-					yy628 := &x.ObjectMeta
-					yy628.CodecEncodeSelf(e)
+				if yyq667[2] {
+					yy675 := &x.ObjectMeta
+					yy675.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq620[2] {
+				if yyq667[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy629 := &x.ObjectMeta
-					yy629.CodecEncodeSelf(e)
+					yy676 := &x.ObjectMeta
+					yy676.CodecEncodeSelf(e)
 				}
 			}
-			if yyr620 || yy2arr620 {
+			if yyr667 || yy2arr667 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq620[3] {
-					yy631 := &x.Spec
-					yy631.CodecEncodeSelf(e)
+				if yyq667[3] {
+					yy678 := &x.Spec
+					yy678.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq620[3] {
+				if yyq667[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy632 := &x.Spec
-					yy632.CodecEncodeSelf(e)
+					yy679 := &x.Spec
+					yy679.CodecEncodeSelf(e)
 				}
 			}
-			if yyr620 || yy2arr620 {
+			if yyr667 || yy2arr667 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq620[4] {
-					yy634 := &x.Status
-					yy634.CodecEncodeSelf(e)
+				if yyq667[4] {
+					yy681 := &x.Status
+					yy681.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq620[4] {
+				if yyq667[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy635 := &x.Status
-					yy635.CodecEncodeSelf(e)
+					yy682 := &x.Status
+					yy682.CodecEncodeSelf(e)
 				}
 			}
-			if yyr620 || yy2arr620 {
+			if yyr667 || yy2arr667 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -7604,25 +8190,25 @@ func (x *DaemonSet) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym636 := z.DecBinary()
-	_ = yym636
+	yym683 := z.DecBinary()
+	_ = yym683
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct637 := r.ContainerType()
-		if yyct637 == codecSelferValueTypeMap1234 {
-			yyl637 := r.ReadMapStart()
-			if yyl637 == 0 {
+		yyct684 := r.ContainerType()
+		if yyct684 == codecSelferValueTypeMap1234 {
+			yyl684 := r.ReadMapStart()
+			if yyl684 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl637, d)
+				x.codecDecodeSelfFromMap(yyl684, d)
 			}
-		} else if yyct637 == codecSelferValueTypeArray1234 {
-			yyl637 := r.ReadArrayStart()
-			if yyl637 == 0 {
+		} else if yyct684 == codecSelferValueTypeArray1234 {
+			yyl684 := r.ReadArrayStart()
+			if yyl684 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl637, d)
+				x.codecDecodeSelfFromArray(yyl684, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -7634,12 +8220,12 @@ func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys638Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys638Slc
-	var yyhl638 bool = l >= 0
-	for yyj638 := 0; ; yyj638++ {
-		if yyhl638 {
-			if yyj638 >= l {
+	var yys685Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys685Slc
+	var yyhl685 bool = l >= 0
+	for yyj685 := 0; ; yyj685++ {
+		if yyhl685 {
+			if yyj685 >= l {
 				break
 			}
 		} else {
@@ -7648,10 +8234,10 @@ func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys638Slc = r.DecodeBytes(yys638Slc, true, true)
-		yys638 := string(yys638Slc)
+		yys685Slc = r.DecodeBytes(yys685Slc, true, true)
+		yys685 := string(yys685Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys638 {
+		switch yys685 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -7668,27 +8254,27 @@ func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_v1.ObjectMeta{}
 			} else {
-				yyv641 := &x.ObjectMeta
-				yyv641.CodecDecodeSelf(d)
+				yyv688 := &x.ObjectMeta
+				yyv688.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = DaemonSetSpec{}
 			} else {
-				yyv642 := &x.Spec
-				yyv642.CodecDecodeSelf(d)
+				yyv689 := &x.Spec
+				yyv689.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = DaemonSetStatus{}
 			} else {
-				yyv643 := &x.Status
-				yyv643.CodecDecodeSelf(d)
+				yyv690 := &x.Status
+				yyv690.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys638)
-		} // end switch yys638
-	} // end for yyj638
+			z.DecStructFieldNotFound(-1, yys685)
+		} // end switch yys685
+	} // end for yyj685
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -7696,16 +8282,16 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj644 int
-	var yyb644 bool
-	var yyhl644 bool = l >= 0
-	yyj644++
-	if yyhl644 {
-		yyb644 = yyj644 > l
+	var yyj691 int
+	var yyb691 bool
+	var yyhl691 bool = l >= 0
+	yyj691++
+	if yyhl691 {
+		yyb691 = yyj691 > l
 	} else {
-		yyb644 = r.CheckBreak()
+		yyb691 = r.CheckBreak()
 	}
-	if yyb644 {
+	if yyb691 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7715,13 +8301,13 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj644++
-	if yyhl644 {
-		yyb644 = yyj644 > l
+	yyj691++
+	if yyhl691 {
+		yyb691 = yyj691 > l
 	} else {
-		yyb644 = r.CheckBreak()
+		yyb691 = r.CheckBreak()
 	}
-	if yyb644 {
+	if yyb691 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7731,13 +8317,13 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj644++
-	if yyhl644 {
-		yyb644 = yyj644 > l
+	yyj691++
+	if yyhl691 {
+		yyb691 = yyj691 > l
 	} else {
-		yyb644 = r.CheckBreak()
+		yyb691 = r.CheckBreak()
 	}
-	if yyb644 {
+	if yyb691 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7745,16 +8331,16 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_v1.ObjectMeta{}
 	} else {
-		yyv647 := &x.ObjectMeta
-		yyv647.CodecDecodeSelf(d)
+		yyv694 := &x.ObjectMeta
+		yyv694.CodecDecodeSelf(d)
 	}
-	yyj644++
-	if yyhl644 {
-		yyb644 = yyj644 > l
+	yyj691++
+	if yyhl691 {
+		yyb691 = yyj691 > l
 	} else {
-		yyb644 = r.CheckBreak()
+		yyb691 = r.CheckBreak()
 	}
-	if yyb644 {
+	if yyb691 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7762,16 +8348,16 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Spec = DaemonSetSpec{}
 	} else {
-		yyv648 := &x.Spec
-		yyv648.CodecDecodeSelf(d)
+		yyv695 := &x.Spec
+		yyv695.CodecDecodeSelf(d)
 	}
-	yyj644++
-	if yyhl644 {
-		yyb644 = yyj644 > l
+	yyj691++
+	if yyhl691 {
+		yyb691 = yyj691 > l
 	} else {
-		yyb644 = r.CheckBreak()
+		yyb691 = r.CheckBreak()
 	}
-	if yyb644 {
+	if yyb691 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7779,21 +8365,21 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Status = DaemonSetStatus{}
 	} else {
-		yyv649 := &x.Status
-		yyv649.CodecDecodeSelf(d)
+		yyv696 := &x.Status
+		yyv696.CodecDecodeSelf(d)
 	}
 	for {
-		yyj644++
-		if yyhl644 {
-			yyb644 = yyj644 > l
+		yyj691++
+		if yyhl691 {
+			yyb691 = yyj691 > l
 		} else {
-			yyb644 = r.CheckBreak()
+			yyb691 = r.CheckBreak()
 		}
-		if yyb644 {
+		if yyb691 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj644-1, "")
+		z.DecStructFieldNotFound(yyj691-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -7805,37 +8391,37 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym650 := z.EncBinary()
-		_ = yym650
+		yym697 := z.EncBinary()
+		_ = yym697
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep651 := !z.EncBinary()
-			yy2arr651 := z.EncBasicHandle().StructToArray
-			var yyq651 [4]bool
-			_, _, _ = yysep651, yyq651, yy2arr651
-			const yyr651 bool = false
-			yyq651[0] = x.Kind != ""
-			yyq651[1] = x.APIVersion != ""
-			yyq651[2] = true
-			var yynn651 int
-			if yyr651 || yy2arr651 {
+			yysep698 := !z.EncBinary()
+			yy2arr698 := z.EncBasicHandle().StructToArray
+			var yyq698 [4]bool
+			_, _, _ = yysep698, yyq698, yy2arr698
+			const yyr698 bool = false
+			yyq698[0] = x.Kind != ""
+			yyq698[1] = x.APIVersion != ""
+			yyq698[2] = true
+			var yynn698 int
+			if yyr698 || yy2arr698 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn651 = 1
-				for _, b := range yyq651 {
+				yynn698 = 1
+				for _, b := range yyq698 {
 					if b {
-						yynn651++
+						yynn698++
 					}
 				}
-				r.EncodeMapStart(yynn651)
-				yynn651 = 0
+				r.EncodeMapStart(yynn698)
+				yynn698 = 0
 			}
-			if yyr651 || yy2arr651 {
+			if yyr698 || yy2arr698 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq651[0] {
-					yym653 := z.EncBinary()
-					_ = yym653
+				if yyq698[0] {
+					yym700 := z.EncBinary()
+					_ = yym700
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -7844,23 +8430,23 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq651[0] {
+				if yyq698[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym654 := z.EncBinary()
-					_ = yym654
+					yym701 := z.EncBinary()
+					_ = yym701
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr651 || yy2arr651 {
+			if yyr698 || yy2arr698 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq651[1] {
-					yym656 := z.EncBinary()
-					_ = yym656
+				if yyq698[1] {
+					yym703 := z.EncBinary()
+					_ = yym703
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -7869,54 +8455,54 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq651[1] {
+				if yyq698[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym657 := z.EncBinary()
-					_ = yym657
+					yym704 := z.EncBinary()
+					_ = yym704
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr651 || yy2arr651 {
+			if yyr698 || yy2arr698 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq651[2] {
-					yy659 := &x.ListMeta
-					yym660 := z.EncBinary()
-					_ = yym660
+				if yyq698[2] {
+					yy706 := &x.ListMeta
+					yym707 := z.EncBinary()
+					_ = yym707
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy659) {
+					} else if z.HasExtensions() && z.EncExt(yy706) {
 					} else {
-						z.EncFallback(yy659)
+						z.EncFallback(yy706)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq651[2] {
+				if yyq698[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy661 := &x.ListMeta
-					yym662 := z.EncBinary()
-					_ = yym662
+					yy708 := &x.ListMeta
+					yym709 := z.EncBinary()
+					_ = yym709
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy661) {
+					} else if z.HasExtensions() && z.EncExt(yy708) {
 					} else {
-						z.EncFallback(yy661)
+						z.EncFallback(yy708)
 					}
 				}
 			}
-			if yyr651 || yy2arr651 {
+			if yyr698 || yy2arr698 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym664 := z.EncBinary()
-					_ = yym664
+					yym711 := z.EncBinary()
+					_ = yym711
 					if false {
 					} else {
 						h.encSliceDaemonSet(([]DaemonSet)(x.Items), e)
@@ -7929,15 +8515,15 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym665 := z.EncBinary()
-					_ = yym665
+					yym712 := z.EncBinary()
+					_ = yym712
 					if false {
 					} else {
 						h.encSliceDaemonSet(([]DaemonSet)(x.Items), e)
 					}
 				}
 			}
-			if yyr651 || yy2arr651 {
+			if yyr698 || yy2arr698 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -7950,25 +8536,25 @@ func (x *DaemonSetList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym666 := z.DecBinary()
-	_ = yym666
+	yym713 := z.DecBinary()
+	_ = yym713
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct667 := r.ContainerType()
-		if yyct667 == codecSelferValueTypeMap1234 {
-			yyl667 := r.ReadMapStart()
-			if yyl667 == 0 {
+		yyct714 := r.ContainerType()
+		if yyct714 == codecSelferValueTypeMap1234 {
+			yyl714 := r.ReadMapStart()
+			if yyl714 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl667, d)
+				x.codecDecodeSelfFromMap(yyl714, d)
 			}
-		} else if yyct667 == codecSelferValueTypeArray1234 {
-			yyl667 := r.ReadArrayStart()
-			if yyl667 == 0 {
+		} else if yyct714 == codecSelferValueTypeArray1234 {
+			yyl714 := r.ReadArrayStart()
+			if yyl714 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl667, d)
+				x.codecDecodeSelfFromArray(yyl714, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -7980,12 +8566,12 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys668Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys668Slc
-	var yyhl668 bool = l >= 0
-	for yyj668 := 0; ; yyj668++ {
-		if yyhl668 {
-			if yyj668 >= l {
+	var yys715Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys715Slc
+	var yyhl715 bool = l >= 0
+	for yyj715 := 0; ; yyj715++ {
+		if yyhl715 {
+			if yyj715 >= l {
 				break
 			}
 		} else {
@@ -7994,10 +8580,10 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys668Slc = r.DecodeBytes(yys668Slc, true, true)
-		yys668 := string(yys668Slc)
+		yys715Slc = r.DecodeBytes(yys715Slc, true, true)
+		yys715 := string(yys715Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys668 {
+		switch yys715 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -8014,31 +8600,31 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv671 := &x.ListMeta
-				yym672 := z.DecBinary()
-				_ = yym672
+				yyv718 := &x.ListMeta
+				yym719 := z.DecBinary()
+				_ = yym719
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv671) {
+				} else if z.HasExtensions() && z.DecExt(yyv718) {
 				} else {
-					z.DecFallback(yyv671, false)
+					z.DecFallback(yyv718, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv673 := &x.Items
-				yym674 := z.DecBinary()
-				_ = yym674
+				yyv720 := &x.Items
+				yym721 := z.DecBinary()
+				_ = yym721
 				if false {
 				} else {
-					h.decSliceDaemonSet((*[]DaemonSet)(yyv673), d)
+					h.decSliceDaemonSet((*[]DaemonSet)(yyv720), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys668)
-		} // end switch yys668
-	} // end for yyj668
+			z.DecStructFieldNotFound(-1, yys715)
+		} // end switch yys715
+	} // end for yyj715
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -8046,16 +8632,16 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj675 int
-	var yyb675 bool
-	var yyhl675 bool = l >= 0
-	yyj675++
-	if yyhl675 {
-		yyb675 = yyj675 > l
+	var yyj722 int
+	var yyb722 bool
+	var yyhl722 bool = l >= 0
+	yyj722++
+	if yyhl722 {
+		yyb722 = yyj722 > l
 	} else {
-		yyb675 = r.CheckBreak()
+		yyb722 = r.CheckBreak()
 	}
-	if yyb675 {
+	if yyb722 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8065,13 +8651,13 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj675++
-	if yyhl675 {
-		yyb675 = yyj675 > l
+	yyj722++
+	if yyhl722 {
+		yyb722 = yyj722 > l
 	} else {
-		yyb675 = r.CheckBreak()
+		yyb722 = r.CheckBreak()
 	}
-	if yyb675 {
+	if yyb722 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8081,13 +8667,13 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj675++
-	if yyhl675 {
-		yyb675 = yyj675 > l
+	yyj722++
+	if yyhl722 {
+		yyb722 = yyj722 > l
 	} else {
-		yyb675 = r.CheckBreak()
+		yyb722 = r.CheckBreak()
 	}
-	if yyb675 {
+	if yyb722 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8095,22 +8681,22 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv678 := &x.ListMeta
-		yym679 := z.DecBinary()
-		_ = yym679
+		yyv725 := &x.ListMeta
+		yym726 := z.DecBinary()
+		_ = yym726
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv678) {
+		} else if z.HasExtensions() && z.DecExt(yyv725) {
 		} else {
-			z.DecFallback(yyv678, false)
+			z.DecFallback(yyv725, false)
 		}
 	}
-	yyj675++
-	if yyhl675 {
-		yyb675 = yyj675 > l
+	yyj722++
+	if yyhl722 {
+		yyb722 = yyj722 > l
 	} else {
-		yyb675 = r.CheckBreak()
+		yyb722 = r.CheckBreak()
 	}
-	if yyb675 {
+	if yyb722 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8118,26 +8704,26 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv680 := &x.Items
-		yym681 := z.DecBinary()
-		_ = yym681
+		yyv727 := &x.Items
+		yym728 := z.DecBinary()
+		_ = yym728
 		if false {
 		} else {
-			h.decSliceDaemonSet((*[]DaemonSet)(yyv680), d)
+			h.decSliceDaemonSet((*[]DaemonSet)(yyv727), d)
 		}
 	}
 	for {
-		yyj675++
-		if yyhl675 {
-			yyb675 = yyj675 > l
+		yyj722++
+		if yyhl722 {
+			yyb722 = yyj722 > l
 		} else {
-			yyb675 = r.CheckBreak()
+			yyb722 = r.CheckBreak()
 		}
-		if yyb675 {
+		if yyb722 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj675-1, "")
+		z.DecStructFieldNotFound(yyj722-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -8149,37 +8735,37 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym682 := z.EncBinary()
-		_ = yym682
+		yym729 := z.EncBinary()
+		_ = yym729
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep683 := !z.EncBinary()
-			yy2arr683 := z.EncBasicHandle().StructToArray
-			var yyq683 [4]bool
-			_, _, _ = yysep683, yyq683, yy2arr683
-			const yyr683 bool = false
-			yyq683[0] = x.Kind != ""
-			yyq683[1] = x.APIVersion != ""
-			yyq683[2] = true
-			var yynn683 int
-			if yyr683 || yy2arr683 {
+			yysep730 := !z.EncBinary()
+			yy2arr730 := z.EncBasicHandle().StructToArray
+			var yyq730 [4]bool
+			_, _, _ = yysep730, yyq730, yy2arr730
+			const yyr730 bool = false
+			yyq730[0] = x.Kind != ""
+			yyq730[1] = x.APIVersion != ""
+			yyq730[2] = true
+			var yynn730 int
+			if yyr730 || yy2arr730 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn683 = 1
-				for _, b := range yyq683 {
+				yynn730 = 1
+				for _, b := range yyq730 {
 					if b {
-						yynn683++
+						yynn730++
 					}
 				}
-				r.EncodeMapStart(yynn683)
-				yynn683 = 0
+				r.EncodeMapStart(yynn730)
+				yynn730 = 0
 			}
-			if yyr683 || yy2arr683 {
+			if yyr730 || yy2arr730 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq683[0] {
-					yym685 := z.EncBinary()
-					_ = yym685
+				if yyq730[0] {
+					yym732 := z.EncBinary()
+					_ = yym732
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -8188,23 +8774,23 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq683[0] {
+				if yyq730[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym686 := z.EncBinary()
-					_ = yym686
+					yym733 := z.EncBinary()
+					_ = yym733
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr683 || yy2arr683 {
+			if yyr730 || yy2arr730 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq683[1] {
-					yym688 := z.EncBinary()
-					_ = yym688
+				if yyq730[1] {
+					yym735 := z.EncBinary()
+					_ = yym735
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -8213,54 +8799,54 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq683[1] {
+				if yyq730[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym689 := z.EncBinary()
-					_ = yym689
+					yym736 := z.EncBinary()
+					_ = yym736
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr683 || yy2arr683 {
+			if yyr730 || yy2arr730 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq683[2] {
-					yy691 := &x.ListMeta
-					yym692 := z.EncBinary()
-					_ = yym692
+				if yyq730[2] {
+					yy738 := &x.ListMeta
+					yym739 := z.EncBinary()
+					_ = yym739
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy691) {
+					} else if z.HasExtensions() && z.EncExt(yy738) {
 					} else {
-						z.EncFallback(yy691)
+						z.EncFallback(yy738)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq683[2] {
+				if yyq730[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy693 := &x.ListMeta
-					yym694 := z.EncBinary()
-					_ = yym694
+					yy740 := &x.ListMeta
+					yym741 := z.EncBinary()
+					_ = yym741
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy693) {
+					} else if z.HasExtensions() && z.EncExt(yy740) {
 					} else {
-						z.EncFallback(yy693)
+						z.EncFallback(yy740)
 					}
 				}
 			}
-			if yyr683 || yy2arr683 {
+			if yyr730 || yy2arr730 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym696 := z.EncBinary()
-					_ = yym696
+					yym743 := z.EncBinary()
+					_ = yym743
 					if false {
 					} else {
 						h.encSliceThirdPartyResourceData(([]ThirdPartyResourceData)(x.Items), e)
@@ -8273,15 +8859,15 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym697 := z.EncBinary()
-					_ = yym697
+					yym744 := z.EncBinary()
+					_ = yym744
 					if false {
 					} else {
 						h.encSliceThirdPartyResourceData(([]ThirdPartyResourceData)(x.Items), e)
 					}
 				}
 			}
-			if yyr683 || yy2arr683 {
+			if yyr730 || yy2arr730 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -8294,25 +8880,25 @@ func (x *ThirdPartyResourceDataList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym698 := z.DecBinary()
-	_ = yym698
+	yym745 := z.DecBinary()
+	_ = yym745
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct699 := r.ContainerType()
-		if yyct699 == codecSelferValueTypeMap1234 {
-			yyl699 := r.ReadMapStart()
-			if yyl699 == 0 {
+		yyct746 := r.ContainerType()
+		if yyct746 == codecSelferValueTypeMap1234 {
+			yyl746 := r.ReadMapStart()
+			if yyl746 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl699, d)
+				x.codecDecodeSelfFromMap(yyl746, d)
 			}
-		} else if yyct699 == codecSelferValueTypeArray1234 {
-			yyl699 := r.ReadArrayStart()
-			if yyl699 == 0 {
+		} else if yyct746 == codecSelferValueTypeArray1234 {
+			yyl746 := r.ReadArrayStart()
+			if yyl746 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl699, d)
+				x.codecDecodeSelfFromArray(yyl746, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -8324,12 +8910,12 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys700Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys700Slc
-	var yyhl700 bool = l >= 0
-	for yyj700 := 0; ; yyj700++ {
-		if yyhl700 {
-			if yyj700 >= l {
+	var yys747Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys747Slc
+	var yyhl747 bool = l >= 0
+	for yyj747 := 0; ; yyj747++ {
+		if yyhl747 {
+			if yyj747 >= l {
 				break
 			}
 		} else {
@@ -8338,10 +8924,10 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys700Slc = r.DecodeBytes(yys700Slc, true, true)
-		yys700 := string(yys700Slc)
+		yys747Slc = r.DecodeBytes(yys747Slc, true, true)
+		yys747 := string(yys747Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys700 {
+		switch yys747 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -8358,31 +8944,31 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv703 := &x.ListMeta
-				yym704 := z.DecBinary()
-				_ = yym704
+				yyv750 := &x.ListMeta
+				yym751 := z.DecBinary()
+				_ = yym751
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv703) {
+				} else if z.HasExtensions() && z.DecExt(yyv750) {
 				} else {
-					z.DecFallback(yyv703, false)
+					z.DecFallback(yyv750, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv705 := &x.Items
-				yym706 := z.DecBinary()
-				_ = yym706
+				yyv752 := &x.Items
+				yym753 := z.DecBinary()
+				_ = yym753
 				if false {
 				} else {
-					h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv705), d)
+					h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv752), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys700)
-		} // end switch yys700
-	} // end for yyj700
+			z.DecStructFieldNotFound(-1, yys747)
+		} // end switch yys747
+	} // end for yyj747
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -8390,16 +8976,16 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj707 int
-	var yyb707 bool
-	var yyhl707 bool = l >= 0
-	yyj707++
-	if yyhl707 {
-		yyb707 = yyj707 > l
+	var yyj754 int
+	var yyb754 bool
+	var yyhl754 bool = l >= 0
+	yyj754++
+	if yyhl754 {
+		yyb754 = yyj754 > l
 	} else {
-		yyb707 = r.CheckBreak()
+		yyb754 = r.CheckBreak()
 	}
-	if yyb707 {
+	if yyb754 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8409,13 +8995,13 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj707++
-	if yyhl707 {
-		yyb707 = yyj707 > l
+	yyj754++
+	if yyhl754 {
+		yyb754 = yyj754 > l
 	} else {
-		yyb707 = r.CheckBreak()
+		yyb754 = r.CheckBreak()
 	}
-	if yyb707 {
+	if yyb754 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8425,13 +9011,13 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj707++
-	if yyhl707 {
-		yyb707 = yyj707 > l
+	yyj754++
+	if yyhl754 {
+		yyb754 = yyj754 > l
 	} else {
-		yyb707 = r.CheckBreak()
+		yyb754 = r.CheckBreak()
 	}
-	if yyb707 {
+	if yyb754 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8439,22 +9025,22 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv710 := &x.ListMeta
-		yym711 := z.DecBinary()
-		_ = yym711
+		yyv757 := &x.ListMeta
+		yym758 := z.DecBinary()
+		_ = yym758
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv710) {
+		} else if z.HasExtensions() && z.DecExt(yyv757) {
 		} else {
-			z.DecFallback(yyv710, false)
+			z.DecFallback(yyv757, false)
 		}
 	}
-	yyj707++
-	if yyhl707 {
-		yyb707 = yyj707 > l
+	yyj754++
+	if yyhl754 {
+		yyb754 = yyj754 > l
 	} else {
-		yyb707 = r.CheckBreak()
+		yyb754 = r.CheckBreak()
 	}
-	if yyb707 {
+	if yyb754 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8462,26 +9048,26 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv712 := &x.Items
-		yym713 := z.DecBinary()
-		_ = yym713
+		yyv759 := &x.Items
+		yym760 := z.DecBinary()
+		_ = yym760
 		if false {
 		} else {
-			h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv712), d)
+			h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv759), d)
 		}
 	}
 	for {
-		yyj707++
-		if yyhl707 {
-			yyb707 = yyj707 > l
+		yyj754++
+		if yyhl754 {
+			yyb754 = yyj754 > l
 		} else {
-			yyb707 = r.CheckBreak()
+			yyb754 = r.CheckBreak()
 		}
-		if yyb707 {
+		if yyb754 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj707-1, "")
+		z.DecStructFieldNotFound(yyj754-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -8493,39 +9079,39 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym714 := z.EncBinary()
-		_ = yym714
+		yym761 := z.EncBinary()
+		_ = yym761
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep715 := !z.EncBinary()
-			yy2arr715 := z.EncBasicHandle().StructToArray
-			var yyq715 [5]bool
-			_, _, _ = yysep715, yyq715, yy2arr715
-			const yyr715 bool = false
-			yyq715[0] = x.Kind != ""
-			yyq715[1] = x.APIVersion != ""
-			yyq715[2] = true
-			yyq715[3] = true
-			yyq715[4] = true
-			var yynn715 int
-			if yyr715 || yy2arr715 {
+			yysep762 := !z.EncBinary()
+			yy2arr762 := z.EncBasicHandle().StructToArray
+			var yyq762 [5]bool
+			_, _, _ = yysep762, yyq762, yy2arr762
+			const yyr762 bool = false
+			yyq762[0] = x.Kind != ""
+			yyq762[1] = x.APIVersion != ""
+			yyq762[2] = true
+			yyq762[3] = true
+			yyq762[4] = true
+			var yynn762 int
+			if yyr762 || yy2arr762 {
 				r.EncodeArrayStart(5)
 			} else {
-				yynn715 = 0
-				for _, b := range yyq715 {
+				yynn762 = 0
+				for _, b := range yyq762 {
 					if b {
-						yynn715++
+						yynn762++
 					}
 				}
-				r.EncodeMapStart(yynn715)
-				yynn715 = 0
+				r.EncodeMapStart(yynn762)
+				yynn762 = 0
 			}
-			if yyr715 || yy2arr715 {
+			if yyr762 || yy2arr762 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq715[0] {
-					yym717 := z.EncBinary()
-					_ = yym717
+				if yyq762[0] {
+					yym764 := z.EncBinary()
+					_ = yym764
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -8534,23 +9120,23 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq715[0] {
+				if yyq762[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym718 := z.EncBinary()
-					_ = yym718
+					yym765 := z.EncBinary()
+					_ = yym765
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr715 || yy2arr715 {
+			if yyr762 || yy2arr762 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq715[1] {
-					yym720 := z.EncBinary()
-					_ = yym720
+				if yyq762[1] {
+					yym767 := z.EncBinary()
+					_ = yym767
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -8559,70 +9145,70 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq715[1] {
+				if yyq762[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym721 := z.EncBinary()
-					_ = yym721
+					yym768 := z.EncBinary()
+					_ = yym768
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr715 || yy2arr715 {
+			if yyr762 || yy2arr762 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq715[2] {
-					yy723 := &x.ObjectMeta
-					yy723.CodecEncodeSelf(e)
+				if yyq762[2] {
+					yy770 := &x.ObjectMeta
+					yy770.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq715[2] {
+				if yyq762[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy724 := &x.ObjectMeta
-					yy724.CodecEncodeSelf(e)
+					yy771 := &x.ObjectMeta
+					yy771.CodecEncodeSelf(e)
 				}
 			}
-			if yyr715 || yy2arr715 {
+			if yyr762 || yy2arr762 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq715[3] {
-					yy726 := &x.Spec
-					yy726.CodecEncodeSelf(e)
+				if yyq762[3] {
+					yy773 := &x.Spec
+					yy773.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq715[3] {
+				if yyq762[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy727 := &x.Spec
-					yy727.CodecEncodeSelf(e)
+					yy774 := &x.Spec
+					yy774.CodecEncodeSelf(e)
 				}
 			}
-			if yyr715 || yy2arr715 {
+			if yyr762 || yy2arr762 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq715[4] {
-					yy729 := &x.Status
-					yy729.CodecEncodeSelf(e)
+				if yyq762[4] {
+					yy776 := &x.Status
+					yy776.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq715[4] {
+				if yyq762[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy730 := &x.Status
-					yy730.CodecEncodeSelf(e)
+					yy777 := &x.Status
+					yy777.CodecEncodeSelf(e)
 				}
 			}
-			if yyr715 || yy2arr715 {
+			if yyr762 || yy2arr762 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -8635,25 +9221,25 @@ func (x *Job) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym731 := z.DecBinary()
-	_ = yym731
+	yym778 := z.DecBinary()
+	_ = yym778
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct732 := r.ContainerType()
-		if yyct732 == codecSelferValueTypeMap1234 {
-			yyl732 := r.ReadMapStart()
-			if yyl732 == 0 {
+		yyct779 := r.ContainerType()
+		if yyct779 == codecSelferValueTypeMap1234 {
+			yyl779 := r.ReadMapStart()
+			if yyl779 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl732, d)
+				x.codecDecodeSelfFromMap(yyl779, d)
 			}
-		} else if yyct732 == codecSelferValueTypeArray1234 {
-			yyl732 := r.ReadArrayStart()
-			if yyl732 == 0 {
+		} else if yyct779 == codecSelferValueTypeArray1234 {
+			yyl779 := r.ReadArrayStart()
+			if yyl779 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl732, d)
+				x.codecDecodeSelfFromArray(yyl779, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -8665,12 +9251,12 @@ func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys733Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys733Slc
-	var yyhl733 bool = l >= 0
-	for yyj733 := 0; ; yyj733++ {
-		if yyhl733 {
-			if yyj733 >= l {
+	var yys780Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys780Slc
+	var yyhl780 bool = l >= 0
+	for yyj780 := 0; ; yyj780++ {
+		if yyhl780 {
+			if yyj780 >= l {
 				break
 			}
 		} else {
@@ -8679,10 +9265,10 @@ func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys733Slc = r.DecodeBytes(yys733Slc, true, true)
-		yys733 := string(yys733Slc)
+		yys780Slc = r.DecodeBytes(yys780Slc, true, true)
+		yys780 := string(yys780Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys733 {
+		switch yys780 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -8699,27 +9285,27 @@ func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_v1.ObjectMeta{}
 			} else {
-				yyv736 := &x.ObjectMeta
-				yyv736.CodecDecodeSelf(d)
+				yyv783 := &x.ObjectMeta
+				yyv783.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = JobSpec{}
 			} else {
-				yyv737 := &x.Spec
-				yyv737.CodecDecodeSelf(d)
+				yyv784 := &x.Spec
+				yyv784.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = JobStatus{}
 			} else {
-				yyv738 := &x.Status
-				yyv738.CodecDecodeSelf(d)
+				yyv785 := &x.Status
+				yyv785.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys733)
-		} // end switch yys733
-	} // end for yyj733
+			z.DecStructFieldNotFound(-1, yys780)
+		} // end switch yys780
+	} // end for yyj780
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -8727,16 +9313,16 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj739 int
-	var yyb739 bool
-	var yyhl739 bool = l >= 0
-	yyj739++
-	if yyhl739 {
-		yyb739 = yyj739 > l
+	var yyj786 int
+	var yyb786 bool
+	var yyhl786 bool = l >= 0
+	yyj786++
+	if yyhl786 {
+		yyb786 = yyj786 > l
 	} else {
-		yyb739 = r.CheckBreak()
+		yyb786 = r.CheckBreak()
 	}
-	if yyb739 {
+	if yyb786 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8746,13 +9332,13 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj739++
-	if yyhl739 {
-		yyb739 = yyj739 > l
+	yyj786++
+	if yyhl786 {
+		yyb786 = yyj786 > l
 	} else {
-		yyb739 = r.CheckBreak()
+		yyb786 = r.CheckBreak()
 	}
-	if yyb739 {
+	if yyb786 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8762,13 +9348,13 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj739++
-	if yyhl739 {
-		yyb739 = yyj739 > l
+	yyj786++
+	if yyhl786 {
+		yyb786 = yyj786 > l
 	} else {
-		yyb739 = r.CheckBreak()
+		yyb786 = r.CheckBreak()
 	}
-	if yyb739 {
+	if yyb786 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8776,16 +9362,16 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_v1.ObjectMeta{}
 	} else {
-		yyv742 := &x.ObjectMeta
-		yyv742.CodecDecodeSelf(d)
+		yyv789 := &x.ObjectMeta
+		yyv789.CodecDecodeSelf(d)
 	}
-	yyj739++
-	if yyhl739 {
-		yyb739 = yyj739 > l
+	yyj786++
+	if yyhl786 {
+		yyb786 = yyj786 > l
 	} else {
-		yyb739 = r.CheckBreak()
+		yyb786 = r.CheckBreak()
 	}
-	if yyb739 {
+	if yyb786 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8793,16 +9379,16 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Spec = JobSpec{}
 	} else {
-		yyv743 := &x.Spec
-		yyv743.CodecDecodeSelf(d)
+		yyv790 := &x.Spec
+		yyv790.CodecDecodeSelf(d)
 	}
-	yyj739++
-	if yyhl739 {
-		yyb739 = yyj739 > l
+	yyj786++
+	if yyhl786 {
+		yyb786 = yyj786 > l
 	} else {
-		yyb739 = r.CheckBreak()
+		yyb786 = r.CheckBreak()
 	}
-	if yyb739 {
+	if yyb786 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8810,21 +9396,21 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Status = JobStatus{}
 	} else {
-		yyv744 := &x.Status
-		yyv744.CodecDecodeSelf(d)
+		yyv791 := &x.Status
+		yyv791.CodecDecodeSelf(d)
 	}
 	for {
-		yyj739++
-		if yyhl739 {
-			yyb739 = yyj739 > l
+		yyj786++
+		if yyhl786 {
+			yyb786 = yyj786 > l
 		} else {
-			yyb739 = r.CheckBreak()
+			yyb786 = r.CheckBreak()
 		}
-		if yyb739 {
+		if yyb786 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj739-1, "")
+		z.DecStructFieldNotFound(yyj786-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -8836,37 +9422,37 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym745 := z.EncBinary()
-		_ = yym745
+		yym792 := z.EncBinary()
+		_ = yym792
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep746 := !z.EncBinary()
-			yy2arr746 := z.EncBasicHandle().StructToArray
-			var yyq746 [4]bool
-			_, _, _ = yysep746, yyq746, yy2arr746
-			const yyr746 bool = false
-			yyq746[0] = x.Kind != ""
-			yyq746[1] = x.APIVersion != ""
-			yyq746[2] = true
-			var yynn746 int
-			if yyr746 || yy2arr746 {
+			yysep793 := !z.EncBinary()
+			yy2arr793 := z.EncBasicHandle().StructToArray
+			var yyq793 [4]bool
+			_, _, _ = yysep793, yyq793, yy2arr793
+			const yyr793 bool = false
+			yyq793[0] = x.Kind != ""
+			yyq793[1] = x.APIVersion != ""
+			yyq793[2] = true
+			var yynn793 int
+			if yyr793 || yy2arr793 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn746 = 1
-				for _, b := range yyq746 {
+				yynn793 = 1
+				for _, b := range yyq793 {
 					if b {
-						yynn746++
+						yynn793++
 					}
 				}
-				r.EncodeMapStart(yynn746)
-				yynn746 = 0
+				r.EncodeMapStart(yynn793)
+				yynn793 = 0
 			}
-			if yyr746 || yy2arr746 {
+			if yyr793 || yy2arr793 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq746[0] {
-					yym748 := z.EncBinary()
-					_ = yym748
+				if yyq793[0] {
+					yym795 := z.EncBinary()
+					_ = yym795
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -8875,23 +9461,23 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq746[0] {
+				if yyq793[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym749 := z.EncBinary()
-					_ = yym749
+					yym796 := z.EncBinary()
+					_ = yym796
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr746 || yy2arr746 {
+			if yyr793 || yy2arr793 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq746[1] {
-					yym751 := z.EncBinary()
-					_ = yym751
+				if yyq793[1] {
+					yym798 := z.EncBinary()
+					_ = yym798
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -8900,54 +9486,54 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq746[1] {
+				if yyq793[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym752 := z.EncBinary()
-					_ = yym752
+					yym799 := z.EncBinary()
+					_ = yym799
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr746 || yy2arr746 {
+			if yyr793 || yy2arr793 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq746[2] {
-					yy754 := &x.ListMeta
-					yym755 := z.EncBinary()
-					_ = yym755
+				if yyq793[2] {
+					yy801 := &x.ListMeta
+					yym802 := z.EncBinary()
+					_ = yym802
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy754) {
+					} else if z.HasExtensions() && z.EncExt(yy801) {
 					} else {
-						z.EncFallback(yy754)
+						z.EncFallback(yy801)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq746[2] {
+				if yyq793[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy756 := &x.ListMeta
-					yym757 := z.EncBinary()
-					_ = yym757
+					yy803 := &x.ListMeta
+					yym804 := z.EncBinary()
+					_ = yym804
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy756) {
+					} else if z.HasExtensions() && z.EncExt(yy803) {
 					} else {
-						z.EncFallback(yy756)
+						z.EncFallback(yy803)
 					}
 				}
 			}
-			if yyr746 || yy2arr746 {
+			if yyr793 || yy2arr793 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym759 := z.EncBinary()
-					_ = yym759
+					yym806 := z.EncBinary()
+					_ = yym806
 					if false {
 					} else {
 						h.encSliceJob(([]Job)(x.Items), e)
@@ -8960,15 +9546,15 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym760 := z.EncBinary()
-					_ = yym760
+					yym807 := z.EncBinary()
+					_ = yym807
 					if false {
 					} else {
 						h.encSliceJob(([]Job)(x.Items), e)
 					}
 				}
 			}
-			if yyr746 || yy2arr746 {
+			if yyr793 || yy2arr793 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -8981,25 +9567,25 @@ func (x *JobList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym761 := z.DecBinary()
-	_ = yym761
+	yym808 := z.DecBinary()
+	_ = yym808
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct762 := r.ContainerType()
-		if yyct762 == codecSelferValueTypeMap1234 {
-			yyl762 := r.ReadMapStart()
-			if yyl762 == 0 {
+		yyct809 := r.ContainerType()
+		if yyct809 == codecSelferValueTypeMap1234 {
+			yyl809 := r.ReadMapStart()
+			if yyl809 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl762, d)
+				x.codecDecodeSelfFromMap(yyl809, d)
 			}
-		} else if yyct762 == codecSelferValueTypeArray1234 {
-			yyl762 := r.ReadArrayStart()
-			if yyl762 == 0 {
+		} else if yyct809 == codecSelferValueTypeArray1234 {
+			yyl809 := r.ReadArrayStart()
+			if yyl809 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl762, d)
+				x.codecDecodeSelfFromArray(yyl809, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -9011,12 +9597,12 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys763Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys763Slc
-	var yyhl763 bool = l >= 0
-	for yyj763 := 0; ; yyj763++ {
-		if yyhl763 {
-			if yyj763 >= l {
+	var yys810Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys810Slc
+	var yyhl810 bool = l >= 0
+	for yyj810 := 0; ; yyj810++ {
+		if yyhl810 {
+			if yyj810 >= l {
 				break
 			}
 		} else {
@@ -9025,10 +9611,10 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys763Slc = r.DecodeBytes(yys763Slc, true, true)
-		yys763 := string(yys763Slc)
+		yys810Slc = r.DecodeBytes(yys810Slc, true, true)
+		yys810 := string(yys810Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys763 {
+		switch yys810 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -9045,31 +9631,31 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv766 := &x.ListMeta
-				yym767 := z.DecBinary()
-				_ = yym767
+				yyv813 := &x.ListMeta
+				yym814 := z.DecBinary()
+				_ = yym814
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv766) {
+				} else if z.HasExtensions() && z.DecExt(yyv813) {
 				} else {
-					z.DecFallback(yyv766, false)
+					z.DecFallback(yyv813, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv768 := &x.Items
-				yym769 := z.DecBinary()
-				_ = yym769
+				yyv815 := &x.Items
+				yym816 := z.DecBinary()
+				_ = yym816
 				if false {
 				} else {
-					h.decSliceJob((*[]Job)(yyv768), d)
+					h.decSliceJob((*[]Job)(yyv815), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys763)
-		} // end switch yys763
-	} // end for yyj763
+			z.DecStructFieldNotFound(-1, yys810)
+		} // end switch yys810
+	} // end for yyj810
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -9077,16 +9663,16 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj770 int
-	var yyb770 bool
-	var yyhl770 bool = l >= 0
-	yyj770++
-	if yyhl770 {
-		yyb770 = yyj770 > l
+	var yyj817 int
+	var yyb817 bool
+	var yyhl817 bool = l >= 0
+	yyj817++
+	if yyhl817 {
+		yyb817 = yyj817 > l
 	} else {
-		yyb770 = r.CheckBreak()
+		yyb817 = r.CheckBreak()
 	}
-	if yyb770 {
+	if yyb817 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9096,13 +9682,13 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj770++
-	if yyhl770 {
-		yyb770 = yyj770 > l
+	yyj817++
+	if yyhl817 {
+		yyb817 = yyj817 > l
 	} else {
-		yyb770 = r.CheckBreak()
+		yyb817 = r.CheckBreak()
 	}
-	if yyb770 {
+	if yyb817 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9112,13 +9698,13 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj770++
-	if yyhl770 {
-		yyb770 = yyj770 > l
+	yyj817++
+	if yyhl817 {
+		yyb817 = yyj817 > l
 	} else {
-		yyb770 = r.CheckBreak()
+		yyb817 = r.CheckBreak()
 	}
-	if yyb770 {
+	if yyb817 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9126,22 +9712,22 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv773 := &x.ListMeta
-		yym774 := z.DecBinary()
-		_ = yym774
+		yyv820 := &x.ListMeta
+		yym821 := z.DecBinary()
+		_ = yym821
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv773) {
+		} else if z.HasExtensions() && z.DecExt(yyv820) {
 		} else {
-			z.DecFallback(yyv773, false)
+			z.DecFallback(yyv820, false)
 		}
 	}
-	yyj770++
-	if yyhl770 {
-		yyb770 = yyj770 > l
+	yyj817++
+	if yyhl817 {
+		yyb817 = yyj817 > l
 	} else {
-		yyb770 = r.CheckBreak()
+		yyb817 = r.CheckBreak()
 	}
-	if yyb770 {
+	if yyb817 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9149,26 +9735,26 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv775 := &x.Items
-		yym776 := z.DecBinary()
-		_ = yym776
+		yyv822 := &x.Items
+		yym823 := z.DecBinary()
+		_ = yym823
 		if false {
 		} else {
-			h.decSliceJob((*[]Job)(yyv775), d)
+			h.decSliceJob((*[]Job)(yyv822), d)
 		}
 	}
 	for {
-		yyj770++
-		if yyhl770 {
-			yyb770 = yyj770 > l
+		yyj817++
+		if yyhl817 {
+			yyb817 = yyj817 > l
 		} else {
-			yyb770 = r.CheckBreak()
+			yyb817 = r.CheckBreak()
 		}
-		if yyb770 {
+		if yyb817 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj770-1, "")
+		z.DecStructFieldNotFound(yyj817-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -9180,141 +9766,141 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym777 := z.EncBinary()
-		_ = yym777
+		yym824 := z.EncBinary()
+		_ = yym824
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep778 := !z.EncBinary()
-			yy2arr778 := z.EncBasicHandle().StructToArray
-			var yyq778 [5]bool
-			_, _, _ = yysep778, yyq778, yy2arr778
-			const yyr778 bool = false
-			yyq778[0] = x.Parallelism != nil
-			yyq778[1] = x.Completions != nil
-			yyq778[2] = x.ActiveDeadlineSeconds != nil
-			yyq778[3] = x.Selector != nil
-			var yynn778 int
-			if yyr778 || yy2arr778 {
+			yysep825 := !z.EncBinary()
+			yy2arr825 := z.EncBasicHandle().StructToArray
+			var yyq825 [5]bool
+			_, _, _ = yysep825, yyq825, yy2arr825
+			const yyr825 bool = false
+			yyq825[0] = x.Parallelism != nil
+			yyq825[1] = x.Completions != nil
+			yyq825[2] = x.ActiveDeadlineSeconds != nil
+			yyq825[3] = x.Selector != nil
+			var yynn825 int
+			if yyr825 || yy2arr825 {
 				r.EncodeArrayStart(5)
 			} else {
-				yynn778 = 1
-				for _, b := range yyq778 {
+				yynn825 = 1
+				for _, b := range yyq825 {
 					if b {
-						yynn778++
+						yynn825++
 					}
 				}
-				r.EncodeMapStart(yynn778)
-				yynn778 = 0
+				r.EncodeMapStart(yynn825)
+				yynn825 = 0
 			}
-			if yyr778 || yy2arr778 {
+			if yyr825 || yy2arr825 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq778[0] {
+				if yyq825[0] {
 					if x.Parallelism == nil {
 						r.EncodeNil()
 					} else {
-						yy780 := *x.Parallelism
-						yym781 := z.EncBinary()
-						_ = yym781
+						yy827 := *x.Parallelism
+						yym828 := z.EncBinary()
+						_ = yym828
 						if false {
 						} else {
-							r.EncodeInt(int64(yy780))
+							r.EncodeInt(int64(yy827))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq778[0] {
+				if yyq825[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("parallelism"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Parallelism == nil {
 						r.EncodeNil()
 					} else {
-						yy782 := *x.Parallelism
-						yym783 := z.EncBinary()
-						_ = yym783
+						yy829 := *x.Parallelism
+						yym830 := z.EncBinary()
+						_ = yym830
 						if false {
 						} else {
-							r.EncodeInt(int64(yy782))
+							r.EncodeInt(int64(yy829))
 						}
 					}
 				}
 			}
-			if yyr778 || yy2arr778 {
+			if yyr825 || yy2arr825 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq778[1] {
+				if yyq825[1] {
 					if x.Completions == nil {
 						r.EncodeNil()
 					} else {
-						yy785 := *x.Completions
-						yym786 := z.EncBinary()
-						_ = yym786
+						yy832 := *x.Completions
+						yym833 := z.EncBinary()
+						_ = yym833
 						if false {
 						} else {
-							r.EncodeInt(int64(yy785))
+							r.EncodeInt(int64(yy832))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq778[1] {
+				if yyq825[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("completions"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Completions == nil {
 						r.EncodeNil()
 					} else {
-						yy787 := *x.Completions
-						yym788 := z.EncBinary()
-						_ = yym788
+						yy834 := *x.Completions
+						yym835 := z.EncBinary()
+						_ = yym835
 						if false {
 						} else {
-							r.EncodeInt(int64(yy787))
+							r.EncodeInt(int64(yy834))
 						}
 					}
 				}
 			}
-			if yyr778 || yy2arr778 {
+			if yyr825 || yy2arr825 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq778[2] {
+				if yyq825[2] {
 					if x.ActiveDeadlineSeconds == nil {
 						r.EncodeNil()
 					} else {
-						yy790 := *x.ActiveDeadlineSeconds
-						yym791 := z.EncBinary()
-						_ = yym791
+						yy837 := *x.ActiveDeadlineSeconds
+						yym838 := z.EncBinary()
+						_ = yym838
 						if false {
 						} else {
-							r.EncodeInt(int64(yy790))
+							r.EncodeInt(int64(yy837))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq778[2] {
+				if yyq825[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("activeDeadlineSeconds"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.ActiveDeadlineSeconds == nil {
 						r.EncodeNil()
 					} else {
-						yy792 := *x.ActiveDeadlineSeconds
-						yym793 := z.EncBinary()
-						_ = yym793
+						yy839 := *x.ActiveDeadlineSeconds
+						yym840 := z.EncBinary()
+						_ = yym840
 						if false {
 						} else {
-							r.EncodeInt(int64(yy792))
+							r.EncodeInt(int64(yy839))
 						}
 					}
 				}
 			}
-			if yyr778 || yy2arr778 {
+			if yyr825 || yy2arr825 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq778[3] {
+				if yyq825[3] {
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
@@ -9324,7 +9910,7 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq778[3] {
+				if yyq825[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
@@ -9335,18 +9921,18 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr778 || yy2arr778 {
+			if yyr825 || yy2arr825 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy796 := &x.Template
-				yy796.CodecEncodeSelf(e)
+				yy843 := &x.Template
+				yy843.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("template"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy797 := &x.Template
-				yy797.CodecEncodeSelf(e)
+				yy844 := &x.Template
+				yy844.CodecEncodeSelf(e)
 			}
-			if yyr778 || yy2arr778 {
+			if yyr825 || yy2arr825 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -9359,25 +9945,25 @@ func (x *JobSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym798 := z.DecBinary()
-	_ = yym798
+	yym845 := z.DecBinary()
+	_ = yym845
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct799 := r.ContainerType()
-		if yyct799 == codecSelferValueTypeMap1234 {
-			yyl799 := r.ReadMapStart()
-			if yyl799 == 0 {
+		yyct846 := r.ContainerType()
+		if yyct846 == codecSelferValueTypeMap1234 {
+			yyl846 := r.ReadMapStart()
+			if yyl846 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl799, d)
+				x.codecDecodeSelfFromMap(yyl846, d)
 			}
-		} else if yyct799 == codecSelferValueTypeArray1234 {
-			yyl799 := r.ReadArrayStart()
-			if yyl799 == 0 {
+		} else if yyct846 == codecSelferValueTypeArray1234 {
+			yyl846 := r.ReadArrayStart()
+			if yyl846 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl799, d)
+				x.codecDecodeSelfFromArray(yyl846, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -9389,12 +9975,12 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys800Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys800Slc
-	var yyhl800 bool = l >= 0
-	for yyj800 := 0; ; yyj800++ {
-		if yyhl800 {
-			if yyj800 >= l {
+	var yys847Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys847Slc
+	var yyhl847 bool = l >= 0
+	for yyj847 := 0; ; yyj847++ {
+		if yyhl847 {
+			if yyj847 >= l {
 				break
 			}
 		} else {
@@ -9403,10 +9989,10 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys800Slc = r.DecodeBytes(yys800Slc, true, true)
-		yys800 := string(yys800Slc)
+		yys847Slc = r.DecodeBytes(yys847Slc, true, true)
+		yys847 := string(yys847Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys800 {
+		switch yys847 {
 		case "parallelism":
 			if r.TryDecodeAsNil() {
 				if x.Parallelism != nil {
@@ -9416,8 +10002,8 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Parallelism == nil {
 					x.Parallelism = new(int32)
 				}
-				yym802 := z.DecBinary()
-				_ = yym802
+				yym849 := z.DecBinary()
+				_ = yym849
 				if false {
 				} else {
 					*((*int32)(x.Parallelism)) = int32(r.DecodeInt(32))
@@ -9432,8 +10018,8 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Completions == nil {
 					x.Completions = new(int32)
 				}
-				yym804 := z.DecBinary()
-				_ = yym804
+				yym851 := z.DecBinary()
+				_ = yym851
 				if false {
 				} else {
 					*((*int32)(x.Completions)) = int32(r.DecodeInt(32))
@@ -9448,8 +10034,8 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.ActiveDeadlineSeconds == nil {
 					x.ActiveDeadlineSeconds = new(int64)
 				}
-				yym806 := z.DecBinary()
-				_ = yym806
+				yym853 := z.DecBinary()
+				_ = yym853
 				if false {
 				} else {
 					*((*int64)(x.ActiveDeadlineSeconds)) = int64(r.DecodeInt(64))
@@ -9470,13 +10056,13 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Template = pkg2_v1.PodTemplateSpec{}
 			} else {
-				yyv808 := &x.Template
-				yyv808.CodecDecodeSelf(d)
+				yyv855 := &x.Template
+				yyv855.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys800)
-		} // end switch yys800
-	} // end for yyj800
+			z.DecStructFieldNotFound(-1, yys847)
+		} // end switch yys847
+	} // end for yyj847
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -9484,16 +10070,16 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj809 int
-	var yyb809 bool
-	var yyhl809 bool = l >= 0
-	yyj809++
-	if yyhl809 {
-		yyb809 = yyj809 > l
+	var yyj856 int
+	var yyb856 bool
+	var yyhl856 bool = l >= 0
+	yyj856++
+	if yyhl856 {
+		yyb856 = yyj856 > l
 	} else {
-		yyb809 = r.CheckBreak()
+		yyb856 = r.CheckBreak()
 	}
-	if yyb809 {
+	if yyb856 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9506,20 +10092,20 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.Parallelism == nil {
 			x.Parallelism = new(int32)
 		}
-		yym811 := z.DecBinary()
-		_ = yym811
+		yym858 := z.DecBinary()
+		_ = yym858
 		if false {
 		} else {
 			*((*int32)(x.Parallelism)) = int32(r.DecodeInt(32))
 		}
 	}
-	yyj809++
-	if yyhl809 {
-		yyb809 = yyj809 > l
+	yyj856++
+	if yyhl856 {
+		yyb856 = yyj856 > l
 	} else {
-		yyb809 = r.CheckBreak()
+		yyb856 = r.CheckBreak()
 	}
-	if yyb809 {
+	if yyb856 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9532,20 +10118,20 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.Completions == nil {
 			x.Completions = new(int32)
 		}
-		yym813 := z.DecBinary()
-		_ = yym813
+		yym860 := z.DecBinary()
+		_ = yym860
 		if false {
 		} else {
 			*((*int32)(x.Completions)) = int32(r.DecodeInt(32))
 		}
 	}
-	yyj809++
-	if yyhl809 {
-		yyb809 = yyj809 > l
+	yyj856++
+	if yyhl856 {
+		yyb856 = yyj856 > l
 	} else {
-		yyb809 = r.CheckBreak()
+		yyb856 = r.CheckBreak()
 	}
-	if yyb809 {
+	if yyb856 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9558,20 +10144,20 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.ActiveDeadlineSeconds == nil {
 			x.ActiveDeadlineSeconds = new(int64)
 		}
-		yym815 := z.DecBinary()
-		_ = yym815
+		yym862 := z.DecBinary()
+		_ = yym862
 		if false {
 		} else {
 			*((*int64)(x.ActiveDeadlineSeconds)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj809++
-	if yyhl809 {
-		yyb809 = yyj809 > l
+	yyj856++
+	if yyhl856 {
+		yyb856 = yyj856 > l
 	} else {
-		yyb809 = r.CheckBreak()
+		yyb856 = r.CheckBreak()
 	}
-	if yyb809 {
+	if yyb856 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9586,13 +10172,13 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Selector.CodecDecodeSelf(d)
 	}
-	yyj809++
-	if yyhl809 {
-		yyb809 = yyj809 > l
+	yyj856++
+	if yyhl856 {
+		yyb856 = yyj856 > l
 	} else {
-		yyb809 = r.CheckBreak()
+		yyb856 = r.CheckBreak()
 	}
-	if yyb809 {
+	if yyb856 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9600,21 +10186,21 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Template = pkg2_v1.PodTemplateSpec{}
 	} else {
-		yyv817 := &x.Template
-		yyv817.CodecDecodeSelf(d)
+		yyv864 := &x.Template
+		yyv864.CodecDecodeSelf(d)
 	}
 	for {
-		yyj809++
-		if yyhl809 {
-			yyb809 = yyj809 > l
+		yyj856++
+		if yyhl856 {
+			yyb856 = yyj856 > l
 		} else {
-			yyb809 = r.CheckBreak()
+			yyb856 = r.CheckBreak()
 		}
-		if yyb809 {
+		if yyb856 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj809-1, "")
+		z.DecStructFieldNotFound(yyj856-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -9626,43 +10212,43 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym818 := z.EncBinary()
-		_ = yym818
+		yym865 := z.EncBinary()
+		_ = yym865
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep819 := !z.EncBinary()
-			yy2arr819 := z.EncBasicHandle().StructToArray
-			var yyq819 [6]bool
-			_, _, _ = yysep819, yyq819, yy2arr819
-			const yyr819 bool = false
-			yyq819[0] = len(x.Conditions) != 0
-			yyq819[1] = x.StartTime != nil
-			yyq819[2] = x.CompletionTime != nil
-			yyq819[3] = x.Active != 0
-			yyq819[4] = x.Succeeded != 0
-			yyq819[5] = x.Failed != 0
-			var yynn819 int
-			if yyr819 || yy2arr819 {
+			yysep866 := !z.EncBinary()
+			yy2arr866 := z.EncBasicHandle().StructToArray
+			var yyq866 [6]bool
+			_, _, _ = yysep866, yyq866, yy2arr866
+			const yyr866 bool = false
+			yyq866[0] = len(x.Conditions) != 0
+			yyq866[1] = x.StartTime != nil
+			yyq866[2] = x.CompletionTime != nil
+			yyq866[3] = x.Active != 0
+			yyq866[4] = x.Succeeded != 0
+			yyq866[5] = x.Failed != 0
+			var yynn866 int
+			if yyr866 || yy2arr866 {
 				r.EncodeArrayStart(6)
 			} else {
-				yynn819 = 0
-				for _, b := range yyq819 {
+				yynn866 = 0
+				for _, b := range yyq866 {
 					if b {
-						yynn819++
+						yynn866++
 					}
 				}
-				r.EncodeMapStart(yynn819)
-				yynn819 = 0
+				r.EncodeMapStart(yynn866)
+				yynn866 = 0
 			}
-			if yyr819 || yy2arr819 {
+			if yyr866 || yy2arr866 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq819[0] {
+				if yyq866[0] {
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym821 := z.EncBinary()
-						_ = yym821
+						yym868 := z.EncBinary()
+						_ = yym868
 						if false {
 						} else {
 							h.encSliceJobCondition(([]JobCondition)(x.Conditions), e)
@@ -9672,15 +10258,15 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq819[0] {
+				if yyq866[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("conditions"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym822 := z.EncBinary()
-						_ = yym822
+						yym869 := z.EncBinary()
+						_ = yym869
 						if false {
 						} else {
 							h.encSliceJobCondition(([]JobCondition)(x.Conditions), e)
@@ -9688,19 +10274,19 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr819 || yy2arr819 {
+			if yyr866 || yy2arr866 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq819[1] {
+				if yyq866[1] {
 					if x.StartTime == nil {
 						r.EncodeNil()
 					} else {
-						yym824 := z.EncBinary()
-						_ = yym824
+						yym871 := z.EncBinary()
+						_ = yym871
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
-						} else if yym824 {
+						} else if yym871 {
 							z.EncBinaryMarshal(x.StartTime)
-						} else if !yym824 && z.IsJSONHandle() {
+						} else if !yym871 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.StartTime)
 						} else {
 							z.EncFallback(x.StartTime)
@@ -9710,20 +10296,20 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq819[1] {
+				if yyq866[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("startTime"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.StartTime == nil {
 						r.EncodeNil()
 					} else {
-						yym825 := z.EncBinary()
-						_ = yym825
+						yym872 := z.EncBinary()
+						_ = yym872
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
-						} else if yym825 {
+						} else if yym872 {
 							z.EncBinaryMarshal(x.StartTime)
-						} else if !yym825 && z.IsJSONHandle() {
+						} else if !yym872 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.StartTime)
 						} else {
 							z.EncFallback(x.StartTime)
@@ -9731,19 +10317,19 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr819 || yy2arr819 {
+			if yyr866 || yy2arr866 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq819[2] {
+				if yyq866[2] {
 					if x.CompletionTime == nil {
 						r.EncodeNil()
 					} else {
-						yym827 := z.EncBinary()
-						_ = yym827
+						yym874 := z.EncBinary()
+						_ = yym874
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.CompletionTime) {
-						} else if yym827 {
+						} else if yym874 {
 							z.EncBinaryMarshal(x.CompletionTime)
-						} else if !yym827 && z.IsJSONHandle() {
+						} else if !yym874 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.CompletionTime)
 						} else {
 							z.EncFallback(x.CompletionTime)
@@ -9753,20 +10339,20 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq819[2] {
+				if yyq866[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("completionTime"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.CompletionTime == nil {
 						r.EncodeNil()
 					} else {
-						yym828 := z.EncBinary()
-						_ = yym828
+						yym875 := z.EncBinary()
+						_ = yym875
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.CompletionTime) {
-						} else if yym828 {
+						} else if yym875 {
 							z.EncBinaryMarshal(x.CompletionTime)
-						} else if !yym828 && z.IsJSONHandle() {
+						} else if !yym875 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.CompletionTime)
 						} else {
 							z.EncFallback(x.CompletionTime)
@@ -9774,11 +10360,11 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr819 || yy2arr819 {
+			if yyr866 || yy2arr866 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq819[3] {
-					yym830 := z.EncBinary()
-					_ = yym830
+				if yyq866[3] {
+					yym877 := z.EncBinary()
+					_ = yym877
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Active))
@@ -9787,23 +10373,23 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq819[3] {
+				if yyq866[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("active"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym831 := z.EncBinary()
-					_ = yym831
+					yym878 := z.EncBinary()
+					_ = yym878
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Active))
 					}
 				}
 			}
-			if yyr819 || yy2arr819 {
+			if yyr866 || yy2arr866 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq819[4] {
-					yym833 := z.EncBinary()
-					_ = yym833
+				if yyq866[4] {
+					yym880 := z.EncBinary()
+					_ = yym880
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Succeeded))
@@ -9812,23 +10398,23 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq819[4] {
+				if yyq866[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("succeeded"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym834 := z.EncBinary()
-					_ = yym834
+					yym881 := z.EncBinary()
+					_ = yym881
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Succeeded))
 					}
 				}
 			}
-			if yyr819 || yy2arr819 {
+			if yyr866 || yy2arr866 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq819[5] {
-					yym836 := z.EncBinary()
-					_ = yym836
+				if yyq866[5] {
+					yym883 := z.EncBinary()
+					_ = yym883
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Failed))
@@ -9837,19 +10423,19 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq819[5] {
+				if yyq866[5] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("failed"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym837 := z.EncBinary()
-					_ = yym837
+					yym884 := z.EncBinary()
+					_ = yym884
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Failed))
 					}
 				}
 			}
-			if yyr819 || yy2arr819 {
+			if yyr866 || yy2arr866 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -9862,25 +10448,25 @@ func (x *JobStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym838 := z.DecBinary()
-	_ = yym838
+	yym885 := z.DecBinary()
+	_ = yym885
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct839 := r.ContainerType()
-		if yyct839 == codecSelferValueTypeMap1234 {
-			yyl839 := r.ReadMapStart()
-			if yyl839 == 0 {
+		yyct886 := r.ContainerType()
+		if yyct886 == codecSelferValueTypeMap1234 {
+			yyl886 := r.ReadMapStart()
+			if yyl886 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl839, d)
+				x.codecDecodeSelfFromMap(yyl886, d)
 			}
-		} else if yyct839 == codecSelferValueTypeArray1234 {
-			yyl839 := r.ReadArrayStart()
-			if yyl839 == 0 {
+		} else if yyct886 == codecSelferValueTypeArray1234 {
+			yyl886 := r.ReadArrayStart()
+			if yyl886 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl839, d)
+				x.codecDecodeSelfFromArray(yyl886, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -9892,12 +10478,12 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys840Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys840Slc
-	var yyhl840 bool = l >= 0
-	for yyj840 := 0; ; yyj840++ {
-		if yyhl840 {
-			if yyj840 >= l {
+	var yys887Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys887Slc
+	var yyhl887 bool = l >= 0
+	for yyj887 := 0; ; yyj887++ {
+		if yyhl887 {
+			if yyj887 >= l {
 				break
 			}
 		} else {
@@ -9906,20 +10492,20 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys840Slc = r.DecodeBytes(yys840Slc, true, true)
-		yys840 := string(yys840Slc)
+		yys887Slc = r.DecodeBytes(yys887Slc, true, true)
+		yys887 := string(yys887Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys840 {
+		switch yys887 {
 		case "conditions":
 			if r.TryDecodeAsNil() {
 				x.Conditions = nil
 			} else {
-				yyv841 := &x.Conditions
-				yym842 := z.DecBinary()
-				_ = yym842
+				yyv888 := &x.Conditions
+				yym889 := z.DecBinary()
+				_ = yym889
 				if false {
 				} else {
-					h.decSliceJobCondition((*[]JobCondition)(yyv841), d)
+					h.decSliceJobCondition((*[]JobCondition)(yyv888), d)
 				}
 			}
 		case "startTime":
@@ -9931,13 +10517,13 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.StartTime == nil {
 					x.StartTime = new(pkg1_unversioned.Time)
 				}
-				yym844 := z.DecBinary()
-				_ = yym844
+				yym891 := z.DecBinary()
+				_ = yym891
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.StartTime) {
-				} else if yym844 {
+				} else if yym891 {
 					z.DecBinaryUnmarshal(x.StartTime)
-				} else if !yym844 && z.IsJSONHandle() {
+				} else if !yym891 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.StartTime)
 				} else {
 					z.DecFallback(x.StartTime, false)
@@ -9952,13 +10538,13 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.CompletionTime == nil {
 					x.CompletionTime = new(pkg1_unversioned.Time)
 				}
-				yym846 := z.DecBinary()
-				_ = yym846
+				yym893 := z.DecBinary()
+				_ = yym893
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.CompletionTime) {
-				} else if yym846 {
+				} else if yym893 {
 					z.DecBinaryUnmarshal(x.CompletionTime)
-				} else if !yym846 && z.IsJSONHandle() {
+				} else if !yym893 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.CompletionTime)
 				} else {
 					z.DecFallback(x.CompletionTime, false)
@@ -9983,9 +10569,9 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Failed = int32(r.DecodeInt(32))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys840)
-		} // end switch yys840
-	} // end for yyj840
+			z.DecStructFieldNotFound(-1, yys887)
+		} // end switch yys887
+	} // end for yyj887
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -9993,16 +10579,16 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj850 int
-	var yyb850 bool
-	var yyhl850 bool = l >= 0
-	yyj850++
-	if yyhl850 {
-		yyb850 = yyj850 > l
+	var yyj897 int
+	var yyb897 bool
+	var yyhl897 bool = l >= 0
+	yyj897++
+	if yyhl897 {
+		yyb897 = yyj897 > l
 	} else {
-		yyb850 = r.CheckBreak()
+		yyb897 = r.CheckBreak()
 	}
-	if yyb850 {
+	if yyb897 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10010,21 +10596,21 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Conditions = nil
 	} else {
-		yyv851 := &x.Conditions
-		yym852 := z.DecBinary()
-		_ = yym852
+		yyv898 := &x.Conditions
+		yym899 := z.DecBinary()
+		_ = yym899
 		if false {
 		} else {
-			h.decSliceJobCondition((*[]JobCondition)(yyv851), d)
+			h.decSliceJobCondition((*[]JobCondition)(yyv898), d)
 		}
 	}
-	yyj850++
-	if yyhl850 {
-		yyb850 = yyj850 > l
+	yyj897++
+	if yyhl897 {
+		yyb897 = yyj897 > l
 	} else {
-		yyb850 = r.CheckBreak()
+		yyb897 = r.CheckBreak()
 	}
-	if yyb850 {
+	if yyb897 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10037,25 +10623,25 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.StartTime == nil {
 			x.StartTime = new(pkg1_unversioned.Time)
 		}
-		yym854 := z.DecBinary()
-		_ = yym854
+		yym901 := z.DecBinary()
+		_ = yym901
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.StartTime) {
-		} else if yym854 {
+		} else if yym901 {
 			z.DecBinaryUnmarshal(x.StartTime)
-		} else if !yym854 && z.IsJSONHandle() {
+		} else if !yym901 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.StartTime)
 		} else {
 			z.DecFallback(x.StartTime, false)
 		}
 	}
-	yyj850++
-	if yyhl850 {
-		yyb850 = yyj850 > l
+	yyj897++
+	if yyhl897 {
+		yyb897 = yyj897 > l
 	} else {
-		yyb850 = r.CheckBreak()
+		yyb897 = r.CheckBreak()
 	}
-	if yyb850 {
+	if yyb897 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10068,25 +10654,25 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.CompletionTime == nil {
 			x.CompletionTime = new(pkg1_unversioned.Time)
 		}
-		yym856 := z.DecBinary()
-		_ = yym856
+		yym903 := z.DecBinary()
+		_ = yym903
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.CompletionTime) {
-		} else if yym856 {
+		} else if yym903 {
 			z.DecBinaryUnmarshal(x.CompletionTime)
-		} else if !yym856 && z.IsJSONHandle() {
+		} else if !yym903 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.CompletionTime)
 		} else {
 			z.DecFallback(x.CompletionTime, false)
 		}
 	}
-	yyj850++
-	if yyhl850 {
-		yyb850 = yyj850 > l
+	yyj897++
+	if yyhl897 {
+		yyb897 = yyj897 > l
 	} else {
-		yyb850 = r.CheckBreak()
+		yyb897 = r.CheckBreak()
 	}
-	if yyb850 {
+	if yyb897 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10096,13 +10682,13 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Active = int32(r.DecodeInt(32))
 	}
-	yyj850++
-	if yyhl850 {
-		yyb850 = yyj850 > l
+	yyj897++
+	if yyhl897 {
+		yyb897 = yyj897 > l
 	} else {
-		yyb850 = r.CheckBreak()
+		yyb897 = r.CheckBreak()
 	}
-	if yyb850 {
+	if yyb897 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10112,13 +10698,13 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Succeeded = int32(r.DecodeInt(32))
 	}
-	yyj850++
-	if yyhl850 {
-		yyb850 = yyj850 > l
+	yyj897++
+	if yyhl897 {
+		yyb897 = yyj897 > l
 	} else {
-		yyb850 = r.CheckBreak()
+		yyb897 = r.CheckBreak()
 	}
-	if yyb850 {
+	if yyb897 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10129,17 +10715,17 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Failed = int32(r.DecodeInt(32))
 	}
 	for {
-		yyj850++
-		if yyhl850 {
-			yyb850 = yyj850 > l
+		yyj897++
+		if yyhl897 {
+			yyb897 = yyj897 > l
 		} else {
-			yyb850 = r.CheckBreak()
+			yyb897 = r.CheckBreak()
 		}
-		if yyb850 {
+		if yyb897 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj850-1, "")
+		z.DecStructFieldNotFound(yyj897-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -10148,8 +10734,8 @@ func (x JobConditionType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym860 := z.EncBinary()
-	_ = yym860
+	yym907 := z.EncBinary()
+	_ = yym907
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -10161,8 +10747,8 @@ func (x *JobConditionType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym861 := z.DecBinary()
-	_ = yym861
+	yym908 := z.DecBinary()
+	_ = yym908
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -10177,34 +10763,34 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym862 := z.EncBinary()
-		_ = yym862
+		yym909 := z.EncBinary()
+		_ = yym909
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep863 := !z.EncBinary()
-			yy2arr863 := z.EncBasicHandle().StructToArray
-			var yyq863 [6]bool
-			_, _, _ = yysep863, yyq863, yy2arr863
-			const yyr863 bool = false
-			yyq863[2] = true
-			yyq863[3] = true
-			yyq863[4] = x.Reason != ""
-			yyq863[5] = x.Message != ""
-			var yynn863 int
-			if yyr863 || yy2arr863 {
+			yysep910 := !z.EncBinary()
+			yy2arr910 := z.EncBasicHandle().StructToArray
+			var yyq910 [6]bool
+			_, _, _ = yysep910, yyq910, yy2arr910
+			const yyr910 bool = false
+			yyq910[2] = true
+			yyq910[3] = true
+			yyq910[4] = x.Reason != ""
+			yyq910[5] = x.Message != ""
+			var yynn910 int
+			if yyr910 || yy2arr910 {
 				r.EncodeArrayStart(6)
 			} else {
-				yynn863 = 2
-				for _, b := range yyq863 {
+				yynn910 = 2
+				for _, b := range yyq910 {
 					if b {
-						yynn863++
+						yynn910++
 					}
 				}
-				r.EncodeMapStart(yynn863)
-				yynn863 = 0
+				r.EncodeMapStart(yynn910)
+				yynn910 = 0
 			}
-			if yyr863 || yy2arr863 {
+			if yyr910 || yy2arr910 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Type.CodecEncodeSelf(e)
 			} else {
@@ -10213,10 +10799,10 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Type.CodecEncodeSelf(e)
 			}
-			if yyr863 || yy2arr863 {
+			if yyr910 || yy2arr910 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym866 := z.EncBinary()
-				_ = yym866
+				yym913 := z.EncBinary()
+				_ = yym913
 				if false {
 				} else if z.HasExtensions() && z.EncExt(x.Status) {
 				} else {
@@ -10226,93 +10812,93 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("status"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym867 := z.EncBinary()
-				_ = yym867
+				yym914 := z.EncBinary()
+				_ = yym914
 				if false {
 				} else if z.HasExtensions() && z.EncExt(x.Status) {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Status))
 				}
 			}
-			if yyr863 || yy2arr863 {
+			if yyr910 || yy2arr910 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq863[2] {
-					yy869 := &x.LastProbeTime
-					yym870 := z.EncBinary()
-					_ = yym870
+				if yyq910[2] {
+					yy916 := &x.LastProbeTime
+					yym917 := z.EncBinary()
+					_ = yym917
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy869) {
-					} else if yym870 {
-						z.EncBinaryMarshal(yy869)
-					} else if !yym870 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy869)
+					} else if z.HasExtensions() && z.EncExt(yy916) {
+					} else if yym917 {
+						z.EncBinaryMarshal(yy916)
+					} else if !yym917 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy916)
 					} else {
-						z.EncFallback(yy869)
+						z.EncFallback(yy916)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq863[2] {
+				if yyq910[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("lastProbeTime"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy871 := &x.LastProbeTime
-					yym872 := z.EncBinary()
-					_ = yym872
+					yy918 := &x.LastProbeTime
+					yym919 := z.EncBinary()
+					_ = yym919
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy871) {
-					} else if yym872 {
-						z.EncBinaryMarshal(yy871)
-					} else if !yym872 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy871)
+					} else if z.HasExtensions() && z.EncExt(yy918) {
+					} else if yym919 {
+						z.EncBinaryMarshal(yy918)
+					} else if !yym919 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy918)
 					} else {
-						z.EncFallback(yy871)
+						z.EncFallback(yy918)
 					}
 				}
 			}
-			if yyr863 || yy2arr863 {
+			if yyr910 || yy2arr910 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq863[3] {
-					yy874 := &x.LastTransitionTime
-					yym875 := z.EncBinary()
-					_ = yym875
+				if yyq910[3] {
+					yy921 := &x.LastTransitionTime
+					yym922 := z.EncBinary()
+					_ = yym922
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy874) {
-					} else if yym875 {
-						z.EncBinaryMarshal(yy874)
-					} else if !yym875 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy874)
+					} else if z.HasExtensions() && z.EncExt(yy921) {
+					} else if yym922 {
+						z.EncBinaryMarshal(yy921)
+					} else if !yym922 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy921)
 					} else {
-						z.EncFallback(yy874)
+						z.EncFallback(yy921)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq863[3] {
+				if yyq910[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("lastTransitionTime"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy876 := &x.LastTransitionTime
-					yym877 := z.EncBinary()
-					_ = yym877
+					yy923 := &x.LastTransitionTime
+					yym924 := z.EncBinary()
+					_ = yym924
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy876) {
-					} else if yym877 {
-						z.EncBinaryMarshal(yy876)
-					} else if !yym877 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy876)
+					} else if z.HasExtensions() && z.EncExt(yy923) {
+					} else if yym924 {
+						z.EncBinaryMarshal(yy923)
+					} else if !yym924 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy923)
 					} else {
-						z.EncFallback(yy876)
+						z.EncFallback(yy923)
 					}
 				}
 			}
-			if yyr863 || yy2arr863 {
+			if yyr910 || yy2arr910 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq863[4] {
-					yym879 := z.EncBinary()
-					_ = yym879
+				if yyq910[4] {
+					yym926 := z.EncBinary()
+					_ = yym926
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
@@ -10321,23 +10907,23 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq863[4] {
+				if yyq910[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("reason"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym880 := z.EncBinary()
-					_ = yym880
+					yym927 := z.EncBinary()
+					_ = yym927
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
 					}
 				}
 			}
-			if yyr863 || yy2arr863 {
+			if yyr910 || yy2arr910 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq863[5] {
-					yym882 := z.EncBinary()
-					_ = yym882
+				if yyq910[5] {
+					yym929 := z.EncBinary()
+					_ = yym929
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
@@ -10346,19 +10932,19 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq863[5] {
+				if yyq910[5] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym883 := z.EncBinary()
-					_ = yym883
+					yym930 := z.EncBinary()
+					_ = yym930
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
 					}
 				}
 			}
-			if yyr863 || yy2arr863 {
+			if yyr910 || yy2arr910 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -10371,25 +10957,25 @@ func (x *JobCondition) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym884 := z.DecBinary()
-	_ = yym884
+	yym931 := z.DecBinary()
+	_ = yym931
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct885 := r.ContainerType()
-		if yyct885 == codecSelferValueTypeMap1234 {
-			yyl885 := r.ReadMapStart()
-			if yyl885 == 0 {
+		yyct932 := r.ContainerType()
+		if yyct932 == codecSelferValueTypeMap1234 {
+			yyl932 := r.ReadMapStart()
+			if yyl932 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl885, d)
+				x.codecDecodeSelfFromMap(yyl932, d)
 			}
-		} else if yyct885 == codecSelferValueTypeArray1234 {
-			yyl885 := r.ReadArrayStart()
-			if yyl885 == 0 {
+		} else if yyct932 == codecSelferValueTypeArray1234 {
+			yyl932 := r.ReadArrayStart()
+			if yyl932 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl885, d)
+				x.codecDecodeSelfFromArray(yyl932, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10401,12 +10987,12 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys886Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys886Slc
-	var yyhl886 bool = l >= 0
-	for yyj886 := 0; ; yyj886++ {
-		if yyhl886 {
-			if yyj886 >= l {
+	var yys933Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys933Slc
+	var yyhl933 bool = l >= 0
+	for yyj933 := 0; ; yyj933++ {
+		if yyhl933 {
+			if yyj933 >= l {
 				break
 			}
 		} else {
@@ -10415,10 +11001,10 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys886Slc = r.DecodeBytes(yys886Slc, true, true)
-		yys886 := string(yys886Slc)
+		yys933Slc = r.DecodeBytes(yys933Slc, true, true)
+		yys933 := string(yys933Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys886 {
+		switch yys933 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -10435,34 +11021,34 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.LastProbeTime = pkg1_unversioned.Time{}
 			} else {
-				yyv889 := &x.LastProbeTime
-				yym890 := z.DecBinary()
-				_ = yym890
+				yyv936 := &x.LastProbeTime
+				yym937 := z.DecBinary()
+				_ = yym937
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv889) {
-				} else if yym890 {
-					z.DecBinaryUnmarshal(yyv889)
-				} else if !yym890 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv889)
+				} else if z.HasExtensions() && z.DecExt(yyv936) {
+				} else if yym937 {
+					z.DecBinaryUnmarshal(yyv936)
+				} else if !yym937 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv936)
 				} else {
-					z.DecFallback(yyv889, false)
+					z.DecFallback(yyv936, false)
 				}
 			}
 		case "lastTransitionTime":
 			if r.TryDecodeAsNil() {
 				x.LastTransitionTime = pkg1_unversioned.Time{}
 			} else {
-				yyv891 := &x.LastTransitionTime
-				yym892 := z.DecBinary()
-				_ = yym892
+				yyv938 := &x.LastTransitionTime
+				yym939 := z.DecBinary()
+				_ = yym939
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv891) {
-				} else if yym892 {
-					z.DecBinaryUnmarshal(yyv891)
-				} else if !yym892 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv891)
+				} else if z.HasExtensions() && z.DecExt(yyv938) {
+				} else if yym939 {
+					z.DecBinaryUnmarshal(yyv938)
+				} else if !yym939 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv938)
 				} else {
-					z.DecFallback(yyv891, false)
+					z.DecFallback(yyv938, false)
 				}
 			}
 		case "reason":
@@ -10478,9 +11064,9 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Message = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys886)
-		} // end switch yys886
-	} // end for yyj886
+			z.DecStructFieldNotFound(-1, yys933)
+		} // end switch yys933
+	} // end for yyj933
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -10488,16 +11074,16 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj895 int
-	var yyb895 bool
-	var yyhl895 bool = l >= 0
-	yyj895++
-	if yyhl895 {
-		yyb895 = yyj895 > l
+	var yyj942 int
+	var yyb942 bool
+	var yyhl942 bool = l >= 0
+	yyj942++
+	if yyhl942 {
+		yyb942 = yyj942 > l
 	} else {
-		yyb895 = r.CheckBreak()
+		yyb942 = r.CheckBreak()
 	}
-	if yyb895 {
+	if yyb942 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10507,13 +11093,13 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Type = JobConditionType(r.DecodeString())
 	}
-	yyj895++
-	if yyhl895 {
-		yyb895 = yyj895 > l
+	yyj942++
+	if yyhl942 {
+		yyb942 = yyj942 > l
 	} else {
-		yyb895 = r.CheckBreak()
+		yyb942 = r.CheckBreak()
 	}
-	if yyb895 {
+	if yyb942 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10523,13 +11109,13 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Status = pkg2_v1.ConditionStatus(r.DecodeString())
 	}
-	yyj895++
-	if yyhl895 {
-		yyb895 = yyj895 > l
+	yyj942++
+	if yyhl942 {
+		yyb942 = yyj942 > l
 	} else {
-		yyb895 = r.CheckBreak()
+		yyb942 = r.CheckBreak()
 	}
-	if yyb895 {
+	if yyb942 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10537,26 +11123,26 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.LastProbeTime = pkg1_unversioned.Time{}
 	} else {
-		yyv898 := &x.LastProbeTime
-		yym899 := z.DecBinary()
-		_ = yym899
+		yyv945 := &x.LastProbeTime
+		yym946 := z.DecBinary()
+		_ = yym946
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv898) {
-		} else if yym899 {
-			z.DecBinaryUnmarshal(yyv898)
-		} else if !yym899 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv898)
+		} else if z.HasExtensions() && z.DecExt(yyv945) {
+		} else if yym946 {
+			z.DecBinaryUnmarshal(yyv945)
+		} else if !yym946 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv945)
 		} else {
-			z.DecFallback(yyv898, false)
+			z.DecFallback(yyv945, false)
 		}
 	}
-	yyj895++
-	if yyhl895 {
-		yyb895 = yyj895 > l
+	yyj942++
+	if yyhl942 {
+		yyb942 = yyj942 > l
 	} else {
-		yyb895 = r.CheckBreak()
+		yyb942 = r.CheckBreak()
 	}
-	if yyb895 {
+	if yyb942 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10564,26 +11150,26 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.LastTransitionTime = pkg1_unversioned.Time{}
 	} else {
-		yyv900 := &x.LastTransitionTime
-		yym901 := z.DecBinary()
-		_ = yym901
+		yyv947 := &x.LastTransitionTime
+		yym948 := z.DecBinary()
+		_ = yym948
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv900) {
-		} else if yym901 {
-			z.DecBinaryUnmarshal(yyv900)
-		} else if !yym901 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv900)
+		} else if z.HasExtensions() && z.DecExt(yyv947) {
+		} else if yym948 {
+			z.DecBinaryUnmarshal(yyv947)
+		} else if !yym948 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv947)
 		} else {
-			z.DecFallback(yyv900, false)
+			z.DecFallback(yyv947, false)
 		}
 	}
-	yyj895++
-	if yyhl895 {
-		yyb895 = yyj895 > l
+	yyj942++
+	if yyhl942 {
+		yyb942 = yyj942 > l
 	} else {
-		yyb895 = r.CheckBreak()
+		yyb942 = r.CheckBreak()
 	}
-	if yyb895 {
+	if yyb942 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10593,13 +11179,13 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Reason = string(r.DecodeString())
 	}
-	yyj895++
-	if yyhl895 {
-		yyb895 = yyj895 > l
+	yyj942++
+	if yyhl942 {
+		yyb942 = yyj942 > l
 	} else {
-		yyb895 = r.CheckBreak()
+		yyb942 = r.CheckBreak()
 	}
-	if yyb895 {
+	if yyb942 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10610,17 +11196,17 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Message = string(r.DecodeString())
 	}
 	for {
-		yyj895++
-		if yyhl895 {
-			yyb895 = yyj895 > l
+		yyj942++
+		if yyhl942 {
+			yyb942 = yyj942 > l
 		} else {
-			yyb895 = r.CheckBreak()
+			yyb942 = r.CheckBreak()
 		}
-		if yyb895 {
+		if yyb942 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj895-1, "")
+		z.DecStructFieldNotFound(yyj942-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -10632,39 +11218,39 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym904 := z.EncBinary()
-		_ = yym904
+		yym951 := z.EncBinary()
+		_ = yym951
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep905 := !z.EncBinary()
-			yy2arr905 := z.EncBasicHandle().StructToArray
-			var yyq905 [5]bool
-			_, _, _ = yysep905, yyq905, yy2arr905
-			const yyr905 bool = false
-			yyq905[0] = x.Kind != ""
-			yyq905[1] = x.APIVersion != ""
-			yyq905[2] = true
-			yyq905[3] = true
-			yyq905[4] = true
-			var yynn905 int
-			if yyr905 || yy2arr905 {
+			yysep952 := !z.EncBinary()
+			yy2arr952 := z.EncBasicHandle().StructToArray
+			var yyq952 [5]bool
+			_, _, _ = yysep952, yyq952, yy2arr952
+			const yyr952 bool = false
+			yyq952[0] = x.Kind != ""
+			yyq952[1] = x.APIVersion != ""
+			yyq952[2] = true
+			yyq952[3] = true
+			yyq952[4] = true
+			var yynn952 int
+			if yyr952 || yy2arr952 {
 				r.EncodeArrayStart(5)
 			} else {
-				yynn905 = 0
-				for _, b := range yyq905 {
+				yynn952 = 0
+				for _, b := range yyq952 {
 					if b {
-						yynn905++
+						yynn952++
 					}
 				}
-				r.EncodeMapStart(yynn905)
-				yynn905 = 0
+				r.EncodeMapStart(yynn952)
+				yynn952 = 0
 			}
-			if yyr905 || yy2arr905 {
+			if yyr952 || yy2arr952 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq905[0] {
-					yym907 := z.EncBinary()
-					_ = yym907
+				if yyq952[0] {
+					yym954 := z.EncBinary()
+					_ = yym954
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -10673,23 +11259,23 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq905[0] {
+				if yyq952[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym908 := z.EncBinary()
-					_ = yym908
+					yym955 := z.EncBinary()
+					_ = yym955
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr905 || yy2arr905 {
+			if yyr952 || yy2arr952 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq905[1] {
-					yym910 := z.EncBinary()
-					_ = yym910
+				if yyq952[1] {
+					yym957 := z.EncBinary()
+					_ = yym957
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -10698,70 +11284,70 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq905[1] {
+				if yyq952[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym911 := z.EncBinary()
-					_ = yym911
+					yym958 := z.EncBinary()
+					_ = yym958
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr905 || yy2arr905 {
+			if yyr952 || yy2arr952 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq905[2] {
-					yy913 := &x.ObjectMeta
-					yy913.CodecEncodeSelf(e)
+				if yyq952[2] {
+					yy960 := &x.ObjectMeta
+					yy960.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq905[2] {
+				if yyq952[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy914 := &x.ObjectMeta
-					yy914.CodecEncodeSelf(e)
+					yy961 := &x.ObjectMeta
+					yy961.CodecEncodeSelf(e)
 				}
 			}
-			if yyr905 || yy2arr905 {
+			if yyr952 || yy2arr952 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq905[3] {
-					yy916 := &x.Spec
-					yy916.CodecEncodeSelf(e)
+				if yyq952[3] {
+					yy963 := &x.Spec
+					yy963.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq905[3] {
+				if yyq952[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy917 := &x.Spec
-					yy917.CodecEncodeSelf(e)
+					yy964 := &x.Spec
+					yy964.CodecEncodeSelf(e)
 				}
 			}
-			if yyr905 || yy2arr905 {
+			if yyr952 || yy2arr952 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq905[4] {
-					yy919 := &x.Status
-					yy919.CodecEncodeSelf(e)
+				if yyq952[4] {
+					yy966 := &x.Status
+					yy966.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq905[4] {
+				if yyq952[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy920 := &x.Status
-					yy920.CodecEncodeSelf(e)
+					yy967 := &x.Status
+					yy967.CodecEncodeSelf(e)
 				}
 			}
-			if yyr905 || yy2arr905 {
+			if yyr952 || yy2arr952 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -10774,25 +11360,25 @@ func (x *Ingress) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym921 := z.DecBinary()
-	_ = yym921
+	yym968 := z.DecBinary()
+	_ = yym968
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct922 := r.ContainerType()
-		if yyct922 == codecSelferValueTypeMap1234 {
-			yyl922 := r.ReadMapStart()
-			if yyl922 == 0 {
+		yyct969 := r.ContainerType()
+		if yyct969 == codecSelferValueTypeMap1234 {
+			yyl969 := r.ReadMapStart()
+			if yyl969 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl922, d)
+				x.codecDecodeSelfFromMap(yyl969, d)
 			}
-		} else if yyct922 == codecSelferValueTypeArray1234 {
-			yyl922 := r.ReadArrayStart()
-			if yyl922 == 0 {
+		} else if yyct969 == codecSelferValueTypeArray1234 {
+			yyl969 := r.ReadArrayStart()
+			if yyl969 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl922, d)
+				x.codecDecodeSelfFromArray(yyl969, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10804,12 +11390,12 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys923Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys923Slc
-	var yyhl923 bool = l >= 0
-	for yyj923 := 0; ; yyj923++ {
-		if yyhl923 {
-			if yyj923 >= l {
+	var yys970Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys970Slc
+	var yyhl970 bool = l >= 0
+	for yyj970 := 0; ; yyj970++ {
+		if yyhl970 {
+			if yyj970 >= l {
 				break
 			}
 		} else {
@@ -10818,10 +11404,10 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys923Slc = r.DecodeBytes(yys923Slc, true, true)
-		yys923 := string(yys923Slc)
+		yys970Slc = r.DecodeBytes(yys970Slc, true, true)
+		yys970 := string(yys970Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys923 {
+		switch yys970 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -10838,27 +11424,27 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_v1.ObjectMeta{}
 			} else {
-				yyv926 := &x.ObjectMeta
-				yyv926.CodecDecodeSelf(d)
+				yyv973 := &x.ObjectMeta
+				yyv973.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = IngressSpec{}
 			} else {
-				yyv927 := &x.Spec
-				yyv927.CodecDecodeSelf(d)
+				yyv974 := &x.Spec
+				yyv974.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = IngressStatus{}
 			} else {
-				yyv928 := &x.Status
-				yyv928.CodecDecodeSelf(d)
+				yyv975 := &x.Status
+				yyv975.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys923)
-		} // end switch yys923
-	} // end for yyj923
+			z.DecStructFieldNotFound(-1, yys970)
+		} // end switch yys970
+	} // end for yyj970
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -10866,16 +11452,16 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj929 int
-	var yyb929 bool
-	var yyhl929 bool = l >= 0
-	yyj929++
-	if yyhl929 {
-		yyb929 = yyj929 > l
+	var yyj976 int
+	var yyb976 bool
+	var yyhl976 bool = l >= 0
+	yyj976++
+	if yyhl976 {
+		yyb976 = yyj976 > l
 	} else {
-		yyb929 = r.CheckBreak()
+		yyb976 = r.CheckBreak()
 	}
-	if yyb929 {
+	if yyb976 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10885,13 +11471,13 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj929++
-	if yyhl929 {
-		yyb929 = yyj929 > l
+	yyj976++
+	if yyhl976 {
+		yyb976 = yyj976 > l
 	} else {
-		yyb929 = r.CheckBreak()
+		yyb976 = r.CheckBreak()
 	}
-	if yyb929 {
+	if yyb976 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10901,13 +11487,13 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj929++
-	if yyhl929 {
-		yyb929 = yyj929 > l
+	yyj976++
+	if yyhl976 {
+		yyb976 = yyj976 > l
 	} else {
-		yyb929 = r.CheckBreak()
+		yyb976 = r.CheckBreak()
 	}
-	if yyb929 {
+	if yyb976 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10915,16 +11501,16 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_v1.ObjectMeta{}
 	} else {
-		yyv932 := &x.ObjectMeta
-		yyv932.CodecDecodeSelf(d)
+		yyv979 := &x.ObjectMeta
+		yyv979.CodecDecodeSelf(d)
 	}
-	yyj929++
-	if yyhl929 {
-		yyb929 = yyj929 > l
+	yyj976++
+	if yyhl976 {
+		yyb976 = yyj976 > l
 	} else {
-		yyb929 = r.CheckBreak()
+		yyb976 = r.CheckBreak()
 	}
-	if yyb929 {
+	if yyb976 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10932,16 +11518,16 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Spec = IngressSpec{}
 	} else {
-		yyv933 := &x.Spec
-		yyv933.CodecDecodeSelf(d)
+		yyv980 := &x.Spec
+		yyv980.CodecDecodeSelf(d)
 	}
-	yyj929++
-	if yyhl929 {
-		yyb929 = yyj929 > l
+	yyj976++
+	if yyhl976 {
+		yyb976 = yyj976 > l
 	} else {
-		yyb929 = r.CheckBreak()
+		yyb976 = r.CheckBreak()
 	}
-	if yyb929 {
+	if yyb976 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10949,21 +11535,21 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Status = IngressStatus{}
 	} else {
-		yyv934 := &x.Status
-		yyv934.CodecDecodeSelf(d)
+		yyv981 := &x.Status
+		yyv981.CodecDecodeSelf(d)
 	}
 	for {
-		yyj929++
-		if yyhl929 {
-			yyb929 = yyj929 > l
+		yyj976++
+		if yyhl976 {
+			yyb976 = yyj976 > l
 		} else {
-			yyb929 = r.CheckBreak()
+			yyb976 = r.CheckBreak()
 		}
-		if yyb929 {
+		if yyb976 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj929-1, "")
+		z.DecStructFieldNotFound(yyj976-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -10975,37 +11561,37 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym935 := z.EncBinary()
-		_ = yym935
+		yym982 := z.EncBinary()
+		_ = yym982
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep936 := !z.EncBinary()
-			yy2arr936 := z.EncBasicHandle().StructToArray
-			var yyq936 [4]bool
-			_, _, _ = yysep936, yyq936, yy2arr936
-			const yyr936 bool = false
-			yyq936[0] = x.Kind != ""
-			yyq936[1] = x.APIVersion != ""
-			yyq936[2] = true
-			var yynn936 int
-			if yyr936 || yy2arr936 {
+			yysep983 := !z.EncBinary()
+			yy2arr983 := z.EncBasicHandle().StructToArray
+			var yyq983 [4]bool
+			_, _, _ = yysep983, yyq983, yy2arr983
+			const yyr983 bool = false
+			yyq983[0] = x.Kind != ""
+			yyq983[1] = x.APIVersion != ""
+			yyq983[2] = true
+			var yynn983 int
+			if yyr983 || yy2arr983 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn936 = 1
-				for _, b := range yyq936 {
+				yynn983 = 1
+				for _, b := range yyq983 {
 					if b {
-						yynn936++
+						yynn983++
 					}
 				}
-				r.EncodeMapStart(yynn936)
-				yynn936 = 0
+				r.EncodeMapStart(yynn983)
+				yynn983 = 0
 			}
-			if yyr936 || yy2arr936 {
+			if yyr983 || yy2arr983 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq936[0] {
-					yym938 := z.EncBinary()
-					_ = yym938
+				if yyq983[0] {
+					yym985 := z.EncBinary()
+					_ = yym985
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -11014,23 +11600,23 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq936[0] {
+				if yyq983[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym939 := z.EncBinary()
-					_ = yym939
+					yym986 := z.EncBinary()
+					_ = yym986
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr936 || yy2arr936 {
+			if yyr983 || yy2arr983 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq936[1] {
-					yym941 := z.EncBinary()
-					_ = yym941
+				if yyq983[1] {
+					yym988 := z.EncBinary()
+					_ = yym988
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -11039,54 +11625,54 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq936[1] {
+				if yyq983[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym942 := z.EncBinary()
-					_ = yym942
+					yym989 := z.EncBinary()
+					_ = yym989
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr936 || yy2arr936 {
+			if yyr983 || yy2arr983 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq936[2] {
-					yy944 := &x.ListMeta
-					yym945 := z.EncBinary()
-					_ = yym945
+				if yyq983[2] {
+					yy991 := &x.ListMeta
+					yym992 := z.EncBinary()
+					_ = yym992
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy944) {
+					} else if z.HasExtensions() && z.EncExt(yy991) {
 					} else {
-						z.EncFallback(yy944)
+						z.EncFallback(yy991)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq936[2] {
+				if yyq983[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy946 := &x.ListMeta
-					yym947 := z.EncBinary()
-					_ = yym947
+					yy993 := &x.ListMeta
+					yym994 := z.EncBinary()
+					_ = yym994
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy946) {
+					} else if z.HasExtensions() && z.EncExt(yy993) {
 					} else {
-						z.EncFallback(yy946)
+						z.EncFallback(yy993)
 					}
 				}
 			}
-			if yyr936 || yy2arr936 {
+			if yyr983 || yy2arr983 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym949 := z.EncBinary()
-					_ = yym949
+					yym996 := z.EncBinary()
+					_ = yym996
 					if false {
 					} else {
 						h.encSliceIngress(([]Ingress)(x.Items), e)
@@ -11099,15 +11685,15 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym950 := z.EncBinary()
-					_ = yym950
+					yym997 := z.EncBinary()
+					_ = yym997
 					if false {
 					} else {
 						h.encSliceIngress(([]Ingress)(x.Items), e)
 					}
 				}
 			}
-			if yyr936 || yy2arr936 {
+			if yyr983 || yy2arr983 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -11120,25 +11706,25 @@ func (x *IngressList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym951 := z.DecBinary()
-	_ = yym951
+	yym998 := z.DecBinary()
+	_ = yym998
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct952 := r.ContainerType()
-		if yyct952 == codecSelferValueTypeMap1234 {
-			yyl952 := r.ReadMapStart()
-			if yyl952 == 0 {
+		yyct999 := r.ContainerType()
+		if yyct999 == codecSelferValueTypeMap1234 {
+			yyl999 := r.ReadMapStart()
+			if yyl999 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl952, d)
+				x.codecDecodeSelfFromMap(yyl999, d)
 			}
-		} else if yyct952 == codecSelferValueTypeArray1234 {
-			yyl952 := r.ReadArrayStart()
-			if yyl952 == 0 {
+		} else if yyct999 == codecSelferValueTypeArray1234 {
+			yyl999 := r.ReadArrayStart()
+			if yyl999 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl952, d)
+				x.codecDecodeSelfFromArray(yyl999, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -11150,12 +11736,12 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys953Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys953Slc
-	var yyhl953 bool = l >= 0
-	for yyj953 := 0; ; yyj953++ {
-		if yyhl953 {
-			if yyj953 >= l {
+	var yys1000Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1000Slc
+	var yyhl1000 bool = l >= 0
+	for yyj1000 := 0; ; yyj1000++ {
+		if yyhl1000 {
+			if yyj1000 >= l {
 				break
 			}
 		} else {
@@ -11164,10 +11750,10 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys953Slc = r.DecodeBytes(yys953Slc, true, true)
-		yys953 := string(yys953Slc)
+		yys1000Slc = r.DecodeBytes(yys1000Slc, true, true)
+		yys1000 := string(yys1000Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys953 {
+		switch yys1000 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -11184,31 +11770,31 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv956 := &x.ListMeta
-				yym957 := z.DecBinary()
-				_ = yym957
+				yyv1003 := &x.ListMeta
+				yym1004 := z.DecBinary()
+				_ = yym1004
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv956) {
+				} else if z.HasExtensions() && z.DecExt(yyv1003) {
 				} else {
-					z.DecFallback(yyv956, false)
+					z.DecFallback(yyv1003, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv958 := &x.Items
-				yym959 := z.DecBinary()
-				_ = yym959
+				yyv1005 := &x.Items
+				yym1006 := z.DecBinary()
+				_ = yym1006
 				if false {
 				} else {
-					h.decSliceIngress((*[]Ingress)(yyv958), d)
+					h.decSliceIngress((*[]Ingress)(yyv1005), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys953)
-		} // end switch yys953
-	} // end for yyj953
+			z.DecStructFieldNotFound(-1, yys1000)
+		} // end switch yys1000
+	} // end for yyj1000
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -11216,16 +11802,16 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj960 int
-	var yyb960 bool
-	var yyhl960 bool = l >= 0
-	yyj960++
-	if yyhl960 {
-		yyb960 = yyj960 > l
+	var yyj1007 int
+	var yyb1007 bool
+	var yyhl1007 bool = l >= 0
+	yyj1007++
+	if yyhl1007 {
+		yyb1007 = yyj1007 > l
 	} else {
-		yyb960 = r.CheckBreak()
+		yyb1007 = r.CheckBreak()
 	}
-	if yyb960 {
+	if yyb1007 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11235,13 +11821,13 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj960++
-	if yyhl960 {
-		yyb960 = yyj960 > l
+	yyj1007++
+	if yyhl1007 {
+		yyb1007 = yyj1007 > l
 	} else {
-		yyb960 = r.CheckBreak()
+		yyb1007 = r.CheckBreak()
 	}
-	if yyb960 {
+	if yyb1007 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11251,13 +11837,13 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj960++
-	if yyhl960 {
-		yyb960 = yyj960 > l
+	yyj1007++
+	if yyhl1007 {
+		yyb1007 = yyj1007 > l
 	} else {
-		yyb960 = r.CheckBreak()
+		yyb1007 = r.CheckBreak()
 	}
-	if yyb960 {
+	if yyb1007 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11265,22 +11851,22 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv963 := &x.ListMeta
-		yym964 := z.DecBinary()
-		_ = yym964
+		yyv1010 := &x.ListMeta
+		yym1011 := z.DecBinary()
+		_ = yym1011
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv963) {
+		} else if z.HasExtensions() && z.DecExt(yyv1010) {
 		} else {
-			z.DecFallback(yyv963, false)
+			z.DecFallback(yyv1010, false)
 		}
 	}
-	yyj960++
-	if yyhl960 {
-		yyb960 = yyj960 > l
+	yyj1007++
+	if yyhl1007 {
+		yyb1007 = yyj1007 > l
 	} else {
-		yyb960 = r.CheckBreak()
+		yyb1007 = r.CheckBreak()
 	}
-	if yyb960 {
+	if yyb1007 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11288,26 +11874,26 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv965 := &x.Items
-		yym966 := z.DecBinary()
-		_ = yym966
+		yyv1012 := &x.Items
+		yym1013 := z.DecBinary()
+		_ = yym1013
 		if false {
 		} else {
-			h.decSliceIngress((*[]Ingress)(yyv965), d)
+			h.decSliceIngress((*[]Ingress)(yyv1012), d)
 		}
 	}
 	for {
-		yyj960++
-		if yyhl960 {
-			yyb960 = yyj960 > l
+		yyj1007++
+		if yyhl1007 {
+			yyb1007 = yyj1007 > l
 		} else {
-			yyb960 = r.CheckBreak()
+			yyb1007 = r.CheckBreak()
 		}
-		if yyb960 {
+		if yyb1007 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj960-1, "")
+		z.DecStructFieldNotFound(yyj1007-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -11319,34 +11905,34 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym967 := z.EncBinary()
-		_ = yym967
+		yym1014 := z.EncBinary()
+		_ = yym1014
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep968 := !z.EncBinary()
-			yy2arr968 := z.EncBasicHandle().StructToArray
-			var yyq968 [2]bool
-			_, _, _ = yysep968, yyq968, yy2arr968
-			const yyr968 bool = false
-			yyq968[0] = x.Backend != nil
-			yyq968[1] = len(x.Rules) != 0
-			var yynn968 int
-			if yyr968 || yy2arr968 {
+			yysep1015 := !z.EncBinary()
+			yy2arr1015 := z.EncBasicHandle().StructToArray
+			var yyq1015 [2]bool
+			_, _, _ = yysep1015, yyq1015, yy2arr1015
+			const yyr1015 bool = false
+			yyq1015[0] = x.Backend != nil
+			yyq1015[1] = len(x.Rules) != 0
+			var yynn1015 int
+			if yyr1015 || yy2arr1015 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn968 = 0
-				for _, b := range yyq968 {
+				yynn1015 = 0
+				for _, b := range yyq1015 {
 					if b {
-						yynn968++
+						yynn1015++
 					}
 				}
-				r.EncodeMapStart(yynn968)
-				yynn968 = 0
+				r.EncodeMapStart(yynn1015)
+				yynn1015 = 0
 			}
-			if yyr968 || yy2arr968 {
+			if yyr1015 || yy2arr1015 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq968[0] {
+				if yyq1015[0] {
 					if x.Backend == nil {
 						r.EncodeNil()
 					} else {
@@ -11356,7 +11942,7 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq968[0] {
+				if yyq1015[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("backend"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
@@ -11367,14 +11953,14 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr968 || yy2arr968 {
+			if yyr1015 || yy2arr1015 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq968[1] {
+				if yyq1015[1] {
 					if x.Rules == nil {
 						r.EncodeNil()
 					} else {
-						yym971 := z.EncBinary()
-						_ = yym971
+						yym1018 := z.EncBinary()
+						_ = yym1018
 						if false {
 						} else {
 							h.encSliceIngressRule(([]IngressRule)(x.Rules), e)
@@ -11384,15 +11970,15 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq968[1] {
+				if yyq1015[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("rules"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Rules == nil {
 						r.EncodeNil()
 					} else {
-						yym972 := z.EncBinary()
-						_ = yym972
+						yym1019 := z.EncBinary()
+						_ = yym1019
 						if false {
 						} else {
 							h.encSliceIngressRule(([]IngressRule)(x.Rules), e)
@@ -11400,7 +11986,7 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr968 || yy2arr968 {
+			if yyr1015 || yy2arr1015 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -11413,25 +11999,25 @@ func (x *IngressSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym973 := z.DecBinary()
-	_ = yym973
+	yym1020 := z.DecBinary()
+	_ = yym1020
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct974 := r.ContainerType()
-		if yyct974 == codecSelferValueTypeMap1234 {
-			yyl974 := r.ReadMapStart()
-			if yyl974 == 0 {
+		yyct1021 := r.ContainerType()
+		if yyct1021 == codecSelferValueTypeMap1234 {
+			yyl1021 := r.ReadMapStart()
+			if yyl1021 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl974, d)
+				x.codecDecodeSelfFromMap(yyl1021, d)
 			}
-		} else if yyct974 == codecSelferValueTypeArray1234 {
-			yyl974 := r.ReadArrayStart()
-			if yyl974 == 0 {
+		} else if yyct1021 == codecSelferValueTypeArray1234 {
+			yyl1021 := r.ReadArrayStart()
+			if yyl1021 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl974, d)
+				x.codecDecodeSelfFromArray(yyl1021, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -11443,12 +12029,12 @@ func (x *IngressSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys975Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys975Slc
-	var yyhl975 bool = l >= 0
-	for yyj975 := 0; ; yyj975++ {
-		if yyhl975 {
-			if yyj975 >= l {
+	var yys1022Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1022Slc
+	var yyhl1022 bool = l >= 0
+	for yyj1022 := 0; ; yyj1022++ {
+		if yyhl1022 {
+			if yyj1022 >= l {
 				break
 			}
 		} else {
@@ -11457,10 +12043,10 @@ func (x *IngressSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys975Slc = r.DecodeBytes(yys975Slc, true, true)
-		yys975 := string(yys975Slc)
+		yys1022Slc = r.DecodeBytes(yys1022Slc, true, true)
+		yys1022 := string(yys1022Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys975 {
+		switch yys1022 {
 		case "backend":
 			if r.TryDecodeAsNil() {
 				if x.Backend != nil {
@@ -11476,18 +12062,18 @@ func (x *IngressSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Rules = nil
 			} else {
-				yyv977 := &x.Rules
-				yym978 := z.DecBinary()
-				_ = yym978
+				yyv1024 := &x.Rules
+				yym1025 := z.DecBinary()
+				_ = yym1025
 				if false {
 				} else {
-					h.decSliceIngressRule((*[]IngressRule)(yyv977), d)
+					h.decSliceIngressRule((*[]IngressRule)(yyv1024), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys975)
-		} // end switch yys975
-	} // end for yyj975
+			z.DecStructFieldNotFound(-1, yys1022)
+		} // end switch yys1022
+	} // end for yyj1022
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -11495,16 +12081,16 @@ func (x *IngressSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj979 int
-	var yyb979 bool
-	var yyhl979 bool = l >= 0
-	yyj979++
-	if yyhl979 {
-		yyb979 = yyj979 > l
+	var yyj1026 int
+	var yyb1026 bool
+	var yyhl1026 bool = l >= 0
+	yyj1026++
+	if yyhl1026 {
+		yyb1026 = yyj1026 > l
 	} else {
-		yyb979 = r.CheckBreak()
+		yyb1026 = r.CheckBreak()
 	}
-	if yyb979 {
+	if yyb1026 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11519,13 +12105,13 @@ func (x *IngressSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Backend.CodecDecodeSelf(d)
 	}
-	yyj979++
-	if yyhl979 {
-		yyb979 = yyj979 > l
+	yyj1026++
+	if yyhl1026 {
+		yyb1026 = yyj1026 > l
 	} else {
-		yyb979 = r.CheckBreak()
+		yyb1026 = r.CheckBreak()
 	}
-	if yyb979 {
+	if yyb1026 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11533,26 +12119,26 @@ func (x *IngressSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Rules = nil
 	} else {
-		yyv981 := &x.Rules
-		yym982 := z.DecBinary()
-		_ = yym982
+		yyv1028 := &x.Rules
+		yym1029 := z.DecBinary()
+		_ = yym1029
 		if false {
 		} else {
-			h.decSliceIngressRule((*[]IngressRule)(yyv981), d)
+			h.decSliceIngressRule((*[]IngressRule)(yyv1028), d)
 		}
 	}
 	for {
-		yyj979++
-		if yyhl979 {
-			yyb979 = yyj979 > l
+		yyj1026++
+		if yyhl1026 {
+			yyb1026 = yyj1026 > l
 		} else {
-			yyb979 = r.CheckBreak()
+			yyb1026 = r.CheckBreak()
 		}
-		if yyb979 {
+		if yyb1026 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj979-1, "")
+		z.DecStructFieldNotFound(yyj1026-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -11564,48 +12150,48 @@ func (x *IngressStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym983 := z.EncBinary()
-		_ = yym983
+		yym1030 := z.EncBinary()
+		_ = yym1030
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep984 := !z.EncBinary()
-			yy2arr984 := z.EncBasicHandle().StructToArray
-			var yyq984 [1]bool
-			_, _, _ = yysep984, yyq984, yy2arr984
-			const yyr984 bool = false
-			yyq984[0] = true
-			var yynn984 int
-			if yyr984 || yy2arr984 {
+			yysep1031 := !z.EncBinary()
+			yy2arr1031 := z.EncBasicHandle().StructToArray
+			var yyq1031 [1]bool
+			_, _, _ = yysep1031, yyq1031, yy2arr1031
+			const yyr1031 bool = false
+			yyq1031[0] = true
+			var yynn1031 int
+			if yyr1031 || yy2arr1031 {
 				r.EncodeArrayStart(1)
 			} else {
-				yynn984 = 0
-				for _, b := range yyq984 {
+				yynn1031 = 0
+				for _, b := range yyq1031 {
 					if b {
-						yynn984++
+						yynn1031++
 					}
 				}
-				r.EncodeMapStart(yynn984)
-				yynn984 = 0
+				r.EncodeMapStart(yynn1031)
+				yynn1031 = 0
 			}
-			if yyr984 || yy2arr984 {
+			if yyr1031 || yy2arr1031 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq984[0] {
-					yy986 := &x.LoadBalancer
-					yy986.CodecEncodeSelf(e)
+				if yyq1031[0] {
+					yy1033 := &x.LoadBalancer
+					yy1033.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq984[0] {
+				if yyq1031[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("loadBalancer"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy987 := &x.LoadBalancer
-					yy987.CodecEncodeSelf(e)
+					yy1034 := &x.LoadBalancer
+					yy1034.CodecEncodeSelf(e)
 				}
 			}
-			if yyr984 || yy2arr984 {
+			if yyr1031 || yy2arr1031 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -11618,25 +12204,25 @@ func (x *IngressStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym988 := z.DecBinary()
-	_ = yym988
+	yym1035 := z.DecBinary()
+	_ = yym1035
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct989 := r.ContainerType()
-		if yyct989 == codecSelferValueTypeMap1234 {
-			yyl989 := r.ReadMapStart()
-			if yyl989 == 0 {
+		yyct1036 := r.ContainerType()
+		if yyct1036 == codecSelferValueTypeMap1234 {
+			yyl1036 := r.ReadMapStart()
+			if yyl1036 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl989, d)
+				x.codecDecodeSelfFromMap(yyl1036, d)
 			}
-		} else if yyct989 == codecSelferValueTypeArray1234 {
-			yyl989 := r.ReadArrayStart()
-			if yyl989 == 0 {
+		} else if yyct1036 == codecSelferValueTypeArray1234 {
+			yyl1036 := r.ReadArrayStart()
+			if yyl1036 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl989, d)
+				x.codecDecodeSelfFromArray(yyl1036, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -11648,12 +12234,12 @@ func (x *IngressStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys990Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys990Slc
-	var yyhl990 bool = l >= 0
-	for yyj990 := 0; ; yyj990++ {
-		if yyhl990 {
-			if yyj990 >= l {
+	var yys1037Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1037Slc
+	var yyhl1037 bool = l >= 0
+	for yyj1037 := 0; ; yyj1037++ {
+		if yyhl1037 {
+			if yyj1037 >= l {
 				break
 			}
 		} else {
@@ -11662,21 +12248,21 @@ func (x *IngressStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys990Slc = r.DecodeBytes(yys990Slc, true, true)
-		yys990 := string(yys990Slc)
+		yys1037Slc = r.DecodeBytes(yys1037Slc, true, true)
+		yys1037 := string(yys1037Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys990 {
+		switch yys1037 {
 		case "loadBalancer":
 			if r.TryDecodeAsNil() {
 				x.LoadBalancer = pkg2_v1.LoadBalancerStatus{}
 			} else {
-				yyv991 := &x.LoadBalancer
-				yyv991.CodecDecodeSelf(d)
+				yyv1038 := &x.LoadBalancer
+				yyv1038.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys990)
-		} // end switch yys990
-	} // end for yyj990
+			z.DecStructFieldNotFound(-1, yys1037)
+		} // end switch yys1037
+	} // end for yyj1037
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -11684,16 +12270,16 @@ func (x *IngressStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj992 int
-	var yyb992 bool
-	var yyhl992 bool = l >= 0
-	yyj992++
-	if yyhl992 {
-		yyb992 = yyj992 > l
+	var yyj1039 int
+	var yyb1039 bool
+	var yyhl1039 bool = l >= 0
+	yyj1039++
+	if yyhl1039 {
+		yyb1039 = yyj1039 > l
 	} else {
-		yyb992 = r.CheckBreak()
+		yyb1039 = r.CheckBreak()
 	}
-	if yyb992 {
+	if yyb1039 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11701,21 +12287,21 @@ func (x *IngressStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.LoadBalancer = pkg2_v1.LoadBalancerStatus{}
 	} else {
-		yyv993 := &x.LoadBalancer
-		yyv993.CodecDecodeSelf(d)
+		yyv1040 := &x.LoadBalancer
+		yyv1040.CodecDecodeSelf(d)
 	}
 	for {
-		yyj992++
-		if yyhl992 {
-			yyb992 = yyj992 > l
+		yyj1039++
+		if yyhl1039 {
+			yyb1039 = yyj1039 > l
 		} else {
-			yyb992 = r.CheckBreak()
+			yyb1039 = r.CheckBreak()
 		}
-		if yyb992 {
+		if yyb1039 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj992-1, "")
+		z.DecStructFieldNotFound(yyj1039-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -11727,36 +12313,36 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym994 := z.EncBinary()
-		_ = yym994
+		yym1041 := z.EncBinary()
+		_ = yym1041
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep995 := !z.EncBinary()
-			yy2arr995 := z.EncBasicHandle().StructToArray
-			var yyq995 [2]bool
-			_, _, _ = yysep995, yyq995, yy2arr995
-			const yyr995 bool = false
-			yyq995[0] = x.Host != ""
-			yyq995[1] = x.IngressRuleValue.HTTP != nil && x.HTTP != nil
-			var yynn995 int
-			if yyr995 || yy2arr995 {
+			yysep1042 := !z.EncBinary()
+			yy2arr1042 := z.EncBasicHandle().StructToArray
+			var yyq1042 [2]bool
+			_, _, _ = yysep1042, yyq1042, yy2arr1042
+			const yyr1042 bool = false
+			yyq1042[0] = x.Host != ""
+			yyq1042[1] = x.IngressRuleValue.HTTP != nil && x.HTTP != nil
+			var yynn1042 int
+			if yyr1042 || yy2arr1042 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn995 = 0
-				for _, b := range yyq995 {
+				yynn1042 = 0
+				for _, b := range yyq1042 {
 					if b {
-						yynn995++
+						yynn1042++
 					}
 				}
-				r.EncodeMapStart(yynn995)
-				yynn995 = 0
+				r.EncodeMapStart(yynn1042)
+				yynn1042 = 0
 			}
-			if yyr995 || yy2arr995 {
+			if yyr1042 || yy2arr1042 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq995[0] {
-					yym997 := z.EncBinary()
-					_ = yym997
+				if yyq1042[0] {
+					yym1044 := z.EncBinary()
+					_ = yym1044
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Host))
@@ -11765,30 +12351,30 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq995[0] {
+				if yyq1042[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("host"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym998 := z.EncBinary()
-					_ = yym998
+					yym1045 := z.EncBinary()
+					_ = yym1045
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Host))
 					}
 				}
 			}
-			var yyn999 bool
+			var yyn1046 bool
 			if x.IngressRuleValue.HTTP == nil {
-				yyn999 = true
-				goto LABEL999
+				yyn1046 = true
+				goto LABEL1046
 			}
-		LABEL999:
-			if yyr995 || yy2arr995 {
-				if yyn999 {
+		LABEL1046:
+			if yyr1042 || yy2arr1042 {
+				if yyn1046 {
 					r.EncodeNil()
 				} else {
 					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq995[1] {
+					if yyq1042[1] {
 						if x.HTTP == nil {
 							r.EncodeNil()
 						} else {
@@ -11799,11 +12385,11 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
-				if yyq995[1] {
+				if yyq1042[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("http"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn999 {
+					if yyn1046 {
 						r.EncodeNil()
 					} else {
 						if x.HTTP == nil {
@@ -11814,7 +12400,7 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr995 || yy2arr995 {
+			if yyr1042 || yy2arr1042 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -11827,25 +12413,25 @@ func (x *IngressRule) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1000 := z.DecBinary()
-	_ = yym1000
+	yym1047 := z.DecBinary()
+	_ = yym1047
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1001 := r.ContainerType()
-		if yyct1001 == codecSelferValueTypeMap1234 {
-			yyl1001 := r.ReadMapStart()
-			if yyl1001 == 0 {
+		yyct1048 := r.ContainerType()
+		if yyct1048 == codecSelferValueTypeMap1234 {
+			yyl1048 := r.ReadMapStart()
+			if yyl1048 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1001, d)
+				x.codecDecodeSelfFromMap(yyl1048, d)
 			}
-		} else if yyct1001 == codecSelferValueTypeArray1234 {
-			yyl1001 := r.ReadArrayStart()
-			if yyl1001 == 0 {
+		} else if yyct1048 == codecSelferValueTypeArray1234 {
+			yyl1048 := r.ReadArrayStart()
+			if yyl1048 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1001, d)
+				x.codecDecodeSelfFromArray(yyl1048, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -11857,12 +12443,12 @@ func (x *IngressRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1002Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1002Slc
-	var yyhl1002 bool = l >= 0
-	for yyj1002 := 0; ; yyj1002++ {
-		if yyhl1002 {
-			if yyj1002 >= l {
+	var yys1049Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1049Slc
+	var yyhl1049 bool = l >= 0
+	for yyj1049 := 0; ; yyj1049++ {
+		if yyhl1049 {
+			if yyj1049 >= l {
 				break
 			}
 		} else {
@@ -11871,10 +12457,10 @@ func (x *IngressRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1002Slc = r.DecodeBytes(yys1002Slc, true, true)
-		yys1002 := string(yys1002Slc)
+		yys1049Slc = r.DecodeBytes(yys1049Slc, true, true)
+		yys1049 := string(yys1049Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1002 {
+		switch yys1049 {
 		case "host":
 			if r.TryDecodeAsNil() {
 				x.Host = ""
@@ -11896,9 +12482,9 @@ func (x *IngressRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.HTTP.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1002)
-		} // end switch yys1002
-	} // end for yyj1002
+			z.DecStructFieldNotFound(-1, yys1049)
+		} // end switch yys1049
+	} // end for yyj1049
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -11906,16 +12492,16 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1005 int
-	var yyb1005 bool
-	var yyhl1005 bool = l >= 0
-	yyj1005++
-	if yyhl1005 {
-		yyb1005 = yyj1005 > l
+	var yyj1052 int
+	var yyb1052 bool
+	var yyhl1052 bool = l >= 0
+	yyj1052++
+	if yyhl1052 {
+		yyb1052 = yyj1052 > l
 	} else {
-		yyb1005 = r.CheckBreak()
+		yyb1052 = r.CheckBreak()
 	}
-	if yyb1005 {
+	if yyb1052 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11928,13 +12514,13 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if x.IngressRuleValue.HTTP == nil {
 		x.IngressRuleValue.HTTP = new(HTTPIngressRuleValue)
 	}
-	yyj1005++
-	if yyhl1005 {
-		yyb1005 = yyj1005 > l
+	yyj1052++
+	if yyhl1052 {
+		yyb1052 = yyj1052 > l
 	} else {
-		yyb1005 = r.CheckBreak()
+		yyb1052 = r.CheckBreak()
 	}
-	if yyb1005 {
+	if yyb1052 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11950,17 +12536,17 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.HTTP.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1005++
-		if yyhl1005 {
-			yyb1005 = yyj1005 > l
+		yyj1052++
+		if yyhl1052 {
+			yyb1052 = yyj1052 > l
 		} else {
-			yyb1005 = r.CheckBreak()
+			yyb1052 = r.CheckBreak()
 		}
-		if yyb1005 {
+		if yyb1052 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1005-1, "")
+		z.DecStructFieldNotFound(yyj1052-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -11972,33 +12558,33 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1008 := z.EncBinary()
-		_ = yym1008
+		yym1055 := z.EncBinary()
+		_ = yym1055
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1009 := !z.EncBinary()
-			yy2arr1009 := z.EncBasicHandle().StructToArray
-			var yyq1009 [1]bool
-			_, _, _ = yysep1009, yyq1009, yy2arr1009
-			const yyr1009 bool = false
-			yyq1009[0] = x.HTTP != nil
-			var yynn1009 int
-			if yyr1009 || yy2arr1009 {
+			yysep1056 := !z.EncBinary()
+			yy2arr1056 := z.EncBasicHandle().StructToArray
+			var yyq1056 [1]bool
+			_, _, _ = yysep1056, yyq1056, yy2arr1056
+			const yyr1056 bool = false
+			yyq1056[0] = x.HTTP != nil
+			var yynn1056 int
+			if yyr1056 || yy2arr1056 {
 				r.EncodeArrayStart(1)
 			} else {
-				yynn1009 = 0
-				for _, b := range yyq1009 {
+				yynn1056 = 0
+				for _, b := range yyq1056 {
 					if b {
-						yynn1009++
+						yynn1056++
 					}
 				}
-				r.EncodeMapStart(yynn1009)
-				yynn1009 = 0
+				r.EncodeMapStart(yynn1056)
+				yynn1056 = 0
 			}
-			if yyr1009 || yy2arr1009 {
+			if yyr1056 || yy2arr1056 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1009[0] {
+				if yyq1056[0] {
 					if x.HTTP == nil {
 						r.EncodeNil()
 					} else {
@@ -12008,7 +12594,7 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1009[0] {
+				if yyq1056[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("http"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
@@ -12019,7 +12605,7 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1009 || yy2arr1009 {
+			if yyr1056 || yy2arr1056 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -12032,25 +12618,25 @@ func (x *IngressRuleValue) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1011 := z.DecBinary()
-	_ = yym1011
+	yym1058 := z.DecBinary()
+	_ = yym1058
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1012 := r.ContainerType()
-		if yyct1012 == codecSelferValueTypeMap1234 {
-			yyl1012 := r.ReadMapStart()
-			if yyl1012 == 0 {
+		yyct1059 := r.ContainerType()
+		if yyct1059 == codecSelferValueTypeMap1234 {
+			yyl1059 := r.ReadMapStart()
+			if yyl1059 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1012, d)
+				x.codecDecodeSelfFromMap(yyl1059, d)
 			}
-		} else if yyct1012 == codecSelferValueTypeArray1234 {
-			yyl1012 := r.ReadArrayStart()
-			if yyl1012 == 0 {
+		} else if yyct1059 == codecSelferValueTypeArray1234 {
+			yyl1059 := r.ReadArrayStart()
+			if yyl1059 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1012, d)
+				x.codecDecodeSelfFromArray(yyl1059, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -12062,12 +12648,12 @@ func (x *IngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1013Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1013Slc
-	var yyhl1013 bool = l >= 0
-	for yyj1013 := 0; ; yyj1013++ {
-		if yyhl1013 {
-			if yyj1013 >= l {
+	var yys1060Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1060Slc
+	var yyhl1060 bool = l >= 0
+	for yyj1060 := 0; ; yyj1060++ {
+		if yyhl1060 {
+			if yyj1060 >= l {
 				break
 			}
 		} else {
@@ -12076,10 +12662,10 @@ func (x *IngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1013Slc = r.DecodeBytes(yys1013Slc, true, true)
-		yys1013 := string(yys1013Slc)
+		yys1060Slc = r.DecodeBytes(yys1060Slc, true, true)
+		yys1060 := string(yys1060Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1013 {
+		switch yys1060 {
 		case "http":
 			if r.TryDecodeAsNil() {
 				if x.HTTP != nil {
@@ -12092,608 +12678,13 @@ func (x *IngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.HTTP.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1013)
-		} // end switch yys1013
-	} // end for yyj1013
+			z.DecStructFieldNotFound(-1, yys1060)
+		} // end switch yys1060
+	} // end for yyj1060
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *IngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj1015 int
-	var yyb1015 bool
-	var yyhl1015 bool = l >= 0
-	yyj1015++
-	if yyhl1015 {
-		yyb1015 = yyj1015 > l
-	} else {
-		yyb1015 = r.CheckBreak()
-	}
-	if yyb1015 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		if x.HTTP != nil {
-			x.HTTP = nil
-		}
-	} else {
-		if x.HTTP == nil {
-			x.HTTP = new(HTTPIngressRuleValue)
-		}
-		x.HTTP.CodecDecodeSelf(d)
-	}
-	for {
-		yyj1015++
-		if yyhl1015 {
-			yyb1015 = yyj1015 > l
-		} else {
-			yyb1015 = r.CheckBreak()
-		}
-		if yyb1015 {
-			break
-		}
-		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1015-1, "")
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x *HTTPIngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym1017 := z.EncBinary()
-		_ = yym1017
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep1018 := !z.EncBinary()
-			yy2arr1018 := z.EncBasicHandle().StructToArray
-			var yyq1018 [1]bool
-			_, _, _ = yysep1018, yyq1018, yy2arr1018
-			const yyr1018 bool = false
-			var yynn1018 int
-			if yyr1018 || yy2arr1018 {
-				r.EncodeArrayStart(1)
-			} else {
-				yynn1018 = 1
-				for _, b := range yyq1018 {
-					if b {
-						yynn1018++
-					}
-				}
-				r.EncodeMapStart(yynn1018)
-				yynn1018 = 0
-			}
-			if yyr1018 || yy2arr1018 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if x.Paths == nil {
-					r.EncodeNil()
-				} else {
-					yym1020 := z.EncBinary()
-					_ = yym1020
-					if false {
-					} else {
-						h.encSliceHTTPIngressPath(([]HTTPIngressPath)(x.Paths), e)
-					}
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("paths"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				if x.Paths == nil {
-					r.EncodeNil()
-				} else {
-					yym1021 := z.EncBinary()
-					_ = yym1021
-					if false {
-					} else {
-						h.encSliceHTTPIngressPath(([]HTTPIngressPath)(x.Paths), e)
-					}
-				}
-			}
-			if yyr1018 || yy2arr1018 {
-				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
-			}
-		}
-	}
-}
-
-func (x *HTTPIngressRuleValue) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym1022 := z.DecBinary()
-	_ = yym1022
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		yyct1023 := r.ContainerType()
-		if yyct1023 == codecSelferValueTypeMap1234 {
-			yyl1023 := r.ReadMapStart()
-			if yyl1023 == 0 {
-				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-			} else {
-				x.codecDecodeSelfFromMap(yyl1023, d)
-			}
-		} else if yyct1023 == codecSelferValueTypeArray1234 {
-			yyl1023 := r.ReadArrayStart()
-			if yyl1023 == 0 {
-				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				x.codecDecodeSelfFromArray(yyl1023, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *HTTPIngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys1024Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1024Slc
-	var yyhl1024 bool = l >= 0
-	for yyj1024 := 0; ; yyj1024++ {
-		if yyhl1024 {
-			if yyj1024 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1024Slc = r.DecodeBytes(yys1024Slc, true, true)
-		yys1024 := string(yys1024Slc)
-		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1024 {
-		case "paths":
-			if r.TryDecodeAsNil() {
-				x.Paths = nil
-			} else {
-				yyv1025 := &x.Paths
-				yym1026 := z.DecBinary()
-				_ = yym1026
-				if false {
-				} else {
-					h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv1025), d)
-				}
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys1024)
-		} // end switch yys1024
-	} // end for yyj1024
-	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-}
-
-func (x *HTTPIngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj1027 int
-	var yyb1027 bool
-	var yyhl1027 bool = l >= 0
-	yyj1027++
-	if yyhl1027 {
-		yyb1027 = yyj1027 > l
-	} else {
-		yyb1027 = r.CheckBreak()
-	}
-	if yyb1027 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Paths = nil
-	} else {
-		yyv1028 := &x.Paths
-		yym1029 := z.DecBinary()
-		_ = yym1029
-		if false {
-		} else {
-			h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv1028), d)
-		}
-	}
-	for {
-		yyj1027++
-		if yyhl1027 {
-			yyb1027 = yyj1027 > l
-		} else {
-			yyb1027 = r.CheckBreak()
-		}
-		if yyb1027 {
-			break
-		}
-		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1027-1, "")
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x *HTTPIngressPath) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym1030 := z.EncBinary()
-		_ = yym1030
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep1031 := !z.EncBinary()
-			yy2arr1031 := z.EncBasicHandle().StructToArray
-			var yyq1031 [2]bool
-			_, _, _ = yysep1031, yyq1031, yy2arr1031
-			const yyr1031 bool = false
-			yyq1031[0] = x.Path != ""
-			var yynn1031 int
-			if yyr1031 || yy2arr1031 {
-				r.EncodeArrayStart(2)
-			} else {
-				yynn1031 = 1
-				for _, b := range yyq1031 {
-					if b {
-						yynn1031++
-					}
-				}
-				r.EncodeMapStart(yynn1031)
-				yynn1031 = 0
-			}
-			if yyr1031 || yy2arr1031 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1031[0] {
-					yym1033 := z.EncBinary()
-					_ = yym1033
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Path))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1031[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("path"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1034 := z.EncBinary()
-					_ = yym1034
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Path))
-					}
-				}
-			}
-			if yyr1031 || yy2arr1031 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy1036 := &x.Backend
-				yy1036.CodecEncodeSelf(e)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("backend"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy1037 := &x.Backend
-				yy1037.CodecEncodeSelf(e)
-			}
-			if yyr1031 || yy2arr1031 {
-				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
-			}
-		}
-	}
-}
-
-func (x *HTTPIngressPath) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym1038 := z.DecBinary()
-	_ = yym1038
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		yyct1039 := r.ContainerType()
-		if yyct1039 == codecSelferValueTypeMap1234 {
-			yyl1039 := r.ReadMapStart()
-			if yyl1039 == 0 {
-				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-			} else {
-				x.codecDecodeSelfFromMap(yyl1039, d)
-			}
-		} else if yyct1039 == codecSelferValueTypeArray1234 {
-			yyl1039 := r.ReadArrayStart()
-			if yyl1039 == 0 {
-				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				x.codecDecodeSelfFromArray(yyl1039, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *HTTPIngressPath) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys1040Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1040Slc
-	var yyhl1040 bool = l >= 0
-	for yyj1040 := 0; ; yyj1040++ {
-		if yyhl1040 {
-			if yyj1040 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1040Slc = r.DecodeBytes(yys1040Slc, true, true)
-		yys1040 := string(yys1040Slc)
-		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1040 {
-		case "path":
-			if r.TryDecodeAsNil() {
-				x.Path = ""
-			} else {
-				x.Path = string(r.DecodeString())
-			}
-		case "backend":
-			if r.TryDecodeAsNil() {
-				x.Backend = IngressBackend{}
-			} else {
-				yyv1042 := &x.Backend
-				yyv1042.CodecDecodeSelf(d)
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys1040)
-		} // end switch yys1040
-	} // end for yyj1040
-	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-}
-
-func (x *HTTPIngressPath) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj1043 int
-	var yyb1043 bool
-	var yyhl1043 bool = l >= 0
-	yyj1043++
-	if yyhl1043 {
-		yyb1043 = yyj1043 > l
-	} else {
-		yyb1043 = r.CheckBreak()
-	}
-	if yyb1043 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Path = ""
-	} else {
-		x.Path = string(r.DecodeString())
-	}
-	yyj1043++
-	if yyhl1043 {
-		yyb1043 = yyj1043 > l
-	} else {
-		yyb1043 = r.CheckBreak()
-	}
-	if yyb1043 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Backend = IngressBackend{}
-	} else {
-		yyv1045 := &x.Backend
-		yyv1045.CodecDecodeSelf(d)
-	}
-	for {
-		yyj1043++
-		if yyhl1043 {
-			yyb1043 = yyj1043 > l
-		} else {
-			yyb1043 = r.CheckBreak()
-		}
-		if yyb1043 {
-			break
-		}
-		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1043-1, "")
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x *IngressBackend) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym1046 := z.EncBinary()
-		_ = yym1046
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep1047 := !z.EncBinary()
-			yy2arr1047 := z.EncBasicHandle().StructToArray
-			var yyq1047 [2]bool
-			_, _, _ = yysep1047, yyq1047, yy2arr1047
-			const yyr1047 bool = false
-			var yynn1047 int
-			if yyr1047 || yy2arr1047 {
-				r.EncodeArrayStart(2)
-			} else {
-				yynn1047 = 2
-				for _, b := range yyq1047 {
-					if b {
-						yynn1047++
-					}
-				}
-				r.EncodeMapStart(yynn1047)
-				yynn1047 = 0
-			}
-			if yyr1047 || yy2arr1047 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1049 := z.EncBinary()
-				_ = yym1049
-				if false {
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceName))
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("serviceName"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1050 := z.EncBinary()
-				_ = yym1050
-				if false {
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceName))
-				}
-			}
-			if yyr1047 || yy2arr1047 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy1052 := &x.ServicePort
-				yym1053 := z.EncBinary()
-				_ = yym1053
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy1052) {
-				} else if !yym1053 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy1052)
-				} else {
-					z.EncFallback(yy1052)
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("servicePort"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy1054 := &x.ServicePort
-				yym1055 := z.EncBinary()
-				_ = yym1055
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy1054) {
-				} else if !yym1055 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy1054)
-				} else {
-					z.EncFallback(yy1054)
-				}
-			}
-			if yyr1047 || yy2arr1047 {
-				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
-			}
-		}
-	}
-}
-
-func (x *IngressBackend) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym1056 := z.DecBinary()
-	_ = yym1056
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		yyct1057 := r.ContainerType()
-		if yyct1057 == codecSelferValueTypeMap1234 {
-			yyl1057 := r.ReadMapStart()
-			if yyl1057 == 0 {
-				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-			} else {
-				x.codecDecodeSelfFromMap(yyl1057, d)
-			}
-		} else if yyct1057 == codecSelferValueTypeArray1234 {
-			yyl1057 := r.ReadArrayStart()
-			if yyl1057 == 0 {
-				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				x.codecDecodeSelfFromArray(yyl1057, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *IngressBackend) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys1058Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1058Slc
-	var yyhl1058 bool = l >= 0
-	for yyj1058 := 0; ; yyj1058++ {
-		if yyhl1058 {
-			if yyj1058 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1058Slc = r.DecodeBytes(yys1058Slc, true, true)
-		yys1058 := string(yys1058Slc)
-		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1058 {
-		case "serviceName":
-			if r.TryDecodeAsNil() {
-				x.ServiceName = ""
-			} else {
-				x.ServiceName = string(r.DecodeString())
-			}
-		case "servicePort":
-			if r.TryDecodeAsNil() {
-				x.ServicePort = pkg6_intstr.IntOrString{}
-			} else {
-				yyv1060 := &x.ServicePort
-				yym1061 := z.DecBinary()
-				_ = yym1061
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1060) {
-				} else if !yym1061 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1060)
-				} else {
-					z.DecFallback(yyv1060, false)
-				}
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys1058)
-		} // end switch yys1058
-	} // end for yyj1058
-	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-}
-
-func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -12712,34 +12703,14 @@ func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.ServiceName = ""
-	} else {
-		x.ServiceName = string(r.DecodeString())
-	}
-	yyj1062++
-	if yyhl1062 {
-		yyb1062 = yyj1062 > l
-	} else {
-		yyb1062 = r.CheckBreak()
-	}
-	if yyb1062 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ServicePort = pkg6_intstr.IntOrString{}
-	} else {
-		yyv1064 := &x.ServicePort
-		yym1065 := z.DecBinary()
-		_ = yym1065
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1064) {
-		} else if !yym1065 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1064)
-		} else {
-			z.DecFallback(yyv1064, false)
+		if x.HTTP != nil {
+			x.HTTP = nil
 		}
+	} else {
+		if x.HTTP == nil {
+			x.HTTP = new(HTTPIngressRuleValue)
+		}
+		x.HTTP.CodecDecodeSelf(d)
 	}
 	for {
 		yyj1062++
@@ -12757,12 +12728,627 @@ func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
+func (x *HTTPIngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym1064 := z.EncBinary()
+		_ = yym1064
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep1065 := !z.EncBinary()
+			yy2arr1065 := z.EncBasicHandle().StructToArray
+			var yyq1065 [1]bool
+			_, _, _ = yysep1065, yyq1065, yy2arr1065
+			const yyr1065 bool = false
+			var yynn1065 int
+			if yyr1065 || yy2arr1065 {
+				r.EncodeArrayStart(1)
+			} else {
+				yynn1065 = 1
+				for _, b := range yyq1065 {
+					if b {
+						yynn1065++
+					}
+				}
+				r.EncodeMapStart(yynn1065)
+				yynn1065 = 0
+			}
+			if yyr1065 || yy2arr1065 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if x.Paths == nil {
+					r.EncodeNil()
+				} else {
+					yym1067 := z.EncBinary()
+					_ = yym1067
+					if false {
+					} else {
+						h.encSliceHTTPIngressPath(([]HTTPIngressPath)(x.Paths), e)
+					}
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("paths"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				if x.Paths == nil {
+					r.EncodeNil()
+				} else {
+					yym1068 := z.EncBinary()
+					_ = yym1068
+					if false {
+					} else {
+						h.encSliceHTTPIngressPath(([]HTTPIngressPath)(x.Paths), e)
+					}
+				}
+			}
+			if yyr1065 || yy2arr1065 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *HTTPIngressRuleValue) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym1069 := z.DecBinary()
+	_ = yym1069
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct1070 := r.ContainerType()
+		if yyct1070 == codecSelferValueTypeMap1234 {
+			yyl1070 := r.ReadMapStart()
+			if yyl1070 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl1070, d)
+			}
+		} else if yyct1070 == codecSelferValueTypeArray1234 {
+			yyl1070 := r.ReadArrayStart()
+			if yyl1070 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl1070, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *HTTPIngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys1071Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1071Slc
+	var yyhl1071 bool = l >= 0
+	for yyj1071 := 0; ; yyj1071++ {
+		if yyhl1071 {
+			if yyj1071 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys1071Slc = r.DecodeBytes(yys1071Slc, true, true)
+		yys1071 := string(yys1071Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys1071 {
+		case "paths":
+			if r.TryDecodeAsNil() {
+				x.Paths = nil
+			} else {
+				yyv1072 := &x.Paths
+				yym1073 := z.DecBinary()
+				_ = yym1073
+				if false {
+				} else {
+					h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv1072), d)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys1071)
+		} // end switch yys1071
+	} // end for yyj1071
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *HTTPIngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj1074 int
+	var yyb1074 bool
+	var yyhl1074 bool = l >= 0
+	yyj1074++
+	if yyhl1074 {
+		yyb1074 = yyj1074 > l
+	} else {
+		yyb1074 = r.CheckBreak()
+	}
+	if yyb1074 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Paths = nil
+	} else {
+		yyv1075 := &x.Paths
+		yym1076 := z.DecBinary()
+		_ = yym1076
+		if false {
+		} else {
+			h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv1075), d)
+		}
+	}
+	for {
+		yyj1074++
+		if yyhl1074 {
+			yyb1074 = yyj1074 > l
+		} else {
+			yyb1074 = r.CheckBreak()
+		}
+		if yyb1074 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj1074-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x *HTTPIngressPath) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym1077 := z.EncBinary()
+		_ = yym1077
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep1078 := !z.EncBinary()
+			yy2arr1078 := z.EncBasicHandle().StructToArray
+			var yyq1078 [2]bool
+			_, _, _ = yysep1078, yyq1078, yy2arr1078
+			const yyr1078 bool = false
+			yyq1078[0] = x.Path != ""
+			var yynn1078 int
+			if yyr1078 || yy2arr1078 {
+				r.EncodeArrayStart(2)
+			} else {
+				yynn1078 = 1
+				for _, b := range yyq1078 {
+					if b {
+						yynn1078++
+					}
+				}
+				r.EncodeMapStart(yynn1078)
+				yynn1078 = 0
+			}
+			if yyr1078 || yy2arr1078 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1078[0] {
+					yym1080 := z.EncBinary()
+					_ = yym1080
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Path))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1078[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("path"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1081 := z.EncBinary()
+					_ = yym1081
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Path))
+					}
+				}
+			}
+			if yyr1078 || yy2arr1078 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yy1083 := &x.Backend
+				yy1083.CodecEncodeSelf(e)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("backend"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yy1084 := &x.Backend
+				yy1084.CodecEncodeSelf(e)
+			}
+			if yyr1078 || yy2arr1078 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *HTTPIngressPath) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym1085 := z.DecBinary()
+	_ = yym1085
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct1086 := r.ContainerType()
+		if yyct1086 == codecSelferValueTypeMap1234 {
+			yyl1086 := r.ReadMapStart()
+			if yyl1086 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl1086, d)
+			}
+		} else if yyct1086 == codecSelferValueTypeArray1234 {
+			yyl1086 := r.ReadArrayStart()
+			if yyl1086 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl1086, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *HTTPIngressPath) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys1087Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1087Slc
+	var yyhl1087 bool = l >= 0
+	for yyj1087 := 0; ; yyj1087++ {
+		if yyhl1087 {
+			if yyj1087 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys1087Slc = r.DecodeBytes(yys1087Slc, true, true)
+		yys1087 := string(yys1087Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys1087 {
+		case "path":
+			if r.TryDecodeAsNil() {
+				x.Path = ""
+			} else {
+				x.Path = string(r.DecodeString())
+			}
+		case "backend":
+			if r.TryDecodeAsNil() {
+				x.Backend = IngressBackend{}
+			} else {
+				yyv1089 := &x.Backend
+				yyv1089.CodecDecodeSelf(d)
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys1087)
+		} // end switch yys1087
+	} // end for yyj1087
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *HTTPIngressPath) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj1090 int
+	var yyb1090 bool
+	var yyhl1090 bool = l >= 0
+	yyj1090++
+	if yyhl1090 {
+		yyb1090 = yyj1090 > l
+	} else {
+		yyb1090 = r.CheckBreak()
+	}
+	if yyb1090 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Path = ""
+	} else {
+		x.Path = string(r.DecodeString())
+	}
+	yyj1090++
+	if yyhl1090 {
+		yyb1090 = yyj1090 > l
+	} else {
+		yyb1090 = r.CheckBreak()
+	}
+	if yyb1090 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Backend = IngressBackend{}
+	} else {
+		yyv1092 := &x.Backend
+		yyv1092.CodecDecodeSelf(d)
+	}
+	for {
+		yyj1090++
+		if yyhl1090 {
+			yyb1090 = yyj1090 > l
+		} else {
+			yyb1090 = r.CheckBreak()
+		}
+		if yyb1090 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj1090-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x *IngressBackend) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym1093 := z.EncBinary()
+		_ = yym1093
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep1094 := !z.EncBinary()
+			yy2arr1094 := z.EncBasicHandle().StructToArray
+			var yyq1094 [2]bool
+			_, _, _ = yysep1094, yyq1094, yy2arr1094
+			const yyr1094 bool = false
+			var yynn1094 int
+			if yyr1094 || yy2arr1094 {
+				r.EncodeArrayStart(2)
+			} else {
+				yynn1094 = 2
+				for _, b := range yyq1094 {
+					if b {
+						yynn1094++
+					}
+				}
+				r.EncodeMapStart(yynn1094)
+				yynn1094 = 0
+			}
+			if yyr1094 || yy2arr1094 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym1096 := z.EncBinary()
+				_ = yym1096
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceName))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("serviceName"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym1097 := z.EncBinary()
+				_ = yym1097
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceName))
+				}
+			}
+			if yyr1094 || yy2arr1094 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yy1099 := &x.ServicePort
+				yym1100 := z.EncBinary()
+				_ = yym1100
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy1099) {
+				} else if !yym1100 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy1099)
+				} else {
+					z.EncFallback(yy1099)
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("servicePort"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yy1101 := &x.ServicePort
+				yym1102 := z.EncBinary()
+				_ = yym1102
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy1101) {
+				} else if !yym1102 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy1101)
+				} else {
+					z.EncFallback(yy1101)
+				}
+			}
+			if yyr1094 || yy2arr1094 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *IngressBackend) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym1103 := z.DecBinary()
+	_ = yym1103
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct1104 := r.ContainerType()
+		if yyct1104 == codecSelferValueTypeMap1234 {
+			yyl1104 := r.ReadMapStart()
+			if yyl1104 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl1104, d)
+			}
+		} else if yyct1104 == codecSelferValueTypeArray1234 {
+			yyl1104 := r.ReadArrayStart()
+			if yyl1104 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl1104, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *IngressBackend) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys1105Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1105Slc
+	var yyhl1105 bool = l >= 0
+	for yyj1105 := 0; ; yyj1105++ {
+		if yyhl1105 {
+			if yyj1105 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys1105Slc = r.DecodeBytes(yys1105Slc, true, true)
+		yys1105 := string(yys1105Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys1105 {
+		case "serviceName":
+			if r.TryDecodeAsNil() {
+				x.ServiceName = ""
+			} else {
+				x.ServiceName = string(r.DecodeString())
+			}
+		case "servicePort":
+			if r.TryDecodeAsNil() {
+				x.ServicePort = pkg6_intstr.IntOrString{}
+			} else {
+				yyv1107 := &x.ServicePort
+				yym1108 := z.DecBinary()
+				_ = yym1108
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv1107) {
+				} else if !yym1108 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1107)
+				} else {
+					z.DecFallback(yyv1107, false)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys1105)
+		} // end switch yys1105
+	} // end for yyj1105
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj1109 int
+	var yyb1109 bool
+	var yyhl1109 bool = l >= 0
+	yyj1109++
+	if yyhl1109 {
+		yyb1109 = yyj1109 > l
+	} else {
+		yyb1109 = r.CheckBreak()
+	}
+	if yyb1109 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ServiceName = ""
+	} else {
+		x.ServiceName = string(r.DecodeString())
+	}
+	yyj1109++
+	if yyhl1109 {
+		yyb1109 = yyj1109 > l
+	} else {
+		yyb1109 = r.CheckBreak()
+	}
+	if yyb1109 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ServicePort = pkg6_intstr.IntOrString{}
+	} else {
+		yyv1111 := &x.ServicePort
+		yym1112 := z.DecBinary()
+		_ = yym1112
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1111) {
+		} else if !yym1112 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv1111)
+		} else {
+			z.DecFallback(yyv1111, false)
+		}
+	}
+	for {
+		yyj1109++
+		if yyhl1109 {
+			yyb1109 = yyj1109 > l
+		} else {
+			yyb1109 = r.CheckBreak()
+		}
+		if yyb1109 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj1109-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
 func (x NodeResource) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym1066 := z.EncBinary()
-	_ = yym1066
+	yym1113 := z.EncBinary()
+	_ = yym1113
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -12774,8 +13360,8 @@ func (x *NodeResource) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1067 := z.DecBinary()
-	_ = yym1067
+	yym1114 := z.DecBinary()
+	_ = yym1114
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -12790,30 +13376,30 @@ func (x *NodeUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1068 := z.EncBinary()
-		_ = yym1068
+		yym1115 := z.EncBinary()
+		_ = yym1115
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1069 := !z.EncBinary()
-			yy2arr1069 := z.EncBasicHandle().StructToArray
-			var yyq1069 [2]bool
-			_, _, _ = yysep1069, yyq1069, yy2arr1069
-			const yyr1069 bool = false
-			var yynn1069 int
-			if yyr1069 || yy2arr1069 {
+			yysep1116 := !z.EncBinary()
+			yy2arr1116 := z.EncBasicHandle().StructToArray
+			var yyq1116 [2]bool
+			_, _, _ = yysep1116, yyq1116, yy2arr1116
+			const yyr1116 bool = false
+			var yynn1116 int
+			if yyr1116 || yy2arr1116 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn1069 = 2
-				for _, b := range yyq1069 {
+				yynn1116 = 2
+				for _, b := range yyq1116 {
 					if b {
-						yynn1069++
+						yynn1116++
 					}
 				}
-				r.EncodeMapStart(yynn1069)
-				yynn1069 = 0
+				r.EncodeMapStart(yynn1116)
+				yynn1116 = 0
 			}
-			if yyr1069 || yy2arr1069 {
+			if yyr1116 || yy2arr1116 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Resource.CodecEncodeSelf(e)
 			} else {
@@ -12822,10 +13408,10 @@ func (x *NodeUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Resource.CodecEncodeSelf(e)
 			}
-			if yyr1069 || yy2arr1069 {
+			if yyr1116 || yy2arr1116 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1072 := z.EncBinary()
-				_ = yym1072
+				yym1119 := z.EncBinary()
+				_ = yym1119
 				if false {
 				} else {
 					r.EncodeFloat64(float64(x.Value))
@@ -12834,14 +13420,14 @@ func (x *NodeUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("value"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1073 := z.EncBinary()
-				_ = yym1073
+				yym1120 := z.EncBinary()
+				_ = yym1120
 				if false {
 				} else {
 					r.EncodeFloat64(float64(x.Value))
 				}
 			}
-			if yyr1069 || yy2arr1069 {
+			if yyr1116 || yy2arr1116 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -12854,25 +13440,25 @@ func (x *NodeUtilization) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1074 := z.DecBinary()
-	_ = yym1074
+	yym1121 := z.DecBinary()
+	_ = yym1121
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1075 := r.ContainerType()
-		if yyct1075 == codecSelferValueTypeMap1234 {
-			yyl1075 := r.ReadMapStart()
-			if yyl1075 == 0 {
+		yyct1122 := r.ContainerType()
+		if yyct1122 == codecSelferValueTypeMap1234 {
+			yyl1122 := r.ReadMapStart()
+			if yyl1122 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1075, d)
+				x.codecDecodeSelfFromMap(yyl1122, d)
 			}
-		} else if yyct1075 == codecSelferValueTypeArray1234 {
-			yyl1075 := r.ReadArrayStart()
-			if yyl1075 == 0 {
+		} else if yyct1122 == codecSelferValueTypeArray1234 {
+			yyl1122 := r.ReadArrayStart()
+			if yyl1122 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1075, d)
+				x.codecDecodeSelfFromArray(yyl1122, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -12884,12 +13470,12 @@ func (x *NodeUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1076Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1076Slc
-	var yyhl1076 bool = l >= 0
-	for yyj1076 := 0; ; yyj1076++ {
-		if yyhl1076 {
-			if yyj1076 >= l {
+	var yys1123Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1123Slc
+	var yyhl1123 bool = l >= 0
+	for yyj1123 := 0; ; yyj1123++ {
+		if yyhl1123 {
+			if yyj1123 >= l {
 				break
 			}
 		} else {
@@ -12898,10 +13484,10 @@ func (x *NodeUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1076Slc = r.DecodeBytes(yys1076Slc, true, true)
-		yys1076 := string(yys1076Slc)
+		yys1123Slc = r.DecodeBytes(yys1123Slc, true, true)
+		yys1123 := string(yys1123Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1076 {
+		switch yys1123 {
 		case "resource":
 			if r.TryDecodeAsNil() {
 				x.Resource = ""
@@ -12915,544 +13501,13 @@ func (x *NodeUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Value = float64(r.DecodeFloat(false))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1076)
-		} // end switch yys1076
-	} // end for yyj1076
+			z.DecStructFieldNotFound(-1, yys1123)
+		} // end switch yys1123
+	} // end for yyj1123
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *NodeUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj1079 int
-	var yyb1079 bool
-	var yyhl1079 bool = l >= 0
-	yyj1079++
-	if yyhl1079 {
-		yyb1079 = yyj1079 > l
-	} else {
-		yyb1079 = r.CheckBreak()
-	}
-	if yyb1079 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Resource = ""
-	} else {
-		x.Resource = NodeResource(r.DecodeString())
-	}
-	yyj1079++
-	if yyhl1079 {
-		yyb1079 = yyj1079 > l
-	} else {
-		yyb1079 = r.CheckBreak()
-	}
-	if yyb1079 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Value = 0
-	} else {
-		x.Value = float64(r.DecodeFloat(false))
-	}
-	for {
-		yyj1079++
-		if yyhl1079 {
-			yyb1079 = yyj1079 > l
-		} else {
-			yyb1079 = r.CheckBreak()
-		}
-		if yyb1079 {
-			break
-		}
-		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1079-1, "")
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym1082 := z.EncBinary()
-		_ = yym1082
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep1083 := !z.EncBinary()
-			yy2arr1083 := z.EncBasicHandle().StructToArray
-			var yyq1083 [3]bool
-			_, _, _ = yysep1083, yyq1083, yy2arr1083
-			const yyr1083 bool = false
-			var yynn1083 int
-			if yyr1083 || yy2arr1083 {
-				r.EncodeArrayStart(3)
-			} else {
-				yynn1083 = 3
-				for _, b := range yyq1083 {
-					if b {
-						yynn1083++
-					}
-				}
-				r.EncodeMapStart(yynn1083)
-				yynn1083 = 0
-			}
-			if yyr1083 || yy2arr1083 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1085 := z.EncBinary()
-				_ = yym1085
-				if false {
-				} else {
-					r.EncodeInt(int64(x.MinNodes))
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("minNodes"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1086 := z.EncBinary()
-				_ = yym1086
-				if false {
-				} else {
-					r.EncodeInt(int64(x.MinNodes))
-				}
-			}
-			if yyr1083 || yy2arr1083 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1088 := z.EncBinary()
-				_ = yym1088
-				if false {
-				} else {
-					r.EncodeInt(int64(x.MaxNodes))
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("maxNodes"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1089 := z.EncBinary()
-				_ = yym1089
-				if false {
-				} else {
-					r.EncodeInt(int64(x.MaxNodes))
-				}
-			}
-			if yyr1083 || yy2arr1083 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if x.TargetUtilization == nil {
-					r.EncodeNil()
-				} else {
-					yym1091 := z.EncBinary()
-					_ = yym1091
-					if false {
-					} else {
-						h.encSliceNodeUtilization(([]NodeUtilization)(x.TargetUtilization), e)
-					}
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("target"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				if x.TargetUtilization == nil {
-					r.EncodeNil()
-				} else {
-					yym1092 := z.EncBinary()
-					_ = yym1092
-					if false {
-					} else {
-						h.encSliceNodeUtilization(([]NodeUtilization)(x.TargetUtilization), e)
-					}
-				}
-			}
-			if yyr1083 || yy2arr1083 {
-				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
-			}
-		}
-	}
-}
-
-func (x *ClusterAutoscalerSpec) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym1093 := z.DecBinary()
-	_ = yym1093
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		yyct1094 := r.ContainerType()
-		if yyct1094 == codecSelferValueTypeMap1234 {
-			yyl1094 := r.ReadMapStart()
-			if yyl1094 == 0 {
-				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-			} else {
-				x.codecDecodeSelfFromMap(yyl1094, d)
-			}
-		} else if yyct1094 == codecSelferValueTypeArray1234 {
-			yyl1094 := r.ReadArrayStart()
-			if yyl1094 == 0 {
-				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				x.codecDecodeSelfFromArray(yyl1094, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *ClusterAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys1095Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1095Slc
-	var yyhl1095 bool = l >= 0
-	for yyj1095 := 0; ; yyj1095++ {
-		if yyhl1095 {
-			if yyj1095 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1095Slc = r.DecodeBytes(yys1095Slc, true, true)
-		yys1095 := string(yys1095Slc)
-		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1095 {
-		case "minNodes":
-			if r.TryDecodeAsNil() {
-				x.MinNodes = 0
-			} else {
-				x.MinNodes = int32(r.DecodeInt(32))
-			}
-		case "maxNodes":
-			if r.TryDecodeAsNil() {
-				x.MaxNodes = 0
-			} else {
-				x.MaxNodes = int32(r.DecodeInt(32))
-			}
-		case "target":
-			if r.TryDecodeAsNil() {
-				x.TargetUtilization = nil
-			} else {
-				yyv1098 := &x.TargetUtilization
-				yym1099 := z.DecBinary()
-				_ = yym1099
-				if false {
-				} else {
-					h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1098), d)
-				}
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys1095)
-		} // end switch yys1095
-	} // end for yyj1095
-	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-}
-
-func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj1100 int
-	var yyb1100 bool
-	var yyhl1100 bool = l >= 0
-	yyj1100++
-	if yyhl1100 {
-		yyb1100 = yyj1100 > l
-	} else {
-		yyb1100 = r.CheckBreak()
-	}
-	if yyb1100 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.MinNodes = 0
-	} else {
-		x.MinNodes = int32(r.DecodeInt(32))
-	}
-	yyj1100++
-	if yyhl1100 {
-		yyb1100 = yyj1100 > l
-	} else {
-		yyb1100 = r.CheckBreak()
-	}
-	if yyb1100 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.MaxNodes = 0
-	} else {
-		x.MaxNodes = int32(r.DecodeInt(32))
-	}
-	yyj1100++
-	if yyhl1100 {
-		yyb1100 = yyj1100 > l
-	} else {
-		yyb1100 = r.CheckBreak()
-	}
-	if yyb1100 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.TargetUtilization = nil
-	} else {
-		yyv1103 := &x.TargetUtilization
-		yym1104 := z.DecBinary()
-		_ = yym1104
-		if false {
-		} else {
-			h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1103), d)
-		}
-	}
-	for {
-		yyj1100++
-		if yyhl1100 {
-			yyb1100 = yyj1100 > l
-		} else {
-			yyb1100 = r.CheckBreak()
-		}
-		if yyb1100 {
-			break
-		}
-		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1100-1, "")
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym1105 := z.EncBinary()
-		_ = yym1105
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep1106 := !z.EncBinary()
-			yy2arr1106 := z.EncBasicHandle().StructToArray
-			var yyq1106 [4]bool
-			_, _, _ = yysep1106, yyq1106, yy2arr1106
-			const yyr1106 bool = false
-			yyq1106[0] = x.Kind != ""
-			yyq1106[1] = x.APIVersion != ""
-			yyq1106[2] = true
-			yyq1106[3] = true
-			var yynn1106 int
-			if yyr1106 || yy2arr1106 {
-				r.EncodeArrayStart(4)
-			} else {
-				yynn1106 = 0
-				for _, b := range yyq1106 {
-					if b {
-						yynn1106++
-					}
-				}
-				r.EncodeMapStart(yynn1106)
-				yynn1106 = 0
-			}
-			if yyr1106 || yy2arr1106 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1106[0] {
-					yym1108 := z.EncBinary()
-					_ = yym1108
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1106[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1109 := z.EncBinary()
-					_ = yym1109
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr1106 || yy2arr1106 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1106[1] {
-					yym1111 := z.EncBinary()
-					_ = yym1111
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1106[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1112 := z.EncBinary()
-					_ = yym1112
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr1106 || yy2arr1106 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1106[2] {
-					yy1114 := &x.ObjectMeta
-					yy1114.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1106[2] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1115 := &x.ObjectMeta
-					yy1115.CodecEncodeSelf(e)
-				}
-			}
-			if yyr1106 || yy2arr1106 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1106[3] {
-					yy1117 := &x.Spec
-					yy1117.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1106[3] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1118 := &x.Spec
-					yy1118.CodecEncodeSelf(e)
-				}
-			}
-			if yyr1106 || yy2arr1106 {
-				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
-			}
-		}
-	}
-}
-
-func (x *ClusterAutoscaler) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym1119 := z.DecBinary()
-	_ = yym1119
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		yyct1120 := r.ContainerType()
-		if yyct1120 == codecSelferValueTypeMap1234 {
-			yyl1120 := r.ReadMapStart()
-			if yyl1120 == 0 {
-				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-			} else {
-				x.codecDecodeSelfFromMap(yyl1120, d)
-			}
-		} else if yyct1120 == codecSelferValueTypeArray1234 {
-			yyl1120 := r.ReadArrayStart()
-			if yyl1120 == 0 {
-				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				x.codecDecodeSelfFromArray(yyl1120, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys1121Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1121Slc
-	var yyhl1121 bool = l >= 0
-	for yyj1121 := 0; ; yyj1121++ {
-		if yyhl1121 {
-			if yyj1121 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1121Slc = r.DecodeBytes(yys1121Slc, true, true)
-		yys1121 := string(yys1121Slc)
-		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1121 {
-		case "kind":
-			if r.TryDecodeAsNil() {
-				x.Kind = ""
-			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = pkg2_v1.ObjectMeta{}
-			} else {
-				yyv1124 := &x.ObjectMeta
-				yyv1124.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = ClusterAutoscalerSpec{}
-			} else {
-				yyv1125 := &x.Spec
-				yyv1125.CodecDecodeSelf(d)
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys1121)
-		} // end switch yys1121
-	} // end for yyj1121
-	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-}
-
-func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -13471,9 +13526,9 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.Kind = ""
+		x.Resource = ""
 	} else {
-		x.Kind = string(r.DecodeString())
+		x.Resource = NodeResource(r.DecodeString())
 	}
 	yyj1126++
 	if yyhl1126 {
@@ -13487,43 +13542,9 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
+		x.Value = 0
 	} else {
-		x.APIVersion = string(r.DecodeString())
-	}
-	yyj1126++
-	if yyhl1126 {
-		yyb1126 = yyj1126 > l
-	} else {
-		yyb1126 = r.CheckBreak()
-	}
-	if yyb1126 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = pkg2_v1.ObjectMeta{}
-	} else {
-		yyv1129 := &x.ObjectMeta
-		yyv1129.CodecDecodeSelf(d)
-	}
-	yyj1126++
-	if yyhl1126 {
-		yyb1126 = yyj1126 > l
-	} else {
-		yyb1126 = r.CheckBreak()
-	}
-	if yyb1126 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = ClusterAutoscalerSpec{}
-	} else {
-		yyv1130 := &x.Spec
-		yyv1130.CodecDecodeSelf(d)
+		x.Value = float64(r.DecodeFloat(false))
 	}
 	for {
 		yyj1126++
@@ -13541,6 +13562,571 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
+func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym1129 := z.EncBinary()
+		_ = yym1129
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep1130 := !z.EncBinary()
+			yy2arr1130 := z.EncBasicHandle().StructToArray
+			var yyq1130 [3]bool
+			_, _, _ = yysep1130, yyq1130, yy2arr1130
+			const yyr1130 bool = false
+			var yynn1130 int
+			if yyr1130 || yy2arr1130 {
+				r.EncodeArrayStart(3)
+			} else {
+				yynn1130 = 3
+				for _, b := range yyq1130 {
+					if b {
+						yynn1130++
+					}
+				}
+				r.EncodeMapStart(yynn1130)
+				yynn1130 = 0
+			}
+			if yyr1130 || yy2arr1130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym1132 := z.EncBinary()
+				_ = yym1132
+				if false {
+				} else {
+					r.EncodeInt(int64(x.MinNodes))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("minNodes"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym1133 := z.EncBinary()
+				_ = yym1133
+				if false {
+				} else {
+					r.EncodeInt(int64(x.MinNodes))
+				}
+			}
+			if yyr1130 || yy2arr1130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym1135 := z.EncBinary()
+				_ = yym1135
+				if false {
+				} else {
+					r.EncodeInt(int64(x.MaxNodes))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("maxNodes"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym1136 := z.EncBinary()
+				_ = yym1136
+				if false {
+				} else {
+					r.EncodeInt(int64(x.MaxNodes))
+				}
+			}
+			if yyr1130 || yy2arr1130 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if x.TargetUtilization == nil {
+					r.EncodeNil()
+				} else {
+					yym1138 := z.EncBinary()
+					_ = yym1138
+					if false {
+					} else {
+						h.encSliceNodeUtilization(([]NodeUtilization)(x.TargetUtilization), e)
+					}
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("target"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				if x.TargetUtilization == nil {
+					r.EncodeNil()
+				} else {
+					yym1139 := z.EncBinary()
+					_ = yym1139
+					if false {
+					} else {
+						h.encSliceNodeUtilization(([]NodeUtilization)(x.TargetUtilization), e)
+					}
+				}
+			}
+			if yyr1130 || yy2arr1130 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *ClusterAutoscalerSpec) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym1140 := z.DecBinary()
+	_ = yym1140
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct1141 := r.ContainerType()
+		if yyct1141 == codecSelferValueTypeMap1234 {
+			yyl1141 := r.ReadMapStart()
+			if yyl1141 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl1141, d)
+			}
+		} else if yyct1141 == codecSelferValueTypeArray1234 {
+			yyl1141 := r.ReadArrayStart()
+			if yyl1141 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl1141, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *ClusterAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys1142Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1142Slc
+	var yyhl1142 bool = l >= 0
+	for yyj1142 := 0; ; yyj1142++ {
+		if yyhl1142 {
+			if yyj1142 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys1142Slc = r.DecodeBytes(yys1142Slc, true, true)
+		yys1142 := string(yys1142Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys1142 {
+		case "minNodes":
+			if r.TryDecodeAsNil() {
+				x.MinNodes = 0
+			} else {
+				x.MinNodes = int32(r.DecodeInt(32))
+			}
+		case "maxNodes":
+			if r.TryDecodeAsNil() {
+				x.MaxNodes = 0
+			} else {
+				x.MaxNodes = int32(r.DecodeInt(32))
+			}
+		case "target":
+			if r.TryDecodeAsNil() {
+				x.TargetUtilization = nil
+			} else {
+				yyv1145 := &x.TargetUtilization
+				yym1146 := z.DecBinary()
+				_ = yym1146
+				if false {
+				} else {
+					h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1145), d)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys1142)
+		} // end switch yys1142
+	} // end for yyj1142
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj1147 int
+	var yyb1147 bool
+	var yyhl1147 bool = l >= 0
+	yyj1147++
+	if yyhl1147 {
+		yyb1147 = yyj1147 > l
+	} else {
+		yyb1147 = r.CheckBreak()
+	}
+	if yyb1147 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.MinNodes = 0
+	} else {
+		x.MinNodes = int32(r.DecodeInt(32))
+	}
+	yyj1147++
+	if yyhl1147 {
+		yyb1147 = yyj1147 > l
+	} else {
+		yyb1147 = r.CheckBreak()
+	}
+	if yyb1147 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.MaxNodes = 0
+	} else {
+		x.MaxNodes = int32(r.DecodeInt(32))
+	}
+	yyj1147++
+	if yyhl1147 {
+		yyb1147 = yyj1147 > l
+	} else {
+		yyb1147 = r.CheckBreak()
+	}
+	if yyb1147 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.TargetUtilization = nil
+	} else {
+		yyv1150 := &x.TargetUtilization
+		yym1151 := z.DecBinary()
+		_ = yym1151
+		if false {
+		} else {
+			h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1150), d)
+		}
+	}
+	for {
+		yyj1147++
+		if yyhl1147 {
+			yyb1147 = yyj1147 > l
+		} else {
+			yyb1147 = r.CheckBreak()
+		}
+		if yyb1147 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj1147-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym1152 := z.EncBinary()
+		_ = yym1152
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep1153 := !z.EncBinary()
+			yy2arr1153 := z.EncBasicHandle().StructToArray
+			var yyq1153 [4]bool
+			_, _, _ = yysep1153, yyq1153, yy2arr1153
+			const yyr1153 bool = false
+			yyq1153[0] = x.Kind != ""
+			yyq1153[1] = x.APIVersion != ""
+			yyq1153[2] = true
+			yyq1153[3] = true
+			var yynn1153 int
+			if yyr1153 || yy2arr1153 {
+				r.EncodeArrayStart(4)
+			} else {
+				yynn1153 = 0
+				for _, b := range yyq1153 {
+					if b {
+						yynn1153++
+					}
+				}
+				r.EncodeMapStart(yynn1153)
+				yynn1153 = 0
+			}
+			if yyr1153 || yy2arr1153 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1153[0] {
+					yym1155 := z.EncBinary()
+					_ = yym1155
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1153[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1156 := z.EncBinary()
+					_ = yym1156
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr1153 || yy2arr1153 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1153[1] {
+					yym1158 := z.EncBinary()
+					_ = yym1158
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1153[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1159 := z.EncBinary()
+					_ = yym1159
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr1153 || yy2arr1153 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1153[2] {
+					yy1161 := &x.ObjectMeta
+					yy1161.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1153[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1162 := &x.ObjectMeta
+					yy1162.CodecEncodeSelf(e)
+				}
+			}
+			if yyr1153 || yy2arr1153 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1153[3] {
+					yy1164 := &x.Spec
+					yy1164.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1153[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1165 := &x.Spec
+					yy1165.CodecEncodeSelf(e)
+				}
+			}
+			if yyr1153 || yy2arr1153 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *ClusterAutoscaler) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym1166 := z.DecBinary()
+	_ = yym1166
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct1167 := r.ContainerType()
+		if yyct1167 == codecSelferValueTypeMap1234 {
+			yyl1167 := r.ReadMapStart()
+			if yyl1167 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl1167, d)
+			}
+		} else if yyct1167 == codecSelferValueTypeArray1234 {
+			yyl1167 := r.ReadArrayStart()
+			if yyl1167 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl1167, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys1168Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1168Slc
+	var yyhl1168 bool = l >= 0
+	for yyj1168 := 0; ; yyj1168++ {
+		if yyhl1168 {
+			if yyj1168 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys1168Slc = r.DecodeBytes(yys1168Slc, true, true)
+		yys1168 := string(yys1168Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys1168 {
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
+			}
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_v1.ObjectMeta{}
+			} else {
+				yyv1171 := &x.ObjectMeta
+				yyv1171.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = ClusterAutoscalerSpec{}
+			} else {
+				yyv1172 := &x.Spec
+				yyv1172.CodecDecodeSelf(d)
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys1168)
+		} // end switch yys1168
+	} // end for yyj1168
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj1173 int
+	var yyb1173 bool
+	var yyhl1173 bool = l >= 0
+	yyj1173++
+	if yyhl1173 {
+		yyb1173 = yyj1173 > l
+	} else {
+		yyb1173 = r.CheckBreak()
+	}
+	if yyb1173 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj1173++
+	if yyhl1173 {
+		yyb1173 = yyj1173 > l
+	} else {
+		yyb1173 = r.CheckBreak()
+	}
+	if yyb1173 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
+	}
+	yyj1173++
+	if yyhl1173 {
+		yyb1173 = yyj1173 > l
+	} else {
+		yyb1173 = r.CheckBreak()
+	}
+	if yyb1173 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_v1.ObjectMeta{}
+	} else {
+		yyv1176 := &x.ObjectMeta
+		yyv1176.CodecDecodeSelf(d)
+	}
+	yyj1173++
+	if yyhl1173 {
+		yyb1173 = yyj1173 > l
+	} else {
+		yyb1173 = r.CheckBreak()
+	}
+	if yyb1173 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = ClusterAutoscalerSpec{}
+	} else {
+		yyv1177 := &x.Spec
+		yyv1177.CodecDecodeSelf(d)
+	}
+	for {
+		yyj1173++
+		if yyhl1173 {
+			yyb1173 = yyj1173 > l
+		} else {
+			yyb1173 = r.CheckBreak()
+		}
+		if yyb1173 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj1173-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
 func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
@@ -13548,37 +14134,37 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1131 := z.EncBinary()
-		_ = yym1131
+		yym1178 := z.EncBinary()
+		_ = yym1178
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1132 := !z.EncBinary()
-			yy2arr1132 := z.EncBasicHandle().StructToArray
-			var yyq1132 [4]bool
-			_, _, _ = yysep1132, yyq1132, yy2arr1132
-			const yyr1132 bool = false
-			yyq1132[0] = x.Kind != ""
-			yyq1132[1] = x.APIVersion != ""
-			yyq1132[2] = true
-			var yynn1132 int
-			if yyr1132 || yy2arr1132 {
+			yysep1179 := !z.EncBinary()
+			yy2arr1179 := z.EncBasicHandle().StructToArray
+			var yyq1179 [4]bool
+			_, _, _ = yysep1179, yyq1179, yy2arr1179
+			const yyr1179 bool = false
+			yyq1179[0] = x.Kind != ""
+			yyq1179[1] = x.APIVersion != ""
+			yyq1179[2] = true
+			var yynn1179 int
+			if yyr1179 || yy2arr1179 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn1132 = 1
-				for _, b := range yyq1132 {
+				yynn1179 = 1
+				for _, b := range yyq1179 {
 					if b {
-						yynn1132++
+						yynn1179++
 					}
 				}
-				r.EncodeMapStart(yynn1132)
-				yynn1132 = 0
+				r.EncodeMapStart(yynn1179)
+				yynn1179 = 0
 			}
-			if yyr1132 || yy2arr1132 {
+			if yyr1179 || yy2arr1179 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1132[0] {
-					yym1134 := z.EncBinary()
-					_ = yym1134
+				if yyq1179[0] {
+					yym1181 := z.EncBinary()
+					_ = yym1181
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -13587,23 +14173,23 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1132[0] {
+				if yyq1179[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1135 := z.EncBinary()
-					_ = yym1135
+					yym1182 := z.EncBinary()
+					_ = yym1182
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1132 || yy2arr1132 {
+			if yyr1179 || yy2arr1179 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1132[1] {
-					yym1137 := z.EncBinary()
-					_ = yym1137
+				if yyq1179[1] {
+					yym1184 := z.EncBinary()
+					_ = yym1184
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -13612,54 +14198,54 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1132[1] {
+				if yyq1179[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1138 := z.EncBinary()
-					_ = yym1138
+					yym1185 := z.EncBinary()
+					_ = yym1185
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1132 || yy2arr1132 {
+			if yyr1179 || yy2arr1179 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1132[2] {
-					yy1140 := &x.ListMeta
-					yym1141 := z.EncBinary()
-					_ = yym1141
+				if yyq1179[2] {
+					yy1187 := &x.ListMeta
+					yym1188 := z.EncBinary()
+					_ = yym1188
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1140) {
+					} else if z.HasExtensions() && z.EncExt(yy1187) {
 					} else {
-						z.EncFallback(yy1140)
+						z.EncFallback(yy1187)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1132[2] {
+				if yyq1179[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1142 := &x.ListMeta
-					yym1143 := z.EncBinary()
-					_ = yym1143
+					yy1189 := &x.ListMeta
+					yym1190 := z.EncBinary()
+					_ = yym1190
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1142) {
+					} else if z.HasExtensions() && z.EncExt(yy1189) {
 					} else {
-						z.EncFallback(yy1142)
+						z.EncFallback(yy1189)
 					}
 				}
 			}
-			if yyr1132 || yy2arr1132 {
+			if yyr1179 || yy2arr1179 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1145 := z.EncBinary()
-					_ = yym1145
+					yym1192 := z.EncBinary()
+					_ = yym1192
 					if false {
 					} else {
 						h.encSliceClusterAutoscaler(([]ClusterAutoscaler)(x.Items), e)
@@ -13672,15 +14258,15 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1146 := z.EncBinary()
-					_ = yym1146
+					yym1193 := z.EncBinary()
+					_ = yym1193
 					if false {
 					} else {
 						h.encSliceClusterAutoscaler(([]ClusterAutoscaler)(x.Items), e)
 					}
 				}
 			}
-			if yyr1132 || yy2arr1132 {
+			if yyr1179 || yy2arr1179 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -13693,25 +14279,25 @@ func (x *ClusterAutoscalerList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1147 := z.DecBinary()
-	_ = yym1147
+	yym1194 := z.DecBinary()
+	_ = yym1194
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1148 := r.ContainerType()
-		if yyct1148 == codecSelferValueTypeMap1234 {
-			yyl1148 := r.ReadMapStart()
-			if yyl1148 == 0 {
+		yyct1195 := r.ContainerType()
+		if yyct1195 == codecSelferValueTypeMap1234 {
+			yyl1195 := r.ReadMapStart()
+			if yyl1195 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1148, d)
+				x.codecDecodeSelfFromMap(yyl1195, d)
 			}
-		} else if yyct1148 == codecSelferValueTypeArray1234 {
-			yyl1148 := r.ReadArrayStart()
-			if yyl1148 == 0 {
+		} else if yyct1195 == codecSelferValueTypeArray1234 {
+			yyl1195 := r.ReadArrayStart()
+			if yyl1195 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1148, d)
+				x.codecDecodeSelfFromArray(yyl1195, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -13723,12 +14309,12 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1149Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1149Slc
-	var yyhl1149 bool = l >= 0
-	for yyj1149 := 0; ; yyj1149++ {
-		if yyhl1149 {
-			if yyj1149 >= l {
+	var yys1196Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1196Slc
+	var yyhl1196 bool = l >= 0
+	for yyj1196 := 0; ; yyj1196++ {
+		if yyhl1196 {
+			if yyj1196 >= l {
 				break
 			}
 		} else {
@@ -13737,10 +14323,10 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1149Slc = r.DecodeBytes(yys1149Slc, true, true)
-		yys1149 := string(yys1149Slc)
+		yys1196Slc = r.DecodeBytes(yys1196Slc, true, true)
+		yys1196 := string(yys1196Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1149 {
+		switch yys1196 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -13757,31 +14343,31 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv1152 := &x.ListMeta
-				yym1153 := z.DecBinary()
-				_ = yym1153
+				yyv1199 := &x.ListMeta
+				yym1200 := z.DecBinary()
+				_ = yym1200
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1152) {
+				} else if z.HasExtensions() && z.DecExt(yyv1199) {
 				} else {
-					z.DecFallback(yyv1152, false)
+					z.DecFallback(yyv1199, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv1154 := &x.Items
-				yym1155 := z.DecBinary()
-				_ = yym1155
+				yyv1201 := &x.Items
+				yym1202 := z.DecBinary()
+				_ = yym1202
 				if false {
 				} else {
-					h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1154), d)
+					h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1201), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1149)
-		} // end switch yys1149
-	} // end for yyj1149
+			z.DecStructFieldNotFound(-1, yys1196)
+		} // end switch yys1196
+	} // end for yyj1196
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -13789,16 +14375,16 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1156 int
-	var yyb1156 bool
-	var yyhl1156 bool = l >= 0
-	yyj1156++
-	if yyhl1156 {
-		yyb1156 = yyj1156 > l
+	var yyj1203 int
+	var yyb1203 bool
+	var yyhl1203 bool = l >= 0
+	yyj1203++
+	if yyhl1203 {
+		yyb1203 = yyj1203 > l
 	} else {
-		yyb1156 = r.CheckBreak()
+		yyb1203 = r.CheckBreak()
 	}
-	if yyb1156 {
+	if yyb1203 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -13808,13 +14394,13 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1156++
-	if yyhl1156 {
-		yyb1156 = yyj1156 > l
+	yyj1203++
+	if yyhl1203 {
+		yyb1203 = yyj1203 > l
 	} else {
-		yyb1156 = r.CheckBreak()
+		yyb1203 = r.CheckBreak()
 	}
-	if yyb1156 {
+	if yyb1203 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -13824,13 +14410,13 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1156++
-	if yyhl1156 {
-		yyb1156 = yyj1156 > l
+	yyj1203++
+	if yyhl1203 {
+		yyb1203 = yyj1203 > l
 	} else {
-		yyb1156 = r.CheckBreak()
+		yyb1203 = r.CheckBreak()
 	}
-	if yyb1156 {
+	if yyb1203 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -13838,22 +14424,22 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv1159 := &x.ListMeta
-		yym1160 := z.DecBinary()
-		_ = yym1160
+		yyv1206 := &x.ListMeta
+		yym1207 := z.DecBinary()
+		_ = yym1207
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1159) {
+		} else if z.HasExtensions() && z.DecExt(yyv1206) {
 		} else {
-			z.DecFallback(yyv1159, false)
+			z.DecFallback(yyv1206, false)
 		}
 	}
-	yyj1156++
-	if yyhl1156 {
-		yyb1156 = yyj1156 > l
+	yyj1203++
+	if yyhl1203 {
+		yyb1203 = yyj1203 > l
 	} else {
-		yyb1156 = r.CheckBreak()
+		yyb1203 = r.CheckBreak()
 	}
-	if yyb1156 {
+	if yyb1203 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -13861,26 +14447,26 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv1161 := &x.Items
-		yym1162 := z.DecBinary()
-		_ = yym1162
+		yyv1208 := &x.Items
+		yym1209 := z.DecBinary()
+		_ = yym1209
 		if false {
 		} else {
-			h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1161), d)
+			h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1208), d)
 		}
 	}
 	for {
-		yyj1156++
-		if yyhl1156 {
-			yyb1156 = yyj1156 > l
+		yyj1203++
+		if yyhl1203 {
+			yyb1203 = yyj1203 > l
 		} else {
-			yyb1156 = r.CheckBreak()
+			yyb1203 = r.CheckBreak()
 		}
-		if yyb1156 {
+		if yyb1203 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1156-1, "")
+		z.DecStructFieldNotFound(yyj1203-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -13892,36 +14478,36 @@ func (x *ExportOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1163 := z.EncBinary()
-		_ = yym1163
+		yym1210 := z.EncBinary()
+		_ = yym1210
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1164 := !z.EncBinary()
-			yy2arr1164 := z.EncBasicHandle().StructToArray
-			var yyq1164 [4]bool
-			_, _, _ = yysep1164, yyq1164, yy2arr1164
-			const yyr1164 bool = false
-			yyq1164[0] = x.Kind != ""
-			yyq1164[1] = x.APIVersion != ""
-			var yynn1164 int
-			if yyr1164 || yy2arr1164 {
+			yysep1211 := !z.EncBinary()
+			yy2arr1211 := z.EncBasicHandle().StructToArray
+			var yyq1211 [4]bool
+			_, _, _ = yysep1211, yyq1211, yy2arr1211
+			const yyr1211 bool = false
+			yyq1211[0] = x.Kind != ""
+			yyq1211[1] = x.APIVersion != ""
+			var yynn1211 int
+			if yyr1211 || yy2arr1211 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn1164 = 2
-				for _, b := range yyq1164 {
+				yynn1211 = 2
+				for _, b := range yyq1211 {
 					if b {
-						yynn1164++
+						yynn1211++
 					}
 				}
-				r.EncodeMapStart(yynn1164)
-				yynn1164 = 0
+				r.EncodeMapStart(yynn1211)
+				yynn1211 = 0
 			}
-			if yyr1164 || yy2arr1164 {
+			if yyr1211 || yy2arr1211 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1164[0] {
-					yym1166 := z.EncBinary()
-					_ = yym1166
+				if yyq1211[0] {
+					yym1213 := z.EncBinary()
+					_ = yym1213
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -13930,23 +14516,23 @@ func (x *ExportOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1164[0] {
+				if yyq1211[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1167 := z.EncBinary()
-					_ = yym1167
+					yym1214 := z.EncBinary()
+					_ = yym1214
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1164 || yy2arr1164 {
+			if yyr1211 || yy2arr1211 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1164[1] {
-					yym1169 := z.EncBinary()
-					_ = yym1169
+				if yyq1211[1] {
+					yym1216 := z.EncBinary()
+					_ = yym1216
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -13955,22 +14541,22 @@ func (x *ExportOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1164[1] {
+				if yyq1211[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1170 := z.EncBinary()
-					_ = yym1170
+					yym1217 := z.EncBinary()
+					_ = yym1217
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1164 || yy2arr1164 {
+			if yyr1211 || yy2arr1211 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1172 := z.EncBinary()
-				_ = yym1172
+				yym1219 := z.EncBinary()
+				_ = yym1219
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Export))
@@ -13979,17 +14565,17 @@ func (x *ExportOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("export"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1173 := z.EncBinary()
-				_ = yym1173
+				yym1220 := z.EncBinary()
+				_ = yym1220
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Export))
 				}
 			}
-			if yyr1164 || yy2arr1164 {
+			if yyr1211 || yy2arr1211 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1175 := z.EncBinary()
-				_ = yym1175
+				yym1222 := z.EncBinary()
+				_ = yym1222
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Exact))
@@ -13998,14 +14584,14 @@ func (x *ExportOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("exact"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1176 := z.EncBinary()
-				_ = yym1176
+				yym1223 := z.EncBinary()
+				_ = yym1223
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Exact))
 				}
 			}
-			if yyr1164 || yy2arr1164 {
+			if yyr1211 || yy2arr1211 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -14018,25 +14604,25 @@ func (x *ExportOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1177 := z.DecBinary()
-	_ = yym1177
+	yym1224 := z.DecBinary()
+	_ = yym1224
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1178 := r.ContainerType()
-		if yyct1178 == codecSelferValueTypeMap1234 {
-			yyl1178 := r.ReadMapStart()
-			if yyl1178 == 0 {
+		yyct1225 := r.ContainerType()
+		if yyct1225 == codecSelferValueTypeMap1234 {
+			yyl1225 := r.ReadMapStart()
+			if yyl1225 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1178, d)
+				x.codecDecodeSelfFromMap(yyl1225, d)
 			}
-		} else if yyct1178 == codecSelferValueTypeArray1234 {
-			yyl1178 := r.ReadArrayStart()
-			if yyl1178 == 0 {
+		} else if yyct1225 == codecSelferValueTypeArray1234 {
+			yyl1225 := r.ReadArrayStart()
+			if yyl1225 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1178, d)
+				x.codecDecodeSelfFromArray(yyl1225, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -14048,12 +14634,12 @@ func (x *ExportOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1179Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1179Slc
-	var yyhl1179 bool = l >= 0
-	for yyj1179 := 0; ; yyj1179++ {
-		if yyhl1179 {
-			if yyj1179 >= l {
+	var yys1226Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1226Slc
+	var yyhl1226 bool = l >= 0
+	for yyj1226 := 0; ; yyj1226++ {
+		if yyhl1226 {
+			if yyj1226 >= l {
 				break
 			}
 		} else {
@@ -14062,10 +14648,10 @@ func (x *ExportOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1179Slc = r.DecodeBytes(yys1179Slc, true, true)
-		yys1179 := string(yys1179Slc)
+		yys1226Slc = r.DecodeBytes(yys1226Slc, true, true)
+		yys1226 := string(yys1226Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1179 {
+		switch yys1226 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -14091,9 +14677,9 @@ func (x *ExportOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Exact = bool(r.DecodeBool())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1179)
-		} // end switch yys1179
-	} // end for yyj1179
+			z.DecStructFieldNotFound(-1, yys1226)
+		} // end switch yys1226
+	} // end for yyj1226
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -14101,16 +14687,16 @@ func (x *ExportOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1184 int
-	var yyb1184 bool
-	var yyhl1184 bool = l >= 0
-	yyj1184++
-	if yyhl1184 {
-		yyb1184 = yyj1184 > l
+	var yyj1231 int
+	var yyb1231 bool
+	var yyhl1231 bool = l >= 0
+	yyj1231++
+	if yyhl1231 {
+		yyb1231 = yyj1231 > l
 	} else {
-		yyb1184 = r.CheckBreak()
+		yyb1231 = r.CheckBreak()
 	}
-	if yyb1184 {
+	if yyb1231 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14120,13 +14706,13 @@ func (x *ExportOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1184++
-	if yyhl1184 {
-		yyb1184 = yyj1184 > l
+	yyj1231++
+	if yyhl1231 {
+		yyb1231 = yyj1231 > l
 	} else {
-		yyb1184 = r.CheckBreak()
+		yyb1231 = r.CheckBreak()
 	}
-	if yyb1184 {
+	if yyb1231 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14136,13 +14722,13 @@ func (x *ExportOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1184++
-	if yyhl1184 {
-		yyb1184 = yyj1184 > l
+	yyj1231++
+	if yyhl1231 {
+		yyb1231 = yyj1231 > l
 	} else {
-		yyb1184 = r.CheckBreak()
+		yyb1231 = r.CheckBreak()
 	}
-	if yyb1184 {
+	if yyb1231 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14152,13 +14738,13 @@ func (x *ExportOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Export = bool(r.DecodeBool())
 	}
-	yyj1184++
-	if yyhl1184 {
-		yyb1184 = yyj1184 > l
+	yyj1231++
+	if yyhl1231 {
+		yyb1231 = yyj1231 > l
 	} else {
-		yyb1184 = r.CheckBreak()
+		yyb1231 = r.CheckBreak()
 	}
-	if yyb1184 {
+	if yyb1231 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14169,17 +14755,17 @@ func (x *ExportOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Exact = bool(r.DecodeBool())
 	}
 	for {
-		yyj1184++
-		if yyhl1184 {
-			yyb1184 = yyj1184 > l
+		yyj1231++
+		if yyhl1231 {
+			yyb1231 = yyj1231 > l
 		} else {
-			yyb1184 = r.CheckBreak()
+			yyb1231 = r.CheckBreak()
 		}
-		if yyb1184 {
+		if yyb1231 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1184-1, "")
+		z.DecStructFieldNotFound(yyj1231-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -14191,41 +14777,41 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1189 := z.EncBinary()
-		_ = yym1189
+		yym1236 := z.EncBinary()
+		_ = yym1236
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1190 := !z.EncBinary()
-			yy2arr1190 := z.EncBasicHandle().StructToArray
-			var yyq1190 [7]bool
-			_, _, _ = yysep1190, yyq1190, yy2arr1190
-			const yyr1190 bool = false
-			yyq1190[0] = x.Kind != ""
-			yyq1190[1] = x.APIVersion != ""
-			yyq1190[2] = x.LabelSelector != ""
-			yyq1190[3] = x.FieldSelector != ""
-			yyq1190[4] = x.Watch != false
-			yyq1190[5] = x.ResourceVersion != ""
-			yyq1190[6] = x.TimeoutSeconds != nil
-			var yynn1190 int
-			if yyr1190 || yy2arr1190 {
+			yysep1237 := !z.EncBinary()
+			yy2arr1237 := z.EncBasicHandle().StructToArray
+			var yyq1237 [7]bool
+			_, _, _ = yysep1237, yyq1237, yy2arr1237
+			const yyr1237 bool = false
+			yyq1237[0] = x.Kind != ""
+			yyq1237[1] = x.APIVersion != ""
+			yyq1237[2] = x.LabelSelector != ""
+			yyq1237[3] = x.FieldSelector != ""
+			yyq1237[4] = x.Watch != false
+			yyq1237[5] = x.ResourceVersion != ""
+			yyq1237[6] = x.TimeoutSeconds != nil
+			var yynn1237 int
+			if yyr1237 || yy2arr1237 {
 				r.EncodeArrayStart(7)
 			} else {
-				yynn1190 = 0
-				for _, b := range yyq1190 {
+				yynn1237 = 0
+				for _, b := range yyq1237 {
 					if b {
-						yynn1190++
+						yynn1237++
 					}
 				}
-				r.EncodeMapStart(yynn1190)
-				yynn1190 = 0
+				r.EncodeMapStart(yynn1237)
+				yynn1237 = 0
 			}
-			if yyr1190 || yy2arr1190 {
+			if yyr1237 || yy2arr1237 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1190[0] {
-					yym1192 := z.EncBinary()
-					_ = yym1192
+				if yyq1237[0] {
+					yym1239 := z.EncBinary()
+					_ = yym1239
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -14234,23 +14820,23 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1190[0] {
+				if yyq1237[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1193 := z.EncBinary()
-					_ = yym1193
+					yym1240 := z.EncBinary()
+					_ = yym1240
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1190 || yy2arr1190 {
+			if yyr1237 || yy2arr1237 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1190[1] {
-					yym1195 := z.EncBinary()
-					_ = yym1195
+				if yyq1237[1] {
+					yym1242 := z.EncBinary()
+					_ = yym1242
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -14259,23 +14845,23 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1190[1] {
+				if yyq1237[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1196 := z.EncBinary()
-					_ = yym1196
+					yym1243 := z.EncBinary()
+					_ = yym1243
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1190 || yy2arr1190 {
+			if yyr1237 || yy2arr1237 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1190[2] {
-					yym1198 := z.EncBinary()
-					_ = yym1198
+				if yyq1237[2] {
+					yym1245 := z.EncBinary()
+					_ = yym1245
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.LabelSelector))
@@ -14284,23 +14870,23 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1190[2] {
+				if yyq1237[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("labelSelector"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1199 := z.EncBinary()
-					_ = yym1199
+					yym1246 := z.EncBinary()
+					_ = yym1246
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.LabelSelector))
 					}
 				}
 			}
-			if yyr1190 || yy2arr1190 {
+			if yyr1237 || yy2arr1237 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1190[3] {
-					yym1201 := z.EncBinary()
-					_ = yym1201
+				if yyq1237[3] {
+					yym1248 := z.EncBinary()
+					_ = yym1248
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.FieldSelector))
@@ -14309,23 +14895,23 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1190[3] {
+				if yyq1237[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("fieldSelector"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1202 := z.EncBinary()
-					_ = yym1202
+					yym1249 := z.EncBinary()
+					_ = yym1249
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.FieldSelector))
 					}
 				}
 			}
-			if yyr1190 || yy2arr1190 {
+			if yyr1237 || yy2arr1237 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1190[4] {
-					yym1204 := z.EncBinary()
-					_ = yym1204
+				if yyq1237[4] {
+					yym1251 := z.EncBinary()
+					_ = yym1251
 					if false {
 					} else {
 						r.EncodeBool(bool(x.Watch))
@@ -14334,23 +14920,23 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq1190[4] {
+				if yyq1237[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("watch"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1205 := z.EncBinary()
-					_ = yym1205
+					yym1252 := z.EncBinary()
+					_ = yym1252
 					if false {
 					} else {
 						r.EncodeBool(bool(x.Watch))
 					}
 				}
 			}
-			if yyr1190 || yy2arr1190 {
+			if yyr1237 || yy2arr1237 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1190[5] {
-					yym1207 := z.EncBinary()
-					_ = yym1207
+				if yyq1237[5] {
+					yym1254 := z.EncBinary()
+					_ = yym1254
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
@@ -14359,54 +14945,54 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1190[5] {
+				if yyq1237[5] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("resourceVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1208 := z.EncBinary()
-					_ = yym1208
+					yym1255 := z.EncBinary()
+					_ = yym1255
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
 					}
 				}
 			}
-			if yyr1190 || yy2arr1190 {
+			if yyr1237 || yy2arr1237 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1190[6] {
+				if yyq1237[6] {
 					if x.TimeoutSeconds == nil {
 						r.EncodeNil()
 					} else {
-						yy1210 := *x.TimeoutSeconds
-						yym1211 := z.EncBinary()
-						_ = yym1211
+						yy1257 := *x.TimeoutSeconds
+						yym1258 := z.EncBinary()
+						_ = yym1258
 						if false {
 						} else {
-							r.EncodeInt(int64(yy1210))
+							r.EncodeInt(int64(yy1257))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1190[6] {
+				if yyq1237[6] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("timeoutSeconds"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.TimeoutSeconds == nil {
 						r.EncodeNil()
 					} else {
-						yy1212 := *x.TimeoutSeconds
-						yym1213 := z.EncBinary()
-						_ = yym1213
+						yy1259 := *x.TimeoutSeconds
+						yym1260 := z.EncBinary()
+						_ = yym1260
 						if false {
 						} else {
-							r.EncodeInt(int64(yy1212))
+							r.EncodeInt(int64(yy1259))
 						}
 					}
 				}
 			}
-			if yyr1190 || yy2arr1190 {
+			if yyr1237 || yy2arr1237 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -14419,25 +15005,25 @@ func (x *ListOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1214 := z.DecBinary()
-	_ = yym1214
+	yym1261 := z.DecBinary()
+	_ = yym1261
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1215 := r.ContainerType()
-		if yyct1215 == codecSelferValueTypeMap1234 {
-			yyl1215 := r.ReadMapStart()
-			if yyl1215 == 0 {
+		yyct1262 := r.ContainerType()
+		if yyct1262 == codecSelferValueTypeMap1234 {
+			yyl1262 := r.ReadMapStart()
+			if yyl1262 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1215, d)
+				x.codecDecodeSelfFromMap(yyl1262, d)
 			}
-		} else if yyct1215 == codecSelferValueTypeArray1234 {
-			yyl1215 := r.ReadArrayStart()
-			if yyl1215 == 0 {
+		} else if yyct1262 == codecSelferValueTypeArray1234 {
+			yyl1262 := r.ReadArrayStart()
+			if yyl1262 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1215, d)
+				x.codecDecodeSelfFromArray(yyl1262, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -14449,12 +15035,12 @@ func (x *ListOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1216Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1216Slc
-	var yyhl1216 bool = l >= 0
-	for yyj1216 := 0; ; yyj1216++ {
-		if yyhl1216 {
-			if yyj1216 >= l {
+	var yys1263Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1263Slc
+	var yyhl1263 bool = l >= 0
+	for yyj1263 := 0; ; yyj1263++ {
+		if yyhl1263 {
+			if yyj1263 >= l {
 				break
 			}
 		} else {
@@ -14463,10 +15049,10 @@ func (x *ListOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1216Slc = r.DecodeBytes(yys1216Slc, true, true)
-		yys1216 := string(yys1216Slc)
+		yys1263Slc = r.DecodeBytes(yys1263Slc, true, true)
+		yys1263 := string(yys1263Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1216 {
+		switch yys1263 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -14512,17 +15098,17 @@ func (x *ListOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TimeoutSeconds == nil {
 					x.TimeoutSeconds = new(int64)
 				}
-				yym1224 := z.DecBinary()
-				_ = yym1224
+				yym1271 := z.DecBinary()
+				_ = yym1271
 				if false {
 				} else {
 					*((*int64)(x.TimeoutSeconds)) = int64(r.DecodeInt(64))
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1216)
-		} // end switch yys1216
-	} // end for yyj1216
+			z.DecStructFieldNotFound(-1, yys1263)
+		} // end switch yys1263
+	} // end for yyj1263
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -14530,16 +15116,16 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1225 int
-	var yyb1225 bool
-	var yyhl1225 bool = l >= 0
-	yyj1225++
-	if yyhl1225 {
-		yyb1225 = yyj1225 > l
+	var yyj1272 int
+	var yyb1272 bool
+	var yyhl1272 bool = l >= 0
+	yyj1272++
+	if yyhl1272 {
+		yyb1272 = yyj1272 > l
 	} else {
-		yyb1225 = r.CheckBreak()
+		yyb1272 = r.CheckBreak()
 	}
-	if yyb1225 {
+	if yyb1272 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14549,13 +15135,13 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1225++
-	if yyhl1225 {
-		yyb1225 = yyj1225 > l
+	yyj1272++
+	if yyhl1272 {
+		yyb1272 = yyj1272 > l
 	} else {
-		yyb1225 = r.CheckBreak()
+		yyb1272 = r.CheckBreak()
 	}
-	if yyb1225 {
+	if yyb1272 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14565,13 +15151,13 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1225++
-	if yyhl1225 {
-		yyb1225 = yyj1225 > l
+	yyj1272++
+	if yyhl1272 {
+		yyb1272 = yyj1272 > l
 	} else {
-		yyb1225 = r.CheckBreak()
+		yyb1272 = r.CheckBreak()
 	}
-	if yyb1225 {
+	if yyb1272 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14581,13 +15167,13 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.LabelSelector = string(r.DecodeString())
 	}
-	yyj1225++
-	if yyhl1225 {
-		yyb1225 = yyj1225 > l
+	yyj1272++
+	if yyhl1272 {
+		yyb1272 = yyj1272 > l
 	} else {
-		yyb1225 = r.CheckBreak()
+		yyb1272 = r.CheckBreak()
 	}
-	if yyb1225 {
+	if yyb1272 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14597,13 +15183,13 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.FieldSelector = string(r.DecodeString())
 	}
-	yyj1225++
-	if yyhl1225 {
-		yyb1225 = yyj1225 > l
+	yyj1272++
+	if yyhl1272 {
+		yyb1272 = yyj1272 > l
 	} else {
-		yyb1225 = r.CheckBreak()
+		yyb1272 = r.CheckBreak()
 	}
-	if yyb1225 {
+	if yyb1272 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14613,13 +15199,13 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Watch = bool(r.DecodeBool())
 	}
-	yyj1225++
-	if yyhl1225 {
-		yyb1225 = yyj1225 > l
+	yyj1272++
+	if yyhl1272 {
+		yyb1272 = yyj1272 > l
 	} else {
-		yyb1225 = r.CheckBreak()
+		yyb1272 = r.CheckBreak()
 	}
-	if yyb1225 {
+	if yyb1272 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14629,13 +15215,13 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.ResourceVersion = string(r.DecodeString())
 	}
-	yyj1225++
-	if yyhl1225 {
-		yyb1225 = yyj1225 > l
+	yyj1272++
+	if yyhl1272 {
+		yyb1272 = yyj1272 > l
 	} else {
-		yyb1225 = r.CheckBreak()
+		yyb1272 = r.CheckBreak()
 	}
-	if yyb1225 {
+	if yyb1272 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14648,25 +15234,25 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TimeoutSeconds == nil {
 			x.TimeoutSeconds = new(int64)
 		}
-		yym1233 := z.DecBinary()
-		_ = yym1233
+		yym1280 := z.DecBinary()
+		_ = yym1280
 		if false {
 		} else {
 			*((*int64)(x.TimeoutSeconds)) = int64(r.DecodeInt(64))
 		}
 	}
 	for {
-		yyj1225++
-		if yyhl1225 {
-			yyb1225 = yyj1225 > l
+		yyj1272++
+		if yyhl1272 {
+			yyb1272 = yyj1272 > l
 		} else {
-			yyb1225 = r.CheckBreak()
+			yyb1272 = r.CheckBreak()
 		}
-		if yyb1225 {
+		if yyb1272 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1225-1, "")
+		z.DecStructFieldNotFound(yyj1272-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -14678,39 +15264,39 @@ func (x *LabelSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1234 := z.EncBinary()
-		_ = yym1234
+		yym1281 := z.EncBinary()
+		_ = yym1281
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1235 := !z.EncBinary()
-			yy2arr1235 := z.EncBasicHandle().StructToArray
-			var yyq1235 [2]bool
-			_, _, _ = yysep1235, yyq1235, yy2arr1235
-			const yyr1235 bool = false
-			yyq1235[0] = len(x.MatchLabels) != 0
-			yyq1235[1] = len(x.MatchExpressions) != 0
-			var yynn1235 int
-			if yyr1235 || yy2arr1235 {
+			yysep1282 := !z.EncBinary()
+			yy2arr1282 := z.EncBasicHandle().StructToArray
+			var yyq1282 [2]bool
+			_, _, _ = yysep1282, yyq1282, yy2arr1282
+			const yyr1282 bool = false
+			yyq1282[0] = len(x.MatchLabels) != 0
+			yyq1282[1] = len(x.MatchExpressions) != 0
+			var yynn1282 int
+			if yyr1282 || yy2arr1282 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn1235 = 0
-				for _, b := range yyq1235 {
+				yynn1282 = 0
+				for _, b := range yyq1282 {
 					if b {
-						yynn1235++
+						yynn1282++
 					}
 				}
-				r.EncodeMapStart(yynn1235)
-				yynn1235 = 0
+				r.EncodeMapStart(yynn1282)
+				yynn1282 = 0
 			}
-			if yyr1235 || yy2arr1235 {
+			if yyr1282 || yy2arr1282 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1235[0] {
+				if yyq1282[0] {
 					if x.MatchLabels == nil {
 						r.EncodeNil()
 					} else {
-						yym1237 := z.EncBinary()
-						_ = yym1237
+						yym1284 := z.EncBinary()
+						_ = yym1284
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.MatchLabels, false, e)
@@ -14720,15 +15306,15 @@ func (x *LabelSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1235[0] {
+				if yyq1282[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("matchLabels"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.MatchLabels == nil {
 						r.EncodeNil()
 					} else {
-						yym1238 := z.EncBinary()
-						_ = yym1238
+						yym1285 := z.EncBinary()
+						_ = yym1285
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.MatchLabels, false, e)
@@ -14736,14 +15322,14 @@ func (x *LabelSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1235 || yy2arr1235 {
+			if yyr1282 || yy2arr1282 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1235[1] {
+				if yyq1282[1] {
 					if x.MatchExpressions == nil {
 						r.EncodeNil()
 					} else {
-						yym1240 := z.EncBinary()
-						_ = yym1240
+						yym1287 := z.EncBinary()
+						_ = yym1287
 						if false {
 						} else {
 							h.encSliceLabelSelectorRequirement(([]LabelSelectorRequirement)(x.MatchExpressions), e)
@@ -14753,15 +15339,15 @@ func (x *LabelSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1235[1] {
+				if yyq1282[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("matchExpressions"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.MatchExpressions == nil {
 						r.EncodeNil()
 					} else {
-						yym1241 := z.EncBinary()
-						_ = yym1241
+						yym1288 := z.EncBinary()
+						_ = yym1288
 						if false {
 						} else {
 							h.encSliceLabelSelectorRequirement(([]LabelSelectorRequirement)(x.MatchExpressions), e)
@@ -14769,7 +15355,7 @@ func (x *LabelSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1235 || yy2arr1235 {
+			if yyr1282 || yy2arr1282 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -14782,25 +15368,25 @@ func (x *LabelSelector) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1242 := z.DecBinary()
-	_ = yym1242
+	yym1289 := z.DecBinary()
+	_ = yym1289
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1243 := r.ContainerType()
-		if yyct1243 == codecSelferValueTypeMap1234 {
-			yyl1243 := r.ReadMapStart()
-			if yyl1243 == 0 {
+		yyct1290 := r.ContainerType()
+		if yyct1290 == codecSelferValueTypeMap1234 {
+			yyl1290 := r.ReadMapStart()
+			if yyl1290 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1243, d)
+				x.codecDecodeSelfFromMap(yyl1290, d)
 			}
-		} else if yyct1243 == codecSelferValueTypeArray1234 {
-			yyl1243 := r.ReadArrayStart()
-			if yyl1243 == 0 {
+		} else if yyct1290 == codecSelferValueTypeArray1234 {
+			yyl1290 := r.ReadArrayStart()
+			if yyl1290 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1243, d)
+				x.codecDecodeSelfFromArray(yyl1290, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -14812,12 +15398,12 @@ func (x *LabelSelector) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1244Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1244Slc
-	var yyhl1244 bool = l >= 0
-	for yyj1244 := 0; ; yyj1244++ {
-		if yyhl1244 {
-			if yyj1244 >= l {
+	var yys1291Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1291Slc
+	var yyhl1291 bool = l >= 0
+	for yyj1291 := 0; ; yyj1291++ {
+		if yyhl1291 {
+			if yyj1291 >= l {
 				break
 			}
 		} else {
@@ -14826,38 +15412,38 @@ func (x *LabelSelector) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1244Slc = r.DecodeBytes(yys1244Slc, true, true)
-		yys1244 := string(yys1244Slc)
+		yys1291Slc = r.DecodeBytes(yys1291Slc, true, true)
+		yys1291 := string(yys1291Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1244 {
+		switch yys1291 {
 		case "matchLabels":
 			if r.TryDecodeAsNil() {
 				x.MatchLabels = nil
 			} else {
-				yyv1245 := &x.MatchLabels
-				yym1246 := z.DecBinary()
-				_ = yym1246
+				yyv1292 := &x.MatchLabels
+				yym1293 := z.DecBinary()
+				_ = yym1293
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv1245, false, d)
+					z.F.DecMapStringStringX(yyv1292, false, d)
 				}
 			}
 		case "matchExpressions":
 			if r.TryDecodeAsNil() {
 				x.MatchExpressions = nil
 			} else {
-				yyv1247 := &x.MatchExpressions
-				yym1248 := z.DecBinary()
-				_ = yym1248
+				yyv1294 := &x.MatchExpressions
+				yym1295 := z.DecBinary()
+				_ = yym1295
 				if false {
 				} else {
-					h.decSliceLabelSelectorRequirement((*[]LabelSelectorRequirement)(yyv1247), d)
+					h.decSliceLabelSelectorRequirement((*[]LabelSelectorRequirement)(yyv1294), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1244)
-		} // end switch yys1244
-	} // end for yyj1244
+			z.DecStructFieldNotFound(-1, yys1291)
+		} // end switch yys1291
+	} // end for yyj1291
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -14865,16 +15451,16 @@ func (x *LabelSelector) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1249 int
-	var yyb1249 bool
-	var yyhl1249 bool = l >= 0
-	yyj1249++
-	if yyhl1249 {
-		yyb1249 = yyj1249 > l
+	var yyj1296 int
+	var yyb1296 bool
+	var yyhl1296 bool = l >= 0
+	yyj1296++
+	if yyhl1296 {
+		yyb1296 = yyj1296 > l
 	} else {
-		yyb1249 = r.CheckBreak()
+		yyb1296 = r.CheckBreak()
 	}
-	if yyb1249 {
+	if yyb1296 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14882,21 +15468,21 @@ func (x *LabelSelector) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.MatchLabels = nil
 	} else {
-		yyv1250 := &x.MatchLabels
-		yym1251 := z.DecBinary()
-		_ = yym1251
+		yyv1297 := &x.MatchLabels
+		yym1298 := z.DecBinary()
+		_ = yym1298
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv1250, false, d)
+			z.F.DecMapStringStringX(yyv1297, false, d)
 		}
 	}
-	yyj1249++
-	if yyhl1249 {
-		yyb1249 = yyj1249 > l
+	yyj1296++
+	if yyhl1296 {
+		yyb1296 = yyj1296 > l
 	} else {
-		yyb1249 = r.CheckBreak()
+		yyb1296 = r.CheckBreak()
 	}
-	if yyb1249 {
+	if yyb1296 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14904,26 +15490,26 @@ func (x *LabelSelector) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.MatchExpressions = nil
 	} else {
-		yyv1252 := &x.MatchExpressions
-		yym1253 := z.DecBinary()
-		_ = yym1253
+		yyv1299 := &x.MatchExpressions
+		yym1300 := z.DecBinary()
+		_ = yym1300
 		if false {
 		} else {
-			h.decSliceLabelSelectorRequirement((*[]LabelSelectorRequirement)(yyv1252), d)
+			h.decSliceLabelSelectorRequirement((*[]LabelSelectorRequirement)(yyv1299), d)
 		}
 	}
 	for {
-		yyj1249++
-		if yyhl1249 {
-			yyb1249 = yyj1249 > l
+		yyj1296++
+		if yyhl1296 {
+			yyb1296 = yyj1296 > l
 		} else {
-			yyb1249 = r.CheckBreak()
+			yyb1296 = r.CheckBreak()
 		}
-		if yyb1249 {
+		if yyb1296 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1249-1, "")
+		z.DecStructFieldNotFound(yyj1296-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -14935,34 +15521,34 @@ func (x *LabelSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1254 := z.EncBinary()
-		_ = yym1254
+		yym1301 := z.EncBinary()
+		_ = yym1301
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1255 := !z.EncBinary()
-			yy2arr1255 := z.EncBasicHandle().StructToArray
-			var yyq1255 [3]bool
-			_, _, _ = yysep1255, yyq1255, yy2arr1255
-			const yyr1255 bool = false
-			yyq1255[2] = len(x.Values) != 0
-			var yynn1255 int
-			if yyr1255 || yy2arr1255 {
+			yysep1302 := !z.EncBinary()
+			yy2arr1302 := z.EncBasicHandle().StructToArray
+			var yyq1302 [3]bool
+			_, _, _ = yysep1302, yyq1302, yy2arr1302
+			const yyr1302 bool = false
+			yyq1302[2] = len(x.Values) != 0
+			var yynn1302 int
+			if yyr1302 || yy2arr1302 {
 				r.EncodeArrayStart(3)
 			} else {
-				yynn1255 = 2
-				for _, b := range yyq1255 {
+				yynn1302 = 2
+				for _, b := range yyq1302 {
 					if b {
-						yynn1255++
+						yynn1302++
 					}
 				}
-				r.EncodeMapStart(yynn1255)
-				yynn1255 = 0
+				r.EncodeMapStart(yynn1302)
+				yynn1302 = 0
 			}
-			if yyr1255 || yy2arr1255 {
+			if yyr1302 || yy2arr1302 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1257 := z.EncBinary()
-				_ = yym1257
+				yym1304 := z.EncBinary()
+				_ = yym1304
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
@@ -14971,14 +15557,14 @@ func (x *LabelSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("key"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1258 := z.EncBinary()
-				_ = yym1258
+				yym1305 := z.EncBinary()
+				_ = yym1305
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
 				}
 			}
-			if yyr1255 || yy2arr1255 {
+			if yyr1302 || yy2arr1302 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Operator.CodecEncodeSelf(e)
 			} else {
@@ -14987,14 +15573,14 @@ func (x *LabelSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Operator.CodecEncodeSelf(e)
 			}
-			if yyr1255 || yy2arr1255 {
+			if yyr1302 || yy2arr1302 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1255[2] {
+				if yyq1302[2] {
 					if x.Values == nil {
 						r.EncodeNil()
 					} else {
-						yym1261 := z.EncBinary()
-						_ = yym1261
+						yym1308 := z.EncBinary()
+						_ = yym1308
 						if false {
 						} else {
 							z.F.EncSliceStringV(x.Values, false, e)
@@ -15004,15 +15590,15 @@ func (x *LabelSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1255[2] {
+				if yyq1302[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("values"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Values == nil {
 						r.EncodeNil()
 					} else {
-						yym1262 := z.EncBinary()
-						_ = yym1262
+						yym1309 := z.EncBinary()
+						_ = yym1309
 						if false {
 						} else {
 							z.F.EncSliceStringV(x.Values, false, e)
@@ -15020,7 +15606,7 @@ func (x *LabelSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1255 || yy2arr1255 {
+			if yyr1302 || yy2arr1302 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -15033,25 +15619,25 @@ func (x *LabelSelectorRequirement) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1263 := z.DecBinary()
-	_ = yym1263
+	yym1310 := z.DecBinary()
+	_ = yym1310
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1264 := r.ContainerType()
-		if yyct1264 == codecSelferValueTypeMap1234 {
-			yyl1264 := r.ReadMapStart()
-			if yyl1264 == 0 {
+		yyct1311 := r.ContainerType()
+		if yyct1311 == codecSelferValueTypeMap1234 {
+			yyl1311 := r.ReadMapStart()
+			if yyl1311 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1264, d)
+				x.codecDecodeSelfFromMap(yyl1311, d)
 			}
-		} else if yyct1264 == codecSelferValueTypeArray1234 {
-			yyl1264 := r.ReadArrayStart()
-			if yyl1264 == 0 {
+		} else if yyct1311 == codecSelferValueTypeArray1234 {
+			yyl1311 := r.ReadArrayStart()
+			if yyl1311 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1264, d)
+				x.codecDecodeSelfFromArray(yyl1311, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -15063,12 +15649,12 @@ func (x *LabelSelectorRequirement) codecDecodeSelfFromMap(l int, d *codec1978.De
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1265Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1265Slc
-	var yyhl1265 bool = l >= 0
-	for yyj1265 := 0; ; yyj1265++ {
-		if yyhl1265 {
-			if yyj1265 >= l {
+	var yys1312Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1312Slc
+	var yyhl1312 bool = l >= 0
+	for yyj1312 := 0; ; yyj1312++ {
+		if yyhl1312 {
+			if yyj1312 >= l {
 				break
 			}
 		} else {
@@ -15077,10 +15663,10 @@ func (x *LabelSelectorRequirement) codecDecodeSelfFromMap(l int, d *codec1978.De
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1265Slc = r.DecodeBytes(yys1265Slc, true, true)
-		yys1265 := string(yys1265Slc)
+		yys1312Slc = r.DecodeBytes(yys1312Slc, true, true)
+		yys1312 := string(yys1312Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1265 {
+		switch yys1312 {
 		case "key":
 			if r.TryDecodeAsNil() {
 				x.Key = ""
@@ -15097,18 +15683,18 @@ func (x *LabelSelectorRequirement) codecDecodeSelfFromMap(l int, d *codec1978.De
 			if r.TryDecodeAsNil() {
 				x.Values = nil
 			} else {
-				yyv1268 := &x.Values
-				yym1269 := z.DecBinary()
-				_ = yym1269
+				yyv1315 := &x.Values
+				yym1316 := z.DecBinary()
+				_ = yym1316
 				if false {
 				} else {
-					z.F.DecSliceStringX(yyv1268, false, d)
+					z.F.DecSliceStringX(yyv1315, false, d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1265)
-		} // end switch yys1265
-	} // end for yyj1265
+			z.DecStructFieldNotFound(-1, yys1312)
+		} // end switch yys1312
+	} // end for yyj1312
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -15116,16 +15702,16 @@ func (x *LabelSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1270 int
-	var yyb1270 bool
-	var yyhl1270 bool = l >= 0
-	yyj1270++
-	if yyhl1270 {
-		yyb1270 = yyj1270 > l
+	var yyj1317 int
+	var yyb1317 bool
+	var yyhl1317 bool = l >= 0
+	yyj1317++
+	if yyhl1317 {
+		yyb1317 = yyj1317 > l
 	} else {
-		yyb1270 = r.CheckBreak()
+		yyb1317 = r.CheckBreak()
 	}
-	if yyb1270 {
+	if yyb1317 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15135,13 +15721,13 @@ func (x *LabelSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.
 	} else {
 		x.Key = string(r.DecodeString())
 	}
-	yyj1270++
-	if yyhl1270 {
-		yyb1270 = yyj1270 > l
+	yyj1317++
+	if yyhl1317 {
+		yyb1317 = yyj1317 > l
 	} else {
-		yyb1270 = r.CheckBreak()
+		yyb1317 = r.CheckBreak()
 	}
-	if yyb1270 {
+	if yyb1317 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15151,13 +15737,13 @@ func (x *LabelSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.
 	} else {
 		x.Operator = LabelSelectorOperator(r.DecodeString())
 	}
-	yyj1270++
-	if yyhl1270 {
-		yyb1270 = yyj1270 > l
+	yyj1317++
+	if yyhl1317 {
+		yyb1317 = yyj1317 > l
 	} else {
-		yyb1270 = r.CheckBreak()
+		yyb1317 = r.CheckBreak()
 	}
-	if yyb1270 {
+	if yyb1317 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15165,26 +15751,26 @@ func (x *LabelSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.
 	if r.TryDecodeAsNil() {
 		x.Values = nil
 	} else {
-		yyv1273 := &x.Values
-		yym1274 := z.DecBinary()
-		_ = yym1274
+		yyv1320 := &x.Values
+		yym1321 := z.DecBinary()
+		_ = yym1321
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv1273, false, d)
+			z.F.DecSliceStringX(yyv1320, false, d)
 		}
 	}
 	for {
-		yyj1270++
-		if yyhl1270 {
-			yyb1270 = yyj1270 > l
+		yyj1317++
+		if yyhl1317 {
+			yyb1317 = yyj1317 > l
 		} else {
-			yyb1270 = r.CheckBreak()
+			yyb1317 = r.CheckBreak()
 		}
-		if yyb1270 {
+		if yyb1317 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1270-1, "")
+		z.DecStructFieldNotFound(yyj1317-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -15193,8 +15779,8 @@ func (x LabelSelectorOperator) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym1275 := z.EncBinary()
-	_ = yym1275
+	yym1322 := z.EncBinary()
+	_ = yym1322
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -15206,8 +15792,8 @@ func (x *LabelSelectorOperator) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1276 := z.DecBinary()
-	_ = yym1276
+	yym1323 := z.DecBinary()
+	_ = yym1323
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -15222,39 +15808,39 @@ func (x *ReplicaSet) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1277 := z.EncBinary()
-		_ = yym1277
+		yym1324 := z.EncBinary()
+		_ = yym1324
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1278 := !z.EncBinary()
-			yy2arr1278 := z.EncBasicHandle().StructToArray
-			var yyq1278 [5]bool
-			_, _, _ = yysep1278, yyq1278, yy2arr1278
-			const yyr1278 bool = false
-			yyq1278[0] = x.Kind != ""
-			yyq1278[1] = x.APIVersion != ""
-			yyq1278[2] = true
-			yyq1278[3] = true
-			yyq1278[4] = true
-			var yynn1278 int
-			if yyr1278 || yy2arr1278 {
+			yysep1325 := !z.EncBinary()
+			yy2arr1325 := z.EncBasicHandle().StructToArray
+			var yyq1325 [5]bool
+			_, _, _ = yysep1325, yyq1325, yy2arr1325
+			const yyr1325 bool = false
+			yyq1325[0] = x.Kind != ""
+			yyq1325[1] = x.APIVersion != ""
+			yyq1325[2] = true
+			yyq1325[3] = true
+			yyq1325[4] = true
+			var yynn1325 int
+			if yyr1325 || yy2arr1325 {
 				r.EncodeArrayStart(5)
 			} else {
-				yynn1278 = 0
-				for _, b := range yyq1278 {
+				yynn1325 = 0
+				for _, b := range yyq1325 {
 					if b {
-						yynn1278++
+						yynn1325++
 					}
 				}
-				r.EncodeMapStart(yynn1278)
-				yynn1278 = 0
+				r.EncodeMapStart(yynn1325)
+				yynn1325 = 0
 			}
-			if yyr1278 || yy2arr1278 {
+			if yyr1325 || yy2arr1325 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1278[0] {
-					yym1280 := z.EncBinary()
-					_ = yym1280
+				if yyq1325[0] {
+					yym1327 := z.EncBinary()
+					_ = yym1327
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -15263,23 +15849,23 @@ func (x *ReplicaSet) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1278[0] {
+				if yyq1325[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1281 := z.EncBinary()
-					_ = yym1281
+					yym1328 := z.EncBinary()
+					_ = yym1328
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1278 || yy2arr1278 {
+			if yyr1325 || yy2arr1325 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1278[1] {
-					yym1283 := z.EncBinary()
-					_ = yym1283
+				if yyq1325[1] {
+					yym1330 := z.EncBinary()
+					_ = yym1330
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -15288,70 +15874,70 @@ func (x *ReplicaSet) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1278[1] {
+				if yyq1325[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1284 := z.EncBinary()
-					_ = yym1284
+					yym1331 := z.EncBinary()
+					_ = yym1331
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1278 || yy2arr1278 {
+			if yyr1325 || yy2arr1325 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1278[2] {
-					yy1286 := &x.ObjectMeta
-					yy1286.CodecEncodeSelf(e)
+				if yyq1325[2] {
+					yy1333 := &x.ObjectMeta
+					yy1333.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1278[2] {
+				if yyq1325[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1287 := &x.ObjectMeta
-					yy1287.CodecEncodeSelf(e)
+					yy1334 := &x.ObjectMeta
+					yy1334.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1278 || yy2arr1278 {
+			if yyr1325 || yy2arr1325 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1278[3] {
-					yy1289 := &x.Spec
-					yy1289.CodecEncodeSelf(e)
+				if yyq1325[3] {
+					yy1336 := &x.Spec
+					yy1336.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1278[3] {
+				if yyq1325[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1290 := &x.Spec
-					yy1290.CodecEncodeSelf(e)
+					yy1337 := &x.Spec
+					yy1337.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1278 || yy2arr1278 {
+			if yyr1325 || yy2arr1325 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1278[4] {
-					yy1292 := &x.Status
-					yy1292.CodecEncodeSelf(e)
+				if yyq1325[4] {
+					yy1339 := &x.Status
+					yy1339.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1278[4] {
+				if yyq1325[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1293 := &x.Status
-					yy1293.CodecEncodeSelf(e)
+					yy1340 := &x.Status
+					yy1340.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1278 || yy2arr1278 {
+			if yyr1325 || yy2arr1325 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -15364,25 +15950,25 @@ func (x *ReplicaSet) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1294 := z.DecBinary()
-	_ = yym1294
+	yym1341 := z.DecBinary()
+	_ = yym1341
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1295 := r.ContainerType()
-		if yyct1295 == codecSelferValueTypeMap1234 {
-			yyl1295 := r.ReadMapStart()
-			if yyl1295 == 0 {
+		yyct1342 := r.ContainerType()
+		if yyct1342 == codecSelferValueTypeMap1234 {
+			yyl1342 := r.ReadMapStart()
+			if yyl1342 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1295, d)
+				x.codecDecodeSelfFromMap(yyl1342, d)
 			}
-		} else if yyct1295 == codecSelferValueTypeArray1234 {
-			yyl1295 := r.ReadArrayStart()
-			if yyl1295 == 0 {
+		} else if yyct1342 == codecSelferValueTypeArray1234 {
+			yyl1342 := r.ReadArrayStart()
+			if yyl1342 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1295, d)
+				x.codecDecodeSelfFromArray(yyl1342, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -15394,12 +15980,12 @@ func (x *ReplicaSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1296Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1296Slc
-	var yyhl1296 bool = l >= 0
-	for yyj1296 := 0; ; yyj1296++ {
-		if yyhl1296 {
-			if yyj1296 >= l {
+	var yys1343Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1343Slc
+	var yyhl1343 bool = l >= 0
+	for yyj1343 := 0; ; yyj1343++ {
+		if yyhl1343 {
+			if yyj1343 >= l {
 				break
 			}
 		} else {
@@ -15408,10 +15994,10 @@ func (x *ReplicaSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1296Slc = r.DecodeBytes(yys1296Slc, true, true)
-		yys1296 := string(yys1296Slc)
+		yys1343Slc = r.DecodeBytes(yys1343Slc, true, true)
+		yys1343 := string(yys1343Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1296 {
+		switch yys1343 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -15428,27 +16014,27 @@ func (x *ReplicaSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_v1.ObjectMeta{}
 			} else {
-				yyv1299 := &x.ObjectMeta
-				yyv1299.CodecDecodeSelf(d)
+				yyv1346 := &x.ObjectMeta
+				yyv1346.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = ReplicaSetSpec{}
 			} else {
-				yyv1300 := &x.Spec
-				yyv1300.CodecDecodeSelf(d)
+				yyv1347 := &x.Spec
+				yyv1347.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = ReplicaSetStatus{}
 			} else {
-				yyv1301 := &x.Status
-				yyv1301.CodecDecodeSelf(d)
+				yyv1348 := &x.Status
+				yyv1348.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1296)
-		} // end switch yys1296
-	} // end for yyj1296
+			z.DecStructFieldNotFound(-1, yys1343)
+		} // end switch yys1343
+	} // end for yyj1343
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -15456,16 +16042,16 @@ func (x *ReplicaSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1302 int
-	var yyb1302 bool
-	var yyhl1302 bool = l >= 0
-	yyj1302++
-	if yyhl1302 {
-		yyb1302 = yyj1302 > l
+	var yyj1349 int
+	var yyb1349 bool
+	var yyhl1349 bool = l >= 0
+	yyj1349++
+	if yyhl1349 {
+		yyb1349 = yyj1349 > l
 	} else {
-		yyb1302 = r.CheckBreak()
+		yyb1349 = r.CheckBreak()
 	}
-	if yyb1302 {
+	if yyb1349 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15475,13 +16061,13 @@ func (x *ReplicaSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1302++
-	if yyhl1302 {
-		yyb1302 = yyj1302 > l
+	yyj1349++
+	if yyhl1349 {
+		yyb1349 = yyj1349 > l
 	} else {
-		yyb1302 = r.CheckBreak()
+		yyb1349 = r.CheckBreak()
 	}
-	if yyb1302 {
+	if yyb1349 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15491,13 +16077,13 @@ func (x *ReplicaSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1302++
-	if yyhl1302 {
-		yyb1302 = yyj1302 > l
+	yyj1349++
+	if yyhl1349 {
+		yyb1349 = yyj1349 > l
 	} else {
-		yyb1302 = r.CheckBreak()
+		yyb1349 = r.CheckBreak()
 	}
-	if yyb1302 {
+	if yyb1349 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15505,16 +16091,16 @@ func (x *ReplicaSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_v1.ObjectMeta{}
 	} else {
-		yyv1305 := &x.ObjectMeta
-		yyv1305.CodecDecodeSelf(d)
+		yyv1352 := &x.ObjectMeta
+		yyv1352.CodecDecodeSelf(d)
 	}
-	yyj1302++
-	if yyhl1302 {
-		yyb1302 = yyj1302 > l
+	yyj1349++
+	if yyhl1349 {
+		yyb1349 = yyj1349 > l
 	} else {
-		yyb1302 = r.CheckBreak()
+		yyb1349 = r.CheckBreak()
 	}
-	if yyb1302 {
+	if yyb1349 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15522,16 +16108,16 @@ func (x *ReplicaSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Spec = ReplicaSetSpec{}
 	} else {
-		yyv1306 := &x.Spec
-		yyv1306.CodecDecodeSelf(d)
+		yyv1353 := &x.Spec
+		yyv1353.CodecDecodeSelf(d)
 	}
-	yyj1302++
-	if yyhl1302 {
-		yyb1302 = yyj1302 > l
+	yyj1349++
+	if yyhl1349 {
+		yyb1349 = yyj1349 > l
 	} else {
-		yyb1302 = r.CheckBreak()
+		yyb1349 = r.CheckBreak()
 	}
-	if yyb1302 {
+	if yyb1349 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15539,21 +16125,21 @@ func (x *ReplicaSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Status = ReplicaSetStatus{}
 	} else {
-		yyv1307 := &x.Status
-		yyv1307.CodecDecodeSelf(d)
+		yyv1354 := &x.Status
+		yyv1354.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1302++
-		if yyhl1302 {
-			yyb1302 = yyj1302 > l
+		yyj1349++
+		if yyhl1349 {
+			yyb1349 = yyj1349 > l
 		} else {
-			yyb1302 = r.CheckBreak()
+			yyb1349 = r.CheckBreak()
 		}
-		if yyb1302 {
+		if yyb1349 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1302-1, "")
+		z.DecStructFieldNotFound(yyj1349-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -15565,37 +16151,37 @@ func (x *ReplicaSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1308 := z.EncBinary()
-		_ = yym1308
+		yym1355 := z.EncBinary()
+		_ = yym1355
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1309 := !z.EncBinary()
-			yy2arr1309 := z.EncBasicHandle().StructToArray
-			var yyq1309 [4]bool
-			_, _, _ = yysep1309, yyq1309, yy2arr1309
-			const yyr1309 bool = false
-			yyq1309[0] = x.Kind != ""
-			yyq1309[1] = x.APIVersion != ""
-			yyq1309[2] = true
-			var yynn1309 int
-			if yyr1309 || yy2arr1309 {
+			yysep1356 := !z.EncBinary()
+			yy2arr1356 := z.EncBasicHandle().StructToArray
+			var yyq1356 [4]bool
+			_, _, _ = yysep1356, yyq1356, yy2arr1356
+			const yyr1356 bool = false
+			yyq1356[0] = x.Kind != ""
+			yyq1356[1] = x.APIVersion != ""
+			yyq1356[2] = true
+			var yynn1356 int
+			if yyr1356 || yy2arr1356 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn1309 = 1
-				for _, b := range yyq1309 {
+				yynn1356 = 1
+				for _, b := range yyq1356 {
 					if b {
-						yynn1309++
+						yynn1356++
 					}
 				}
-				r.EncodeMapStart(yynn1309)
-				yynn1309 = 0
+				r.EncodeMapStart(yynn1356)
+				yynn1356 = 0
 			}
-			if yyr1309 || yy2arr1309 {
+			if yyr1356 || yy2arr1356 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1309[0] {
-					yym1311 := z.EncBinary()
-					_ = yym1311
+				if yyq1356[0] {
+					yym1358 := z.EncBinary()
+					_ = yym1358
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -15604,23 +16190,23 @@ func (x *ReplicaSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1309[0] {
+				if yyq1356[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1312 := z.EncBinary()
-					_ = yym1312
+					yym1359 := z.EncBinary()
+					_ = yym1359
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1309 || yy2arr1309 {
+			if yyr1356 || yy2arr1356 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1309[1] {
-					yym1314 := z.EncBinary()
-					_ = yym1314
+				if yyq1356[1] {
+					yym1361 := z.EncBinary()
+					_ = yym1361
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -15629,54 +16215,54 @@ func (x *ReplicaSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1309[1] {
+				if yyq1356[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1315 := z.EncBinary()
-					_ = yym1315
+					yym1362 := z.EncBinary()
+					_ = yym1362
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1309 || yy2arr1309 {
+			if yyr1356 || yy2arr1356 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1309[2] {
-					yy1317 := &x.ListMeta
-					yym1318 := z.EncBinary()
-					_ = yym1318
+				if yyq1356[2] {
+					yy1364 := &x.ListMeta
+					yym1365 := z.EncBinary()
+					_ = yym1365
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1317) {
+					} else if z.HasExtensions() && z.EncExt(yy1364) {
 					} else {
-						z.EncFallback(yy1317)
+						z.EncFallback(yy1364)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1309[2] {
+				if yyq1356[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1319 := &x.ListMeta
-					yym1320 := z.EncBinary()
-					_ = yym1320
+					yy1366 := &x.ListMeta
+					yym1367 := z.EncBinary()
+					_ = yym1367
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1319) {
+					} else if z.HasExtensions() && z.EncExt(yy1366) {
 					} else {
-						z.EncFallback(yy1319)
+						z.EncFallback(yy1366)
 					}
 				}
 			}
-			if yyr1309 || yy2arr1309 {
+			if yyr1356 || yy2arr1356 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1322 := z.EncBinary()
-					_ = yym1322
+					yym1369 := z.EncBinary()
+					_ = yym1369
 					if false {
 					} else {
 						h.encSliceReplicaSet(([]ReplicaSet)(x.Items), e)
@@ -15689,15 +16275,15 @@ func (x *ReplicaSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1323 := z.EncBinary()
-					_ = yym1323
+					yym1370 := z.EncBinary()
+					_ = yym1370
 					if false {
 					} else {
 						h.encSliceReplicaSet(([]ReplicaSet)(x.Items), e)
 					}
 				}
 			}
-			if yyr1309 || yy2arr1309 {
+			if yyr1356 || yy2arr1356 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -15710,25 +16296,25 @@ func (x *ReplicaSetList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1324 := z.DecBinary()
-	_ = yym1324
+	yym1371 := z.DecBinary()
+	_ = yym1371
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1325 := r.ContainerType()
-		if yyct1325 == codecSelferValueTypeMap1234 {
-			yyl1325 := r.ReadMapStart()
-			if yyl1325 == 0 {
+		yyct1372 := r.ContainerType()
+		if yyct1372 == codecSelferValueTypeMap1234 {
+			yyl1372 := r.ReadMapStart()
+			if yyl1372 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1325, d)
+				x.codecDecodeSelfFromMap(yyl1372, d)
 			}
-		} else if yyct1325 == codecSelferValueTypeArray1234 {
-			yyl1325 := r.ReadArrayStart()
-			if yyl1325 == 0 {
+		} else if yyct1372 == codecSelferValueTypeArray1234 {
+			yyl1372 := r.ReadArrayStart()
+			if yyl1372 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1325, d)
+				x.codecDecodeSelfFromArray(yyl1372, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -15740,12 +16326,12 @@ func (x *ReplicaSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1326Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1326Slc
-	var yyhl1326 bool = l >= 0
-	for yyj1326 := 0; ; yyj1326++ {
-		if yyhl1326 {
-			if yyj1326 >= l {
+	var yys1373Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1373Slc
+	var yyhl1373 bool = l >= 0
+	for yyj1373 := 0; ; yyj1373++ {
+		if yyhl1373 {
+			if yyj1373 >= l {
 				break
 			}
 		} else {
@@ -15754,10 +16340,10 @@ func (x *ReplicaSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1326Slc = r.DecodeBytes(yys1326Slc, true, true)
-		yys1326 := string(yys1326Slc)
+		yys1373Slc = r.DecodeBytes(yys1373Slc, true, true)
+		yys1373 := string(yys1373Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1326 {
+		switch yys1373 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -15774,31 +16360,31 @@ func (x *ReplicaSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv1329 := &x.ListMeta
-				yym1330 := z.DecBinary()
-				_ = yym1330
+				yyv1376 := &x.ListMeta
+				yym1377 := z.DecBinary()
+				_ = yym1377
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1329) {
+				} else if z.HasExtensions() && z.DecExt(yyv1376) {
 				} else {
-					z.DecFallback(yyv1329, false)
+					z.DecFallback(yyv1376, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv1331 := &x.Items
-				yym1332 := z.DecBinary()
-				_ = yym1332
+				yyv1378 := &x.Items
+				yym1379 := z.DecBinary()
+				_ = yym1379
 				if false {
 				} else {
-					h.decSliceReplicaSet((*[]ReplicaSet)(yyv1331), d)
+					h.decSliceReplicaSet((*[]ReplicaSet)(yyv1378), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1326)
-		} // end switch yys1326
-	} // end for yyj1326
+			z.DecStructFieldNotFound(-1, yys1373)
+		} // end switch yys1373
+	} // end for yyj1373
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -15806,16 +16392,16 @@ func (x *ReplicaSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1333 int
-	var yyb1333 bool
-	var yyhl1333 bool = l >= 0
-	yyj1333++
-	if yyhl1333 {
-		yyb1333 = yyj1333 > l
+	var yyj1380 int
+	var yyb1380 bool
+	var yyhl1380 bool = l >= 0
+	yyj1380++
+	if yyhl1380 {
+		yyb1380 = yyj1380 > l
 	} else {
-		yyb1333 = r.CheckBreak()
+		yyb1380 = r.CheckBreak()
 	}
-	if yyb1333 {
+	if yyb1380 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15825,13 +16411,13 @@ func (x *ReplicaSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1333++
-	if yyhl1333 {
-		yyb1333 = yyj1333 > l
+	yyj1380++
+	if yyhl1380 {
+		yyb1380 = yyj1380 > l
 	} else {
-		yyb1333 = r.CheckBreak()
+		yyb1380 = r.CheckBreak()
 	}
-	if yyb1333 {
+	if yyb1380 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15841,13 +16427,13 @@ func (x *ReplicaSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1333++
-	if yyhl1333 {
-		yyb1333 = yyj1333 > l
+	yyj1380++
+	if yyhl1380 {
+		yyb1380 = yyj1380 > l
 	} else {
-		yyb1333 = r.CheckBreak()
+		yyb1380 = r.CheckBreak()
 	}
-	if yyb1333 {
+	if yyb1380 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15855,22 +16441,22 @@ func (x *ReplicaSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv1336 := &x.ListMeta
-		yym1337 := z.DecBinary()
-		_ = yym1337
+		yyv1383 := &x.ListMeta
+		yym1384 := z.DecBinary()
+		_ = yym1384
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1336) {
+		} else if z.HasExtensions() && z.DecExt(yyv1383) {
 		} else {
-			z.DecFallback(yyv1336, false)
+			z.DecFallback(yyv1383, false)
 		}
 	}
-	yyj1333++
-	if yyhl1333 {
-		yyb1333 = yyj1333 > l
+	yyj1380++
+	if yyhl1380 {
+		yyb1380 = yyj1380 > l
 	} else {
-		yyb1333 = r.CheckBreak()
+		yyb1380 = r.CheckBreak()
 	}
-	if yyb1333 {
+	if yyb1380 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15878,26 +16464,26 @@ func (x *ReplicaSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv1338 := &x.Items
-		yym1339 := z.DecBinary()
-		_ = yym1339
+		yyv1385 := &x.Items
+		yym1386 := z.DecBinary()
+		_ = yym1386
 		if false {
 		} else {
-			h.decSliceReplicaSet((*[]ReplicaSet)(yyv1338), d)
+			h.decSliceReplicaSet((*[]ReplicaSet)(yyv1385), d)
 		}
 	}
 	for {
-		yyj1333++
-		if yyhl1333 {
-			yyb1333 = yyj1333 > l
+		yyj1380++
+		if yyhl1380 {
+			yyb1380 = yyj1380 > l
 		} else {
-			yyb1333 = r.CheckBreak()
+			yyb1380 = r.CheckBreak()
 		}
-		if yyb1333 {
+		if yyb1380 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1333-1, "")
+		z.DecStructFieldNotFound(yyj1380-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -15909,70 +16495,70 @@ func (x *ReplicaSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1340 := z.EncBinary()
-		_ = yym1340
+		yym1387 := z.EncBinary()
+		_ = yym1387
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1341 := !z.EncBinary()
-			yy2arr1341 := z.EncBasicHandle().StructToArray
-			var yyq1341 [3]bool
-			_, _, _ = yysep1341, yyq1341, yy2arr1341
-			const yyr1341 bool = false
-			yyq1341[0] = x.Replicas != nil
-			yyq1341[1] = x.Selector != nil
-			yyq1341[2] = x.Template != nil
-			var yynn1341 int
-			if yyr1341 || yy2arr1341 {
+			yysep1388 := !z.EncBinary()
+			yy2arr1388 := z.EncBasicHandle().StructToArray
+			var yyq1388 [3]bool
+			_, _, _ = yysep1388, yyq1388, yy2arr1388
+			const yyr1388 bool = false
+			yyq1388[0] = x.Replicas != nil
+			yyq1388[1] = x.Selector != nil
+			yyq1388[2] = x.Template != nil
+			var yynn1388 int
+			if yyr1388 || yy2arr1388 {
 				r.EncodeArrayStart(3)
 			} else {
-				yynn1341 = 0
-				for _, b := range yyq1341 {
+				yynn1388 = 0
+				for _, b := range yyq1388 {
 					if b {
-						yynn1341++
+						yynn1388++
 					}
 				}
-				r.EncodeMapStart(yynn1341)
-				yynn1341 = 0
+				r.EncodeMapStart(yynn1388)
+				yynn1388 = 0
 			}
-			if yyr1341 || yy2arr1341 {
+			if yyr1388 || yy2arr1388 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1341[0] {
+				if yyq1388[0] {
 					if x.Replicas == nil {
 						r.EncodeNil()
 					} else {
-						yy1343 := *x.Replicas
-						yym1344 := z.EncBinary()
-						_ = yym1344
+						yy1390 := *x.Replicas
+						yym1391 := z.EncBinary()
+						_ = yym1391
 						if false {
 						} else {
-							r.EncodeInt(int64(yy1343))
+							r.EncodeInt(int64(yy1390))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1341[0] {
+				if yyq1388[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("replicas"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Replicas == nil {
 						r.EncodeNil()
 					} else {
-						yy1345 := *x.Replicas
-						yym1346 := z.EncBinary()
-						_ = yym1346
+						yy1392 := *x.Replicas
+						yym1393 := z.EncBinary()
+						_ = yym1393
 						if false {
 						} else {
-							r.EncodeInt(int64(yy1345))
+							r.EncodeInt(int64(yy1392))
 						}
 					}
 				}
 			}
-			if yyr1341 || yy2arr1341 {
+			if yyr1388 || yy2arr1388 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1341[1] {
+				if yyq1388[1] {
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
@@ -15982,7 +16568,7 @@ func (x *ReplicaSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1341[1] {
+				if yyq1388[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
@@ -15993,9 +16579,9 @@ func (x *ReplicaSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1341 || yy2arr1341 {
+			if yyr1388 || yy2arr1388 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1341[2] {
+				if yyq1388[2] {
 					if x.Template == nil {
 						r.EncodeNil()
 					} else {
@@ -16005,7 +16591,7 @@ func (x *ReplicaSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1341[2] {
+				if yyq1388[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("template"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
@@ -16016,7 +16602,7 @@ func (x *ReplicaSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1341 || yy2arr1341 {
+			if yyr1388 || yy2arr1388 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -16029,25 +16615,25 @@ func (x *ReplicaSetSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1349 := z.DecBinary()
-	_ = yym1349
+	yym1396 := z.DecBinary()
+	_ = yym1396
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1350 := r.ContainerType()
-		if yyct1350 == codecSelferValueTypeMap1234 {
-			yyl1350 := r.ReadMapStart()
-			if yyl1350 == 0 {
+		yyct1397 := r.ContainerType()
+		if yyct1397 == codecSelferValueTypeMap1234 {
+			yyl1397 := r.ReadMapStart()
+			if yyl1397 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1350, d)
+				x.codecDecodeSelfFromMap(yyl1397, d)
 			}
-		} else if yyct1350 == codecSelferValueTypeArray1234 {
-			yyl1350 := r.ReadArrayStart()
-			if yyl1350 == 0 {
+		} else if yyct1397 == codecSelferValueTypeArray1234 {
+			yyl1397 := r.ReadArrayStart()
+			if yyl1397 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1350, d)
+				x.codecDecodeSelfFromArray(yyl1397, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -16059,12 +16645,12 @@ func (x *ReplicaSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1351Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1351Slc
-	var yyhl1351 bool = l >= 0
-	for yyj1351 := 0; ; yyj1351++ {
-		if yyhl1351 {
-			if yyj1351 >= l {
+	var yys1398Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1398Slc
+	var yyhl1398 bool = l >= 0
+	for yyj1398 := 0; ; yyj1398++ {
+		if yyhl1398 {
+			if yyj1398 >= l {
 				break
 			}
 		} else {
@@ -16073,10 +16659,10 @@ func (x *ReplicaSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1351Slc = r.DecodeBytes(yys1351Slc, true, true)
-		yys1351 := string(yys1351Slc)
+		yys1398Slc = r.DecodeBytes(yys1398Slc, true, true)
+		yys1398 := string(yys1398Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1351 {
+		switch yys1398 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
 				if x.Replicas != nil {
@@ -16086,8 +16672,8 @@ func (x *ReplicaSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Replicas == nil {
 					x.Replicas = new(int32)
 				}
-				yym1353 := z.DecBinary()
-				_ = yym1353
+				yym1400 := z.DecBinary()
+				_ = yym1400
 				if false {
 				} else {
 					*((*int32)(x.Replicas)) = int32(r.DecodeInt(32))
@@ -16116,9 +16702,9 @@ func (x *ReplicaSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Template.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1351)
-		} // end switch yys1351
-	} // end for yyj1351
+			z.DecStructFieldNotFound(-1, yys1398)
+		} // end switch yys1398
+	} // end for yyj1398
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -16126,16 +16712,16 @@ func (x *ReplicaSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1356 int
-	var yyb1356 bool
-	var yyhl1356 bool = l >= 0
-	yyj1356++
-	if yyhl1356 {
-		yyb1356 = yyj1356 > l
+	var yyj1403 int
+	var yyb1403 bool
+	var yyhl1403 bool = l >= 0
+	yyj1403++
+	if yyhl1403 {
+		yyb1403 = yyj1403 > l
 	} else {
-		yyb1356 = r.CheckBreak()
+		yyb1403 = r.CheckBreak()
 	}
-	if yyb1356 {
+	if yyb1403 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -16148,20 +16734,20 @@ func (x *ReplicaSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.Replicas == nil {
 			x.Replicas = new(int32)
 		}
-		yym1358 := z.DecBinary()
-		_ = yym1358
+		yym1405 := z.DecBinary()
+		_ = yym1405
 		if false {
 		} else {
 			*((*int32)(x.Replicas)) = int32(r.DecodeInt(32))
 		}
 	}
-	yyj1356++
-	if yyhl1356 {
-		yyb1356 = yyj1356 > l
+	yyj1403++
+	if yyhl1403 {
+		yyb1403 = yyj1403 > l
 	} else {
-		yyb1356 = r.CheckBreak()
+		yyb1403 = r.CheckBreak()
 	}
-	if yyb1356 {
+	if yyb1403 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -16176,13 +16762,13 @@ func (x *ReplicaSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Selector.CodecDecodeSelf(d)
 	}
-	yyj1356++
-	if yyhl1356 {
-		yyb1356 = yyj1356 > l
+	yyj1403++
+	if yyhl1403 {
+		yyb1403 = yyj1403 > l
 	} else {
-		yyb1356 = r.CheckBreak()
+		yyb1403 = r.CheckBreak()
 	}
-	if yyb1356 {
+	if yyb1403 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -16198,17 +16784,17 @@ func (x *ReplicaSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Template.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1356++
-		if yyhl1356 {
-			yyb1356 = yyj1356 > l
+		yyj1403++
+		if yyhl1403 {
+			yyb1403 = yyj1403 > l
 		} else {
-			yyb1356 = r.CheckBreak()
+			yyb1403 = r.CheckBreak()
 		}
-		if yyb1356 {
+		if yyb1403 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1356-1, "")
+		z.DecStructFieldNotFound(yyj1403-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -16220,34 +16806,34 @@ func (x *ReplicaSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1361 := z.EncBinary()
-		_ = yym1361
+		yym1408 := z.EncBinary()
+		_ = yym1408
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1362 := !z.EncBinary()
-			yy2arr1362 := z.EncBasicHandle().StructToArray
-			var yyq1362 [2]bool
-			_, _, _ = yysep1362, yyq1362, yy2arr1362
-			const yyr1362 bool = false
-			yyq1362[1] = x.ObservedGeneration != 0
-			var yynn1362 int
-			if yyr1362 || yy2arr1362 {
+			yysep1409 := !z.EncBinary()
+			yy2arr1409 := z.EncBasicHandle().StructToArray
+			var yyq1409 [2]bool
+			_, _, _ = yysep1409, yyq1409, yy2arr1409
+			const yyr1409 bool = false
+			yyq1409[1] = x.ObservedGeneration != 0
+			var yynn1409 int
+			if yyr1409 || yy2arr1409 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn1362 = 1
-				for _, b := range yyq1362 {
+				yynn1409 = 1
+				for _, b := range yyq1409 {
 					if b {
-						yynn1362++
+						yynn1409++
 					}
 				}
-				r.EncodeMapStart(yynn1362)
-				yynn1362 = 0
+				r.EncodeMapStart(yynn1409)
+				yynn1409 = 0
 			}
-			if yyr1362 || yy2arr1362 {
+			if yyr1409 || yy2arr1409 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1364 := z.EncBinary()
-				_ = yym1364
+				yym1411 := z.EncBinary()
+				_ = yym1411
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Replicas))
@@ -16256,18 +16842,18 @@ func (x *ReplicaSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("replicas"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1365 := z.EncBinary()
-				_ = yym1365
+				yym1412 := z.EncBinary()
+				_ = yym1412
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Replicas))
 				}
 			}
-			if yyr1362 || yy2arr1362 {
+			if yyr1409 || yy2arr1409 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1362[1] {
-					yym1367 := z.EncBinary()
-					_ = yym1367
+				if yyq1409[1] {
+					yym1414 := z.EncBinary()
+					_ = yym1414
 					if false {
 					} else {
 						r.EncodeInt(int64(x.ObservedGeneration))
@@ -16276,19 +16862,19 @@ func (x *ReplicaSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq1362[1] {
+				if yyq1409[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("observedGeneration"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1368 := z.EncBinary()
-					_ = yym1368
+					yym1415 := z.EncBinary()
+					_ = yym1415
 					if false {
 					} else {
 						r.EncodeInt(int64(x.ObservedGeneration))
 					}
 				}
 			}
-			if yyr1362 || yy2arr1362 {
+			if yyr1409 || yy2arr1409 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -16301,25 +16887,25 @@ func (x *ReplicaSetStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1369 := z.DecBinary()
-	_ = yym1369
+	yym1416 := z.DecBinary()
+	_ = yym1416
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1370 := r.ContainerType()
-		if yyct1370 == codecSelferValueTypeMap1234 {
-			yyl1370 := r.ReadMapStart()
-			if yyl1370 == 0 {
+		yyct1417 := r.ContainerType()
+		if yyct1417 == codecSelferValueTypeMap1234 {
+			yyl1417 := r.ReadMapStart()
+			if yyl1417 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1370, d)
+				x.codecDecodeSelfFromMap(yyl1417, d)
 			}
-		} else if yyct1370 == codecSelferValueTypeArray1234 {
-			yyl1370 := r.ReadArrayStart()
-			if yyl1370 == 0 {
+		} else if yyct1417 == codecSelferValueTypeArray1234 {
+			yyl1417 := r.ReadArrayStart()
+			if yyl1417 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1370, d)
+				x.codecDecodeSelfFromArray(yyl1417, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -16331,12 +16917,12 @@ func (x *ReplicaSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1371Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1371Slc
-	var yyhl1371 bool = l >= 0
-	for yyj1371 := 0; ; yyj1371++ {
-		if yyhl1371 {
-			if yyj1371 >= l {
+	var yys1418Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1418Slc
+	var yyhl1418 bool = l >= 0
+	for yyj1418 := 0; ; yyj1418++ {
+		if yyhl1418 {
+			if yyj1418 >= l {
 				break
 			}
 		} else {
@@ -16345,10 +16931,10 @@ func (x *ReplicaSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1371Slc = r.DecodeBytes(yys1371Slc, true, true)
-		yys1371 := string(yys1371Slc)
+		yys1418Slc = r.DecodeBytes(yys1418Slc, true, true)
+		yys1418 := string(yys1418Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1371 {
+		switch yys1418 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
 				x.Replicas = 0
@@ -16362,9 +16948,9 @@ func (x *ReplicaSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.ObservedGeneration = int64(r.DecodeInt(64))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1371)
-		} // end switch yys1371
-	} // end for yyj1371
+			z.DecStructFieldNotFound(-1, yys1418)
+		} // end switch yys1418
+	} // end for yyj1418
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -16372,16 +16958,16 @@ func (x *ReplicaSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1374 int
-	var yyb1374 bool
-	var yyhl1374 bool = l >= 0
-	yyj1374++
-	if yyhl1374 {
-		yyb1374 = yyj1374 > l
+	var yyj1421 int
+	var yyb1421 bool
+	var yyhl1421 bool = l >= 0
+	yyj1421++
+	if yyhl1421 {
+		yyb1421 = yyj1421 > l
 	} else {
-		yyb1374 = r.CheckBreak()
+		yyb1421 = r.CheckBreak()
 	}
-	if yyb1374 {
+	if yyb1421 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -16391,13 +16977,13 @@ func (x *ReplicaSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Replicas = int32(r.DecodeInt(32))
 	}
-	yyj1374++
-	if yyhl1374 {
-		yyb1374 = yyj1374 > l
+	yyj1421++
+	if yyhl1421 {
+		yyb1421 = yyj1421 > l
 	} else {
-		yyb1374 = r.CheckBreak()
+		yyb1421 = r.CheckBreak()
 	}
-	if yyb1374 {
+	if yyb1421 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -16408,17 +16994,17 @@ func (x *ReplicaSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		x.ObservedGeneration = int64(r.DecodeInt(64))
 	}
 	for {
-		yyj1374++
-		if yyhl1374 {
-			yyb1374 = yyj1374 > l
+		yyj1421++
+		if yyhl1421 {
+			yyb1421 = yyj1421 > l
 		} else {
-			yyb1374 = r.CheckBreak()
+			yyb1421 = r.CheckBreak()
 		}
-		if yyb1374 {
+		if yyb1421 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1374-1, "")
+		z.DecStructFieldNotFound(yyj1421-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -16428,10 +17014,10 @@ func (x codecSelfer1234) encSliceHorizontalPodAutoscaler(v []HorizontalPodAutosc
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1377 := range v {
+	for _, yyv1424 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1378 := &yyv1377
-		yy1378.CodecEncodeSelf(e)
+		yy1425 := &yyv1424
+		yy1425.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -16441,83 +17027,83 @@ func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutos
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1379 := *v
-	yyh1379, yyl1379 := z.DecSliceHelperStart()
-	var yyc1379 bool
-	if yyl1379 == 0 {
-		if yyv1379 == nil {
-			yyv1379 = []HorizontalPodAutoscaler{}
-			yyc1379 = true
-		} else if len(yyv1379) != 0 {
-			yyv1379 = yyv1379[:0]
-			yyc1379 = true
+	yyv1426 := *v
+	yyh1426, yyl1426 := z.DecSliceHelperStart()
+	var yyc1426 bool
+	if yyl1426 == 0 {
+		if yyv1426 == nil {
+			yyv1426 = []HorizontalPodAutoscaler{}
+			yyc1426 = true
+		} else if len(yyv1426) != 0 {
+			yyv1426 = yyv1426[:0]
+			yyc1426 = true
 		}
-	} else if yyl1379 > 0 {
-		var yyrr1379, yyrl1379 int
-		var yyrt1379 bool
-		if yyl1379 > cap(yyv1379) {
+	} else if yyl1426 > 0 {
+		var yyrr1426, yyrl1426 int
+		var yyrt1426 bool
+		if yyl1426 > cap(yyv1426) {
 
-			yyrg1379 := len(yyv1379) > 0
-			yyv21379 := yyv1379
-			yyrl1379, yyrt1379 = z.DecInferLen(yyl1379, z.DecBasicHandle().MaxInitLen, 312)
-			if yyrt1379 {
-				if yyrl1379 <= cap(yyv1379) {
-					yyv1379 = yyv1379[:yyrl1379]
+			yyrg1426 := len(yyv1426) > 0
+			yyv21426 := yyv1426
+			yyrl1426, yyrt1426 = z.DecInferLen(yyl1426, z.DecBasicHandle().MaxInitLen, 312)
+			if yyrt1426 {
+				if yyrl1426 <= cap(yyv1426) {
+					yyv1426 = yyv1426[:yyrl1426]
 				} else {
-					yyv1379 = make([]HorizontalPodAutoscaler, yyrl1379)
+					yyv1426 = make([]HorizontalPodAutoscaler, yyrl1426)
 				}
 			} else {
-				yyv1379 = make([]HorizontalPodAutoscaler, yyrl1379)
+				yyv1426 = make([]HorizontalPodAutoscaler, yyrl1426)
 			}
-			yyc1379 = true
-			yyrr1379 = len(yyv1379)
-			if yyrg1379 {
-				copy(yyv1379, yyv21379)
+			yyc1426 = true
+			yyrr1426 = len(yyv1426)
+			if yyrg1426 {
+				copy(yyv1426, yyv21426)
 			}
-		} else if yyl1379 != len(yyv1379) {
-			yyv1379 = yyv1379[:yyl1379]
-			yyc1379 = true
+		} else if yyl1426 != len(yyv1426) {
+			yyv1426 = yyv1426[:yyl1426]
+			yyc1426 = true
 		}
-		yyj1379 := 0
-		for ; yyj1379 < yyrr1379; yyj1379++ {
-			yyh1379.ElemContainerState(yyj1379)
+		yyj1426 := 0
+		for ; yyj1426 < yyrr1426; yyj1426++ {
+			yyh1426.ElemContainerState(yyj1426)
 			if r.TryDecodeAsNil() {
-				yyv1379[yyj1379] = HorizontalPodAutoscaler{}
+				yyv1426[yyj1426] = HorizontalPodAutoscaler{}
 			} else {
-				yyv1380 := &yyv1379[yyj1379]
-				yyv1380.CodecDecodeSelf(d)
+				yyv1427 := &yyv1426[yyj1426]
+				yyv1427.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1379 {
-			for ; yyj1379 < yyl1379; yyj1379++ {
-				yyv1379 = append(yyv1379, HorizontalPodAutoscaler{})
-				yyh1379.ElemContainerState(yyj1379)
+		if yyrt1426 {
+			for ; yyj1426 < yyl1426; yyj1426++ {
+				yyv1426 = append(yyv1426, HorizontalPodAutoscaler{})
+				yyh1426.ElemContainerState(yyj1426)
 				if r.TryDecodeAsNil() {
-					yyv1379[yyj1379] = HorizontalPodAutoscaler{}
+					yyv1426[yyj1426] = HorizontalPodAutoscaler{}
 				} else {
-					yyv1381 := &yyv1379[yyj1379]
-					yyv1381.CodecDecodeSelf(d)
+					yyv1428 := &yyv1426[yyj1426]
+					yyv1428.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1379 := 0
-		for ; !r.CheckBreak(); yyj1379++ {
+		yyj1426 := 0
+		for ; !r.CheckBreak(); yyj1426++ {
 
-			if yyj1379 >= len(yyv1379) {
-				yyv1379 = append(yyv1379, HorizontalPodAutoscaler{}) // var yyz1379 HorizontalPodAutoscaler
-				yyc1379 = true
+			if yyj1426 >= len(yyv1426) {
+				yyv1426 = append(yyv1426, HorizontalPodAutoscaler{}) // var yyz1426 HorizontalPodAutoscaler
+				yyc1426 = true
 			}
-			yyh1379.ElemContainerState(yyj1379)
-			if yyj1379 < len(yyv1379) {
+			yyh1426.ElemContainerState(yyj1426)
+			if yyj1426 < len(yyv1426) {
 				if r.TryDecodeAsNil() {
-					yyv1379[yyj1379] = HorizontalPodAutoscaler{}
+					yyv1426[yyj1426] = HorizontalPodAutoscaler{}
 				} else {
-					yyv1382 := &yyv1379[yyj1379]
-					yyv1382.CodecDecodeSelf(d)
+					yyv1429 := &yyv1426[yyj1426]
+					yyv1429.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -16525,17 +17111,17 @@ func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutos
 			}
 
 		}
-		if yyj1379 < len(yyv1379) {
-			yyv1379 = yyv1379[:yyj1379]
-			yyc1379 = true
-		} else if yyj1379 == 0 && yyv1379 == nil {
-			yyv1379 = []HorizontalPodAutoscaler{}
-			yyc1379 = true
+		if yyj1426 < len(yyv1426) {
+			yyv1426 = yyv1426[:yyj1426]
+			yyc1426 = true
+		} else if yyj1426 == 0 && yyv1426 == nil {
+			yyv1426 = []HorizontalPodAutoscaler{}
+			yyc1426 = true
 		}
 	}
-	yyh1379.End()
-	if yyc1379 {
-		*v = yyv1379
+	yyh1426.End()
+	if yyc1426 {
+		*v = yyv1426
 	}
 }
 
@@ -16544,10 +17130,10 @@ func (x codecSelfer1234) encSliceAPIVersion(v []APIVersion, e *codec1978.Encoder
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1383 := range v {
+	for _, yyv1430 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1384 := &yyv1383
-		yy1384.CodecEncodeSelf(e)
+		yy1431 := &yyv1430
+		yy1431.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -16557,83 +17143,83 @@ func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decode
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1385 := *v
-	yyh1385, yyl1385 := z.DecSliceHelperStart()
-	var yyc1385 bool
-	if yyl1385 == 0 {
-		if yyv1385 == nil {
-			yyv1385 = []APIVersion{}
-			yyc1385 = true
-		} else if len(yyv1385) != 0 {
-			yyv1385 = yyv1385[:0]
-			yyc1385 = true
+	yyv1432 := *v
+	yyh1432, yyl1432 := z.DecSliceHelperStart()
+	var yyc1432 bool
+	if yyl1432 == 0 {
+		if yyv1432 == nil {
+			yyv1432 = []APIVersion{}
+			yyc1432 = true
+		} else if len(yyv1432) != 0 {
+			yyv1432 = yyv1432[:0]
+			yyc1432 = true
 		}
-	} else if yyl1385 > 0 {
-		var yyrr1385, yyrl1385 int
-		var yyrt1385 bool
-		if yyl1385 > cap(yyv1385) {
+	} else if yyl1432 > 0 {
+		var yyrr1432, yyrl1432 int
+		var yyrt1432 bool
+		if yyl1432 > cap(yyv1432) {
 
-			yyrg1385 := len(yyv1385) > 0
-			yyv21385 := yyv1385
-			yyrl1385, yyrt1385 = z.DecInferLen(yyl1385, z.DecBasicHandle().MaxInitLen, 32)
-			if yyrt1385 {
-				if yyrl1385 <= cap(yyv1385) {
-					yyv1385 = yyv1385[:yyrl1385]
+			yyrg1432 := len(yyv1432) > 0
+			yyv21432 := yyv1432
+			yyrl1432, yyrt1432 = z.DecInferLen(yyl1432, z.DecBasicHandle().MaxInitLen, 32)
+			if yyrt1432 {
+				if yyrl1432 <= cap(yyv1432) {
+					yyv1432 = yyv1432[:yyrl1432]
 				} else {
-					yyv1385 = make([]APIVersion, yyrl1385)
+					yyv1432 = make([]APIVersion, yyrl1432)
 				}
 			} else {
-				yyv1385 = make([]APIVersion, yyrl1385)
+				yyv1432 = make([]APIVersion, yyrl1432)
 			}
-			yyc1385 = true
-			yyrr1385 = len(yyv1385)
-			if yyrg1385 {
-				copy(yyv1385, yyv21385)
+			yyc1432 = true
+			yyrr1432 = len(yyv1432)
+			if yyrg1432 {
+				copy(yyv1432, yyv21432)
 			}
-		} else if yyl1385 != len(yyv1385) {
-			yyv1385 = yyv1385[:yyl1385]
-			yyc1385 = true
+		} else if yyl1432 != len(yyv1432) {
+			yyv1432 = yyv1432[:yyl1432]
+			yyc1432 = true
 		}
-		yyj1385 := 0
-		for ; yyj1385 < yyrr1385; yyj1385++ {
-			yyh1385.ElemContainerState(yyj1385)
+		yyj1432 := 0
+		for ; yyj1432 < yyrr1432; yyj1432++ {
+			yyh1432.ElemContainerState(yyj1432)
 			if r.TryDecodeAsNil() {
-				yyv1385[yyj1385] = APIVersion{}
+				yyv1432[yyj1432] = APIVersion{}
 			} else {
-				yyv1386 := &yyv1385[yyj1385]
-				yyv1386.CodecDecodeSelf(d)
+				yyv1433 := &yyv1432[yyj1432]
+				yyv1433.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1385 {
-			for ; yyj1385 < yyl1385; yyj1385++ {
-				yyv1385 = append(yyv1385, APIVersion{})
-				yyh1385.ElemContainerState(yyj1385)
+		if yyrt1432 {
+			for ; yyj1432 < yyl1432; yyj1432++ {
+				yyv1432 = append(yyv1432, APIVersion{})
+				yyh1432.ElemContainerState(yyj1432)
 				if r.TryDecodeAsNil() {
-					yyv1385[yyj1385] = APIVersion{}
+					yyv1432[yyj1432] = APIVersion{}
 				} else {
-					yyv1387 := &yyv1385[yyj1385]
-					yyv1387.CodecDecodeSelf(d)
+					yyv1434 := &yyv1432[yyj1432]
+					yyv1434.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1385 := 0
-		for ; !r.CheckBreak(); yyj1385++ {
+		yyj1432 := 0
+		for ; !r.CheckBreak(); yyj1432++ {
 
-			if yyj1385 >= len(yyv1385) {
-				yyv1385 = append(yyv1385, APIVersion{}) // var yyz1385 APIVersion
-				yyc1385 = true
+			if yyj1432 >= len(yyv1432) {
+				yyv1432 = append(yyv1432, APIVersion{}) // var yyz1432 APIVersion
+				yyc1432 = true
 			}
-			yyh1385.ElemContainerState(yyj1385)
-			if yyj1385 < len(yyv1385) {
+			yyh1432.ElemContainerState(yyj1432)
+			if yyj1432 < len(yyv1432) {
 				if r.TryDecodeAsNil() {
-					yyv1385[yyj1385] = APIVersion{}
+					yyv1432[yyj1432] = APIVersion{}
 				} else {
-					yyv1388 := &yyv1385[yyj1385]
-					yyv1388.CodecDecodeSelf(d)
+					yyv1435 := &yyv1432[yyj1432]
+					yyv1435.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -16641,17 +17227,17 @@ func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decode
 			}
 
 		}
-		if yyj1385 < len(yyv1385) {
-			yyv1385 = yyv1385[:yyj1385]
-			yyc1385 = true
-		} else if yyj1385 == 0 && yyv1385 == nil {
-			yyv1385 = []APIVersion{}
-			yyc1385 = true
+		if yyj1432 < len(yyv1432) {
+			yyv1432 = yyv1432[:yyj1432]
+			yyc1432 = true
+		} else if yyj1432 == 0 && yyv1432 == nil {
+			yyv1432 = []APIVersion{}
+			yyc1432 = true
 		}
 	}
-	yyh1385.End()
-	if yyc1385 {
-		*v = yyv1385
+	yyh1432.End()
+	if yyc1432 {
+		*v = yyv1432
 	}
 }
 
@@ -16660,10 +17246,10 @@ func (x codecSelfer1234) encSliceThirdPartyResource(v []ThirdPartyResource, e *c
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1389 := range v {
+	for _, yyv1436 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1390 := &yyv1389
-		yy1390.CodecEncodeSelf(e)
+		yy1437 := &yyv1436
+		yy1437.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -16673,83 +17259,83 @@ func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1391 := *v
-	yyh1391, yyl1391 := z.DecSliceHelperStart()
-	var yyc1391 bool
-	if yyl1391 == 0 {
-		if yyv1391 == nil {
-			yyv1391 = []ThirdPartyResource{}
-			yyc1391 = true
-		} else if len(yyv1391) != 0 {
-			yyv1391 = yyv1391[:0]
-			yyc1391 = true
+	yyv1438 := *v
+	yyh1438, yyl1438 := z.DecSliceHelperStart()
+	var yyc1438 bool
+	if yyl1438 == 0 {
+		if yyv1438 == nil {
+			yyv1438 = []ThirdPartyResource{}
+			yyc1438 = true
+		} else if len(yyv1438) != 0 {
+			yyv1438 = yyv1438[:0]
+			yyc1438 = true
 		}
-	} else if yyl1391 > 0 {
-		var yyrr1391, yyrl1391 int
-		var yyrt1391 bool
-		if yyl1391 > cap(yyv1391) {
+	} else if yyl1438 > 0 {
+		var yyrr1438, yyrl1438 int
+		var yyrt1438 bool
+		if yyl1438 > cap(yyv1438) {
 
-			yyrg1391 := len(yyv1391) > 0
-			yyv21391 := yyv1391
-			yyrl1391, yyrt1391 = z.DecInferLen(yyl1391, z.DecBasicHandle().MaxInitLen, 232)
-			if yyrt1391 {
-				if yyrl1391 <= cap(yyv1391) {
-					yyv1391 = yyv1391[:yyrl1391]
+			yyrg1438 := len(yyv1438) > 0
+			yyv21438 := yyv1438
+			yyrl1438, yyrt1438 = z.DecInferLen(yyl1438, z.DecBasicHandle().MaxInitLen, 232)
+			if yyrt1438 {
+				if yyrl1438 <= cap(yyv1438) {
+					yyv1438 = yyv1438[:yyrl1438]
 				} else {
-					yyv1391 = make([]ThirdPartyResource, yyrl1391)
+					yyv1438 = make([]ThirdPartyResource, yyrl1438)
 				}
 			} else {
-				yyv1391 = make([]ThirdPartyResource, yyrl1391)
+				yyv1438 = make([]ThirdPartyResource, yyrl1438)
 			}
-			yyc1391 = true
-			yyrr1391 = len(yyv1391)
-			if yyrg1391 {
-				copy(yyv1391, yyv21391)
+			yyc1438 = true
+			yyrr1438 = len(yyv1438)
+			if yyrg1438 {
+				copy(yyv1438, yyv21438)
 			}
-		} else if yyl1391 != len(yyv1391) {
-			yyv1391 = yyv1391[:yyl1391]
-			yyc1391 = true
+		} else if yyl1438 != len(yyv1438) {
+			yyv1438 = yyv1438[:yyl1438]
+			yyc1438 = true
 		}
-		yyj1391 := 0
-		for ; yyj1391 < yyrr1391; yyj1391++ {
-			yyh1391.ElemContainerState(yyj1391)
+		yyj1438 := 0
+		for ; yyj1438 < yyrr1438; yyj1438++ {
+			yyh1438.ElemContainerState(yyj1438)
 			if r.TryDecodeAsNil() {
-				yyv1391[yyj1391] = ThirdPartyResource{}
+				yyv1438[yyj1438] = ThirdPartyResource{}
 			} else {
-				yyv1392 := &yyv1391[yyj1391]
-				yyv1392.CodecDecodeSelf(d)
+				yyv1439 := &yyv1438[yyj1438]
+				yyv1439.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1391 {
-			for ; yyj1391 < yyl1391; yyj1391++ {
-				yyv1391 = append(yyv1391, ThirdPartyResource{})
-				yyh1391.ElemContainerState(yyj1391)
+		if yyrt1438 {
+			for ; yyj1438 < yyl1438; yyj1438++ {
+				yyv1438 = append(yyv1438, ThirdPartyResource{})
+				yyh1438.ElemContainerState(yyj1438)
 				if r.TryDecodeAsNil() {
-					yyv1391[yyj1391] = ThirdPartyResource{}
+					yyv1438[yyj1438] = ThirdPartyResource{}
 				} else {
-					yyv1393 := &yyv1391[yyj1391]
-					yyv1393.CodecDecodeSelf(d)
+					yyv1440 := &yyv1438[yyj1438]
+					yyv1440.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1391 := 0
-		for ; !r.CheckBreak(); yyj1391++ {
+		yyj1438 := 0
+		for ; !r.CheckBreak(); yyj1438++ {
 
-			if yyj1391 >= len(yyv1391) {
-				yyv1391 = append(yyv1391, ThirdPartyResource{}) // var yyz1391 ThirdPartyResource
-				yyc1391 = true
+			if yyj1438 >= len(yyv1438) {
+				yyv1438 = append(yyv1438, ThirdPartyResource{}) // var yyz1438 ThirdPartyResource
+				yyc1438 = true
 			}
-			yyh1391.ElemContainerState(yyj1391)
-			if yyj1391 < len(yyv1391) {
+			yyh1438.ElemContainerState(yyj1438)
+			if yyj1438 < len(yyv1438) {
 				if r.TryDecodeAsNil() {
-					yyv1391[yyj1391] = ThirdPartyResource{}
+					yyv1438[yyj1438] = ThirdPartyResource{}
 				} else {
-					yyv1394 := &yyv1391[yyj1391]
-					yyv1394.CodecDecodeSelf(d)
+					yyv1441 := &yyv1438[yyj1438]
+					yyv1441.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -16757,17 +17343,17 @@ func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *
 			}
 
 		}
-		if yyj1391 < len(yyv1391) {
-			yyv1391 = yyv1391[:yyj1391]
-			yyc1391 = true
-		} else if yyj1391 == 0 && yyv1391 == nil {
-			yyv1391 = []ThirdPartyResource{}
-			yyc1391 = true
+		if yyj1438 < len(yyv1438) {
+			yyv1438 = yyv1438[:yyj1438]
+			yyc1438 = true
+		} else if yyj1438 == 0 && yyv1438 == nil {
+			yyv1438 = []ThirdPartyResource{}
+			yyc1438 = true
 		}
 	}
-	yyh1391.End()
-	if yyc1391 {
-		*v = yyv1391
+	yyh1438.End()
+	if yyc1438 {
+		*v = yyv1438
 	}
 }
 
@@ -16776,10 +17362,10 @@ func (x codecSelfer1234) encSliceDeployment(v []Deployment, e *codec1978.Encoder
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1395 := range v {
+	for _, yyv1442 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1396 := &yyv1395
-		yy1396.CodecEncodeSelf(e)
+		yy1443 := &yyv1442
+		yy1443.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -16789,83 +17375,83 @@ func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decode
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1397 := *v
-	yyh1397, yyl1397 := z.DecSliceHelperStart()
-	var yyc1397 bool
-	if yyl1397 == 0 {
-		if yyv1397 == nil {
-			yyv1397 = []Deployment{}
-			yyc1397 = true
-		} else if len(yyv1397) != 0 {
-			yyv1397 = yyv1397[:0]
-			yyc1397 = true
+	yyv1444 := *v
+	yyh1444, yyl1444 := z.DecSliceHelperStart()
+	var yyc1444 bool
+	if yyl1444 == 0 {
+		if yyv1444 == nil {
+			yyv1444 = []Deployment{}
+			yyc1444 = true
+		} else if len(yyv1444) != 0 {
+			yyv1444 = yyv1444[:0]
+			yyc1444 = true
 		}
-	} else if yyl1397 > 0 {
-		var yyrr1397, yyrl1397 int
-		var yyrt1397 bool
-		if yyl1397 > cap(yyv1397) {
+	} else if yyl1444 > 0 {
+		var yyrr1444, yyrl1444 int
+		var yyrt1444 bool
+		if yyl1444 > cap(yyv1444) {
 
-			yyrg1397 := len(yyv1397) > 0
-			yyv21397 := yyv1397
-			yyrl1397, yyrt1397 = z.DecInferLen(yyl1397, z.DecBasicHandle().MaxInitLen, 624)
-			if yyrt1397 {
-				if yyrl1397 <= cap(yyv1397) {
-					yyv1397 = yyv1397[:yyrl1397]
+			yyrg1444 := len(yyv1444) > 0
+			yyv21444 := yyv1444
+			yyrl1444, yyrt1444 = z.DecInferLen(yyl1444, z.DecBasicHandle().MaxInitLen, 632)
+			if yyrt1444 {
+				if yyrl1444 <= cap(yyv1444) {
+					yyv1444 = yyv1444[:yyrl1444]
 				} else {
-					yyv1397 = make([]Deployment, yyrl1397)
+					yyv1444 = make([]Deployment, yyrl1444)
 				}
 			} else {
-				yyv1397 = make([]Deployment, yyrl1397)
+				yyv1444 = make([]Deployment, yyrl1444)
 			}
-			yyc1397 = true
-			yyrr1397 = len(yyv1397)
-			if yyrg1397 {
-				copy(yyv1397, yyv21397)
+			yyc1444 = true
+			yyrr1444 = len(yyv1444)
+			if yyrg1444 {
+				copy(yyv1444, yyv21444)
 			}
-		} else if yyl1397 != len(yyv1397) {
-			yyv1397 = yyv1397[:yyl1397]
-			yyc1397 = true
+		} else if yyl1444 != len(yyv1444) {
+			yyv1444 = yyv1444[:yyl1444]
+			yyc1444 = true
 		}
-		yyj1397 := 0
-		for ; yyj1397 < yyrr1397; yyj1397++ {
-			yyh1397.ElemContainerState(yyj1397)
+		yyj1444 := 0
+		for ; yyj1444 < yyrr1444; yyj1444++ {
+			yyh1444.ElemContainerState(yyj1444)
 			if r.TryDecodeAsNil() {
-				yyv1397[yyj1397] = Deployment{}
+				yyv1444[yyj1444] = Deployment{}
 			} else {
-				yyv1398 := &yyv1397[yyj1397]
-				yyv1398.CodecDecodeSelf(d)
+				yyv1445 := &yyv1444[yyj1444]
+				yyv1445.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1397 {
-			for ; yyj1397 < yyl1397; yyj1397++ {
-				yyv1397 = append(yyv1397, Deployment{})
-				yyh1397.ElemContainerState(yyj1397)
+		if yyrt1444 {
+			for ; yyj1444 < yyl1444; yyj1444++ {
+				yyv1444 = append(yyv1444, Deployment{})
+				yyh1444.ElemContainerState(yyj1444)
 				if r.TryDecodeAsNil() {
-					yyv1397[yyj1397] = Deployment{}
+					yyv1444[yyj1444] = Deployment{}
 				} else {
-					yyv1399 := &yyv1397[yyj1397]
-					yyv1399.CodecDecodeSelf(d)
+					yyv1446 := &yyv1444[yyj1444]
+					yyv1446.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1397 := 0
-		for ; !r.CheckBreak(); yyj1397++ {
+		yyj1444 := 0
+		for ; !r.CheckBreak(); yyj1444++ {
 
-			if yyj1397 >= len(yyv1397) {
-				yyv1397 = append(yyv1397, Deployment{}) // var yyz1397 Deployment
-				yyc1397 = true
+			if yyj1444 >= len(yyv1444) {
+				yyv1444 = append(yyv1444, Deployment{}) // var yyz1444 Deployment
+				yyc1444 = true
 			}
-			yyh1397.ElemContainerState(yyj1397)
-			if yyj1397 < len(yyv1397) {
+			yyh1444.ElemContainerState(yyj1444)
+			if yyj1444 < len(yyv1444) {
 				if r.TryDecodeAsNil() {
-					yyv1397[yyj1397] = Deployment{}
+					yyv1444[yyj1444] = Deployment{}
 				} else {
-					yyv1400 := &yyv1397[yyj1397]
-					yyv1400.CodecDecodeSelf(d)
+					yyv1447 := &yyv1444[yyj1444]
+					yyv1447.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -16873,17 +17459,17 @@ func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decode
 			}
 
 		}
-		if yyj1397 < len(yyv1397) {
-			yyv1397 = yyv1397[:yyj1397]
-			yyc1397 = true
-		} else if yyj1397 == 0 && yyv1397 == nil {
-			yyv1397 = []Deployment{}
-			yyc1397 = true
+		if yyj1444 < len(yyv1444) {
+			yyv1444 = yyv1444[:yyj1444]
+			yyc1444 = true
+		} else if yyj1444 == 0 && yyv1444 == nil {
+			yyv1444 = []Deployment{}
+			yyc1444 = true
 		}
 	}
-	yyh1397.End()
-	if yyc1397 {
-		*v = yyv1397
+	yyh1444.End()
+	if yyc1444 {
+		*v = yyv1444
 	}
 }
 
@@ -16892,10 +17478,10 @@ func (x codecSelfer1234) encSliceDaemonSet(v []DaemonSet, e *codec1978.Encoder) 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1401 := range v {
+	for _, yyv1448 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1402 := &yyv1401
-		yy1402.CodecEncodeSelf(e)
+		yy1449 := &yyv1448
+		yy1449.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -16905,83 +17491,83 @@ func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder)
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1403 := *v
-	yyh1403, yyl1403 := z.DecSliceHelperStart()
-	var yyc1403 bool
-	if yyl1403 == 0 {
-		if yyv1403 == nil {
-			yyv1403 = []DaemonSet{}
-			yyc1403 = true
-		} else if len(yyv1403) != 0 {
-			yyv1403 = yyv1403[:0]
-			yyc1403 = true
+	yyv1450 := *v
+	yyh1450, yyl1450 := z.DecSliceHelperStart()
+	var yyc1450 bool
+	if yyl1450 == 0 {
+		if yyv1450 == nil {
+			yyv1450 = []DaemonSet{}
+			yyc1450 = true
+		} else if len(yyv1450) != 0 {
+			yyv1450 = yyv1450[:0]
+			yyc1450 = true
 		}
-	} else if yyl1403 > 0 {
-		var yyrr1403, yyrl1403 int
-		var yyrt1403 bool
-		if yyl1403 > cap(yyv1403) {
+	} else if yyl1450 > 0 {
+		var yyrr1450, yyrl1450 int
+		var yyrt1450 bool
+		if yyl1450 > cap(yyv1450) {
 
-			yyrg1403 := len(yyv1403) > 0
-			yyv21403 := yyv1403
-			yyrl1403, yyrt1403 = z.DecInferLen(yyl1403, z.DecBasicHandle().MaxInitLen, 600)
-			if yyrt1403 {
-				if yyrl1403 <= cap(yyv1403) {
-					yyv1403 = yyv1403[:yyrl1403]
+			yyrg1450 := len(yyv1450) > 0
+			yyv21450 := yyv1450
+			yyrl1450, yyrt1450 = z.DecInferLen(yyl1450, z.DecBasicHandle().MaxInitLen, 600)
+			if yyrt1450 {
+				if yyrl1450 <= cap(yyv1450) {
+					yyv1450 = yyv1450[:yyrl1450]
 				} else {
-					yyv1403 = make([]DaemonSet, yyrl1403)
+					yyv1450 = make([]DaemonSet, yyrl1450)
 				}
 			} else {
-				yyv1403 = make([]DaemonSet, yyrl1403)
+				yyv1450 = make([]DaemonSet, yyrl1450)
 			}
-			yyc1403 = true
-			yyrr1403 = len(yyv1403)
-			if yyrg1403 {
-				copy(yyv1403, yyv21403)
+			yyc1450 = true
+			yyrr1450 = len(yyv1450)
+			if yyrg1450 {
+				copy(yyv1450, yyv21450)
 			}
-		} else if yyl1403 != len(yyv1403) {
-			yyv1403 = yyv1403[:yyl1403]
-			yyc1403 = true
+		} else if yyl1450 != len(yyv1450) {
+			yyv1450 = yyv1450[:yyl1450]
+			yyc1450 = true
 		}
-		yyj1403 := 0
-		for ; yyj1403 < yyrr1403; yyj1403++ {
-			yyh1403.ElemContainerState(yyj1403)
+		yyj1450 := 0
+		for ; yyj1450 < yyrr1450; yyj1450++ {
+			yyh1450.ElemContainerState(yyj1450)
 			if r.TryDecodeAsNil() {
-				yyv1403[yyj1403] = DaemonSet{}
+				yyv1450[yyj1450] = DaemonSet{}
 			} else {
-				yyv1404 := &yyv1403[yyj1403]
-				yyv1404.CodecDecodeSelf(d)
+				yyv1451 := &yyv1450[yyj1450]
+				yyv1451.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1403 {
-			for ; yyj1403 < yyl1403; yyj1403++ {
-				yyv1403 = append(yyv1403, DaemonSet{})
-				yyh1403.ElemContainerState(yyj1403)
+		if yyrt1450 {
+			for ; yyj1450 < yyl1450; yyj1450++ {
+				yyv1450 = append(yyv1450, DaemonSet{})
+				yyh1450.ElemContainerState(yyj1450)
 				if r.TryDecodeAsNil() {
-					yyv1403[yyj1403] = DaemonSet{}
+					yyv1450[yyj1450] = DaemonSet{}
 				} else {
-					yyv1405 := &yyv1403[yyj1403]
-					yyv1405.CodecDecodeSelf(d)
+					yyv1452 := &yyv1450[yyj1450]
+					yyv1452.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1403 := 0
-		for ; !r.CheckBreak(); yyj1403++ {
+		yyj1450 := 0
+		for ; !r.CheckBreak(); yyj1450++ {
 
-			if yyj1403 >= len(yyv1403) {
-				yyv1403 = append(yyv1403, DaemonSet{}) // var yyz1403 DaemonSet
-				yyc1403 = true
+			if yyj1450 >= len(yyv1450) {
+				yyv1450 = append(yyv1450, DaemonSet{}) // var yyz1450 DaemonSet
+				yyc1450 = true
 			}
-			yyh1403.ElemContainerState(yyj1403)
-			if yyj1403 < len(yyv1403) {
+			yyh1450.ElemContainerState(yyj1450)
+			if yyj1450 < len(yyv1450) {
 				if r.TryDecodeAsNil() {
-					yyv1403[yyj1403] = DaemonSet{}
+					yyv1450[yyj1450] = DaemonSet{}
 				} else {
-					yyv1406 := &yyv1403[yyj1403]
-					yyv1406.CodecDecodeSelf(d)
+					yyv1453 := &yyv1450[yyj1450]
+					yyv1453.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -16989,17 +17575,17 @@ func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder)
 			}
 
 		}
-		if yyj1403 < len(yyv1403) {
-			yyv1403 = yyv1403[:yyj1403]
-			yyc1403 = true
-		} else if yyj1403 == 0 && yyv1403 == nil {
-			yyv1403 = []DaemonSet{}
-			yyc1403 = true
+		if yyj1450 < len(yyv1450) {
+			yyv1450 = yyv1450[:yyj1450]
+			yyc1450 = true
+		} else if yyj1450 == 0 && yyv1450 == nil {
+			yyv1450 = []DaemonSet{}
+			yyc1450 = true
 		}
 	}
-	yyh1403.End()
-	if yyc1403 {
-		*v = yyv1403
+	yyh1450.End()
+	if yyc1450 {
+		*v = yyv1450
 	}
 }
 
@@ -17008,10 +17594,10 @@ func (x codecSelfer1234) encSliceThirdPartyResourceData(v []ThirdPartyResourceDa
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1407 := range v {
+	for _, yyv1454 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1408 := &yyv1407
-		yy1408.CodecEncodeSelf(e)
+		yy1455 := &yyv1454
+		yy1455.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -17021,83 +17607,83 @@ func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceD
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1409 := *v
-	yyh1409, yyl1409 := z.DecSliceHelperStart()
-	var yyc1409 bool
-	if yyl1409 == 0 {
-		if yyv1409 == nil {
-			yyv1409 = []ThirdPartyResourceData{}
-			yyc1409 = true
-		} else if len(yyv1409) != 0 {
-			yyv1409 = yyv1409[:0]
-			yyc1409 = true
+	yyv1456 := *v
+	yyh1456, yyl1456 := z.DecSliceHelperStart()
+	var yyc1456 bool
+	if yyl1456 == 0 {
+		if yyv1456 == nil {
+			yyv1456 = []ThirdPartyResourceData{}
+			yyc1456 = true
+		} else if len(yyv1456) != 0 {
+			yyv1456 = yyv1456[:0]
+			yyc1456 = true
 		}
-	} else if yyl1409 > 0 {
-		var yyrr1409, yyrl1409 int
-		var yyrt1409 bool
-		if yyl1409 > cap(yyv1409) {
+	} else if yyl1456 > 0 {
+		var yyrr1456, yyrl1456 int
+		var yyrt1456 bool
+		if yyl1456 > cap(yyv1456) {
 
-			yyrg1409 := len(yyv1409) > 0
-			yyv21409 := yyv1409
-			yyrl1409, yyrt1409 = z.DecInferLen(yyl1409, z.DecBasicHandle().MaxInitLen, 216)
-			if yyrt1409 {
-				if yyrl1409 <= cap(yyv1409) {
-					yyv1409 = yyv1409[:yyrl1409]
+			yyrg1456 := len(yyv1456) > 0
+			yyv21456 := yyv1456
+			yyrl1456, yyrt1456 = z.DecInferLen(yyl1456, z.DecBasicHandle().MaxInitLen, 216)
+			if yyrt1456 {
+				if yyrl1456 <= cap(yyv1456) {
+					yyv1456 = yyv1456[:yyrl1456]
 				} else {
-					yyv1409 = make([]ThirdPartyResourceData, yyrl1409)
+					yyv1456 = make([]ThirdPartyResourceData, yyrl1456)
 				}
 			} else {
-				yyv1409 = make([]ThirdPartyResourceData, yyrl1409)
+				yyv1456 = make([]ThirdPartyResourceData, yyrl1456)
 			}
-			yyc1409 = true
-			yyrr1409 = len(yyv1409)
-			if yyrg1409 {
-				copy(yyv1409, yyv21409)
+			yyc1456 = true
+			yyrr1456 = len(yyv1456)
+			if yyrg1456 {
+				copy(yyv1456, yyv21456)
 			}
-		} else if yyl1409 != len(yyv1409) {
-			yyv1409 = yyv1409[:yyl1409]
-			yyc1409 = true
+		} else if yyl1456 != len(yyv1456) {
+			yyv1456 = yyv1456[:yyl1456]
+			yyc1456 = true
 		}
-		yyj1409 := 0
-		for ; yyj1409 < yyrr1409; yyj1409++ {
-			yyh1409.ElemContainerState(yyj1409)
+		yyj1456 := 0
+		for ; yyj1456 < yyrr1456; yyj1456++ {
+			yyh1456.ElemContainerState(yyj1456)
 			if r.TryDecodeAsNil() {
-				yyv1409[yyj1409] = ThirdPartyResourceData{}
+				yyv1456[yyj1456] = ThirdPartyResourceData{}
 			} else {
-				yyv1410 := &yyv1409[yyj1409]
-				yyv1410.CodecDecodeSelf(d)
+				yyv1457 := &yyv1456[yyj1456]
+				yyv1457.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1409 {
-			for ; yyj1409 < yyl1409; yyj1409++ {
-				yyv1409 = append(yyv1409, ThirdPartyResourceData{})
-				yyh1409.ElemContainerState(yyj1409)
+		if yyrt1456 {
+			for ; yyj1456 < yyl1456; yyj1456++ {
+				yyv1456 = append(yyv1456, ThirdPartyResourceData{})
+				yyh1456.ElemContainerState(yyj1456)
 				if r.TryDecodeAsNil() {
-					yyv1409[yyj1409] = ThirdPartyResourceData{}
+					yyv1456[yyj1456] = ThirdPartyResourceData{}
 				} else {
-					yyv1411 := &yyv1409[yyj1409]
-					yyv1411.CodecDecodeSelf(d)
+					yyv1458 := &yyv1456[yyj1456]
+					yyv1458.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1409 := 0
-		for ; !r.CheckBreak(); yyj1409++ {
+		yyj1456 := 0
+		for ; !r.CheckBreak(); yyj1456++ {
 
-			if yyj1409 >= len(yyv1409) {
-				yyv1409 = append(yyv1409, ThirdPartyResourceData{}) // var yyz1409 ThirdPartyResourceData
-				yyc1409 = true
+			if yyj1456 >= len(yyv1456) {
+				yyv1456 = append(yyv1456, ThirdPartyResourceData{}) // var yyz1456 ThirdPartyResourceData
+				yyc1456 = true
 			}
-			yyh1409.ElemContainerState(yyj1409)
-			if yyj1409 < len(yyv1409) {
+			yyh1456.ElemContainerState(yyj1456)
+			if yyj1456 < len(yyv1456) {
 				if r.TryDecodeAsNil() {
-					yyv1409[yyj1409] = ThirdPartyResourceData{}
+					yyv1456[yyj1456] = ThirdPartyResourceData{}
 				} else {
-					yyv1412 := &yyv1409[yyj1409]
-					yyv1412.CodecDecodeSelf(d)
+					yyv1459 := &yyv1456[yyj1456]
+					yyv1459.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -17105,17 +17691,17 @@ func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceD
 			}
 
 		}
-		if yyj1409 < len(yyv1409) {
-			yyv1409 = yyv1409[:yyj1409]
-			yyc1409 = true
-		} else if yyj1409 == 0 && yyv1409 == nil {
-			yyv1409 = []ThirdPartyResourceData{}
-			yyc1409 = true
+		if yyj1456 < len(yyv1456) {
+			yyv1456 = yyv1456[:yyj1456]
+			yyc1456 = true
+		} else if yyj1456 == 0 && yyv1456 == nil {
+			yyv1456 = []ThirdPartyResourceData{}
+			yyc1456 = true
 		}
 	}
-	yyh1409.End()
-	if yyc1409 {
-		*v = yyv1409
+	yyh1456.End()
+	if yyc1456 {
+		*v = yyv1456
 	}
 }
 
@@ -17124,10 +17710,10 @@ func (x codecSelfer1234) encSliceJob(v []Job, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1413 := range v {
+	for _, yyv1460 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1414 := &yyv1413
-		yy1414.CodecEncodeSelf(e)
+		yy1461 := &yyv1460
+		yy1461.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -17137,83 +17723,83 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1415 := *v
-	yyh1415, yyl1415 := z.DecSliceHelperStart()
-	var yyc1415 bool
-	if yyl1415 == 0 {
-		if yyv1415 == nil {
-			yyv1415 = []Job{}
-			yyc1415 = true
-		} else if len(yyv1415) != 0 {
-			yyv1415 = yyv1415[:0]
-			yyc1415 = true
+	yyv1462 := *v
+	yyh1462, yyl1462 := z.DecSliceHelperStart()
+	var yyc1462 bool
+	if yyl1462 == 0 {
+		if yyv1462 == nil {
+			yyv1462 = []Job{}
+			yyc1462 = true
+		} else if len(yyv1462) != 0 {
+			yyv1462 = yyv1462[:0]
+			yyc1462 = true
 		}
-	} else if yyl1415 > 0 {
-		var yyrr1415, yyrl1415 int
-		var yyrt1415 bool
-		if yyl1415 > cap(yyv1415) {
+	} else if yyl1462 > 0 {
+		var yyrr1462, yyrl1462 int
+		var yyrt1462 bool
+		if yyl1462 > cap(yyv1462) {
 
-			yyrg1415 := len(yyv1415) > 0
-			yyv21415 := yyv1415
-			yyrl1415, yyrt1415 = z.DecInferLen(yyl1415, z.DecBasicHandle().MaxInitLen, 632)
-			if yyrt1415 {
-				if yyrl1415 <= cap(yyv1415) {
-					yyv1415 = yyv1415[:yyrl1415]
+			yyrg1462 := len(yyv1462) > 0
+			yyv21462 := yyv1462
+			yyrl1462, yyrt1462 = z.DecInferLen(yyl1462, z.DecBasicHandle().MaxInitLen, 632)
+			if yyrt1462 {
+				if yyrl1462 <= cap(yyv1462) {
+					yyv1462 = yyv1462[:yyrl1462]
 				} else {
-					yyv1415 = make([]Job, yyrl1415)
+					yyv1462 = make([]Job, yyrl1462)
 				}
 			} else {
-				yyv1415 = make([]Job, yyrl1415)
+				yyv1462 = make([]Job, yyrl1462)
 			}
-			yyc1415 = true
-			yyrr1415 = len(yyv1415)
-			if yyrg1415 {
-				copy(yyv1415, yyv21415)
+			yyc1462 = true
+			yyrr1462 = len(yyv1462)
+			if yyrg1462 {
+				copy(yyv1462, yyv21462)
 			}
-		} else if yyl1415 != len(yyv1415) {
-			yyv1415 = yyv1415[:yyl1415]
-			yyc1415 = true
+		} else if yyl1462 != len(yyv1462) {
+			yyv1462 = yyv1462[:yyl1462]
+			yyc1462 = true
 		}
-		yyj1415 := 0
-		for ; yyj1415 < yyrr1415; yyj1415++ {
-			yyh1415.ElemContainerState(yyj1415)
+		yyj1462 := 0
+		for ; yyj1462 < yyrr1462; yyj1462++ {
+			yyh1462.ElemContainerState(yyj1462)
 			if r.TryDecodeAsNil() {
-				yyv1415[yyj1415] = Job{}
+				yyv1462[yyj1462] = Job{}
 			} else {
-				yyv1416 := &yyv1415[yyj1415]
-				yyv1416.CodecDecodeSelf(d)
+				yyv1463 := &yyv1462[yyj1462]
+				yyv1463.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1415 {
-			for ; yyj1415 < yyl1415; yyj1415++ {
-				yyv1415 = append(yyv1415, Job{})
-				yyh1415.ElemContainerState(yyj1415)
+		if yyrt1462 {
+			for ; yyj1462 < yyl1462; yyj1462++ {
+				yyv1462 = append(yyv1462, Job{})
+				yyh1462.ElemContainerState(yyj1462)
 				if r.TryDecodeAsNil() {
-					yyv1415[yyj1415] = Job{}
+					yyv1462[yyj1462] = Job{}
 				} else {
-					yyv1417 := &yyv1415[yyj1415]
-					yyv1417.CodecDecodeSelf(d)
+					yyv1464 := &yyv1462[yyj1462]
+					yyv1464.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1415 := 0
-		for ; !r.CheckBreak(); yyj1415++ {
+		yyj1462 := 0
+		for ; !r.CheckBreak(); yyj1462++ {
 
-			if yyj1415 >= len(yyv1415) {
-				yyv1415 = append(yyv1415, Job{}) // var yyz1415 Job
-				yyc1415 = true
+			if yyj1462 >= len(yyv1462) {
+				yyv1462 = append(yyv1462, Job{}) // var yyz1462 Job
+				yyc1462 = true
 			}
-			yyh1415.ElemContainerState(yyj1415)
-			if yyj1415 < len(yyv1415) {
+			yyh1462.ElemContainerState(yyj1462)
+			if yyj1462 < len(yyv1462) {
 				if r.TryDecodeAsNil() {
-					yyv1415[yyj1415] = Job{}
+					yyv1462[yyj1462] = Job{}
 				} else {
-					yyv1418 := &yyv1415[yyj1415]
-					yyv1418.CodecDecodeSelf(d)
+					yyv1465 := &yyv1462[yyj1462]
+					yyv1465.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -17221,17 +17807,17 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 			}
 
 		}
-		if yyj1415 < len(yyv1415) {
-			yyv1415 = yyv1415[:yyj1415]
-			yyc1415 = true
-		} else if yyj1415 == 0 && yyv1415 == nil {
-			yyv1415 = []Job{}
-			yyc1415 = true
+		if yyj1462 < len(yyv1462) {
+			yyv1462 = yyv1462[:yyj1462]
+			yyc1462 = true
+		} else if yyj1462 == 0 && yyv1462 == nil {
+			yyv1462 = []Job{}
+			yyc1462 = true
 		}
 	}
-	yyh1415.End()
-	if yyc1415 {
-		*v = yyv1415
+	yyh1462.End()
+	if yyc1462 {
+		*v = yyv1462
 	}
 }
 
@@ -17240,10 +17826,10 @@ func (x codecSelfer1234) encSliceJobCondition(v []JobCondition, e *codec1978.Enc
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1419 := range v {
+	for _, yyv1466 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1420 := &yyv1419
-		yy1420.CodecEncodeSelf(e)
+		yy1467 := &yyv1466
+		yy1467.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -17253,83 +17839,83 @@ func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.De
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1421 := *v
-	yyh1421, yyl1421 := z.DecSliceHelperStart()
-	var yyc1421 bool
-	if yyl1421 == 0 {
-		if yyv1421 == nil {
-			yyv1421 = []JobCondition{}
-			yyc1421 = true
-		} else if len(yyv1421) != 0 {
-			yyv1421 = yyv1421[:0]
-			yyc1421 = true
+	yyv1468 := *v
+	yyh1468, yyl1468 := z.DecSliceHelperStart()
+	var yyc1468 bool
+	if yyl1468 == 0 {
+		if yyv1468 == nil {
+			yyv1468 = []JobCondition{}
+			yyc1468 = true
+		} else if len(yyv1468) != 0 {
+			yyv1468 = yyv1468[:0]
+			yyc1468 = true
 		}
-	} else if yyl1421 > 0 {
-		var yyrr1421, yyrl1421 int
-		var yyrt1421 bool
-		if yyl1421 > cap(yyv1421) {
+	} else if yyl1468 > 0 {
+		var yyrr1468, yyrl1468 int
+		var yyrt1468 bool
+		if yyl1468 > cap(yyv1468) {
 
-			yyrg1421 := len(yyv1421) > 0
-			yyv21421 := yyv1421
-			yyrl1421, yyrt1421 = z.DecInferLen(yyl1421, z.DecBasicHandle().MaxInitLen, 112)
-			if yyrt1421 {
-				if yyrl1421 <= cap(yyv1421) {
-					yyv1421 = yyv1421[:yyrl1421]
+			yyrg1468 := len(yyv1468) > 0
+			yyv21468 := yyv1468
+			yyrl1468, yyrt1468 = z.DecInferLen(yyl1468, z.DecBasicHandle().MaxInitLen, 112)
+			if yyrt1468 {
+				if yyrl1468 <= cap(yyv1468) {
+					yyv1468 = yyv1468[:yyrl1468]
 				} else {
-					yyv1421 = make([]JobCondition, yyrl1421)
+					yyv1468 = make([]JobCondition, yyrl1468)
 				}
 			} else {
-				yyv1421 = make([]JobCondition, yyrl1421)
+				yyv1468 = make([]JobCondition, yyrl1468)
 			}
-			yyc1421 = true
-			yyrr1421 = len(yyv1421)
-			if yyrg1421 {
-				copy(yyv1421, yyv21421)
+			yyc1468 = true
+			yyrr1468 = len(yyv1468)
+			if yyrg1468 {
+				copy(yyv1468, yyv21468)
 			}
-		} else if yyl1421 != len(yyv1421) {
-			yyv1421 = yyv1421[:yyl1421]
-			yyc1421 = true
+		} else if yyl1468 != len(yyv1468) {
+			yyv1468 = yyv1468[:yyl1468]
+			yyc1468 = true
 		}
-		yyj1421 := 0
-		for ; yyj1421 < yyrr1421; yyj1421++ {
-			yyh1421.ElemContainerState(yyj1421)
+		yyj1468 := 0
+		for ; yyj1468 < yyrr1468; yyj1468++ {
+			yyh1468.ElemContainerState(yyj1468)
 			if r.TryDecodeAsNil() {
-				yyv1421[yyj1421] = JobCondition{}
+				yyv1468[yyj1468] = JobCondition{}
 			} else {
-				yyv1422 := &yyv1421[yyj1421]
-				yyv1422.CodecDecodeSelf(d)
+				yyv1469 := &yyv1468[yyj1468]
+				yyv1469.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1421 {
-			for ; yyj1421 < yyl1421; yyj1421++ {
-				yyv1421 = append(yyv1421, JobCondition{})
-				yyh1421.ElemContainerState(yyj1421)
+		if yyrt1468 {
+			for ; yyj1468 < yyl1468; yyj1468++ {
+				yyv1468 = append(yyv1468, JobCondition{})
+				yyh1468.ElemContainerState(yyj1468)
 				if r.TryDecodeAsNil() {
-					yyv1421[yyj1421] = JobCondition{}
+					yyv1468[yyj1468] = JobCondition{}
 				} else {
-					yyv1423 := &yyv1421[yyj1421]
-					yyv1423.CodecDecodeSelf(d)
+					yyv1470 := &yyv1468[yyj1468]
+					yyv1470.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1421 := 0
-		for ; !r.CheckBreak(); yyj1421++ {
+		yyj1468 := 0
+		for ; !r.CheckBreak(); yyj1468++ {
 
-			if yyj1421 >= len(yyv1421) {
-				yyv1421 = append(yyv1421, JobCondition{}) // var yyz1421 JobCondition
-				yyc1421 = true
+			if yyj1468 >= len(yyv1468) {
+				yyv1468 = append(yyv1468, JobCondition{}) // var yyz1468 JobCondition
+				yyc1468 = true
 			}
-			yyh1421.ElemContainerState(yyj1421)
-			if yyj1421 < len(yyv1421) {
+			yyh1468.ElemContainerState(yyj1468)
+			if yyj1468 < len(yyv1468) {
 				if r.TryDecodeAsNil() {
-					yyv1421[yyj1421] = JobCondition{}
+					yyv1468[yyj1468] = JobCondition{}
 				} else {
-					yyv1424 := &yyv1421[yyj1421]
-					yyv1424.CodecDecodeSelf(d)
+					yyv1471 := &yyv1468[yyj1468]
+					yyv1471.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -17337,17 +17923,17 @@ func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.De
 			}
 
 		}
-		if yyj1421 < len(yyv1421) {
-			yyv1421 = yyv1421[:yyj1421]
-			yyc1421 = true
-		} else if yyj1421 == 0 && yyv1421 == nil {
-			yyv1421 = []JobCondition{}
-			yyc1421 = true
+		if yyj1468 < len(yyv1468) {
+			yyv1468 = yyv1468[:yyj1468]
+			yyc1468 = true
+		} else if yyj1468 == 0 && yyv1468 == nil {
+			yyv1468 = []JobCondition{}
+			yyc1468 = true
 		}
 	}
-	yyh1421.End()
-	if yyc1421 {
-		*v = yyv1421
+	yyh1468.End()
+	if yyc1468 {
+		*v = yyv1468
 	}
 }
 
@@ -17356,10 +17942,10 @@ func (x codecSelfer1234) encSliceIngress(v []Ingress, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1425 := range v {
+	for _, yyv1472 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1426 := &yyv1425
-		yy1426.CodecEncodeSelf(e)
+		yy1473 := &yyv1472
+		yy1473.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -17369,83 +17955,83 @@ func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1427 := *v
-	yyh1427, yyl1427 := z.DecSliceHelperStart()
-	var yyc1427 bool
-	if yyl1427 == 0 {
-		if yyv1427 == nil {
-			yyv1427 = []Ingress{}
-			yyc1427 = true
-		} else if len(yyv1427) != 0 {
-			yyv1427 = yyv1427[:0]
-			yyc1427 = true
+	yyv1474 := *v
+	yyh1474, yyl1474 := z.DecSliceHelperStart()
+	var yyc1474 bool
+	if yyl1474 == 0 {
+		if yyv1474 == nil {
+			yyv1474 = []Ingress{}
+			yyc1474 = true
+		} else if len(yyv1474) != 0 {
+			yyv1474 = yyv1474[:0]
+			yyc1474 = true
 		}
-	} else if yyl1427 > 0 {
-		var yyrr1427, yyrl1427 int
-		var yyrt1427 bool
-		if yyl1427 > cap(yyv1427) {
+	} else if yyl1474 > 0 {
+		var yyrr1474, yyrl1474 int
+		var yyrt1474 bool
+		if yyl1474 > cap(yyv1474) {
 
-			yyrg1427 := len(yyv1427) > 0
-			yyv21427 := yyv1427
-			yyrl1427, yyrt1427 = z.DecInferLen(yyl1427, z.DecBasicHandle().MaxInitLen, 248)
-			if yyrt1427 {
-				if yyrl1427 <= cap(yyv1427) {
-					yyv1427 = yyv1427[:yyrl1427]
+			yyrg1474 := len(yyv1474) > 0
+			yyv21474 := yyv1474
+			yyrl1474, yyrt1474 = z.DecInferLen(yyl1474, z.DecBasicHandle().MaxInitLen, 248)
+			if yyrt1474 {
+				if yyrl1474 <= cap(yyv1474) {
+					yyv1474 = yyv1474[:yyrl1474]
 				} else {
-					yyv1427 = make([]Ingress, yyrl1427)
+					yyv1474 = make([]Ingress, yyrl1474)
 				}
 			} else {
-				yyv1427 = make([]Ingress, yyrl1427)
+				yyv1474 = make([]Ingress, yyrl1474)
 			}
-			yyc1427 = true
-			yyrr1427 = len(yyv1427)
-			if yyrg1427 {
-				copy(yyv1427, yyv21427)
+			yyc1474 = true
+			yyrr1474 = len(yyv1474)
+			if yyrg1474 {
+				copy(yyv1474, yyv21474)
 			}
-		} else if yyl1427 != len(yyv1427) {
-			yyv1427 = yyv1427[:yyl1427]
-			yyc1427 = true
+		} else if yyl1474 != len(yyv1474) {
+			yyv1474 = yyv1474[:yyl1474]
+			yyc1474 = true
 		}
-		yyj1427 := 0
-		for ; yyj1427 < yyrr1427; yyj1427++ {
-			yyh1427.ElemContainerState(yyj1427)
+		yyj1474 := 0
+		for ; yyj1474 < yyrr1474; yyj1474++ {
+			yyh1474.ElemContainerState(yyj1474)
 			if r.TryDecodeAsNil() {
-				yyv1427[yyj1427] = Ingress{}
+				yyv1474[yyj1474] = Ingress{}
 			} else {
-				yyv1428 := &yyv1427[yyj1427]
-				yyv1428.CodecDecodeSelf(d)
+				yyv1475 := &yyv1474[yyj1474]
+				yyv1475.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1427 {
-			for ; yyj1427 < yyl1427; yyj1427++ {
-				yyv1427 = append(yyv1427, Ingress{})
-				yyh1427.ElemContainerState(yyj1427)
+		if yyrt1474 {
+			for ; yyj1474 < yyl1474; yyj1474++ {
+				yyv1474 = append(yyv1474, Ingress{})
+				yyh1474.ElemContainerState(yyj1474)
 				if r.TryDecodeAsNil() {
-					yyv1427[yyj1427] = Ingress{}
+					yyv1474[yyj1474] = Ingress{}
 				} else {
-					yyv1429 := &yyv1427[yyj1427]
-					yyv1429.CodecDecodeSelf(d)
+					yyv1476 := &yyv1474[yyj1474]
+					yyv1476.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1427 := 0
-		for ; !r.CheckBreak(); yyj1427++ {
+		yyj1474 := 0
+		for ; !r.CheckBreak(); yyj1474++ {
 
-			if yyj1427 >= len(yyv1427) {
-				yyv1427 = append(yyv1427, Ingress{}) // var yyz1427 Ingress
-				yyc1427 = true
+			if yyj1474 >= len(yyv1474) {
+				yyv1474 = append(yyv1474, Ingress{}) // var yyz1474 Ingress
+				yyc1474 = true
 			}
-			yyh1427.ElemContainerState(yyj1427)
-			if yyj1427 < len(yyv1427) {
+			yyh1474.ElemContainerState(yyj1474)
+			if yyj1474 < len(yyv1474) {
 				if r.TryDecodeAsNil() {
-					yyv1427[yyj1427] = Ingress{}
+					yyv1474[yyj1474] = Ingress{}
 				} else {
-					yyv1430 := &yyv1427[yyj1427]
-					yyv1430.CodecDecodeSelf(d)
+					yyv1477 := &yyv1474[yyj1474]
+					yyv1477.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -17453,17 +18039,17 @@ func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
 			}
 
 		}
-		if yyj1427 < len(yyv1427) {
-			yyv1427 = yyv1427[:yyj1427]
-			yyc1427 = true
-		} else if yyj1427 == 0 && yyv1427 == nil {
-			yyv1427 = []Ingress{}
-			yyc1427 = true
+		if yyj1474 < len(yyv1474) {
+			yyv1474 = yyv1474[:yyj1474]
+			yyc1474 = true
+		} else if yyj1474 == 0 && yyv1474 == nil {
+			yyv1474 = []Ingress{}
+			yyc1474 = true
 		}
 	}
-	yyh1427.End()
-	if yyc1427 {
-		*v = yyv1427
+	yyh1474.End()
+	if yyc1474 {
+		*v = yyv1474
 	}
 }
 
@@ -17472,10 +18058,10 @@ func (x codecSelfer1234) encSliceIngressRule(v []IngressRule, e *codec1978.Encod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1431 := range v {
+	for _, yyv1478 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1432 := &yyv1431
-		yy1432.CodecEncodeSelf(e)
+		yy1479 := &yyv1478
+		yy1479.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -17485,83 +18071,83 @@ func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Deco
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1433 := *v
-	yyh1433, yyl1433 := z.DecSliceHelperStart()
-	var yyc1433 bool
-	if yyl1433 == 0 {
-		if yyv1433 == nil {
-			yyv1433 = []IngressRule{}
-			yyc1433 = true
-		} else if len(yyv1433) != 0 {
-			yyv1433 = yyv1433[:0]
-			yyc1433 = true
+	yyv1480 := *v
+	yyh1480, yyl1480 := z.DecSliceHelperStart()
+	var yyc1480 bool
+	if yyl1480 == 0 {
+		if yyv1480 == nil {
+			yyv1480 = []IngressRule{}
+			yyc1480 = true
+		} else if len(yyv1480) != 0 {
+			yyv1480 = yyv1480[:0]
+			yyc1480 = true
 		}
-	} else if yyl1433 > 0 {
-		var yyrr1433, yyrl1433 int
-		var yyrt1433 bool
-		if yyl1433 > cap(yyv1433) {
+	} else if yyl1480 > 0 {
+		var yyrr1480, yyrl1480 int
+		var yyrt1480 bool
+		if yyl1480 > cap(yyv1480) {
 
-			yyrg1433 := len(yyv1433) > 0
-			yyv21433 := yyv1433
-			yyrl1433, yyrt1433 = z.DecInferLen(yyl1433, z.DecBasicHandle().MaxInitLen, 24)
-			if yyrt1433 {
-				if yyrl1433 <= cap(yyv1433) {
-					yyv1433 = yyv1433[:yyrl1433]
+			yyrg1480 := len(yyv1480) > 0
+			yyv21480 := yyv1480
+			yyrl1480, yyrt1480 = z.DecInferLen(yyl1480, z.DecBasicHandle().MaxInitLen, 24)
+			if yyrt1480 {
+				if yyrl1480 <= cap(yyv1480) {
+					yyv1480 = yyv1480[:yyrl1480]
 				} else {
-					yyv1433 = make([]IngressRule, yyrl1433)
+					yyv1480 = make([]IngressRule, yyrl1480)
 				}
 			} else {
-				yyv1433 = make([]IngressRule, yyrl1433)
+				yyv1480 = make([]IngressRule, yyrl1480)
 			}
-			yyc1433 = true
-			yyrr1433 = len(yyv1433)
-			if yyrg1433 {
-				copy(yyv1433, yyv21433)
+			yyc1480 = true
+			yyrr1480 = len(yyv1480)
+			if yyrg1480 {
+				copy(yyv1480, yyv21480)
 			}
-		} else if yyl1433 != len(yyv1433) {
-			yyv1433 = yyv1433[:yyl1433]
-			yyc1433 = true
+		} else if yyl1480 != len(yyv1480) {
+			yyv1480 = yyv1480[:yyl1480]
+			yyc1480 = true
 		}
-		yyj1433 := 0
-		for ; yyj1433 < yyrr1433; yyj1433++ {
-			yyh1433.ElemContainerState(yyj1433)
+		yyj1480 := 0
+		for ; yyj1480 < yyrr1480; yyj1480++ {
+			yyh1480.ElemContainerState(yyj1480)
 			if r.TryDecodeAsNil() {
-				yyv1433[yyj1433] = IngressRule{}
+				yyv1480[yyj1480] = IngressRule{}
 			} else {
-				yyv1434 := &yyv1433[yyj1433]
-				yyv1434.CodecDecodeSelf(d)
+				yyv1481 := &yyv1480[yyj1480]
+				yyv1481.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1433 {
-			for ; yyj1433 < yyl1433; yyj1433++ {
-				yyv1433 = append(yyv1433, IngressRule{})
-				yyh1433.ElemContainerState(yyj1433)
+		if yyrt1480 {
+			for ; yyj1480 < yyl1480; yyj1480++ {
+				yyv1480 = append(yyv1480, IngressRule{})
+				yyh1480.ElemContainerState(yyj1480)
 				if r.TryDecodeAsNil() {
-					yyv1433[yyj1433] = IngressRule{}
+					yyv1480[yyj1480] = IngressRule{}
 				} else {
-					yyv1435 := &yyv1433[yyj1433]
-					yyv1435.CodecDecodeSelf(d)
+					yyv1482 := &yyv1480[yyj1480]
+					yyv1482.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1433 := 0
-		for ; !r.CheckBreak(); yyj1433++ {
+		yyj1480 := 0
+		for ; !r.CheckBreak(); yyj1480++ {
 
-			if yyj1433 >= len(yyv1433) {
-				yyv1433 = append(yyv1433, IngressRule{}) // var yyz1433 IngressRule
-				yyc1433 = true
+			if yyj1480 >= len(yyv1480) {
+				yyv1480 = append(yyv1480, IngressRule{}) // var yyz1480 IngressRule
+				yyc1480 = true
 			}
-			yyh1433.ElemContainerState(yyj1433)
-			if yyj1433 < len(yyv1433) {
+			yyh1480.ElemContainerState(yyj1480)
+			if yyj1480 < len(yyv1480) {
 				if r.TryDecodeAsNil() {
-					yyv1433[yyj1433] = IngressRule{}
+					yyv1480[yyj1480] = IngressRule{}
 				} else {
-					yyv1436 := &yyv1433[yyj1433]
-					yyv1436.CodecDecodeSelf(d)
+					yyv1483 := &yyv1480[yyj1480]
+					yyv1483.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -17569,17 +18155,17 @@ func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Deco
 			}
 
 		}
-		if yyj1433 < len(yyv1433) {
-			yyv1433 = yyv1433[:yyj1433]
-			yyc1433 = true
-		} else if yyj1433 == 0 && yyv1433 == nil {
-			yyv1433 = []IngressRule{}
-			yyc1433 = true
+		if yyj1480 < len(yyv1480) {
+			yyv1480 = yyv1480[:yyj1480]
+			yyc1480 = true
+		} else if yyj1480 == 0 && yyv1480 == nil {
+			yyv1480 = []IngressRule{}
+			yyc1480 = true
 		}
 	}
-	yyh1433.End()
-	if yyc1433 {
-		*v = yyv1433
+	yyh1480.End()
+	if yyc1480 {
+		*v = yyv1480
 	}
 }
 
@@ -17588,10 +18174,10 @@ func (x codecSelfer1234) encSliceHTTPIngressPath(v []HTTPIngressPath, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1437 := range v {
+	for _, yyv1484 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1438 := &yyv1437
-		yy1438.CodecEncodeSelf(e)
+		yy1485 := &yyv1484
+		yy1485.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -17601,83 +18187,83 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1439 := *v
-	yyh1439, yyl1439 := z.DecSliceHelperStart()
-	var yyc1439 bool
-	if yyl1439 == 0 {
-		if yyv1439 == nil {
-			yyv1439 = []HTTPIngressPath{}
-			yyc1439 = true
-		} else if len(yyv1439) != 0 {
-			yyv1439 = yyv1439[:0]
-			yyc1439 = true
+	yyv1486 := *v
+	yyh1486, yyl1486 := z.DecSliceHelperStart()
+	var yyc1486 bool
+	if yyl1486 == 0 {
+		if yyv1486 == nil {
+			yyv1486 = []HTTPIngressPath{}
+			yyc1486 = true
+		} else if len(yyv1486) != 0 {
+			yyv1486 = yyv1486[:0]
+			yyc1486 = true
 		}
-	} else if yyl1439 > 0 {
-		var yyrr1439, yyrl1439 int
-		var yyrt1439 bool
-		if yyl1439 > cap(yyv1439) {
+	} else if yyl1486 > 0 {
+		var yyrr1486, yyrl1486 int
+		var yyrt1486 bool
+		if yyl1486 > cap(yyv1486) {
 
-			yyrg1439 := len(yyv1439) > 0
-			yyv21439 := yyv1439
-			yyrl1439, yyrt1439 = z.DecInferLen(yyl1439, z.DecBasicHandle().MaxInitLen, 64)
-			if yyrt1439 {
-				if yyrl1439 <= cap(yyv1439) {
-					yyv1439 = yyv1439[:yyrl1439]
+			yyrg1486 := len(yyv1486) > 0
+			yyv21486 := yyv1486
+			yyrl1486, yyrt1486 = z.DecInferLen(yyl1486, z.DecBasicHandle().MaxInitLen, 64)
+			if yyrt1486 {
+				if yyrl1486 <= cap(yyv1486) {
+					yyv1486 = yyv1486[:yyrl1486]
 				} else {
-					yyv1439 = make([]HTTPIngressPath, yyrl1439)
+					yyv1486 = make([]HTTPIngressPath, yyrl1486)
 				}
 			} else {
-				yyv1439 = make([]HTTPIngressPath, yyrl1439)
+				yyv1486 = make([]HTTPIngressPath, yyrl1486)
 			}
-			yyc1439 = true
-			yyrr1439 = len(yyv1439)
-			if yyrg1439 {
-				copy(yyv1439, yyv21439)
+			yyc1486 = true
+			yyrr1486 = len(yyv1486)
+			if yyrg1486 {
+				copy(yyv1486, yyv21486)
 			}
-		} else if yyl1439 != len(yyv1439) {
-			yyv1439 = yyv1439[:yyl1439]
-			yyc1439 = true
+		} else if yyl1486 != len(yyv1486) {
+			yyv1486 = yyv1486[:yyl1486]
+			yyc1486 = true
 		}
-		yyj1439 := 0
-		for ; yyj1439 < yyrr1439; yyj1439++ {
-			yyh1439.ElemContainerState(yyj1439)
+		yyj1486 := 0
+		for ; yyj1486 < yyrr1486; yyj1486++ {
+			yyh1486.ElemContainerState(yyj1486)
 			if r.TryDecodeAsNil() {
-				yyv1439[yyj1439] = HTTPIngressPath{}
+				yyv1486[yyj1486] = HTTPIngressPath{}
 			} else {
-				yyv1440 := &yyv1439[yyj1439]
-				yyv1440.CodecDecodeSelf(d)
+				yyv1487 := &yyv1486[yyj1486]
+				yyv1487.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1439 {
-			for ; yyj1439 < yyl1439; yyj1439++ {
-				yyv1439 = append(yyv1439, HTTPIngressPath{})
-				yyh1439.ElemContainerState(yyj1439)
+		if yyrt1486 {
+			for ; yyj1486 < yyl1486; yyj1486++ {
+				yyv1486 = append(yyv1486, HTTPIngressPath{})
+				yyh1486.ElemContainerState(yyj1486)
 				if r.TryDecodeAsNil() {
-					yyv1439[yyj1439] = HTTPIngressPath{}
+					yyv1486[yyj1486] = HTTPIngressPath{}
 				} else {
-					yyv1441 := &yyv1439[yyj1439]
-					yyv1441.CodecDecodeSelf(d)
+					yyv1488 := &yyv1486[yyj1486]
+					yyv1488.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1439 := 0
-		for ; !r.CheckBreak(); yyj1439++ {
+		yyj1486 := 0
+		for ; !r.CheckBreak(); yyj1486++ {
 
-			if yyj1439 >= len(yyv1439) {
-				yyv1439 = append(yyv1439, HTTPIngressPath{}) // var yyz1439 HTTPIngressPath
-				yyc1439 = true
+			if yyj1486 >= len(yyv1486) {
+				yyv1486 = append(yyv1486, HTTPIngressPath{}) // var yyz1486 HTTPIngressPath
+				yyc1486 = true
 			}
-			yyh1439.ElemContainerState(yyj1439)
-			if yyj1439 < len(yyv1439) {
+			yyh1486.ElemContainerState(yyj1486)
+			if yyj1486 < len(yyv1486) {
 				if r.TryDecodeAsNil() {
-					yyv1439[yyj1439] = HTTPIngressPath{}
+					yyv1486[yyj1486] = HTTPIngressPath{}
 				} else {
-					yyv1442 := &yyv1439[yyj1439]
-					yyv1442.CodecDecodeSelf(d)
+					yyv1489 := &yyv1486[yyj1486]
+					yyv1489.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -17685,17 +18271,17 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 			}
 
 		}
-		if yyj1439 < len(yyv1439) {
-			yyv1439 = yyv1439[:yyj1439]
-			yyc1439 = true
-		} else if yyj1439 == 0 && yyv1439 == nil {
-			yyv1439 = []HTTPIngressPath{}
-			yyc1439 = true
+		if yyj1486 < len(yyv1486) {
+			yyv1486 = yyv1486[:yyj1486]
+			yyc1486 = true
+		} else if yyj1486 == 0 && yyv1486 == nil {
+			yyv1486 = []HTTPIngressPath{}
+			yyc1486 = true
 		}
 	}
-	yyh1439.End()
-	if yyc1439 {
-		*v = yyv1439
+	yyh1486.End()
+	if yyc1486 {
+		*v = yyv1486
 	}
 }
 
@@ -17704,10 +18290,10 @@ func (x codecSelfer1234) encSliceNodeUtilization(v []NodeUtilization, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1443 := range v {
+	for _, yyv1490 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1444 := &yyv1443
-		yy1444.CodecEncodeSelf(e)
+		yy1491 := &yyv1490
+		yy1491.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -17717,83 +18303,83 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1445 := *v
-	yyh1445, yyl1445 := z.DecSliceHelperStart()
-	var yyc1445 bool
-	if yyl1445 == 0 {
-		if yyv1445 == nil {
-			yyv1445 = []NodeUtilization{}
-			yyc1445 = true
-		} else if len(yyv1445) != 0 {
-			yyv1445 = yyv1445[:0]
-			yyc1445 = true
+	yyv1492 := *v
+	yyh1492, yyl1492 := z.DecSliceHelperStart()
+	var yyc1492 bool
+	if yyl1492 == 0 {
+		if yyv1492 == nil {
+			yyv1492 = []NodeUtilization{}
+			yyc1492 = true
+		} else if len(yyv1492) != 0 {
+			yyv1492 = yyv1492[:0]
+			yyc1492 = true
 		}
-	} else if yyl1445 > 0 {
-		var yyrr1445, yyrl1445 int
-		var yyrt1445 bool
-		if yyl1445 > cap(yyv1445) {
+	} else if yyl1492 > 0 {
+		var yyrr1492, yyrl1492 int
+		var yyrt1492 bool
+		if yyl1492 > cap(yyv1492) {
 
-			yyrg1445 := len(yyv1445) > 0
-			yyv21445 := yyv1445
-			yyrl1445, yyrt1445 = z.DecInferLen(yyl1445, z.DecBasicHandle().MaxInitLen, 24)
-			if yyrt1445 {
-				if yyrl1445 <= cap(yyv1445) {
-					yyv1445 = yyv1445[:yyrl1445]
+			yyrg1492 := len(yyv1492) > 0
+			yyv21492 := yyv1492
+			yyrl1492, yyrt1492 = z.DecInferLen(yyl1492, z.DecBasicHandle().MaxInitLen, 24)
+			if yyrt1492 {
+				if yyrl1492 <= cap(yyv1492) {
+					yyv1492 = yyv1492[:yyrl1492]
 				} else {
-					yyv1445 = make([]NodeUtilization, yyrl1445)
+					yyv1492 = make([]NodeUtilization, yyrl1492)
 				}
 			} else {
-				yyv1445 = make([]NodeUtilization, yyrl1445)
+				yyv1492 = make([]NodeUtilization, yyrl1492)
 			}
-			yyc1445 = true
-			yyrr1445 = len(yyv1445)
-			if yyrg1445 {
-				copy(yyv1445, yyv21445)
+			yyc1492 = true
+			yyrr1492 = len(yyv1492)
+			if yyrg1492 {
+				copy(yyv1492, yyv21492)
 			}
-		} else if yyl1445 != len(yyv1445) {
-			yyv1445 = yyv1445[:yyl1445]
-			yyc1445 = true
+		} else if yyl1492 != len(yyv1492) {
+			yyv1492 = yyv1492[:yyl1492]
+			yyc1492 = true
 		}
-		yyj1445 := 0
-		for ; yyj1445 < yyrr1445; yyj1445++ {
-			yyh1445.ElemContainerState(yyj1445)
+		yyj1492 := 0
+		for ; yyj1492 < yyrr1492; yyj1492++ {
+			yyh1492.ElemContainerState(yyj1492)
 			if r.TryDecodeAsNil() {
-				yyv1445[yyj1445] = NodeUtilization{}
+				yyv1492[yyj1492] = NodeUtilization{}
 			} else {
-				yyv1446 := &yyv1445[yyj1445]
-				yyv1446.CodecDecodeSelf(d)
+				yyv1493 := &yyv1492[yyj1492]
+				yyv1493.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1445 {
-			for ; yyj1445 < yyl1445; yyj1445++ {
-				yyv1445 = append(yyv1445, NodeUtilization{})
-				yyh1445.ElemContainerState(yyj1445)
+		if yyrt1492 {
+			for ; yyj1492 < yyl1492; yyj1492++ {
+				yyv1492 = append(yyv1492, NodeUtilization{})
+				yyh1492.ElemContainerState(yyj1492)
 				if r.TryDecodeAsNil() {
-					yyv1445[yyj1445] = NodeUtilization{}
+					yyv1492[yyj1492] = NodeUtilization{}
 				} else {
-					yyv1447 := &yyv1445[yyj1445]
-					yyv1447.CodecDecodeSelf(d)
+					yyv1494 := &yyv1492[yyj1492]
+					yyv1494.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1445 := 0
-		for ; !r.CheckBreak(); yyj1445++ {
+		yyj1492 := 0
+		for ; !r.CheckBreak(); yyj1492++ {
 
-			if yyj1445 >= len(yyv1445) {
-				yyv1445 = append(yyv1445, NodeUtilization{}) // var yyz1445 NodeUtilization
-				yyc1445 = true
+			if yyj1492 >= len(yyv1492) {
+				yyv1492 = append(yyv1492, NodeUtilization{}) // var yyz1492 NodeUtilization
+				yyc1492 = true
 			}
-			yyh1445.ElemContainerState(yyj1445)
-			if yyj1445 < len(yyv1445) {
+			yyh1492.ElemContainerState(yyj1492)
+			if yyj1492 < len(yyv1492) {
 				if r.TryDecodeAsNil() {
-					yyv1445[yyj1445] = NodeUtilization{}
+					yyv1492[yyj1492] = NodeUtilization{}
 				} else {
-					yyv1448 := &yyv1445[yyj1445]
-					yyv1448.CodecDecodeSelf(d)
+					yyv1495 := &yyv1492[yyj1492]
+					yyv1495.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -17801,17 +18387,17 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 			}
 
 		}
-		if yyj1445 < len(yyv1445) {
-			yyv1445 = yyv1445[:yyj1445]
-			yyc1445 = true
-		} else if yyj1445 == 0 && yyv1445 == nil {
-			yyv1445 = []NodeUtilization{}
-			yyc1445 = true
+		if yyj1492 < len(yyv1492) {
+			yyv1492 = yyv1492[:yyj1492]
+			yyc1492 = true
+		} else if yyj1492 == 0 && yyv1492 == nil {
+			yyv1492 = []NodeUtilization{}
+			yyc1492 = true
 		}
 	}
-	yyh1445.End()
-	if yyc1445 {
-		*v = yyv1445
+	yyh1492.End()
+	if yyc1492 {
+		*v = yyv1492
 	}
 }
 
@@ -17820,10 +18406,10 @@ func (x codecSelfer1234) encSliceClusterAutoscaler(v []ClusterAutoscaler, e *cod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1449 := range v {
+	for _, yyv1496 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1450 := &yyv1449
-		yy1450.CodecEncodeSelf(e)
+		yy1497 := &yyv1496
+		yy1497.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -17833,83 +18419,83 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1451 := *v
-	yyh1451, yyl1451 := z.DecSliceHelperStart()
-	var yyc1451 bool
-	if yyl1451 == 0 {
-		if yyv1451 == nil {
-			yyv1451 = []ClusterAutoscaler{}
-			yyc1451 = true
-		} else if len(yyv1451) != 0 {
-			yyv1451 = yyv1451[:0]
-			yyc1451 = true
+	yyv1498 := *v
+	yyh1498, yyl1498 := z.DecSliceHelperStart()
+	var yyc1498 bool
+	if yyl1498 == 0 {
+		if yyv1498 == nil {
+			yyv1498 = []ClusterAutoscaler{}
+			yyc1498 = true
+		} else if len(yyv1498) != 0 {
+			yyv1498 = yyv1498[:0]
+			yyc1498 = true
 		}
-	} else if yyl1451 > 0 {
-		var yyrr1451, yyrl1451 int
-		var yyrt1451 bool
-		if yyl1451 > cap(yyv1451) {
+	} else if yyl1498 > 0 {
+		var yyrr1498, yyrl1498 int
+		var yyrt1498 bool
+		if yyl1498 > cap(yyv1498) {
 
-			yyrg1451 := len(yyv1451) > 0
-			yyv21451 := yyv1451
-			yyrl1451, yyrt1451 = z.DecInferLen(yyl1451, z.DecBasicHandle().MaxInitLen, 224)
-			if yyrt1451 {
-				if yyrl1451 <= cap(yyv1451) {
-					yyv1451 = yyv1451[:yyrl1451]
+			yyrg1498 := len(yyv1498) > 0
+			yyv21498 := yyv1498
+			yyrl1498, yyrt1498 = z.DecInferLen(yyl1498, z.DecBasicHandle().MaxInitLen, 224)
+			if yyrt1498 {
+				if yyrl1498 <= cap(yyv1498) {
+					yyv1498 = yyv1498[:yyrl1498]
 				} else {
-					yyv1451 = make([]ClusterAutoscaler, yyrl1451)
+					yyv1498 = make([]ClusterAutoscaler, yyrl1498)
 				}
 			} else {
-				yyv1451 = make([]ClusterAutoscaler, yyrl1451)
+				yyv1498 = make([]ClusterAutoscaler, yyrl1498)
 			}
-			yyc1451 = true
-			yyrr1451 = len(yyv1451)
-			if yyrg1451 {
-				copy(yyv1451, yyv21451)
+			yyc1498 = true
+			yyrr1498 = len(yyv1498)
+			if yyrg1498 {
+				copy(yyv1498, yyv21498)
 			}
-		} else if yyl1451 != len(yyv1451) {
-			yyv1451 = yyv1451[:yyl1451]
-			yyc1451 = true
+		} else if yyl1498 != len(yyv1498) {
+			yyv1498 = yyv1498[:yyl1498]
+			yyc1498 = true
 		}
-		yyj1451 := 0
-		for ; yyj1451 < yyrr1451; yyj1451++ {
-			yyh1451.ElemContainerState(yyj1451)
+		yyj1498 := 0
+		for ; yyj1498 < yyrr1498; yyj1498++ {
+			yyh1498.ElemContainerState(yyj1498)
 			if r.TryDecodeAsNil() {
-				yyv1451[yyj1451] = ClusterAutoscaler{}
+				yyv1498[yyj1498] = ClusterAutoscaler{}
 			} else {
-				yyv1452 := &yyv1451[yyj1451]
-				yyv1452.CodecDecodeSelf(d)
+				yyv1499 := &yyv1498[yyj1498]
+				yyv1499.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1451 {
-			for ; yyj1451 < yyl1451; yyj1451++ {
-				yyv1451 = append(yyv1451, ClusterAutoscaler{})
-				yyh1451.ElemContainerState(yyj1451)
+		if yyrt1498 {
+			for ; yyj1498 < yyl1498; yyj1498++ {
+				yyv1498 = append(yyv1498, ClusterAutoscaler{})
+				yyh1498.ElemContainerState(yyj1498)
 				if r.TryDecodeAsNil() {
-					yyv1451[yyj1451] = ClusterAutoscaler{}
+					yyv1498[yyj1498] = ClusterAutoscaler{}
 				} else {
-					yyv1453 := &yyv1451[yyj1451]
-					yyv1453.CodecDecodeSelf(d)
+					yyv1500 := &yyv1498[yyj1498]
+					yyv1500.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1451 := 0
-		for ; !r.CheckBreak(); yyj1451++ {
+		yyj1498 := 0
+		for ; !r.CheckBreak(); yyj1498++ {
 
-			if yyj1451 >= len(yyv1451) {
-				yyv1451 = append(yyv1451, ClusterAutoscaler{}) // var yyz1451 ClusterAutoscaler
-				yyc1451 = true
+			if yyj1498 >= len(yyv1498) {
+				yyv1498 = append(yyv1498, ClusterAutoscaler{}) // var yyz1498 ClusterAutoscaler
+				yyc1498 = true
 			}
-			yyh1451.ElemContainerState(yyj1451)
-			if yyj1451 < len(yyv1451) {
+			yyh1498.ElemContainerState(yyj1498)
+			if yyj1498 < len(yyv1498) {
 				if r.TryDecodeAsNil() {
-					yyv1451[yyj1451] = ClusterAutoscaler{}
+					yyv1498[yyj1498] = ClusterAutoscaler{}
 				} else {
-					yyv1454 := &yyv1451[yyj1451]
-					yyv1454.CodecDecodeSelf(d)
+					yyv1501 := &yyv1498[yyj1498]
+					yyv1501.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -17917,17 +18503,17 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 			}
 
 		}
-		if yyj1451 < len(yyv1451) {
-			yyv1451 = yyv1451[:yyj1451]
-			yyc1451 = true
-		} else if yyj1451 == 0 && yyv1451 == nil {
-			yyv1451 = []ClusterAutoscaler{}
-			yyc1451 = true
+		if yyj1498 < len(yyv1498) {
+			yyv1498 = yyv1498[:yyj1498]
+			yyc1498 = true
+		} else if yyj1498 == 0 && yyv1498 == nil {
+			yyv1498 = []ClusterAutoscaler{}
+			yyc1498 = true
 		}
 	}
-	yyh1451.End()
-	if yyc1451 {
-		*v = yyv1451
+	yyh1498.End()
+	if yyc1498 {
+		*v = yyv1498
 	}
 }
 
@@ -17936,10 +18522,10 @@ func (x codecSelfer1234) encSliceLabelSelectorRequirement(v []LabelSelectorRequi
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1455 := range v {
+	for _, yyv1502 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1456 := &yyv1455
-		yy1456.CodecEncodeSelf(e)
+		yy1503 := &yyv1502
+		yy1503.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -17949,83 +18535,83 @@ func (x codecSelfer1234) decSliceLabelSelectorRequirement(v *[]LabelSelectorRequ
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1457 := *v
-	yyh1457, yyl1457 := z.DecSliceHelperStart()
-	var yyc1457 bool
-	if yyl1457 == 0 {
-		if yyv1457 == nil {
-			yyv1457 = []LabelSelectorRequirement{}
-			yyc1457 = true
-		} else if len(yyv1457) != 0 {
-			yyv1457 = yyv1457[:0]
-			yyc1457 = true
+	yyv1504 := *v
+	yyh1504, yyl1504 := z.DecSliceHelperStart()
+	var yyc1504 bool
+	if yyl1504 == 0 {
+		if yyv1504 == nil {
+			yyv1504 = []LabelSelectorRequirement{}
+			yyc1504 = true
+		} else if len(yyv1504) != 0 {
+			yyv1504 = yyv1504[:0]
+			yyc1504 = true
 		}
-	} else if yyl1457 > 0 {
-		var yyrr1457, yyrl1457 int
-		var yyrt1457 bool
-		if yyl1457 > cap(yyv1457) {
+	} else if yyl1504 > 0 {
+		var yyrr1504, yyrl1504 int
+		var yyrt1504 bool
+		if yyl1504 > cap(yyv1504) {
 
-			yyrg1457 := len(yyv1457) > 0
-			yyv21457 := yyv1457
-			yyrl1457, yyrt1457 = z.DecInferLen(yyl1457, z.DecBasicHandle().MaxInitLen, 56)
-			if yyrt1457 {
-				if yyrl1457 <= cap(yyv1457) {
-					yyv1457 = yyv1457[:yyrl1457]
+			yyrg1504 := len(yyv1504) > 0
+			yyv21504 := yyv1504
+			yyrl1504, yyrt1504 = z.DecInferLen(yyl1504, z.DecBasicHandle().MaxInitLen, 56)
+			if yyrt1504 {
+				if yyrl1504 <= cap(yyv1504) {
+					yyv1504 = yyv1504[:yyrl1504]
 				} else {
-					yyv1457 = make([]LabelSelectorRequirement, yyrl1457)
+					yyv1504 = make([]LabelSelectorRequirement, yyrl1504)
 				}
 			} else {
-				yyv1457 = make([]LabelSelectorRequirement, yyrl1457)
+				yyv1504 = make([]LabelSelectorRequirement, yyrl1504)
 			}
-			yyc1457 = true
-			yyrr1457 = len(yyv1457)
-			if yyrg1457 {
-				copy(yyv1457, yyv21457)
+			yyc1504 = true
+			yyrr1504 = len(yyv1504)
+			if yyrg1504 {
+				copy(yyv1504, yyv21504)
 			}
-		} else if yyl1457 != len(yyv1457) {
-			yyv1457 = yyv1457[:yyl1457]
-			yyc1457 = true
+		} else if yyl1504 != len(yyv1504) {
+			yyv1504 = yyv1504[:yyl1504]
+			yyc1504 = true
 		}
-		yyj1457 := 0
-		for ; yyj1457 < yyrr1457; yyj1457++ {
-			yyh1457.ElemContainerState(yyj1457)
+		yyj1504 := 0
+		for ; yyj1504 < yyrr1504; yyj1504++ {
+			yyh1504.ElemContainerState(yyj1504)
 			if r.TryDecodeAsNil() {
-				yyv1457[yyj1457] = LabelSelectorRequirement{}
+				yyv1504[yyj1504] = LabelSelectorRequirement{}
 			} else {
-				yyv1458 := &yyv1457[yyj1457]
-				yyv1458.CodecDecodeSelf(d)
+				yyv1505 := &yyv1504[yyj1504]
+				yyv1505.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1457 {
-			for ; yyj1457 < yyl1457; yyj1457++ {
-				yyv1457 = append(yyv1457, LabelSelectorRequirement{})
-				yyh1457.ElemContainerState(yyj1457)
+		if yyrt1504 {
+			for ; yyj1504 < yyl1504; yyj1504++ {
+				yyv1504 = append(yyv1504, LabelSelectorRequirement{})
+				yyh1504.ElemContainerState(yyj1504)
 				if r.TryDecodeAsNil() {
-					yyv1457[yyj1457] = LabelSelectorRequirement{}
+					yyv1504[yyj1504] = LabelSelectorRequirement{}
 				} else {
-					yyv1459 := &yyv1457[yyj1457]
-					yyv1459.CodecDecodeSelf(d)
+					yyv1506 := &yyv1504[yyj1504]
+					yyv1506.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1457 := 0
-		for ; !r.CheckBreak(); yyj1457++ {
+		yyj1504 := 0
+		for ; !r.CheckBreak(); yyj1504++ {
 
-			if yyj1457 >= len(yyv1457) {
-				yyv1457 = append(yyv1457, LabelSelectorRequirement{}) // var yyz1457 LabelSelectorRequirement
-				yyc1457 = true
+			if yyj1504 >= len(yyv1504) {
+				yyv1504 = append(yyv1504, LabelSelectorRequirement{}) // var yyz1504 LabelSelectorRequirement
+				yyc1504 = true
 			}
-			yyh1457.ElemContainerState(yyj1457)
-			if yyj1457 < len(yyv1457) {
+			yyh1504.ElemContainerState(yyj1504)
+			if yyj1504 < len(yyv1504) {
 				if r.TryDecodeAsNil() {
-					yyv1457[yyj1457] = LabelSelectorRequirement{}
+					yyv1504[yyj1504] = LabelSelectorRequirement{}
 				} else {
-					yyv1460 := &yyv1457[yyj1457]
-					yyv1460.CodecDecodeSelf(d)
+					yyv1507 := &yyv1504[yyj1504]
+					yyv1507.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -18033,17 +18619,17 @@ func (x codecSelfer1234) decSliceLabelSelectorRequirement(v *[]LabelSelectorRequ
 			}
 
 		}
-		if yyj1457 < len(yyv1457) {
-			yyv1457 = yyv1457[:yyj1457]
-			yyc1457 = true
-		} else if yyj1457 == 0 && yyv1457 == nil {
-			yyv1457 = []LabelSelectorRequirement{}
-			yyc1457 = true
+		if yyj1504 < len(yyv1504) {
+			yyv1504 = yyv1504[:yyj1504]
+			yyc1504 = true
+		} else if yyj1504 == 0 && yyv1504 == nil {
+			yyv1504 = []LabelSelectorRequirement{}
+			yyc1504 = true
 		}
 	}
-	yyh1457.End()
-	if yyc1457 {
-		*v = yyv1457
+	yyh1504.End()
+	if yyc1504 {
+		*v = yyv1504
 	}
 }
 
@@ -18052,10 +18638,10 @@ func (x codecSelfer1234) encSliceReplicaSet(v []ReplicaSet, e *codec1978.Encoder
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1461 := range v {
+	for _, yyv1508 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1462 := &yyv1461
-		yy1462.CodecEncodeSelf(e)
+		yy1509 := &yyv1508
+		yy1509.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -18065,83 +18651,83 @@ func (x codecSelfer1234) decSliceReplicaSet(v *[]ReplicaSet, d *codec1978.Decode
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1463 := *v
-	yyh1463, yyl1463 := z.DecSliceHelperStart()
-	var yyc1463 bool
-	if yyl1463 == 0 {
-		if yyv1463 == nil {
-			yyv1463 = []ReplicaSet{}
-			yyc1463 = true
-		} else if len(yyv1463) != 0 {
-			yyv1463 = yyv1463[:0]
-			yyc1463 = true
+	yyv1510 := *v
+	yyh1510, yyl1510 := z.DecSliceHelperStart()
+	var yyc1510 bool
+	if yyl1510 == 0 {
+		if yyv1510 == nil {
+			yyv1510 = []ReplicaSet{}
+			yyc1510 = true
+		} else if len(yyv1510) != 0 {
+			yyv1510 = yyv1510[:0]
+			yyc1510 = true
 		}
-	} else if yyl1463 > 0 {
-		var yyrr1463, yyrl1463 int
-		var yyrt1463 bool
-		if yyl1463 > cap(yyv1463) {
+	} else if yyl1510 > 0 {
+		var yyrr1510, yyrl1510 int
+		var yyrt1510 bool
+		if yyl1510 > cap(yyv1510) {
 
-			yyrg1463 := len(yyv1463) > 0
-			yyv21463 := yyv1463
-			yyrl1463, yyrt1463 = z.DecInferLen(yyl1463, z.DecBasicHandle().MaxInitLen, 232)
-			if yyrt1463 {
-				if yyrl1463 <= cap(yyv1463) {
-					yyv1463 = yyv1463[:yyrl1463]
+			yyrg1510 := len(yyv1510) > 0
+			yyv21510 := yyv1510
+			yyrl1510, yyrt1510 = z.DecInferLen(yyl1510, z.DecBasicHandle().MaxInitLen, 232)
+			if yyrt1510 {
+				if yyrl1510 <= cap(yyv1510) {
+					yyv1510 = yyv1510[:yyrl1510]
 				} else {
-					yyv1463 = make([]ReplicaSet, yyrl1463)
+					yyv1510 = make([]ReplicaSet, yyrl1510)
 				}
 			} else {
-				yyv1463 = make([]ReplicaSet, yyrl1463)
+				yyv1510 = make([]ReplicaSet, yyrl1510)
 			}
-			yyc1463 = true
-			yyrr1463 = len(yyv1463)
-			if yyrg1463 {
-				copy(yyv1463, yyv21463)
+			yyc1510 = true
+			yyrr1510 = len(yyv1510)
+			if yyrg1510 {
+				copy(yyv1510, yyv21510)
 			}
-		} else if yyl1463 != len(yyv1463) {
-			yyv1463 = yyv1463[:yyl1463]
-			yyc1463 = true
+		} else if yyl1510 != len(yyv1510) {
+			yyv1510 = yyv1510[:yyl1510]
+			yyc1510 = true
 		}
-		yyj1463 := 0
-		for ; yyj1463 < yyrr1463; yyj1463++ {
-			yyh1463.ElemContainerState(yyj1463)
+		yyj1510 := 0
+		for ; yyj1510 < yyrr1510; yyj1510++ {
+			yyh1510.ElemContainerState(yyj1510)
 			if r.TryDecodeAsNil() {
-				yyv1463[yyj1463] = ReplicaSet{}
+				yyv1510[yyj1510] = ReplicaSet{}
 			} else {
-				yyv1464 := &yyv1463[yyj1463]
-				yyv1464.CodecDecodeSelf(d)
+				yyv1511 := &yyv1510[yyj1510]
+				yyv1511.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1463 {
-			for ; yyj1463 < yyl1463; yyj1463++ {
-				yyv1463 = append(yyv1463, ReplicaSet{})
-				yyh1463.ElemContainerState(yyj1463)
+		if yyrt1510 {
+			for ; yyj1510 < yyl1510; yyj1510++ {
+				yyv1510 = append(yyv1510, ReplicaSet{})
+				yyh1510.ElemContainerState(yyj1510)
 				if r.TryDecodeAsNil() {
-					yyv1463[yyj1463] = ReplicaSet{}
+					yyv1510[yyj1510] = ReplicaSet{}
 				} else {
-					yyv1465 := &yyv1463[yyj1463]
-					yyv1465.CodecDecodeSelf(d)
+					yyv1512 := &yyv1510[yyj1510]
+					yyv1512.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1463 := 0
-		for ; !r.CheckBreak(); yyj1463++ {
+		yyj1510 := 0
+		for ; !r.CheckBreak(); yyj1510++ {
 
-			if yyj1463 >= len(yyv1463) {
-				yyv1463 = append(yyv1463, ReplicaSet{}) // var yyz1463 ReplicaSet
-				yyc1463 = true
+			if yyj1510 >= len(yyv1510) {
+				yyv1510 = append(yyv1510, ReplicaSet{}) // var yyz1510 ReplicaSet
+				yyc1510 = true
 			}
-			yyh1463.ElemContainerState(yyj1463)
-			if yyj1463 < len(yyv1463) {
+			yyh1510.ElemContainerState(yyj1510)
+			if yyj1510 < len(yyv1510) {
 				if r.TryDecodeAsNil() {
-					yyv1463[yyj1463] = ReplicaSet{}
+					yyv1510[yyj1510] = ReplicaSet{}
 				} else {
-					yyv1466 := &yyv1463[yyj1463]
-					yyv1466.CodecDecodeSelf(d)
+					yyv1513 := &yyv1510[yyj1510]
+					yyv1513.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -18149,16 +18735,16 @@ func (x codecSelfer1234) decSliceReplicaSet(v *[]ReplicaSet, d *codec1978.Decode
 			}
 
 		}
-		if yyj1463 < len(yyv1463) {
-			yyv1463 = yyv1463[:yyj1463]
-			yyc1463 = true
-		} else if yyj1463 == 0 && yyv1463 == nil {
-			yyv1463 = []ReplicaSet{}
-			yyc1463 = true
+		if yyj1510 < len(yyv1510) {
+			yyv1510 = yyv1510[:yyj1510]
+			yyc1510 = true
+		} else if yyj1510 == 0 && yyv1510 == nil {
+			yyv1510 = []ReplicaSet{}
+			yyc1510 = true
 		}
 	}
-	yyh1463.End()
-	if yyc1463 {
-		*v = yyv1463
+	yyh1510.End()
+	if yyc1510 {
+		*v = yyv1510
 	}
 }

--- a/pkg/apis/extensions/v1beta1/types.go
+++ b/pkg/apis/extensions/v1beta1/types.go
@@ -221,6 +221,24 @@ type DeploymentSpec struct {
 	// Indicates that the deployment is paused and will not be processed by the
 	// deployment controller.
 	Paused bool `json:"paused,omitempty"`
+	// The config this deployment is rolling back to. Will be cleared after rollback is done.
+	RollbackTo *RollbackConfig `json:"rollbackTo,omitempty"`
+}
+
+// DeploymentRollback stores the information required to rollback a deployment.
+type DeploymentRollback struct {
+	unversioned.TypeMeta `json:",inline"`
+	// Required: This must match the Name of a deployment.
+	Name string `json:"name"`
+	// The annotations to be updated to a deployment
+	UpdatedAnnotations map[string]string `json:"updatedAnnotations,omitempty"`
+	// The config of this deployment rollback.
+	RollbackTo RollbackConfig `json:"rollbackTo"`
+}
+
+type RollbackConfig struct {
+	// The revision to rollback to. If set to 0, rollbck to the last revision.
+	Revision int64 `json:"revision,omitempty"`
 }
 
 const (

--- a/pkg/apis/extensions/v1beta1/types_swagger_doc_generated.go
+++ b/pkg/apis/extensions/v1beta1/types_swagger_doc_generated.go
@@ -148,6 +148,17 @@ func (DeploymentList) SwaggerDoc() map[string]string {
 	return map_DeploymentList
 }
 
+var map_DeploymentRollback = map[string]string{
+	"":                   "DeploymentRollback stores the information required to rollback a deployment.",
+	"name":               "Required: This must match the Name of a deployment.",
+	"updatedAnnotations": "The annotations to be updated to a deployment",
+	"rollbackTo":         "The config of this deployment rollback.",
+}
+
+func (DeploymentRollback) SwaggerDoc() map[string]string {
+	return map_DeploymentRollback
+}
+
 var map_DeploymentSpec = map[string]string{
 	"":                     "DeploymentSpec is the specification of the desired behavior of the Deployment.",
 	"replicas":             "Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.",
@@ -157,6 +168,7 @@ var map_DeploymentSpec = map[string]string{
 	"revisionHistoryLimit": "The number of old ReplicationControllers to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified.",
 	"uniqueLabelKey":       "Key of the selector that is added to existing RCs (and label key that is added to its pods) to prevent the existing RCs to select new pods (and old pods being selected by new RC). Users can set this to an empty string to indicate that the system should not add any selector and label. If unspecified, system uses DefaultDeploymentUniqueLabelKey(\"deployment.kubernetes.io/podTemplateHash\"). Value of this key is hash of DeploymentSpec.PodTemplateSpec. No label is added if this is set to empty string.",
 	"paused":               "Indicates that the deployment is paused and will not be processed by the deployment controller.",
+	"rollbackTo":           "The config this deployment is rolling back to. Will be cleared after rollback is done.",
 }
 
 func (DeploymentSpec) SwaggerDoc() map[string]string {
@@ -480,6 +492,14 @@ var map_ReplicationControllerDummy = map[string]string{
 
 func (ReplicationControllerDummy) SwaggerDoc() map[string]string {
 	return map_ReplicationControllerDummy
+}
+
+var map_RollbackConfig = map[string]string{
+	"revision": "The revision to rollback to. If set to 0, rollbck to the last revision.",
+}
+
+func (RollbackConfig) SwaggerDoc() map[string]string {
+	return map_RollbackConfig
 }
 
 var map_RollingUpdateDaemonSet = map[string]string{

--- a/pkg/client/unversioned/deployment.go
+++ b/pkg/client/unversioned/deployment.go
@@ -36,6 +36,7 @@ type DeploymentInterface interface {
 	Update(*extensions.Deployment) (*extensions.Deployment, error)
 	UpdateStatus(*extensions.Deployment) (*extensions.Deployment, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Rollback(*extensions.DeploymentRollback) error
 }
 
 // deployments implements DeploymentInterface
@@ -99,4 +100,9 @@ func (c *deployments) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("deployments").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Rollback applied the provided DeploymentRollback to the named deployment in the current namespace.
+func (c *deployments) Rollback(deploymentRollback *extensions.DeploymentRollback) error {
+	return c.client.Post().Namespace(c.ns).Resource("deployments").Name(deploymentRollback.Name).SubResource("rollback").Body(deploymentRollback).Do().Error()
 }

--- a/pkg/client/unversioned/deployment_test.go
+++ b/pkg/client/unversioned/deployment_test.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 )
 
-func getDeploymentsResoureName() string {
+func getDeploymentsResourceName() string {
 	return "deployments"
 }
 
@@ -48,7 +48,7 @@ func TestDeploymentCreate(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "POST",
-			Path:   testapi.Extensions.ResourcePath(getDeploymentsResoureName(), ns, ""),
+			Path:   testapi.Extensions.ResourcePath(getDeploymentsResourceName(), ns, ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   &deployment,
 		},
@@ -74,7 +74,7 @@ func TestDeploymentGet(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Extensions.ResourcePath(getDeploymentsResoureName(), ns, "abc"),
+			Path:   testapi.Extensions.ResourcePath(getDeploymentsResourceName(), ns, "abc"),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
@@ -101,7 +101,7 @@ func TestDeploymentList(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Extensions.ResourcePath(getDeploymentsResoureName(), ns, ""),
+			Path:   testapi.Extensions.ResourcePath(getDeploymentsResourceName(), ns, ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
@@ -124,7 +124,7 @@ func TestDeploymentUpdate(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "PUT",
-			Path:   testapi.Extensions.ResourcePath(getDeploymentsResoureName(), ns, "abc"),
+			Path:   testapi.Extensions.ResourcePath(getDeploymentsResourceName(), ns, "abc"),
 			Query:  simple.BuildQueryValues(nil),
 		},
 		Response: simple.Response{StatusCode: 200, Body: deployment},
@@ -146,7 +146,7 @@ func TestDeploymentUpdateStatus(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "PUT",
-			Path:   testapi.Extensions.ResourcePath(getDeploymentsResoureName(), ns, "abc") + "/status",
+			Path:   testapi.Extensions.ResourcePath(getDeploymentsResourceName(), ns, "abc") + "/status",
 			Query:  simple.BuildQueryValues(nil),
 		},
 		Response: simple.Response{StatusCode: 200, Body: deployment},
@@ -161,7 +161,7 @@ func TestDeploymentDelete(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "DELETE",
-			Path:   testapi.Extensions.ResourcePath(getDeploymentsResoureName(), ns, "foo"),
+			Path:   testapi.Extensions.ResourcePath(getDeploymentsResourceName(), ns, "foo"),
 			Query:  simple.BuildQueryValues(nil),
 		},
 		Response: simple.Response{StatusCode: 200},
@@ -175,7 +175,7 @@ func TestDeploymentWatch(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Extensions.ResourcePathWithPrefix("watch", getDeploymentsResoureName(), "", ""),
+			Path:   testapi.Extensions.ResourcePathWithPrefix("watch", getDeploymentsResourceName(), "", ""),
 			Query:  url.Values{"resourceVersion": []string{}},
 		},
 		Response: simple.Response{StatusCode: 200},
@@ -216,4 +216,25 @@ func TestListDeploymentsLabels(t *testing.T) {
 	options := api.ListOptions{LabelSelector: selector}
 	receivedPodList, err := c.Deployments(ns).List(options)
 	c.Validate(t, receivedPodList, err)
+}
+
+func TestDeploymentRollback(t *testing.T) {
+	ns := api.NamespaceDefault
+	deploymentRollback := &extensions.DeploymentRollback{
+		Name:               "abc",
+		UpdatedAnnotations: map[string]string{},
+		RollbackTo:         extensions.RollbackConfig{Revision: 1},
+	}
+	c := &simple.Client{
+		Request: simple.Request{
+			Method: "POST",
+			Path:   testapi.Extensions.ResourcePath(getDeploymentsResourceName(), ns, "abc") + "/rollback",
+			Query:  simple.BuildQueryValues(nil),
+			Body:   deploymentRollback,
+		},
+		Response: simple.Response{StatusCode: http.StatusOK},
+	}
+	err := c.Setup(t).Deployments(ns).Rollback(deploymentRollback)
+	defer c.Close()
+	c.ValidateCommon(t, err)
 }

--- a/pkg/client/unversioned/testclient/fake_deployments.go
+++ b/pkg/client/unversioned/testclient/fake_deployments.go
@@ -92,3 +92,14 @@ func (c *FakeDeployments) Delete(name string, options *api.DeleteOptions) error 
 func (c *FakeDeployments) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.Fake.InvokesWatch(NewWatchAction("deployments", c.Namespace, opts))
 }
+
+func (c *FakeDeployments) Rollback(deploymentRollback *extensions.DeploymentRollback) error {
+	action := CreateActionImpl{}
+	action.Verb = "create"
+	action.Resource = "deployments"
+	action.Subresource = "rollback"
+	action.Object = deploymentRollback
+
+	_, err := c.Fake.Invokes(action, deploymentRollback)
+	return err
+}

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -622,6 +622,7 @@ func (m *Master) getExtensionResources(c *Config) map[string]rest.Storage {
 		storage["deployments"] = deploymentStorage.Deployment
 		storage["deployments/status"] = deploymentStorage.Status
 		storage["deployments/scale"] = deploymentStorage.Scale
+		storage["deployments/rollback"] = deploymentStorage.Rollback
 	}
 	if isEnabled("jobs") {
 		jobStorage, jobStatusStorage := jobetcd.NewREST(dbClient("jobs"), storageDecorator)

--- a/pkg/registry/deployment/etcd/etcd_test.go
+++ b/pkg/registry/deployment/etcd/etcd_test.go
@@ -17,9 +17,12 @@ limitations under the License.
 package etcd
 
 import (
+	"reflect"
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/errors"
+	etcderrors "k8s.io/kubernetes/pkg/api/errors/etcd"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -276,5 +279,90 @@ func TestStatusUpdate(t *testing.T) {
 	}
 	if deployment.Status.Replicas != 100 {
 		t.Errorf("we expected .status.replicas to be updated to 100 but it was %v", deployment.Status.Replicas)
+	}
+}
+
+func TestEtcdCreateDeploymentRollback(t *testing.T) {
+	ctx := api.WithNamespace(api.NewContext(), namespace)
+
+	testCases := map[string]struct {
+		rollback extensions.DeploymentRollback
+		errOK    func(error) bool
+	}{
+		"normal": {
+			rollback: extensions.DeploymentRollback{
+				Name:               name,
+				UpdatedAnnotations: map[string]string{},
+				RollbackTo:         extensions.RollbackConfig{Revision: 1},
+			},
+			errOK: func(err error) bool { return err == nil },
+		},
+		"noAnnotation": {
+			rollback: extensions.DeploymentRollback{
+				Name:       name,
+				RollbackTo: extensions.RollbackConfig{Revision: 1},
+			},
+			errOK: func(err error) bool { return err == nil },
+		},
+		"noName": {
+			rollback: extensions.DeploymentRollback{
+				UpdatedAnnotations: map[string]string{},
+				RollbackTo:         extensions.RollbackConfig{Revision: 1},
+			},
+			errOK: func(err error) bool { return err != nil },
+		},
+	}
+	for k, test := range testCases {
+		storage, server := newStorage(t)
+		rollbackStorage := storage.Rollback
+		key, _ := storage.Deployment.KeyFunc(ctx, name)
+		key = etcdtest.AddPrefix(key)
+
+		if _, err := storage.Deployment.Create(ctx, validNewDeployment()); err != nil {
+			t.Fatalf("%s: unexpected error: %v", k, err)
+		}
+		if _, err := rollbackStorage.Create(ctx, &test.rollback); !test.errOK(err) {
+			t.Errorf("%s: unexpected error: %v", k, err)
+		} else if err == nil {
+			// If rollback succeeded, verify Rollback field of deployment
+			d, err := storage.Deployment.Get(ctx, validNewDeployment().ObjectMeta.Name)
+			if err != nil {
+				t.Errorf("%s: unexpected error: %v", k, err)
+			} else if !reflect.DeepEqual(*d.(*extensions.Deployment).Spec.RollbackTo, test.rollback.RollbackTo) {
+				t.Errorf("%s: expected: %v, got: %v", k, *d.(*extensions.Deployment).Spec.RollbackTo, test.rollback.RollbackTo)
+			}
+		}
+		server.Terminate(t)
+	}
+}
+
+// Ensure that when a deploymentRollback is created for a deployment that has already been deleted
+// by the API server, API server returns not-found error.
+func TestEtcdCreateDeploymentRollbackNoDeployment(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	rollbackStorage := storage.Rollback
+	ctx := api.WithNamespace(api.NewContext(), namespace)
+
+	key, _ := storage.Deployment.KeyFunc(ctx, name)
+	key = etcdtest.AddPrefix(key)
+	_, err := rollbackStorage.Create(ctx, &extensions.DeploymentRollback{
+		Name:               name,
+		UpdatedAnnotations: map[string]string{},
+		RollbackTo:         extensions.RollbackConfig{Revision: 1},
+	})
+	if err == nil {
+		t.Fatalf("Expected not-found-error but got nothing")
+	}
+	if !errors.IsNotFound(etcderrors.InterpretGetError(err, extensions.Resource("deployments"), name)) {
+		t.Fatalf("Unexpected error returned: %#v", err)
+	}
+
+	_, err = storage.Deployment.Get(ctx, name)
+	if err == nil {
+		t.Fatalf("Expected not-found-error but got nothing")
+	}
+	if !errors.IsNotFound(etcderrors.InterpretGetError(err, extensions.Resource("deployments"), name)) {
+		t.Fatalf("Unexpected error: %v", err)
 	}
 }

--- a/pkg/util/labels/labels.go
+++ b/pkg/util/labels/labels.go
@@ -35,3 +35,19 @@ func CloneAndAddLabel(labels map[string]string, labelKey string, labelValue uint
 	newLabels[labelKey] = fmt.Sprintf("%d", labelValue)
 	return newLabels
 }
+
+// CloneAndRemoveLabel clones the given map and returns a new map with the given key removed.
+// Returns the given map, if labelKey is empty.
+func CloneAndRemoveLabel(labels map[string]string, labelKey string) map[string]string {
+	if labelKey == "" {
+		// Dont need to add a label.
+		return labels
+	}
+	// Clone.
+	newLabels := map[string]string{}
+	for key, value := range labels {
+		newLabels[key] = value
+	}
+	delete(newLabels, labelKey)
+	return newLabels
+}


### PR DESCRIPTION
Addresses #17168; depends on #19581
See [proposal](https://github.com/kubernetes/kubernetes/blob/master/docs/proposals/deploy.md#deployment-version). 

API:

``` go
type DeploymentSpec struct {
...
    // The config this deployment is rolling back to. Will be cleared after rollback is done.
    RollbackTo *RollbackConfig `json:"rollbackTo,omitempty"`
}

// DeploymentRollback stores the information required to rollback a deployment.
type DeploymentRollback struct {
    unversioned.TypeMeta `json:",inline"`
    // Required: This must match the Name of a deployment.
    Name string `json:"name"`
    // The annotations to be updated to a deployment
    UpdatedAnnotations map[string]string `json:"updatedAnnotations,omitempty"`
    // The config of this deployment rollback.
    RollbackTo RollbackConfig `json:"rollbackTo"`
}

type RollbackConfig struct {
    // The revision to rollback to. If set to 0, rollbck to the last revision.
    Revision int64 `json:"revision,omitempty"`
}
```

cc @bgrant0607 @nikhiljindal @ironcladlou @kargakis @kubernetes/sig-config
