### PR TITLE
MESOS: experimental support for task discovery-info generation

### DIFF
--- a/contrib/mesos/pkg/scheduler/meta/annotations.go
+++ b/contrib/mesos/pkg/scheduler/meta/annotations.go
@@ -18,21 +18,24 @@ package meta
 
 // kubernetes api object annotations
 const (
+	// Namespace is the label and annotation namespace for mesos keys
+	Namespace = "k8s.mesosphere.io"
+
 	// the BindingHostKey pod annotation marks a pod as being assigned to a Mesos
 	// slave. It is already or will be launched on the slave as a task.
-	BindingHostKey = "k8s.mesosphere.io/bindingHost"
+	BindingHostKey = Namespace + "/bindingHost"
 
-	TaskIdKey                = "k8s.mesosphere.io/taskId"
-	SlaveIdKey               = "k8s.mesosphere.io/slaveId"
-	OfferIdKey               = "k8s.mesosphere.io/offerId"
-	ExecutorIdKey            = "k8s.mesosphere.io/executorId"
-	ExecutorResourcesKey     = "k8s.mesosphere.io/executorResources"
-	PortMappingKey           = "k8s.mesosphere.io/portMapping"
-	PortMappingKeyPrefix     = "k8s.mesosphere.io/port_"
+	TaskIdKey                = Namespace + "/taskId"
+	SlaveIdKey               = Namespace + "/slaveId"
+	OfferIdKey               = Namespace + "/offerId"
+	ExecutorIdKey            = Namespace + "/executorId"
+	ExecutorResourcesKey     = Namespace + "/executorResources"
+	PortMappingKey           = Namespace + "/portMapping"
+	PortMappingKeyPrefix     = Namespace + "/port_"
 	PortMappingKeyFormat     = PortMappingKeyPrefix + "%s_%d"
-	PortNameMappingKeyPrefix = "k8s.mesosphere.io/portName_"
+	PortNameMappingKeyPrefix = Namespace + "/portName_"
 	PortNameMappingKeyFormat = PortNameMappingKeyPrefix + "%s_%s"
-	ContainerPortKeyFormat   = "k8s.mesosphere.io/containerPort_%s_%s_%d"
-	StaticPodFilenameKey     = "k8s.mesosphere.io/staticPodFilename"
-	RolesKey                 = "k8s.mesosphere.io/roles"
+	ContainerPortKeyFormat   = Namespace + "/containerPort_%s_%s_%d"
+	StaticPodFilenameKey     = Namespace + "/staticPodFilename"
+	RolesKey                 = Namespace + "/roles"
 )

--- a/contrib/mesos/pkg/scheduler/podtask/pod_task_test.go
+++ b/contrib/mesos/pkg/scheduler/podtask/pod_task_test.go
@@ -299,14 +299,14 @@ func TestGeneratePodName(t *testing.T) {
 		},
 	}
 	name := generateTaskName(p)
-	expected := "foo.bar.pods"
+	expected := "foo.bar.pod"
 	if name != expected {
 		t.Fatalf("expected %q instead of %q", expected, name)
 	}
 
 	p.Namespace = ""
 	name = generateTaskName(p)
-	expected = "foo.default.pods"
+	expected = "foo.default.pod"
 	if name != expected {
 		t.Fatalf("expected %q instead of %q", expected, name)
 	}

--- a/contrib/mesos/pkg/scheduler/service/service.go
+++ b/contrib/mesos/pkg/scheduler/service/service.go
@@ -96,26 +96,27 @@ const (
 )
 
 type SchedulerServer struct {
-	port                int
-	address             net.IP
-	enableProfiling     bool
-	authPath            string
-	apiServerList       []string
-	etcdServerList      []string
-	allowPrivileged     bool
-	executorPath        string
-	proxyPath           string
-	mesosMaster         string
-	mesosUser           string
-	frameworkRoles      []string
-	defaultPodRoles     []string
-	mesosAuthPrincipal  string
-	mesosAuthSecretFile string
-	mesosCgroupPrefix   string
-	mesosExecutorCPUs   mresource.CPUShares
-	mesosExecutorMem    mresource.MegaBytes
-	checkpoint          bool
-	failoverTimeout     float64
+	port                  int
+	address               net.IP
+	enableProfiling       bool
+	authPath              string
+	apiServerList         []string
+	etcdServerList        []string
+	allowPrivileged       bool
+	executorPath          string
+	proxyPath             string
+	mesosMaster           string
+	mesosUser             string
+	frameworkRoles        []string
+	defaultPodRoles       []string
+	mesosAuthPrincipal    string
+	mesosAuthSecretFile   string
+	mesosCgroupPrefix     string
+	mesosExecutorCPUs     mresource.CPUShares
+	mesosExecutorMem      mresource.MegaBytes
+	checkpoint            bool
+	failoverTimeout       float64
+	generateTaskDiscovery bool
 
 	executorLogV                   int
 	executorBindall                bool
@@ -262,6 +263,7 @@ func (s *SchedulerServer) addCoreFlags(fs *pflag.FlagSet) {
 	fs.Var(&s.mesosExecutorMem, "mesos-executor-mem", "Initial memory (MB) to allocate for each Mesos executor container.")
 	fs.BoolVar(&s.checkpoint, "checkpoint", s.checkpoint, "Enable/disable checkpointing for the kubernetes-mesos framework.")
 	fs.Float64Var(&s.failoverTimeout, "failover-timeout", s.failoverTimeout, fmt.Sprintf("Framework failover timeout, in sec."))
+	fs.BoolVar(&s.generateTaskDiscovery, "mesos-generate-task-discovery", s.generateTaskDiscovery, "Enable/disable generation of DiscoveryInfo for Mesos tasks.")
 	fs.UintVar(&s.driverPort, "driver-port", s.driverPort, "Port that the Mesos scheduler driver process should listen on.")
 	fs.StringVar(&s.hostnameOverride, "hostname-override", s.hostnameOverride, "If non-empty, will use this string as identification instead of the actual hostname.")
 	fs.Int64Var(&s.reconcileInterval, "reconcile-interval", s.reconcileInterval, "Interval at which to execute task reconciliation, in sec. Zero disables.")
@@ -553,6 +555,7 @@ func (s *SchedulerServer) getDriver() (driver bindings.SchedulerDriver) {
 }
 
 func (s *SchedulerServer) Run(hks hyperkube.Interface, _ []string) error {
+	podtask.GenerateTaskDiscoveryEnabled = s.generateTaskDiscovery
 	if n := len(s.frameworkRoles); n == 0 || n > 2 || (n == 2 && s.frameworkRoles[0] != "*" && s.frameworkRoles[1] != "*") {
 		log.Fatalf(`only one custom role allowed in addition to "*"`)
 	}

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -207,6 +207,7 @@ mesos-default-pod-roles
 mesos-executor-cpus
 mesos-executor-mem
 mesos-framework-roles
+mesos-generate-task-discovery
 mesos-launch-grace-period
 mesos-master
 mesos-sandbox-overlay


### PR DESCRIPTION
xref https://github.com/mesosphere/kubernetes-mesos/issues/256
- enable DiscoveryInfo for TaskInfo such that pods will get records in mesos-dns
- this PR does NOT introduce support for k8s services in mesos-dns
