### PR TITLE
Revert "Add protobuf to the kube build image"

### DIFF
--- a/build/build-image/cross/Dockerfile
+++ b/build/build-image/cross/Dockerfile
@@ -24,16 +24,3 @@ ENV KUBE_CROSSPLATFORMS \
   windows/amd64 windows/386
 
 RUN cd /usr/src/go/src && for platform in ${KUBE_CROSSPLATFORMS}; do GOOS=${platform%/*} GOARCH=${platform##*/} ./make.bash --no-clean; done
-
-# Download and install protoc for generating protobuf output
-RUN mkdir -p /usr/local/src/protobuf && cd /usr/local/src/protobuf &&\
-    wget -q https://github.com/google/protobuf/releases/download/v3.0.0-beta-2/protobuf-cpp-3.0.0-beta-2.tar.gz &&\
-    tar xzvf protobuf-cpp-3.0.0-beta-2.tar.gz &&\
-    cd protobuf-3.0.0-beta-2 &&\
-    ./configure &&\
-    make install &&\
-    ldconfig &&\
-    cd .. &&\
-    rm -rf protobuf-3.0.0-beta-2 &&\
-    protoc --version
-


### PR DESCRIPTION
Reverts kubernetes/kubernetes#19359

cc @smarterclayton 

I believe it broke the build:

```
08:04:35 [0mThe command '/bin/sh -c mkdir -p /usr/local/src/protobuf && cd /usr/local/src/protobuf &&    wget -q https://github.com/google/protobuf/releases/download/v3.0.0-beta-2/protobuf-cpp-3.0.0-beta-2.tar.gz &&    tar xzvf protobuf-cpp-3.0.0-beta-2.tar.gz &&    cd protobuf-3.0.0-beta-2 &&    ./configure &&    make install &&    ldconfig &&    cd .. &&    rm -rf protobuf-3.0.0-beta-2 &&    protoc --version' returned a non-zero code: 1
08:04:35 
```
