### PR TITLE
Fix race condition in cinder attach/detach

### DIFF
--- a/pkg/volume/cinder/cinder_test.go
+++ b/pkg/volume/cinder/cinder_test.go
@@ -18,9 +18,14 @@ package cinder
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/golang/glog"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
@@ -55,20 +60,60 @@ func TestCanSupport(t *testing.T) {
 	}
 }
 
-type fakePDManager struct{}
+type fakePDManager struct {
+	// How long should AttachDisk/DetachDisk take - we need slower AttachDisk in a test.
+	attachDetachDuration time.Duration
+}
 
+func getFakeDeviceName(host volume.VolumeHost, pdName string) string {
+	return path.Join(host.GetPluginDir(cinderVolumePluginName), "device", pdName)
+}
+
+// Real Cinder AttachDisk attaches a cinder volume. If it is not yet mounted,
+// it mounts it it to globalPDPath.
+// We create a dummy directory (="device") and bind-mount it to globalPDPath
 func (fake *fakePDManager) AttachDisk(b *cinderVolumeBuilder, globalPDPath string) error {
 	globalPath := makeGlobalPDName(b.plugin.host, b.pdName)
-	err := os.MkdirAll(globalPath, 0750)
+	fakeDeviceName := getFakeDeviceName(b.plugin.host, b.pdName)
+	err := os.MkdirAll(fakeDeviceName, 0750)
 	if err != nil {
 		return err
+	}
+	// Attaching a Cinder volume can be slow...
+	time.Sleep(fake.attachDetachDuration)
+
+	// The volume is "attached", bind-mount it if it's not mounted yet.
+	notmnt, err := b.mounter.IsLikelyNotMountPoint(globalPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			if err := os.MkdirAll(globalPath, 0750); err != nil {
+				return err
+			}
+			notmnt = true
+		} else {
+			return err
+		}
+	}
+	if notmnt {
+		err = b.mounter.Mount(fakeDeviceName, globalPath, "", []string{"bind"})
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }
 
 func (fake *fakePDManager) DetachDisk(c *cinderVolumeCleaner) error {
 	globalPath := makeGlobalPDName(c.plugin.host, c.pdName)
-	err := os.RemoveAll(globalPath)
+	fakeDeviceName := getFakeDeviceName(c.plugin.host, c.pdName)
+	// unmount the bind-mount - should be fast
+	err := c.mounter.Unmount(globalPath)
+	if err != nil {
+		return err
+	}
+
+	// "Detach" the fake "device"
+	err = os.RemoveAll(fakeDeviceName)
 	if err != nil {
 		return err
 	}
@@ -108,7 +153,7 @@ func TestPlugin(t *testing.T) {
 			},
 		},
 	}
-	builder, err := plug.(*cinderPlugin).newBuilderInternal(volume.NewSpecFromVolume(spec), types.UID("poduid"), &fakePDManager{}, &mount.FakeMounter{})
+	builder, err := plug.(*cinderPlugin).newBuilderInternal(volume.NewSpecFromVolume(spec), types.UID("poduid"), &fakePDManager{0}, &mount.FakeMounter{})
 	if err != nil {
 		t.Errorf("Failed to make a new Builder: %v", err)
 	}
@@ -139,7 +184,7 @@ func TestPlugin(t *testing.T) {
 		}
 	}
 
-	cleaner, err := plug.(*cinderPlugin).newCleanerInternal("vol1", types.UID("poduid"), &fakePDManager{}, &mount.FakeMounter{})
+	cleaner, err := plug.(*cinderPlugin).newCleanerInternal("vol1", types.UID("poduid"), &fakePDManager{0}, &mount.FakeMounter{})
 	if err != nil {
 		t.Errorf("Failed to make a new Cleaner: %v", err)
 	}
@@ -165,14 +210,14 @@ func TestPlugin(t *testing.T) {
 		},
 		PersistentVolumeReclaimPolicy: api.PersistentVolumeReclaimDelete,
 	}
-	provisioner, err := plug.(*cinderPlugin).newProvisionerInternal(options, &fakePDManager{})
+	provisioner, err := plug.(*cinderPlugin).newProvisionerInternal(options, &fakePDManager{0})
 	persistentSpec, err := provisioner.NewPersistentVolumeTemplate()
 	if err != nil {
 		t.Errorf("NewPersistentVolumeTemplate() failed: %v", err)
 	}
 
 	// get 2nd Provisioner - persistent volume controller will do the same
-	provisioner, err = plug.(*cinderPlugin).newProvisionerInternal(options, &fakePDManager{})
+	provisioner, err = plug.(*cinderPlugin).newProvisionerInternal(options, &fakePDManager{0})
 	err = provisioner.Provision(persistentSpec)
 	if err != nil {
 		t.Errorf("Provision() failed: %v", err)
@@ -191,9 +236,121 @@ func TestPlugin(t *testing.T) {
 	volSpec := &volume.Spec{
 		PersistentVolume: persistentSpec,
 	}
-	deleter, err := plug.(*cinderPlugin).newDeleterInternal(volSpec, &fakePDManager{})
+	deleter, err := plug.(*cinderPlugin).newDeleterInternal(volSpec, &fakePDManager{0})
 	err = deleter.Delete()
 	if err != nil {
 		t.Errorf("Deleter() failed: %v", err)
+	}
+}
+
+// Test a race when a volume is simultaneously SetUp and TearedDown
+func TestAttachDetachRace(t *testing.T) {
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "cinderTest")
+	if err != nil {
+		t.Fatalf("can't make a temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	plugMgr := volume.VolumePluginMgr{}
+	host := volume.NewFakeVolumeHost(tmpDir, nil, nil)
+	plugMgr.InitPlugins(ProbeVolumePlugins(), host)
+
+	plug, err := plugMgr.FindPluginByName("kubernetes.io/cinder")
+	if err != nil {
+		t.Errorf("Can't find the plugin by name")
+	}
+	spec := &api.Volume{
+		Name: "vol1",
+		VolumeSource: api.VolumeSource{
+			Cinder: &api.CinderVolumeSource{
+				VolumeID: "pd",
+				FSType:   "ext4",
+			},
+		},
+	}
+	fakeMounter := &mount.FakeMounter{}
+	// SetUp the volume for 1st time
+	builder, err := plug.(*cinderPlugin).newBuilderInternal(volume.NewSpecFromVolume(spec), types.UID("poduid"), &fakePDManager{time.Second}, fakeMounter)
+	if err != nil {
+		t.Errorf("Failed to make a new Builder: %v", err)
+	}
+	if builder == nil {
+		t.Errorf("Got a nil Builder: %v")
+	}
+
+	if err := builder.SetUp(nil); err != nil {
+		t.Errorf("Expected success, got: %v", err)
+	}
+	path := builder.GetPath()
+
+	// TearDown the 1st volume and SetUp the 2nd volume (to different pod) at the same time
+	builder, err = plug.(*cinderPlugin).newBuilderInternal(volume.NewSpecFromVolume(spec), types.UID("poduid2"), &fakePDManager{time.Second}, fakeMounter)
+	if err != nil {
+		t.Errorf("Failed to make a new Builder: %v", err)
+	}
+	if builder == nil {
+		t.Errorf("Got a nil Builder: %v")
+	}
+
+	cleaner, err := plug.(*cinderPlugin).newCleanerInternal("vol1", types.UID("poduid"), &fakePDManager{time.Second}, fakeMounter)
+	if err != nil {
+		t.Errorf("Failed to make a new Cleaner: %v", err)
+	}
+
+	var buildComplete uint32 = 0
+
+	go func() {
+		glog.Infof("Attaching volume")
+		if err := builder.SetUp(nil); err != nil {
+			t.Errorf("Expected success, got: %v", err)
+		}
+		glog.Infof("Volume attached")
+		atomic.AddUint32(&buildComplete, 1)
+	}()
+
+	// builder is attaching the volume, which takes 1 second. Detach it in the middle of this interval
+	time.Sleep(time.Second / 2)
+
+	glog.Infof("Detaching volume")
+	if err = cleaner.TearDown(); err != nil {
+		t.Errorf("Expected success, got: %v", err)
+	}
+	glog.Infof("Volume detached")
+
+	// wait for the builder to finish
+	for atomic.LoadUint32(&buildComplete) == 0 {
+		time.Sleep(time.Millisecond * 100)
+	}
+
+	// The volume should still be attached
+	devicePath := getFakeDeviceName(host, "pd")
+	if _, err := os.Stat(devicePath); err != nil {
+		if os.IsNotExist(err) {
+			t.Errorf("SetUp() failed, volume detached by simultaneous TearDown: %s", path)
+		} else {
+			t.Errorf("SetUp() failed: %v", err)
+		}
+	}
+
+	// TearDown the 2nd volume
+	cleaner, err = plug.(*cinderPlugin).newCleanerInternal("vol1", types.UID("poduid2"), &fakePDManager{0}, fakeMounter)
+	if err != nil {
+		t.Errorf("Failed to make a new Cleaner: %v", err)
+	}
+	if cleaner == nil {
+		t.Errorf("Got a nil Cleaner: %v")
+	}
+
+	if err := cleaner.TearDown(); err != nil {
+		t.Errorf("Expected success, got: %v", err)
+	}
+	if _, err := os.Stat(path); err == nil {
+		t.Errorf("TearDown() failed, volume path still exists: %s", path)
+	} else if !os.IsNotExist(err) {
+		t.Errorf("SetUp() failed: %v", err)
+	}
+	if _, err := os.Stat(devicePath); err == nil {
+		t.Errorf("TearDown() failed, volume is still attached: %s", devicePath)
+	} else if !os.IsNotExist(err) {
+		t.Errorf("SetUp() failed: %v", err)
 	}
 }


### PR DESCRIPTION
Resolves https://github.com/kubernetes/kubernetes/issues/19602

Most of the changes are related to unit test. The real fix is in cinder.go. Similar change is needed in most of the volume plugins! Cinder seems to be the easiest to reproduce in real world, as it's the slowest to attach volumes (and thus the window of opportunity is the largest).

Also, I added some logs here and there to debug this issue easily next time.
