### PR TITLE
Add gce-serial and gke-serial jobs

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -498,13 +498,45 @@ case ${JOB_NAME} in
     NUM_NODES=${NUM_NODES_PARALLEL}
     ;;
 
-  # Run the DISRUPTIVE_TESTS on GCE. (#19681)
+  # Run the Reboot tests on GCE. (#19681)
   kubernetes-e2e-gce-reboot)
     : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-reboot"}
     : ${E2E_NETWORK:="e2e-reboot"}
     : ${GINKGO_TEST_ARGS:="--ginkgo.focus=Reboot"}
     : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-reboot"}
     : ${PROJECT:="kubernetes-jenkins"}
+    ;;
+
+  # Run the [Serial], [Disruptive], and [Feature:Restart] tests on GCE.
+  kubernetes-e2e-gce-serial)
+    : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-serial"}
+    : ${E2E_NETWORK:="jenkins-gce-e2e-serial"}
+    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
+    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=$(join_regex_no_empty \
+          \[Serial\] \
+          \[Disruptive\] \
+          \[Feature:Restart\] \
+          ) --ginkgo.skip=$(join_regex_no_empty \
+	  \[Flaky\]
+          )"}
+    : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-serial"}
+    : ${PROJECT:="kubernetes-jkns-e2e-gce-serial"}
+    ;;
+
+  # Run the [Serial], [Disruptive], and [Feature:Restart] tests on GKE.
+  kubernetes-e2e-gke-serial)
+    : ${E2E_CLUSTER_NAME:="jenkins-gke-e2e-serial"}
+    : ${E2E_NETWORK:="jenkins-gke-e2e-serial"}
+    : ${E2E_SET_CLUSTER_API_VERSION:=y}
+    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
+    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=$(join_regex_no_empty \
+          \[Serial\] \
+          \[Disruptive\] \
+          \[Feature:Restart\] \
+          ) --ginkgo.skip=$(join_regex_no_empty \
+	  \[Flaky\]
+          )"}
+    : ${PROJECT:="kubernetes-jkns-e2e-gke-serial"}
     ;;
 
   # Runs the performance/scalability tests on GCE. A larger cluster is used.

--- a/hack/jenkins/job-configs/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-e2e.yaml
@@ -191,7 +191,7 @@
         - 'kubernetes-e2e-{suffix}'
 
 - project:
-    name: kubernetes-e2e-gce-features
+    name: kubernetes-e2e-features
     trigger-job: 'kubernetes-build'
     branch: 'master'
     suffix:
@@ -200,14 +200,6 @@
             timeout: 300
             emails: '$DEFAULT_RECIPIENTS, ihmccreery@google.com'
             test-owner: 'ihmccreery'
-    jobs:
-        - 'kubernetes-e2e-{suffix}'
-
-- project:
-    name: kubernetes-e2e-gke-features
-    trigger-job: 'kubernetes-build'
-    branch: 'master'
-    suffix:
         - 'gke-serial':
             description: 'Run [Serial], [Disruptive], and [Feature:Restart] tests on GKE using the latest successful build.'
             timeout: 300

--- a/hack/jenkins/job-configs/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-e2e.yaml
@@ -189,3 +189,29 @@
             description: 'Run E2E tests on GCE from the release-1.0 branch.'
     jobs:
         - 'kubernetes-e2e-{suffix}'
+
+- project:
+    name: kubernetes-e2e-gce-features
+    trigger-job: 'kubernetes-build'
+    branch: 'master'
+    suffix:
+        - 'gce-serial':
+            description: 'Run [Serial], [Disruptive], and [Feature:Restart] tests on GCE using the latest successful build.'
+            timeout: 300
+            emails: '$DEFAULT_RECIPIENTS, ihmccreery@google.com'
+            test-owner: 'ihmccreery'
+    jobs:
+        - 'kubernetes-e2e-{suffix}'
+
+- project:
+    name: kubernetes-e2e-gke-features
+    trigger-job: 'kubernetes-build'
+    branch: 'master'
+    suffix:
+        - 'gke-serial':
+            description: 'Run [Serial], [Disruptive], and [Feature:Restart] tests on GKE using the latest successful build.'
+            timeout: 300
+            emails: '$DEFAULT_RECIPIENTS, ihmccreery@google.com'
+            test-owner: 'ihmccreery'
+    jobs:
+        - 'kubernetes-e2e-{suffix}'


### PR DESCRIPTION
To start deflaking serial, disruptive, and restart tests.

Need to do this per #19681; looks like Reboot tests don't play with other tests.
