### PR TITLE
Update to option enable cadvisor parameters to minimize memory overhead

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -291,6 +291,7 @@ function start_kubelet {
         --rkt-stage1-image="${RKT_STAGE1_IMAGE}" \
         --hostname-override="127.0.0.1" \
         --address="127.0.0.1" \
+        --max-pods="100" \
         --api-servers="${API_HOST}:${API_PORT}" \
         --cpu-cfs-quota=${CPU_CFS_QUOTA} \
         --cluster-dns="127.0.0.1" \

--- a/pkg/kubelet/cadvisor/cadvisor_linux.go
+++ b/pkg/kubelet/cadvisor/cadvisor_linux.go
@@ -43,10 +43,10 @@ type cadvisorClient struct {
 
 var _ Interface = new(cadvisorClient)
 
-// TODO(vmarmol): Make configurable.
-// The amount of time for which to keep stats in memory.
-const statsCacheDuration = 2 * time.Minute
-const maxHousekeepingInterval = 15 * time.Second
+// TODO: This code will likely be removed once cadvisor is a daemonset pod.
+var statsCacheDuration = flag.Duration("cadvisor_storage_duration", 2*time.Minute, "How long to keep data stored (Default: 2min).")
+var maxHousekeepingInterval = flag.Duration("cadvisor_max_housekeeping_interval", 60*time.Second, "Max-interval between container housekeepings")
+
 const defaultHousekeepingInterval = 10 * time.Second
 const allowDynamicHousekeeping = true
 
@@ -66,7 +66,7 @@ func New(port uint) (Interface, error) {
 	}
 
 	// Create and start the cAdvisor container manager.
-	m, err := manager.New(memory.New(statsCacheDuration, nil), sysFs, maxHousekeepingInterval, allowDynamicHousekeeping)
+	m, err := manager.New(memory.New(*statsCacheDuration, nil), sysFs, *maxHousekeepingInterval, allowDynamicHousekeeping)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Stemmed from https://github.com/kubernetes/kubernetes/issues/19341 investigation we found we can minimize memory overhead by adjusting tuning parameters that are options in cadvisor, but did not exist on the kubelet itself. 

Also, minor addition to local-cluster to allow for 100 pods for testing purposes. 

/cc @yujuhong @vishh @kubernetes/rh-cluster-infra 
