### PR TITLE
Fix e2e flake: Sync deployment status when with RecreateDeploymentStrategy

### DIFF
--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -450,7 +450,10 @@ func (dc *DeploymentController) syncRecreateDeployment(deployment extensions.Dep
 		return dc.updateDeploymentStatus(allRCs, newRC, deployment)
 	}
 
-	return nil
+	// Sync deployment status
+	return dc.syncDeploymentStatus(allRCs, newRC, deployment)
+
+	// TODO: raise an event, neither scaled up nor down.
 }
 
 func (dc *DeploymentController) syncRollingUpdateDeployment(deployment extensions.Deployment) error {
@@ -487,13 +490,18 @@ func (dc *DeploymentController) syncRollingUpdateDeployment(deployment extension
 	}
 
 	// Sync deployment status
+	return dc.syncDeploymentStatus(allRCs, newRC, deployment)
+
+	// TODO: raise an event, neither scaled up nor down.
+}
+
+// syncDeploymentStatus checks if the status is up-to-date and sync it if necessary
+func (dc *DeploymentController) syncDeploymentStatus(allRCs []*api.ReplicationController, newRC *api.ReplicationController, deployment extensions.Deployment) error {
 	totalReplicas := deploymentutil.GetReplicaCountForRCs(allRCs)
 	updatedReplicas := deploymentutil.GetReplicaCountForRCs([]*api.ReplicationController{newRC})
 	if deployment.Status.Replicas != totalReplicas || deployment.Status.UpdatedReplicas != updatedReplicas {
 		return dc.updateDeploymentStatus(allRCs, newRC, deployment)
 	}
-
-	// TODO: raise an event, neither scaled up nor down.
 	return nil
 }
 

--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -285,6 +285,10 @@ func testRecreateDeployment(f *Framework) {
 	}()
 
 	err = waitForDeploymentStatus(c, ns, deploymentName, replicas, 0, replicas, 0)
+	if err != nil {
+		deployment, _ := c.Deployments(ns).Get(deploymentName)
+		Logf("deployment = %+v", deployment)
+	}
 	Expect(err).NotTo(HaveOccurred())
 
 	// Verify that the pods were scaled up and down as expected. We use events to verify that.


### PR DESCRIPTION
Addresses #19732

Deployment status may fail to update due to conflict. Retry it periodically. 

cc @mqliang @nikhiljindal @ghodss @ironcladlou @kargakis @bgrant0607 
