### PR TITLE
Generate fake client

### DIFF
--- a/cmd/libs/go2idl/client-gen/generators/fake/fake-client-generator.go
+++ b/cmd/libs/go2idl/client-gen/generators/fake/fake-client-generator.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"path/filepath"
+	"strings"
+
+	"k8s.io/kubernetes/cmd/libs/go2idl/generator"
+	"k8s.io/kubernetes/cmd/libs/go2idl/types"
+)
+
+func PackageForGroup(group string, version string, typeList []*types.Type, packageBasePath string, srcTreePath string, boilerplate []byte) generator.Package {
+	outputPackagePath := filepath.Join(packageBasePath, group, version, "fake")
+	// TODO: should make this a function, called by here and in client-generator.go
+	realClientPath := filepath.Join(packageBasePath, group, version)
+	return &generator.DefaultPackage{
+		PackageName: "fake",
+		PackagePath: outputPackagePath,
+		HeaderText:  boilerplate,
+		PackageDocumentation: []byte(
+			`// Package fake has the automatically generated clients.
+`),
+		// GeneratorFunc returns a list of generators. Each generator makes a
+		// single file.
+		GeneratorFunc: func(c *generator.Context) (generators []generator.Generator) {
+			generators = []generator.Generator{
+				// Always generate a "doc.go" file.
+				generator.DefaultGen{OptionalName: "doc"},
+			}
+			// Since we want a file per type that we generate a client for, we
+			// have to provide a function for this.
+			for _, t := range typeList {
+				generators = append(generators, &genFakeForType{
+					DefaultGen: generator.DefaultGen{
+						OptionalName: "fake_" + strings.ToLower(c.Namers["private"].Name(t)),
+					},
+					outputPackage: outputPackagePath,
+					group:         group,
+					typeToMatch:   t,
+					imports:       generator.NewImportTracker(),
+				})
+			}
+
+			generators = append(generators, &genFakeForGroup{
+				DefaultGen: generator.DefaultGen{
+					OptionalName: "fake_" + group + "_client",
+				},
+				outputPackage:  outputPackagePath,
+				realClientPath: realClientPath,
+				group:          group,
+				types:          typeList,
+				imports:        generator.NewImportTracker(),
+			})
+			return generators
+		},
+		FilterFunc: func(c *generator.Context, t *types.Type) bool {
+			return types.ExtractCommentTags("+", t.SecondClosestCommentLines)["genclient"] == "true"
+		},
+	}
+}

--- a/cmd/libs/go2idl/client-gen/generators/fake/generator-fake-for-group.go
+++ b/cmd/libs/go2idl/client-gen/generators/fake/generator-fake-for-group.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"k8s.io/kubernetes/cmd/libs/go2idl/generator"
+	"k8s.io/kubernetes/cmd/libs/go2idl/namer"
+	"k8s.io/kubernetes/cmd/libs/go2idl/types"
+)
+
+// genFakeForGroup produces a file for a group client, e.g. ExtensionsClient for the extension group.
+type genFakeForGroup struct {
+	generator.DefaultGen
+	outputPackage  string
+	realClientPath string
+	group          string
+	// types in this group
+	types   []*types.Type
+	imports *generator.ImportTracker
+}
+
+var _ generator.Generator = &genFakeForGroup{}
+
+// We only want to call GenerateType() once per group.
+func (g *genFakeForGroup) Filter(c *generator.Context, t *types.Type) bool {
+	return t == g.types[0]
+}
+
+func (g *genFakeForGroup) Namers(c *generator.Context) namer.NameSystems {
+	return namer.NameSystems{
+		"raw": namer.NewRawNamer(g.outputPackage, g.imports),
+	}
+}
+
+func (g *genFakeForGroup) Imports(c *generator.Context) (imports []string) {
+	return append(g.imports.ImportLines(), fmt.Sprintf("%s \"%s\"", filepath.Base(g.realClientPath), g.realClientPath))
+}
+
+func (g *genFakeForGroup) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {
+	sw := generator.NewSnippetWriter(w, c, "$", "$")
+	const pkgTestingCore = "k8s.io/kubernetes/pkg/client/testing/core"
+	m := map[string]interface{}{
+		"group": g.group,
+		"Group": namer.IC(g.group),
+		"Fake":  c.Universe.Type(types.Name{Package: pkgTestingCore, Name: "Fake"}),
+	}
+	sw.Do(groupClientTemplate, m)
+	for _, t := range g.types {
+		wrapper := map[string]interface{}{
+			"type":              t,
+			"Group":             namer.IC(g.group),
+			"realClientPackage": filepath.Base(g.realClientPath),
+		}
+		namespaced := !(types.ExtractCommentTags("+", t.SecondClosestCommentLines)["nonNamespaced"] == "true")
+		if namespaced {
+			sw.Do(getterImplNamespaced, wrapper)
+		} else {
+			sw.Do(getterImplNonNamespaced, wrapper)
+
+		}
+	}
+	return sw.Error()
+}
+
+var groupClientTemplate = `
+type Fake$.Group$ struct {
+	*$.Fake|raw$
+}
+`
+
+var getterImplNamespaced = `
+func (c *Fake$.Group$) $.type|publicPlural$(namespace string) $.realClientPackage$.$.type|public$Interface {
+	return &Fake$.type|publicPlural${c, namespace}
+}
+`
+
+var getterImplNonNamespaced = `
+func (c *Fake$.Group$) $.type|publicPlural$() $.realClientPackage$.$.type|public$Interface {
+	return &Fake$.type|publicPlural${c}
+}
+`

--- a/cmd/libs/go2idl/client-gen/generators/fake/generator-fake-for-type.go
+++ b/cmd/libs/go2idl/client-gen/generators/fake/generator-fake-for-type.go
@@ -1,0 +1,266 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"io"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/kubernetes/cmd/libs/go2idl/generator"
+	"k8s.io/kubernetes/cmd/libs/go2idl/namer"
+	"k8s.io/kubernetes/cmd/libs/go2idl/types"
+)
+
+// genFakeForType produces a file for each top-level type.
+type genFakeForType struct {
+	generator.DefaultGen
+	outputPackage string
+	group         string
+	typeToMatch   *types.Type
+	imports       *generator.ImportTracker
+}
+
+var _ generator.Generator = &genFakeForType{}
+
+// Filter ignores all but one type because we're making a single file per type.
+func (g *genFakeForType) Filter(c *generator.Context, t *types.Type) bool { return t == g.typeToMatch }
+
+func (g *genFakeForType) Namers(c *generator.Context) namer.NameSystems {
+	return namer.NameSystems{
+		"raw": namer.NewRawNamer(g.outputPackage, g.imports),
+	}
+}
+
+func (g *genFakeForType) Imports(c *generator.Context) (imports []string) {
+	return g.imports.ImportLines()
+}
+
+// Ideally, we'd like hasStatus to return true if there is a subresource path
+// registered for "status" in the API server, but we do not have that
+// information, so hasStatus returns true if the type has a status field.
+func hasStatus(t *types.Type) bool {
+	for _, m := range t.Members {
+		if m.Name == "Status" && strings.Contains(m.Tags, `json:"status`) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasObjectMeta returns true if the type has a ObjectMeta field.
+func hasObjectMeta(t *types.Type) bool {
+	for _, m := range t.Members {
+		if m.Embedded == true && m.Name == "ObjectMeta" {
+			return true
+		}
+	}
+	return false
+}
+
+// GenerateType makes the body of a file implementing the individual typed client for type t.
+func (g *genFakeForType) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {
+	sw := generator.NewSnippetWriter(w, c, "$", "$")
+	pkg := filepath.Base(t.Name.Package)
+	const pkgTestingCore = "k8s.io/kubernetes/pkg/client/testing/core"
+	namespaced := !(types.ExtractCommentTags("+", t.SecondClosestCommentLines)["nonNamespaced"] == "true")
+	m := map[string]interface{}{
+		"type":             t,
+		"package":          pkg,
+		"Package":          namer.IC(pkg),
+		"namespaced":       namespaced,
+		"Group":            namer.IC(g.group),
+		"watchInterface":   c.Universe.Type(types.Name{Package: "k8s.io/kubernetes/pkg/watch", Name: "Interface"}),
+		"apiDeleteOptions": c.Universe.Type(types.Name{Package: "k8s.io/kubernetes/pkg/api", Name: "DeleteOptions"}),
+		"apiListOptions":   c.Universe.Type(types.Name{Package: "k8s.io/kubernetes/pkg/api", Name: "ListOptions"}),
+		"Everything":       c.Universe.Function(types.Name{Package: "k8s.io/kubernetes/pkg/labels", Name: "Everything"}),
+
+		"NewRootListAction":              c.Universe.Function(types.Name{Package: pkgTestingCore, Name: "NewRootListAction"}),
+		"NewListAction":                  c.Universe.Function(types.Name{Package: pkgTestingCore, Name: "NewListAction"}),
+		"NewRootGetAction":               c.Universe.Function(types.Name{Package: pkgTestingCore, Name: "NewRootGetAction"}),
+		"NewGetAction":                   c.Universe.Function(types.Name{Package: pkgTestingCore, Name: "NewGetAction"}),
+		"NewRootDeleteAction":            c.Universe.Function(types.Name{Package: pkgTestingCore, Name: "NewRootDeleteAction"}),
+		"NewDeleteAction":                c.Universe.Function(types.Name{Package: pkgTestingCore, Name: "NewDeleteAction"}),
+		"NewRootDeleteCollectionAction":  c.Universe.Function(types.Name{Package: pkgTestingCore, Name: "NewRootDeleteCollectionAction"}),
+		"NewDeleteCollectionAction":      c.Universe.Function(types.Name{Package: pkgTestingCore, Name: "NewDeleteCollectionAction"}),
+		"NewRootUpdateAction":            c.Universe.Function(types.Name{Package: pkgTestingCore, Name: "NewRootUpdateAction"}),
+		"NewUpdateAction":                c.Universe.Function(types.Name{Package: pkgTestingCore, Name: "NewUpdateAction"}),
+		"NewRootCreateAction":            c.Universe.Function(types.Name{Package: pkgTestingCore, Name: "NewRootCreateAction"}),
+		"NewCreateAction":                c.Universe.Function(types.Name{Package: pkgTestingCore, Name: "NewCreateAction"}),
+		"NewRootWatchAction":             c.Universe.Function(types.Name{Package: pkgTestingCore, Name: "NewRootWatchAction"}),
+		"NewWatchAction":                 c.Universe.Function(types.Name{Package: pkgTestingCore, Name: "NewWatchAction"}),
+		"NewUpdateSubresourceAction":     c.Universe.Function(types.Name{Package: pkgTestingCore, Name: "NewUpdateSubresourceAction"}),
+		"NewRootUpdateSubresourceAction": c.Universe.Function(types.Name{Package: pkgTestingCore, Name: "NewRootUpdateSubresourceAction"}),
+	}
+
+	noMethods := types.ExtractCommentTags("+", t.SecondClosestCommentLines)["noMethods"] == "true"
+
+	if namespaced {
+		sw.Do(structNamespaced, m)
+	} else {
+		sw.Do(structNonNamespaced, m)
+	}
+
+	if !noMethods {
+		sw.Do(createTemplate, m)
+		sw.Do(updateTemplate, m)
+		// Generate the UpdateStatus method if the type has a status
+		if hasStatus(t) {
+			sw.Do(updateStatusTemplate, m)
+		}
+		sw.Do(deleteTemplate, m)
+		sw.Do(deleteCollectionTemplate, m)
+		sw.Do(getTemplate, m)
+		if hasObjectMeta(t) {
+			sw.Do(listUsingOptionsTemplate, m)
+		} else {
+			sw.Do(listTemplate, m)
+		}
+		sw.Do(watchTemplate, m)
+
+	}
+
+	return sw.Error()
+}
+
+// template for the struct that implements the type's interface
+var structNamespaced = `
+// Fake$.type|publicPlural$ implements $.type|public$Interface
+type Fake$.type|publicPlural$ struct {
+	Fake *Fake$.Group$
+	ns     string
+}
+`
+
+// template for the struct that implements the type's interface
+var structNonNamespaced = `
+// Fake$.type|publicPlural$ implements $.type|public$Interface
+type Fake$.type|publicPlural$ struct {
+	Fake *Fake$.Group$
+}
+`
+
+var listTemplate = `
+func (c *Fake$.type|publicPlural$) List(opts $.apiListOptions|raw$) (result *$.type|raw$List, err error) {
+	obj, err := c.Fake.
+		$if .namespaced$Invokes($.NewListAction|raw$("$.type|privatePlural$", c.ns, opts), &$.type|raw$List{})
+		$else$Invokes($.NewRootListAction|raw$("$.type|privatePlural$", opts), &$.type|raw$List{})$end$
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*$.type|raw$List), err
+}
+`
+
+var listUsingOptionsTemplate = `
+func (c *Fake$.type|publicPlural$) List(opts $.apiListOptions|raw$) (result *$.type|raw$List, err error) {
+	obj, err := c.Fake.
+		$if .namespaced$Invokes($.NewListAction|raw$("$.type|privatePlural$", c.ns, opts), &$.type|raw$List{})
+		$else$Invokes($.NewRootListAction|raw$("$.type|privatePlural$", opts), &$.type|raw$List{})$end$
+	if obj == nil {
+		return nil, err
+	}
+
+	label := opts.LabelSelector
+	if label == nil {
+		label = $.Everything|raw$()
+	}
+	list := &$.type|raw$List{}
+	for _, item := range obj.(*$.type|raw$List).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+`
+
+var getTemplate = `
+func (c *Fake$.type|publicPlural$) Get(name string) (result *$.type|raw$, err error) {
+	obj, err := c.Fake.
+		$if .namespaced$Invokes($.NewGetAction|raw$("$.type|privatePlural$", c.ns, name), &$.type|raw${})
+		$else$Invokes($.NewRootGetAction|raw$("$.type|privatePlural$", name), &$.type|raw${})$end$
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*$.type|raw$), err
+}
+`
+
+var deleteTemplate = `
+func (c *Fake$.type|publicPlural$) Delete(name string, options *$.apiDeleteOptions|raw$) error {
+	_, err := c.Fake.
+		$if .namespaced$Invokes($.NewDeleteAction|raw$("$.type|privatePlural$", c.ns, name), &$.type|raw${})
+		$else$Invokes($.NewRootDeleteAction|raw$("$.type|privatePlural$", name), &$.type|raw${})$end$
+	return err
+}
+`
+
+var deleteCollectionTemplate = `
+func (c *Fake$.type|publicPlural$) DeleteCollection(options *$.apiDeleteOptions|raw$, listOptions $.apiListOptions|raw$) error {
+	$if .namespaced$action := $.NewDeleteCollectionAction|raw$("events", c.ns, listOptions)
+	$else$action := $.NewRootDeleteCollectionAction|raw$("events", listOptions)
+	$end$
+	_, err := c.Fake.Invokes(action, &$.type|raw$List{})
+	return err
+}
+`
+
+var createTemplate = `
+func (c *Fake$.type|publicPlural$) Create($.type|private$ *$.type|raw$) (result *$.type|raw$, err error) {
+	obj, err := c.Fake.
+		$if .namespaced$Invokes($.NewCreateAction|raw$("$.type|privatePlural$", c.ns, $.type|private$), &$.type|raw${})
+		$else$Invokes($.NewRootCreateAction|raw$("$.type|privatePlural$", $.type|private$), &$.type|raw${})$end$
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*$.type|raw$), err
+}
+`
+
+var updateTemplate = `
+func (c *Fake$.type|publicPlural$) Update($.type|private$ *$.type|raw$) (result *$.type|raw$, err error) {
+	obj, err := c.Fake.
+		$if .namespaced$Invokes($.NewUpdateAction|raw$("$.type|privatePlural$", c.ns, $.type|private$), &$.type|raw${})
+		$else$Invokes($.NewRootUpdateAction|raw$("$.type|privatePlural$", $.type|private$), &$.type|raw${})$end$
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*$.type|raw$), err
+}
+`
+
+var updateStatusTemplate = `
+func (c *Fake$.type|publicPlural$) UpdateStatus($.type|private$ *$.type|raw$) (*$.type|raw$, error) {
+	obj, err := c.Fake.
+		$if .namespaced$Invokes($.NewUpdateSubresourceAction|raw$("$.type|privatePlural$", "status", c.ns, $.type|private$), &$.type|raw${})
+		$else$Invokes($.NewRootUpdateSubresourceAction|raw$("$.type|privatePlural$", "status", $.type|private$), &$.type|raw${})$end$
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*$.type|raw$), err
+}
+`
+
+var watchTemplate = `
+// Watch returns a $.watchInterface|raw$ that watches the requested $.type|privatePlural$.
+func (c *Fake$.type|publicPlural$) Watch(opts $.apiListOptions|raw$) ($.watchInterface|raw$, error) {
+	return c.Fake.
+		$if .namespaced$InvokesWatch($.NewWatchAction|raw$("$.type|privatePlural$", c.ns, opts))
+		$else$InvokesWatch($.NewRootWatchAction|raw$("$.type|privatePlural$", opts))$end$
+}
+`

--- a/cmd/libs/go2idl/client-gen/generators/generator-for-clientset.go
+++ b/cmd/libs/go2idl/client-gen/generators/generator-for-clientset.go
@@ -116,7 +116,7 @@ func (g *genClientset) GenerateType(c *generator.Context, t *types.Type, w io.Wr
 
 var clientsetInterfaceTemplate = `
 type Interface interface {
-    $range .allGroups$$.Group$() $.PackageName$.$.Group$Client
+    $range .allGroups$$.Group$() $.PackageName$.$.Group$Interface
     $end$
 }
 `
@@ -132,7 +132,7 @@ type Clientset struct {
 
 var clientsetInterfaceImplTemplate = `
 // $.Group$ retrieves the $.Group$Client
-func (c *Clientset) $.Group$() *$.PackageName$.$.Group$Client {
+func (c *Clientset) $.Group$() $.PackageName$.$.Group$Interface {
 	return c.$.Group$Client
 }
 `

--- a/cmd/libs/go2idl/client-gen/generators/generator-for-type.go
+++ b/cmd/libs/go2idl/client-gen/generators/generator-for-type.go
@@ -62,7 +62,7 @@ func hasStatus(t *types.Type) bool {
 	return false
 }
 
-// GenerateType makes the body of a file implementing a set for type t.
+// GenerateType makes the body of a file implementing the individual typed client for type t.
 func (g *genClientForType) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {
 	sw := generator.NewSnippetWriter(w, c, "$", "$")
 	pkg := filepath.Base(t.Name.Package)

--- a/cmd/libs/go2idl/client-gen/main.go
+++ b/cmd/libs/go2idl/client-gen/main.go
@@ -77,6 +77,7 @@ func main() {
 		"k8s.io/kubernetes/pkg/watch",
 		"k8s.io/kubernetes/pkg/client/unversioned",
 		"k8s.io/kubernetes/pkg/api/latest",
+		"k8s.io/kubernetes/pkg/client/testing/fake",
 	}
 
 	if *test {
@@ -89,6 +90,7 @@ func main() {
 			[]unversioned.GroupVersion{{"testgroup", ""}},
 			"test_release_1_1",
 			"k8s.io/kubernetes/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/",
+			false,
 			false,
 		}
 	} else {
@@ -110,6 +112,7 @@ func main() {
 			*clientsetName,
 			*clientsetPath,
 			*clientsetOnly,
+			true,
 		}
 	}
 

--- a/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_release_1_1/clientset.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_release_1_1/clientset.go
@@ -22,7 +22,7 @@ import (
 )
 
 type Interface interface {
-	Testgroup() testgroup_unversioned.TestgroupClient
+	Testgroup() testgroup_unversioned.TestgroupInterface
 }
 
 // Clientset contains the clients for groups. Each group has exactly one
@@ -32,7 +32,7 @@ type Clientset struct {
 }
 
 // Testgroup retrieves the TestgroupClient
-func (c *Clientset) Testgroup() *testgroup_unversioned.TestgroupClient {
+func (c *Clientset) Testgroup() testgroup_unversioned.TestgroupInterface {
 	return c.TestgroupClient
 }
 

--- a/pkg/client/clientset_generated/release_1_1/clientset.go
+++ b/pkg/client/clientset_generated/release_1_1/clientset.go
@@ -23,8 +23,8 @@ import (
 )
 
 type Interface interface {
-	Legacy() legacy_unversioned.LegacyClient
-	Extensions() extensions_unversioned.ExtensionsClient
+	Legacy() legacy_unversioned.LegacyInterface
+	Extensions() extensions_unversioned.ExtensionsInterface
 }
 
 // Clientset contains the clients for groups. Each group has exactly one
@@ -35,12 +35,12 @@ type Clientset struct {
 }
 
 // Legacy retrieves the LegacyClient
-func (c *Clientset) Legacy() *legacy_unversioned.LegacyClient {
+func (c *Clientset) Legacy() legacy_unversioned.LegacyInterface {
 	return c.LegacyClient
 }
 
 // Extensions retrieves the ExtensionsClient
-func (c *Clientset) Extensions() *extensions_unversioned.ExtensionsClient {
+func (c *Clientset) Extensions() extensions_unversioned.ExtensionsInterface {
 	return c.ExtensionsClient
 }
 

--- a/pkg/client/testing/core/actions.go
+++ b/pkg/client/testing/core/actions.go
@@ -1,0 +1,455 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"strings"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+func NewRootGetAction(resource, name string) GetActionImpl {
+	action := GetActionImpl{}
+	action.Verb = "get"
+	action.Resource = resource
+	action.Name = name
+
+	return action
+}
+
+func NewGetAction(resource, namespace, name string) GetActionImpl {
+	action := GetActionImpl{}
+	action.Verb = "get"
+	action.Resource = resource
+	action.Namespace = namespace
+	action.Name = name
+
+	return action
+}
+
+func NewRootListAction(resource string, opts api.ListOptions) ListActionImpl {
+	action := ListActionImpl{}
+	action.Verb = "list"
+	action.Resource = resource
+	labelSelector := opts.LabelSelector
+	if labelSelector == nil {
+		labelSelector = labels.Everything()
+	}
+	fieldSelector := opts.FieldSelector
+	if fieldSelector == nil {
+		fieldSelector = fields.Everything()
+	}
+	action.ListRestrictions = ListRestrictions{labelSelector, fieldSelector}
+
+	return action
+}
+
+func NewListAction(resource, namespace string, opts api.ListOptions) ListActionImpl {
+	action := ListActionImpl{}
+	action.Verb = "list"
+	action.Resource = resource
+	action.Namespace = namespace
+	labelSelector := opts.LabelSelector
+	if labelSelector == nil {
+		labelSelector = labels.Everything()
+	}
+	fieldSelector := opts.FieldSelector
+	if fieldSelector == nil {
+		fieldSelector = fields.Everything()
+	}
+	action.ListRestrictions = ListRestrictions{labelSelector, fieldSelector}
+
+	return action
+}
+
+func NewRootCreateAction(resource string, object runtime.Object) CreateActionImpl {
+	action := CreateActionImpl{}
+	action.Verb = "create"
+	action.Resource = resource
+	action.Object = object
+
+	return action
+}
+
+func NewCreateAction(resource, namespace string, object runtime.Object) CreateActionImpl {
+	action := CreateActionImpl{}
+	action.Verb = "create"
+	action.Resource = resource
+	action.Namespace = namespace
+	action.Object = object
+
+	return action
+}
+
+func NewRootUpdateAction(resource string, object runtime.Object) UpdateActionImpl {
+	action := UpdateActionImpl{}
+	action.Verb = "update"
+	action.Resource = resource
+	action.Object = object
+
+	return action
+}
+
+func NewUpdateAction(resource, namespace string, object runtime.Object) UpdateActionImpl {
+	action := UpdateActionImpl{}
+	action.Verb = "update"
+	action.Resource = resource
+	action.Namespace = namespace
+	action.Object = object
+
+	return action
+}
+
+func NewRootPatchAction(resource string, object runtime.Object) PatchActionImpl {
+	action := PatchActionImpl{}
+	action.Verb = "patch"
+	action.Resource = resource
+	action.Object = object
+
+	return action
+}
+
+func NewPatchAction(resource, namespace string, object runtime.Object) PatchActionImpl {
+	action := PatchActionImpl{}
+	action.Verb = "patch"
+	action.Resource = resource
+	action.Namespace = namespace
+	action.Object = object
+
+	return action
+}
+
+func NewRootUpdateSubresourceAction(resource, subresource string, object runtime.Object) UpdateActionImpl {
+	action := UpdateActionImpl{}
+	action.Verb = "update"
+	action.Resource = resource
+	action.Subresource = subresource
+	action.Object = object
+
+	return action
+}
+func NewUpdateSubresourceAction(resource, subresource, namespace string, object runtime.Object) UpdateActionImpl {
+	action := UpdateActionImpl{}
+	action.Verb = "update"
+	action.Resource = resource
+	action.Subresource = subresource
+	action.Namespace = namespace
+	action.Object = object
+
+	return action
+}
+
+func NewRootDeleteAction(resource, name string) DeleteActionImpl {
+	action := DeleteActionImpl{}
+	action.Verb = "delete"
+	action.Resource = resource
+	action.Name = name
+
+	return action
+}
+
+func NewDeleteAction(resource, namespace, name string) DeleteActionImpl {
+	action := DeleteActionImpl{}
+	action.Verb = "delete"
+	action.Resource = resource
+	action.Namespace = namespace
+	action.Name = name
+
+	return action
+}
+
+func NewRootDeleteCollectionAction(resource string, opts api.ListOptions) DeleteCollectionActionImpl {
+	action := DeleteCollectionActionImpl{}
+	action.Verb = "delete-collection"
+	action.Resource = resource
+	labelSelector := opts.LabelSelector
+	if labelSelector == nil {
+		labelSelector = labels.Everything()
+	}
+	fieldSelector := opts.FieldSelector
+	if fieldSelector == nil {
+		fieldSelector = fields.Everything()
+	}
+	action.ListRestrictions = ListRestrictions{labelSelector, fieldSelector}
+
+	return action
+}
+
+func NewDeleteCollectionAction(resource, namespace string, opts api.ListOptions) DeleteCollectionActionImpl {
+	action := DeleteCollectionActionImpl{}
+	action.Verb = "delete-collection"
+	action.Resource = resource
+	action.Namespace = namespace
+	labelSelector := opts.LabelSelector
+	if labelSelector == nil {
+		labelSelector = labels.Everything()
+	}
+	fieldSelector := opts.FieldSelector
+	if fieldSelector == nil {
+		fieldSelector = fields.Everything()
+	}
+	action.ListRestrictions = ListRestrictions{labelSelector, fieldSelector}
+
+	return action
+}
+
+func NewRootWatchAction(resource string, opts api.ListOptions) WatchActionImpl {
+	action := WatchActionImpl{}
+	action.Verb = "watch"
+	action.Resource = resource
+	labelSelector := opts.LabelSelector
+	if labelSelector == nil {
+		labelSelector = labels.Everything()
+	}
+	fieldSelector := opts.FieldSelector
+	if fieldSelector == nil {
+		fieldSelector = fields.Everything()
+	}
+	action.WatchRestrictions = WatchRestrictions{labelSelector, fieldSelector, opts.ResourceVersion}
+
+	return action
+}
+
+func NewWatchAction(resource, namespace string, opts api.ListOptions) WatchActionImpl {
+	action := WatchActionImpl{}
+	action.Verb = "watch"
+	action.Resource = resource
+	action.Namespace = namespace
+	labelSelector := opts.LabelSelector
+	if labelSelector == nil {
+		labelSelector = labels.Everything()
+	}
+	fieldSelector := opts.FieldSelector
+	if fieldSelector == nil {
+		fieldSelector = fields.Everything()
+	}
+	action.WatchRestrictions = WatchRestrictions{labelSelector, fieldSelector, opts.ResourceVersion}
+
+	return action
+}
+
+func NewProxyGetAction(resource, namespace, scheme, name, port, path string, params map[string]string) ProxyGetActionImpl {
+	action := ProxyGetActionImpl{}
+	action.Verb = "get"
+	action.Resource = resource
+	action.Namespace = namespace
+	action.Scheme = scheme
+	action.Name = name
+	action.Port = port
+	action.Path = path
+	action.Params = params
+	return action
+}
+
+type ListRestrictions struct {
+	Labels labels.Selector
+	Fields fields.Selector
+}
+type WatchRestrictions struct {
+	Labels          labels.Selector
+	Fields          fields.Selector
+	ResourceVersion string
+}
+
+type Action interface {
+	GetNamespace() string
+	GetVerb() string
+	GetResource() string
+	GetSubresource() string
+	Matches(verb, resource string) bool
+}
+
+type GenericAction interface {
+	Action
+	GetValue() interface{}
+}
+
+type GetAction interface {
+	Action
+	GetName() string
+}
+
+type ListAction interface {
+	Action
+	GetListRestrictions() ListRestrictions
+}
+
+type CreateAction interface {
+	Action
+	GetObject() runtime.Object
+}
+
+type UpdateAction interface {
+	Action
+	GetObject() runtime.Object
+}
+
+type DeleteAction interface {
+	Action
+	GetName() string
+}
+
+type WatchAction interface {
+	Action
+	GetWatchRestrictions() WatchRestrictions
+}
+
+type ProxyGetAction interface {
+	Action
+	GetScheme() string
+	GetName() string
+	GetPort() string
+	GetPath() string
+	GetParams() map[string]string
+}
+
+type ActionImpl struct {
+	Namespace   string
+	Verb        string
+	Resource    string
+	Subresource string
+}
+
+func (a ActionImpl) GetNamespace() string {
+	return a.Namespace
+}
+func (a ActionImpl) GetVerb() string {
+	return a.Verb
+}
+func (a ActionImpl) GetResource() string {
+	return a.Resource
+}
+func (a ActionImpl) GetSubresource() string {
+	return a.Subresource
+}
+func (a ActionImpl) Matches(verb, resource string) bool {
+	return strings.ToLower(verb) == strings.ToLower(a.Verb) &&
+		strings.ToLower(resource) == strings.ToLower(a.Resource)
+}
+
+type GenericActionImpl struct {
+	ActionImpl
+	Value interface{}
+}
+
+func (a GenericActionImpl) GetValue() interface{} {
+	return a.Value
+}
+
+type GetActionImpl struct {
+	ActionImpl
+	Name string
+}
+
+func (a GetActionImpl) GetName() string {
+	return a.Name
+}
+
+type ListActionImpl struct {
+	ActionImpl
+	ListRestrictions ListRestrictions
+}
+
+func (a ListActionImpl) GetListRestrictions() ListRestrictions {
+	return a.ListRestrictions
+}
+
+type CreateActionImpl struct {
+	ActionImpl
+	Object runtime.Object
+}
+
+func (a CreateActionImpl) GetObject() runtime.Object {
+	return a.Object
+}
+
+type UpdateActionImpl struct {
+	ActionImpl
+	Object runtime.Object
+}
+
+func (a UpdateActionImpl) GetObject() runtime.Object {
+	return a.Object
+}
+
+type PatchActionImpl struct {
+	ActionImpl
+	Object runtime.Object
+}
+
+func (a PatchActionImpl) GetObject() runtime.Object {
+	return a.Object
+}
+
+type DeleteActionImpl struct {
+	ActionImpl
+	Name string
+}
+
+func (a DeleteActionImpl) GetName() string {
+	return a.Name
+}
+
+type DeleteCollectionActionImpl struct {
+	ActionImpl
+	ListRestrictions ListRestrictions
+}
+
+func (a DeleteCollectionActionImpl) GetListRestrictions() ListRestrictions {
+	return a.ListRestrictions
+}
+
+type WatchActionImpl struct {
+	ActionImpl
+	WatchRestrictions WatchRestrictions
+}
+
+func (a WatchActionImpl) GetWatchRestrictions() WatchRestrictions {
+	return a.WatchRestrictions
+}
+
+type ProxyGetActionImpl struct {
+	ActionImpl
+	Scheme string
+	Name   string
+	Port   string
+	Path   string
+	Params map[string]string
+}
+
+func (a ProxyGetActionImpl) GetScheme() string {
+	return a.Scheme
+}
+
+func (a ProxyGetActionImpl) GetName() string {
+	return a.Name
+}
+
+func (a ProxyGetActionImpl) GetPort() string {
+	return a.Port
+}
+
+func (a ProxyGetActionImpl) GetPath() string {
+	return a.Path
+}
+
+func (a ProxyGetActionImpl) GetParams() map[string]string {
+	return a.Params
+}

--- a/pkg/client/testing/core/fake.go
+++ b/pkg/client/testing/core/fake.go
@@ -1,0 +1,231 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"fmt"
+	"sync"
+
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/version"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// Fake implements client.Interface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the method you want to test easier.
+type Fake struct {
+	sync.RWMutex
+	actions []Action // these may be castable to other types, but "Action" is the minimum
+
+	// ReactionChain is the list of reactors that will be attempted for every request in the order they are tried
+	ReactionChain []Reactor
+	// WatchReactionChain is the list of watch reactors that will be attempted for every request in the order they are tried
+	WatchReactionChain []WatchReactor
+	// ProxyReactionChain is the list of proxy reactors that will be attempted for every request in the order they are tried
+	ProxyReactionChain []ProxyReactor
+
+	Resources map[string]*unversioned.APIResourceList
+}
+
+// Reactor is an interface to allow the composition of reaction functions.
+type Reactor interface {
+	// Handles indicates whether or not this Reactor deals with a given action
+	Handles(action Action) bool
+	// React handles the action and returns results.  It may choose to delegate by indicated handled=false
+	React(action Action) (handled bool, ret runtime.Object, err error)
+}
+
+// WatchReactor is an interface to allow the composition of watch functions.
+type WatchReactor interface {
+	// Handles indicates whether or not this Reactor deals with a given action
+	Handles(action Action) bool
+	// React handles a watch action and returns results.  It may choose to delegate by indicated handled=false
+	React(action Action) (handled bool, ret watch.Interface, err error)
+}
+
+// ProxyReactor is an interface to allow the composition of proxy get functions.
+type ProxyReactor interface {
+	// Handles indicates whether or not this Reactor deals with a given action
+	Handles(action Action) bool
+	// React handles a watch action and returns results.  It may choose to delegate by indicated handled=false
+	React(action Action) (handled bool, ret client.ResponseWrapper, err error)
+}
+
+// ReactionFunc is a function that returns an object or error for a given Action.  If "handled" is false,
+// then the test client will continue ignore the results and continue to the next ReactionFunc
+type ReactionFunc func(action Action) (handled bool, ret runtime.Object, err error)
+
+// WatchReactionFunc is a function that returns a watch interface.  If "handled" is false,
+// then the test client will continue ignore the results and continue to the next ReactionFunc
+type WatchReactionFunc func(action Action) (handled bool, ret watch.Interface, err error)
+
+// ProxyReactionFunc is a function that returns a ResponseWrapper interface for a given Action.  If "handled" is false,
+// then the test client will continue ignore the results and continue to the next ProxyReactionFunc
+type ProxyReactionFunc func(action Action) (handled bool, ret client.ResponseWrapper, err error)
+
+// AddReactor appends a reactor to the end of the chain
+func (c *Fake) AddReactor(verb, resource string, reaction ReactionFunc) {
+	c.ReactionChain = append(c.ReactionChain, &SimpleReactor{verb, resource, reaction})
+}
+
+// PrependReactor adds a reactor to the beginning of the chain
+func (c *Fake) PrependReactor(verb, resource string, reaction ReactionFunc) {
+	c.ReactionChain = append([]Reactor{&SimpleReactor{verb, resource, reaction}}, c.ReactionChain...)
+}
+
+// AddWatchReactor appends a reactor to the end of the chain
+func (c *Fake) AddWatchReactor(resource string, reaction WatchReactionFunc) {
+	c.WatchReactionChain = append(c.WatchReactionChain, &SimpleWatchReactor{resource, reaction})
+}
+
+// PrependWatchReactor adds a reactor to the beginning of the chain
+func (c *Fake) PrependWatchReactor(resource string, reaction WatchReactionFunc) {
+	c.WatchReactionChain = append([]WatchReactor{&SimpleWatchReactor{resource, reaction}}, c.WatchReactionChain...)
+}
+
+// AddProxyReactor appends a reactor to the end of the chain
+func (c *Fake) AddProxyReactor(resource string, reaction ProxyReactionFunc) {
+	c.ProxyReactionChain = append(c.ProxyReactionChain, &SimpleProxyReactor{resource, reaction})
+}
+
+// PrependProxyReactor adds a reactor to the beginning of the chain
+func (c *Fake) PrependProxyReactor(resource string, reaction ProxyReactionFunc) {
+	c.ProxyReactionChain = append([]ProxyReactor{&SimpleProxyReactor{resource, reaction}}, c.ProxyReactionChain...)
+}
+
+// Invokes records the provided Action and then invokes the ReactFn (if provided).
+// defaultReturnObj is expected to be of the same type a normal call would return.
+func (c *Fake) Invokes(action Action, defaultReturnObj runtime.Object) (runtime.Object, error) {
+	c.Lock()
+	defer c.Unlock()
+
+	c.actions = append(c.actions, action)
+	for _, reactor := range c.ReactionChain {
+		if !reactor.Handles(action) {
+			continue
+		}
+
+		handled, ret, err := reactor.React(action)
+		if !handled {
+			continue
+		}
+
+		return ret, err
+	}
+
+	return defaultReturnObj, nil
+}
+
+// InvokesWatch records the provided Action and then invokes the ReactFn (if provided).
+func (c *Fake) InvokesWatch(action Action) (watch.Interface, error) {
+	c.Lock()
+	defer c.Unlock()
+
+	c.actions = append(c.actions, action)
+	for _, reactor := range c.WatchReactionChain {
+		if !reactor.Handles(action) {
+			continue
+		}
+
+		handled, ret, err := reactor.React(action)
+		if !handled {
+			continue
+		}
+
+		return ret, err
+	}
+
+	return nil, fmt.Errorf("unhandled watch: %#v", action)
+}
+
+// InvokesProxy records the provided Action and then invokes the ReactFn (if provided).
+func (c *Fake) InvokesProxy(action Action) client.ResponseWrapper {
+	c.Lock()
+	defer c.Unlock()
+
+	c.actions = append(c.actions, action)
+	for _, reactor := range c.ProxyReactionChain {
+		if !reactor.Handles(action) {
+			continue
+		}
+
+		handled, ret, err := reactor.React(action)
+		if !handled || err != nil {
+			continue
+		}
+
+		return ret
+	}
+
+	return nil
+}
+
+// ClearActions clears the history of actions called on the fake client
+func (c *Fake) ClearActions() {
+	c.Lock()
+	c.Unlock()
+
+	c.actions = make([]Action, 0)
+}
+
+// Actions returns a chronologically ordered slice fake actions called on the fake client
+func (c *Fake) Actions() []Action {
+	c.RLock()
+	defer c.RUnlock()
+	fa := make([]Action, len(c.actions))
+	copy(fa, c.actions)
+	return fa
+}
+
+// TODO: this probably should be moved to somewhere else.
+type FakeDiscovery struct {
+	*Fake
+}
+
+func (c *FakeDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*unversioned.APIResourceList, error) {
+	action := ActionImpl{
+		Verb:     "get",
+		Resource: "resource",
+	}
+	c.Invokes(action, nil)
+	return c.Resources[groupVersion], nil
+}
+
+func (c *FakeDiscovery) ServerResources() (map[string]*unversioned.APIResourceList, error) {
+	action := ActionImpl{
+		Verb:     "get",
+		Resource: "resource",
+	}
+	c.Invokes(action, nil)
+	return c.Resources, nil
+}
+
+func (c *FakeDiscovery) ServerGroups() (*unversioned.APIGroupList, error) {
+	return nil, nil
+}
+
+func (c *FakeDiscovery) ServerVersion() (*version.Info, error) {
+	action := ActionImpl{}
+	action.Verb = "get"
+	action.Resource = "version"
+
+	c.Invokes(action, nil)
+	versionInfo := version.Get()
+	return &versionInfo, nil
+}

--- a/pkg/client/testing/core/fixture.go
+++ b/pkg/client/testing/core/fixture.go
@@ -1,0 +1,319 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"fmt"
+	"io/ioutil"
+	"reflect"
+	"strings"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/yaml"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// ObjectRetriever abstracts the implementation for retrieving or setting generic
+// objects. It is intended to be used to fake calls to a server by returning
+// objects based on their kind and name.
+type ObjectRetriever interface {
+	// Kind should return a resource or a list of resources (depending on the provided kind and
+	// name). It should return an error if the caller should communicate an error to the server.
+	Kind(gvk unversioned.GroupVersionKind, name string) (runtime.Object, error)
+	// Add adds a runtime object for test purposes into this object.
+	Add(runtime.Object) error
+}
+
+// ObjectScheme abstracts the implementation of common operations on objects.
+type ObjectScheme interface {
+	runtime.ObjectCreater
+	runtime.ObjectCopier
+	runtime.ObjectTyper
+}
+
+// ObjectReaction returns a ReactionFunc that takes a generic action string of the form
+// <verb>-<resource> or <verb>-<subresource>-<resource> and attempts to return a runtime
+// Object or error that matches the requested action. For instance, list-replicationControllers
+// should attempt to return a list of replication controllers. This method delegates to the
+// ObjectRetriever interface to satisfy retrieval of lists or retrieval of single items.
+// TODO: add support for sub resources
+func ObjectReaction(o ObjectRetriever, mapper meta.RESTMapper) ReactionFunc {
+
+	return func(action Action) (bool, runtime.Object, error) {
+		kind, err := mapper.KindFor(unversioned.GroupVersionResource{Resource: action.GetResource()})
+		if err != nil {
+			return false, nil, fmt.Errorf("unrecognized action %s: %v", action.GetResource(), err)
+		}
+
+		// TODO: have mapper return a Kind for a subresource?
+		switch castAction := action.(type) {
+		case ListAction:
+			kind.Kind += "List"
+			resource, err := o.Kind(kind, "")
+			return true, resource, err
+
+		case GetAction:
+			resource, err := o.Kind(kind, castAction.GetName())
+			return true, resource, err
+
+		case DeleteAction:
+			resource, err := o.Kind(kind, castAction.GetName())
+			return true, resource, err
+
+		case CreateAction:
+			meta, err := api.ObjectMetaFor(castAction.GetObject())
+			if err != nil {
+				return true, nil, err
+			}
+			resource, err := o.Kind(kind, meta.Name)
+			return true, resource, err
+
+		case UpdateAction:
+			meta, err := api.ObjectMetaFor(castAction.GetObject())
+			if err != nil {
+				return true, nil, err
+			}
+			resource, err := o.Kind(kind, meta.Name)
+			return true, resource, err
+
+		default:
+			return false, nil, fmt.Errorf("no reaction implemented for %s", action)
+		}
+
+		return true, nil, nil
+	}
+}
+
+// AddObjectsFromPath loads the JSON or YAML file containing Kubernetes API resources
+// and adds them to the provided ObjectRetriever.
+func AddObjectsFromPath(path string, o ObjectRetriever, decoder runtime.Decoder) error {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	data, err = yaml.ToJSON(data)
+	if err != nil {
+		return err
+	}
+	obj, err := runtime.Decode(decoder, data)
+	if err != nil {
+		return err
+	}
+	if err := o.Add(obj); err != nil {
+		return err
+	}
+	return nil
+}
+
+type objects struct {
+	types   map[string][]runtime.Object
+	last    map[string]int
+	scheme  ObjectScheme
+	decoder runtime.ObjectDecoder
+}
+
+var _ ObjectRetriever = &objects{}
+
+// NewObjects implements the ObjectRetriever interface by introspecting the
+// objects provided to Add() and returning them when the Kind method is invoked.
+// If an api.List object is provided to Add(), each child item is added. If an
+// object is added that is itself a list (PodList, ServiceList) then that is added
+// to the "PodList" kind. If no PodList is added, the retriever will take any loaded
+// Pods and return them in a list. If an api.Status is added, and the Details.Kind field
+// is set, that status will be returned instead (as an error if Status != Success, or
+// as a runtime.Object if Status == Success).  If multiple PodLists are provided, they
+// will be returned in order by the Kind call, and the last PodList will be reused for
+// subsequent calls.
+func NewObjects(scheme ObjectScheme, decoder runtime.ObjectDecoder) ObjectRetriever {
+	return objects{
+		types:   make(map[string][]runtime.Object),
+		last:    make(map[string]int),
+		scheme:  scheme,
+		decoder: decoder,
+	}
+}
+
+func (o objects) Kind(kind unversioned.GroupVersionKind, name string) (runtime.Object, error) {
+	// TODO our test clients deal in internal versions.  We need to plumb that knowledge down here
+	// we might do this via an extra function to the scheme to allow getting internal group versions
+	// I'm punting for now
+	kind.Version = ""
+
+	empty, _ := o.scheme.New(kind)
+	nilValue := reflect.Zero(reflect.TypeOf(empty)).Interface().(runtime.Object)
+
+	arr, ok := o.types[kind.Kind]
+	if !ok {
+		if strings.HasSuffix(kind.Kind, "List") {
+			itemKind := kind.Kind[:len(kind.Kind)-4]
+			arr, ok := o.types[itemKind]
+			if !ok {
+				return empty, nil
+			}
+			out, err := o.scheme.New(kind)
+			if err != nil {
+				return nilValue, err
+			}
+			if err := meta.SetList(out, arr); err != nil {
+				return nilValue, err
+			}
+			if out, err = o.scheme.Copy(out); err != nil {
+				return nilValue, err
+			}
+			return out, nil
+		}
+		return nilValue, errors.NewNotFound(unversioned.GroupResource{Group: kind.Group, Resource: kind.Kind}, name)
+	}
+
+	index := o.last[kind.Kind]
+	if index >= len(arr) {
+		index = len(arr) - 1
+	}
+	if index < 0 {
+		return nilValue, errors.NewNotFound(unversioned.GroupResource{Group: kind.Group, Resource: kind.Kind}, name)
+	}
+	out, err := o.scheme.Copy(arr[index])
+	if err != nil {
+		return nilValue, err
+	}
+	o.last[kind.Kind] = index + 1
+
+	if status, ok := out.(*unversioned.Status); ok {
+		if status.Details != nil {
+			status.Details.Kind = kind.Kind
+		}
+		if status.Status != unversioned.StatusSuccess {
+			return nilValue, &errors.StatusError{ErrStatus: *status}
+		}
+	}
+
+	return out, nil
+}
+
+func (o objects) Add(obj runtime.Object) error {
+	gvk, err := o.scheme.ObjectKind(obj)
+	if err != nil {
+		return err
+	}
+	kind := gvk.Kind
+
+	switch {
+	case meta.IsListType(obj):
+		if kind != "List" {
+			o.types[kind] = append(o.types[kind], obj)
+		}
+
+		list, err := meta.ExtractList(obj)
+		if err != nil {
+			return err
+		}
+		if errs := runtime.DecodeList(list, o.decoder); len(errs) > 0 {
+			return errs[0]
+		}
+		for _, obj := range list {
+			if err := o.Add(obj); err != nil {
+				return err
+			}
+		}
+	default:
+		if status, ok := obj.(*unversioned.Status); ok && status.Details != nil {
+			kind = status.Details.Kind
+		}
+		o.types[kind] = append(o.types[kind], obj)
+	}
+
+	return nil
+}
+
+func DefaultWatchReactor(watchInterface watch.Interface, err error) WatchReactionFunc {
+	return func(action Action) (bool, watch.Interface, error) {
+		return true, watchInterface, err
+	}
+}
+
+// SimpleReactor is a Reactor.  Each reaction function is attached to a given verb,resource tuple.  "*" in either field matches everything for that value.
+// For instance, *,pods matches all verbs on pods.  This allows for easier composition of reaction functions
+type SimpleReactor struct {
+	Verb     string
+	Resource string
+
+	Reaction ReactionFunc
+}
+
+func (r *SimpleReactor) Handles(action Action) bool {
+	verbCovers := r.Verb == "*" || r.Verb == action.GetVerb()
+	if !verbCovers {
+		return false
+	}
+	resourceCovers := r.Resource == "*" || r.Resource == action.GetResource()
+	if !resourceCovers {
+		return false
+	}
+
+	return true
+}
+
+func (r *SimpleReactor) React(action Action) (bool, runtime.Object, error) {
+	return r.Reaction(action)
+}
+
+// SimpleWatchReactor is a WatchReactor.  Each reaction function is attached to a given resource.  "*" matches everything for that value.
+// For instance, *,pods matches all verbs on pods.  This allows for easier composition of reaction functions
+type SimpleWatchReactor struct {
+	Resource string
+
+	Reaction WatchReactionFunc
+}
+
+func (r *SimpleWatchReactor) Handles(action Action) bool {
+	resourceCovers := r.Resource == "*" || r.Resource == action.GetResource()
+	if !resourceCovers {
+		return false
+	}
+
+	return true
+}
+
+func (r *SimpleWatchReactor) React(action Action) (bool, watch.Interface, error) {
+	return r.Reaction(action)
+}
+
+// SimpleProxyReactor is a ProxyReactor.  Each reaction function is attached to a given resource.  "*" matches everything for that value.
+// For instance, *,pods matches all verbs on pods.  This allows for easier composition of reaction functions.
+type SimpleProxyReactor struct {
+	Resource string
+
+	Reaction ProxyReactionFunc
+}
+
+func (r *SimpleProxyReactor) Handles(action Action) bool {
+	resourceCovers := r.Resource == "*" || r.Resource == action.GetResource()
+	if !resourceCovers {
+		return false
+	}
+
+	return true
+}
+
+func (r *SimpleProxyReactor) React(action Action) (bool, client.ResponseWrapper, error) {
+	return r.Reaction(action)
+}

--- a/pkg/client/testing/fake/clientset.go
+++ b/pkg/client/testing/fake/clientset.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/release_1_1"
+	"k8s.io/kubernetes/pkg/client/testing/core"
+	extensions_unversioned "k8s.io/kubernetes/pkg/client/typed/generated/extensions/unversioned"
+	extensions_unversioned_fake "k8s.io/kubernetes/pkg/client/typed/generated/extensions/unversioned/fake"
+	legacy_unversioned "k8s.io/kubernetes/pkg/client/typed/generated/legacy/unversioned"
+	legacy_unversioned_fake "k8s.io/kubernetes/pkg/client/typed/generated/legacy/unversioned/fake"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// Clientset returns a clientset that will respond with the provided objects
+func NewSimpleClientset(objects ...runtime.Object) *Clientset {
+	o := core.NewObjects(api.Scheme, api.Scheme)
+	for _, obj := range objects {
+		if err := o.Add(obj); err != nil {
+			panic(err)
+		}
+	}
+
+	fakePtr := core.Fake{}
+	fakePtr.AddReactor("*", "*", core.ObjectReaction(o, api.RESTMapper))
+
+	fakePtr.AddWatchReactor("*", core.DefaultWatchReactor(watch.NewFake(), nil))
+
+	return &Clientset{fakePtr}
+}
+
+// Clientset implements release_1_1.Interface. Meant to be embedded into a
+// struct to get a default implementation. This makes faking out just the method
+// you want to test easier.
+type Clientset struct {
+	core.Fake
+}
+
+var _ release_1_1.Interface = &Clientset{}
+
+func (c *Clientset) Legacy() legacy_unversioned.LegacyInterface {
+	return &legacy_unversioned_fake.FakeLegacy{&c.Fake}
+}
+
+func (c *Clientset) Extensions() extensions_unversioned.ExtensionsInterface {
+	return &extensions_unversioned_fake.FakeExtensions{&c.Fake}
+}

--- a/pkg/client/typed/generated/extensions/unversioned/fake/doc.go
+++ b/pkg/client/typed/generated/extensions/unversioned/fake/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package fake has the automatically generated clients.
+package fake

--- a/pkg/client/typed/generated/extensions/unversioned/fake/fake_daemonset.go
+++ b/pkg/client/typed/generated/extensions/unversioned/fake/fake_daemonset.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	extensions "k8s.io/kubernetes/pkg/apis/extensions"
+	core "k8s.io/kubernetes/pkg/client/testing/core"
+	labels "k8s.io/kubernetes/pkg/labels"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeDaemonSets implements DaemonSetInterface
+type FakeDaemonSets struct {
+	Fake *FakeExtensions
+	ns   string
+}
+
+func (c *FakeDaemonSets) Create(daemonSet *extensions.DaemonSet) (result *extensions.DaemonSet, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewCreateAction("daemonSets", c.ns, daemonSet), &extensions.DaemonSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.DaemonSet), err
+}
+
+func (c *FakeDaemonSets) Update(daemonSet *extensions.DaemonSet) (result *extensions.DaemonSet, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateAction("daemonSets", c.ns, daemonSet), &extensions.DaemonSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.DaemonSet), err
+}
+
+func (c *FakeDaemonSets) UpdateStatus(daemonSet *extensions.DaemonSet) (*extensions.DaemonSet, error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateSubresourceAction("daemonSets", "status", c.ns, daemonSet), &extensions.DaemonSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.DaemonSet), err
+}
+
+func (c *FakeDaemonSets) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(core.NewDeleteAction("daemonSets", c.ns, name), &extensions.DaemonSet{})
+
+	return err
+}
+
+func (c *FakeDaemonSets) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &extensions.DaemonSetList{})
+	return err
+}
+
+func (c *FakeDaemonSets) Get(name string) (result *extensions.DaemonSet, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewGetAction("daemonSets", c.ns, name), &extensions.DaemonSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.DaemonSet), err
+}
+
+func (c *FakeDaemonSets) List(opts api.ListOptions) (result *extensions.DaemonSetList, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewListAction("daemonSets", c.ns, opts), &extensions.DaemonSetList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label := opts.LabelSelector
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &extensions.DaemonSetList{}
+	for _, item := range obj.(*extensions.DaemonSetList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested daemonSets.
+func (c *FakeDaemonSets) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(core.NewWatchAction("daemonSets", c.ns, opts))
+
+}

--- a/pkg/client/typed/generated/extensions/unversioned/fake/fake_deployment.go
+++ b/pkg/client/typed/generated/extensions/unversioned/fake/fake_deployment.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	extensions "k8s.io/kubernetes/pkg/apis/extensions"
+	core "k8s.io/kubernetes/pkg/client/testing/core"
+	labels "k8s.io/kubernetes/pkg/labels"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeDeployments implements DeploymentInterface
+type FakeDeployments struct {
+	Fake *FakeExtensions
+	ns   string
+}
+
+func (c *FakeDeployments) Create(deployment *extensions.Deployment) (result *extensions.Deployment, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewCreateAction("deployments", c.ns, deployment), &extensions.Deployment{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Deployment), err
+}
+
+func (c *FakeDeployments) Update(deployment *extensions.Deployment) (result *extensions.Deployment, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateAction("deployments", c.ns, deployment), &extensions.Deployment{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Deployment), err
+}
+
+func (c *FakeDeployments) UpdateStatus(deployment *extensions.Deployment) (*extensions.Deployment, error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateSubresourceAction("deployments", "status", c.ns, deployment), &extensions.Deployment{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Deployment), err
+}
+
+func (c *FakeDeployments) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(core.NewDeleteAction("deployments", c.ns, name), &extensions.Deployment{})
+
+	return err
+}
+
+func (c *FakeDeployments) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &extensions.DeploymentList{})
+	return err
+}
+
+func (c *FakeDeployments) Get(name string) (result *extensions.Deployment, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewGetAction("deployments", c.ns, name), &extensions.Deployment{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Deployment), err
+}
+
+func (c *FakeDeployments) List(opts api.ListOptions) (result *extensions.DeploymentList, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewListAction("deployments", c.ns, opts), &extensions.DeploymentList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label := opts.LabelSelector
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &extensions.DeploymentList{}
+	for _, item := range obj.(*extensions.DeploymentList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested deployments.
+func (c *FakeDeployments) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(core.NewWatchAction("deployments", c.ns, opts))
+
+}

--- a/pkg/client/typed/generated/extensions/unversioned/fake/fake_extensions_client.go
+++ b/pkg/client/typed/generated/extensions/unversioned/fake/fake_extensions_client.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	core "k8s.io/kubernetes/pkg/client/testing/core"
+	unversioned "k8s.io/kubernetes/pkg/client/typed/generated/extensions/unversioned"
+)
+
+type FakeExtensions struct {
+	*core.Fake
+}
+
+func (c *FakeExtensions) DaemonSets(namespace string) unversioned.DaemonSetInterface {
+	return &FakeDaemonSets{c, namespace}
+}
+
+func (c *FakeExtensions) Deployments(namespace string) unversioned.DeploymentInterface {
+	return &FakeDeployments{c, namespace}
+}
+
+func (c *FakeExtensions) HorizontalPodAutoscalers(namespace string) unversioned.HorizontalPodAutoscalerInterface {
+	return &FakeHorizontalPodAutoscalers{c, namespace}
+}
+
+func (c *FakeExtensions) Ingresses(namespace string) unversioned.IngressInterface {
+	return &FakeIngresses{c, namespace}
+}
+
+func (c *FakeExtensions) Jobs(namespace string) unversioned.JobInterface {
+	return &FakeJobs{c, namespace}
+}
+
+func (c *FakeExtensions) Scales(namespace string) unversioned.ScaleInterface {
+	return &FakeScales{c, namespace}
+}
+
+func (c *FakeExtensions) ThirdPartyResources(namespace string) unversioned.ThirdPartyResourceInterface {
+	return &FakeThirdPartyResources{c, namespace}
+}

--- a/pkg/client/typed/generated/extensions/unversioned/fake/fake_horizontalpodautoscaler.go
+++ b/pkg/client/typed/generated/extensions/unversioned/fake/fake_horizontalpodautoscaler.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	extensions "k8s.io/kubernetes/pkg/apis/extensions"
+	core "k8s.io/kubernetes/pkg/client/testing/core"
+	labels "k8s.io/kubernetes/pkg/labels"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeHorizontalPodAutoscalers implements HorizontalPodAutoscalerInterface
+type FakeHorizontalPodAutoscalers struct {
+	Fake *FakeExtensions
+	ns   string
+}
+
+func (c *FakeHorizontalPodAutoscalers) Create(horizontalPodAutoscaler *extensions.HorizontalPodAutoscaler) (result *extensions.HorizontalPodAutoscaler, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewCreateAction("horizontalPodAutoscalers", c.ns, horizontalPodAutoscaler), &extensions.HorizontalPodAutoscaler{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.HorizontalPodAutoscaler), err
+}
+
+func (c *FakeHorizontalPodAutoscalers) Update(horizontalPodAutoscaler *extensions.HorizontalPodAutoscaler) (result *extensions.HorizontalPodAutoscaler, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateAction("horizontalPodAutoscalers", c.ns, horizontalPodAutoscaler), &extensions.HorizontalPodAutoscaler{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.HorizontalPodAutoscaler), err
+}
+
+func (c *FakeHorizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *extensions.HorizontalPodAutoscaler) (*extensions.HorizontalPodAutoscaler, error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateSubresourceAction("horizontalPodAutoscalers", "status", c.ns, horizontalPodAutoscaler), &extensions.HorizontalPodAutoscaler{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.HorizontalPodAutoscaler), err
+}
+
+func (c *FakeHorizontalPodAutoscalers) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(core.NewDeleteAction("horizontalPodAutoscalers", c.ns, name), &extensions.HorizontalPodAutoscaler{})
+
+	return err
+}
+
+func (c *FakeHorizontalPodAutoscalers) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &extensions.HorizontalPodAutoscalerList{})
+	return err
+}
+
+func (c *FakeHorizontalPodAutoscalers) Get(name string) (result *extensions.HorizontalPodAutoscaler, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewGetAction("horizontalPodAutoscalers", c.ns, name), &extensions.HorizontalPodAutoscaler{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.HorizontalPodAutoscaler), err
+}
+
+func (c *FakeHorizontalPodAutoscalers) List(opts api.ListOptions) (result *extensions.HorizontalPodAutoscalerList, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewListAction("horizontalPodAutoscalers", c.ns, opts), &extensions.HorizontalPodAutoscalerList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label := opts.LabelSelector
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &extensions.HorizontalPodAutoscalerList{}
+	for _, item := range obj.(*extensions.HorizontalPodAutoscalerList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested horizontalPodAutoscalers.
+func (c *FakeHorizontalPodAutoscalers) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(core.NewWatchAction("horizontalPodAutoscalers", c.ns, opts))
+
+}

--- a/pkg/client/typed/generated/extensions/unversioned/fake/fake_ingress.go
+++ b/pkg/client/typed/generated/extensions/unversioned/fake/fake_ingress.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	extensions "k8s.io/kubernetes/pkg/apis/extensions"
+	core "k8s.io/kubernetes/pkg/client/testing/core"
+	labels "k8s.io/kubernetes/pkg/labels"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeIngresses implements IngressInterface
+type FakeIngresses struct {
+	Fake *FakeExtensions
+	ns   string
+}
+
+func (c *FakeIngresses) Create(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewCreateAction("ingresses", c.ns, ingress), &extensions.Ingress{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Ingress), err
+}
+
+func (c *FakeIngresses) Update(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateAction("ingresses", c.ns, ingress), &extensions.Ingress{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Ingress), err
+}
+
+func (c *FakeIngresses) UpdateStatus(ingress *extensions.Ingress) (*extensions.Ingress, error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateSubresourceAction("ingresses", "status", c.ns, ingress), &extensions.Ingress{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Ingress), err
+}
+
+func (c *FakeIngresses) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(core.NewDeleteAction("ingresses", c.ns, name), &extensions.Ingress{})
+
+	return err
+}
+
+func (c *FakeIngresses) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &extensions.IngressList{})
+	return err
+}
+
+func (c *FakeIngresses) Get(name string) (result *extensions.Ingress, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewGetAction("ingresses", c.ns, name), &extensions.Ingress{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Ingress), err
+}
+
+func (c *FakeIngresses) List(opts api.ListOptions) (result *extensions.IngressList, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewListAction("ingresses", c.ns, opts), &extensions.IngressList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label := opts.LabelSelector
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &extensions.IngressList{}
+	for _, item := range obj.(*extensions.IngressList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested ingresses.
+func (c *FakeIngresses) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(core.NewWatchAction("ingresses", c.ns, opts))
+
+}

--- a/pkg/client/typed/generated/extensions/unversioned/fake/fake_job.go
+++ b/pkg/client/typed/generated/extensions/unversioned/fake/fake_job.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	extensions "k8s.io/kubernetes/pkg/apis/extensions"
+	core "k8s.io/kubernetes/pkg/client/testing/core"
+	labels "k8s.io/kubernetes/pkg/labels"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeJobs implements JobInterface
+type FakeJobs struct {
+	Fake *FakeExtensions
+	ns   string
+}
+
+func (c *FakeJobs) Create(job *extensions.Job) (result *extensions.Job, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewCreateAction("jobs", c.ns, job), &extensions.Job{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Job), err
+}
+
+func (c *FakeJobs) Update(job *extensions.Job) (result *extensions.Job, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateAction("jobs", c.ns, job), &extensions.Job{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Job), err
+}
+
+func (c *FakeJobs) UpdateStatus(job *extensions.Job) (*extensions.Job, error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateSubresourceAction("jobs", "status", c.ns, job), &extensions.Job{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Job), err
+}
+
+func (c *FakeJobs) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(core.NewDeleteAction("jobs", c.ns, name), &extensions.Job{})
+
+	return err
+}
+
+func (c *FakeJobs) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &extensions.JobList{})
+	return err
+}
+
+func (c *FakeJobs) Get(name string) (result *extensions.Job, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewGetAction("jobs", c.ns, name), &extensions.Job{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Job), err
+}
+
+func (c *FakeJobs) List(opts api.ListOptions) (result *extensions.JobList, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewListAction("jobs", c.ns, opts), &extensions.JobList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label := opts.LabelSelector
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &extensions.JobList{}
+	for _, item := range obj.(*extensions.JobList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested jobs.
+func (c *FakeJobs) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(core.NewWatchAction("jobs", c.ns, opts))
+
+}

--- a/pkg/client/typed/generated/extensions/unversioned/fake/fake_scale.go
+++ b/pkg/client/typed/generated/extensions/unversioned/fake/fake_scale.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+// FakeScales implements ScaleInterface
+type FakeScales struct {
+	Fake *FakeExtensions
+	ns   string
+}

--- a/pkg/client/typed/generated/extensions/unversioned/fake/fake_scale_expansion.go
+++ b/pkg/client/typed/generated/extensions/unversioned/fake/fake_scale_expansion.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/client/testing/core"
+)
+
+func (c *FakeScales) Get(kind string, name string) (result *extensions.Scale, err error) {
+	action := core.GetActionImpl{}
+	action.Verb = "get"
+	action.Namespace = c.ns
+	action.Resource = kind
+	action.Subresource = "scale"
+	action.Name = name
+	obj, err := c.Fake.Invokes(action, &extensions.Scale{})
+	result = obj.(*extensions.Scale)
+	return
+}
+
+func (c *FakeScales) Update(kind string, scale *extensions.Scale) (result *extensions.Scale, err error) {
+	action := core.UpdateActionImpl{}
+	action.Verb = "update"
+	action.Namespace = c.ns
+	action.Resource = kind
+	action.Subresource = "scale"
+	action.Object = scale
+	obj, err := c.Fake.Invokes(action, scale)
+	result = obj.(*extensions.Scale)
+	return
+}

--- a/pkg/client/typed/generated/extensions/unversioned/fake/fake_thirdpartyresource.go
+++ b/pkg/client/typed/generated/extensions/unversioned/fake/fake_thirdpartyresource.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	extensions "k8s.io/kubernetes/pkg/apis/extensions"
+	core "k8s.io/kubernetes/pkg/client/testing/core"
+	labels "k8s.io/kubernetes/pkg/labels"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeThirdPartyResources implements ThirdPartyResourceInterface
+type FakeThirdPartyResources struct {
+	Fake *FakeExtensions
+	ns   string
+}
+
+func (c *FakeThirdPartyResources) Create(thirdPartyResource *extensions.ThirdPartyResource) (result *extensions.ThirdPartyResource, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewCreateAction("thirdPartyResources", c.ns, thirdPartyResource), &extensions.ThirdPartyResource{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.ThirdPartyResource), err
+}
+
+func (c *FakeThirdPartyResources) Update(thirdPartyResource *extensions.ThirdPartyResource) (result *extensions.ThirdPartyResource, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateAction("thirdPartyResources", c.ns, thirdPartyResource), &extensions.ThirdPartyResource{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.ThirdPartyResource), err
+}
+
+func (c *FakeThirdPartyResources) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(core.NewDeleteAction("thirdPartyResources", c.ns, name), &extensions.ThirdPartyResource{})
+
+	return err
+}
+
+func (c *FakeThirdPartyResources) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &extensions.ThirdPartyResourceList{})
+	return err
+}
+
+func (c *FakeThirdPartyResources) Get(name string) (result *extensions.ThirdPartyResource, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewGetAction("thirdPartyResources", c.ns, name), &extensions.ThirdPartyResource{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.ThirdPartyResource), err
+}
+
+func (c *FakeThirdPartyResources) List(opts api.ListOptions) (result *extensions.ThirdPartyResourceList, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewListAction("thirdPartyResources", c.ns, opts), &extensions.ThirdPartyResourceList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label := opts.LabelSelector
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &extensions.ThirdPartyResourceList{}
+	for _, item := range obj.(*extensions.ThirdPartyResourceList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested thirdPartyResources.
+func (c *FakeThirdPartyResources) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(core.NewWatchAction("thirdPartyResources", c.ns, opts))
+
+}

--- a/pkg/client/typed/generated/legacy/unversioned/fake/doc.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package fake has the automatically generated clients.
+package fake

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_componentstatus.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_componentstatus.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	core "k8s.io/kubernetes/pkg/client/testing/core"
+	labels "k8s.io/kubernetes/pkg/labels"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeComponentStatus implements ComponentStatusInterface
+type FakeComponentStatus struct {
+	Fake *FakeLegacy
+}
+
+func (c *FakeComponentStatus) Create(componentStatus *api.ComponentStatus) (result *api.ComponentStatus, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootCreateAction("componentStatus", componentStatus), &api.ComponentStatus{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ComponentStatus), err
+}
+
+func (c *FakeComponentStatus) Update(componentStatus *api.ComponentStatus) (result *api.ComponentStatus, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootUpdateAction("componentStatus", componentStatus), &api.ComponentStatus{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ComponentStatus), err
+}
+
+func (c *FakeComponentStatus) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(core.NewRootDeleteAction("componentStatus", name), &api.ComponentStatus{})
+	return err
+}
+
+func (c *FakeComponentStatus) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+	action := core.NewRootDeleteCollectionAction("events", listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.ComponentStatusList{})
+	return err
+}
+
+func (c *FakeComponentStatus) Get(name string) (result *api.ComponentStatus, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootGetAction("componentStatus", name), &api.ComponentStatus{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ComponentStatus), err
+}
+
+func (c *FakeComponentStatus) List(opts api.ListOptions) (result *api.ComponentStatusList, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootListAction("componentStatus", opts), &api.ComponentStatusList{})
+	if obj == nil {
+		return nil, err
+	}
+
+	label := opts.LabelSelector
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &api.ComponentStatusList{}
+	for _, item := range obj.(*api.ComponentStatusList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested componentStatus.
+func (c *FakeComponentStatus) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(core.NewRootWatchAction("componentStatus", opts))
+}

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_endpoints.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_endpoints.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	core "k8s.io/kubernetes/pkg/client/testing/core"
+	labels "k8s.io/kubernetes/pkg/labels"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeEndpoints implements EndpointsInterface
+type FakeEndpoints struct {
+	Fake *FakeLegacy
+	ns   string
+}
+
+func (c *FakeEndpoints) Create(endpoints *api.Endpoints) (result *api.Endpoints, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewCreateAction("endpoints", c.ns, endpoints), &api.Endpoints{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Endpoints), err
+}
+
+func (c *FakeEndpoints) Update(endpoints *api.Endpoints) (result *api.Endpoints, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateAction("endpoints", c.ns, endpoints), &api.Endpoints{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Endpoints), err
+}
+
+func (c *FakeEndpoints) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(core.NewDeleteAction("endpoints", c.ns, name), &api.Endpoints{})
+
+	return err
+}
+
+func (c *FakeEndpoints) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.EndpointsList{})
+	return err
+}
+
+func (c *FakeEndpoints) Get(name string) (result *api.Endpoints, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewGetAction("endpoints", c.ns, name), &api.Endpoints{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Endpoints), err
+}
+
+func (c *FakeEndpoints) List(opts api.ListOptions) (result *api.EndpointsList, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewListAction("endpoints", c.ns, opts), &api.EndpointsList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label := opts.LabelSelector
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &api.EndpointsList{}
+	for _, item := range obj.(*api.EndpointsList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested endpoints.
+func (c *FakeEndpoints) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(core.NewWatchAction("endpoints", c.ns, opts))
+
+}

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_event.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_event.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	core "k8s.io/kubernetes/pkg/client/testing/core"
+	labels "k8s.io/kubernetes/pkg/labels"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeEvents implements EventInterface
+type FakeEvents struct {
+	Fake *FakeLegacy
+	ns   string
+}
+
+func (c *FakeEvents) Create(event *api.Event) (result *api.Event, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewCreateAction("events", c.ns, event), &api.Event{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Event), err
+}
+
+func (c *FakeEvents) Update(event *api.Event) (result *api.Event, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateAction("events", c.ns, event), &api.Event{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Event), err
+}
+
+func (c *FakeEvents) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(core.NewDeleteAction("events", c.ns, name), &api.Event{})
+
+	return err
+}
+
+func (c *FakeEvents) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.EventList{})
+	return err
+}
+
+func (c *FakeEvents) Get(name string) (result *api.Event, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewGetAction("events", c.ns, name), &api.Event{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Event), err
+}
+
+func (c *FakeEvents) List(opts api.ListOptions) (result *api.EventList, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewListAction("events", c.ns, opts), &api.EventList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label := opts.LabelSelector
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &api.EventList{}
+	for _, item := range obj.(*api.EventList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested events.
+func (c *FakeEvents) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(core.NewWatchAction("events", c.ns, opts))
+
+}

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_event_expansion.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_event_expansion.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/testing/core"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+func (c *FakeEvents) CreateWithEventNamespace(event *api.Event) (*api.Event, error) {
+	action := core.NewRootCreateAction("events", event)
+	if c.ns != "" {
+		action = core.NewCreateAction("events", c.ns, event)
+	}
+	obj, err := c.Fake.Invokes(action, event)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.Event), err
+}
+
+// Update replaces an existing event. Returns the copy of the event the server returns, or an error.
+func (c *FakeEvents) UpdateWithEventNamespace(event *api.Event) (*api.Event, error) {
+	action := core.NewRootUpdateAction("events", event)
+	if c.ns != "" {
+		action = core.NewUpdateAction("events", c.ns, event)
+	}
+	obj, err := c.Fake.Invokes(action, event)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.Event), err
+}
+
+// Patch patches an existing event. Returns the copy of the event the server returns, or an error.
+func (c *FakeEvents) Patch(event *api.Event, data []byte) (*api.Event, error) {
+	action := core.NewRootPatchAction("events", event)
+	if c.ns != "" {
+		action = core.NewPatchAction("events", c.ns, event)
+	}
+	obj, err := c.Fake.Invokes(action, event)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.Event), err
+}
+
+// Search returns a list of events matching the specified object.
+func (c *FakeEvents) Search(objOrRef runtime.Object) (*api.EventList, error) {
+	action := core.NewRootListAction("events", api.ListOptions{})
+	if c.ns != "" {
+		action = core.NewListAction("events", c.ns, api.ListOptions{})
+	}
+	obj, err := c.Fake.Invokes(action, &api.EventList{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.EventList), err
+}
+
+func (c *FakeEvents) GetFieldSelector(involvedObjectName, involvedObjectNamespace, involvedObjectKind, involvedObjectUID *string) fields.Selector {
+	action := core.GenericActionImpl{}
+	action.Verb = "get-field-selector"
+	action.Resource = "events"
+
+	c.Fake.Invokes(action, nil)
+	return fields.Everything()
+}

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_legacy_client.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_legacy_client.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	core "k8s.io/kubernetes/pkg/client/testing/core"
+	unversioned "k8s.io/kubernetes/pkg/client/typed/generated/legacy/unversioned"
+)
+
+type FakeLegacy struct {
+	*core.Fake
+}
+
+func (c *FakeLegacy) ComponentStatus() unversioned.ComponentStatusInterface {
+	return &FakeComponentStatus{c}
+}
+
+func (c *FakeLegacy) Endpoints(namespace string) unversioned.EndpointsInterface {
+	return &FakeEndpoints{c, namespace}
+}
+
+func (c *FakeLegacy) Events(namespace string) unversioned.EventInterface {
+	return &FakeEvents{c, namespace}
+}
+
+func (c *FakeLegacy) LimitRanges(namespace string) unversioned.LimitRangeInterface {
+	return &FakeLimitRanges{c, namespace}
+}
+
+func (c *FakeLegacy) Namespaces() unversioned.NamespaceInterface {
+	return &FakeNamespaces{c}
+}
+
+func (c *FakeLegacy) Nodes() unversioned.NodeInterface {
+	return &FakeNodes{c}
+}
+
+func (c *FakeLegacy) PersistentVolumes() unversioned.PersistentVolumeInterface {
+	return &FakePersistentVolumes{c}
+}
+
+func (c *FakeLegacy) PersistentVolumeClaims(namespace string) unversioned.PersistentVolumeClaimInterface {
+	return &FakePersistentVolumeClaims{c, namespace}
+}
+
+func (c *FakeLegacy) Pods(namespace string) unversioned.PodInterface {
+	return &FakePods{c, namespace}
+}
+
+func (c *FakeLegacy) PodTemplates(namespace string) unversioned.PodTemplateInterface {
+	return &FakePodTemplates{c, namespace}
+}
+
+func (c *FakeLegacy) ReplicationControllers(namespace string) unversioned.ReplicationControllerInterface {
+	return &FakeReplicationControllers{c, namespace}
+}
+
+func (c *FakeLegacy) ResourceQuotas(namespace string) unversioned.ResourceQuotaInterface {
+	return &FakeResourceQuotas{c, namespace}
+}
+
+func (c *FakeLegacy) Secrets(namespace string) unversioned.SecretInterface {
+	return &FakeSecrets{c, namespace}
+}
+
+func (c *FakeLegacy) Services(namespace string) unversioned.ServiceInterface {
+	return &FakeServices{c, namespace}
+}
+
+func (c *FakeLegacy) ServiceAccounts(namespace string) unversioned.ServiceAccountInterface {
+	return &FakeServiceAccounts{c, namespace}
+}

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_limitrange.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_limitrange.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	core "k8s.io/kubernetes/pkg/client/testing/core"
+	labels "k8s.io/kubernetes/pkg/labels"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeLimitRanges implements LimitRangeInterface
+type FakeLimitRanges struct {
+	Fake *FakeLegacy
+	ns   string
+}
+
+func (c *FakeLimitRanges) Create(limitRange *api.LimitRange) (result *api.LimitRange, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewCreateAction("limitRanges", c.ns, limitRange), &api.LimitRange{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.LimitRange), err
+}
+
+func (c *FakeLimitRanges) Update(limitRange *api.LimitRange) (result *api.LimitRange, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateAction("limitRanges", c.ns, limitRange), &api.LimitRange{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.LimitRange), err
+}
+
+func (c *FakeLimitRanges) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(core.NewDeleteAction("limitRanges", c.ns, name), &api.LimitRange{})
+
+	return err
+}
+
+func (c *FakeLimitRanges) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.LimitRangeList{})
+	return err
+}
+
+func (c *FakeLimitRanges) Get(name string) (result *api.LimitRange, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewGetAction("limitRanges", c.ns, name), &api.LimitRange{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.LimitRange), err
+}
+
+func (c *FakeLimitRanges) List(opts api.ListOptions) (result *api.LimitRangeList, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewListAction("limitRanges", c.ns, opts), &api.LimitRangeList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label := opts.LabelSelector
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &api.LimitRangeList{}
+	for _, item := range obj.(*api.LimitRangeList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested limitRanges.
+func (c *FakeLimitRanges) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(core.NewWatchAction("limitRanges", c.ns, opts))
+
+}

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_namespace.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_namespace.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	core "k8s.io/kubernetes/pkg/client/testing/core"
+	labels "k8s.io/kubernetes/pkg/labels"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeNamespaces implements NamespaceInterface
+type FakeNamespaces struct {
+	Fake *FakeLegacy
+}
+
+func (c *FakeNamespaces) Create(namespace *api.Namespace) (result *api.Namespace, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootCreateAction("namespaces", namespace), &api.Namespace{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Namespace), err
+}
+
+func (c *FakeNamespaces) Update(namespace *api.Namespace) (result *api.Namespace, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootUpdateAction("namespaces", namespace), &api.Namespace{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Namespace), err
+}
+
+func (c *FakeNamespaces) UpdateStatus(namespace *api.Namespace) (*api.Namespace, error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootUpdateSubresourceAction("namespaces", "status", namespace), &api.Namespace{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Namespace), err
+}
+
+func (c *FakeNamespaces) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(core.NewRootDeleteAction("namespaces", name), &api.Namespace{})
+	return err
+}
+
+func (c *FakeNamespaces) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+	action := core.NewRootDeleteCollectionAction("events", listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.NamespaceList{})
+	return err
+}
+
+func (c *FakeNamespaces) Get(name string) (result *api.Namespace, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootGetAction("namespaces", name), &api.Namespace{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Namespace), err
+}
+
+func (c *FakeNamespaces) List(opts api.ListOptions) (result *api.NamespaceList, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootListAction("namespaces", opts), &api.NamespaceList{})
+	if obj == nil {
+		return nil, err
+	}
+
+	label := opts.LabelSelector
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &api.NamespaceList{}
+	for _, item := range obj.(*api.NamespaceList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested namespaces.
+func (c *FakeNamespaces) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(core.NewRootWatchAction("namespaces", opts))
+}

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_namespace_expansion.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_namespace_expansion.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/testing/core"
+)
+
+func (c *FakeNamespaces) Finalize(namespace *api.Namespace) (*api.Namespace, error) {
+	action := core.CreateActionImpl{}
+	action.Verb = "create"
+	action.Resource = "namespaces"
+	action.Subresource = "finalize"
+	action.Object = namespace
+
+	obj, err := c.Fake.Invokes(action, namespace)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.Namespace), err
+}

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_node.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_node.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	core "k8s.io/kubernetes/pkg/client/testing/core"
+	labels "k8s.io/kubernetes/pkg/labels"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeNodes implements NodeInterface
+type FakeNodes struct {
+	Fake *FakeLegacy
+}
+
+func (c *FakeNodes) Create(node *api.Node) (result *api.Node, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootCreateAction("nodes", node), &api.Node{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Node), err
+}
+
+func (c *FakeNodes) Update(node *api.Node) (result *api.Node, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootUpdateAction("nodes", node), &api.Node{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Node), err
+}
+
+func (c *FakeNodes) UpdateStatus(node *api.Node) (*api.Node, error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootUpdateSubresourceAction("nodes", "status", node), &api.Node{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Node), err
+}
+
+func (c *FakeNodes) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(core.NewRootDeleteAction("nodes", name), &api.Node{})
+	return err
+}
+
+func (c *FakeNodes) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+	action := core.NewRootDeleteCollectionAction("events", listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.NodeList{})
+	return err
+}
+
+func (c *FakeNodes) Get(name string) (result *api.Node, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootGetAction("nodes", name), &api.Node{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Node), err
+}
+
+func (c *FakeNodes) List(opts api.ListOptions) (result *api.NodeList, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootListAction("nodes", opts), &api.NodeList{})
+	if obj == nil {
+		return nil, err
+	}
+
+	label := opts.LabelSelector
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &api.NodeList{}
+	for _, item := range obj.(*api.NodeList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested nodes.
+func (c *FakeNodes) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(core.NewRootWatchAction("nodes", opts))
+}

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_persistentvolume.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_persistentvolume.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	core "k8s.io/kubernetes/pkg/client/testing/core"
+	labels "k8s.io/kubernetes/pkg/labels"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// FakePersistentVolumes implements PersistentVolumeInterface
+type FakePersistentVolumes struct {
+	Fake *FakeLegacy
+}
+
+func (c *FakePersistentVolumes) Create(persistentVolume *api.PersistentVolume) (result *api.PersistentVolume, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootCreateAction("persistentVolumes", persistentVolume), &api.PersistentVolume{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.PersistentVolume), err
+}
+
+func (c *FakePersistentVolumes) Update(persistentVolume *api.PersistentVolume) (result *api.PersistentVolume, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootUpdateAction("persistentVolumes", persistentVolume), &api.PersistentVolume{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.PersistentVolume), err
+}
+
+func (c *FakePersistentVolumes) UpdateStatus(persistentVolume *api.PersistentVolume) (*api.PersistentVolume, error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootUpdateSubresourceAction("persistentVolumes", "status", persistentVolume), &api.PersistentVolume{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.PersistentVolume), err
+}
+
+func (c *FakePersistentVolumes) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(core.NewRootDeleteAction("persistentVolumes", name), &api.PersistentVolume{})
+	return err
+}
+
+func (c *FakePersistentVolumes) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+	action := core.NewRootDeleteCollectionAction("events", listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.PersistentVolumeList{})
+	return err
+}
+
+func (c *FakePersistentVolumes) Get(name string) (result *api.PersistentVolume, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootGetAction("persistentVolumes", name), &api.PersistentVolume{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.PersistentVolume), err
+}
+
+func (c *FakePersistentVolumes) List(opts api.ListOptions) (result *api.PersistentVolumeList, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootListAction("persistentVolumes", opts), &api.PersistentVolumeList{})
+	if obj == nil {
+		return nil, err
+	}
+
+	label := opts.LabelSelector
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &api.PersistentVolumeList{}
+	for _, item := range obj.(*api.PersistentVolumeList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested persistentVolumes.
+func (c *FakePersistentVolumes) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(core.NewRootWatchAction("persistentVolumes", opts))
+}

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_persistentvolumeclaim.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_persistentvolumeclaim.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	core "k8s.io/kubernetes/pkg/client/testing/core"
+	labels "k8s.io/kubernetes/pkg/labels"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// FakePersistentVolumeClaims implements PersistentVolumeClaimInterface
+type FakePersistentVolumeClaims struct {
+	Fake *FakeLegacy
+	ns   string
+}
+
+func (c *FakePersistentVolumeClaims) Create(persistentVolumeClaim *api.PersistentVolumeClaim) (result *api.PersistentVolumeClaim, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewCreateAction("persistentVolumeClaims", c.ns, persistentVolumeClaim), &api.PersistentVolumeClaim{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.PersistentVolumeClaim), err
+}
+
+func (c *FakePersistentVolumeClaims) Update(persistentVolumeClaim *api.PersistentVolumeClaim) (result *api.PersistentVolumeClaim, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateAction("persistentVolumeClaims", c.ns, persistentVolumeClaim), &api.PersistentVolumeClaim{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.PersistentVolumeClaim), err
+}
+
+func (c *FakePersistentVolumeClaims) UpdateStatus(persistentVolumeClaim *api.PersistentVolumeClaim) (*api.PersistentVolumeClaim, error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateSubresourceAction("persistentVolumeClaims", "status", c.ns, persistentVolumeClaim), &api.PersistentVolumeClaim{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.PersistentVolumeClaim), err
+}
+
+func (c *FakePersistentVolumeClaims) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(core.NewDeleteAction("persistentVolumeClaims", c.ns, name), &api.PersistentVolumeClaim{})
+
+	return err
+}
+
+func (c *FakePersistentVolumeClaims) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.PersistentVolumeClaimList{})
+	return err
+}
+
+func (c *FakePersistentVolumeClaims) Get(name string) (result *api.PersistentVolumeClaim, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewGetAction("persistentVolumeClaims", c.ns, name), &api.PersistentVolumeClaim{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.PersistentVolumeClaim), err
+}
+
+func (c *FakePersistentVolumeClaims) List(opts api.ListOptions) (result *api.PersistentVolumeClaimList, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewListAction("persistentVolumeClaims", c.ns, opts), &api.PersistentVolumeClaimList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label := opts.LabelSelector
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &api.PersistentVolumeClaimList{}
+	for _, item := range obj.(*api.PersistentVolumeClaimList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested persistentVolumeClaims.
+func (c *FakePersistentVolumeClaims) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(core.NewWatchAction("persistentVolumeClaims", c.ns, opts))
+
+}

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_pod.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_pod.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	core "k8s.io/kubernetes/pkg/client/testing/core"
+	labels "k8s.io/kubernetes/pkg/labels"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// FakePods implements PodInterface
+type FakePods struct {
+	Fake *FakeLegacy
+	ns   string
+}
+
+func (c *FakePods) Create(pod *api.Pod) (result *api.Pod, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewCreateAction("pods", c.ns, pod), &api.Pod{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Pod), err
+}
+
+func (c *FakePods) Update(pod *api.Pod) (result *api.Pod, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateAction("pods", c.ns, pod), &api.Pod{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Pod), err
+}
+
+func (c *FakePods) UpdateStatus(pod *api.Pod) (*api.Pod, error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateSubresourceAction("pods", "status", c.ns, pod), &api.Pod{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Pod), err
+}
+
+func (c *FakePods) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(core.NewDeleteAction("pods", c.ns, name), &api.Pod{})
+
+	return err
+}
+
+func (c *FakePods) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.PodList{})
+	return err
+}
+
+func (c *FakePods) Get(name string) (result *api.Pod, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewGetAction("pods", c.ns, name), &api.Pod{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Pod), err
+}
+
+func (c *FakePods) List(opts api.ListOptions) (result *api.PodList, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewListAction("pods", c.ns, opts), &api.PodList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label := opts.LabelSelector
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &api.PodList{}
+	for _, item := range obj.(*api.PodList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested pods.
+func (c *FakePods) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(core.NewWatchAction("pods", c.ns, opts))
+
+}

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_pod_expansion.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_pod_expansion.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/testing/core"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+)
+
+func (c *FakePods) Bind(binding *api.Binding) error {
+	action := core.CreateActionImpl{}
+	action.Verb = "create"
+	action.Resource = "pods"
+	action.Subresource = "bindings"
+	action.Object = binding
+
+	_, err := c.Fake.Invokes(action, binding)
+	return err
+}
+
+func (c *FakePods) GetLogs(name string, opts *api.PodLogOptions) *client.Request {
+	action := core.GenericActionImpl{}
+	action.Verb = "get"
+	action.Namespace = c.ns
+	action.Resource = "pod"
+	action.Subresource = "logs"
+	action.Value = opts
+
+	_, _ = c.Fake.Invokes(action, &api.Pod{})
+	return &client.Request{}
+}

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_podtemplate.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_podtemplate.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	core "k8s.io/kubernetes/pkg/client/testing/core"
+	labels "k8s.io/kubernetes/pkg/labels"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// FakePodTemplates implements PodTemplateInterface
+type FakePodTemplates struct {
+	Fake *FakeLegacy
+	ns   string
+}
+
+func (c *FakePodTemplates) Create(podTemplate *api.PodTemplate) (result *api.PodTemplate, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewCreateAction("podTemplates", c.ns, podTemplate), &api.PodTemplate{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.PodTemplate), err
+}
+
+func (c *FakePodTemplates) Update(podTemplate *api.PodTemplate) (result *api.PodTemplate, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateAction("podTemplates", c.ns, podTemplate), &api.PodTemplate{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.PodTemplate), err
+}
+
+func (c *FakePodTemplates) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(core.NewDeleteAction("podTemplates", c.ns, name), &api.PodTemplate{})
+
+	return err
+}
+
+func (c *FakePodTemplates) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.PodTemplateList{})
+	return err
+}
+
+func (c *FakePodTemplates) Get(name string) (result *api.PodTemplate, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewGetAction("podTemplates", c.ns, name), &api.PodTemplate{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.PodTemplate), err
+}
+
+func (c *FakePodTemplates) List(opts api.ListOptions) (result *api.PodTemplateList, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewListAction("podTemplates", c.ns, opts), &api.PodTemplateList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label := opts.LabelSelector
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &api.PodTemplateList{}
+	for _, item := range obj.(*api.PodTemplateList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested podTemplates.
+func (c *FakePodTemplates) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(core.NewWatchAction("podTemplates", c.ns, opts))
+
+}

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_replicationcontroller.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_replicationcontroller.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	core "k8s.io/kubernetes/pkg/client/testing/core"
+	labels "k8s.io/kubernetes/pkg/labels"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeReplicationControllers implements ReplicationControllerInterface
+type FakeReplicationControllers struct {
+	Fake *FakeLegacy
+	ns   string
+}
+
+func (c *FakeReplicationControllers) Create(replicationController *api.ReplicationController) (result *api.ReplicationController, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewCreateAction("replicationControllers", c.ns, replicationController), &api.ReplicationController{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ReplicationController), err
+}
+
+func (c *FakeReplicationControllers) Update(replicationController *api.ReplicationController) (result *api.ReplicationController, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateAction("replicationControllers", c.ns, replicationController), &api.ReplicationController{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ReplicationController), err
+}
+
+func (c *FakeReplicationControllers) UpdateStatus(replicationController *api.ReplicationController) (*api.ReplicationController, error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateSubresourceAction("replicationControllers", "status", c.ns, replicationController), &api.ReplicationController{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ReplicationController), err
+}
+
+func (c *FakeReplicationControllers) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(core.NewDeleteAction("replicationControllers", c.ns, name), &api.ReplicationController{})
+
+	return err
+}
+
+func (c *FakeReplicationControllers) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.ReplicationControllerList{})
+	return err
+}
+
+func (c *FakeReplicationControllers) Get(name string) (result *api.ReplicationController, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewGetAction("replicationControllers", c.ns, name), &api.ReplicationController{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ReplicationController), err
+}
+
+func (c *FakeReplicationControllers) List(opts api.ListOptions) (result *api.ReplicationControllerList, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewListAction("replicationControllers", c.ns, opts), &api.ReplicationControllerList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label := opts.LabelSelector
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &api.ReplicationControllerList{}
+	for _, item := range obj.(*api.ReplicationControllerList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested replicationControllers.
+func (c *FakeReplicationControllers) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(core.NewWatchAction("replicationControllers", c.ns, opts))
+
+}

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_resourcequota.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_resourcequota.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	core "k8s.io/kubernetes/pkg/client/testing/core"
+	labels "k8s.io/kubernetes/pkg/labels"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeResourceQuotas implements ResourceQuotaInterface
+type FakeResourceQuotas struct {
+	Fake *FakeLegacy
+	ns   string
+}
+
+func (c *FakeResourceQuotas) Create(resourceQuota *api.ResourceQuota) (result *api.ResourceQuota, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewCreateAction("resourceQuotas", c.ns, resourceQuota), &api.ResourceQuota{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ResourceQuota), err
+}
+
+func (c *FakeResourceQuotas) Update(resourceQuota *api.ResourceQuota) (result *api.ResourceQuota, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateAction("resourceQuotas", c.ns, resourceQuota), &api.ResourceQuota{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ResourceQuota), err
+}
+
+func (c *FakeResourceQuotas) UpdateStatus(resourceQuota *api.ResourceQuota) (*api.ResourceQuota, error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateSubresourceAction("resourceQuotas", "status", c.ns, resourceQuota), &api.ResourceQuota{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ResourceQuota), err
+}
+
+func (c *FakeResourceQuotas) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(core.NewDeleteAction("resourceQuotas", c.ns, name), &api.ResourceQuota{})
+
+	return err
+}
+
+func (c *FakeResourceQuotas) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.ResourceQuotaList{})
+	return err
+}
+
+func (c *FakeResourceQuotas) Get(name string) (result *api.ResourceQuota, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewGetAction("resourceQuotas", c.ns, name), &api.ResourceQuota{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ResourceQuota), err
+}
+
+func (c *FakeResourceQuotas) List(opts api.ListOptions) (result *api.ResourceQuotaList, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewListAction("resourceQuotas", c.ns, opts), &api.ResourceQuotaList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label := opts.LabelSelector
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &api.ResourceQuotaList{}
+	for _, item := range obj.(*api.ResourceQuotaList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested resourceQuotas.
+func (c *FakeResourceQuotas) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(core.NewWatchAction("resourceQuotas", c.ns, opts))
+
+}

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_secret.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_secret.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	core "k8s.io/kubernetes/pkg/client/testing/core"
+	labels "k8s.io/kubernetes/pkg/labels"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeSecrets implements SecretInterface
+type FakeSecrets struct {
+	Fake *FakeLegacy
+	ns   string
+}
+
+func (c *FakeSecrets) Create(secret *api.Secret) (result *api.Secret, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewCreateAction("secrets", c.ns, secret), &api.Secret{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Secret), err
+}
+
+func (c *FakeSecrets) Update(secret *api.Secret) (result *api.Secret, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateAction("secrets", c.ns, secret), &api.Secret{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Secret), err
+}
+
+func (c *FakeSecrets) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(core.NewDeleteAction("secrets", c.ns, name), &api.Secret{})
+
+	return err
+}
+
+func (c *FakeSecrets) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.SecretList{})
+	return err
+}
+
+func (c *FakeSecrets) Get(name string) (result *api.Secret, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewGetAction("secrets", c.ns, name), &api.Secret{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Secret), err
+}
+
+func (c *FakeSecrets) List(opts api.ListOptions) (result *api.SecretList, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewListAction("secrets", c.ns, opts), &api.SecretList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label := opts.LabelSelector
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &api.SecretList{}
+	for _, item := range obj.(*api.SecretList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested secrets.
+func (c *FakeSecrets) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(core.NewWatchAction("secrets", c.ns, opts))
+
+}

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_service.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_service.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	core "k8s.io/kubernetes/pkg/client/testing/core"
+	labels "k8s.io/kubernetes/pkg/labels"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeServices implements ServiceInterface
+type FakeServices struct {
+	Fake *FakeLegacy
+	ns   string
+}
+
+func (c *FakeServices) Create(service *api.Service) (result *api.Service, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewCreateAction("services", c.ns, service), &api.Service{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Service), err
+}
+
+func (c *FakeServices) Update(service *api.Service) (result *api.Service, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateAction("services", c.ns, service), &api.Service{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Service), err
+}
+
+func (c *FakeServices) UpdateStatus(service *api.Service) (*api.Service, error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateSubresourceAction("services", "status", c.ns, service), &api.Service{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Service), err
+}
+
+func (c *FakeServices) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(core.NewDeleteAction("services", c.ns, name), &api.Service{})
+
+	return err
+}
+
+func (c *FakeServices) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.ServiceList{})
+	return err
+}
+
+func (c *FakeServices) Get(name string) (result *api.Service, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewGetAction("services", c.ns, name), &api.Service{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Service), err
+}
+
+func (c *FakeServices) List(opts api.ListOptions) (result *api.ServiceList, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewListAction("services", c.ns, opts), &api.ServiceList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label := opts.LabelSelector
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &api.ServiceList{}
+	for _, item := range obj.(*api.ServiceList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested services.
+func (c *FakeServices) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(core.NewWatchAction("services", c.ns, opts))
+
+}

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_serviceaccount.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_serviceaccount.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	core "k8s.io/kubernetes/pkg/client/testing/core"
+	labels "k8s.io/kubernetes/pkg/labels"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeServiceAccounts implements ServiceAccountInterface
+type FakeServiceAccounts struct {
+	Fake *FakeLegacy
+	ns   string
+}
+
+func (c *FakeServiceAccounts) Create(serviceAccount *api.ServiceAccount) (result *api.ServiceAccount, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewCreateAction("serviceAccounts", c.ns, serviceAccount), &api.ServiceAccount{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ServiceAccount), err
+}
+
+func (c *FakeServiceAccounts) Update(serviceAccount *api.ServiceAccount) (result *api.ServiceAccount, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateAction("serviceAccounts", c.ns, serviceAccount), &api.ServiceAccount{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ServiceAccount), err
+}
+
+func (c *FakeServiceAccounts) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(core.NewDeleteAction("serviceAccounts", c.ns, name), &api.ServiceAccount{})
+
+	return err
+}
+
+func (c *FakeServiceAccounts) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.ServiceAccountList{})
+	return err
+}
+
+func (c *FakeServiceAccounts) Get(name string) (result *api.ServiceAccount, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewGetAction("serviceAccounts", c.ns, name), &api.ServiceAccount{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ServiceAccount), err
+}
+
+func (c *FakeServiceAccounts) List(opts api.ListOptions) (result *api.ServiceAccountList, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewListAction("serviceAccounts", c.ns, opts), &api.ServiceAccountList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label := opts.LabelSelector
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &api.ServiceAccountList{}
+	for _, item := range obj.(*api.ServiceAccountList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested serviceAccounts.
+func (c *FakeServiceAccounts) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(core.NewWatchAction("serviceAccounts", c.ns, opts))
+
+}


### PR DESCRIPTION
Generating the fake client, which will replace the handwritten fake client [here](https://github.com/kubernetes/kubernetes/tree/master/pkg/client/unversioned/testclient).

When writing tests, develops used to embed the `testclient.Fake{}` in their struct, now they need to embed the `fake.Clientset{}`. This [line](https://github.com/kubernetes/kubernetes/pull/19737/files#diff-d4e64ea1d969a58a97a8f212222cca9dR94) in #19737 demonstrates the use case.

Reviewer, please take a look at the directories, I'm not sure if my arrangement is good:
The `fake.Clientset` is in `pkg/client/testing/fake`;
The fake typed clients are in `pkg/client/typed/generated/<group>/<version>/fake/`.

@kubernetes/goog-csi
