### PR TITLE
Replace handwritten client with the generated one in Deployment

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/kubernetes/cmd/kube-controller-manager/app/options"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/release_1_1"
 	"k8s.io/kubernetes/pkg/client/leaderelection"
 	"k8s.io/kubernetes/pkg/client/record"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
@@ -100,6 +101,17 @@ func clientForUserAgentOrDie(config client.Config, userAgent string) *client.Cli
 	fullUserAgent := client.DefaultKubernetesUserAgent() + "/" + userAgent
 	config.UserAgent = fullUserAgent
 	kubeClient, err := client.New(&config)
+	if err != nil {
+		glog.Fatalf("Invalid API configuration: %v", err)
+	}
+	return kubeClient
+}
+
+// clientsetForUserAgentOrDie is going to replace clientForUserAgentOrDie
+func clientsetForUserAgentOrDie(config client.Config, userAgent string) release_1_1.Interface {
+	fullUserAgent := client.DefaultKubernetesUserAgent() + "/" + userAgent
+	config.UserAgent = fullUserAgent
+	kubeClient, err := release_1_1.NewForConfig(&config)
 	if err != nil {
 		glog.Fatalf("Invalid API configuration: %v", err)
 	}
@@ -284,7 +296,7 @@ func StartControllers(s *options.CMServer, kubeClient *client.Client, kubeconfig
 
 		if containsResource(resources, "deployments") {
 			glog.Infof("Starting deployment controller")
-			go deployment.NewDeploymentController(clientForUserAgentOrDie(*kubeconfig, "deployment-controller"), ResyncPeriod(s)).
+			go deployment.NewDeploymentController(clientsetForUserAgentOrDie(*kubeconfig, "deployment-controller"), ResyncPeriod(s)).
 				Run(s.ConcurrentDeploymentSyncs, util.NeverStop)
 		}
 	}

--- a/pkg/client/clientset_generated/release_1_1/clientset_adaption.go
+++ b/pkg/client/clientset_generated/release_1_1/clientset_adaption.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package release_1_1
+
+import (
+	extensions_unversioned "k8s.io/kubernetes/pkg/client/typed/generated/extensions/unversioned"
+	legacy_unversioned "k8s.io/kubernetes/pkg/client/typed/generated/legacy/unversioned"
+	"k8s.io/kubernetes/pkg/client/unversioned"
+)
+
+// AdaptOldClient adapts a pkg/client/unversioned#Client to a Clientset.
+// This function is temporary. We will remove it when everyone has moved to using
+// Clientset. New code should NOT use this function.
+func AdaptOldClient(c *unversioned.Client) *Clientset {
+	var clientset Clientset
+	if c != nil {
+		clientset.LegacyClient = legacy_unversioned.New(c.RESTClient)
+	} else {
+		clientset.LegacyClient = legacy_unversioned.New(nil)
+	}
+	if c != nil && c.ExtensionsClient != nil {
+		clientset.ExtensionsClient = extensions_unversioned.New(c.ExtensionsClient.RESTClient)
+	} else {
+		clientset.ExtensionsClient = extensions_unversioned.New(nil)
+	}
+
+	return &clientset
+}

--- a/pkg/client/testing/core/fixture.go
+++ b/pkg/client/testing/core/fixture.go
@@ -153,12 +153,8 @@ func NewObjects(scheme ObjectScheme, decoder runtime.Decoder) ObjectRetriever {
 }
 
 func (o objects) Kind(kind unversioned.GroupVersionKind, name string) (runtime.Object, error) {
-	// TODO our test clients deal in internal versions.  We need to plumb that knowledge down here
-	// we might do this via an extra function to the scheme to allow getting internal group versions
-	// I'm punting for now
-	kind.Version = ""
-
-	empty, _ := o.scheme.New(kind)
+	kind.Version = runtime.APIVersionInternal
+	empty, err := o.scheme.New(kind)
 	nilValue := reflect.Zero(reflect.TypeOf(empty)).Interface().(runtime.Object)
 
 	arr, ok := o.types[kind.Kind]

--- a/pkg/client/unversioned/testclient/simple/simple_testclient.go
+++ b/pkg/client/unversioned/testclient/simple/simple_testclient.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/release_1_1"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -53,12 +54,13 @@ type Response struct {
 
 type Client struct {
 	*client.Client
-	Request  Request
-	Response Response
-	Error    bool
-	Created  bool
-	server   *httptest.Server
-	handler  *utiltesting.FakeHandler
+	Clientset *release_1_1.Clientset
+	Request   Request
+	Response  Response
+	Error     bool
+	Created   bool
+	server    *httptest.Server
+	handler   *utiltesting.FakeHandler
 	// For query args, an optional function to validate the contents
 	// useful when the contents can change but still be correct.
 	// Maps from query arg key to validator.
@@ -86,6 +88,8 @@ func (c *Client) Setup(t *testing.T) *Client {
 			Host:         c.server.URL,
 			GroupVersion: testapi.Extensions.GroupVersion(),
 		})
+
+		c.Clientset = release_1_1.NewForConfigOrDie(&client.Config{Host: c.server.URL})
 	}
 	c.QueryValidator = map[string]func(string, string) bool{}
 	return c

--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -26,8 +26,8 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/client/cache"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/release_1_1"
 	"k8s.io/kubernetes/pkg/client/record"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/framework"
 	"k8s.io/kubernetes/pkg/labels"
@@ -53,8 +53,7 @@ const (
 // DeploymentController is responsible for synchronizing Deployment objects stored
 // in the system with actual running rcs and pods.
 type DeploymentController struct {
-	client        client.Interface
-	expClient     client.ExtensionsInterface
+	client        release_1_1.Interface
 	eventRecorder record.EventRecorder
 
 	// To allow injection of syncDeployment for testing.
@@ -91,14 +90,13 @@ type DeploymentController struct {
 }
 
 // NewDeploymentController creates a new DeploymentController.
-func NewDeploymentController(client client.Interface, resyncPeriod controller.ResyncPeriodFunc) *DeploymentController {
+func NewDeploymentController(client release_1_1.Interface, resyncPeriod controller.ResyncPeriodFunc) *DeploymentController {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(glog.Infof)
-	eventBroadcaster.StartRecordingToSink(client.Events(""))
+	eventBroadcaster.StartRecordingToSink(client.Legacy().Events(""))
 
 	dc := &DeploymentController{
 		client:          client,
-		expClient:       client.Extensions(),
 		eventRecorder:   eventBroadcaster.NewRecorder(api.EventSource{Component: "deployment-controller"}),
 		queue:           workqueue.New(),
 		podExpectations: controller.NewControllerExpectations(),
@@ -108,10 +106,10 @@ func NewDeploymentController(client client.Interface, resyncPeriod controller.Re
 	dc.dStore.Store, dc.dController = framework.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func(options api.ListOptions) (runtime.Object, error) {
-				return dc.expClient.Deployments(api.NamespaceAll).List(options)
+				return dc.client.Extensions().Deployments(api.NamespaceAll).List(options)
 			},
 			WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
-				return dc.expClient.Deployments(api.NamespaceAll).Watch(options)
+				return dc.client.Extensions().Deployments(api.NamespaceAll).Watch(options)
 			},
 		},
 		&extensions.Deployment{},
@@ -140,10 +138,10 @@ func NewDeploymentController(client client.Interface, resyncPeriod controller.Re
 	dc.rcStore.Store, dc.rcController = framework.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func(options api.ListOptions) (runtime.Object, error) {
-				return dc.client.ReplicationControllers(api.NamespaceAll).List(options)
+				return dc.client.Legacy().ReplicationControllers(api.NamespaceAll).List(options)
 			},
 			WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
-				return dc.client.ReplicationControllers(api.NamespaceAll).Watch(options)
+				return dc.client.Legacy().ReplicationControllers(api.NamespaceAll).Watch(options)
 			},
 		},
 		&api.ReplicationController{},
@@ -158,10 +156,10 @@ func NewDeploymentController(client client.Interface, resyncPeriod controller.Re
 	dc.podStore.Store, dc.podController = framework.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func(options api.ListOptions) (runtime.Object, error) {
-				return dc.client.Pods(api.NamespaceAll).List(options)
+				return dc.client.Legacy().Pods(api.NamespaceAll).List(options)
 			},
 			WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
-				return dc.client.Pods(api.NamespaceAll).Watch(options)
+				return dc.client.Legacy().Pods(api.NamespaceAll).Watch(options)
 			},
 		},
 		&api.Pod{},
@@ -571,7 +569,7 @@ func (dc *DeploymentController) getNewRC(deployment extensions.Deployment) (*api
 			Template: &newRCTemplate,
 		},
 	}
-	createdRC, err := dc.client.ReplicationControllers(namespace).Create(&newRC)
+	createdRC, err := dc.client.Legacy().ReplicationControllers(namespace).Create(&newRC)
 	if err != nil {
 		dc.rcExpectations.DeleteExpectations(dKey)
 		return nil, fmt.Errorf("error creating replication controller: %v", err)
@@ -723,7 +721,7 @@ func (dc *DeploymentController) updateDeploymentStatus(allRCs []*api.Replication
 		AvailableReplicas:   availablePods,
 		UnavailableReplicas: totalReplicas - availablePods,
 	}
-	_, err = dc.expClient.Deployments(deployment.ObjectMeta.Namespace).UpdateStatus(&newDeployment)
+	_, err = dc.client.Extensions().Deployments(deployment.ObjectMeta.Namespace).UpdateStatus(&newDeployment)
 	return err
 }
 
@@ -742,10 +740,10 @@ func (dc *DeploymentController) scaleRCAndRecordEvent(rc *api.ReplicationControl
 func (dc *DeploymentController) scaleRC(rc *api.ReplicationController, newScale int) (*api.ReplicationController, error) {
 	// TODO: Using client for now, update to use store when it is ready.
 	rc.Spec.Replicas = newScale
-	return dc.client.ReplicationControllers(rc.ObjectMeta.Namespace).Update(rc)
+	return dc.client.Legacy().ReplicationControllers(rc.ObjectMeta.Namespace).Update(rc)
 }
 
 func (dc *DeploymentController) updateDeployment(deployment *extensions.Deployment) (*extensions.Deployment, error) {
 	// TODO: Using client for now, update to use store when it is ready.
-	return dc.expClient.Deployments(deployment.ObjectMeta.Namespace).Update(deployment)
+	return dc.client.Extensions().Deployments(deployment.ObjectMeta.Namespace).Update(deployment)
 }

--- a/pkg/controller/deployment/deployment_controller_test.go
+++ b/pkg/controller/deployment/deployment_controller_test.go
@@ -25,6 +25,8 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	exp "k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/client/record"
+	"k8s.io/kubernetes/pkg/client/testing/core"
+	"k8s.io/kubernetes/pkg/client/testing/fake"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/runtime"
@@ -89,9 +91,9 @@ func TestDeploymentController_reconcileNewRC(t *testing.T) {
 		oldRc := rc("foo-v2", test.oldReplicas)
 		allRcs := []*api.ReplicationController{newRc, oldRc}
 		deployment := deployment("foo", test.deploymentReplicas, test.maxSurge, intstr.FromInt(0))
-		fake := &testclient.Fake{}
+		fake := fake.Clientset{}
 		controller := &DeploymentController{
-			client:        fake,
+			client:        &fake,
 			eventRecorder: &record.FakeRecorder{},
 		}
 		scaled, err := controller.reconcileNewRC(allRcs, newRc, deployment)
@@ -166,10 +168,10 @@ func TestDeploymentController_reconcileOldRCs(t *testing.T) {
 		allRcs := []*api.ReplicationController{oldRc}
 		oldRcs := []*api.ReplicationController{oldRc}
 		deployment := deployment("foo", test.deploymentReplicas, intstr.FromInt(0), test.maxUnavailable)
-		fake := &testclient.Fake{}
-		fake.AddReactor("list", "pods", func(action testclient.Action) (handled bool, ret runtime.Object, err error) {
+		fakeClientset := fake.Clientset{}
+		fakeClientset.AddReactor("list", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
 			switch action.(type) {
-			case testclient.ListAction:
+			case core.ListAction:
 				podList := &api.PodList{}
 				for podIndex := 0; podIndex < test.readyPods; podIndex++ {
 					podList.Items = append(podList.Items, api.Pod{
@@ -191,7 +193,7 @@ func TestDeploymentController_reconcileOldRCs(t *testing.T) {
 			return false, nil, nil
 		})
 		controller := &DeploymentController{
-			client:        fake,
+			client:        &fakeClientset,
 			eventRecorder: &record.FakeRecorder{},
 		}
 		scaled, err := controller.reconcileOldRCs(allRcs, oldRcs, nil, deployment, false)
@@ -201,18 +203,18 @@ func TestDeploymentController_reconcileOldRCs(t *testing.T) {
 		}
 		if !test.scaleExpected {
 			if scaled {
-				t.Errorf("unexpected scaling: %v", fake.Actions())
+				t.Errorf("unexpected scaling: %v", fakeClientset.Actions())
 			}
 			continue
 		}
 		if test.scaleExpected && !scaled {
-			t.Errorf("expected scaling to occur; actions: %v", fake.Actions())
+			t.Errorf("expected scaling to occur; actions: %v", fakeClientset.Actions())
 			continue
 		}
 		// There are both list and update actions logged, so extract the update
 		// action for verification.
 		var updateAction testclient.UpdateAction
-		for _, action := range fake.Actions() {
+		for _, action := range fakeClientset.Actions() {
 			switch a := action.(type) {
 			case testclient.UpdateAction:
 				if updateAction != nil {
@@ -331,8 +333,7 @@ func newListOptions() api.ListOptions {
 type fixture struct {
 	t *testing.T
 
-	client *testclient.Fake
-
+	client *fake.Clientset
 	// Objects to put in the store.
 	dStore   []*exp.Deployment
 	rcStore  []*api.ReplicationController
@@ -340,22 +341,22 @@ type fixture struct {
 
 	// Actions expected to happen on the client. Objects from here are also
 	// preloaded into NewSimpleFake.
-	actions []testclient.Action
+	actions []core.Action
 	objects *api.List
 }
 
 func (f *fixture) expectUpdateDeploymentAction(d *exp.Deployment) {
-	f.actions = append(f.actions, testclient.NewUpdateAction("deployments", d.Namespace, d))
+	f.actions = append(f.actions, core.NewUpdateAction("deployments", d.Namespace, d))
 	f.objects.Items = append(f.objects.Items, d)
 }
 
 func (f *fixture) expectCreateRCAction(rc *api.ReplicationController) {
-	f.actions = append(f.actions, testclient.NewCreateAction("replicationcontrollers", rc.Namespace, rc))
+	f.actions = append(f.actions, core.NewCreateAction("replicationcontrollers", rc.Namespace, rc))
 	f.objects.Items = append(f.objects.Items, rc)
 }
 
 func (f *fixture) expectUpdateRCAction(rc *api.ReplicationController) {
-	f.actions = append(f.actions, testclient.NewUpdateAction("replicationcontrollers", rc.Namespace, rc))
+	f.actions = append(f.actions, core.NewUpdateAction("replicationcontrollers", rc.Namespace, rc))
 	f.objects.Items = append(f.objects.Items, rc)
 }
 
@@ -371,7 +372,7 @@ func newFixture(t *testing.T) *fixture {
 }
 
 func (f *fixture) run(deploymentName string) {
-	f.client = testclient.NewSimpleFake(f.objects)
+	f.client = fake.NewSimpleClientset(f.objects)
 	c := NewDeploymentController(f.client, controller.NoResyncPeriodFunc)
 	c.eventRecorder = &record.FakeRecorder{}
 	c.rcStoreSynced = alwaysReady

--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/release_1_1"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fieldpath"
 	"k8s.io/kubernetes/pkg/fields"
@@ -87,8 +88,8 @@ func describerMap(c *client.Client) map[unversioned.GroupKind]Describer {
 
 		extensions.Kind("HorizontalPodAutoscaler"): &HorizontalPodAutoscalerDescriber{c},
 		extensions.Kind("DaemonSet"):               &DaemonSetDescriber{c},
+		extensions.Kind("Deployment"):              &DeploymentDescriber{release_1_1.AdaptOldClient(c)},
 		extensions.Kind("Job"):                     &JobDescriber{c},
-		extensions.Kind("Deployment"):              &DeploymentDescriber{c},
 		extensions.Kind("Ingress"):                 &IngressDescriber{c},
 		extensions.Kind("ConfigMap"):               &ConfigMapDescriber{c},
 	}
@@ -1577,11 +1578,11 @@ func DescribeEvents(el *api.EventList, w io.Writer) {
 
 // DeploymentDescriber generates information about a deployment.
 type DeploymentDescriber struct {
-	client.Interface
+	clientset release_1_1.Interface
 }
 
 func (dd *DeploymentDescriber) Describe(namespace, name string) (string, error) {
-	d, err := dd.Extensions().Deployments(namespace).Get(name)
+	d, err := dd.clientset.Extensions().Deployments(namespace).Get(name)
 	if err != nil {
 		return "", err
 	}
@@ -1597,11 +1598,11 @@ func (dd *DeploymentDescriber) Describe(namespace, name string) (string, error) 
 			ru := d.Spec.Strategy.RollingUpdate
 			fmt.Fprintf(out, "RollingUpdateStrategy:\t%s max unavailable, %s max surge, %d min ready seconds\n", ru.MaxUnavailable.String(), ru.MaxSurge.String(), ru.MinReadySeconds)
 		}
-		oldRCs, err := deploymentutil.GetOldRCs(*d, dd)
+		oldRCs, err := deploymentutil.GetOldRCs(*d, dd.clientset)
 		if err == nil {
 			fmt.Fprintf(out, "OldReplicationControllers:\t%s\n", printReplicationControllersByLabels(oldRCs))
 		}
-		newRC, err := deploymentutil.GetNewRC(*d, dd)
+		newRC, err := deploymentutil.GetNewRC(*d, dd.clientset)
 		if err == nil {
 			var newRCs []*api.ReplicationController
 			if newRC != nil {
@@ -1609,7 +1610,7 @@ func (dd *DeploymentDescriber) Describe(namespace, name string) (string, error) 
 			}
 			fmt.Fprintf(out, "NewReplicationController:\t%s\n", printReplicationControllersByLabels(newRCs))
 		}
-		events, err := dd.Events(namespace).Search(d)
+		events, err := dd.clientset.Legacy().Events(namespace).Search(d)
 		if err == nil && events != nil {
 			DescribeEvents(events, out)
 		}

--- a/pkg/kubectl/describe_test.go
+++ b/pkg/kubectl/describe_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/client/testing/fake"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
 )
@@ -502,7 +503,7 @@ func TestPersistentVolumeDescriber(t *testing.T) {
 }
 
 func TestDescribeDeployment(t *testing.T) {
-	fake := testclient.NewSimpleFake(&extensions.Deployment{
+	fake := fake.NewSimpleClientset(&extensions.Deployment{
 		ObjectMeta: api.ObjectMeta{
 			Name:      "bar",
 			Namespace: "foo",
@@ -511,8 +512,7 @@ func TestDescribeDeployment(t *testing.T) {
 			Template: api.PodTemplateSpec{},
 		},
 	})
-	c := &describeClient{T: t, Namespace: "foo", Interface: fake}
-	d := DeploymentDescriber{c}
+	d := DeploymentDescriber{fake}
 	out, err := d.Describe("foo", "bar")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)

--- a/pkg/util/deployment/deployment.go
+++ b/pkg/util/deployment/deployment.go
@@ -22,26 +22,26 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/extensions"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/release_1_1"
 	"k8s.io/kubernetes/pkg/labels"
 	labelsutil "k8s.io/kubernetes/pkg/util/labels"
 	podutil "k8s.io/kubernetes/pkg/util/pod"
 )
 
 // GetOldRCs returns the old RCs targeted by the given Deployment; get PodList and RCList from client interface.
-func GetOldRCs(deployment extensions.Deployment, c client.Interface) ([]*api.ReplicationController, error) {
+func GetOldRCs(deployment extensions.Deployment, c release_1_1.Interface) ([]*api.ReplicationController, error) {
 	return GetOldRCsFromLists(deployment, c,
 		func(namespace string, options api.ListOptions) (*api.PodList, error) {
-			return c.Pods(namespace).List(options)
+			return c.Legacy().Pods(namespace).List(options)
 		},
 		func(namespace string, options api.ListOptions) ([]api.ReplicationController, error) {
-			rcList, err := c.ReplicationControllers(namespace).List(options)
+			rcList, err := c.Legacy().ReplicationControllers(namespace).List(options)
 			return rcList.Items, err
 		})
 }
 
 // GetOldRCsFromLists returns the old RCs targeted by the given Deployment; get PodList and RCList with input functions.
-func GetOldRCsFromLists(deployment extensions.Deployment, c client.Interface, getPodList func(string, api.ListOptions) (*api.PodList, error), getRcList func(string, api.ListOptions) ([]api.ReplicationController, error)) ([]*api.ReplicationController, error) {
+func GetOldRCsFromLists(deployment extensions.Deployment, c release_1_1.Interface, getPodList func(string, api.ListOptions) (*api.PodList, error), getRcList func(string, api.ListOptions) ([]api.ReplicationController, error)) ([]*api.ReplicationController, error) {
 	namespace := deployment.ObjectMeta.Namespace
 	// 1. Find all pods whose labels match deployment.Spec.Selector
 	selector := labels.SelectorFromSet(deployment.Spec.Selector)
@@ -81,17 +81,17 @@ func GetOldRCsFromLists(deployment extensions.Deployment, c client.Interface, ge
 
 // GetNewRC returns an RC that matches the intent of the given deployment; get RCList from client interface.
 // Returns nil if the new RC doesnt exist yet.
-func GetNewRC(deployment extensions.Deployment, c client.Interface) (*api.ReplicationController, error) {
+func GetNewRC(deployment extensions.Deployment, c release_1_1.Interface) (*api.ReplicationController, error) {
 	return GetNewRCFromList(deployment, c,
 		func(namespace string, options api.ListOptions) ([]api.ReplicationController, error) {
-			rcList, err := c.ReplicationControllers(namespace).List(options)
+			rcList, err := c.Legacy().ReplicationControllers(namespace).List(options)
 			return rcList.Items, err
 		})
 }
 
 // GetNewRCFromList returns an RC that matches the intent of the given deployment; get RCList with the input function.
 // Returns nil if the new RC doesnt exist yet.
-func GetNewRCFromList(deployment extensions.Deployment, c client.Interface, getRcList func(string, api.ListOptions) ([]api.ReplicationController, error)) (*api.ReplicationController, error) {
+func GetNewRCFromList(deployment extensions.Deployment, c release_1_1.Interface, getRcList func(string, api.ListOptions) ([]api.ReplicationController, error)) (*api.ReplicationController, error) {
 	namespace := deployment.ObjectMeta.Namespace
 	rcList, err := getRcList(namespace, api.ListOptions{})
 	if err != nil {
@@ -133,7 +133,7 @@ func GetReplicaCountForRCs(replicationControllers []*api.ReplicationController) 
 }
 
 // Returns the number of available pods corresponding to the given RCs.
-func GetAvailablePodsForRCs(c client.Interface, rcs []*api.ReplicationController, minReadySeconds int) (int, error) {
+func GetAvailablePodsForRCs(c release_1_1.Interface, rcs []*api.ReplicationController, minReadySeconds int) (int, error) {
 	allPods, err := getPodsForRCs(c, rcs)
 	if err != nil {
 		return 0, err
@@ -165,12 +165,12 @@ func getReadyPodsCount(pods []api.Pod, minReadySeconds int) int {
 	return readyPodCount
 }
 
-func getPodsForRCs(c client.Interface, replicationControllers []*api.ReplicationController) ([]api.Pod, error) {
+func getPodsForRCs(c release_1_1.Interface, replicationControllers []*api.ReplicationController) ([]api.Pod, error) {
 	allPods := []api.Pod{}
 	for _, rc := range replicationControllers {
 		selector := labels.SelectorFromSet(rc.Spec.Selector)
 		options := api.ListOptions{LabelSelector: selector}
-		podList, err := c.Pods(rc.ObjectMeta.Namespace).List(options)
+		podList, err := c.Legacy().Pods(rc.ObjectMeta.Namespace).List(options)
 		if err != nil {
 			return allPods, fmt.Errorf("error listing pods: %v", err)
 		}

--- a/pkg/util/deployment/deployment_test.go
+++ b/pkg/util/deployment/deployment_test.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/extensions"
-	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	"k8s.io/kubernetes/pkg/client/testing/fake"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient/simple"
 	"k8s.io/kubernetes/pkg/runtime"
 )
@@ -231,7 +231,7 @@ func TestGetNewRC(t *testing.T) {
 				Body:       &test.rcList,
 			},
 		}
-		rc, err := GetNewRC(newDeployment, c.Setup(t))
+		rc, err := GetNewRC(newDeployment, c.Setup(t).Clientset)
 		if err != nil {
 			t.Errorf("In test case %s, got unexpected error %v", test.test, err)
 		}
@@ -314,7 +314,7 @@ func TestGetOldRCs(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		rcs, err := GetOldRCs(newDeployment, testclient.NewSimpleFake(test.objs...))
+		rcs, err := GetOldRCs(newDeployment, fake.NewSimpleClientset(test.objs...))
 		if err != nil {
 			t.Errorf("In test case %s, got unexpected error %v", test.test, err)
 		}

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/client/cache"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/release_1_1"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
@@ -1927,10 +1928,10 @@ func waitForRCPodsGone(c *client.Client, rc *api.ReplicationController) error {
 
 // Waits for the deployment to reach desired state.
 // Returns an error if minAvailable or maxCreated is broken at any times.
-func waitForDeploymentStatus(c *client.Client, ns, deploymentName string, desiredUpdatedReplicas, minAvailable, maxCreated, minReadySeconds int) error {
+func waitForDeploymentStatus(c release_1_1.Interface, ns, deploymentName string, desiredUpdatedReplicas, minAvailable, maxCreated, minReadySeconds int) error {
 	return wait.Poll(poll, 5*time.Minute, func() (bool, error) {
 
-		deployment, err := c.Deployments(ns).Get(deploymentName)
+		deployment, err := c.Extensions().Deployments(ns).Get(deploymentName)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
This is the first attempt to replace the handwritten client with the generated one.
