### PR TITLE
Increase api call latency threshold.

### DIFF
--- a/test/e2e/metrics_util.go
+++ b/test/e2e/metrics_util.go
@@ -42,8 +42,8 @@ const (
 	listPodLatencyMediumThreshold time.Duration = 1 * time.Second
 	listPodLatencyLargeThreshold  time.Duration = 1 * time.Second
 	// TODO: Decrease the small threshold to 250ms once tests are fixed.
-	apiCallLatencySmallThreshold  time.Duration = 500 * time.Millisecond
-	apiCallLatencyMediumThreshold time.Duration = 500 * time.Millisecond
+	apiCallLatencySmallThreshold  time.Duration = 1 * time.Second
+	apiCallLatencyMediumThreshold time.Duration = 1 * time.Second
 	apiCallLatencyLargeThreshold  time.Duration = 1 * time.Second
 )
 


### PR DESCRIPTION
Past 3 runs on kubernetes-e2e-gce-scalability have just over 500ms latency for pod list, and 2 that passed inbetween were 300ms. 

```
Jan 15 15:27:09.089: INFO: Top latency metric: {Resource:pods Verb:LIST Latency:{Perc50:12.814ms Perc90:47.439ms Perc99:513.108ms}}
Jan 15 11:32:26.535: INFO: WARNING Top latency metric: {Resource:pods Verb:POST Latency:{Perc50:2.339ms Perc90:13.287ms Perc99:527.598ms}}
Jan 15 10:12:53.628: INFO: WARNING Top latency metric: {Resource:pods Verb:POST Latency:{Perc50:2.367ms Perc90:15.613ms Perc99:645.958ms}}
```

The submit queue is backed up, so I think increasing the timeout temporarily is justified. @kubernetes/goog-control-plane @gmarek @wojtek-t 
