### PR TITLE
Remove undefined color_ variables

### DIFF
--- a/cluster/gce/list-resources.sh
+++ b/cluster/gce/list-resources.sh
@@ -45,10 +45,10 @@ function gcloud-compute-list() {
       echo "${result}"
       return
     fi
-    echo -e "${color_yellow}Attempt ${attempt} failed to list ${resource}. Retrying.${color_norm}" >&2
+    echo -e "Attempt ${attempt} failed to list ${resource}. Retrying." >&2
     attempt=$(($attempt+1))
     if [[ ${attempt} > 5 ]]; then
-      echo -e "${color_red}List ${resource} failed!${color_norm}" >&2
+      echo -e "List ${resource} failed!" >&2
       exit 2
     fi
     sleep $((5*${attempt}))


### PR DESCRIPTION
I'm guessing this is what happened in http://kubekins.dls.corp.google.com/job/kubernetes-e2e-gce-reboot/10502/consoleFull because everything passed except a list operation, which we should've retried.

```
17:01:39 ++ ./cluster/gce/list-resources.sh
17:01:47 ERROR: (gcloud.compute.instances.list) Some requests did not succeed:
17:01:47  - Internal Error
17:01:47  
17:01:47 ./cluster/gce/list-resources.sh: line 48: color_yellow: unbound variable
17:01:47 Build step 'Execute shell' marked build as failure
17:01:47 Recording test results
```

I _think_ KUBE_ROOT should be in the env. 
