### PR TITLE
Do not dirname on the dependency file's path twice while generating types using codecgen.

### DIFF
--- a/hack/update-codecgen.sh
+++ b/hack/update-codecgen.sh
@@ -53,8 +53,7 @@ result=""
 function depends {
   file=${generated_files[$1]//\.generated\.go/.go}
   deps=$(go list -f "{{.Deps}}" ${file} | tr "[" " " | tr "]" " ")
-  fullpath=$(readlinkdashf "${generated_files[$2]//\.generated\.go/.go}")
-  candidate=$(dirname "${fullpath}")
+  candidate=$(readlinkdashf "${generated_files[$2]//\.generated\.go/.go}")
   result=false
   for dep in ${deps}; do
     if [[ ${candidate} = *${dep} ]]; then

--- a/hack/verify-codecgen.sh
+++ b/hack/verify-codecgen.sh
@@ -53,8 +53,7 @@ result=""
 function depends {
   file=${generated_files[$1]//\.generated\.go/.go}
   deps=$(go list -f "{{.Deps}}" ${file} | tr "[" " " | tr "]" " ")
-  fullpath=$(readlinkdashf "${generated_files[$2]//\.generated\.go/.go}")
-  candidate=$(dirname "${fullpath}")
+  candidate=$(readlinkdashf "${generated_files[$2]//\.generated\.go/.go}")
   result=false
   for dep in ${deps}; do
     if [[ ${candidate} = *${dep} ]]; then


### PR DESCRIPTION
Fixes #18907.

CC'ing a lot of people to cast a wide net for reviews. The pain caused by this bug is immense, so need to get this in soon. It won't be an exaggeration if I claim that I have spent over 50% of my time since https://github.com/kubernetes/kubernetes/pull/16900#discussion_r48243033 fighting against this problem. PTAL.

cc @mikedanese @davidopp @pmorie @lavalamp 
