### PR TITLE
Add field selector for pod.spec.restartPolicy

### DIFF
--- a/pkg/api/v1/conversion.go
+++ b/pkg/api/v1/conversion.go
@@ -87,7 +87,8 @@ func addConversionFuncs(scheme *runtime.Scheme) {
 				"metadata.annotations",
 				"status.phase",
 				"status.podIP",
-				"spec.nodeName":
+				"spec.nodeName",
+				"spec.restartPolicy":
 				return label, value, nil
 				// This is for backwards compatibility with old v1 clients which send spec.host
 			case "spec.host":

--- a/pkg/registry/pod/strategy.go
+++ b/pkg/registry/pod/strategy.go
@@ -173,8 +173,9 @@ func MatchPod(label labels.Selector, field fields.Selector) generic.Matcher {
 func PodToSelectableFields(pod *api.Pod) fields.Set {
 	objectMetaFieldsSet := generic.ObjectMetaFieldsSet(pod.ObjectMeta, true)
 	podSpecificFieldsSet := fields.Set{
-		"spec.nodeName": pod.Spec.NodeName,
-		"status.phase":  string(pod.Status.Phase),
+		"spec.nodeName":      pod.Spec.NodeName,
+		"spec.restartPolicy": string(pod.Spec.RestartPolicy),
+		"status.phase":       string(pod.Status.Phase),
 	}
 	return generic.MergeFieldsSets(objectMetaFieldsSet, podSpecificFieldsSet)
 }


### PR DESCRIPTION
This is a prerequisite to supporting quota based on non-terminating vs. terminating workloads.

See https://github.com/kubernetes/kubernetes/pull/19761

/cc @ncdc @smarterclayton @eparis 
