### PR TITLE
docs/getting-started/rkt/: Add and tune rkt network setup info

### DIFF
--- a/docs/getting-started-guides/rkt/README.md
+++ b/docs/getting-started-guides/rkt/README.md
@@ -82,9 +82,9 @@ More details about the flannel CNI plugin can be found
 
 #### On GCE
 
-Each VM on GCE can have up to 256 IP addresses routed to it, so flannel isn't called
-for in most smaller Kubernetes clusters on GCE. This makes the necessary CNI config
-file a bit more verbose:
+Each VM on GCE has an additional 256 IP addresses routed to it, so
+it is possible to forego flannel in smaller clusters. This makes the
+necessary CNI config file a bit more verbose:
 
 ```console
 $ cat <<EOF >/etc/rkt/net.d/k8s_cluster.conf

--- a/docs/getting-started-guides/rkt/README.md
+++ b/docs/getting-started-guides/rkt/README.md
@@ -109,8 +109,8 @@ Creating these files for any moderately-sized cluster is at best inconvenient.
 Work is in progress to
 [enable Kubernetes to use the CNI by default]
 (https://github.com/kubernetes/kubernetes/pull/18795/files).
-As that work matures, such manual CNI config munging will become unneccessary for
-primary use cases. For early adopters, an initial example shows one way to
+As that work matures, such manual CNI config munging will become unnecessary
+for primary use cases. For early adopters, an initial example shows one way to
 [automatically generate these CNI configurations]
 (https://gist.github.com/yifan-gu/fbb911db83d785915543)
 for rkt.

--- a/docs/getting-started-guides/rkt/README.md
+++ b/docs/getting-started-guides/rkt/README.md
@@ -62,8 +62,12 @@ edited to add this `rkt.kubernetes.io` network:
 
 #### Using flannel
 
-[flannel](https://github.com/coreos/flannel) can be configured with a
-CNI config like:
+In addition to the basic prerequisites above, each node must be running
+a [flannel](https://github.com/coreos/flannel) daemon. This implies
+that a flannel-supporting etcd service must be available to the cluster
+as well, apart from the Kubernetes etcd, which will not yet be
+available at flannel configuration time. Once it's running, flannel can
+be set up with a CNI config like:
 
 ```console
 $ cat <<EOF >/etc/rkt/net.d/k8s_cluster.conf

--- a/docs/getting-started-guides/rkt/README.md
+++ b/docs/getting-started-guides/rkt/README.md
@@ -97,7 +97,10 @@ $ cat <<EOF >/etc/rkt/net.d/k8s_cluster.conf
         "type": "host-local",
         "subnet": "10.255.228.1/24",
         "gateway": "10.255.228.1"
-    }
+    },
+    "routes": [
+      { "dst": "0.0.0.0/0" }
+    ]
 }
 EOF
 ```


### PR DESCRIPTION
Add info about rkt CNI networking setup to `README.md`.

Supersedes #19745.

cc @yifan-gu 
