### PR TITLE
kube-up scripts: don't 'echo sleep'

### DIFF
--- a/cluster/aws/templates/common.sh
+++ b/cluster/aws/templates/common.sh
@@ -47,7 +47,7 @@ install-salt() {
   echo "== Refreshing package database =="
   until apt-get update; do
     echo "== apt-get update failed, retrying =="
-    echo sleep 5
+    sleep 5
   done
 
   mkdir -p /var/cache/salt-install
@@ -79,7 +79,7 @@ install-salt() {
   echo "== Installing unmet dependencies =="
   until apt-get install -f -y; do
     echo "== apt-get install failed, retrying =="
-    echo sleep 5
+    sleep 5
   done
 
   # Log a timestamp

--- a/cluster/gce/configure-vm.sh
+++ b/cluster/gce/configure-vm.sh
@@ -136,7 +136,7 @@ install-salt() {
   echo "== Refreshing package database =="
   until apt-get update; do
     echo "== apt-get update failed, retrying =="
-    echo sleep 5
+    sleep 5
   done
 
   mkdir -p /var/cache/salt-install
@@ -178,7 +178,7 @@ EOF
   echo "== Installing unmet dependencies =="
   until apt-get install -f -y; do
     echo "== apt-get install failed, retrying =="
-    echo sleep 5
+    sleep 5
   done
 
   rm /usr/sbin/policy-rc.d


### PR DESCRIPTION
'echo sleep 5' just prints 'sleep 5'; replace with 'sleep 5'.
