### PR TITLE
Remove temporary function GetPodStatusAndAPIPodStatus()

### DIFF
--- a/pkg/kubelet/container/fake_runtime.go
+++ b/pkg/kubelet/container/fake_runtime.go
@@ -259,17 +259,6 @@ func (f *FakeRuntime) ConvertPodStatusToAPIPodStatus(_ *api.Pod, _ *PodStatus) (
 	return &status, f.Err
 }
 
-func (f *FakeRuntime) GetPodStatusAndAPIPodStatus(_ *api.Pod) (*PodStatus, *api.PodStatus, error) {
-	f.Lock()
-	defer f.Unlock()
-
-	// This is only a temporary function, it should be logged as GetAPIPodStatus
-	f.CalledFunctions = append(f.CalledFunctions, "GetAPIPodStatus")
-	apiPodStatus := f.APIPodStatus
-	podStatus := f.PodStatus
-	return &podStatus, &apiPodStatus, f.Err
-}
-
 func (f *FakeRuntime) ExecInContainer(containerID ContainerID, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool) error {
 	f.Lock()
 	defer f.Unlock()

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -82,9 +82,6 @@ type Runtime interface {
 	// exists to determine the reason). We should try generalizing the logic
 	// for all container runtimes in kubelet and remove this funciton.
 	ConvertPodStatusToAPIPodStatus(*api.Pod, *PodStatus) (*api.PodStatus, error)
-	// Return both PodStatus and api.PodStatus, this is just a temporary function.
-	// TODO(random-liu): Remove this method later
-	GetPodStatusAndAPIPodStatus(*api.Pod) (*PodStatus, *api.PodStatus, error)
 	// PullImage pulls an image from the network to local storage using the supplied
 	// secrets if necessary.
 	PullImage(image ImageSpec, pullSecrets []api.Secret) error

--- a/pkg/kubelet/container/runtime_mock.go
+++ b/pkg/kubelet/container/runtime_mock.go
@@ -87,11 +87,6 @@ func (r *Mock) GetPodStatus(uid types.UID, name, namespace string) (*PodStatus, 
 	return args.Get(0).(*PodStatus), args.Error(1)
 }
 
-func (r *Mock) GetPodStatusAndAPIPodStatus(pod *api.Pod) (*PodStatus, *api.PodStatus, error) {
-	args := r.Called(pod)
-	return args.Get(0).(*PodStatus), args.Get(0).(*api.PodStatus), args.Error(2)
-}
-
 func (r *Mock) ConvertPodStatusToAPIPodStatus(pod *api.Pod, podStatus *PodStatus) (*api.PodStatus, error) {
 	args := r.Called(pod, podStatus)
 	return args.Get(0).(*api.PodStatus), args.Error(1)

--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -2172,14 +2172,3 @@ func (dm *DockerManager) GetPodStatus(uid types.UID, name, namespace string) (*k
 	podStatus.ContainerStatuses = containerStatuses
 	return podStatus, nil
 }
-
-func (dm *DockerManager) GetPodStatusAndAPIPodStatus(pod *api.Pod) (*kubecontainer.PodStatus, *api.PodStatus, error) {
-	// Get the pod status.
-	podStatus, err := dm.GetPodStatus(pod.UID, pod.Name, pod.Namespace)
-	if err != nil {
-		return nil, nil, err
-	}
-	var apiPodStatus *api.PodStatus
-	apiPodStatus, err = dm.ConvertPodStatusToAPIPodStatus(pod, podStatus)
-	return podStatus, apiPodStatus, err
-}

--- a/pkg/kubelet/dockertools/manager_test.go
+++ b/pkg/kubelet/dockertools/manager_test.go
@@ -543,10 +543,16 @@ func generatePodInfraContainerHash(pod *api.Pod) uint64 {
 // runSyncPod is a helper function to retrieve the running pods from the fake
 // docker client and runs SyncPod for the given pod.
 func runSyncPod(t *testing.T, dm *DockerManager, fakeDocker *FakeDockerClient, pod *api.Pod, backOff *util.Backoff, expectErr bool) {
-	podStatus, apiPodStatus, err := dm.GetPodStatusAndAPIPodStatus(pod)
+	podStatus, err := dm.GetPodStatus(pod.UID, pod.Name, pod.Namespace)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
+	var apiPodStatus *api.PodStatus
+	apiPodStatus, err = dm.ConvertPodStatusToAPIPodStatus(pod, podStatus)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
 	fakeDocker.ClearCalls()
 	if backOff == nil {
 		backOff = util.NewBackOff(time.Second, time.Minute)

--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -1449,14 +1449,3 @@ func (r *Runtime) ConvertPodStatusToAPIPodStatus(pod *api.Pod, status *kubeconta
 
 	return apiPodStatus, nil
 }
-
-// TODO(yifan): Delete this function when the logic is moved to kubelet.
-func (r *Runtime) GetPodStatusAndAPIPodStatus(pod *api.Pod) (*kubecontainer.PodStatus, *api.PodStatus, error) {
-	// Get the pod status.
-	podStatus, err := r.GetPodStatus(pod.UID, pod.Name, pod.Namespace)
-	if err != nil {
-		return nil, nil, err
-	}
-	apiPodStatus, err := r.ConvertPodStatusToAPIPodStatus(pod, podStatus)
-	return podStatus, apiPodStatus, err
-}


### PR DESCRIPTION
For issue #18302.

Based on #19850.

`GetPodStatusAndAPIPodStatus()` is a temporary function added in #17420. We add it to help refactor the pod status.

Now, since #19436 is merged, this function should never be used any more.

@yujuhong @yifan-gu 
