### PR TITLE
Revert "Increase api call latency threshold."

### DIFF
--- a/test/e2e/metrics_util.go
+++ b/test/e2e/metrics_util.go
@@ -42,8 +42,8 @@ const (
 	listPodLatencyMediumThreshold time.Duration = 1 * time.Second
 	listPodLatencyLargeThreshold  time.Duration = 1 * time.Second
 	// TODO: Decrease the small threshold to 250ms once tests are fixed.
-	apiCallLatencySmallThreshold  time.Duration = 1 * time.Second
-	apiCallLatencyMediumThreshold time.Duration = 1 * time.Second
+	apiCallLatencySmallThreshold  time.Duration = 500 * time.Millisecond
+	apiCallLatencyMediumThreshold time.Duration = 500 * time.Millisecond
 	apiCallLatencyLargeThreshold  time.Duration = 1 * time.Second
 )
 


### PR DESCRIPTION
Reverts kubernetes/kubernetes#19743

cc @bprashanth @mikedanese  @wojtek-t 

When a test is failing we should fix it rather than disable it.
