### PR TITLE
add event gc controller

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -153,7 +153,7 @@ func (s *APIServer) AddFlags(fs *pflag.FlagSet) {
 		"It defaults to a list of preferred versions of all registered groups, which is derived from the KUBE_API_VERSIONS environment variable.")
 	fs.StringVar(&s.CloudProvider, "cloud-provider", s.CloudProvider, "The provider for cloud services.  Empty string for no provider.")
 	fs.StringVar(&s.CloudConfigFile, "cloud-config", s.CloudConfigFile, "The path to the cloud provider configuration file.  Empty string for no configuration file.")
-	fs.DurationVar(&s.EventTTL, "event-ttl", s.EventTTL, "Amount of time to retain events. Default 1 hour.")
+	fs.MarkDeprecated("event-ttl", "--event-ttl is deprecated and will be removed when the v1 API is retired.")
 	fs.StringVar(&s.BasicAuthFile, "basic-auth-file", s.BasicAuthFile, "If set, the file that will be used to admit requests to the secure port of the API server via http basic authentication.")
 	fs.StringVar(&s.ClientCAFile, "client-ca-file", s.ClientCAFile, "If set, any request presenting a client certificate signed by one of the authorities in the client-ca-file is authenticated with an identity corresponding to the CommonName of the client certificate.")
 	fs.StringVar(&s.TokenAuthFile, "token-auth-file", s.TokenAuthFile, "If set, the file that will be used to secure the secure port of the API server via token authentication.")

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/kubernetes/pkg/controller/daemon"
 	"k8s.io/kubernetes/pkg/controller/deployment"
 	endpointcontroller "k8s.io/kubernetes/pkg/controller/endpoint"
+	eventgc "k8s.io/kubernetes/pkg/controller/event"
 	"k8s.io/kubernetes/pkg/controller/gc"
 	"k8s.io/kubernetes/pkg/controller/job"
 	namespacecontroller "k8s.io/kubernetes/pkg/controller/namespace"
@@ -146,6 +147,11 @@ func Run(s *options.CMServer) error {
 
 	if s.TerminatedPodGCThreshold > 0 {
 		go gc.New(clientForUserAgentOrDie(*kubeconfig, "garbage-collector"), ResyncPeriod(s), s.TerminatedPodGCThreshold).
+			Run(util.NeverStop)
+	}
+
+	if s.EventTTL > 0 {
+		go eventgc.New(clientForUserAgentOrDie(*kubeconfig, "event-garbage-collector"), ResyncPeriod(s), s.EventTTL).
 			Run(util.NeverStop)
 	}
 

--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -48,6 +48,7 @@ type CMServer struct {
 	PVClaimBinderSyncPeriod           time.Duration
 	VolumeConfigFlags                 VolumeConfigFlags
 	TerminatedPodGCThreshold          int
+	EventTTL                          time.Duration
 	HorizontalPodAutoscalerSyncPeriod time.Duration
 	DeploymentControllerSyncPeriod    time.Duration
 	MinResyncPeriod                   time.Duration
@@ -113,6 +114,7 @@ func NewCMServer() *CMServer {
 		NodeMonitorPeriod:                 5 * time.Second,
 		ClusterName:                       "kubernetes",
 		TerminatedPodGCThreshold:          12500,
+		EventTTL:                          1 * time.Hour,
 		VolumeConfigFlags: VolumeConfigFlags{
 			// default values here
 			PersistentVolumeRecyclerMinimumTimeoutNFS:        300,
@@ -153,6 +155,7 @@ func (s *CMServer) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&s.VolumeConfigFlags.PersistentVolumeRecyclerIncrementTimeoutHostPath, "pv-recycler-timeout-increment-hostpath", s.VolumeConfigFlags.PersistentVolumeRecyclerIncrementTimeoutHostPath, "the increment of time added per Gi to ActiveDeadlineSeconds for a HostPath scrubber pod.  This is for development and testing only and will not work in a multi-node cluster.")
 	fs.BoolVar(&s.VolumeConfigFlags.EnableHostPathProvisioning, "enable-hostpath-provisioner", s.VolumeConfigFlags.EnableHostPathProvisioning, "Enable HostPath PV provisioning when running without a cloud provider. This allows testing and development of provisioning features.  HostPath provisioning is not supported in any way, won't work in a multi-node cluster, and should not be used for anything other than testing or development.")
 	fs.IntVar(&s.TerminatedPodGCThreshold, "terminated-pod-gc-threshold", s.TerminatedPodGCThreshold, "Number of terminated pods that can exist before the terminated pod garbage collector starts deleting terminated pods. If <= 0, the terminated pod garbage collector is disabled.")
+	fs.DurationVar(&s.EventTTL, "event-ttl", s.EventTTL, "Amount of time to retain events. Default 1 hour.")
 	fs.DurationVar(&s.HorizontalPodAutoscalerSyncPeriod, "horizontal-pod-autoscaler-sync-period", s.HorizontalPodAutoscalerSyncPeriod, "The period for syncing the number of pods in horizontal pod autoscaler.")
 	fs.DurationVar(&s.DeploymentControllerSyncPeriod, "deployment-controller-sync-period", s.DeploymentControllerSyncPeriod, "Period for syncing the deployments.")
 	fs.DurationVar(&s.PodEvictionTimeout, "pod-eviction-timeout", s.PodEvictionTimeout, "The grace period for deleting pods on failed nodes.")

--- a/pkg/client/cache/listers.go
+++ b/pkg/client/cache/listers.go
@@ -245,6 +245,19 @@ func (s *StoreToDeploymentLister) GetDeploymentsForRC(rc *api.ReplicationControl
 	return
 }
 
+// StoreToEventLister gives a store List method. The store must contain only Events.
+type StoreToEventLister struct {
+	Store
+}
+
+// StoreToEventLister lists all events in the store.
+func (s *StoreToEventLister) List() (events api.EventList, err error) {
+	for _, c := range s.Store.List() {
+		events.Items = append(events.Items, *(c.(*api.Event)))
+	}
+	return events, nil
+}
+
 // StoreToDaemonSetLister gives a store List and Exists methods. The store must contain only DaemonSets.
 type StoreToDaemonSetLister struct {
 	Store

--- a/pkg/client/cache/listers_test.go
+++ b/pkg/client/cache/listers_test.go
@@ -606,3 +606,24 @@ func TestStoreToServiceLister(t *testing.T) {
 		t.Errorf("Expected service %q, got %q", e, a)
 	}
 }
+
+func TestStoreToEventLister(t *testing.T) {
+	store := NewStore(MetaNamespaceKeyFunc)
+	ids := []string{"foo", "bar", "baz"}
+	for _, id := range ids {
+		store.Add(&api.Event{
+			ObjectMeta: api.ObjectMeta{
+				Name: id,
+			},
+		})
+	}
+	spl := StoreToEventLister{store}
+
+	got, err := spl.List()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if e, a := len(ids), len(got.Items); e != a {
+		t.Fatalf("Expected %v, got %v", e, a)
+	}
+}

--- a/pkg/controller/event/event_gc_controller.go
+++ b/pkg/controller/event/event_gc_controller.go
@@ -1,0 +1,99 @@
+package event
+
+import (
+	"sort"
+	"sync"
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/cache"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/pkg/controller/framework"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+const (
+	gcCheckPeriod = 20 * time.Second
+)
+
+type GCController struct {
+	kubeClient       client.Interface
+	eventStore       cache.StoreToEventLister
+	eventStoreSyncer *framework.Controller
+	eventTTL         time.Duration
+	// extract the shouldGC logic for injection for testing.
+	shouldGC    func(api.Event) bool
+	deleteEvent func(namespace, name string) error
+}
+
+func New(kubeClient client.Interface, resyncPeriod controller.ResyncPeriodFunc, eventTTL time.Duration) *GCController {
+	gcc := &GCController{
+		kubeClient: kubeClient,
+		eventTTL:   eventTTL,
+		shouldGC: func(event api.Event) bool {
+			return time.Now().Sub(event.CreationTimestamp.Time) >= eventTTL
+		},
+		deleteEvent: func(namespace, name string) error {
+			return kubeClient.Events(namespace).Delete(name)
+		},
+	}
+
+	gcc.eventStore.Store, gcc.eventStoreSyncer = framework.NewInformer(
+		&cache.ListWatch{
+			ListFunc: func(options api.ListOptions) (runtime.Object, error) {
+				return gcc.kubeClient.Events(api.NamespaceAll).List(options)
+			},
+			WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
+				return gcc.kubeClient.Events(api.NamespaceAll).Watch(options)
+			},
+		},
+		&api.Pod{},
+		resyncPeriod(),
+		framework.ResourceEventHandlerFuncs{},
+	)
+	return gcc
+}
+
+func (gcc *GCController) Run(stop <-chan struct{}) {
+	go gcc.eventStoreSyncer.Run(stop)
+	go util.Until(gcc.gc, gcCheckPeriod, stop)
+	<-stop
+}
+
+func (gcc *GCController) gc() {
+	events, _ := gcc.eventStore.List()
+	sort.Sort(byCreationTimestamp(events.Items))
+
+	index := sort.Search(len(events.Items), func(i int) bool {
+		return !gcc.shouldGC(events.Items[i])
+	})
+
+	var wait sync.WaitGroup
+	for i := 0; i < index; i++ {
+		wait.Add(1)
+		go func(namespace string, name string) {
+			defer wait.Done()
+			if err := gcc.deleteEvent(namespace, name); err != nil {
+				// ignore not founds
+				defer util.HandleError(err)
+			}
+		}(events.Items[i].Namespace, events.Items[i].Name)
+	}
+	wait.Wait()
+}
+
+// byCreationTimestamp sorts a list by creation timestamp, using their names as a tie breaker.
+type byCreationTimestamp []api.Event
+
+func (o byCreationTimestamp) Len() int      { return len(o) }
+func (o byCreationTimestamp) Swap(i, j int) { o[i], o[j] = o[j], o[i] }
+
+func (o byCreationTimestamp) Less(i, j int) bool {
+	if o[i].CreationTimestamp.Equal(o[j].CreationTimestamp) {
+		return o[i].Name < o[j].Name
+	}
+	return o[i].CreationTimestamp.Before(o[j].CreationTimestamp)
+}

--- a/pkg/controller/event/event_gc_controller_test.go
+++ b/pkg/controller/event/event_gc_controller_test.go
@@ -1,0 +1,106 @@
+package event
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/pkg/util/sets"
+)
+
+func TestGC(t *testing.T) {
+	timea, err := time.Parse(time.RFC3339, "2006-01-02T15:04:05Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	timeb, _ := time.Parse(time.RFC3339, "2016-01-02T15:04:05Z")
+	testCases := []struct {
+		events            []api.Event
+		shouldGC          func(api.Event) bool
+		deletedEventNames sets.String
+	}{
+		{
+			events: []api.Event{
+				{
+					ObjectMeta: api.ObjectMeta{Name: "a", CreationTimestamp: unversioned.Time{timea}},
+				},
+				{
+					ObjectMeta: api.ObjectMeta{Name: "b", CreationTimestamp: unversioned.Time{timeb}},
+				},
+			},
+			shouldGC: func(event api.Event) bool {
+				timegc, _ := time.Parse(time.RFC3339, "2020-01-02T15:04:05Z")
+				return event.CreationTimestamp.Time.Before(timegc)
+			},
+			deletedEventNames: sets.NewString("a", "b"),
+		},
+		{
+			events: []api.Event{
+				{
+					ObjectMeta: api.ObjectMeta{Name: "a", CreationTimestamp: unversioned.Time{timea}},
+				},
+				{
+					ObjectMeta: api.ObjectMeta{Name: "b", CreationTimestamp: unversioned.Time{timeb}},
+				},
+			},
+			shouldGC: func(event api.Event) bool {
+				timegc, _ := time.Parse(time.RFC3339, "2010-01-02T15:04:05Z")
+				return event.CreationTimestamp.Time.Before(timegc)
+			},
+			deletedEventNames: sets.NewString("a"),
+		},
+		{
+			events: []api.Event{
+				{
+					ObjectMeta: api.ObjectMeta{Name: "a", CreationTimestamp: unversioned.Time{timea}},
+				},
+				{
+					ObjectMeta: api.ObjectMeta{Name: "b", CreationTimestamp: unversioned.Time{timeb}},
+				},
+			},
+			shouldGC: func(event api.Event) bool {
+				timegc, _ := time.Parse(time.RFC3339, "2000-01-02T15:04:05Z")
+				return event.CreationTimestamp.Time.Before(timegc)
+			},
+			deletedEventNames: sets.NewString(),
+		},
+	}
+
+	for i, test := range testCases {
+		client := testclient.NewSimpleFake()
+		gcc := New(client, controller.NoResyncPeriodFunc, time.Duration(0))
+		deletedEventNames := make([]string, 0)
+
+		var lock sync.Mutex
+		gcc.deleteEvent = func(_, name string) error {
+			lock.Lock()
+			defer lock.Unlock()
+			deletedEventNames = append(deletedEventNames, name)
+			return nil
+		}
+		gcc.shouldGC = test.shouldGC
+
+		for i := range test.events {
+			gcc.eventStore.Store.Add(&test.events[i])
+		}
+
+		gcc.gc()
+
+		pass := true
+		for _, event := range deletedEventNames {
+			if !test.deletedEventNames.Has(event) {
+				pass = false
+			}
+		}
+		if len(deletedEventNames) != len(test.deletedEventNames) {
+			pass = false
+		}
+		if !pass {
+			t.Errorf("[%v]event's deleted expected and actual did not match.\n\texpected: %v\n\tactual: %v", i, test.deletedEventNames, deletedEventNames)
+		}
+	}
+}


### PR DESCRIPTION
@smarterclayton @erictune @nikhiljindal @bgrant0607 @davidopp

This PR:
- mark `--event-ttl`  flag of api-server as deprecated
- add a event-gc controller to gc old event

ref https://github.com/kubernetes/kubernetes/issues/1957
