### PR TITLE
Add internal support for field selectors to use set and equality based matches

### DIFF
--- a/pkg/apis/extensions/helpers.go
+++ b/pkg/apis/extensions/helpers.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/util/selectors"
 	"k8s.io/kubernetes/pkg/util/sets"
 )
 
@@ -35,23 +36,23 @@ func LabelSelectorAsSelector(ps *LabelSelector) (labels.Selector, error) {
 	}
 	selector := labels.NewSelector()
 	for k, v := range ps.MatchLabels {
-		r, err := labels.NewRequirement(k, labels.InOperator, sets.NewString(v))
+		r, err := labels.NewRequirement(k, selectors.InOperator, sets.NewString(v))
 		if err != nil {
 			return nil, err
 		}
 		selector = selector.Add(*r)
 	}
 	for _, expr := range ps.MatchExpressions {
-		var op labels.Operator
+		var op selectors.Operator
 		switch expr.Operator {
 		case LabelSelectorOpIn:
-			op = labels.InOperator
+			op = selectors.InOperator
 		case LabelSelectorOpNotIn:
-			op = labels.NotInOperator
+			op = selectors.NotInOperator
 		case LabelSelectorOpExists:
-			op = labels.ExistsOperator
+			op = selectors.ExistsOperator
 		case LabelSelectorOpDoesNotExist:
-			op = labels.DoesNotExistOperator
+			op = selectors.DoesNotExistOperator
 		default:
 			return nil, fmt.Errorf("%q is not a valid pod selector operator", expr.Operator)
 		}

--- a/pkg/util/selectors/selectors.go
+++ b/pkg/util/selectors/selectors.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selectors
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"k8s.io/kubernetes/pkg/util/sets"
+)
+
+// KeyValues allows you to present keys independently from their storage
+type KeyValues interface {
+	// Has returns whether the provided key exists.
+	Has(key string) (exists bool)
+
+	// Get returns the value for the provided key.
+	Get(key string) (value string)
+}
+
+// Operator represents a key's relationship
+// to a set of values in a Requirement.
+type Operator string
+
+const (
+	DoesNotExistOperator Operator = "!"
+	EqualsOperator       Operator = "="
+	DoubleEqualsOperator Operator = "=="
+	InOperator           Operator = "in"
+	NotEqualsOperator    Operator = "!="
+	NotInOperator        Operator = "notin"
+	ExistsOperator       Operator = "exists"
+)
+
+// Requirement is a selector that contains values, a key
+// and an operator that relates the key and values. The zero
+// value of Requirement is invalid.
+// Requirement implements both set based match and exact match
+// Requirement is initialized via NewRequirement constructor for creating a valid Requirement.
+type Requirement struct {
+	key       string
+	operator  Operator
+	strValues sets.String
+}
+
+// Sort by key to obtain deterministic parser
+type ByKey []Requirement
+
+func (a ByKey) Len() int { return len(a) }
+
+func (a ByKey) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+
+func (a ByKey) Less(i, j int) bool { return a[i].key < a[j].key }
+
+// NewRequirement is the constructor for a Requirement.
+// If any of these rules is violated, an error is returned:
+// (1) The operator can only be In, NotIn, Equals, DoubleEquals, NotEquals, Exists, or DoesNotExist.
+// (2) If the operator is In or NotIn, the values set must be non-empty.
+// (3) If the operator is Equals, DoubleEquals, or NotEquals, the values set must contain one value.
+// (4) If the operator is Exists or DoesNotExist, the value set must be empty.
+//
+// The empty string is a valid value in the input values set.
+func NewRequirement(key string, op Operator, vals sets.String) (*Requirement, error) {
+	switch op {
+	case InOperator, NotInOperator:
+		if len(vals) == 0 {
+			return nil, fmt.Errorf("for 'in', 'notin' operators, values set can't be empty")
+		}
+	case EqualsOperator, DoubleEqualsOperator, NotEqualsOperator:
+		if len(vals) != 1 {
+			return nil, fmt.Errorf("exact-match compatibility requires one single value")
+		}
+	case ExistsOperator, DoesNotExistOperator:
+		if len(vals) != 0 {
+			return nil, fmt.Errorf("values set must be empty for exists and does not exist")
+		}
+	default:
+		return nil, fmt.Errorf("operator '%v' is not recognized", op)
+	}
+	return &Requirement{key: key, operator: op, strValues: vals}, nil
+}
+
+// Matches returns true if the Requirement matches the input KeyValues.
+// There is a match in the following cases:
+// (1) The operator is Exists and KeyValues has the Requirement's key.
+// (2) The operator is In, KeyValues has the Requirement's key and KeyValues'
+//     value for that key is in Requirement's value set.
+// (3) The operator is NotIn, Labels has the Requirement's key and
+//     KeyValues' value for that key is not in Requirement's value set.
+// (4) The operator is DoesNotExist or NotIn and KeyValues does not have the
+//     Requirement's key.
+func (r *Requirement) Matches(kvs KeyValues) bool {
+	switch r.operator {
+	case InOperator, EqualsOperator, DoubleEqualsOperator:
+		if !kvs.Has(r.key) {
+			return false
+		}
+		return r.strValues.Has(kvs.Get(r.key))
+	case NotInOperator, NotEqualsOperator:
+		if !kvs.Has(r.key) {
+			return true
+		}
+		return !r.strValues.Has(kvs.Get(r.key))
+	case ExistsOperator:
+		return kvs.Has(r.key)
+	case DoesNotExistOperator:
+		return !kvs.Has(r.key)
+	default:
+		return false
+	}
+}
+
+func (r *Requirement) Key() string {
+	return r.key
+}
+func (r *Requirement) Operator() Operator {
+	return r.operator
+}
+func (r *Requirement) Values() sets.String {
+	ret := sets.String{}
+	for k := range r.strValues {
+		ret.Insert(k)
+	}
+	return ret
+}
+
+// String returns a human-readable string that represents this
+// Requirement. If called on an invalid Requirement, an error is
+// returned. See NewRequirement for creating a valid Requirement.
+func (r *Requirement) String() string {
+	var buffer bytes.Buffer
+	if r.operator == DoesNotExistOperator {
+		buffer.WriteString("!")
+	}
+	buffer.WriteString(r.key)
+
+	switch r.operator {
+	case EqualsOperator:
+		buffer.WriteString("=")
+	case DoubleEqualsOperator:
+		buffer.WriteString("==")
+	case NotEqualsOperator:
+		buffer.WriteString("!=")
+	case InOperator:
+		buffer.WriteString(" in ")
+	case NotInOperator:
+		buffer.WriteString(" notin ")
+	case ExistsOperator, DoesNotExistOperator:
+		return buffer.String()
+	}
+
+	switch r.operator {
+	case InOperator, NotInOperator:
+		buffer.WriteString("(")
+	}
+	if len(r.strValues) == 1 {
+		buffer.WriteString(r.strValues.List()[0])
+	} else { // only > 1 since == 0 prohibited by NewRequirement
+		buffer.WriteString(strings.Join(r.strValues.List(), ","))
+	}
+
+	switch r.operator {
+	case InOperator, NotInOperator:
+		buffer.WriteString(")")
+	}
+	return buffer.String()
+}


### PR DESCRIPTION
PR does following:
- move label selector set and equality based matching into a common utility.
- update field selectors internal implementation to support generic requirements pattern

Each bullet is its own commit to ease review.

Requirement:
I plan to use this to support `ResourceQuota` enhancements described here that can target a quota to pods that match "spec.restartPolicy in (Never, Failure)" differently than pods that match "spec.restartPolicy=Always".  To support that requirement, I need to support building an internal structure that can do the set-based in match to cover non-terminating vs. terminating pods.

see: https://github.com/kubernetes/kubernetes/pull/19761

Result:
Internally, you can build a `fields.Selector` by adding `Requirements` that can support matching on the equivalent syntax like: `x in (y, z)`.  You cannot yet parse the string `x in (y, z)` into a valid field selector (you have to manually build the object yourself).  This was fine for my needs since we persist the user specified field selector as a set of match requirements similar to how controllers in extensions API persist their `LabelSelector`.

Adding parse support if desired would need to be a follow-on.

/cc @bgrant0607 @smarterclayton @sdminonne @mikedanese @ncdc @pmorie @davidopp 
