### PR TITLE
Problem with centos cluster creation script

### DIFF
--- a/cluster/centos/node/scripts/docker.sh
+++ b/cluster/centos/node/scripts/docker.sh
@@ -35,7 +35,6 @@ Type=notify
 EnvironmentFile=-/run/flannel/docker
 EnvironmentFile=-/opt/kubernetes/cfg/docker
 WorkingDirectory=/opt/kubernetes/bin
-ExecStartPre=/opt/kubernetes/bin/remove-docker0.sh
 ExecStart=/opt/kubernetes/bin/docker daemon \$DOCKER_OPT_BIP \$DOCKER_OPT_MTU \$DOCKER_OPTS
 LimitNOFILE=1048576
 LimitNPROC=1048576

--- a/cluster/centos/node/scripts/flannel.sh
+++ b/cluster/centos/node/scripts/flannel.sh
@@ -32,6 +32,7 @@ Before=docker.service
 
 [Service]
 EnvironmentFile=-/opt/kubernetes/cfg/flannel
+ExecStartPre=/opt/kubernetes/bin/remove-docker0.sh
 ExecStart=/opt/kubernetes/bin/flanneld --ip-masq \${FLANNEL_ETCD} \${FLANNEL_ETCD_KEY}
 ExecStartPost=/opt/kubernetes/bin/mk-docker-opts.sh -d /run/flannel/docker
 


### PR DESCRIPTION
`ExecStartPre` which runs `remove-docker0.sh` removes docker0 interface after flanneld creates the flannel0 interface which leads to removal of route.

**Ref:** coreos/flannel#396
