### PR TITLE
WIP: Added Resource Metrics API types

### DIFF
--- a/pkg/apis/metrics/deep_copy_generated.go
+++ b/pkg/apis/metrics/deep_copy_generated.go
@@ -19,14 +19,133 @@ limitations under the License.
 package metrics
 
 import (
+	time "time"
+
 	api "k8s.io/kubernetes/pkg/api"
+	resource "k8s.io/kubernetes/pkg/api/resource"
 	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
 	conversion "k8s.io/kubernetes/pkg/conversion"
+	inf "speter.net/go/exp/math/dec/inf"
 )
+
+func deepCopy_api_ObjectMeta(in api.ObjectMeta, out *api.ObjectMeta, c *conversion.Cloner) error {
+	out.Name = in.Name
+	out.GenerateName = in.GenerateName
+	out.Namespace = in.Namespace
+	out.SelfLink = in.SelfLink
+	out.UID = in.UID
+	out.ResourceVersion = in.ResourceVersion
+	out.Generation = in.Generation
+	if err := deepCopy_unversioned_Time(in.CreationTimestamp, &out.CreationTimestamp, c); err != nil {
+		return err
+	}
+	if in.DeletionTimestamp != nil {
+		out.DeletionTimestamp = new(unversioned.Time)
+		if err := deepCopy_unversioned_Time(*in.DeletionTimestamp, out.DeletionTimestamp, c); err != nil {
+			return err
+		}
+	} else {
+		out.DeletionTimestamp = nil
+	}
+	if in.DeletionGracePeriodSeconds != nil {
+		out.DeletionGracePeriodSeconds = new(int64)
+		*out.DeletionGracePeriodSeconds = *in.DeletionGracePeriodSeconds
+	} else {
+		out.DeletionGracePeriodSeconds = nil
+	}
+	if in.Labels != nil {
+		out.Labels = make(map[string]string)
+		for key, val := range in.Labels {
+			out.Labels[key] = val
+		}
+	} else {
+		out.Labels = nil
+	}
+	if in.Annotations != nil {
+		out.Annotations = make(map[string]string)
+		for key, val := range in.Annotations {
+			out.Annotations[key] = val
+		}
+	} else {
+		out.Annotations = nil
+	}
+	return nil
+}
+
+func deepCopy_resource_Quantity(in resource.Quantity, out *resource.Quantity, c *conversion.Cloner) error {
+	if in.Amount != nil {
+		if newVal, err := c.DeepCopy(in.Amount); err != nil {
+			return err
+		} else {
+			out.Amount = newVal.(*inf.Dec)
+		}
+	} else {
+		out.Amount = nil
+	}
+	out.Format = in.Format
+	return nil
+}
+
+func deepCopy_unversioned_Time(in unversioned.Time, out *unversioned.Time, c *conversion.Cloner) error {
+	if newVal, err := c.DeepCopy(in.Time); err != nil {
+		return err
+	} else {
+		out.Time = newVal.(time.Time)
+	}
+	return nil
+}
 
 func deepCopy_unversioned_TypeMeta(in unversioned.TypeMeta, out *unversioned.TypeMeta, c *conversion.Cloner) error {
 	out.Kind = in.Kind
 	out.APIVersion = in.APIVersion
+	return nil
+}
+
+func deepCopy_metrics_Metrics(in Metrics, out *Metrics, c *conversion.Cloner) error {
+	if err := deepCopy_unversioned_Time(in.StartTime, &out.StartTime, c); err != nil {
+		return err
+	}
+	if err := deepCopy_unversioned_Time(in.EndTime, &out.EndTime, c); err != nil {
+		return err
+	}
+	if in.Usage != nil {
+		out.Usage = make(api.ResourceList)
+		for key, val := range in.Usage {
+			newVal := new(resource.Quantity)
+			if err := deepCopy_resource_Quantity(val, newVal, c); err != nil {
+				return err
+			}
+			out.Usage[key] = *newVal
+		}
+	} else {
+		out.Usage = nil
+	}
+	return nil
+}
+
+func deepCopy_metrics_Node(in Node, out *Node, c *conversion.Cloner) error {
+	if err := deepCopy_unversioned_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_api_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_metrics_Metrics(in.Metrics, &out.Metrics, c); err != nil {
+		return err
+	}
+	return nil
+}
+
+func deepCopy_metrics_Pod(in Pod, out *Pod, c *conversion.Cloner) error {
+	if err := deepCopy_unversioned_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_api_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_metrics_Metrics(in.Metrics, &out.Metrics, c); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -46,7 +165,13 @@ func deepCopy_metrics_RawPod(in RawPod, out *RawPod, c *conversion.Cloner) error
 
 func init() {
 	err := api.Scheme.AddGeneratedDeepCopyFuncs(
+		deepCopy_api_ObjectMeta,
+		deepCopy_resource_Quantity,
+		deepCopy_unversioned_Time,
 		deepCopy_unversioned_TypeMeta,
+		deepCopy_metrics_Metrics,
+		deepCopy_metrics_Node,
+		deepCopy_metrics_Pod,
 		deepCopy_metrics_RawNode,
 		deepCopy_metrics_RawPod,
 	)

--- a/pkg/apis/metrics/register.go
+++ b/pkg/apis/metrics/register.go
@@ -48,8 +48,12 @@ func addKnownTypes(scheme *runtime.Scheme) {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&RawNode{},
 		&RawPod{},
+		&Node{},
+		&Pod{},
 	)
 }
 
 func (obj *RawNode) GetObjectKind() unversioned.ObjectKind { return &obj.TypeMeta }
 func (obj *RawPod) GetObjectKind() unversioned.ObjectKind  { return &obj.TypeMeta }
+func (obj *Node) GetObjectKind() unversioned.ObjectKind    { return &obj.TypeMeta }
+func (obj *Pod) GetObjectKind() unversioned.ObjectKind     { return &obj.TypeMeta }

--- a/pkg/apis/metrics/types.generated.go
+++ b/pkg/apis/metrics/types.generated.go
@@ -25,9 +25,14 @@ import (
 	"errors"
 	"fmt"
 	codec1978 "github.com/ugorji/go/codec"
+	pkg2_api "k8s.io/kubernetes/pkg/api"
+	pkg4_resource "k8s.io/kubernetes/pkg/api/resource"
 	pkg1_unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	pkg3_types "k8s.io/kubernetes/pkg/types"
 	"reflect"
 	"runtime"
+	pkg5_inf "speter.net/go/exp/math/dec/inf"
+	time "time"
 )
 
 const (
@@ -60,8 +65,13 @@ func init() {
 		panic(err)
 	}
 	if false { // reference the types, but skip this branch at build/run time
-		var v0 pkg1_unversioned.TypeMeta
-		_ = v0
+		var v0 pkg2_api.ObjectMeta
+		var v1 pkg4_resource.Quantity
+		var v2 pkg1_unversioned.TypeMeta
+		var v3 pkg3_types.UID
+		var v4 pkg5_inf.Dec
+		var v5 time.Time
+		_, _, _, _, _, _ = v0, v1, v2, v3, v4, v5
 	}
 }
 
@@ -497,4 +507,1050 @@ func (x *RawPod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		z.DecStructFieldNotFound(yyj30-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym33 := z.EncBinary()
+		_ = yym33
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep34 := !z.EncBinary()
+			yy2arr34 := z.EncBasicHandle().StructToArray
+			var yyq34 [4]bool
+			_, _, _ = yysep34, yyq34, yy2arr34
+			const yyr34 bool = false
+			yyq34[0] = x.Kind != ""
+			yyq34[1] = x.APIVersion != ""
+			yyq34[2] = true
+			yyq34[3] = true
+			var yynn34 int
+			if yyr34 || yy2arr34 {
+				r.EncodeArrayStart(4)
+			} else {
+				yynn34 = 0
+				for _, b := range yyq34 {
+					if b {
+						yynn34++
+					}
+				}
+				r.EncodeMapStart(yynn34)
+				yynn34 = 0
+			}
+			if yyr34 || yy2arr34 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq34[0] {
+					yym36 := z.EncBinary()
+					_ = yym36
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq34[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym37 := z.EncBinary()
+					_ = yym37
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr34 || yy2arr34 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq34[1] {
+					yym39 := z.EncBinary()
+					_ = yym39
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq34[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym40 := z.EncBinary()
+					_ = yym40
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr34 || yy2arr34 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq34[2] {
+					yy42 := &x.ObjectMeta
+					yy42.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq34[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy43 := &x.ObjectMeta
+					yy43.CodecEncodeSelf(e)
+				}
+			}
+			if yyr34 || yy2arr34 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq34[3] {
+					yy45 := &x.Metrics
+					yy45.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq34[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("metrics"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy46 := &x.Metrics
+					yy46.CodecEncodeSelf(e)
+				}
+			}
+			if yyr34 || yy2arr34 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *Node) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym47 := z.DecBinary()
+	_ = yym47
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct48 := r.ContainerType()
+		if yyct48 == codecSelferValueTypeMap1234 {
+			yyl48 := r.ReadMapStart()
+			if yyl48 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl48, d)
+			}
+		} else if yyct48 == codecSelferValueTypeArray1234 {
+			yyl48 := r.ReadArrayStart()
+			if yyl48 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl48, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys49Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys49Slc
+	var yyhl49 bool = l >= 0
+	for yyj49 := 0; ; yyj49++ {
+		if yyhl49 {
+			if yyj49 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys49Slc = r.DecodeBytes(yys49Slc, true, true)
+		yys49 := string(yys49Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys49 {
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
+			}
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_api.ObjectMeta{}
+			} else {
+				yyv52 := &x.ObjectMeta
+				yyv52.CodecDecodeSelf(d)
+			}
+		case "metrics":
+			if r.TryDecodeAsNil() {
+				x.Metrics = Metrics{}
+			} else {
+				yyv53 := &x.Metrics
+				yyv53.CodecDecodeSelf(d)
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys49)
+		} // end switch yys49
+	} // end for yyj49
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj54 int
+	var yyb54 bool
+	var yyhl54 bool = l >= 0
+	yyj54++
+	if yyhl54 {
+		yyb54 = yyj54 > l
+	} else {
+		yyb54 = r.CheckBreak()
+	}
+	if yyb54 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj54++
+	if yyhl54 {
+		yyb54 = yyj54 > l
+	} else {
+		yyb54 = r.CheckBreak()
+	}
+	if yyb54 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
+	}
+	yyj54++
+	if yyhl54 {
+		yyb54 = yyj54 > l
+	} else {
+		yyb54 = r.CheckBreak()
+	}
+	if yyb54 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_api.ObjectMeta{}
+	} else {
+		yyv57 := &x.ObjectMeta
+		yyv57.CodecDecodeSelf(d)
+	}
+	yyj54++
+	if yyhl54 {
+		yyb54 = yyj54 > l
+	} else {
+		yyb54 = r.CheckBreak()
+	}
+	if yyb54 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Metrics = Metrics{}
+	} else {
+		yyv58 := &x.Metrics
+		yyv58.CodecDecodeSelf(d)
+	}
+	for {
+		yyj54++
+		if yyhl54 {
+			yyb54 = yyj54 > l
+		} else {
+			yyb54 = r.CheckBreak()
+		}
+		if yyb54 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj54-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x *Pod) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym59 := z.EncBinary()
+		_ = yym59
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep60 := !z.EncBinary()
+			yy2arr60 := z.EncBasicHandle().StructToArray
+			var yyq60 [4]bool
+			_, _, _ = yysep60, yyq60, yy2arr60
+			const yyr60 bool = false
+			yyq60[0] = x.Kind != ""
+			yyq60[1] = x.APIVersion != ""
+			yyq60[2] = true
+			yyq60[3] = true
+			var yynn60 int
+			if yyr60 || yy2arr60 {
+				r.EncodeArrayStart(4)
+			} else {
+				yynn60 = 0
+				for _, b := range yyq60 {
+					if b {
+						yynn60++
+					}
+				}
+				r.EncodeMapStart(yynn60)
+				yynn60 = 0
+			}
+			if yyr60 || yy2arr60 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq60[0] {
+					yym62 := z.EncBinary()
+					_ = yym62
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq60[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym63 := z.EncBinary()
+					_ = yym63
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr60 || yy2arr60 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq60[1] {
+					yym65 := z.EncBinary()
+					_ = yym65
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq60[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym66 := z.EncBinary()
+					_ = yym66
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr60 || yy2arr60 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq60[2] {
+					yy68 := &x.ObjectMeta
+					yy68.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq60[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy69 := &x.ObjectMeta
+					yy69.CodecEncodeSelf(e)
+				}
+			}
+			if yyr60 || yy2arr60 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq60[3] {
+					yy71 := &x.Metrics
+					yy71.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq60[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("metrics"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy72 := &x.Metrics
+					yy72.CodecEncodeSelf(e)
+				}
+			}
+			if yyr60 || yy2arr60 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *Pod) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym73 := z.DecBinary()
+	_ = yym73
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct74 := r.ContainerType()
+		if yyct74 == codecSelferValueTypeMap1234 {
+			yyl74 := r.ReadMapStart()
+			if yyl74 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl74, d)
+			}
+		} else if yyct74 == codecSelferValueTypeArray1234 {
+			yyl74 := r.ReadArrayStart()
+			if yyl74 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl74, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *Pod) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys75Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys75Slc
+	var yyhl75 bool = l >= 0
+	for yyj75 := 0; ; yyj75++ {
+		if yyhl75 {
+			if yyj75 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys75Slc = r.DecodeBytes(yys75Slc, true, true)
+		yys75 := string(yys75Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys75 {
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
+			}
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_api.ObjectMeta{}
+			} else {
+				yyv78 := &x.ObjectMeta
+				yyv78.CodecDecodeSelf(d)
+			}
+		case "metrics":
+			if r.TryDecodeAsNil() {
+				x.Metrics = Metrics{}
+			} else {
+				yyv79 := &x.Metrics
+				yyv79.CodecDecodeSelf(d)
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys75)
+		} // end switch yys75
+	} // end for yyj75
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *Pod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj80 int
+	var yyb80 bool
+	var yyhl80 bool = l >= 0
+	yyj80++
+	if yyhl80 {
+		yyb80 = yyj80 > l
+	} else {
+		yyb80 = r.CheckBreak()
+	}
+	if yyb80 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj80++
+	if yyhl80 {
+		yyb80 = yyj80 > l
+	} else {
+		yyb80 = r.CheckBreak()
+	}
+	if yyb80 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
+	}
+	yyj80++
+	if yyhl80 {
+		yyb80 = yyj80 > l
+	} else {
+		yyb80 = r.CheckBreak()
+	}
+	if yyb80 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_api.ObjectMeta{}
+	} else {
+		yyv83 := &x.ObjectMeta
+		yyv83.CodecDecodeSelf(d)
+	}
+	yyj80++
+	if yyhl80 {
+		yyb80 = yyj80 > l
+	} else {
+		yyb80 = r.CheckBreak()
+	}
+	if yyb80 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Metrics = Metrics{}
+	} else {
+		yyv84 := &x.Metrics
+		yyv84.CodecDecodeSelf(d)
+	}
+	for {
+		yyj80++
+		if yyhl80 {
+			yyb80 = yyj80 > l
+		} else {
+			yyb80 = r.CheckBreak()
+		}
+		if yyb80 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj80-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x *Metrics) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym85 := z.EncBinary()
+		_ = yym85
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep86 := !z.EncBinary()
+			yy2arr86 := z.EncBasicHandle().StructToArray
+			var yyq86 [3]bool
+			_, _, _ = yysep86, yyq86, yy2arr86
+			const yyr86 bool = false
+			var yynn86 int
+			if yyr86 || yy2arr86 {
+				r.EncodeArrayStart(3)
+			} else {
+				yynn86 = 3
+				for _, b := range yyq86 {
+					if b {
+						yynn86++
+					}
+				}
+				r.EncodeMapStart(yynn86)
+				yynn86 = 0
+			}
+			if yyr86 || yy2arr86 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yy88 := &x.StartTime
+				yym89 := z.EncBinary()
+				_ = yym89
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy88) {
+				} else if yym89 {
+					z.EncBinaryMarshal(yy88)
+				} else if !yym89 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy88)
+				} else {
+					z.EncFallback(yy88)
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("start"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yy90 := &x.StartTime
+				yym91 := z.EncBinary()
+				_ = yym91
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy90) {
+				} else if yym91 {
+					z.EncBinaryMarshal(yy90)
+				} else if !yym91 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy90)
+				} else {
+					z.EncFallback(yy90)
+				}
+			}
+			if yyr86 || yy2arr86 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yy93 := &x.EndTime
+				yym94 := z.EncBinary()
+				_ = yym94
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy93) {
+				} else if yym94 {
+					z.EncBinaryMarshal(yy93)
+				} else if !yym94 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy93)
+				} else {
+					z.EncFallback(yy93)
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("end"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yy95 := &x.EndTime
+				yym96 := z.EncBinary()
+				_ = yym96
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy95) {
+				} else if yym96 {
+					z.EncBinaryMarshal(yy95)
+				} else if !yym96 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy95)
+				} else {
+					z.EncFallback(yy95)
+				}
+			}
+			if yyr86 || yy2arr86 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if x.Usage == nil {
+					r.EncodeNil()
+				} else {
+					yym98 := z.EncBinary()
+					_ = yym98
+					if false {
+					} else if z.HasExtensions() && z.EncExt(x.Usage) {
+					} else {
+						h.encapi_ResourceList((pkg2_api.ResourceList)(x.Usage), e)
+					}
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("usage"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				if x.Usage == nil {
+					r.EncodeNil()
+				} else {
+					yym99 := z.EncBinary()
+					_ = yym99
+					if false {
+					} else if z.HasExtensions() && z.EncExt(x.Usage) {
+					} else {
+						h.encapi_ResourceList((pkg2_api.ResourceList)(x.Usage), e)
+					}
+				}
+			}
+			if yyr86 || yy2arr86 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *Metrics) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym100 := z.DecBinary()
+	_ = yym100
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct101 := r.ContainerType()
+		if yyct101 == codecSelferValueTypeMap1234 {
+			yyl101 := r.ReadMapStart()
+			if yyl101 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl101, d)
+			}
+		} else if yyct101 == codecSelferValueTypeArray1234 {
+			yyl101 := r.ReadArrayStart()
+			if yyl101 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl101, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *Metrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys102Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys102Slc
+	var yyhl102 bool = l >= 0
+	for yyj102 := 0; ; yyj102++ {
+		if yyhl102 {
+			if yyj102 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys102Slc = r.DecodeBytes(yys102Slc, true, true)
+		yys102 := string(yys102Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys102 {
+		case "start":
+			if r.TryDecodeAsNil() {
+				x.StartTime = pkg1_unversioned.Time{}
+			} else {
+				yyv103 := &x.StartTime
+				yym104 := z.DecBinary()
+				_ = yym104
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv103) {
+				} else if yym104 {
+					z.DecBinaryUnmarshal(yyv103)
+				} else if !yym104 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv103)
+				} else {
+					z.DecFallback(yyv103, false)
+				}
+			}
+		case "end":
+			if r.TryDecodeAsNil() {
+				x.EndTime = pkg1_unversioned.Time{}
+			} else {
+				yyv105 := &x.EndTime
+				yym106 := z.DecBinary()
+				_ = yym106
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv105) {
+				} else if yym106 {
+					z.DecBinaryUnmarshal(yyv105)
+				} else if !yym106 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv105)
+				} else {
+					z.DecFallback(yyv105, false)
+				}
+			}
+		case "usage":
+			if r.TryDecodeAsNil() {
+				x.Usage = nil
+			} else {
+				yyv107 := &x.Usage
+				yyv107.CodecDecodeSelf(d)
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys102)
+		} // end switch yys102
+	} // end for yyj102
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *Metrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj108 int
+	var yyb108 bool
+	var yyhl108 bool = l >= 0
+	yyj108++
+	if yyhl108 {
+		yyb108 = yyj108 > l
+	} else {
+		yyb108 = r.CheckBreak()
+	}
+	if yyb108 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.StartTime = pkg1_unversioned.Time{}
+	} else {
+		yyv109 := &x.StartTime
+		yym110 := z.DecBinary()
+		_ = yym110
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv109) {
+		} else if yym110 {
+			z.DecBinaryUnmarshal(yyv109)
+		} else if !yym110 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv109)
+		} else {
+			z.DecFallback(yyv109, false)
+		}
+	}
+	yyj108++
+	if yyhl108 {
+		yyb108 = yyj108 > l
+	} else {
+		yyb108 = r.CheckBreak()
+	}
+	if yyb108 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.EndTime = pkg1_unversioned.Time{}
+	} else {
+		yyv111 := &x.EndTime
+		yym112 := z.DecBinary()
+		_ = yym112
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv111) {
+		} else if yym112 {
+			z.DecBinaryUnmarshal(yyv111)
+		} else if !yym112 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv111)
+		} else {
+			z.DecFallback(yyv111, false)
+		}
+	}
+	yyj108++
+	if yyhl108 {
+		yyb108 = yyj108 > l
+	} else {
+		yyb108 = r.CheckBreak()
+	}
+	if yyb108 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Usage = nil
+	} else {
+		yyv113 := &x.Usage
+		yyv113.CodecDecodeSelf(d)
+	}
+	for {
+		yyj108++
+		if yyhl108 {
+			yyb108 = yyj108 > l
+		} else {
+			yyb108 = r.CheckBreak()
+		}
+		if yyb108 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj108-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x codecSelfer1234) encapi_ResourceList(v pkg2_api.ResourceList, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeMapStart(len(v))
+	for yyk114, yyv114 := range v {
+		z.EncSendContainerState(codecSelfer_containerMapKey1234)
+		yym115 := z.EncBinary()
+		_ = yym115
+		if false {
+		} else if z.HasExtensions() && z.EncExt(yyk114) {
+		} else {
+			r.EncodeString(codecSelferC_UTF81234, string(yyk114))
+		}
+		z.EncSendContainerState(codecSelfer_containerMapValue1234)
+		yy116 := &yyv114
+		yym117 := z.EncBinary()
+		_ = yym117
+		if false {
+		} else if z.HasExtensions() && z.EncExt(yy116) {
+		} else if !yym117 && z.IsJSONHandle() {
+			z.EncJSONMarshal(yy116)
+		} else {
+			z.EncFallback(yy116)
+		}
+	}
+	z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x codecSelfer1234) decapi_ResourceList(v *pkg2_api.ResourceList, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv118 := *v
+	yyl118 := r.ReadMapStart()
+	yybh118 := z.DecBasicHandle()
+	if yyv118 == nil {
+		yyrl118, _ := z.DecInferLen(yyl118, yybh118.MaxInitLen, 40)
+		yyv118 = make(map[pkg2_api.ResourceName]pkg4_resource.Quantity, yyrl118)
+		*v = yyv118
+	}
+	var yymk118 pkg2_api.ResourceName
+	var yymv118 pkg4_resource.Quantity
+	var yymg118 bool
+	if yybh118.MapValueReset {
+		yymg118 = true
+	}
+	if yyl118 > 0 {
+		for yyj118 := 0; yyj118 < yyl118; yyj118++ {
+			z.DecSendContainerState(codecSelfer_containerMapKey1234)
+			if r.TryDecodeAsNil() {
+				yymk118 = ""
+			} else {
+				yymk118 = pkg2_api.ResourceName(r.DecodeString())
+			}
+
+			if yymg118 {
+				yymv118 = yyv118[yymk118]
+			} else {
+				yymv118 = pkg4_resource.Quantity{}
+			}
+			z.DecSendContainerState(codecSelfer_containerMapValue1234)
+			if r.TryDecodeAsNil() {
+				yymv118 = pkg4_resource.Quantity{}
+			} else {
+				yyv120 := &yymv118
+				yym121 := z.DecBinary()
+				_ = yym121
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv120) {
+				} else if !yym121 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv120)
+				} else {
+					z.DecFallback(yyv120, false)
+				}
+			}
+
+			if yyv118 != nil {
+				yyv118[yymk118] = yymv118
+			}
+		}
+	} else if yyl118 < 0 {
+		for yyj118 := 0; !r.CheckBreak(); yyj118++ {
+			z.DecSendContainerState(codecSelfer_containerMapKey1234)
+			if r.TryDecodeAsNil() {
+				yymk118 = ""
+			} else {
+				yymk118 = pkg2_api.ResourceName(r.DecodeString())
+			}
+
+			if yymg118 {
+				yymv118 = yyv118[yymk118]
+			} else {
+				yymv118 = pkg4_resource.Quantity{}
+			}
+			z.DecSendContainerState(codecSelfer_containerMapValue1234)
+			if r.TryDecodeAsNil() {
+				yymv118 = pkg4_resource.Quantity{}
+			} else {
+				yyv123 := &yymv118
+				yym124 := z.DecBinary()
+				_ = yym124
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv123) {
+				} else if !yym124 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv123)
+				} else {
+					z.DecFallback(yyv123, false)
+				}
+			}
+
+			if yyv118 != nil {
+				yyv118[yymk118] = yymv118
+			}
+		}
+	} // else len==0: TODO: Should we clear map entries?
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }

--- a/pkg/apis/metrics/types.go
+++ b/pkg/apis/metrics/types.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package metrics
 
-import "k8s.io/kubernetes/pkg/api/unversioned"
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+)
 
 // Placeholder top-level node resource metrics.
 type RawNode struct {
@@ -26,4 +29,27 @@ type RawNode struct {
 // Placeholder top-level pod resource metrics.
 type RawPod struct {
 	unversioned.TypeMeta `json:",inline"`
+}
+
+// Node-level metrics.
+type Node struct {
+	unversioned.TypeMeta `json:",inline"`
+	api.ObjectMeta       `json:"metadata,omitempty"`
+	Metrics              Metrics `json:"metrics,omitempty"`
+}
+
+// Pod-level metrics.
+type Pod struct {
+	unversioned.TypeMeta `json:",inline"`
+	api.ObjectMeta       `json:"metadata,omitempty"`
+	Metrics              Metrics `json:"metrics,omitempty"`
+}
+
+// The latest available metrics for the appriopriate resource.
+type Metrics struct {
+	// StartTime and EndTime specifies the time window from which the response was returned.
+	StartTime unversioned.Time `json:"start"`
+	EndTime   unversioned.Time `json:"end"`
+	// List of available resources' usage.
+	Usage api.ResourceList `json:"usage",omitempty`
 }

--- a/pkg/apis/metrics/v1alpha1/conversion_generated.go
+++ b/pkg/apis/metrics/v1alpha1/conversion_generated.go
@@ -22,9 +22,185 @@ import (
 	reflect "reflect"
 
 	api "k8s.io/kubernetes/pkg/api"
+	resource "k8s.io/kubernetes/pkg/api/resource"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	v1 "k8s.io/kubernetes/pkg/api/v1"
 	metrics "k8s.io/kubernetes/pkg/apis/metrics"
 	conversion "k8s.io/kubernetes/pkg/conversion"
 )
+
+func autoConvert_api_ObjectMeta_To_v1_ObjectMeta(in *api.ObjectMeta, out *v1.ObjectMeta, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*api.ObjectMeta))(in)
+	}
+	out.Name = in.Name
+	out.GenerateName = in.GenerateName
+	out.Namespace = in.Namespace
+	out.SelfLink = in.SelfLink
+	out.UID = in.UID
+	out.ResourceVersion = in.ResourceVersion
+	out.Generation = in.Generation
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.CreationTimestamp, &out.CreationTimestamp, s); err != nil {
+		return err
+	}
+	// unable to generate simple pointer conversion for unversioned.Time -> unversioned.Time
+	if in.DeletionTimestamp != nil {
+		out.DeletionTimestamp = new(unversioned.Time)
+		if err := api.Convert_unversioned_Time_To_unversioned_Time(in.DeletionTimestamp, out.DeletionTimestamp, s); err != nil {
+			return err
+		}
+	} else {
+		out.DeletionTimestamp = nil
+	}
+	if in.DeletionGracePeriodSeconds != nil {
+		out.DeletionGracePeriodSeconds = new(int64)
+		*out.DeletionGracePeriodSeconds = *in.DeletionGracePeriodSeconds
+	} else {
+		out.DeletionGracePeriodSeconds = nil
+	}
+	if in.Labels != nil {
+		out.Labels = make(map[string]string)
+		for key, val := range in.Labels {
+			out.Labels[key] = val
+		}
+	} else {
+		out.Labels = nil
+	}
+	if in.Annotations != nil {
+		out.Annotations = make(map[string]string)
+		for key, val := range in.Annotations {
+			out.Annotations[key] = val
+		}
+	} else {
+		out.Annotations = nil
+	}
+	return nil
+}
+
+func Convert_api_ObjectMeta_To_v1_ObjectMeta(in *api.ObjectMeta, out *v1.ObjectMeta, s conversion.Scope) error {
+	return autoConvert_api_ObjectMeta_To_v1_ObjectMeta(in, out, s)
+}
+
+func autoConvert_v1_ObjectMeta_To_api_ObjectMeta(in *v1.ObjectMeta, out *api.ObjectMeta, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*v1.ObjectMeta))(in)
+	}
+	out.Name = in.Name
+	out.GenerateName = in.GenerateName
+	out.Namespace = in.Namespace
+	out.SelfLink = in.SelfLink
+	out.UID = in.UID
+	out.ResourceVersion = in.ResourceVersion
+	out.Generation = in.Generation
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.CreationTimestamp, &out.CreationTimestamp, s); err != nil {
+		return err
+	}
+	// unable to generate simple pointer conversion for unversioned.Time -> unversioned.Time
+	if in.DeletionTimestamp != nil {
+		out.DeletionTimestamp = new(unversioned.Time)
+		if err := api.Convert_unversioned_Time_To_unversioned_Time(in.DeletionTimestamp, out.DeletionTimestamp, s); err != nil {
+			return err
+		}
+	} else {
+		out.DeletionTimestamp = nil
+	}
+	if in.DeletionGracePeriodSeconds != nil {
+		out.DeletionGracePeriodSeconds = new(int64)
+		*out.DeletionGracePeriodSeconds = *in.DeletionGracePeriodSeconds
+	} else {
+		out.DeletionGracePeriodSeconds = nil
+	}
+	if in.Labels != nil {
+		out.Labels = make(map[string]string)
+		for key, val := range in.Labels {
+			out.Labels[key] = val
+		}
+	} else {
+		out.Labels = nil
+	}
+	if in.Annotations != nil {
+		out.Annotations = make(map[string]string)
+		for key, val := range in.Annotations {
+			out.Annotations[key] = val
+		}
+	} else {
+		out.Annotations = nil
+	}
+	return nil
+}
+
+func Convert_v1_ObjectMeta_To_api_ObjectMeta(in *v1.ObjectMeta, out *api.ObjectMeta, s conversion.Scope) error {
+	return autoConvert_v1_ObjectMeta_To_api_ObjectMeta(in, out, s)
+}
+
+func autoConvert_metrics_Metrics_To_v1alpha1_Metrics(in *metrics.Metrics, out *Metrics, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*metrics.Metrics))(in)
+	}
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.StartTime, &out.StartTime, s); err != nil {
+		return err
+	}
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.EndTime, &out.EndTime, s); err != nil {
+		return err
+	}
+	if in.Usage != nil {
+		out.Usage = make(v1.ResourceList)
+		for key, val := range in.Usage {
+			newVal := resource.Quantity{}
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
+				return err
+			}
+			out.Usage[v1.ResourceName(key)] = newVal
+		}
+	} else {
+		out.Usage = nil
+	}
+	return nil
+}
+
+func Convert_metrics_Metrics_To_v1alpha1_Metrics(in *metrics.Metrics, out *Metrics, s conversion.Scope) error {
+	return autoConvert_metrics_Metrics_To_v1alpha1_Metrics(in, out, s)
+}
+
+func autoConvert_metrics_Node_To_v1alpha1_Node(in *metrics.Node, out *Node, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*metrics.Node))(in)
+	}
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if err := Convert_metrics_Metrics_To_v1alpha1_Metrics(&in.Metrics, &out.Metrics, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Convert_metrics_Node_To_v1alpha1_Node(in *metrics.Node, out *Node, s conversion.Scope) error {
+	return autoConvert_metrics_Node_To_v1alpha1_Node(in, out, s)
+}
+
+func autoConvert_metrics_Pod_To_v1alpha1_Pod(in *metrics.Pod, out *Pod, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*metrics.Pod))(in)
+	}
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if err := Convert_metrics_Metrics_To_v1alpha1_Metrics(&in.Metrics, &out.Metrics, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Convert_metrics_Pod_To_v1alpha1_Pod(in *metrics.Pod, out *Pod, s conversion.Scope) error {
+	return autoConvert_metrics_Pod_To_v1alpha1_Pod(in, out, s)
+}
 
 func autoConvert_metrics_RawNode_To_v1alpha1_RawNode(in *metrics.RawNode, out *RawNode, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
@@ -52,6 +228,75 @@ func autoConvert_metrics_RawPod_To_v1alpha1_RawPod(in *metrics.RawPod, out *RawP
 
 func Convert_metrics_RawPod_To_v1alpha1_RawPod(in *metrics.RawPod, out *RawPod, s conversion.Scope) error {
 	return autoConvert_metrics_RawPod_To_v1alpha1_RawPod(in, out, s)
+}
+
+func autoConvert_v1alpha1_Metrics_To_metrics_Metrics(in *Metrics, out *metrics.Metrics, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*Metrics))(in)
+	}
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.StartTime, &out.StartTime, s); err != nil {
+		return err
+	}
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.EndTime, &out.EndTime, s); err != nil {
+		return err
+	}
+	if in.Usage != nil {
+		out.Usage = make(api.ResourceList)
+		for key, val := range in.Usage {
+			newVal := resource.Quantity{}
+			if err := api.Convert_resource_Quantity_To_resource_Quantity(&val, &newVal, s); err != nil {
+				return err
+			}
+			out.Usage[api.ResourceName(key)] = newVal
+		}
+	} else {
+		out.Usage = nil
+	}
+	return nil
+}
+
+func Convert_v1alpha1_Metrics_To_metrics_Metrics(in *Metrics, out *metrics.Metrics, s conversion.Scope) error {
+	return autoConvert_v1alpha1_Metrics_To_metrics_Metrics(in, out, s)
+}
+
+func autoConvert_v1alpha1_Node_To_metrics_Node(in *Node, out *metrics.Node, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*Node))(in)
+	}
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if err := Convert_v1alpha1_Metrics_To_metrics_Metrics(&in.Metrics, &out.Metrics, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Convert_v1alpha1_Node_To_metrics_Node(in *Node, out *metrics.Node, s conversion.Scope) error {
+	return autoConvert_v1alpha1_Node_To_metrics_Node(in, out, s)
+}
+
+func autoConvert_v1alpha1_Pod_To_metrics_Pod(in *Pod, out *metrics.Pod, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*Pod))(in)
+	}
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if err := Convert_v1alpha1_Metrics_To_metrics_Metrics(&in.Metrics, &out.Metrics, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Convert_v1alpha1_Pod_To_metrics_Pod(in *Pod, out *metrics.Pod, s conversion.Scope) error {
+	return autoConvert_v1alpha1_Pod_To_metrics_Pod(in, out, s)
 }
 
 func autoConvert_v1alpha1_RawNode_To_metrics_RawNode(in *RawNode, out *metrics.RawNode, s conversion.Scope) error {
@@ -84,8 +329,16 @@ func Convert_v1alpha1_RawPod_To_metrics_RawPod(in *RawPod, out *metrics.RawPod, 
 
 func init() {
 	err := api.Scheme.AddGeneratedConversionFuncs(
+		autoConvert_api_ObjectMeta_To_v1_ObjectMeta,
+		autoConvert_metrics_Metrics_To_v1alpha1_Metrics,
+		autoConvert_metrics_Node_To_v1alpha1_Node,
+		autoConvert_metrics_Pod_To_v1alpha1_Pod,
 		autoConvert_metrics_RawNode_To_v1alpha1_RawNode,
 		autoConvert_metrics_RawPod_To_v1alpha1_RawPod,
+		autoConvert_v1_ObjectMeta_To_api_ObjectMeta,
+		autoConvert_v1alpha1_Metrics_To_metrics_Metrics,
+		autoConvert_v1alpha1_Node_To_metrics_Node,
+		autoConvert_v1alpha1_Pod_To_metrics_Pod,
 		autoConvert_v1alpha1_RawNode_To_metrics_RawNode,
 		autoConvert_v1alpha1_RawPod_To_metrics_RawPod,
 	)

--- a/pkg/apis/metrics/v1alpha1/register.go
+++ b/pkg/apis/metrics/v1alpha1/register.go
@@ -41,9 +41,13 @@ func addKnownTypes(scheme *runtime.Scheme) {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&RawNode{},
 		&RawPod{},
+		&Node{},
+		&Pod{},
 		&v1.DeleteOptions{},
 	)
 }
 
 func (obj *RawNode) GetObjectKind() unversioned.ObjectKind { return &obj.TypeMeta }
 func (obj *RawPod) GetObjectKind() unversioned.ObjectKind  { return &obj.TypeMeta }
+func (obj *Node) GetObjectKind() unversioned.ObjectKind    { return &obj.TypeMeta }
+func (obj *Pod) GetObjectKind() unversioned.ObjectKind     { return &obj.TypeMeta }

--- a/pkg/apis/metrics/v1alpha1/types.generated.go
+++ b/pkg/apis/metrics/v1alpha1/types.generated.go
@@ -25,9 +25,14 @@ import (
 	"errors"
 	"fmt"
 	codec1978 "github.com/ugorji/go/codec"
+	pkg4_resource "k8s.io/kubernetes/pkg/api/resource"
 	pkg1_unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	pkg2_v1 "k8s.io/kubernetes/pkg/api/v1"
+	pkg3_types "k8s.io/kubernetes/pkg/types"
 	"reflect"
 	"runtime"
+	pkg5_inf "speter.net/go/exp/math/dec/inf"
+	time "time"
 )
 
 const (
@@ -60,8 +65,13 @@ func init() {
 		panic(err)
 	}
 	if false { // reference the types, but skip this branch at build/run time
-		var v0 pkg1_unversioned.TypeMeta
-		_ = v0
+		var v0 pkg4_resource.Quantity
+		var v1 pkg1_unversioned.TypeMeta
+		var v2 pkg2_v1.ObjectMeta
+		var v3 pkg3_types.UID
+		var v4 pkg5_inf.Dec
+		var v5 time.Time
+		_, _, _, _, _, _ = v0, v1, v2, v3, v4, v5
 	}
 }
 
@@ -497,4 +507,1050 @@ func (x *RawPod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		z.DecStructFieldNotFound(yyj30-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym33 := z.EncBinary()
+		_ = yym33
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep34 := !z.EncBinary()
+			yy2arr34 := z.EncBasicHandle().StructToArray
+			var yyq34 [4]bool
+			_, _, _ = yysep34, yyq34, yy2arr34
+			const yyr34 bool = false
+			yyq34[0] = x.Kind != ""
+			yyq34[1] = x.APIVersion != ""
+			yyq34[2] = true
+			yyq34[3] = true
+			var yynn34 int
+			if yyr34 || yy2arr34 {
+				r.EncodeArrayStart(4)
+			} else {
+				yynn34 = 0
+				for _, b := range yyq34 {
+					if b {
+						yynn34++
+					}
+				}
+				r.EncodeMapStart(yynn34)
+				yynn34 = 0
+			}
+			if yyr34 || yy2arr34 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq34[0] {
+					yym36 := z.EncBinary()
+					_ = yym36
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq34[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym37 := z.EncBinary()
+					_ = yym37
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr34 || yy2arr34 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq34[1] {
+					yym39 := z.EncBinary()
+					_ = yym39
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq34[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym40 := z.EncBinary()
+					_ = yym40
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr34 || yy2arr34 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq34[2] {
+					yy42 := &x.ObjectMeta
+					yy42.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq34[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy43 := &x.ObjectMeta
+					yy43.CodecEncodeSelf(e)
+				}
+			}
+			if yyr34 || yy2arr34 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq34[3] {
+					yy45 := &x.Metrics
+					yy45.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq34[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("metrics"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy46 := &x.Metrics
+					yy46.CodecEncodeSelf(e)
+				}
+			}
+			if yyr34 || yy2arr34 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *Node) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym47 := z.DecBinary()
+	_ = yym47
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct48 := r.ContainerType()
+		if yyct48 == codecSelferValueTypeMap1234 {
+			yyl48 := r.ReadMapStart()
+			if yyl48 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl48, d)
+			}
+		} else if yyct48 == codecSelferValueTypeArray1234 {
+			yyl48 := r.ReadArrayStart()
+			if yyl48 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl48, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys49Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys49Slc
+	var yyhl49 bool = l >= 0
+	for yyj49 := 0; ; yyj49++ {
+		if yyhl49 {
+			if yyj49 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys49Slc = r.DecodeBytes(yys49Slc, true, true)
+		yys49 := string(yys49Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys49 {
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
+			}
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_v1.ObjectMeta{}
+			} else {
+				yyv52 := &x.ObjectMeta
+				yyv52.CodecDecodeSelf(d)
+			}
+		case "metrics":
+			if r.TryDecodeAsNil() {
+				x.Metrics = Metrics{}
+			} else {
+				yyv53 := &x.Metrics
+				yyv53.CodecDecodeSelf(d)
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys49)
+		} // end switch yys49
+	} // end for yyj49
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj54 int
+	var yyb54 bool
+	var yyhl54 bool = l >= 0
+	yyj54++
+	if yyhl54 {
+		yyb54 = yyj54 > l
+	} else {
+		yyb54 = r.CheckBreak()
+	}
+	if yyb54 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj54++
+	if yyhl54 {
+		yyb54 = yyj54 > l
+	} else {
+		yyb54 = r.CheckBreak()
+	}
+	if yyb54 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
+	}
+	yyj54++
+	if yyhl54 {
+		yyb54 = yyj54 > l
+	} else {
+		yyb54 = r.CheckBreak()
+	}
+	if yyb54 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_v1.ObjectMeta{}
+	} else {
+		yyv57 := &x.ObjectMeta
+		yyv57.CodecDecodeSelf(d)
+	}
+	yyj54++
+	if yyhl54 {
+		yyb54 = yyj54 > l
+	} else {
+		yyb54 = r.CheckBreak()
+	}
+	if yyb54 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Metrics = Metrics{}
+	} else {
+		yyv58 := &x.Metrics
+		yyv58.CodecDecodeSelf(d)
+	}
+	for {
+		yyj54++
+		if yyhl54 {
+			yyb54 = yyj54 > l
+		} else {
+			yyb54 = r.CheckBreak()
+		}
+		if yyb54 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj54-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x *Pod) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym59 := z.EncBinary()
+		_ = yym59
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep60 := !z.EncBinary()
+			yy2arr60 := z.EncBasicHandle().StructToArray
+			var yyq60 [4]bool
+			_, _, _ = yysep60, yyq60, yy2arr60
+			const yyr60 bool = false
+			yyq60[0] = x.Kind != ""
+			yyq60[1] = x.APIVersion != ""
+			yyq60[2] = true
+			yyq60[3] = true
+			var yynn60 int
+			if yyr60 || yy2arr60 {
+				r.EncodeArrayStart(4)
+			} else {
+				yynn60 = 0
+				for _, b := range yyq60 {
+					if b {
+						yynn60++
+					}
+				}
+				r.EncodeMapStart(yynn60)
+				yynn60 = 0
+			}
+			if yyr60 || yy2arr60 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq60[0] {
+					yym62 := z.EncBinary()
+					_ = yym62
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq60[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym63 := z.EncBinary()
+					_ = yym63
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr60 || yy2arr60 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq60[1] {
+					yym65 := z.EncBinary()
+					_ = yym65
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq60[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym66 := z.EncBinary()
+					_ = yym66
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr60 || yy2arr60 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq60[2] {
+					yy68 := &x.ObjectMeta
+					yy68.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq60[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy69 := &x.ObjectMeta
+					yy69.CodecEncodeSelf(e)
+				}
+			}
+			if yyr60 || yy2arr60 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq60[3] {
+					yy71 := &x.Metrics
+					yy71.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq60[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("metrics"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy72 := &x.Metrics
+					yy72.CodecEncodeSelf(e)
+				}
+			}
+			if yyr60 || yy2arr60 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *Pod) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym73 := z.DecBinary()
+	_ = yym73
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct74 := r.ContainerType()
+		if yyct74 == codecSelferValueTypeMap1234 {
+			yyl74 := r.ReadMapStart()
+			if yyl74 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl74, d)
+			}
+		} else if yyct74 == codecSelferValueTypeArray1234 {
+			yyl74 := r.ReadArrayStart()
+			if yyl74 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl74, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *Pod) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys75Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys75Slc
+	var yyhl75 bool = l >= 0
+	for yyj75 := 0; ; yyj75++ {
+		if yyhl75 {
+			if yyj75 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys75Slc = r.DecodeBytes(yys75Slc, true, true)
+		yys75 := string(yys75Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys75 {
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
+			}
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_v1.ObjectMeta{}
+			} else {
+				yyv78 := &x.ObjectMeta
+				yyv78.CodecDecodeSelf(d)
+			}
+		case "metrics":
+			if r.TryDecodeAsNil() {
+				x.Metrics = Metrics{}
+			} else {
+				yyv79 := &x.Metrics
+				yyv79.CodecDecodeSelf(d)
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys75)
+		} // end switch yys75
+	} // end for yyj75
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *Pod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj80 int
+	var yyb80 bool
+	var yyhl80 bool = l >= 0
+	yyj80++
+	if yyhl80 {
+		yyb80 = yyj80 > l
+	} else {
+		yyb80 = r.CheckBreak()
+	}
+	if yyb80 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj80++
+	if yyhl80 {
+		yyb80 = yyj80 > l
+	} else {
+		yyb80 = r.CheckBreak()
+	}
+	if yyb80 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
+	}
+	yyj80++
+	if yyhl80 {
+		yyb80 = yyj80 > l
+	} else {
+		yyb80 = r.CheckBreak()
+	}
+	if yyb80 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_v1.ObjectMeta{}
+	} else {
+		yyv83 := &x.ObjectMeta
+		yyv83.CodecDecodeSelf(d)
+	}
+	yyj80++
+	if yyhl80 {
+		yyb80 = yyj80 > l
+	} else {
+		yyb80 = r.CheckBreak()
+	}
+	if yyb80 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Metrics = Metrics{}
+	} else {
+		yyv84 := &x.Metrics
+		yyv84.CodecDecodeSelf(d)
+	}
+	for {
+		yyj80++
+		if yyhl80 {
+			yyb80 = yyj80 > l
+		} else {
+			yyb80 = r.CheckBreak()
+		}
+		if yyb80 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj80-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x *Metrics) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym85 := z.EncBinary()
+		_ = yym85
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep86 := !z.EncBinary()
+			yy2arr86 := z.EncBasicHandle().StructToArray
+			var yyq86 [3]bool
+			_, _, _ = yysep86, yyq86, yy2arr86
+			const yyr86 bool = false
+			var yynn86 int
+			if yyr86 || yy2arr86 {
+				r.EncodeArrayStart(3)
+			} else {
+				yynn86 = 3
+				for _, b := range yyq86 {
+					if b {
+						yynn86++
+					}
+				}
+				r.EncodeMapStart(yynn86)
+				yynn86 = 0
+			}
+			if yyr86 || yy2arr86 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yy88 := &x.StartTime
+				yym89 := z.EncBinary()
+				_ = yym89
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy88) {
+				} else if yym89 {
+					z.EncBinaryMarshal(yy88)
+				} else if !yym89 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy88)
+				} else {
+					z.EncFallback(yy88)
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("start"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yy90 := &x.StartTime
+				yym91 := z.EncBinary()
+				_ = yym91
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy90) {
+				} else if yym91 {
+					z.EncBinaryMarshal(yy90)
+				} else if !yym91 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy90)
+				} else {
+					z.EncFallback(yy90)
+				}
+			}
+			if yyr86 || yy2arr86 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yy93 := &x.EndTime
+				yym94 := z.EncBinary()
+				_ = yym94
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy93) {
+				} else if yym94 {
+					z.EncBinaryMarshal(yy93)
+				} else if !yym94 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy93)
+				} else {
+					z.EncFallback(yy93)
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("end"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yy95 := &x.EndTime
+				yym96 := z.EncBinary()
+				_ = yym96
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy95) {
+				} else if yym96 {
+					z.EncBinaryMarshal(yy95)
+				} else if !yym96 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy95)
+				} else {
+					z.EncFallback(yy95)
+				}
+			}
+			if yyr86 || yy2arr86 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if x.Usage == nil {
+					r.EncodeNil()
+				} else {
+					yym98 := z.EncBinary()
+					_ = yym98
+					if false {
+					} else if z.HasExtensions() && z.EncExt(x.Usage) {
+					} else {
+						h.encv1_ResourceList((pkg2_v1.ResourceList)(x.Usage), e)
+					}
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("usage"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				if x.Usage == nil {
+					r.EncodeNil()
+				} else {
+					yym99 := z.EncBinary()
+					_ = yym99
+					if false {
+					} else if z.HasExtensions() && z.EncExt(x.Usage) {
+					} else {
+						h.encv1_ResourceList((pkg2_v1.ResourceList)(x.Usage), e)
+					}
+				}
+			}
+			if yyr86 || yy2arr86 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *Metrics) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym100 := z.DecBinary()
+	_ = yym100
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct101 := r.ContainerType()
+		if yyct101 == codecSelferValueTypeMap1234 {
+			yyl101 := r.ReadMapStart()
+			if yyl101 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl101, d)
+			}
+		} else if yyct101 == codecSelferValueTypeArray1234 {
+			yyl101 := r.ReadArrayStart()
+			if yyl101 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl101, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *Metrics) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys102Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys102Slc
+	var yyhl102 bool = l >= 0
+	for yyj102 := 0; ; yyj102++ {
+		if yyhl102 {
+			if yyj102 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys102Slc = r.DecodeBytes(yys102Slc, true, true)
+		yys102 := string(yys102Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys102 {
+		case "start":
+			if r.TryDecodeAsNil() {
+				x.StartTime = pkg1_unversioned.Time{}
+			} else {
+				yyv103 := &x.StartTime
+				yym104 := z.DecBinary()
+				_ = yym104
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv103) {
+				} else if yym104 {
+					z.DecBinaryUnmarshal(yyv103)
+				} else if !yym104 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv103)
+				} else {
+					z.DecFallback(yyv103, false)
+				}
+			}
+		case "end":
+			if r.TryDecodeAsNil() {
+				x.EndTime = pkg1_unversioned.Time{}
+			} else {
+				yyv105 := &x.EndTime
+				yym106 := z.DecBinary()
+				_ = yym106
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv105) {
+				} else if yym106 {
+					z.DecBinaryUnmarshal(yyv105)
+				} else if !yym106 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv105)
+				} else {
+					z.DecFallback(yyv105, false)
+				}
+			}
+		case "usage":
+			if r.TryDecodeAsNil() {
+				x.Usage = nil
+			} else {
+				yyv107 := &x.Usage
+				yyv107.CodecDecodeSelf(d)
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys102)
+		} // end switch yys102
+	} // end for yyj102
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *Metrics) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj108 int
+	var yyb108 bool
+	var yyhl108 bool = l >= 0
+	yyj108++
+	if yyhl108 {
+		yyb108 = yyj108 > l
+	} else {
+		yyb108 = r.CheckBreak()
+	}
+	if yyb108 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.StartTime = pkg1_unversioned.Time{}
+	} else {
+		yyv109 := &x.StartTime
+		yym110 := z.DecBinary()
+		_ = yym110
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv109) {
+		} else if yym110 {
+			z.DecBinaryUnmarshal(yyv109)
+		} else if !yym110 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv109)
+		} else {
+			z.DecFallback(yyv109, false)
+		}
+	}
+	yyj108++
+	if yyhl108 {
+		yyb108 = yyj108 > l
+	} else {
+		yyb108 = r.CheckBreak()
+	}
+	if yyb108 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.EndTime = pkg1_unversioned.Time{}
+	} else {
+		yyv111 := &x.EndTime
+		yym112 := z.DecBinary()
+		_ = yym112
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv111) {
+		} else if yym112 {
+			z.DecBinaryUnmarshal(yyv111)
+		} else if !yym112 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv111)
+		} else {
+			z.DecFallback(yyv111, false)
+		}
+	}
+	yyj108++
+	if yyhl108 {
+		yyb108 = yyj108 > l
+	} else {
+		yyb108 = r.CheckBreak()
+	}
+	if yyb108 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Usage = nil
+	} else {
+		yyv113 := &x.Usage
+		yyv113.CodecDecodeSelf(d)
+	}
+	for {
+		yyj108++
+		if yyhl108 {
+			yyb108 = yyj108 > l
+		} else {
+			yyb108 = r.CheckBreak()
+		}
+		if yyb108 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj108-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x codecSelfer1234) encv1_ResourceList(v pkg2_v1.ResourceList, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeMapStart(len(v))
+	for yyk114, yyv114 := range v {
+		z.EncSendContainerState(codecSelfer_containerMapKey1234)
+		yym115 := z.EncBinary()
+		_ = yym115
+		if false {
+		} else if z.HasExtensions() && z.EncExt(yyk114) {
+		} else {
+			r.EncodeString(codecSelferC_UTF81234, string(yyk114))
+		}
+		z.EncSendContainerState(codecSelfer_containerMapValue1234)
+		yy116 := &yyv114
+		yym117 := z.EncBinary()
+		_ = yym117
+		if false {
+		} else if z.HasExtensions() && z.EncExt(yy116) {
+		} else if !yym117 && z.IsJSONHandle() {
+			z.EncJSONMarshal(yy116)
+		} else {
+			z.EncFallback(yy116)
+		}
+	}
+	z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x codecSelfer1234) decv1_ResourceList(v *pkg2_v1.ResourceList, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv118 := *v
+	yyl118 := r.ReadMapStart()
+	yybh118 := z.DecBasicHandle()
+	if yyv118 == nil {
+		yyrl118, _ := z.DecInferLen(yyl118, yybh118.MaxInitLen, 40)
+		yyv118 = make(map[pkg2_v1.ResourceName]pkg4_resource.Quantity, yyrl118)
+		*v = yyv118
+	}
+	var yymk118 pkg2_v1.ResourceName
+	var yymv118 pkg4_resource.Quantity
+	var yymg118 bool
+	if yybh118.MapValueReset {
+		yymg118 = true
+	}
+	if yyl118 > 0 {
+		for yyj118 := 0; yyj118 < yyl118; yyj118++ {
+			z.DecSendContainerState(codecSelfer_containerMapKey1234)
+			if r.TryDecodeAsNil() {
+				yymk118 = ""
+			} else {
+				yymk118 = pkg2_v1.ResourceName(r.DecodeString())
+			}
+
+			if yymg118 {
+				yymv118 = yyv118[yymk118]
+			} else {
+				yymv118 = pkg4_resource.Quantity{}
+			}
+			z.DecSendContainerState(codecSelfer_containerMapValue1234)
+			if r.TryDecodeAsNil() {
+				yymv118 = pkg4_resource.Quantity{}
+			} else {
+				yyv120 := &yymv118
+				yym121 := z.DecBinary()
+				_ = yym121
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv120) {
+				} else if !yym121 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv120)
+				} else {
+					z.DecFallback(yyv120, false)
+				}
+			}
+
+			if yyv118 != nil {
+				yyv118[yymk118] = yymv118
+			}
+		}
+	} else if yyl118 < 0 {
+		for yyj118 := 0; !r.CheckBreak(); yyj118++ {
+			z.DecSendContainerState(codecSelfer_containerMapKey1234)
+			if r.TryDecodeAsNil() {
+				yymk118 = ""
+			} else {
+				yymk118 = pkg2_v1.ResourceName(r.DecodeString())
+			}
+
+			if yymg118 {
+				yymv118 = yyv118[yymk118]
+			} else {
+				yymv118 = pkg4_resource.Quantity{}
+			}
+			z.DecSendContainerState(codecSelfer_containerMapValue1234)
+			if r.TryDecodeAsNil() {
+				yymv118 = pkg4_resource.Quantity{}
+			} else {
+				yyv123 := &yymv118
+				yym124 := z.DecBinary()
+				_ = yym124
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv123) {
+				} else if !yym124 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv123)
+				} else {
+					z.DecFallback(yyv123, false)
+				}
+			}
+
+			if yyv118 != nil {
+				yyv118[yymk118] = yymv118
+			}
+		}
+	} // else len==0: TODO: Should we clear map entries?
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }

--- a/pkg/apis/metrics/v1alpha1/types.go
+++ b/pkg/apis/metrics/v1alpha1/types.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package v1alpha1
 
-import "k8s.io/kubernetes/pkg/api/unversioned"
+import (
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/v1"
+)
 
 // Placeholder top-level node resource metrics.
 type RawNode struct {
@@ -26,4 +29,29 @@ type RawNode struct {
 // Placeholder top-level pod resource metrics.
 type RawPod struct {
 	unversioned.TypeMeta `json:",inline"`
+}
+
+// Node-level metrics.
+// TODO(piosz): move to a separate API group before promoting beta/GA.
+type Node struct {
+	unversioned.TypeMeta `json:",inline"`
+	v1.ObjectMeta        `json:"metadata,omitempty"`
+	Metrics              Metrics `json:"metrics,omitempty"`
+}
+
+// Pod-level metrics.
+// TODO(piosz): move to a separate API group before promoting beta/GA.
+type Pod struct {
+	unversioned.TypeMeta `json:",inline"`
+	v1.ObjectMeta        `json:"metadata,omitempty"`
+	Metrics              Metrics `json:"metrics,omitempty"`
+}
+
+// The latest available metrics for the appriopriate resource.
+type Metrics struct {
+	// StartTime and EndTime specifies the time window from which the response was returned.
+	StartTime unversioned.Time `json:"start"`
+	EndTime   unversioned.Time `json:"end"`
+	// List of available resources' usage.
+	Usage v1.ResourceList `json:"usage",omitempty`
 }


### PR DESCRIPTION
This PRs implement types defined in proposal #18824. The proposal is still in flight but we are reaching 1.2 feature freeze soon, so I created it.

The objects are defined in `metrics` API group defined by @timstclair but according to @erictune's https://github.com/kubernetes/kubernetes/pull/18824#discussion_r49902002 should be migrated to separate API groups before going to beta/GA.

cc @erictune @vishh @davidopp @fgrzadkowski @mwielgus @timstclair @kubernetes/goog-control-plane
