### PR TITLE
Stop test spew on non-Linux.

### DIFF
--- a/cmd/kube-proxy/app/server_test.go
+++ b/cmd/kube-proxy/app/server_test.go
@@ -18,6 +18,7 @@ package app
 
 import (
 	"fmt"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -45,6 +46,9 @@ func (fake *fakeIptablesVersioner) GetVersion() (string, error) {
 }
 
 func Test_getProxyMode(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("skipping on non-Linux")
+	}
 	var cases = []struct {
 		flag            string
 		annotationKey   string


### PR DESCRIPTION
Make kube-proxy test not run on non-linux to avoid
error spew.
