### PR TITLE
Update vagrant prereq to 1.7.4

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 # Require a recent version of vagrant otherwise some have reported errors setting host names on boxes
-Vagrant.require_version ">= 1.6.2"
+Vagrant.require_version ">= 1.7.4"
 
 if ARGV.first == "up" && ENV['USING_KUBE_SCRIPTS'] != 'true'
   raise Vagrant::Errors::VagrantError.new, <<END

--- a/docs/getting-started-guides/vagrant.md
+++ b/docs/getting-started-guides/vagrant.md
@@ -57,7 +57,7 @@ Running Kubernetes with Vagrant (and VirtualBox) is an easy way to run/test/deve
 
 ### Prerequisites
 
-1. Install latest version >= 1.6.2 of vagrant from http://www.vagrantup.com/downloads.html
+1. Install latest version >= 1.7.4 of vagrant from http://www.vagrantup.com/downloads.html
 2. Install one of:
    1. The latest version of Virtual Box from https://www.virtualbox.org/wiki/Downloads
    2. [VMWare Fusion](https://www.vmware.com/products/fusion/) version 5 or greater as well as the appropriate [Vagrant VMWare Fusion provider](https://www.vagrantup.com/vmware)


### PR DESCRIPTION
As part of the move to Fedora 23 boxes, we need to upgrade vagrant prereq to 1.7.4.

/cc @jayunit100 
