### PR TITLE
Fix serial jobs by using right project and using selectors properly

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -512,13 +512,8 @@ case ${JOB_NAME} in
     : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-serial"}
     : ${E2E_NETWORK:="jenkins-gce-e2e-serial"}
     : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=$(join_regex_no_empty \
-          \[Serial\] \
-          \[Disruptive\] \
-          \[Feature:Restart\] \
-          ) --ginkgo.skip=$(join_regex_no_empty \
-	  \[Flaky\]
-          )"}
+    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Serial\]|\[Disruptive\]|\[Feature:Restart\] \
+                           --ginkgo.skip=\[Flaky\]"}
     : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-serial"}
     : ${PROJECT:="kubernetes-jkns-e2e-gce-serial"}
     ;;
@@ -529,14 +524,9 @@ case ${JOB_NAME} in
     : ${E2E_NETWORK:="jenkins-gke-e2e-serial"}
     : ${E2E_SET_CLUSTER_API_VERSION:=y}
     : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=$(join_regex_no_empty \
-          \[Serial\] \
-          \[Disruptive\] \
-          \[Feature:Restart\] \
-          ) --ginkgo.skip=$(join_regex_no_empty \
-	  \[Flaky\]
-          )"}
-    : ${PROJECT:="kubernetes-jkns-e2e-gke-serial"}
+    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Serial\]|\[Disruptive\]|\[Feature:Restart\] \
+                           --ginkgo.skip=\[Flaky\]"}
+    : ${PROJECT:="jenkins-gke-e2e-serial"}
     ;;
 
   # Runs the performance/scalability tests on GCE. A larger cluster is used.


### PR DESCRIPTION
`join_regex_no_empty` was causing the `\[` to resolve to `[`, which meant no tests were running, because `\[Flaky\]` regex was becoming `[Flaky]`.

Also, I got the project name for `gke-e2e-serial` wrong.

@spxtr @ixdy Sorry about the spam.
