### PR TITLE
Update kubekins-test image to include netcat

### DIFF
--- a/hack/jenkins/gotest-dockerized.sh
+++ b/hack/jenkins/gotest-dockerized.sh
@@ -42,5 +42,5 @@ docker run --rm=true \
   -v "${REPO_DIR}":/go/src/k8s.io/kubernetes \
   -v "${KUBE_JUNIT_REPORT_DIR}":/workspace/artifacts \
   --env REPO_DIR="${REPO_DIR}" \
-  -i gcr.io/google_containers/kubekins-test:0.5 \
+  -i gcr.io/google_containers/kubekins-test:0.6 \
   bash -c "cd kubernetes && ./hack/jenkins/test-dockerized.sh"

--- a/hack/jenkins/test-image/Dockerfile
+++ b/hack/jenkins/test-image/Dockerfile
@@ -24,8 +24,12 @@ ENV TERM                    xterm
 WORKDIR /workspace
 
 RUN apt-get -o Acquire::Check-Valid-Until=false update && apt-get install -y rsync
+# file is used when uploading test artifacts to GCS.
+RUN apt-get install -y file
 # libapparmor1 is needed for docker-in-docker.
-RUN apt-get install -y file libapparmor1
+RUN apt-get install -y libapparmor1
+# netcat is used by integration test scripts.
+RUN apt-get install -y netcat-openbsd
 RUN mkdir -p /go/src/k8s.io/kubernetes
 RUN ln -s /go/src/k8s.io/kubernetes /workspace/kubernetes
 

--- a/hack/jenkins/test-image/Makefile
+++ b/hack/jenkins/test-image/Makefile
@@ -1,6 +1,6 @@
 all: push
 
-TAG = 0.5
+TAG = 0.6
 
 container:
 	docker build -t gcr.io/google_containers/kubekins-test .

--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -50,7 +50,7 @@ kube::util::wait_for_url() {
 
 # returns a random port
 kube::util::get_random_port() {
-  awk -v min=1 -v max=65535 'BEGIN{srand(); print int(min+rand()*(max-min+1))}'
+  awk -v min=1024 -v max=65535 'BEGIN{srand(); print int(min+rand()*(max-min+1))}'
 }
 
 # use netcat to check if the host($1):port($2) is free (return 0 means free, 1 means used)
@@ -65,7 +65,7 @@ kube::util::test_host_port_free() {
     return ${success}
   }
 
-  if [ ! $(nc -vz "${host} ${port}") ]; then
+  if [ ! $(nc -vz "${host}" "${port}") ]; then
     kube::log::status "${host}:${port} is free, proceeding..."
     return ${success}
   else


### PR DESCRIPTION
Also fix a small bug in `kube::util::get_random_port()` to return only unprivileged ports.

At least partially fixes #19252.

@janetkuo @nikhiljindal @lavalamp @kubernetes/goog-testing 
