### PR TITLE
Fix empty ADD update on kubelet restarts

### DIFF
--- a/pkg/kubelet/config/common.go
+++ b/pkg/kubelet/config/common.go
@@ -70,6 +70,9 @@ func applyDefaults(pod *api.Pod, source string, isFile bool, nodeName string) er
 	}
 	// The generated UID is the hash of the file.
 	pod.Annotations[kubetypes.ConfigHashAnnotationKey] = string(pod.UID)
+
+	// Set the default status to pending.
+	pod.Status.Phase = api.PodPending
 	return nil
 }
 

--- a/pkg/kubelet/config/file_test.go
+++ b/pkg/kubelet/config/file_test.go
@@ -93,6 +93,9 @@ func TestReadPodsFromFile(t *testing.T) {
 					Containers:      []api.Container{{Name: "image", Image: "test/image", SecurityContext: securitycontext.ValidSecurityContextWithContainerDefaults()}},
 					SecurityContext: &api.PodSecurityContext{},
 				},
+				Status: api.PodStatus{
+					Phase: api.PodPending,
+				},
 			},
 			expected: CreatePodUpdate(kubetypes.SET, kubetypes.FileSource, &api.Pod{
 				ObjectMeta: api.ObjectMeta{
@@ -114,6 +117,9 @@ func TestReadPodsFromFile(t *testing.T) {
 						ImagePullPolicy:        "Always",
 						SecurityContext:        securitycontext.ValidSecurityContextWithContainerDefaults()}},
 					SecurityContext: &api.PodSecurityContext{},
+				},
+				Status: api.PodStatus{
+					Phase: api.PodPending,
 				},
 			}),
 		},

--- a/pkg/kubelet/config/http_test.go
+++ b/pkg/kubelet/config/http_test.go
@@ -147,6 +147,9 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 					Containers:      []api.Container{{Name: "1", Image: "foo", ImagePullPolicy: api.PullAlways}},
 					SecurityContext: &api.PodSecurityContext{},
 				},
+				Status: api.PodStatus{
+					Phase: api.PodPending,
+				},
 			},
 			expected: CreatePodUpdate(kubetypes.SET,
 				kubetypes.HTTPSource,
@@ -172,6 +175,9 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 							ImagePullPolicy:        "Always",
 						}},
 					},
+					Status: api.PodStatus{
+						Phase: api.PodPending,
+					},
 				}),
 		},
 		{
@@ -192,6 +198,9 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 							Containers:      []api.Container{{Name: "1", Image: "foo", ImagePullPolicy: api.PullAlways}},
 							SecurityContext: &api.PodSecurityContext{},
 						},
+						Status: api.PodStatus{
+							Phase: api.PodPending,
+						},
 					},
 					{
 						ObjectMeta: api.ObjectMeta{
@@ -202,6 +211,9 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 							NodeName:        hostname,
 							Containers:      []api.Container{{Name: "2", Image: "bar:bartag", ImagePullPolicy: ""}},
 							SecurityContext: &api.PodSecurityContext{},
+						},
+						Status: api.PodStatus{
+							Phase: api.PodPending,
 						},
 					},
 				},
@@ -230,6 +242,9 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 							ImagePullPolicy:        "Always",
 						}},
 					},
+					Status: api.PodStatus{
+						Phase: api.PodPending,
+					},
 				},
 				&api.Pod{
 					ObjectMeta: api.ObjectMeta{
@@ -252,6 +267,9 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 							TerminationMessagePath: "/dev/termination-log",
 							ImagePullPolicy:        "IfNotPresent",
 						}},
+					},
+					Status: api.PodStatus{
+						Phase: api.PodPending,
 					},
 				}),
 		},


### PR DESCRIPTION
UPDATE: Changed the PR to correctly set the default PodStatus of the pods from non-apiserver sources. Verified the fix in an e2e cluster.

When kubelet restarts, it treats non-pending pods as UPDATEs (not ADD).
Fix the log in kubelet/config to _not_ send an empty ADD operation when there
are pods in UPDATE.
