### PR TITLE
Fix vagrant support for Fedora 23

### DIFF
--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -104,7 +104,7 @@ fi
 if ! which /usr/libexec/cockpit-ws &>/dev/null; then
 
   pushd /etc/yum.repos.d
-    wget https://copr.fedoraproject.org/coprs/sgallagh/cockpit-preview/repo/fedora-22/sgallagh-cockpit-preview-fedora-22.repo
+    curl -OL https://copr.fedorainfracloud.org/coprs/g/cockpit/cockpit-preview/repo/fedora-23/msuchy-cockpit-preview-fedora-23.repo
     dnf install -y cockpit cockpit-kubernetes
   popd
 

--- a/cluster/vagrant/provision-utils.sh
+++ b/cluster/vagrant/provision-utils.sh
@@ -95,6 +95,20 @@ function install-salt() {
   if ! which salt-call >/dev/null 2>&1; then
     # Install salt binaries
     curl -sS -L --connect-timeout 20 --retry 6 --retry-delay 10 https://bootstrap.saltstack.com | sh -s
+
+    # Fedora >= 23 includes salt packages but the bootstrap is
+    # creating configuration for a (non-existent) salt repo anyway.
+    # Remove the invalid repo to prevent dnf from warning about it on
+    # every update.  Assume this problem is specific to Fedora 23 and
+    # will fixed by the time another version of Fedora lands.
+    local fedora_version=$(grep 'VERSION_ID' /etc/os-release | sed 's+VERSION_ID=++')
+    if [[ "${fedora_version}" = '23' ]]; then
+      local repo_file='/etc/yum.repos.d/saltstack-salt-fedora-23.repo'
+      if [[ -f "${repo_file}" ]]; then
+        rm "${repo_file}"
+      fi
+    fi
+
   fi
 }
 


### PR DESCRIPTION
~~Fedora 21 is end-of-life as of 2015-12-01.  Updating to Fedora 23 to
ensure that those using vagrant+libvirt will be using a supported
release.  This change also updates the vagrant provision scripts to
support versions of Fedora other than 21.~~

Vagrant fixes for fedora 23
- wget is not installed by default on fedora 23.  Use curl instead since it is always available on recent Fedora.
- The repo url for cockpit resulted in an http redirect message being saved as the repo file which broke deployment.  Update the url to reflect the url that was redirected to.
- The main Fedora 23 repo includes salt packages, and there is no salt repo for 23. The salt bootstrap still creates a repo file for a nonexistent repo, though, and this change removes it to avoid having dnf report an error on every update.

This should also resolve #19834 

I've filed an issue for the salt bootstrapping problem: https://github.com/saltstack/salt-bootstrap/issues/736
