### PR TITLE
Don't handle graceful deletion of mirror pods in status manager

### DIFF
--- a/pkg/kubelet/status/manager.go
+++ b/pkg/kubelet/status/manager.go
@@ -370,7 +370,10 @@ func (m *manager) syncPod(uid types.UID, status versionedPodStatus) {
 		if err == nil {
 			glog.V(3).Infof("Status for pod %q updated successfully: %+v", format.Pod(pod), status)
 			m.apiStatusVersions[pod.UID] = status.version
-
+			if kubepod.IsMirrorPod(pod) {
+				// We don't handle graceful deletion of mirror pods.
+				return
+			}
 			if pod.DeletionTimestamp == nil {
 				return
 			}


### PR DESCRIPTION
This partially addresses https://github.com/kubernetes/kubernetes/pull/19436#issuecomment-172982445
