### PR TITLE
Pin golang build to 1.4.2 instead of floating on 1.4 and force pull the base golang image

### DIFF
--- a/build/build-image/cross/Dockerfile
+++ b/build/build-image/cross/Dockerfile
@@ -15,7 +15,7 @@
 # This file creates a standard build environment for building cross
 # platform go binary for the architecture kubernetes cares about.
 
-FROM  golang:1.4
+FROM  golang:1.4.2
 MAINTAINER  Joe Beda <jbeda@google.com>
 
 ENV KUBE_CROSSPLATFORMS \


### PR DESCRIPTION
We've experienced some performance regressions since latest golang went from 1.4.2 to 1.4.3.  We should pin at a known-good version, at least for now. (#17524)
