### PR TITLE
clientcmd: remove needless format specifier in a log

### DIFF
--- a/pkg/client/unversioned/clientcmd/client_config.go
+++ b/pkg/client/unversioned/clientcmd/client_config.go
@@ -356,7 +356,7 @@ func BuildConfigFromFlags(masterUrl, kubeconfigPath string) (*client.Config, err
 		if err == nil {
 			return kubeconfig, nil
 		}
-		glog.Warning("error creating inClusterConfig, falling back to default config: %v", err)
+		glog.Warning("error creating inClusterConfig, falling back to default config: ", err)
 	}
 
 	return NewNonInteractiveDeferredLoadingClientConfig(


### PR DESCRIPTION
Current BuildConfigFromFlags() seems to print a log like below when
config path isn't specified:

```
W0120 15:30:06.196820   13323 client_config.go:359] error creating
inClusterConfig, falling back to default config: %vunable to load
in-cluster configuration, KUBERNETES_SERVICE_HOST and
KUBERNETES_SERVICE_PORT must be defined
```

This commit removes the needless "%v"
