### PR TITLE
AWS: Eliminate assumptions about all load-balancer ports matching

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -1700,9 +1700,10 @@ func (s *AWSCloud) EnsureLoadBalancer(name, region string, publicIP net.IP, port
 		return nil, fmt.Errorf("requested load balancer with no ports")
 	}
 
-	// The service controller verified all the protocols match on the ports, just check and use the first one
-	if ports[0].Protocol != api.ProtocolTCP {
-		return nil, fmt.Errorf("Only TCP LoadBalancer is supported for AWS ELB")
+	for _, port := range ports {
+		if port.Protocol != api.ProtocolTCP {
+			return nil, fmt.Errorf("Only TCP LoadBalancer is supported for AWS ELB")
+		}
 	}
 
 	if publicIP != nil {


### PR DESCRIPTION
It costs us basically nothing to just check all the ports, and
protects us against future changes to the controller.
