### PR TITLE
AWS: Fix the docker-engine package name

### DIFF
--- a/cluster/saltbase/salt/docker/init.sls
+++ b/cluster/saltbase/salt/docker/init.sls
@@ -113,8 +113,8 @@ net.ipv4.ip_forward:
    and grains.get('os_family', '') == 'Debian'
    and grains.get('oscodename', '') == 'vivid' -%}
 # TODO: Get from google storage?
-{% set docker_pkg_name='docker-engine-1.8.3' %}
-{% set override_docker_ver='1.8.3' %}
+{% set docker_pkg_name='docker-engine' %}
+{% set override_docker_ver='1.8.3-0~vivid' %}
 {% set override_deb='docker-engine_1.8.3-0~vivid_amd64.deb' %}
 {% set override_deb_url='http://apt.dockerproject.org/repo/pool/main/d/docker-engine/docker-engine_1.8.3-0~vivid_amd64.deb' %}
 {% set override_deb_sha1='f0259b1f04635977325c0cfa7c0006e1e5de1341' %}


### PR DESCRIPTION
I got the package name wrong before, which meant that salt was failing
on invocations after the first (the name apparently doesn't matter on
the first invocation).
