### PR TITLE
Salt: force service provider to systemd if systemd

### DIFF
--- a/cluster/saltbase/salt/kube-addons/init.sls
+++ b/cluster/saltbase/salt/kube-addons/init.sls
@@ -212,3 +212,7 @@ kube-addons:
 {% else %}
       - file: /etc/init.d/kube-addons
 {% endif %}
+{% if pillar.get('is_systemd') %}
+    - provider:
+      - service: systemd
+{%- endif %}

--- a/cluster/saltbase/salt/kubelet/init.sls
+++ b/cluster/saltbase/salt/kubelet/init.sls
@@ -79,3 +79,7 @@ kubelet:
 {% endif %}
       - file: {{ environment_file }}
       - file: /var/lib/kubelet/kubeconfig
+{% if pillar.get('is_systemd') %}
+    - provider:
+      - service: systemd
+{%- endif %}


### PR DESCRIPTION
The version of Salt we're running doesn't do a good job of detecting
systemd.  Inspired by https://github.com/saltstack/salt/issues/13926,
I added a provider-force to the services.

With this change, salt-call -l debug state.highstate succeeds, even for
repeated invocations.

The issue was (probably) benign, but definitely caused noised (e.g. #11297)
