### PR TITLE
Add kubernetes.tar.gz to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ kubernetes/
 
 # direnv .envrc files
 .envrc
+
+# Downloaded kubernetes binary release tar ball
+kubernetes.tar.gz


### PR DESCRIPTION
This patch avoids adding kubernetes.tar.gz to git staging as it gets downloaded during get-kube.sh script.
