### PR TITLE
MESOS: conformance fix: scheduler name should match api.DefaultSchedulerName

### DIFF
--- a/contrib/mesos/pkg/scheduler/service/service.go
+++ b/contrib/mesos/pkg/scheduler/service/service.go
@@ -785,7 +785,8 @@ func (s *SchedulerServer) bootstrap(hks hyperkube.Interface, sc *schedcfg.Config
 
 	// create event recorder sending events to the "" namespace of the apiserver
 	broadcaster := record.NewBroadcaster()
-	recorder := broadcaster.NewRecorder(api.EventSource{Component: "scheduler"})
+	recorder := broadcaster.NewRecorder(api.EventSource{Component: api.DefaultSchedulerName})
+	broadcaster.StartLogging(log.Infof)
 	broadcaster.StartRecordingToSink(client.Events(""))
 
 	// create scheduler core with all components arranged around it


### PR DESCRIPTION
fixes k8s/mesos conformance bug: https://github.com/mesosphere/kubernetes-mesos/issues/735
- use the default scheduler name from the API when generating events
- also start logging events to Infof
