### PR TITLE
Improve the concurrency management in the service controller.

### DIFF
--- a/pkg/controller/service/servicecontroller_test.go
+++ b/pkg/controller/service/servicecontroller_test.go
@@ -217,7 +217,7 @@ func TestUpdateNodesInExternalLoadBalancer(t *testing.T) {
 
 		var services []*cachedService
 		for _, service := range item.services {
-			services = append(services, &cachedService{lastState: service, appliedState: service})
+			services = append(services, &cachedService{lastReceivedState: service, lastAppliedState: service})
 		}
 		if err := controller.updateLoadBalancerHosts(services, hosts); err != nil {
 			t.Errorf("unexpected error: %v", err)


### PR DESCRIPTION
This is a refactor that should fix an existing broken edge case where
a retried delta could get added back to the queue after an unrelated
legitimate update to the service.

I was originally planning to use the keymutex class for this, but we
don't want to block our worker threads on waiting for other worker
threads, so I've used a 1-item channel as a semaphore that we can try
to grab without blocking on.

I've had this code sitting around for a few days while trying to get e2e tests to work at all for me, but am just giving up for the moment by opening #19878 and letting the PR builder test this for now until I can get them to run locally.

@cjcullen @saad-ali
