### PR TITLE
add dockertools.LabelFactory and associated config for customizing docker runtime of Kubelet

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -195,6 +195,7 @@ func UnsecuredKubeletConfig(s *options.KubeletServer) (*KubeletConfig, error) {
 		DockerClient:              dockertools.ConnectToDockerOrDie(s.DockerEndpoint),
 		DockerDaemonContainer:     s.DockerDaemonContainer,
 		DockerExecHandler:         dockerExecHandler,
+		DockerLabelFactory:        dockertools.DefaultLabelFactory(),
 		EnableDebuggingHandlers:   s.EnableDebuggingHandlers,
 		EnableServer:              s.EnableServer,
 		EventBurst:                s.EventBurst,
@@ -494,6 +495,7 @@ func SimpleKubelet(client *client.Client,
 		DockerClient:              dockerClient,
 		DockerDaemonContainer:     "/docker-daemon",
 		DockerExecHandler:         &dockertools.NativeExecHandler{},
+		DockerLabelFactory:        dockertools.DefaultLabelFactory(),
 		EnableDebuggingHandlers:   true,
 		EnableServer:              true,
 		FileCheckFrequency:        fileCheckFrequency,
@@ -670,6 +672,7 @@ type KubeletConfig struct {
 	DockerClient                   dockertools.DockerInterface
 	DockerDaemonContainer          string
 	DockerExecHandler              dockertools.ExecHandler
+	DockerLabelFactory             dockertools.LabelFactory
 	EnableDebuggingHandlers        bool
 	EnableServer                   bool
 	EventClient                    *client.Client
@@ -817,6 +820,7 @@ func CreateAndInitKubelet(kc *KubeletConfig) (k KubeletBootstrap, pc *config.Pod
 		kc.ExperimentalFlannelOverlay,
 		kc.NodeIP,
 		kc.Reservation,
+		kc.DockerLabelFactory,
 	)
 
 	if err != nil {

--- a/pkg/kubelet/dockertools/fake_manager.go
+++ b/pkg/kubelet/dockertools/fake_manager.go
@@ -47,7 +47,7 @@ func NewFakeDockerManager(
 	fakeProcFs := procfs.NewFakeProcFS()
 	dm := NewDockerManager(client, recorder, livenessManager, containerRefManager, machineInfo, podInfraContainerImage, qps,
 		burst, containerLogsDir, osInterface, networkPlugin, generator, httpClient, &NativeExecHandler{},
-		fakeOOMAdjuster, fakeProcFs, false, imageBackOff, true)
+		fakeOOMAdjuster, fakeProcFs, false, imageBackOff, true, DefaultLabelFactory())
 	dm.dockerPuller = &FakeDockerPuller{}
 	return dm
 }

--- a/pkg/kubelet/dockertools/labels.go
+++ b/pkg/kubelet/dockertools/labels.go
@@ -49,6 +49,8 @@ const (
 	kubernetesPodLabel = "io.kubernetes.pod.data"
 )
 
+type LabelFactory func(_ *api.Container, _ *api.Pod, restartCount int) map[string]string
+
 // Container information which has been labelled on each docker container
 // TODO(random-liu): The type of Hash should be compliance with kubelet container status.
 type labelledContainerInfo struct {
@@ -62,6 +64,10 @@ type labelledContainerInfo struct {
 	RestartCount              int
 	TerminationMessagePath    string
 	PreStopHandler            *api.Handler
+}
+
+func DefaultLabelFactory() LabelFactory {
+	return newLabels
 }
 
 func newLabels(container *api.Container, pod *api.Pod, restartCount int) map[string]string {

--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -142,6 +142,9 @@ type DockerManager struct {
 
 	// Container GC manager
 	containerGC *containerGC
+
+	// build a set of labels for a pod/container
+	labelFactory LabelFactory
 }
 
 func NewDockerManager(
@@ -163,7 +166,8 @@ func NewDockerManager(
 	procFs procfs.ProcFSInterface,
 	cpuCFSQuota bool,
 	imageBackOff *util.Backoff,
-	serializeImagePulls bool) *DockerManager {
+	serializeImagePulls bool,
+	labelFactory LabelFactory) *DockerManager {
 
 	// Work out the location of the Docker runtime, defaulting to /var/lib/docker
 	// if there are any problems.
@@ -215,6 +219,7 @@ func NewDockerManager(
 		oomAdjuster:            oomAdjuster,
 		procFs:                 procFs,
 		cpuCFSQuota:            cpuCFSQuota,
+		labelFactory:           labelFactory,
 	}
 	dm.runner = lifecycle.NewHandlerRunner(httpClient, dm, dm)
 	if serializeImagePulls {
@@ -650,7 +655,7 @@ func (dm *DockerManager) runContainer(
 	// Pod information is recorded on the container as labels to preserve it in the event the pod is deleted
 	// while the Kubelet is down and there is no information available to recover the pod.
 	// TODO: keep these labels up to date if the pod changes
-	labels := newLabels(container, pod, restartCount)
+	labels := dm.labelFactory(container, pod, restartCount)
 
 	// TODO(random-liu): Remove this when we start to use new labels for KillContainerInPod
 	if container.Lifecycle != nil && container.Lifecycle.PreStop != nil {

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -196,6 +196,7 @@ func NewMainKubelet(
 	flannelExperimentalOverlay bool,
 	nodeIP net.IP,
 	reservation kubetypes.Reservation,
+	dockerLabelFactory dockertools.LabelFactory,
 ) (*Kubelet, error) {
 	if rootDirectory == "" {
 		return nil, fmt.Errorf("invalid root directory %q", rootDirectory)
@@ -364,6 +365,7 @@ func NewMainKubelet(
 			klet.cpuCFSQuota,
 			imageBackOff,
 			serializeImagePulls,
+			dockerLabelFactory,
 		)
 
 		klet.pleg = pleg.NewGenericPLEG(klet.containerRuntime, plegChannelCapacity, plegRelistPeriod, nil)


### PR DESCRIPTION
- new dockertools.LabelFactory type
- NewKubelet() accepts a label-factory as an init parameter, passes to dockertools.DockerManager
- default label factory is dockertools.newLabels (existing func that creates the labels map)

xref https://github.com/mesosphere/kubernetes-mesos/issues/739
