### PR TITLE
Adding an example for an independent apiserver

### DIFF
--- a/cmd/libs/go2idl/client-gen/testdata/apis/testgroup/install/install.go
+++ b/cmd/libs/go2idl/client-gen/testdata/apis/testgroup/install/install.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/sets"
 )
 
-const importPrefix = "k8s.io/kubernetes/pkg/apis/testgroup"
+const importPrefix = "k8s.io/kubernetes/cmd/libs/go2idl/client-gen/testdata/apis/testgroup"
 
 var accessor = meta.NewAccessor()
 

--- a/cmd/libs/go2idl/client-gen/testdata/apis/testgroup/v1/register.go
+++ b/cmd/libs/go2idl/client-gen/testdata/apis/testgroup/v1/register.go
@@ -40,7 +40,10 @@ func addKnownTypes(scheme *runtime.Scheme) {
 	)
 
 	scheme.AddKnownTypes(SchemeGroupVersion,
-		&v1.ListOptions{})
+		&v1.ListOptions{},
+		&v1.DeleteOptions{},
+		&unversioned.Status{},
+		&v1.ExportOptions{})
 }
 
 func (obj *TestType) GetObjectKind() unversioned.ObjectKind     { return &obj.TypeMeta }

--- a/examples/apiserver/README.md
+++ b/examples/apiserver/README.md
@@ -1,0 +1,45 @@
+<!-- BEGIN MUNGE: UNVERSIONED_WARNING -->
+
+<!-- BEGIN STRIP_FOR_RELEASE -->
+
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+
+<h2>PLEASE NOTE: This document applies to the HEAD of the source tree</h2>
+
+If you are using a released version of Kubernetes, you should
+refer to the docs that go with that version.
+
+Documentation for other releases can be found at
+[releases.k8s.io](http://releases.k8s.io).
+</strong>
+--
+
+<!-- END STRIP_FOR_RELEASE -->
+
+<!-- END MUNGE: UNVERSIONED_WARNING -->
+
+# API Server
+
+This is a work in progress example for an API Server.
+We are working on isolating the generic api server code from kubernetes specific
+API objects. Some relevant issues:
+
+* https://github.com/kubernetes/kubernetes/issues/17412
+* https://github.com/kubernetes/kubernetes/issues/2742
+* https://github.com/kubernetes/kubernetes/issues/13541
+
+This code here is to examplify what it takes to write your own API server.
+
+
+<!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/examples/apiserver/README.md?pixel)]()
+<!-- END MUNGE: GENERATED_ANALYTICS -->

--- a/examples/apiserver/rest/reststorage.go
+++ b/examples/apiserver/rest/reststorage.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"k8s.io/kubernetes/cmd/libs/go2idl/client-gen/testdata/apis/testgroup"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/registry/generic"
+	etcdgeneric "k8s.io/kubernetes/pkg/registry/generic/etcd"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
+)
+
+type REST struct {
+	*etcdgeneric.Etcd
+}
+
+// NewREST returns a RESTStorage object that will work with testtype.
+func NewREST(s storage.Interface, storageDecorator generic.StorageDecorator) *REST {
+	prefix := "/testtype"
+	newListFunc := func() runtime.Object { return &testgroup.TestTypeList{} }
+	storageInterface := storageDecorator(
+		s, 100, &testgroup.TestType{}, prefix, false, newListFunc)
+	store := &etcdgeneric.Etcd{
+		NewFunc: func() runtime.Object { return &testgroup.TestType{} },
+		// NewListFunc returns an object capable of storing results of an etcd list.
+		NewListFunc: newListFunc,
+		// Produces a path that etcd understands, to the root of the resource
+		// by combining the namespace in the context with the given prefix.
+		KeyRootFunc: func(ctx api.Context) string {
+			return etcdgeneric.NamespaceKeyRootFunc(ctx, prefix)
+		},
+		// Produces a path that etcd understands, to the resource by combining
+		// the namespace in the context with the given prefix.
+		KeyFunc: func(ctx api.Context, name string) (string, error) {
+			return etcdgeneric.NamespaceKeyFunc(ctx, prefix, name)
+		},
+		// Retrieve the name field of the resource.
+		ObjectNameFunc: func(obj runtime.Object) (string, error) {
+			return obj.(*testgroup.TestType).Name, nil
+		},
+		// Used to match objects based on labels/fields for list.
+		PredicateFunc: func(label labels.Selector, field fields.Selector) generic.Matcher {
+			return generic.MatcherFunc(nil)
+		},
+		Storage: storageInterface,
+	}
+	return &REST{store}
+}

--- a/examples/apiserver/server.go
+++ b/examples/apiserver/server.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/cmd/libs/go2idl/client-gen/testdata/apis/testgroup/v1"
+	testgroupetcd "k8s.io/kubernetes/examples/apiserver/rest"
+	"k8s.io/kubernetes/pkg/api/rest"
+	"k8s.io/kubernetes/pkg/apimachinery"
+	"k8s.io/kubernetes/pkg/apimachinery/registered"
+	"k8s.io/kubernetes/pkg/genericapiserver"
+	etcdstorage "k8s.io/kubernetes/pkg/storage/etcd"
+
+	// Install the testgroup API
+	_ "k8s.io/kubernetes/cmd/libs/go2idl/client-gen/testdata/apis/testgroup/install"
+)
+
+func newStorageDestinations(groupName string, groupMeta *apimachinery.GroupMeta) (*genericapiserver.StorageDestinations, error) {
+	storageDestinations := genericapiserver.NewStorageDestinations()
+	var storageConfig etcdstorage.EtcdConfig
+	storageConfig.ServerList = []string{"http://127.0.0.1:4001"}
+	storageConfig.Prefix = genericapiserver.DefaultEtcdPathPrefix
+	storageConfig.Codec = groupMeta.Codec
+	storageInterface, err := storageConfig.NewStorage()
+	if err != nil {
+		return nil, err
+	}
+	storageDestinations.AddAPIGroup(groupName, storageInterface)
+	return &storageDestinations, nil
+}
+
+func main() {
+	config := genericapiserver.Config{
+		EnableIndex:    true,
+		APIPrefix:      "/api",
+		APIGroupPrefix: "/apis",
+	}
+	s := genericapiserver.New(&config)
+
+	groupVersion := v1.SchemeGroupVersion
+	groupName := groupVersion.Group
+	groupMeta, err := registered.Group(groupName)
+	if err != nil {
+		glog.Fatalf("%v", err)
+	}
+	storageDestinations, err := newStorageDestinations(groupName, groupMeta)
+	if err != nil {
+		glog.Fatalf("Unable to init etcd: %v", err)
+	}
+	restStorageMap := map[string]rest.Storage{
+		"testtypes": testgroupetcd.NewREST(storageDestinations.Get(groupName, "testtype"), s.StorageDecorator()),
+	}
+	apiGroupInfo := genericapiserver.APIGroupInfo{
+		GroupMeta: *groupMeta,
+		VersionedResourcesStorageMap: map[string]map[string]rest.Storage{
+			groupVersion.Version: restStorageMap,
+		},
+	}
+	if err := s.InstallAPIGroups([]genericapiserver.APIGroupInfo{apiGroupInfo}); err != nil {
+		glog.Fatalf("Error in installing API: %v", err)
+	}
+	s.Run(genericapiserver.NewServerRunOptions())
+}


### PR DESCRIPTION
Adding an example for an independent apiserver.

This exemplifies what it takes to write your own apiserver and will help us prioritize what all we need to improve.

cc @kubernetes/sig-api-machinery @lavalamp @smarterclayton @caesarxuchao 
