### PR TITLE
Remove RuntimeCache from sync path

### DIFF
--- a/pkg/kubelet/container/fake_cache.go
+++ b/pkg/kubelet/container/fake_cache.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package container
+
+import (
+	"time"
+
+	"k8s.io/kubernetes/pkg/types"
+)
+
+type fakeCache struct {
+	runtime Runtime
+}
+
+func NewFakeCache(runtime Runtime) Cache {
+	return &fakeCache{runtime: runtime}
+}
+
+func (c *fakeCache) Get(id types.UID) (*PodStatus, error) {
+	return c.runtime.GetPodStatus(id, "", "")
+}
+
+func (c *fakeCache) GetNewerThan(id types.UID, minTime time.Time) (*PodStatus, error) {
+	return c.Get(id)
+}
+
+func (c *fakeCache) Set(id types.UID, status *PodStatus, err error, timestamp time.Time) {
+}
+
+func (c *fakeCache) Delete(id types.UID) {
+}
+
+func (c *fakeCache) UpdateTime(_ time.Time) {
+}

--- a/pkg/kubelet/fake_pod_workers.go
+++ b/pkg/kubelet/fake_pod_workers.go
@@ -26,17 +26,17 @@ import (
 // fakePodWorkers runs sync pod function in serial, so we can have
 // deterministic behaviour in testing.
 type fakePodWorkers struct {
-	syncPodFn    syncPodFnType
-	runtimeCache kubecontainer.RuntimeCache
-	t            TestingInterface
+	syncPodFn syncPodFnType
+	cache     kubecontainer.Cache
+	t         TestingInterface
 }
 
 func (f *fakePodWorkers) UpdatePod(pod *api.Pod, mirrorPod *api.Pod, updateType kubetypes.SyncPodType, updateComplete func()) {
-	pods, err := f.runtimeCache.GetPods()
+	status, err := f.cache.Get(pod.UID)
 	if err != nil {
 		f.t.Errorf("Unexpected error: %v", err)
 	}
-	if err := f.syncPodFn(pod, mirrorPod, kubecontainer.Pods(pods).FindPodByID(pod.UID), kubetypes.SyncPodUpdate); err != nil {
+	if err := f.syncPodFn(pod, mirrorPod, status, kubetypes.SyncPodUpdate); err != nil {
 		f.t.Errorf("Unexpected error: %v", err)
 	}
 }

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -447,7 +447,7 @@ func NewMainKubelet(
 	klet.runtimeCache = runtimeCache
 	klet.reasonCache = NewReasonCache()
 	klet.workQueue = queue.NewBasicWorkQueue()
-	klet.podWorkers = newPodWorkers(runtimeCache, klet.syncPod, recorder, klet.workQueue, klet.resyncInterval, backOffPeriod, klet.podCache)
+	klet.podWorkers = newPodWorkers(klet.syncPod, recorder, klet.workQueue, klet.resyncInterval, backOffPeriod, klet.podCache)
 
 	klet.backOff = util.NewBackOff(backOffPeriod, MaxContainerBackOff)
 	klet.podKillingCh = make(chan *kubecontainer.Pod, podKillingChannelCapacity)
@@ -1571,9 +1571,16 @@ func parseResolvConf(reader io.Reader, dnsScrubber dnsScrubber) (nameservers []s
 	return nameservers, searches, nil
 }
 
-// Kill all running containers in a pod (includes the pod infra container).
-func (kl *Kubelet) killPod(pod *api.Pod, runningPod kubecontainer.Pod) error {
-	return kl.containerRuntime.KillPod(pod, runningPod)
+// One of the following aruguements must be non-nil: runningPod, status.
+// TODO: Modify containerRuntime.KillPod() to accept the right arguements.
+func (kl *Kubelet) killPod(pod *api.Pod, runningPod *kubecontainer.Pod, status *kubecontainer.PodStatus) error {
+	var p kubecontainer.Pod
+	if runningPod != nil {
+		p = *runningPod
+	} else if status != nil {
+		p = kubecontainer.ConvertPodStatusToRunningPod(status)
+	}
+	return kl.containerRuntime.KillPod(pod, p)
 }
 
 type empty struct{}
@@ -1593,8 +1600,7 @@ func (kl *Kubelet) makePodDataDirs(pod *api.Pod) error {
 	return nil
 }
 
-// TODO: Remove runningPod from the arguments.
-func (kl *Kubelet) syncPod(pod *api.Pod, mirrorPod *api.Pod, runningPod kubecontainer.Pod, updateType kubetypes.SyncPodType) error {
+func (kl *Kubelet) syncPod(pod *api.Pod, mirrorPod *api.Pod, podStatus *kubecontainer.PodStatus, updateType kubetypes.SyncPodType) error {
 	var firstSeenTime time.Time
 	if firstSeenTimeStr, ok := pod.Annotations[kubetypes.ConfigFirstSeenAnnotationKey]; ok {
 		firstSeenTime = kubetypes.ConvertToTimestamp(firstSeenTimeStr).Get()
@@ -1610,29 +1616,21 @@ func (kl *Kubelet) syncPod(pod *api.Pod, mirrorPod *api.Pod, runningPod kubecont
 		}
 	}
 
-	// Query the container runtime (or cache) to retrieve the pod status, and
-	// update it in the status manager.
-	podStatus, statusErr := kl.getRuntimePodStatus(pod)
-	apiPodStatus, err := kl.generatePodStatus(pod, podStatus, statusErr)
+	apiPodStatus, err := kl.generatePodStatus(pod, podStatus)
 	if err != nil {
 		return err
 	}
 	// Record the time it takes for the pod to become running.
 	existingStatus, ok := kl.statusManager.GetPodStatus(pod.UID)
-	// TODO: The logic seems wrong since the pod phase can become pending when
-	// the container runtime is temporarily not available.
-	if statusErr == nil && !ok || existingStatus.Phase == api.PodPending && apiPodStatus.Phase == api.PodRunning &&
+	if !ok || existingStatus.Phase == api.PodPending && apiPodStatus.Phase == api.PodRunning &&
 		!firstSeenTime.IsZero() {
 		metrics.PodStartLatency.Observe(metrics.SinceInMicroseconds(firstSeenTime))
 	}
 	kl.statusManager.SetPodStatus(pod, apiPodStatus)
-	if statusErr != nil {
-		return statusErr
-	}
 
 	// Kill pods we can't run.
 	if err := canRunPod(pod); err != nil || pod.DeletionTimestamp != nil {
-		if err := kl.killPod(pod, runningPod); err != nil {
+		if err := kl.killPod(pod, nil, podStatus); err != nil {
 			utilruntime.HandleError(err)
 		}
 		return err
@@ -2100,7 +2098,7 @@ func (kl *Kubelet) podKiller() {
 					ch <- pod.ID
 				}()
 				glog.V(2).Infof("Killing unwanted pod %q", pod.Name)
-				err := kl.killPod(nil, *pod)
+				err := kl.killPod(nil, pod, nil)
 				if err != nil {
 					glog.Errorf("Failed killing the pod %q: %v", pod.Name, err)
 				}
@@ -3092,7 +3090,7 @@ func (kl *Kubelet) getRuntimePodStatus(pod *api.Pod) (*kubecontainer.PodStatus, 
 	return kl.containerRuntime.GetPodStatus(pod.UID, pod.Name, pod.Namespace)
 }
 
-func (kl *Kubelet) generatePodStatus(pod *api.Pod, podStatus *kubecontainer.PodStatus, statusErr error) (api.PodStatus, error) {
+func (kl *Kubelet) generatePodStatus(pod *api.Pod, podStatus *kubecontainer.PodStatus) (api.PodStatus, error) {
 	glog.V(3).Infof("Generating status for %q", format.Pod(pod))
 	// TODO: Consider include the container information.
 	if kl.pastActiveDeadline(pod) {
@@ -3104,16 +3102,6 @@ func (kl *Kubelet) generatePodStatus(pod *api.Pod, podStatus *kubecontainer.PodS
 			Message: "Pod was active on the node longer than specified deadline"}, nil
 	}
 
-	if statusErr != nil {
-		// TODO: Re-evaluate whether we should set the status to "Pending".
-		glog.Infof("Query container info for pod %q failed with error (%v)", format.Pod(pod), statusErr)
-		return api.PodStatus{
-			Phase:   api.PodPending,
-			Reason:  "GeneralError",
-			Message: fmt.Sprintf("Query container info failed with error (%v)", statusErr),
-		}, nil
-	}
-	// Convert the internal PodStatus to api.PodStatus.
 	s := kl.convertStatusToAPIStatus(pod, podStatus)
 
 	// Assume info is ready to process

--- a/pkg/kubelet/pod_workers_test.go
+++ b/pkg/kubelet/pod_workers_test.go
@@ -18,7 +18,6 @@ package kubelet
 
 import (
 	"reflect"
-	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -45,10 +44,9 @@ func createPodWorkers() (*podWorkers, map[types.UID][]string) {
 	processed := make(map[types.UID][]string)
 	fakeRecorder := &record.FakeRecorder{}
 	fakeRuntime := &kubecontainer.FakeRuntime{}
-	fakeRuntimeCache := kubecontainer.NewFakeRuntimeCache(fakeRuntime)
+	fakeCache := kubecontainer.NewFakeCache(fakeRuntime)
 	podWorkers := newPodWorkers(
-		fakeRuntimeCache,
-		func(pod *api.Pod, mirrorPod *api.Pod, runningPod kubecontainer.Pod, updateType kubetypes.SyncPodType) error {
+		func(pod *api.Pod, mirrorPod *api.Pod, status *kubecontainer.PodStatus, updateType kubetypes.SyncPodType) error {
 			func() {
 				lock.Lock()
 				defer lock.Unlock()
@@ -60,7 +58,7 @@ func createPodWorkers() (*podWorkers, map[types.UID][]string) {
 		queue.NewBasicWorkQueue(),
 		time.Second,
 		time.Second,
-		nil,
+		fakeCache,
 	)
 	return podWorkers, processed
 }
@@ -151,19 +149,19 @@ func TestForgetNonExistingPodWorkers(t *testing.T) {
 }
 
 type simpleFakeKubelet struct {
-	pod        *api.Pod
-	mirrorPod  *api.Pod
-	runningPod kubecontainer.Pod
-	wg         sync.WaitGroup
+	pod       *api.Pod
+	mirrorPod *api.Pod
+	podStatus *kubecontainer.PodStatus
+	wg        sync.WaitGroup
 }
 
-func (kl *simpleFakeKubelet) syncPod(pod *api.Pod, mirrorPod *api.Pod, runningPod kubecontainer.Pod, updateType kubetypes.SyncPodType) error {
-	kl.pod, kl.mirrorPod, kl.runningPod = pod, mirrorPod, runningPod
+func (kl *simpleFakeKubelet) syncPod(pod *api.Pod, mirrorPod *api.Pod, status *kubecontainer.PodStatus, updateType kubetypes.SyncPodType) error {
+	kl.pod, kl.mirrorPod, kl.podStatus = pod, mirrorPod, status
 	return nil
 }
 
-func (kl *simpleFakeKubelet) syncPodWithWaitGroup(pod *api.Pod, mirrorPod *api.Pod, runningPod kubecontainer.Pod, updateType kubetypes.SyncPodType) error {
-	kl.pod, kl.mirrorPod, kl.runningPod = pod, mirrorPod, runningPod
+func (kl *simpleFakeKubelet) syncPodWithWaitGroup(pod *api.Pod, mirrorPod *api.Pod, status *kubecontainer.PodStatus, updateType kubetypes.SyncPodType) error {
+	kl.pod, kl.mirrorPod, kl.podStatus = pod, mirrorPod, status
 	kl.wg.Done()
 	return nil
 }
@@ -186,25 +184,21 @@ func (b byContainerName) Less(i, j int) bool {
 func TestFakePodWorkers(t *testing.T) {
 	fakeRecorder := &record.FakeRecorder{}
 	fakeRuntime := &kubecontainer.FakeRuntime{}
-	fakeRuntimeCache := kubecontainer.NewFakeRuntimeCache(fakeRuntime)
+	fakeCache := kubecontainer.NewFakeCache(fakeRuntime)
 
 	kubeletForRealWorkers := &simpleFakeKubelet{}
 	kubeletForFakeWorkers := &simpleFakeKubelet{}
 
-	realPodWorkers := newPodWorkers(fakeRuntimeCache, kubeletForRealWorkers.syncPodWithWaitGroup, fakeRecorder, queue.NewBasicWorkQueue(), time.Second, time.Second, nil)
-	fakePodWorkers := &fakePodWorkers{kubeletForFakeWorkers.syncPod, fakeRuntimeCache, t}
+	realPodWorkers := newPodWorkers(kubeletForRealWorkers.syncPodWithWaitGroup, fakeRecorder, queue.NewBasicWorkQueue(), time.Second, time.Second, fakeCache)
+	fakePodWorkers := &fakePodWorkers{kubeletForFakeWorkers.syncPod, fakeCache, t}
 
 	tests := []struct {
-		pod                    *api.Pod
-		mirrorPod              *api.Pod
-		podList                []*kubecontainer.Pod
-		containersInRunningPod int
+		pod       *api.Pod
+		mirrorPod *api.Pod
 	}{
 		{
 			&api.Pod{},
 			&api.Pod{},
-			[]*kubecontainer.Pod{},
-			0,
 		},
 		{
 			&api.Pod{
@@ -221,29 +215,6 @@ func TestFakePodWorkers(t *testing.T) {
 					Namespace: "new",
 				},
 			},
-			[]*kubecontainer.Pod{
-				{
-					ID:        "12345678",
-					Name:      "foo",
-					Namespace: "new",
-					Containers: []*kubecontainer.Container{
-						{
-							Name: "fooContainer",
-						},
-					},
-				},
-				{
-					ID:        "12345678",
-					Name:      "fooMirror",
-					Namespace: "new",
-					Containers: []*kubecontainer.Container{
-						{
-							Name: "fooContainerMirror",
-						},
-					},
-				},
-			},
-			1,
 		},
 		{
 			&api.Pod{
@@ -260,42 +231,11 @@ func TestFakePodWorkers(t *testing.T) {
 					Namespace: "new",
 				},
 			},
-			[]*kubecontainer.Pod{
-				{
-					ID:        "98765",
-					Name:      "bar",
-					Namespace: "new",
-					Containers: []*kubecontainer.Container{
-						{
-							Name: "barContainer0",
-						},
-						{
-							Name: "barContainer1",
-						},
-					},
-				},
-				{
-					ID:        "98765",
-					Name:      "barMirror",
-					Namespace: "new",
-					Containers: []*kubecontainer.Container{
-						{
-							Name: "barContainerMirror0",
-						},
-						{
-							Name: "barContainerMirror1",
-						},
-					},
-				},
-			},
-			2,
 		},
 	}
 
 	for i, tt := range tests {
 		kubeletForRealWorkers.wg.Add(1)
-
-		fakeRuntime.PodList = tt.podList
 		realPodWorkers.UpdatePod(tt.pod, tt.mirrorPod, kubetypes.SyncPodUpdate, func() {})
 		fakePodWorkers.UpdatePod(tt.pod, tt.mirrorPod, kubetypes.SyncPodUpdate, func() {})
 
@@ -309,14 +249,8 @@ func TestFakePodWorkers(t *testing.T) {
 			t.Errorf("%d: Expected: %#v, Actual: %#v", i, kubeletForRealWorkers.mirrorPod, kubeletForFakeWorkers.mirrorPod)
 		}
 
-		if tt.containersInRunningPod != len(kubeletForFakeWorkers.runningPod.Containers) {
-			t.Errorf("%d: Expected: %#v, Actual: %#v", i, tt.containersInRunningPod, len(kubeletForFakeWorkers.runningPod.Containers))
-		}
-
-		sort.Sort(byContainerName(kubeletForRealWorkers.runningPod))
-		sort.Sort(byContainerName(kubeletForFakeWorkers.runningPod))
-		if !reflect.DeepEqual(kubeletForRealWorkers.runningPod, kubeletForFakeWorkers.runningPod) {
-			t.Errorf("%d: Expected: %#v, Actual: %#v", i, kubeletForRealWorkers.runningPod, kubeletForFakeWorkers.runningPod)
+		if !reflect.DeepEqual(kubeletForRealWorkers.podStatus, kubeletForFakeWorkers.podStatus) {
+			t.Errorf("%d: Expected: %#v, Actual: %#v", i, kubeletForRealWorkers.podStatus, kubeletForFakeWorkers.podStatus)
 		}
 	}
 }


### PR DESCRIPTION
This change removes RuntimeCache in the pod workers and the syncPod() function.
Note that it doesn't deprecate RuntimeCache completely as other components
still rely on the cache.

This PR depends on #19850 (the first commit).
