### PR TITLE
Update tests from Go 1.5.2 to Go 1.5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ language: go
 
 matrix:
   include:
-    - go: 1.5.2
+    - go: 1.5.3
 
 install:
   - go get github.com/tools/godep

--- a/cluster/images/etcd/build-etcd.sh
+++ b/cluster/images/etcd/build-etcd.sh
@@ -27,7 +27,7 @@ TAG=$1
 ARCH=$2
 TARGET_DIR=$3
 
-GOLANG_VERSION=${GOLANG_VERSION:-1.5.2}
+GOLANG_VERSION=${GOLANG_VERSION:-1.5.3}
 GOARM=6
 
 # Create the ${TARGET_DIR} directory, if it doesn't exist

--- a/hack/jenkins/gotest-dockerized.sh
+++ b/hack/jenkins/gotest-dockerized.sh
@@ -42,5 +42,5 @@ docker run --rm=true \
   -v "${REPO_DIR}":/go/src/k8s.io/kubernetes \
   -v "${KUBE_JUNIT_REPORT_DIR}":/workspace/artifacts \
   --env REPO_DIR="${REPO_DIR}" \
-  -i gcr.io/google_containers/kubekins-test:0.6 \
+  -i gcr.io/google_containers/kubekins-test:0.7 \
   bash -c "cd kubernetes && ./hack/jenkins/test-dockerized.sh"

--- a/hack/jenkins/test-image/Dockerfile
+++ b/hack/jenkins/test-image/Dockerfile
@@ -15,7 +15,7 @@
 # This file creates a build environment for building and running kubernetes
 # unit and integration tests
 
-FROM golang:1.5.2
+FROM golang:1.5.3
 MAINTAINER  Jeff Lowdermilk <jeffml@google.com>
 
 ENV WORKSPACE               /workspace

--- a/hack/jenkins/test-image/Makefile
+++ b/hack/jenkins/test-image/Makefile
@@ -1,6 +1,6 @@
 all: push
 
-TAG = 0.6
+TAG = 0.7
 
 container:
 	docker build -t gcr.io/google_containers/kubekins-test .

--- a/shippable.yml
+++ b/shippable.yml
@@ -4,7 +4,7 @@ language: go
 
 matrix:
   include:
-    - go: 1.5.2
+    - go: 1.5.3
       env:
         - KUBE_TEST_API_VERSIONS=v1,extensions/v1beta1 KUBE_TEST_ETCD_PREFIXES=registry
         - KUBE_JUNIT_REPORT_DIR="${SHIPPABLE_REPO_DIR}/shippable/testresults"


### PR DESCRIPTION
Ref #19616 and #14873.

This only updates tests, which are already using Go 1.5.2, to 1.5.3. As such, it should be fairly harmless, but hopefully give us early signal for #14873.

Note that due to pending changes to the Jenkins test image,
a) this should not be merged before #19836
b) I haven't build version 0.7 yet, so this will fail on PR Jenkins

I will push this image after #19836 merges and I rebase.

@mikedanese @brendandburns @a-robinson @gmarek @zmerlynn @kubernetes/goog-testing 
