### PR TITLE
Upload useful Jenkins build information to GCS.

### DIFF
--- a/hack/jenkins/e2e-runner.sh
+++ b/hack/jenkins/e2e-runner.sh
@@ -115,6 +115,11 @@ fi
 
 cd kubernetes
 
+# Upload build start time and k8s version to GCS, but not on PR Jenkins.
+if [[ ! "${JOB_NAME}" =~ -pull- ]]; then
+    bash <(curl -fsS --retry 3 "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/upload-started.sh")
+fi
+
 # Have cmd/e2e run by goe2e.sh generate JUnit report in ${WORKSPACE}/junit*.xml
 ARTIFACTS=${WORKSPACE}/_artifacts
 mkdir -p ${ARTIFACTS}

--- a/hack/jenkins/job-configs/global.yaml
+++ b/hack/jenkins/job-configs/global.yaml
@@ -29,6 +29,33 @@
                     else
                       curl -fsS --retry 3 "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/upload-to-gcs.sh" | bash -
                     fi
+                - shell: |
+                    curl -fsS --retry 3 "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/upload-finished.sh" > upload-finished.sh
+                    chmod +x upload-finished.sh
+                - conditional-step:
+                    condition-kind: current-status
+                    condition-worst: SUCCESS
+                    condition-best: SUCCESS
+                    steps:
+                        - shell: './upload-finished.sh SUCCESS'
+                - conditional-step:
+                    condition-kind: current-status
+                    condition-worst: UNSTABLE
+                    condition-best: UNSTABLE
+                    steps:
+                        - shell: './upload-finished.sh UNSTABLE'
+                - conditional-step:
+                    condition-kind: current-status
+                    condition-worst: FAILURE
+                    condition-best: FAILURE
+                    steps:
+                        - shell: './upload-finished.sh FAILURE'
+                - conditional-step:
+                    condition-kind: current-status
+                    condition-worst: ABORTED
+                    condition-best: ABORTED
+                    steps:
+                        - shell: './upload-finished.sh ABORTED'
             script-only-if-succeeded: False
             script-only-if-failed: False
 

--- a/hack/jenkins/job-configs/kubernetes-build.yaml
+++ b/hack/jenkins/job-configs/kubernetes-build.yaml
@@ -4,6 +4,7 @@
     logrotate:
         numToKeep: 200
     builders:
+        - shell: 'bash <(curl -fsS --retry 3 "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/upload-started.sh")'
         - shell: './hack/jenkins/build.sh'
     properties:
         - mail-watcher

--- a/hack/jenkins/job-configs/kubernetes-test-go.yaml
+++ b/hack/jenkins/job-configs/kubernetes-test-go.yaml
@@ -7,6 +7,7 @@
         numToKeep: 200
     node: unittest
     builders:
+        - shell: 'bash <(curl -fsS --retry 3 "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/upload-started.sh")'
         - shell: './hack/jenkins/gotest-dockerized.sh'
     publishers:
         - claim-build

--- a/hack/jenkins/upload-finished.sh
+++ b/hack/jenkins/upload-finished.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This is meant to be run at the end of every Jenkins job.
+#
+# Pass in the result of the build in $1. This will upload that, along with the
+# current time, to GCS.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: hack/jenkins/upload-finished.sh RESULT" >&2
+    exit 1
+fi
+
+readonly result="$1"
+readonly timestamp=$(date +%s)
+readonly location="gs://kubernetes-jenkins/logs/${JOB_NAME}/${BUILD_NUMBER}/finished.json"
+
+echo "Uploading build result to: ${location}"
+gsutil -q cp -a "public-read" <(
+    echo "{"
+    echo "    \"result\": \"${result}\","
+    echo "    \"timestamp\": ${timestamp}"
+    echo "}"
+) "${location}"

--- a/hack/jenkins/upload-started.sh
+++ b/hack/jenkins/upload-started.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This is meant to be run at the start of every Jenkins job.
+#
+# Discovers the local kubernetes version and uploads it, along with
+# the current time, to GCS.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+version=""
+readonly timestamp=$(date +%s)
+readonly location="gs://kubernetes-jenkins/logs/${JOB_NAME}/${BUILD_NUMBER}/started.json"
+
+# Try to discover the kubernetes version.
+if [[ -e "version" ]]; then
+    version=$(cat "version")
+elif [[ -e "hack/lib/version.sh" ]]; then
+    version=$(
+        export KUBE_ROOT="."
+        source "hack/lib/version.sh"
+        kube::version::get_version_vars
+        echo "${KUBE_GIT_VERSION-}"
+    )
+fi
+
+if [[ -n "${version}" ]]; then
+    echo "Found Kubernetes version: ${version}"
+else
+    echo "Could not find Kubernetes version"
+fi
+
+echo "Uploading version to: ${location}"
+gsutil -q cp -a "public-read" <(
+    echo "{"
+    echo "    \"version\": \"${version}\","
+    echo "    \"timestamp\": ${timestamp}"
+    echo "}"
+) "${location}"


### PR DESCRIPTION
ref: #19727

It was a little tricky to get the Kubernetes version as well as the build result in a way that will work for all jobs.

For the version, it first looks for a file called `version`, which is present in newer k8s tarballs, and so also in e2e tests. Otherwise, it calls into `hack/lib/version.sh`, which will be checked out in build jobs and test-go jobs, as well as downloaded in older e2e jobs. Note, this script will append "-dirty" to the version if there is junk left around in the workspace, which is the case for a few I looked at. If none of these are available, it will fail.

To get the build result... well it's not pretty, but it's better than using groovy. If you can think of a better way, please let me know. I toyed with writing a wrapper script for all of these, writing out the build result to a file when it fails, and some other things, too. This was the simplest, most robust way.

I've tested this in Jenkins, in some of those jobs that nobody looks at, but it might still explode the world, so please don't put on the LGTM tag.
