### PR TITLE
Include Go version, platform, and other build info in version string

### DIFF
--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -126,7 +126,7 @@ kube::version::ldflag() {
 kube::version::ldflags() {
   kube::version::get_version_vars
 
-  local -a ldflags=()
+  local -a ldflags=($(kube::version::ldflag "buildDate" "$(date -u +'%Y-%m-%dT%H:%M:%SZ')"))
   if [[ -n ${KUBE_GIT_COMMIT-} ]]; then
     ldflags+=($(kube::version::ldflag "gitCommit" "${KUBE_GIT_COMMIT}"))
     ldflags+=($(kube::version::ldflag "gitTreeState" "${KUBE_GIT_TREE_STATE}"))

--- a/pkg/client/unversioned/helper.go
+++ b/pkg/client/unversioned/helper.go
@@ -18,7 +18,6 @@ package unversioned
 
 import (
 	"fmt"
-	"reflect"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
@@ -98,13 +97,14 @@ func MatchesServerVersion(client *Client, c *restclient.Config) error {
 			return err
 		}
 	}
-	clientVersion := version.Get()
-	serverVersion, err := client.Discovery().ServerVersion()
+	cVer := version.Get()
+	sVer, err := client.Discovery().ServerVersion()
 	if err != nil {
 		return fmt.Errorf("couldn't read version from server: %v\n", err)
 	}
-	if s := *serverVersion; !reflect.DeepEqual(clientVersion, s) {
-		return fmt.Errorf("server version (%#v) differs from client version (%#v)!\n", s, clientVersion)
+	// GitVersion includes GitCommit and GitTreeState, but best to be safe?
+	if cVer.GitVersion != sVer.GitVersion || cVer.GitCommit != sVer.GitCommit || cVer.GitTreeState != cVer.GitTreeState {
+		return fmt.Errorf("server version (%#v) differs from client version (%#v)!\n", sVer, cVer)
 	}
 
 	return nil

--- a/pkg/metrics/generic_metrics.go
+++ b/pkg/metrics/generic_metrics.go
@@ -46,7 +46,7 @@ var CommonMetrics = map[string][]string{
 	"http_response_size_bytes":                 {"handler", "quantile"},
 	"http_response_size_bytes_count":           {"handler"},
 	"http_response_size_bytes_sum":             {"handler"},
-	"kubernetes_build_info":                    {"major", "minor", "gitCommit", "gitTreeState", "gitVersion"},
+	"kubernetes_build_info":                    {"major", "minor", "gitCommit", "gitTreeState", "gitVersion", "buildDate", "goVersion", "compiler", "platform"},
 	"process_cpu_seconds_total":                {},
 	"process_max_fds":                          {},
 	"process_open_fds":                         {},

--- a/pkg/version/base.go
+++ b/pkg/version/base.go
@@ -54,4 +54,6 @@ var (
 	gitVersion   string = "v0.0.0-master+$Format:%h$"
 	gitCommit    string = "$Format:%H$"    // sha1 from git, output of $(git rev-parse HEAD)
 	gitTreeState string = "not a git tree" // state of git tree, either "clean" or "dirty"
+
+	buildDate string = "1970-01-01T00:00:00Z" // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
 )

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,7 +16,12 @@ limitations under the License.
 
 package version
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 // Info contains versioning information.
 // TODO: Add []string of api versions supported? It's still unclear
@@ -27,6 +32,10 @@ type Info struct {
 	GitVersion   string `json:"gitVersion"`
 	GitCommit    string `json:"gitCommit"`
 	GitTreeState string `json:"gitTreeState"`
+	BuildDate    string `json:"buildDate"`
+	GoVersion    string `json:"goVersion"`
+	Compiler     string `json:"compiler"`
+	Platform     string `json:"platform"`
 }
 
 // Get returns the overall codebase version. It's for detecting
@@ -40,6 +49,10 @@ func Get() Info {
 		GitVersion:   gitVersion,
 		GitCommit:    gitCommit,
 		GitTreeState: gitTreeState,
+		BuildDate:    buildDate,
+		GoVersion:    runtime.Version(),
+		Compiler:     runtime.Compiler,
+		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	}
 }
 
@@ -52,12 +65,12 @@ func init() {
 	buildInfo := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "kubernetes_build_info",
-			Help: "A metric with a constant '1' value labeled by major, minor, git version, git commit and git tree state from which Kubernetes was built.",
+			Help: "A metric with a constant '1' value labeled by major, minor, git version, git commit, git tree state, build date, Go version, and compiler from which Kubernetes was built, and platform on which it is running.",
 		},
-		[]string{"major", "minor", "gitVersion", "gitCommit", "gitTreeState"},
+		[]string{"major", "minor", "gitVersion", "gitCommit", "gitTreeState", "buildDate", "goVersion", "compiler", "platform"},
 	)
 	info := Get()
-	buildInfo.WithLabelValues(info.Major, info.Minor, info.GitVersion, info.GitCommit, info.GitTreeState).Set(1)
+	buildInfo.WithLabelValues(info.Major, info.Minor, info.GitVersion, info.GitCommit, info.GitTreeState, info.BuildDate, info.GoVersion, info.Compiler, info.Platform).Set(1)
 
 	prometheus.MustRegister(buildInfo)
 }


### PR DESCRIPTION
Tracking down the root cause of #17524 probably would've been easier if we'd more readily exposed the Go version used to build Kubernetes, so this PR adds it to the version string exported.

This is fairly similar to the build information contained in Linux's version string or the command `docker version`.

Note that this will make [`MatchesServerVersion`](https://github.com/kubernetes/kubernetes/blob/36dc6eab3437063147d6daac76add2258eb37561/pkg/client/unversioned/helper.go#L151) fail if the client/server were built at the same git hash but with a different version of Go. I'm not sure if this is something to worry about.

I don't think this is likely to break anything, but I'm not entirely confident on that.

(I also considered whether we want to add a build timestamp, like Linux and Docker have, but then we'd definitely want to ignore it in `MatchesServerVersion`, so I left that out for now.)
