### PR TITLE
hack/kube-dump.sh: pass --quorum to etcdctl for getting consistent re…

### DIFF
--- a/hack/kube-dump.sh
+++ b/hack/kube-dump.sh
@@ -45,8 +45,8 @@ echo
 echo "kube-dump.sh: Getting boundpods from etcd..."
 ssh-to-node "${MASTER_NAME}" '
   ETCD_SERVER=$(hostname -i):4001 
-  for DIR in $(etcdctl -C $ETCD_SERVER ls /registry/nodes); do 
+  for DIR in $(etcdctl -C $ETCD_SERVER ls --quorum /registry/nodes); do 
     echo "kube-dump.sh: Dir $DIR:"
-    etcdctl -C $ETCD_SERVER get $DIR/boundpods
+    etcdctl -C $ETCD_SERVER get --quorum $DIR/boundpods
   done 
 '


### PR DESCRIPTION
…sult

This commit adds --quorum flag to `etcdctl ls` and `etcdctl get` in
kube-dump.sh. Without the flag, the commands can return stale results.

CAUTION: the flag of `get` is already introduced in the latest stable
release of etcd (v2.2), but the flag of `ls` isn't backported to the
stable release. It will be introduced in v2.3.

I don't know which version of etcd is assumed by kubernetes. Therefore I'm not sure when this PR can be merged safely. Can anyone let me know?
