### PR TITLE
etcd helper: turn on Quorum in GetOption

### DIFF
--- a/pkg/storage/etcd/etcd_helper.go
+++ b/pkg/storage/etcd/etcd_helper.go
@@ -462,6 +462,7 @@ func (h *etcdHelper) listEtcdNode(ctx context.Context, key string) ([]*etcd.Node
 	opts := etcd.GetOptions{
 		Recursive: true,
 		Sort:      true,
+		Quorum:    true,
 	}
 	result, err := h.client.Get(ctx, key, &opts)
 	if err != nil {


### PR DESCRIPTION
Without turning on the GetOption.Quorum, etcd can return stale value.
