### PR TITLE
remove etcd dependency on sysvinit scripts for nodes when deploying on ubuntu

### DIFF
--- a/cluster/ubuntu/minion/init_scripts/flanneld
+++ b/cluster/ubuntu/minion/init_scripts/flanneld
@@ -3,7 +3,7 @@ set -e
 
 ### BEGIN INIT INFO
 # Provides:           flannel
-# Required-Start:     $etcd
+# Required-Start:
 # Required-Stop:      
 # Should-Start:       
 # Should-Stop:        

--- a/cluster/ubuntu/minion/init_scripts/kube-proxy
+++ b/cluster/ubuntu/minion/init_scripts/kube-proxy
@@ -3,7 +3,7 @@ set -e
 
 ### BEGIN INIT INFO
 # Provides:           kube-proxy
-# Required-Start:     $etcd
+# Required-Start:     $flannel
 # Required-Stop:      
 # Should-Start:       
 # Should-Stop:        

--- a/cluster/ubuntu/minion/init_scripts/kubelet
+++ b/cluster/ubuntu/minion/init_scripts/kubelet
@@ -3,7 +3,7 @@ set -e
 
 ### BEGIN INIT INFO
 # Provides:           kubelet
-# Required-Start:     $etcd
+# Required-Start:     $flannel
 # Required-Stop:      
 # Should-Start:       
 # Should-Stop:        


### PR DESCRIPTION
etcd was deprecated on nodes when deploying ubuntu in PR #13609

This PR adjusts the sysvinit script so that:
- flannel does not depend on etcd anymore
- kube-proxy and kubelet depend on flannel instead of etcd

This also make sure the sysvinit script have the same behaviour as the upstart configs regarding dependencies.
