### PR TITLE
Update docker and docker-multinode docs on master to require 1.2.x

### DIFF
--- a/docs/getting-started-guides/docker-multinode.md
+++ b/docs/getting-started-guides/docker-multinode.md
@@ -74,7 +74,7 @@ it is still useful to use containers for deployment and management, so we create
 You can specify the version on every node before install:
 
 ```sh
-export K8S_VERSION=<your_k8s_version (e.g. 1.1.3)>
+export K8S_VERSION=<your_k8s_version (e.g. 1.2.0-alpha.6)>
 export ETCD_VERSION=<your_etcd_version (e.g. 2.2.1)>
 export FLANNEL_VERSION=<your_flannel_version (e.g. 0.5.5)>
 export FLANNEL_IFACE=<flannel_interface (defaults to eth0)>

--- a/docs/getting-started-guides/docker-multinode/master.md
+++ b/docs/getting-started-guides/docker-multinode/master.md
@@ -36,13 +36,13 @@ Documentation for other releases can be found at
 
 We'll begin by setting up the master node.  For the purposes of illustration, we'll assume that the IP of this machine
 is `${MASTER_IP}`.  We'll need to run several versioned Kubernetes components, so we'll assume that the version we want
-to run is `${K8S_VERSION}`, which should hold a value such as "1.1.3".
+to run is `${K8S_VERSION}`, which should hold a released version of Kubernetes >= "1.2.0-alpha.6"
 
 Enviroinment variables used:
 
 ```sh
 export MASTER_IP=<the_master_ip_here>
-export K8S_VERSION=<your_k8s_version (e.g. 1.1.3)>
+export K8S_VERSION=<your_k8s_version (e.g. 1.2.0-alpha.6)>
 export ETCD_VERSION=<your_etcd_version (e.g. 2.2.1)>
 export FLANNEL_VERSION=<your_flannel_version (e.g. 0.5.5)>
 export FLANNEL_IFACE=<flannel_interface (defaults to eth0)>
@@ -204,7 +204,7 @@ sudo docker run \
     --privileged=true \
     --pid=host \
     -d \
-    gcr.io/google_containers/hyperkube:v${K8S_VERSION} \
+    gcr.io/google_containers/hyperkube-amd64:v${K8S_VERSION} \
     /hyperkube kubelet \
         --allow-privileged=true \
         --api-servers=http://localhost:8080 \
@@ -225,8 +225,11 @@ sudo docker run \
 At this point, you should have a functioning 1-node cluster.  Let's test it out!
 
 Download the kubectl binary for `${K8S_VERSION}` (look at the URL in the following links) and make it available by editing your PATH environment variable.
-([OS X](http://storage.googleapis.com/kubernetes-release/release/v1.1.3/bin/darwin/amd64/kubectl))
-([linux](http://storage.googleapis.com/kubernetes-release/release/v1.1.3/bin/linux/amd64/kubectl))
+([OS X/amd64](http://storage.googleapis.com/kubernetes-release/release/v1.2.0-alpha.6/bin/darwin/amd64/kubectl))
+([OS X/386](http://storage.googleapis.com/kubernetes-release/release/v1.2.0-alpha.6/bin/darwin/386/kubectl))
+([linux/amd64](http://storage.googleapis.com/kubernetes-release/release/v1.2.0-alpha.6/bin/linux/amd64/kubectl))
+([linux/386](http://storage.googleapis.com/kubernetes-release/release/v1.2.0-alpha.6/bin/linux/386/kubectl))
+([linux/arm](http://storage.googleapis.com/kubernetes-release/release/v1.2.0-alpha.6/bin/linux/arm/kubectl))
 
 For example, OS X:
 

--- a/docs/getting-started-guides/docker-multinode/master.sh
+++ b/docs/getting-started-guides/docker-multinode/master.sh
@@ -26,10 +26,11 @@ if ( ! ps -ef | grep "/usr/bin/docker" | grep -v 'grep' &> /dev/null ); then
 fi
 
 # Make sure k8s version env is properly set
-K8S_VERSION=${K8S_VERSION:-"1.1.3"}
+K8S_VERSION=${K8S_VERSION:-"1.2.0-alpha.6"}
 ETCD_VERSION=${ETCD_VERSION:-"2.2.1"}
 FLANNEL_VERSION=${FLANNEL_VERSION:-"0.5.5"}
 FLANNEL_IFACE=${FLANNEL_IFACE:-"eth0"}
+ARCH=${ARCH:-"amd64"}
 
 # Run as root
 if [ "$(id -u)" != "0" ]; then
@@ -47,6 +48,7 @@ echo "ETCD_VERSION is set to: ${ETCD_VERSION}"
 echo "FLANNEL_VERSION is set to: ${FLANNEL_VERSION}"
 echo "FLANNEL_IFACE is set to: ${FLANNEL_IFACE}"
 echo "MASTER_IP is set to: ${MASTER_IP}"
+echo "ARCH is set to: ${ARCH}"
 
 # Check if a command is valid
 command_exists() {
@@ -57,6 +59,7 @@ lsb_dist=""
 
 # Detect the OS distro, we support ubuntu, debian, mint, centos, fedora dist
 detect_lsb() {
+    # TODO: remove this when ARM support is fully merged
     case "$(uname -m)" in
         *64)
             ;;
@@ -205,7 +208,7 @@ start_k8s(){
         -v /dev:/dev \
         -v /var/lib/docker/:/var/lib/docker:rw \
         -v /var/lib/kubelet/:/var/lib/kubelet:rw \
-        gcr.io/google_containers/hyperkube:v${K8S_VERSION} \
+        gcr.io/google_containers/hyperkube-${ARCH}:v${K8S_VERSION} \
         /hyperkube kubelet \
             --address=0.0.0.0 \
             --allow-privileged=true \

--- a/docs/getting-started-guides/docker-multinode/worker.md
+++ b/docs/getting-started-guides/docker-multinode/worker.md
@@ -38,13 +38,13 @@ Documentation for other releases can be found at
 These instructions are very similar to the master set-up above, but they are duplicated for clarity.
 You need to repeat these instructions for each node you want to join the cluster.
 We will assume that you have the IP address of the master in `${MASTER_IP}` that you created in the [master instructions](master.md).  We'll need to run several versioned Kubernetes components, so we'll assume that the version we want
-to run is `${K8S_VERSION}`, which should hold a value such as "1.1.3".
+to run is `${K8S_VERSION}`, which should hold a released version of Kubernetes >= "1.2.0-alpha.6"
 
 Enviroinment variables used:
 
 ```sh
 export MASTER_IP=<the_master_ip_here>
-export K8S_VERSION=<your_k8s_version (e.g. 1.1.3)>
+export K8S_VERSION=<your_k8s_version (e.g. 1.2.0-alpha.6)>
 export FLANNEL_VERSION=<your_flannel_version (e.g. 0.5.5)>
 export FLANNEL_IFACE=<flannel_interface (defaults to eth0)>
 ```
@@ -174,7 +174,7 @@ sudo docker run \
     --privileged=true \
     --pid=host \ 
     -d \
-    gcr.io/google_containers/hyperkube:v${K8S_VERSION} \
+    gcr.io/google_containers/hyperkube-amd64:v${K8S_VERSION} \
     /hyperkube kubelet \
         --allow-privileged=true \
         --api-servers=http://${MASTER_IP}:8080 \
@@ -194,7 +194,7 @@ The service proxy provides load-balancing between groups of containers defined b
 sudo docker run -d \
     --net=host \
     --privileged \
-    gcr.io/google_containers/hyperkube:v${K8S_VERSION} \
+    gcr.io/google_containers/hyperkube-amd64:v${K8S_VERSION} \
     /hyperkube proxy \
         --master=http://${MASTER_IP}:8080 \
         --v=2

--- a/docs/getting-started-guides/docker.md
+++ b/docs/getting-started-guides/docker.md
@@ -58,7 +58,7 @@ Here's a diagram of what the final result will look like:
 
 1. You need to have docker installed on one machine.
 2. Decide what Kubernetes version to use.  Set the `${K8S_VERSION}` variable to
-   a value such as "1.1.1".
+   a released version of Kubernetes >= "1.2.0-alpha.6"
 
 ### Run it
 
@@ -74,7 +74,7 @@ docker run \
     --pid=host \
     --privileged=true \
     -d \
-    gcr.io/google_containers/hyperkube:v${K8S_VERSION} \
+    gcr.io/google_containers/hyperkube-amd64:v${K8S_VERSION} \
     /hyperkube kubelet \
         --containerized \
         --hostname-override="127.0.0.1" \
@@ -96,8 +96,11 @@ At this point you should have a running Kubernetes cluster.  You can test this
 by downloading the kubectl binary for `${K8S_VERSION}` (look at the URL in the
 following links) and make it available by editing your PATH environment
 variable.
-([OS X](http://storage.googleapis.com/kubernetes-release/release/v1.1.1/bin/darwin/amd64/kubectl))
-([linux](http://storage.googleapis.com/kubernetes-release/release/v1.1.1/bin/linux/amd64/kubectl))
+([OS X/amd64](http://storage.googleapis.com/kubernetes-release/release/v1.2.0-alpha.6/bin/darwin/amd64/kubectl))
+([OS X/386](http://storage.googleapis.com/kubernetes-release/release/v1.2.0-alpha.6/bin/darwin/386/kubectl))
+([linux/amd64](http://storage.googleapis.com/kubernetes-release/release/v1.2.0-alpha.6/bin/linux/amd64/kubectl))
+([linux/386](http://storage.googleapis.com/kubernetes-release/release/v1.2.0-alpha.6/bin/linux/386/kubectl))
+([linux/arm](http://storage.googleapis.com/kubernetes-release/release/v1.2.0-alpha.6/bin/linux/arm/kubectl))
 
 For example, OS X:
 


### PR DESCRIPTION
Proposed fix for: #19227 

Full comment [here](https://github.com/kubernetes/kubernetes/issues/19227#issuecomment-173332005)

> But the easiest way to solve this, is to update the hyperkube version to v1.2.0-alpha.6 which is pushed thanks to #19061, then everything except for default ServiceAccounts combined with docker-multinode should work. And that will be fixed in #17213 => v1.2.0-alpha.7

@brendandburns @ihmccreery @fgrzadkowski @david-mcmahon @borg286
