### PR TITLE
Restrict build jobs to running on build node instead of master

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-build.yaml
+++ b/hack/jenkins/job-configs/kubernetes-build.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: 'kubernetes-{build}'
     description: 'Grab the latest from GitHub, build. Test owner: Build Cop.'
+    node: 'build'
     logrotate:
         numToKeep: 200
     builders:


### PR DESCRIPTION
With #19847 and #19891 we should be safe to do this now and avoid the problems originally encountered in #17524.

The motivation for this PR is to get CPU-intensive work (such as builds) off of the heavily-loaded Jenkins master. Unit/integration tests have already been moved off master.

@spxtr @ihmccreery @zmerlynn @gmarek 
