### PR TITLE
collector interfaces and structs

### DIFF
--- a/pkg/kubelet/collector/interfaces.go
+++ b/pkg/kubelet/collector/interfaces.go
@@ -16,6 +16,12 @@ limitations under the License.
 
 package collector
 
+import (
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+)
+
+type ContainerInfoData interface{}
+
 type Interface interface {
 	// Starts the collector process if necessary, e.g. when using the builtin cadvisor.
 	// Otherwise, does nothing and just returns.
@@ -39,14 +45,14 @@ type Interface interface {
 	// used by oom watcher to detect oom events.
 	WatchEvents(request *EventRequest) (chan *Event, error)
 
-	// Get raw metrics of a Docker container
+	// Get raw metrics of a Docker/Rkt container
 	// containerID: Docker container ID
 	// numStats: max number of metrics to return
 	// start: start time to query the metrics data, and if omitted, the beginning of time is assumed
 	// end: end time to query the metrics data, and if omitted, the current time is assumed
 	// Returned value is a map of container name to its metrics data, and this data can be in a
 	// collector-specific format, e.g. can be used to handle /stats/... REST calls
-	DockerContainerInfo(containerID string, numStats int, start time.Time, end time.Time) (map[string]interface{}, error)
+	ContainerInfo(containerID kubecontainer.ContainerID, numStats int, start time.Time, end time.Time) (ContainerInfoData, error)
 
 	// Get raw metrics of a Linux container
 	// containerName: absolute path of a Linux container
@@ -54,7 +60,7 @@ type Interface interface {
 	// start: start time to query the metrics data, and if omitted, the beginning of time is assumed
 	// end: end time to query the metrics data, and if omitted, the current time is assumed
 	// subcontainer: if true, returns raw metrics information of this container and its child containers
-	RawContainerInfo(containerName string, numStats int, start time.Time, end time.Time, subcontainers bool) (map[string]interface{}, error)
+	RawContainerInfo(containerName string, numStats int, start time.Time, end time.Time, subcontainers bool) (map[string]ContainerInfoData, error)
 
 	// DockerContainerInfo() and RawContainerInfo() return collector-specific raw data, which need to be
 	// parsed to retrieve a particular metric type, e.g. cpu, memory, cpu load, file system. The respective

--- a/pkg/kubelet/collector/interfaces.go
+++ b/pkg/kubelet/collector/interfaces.go
@@ -62,4 +62,6 @@ type Interface interface {
 	// etc., should be defined to retrieve such data in a format consumeable by Kubernetes. However, as of now
 	// Kubernetes is currently not using any of such metrics data, thus, these interface functions (along with the
 	// corresponding data structs) should be defined and tuned at the time when such code is added.
+
+	// TODO: Define parsing interface functions as use cases are more concrete
 }

--- a/pkg/kubelet/collector/interfaces.go
+++ b/pkg/kubelet/collector/interfaces.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+type Interface interface {
+	// Starts the collector process if necessary, e.g., the builtin cadvisor
+	// Otherwise, does nothing and just returns
+	Start() error
+
+	// Returns the basic machine spec
+	// Currently used to report to k8s master the basic information about a node
+	MachineInfo() (*MachineInfo, error)
+
+	// Returns the software version of various components of a node, e.g., kernel, container runtime, etc.
+	// Currently used to report back to k8s master the versions of relevant software on a node
+	VersionInfo() (*VersionInfo, error)
+
+	// Returns the file system information of a given label or mount point
+	// Currently used by kubelet to check if there's enough disk space to schedule new pods and
+	// by the image manager to decide if garbage collection should start
+	FsInfo(fslabel string) (*FsInfo, error)
+
+	// Returns a channel for watching requested event types
+	// Currently used by oom watcher to detect oom events.
+	WatchEvents(request *Request) (chan *Event, error)
+
+	// Get detailed metrics information (cpu, memory, disk, network, etc.) about one or more containers
+	// When isRawContainer=true, containerName refers to a raw Linux container; otherwise it refers to a Docker container
+	// When isRawContainer=true and subcontainer=true, returns not only the metrics information of this container, but
+	// also the child containers
+	// Returned value is a map of container name to its metrics data, and this data is in a collector-specific format
+	// Currently used by kubelet to handle /stats/... REST calls
+	ContainerInfo(containerName string, req *ContainerInfoRequest, subcontainers bool, isRawContainer bool) (map[string]interface{}, error)
+
+	// ContainerInfo() returns collector-specific raw data, which should be parsed to retrieve its various components,
+	// e.g., cpu, memory, cpu load, file system, etc., thus the raw data should be cached locally to avoid frequent polls.
+	// These parsing interface functions, e.g., GetContainerCPUInfo(), GetContainerMemoryInfo(), GetContainerNetworkInfo(),
+	// etc., should be defined to retrieve such data in a format defined by Kubernetes. However, as Kubernetes is currently
+	// not using any of these metrics data, these interface functions (along with the corresponding structs) should be
+	// defined and tuned at the time when such code is added.
+
+}

--- a/pkg/kubelet/collector/types.go
+++ b/pkg/kubelet/collector/types.go
@@ -27,34 +27,34 @@ import (
 // Basic node information
 type NodeInfo struct {
 	// The number of cores on this node
-	NumCores uint `json:"num_cores"`
+	NumCores int32 `json:"numCores"`
 
-	// The amount of memory (in bytes) on this node
-	MemoryCapacity uint64 `json:"memory_capacity"`
+	// The amount of memory on this node
+	MemoryCapacityBytes int64 `json:"memoryCapacityBytes"`
 
 	// Machine ID that uniquely identifies a node across reboots or network changes
-	MachineID string `json:"machine_id"`
+	MachineID string `json:"machineId"`
 
 	// System UUID reported by a node
-	SystemUUID string `json:"system_uuid"`
+	SystemUUID string `json:"systemUuid"`
 
 	// The boot ID of a node, which changes upon reboots
-	BootID string `json:"boot_id"`
+	BootID string `json:"bootId"`
 }
 
 // Software version of a node
 type VersionInfo struct {
-	// Kernel version
-	KernelVersion string `json:"kernel_version"`
+	// Host machine kernel version
+	KernelVersion string `json:"kernelVersion"`
 
 	// OS image being used for collector container, or host image if running on host directly
-	ContainerOsVersion string `json:"container_os_version"`
+	ContainerOsVersion string `json:"containerOsVersion"`
 
-	// Container runtime version, e.g., Docker/Rkt version
-	ContainerRuntimeVersion string `json:"container_runtime_version"`
+	// Version of a specific container runtime, e.g. Docker/Rkt
+	ContainerRuntimeVersion string `json:"containerRuntimeVersion"`
 
-	// Collector version
-	CollectorVersion string `json:"collector_version"`
+	// Version of a collector instance
+	CollectorVersion string `json:"collectorVersion"`
 }
 
 const (
@@ -71,19 +71,19 @@ type FsInfo struct {
 	Device string `json:"device"`
 
 	// Path where the filesystem is mounted.
-	Mountpoint string `json:"mountpoint"`
+	MountPoint string `json:"mountPoint"`
 
-	// Filesystem usage in bytes.
-	Capacity uint64 `json:"capacity"`
+	// Total filesystem capacity
+	CapacityBytes int64 `json:"capacityBytes"`
 
 	// Bytes available for non-root use.
-	Available uint64 `json:"available"`
+	AvailableBytes int64 `json:"availableBytes"`
 
 	// Number of bytes used on this filesystem.
-	Usage uint64 `json:"usage"`
+	UsedBytes int64 `json:"usedBytes"`
 
 	// Labels associated with this filesystem.
-	Labels []string `json:"labels"`
+	Labels []string `json:"labels,omitempty"`
 }
 
 type EventType string
@@ -91,30 +91,27 @@ type EventType string
 // Event monitored and returned by collector
 type Event struct {
 	// The absolute container name for which the event occurred
-	ContainerName string `json:"container_name"`
+	ContainerName string `json:"containerName"`
 
 	// The time at which the event occurred
 	Timestamp time.Time `json:"timestamp"`
 
 	// The type of event. EventType is an enumerated type
-	EventType EventType `json:"event_type"`
+	EventType EventType `json:"eventType"`
 }
 
 const (
-	EventOom               EventType = "oom"
-	EventOomKill           EventType = "oomKill"
-	EventContainerCreation EventType = "containerCreation"
-	EventContainerDeletion EventType = "containerDeletion"
+	EventOom               EventType = "Oom"
+	EventOomKill           EventType = "OomKill"
+	EventContainerCreation EventType = "ContainerCreation"
+	EventContainerDeletion EventType = "ContainerDeletion"
 )
 
+// Request sent to the collector to monitor for various event types
 type EventRequest struct {
-	// EventType is a list of event types wanted
-	EventType map[EventType]bool
+	// EventType is a list of event types to be watched
+	EventType []EventType `json:"eventType"`
 
 	// The absolute container name for which the event occurred
-	ContainerName string
-
-	// If IncludeSubcontainers is false, only events occurring in the specific
-	// container, and not the subcontainers, will be returned
-	IncludeSubcontainers bool
+	ContainerName string `json:"containerName"`
 }

--- a/pkg/kubelet/collector/types.go
+++ b/pkg/kubelet/collector/types.go
@@ -101,8 +101,8 @@ type Event struct {
 }
 
 const (
-	EventOom               EventType = "Oom"
-	EventOomKill           EventType = "OomKill"
+	EventOOM               EventType = "OOM"
+	EventOOMKill           EventType = "OOMKill"
 	EventContainerCreation EventType = "ContainerCreation"
 	EventContainerDeletion EventType = "ContainerDeletion"
 )

--- a/pkg/kubelet/collector/types.go
+++ b/pkg/kubelet/collector/types.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"time"
+)
+
+// These types are mostly taken directly from cadvisor to minimize the amount of changes
+// we need to do in this iteration, but these need to be cleaned up further to
+// be less cadvisor-specific and more generic to kubernetes
+
+// Simplified cadvisor.MachineInfo
+type MachineInfo struct {
+	// The number of cores in this machine.
+	NumCores int
+
+	// The amount of memory (in bytes) in this machine
+	MemoryCapacity int64
+
+	// The machine id
+	MachineID string
+
+	// The system uuid
+	SystemUUID string
+
+	// The boot id
+	BootID string
+}
+
+// Simplified cadvisor.VersionInfo
+type VersionInfo struct {
+	// Kernel version.
+	KernelVersion string
+
+	// OS image being used for collector container, or host image if running on host directly.
+	ContainerOsVersion string
+
+	// Docker version.
+	DockerVersion string
+
+	// Collector version.
+	CollectorVersion string
+}
+
+const (
+	LabelSystemRoot   = "root"
+	LabelDockerImages = "docker-images"
+)
+
+// Same as cadvisor.FsInfo
+type FsInfo struct {
+	// The block device name associated with the filesystem.
+	Device string
+
+	// Path where the filesystem is mounted.
+	Mountpoint string
+
+	// Filesystem usage in bytes.
+	Capacity uint64
+
+	// Bytes available for non-root use.
+	Available uint64
+
+	// Number of bytes used on this filesystem.
+	Usage uint64
+
+	// Labels associated with this filesystem.
+	Labels []string
+}
+
+type EventType string
+
+// Simplified cadvisor.Event
+type Event struct {
+	// the absolute container name for which the event occurred
+	ContainerName string
+
+	// the time at which the event occurred
+	Timestamp time.Time
+
+	// the type of event. EventType is an enumerated type
+	EventType EventType
+}
+
+const (
+	EventOom               EventType = "oom"
+	EventOomKill                     = "oomKill"
+	EventContainerCreation           = "containerCreation"
+	EventContainerDeletion           = "containerDeletion"
+)
+
+// Simplified cadvisor.Request
+type Request struct {
+	// EventType is a list of event types wanted
+	EventType map[EventType]bool
+
+	// the absolute container name for which the event occurred
+	ContainerName string
+
+	// if IncludeSubcontainers is false, only events occurring in the specific
+	// container, and not the subcontainers, will be returned
+	IncludeSubcontainers bool
+}
+
+// Same as cadvisor.ContainerInfoRequest
+type ContainerInfoRequest struct {
+	// Max number of stats to return. Specify -1 for all stats currently available.
+	// Default: 60
+	NumStats int
+
+	// Start time for which to query information.
+	// If ommitted, the beginning of time is assumed.
+	Start time.Time
+
+	// End time for which to query information.
+	// If ommitted, current time is assumed.
+	End time.Time
+}

--- a/pkg/kubelet/collector/types.go
+++ b/pkg/kubelet/collector/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 The Kubernetes Authors All rights reserved.
+Copyright 2016 The Kubernetes Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,114 +20,101 @@ import (
 	"time"
 )
 
-// These types are mostly taken directly from cadvisor to minimize the amount of changes
-// we need to do in this iteration, but these need to be cleaned up further to
-// be less cadvisor-specific and more generic to kubernetes
+// TODO: These structs are mostly taken directly from cadvisor to minimize the
+// amount of changes we need to do in this iteration, but these eventually need
+// to be cleaned up further to be less cadvisor-specific and more generic to kubernetes
 
-// Simplified cadvisor.MachineInfo
-type MachineInfo struct {
-	// The number of cores in this machine.
-	NumCores int
+// Basic node information
+type NodeInfo struct {
+	// The number of cores on this node
+	NumCores uint `json:"num_cores"`
 
-	// The amount of memory (in bytes) in this machine
-	MemoryCapacity int64
+	// The amount of memory (in bytes) on this node
+	MemoryCapacity uint64 `json:"memory_capacity"`
 
-	// The machine id
-	MachineID string
+	// Machine ID that uniquely identifies a node across reboots or network changes
+	MachineID string `json:"machine_id"`
 
-	// The system uuid
-	SystemUUID string
+	// System UUID reported by a node
+	SystemUUID string `json:"system_uuid"`
 
-	// The boot id
-	BootID string
+	// The boot ID of a node, which changes upon reboots
+	BootID string `json:"boot_id"`
 }
 
-// Simplified cadvisor.VersionInfo
+// Software version of a node
 type VersionInfo struct {
-	// Kernel version.
-	KernelVersion string
+	// Kernel version
+	KernelVersion string `json:"kernel_version"`
 
-	// OS image being used for collector container, or host image if running on host directly.
-	ContainerOsVersion string
+	// OS image being used for collector container, or host image if running on host directly
+	ContainerOsVersion string `json:"container_os_version"`
 
-	// Docker version.
-	DockerVersion string
+	// Container runtime version, e.g., Docker/Rkt version
+	ContainerRuntimeVersion string `json:"container_runtime_version"`
 
-	// Collector version.
-	CollectorVersion string
+	// Collector version
+	CollectorVersion string `json:"collector_version"`
 }
 
 const (
-	LabelSystemRoot   = "root"
-	LabelDockerImages = "docker-images"
+	// Label of the mount point where container top layer file systems are placed
+	LabelSystemRoot = "root"
+
+	// Label of the mount point where container images are placed
+	LabelImages = "images"
 )
 
-// Same as cadvisor.FsInfo
+// Basic file system information
 type FsInfo struct {
 	// The block device name associated with the filesystem.
-	Device string
+	Device string `json:"device"`
 
 	// Path where the filesystem is mounted.
-	Mountpoint string
+	Mountpoint string `json:"mountpoint"`
 
 	// Filesystem usage in bytes.
-	Capacity uint64
+	Capacity uint64 `json:"capacity"`
 
 	// Bytes available for non-root use.
-	Available uint64
+	Available uint64 `json:"available"`
 
 	// Number of bytes used on this filesystem.
-	Usage uint64
+	Usage uint64 `json:"usage"`
 
 	// Labels associated with this filesystem.
-	Labels []string
+	Labels []string `json:"labels"`
 }
 
 type EventType string
 
-// Simplified cadvisor.Event
+// Event monitored and returned by collector
 type Event struct {
-	// the absolute container name for which the event occurred
-	ContainerName string
+	// The absolute container name for which the event occurred
+	ContainerName string `json:"container_name"`
 
-	// the time at which the event occurred
-	Timestamp time.Time
+	// The time at which the event occurred
+	Timestamp time.Time `json:"timestamp"`
 
-	// the type of event. EventType is an enumerated type
-	EventType EventType
+	// The type of event. EventType is an enumerated type
+	EventType EventType `json:"event_type"`
 }
 
 const (
 	EventOom               EventType = "oom"
-	EventOomKill                     = "oomKill"
-	EventContainerCreation           = "containerCreation"
-	EventContainerDeletion           = "containerDeletion"
+	EventOomKill           EventType = "oomKill"
+	EventContainerCreation EventType = "containerCreation"
+	EventContainerDeletion EventType = "containerDeletion"
 )
 
-// Simplified cadvisor.Request
-type Request struct {
+type EventRequest struct {
 	// EventType is a list of event types wanted
 	EventType map[EventType]bool
 
-	// the absolute container name for which the event occurred
+	// The absolute container name for which the event occurred
 	ContainerName string
 
-	// if IncludeSubcontainers is false, only events occurring in the specific
+	// If IncludeSubcontainers is false, only events occurring in the specific
 	// container, and not the subcontainers, will be returned
 	IncludeSubcontainers bool
-}
-
-// Same as cadvisor.ContainerInfoRequest
-type ContainerInfoRequest struct {
-	// Max number of stats to return. Specify -1 for all stats currently available.
-	// Default: 60
-	NumStats int
-
-	// Start time for which to query information.
-	// If ommitted, the beginning of time is assumed.
-	Start time.Time
-
-	// End time for which to query information.
-	// If ommitted, current time is assumed.
-	End time.Time
 }


### PR DESCRIPTION
Excerpt from PR #19708 to facilitate the review of the proposed interface. The collector interface is meant to capture how Kubernetes interacts with cadvisor today. As additional interactions between them are defined over time (e.g., to support auto-scaling, auto-eviction, etc.), what additional metrics are needed will become more clear, and at which time, we will need to evolve the interface and structs accordingly. Since we will only support cadvisor behind this interface (until we feel the interface has reached a certain maturity level), these interface changes should not cause additional work for us. In the mean time, defining this interface will help us decouple the kubelet code from cadvisor to prep for pluggability in the future.

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/19951)

<!-- Reviewable:end -->
