### PR TITLE
Make resources' names in lowercase in generated clients

### DIFF
--- a/cmd/libs/go2idl/client-gen/generators/client-generator.go
+++ b/cmd/libs/go2idl/client-gen/generators/client-generator.go
@@ -60,11 +60,12 @@ func NameSystems() namer.NameSystems {
 		"Ingress":         "Ingress",
 	}
 	return namer.NameSystems{
-		"public":        namer.NewPublicNamer(0),
-		"private":       namer.NewPrivateNamer(0),
-		"raw":           namer.NewRawNamer("", nil),
-		"publicPlural":  namer.NewPublicPluralNamer(pluralExceptions),
-		"privatePlural": namer.NewPrivatePluralNamer(pluralExceptions),
+		"public":             namer.NewPublicNamer(0),
+		"private":            namer.NewPrivateNamer(0),
+		"raw":                namer.NewRawNamer("", nil),
+		"publicPlural":       namer.NewPublicPluralNamer(pluralExceptions),
+		"privatePlural":      namer.NewPrivatePluralNamer(pluralExceptions),
+		"allLowercasePlural": namer.NewAllLowercasePluralNamer(pluralExceptions),
 	}
 }
 

--- a/cmd/libs/go2idl/client-gen/generators/client-generator.go
+++ b/cmd/libs/go2idl/client-gen/generators/client-generator.go
@@ -57,6 +57,7 @@ func NameSystems() namer.NameSystems {
 	pluralExceptions := map[string]string{
 		"Endpoints":       "Endpoints",
 		"ComponentStatus": "ComponentStatus",
+		"Ingress":         "Ingress",
 	}
 	return namer.NameSystems{
 		"public":        namer.NewPublicNamer(0),

--- a/cmd/libs/go2idl/client-gen/generators/fake/generator-fake-for-type.go
+++ b/cmd/libs/go2idl/client-gen/generators/fake/generator-fake-for-type.go
@@ -157,8 +157,8 @@ type Fake$.type|publicPlural$ struct {
 var listTemplate = `
 func (c *Fake$.type|publicPlural$) List(opts $.apiListOptions|raw$) (result *$.type|raw$List, err error) {
 	obj, err := c.Fake.
-		$if .namespaced$Invokes($.NewListAction|raw$("$.type|privatePlural$", c.ns, opts), &$.type|raw$List{})
-		$else$Invokes($.NewRootListAction|raw$("$.type|privatePlural$", opts), &$.type|raw$List{})$end$
+		$if .namespaced$Invokes($.NewListAction|raw$("$.type|allLowercasePlural$", c.ns, opts), &$.type|raw$List{})
+		$else$Invokes($.NewRootListAction|raw$("$.type|allLowercasePlural$", opts), &$.type|raw$List{})$end$
 	if obj == nil {
 		return nil, err
 	}
@@ -169,8 +169,8 @@ func (c *Fake$.type|publicPlural$) List(opts $.apiListOptions|raw$) (result *$.t
 var listUsingOptionsTemplate = `
 func (c *Fake$.type|publicPlural$) List(opts $.apiListOptions|raw$) (result *$.type|raw$List, err error) {
 	obj, err := c.Fake.
-		$if .namespaced$Invokes($.NewListAction|raw$("$.type|privatePlural$", c.ns, opts), &$.type|raw$List{})
-		$else$Invokes($.NewRootListAction|raw$("$.type|privatePlural$", opts), &$.type|raw$List{})$end$
+		$if .namespaced$Invokes($.NewListAction|raw$("$.type|allLowercasePlural$", c.ns, opts), &$.type|raw$List{})
+		$else$Invokes($.NewRootListAction|raw$("$.type|allLowercasePlural$", opts), &$.type|raw$List{})$end$
 	if obj == nil {
 		return nil, err
 	}
@@ -192,8 +192,8 @@ func (c *Fake$.type|publicPlural$) List(opts $.apiListOptions|raw$) (result *$.t
 var getTemplate = `
 func (c *Fake$.type|publicPlural$) Get(name string) (result *$.type|raw$, err error) {
 	obj, err := c.Fake.
-		$if .namespaced$Invokes($.NewGetAction|raw$("$.type|privatePlural$", c.ns, name), &$.type|raw${})
-		$else$Invokes($.NewRootGetAction|raw$("$.type|privatePlural$", name), &$.type|raw${})$end$
+		$if .namespaced$Invokes($.NewGetAction|raw$("$.type|allLowercasePlural$", c.ns, name), &$.type|raw${})
+		$else$Invokes($.NewRootGetAction|raw$("$.type|allLowercasePlural$", name), &$.type|raw${})$end$
 	if obj == nil {
 		return nil, err
 	}
@@ -204,8 +204,8 @@ func (c *Fake$.type|publicPlural$) Get(name string) (result *$.type|raw$, err er
 var deleteTemplate = `
 func (c *Fake$.type|publicPlural$) Delete(name string, options *$.apiDeleteOptions|raw$) error {
 	_, err := c.Fake.
-		$if .namespaced$Invokes($.NewDeleteAction|raw$("$.type|privatePlural$", c.ns, name), &$.type|raw${})
-		$else$Invokes($.NewRootDeleteAction|raw$("$.type|privatePlural$", name), &$.type|raw${})$end$
+		$if .namespaced$Invokes($.NewDeleteAction|raw$("$.type|allLowercasePlural$", c.ns, name), &$.type|raw${})
+		$else$Invokes($.NewRootDeleteAction|raw$("$.type|allLowercasePlural$", name), &$.type|raw${})$end$
 	return err
 }
 `
@@ -223,8 +223,8 @@ func (c *Fake$.type|publicPlural$) DeleteCollection(options *$.apiDeleteOptions|
 var createTemplate = `
 func (c *Fake$.type|publicPlural$) Create($.type|private$ *$.type|raw$) (result *$.type|raw$, err error) {
 	obj, err := c.Fake.
-		$if .namespaced$Invokes($.NewCreateAction|raw$("$.type|privatePlural$", c.ns, $.type|private$), &$.type|raw${})
-		$else$Invokes($.NewRootCreateAction|raw$("$.type|privatePlural$", $.type|private$), &$.type|raw${})$end$
+		$if .namespaced$Invokes($.NewCreateAction|raw$("$.type|allLowercasePlural$", c.ns, $.type|private$), &$.type|raw${})
+		$else$Invokes($.NewRootCreateAction|raw$("$.type|allLowercasePlural$", $.type|private$), &$.type|raw${})$end$
 	if obj == nil {
 		return nil, err
 	}
@@ -235,8 +235,8 @@ func (c *Fake$.type|publicPlural$) Create($.type|private$ *$.type|raw$) (result 
 var updateTemplate = `
 func (c *Fake$.type|publicPlural$) Update($.type|private$ *$.type|raw$) (result *$.type|raw$, err error) {
 	obj, err := c.Fake.
-		$if .namespaced$Invokes($.NewUpdateAction|raw$("$.type|privatePlural$", c.ns, $.type|private$), &$.type|raw${})
-		$else$Invokes($.NewRootUpdateAction|raw$("$.type|privatePlural$", $.type|private$), &$.type|raw${})$end$
+		$if .namespaced$Invokes($.NewUpdateAction|raw$("$.type|allLowercasePlural$", c.ns, $.type|private$), &$.type|raw${})
+		$else$Invokes($.NewRootUpdateAction|raw$("$.type|allLowercasePlural$", $.type|private$), &$.type|raw${})$end$
 	if obj == nil {
 		return nil, err
 	}
@@ -247,8 +247,8 @@ func (c *Fake$.type|publicPlural$) Update($.type|private$ *$.type|raw$) (result 
 var updateStatusTemplate = `
 func (c *Fake$.type|publicPlural$) UpdateStatus($.type|private$ *$.type|raw$) (*$.type|raw$, error) {
 	obj, err := c.Fake.
-		$if .namespaced$Invokes($.NewUpdateSubresourceAction|raw$("$.type|privatePlural$", "status", c.ns, $.type|private$), &$.type|raw${})
-		$else$Invokes($.NewRootUpdateSubresourceAction|raw$("$.type|privatePlural$", "status", $.type|private$), &$.type|raw${})$end$
+		$if .namespaced$Invokes($.NewUpdateSubresourceAction|raw$("$.type|allLowercasePlural$", "status", c.ns, $.type|private$), &$.type|raw${})
+		$else$Invokes($.NewRootUpdateSubresourceAction|raw$("$.type|allLowercasePlural$", "status", $.type|private$), &$.type|raw${})$end$
 	if obj == nil {
 		return nil, err
 	}
@@ -260,7 +260,7 @@ var watchTemplate = `
 // Watch returns a $.watchInterface|raw$ that watches the requested $.type|privatePlural$.
 func (c *Fake$.type|publicPlural$) Watch(opts $.apiListOptions|raw$) ($.watchInterface|raw$, error) {
 	return c.Fake.
-		$if .namespaced$InvokesWatch($.NewWatchAction|raw$("$.type|privatePlural$", c.ns, opts))
-		$else$InvokesWatch($.NewRootWatchAction|raw$("$.type|privatePlural$", opts))$end$
+		$if .namespaced$InvokesWatch($.NewWatchAction|raw$("$.type|allLowercasePlural$", c.ns, opts))
+		$else$InvokesWatch($.NewRootWatchAction|raw$("$.type|allLowercasePlural$", opts))$end$
 }
 `

--- a/cmd/libs/go2idl/client-gen/generators/generator-for-type.go
+++ b/cmd/libs/go2idl/client-gen/generators/generator-for-type.go
@@ -283,10 +283,17 @@ func (c *$.type|privatePlural$) Update($.type|private$ *$.type|raw$) (result *$.
 `
 
 var updateStatusTemplate = `
-func (c *$.type|privatePlural$) UpdateStatus($.type|private$ *$.type|raw$) (*$.type|raw$, error) {
-	result := &$.type|raw${}
-	err := c.client.Put().Resource("$.type|privatePlural$").Name($.type|private$.Name).SubResource("status").Body($.type|private$).Do().Into(result)
-	return result, err
+func (c *$.type|privatePlural$) UpdateStatus($.type|private$ *$.type|raw$) (result *$.type|raw$, err error) {
+	result = &$.type|raw${}
+	err = c.client.Put().
+		$if .namespaced$Namespace(c.ns).$end$
+		Resource("$.type|privatePlural$").
+		Name($.type|private$.Name).
+		SubResource("status").
+		Body($.type|private$).
+		Do().
+		Into(result)
+	return
 }
 `
 

--- a/cmd/libs/go2idl/client-gen/generators/generator-for-type.go
+++ b/cmd/libs/go2idl/client-gen/generators/generator-for-type.go
@@ -206,7 +206,7 @@ func (c *$.type|privatePlural$) List(opts $.apiListOptions|raw$) (result *$.type
 	result = &$.type|raw$List{}
 	err = c.client.Get().
 		$if .namespaced$Namespace(c.ns).$end$
-		Resource("$.type|privatePlural$").
+		Resource("$.type|allLowercasePlural$").
 		VersionedParams(&opts, api.Scheme).
 		Do().
 		Into(result)
@@ -219,7 +219,7 @@ func (c *$.type|privatePlural$) Get(name string) (result *$.type|raw$, err error
 	result = &$.type|raw${}
 	err = c.client.Get().
 		$if .namespaced$Namespace(c.ns).$end$
-		Resource("$.type|privatePlural$").
+		Resource("$.type|allLowercasePlural$").
 		Name(name).
 		Do().
 		Into(result)
@@ -232,7 +232,7 @@ var deleteTemplate = `
 func (c *$.type|privatePlural$) Delete(name string, options *$.apiDeleteOptions|raw$) error {
 	return c.client.Delete().
 		$if .namespaced$Namespace(c.ns).$end$
-		Resource("$.type|privatePlural$").
+		Resource("$.type|allLowercasePlural$").
 		Name(name).
 		Body(options).
 		Do().
@@ -245,7 +245,7 @@ var deleteCollectionTemplate = `
 func (c *$.type|privatePlural$) DeleteCollection(options *$.apiDeleteOptions|raw$, listOptions $.apiListOptions|raw$) error {
 	return c.client.Delete().
 		$if .namespaced$Namespace(c.ns).$end$
-		Resource("$.type|privatePlural$").
+		Resource("$.type|allLowercasePlural$").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).
 		Do().
@@ -259,7 +259,7 @@ func (c *$.type|privatePlural$) Create($.type|private$ *$.type|raw$) (result *$.
 	result = &$.type|raw${}
 	err = c.client.Post().
 		$if .namespaced$Namespace(c.ns).$end$
-		Resource("$.type|privatePlural$").
+		Resource("$.type|allLowercasePlural$").
 		Body($.type|private$).
 		Do().
 		Into(result)
@@ -273,7 +273,7 @@ func (c *$.type|privatePlural$) Update($.type|private$ *$.type|raw$) (result *$.
 	result = &$.type|raw${}
 	err = c.client.Put().
 		$if .namespaced$Namespace(c.ns).$end$
-		Resource("$.type|privatePlural$").
+		Resource("$.type|allLowercasePlural$").
 		Name($.type|private$.Name).
 		Body($.type|private$).
 		Do().
@@ -287,7 +287,7 @@ func (c *$.type|privatePlural$) UpdateStatus($.type|private$ *$.type|raw$) (resu
 	result = &$.type|raw${}
 	err = c.client.Put().
 		$if .namespaced$Namespace(c.ns).$end$
-		Resource("$.type|privatePlural$").
+		Resource("$.type|allLowercasePlural$").
 		Name($.type|private$.Name).
 		SubResource("status").
 		Body($.type|private$).
@@ -303,7 +303,7 @@ func (c *$.type|privatePlural$) Watch(opts $.apiListOptions|raw$) ($.watchInterf
 	return c.client.Get().
 		Prefix("watch").
 		$if .namespaced$Namespace(c.ns).$end$
-		Resource("$.type|privatePlural$").
+		Resource("$.type|allLowercasePlural$").
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }

--- a/cmd/libs/go2idl/client-gen/testoutput/testgroup/unversioned/testtype.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/testgroup/unversioned/testtype.go
@@ -80,10 +80,17 @@ func (c *testTypes) Update(testType *testgroup.TestType) (result *testgroup.Test
 	return
 }
 
-func (c *testTypes) UpdateStatus(testType *testgroup.TestType) (*testgroup.TestType, error) {
-	result := &testgroup.TestType{}
-	err := c.client.Put().Resource("testTypes").Name(testType.Name).SubResource("status").Body(testType).Do().Into(result)
-	return result, err
+func (c *testTypes) UpdateStatus(testType *testgroup.TestType) (result *testgroup.TestType, err error) {
+	result = &testgroup.TestType{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("testTypes").
+		Name(testType.Name).
+		SubResource("status").
+		Body(testType).
+		Do().
+		Into(result)
+	return
 }
 
 // Delete takes name of the testType and deletes it. Returns an error if one occurs.

--- a/cmd/libs/go2idl/client-gen/testoutput/testgroup/unversioned/testtype.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/testgroup/unversioned/testtype.go
@@ -60,7 +60,7 @@ func (c *testTypes) Create(testType *testgroup.TestType) (result *testgroup.Test
 	result = &testgroup.TestType{}
 	err = c.client.Post().
 		Namespace(c.ns).
-		Resource("testTypes").
+		Resource("testtypes").
 		Body(testType).
 		Do().
 		Into(result)
@@ -72,7 +72,7 @@ func (c *testTypes) Update(testType *testgroup.TestType) (result *testgroup.Test
 	result = &testgroup.TestType{}
 	err = c.client.Put().
 		Namespace(c.ns).
-		Resource("testTypes").
+		Resource("testtypes").
 		Name(testType.Name).
 		Body(testType).
 		Do().
@@ -84,7 +84,7 @@ func (c *testTypes) UpdateStatus(testType *testgroup.TestType) (result *testgrou
 	result = &testgroup.TestType{}
 	err = c.client.Put().
 		Namespace(c.ns).
-		Resource("testTypes").
+		Resource("testtypes").
 		Name(testType.Name).
 		SubResource("status").
 		Body(testType).
@@ -97,7 +97,7 @@ func (c *testTypes) UpdateStatus(testType *testgroup.TestType) (result *testgrou
 func (c *testTypes) Delete(name string, options *api.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("testTypes").
+		Resource("testtypes").
 		Name(name).
 		Body(options).
 		Do().
@@ -108,7 +108,7 @@ func (c *testTypes) Delete(name string, options *api.DeleteOptions) error {
 func (c *testTypes) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("testTypes").
+		Resource("testtypes").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).
 		Do().
@@ -120,7 +120,7 @@ func (c *testTypes) Get(name string) (result *testgroup.TestType, err error) {
 	result = &testgroup.TestType{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("testTypes").
+		Resource("testtypes").
 		Name(name).
 		Do().
 		Into(result)
@@ -132,7 +132,7 @@ func (c *testTypes) List(opts api.ListOptions) (result *testgroup.TestTypeList, 
 	result = &testgroup.TestTypeList{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("testTypes").
+		Resource("testtypes").
 		VersionedParams(&opts, api.Scheme).
 		Do().
 		Into(result)
@@ -144,7 +144,7 @@ func (c *testTypes) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.client.Get().
 		Prefix("watch").
 		Namespace(c.ns).
-		Resource("testTypes").
+		Resource("testtypes").
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }

--- a/cmd/libs/go2idl/namer/plural_namer.go
+++ b/cmd/libs/go2idl/namer/plural_namer.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package namer
 
-import "k8s.io/kubernetes/cmd/libs/go2idl/types"
+import (
+	"strings"
+
+	"k8s.io/kubernetes/cmd/libs/go2idl/types"
+)
 
 type pluralNamer struct {
 	// key is the case-sensitive type name, value is the case-insensitive
@@ -35,6 +39,12 @@ func NewPublicPluralNamer(exceptions map[string]string) *pluralNamer {
 // type's name, starting with a lowercase letter.
 func NewPrivatePluralNamer(exceptions map[string]string) *pluralNamer {
 	return &pluralNamer{exceptions, IL}
+}
+
+// NewAllLowercasePluralNamer returns a namer that returns the plural form of the input
+// type's name, with all letters in lowercase.
+func NewAllLowercasePluralNamer(exceptions map[string]string) *pluralNamer {
+	return &pluralNamer{exceptions, strings.ToLower}
 }
 
 // Name returns the plural form of the type's name. If the type's name is found

--- a/pkg/client/typed/generated/extensions/unversioned/daemonset.go
+++ b/pkg/client/typed/generated/extensions/unversioned/daemonset.go
@@ -80,10 +80,17 @@ func (c *daemonSets) Update(daemonSet *extensions.DaemonSet) (result *extensions
 	return
 }
 
-func (c *daemonSets) UpdateStatus(daemonSet *extensions.DaemonSet) (*extensions.DaemonSet, error) {
-	result := &extensions.DaemonSet{}
-	err := c.client.Put().Resource("daemonSets").Name(daemonSet.Name).SubResource("status").Body(daemonSet).Do().Into(result)
-	return result, err
+func (c *daemonSets) UpdateStatus(daemonSet *extensions.DaemonSet) (result *extensions.DaemonSet, err error) {
+	result = &extensions.DaemonSet{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("daemonSets").
+		Name(daemonSet.Name).
+		SubResource("status").
+		Body(daemonSet).
+		Do().
+		Into(result)
+	return
 }
 
 // Delete takes name of the daemonSet and deletes it. Returns an error if one occurs.

--- a/pkg/client/typed/generated/extensions/unversioned/daemonset.go
+++ b/pkg/client/typed/generated/extensions/unversioned/daemonset.go
@@ -60,7 +60,7 @@ func (c *daemonSets) Create(daemonSet *extensions.DaemonSet) (result *extensions
 	result = &extensions.DaemonSet{}
 	err = c.client.Post().
 		Namespace(c.ns).
-		Resource("daemonSets").
+		Resource("daemonsets").
 		Body(daemonSet).
 		Do().
 		Into(result)
@@ -72,7 +72,7 @@ func (c *daemonSets) Update(daemonSet *extensions.DaemonSet) (result *extensions
 	result = &extensions.DaemonSet{}
 	err = c.client.Put().
 		Namespace(c.ns).
-		Resource("daemonSets").
+		Resource("daemonsets").
 		Name(daemonSet.Name).
 		Body(daemonSet).
 		Do().
@@ -84,7 +84,7 @@ func (c *daemonSets) UpdateStatus(daemonSet *extensions.DaemonSet) (result *exte
 	result = &extensions.DaemonSet{}
 	err = c.client.Put().
 		Namespace(c.ns).
-		Resource("daemonSets").
+		Resource("daemonsets").
 		Name(daemonSet.Name).
 		SubResource("status").
 		Body(daemonSet).
@@ -97,7 +97,7 @@ func (c *daemonSets) UpdateStatus(daemonSet *extensions.DaemonSet) (result *exte
 func (c *daemonSets) Delete(name string, options *api.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("daemonSets").
+		Resource("daemonsets").
 		Name(name).
 		Body(options).
 		Do().
@@ -108,7 +108,7 @@ func (c *daemonSets) Delete(name string, options *api.DeleteOptions) error {
 func (c *daemonSets) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("daemonSets").
+		Resource("daemonsets").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).
 		Do().
@@ -120,7 +120,7 @@ func (c *daemonSets) Get(name string) (result *extensions.DaemonSet, err error) 
 	result = &extensions.DaemonSet{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("daemonSets").
+		Resource("daemonsets").
 		Name(name).
 		Do().
 		Into(result)
@@ -132,7 +132,7 @@ func (c *daemonSets) List(opts api.ListOptions) (result *extensions.DaemonSetLis
 	result = &extensions.DaemonSetList{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("daemonSets").
+		Resource("daemonsets").
 		VersionedParams(&opts, api.Scheme).
 		Do().
 		Into(result)
@@ -144,7 +144,7 @@ func (c *daemonSets) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.client.Get().
 		Prefix("watch").
 		Namespace(c.ns).
-		Resource("daemonSets").
+		Resource("daemonsets").
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }

--- a/pkg/client/typed/generated/extensions/unversioned/deployment.go
+++ b/pkg/client/typed/generated/extensions/unversioned/deployment.go
@@ -80,10 +80,17 @@ func (c *deployments) Update(deployment *extensions.Deployment) (result *extensi
 	return
 }
 
-func (c *deployments) UpdateStatus(deployment *extensions.Deployment) (*extensions.Deployment, error) {
-	result := &extensions.Deployment{}
-	err := c.client.Put().Resource("deployments").Name(deployment.Name).SubResource("status").Body(deployment).Do().Into(result)
-	return result, err
+func (c *deployments) UpdateStatus(deployment *extensions.Deployment) (result *extensions.Deployment, err error) {
+	result = &extensions.Deployment{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("deployments").
+		Name(deployment.Name).
+		SubResource("status").
+		Body(deployment).
+		Do().
+		Into(result)
+	return
 }
 
 // Delete takes name of the deployment and deletes it. Returns an error if one occurs.

--- a/pkg/client/typed/generated/extensions/unversioned/extensions_client.go
+++ b/pkg/client/typed/generated/extensions/unversioned/extensions_client.go
@@ -26,7 +26,7 @@ type ExtensionsInterface interface {
 	DaemonSetsGetter
 	DeploymentsGetter
 	HorizontalPodAutoscalersGetter
-	IngressesGetter
+	IngressGetter
 	JobsGetter
 	ScalesGetter
 	ThirdPartyResourcesGetter
@@ -49,8 +49,8 @@ func (c *ExtensionsClient) HorizontalPodAutoscalers(namespace string) Horizontal
 	return newHorizontalPodAutoscalers(c, namespace)
 }
 
-func (c *ExtensionsClient) Ingresses(namespace string) IngressInterface {
-	return newIngresses(c, namespace)
+func (c *ExtensionsClient) Ingress(namespace string) IngressInterface {
+	return newIngress(c, namespace)
 }
 
 func (c *ExtensionsClient) Jobs(namespace string) JobInterface {

--- a/pkg/client/typed/generated/extensions/unversioned/fake/fake_daemonset.go
+++ b/pkg/client/typed/generated/extensions/unversioned/fake/fake_daemonset.go
@@ -32,7 +32,7 @@ type FakeDaemonSets struct {
 
 func (c *FakeDaemonSets) Create(daemonSet *extensions.DaemonSet) (result *extensions.DaemonSet, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewCreateAction("daemonSets", c.ns, daemonSet), &extensions.DaemonSet{})
+		Invokes(core.NewCreateAction("daemonsets", c.ns, daemonSet), &extensions.DaemonSet{})
 
 	if obj == nil {
 		return nil, err
@@ -42,7 +42,7 @@ func (c *FakeDaemonSets) Create(daemonSet *extensions.DaemonSet) (result *extens
 
 func (c *FakeDaemonSets) Update(daemonSet *extensions.DaemonSet) (result *extensions.DaemonSet, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewUpdateAction("daemonSets", c.ns, daemonSet), &extensions.DaemonSet{})
+		Invokes(core.NewUpdateAction("daemonsets", c.ns, daemonSet), &extensions.DaemonSet{})
 
 	if obj == nil {
 		return nil, err
@@ -52,7 +52,7 @@ func (c *FakeDaemonSets) Update(daemonSet *extensions.DaemonSet) (result *extens
 
 func (c *FakeDaemonSets) UpdateStatus(daemonSet *extensions.DaemonSet) (*extensions.DaemonSet, error) {
 	obj, err := c.Fake.
-		Invokes(core.NewUpdateSubresourceAction("daemonSets", "status", c.ns, daemonSet), &extensions.DaemonSet{})
+		Invokes(core.NewUpdateSubresourceAction("daemonsets", "status", c.ns, daemonSet), &extensions.DaemonSet{})
 
 	if obj == nil {
 		return nil, err
@@ -62,7 +62,7 @@ func (c *FakeDaemonSets) UpdateStatus(daemonSet *extensions.DaemonSet) (*extensi
 
 func (c *FakeDaemonSets) Delete(name string, options *api.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(core.NewDeleteAction("daemonSets", c.ns, name), &extensions.DaemonSet{})
+		Invokes(core.NewDeleteAction("daemonsets", c.ns, name), &extensions.DaemonSet{})
 
 	return err
 }
@@ -76,7 +76,7 @@ func (c *FakeDaemonSets) DeleteCollection(options *api.DeleteOptions, listOption
 
 func (c *FakeDaemonSets) Get(name string) (result *extensions.DaemonSet, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewGetAction("daemonSets", c.ns, name), &extensions.DaemonSet{})
+		Invokes(core.NewGetAction("daemonsets", c.ns, name), &extensions.DaemonSet{})
 
 	if obj == nil {
 		return nil, err
@@ -86,7 +86,7 @@ func (c *FakeDaemonSets) Get(name string) (result *extensions.DaemonSet, err err
 
 func (c *FakeDaemonSets) List(opts api.ListOptions) (result *extensions.DaemonSetList, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewListAction("daemonSets", c.ns, opts), &extensions.DaemonSetList{})
+		Invokes(core.NewListAction("daemonsets", c.ns, opts), &extensions.DaemonSetList{})
 
 	if obj == nil {
 		return nil, err
@@ -108,6 +108,6 @@ func (c *FakeDaemonSets) List(opts api.ListOptions) (result *extensions.DaemonSe
 // Watch returns a watch.Interface that watches the requested daemonSets.
 func (c *FakeDaemonSets) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(core.NewWatchAction("daemonSets", c.ns, opts))
+		InvokesWatch(core.NewWatchAction("daemonsets", c.ns, opts))
 
 }

--- a/pkg/client/typed/generated/extensions/unversioned/fake/fake_extensions_client.go
+++ b/pkg/client/typed/generated/extensions/unversioned/fake/fake_extensions_client.go
@@ -37,8 +37,8 @@ func (c *FakeExtensions) HorizontalPodAutoscalers(namespace string) unversioned.
 	return &FakeHorizontalPodAutoscalers{c, namespace}
 }
 
-func (c *FakeExtensions) Ingresses(namespace string) unversioned.IngressInterface {
-	return &FakeIngresses{c, namespace}
+func (c *FakeExtensions) Ingress(namespace string) unversioned.IngressInterface {
+	return &FakeIngress{c, namespace}
 }
 
 func (c *FakeExtensions) Jobs(namespace string) unversioned.JobInterface {

--- a/pkg/client/typed/generated/extensions/unversioned/fake/fake_horizontalpodautoscaler.go
+++ b/pkg/client/typed/generated/extensions/unversioned/fake/fake_horizontalpodautoscaler.go
@@ -32,7 +32,7 @@ type FakeHorizontalPodAutoscalers struct {
 
 func (c *FakeHorizontalPodAutoscalers) Create(horizontalPodAutoscaler *extensions.HorizontalPodAutoscaler) (result *extensions.HorizontalPodAutoscaler, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewCreateAction("horizontalPodAutoscalers", c.ns, horizontalPodAutoscaler), &extensions.HorizontalPodAutoscaler{})
+		Invokes(core.NewCreateAction("horizontalpodautoscalers", c.ns, horizontalPodAutoscaler), &extensions.HorizontalPodAutoscaler{})
 
 	if obj == nil {
 		return nil, err
@@ -42,7 +42,7 @@ func (c *FakeHorizontalPodAutoscalers) Create(horizontalPodAutoscaler *extension
 
 func (c *FakeHorizontalPodAutoscalers) Update(horizontalPodAutoscaler *extensions.HorizontalPodAutoscaler) (result *extensions.HorizontalPodAutoscaler, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewUpdateAction("horizontalPodAutoscalers", c.ns, horizontalPodAutoscaler), &extensions.HorizontalPodAutoscaler{})
+		Invokes(core.NewUpdateAction("horizontalpodautoscalers", c.ns, horizontalPodAutoscaler), &extensions.HorizontalPodAutoscaler{})
 
 	if obj == nil {
 		return nil, err
@@ -52,7 +52,7 @@ func (c *FakeHorizontalPodAutoscalers) Update(horizontalPodAutoscaler *extension
 
 func (c *FakeHorizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *extensions.HorizontalPodAutoscaler) (*extensions.HorizontalPodAutoscaler, error) {
 	obj, err := c.Fake.
-		Invokes(core.NewUpdateSubresourceAction("horizontalPodAutoscalers", "status", c.ns, horizontalPodAutoscaler), &extensions.HorizontalPodAutoscaler{})
+		Invokes(core.NewUpdateSubresourceAction("horizontalpodautoscalers", "status", c.ns, horizontalPodAutoscaler), &extensions.HorizontalPodAutoscaler{})
 
 	if obj == nil {
 		return nil, err
@@ -62,7 +62,7 @@ func (c *FakeHorizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *ext
 
 func (c *FakeHorizontalPodAutoscalers) Delete(name string, options *api.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(core.NewDeleteAction("horizontalPodAutoscalers", c.ns, name), &extensions.HorizontalPodAutoscaler{})
+		Invokes(core.NewDeleteAction("horizontalpodautoscalers", c.ns, name), &extensions.HorizontalPodAutoscaler{})
 
 	return err
 }
@@ -76,7 +76,7 @@ func (c *FakeHorizontalPodAutoscalers) DeleteCollection(options *api.DeleteOptio
 
 func (c *FakeHorizontalPodAutoscalers) Get(name string) (result *extensions.HorizontalPodAutoscaler, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewGetAction("horizontalPodAutoscalers", c.ns, name), &extensions.HorizontalPodAutoscaler{})
+		Invokes(core.NewGetAction("horizontalpodautoscalers", c.ns, name), &extensions.HorizontalPodAutoscaler{})
 
 	if obj == nil {
 		return nil, err
@@ -86,7 +86,7 @@ func (c *FakeHorizontalPodAutoscalers) Get(name string) (result *extensions.Hori
 
 func (c *FakeHorizontalPodAutoscalers) List(opts api.ListOptions) (result *extensions.HorizontalPodAutoscalerList, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewListAction("horizontalPodAutoscalers", c.ns, opts), &extensions.HorizontalPodAutoscalerList{})
+		Invokes(core.NewListAction("horizontalpodautoscalers", c.ns, opts), &extensions.HorizontalPodAutoscalerList{})
 
 	if obj == nil {
 		return nil, err
@@ -108,6 +108,6 @@ func (c *FakeHorizontalPodAutoscalers) List(opts api.ListOptions) (result *exten
 // Watch returns a watch.Interface that watches the requested horizontalPodAutoscalers.
 func (c *FakeHorizontalPodAutoscalers) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(core.NewWatchAction("horizontalPodAutoscalers", c.ns, opts))
+		InvokesWatch(core.NewWatchAction("horizontalpodautoscalers", c.ns, opts))
 
 }

--- a/pkg/client/typed/generated/extensions/unversioned/fake/fake_ingress.go
+++ b/pkg/client/typed/generated/extensions/unversioned/fake/fake_ingress.go
@@ -24,15 +24,15 @@ import (
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
-// FakeIngresses implements IngressInterface
-type FakeIngresses struct {
+// FakeIngress implements IngressInterface
+type FakeIngress struct {
 	Fake *FakeExtensions
 	ns   string
 }
 
-func (c *FakeIngresses) Create(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
+func (c *FakeIngress) Create(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewCreateAction("ingresses", c.ns, ingress), &extensions.Ingress{})
+		Invokes(core.NewCreateAction("ingress", c.ns, ingress), &extensions.Ingress{})
 
 	if obj == nil {
 		return nil, err
@@ -40,9 +40,9 @@ func (c *FakeIngresses) Create(ingress *extensions.Ingress) (result *extensions.
 	return obj.(*extensions.Ingress), err
 }
 
-func (c *FakeIngresses) Update(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
+func (c *FakeIngress) Update(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewUpdateAction("ingresses", c.ns, ingress), &extensions.Ingress{})
+		Invokes(core.NewUpdateAction("ingress", c.ns, ingress), &extensions.Ingress{})
 
 	if obj == nil {
 		return nil, err
@@ -50,9 +50,9 @@ func (c *FakeIngresses) Update(ingress *extensions.Ingress) (result *extensions.
 	return obj.(*extensions.Ingress), err
 }
 
-func (c *FakeIngresses) UpdateStatus(ingress *extensions.Ingress) (*extensions.Ingress, error) {
+func (c *FakeIngress) UpdateStatus(ingress *extensions.Ingress) (*extensions.Ingress, error) {
 	obj, err := c.Fake.
-		Invokes(core.NewUpdateSubresourceAction("ingresses", "status", c.ns, ingress), &extensions.Ingress{})
+		Invokes(core.NewUpdateSubresourceAction("ingress", "status", c.ns, ingress), &extensions.Ingress{})
 
 	if obj == nil {
 		return nil, err
@@ -60,23 +60,23 @@ func (c *FakeIngresses) UpdateStatus(ingress *extensions.Ingress) (*extensions.I
 	return obj.(*extensions.Ingress), err
 }
 
-func (c *FakeIngresses) Delete(name string, options *api.DeleteOptions) error {
+func (c *FakeIngress) Delete(name string, options *api.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(core.NewDeleteAction("ingresses", c.ns, name), &extensions.Ingress{})
+		Invokes(core.NewDeleteAction("ingress", c.ns, name), &extensions.Ingress{})
 
 	return err
 }
 
-func (c *FakeIngresses) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+func (c *FakeIngress) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
 
 	_, err := c.Fake.Invokes(action, &extensions.IngressList{})
 	return err
 }
 
-func (c *FakeIngresses) Get(name string) (result *extensions.Ingress, err error) {
+func (c *FakeIngress) Get(name string) (result *extensions.Ingress, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewGetAction("ingresses", c.ns, name), &extensions.Ingress{})
+		Invokes(core.NewGetAction("ingress", c.ns, name), &extensions.Ingress{})
 
 	if obj == nil {
 		return nil, err
@@ -84,9 +84,9 @@ func (c *FakeIngresses) Get(name string) (result *extensions.Ingress, err error)
 	return obj.(*extensions.Ingress), err
 }
 
-func (c *FakeIngresses) List(opts api.ListOptions) (result *extensions.IngressList, err error) {
+func (c *FakeIngress) List(opts api.ListOptions) (result *extensions.IngressList, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewListAction("ingresses", c.ns, opts), &extensions.IngressList{})
+		Invokes(core.NewListAction("ingress", c.ns, opts), &extensions.IngressList{})
 
 	if obj == nil {
 		return nil, err
@@ -105,9 +105,9 @@ func (c *FakeIngresses) List(opts api.ListOptions) (result *extensions.IngressLi
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested ingresses.
-func (c *FakeIngresses) Watch(opts api.ListOptions) (watch.Interface, error) {
+// Watch returns a watch.Interface that watches the requested ingress.
+func (c *FakeIngress) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(core.NewWatchAction("ingresses", c.ns, opts))
+		InvokesWatch(core.NewWatchAction("ingress", c.ns, opts))
 
 }

--- a/pkg/client/typed/generated/extensions/unversioned/fake/fake_thirdpartyresource.go
+++ b/pkg/client/typed/generated/extensions/unversioned/fake/fake_thirdpartyresource.go
@@ -32,7 +32,7 @@ type FakeThirdPartyResources struct {
 
 func (c *FakeThirdPartyResources) Create(thirdPartyResource *extensions.ThirdPartyResource) (result *extensions.ThirdPartyResource, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewCreateAction("thirdPartyResources", c.ns, thirdPartyResource), &extensions.ThirdPartyResource{})
+		Invokes(core.NewCreateAction("thirdpartyresources", c.ns, thirdPartyResource), &extensions.ThirdPartyResource{})
 
 	if obj == nil {
 		return nil, err
@@ -42,7 +42,7 @@ func (c *FakeThirdPartyResources) Create(thirdPartyResource *extensions.ThirdPar
 
 func (c *FakeThirdPartyResources) Update(thirdPartyResource *extensions.ThirdPartyResource) (result *extensions.ThirdPartyResource, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewUpdateAction("thirdPartyResources", c.ns, thirdPartyResource), &extensions.ThirdPartyResource{})
+		Invokes(core.NewUpdateAction("thirdpartyresources", c.ns, thirdPartyResource), &extensions.ThirdPartyResource{})
 
 	if obj == nil {
 		return nil, err
@@ -52,7 +52,7 @@ func (c *FakeThirdPartyResources) Update(thirdPartyResource *extensions.ThirdPar
 
 func (c *FakeThirdPartyResources) Delete(name string, options *api.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(core.NewDeleteAction("thirdPartyResources", c.ns, name), &extensions.ThirdPartyResource{})
+		Invokes(core.NewDeleteAction("thirdpartyresources", c.ns, name), &extensions.ThirdPartyResource{})
 
 	return err
 }
@@ -66,7 +66,7 @@ func (c *FakeThirdPartyResources) DeleteCollection(options *api.DeleteOptions, l
 
 func (c *FakeThirdPartyResources) Get(name string) (result *extensions.ThirdPartyResource, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewGetAction("thirdPartyResources", c.ns, name), &extensions.ThirdPartyResource{})
+		Invokes(core.NewGetAction("thirdpartyresources", c.ns, name), &extensions.ThirdPartyResource{})
 
 	if obj == nil {
 		return nil, err
@@ -76,7 +76,7 @@ func (c *FakeThirdPartyResources) Get(name string) (result *extensions.ThirdPart
 
 func (c *FakeThirdPartyResources) List(opts api.ListOptions) (result *extensions.ThirdPartyResourceList, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewListAction("thirdPartyResources", c.ns, opts), &extensions.ThirdPartyResourceList{})
+		Invokes(core.NewListAction("thirdpartyresources", c.ns, opts), &extensions.ThirdPartyResourceList{})
 
 	if obj == nil {
 		return nil, err
@@ -98,6 +98,6 @@ func (c *FakeThirdPartyResources) List(opts api.ListOptions) (result *extensions
 // Watch returns a watch.Interface that watches the requested thirdPartyResources.
 func (c *FakeThirdPartyResources) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(core.NewWatchAction("thirdPartyResources", c.ns, opts))
+		InvokesWatch(core.NewWatchAction("thirdpartyresources", c.ns, opts))
 
 }

--- a/pkg/client/typed/generated/extensions/unversioned/horizontalpodautoscaler.go
+++ b/pkg/client/typed/generated/extensions/unversioned/horizontalpodautoscaler.go
@@ -80,10 +80,17 @@ func (c *horizontalPodAutoscalers) Update(horizontalPodAutoscaler *extensions.Ho
 	return
 }
 
-func (c *horizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *extensions.HorizontalPodAutoscaler) (*extensions.HorizontalPodAutoscaler, error) {
-	result := &extensions.HorizontalPodAutoscaler{}
-	err := c.client.Put().Resource("horizontalPodAutoscalers").Name(horizontalPodAutoscaler.Name).SubResource("status").Body(horizontalPodAutoscaler).Do().Into(result)
-	return result, err
+func (c *horizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *extensions.HorizontalPodAutoscaler) (result *extensions.HorizontalPodAutoscaler, err error) {
+	result = &extensions.HorizontalPodAutoscaler{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("horizontalPodAutoscalers").
+		Name(horizontalPodAutoscaler.Name).
+		SubResource("status").
+		Body(horizontalPodAutoscaler).
+		Do().
+		Into(result)
+	return
 }
 
 // Delete takes name of the horizontalPodAutoscaler and deletes it. Returns an error if one occurs.

--- a/pkg/client/typed/generated/extensions/unversioned/horizontalpodautoscaler.go
+++ b/pkg/client/typed/generated/extensions/unversioned/horizontalpodautoscaler.go
@@ -60,7 +60,7 @@ func (c *horizontalPodAutoscalers) Create(horizontalPodAutoscaler *extensions.Ho
 	result = &extensions.HorizontalPodAutoscaler{}
 	err = c.client.Post().
 		Namespace(c.ns).
-		Resource("horizontalPodAutoscalers").
+		Resource("horizontalpodautoscalers").
 		Body(horizontalPodAutoscaler).
 		Do().
 		Into(result)
@@ -72,7 +72,7 @@ func (c *horizontalPodAutoscalers) Update(horizontalPodAutoscaler *extensions.Ho
 	result = &extensions.HorizontalPodAutoscaler{}
 	err = c.client.Put().
 		Namespace(c.ns).
-		Resource("horizontalPodAutoscalers").
+		Resource("horizontalpodautoscalers").
 		Name(horizontalPodAutoscaler.Name).
 		Body(horizontalPodAutoscaler).
 		Do().
@@ -84,7 +84,7 @@ func (c *horizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *extensi
 	result = &extensions.HorizontalPodAutoscaler{}
 	err = c.client.Put().
 		Namespace(c.ns).
-		Resource("horizontalPodAutoscalers").
+		Resource("horizontalpodautoscalers").
 		Name(horizontalPodAutoscaler.Name).
 		SubResource("status").
 		Body(horizontalPodAutoscaler).
@@ -97,7 +97,7 @@ func (c *horizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *extensi
 func (c *horizontalPodAutoscalers) Delete(name string, options *api.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("horizontalPodAutoscalers").
+		Resource("horizontalpodautoscalers").
 		Name(name).
 		Body(options).
 		Do().
@@ -108,7 +108,7 @@ func (c *horizontalPodAutoscalers) Delete(name string, options *api.DeleteOption
 func (c *horizontalPodAutoscalers) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("horizontalPodAutoscalers").
+		Resource("horizontalpodautoscalers").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).
 		Do().
@@ -120,7 +120,7 @@ func (c *horizontalPodAutoscalers) Get(name string) (result *extensions.Horizont
 	result = &extensions.HorizontalPodAutoscaler{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("horizontalPodAutoscalers").
+		Resource("horizontalpodautoscalers").
 		Name(name).
 		Do().
 		Into(result)
@@ -132,7 +132,7 @@ func (c *horizontalPodAutoscalers) List(opts api.ListOptions) (result *extension
 	result = &extensions.HorizontalPodAutoscalerList{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("horizontalPodAutoscalers").
+		Resource("horizontalpodautoscalers").
 		VersionedParams(&opts, api.Scheme).
 		Do().
 		Into(result)
@@ -144,7 +144,7 @@ func (c *horizontalPodAutoscalers) Watch(opts api.ListOptions) (watch.Interface,
 	return c.client.Get().
 		Prefix("watch").
 		Namespace(c.ns).
-		Resource("horizontalPodAutoscalers").
+		Resource("horizontalpodautoscalers").
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }

--- a/pkg/client/typed/generated/extensions/unversioned/ingress.go
+++ b/pkg/client/typed/generated/extensions/unversioned/ingress.go
@@ -80,10 +80,17 @@ func (c *ingresses) Update(ingress *extensions.Ingress) (result *extensions.Ingr
 	return
 }
 
-func (c *ingresses) UpdateStatus(ingress *extensions.Ingress) (*extensions.Ingress, error) {
-	result := &extensions.Ingress{}
-	err := c.client.Put().Resource("ingresses").Name(ingress.Name).SubResource("status").Body(ingress).Do().Into(result)
-	return result, err
+func (c *ingresses) UpdateStatus(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
+	result = &extensions.Ingress{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("ingresses").
+		Name(ingress.Name).
+		SubResource("status").
+		Body(ingress).
+		Do().
+		Into(result)
+	return
 }
 
 // Delete takes name of the ingress and deletes it. Returns an error if one occurs.

--- a/pkg/client/typed/generated/extensions/unversioned/ingress.go
+++ b/pkg/client/typed/generated/extensions/unversioned/ingress.go
@@ -22,10 +22,10 @@ import (
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
-// IngressesGetter has a method to return a IngressInterface.
+// IngressGetter has a method to return a IngressInterface.
 // A group's client should implement this interface.
-type IngressesGetter interface {
-	Ingresses(namespace string) IngressInterface
+type IngressGetter interface {
+	Ingress(namespace string) IngressInterface
 }
 
 // IngressInterface has methods to work with Ingress resources.
@@ -41,26 +41,26 @@ type IngressInterface interface {
 	IngressExpansion
 }
 
-// ingresses implements IngressInterface
-type ingresses struct {
+// ingress implements IngressInterface
+type ingress struct {
 	client *ExtensionsClient
 	ns     string
 }
 
-// newIngresses returns a Ingresses
-func newIngresses(c *ExtensionsClient, namespace string) *ingresses {
-	return &ingresses{
+// newIngress returns a Ingress
+func newIngress(c *ExtensionsClient, namespace string) *ingress {
+	return &ingress{
 		client: c,
 		ns:     namespace,
 	}
 }
 
 // Create takes the representation of a ingress and creates it.  Returns the server's representation of the ingress, and an error, if there is any.
-func (c *ingresses) Create(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
+func (c *ingress) Create(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
 	result = &extensions.Ingress{}
 	err = c.client.Post().
 		Namespace(c.ns).
-		Resource("ingresses").
+		Resource("ingress").
 		Body(ingress).
 		Do().
 		Into(result)
@@ -68,11 +68,11 @@ func (c *ingresses) Create(ingress *extensions.Ingress) (result *extensions.Ingr
 }
 
 // Update takes the representation of a ingress and updates it. Returns the server's representation of the ingress, and an error, if there is any.
-func (c *ingresses) Update(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
+func (c *ingress) Update(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
 	result = &extensions.Ingress{}
 	err = c.client.Put().
 		Namespace(c.ns).
-		Resource("ingresses").
+		Resource("ingress").
 		Name(ingress.Name).
 		Body(ingress).
 		Do().
@@ -80,11 +80,11 @@ func (c *ingresses) Update(ingress *extensions.Ingress) (result *extensions.Ingr
 	return
 }
 
-func (c *ingresses) UpdateStatus(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
+func (c *ingress) UpdateStatus(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
 	result = &extensions.Ingress{}
 	err = c.client.Put().
 		Namespace(c.ns).
-		Resource("ingresses").
+		Resource("ingress").
 		Name(ingress.Name).
 		SubResource("status").
 		Body(ingress).
@@ -94,10 +94,10 @@ func (c *ingresses) UpdateStatus(ingress *extensions.Ingress) (result *extension
 }
 
 // Delete takes name of the ingress and deletes it. Returns an error if one occurs.
-func (c *ingresses) Delete(name string, options *api.DeleteOptions) error {
+func (c *ingress) Delete(name string, options *api.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("ingresses").
+		Resource("ingress").
 		Name(name).
 		Body(options).
 		Do().
@@ -105,10 +105,10 @@ func (c *ingresses) Delete(name string, options *api.DeleteOptions) error {
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *ingresses) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+func (c *ingress) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("ingresses").
+		Resource("ingress").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).
 		Do().
@@ -116,35 +116,35 @@ func (c *ingresses) DeleteCollection(options *api.DeleteOptions, listOptions api
 }
 
 // Get takes name of the ingress, and returns the corresponding ingress object, and an error if there is any.
-func (c *ingresses) Get(name string) (result *extensions.Ingress, err error) {
+func (c *ingress) Get(name string) (result *extensions.Ingress, err error) {
 	result = &extensions.Ingress{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("ingresses").
+		Resource("ingress").
 		Name(name).
 		Do().
 		Into(result)
 	return
 }
 
-// List takes label and field selectors, and returns the list of Ingresses that match those selectors.
-func (c *ingresses) List(opts api.ListOptions) (result *extensions.IngressList, err error) {
+// List takes label and field selectors, and returns the list of Ingress that match those selectors.
+func (c *ingress) List(opts api.ListOptions) (result *extensions.IngressList, err error) {
 	result = &extensions.IngressList{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("ingresses").
+		Resource("ingress").
 		VersionedParams(&opts, api.Scheme).
 		Do().
 		Into(result)
 	return
 }
 
-// Watch returns a watch.Interface that watches the requested ingresses.
-func (c *ingresses) Watch(opts api.ListOptions) (watch.Interface, error) {
+// Watch returns a watch.Interface that watches the requested ingress.
+func (c *ingress) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.client.Get().
 		Prefix("watch").
 		Namespace(c.ns).
-		Resource("ingresses").
+		Resource("ingress").
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }

--- a/pkg/client/typed/generated/extensions/unversioned/job.go
+++ b/pkg/client/typed/generated/extensions/unversioned/job.go
@@ -80,10 +80,17 @@ func (c *jobs) Update(job *extensions.Job) (result *extensions.Job, err error) {
 	return
 }
 
-func (c *jobs) UpdateStatus(job *extensions.Job) (*extensions.Job, error) {
-	result := &extensions.Job{}
-	err := c.client.Put().Resource("jobs").Name(job.Name).SubResource("status").Body(job).Do().Into(result)
-	return result, err
+func (c *jobs) UpdateStatus(job *extensions.Job) (result *extensions.Job, err error) {
+	result = &extensions.Job{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("jobs").
+		Name(job.Name).
+		SubResource("status").
+		Body(job).
+		Do().
+		Into(result)
+	return
 }
 
 // Delete takes name of the job and deletes it. Returns an error if one occurs.

--- a/pkg/client/typed/generated/extensions/unversioned/thirdpartyresource.go
+++ b/pkg/client/typed/generated/extensions/unversioned/thirdpartyresource.go
@@ -59,7 +59,7 @@ func (c *thirdPartyResources) Create(thirdPartyResource *extensions.ThirdPartyRe
 	result = &extensions.ThirdPartyResource{}
 	err = c.client.Post().
 		Namespace(c.ns).
-		Resource("thirdPartyResources").
+		Resource("thirdpartyresources").
 		Body(thirdPartyResource).
 		Do().
 		Into(result)
@@ -71,7 +71,7 @@ func (c *thirdPartyResources) Update(thirdPartyResource *extensions.ThirdPartyRe
 	result = &extensions.ThirdPartyResource{}
 	err = c.client.Put().
 		Namespace(c.ns).
-		Resource("thirdPartyResources").
+		Resource("thirdpartyresources").
 		Name(thirdPartyResource.Name).
 		Body(thirdPartyResource).
 		Do().
@@ -83,7 +83,7 @@ func (c *thirdPartyResources) Update(thirdPartyResource *extensions.ThirdPartyRe
 func (c *thirdPartyResources) Delete(name string, options *api.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("thirdPartyResources").
+		Resource("thirdpartyresources").
 		Name(name).
 		Body(options).
 		Do().
@@ -94,7 +94,7 @@ func (c *thirdPartyResources) Delete(name string, options *api.DeleteOptions) er
 func (c *thirdPartyResources) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("thirdPartyResources").
+		Resource("thirdpartyresources").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).
 		Do().
@@ -106,7 +106,7 @@ func (c *thirdPartyResources) Get(name string) (result *extensions.ThirdPartyRes
 	result = &extensions.ThirdPartyResource{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("thirdPartyResources").
+		Resource("thirdpartyresources").
 		Name(name).
 		Do().
 		Into(result)
@@ -118,7 +118,7 @@ func (c *thirdPartyResources) List(opts api.ListOptions) (result *extensions.Thi
 	result = &extensions.ThirdPartyResourceList{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("thirdPartyResources").
+		Resource("thirdpartyresources").
 		VersionedParams(&opts, api.Scheme).
 		Do().
 		Into(result)
@@ -130,7 +130,7 @@ func (c *thirdPartyResources) Watch(opts api.ListOptions) (watch.Interface, erro
 	return c.client.Get().
 		Prefix("watch").
 		Namespace(c.ns).
-		Resource("thirdPartyResources").
+		Resource("thirdpartyresources").
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }

--- a/pkg/client/typed/generated/legacy/unversioned/componentstatus.go
+++ b/pkg/client/typed/generated/legacy/unversioned/componentstatus.go
@@ -55,7 +55,7 @@ func newComponentStatus(c *LegacyClient) *componentStatus {
 func (c *componentStatus) Create(componentStatus *api.ComponentStatus) (result *api.ComponentStatus, err error) {
 	result = &api.ComponentStatus{}
 	err = c.client.Post().
-		Resource("componentStatus").
+		Resource("componentstatus").
 		Body(componentStatus).
 		Do().
 		Into(result)
@@ -66,7 +66,7 @@ func (c *componentStatus) Create(componentStatus *api.ComponentStatus) (result *
 func (c *componentStatus) Update(componentStatus *api.ComponentStatus) (result *api.ComponentStatus, err error) {
 	result = &api.ComponentStatus{}
 	err = c.client.Put().
-		Resource("componentStatus").
+		Resource("componentstatus").
 		Name(componentStatus.Name).
 		Body(componentStatus).
 		Do().
@@ -77,7 +77,7 @@ func (c *componentStatus) Update(componentStatus *api.ComponentStatus) (result *
 // Delete takes name of the componentStatus and deletes it. Returns an error if one occurs.
 func (c *componentStatus) Delete(name string, options *api.DeleteOptions) error {
 	return c.client.Delete().
-		Resource("componentStatus").
+		Resource("componentstatus").
 		Name(name).
 		Body(options).
 		Do().
@@ -87,7 +87,7 @@ func (c *componentStatus) Delete(name string, options *api.DeleteOptions) error 
 // DeleteCollection deletes a collection of objects.
 func (c *componentStatus) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
-		Resource("componentStatus").
+		Resource("componentstatus").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).
 		Do().
@@ -98,7 +98,7 @@ func (c *componentStatus) DeleteCollection(options *api.DeleteOptions, listOptio
 func (c *componentStatus) Get(name string) (result *api.ComponentStatus, err error) {
 	result = &api.ComponentStatus{}
 	err = c.client.Get().
-		Resource("componentStatus").
+		Resource("componentstatus").
 		Name(name).
 		Do().
 		Into(result)
@@ -109,7 +109,7 @@ func (c *componentStatus) Get(name string) (result *api.ComponentStatus, err err
 func (c *componentStatus) List(opts api.ListOptions) (result *api.ComponentStatusList, err error) {
 	result = &api.ComponentStatusList{}
 	err = c.client.Get().
-		Resource("componentStatus").
+		Resource("componentstatus").
 		VersionedParams(&opts, api.Scheme).
 		Do().
 		Into(result)
@@ -120,7 +120,7 @@ func (c *componentStatus) List(opts api.ListOptions) (result *api.ComponentStatu
 func (c *componentStatus) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.client.Get().
 		Prefix("watch").
-		Resource("componentStatus").
+		Resource("componentstatus").
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_componentstatus.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_componentstatus.go
@@ -30,7 +30,7 @@ type FakeComponentStatus struct {
 
 func (c *FakeComponentStatus) Create(componentStatus *api.ComponentStatus) (result *api.ComponentStatus, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewRootCreateAction("componentStatus", componentStatus), &api.ComponentStatus{})
+		Invokes(core.NewRootCreateAction("componentstatus", componentStatus), &api.ComponentStatus{})
 	if obj == nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func (c *FakeComponentStatus) Create(componentStatus *api.ComponentStatus) (resu
 
 func (c *FakeComponentStatus) Update(componentStatus *api.ComponentStatus) (result *api.ComponentStatus, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewRootUpdateAction("componentStatus", componentStatus), &api.ComponentStatus{})
+		Invokes(core.NewRootUpdateAction("componentstatus", componentStatus), &api.ComponentStatus{})
 	if obj == nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func (c *FakeComponentStatus) Update(componentStatus *api.ComponentStatus) (resu
 
 func (c *FakeComponentStatus) Delete(name string, options *api.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(core.NewRootDeleteAction("componentStatus", name), &api.ComponentStatus{})
+		Invokes(core.NewRootDeleteAction("componentstatus", name), &api.ComponentStatus{})
 	return err
 }
 
@@ -61,7 +61,7 @@ func (c *FakeComponentStatus) DeleteCollection(options *api.DeleteOptions, listO
 
 func (c *FakeComponentStatus) Get(name string) (result *api.ComponentStatus, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewRootGetAction("componentStatus", name), &api.ComponentStatus{})
+		Invokes(core.NewRootGetAction("componentstatus", name), &api.ComponentStatus{})
 	if obj == nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func (c *FakeComponentStatus) Get(name string) (result *api.ComponentStatus, err
 
 func (c *FakeComponentStatus) List(opts api.ListOptions) (result *api.ComponentStatusList, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewRootListAction("componentStatus", opts), &api.ComponentStatusList{})
+		Invokes(core.NewRootListAction("componentstatus", opts), &api.ComponentStatusList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -91,5 +91,5 @@ func (c *FakeComponentStatus) List(opts api.ListOptions) (result *api.ComponentS
 // Watch returns a watch.Interface that watches the requested componentStatus.
 func (c *FakeComponentStatus) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(core.NewRootWatchAction("componentStatus", opts))
+		InvokesWatch(core.NewRootWatchAction("componentstatus", opts))
 }

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_limitrange.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_limitrange.go
@@ -31,7 +31,7 @@ type FakeLimitRanges struct {
 
 func (c *FakeLimitRanges) Create(limitRange *api.LimitRange) (result *api.LimitRange, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewCreateAction("limitRanges", c.ns, limitRange), &api.LimitRange{})
+		Invokes(core.NewCreateAction("limitranges", c.ns, limitRange), &api.LimitRange{})
 
 	if obj == nil {
 		return nil, err
@@ -41,7 +41,7 @@ func (c *FakeLimitRanges) Create(limitRange *api.LimitRange) (result *api.LimitR
 
 func (c *FakeLimitRanges) Update(limitRange *api.LimitRange) (result *api.LimitRange, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewUpdateAction("limitRanges", c.ns, limitRange), &api.LimitRange{})
+		Invokes(core.NewUpdateAction("limitranges", c.ns, limitRange), &api.LimitRange{})
 
 	if obj == nil {
 		return nil, err
@@ -51,7 +51,7 @@ func (c *FakeLimitRanges) Update(limitRange *api.LimitRange) (result *api.LimitR
 
 func (c *FakeLimitRanges) Delete(name string, options *api.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(core.NewDeleteAction("limitRanges", c.ns, name), &api.LimitRange{})
+		Invokes(core.NewDeleteAction("limitranges", c.ns, name), &api.LimitRange{})
 
 	return err
 }
@@ -65,7 +65,7 @@ func (c *FakeLimitRanges) DeleteCollection(options *api.DeleteOptions, listOptio
 
 func (c *FakeLimitRanges) Get(name string) (result *api.LimitRange, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewGetAction("limitRanges", c.ns, name), &api.LimitRange{})
+		Invokes(core.NewGetAction("limitranges", c.ns, name), &api.LimitRange{})
 
 	if obj == nil {
 		return nil, err
@@ -75,7 +75,7 @@ func (c *FakeLimitRanges) Get(name string) (result *api.LimitRange, err error) {
 
 func (c *FakeLimitRanges) List(opts api.ListOptions) (result *api.LimitRangeList, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewListAction("limitRanges", c.ns, opts), &api.LimitRangeList{})
+		Invokes(core.NewListAction("limitranges", c.ns, opts), &api.LimitRangeList{})
 
 	if obj == nil {
 		return nil, err
@@ -97,6 +97,6 @@ func (c *FakeLimitRanges) List(opts api.ListOptions) (result *api.LimitRangeList
 // Watch returns a watch.Interface that watches the requested limitRanges.
 func (c *FakeLimitRanges) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(core.NewWatchAction("limitRanges", c.ns, opts))
+		InvokesWatch(core.NewWatchAction("limitranges", c.ns, opts))
 
 }

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_persistentvolume.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_persistentvolume.go
@@ -30,7 +30,7 @@ type FakePersistentVolumes struct {
 
 func (c *FakePersistentVolumes) Create(persistentVolume *api.PersistentVolume) (result *api.PersistentVolume, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewRootCreateAction("persistentVolumes", persistentVolume), &api.PersistentVolume{})
+		Invokes(core.NewRootCreateAction("persistentvolumes", persistentVolume), &api.PersistentVolume{})
 	if obj == nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func (c *FakePersistentVolumes) Create(persistentVolume *api.PersistentVolume) (
 
 func (c *FakePersistentVolumes) Update(persistentVolume *api.PersistentVolume) (result *api.PersistentVolume, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewRootUpdateAction("persistentVolumes", persistentVolume), &api.PersistentVolume{})
+		Invokes(core.NewRootUpdateAction("persistentvolumes", persistentVolume), &api.PersistentVolume{})
 	if obj == nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func (c *FakePersistentVolumes) Update(persistentVolume *api.PersistentVolume) (
 
 func (c *FakePersistentVolumes) UpdateStatus(persistentVolume *api.PersistentVolume) (*api.PersistentVolume, error) {
 	obj, err := c.Fake.
-		Invokes(core.NewRootUpdateSubresourceAction("persistentVolumes", "status", persistentVolume), &api.PersistentVolume{})
+		Invokes(core.NewRootUpdateSubresourceAction("persistentvolumes", "status", persistentVolume), &api.PersistentVolume{})
 	if obj == nil {
 		return nil, err
 	}
@@ -57,7 +57,7 @@ func (c *FakePersistentVolumes) UpdateStatus(persistentVolume *api.PersistentVol
 
 func (c *FakePersistentVolumes) Delete(name string, options *api.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(core.NewRootDeleteAction("persistentVolumes", name), &api.PersistentVolume{})
+		Invokes(core.NewRootDeleteAction("persistentvolumes", name), &api.PersistentVolume{})
 	return err
 }
 
@@ -70,7 +70,7 @@ func (c *FakePersistentVolumes) DeleteCollection(options *api.DeleteOptions, lis
 
 func (c *FakePersistentVolumes) Get(name string) (result *api.PersistentVolume, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewRootGetAction("persistentVolumes", name), &api.PersistentVolume{})
+		Invokes(core.NewRootGetAction("persistentvolumes", name), &api.PersistentVolume{})
 	if obj == nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func (c *FakePersistentVolumes) Get(name string) (result *api.PersistentVolume, 
 
 func (c *FakePersistentVolumes) List(opts api.ListOptions) (result *api.PersistentVolumeList, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewRootListAction("persistentVolumes", opts), &api.PersistentVolumeList{})
+		Invokes(core.NewRootListAction("persistentvolumes", opts), &api.PersistentVolumeList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -100,5 +100,5 @@ func (c *FakePersistentVolumes) List(opts api.ListOptions) (result *api.Persiste
 // Watch returns a watch.Interface that watches the requested persistentVolumes.
 func (c *FakePersistentVolumes) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(core.NewRootWatchAction("persistentVolumes", opts))
+		InvokesWatch(core.NewRootWatchAction("persistentvolumes", opts))
 }

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_persistentvolumeclaim.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_persistentvolumeclaim.go
@@ -31,7 +31,7 @@ type FakePersistentVolumeClaims struct {
 
 func (c *FakePersistentVolumeClaims) Create(persistentVolumeClaim *api.PersistentVolumeClaim) (result *api.PersistentVolumeClaim, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewCreateAction("persistentVolumeClaims", c.ns, persistentVolumeClaim), &api.PersistentVolumeClaim{})
+		Invokes(core.NewCreateAction("persistentvolumeclaims", c.ns, persistentVolumeClaim), &api.PersistentVolumeClaim{})
 
 	if obj == nil {
 		return nil, err
@@ -41,7 +41,7 @@ func (c *FakePersistentVolumeClaims) Create(persistentVolumeClaim *api.Persisten
 
 func (c *FakePersistentVolumeClaims) Update(persistentVolumeClaim *api.PersistentVolumeClaim) (result *api.PersistentVolumeClaim, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewUpdateAction("persistentVolumeClaims", c.ns, persistentVolumeClaim), &api.PersistentVolumeClaim{})
+		Invokes(core.NewUpdateAction("persistentvolumeclaims", c.ns, persistentVolumeClaim), &api.PersistentVolumeClaim{})
 
 	if obj == nil {
 		return nil, err
@@ -51,7 +51,7 @@ func (c *FakePersistentVolumeClaims) Update(persistentVolumeClaim *api.Persisten
 
 func (c *FakePersistentVolumeClaims) UpdateStatus(persistentVolumeClaim *api.PersistentVolumeClaim) (*api.PersistentVolumeClaim, error) {
 	obj, err := c.Fake.
-		Invokes(core.NewUpdateSubresourceAction("persistentVolumeClaims", "status", c.ns, persistentVolumeClaim), &api.PersistentVolumeClaim{})
+		Invokes(core.NewUpdateSubresourceAction("persistentvolumeclaims", "status", c.ns, persistentVolumeClaim), &api.PersistentVolumeClaim{})
 
 	if obj == nil {
 		return nil, err
@@ -61,7 +61,7 @@ func (c *FakePersistentVolumeClaims) UpdateStatus(persistentVolumeClaim *api.Per
 
 func (c *FakePersistentVolumeClaims) Delete(name string, options *api.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(core.NewDeleteAction("persistentVolumeClaims", c.ns, name), &api.PersistentVolumeClaim{})
+		Invokes(core.NewDeleteAction("persistentvolumeclaims", c.ns, name), &api.PersistentVolumeClaim{})
 
 	return err
 }
@@ -75,7 +75,7 @@ func (c *FakePersistentVolumeClaims) DeleteCollection(options *api.DeleteOptions
 
 func (c *FakePersistentVolumeClaims) Get(name string) (result *api.PersistentVolumeClaim, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewGetAction("persistentVolumeClaims", c.ns, name), &api.PersistentVolumeClaim{})
+		Invokes(core.NewGetAction("persistentvolumeclaims", c.ns, name), &api.PersistentVolumeClaim{})
 
 	if obj == nil {
 		return nil, err
@@ -85,7 +85,7 @@ func (c *FakePersistentVolumeClaims) Get(name string) (result *api.PersistentVol
 
 func (c *FakePersistentVolumeClaims) List(opts api.ListOptions) (result *api.PersistentVolumeClaimList, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewListAction("persistentVolumeClaims", c.ns, opts), &api.PersistentVolumeClaimList{})
+		Invokes(core.NewListAction("persistentvolumeclaims", c.ns, opts), &api.PersistentVolumeClaimList{})
 
 	if obj == nil {
 		return nil, err
@@ -107,6 +107,6 @@ func (c *FakePersistentVolumeClaims) List(opts api.ListOptions) (result *api.Per
 // Watch returns a watch.Interface that watches the requested persistentVolumeClaims.
 func (c *FakePersistentVolumeClaims) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(core.NewWatchAction("persistentVolumeClaims", c.ns, opts))
+		InvokesWatch(core.NewWatchAction("persistentvolumeclaims", c.ns, opts))
 
 }

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_podtemplate.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_podtemplate.go
@@ -31,7 +31,7 @@ type FakePodTemplates struct {
 
 func (c *FakePodTemplates) Create(podTemplate *api.PodTemplate) (result *api.PodTemplate, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewCreateAction("podTemplates", c.ns, podTemplate), &api.PodTemplate{})
+		Invokes(core.NewCreateAction("podtemplates", c.ns, podTemplate), &api.PodTemplate{})
 
 	if obj == nil {
 		return nil, err
@@ -41,7 +41,7 @@ func (c *FakePodTemplates) Create(podTemplate *api.PodTemplate) (result *api.Pod
 
 func (c *FakePodTemplates) Update(podTemplate *api.PodTemplate) (result *api.PodTemplate, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewUpdateAction("podTemplates", c.ns, podTemplate), &api.PodTemplate{})
+		Invokes(core.NewUpdateAction("podtemplates", c.ns, podTemplate), &api.PodTemplate{})
 
 	if obj == nil {
 		return nil, err
@@ -51,7 +51,7 @@ func (c *FakePodTemplates) Update(podTemplate *api.PodTemplate) (result *api.Pod
 
 func (c *FakePodTemplates) Delete(name string, options *api.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(core.NewDeleteAction("podTemplates", c.ns, name), &api.PodTemplate{})
+		Invokes(core.NewDeleteAction("podtemplates", c.ns, name), &api.PodTemplate{})
 
 	return err
 }
@@ -65,7 +65,7 @@ func (c *FakePodTemplates) DeleteCollection(options *api.DeleteOptions, listOpti
 
 func (c *FakePodTemplates) Get(name string) (result *api.PodTemplate, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewGetAction("podTemplates", c.ns, name), &api.PodTemplate{})
+		Invokes(core.NewGetAction("podtemplates", c.ns, name), &api.PodTemplate{})
 
 	if obj == nil {
 		return nil, err
@@ -75,7 +75,7 @@ func (c *FakePodTemplates) Get(name string) (result *api.PodTemplate, err error)
 
 func (c *FakePodTemplates) List(opts api.ListOptions) (result *api.PodTemplateList, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewListAction("podTemplates", c.ns, opts), &api.PodTemplateList{})
+		Invokes(core.NewListAction("podtemplates", c.ns, opts), &api.PodTemplateList{})
 
 	if obj == nil {
 		return nil, err
@@ -97,6 +97,6 @@ func (c *FakePodTemplates) List(opts api.ListOptions) (result *api.PodTemplateLi
 // Watch returns a watch.Interface that watches the requested podTemplates.
 func (c *FakePodTemplates) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(core.NewWatchAction("podTemplates", c.ns, opts))
+		InvokesWatch(core.NewWatchAction("podtemplates", c.ns, opts))
 
 }

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_replicationcontroller.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_replicationcontroller.go
@@ -31,7 +31,7 @@ type FakeReplicationControllers struct {
 
 func (c *FakeReplicationControllers) Create(replicationController *api.ReplicationController) (result *api.ReplicationController, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewCreateAction("replicationControllers", c.ns, replicationController), &api.ReplicationController{})
+		Invokes(core.NewCreateAction("replicationcontrollers", c.ns, replicationController), &api.ReplicationController{})
 
 	if obj == nil {
 		return nil, err
@@ -41,7 +41,7 @@ func (c *FakeReplicationControllers) Create(replicationController *api.Replicati
 
 func (c *FakeReplicationControllers) Update(replicationController *api.ReplicationController) (result *api.ReplicationController, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewUpdateAction("replicationControllers", c.ns, replicationController), &api.ReplicationController{})
+		Invokes(core.NewUpdateAction("replicationcontrollers", c.ns, replicationController), &api.ReplicationController{})
 
 	if obj == nil {
 		return nil, err
@@ -51,7 +51,7 @@ func (c *FakeReplicationControllers) Update(replicationController *api.Replicati
 
 func (c *FakeReplicationControllers) UpdateStatus(replicationController *api.ReplicationController) (*api.ReplicationController, error) {
 	obj, err := c.Fake.
-		Invokes(core.NewUpdateSubresourceAction("replicationControllers", "status", c.ns, replicationController), &api.ReplicationController{})
+		Invokes(core.NewUpdateSubresourceAction("replicationcontrollers", "status", c.ns, replicationController), &api.ReplicationController{})
 
 	if obj == nil {
 		return nil, err
@@ -61,7 +61,7 @@ func (c *FakeReplicationControllers) UpdateStatus(replicationController *api.Rep
 
 func (c *FakeReplicationControllers) Delete(name string, options *api.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(core.NewDeleteAction("replicationControllers", c.ns, name), &api.ReplicationController{})
+		Invokes(core.NewDeleteAction("replicationcontrollers", c.ns, name), &api.ReplicationController{})
 
 	return err
 }
@@ -75,7 +75,7 @@ func (c *FakeReplicationControllers) DeleteCollection(options *api.DeleteOptions
 
 func (c *FakeReplicationControllers) Get(name string) (result *api.ReplicationController, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewGetAction("replicationControllers", c.ns, name), &api.ReplicationController{})
+		Invokes(core.NewGetAction("replicationcontrollers", c.ns, name), &api.ReplicationController{})
 
 	if obj == nil {
 		return nil, err
@@ -85,7 +85,7 @@ func (c *FakeReplicationControllers) Get(name string) (result *api.ReplicationCo
 
 func (c *FakeReplicationControllers) List(opts api.ListOptions) (result *api.ReplicationControllerList, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewListAction("replicationControllers", c.ns, opts), &api.ReplicationControllerList{})
+		Invokes(core.NewListAction("replicationcontrollers", c.ns, opts), &api.ReplicationControllerList{})
 
 	if obj == nil {
 		return nil, err
@@ -107,6 +107,6 @@ func (c *FakeReplicationControllers) List(opts api.ListOptions) (result *api.Rep
 // Watch returns a watch.Interface that watches the requested replicationControllers.
 func (c *FakeReplicationControllers) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(core.NewWatchAction("replicationControllers", c.ns, opts))
+		InvokesWatch(core.NewWatchAction("replicationcontrollers", c.ns, opts))
 
 }

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_resourcequota.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_resourcequota.go
@@ -31,7 +31,7 @@ type FakeResourceQuotas struct {
 
 func (c *FakeResourceQuotas) Create(resourceQuota *api.ResourceQuota) (result *api.ResourceQuota, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewCreateAction("resourceQuotas", c.ns, resourceQuota), &api.ResourceQuota{})
+		Invokes(core.NewCreateAction("resourcequotas", c.ns, resourceQuota), &api.ResourceQuota{})
 
 	if obj == nil {
 		return nil, err
@@ -41,7 +41,7 @@ func (c *FakeResourceQuotas) Create(resourceQuota *api.ResourceQuota) (result *a
 
 func (c *FakeResourceQuotas) Update(resourceQuota *api.ResourceQuota) (result *api.ResourceQuota, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewUpdateAction("resourceQuotas", c.ns, resourceQuota), &api.ResourceQuota{})
+		Invokes(core.NewUpdateAction("resourcequotas", c.ns, resourceQuota), &api.ResourceQuota{})
 
 	if obj == nil {
 		return nil, err
@@ -51,7 +51,7 @@ func (c *FakeResourceQuotas) Update(resourceQuota *api.ResourceQuota) (result *a
 
 func (c *FakeResourceQuotas) UpdateStatus(resourceQuota *api.ResourceQuota) (*api.ResourceQuota, error) {
 	obj, err := c.Fake.
-		Invokes(core.NewUpdateSubresourceAction("resourceQuotas", "status", c.ns, resourceQuota), &api.ResourceQuota{})
+		Invokes(core.NewUpdateSubresourceAction("resourcequotas", "status", c.ns, resourceQuota), &api.ResourceQuota{})
 
 	if obj == nil {
 		return nil, err
@@ -61,7 +61,7 @@ func (c *FakeResourceQuotas) UpdateStatus(resourceQuota *api.ResourceQuota) (*ap
 
 func (c *FakeResourceQuotas) Delete(name string, options *api.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(core.NewDeleteAction("resourceQuotas", c.ns, name), &api.ResourceQuota{})
+		Invokes(core.NewDeleteAction("resourcequotas", c.ns, name), &api.ResourceQuota{})
 
 	return err
 }
@@ -75,7 +75,7 @@ func (c *FakeResourceQuotas) DeleteCollection(options *api.DeleteOptions, listOp
 
 func (c *FakeResourceQuotas) Get(name string) (result *api.ResourceQuota, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewGetAction("resourceQuotas", c.ns, name), &api.ResourceQuota{})
+		Invokes(core.NewGetAction("resourcequotas", c.ns, name), &api.ResourceQuota{})
 
 	if obj == nil {
 		return nil, err
@@ -85,7 +85,7 @@ func (c *FakeResourceQuotas) Get(name string) (result *api.ResourceQuota, err er
 
 func (c *FakeResourceQuotas) List(opts api.ListOptions) (result *api.ResourceQuotaList, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewListAction("resourceQuotas", c.ns, opts), &api.ResourceQuotaList{})
+		Invokes(core.NewListAction("resourcequotas", c.ns, opts), &api.ResourceQuotaList{})
 
 	if obj == nil {
 		return nil, err
@@ -107,6 +107,6 @@ func (c *FakeResourceQuotas) List(opts api.ListOptions) (result *api.ResourceQuo
 // Watch returns a watch.Interface that watches the requested resourceQuotas.
 func (c *FakeResourceQuotas) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(core.NewWatchAction("resourceQuotas", c.ns, opts))
+		InvokesWatch(core.NewWatchAction("resourcequotas", c.ns, opts))
 
 }

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_serviceaccount.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_serviceaccount.go
@@ -31,7 +31,7 @@ type FakeServiceAccounts struct {
 
 func (c *FakeServiceAccounts) Create(serviceAccount *api.ServiceAccount) (result *api.ServiceAccount, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewCreateAction("serviceAccounts", c.ns, serviceAccount), &api.ServiceAccount{})
+		Invokes(core.NewCreateAction("serviceaccounts", c.ns, serviceAccount), &api.ServiceAccount{})
 
 	if obj == nil {
 		return nil, err
@@ -41,7 +41,7 @@ func (c *FakeServiceAccounts) Create(serviceAccount *api.ServiceAccount) (result
 
 func (c *FakeServiceAccounts) Update(serviceAccount *api.ServiceAccount) (result *api.ServiceAccount, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewUpdateAction("serviceAccounts", c.ns, serviceAccount), &api.ServiceAccount{})
+		Invokes(core.NewUpdateAction("serviceaccounts", c.ns, serviceAccount), &api.ServiceAccount{})
 
 	if obj == nil {
 		return nil, err
@@ -51,7 +51,7 @@ func (c *FakeServiceAccounts) Update(serviceAccount *api.ServiceAccount) (result
 
 func (c *FakeServiceAccounts) Delete(name string, options *api.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(core.NewDeleteAction("serviceAccounts", c.ns, name), &api.ServiceAccount{})
+		Invokes(core.NewDeleteAction("serviceaccounts", c.ns, name), &api.ServiceAccount{})
 
 	return err
 }
@@ -65,7 +65,7 @@ func (c *FakeServiceAccounts) DeleteCollection(options *api.DeleteOptions, listO
 
 func (c *FakeServiceAccounts) Get(name string) (result *api.ServiceAccount, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewGetAction("serviceAccounts", c.ns, name), &api.ServiceAccount{})
+		Invokes(core.NewGetAction("serviceaccounts", c.ns, name), &api.ServiceAccount{})
 
 	if obj == nil {
 		return nil, err
@@ -75,7 +75,7 @@ func (c *FakeServiceAccounts) Get(name string) (result *api.ServiceAccount, err 
 
 func (c *FakeServiceAccounts) List(opts api.ListOptions) (result *api.ServiceAccountList, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewListAction("serviceAccounts", c.ns, opts), &api.ServiceAccountList{})
+		Invokes(core.NewListAction("serviceaccounts", c.ns, opts), &api.ServiceAccountList{})
 
 	if obj == nil {
 		return nil, err
@@ -97,6 +97,6 @@ func (c *FakeServiceAccounts) List(opts api.ListOptions) (result *api.ServiceAcc
 // Watch returns a watch.Interface that watches the requested serviceAccounts.
 func (c *FakeServiceAccounts) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(core.NewWatchAction("serviceAccounts", c.ns, opts))
+		InvokesWatch(core.NewWatchAction("serviceaccounts", c.ns, opts))
 
 }

--- a/pkg/client/typed/generated/legacy/unversioned/limitrange.go
+++ b/pkg/client/typed/generated/legacy/unversioned/limitrange.go
@@ -58,7 +58,7 @@ func (c *limitRanges) Create(limitRange *api.LimitRange) (result *api.LimitRange
 	result = &api.LimitRange{}
 	err = c.client.Post().
 		Namespace(c.ns).
-		Resource("limitRanges").
+		Resource("limitranges").
 		Body(limitRange).
 		Do().
 		Into(result)
@@ -70,7 +70,7 @@ func (c *limitRanges) Update(limitRange *api.LimitRange) (result *api.LimitRange
 	result = &api.LimitRange{}
 	err = c.client.Put().
 		Namespace(c.ns).
-		Resource("limitRanges").
+		Resource("limitranges").
 		Name(limitRange.Name).
 		Body(limitRange).
 		Do().
@@ -82,7 +82,7 @@ func (c *limitRanges) Update(limitRange *api.LimitRange) (result *api.LimitRange
 func (c *limitRanges) Delete(name string, options *api.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("limitRanges").
+		Resource("limitranges").
 		Name(name).
 		Body(options).
 		Do().
@@ -93,7 +93,7 @@ func (c *limitRanges) Delete(name string, options *api.DeleteOptions) error {
 func (c *limitRanges) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("limitRanges").
+		Resource("limitranges").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).
 		Do().
@@ -105,7 +105,7 @@ func (c *limitRanges) Get(name string) (result *api.LimitRange, err error) {
 	result = &api.LimitRange{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("limitRanges").
+		Resource("limitranges").
 		Name(name).
 		Do().
 		Into(result)
@@ -117,7 +117,7 @@ func (c *limitRanges) List(opts api.ListOptions) (result *api.LimitRangeList, er
 	result = &api.LimitRangeList{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("limitRanges").
+		Resource("limitranges").
 		VersionedParams(&opts, api.Scheme).
 		Do().
 		Into(result)
@@ -129,7 +129,7 @@ func (c *limitRanges) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.client.Get().
 		Prefix("watch").
 		Namespace(c.ns).
-		Resource("limitRanges").
+		Resource("limitranges").
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }

--- a/pkg/client/typed/generated/legacy/unversioned/namespace.go
+++ b/pkg/client/typed/generated/legacy/unversioned/namespace.go
@@ -75,10 +75,16 @@ func (c *namespaces) Update(namespace *api.Namespace) (result *api.Namespace, er
 	return
 }
 
-func (c *namespaces) UpdateStatus(namespace *api.Namespace) (*api.Namespace, error) {
-	result := &api.Namespace{}
-	err := c.client.Put().Resource("namespaces").Name(namespace.Name).SubResource("status").Body(namespace).Do().Into(result)
-	return result, err
+func (c *namespaces) UpdateStatus(namespace *api.Namespace) (result *api.Namespace, err error) {
+	result = &api.Namespace{}
+	err = c.client.Put().
+		Resource("namespaces").
+		Name(namespace.Name).
+		SubResource("status").
+		Body(namespace).
+		Do().
+		Into(result)
+	return
 }
 
 // Delete takes name of the namespace and deletes it. Returns an error if one occurs.

--- a/pkg/client/typed/generated/legacy/unversioned/node.go
+++ b/pkg/client/typed/generated/legacy/unversioned/node.go
@@ -75,10 +75,16 @@ func (c *nodes) Update(node *api.Node) (result *api.Node, err error) {
 	return
 }
 
-func (c *nodes) UpdateStatus(node *api.Node) (*api.Node, error) {
-	result := &api.Node{}
-	err := c.client.Put().Resource("nodes").Name(node.Name).SubResource("status").Body(node).Do().Into(result)
-	return result, err
+func (c *nodes) UpdateStatus(node *api.Node) (result *api.Node, err error) {
+	result = &api.Node{}
+	err = c.client.Put().
+		Resource("nodes").
+		Name(node.Name).
+		SubResource("status").
+		Body(node).
+		Do().
+		Into(result)
+	return
 }
 
 // Delete takes name of the node and deletes it. Returns an error if one occurs.

--- a/pkg/client/typed/generated/legacy/unversioned/persistentvolume.go
+++ b/pkg/client/typed/generated/legacy/unversioned/persistentvolume.go
@@ -75,10 +75,16 @@ func (c *persistentVolumes) Update(persistentVolume *api.PersistentVolume) (resu
 	return
 }
 
-func (c *persistentVolumes) UpdateStatus(persistentVolume *api.PersistentVolume) (*api.PersistentVolume, error) {
-	result := &api.PersistentVolume{}
-	err := c.client.Put().Resource("persistentVolumes").Name(persistentVolume.Name).SubResource("status").Body(persistentVolume).Do().Into(result)
-	return result, err
+func (c *persistentVolumes) UpdateStatus(persistentVolume *api.PersistentVolume) (result *api.PersistentVolume, err error) {
+	result = &api.PersistentVolume{}
+	err = c.client.Put().
+		Resource("persistentVolumes").
+		Name(persistentVolume.Name).
+		SubResource("status").
+		Body(persistentVolume).
+		Do().
+		Into(result)
+	return
 }
 
 // Delete takes name of the persistentVolume and deletes it. Returns an error if one occurs.

--- a/pkg/client/typed/generated/legacy/unversioned/persistentvolume.go
+++ b/pkg/client/typed/generated/legacy/unversioned/persistentvolume.go
@@ -56,7 +56,7 @@ func newPersistentVolumes(c *LegacyClient) *persistentVolumes {
 func (c *persistentVolumes) Create(persistentVolume *api.PersistentVolume) (result *api.PersistentVolume, err error) {
 	result = &api.PersistentVolume{}
 	err = c.client.Post().
-		Resource("persistentVolumes").
+		Resource("persistentvolumes").
 		Body(persistentVolume).
 		Do().
 		Into(result)
@@ -67,7 +67,7 @@ func (c *persistentVolumes) Create(persistentVolume *api.PersistentVolume) (resu
 func (c *persistentVolumes) Update(persistentVolume *api.PersistentVolume) (result *api.PersistentVolume, err error) {
 	result = &api.PersistentVolume{}
 	err = c.client.Put().
-		Resource("persistentVolumes").
+		Resource("persistentvolumes").
 		Name(persistentVolume.Name).
 		Body(persistentVolume).
 		Do().
@@ -78,7 +78,7 @@ func (c *persistentVolumes) Update(persistentVolume *api.PersistentVolume) (resu
 func (c *persistentVolumes) UpdateStatus(persistentVolume *api.PersistentVolume) (result *api.PersistentVolume, err error) {
 	result = &api.PersistentVolume{}
 	err = c.client.Put().
-		Resource("persistentVolumes").
+		Resource("persistentvolumes").
 		Name(persistentVolume.Name).
 		SubResource("status").
 		Body(persistentVolume).
@@ -90,7 +90,7 @@ func (c *persistentVolumes) UpdateStatus(persistentVolume *api.PersistentVolume)
 // Delete takes name of the persistentVolume and deletes it. Returns an error if one occurs.
 func (c *persistentVolumes) Delete(name string, options *api.DeleteOptions) error {
 	return c.client.Delete().
-		Resource("persistentVolumes").
+		Resource("persistentvolumes").
 		Name(name).
 		Body(options).
 		Do().
@@ -100,7 +100,7 @@ func (c *persistentVolumes) Delete(name string, options *api.DeleteOptions) erro
 // DeleteCollection deletes a collection of objects.
 func (c *persistentVolumes) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
-		Resource("persistentVolumes").
+		Resource("persistentvolumes").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).
 		Do().
@@ -111,7 +111,7 @@ func (c *persistentVolumes) DeleteCollection(options *api.DeleteOptions, listOpt
 func (c *persistentVolumes) Get(name string) (result *api.PersistentVolume, err error) {
 	result = &api.PersistentVolume{}
 	err = c.client.Get().
-		Resource("persistentVolumes").
+		Resource("persistentvolumes").
 		Name(name).
 		Do().
 		Into(result)
@@ -122,7 +122,7 @@ func (c *persistentVolumes) Get(name string) (result *api.PersistentVolume, err 
 func (c *persistentVolumes) List(opts api.ListOptions) (result *api.PersistentVolumeList, err error) {
 	result = &api.PersistentVolumeList{}
 	err = c.client.Get().
-		Resource("persistentVolumes").
+		Resource("persistentvolumes").
 		VersionedParams(&opts, api.Scheme).
 		Do().
 		Into(result)
@@ -133,7 +133,7 @@ func (c *persistentVolumes) List(opts api.ListOptions) (result *api.PersistentVo
 func (c *persistentVolumes) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.client.Get().
 		Prefix("watch").
-		Resource("persistentVolumes").
+		Resource("persistentvolumes").
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }

--- a/pkg/client/typed/generated/legacy/unversioned/persistentvolumeclaim.go
+++ b/pkg/client/typed/generated/legacy/unversioned/persistentvolumeclaim.go
@@ -79,10 +79,17 @@ func (c *persistentVolumeClaims) Update(persistentVolumeClaim *api.PersistentVol
 	return
 }
 
-func (c *persistentVolumeClaims) UpdateStatus(persistentVolumeClaim *api.PersistentVolumeClaim) (*api.PersistentVolumeClaim, error) {
-	result := &api.PersistentVolumeClaim{}
-	err := c.client.Put().Resource("persistentVolumeClaims").Name(persistentVolumeClaim.Name).SubResource("status").Body(persistentVolumeClaim).Do().Into(result)
-	return result, err
+func (c *persistentVolumeClaims) UpdateStatus(persistentVolumeClaim *api.PersistentVolumeClaim) (result *api.PersistentVolumeClaim, err error) {
+	result = &api.PersistentVolumeClaim{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("persistentVolumeClaims").
+		Name(persistentVolumeClaim.Name).
+		SubResource("status").
+		Body(persistentVolumeClaim).
+		Do().
+		Into(result)
+	return
 }
 
 // Delete takes name of the persistentVolumeClaim and deletes it. Returns an error if one occurs.

--- a/pkg/client/typed/generated/legacy/unversioned/persistentvolumeclaim.go
+++ b/pkg/client/typed/generated/legacy/unversioned/persistentvolumeclaim.go
@@ -59,7 +59,7 @@ func (c *persistentVolumeClaims) Create(persistentVolumeClaim *api.PersistentVol
 	result = &api.PersistentVolumeClaim{}
 	err = c.client.Post().
 		Namespace(c.ns).
-		Resource("persistentVolumeClaims").
+		Resource("persistentvolumeclaims").
 		Body(persistentVolumeClaim).
 		Do().
 		Into(result)
@@ -71,7 +71,7 @@ func (c *persistentVolumeClaims) Update(persistentVolumeClaim *api.PersistentVol
 	result = &api.PersistentVolumeClaim{}
 	err = c.client.Put().
 		Namespace(c.ns).
-		Resource("persistentVolumeClaims").
+		Resource("persistentvolumeclaims").
 		Name(persistentVolumeClaim.Name).
 		Body(persistentVolumeClaim).
 		Do().
@@ -83,7 +83,7 @@ func (c *persistentVolumeClaims) UpdateStatus(persistentVolumeClaim *api.Persist
 	result = &api.PersistentVolumeClaim{}
 	err = c.client.Put().
 		Namespace(c.ns).
-		Resource("persistentVolumeClaims").
+		Resource("persistentvolumeclaims").
 		Name(persistentVolumeClaim.Name).
 		SubResource("status").
 		Body(persistentVolumeClaim).
@@ -96,7 +96,7 @@ func (c *persistentVolumeClaims) UpdateStatus(persistentVolumeClaim *api.Persist
 func (c *persistentVolumeClaims) Delete(name string, options *api.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("persistentVolumeClaims").
+		Resource("persistentvolumeclaims").
 		Name(name).
 		Body(options).
 		Do().
@@ -107,7 +107,7 @@ func (c *persistentVolumeClaims) Delete(name string, options *api.DeleteOptions)
 func (c *persistentVolumeClaims) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("persistentVolumeClaims").
+		Resource("persistentvolumeclaims").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).
 		Do().
@@ -119,7 +119,7 @@ func (c *persistentVolumeClaims) Get(name string) (result *api.PersistentVolumeC
 	result = &api.PersistentVolumeClaim{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("persistentVolumeClaims").
+		Resource("persistentvolumeclaims").
 		Name(name).
 		Do().
 		Into(result)
@@ -131,7 +131,7 @@ func (c *persistentVolumeClaims) List(opts api.ListOptions) (result *api.Persist
 	result = &api.PersistentVolumeClaimList{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("persistentVolumeClaims").
+		Resource("persistentvolumeclaims").
 		VersionedParams(&opts, api.Scheme).
 		Do().
 		Into(result)
@@ -143,7 +143,7 @@ func (c *persistentVolumeClaims) Watch(opts api.ListOptions) (watch.Interface, e
 	return c.client.Get().
 		Prefix("watch").
 		Namespace(c.ns).
-		Resource("persistentVolumeClaims").
+		Resource("persistentvolumeclaims").
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }

--- a/pkg/client/typed/generated/legacy/unversioned/pod.go
+++ b/pkg/client/typed/generated/legacy/unversioned/pod.go
@@ -79,10 +79,17 @@ func (c *pods) Update(pod *api.Pod) (result *api.Pod, err error) {
 	return
 }
 
-func (c *pods) UpdateStatus(pod *api.Pod) (*api.Pod, error) {
-	result := &api.Pod{}
-	err := c.client.Put().Resource("pods").Name(pod.Name).SubResource("status").Body(pod).Do().Into(result)
-	return result, err
+func (c *pods) UpdateStatus(pod *api.Pod) (result *api.Pod, err error) {
+	result = &api.Pod{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("pods").
+		Name(pod.Name).
+		SubResource("status").
+		Body(pod).
+		Do().
+		Into(result)
+	return
 }
 
 // Delete takes name of the pod and deletes it. Returns an error if one occurs.

--- a/pkg/client/typed/generated/legacy/unversioned/podtemplate.go
+++ b/pkg/client/typed/generated/legacy/unversioned/podtemplate.go
@@ -58,7 +58,7 @@ func (c *podTemplates) Create(podTemplate *api.PodTemplate) (result *api.PodTemp
 	result = &api.PodTemplate{}
 	err = c.client.Post().
 		Namespace(c.ns).
-		Resource("podTemplates").
+		Resource("podtemplates").
 		Body(podTemplate).
 		Do().
 		Into(result)
@@ -70,7 +70,7 @@ func (c *podTemplates) Update(podTemplate *api.PodTemplate) (result *api.PodTemp
 	result = &api.PodTemplate{}
 	err = c.client.Put().
 		Namespace(c.ns).
-		Resource("podTemplates").
+		Resource("podtemplates").
 		Name(podTemplate.Name).
 		Body(podTemplate).
 		Do().
@@ -82,7 +82,7 @@ func (c *podTemplates) Update(podTemplate *api.PodTemplate) (result *api.PodTemp
 func (c *podTemplates) Delete(name string, options *api.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("podTemplates").
+		Resource("podtemplates").
 		Name(name).
 		Body(options).
 		Do().
@@ -93,7 +93,7 @@ func (c *podTemplates) Delete(name string, options *api.DeleteOptions) error {
 func (c *podTemplates) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("podTemplates").
+		Resource("podtemplates").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).
 		Do().
@@ -105,7 +105,7 @@ func (c *podTemplates) Get(name string) (result *api.PodTemplate, err error) {
 	result = &api.PodTemplate{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("podTemplates").
+		Resource("podtemplates").
 		Name(name).
 		Do().
 		Into(result)
@@ -117,7 +117,7 @@ func (c *podTemplates) List(opts api.ListOptions) (result *api.PodTemplateList, 
 	result = &api.PodTemplateList{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("podTemplates").
+		Resource("podtemplates").
 		VersionedParams(&opts, api.Scheme).
 		Do().
 		Into(result)
@@ -129,7 +129,7 @@ func (c *podTemplates) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.client.Get().
 		Prefix("watch").
 		Namespace(c.ns).
-		Resource("podTemplates").
+		Resource("podtemplates").
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }

--- a/pkg/client/typed/generated/legacy/unversioned/replicationcontroller.go
+++ b/pkg/client/typed/generated/legacy/unversioned/replicationcontroller.go
@@ -79,10 +79,17 @@ func (c *replicationControllers) Update(replicationController *api.ReplicationCo
 	return
 }
 
-func (c *replicationControllers) UpdateStatus(replicationController *api.ReplicationController) (*api.ReplicationController, error) {
-	result := &api.ReplicationController{}
-	err := c.client.Put().Resource("replicationControllers").Name(replicationController.Name).SubResource("status").Body(replicationController).Do().Into(result)
-	return result, err
+func (c *replicationControllers) UpdateStatus(replicationController *api.ReplicationController) (result *api.ReplicationController, err error) {
+	result = &api.ReplicationController{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("replicationControllers").
+		Name(replicationController.Name).
+		SubResource("status").
+		Body(replicationController).
+		Do().
+		Into(result)
+	return
 }
 
 // Delete takes name of the replicationController and deletes it. Returns an error if one occurs.

--- a/pkg/client/typed/generated/legacy/unversioned/replicationcontroller.go
+++ b/pkg/client/typed/generated/legacy/unversioned/replicationcontroller.go
@@ -59,7 +59,7 @@ func (c *replicationControllers) Create(replicationController *api.ReplicationCo
 	result = &api.ReplicationController{}
 	err = c.client.Post().
 		Namespace(c.ns).
-		Resource("replicationControllers").
+		Resource("replicationcontrollers").
 		Body(replicationController).
 		Do().
 		Into(result)
@@ -71,7 +71,7 @@ func (c *replicationControllers) Update(replicationController *api.ReplicationCo
 	result = &api.ReplicationController{}
 	err = c.client.Put().
 		Namespace(c.ns).
-		Resource("replicationControllers").
+		Resource("replicationcontrollers").
 		Name(replicationController.Name).
 		Body(replicationController).
 		Do().
@@ -83,7 +83,7 @@ func (c *replicationControllers) UpdateStatus(replicationController *api.Replica
 	result = &api.ReplicationController{}
 	err = c.client.Put().
 		Namespace(c.ns).
-		Resource("replicationControllers").
+		Resource("replicationcontrollers").
 		Name(replicationController.Name).
 		SubResource("status").
 		Body(replicationController).
@@ -96,7 +96,7 @@ func (c *replicationControllers) UpdateStatus(replicationController *api.Replica
 func (c *replicationControllers) Delete(name string, options *api.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("replicationControllers").
+		Resource("replicationcontrollers").
 		Name(name).
 		Body(options).
 		Do().
@@ -107,7 +107,7 @@ func (c *replicationControllers) Delete(name string, options *api.DeleteOptions)
 func (c *replicationControllers) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("replicationControllers").
+		Resource("replicationcontrollers").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).
 		Do().
@@ -119,7 +119,7 @@ func (c *replicationControllers) Get(name string) (result *api.ReplicationContro
 	result = &api.ReplicationController{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("replicationControllers").
+		Resource("replicationcontrollers").
 		Name(name).
 		Do().
 		Into(result)
@@ -131,7 +131,7 @@ func (c *replicationControllers) List(opts api.ListOptions) (result *api.Replica
 	result = &api.ReplicationControllerList{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("replicationControllers").
+		Resource("replicationcontrollers").
 		VersionedParams(&opts, api.Scheme).
 		Do().
 		Into(result)
@@ -143,7 +143,7 @@ func (c *replicationControllers) Watch(opts api.ListOptions) (watch.Interface, e
 	return c.client.Get().
 		Prefix("watch").
 		Namespace(c.ns).
-		Resource("replicationControllers").
+		Resource("replicationcontrollers").
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }

--- a/pkg/client/typed/generated/legacy/unversioned/resourcequota.go
+++ b/pkg/client/typed/generated/legacy/unversioned/resourcequota.go
@@ -79,10 +79,17 @@ func (c *resourceQuotas) Update(resourceQuota *api.ResourceQuota) (result *api.R
 	return
 }
 
-func (c *resourceQuotas) UpdateStatus(resourceQuota *api.ResourceQuota) (*api.ResourceQuota, error) {
-	result := &api.ResourceQuota{}
-	err := c.client.Put().Resource("resourceQuotas").Name(resourceQuota.Name).SubResource("status").Body(resourceQuota).Do().Into(result)
-	return result, err
+func (c *resourceQuotas) UpdateStatus(resourceQuota *api.ResourceQuota) (result *api.ResourceQuota, err error) {
+	result = &api.ResourceQuota{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("resourceQuotas").
+		Name(resourceQuota.Name).
+		SubResource("status").
+		Body(resourceQuota).
+		Do().
+		Into(result)
+	return
 }
 
 // Delete takes name of the resourceQuota and deletes it. Returns an error if one occurs.

--- a/pkg/client/typed/generated/legacy/unversioned/resourcequota.go
+++ b/pkg/client/typed/generated/legacy/unversioned/resourcequota.go
@@ -59,7 +59,7 @@ func (c *resourceQuotas) Create(resourceQuota *api.ResourceQuota) (result *api.R
 	result = &api.ResourceQuota{}
 	err = c.client.Post().
 		Namespace(c.ns).
-		Resource("resourceQuotas").
+		Resource("resourcequotas").
 		Body(resourceQuota).
 		Do().
 		Into(result)
@@ -71,7 +71,7 @@ func (c *resourceQuotas) Update(resourceQuota *api.ResourceQuota) (result *api.R
 	result = &api.ResourceQuota{}
 	err = c.client.Put().
 		Namespace(c.ns).
-		Resource("resourceQuotas").
+		Resource("resourcequotas").
 		Name(resourceQuota.Name).
 		Body(resourceQuota).
 		Do().
@@ -83,7 +83,7 @@ func (c *resourceQuotas) UpdateStatus(resourceQuota *api.ResourceQuota) (result 
 	result = &api.ResourceQuota{}
 	err = c.client.Put().
 		Namespace(c.ns).
-		Resource("resourceQuotas").
+		Resource("resourcequotas").
 		Name(resourceQuota.Name).
 		SubResource("status").
 		Body(resourceQuota).
@@ -96,7 +96,7 @@ func (c *resourceQuotas) UpdateStatus(resourceQuota *api.ResourceQuota) (result 
 func (c *resourceQuotas) Delete(name string, options *api.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("resourceQuotas").
+		Resource("resourcequotas").
 		Name(name).
 		Body(options).
 		Do().
@@ -107,7 +107,7 @@ func (c *resourceQuotas) Delete(name string, options *api.DeleteOptions) error {
 func (c *resourceQuotas) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("resourceQuotas").
+		Resource("resourcequotas").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).
 		Do().
@@ -119,7 +119,7 @@ func (c *resourceQuotas) Get(name string) (result *api.ResourceQuota, err error)
 	result = &api.ResourceQuota{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("resourceQuotas").
+		Resource("resourcequotas").
 		Name(name).
 		Do().
 		Into(result)
@@ -131,7 +131,7 @@ func (c *resourceQuotas) List(opts api.ListOptions) (result *api.ResourceQuotaLi
 	result = &api.ResourceQuotaList{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("resourceQuotas").
+		Resource("resourcequotas").
 		VersionedParams(&opts, api.Scheme).
 		Do().
 		Into(result)
@@ -143,7 +143,7 @@ func (c *resourceQuotas) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.client.Get().
 		Prefix("watch").
 		Namespace(c.ns).
-		Resource("resourceQuotas").
+		Resource("resourcequotas").
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }

--- a/pkg/client/typed/generated/legacy/unversioned/service.go
+++ b/pkg/client/typed/generated/legacy/unversioned/service.go
@@ -79,10 +79,17 @@ func (c *services) Update(service *api.Service) (result *api.Service, err error)
 	return
 }
 
-func (c *services) UpdateStatus(service *api.Service) (*api.Service, error) {
-	result := &api.Service{}
-	err := c.client.Put().Resource("services").Name(service.Name).SubResource("status").Body(service).Do().Into(result)
-	return result, err
+func (c *services) UpdateStatus(service *api.Service) (result *api.Service, err error) {
+	result = &api.Service{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("services").
+		Name(service.Name).
+		SubResource("status").
+		Body(service).
+		Do().
+		Into(result)
+	return
 }
 
 // Delete takes name of the service and deletes it. Returns an error if one occurs.

--- a/pkg/client/typed/generated/legacy/unversioned/serviceaccount.go
+++ b/pkg/client/typed/generated/legacy/unversioned/serviceaccount.go
@@ -58,7 +58,7 @@ func (c *serviceAccounts) Create(serviceAccount *api.ServiceAccount) (result *ap
 	result = &api.ServiceAccount{}
 	err = c.client.Post().
 		Namespace(c.ns).
-		Resource("serviceAccounts").
+		Resource("serviceaccounts").
 		Body(serviceAccount).
 		Do().
 		Into(result)
@@ -70,7 +70,7 @@ func (c *serviceAccounts) Update(serviceAccount *api.ServiceAccount) (result *ap
 	result = &api.ServiceAccount{}
 	err = c.client.Put().
 		Namespace(c.ns).
-		Resource("serviceAccounts").
+		Resource("serviceaccounts").
 		Name(serviceAccount.Name).
 		Body(serviceAccount).
 		Do().
@@ -82,7 +82,7 @@ func (c *serviceAccounts) Update(serviceAccount *api.ServiceAccount) (result *ap
 func (c *serviceAccounts) Delete(name string, options *api.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("serviceAccounts").
+		Resource("serviceaccounts").
 		Name(name).
 		Body(options).
 		Do().
@@ -93,7 +93,7 @@ func (c *serviceAccounts) Delete(name string, options *api.DeleteOptions) error 
 func (c *serviceAccounts) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("serviceAccounts").
+		Resource("serviceaccounts").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).
 		Do().
@@ -105,7 +105,7 @@ func (c *serviceAccounts) Get(name string) (result *api.ServiceAccount, err erro
 	result = &api.ServiceAccount{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("serviceAccounts").
+		Resource("serviceaccounts").
 		Name(name).
 		Do().
 		Into(result)
@@ -117,7 +117,7 @@ func (c *serviceAccounts) List(opts api.ListOptions) (result *api.ServiceAccount
 	result = &api.ServiceAccountList{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("serviceAccounts").
+		Resource("serviceaccounts").
 		VersionedParams(&opts, api.Scheme).
 		Do().
 		Into(result)
@@ -129,7 +129,7 @@ func (c *serviceAccounts) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.client.Get().
 		Prefix("watch").
 		Namespace(c.ns).
-		Resource("serviceAccounts").
+		Resource("serviceaccounts").
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }


### PR DESCRIPTION
Depending on #19912, only the commit "Use lowercase names in individual typed clients" is relevant.

Fixing #19894 for the generated clients.
