### PR TITLE
Promote ServiceAccount e2e out of [Flaky] status

### DIFF
--- a/test/e2e/service_accounts.go
+++ b/test/e2e/service_accounts.go
@@ -30,8 +30,7 @@ import (
 	. "github.com/onsi/ginkgo"
 )
 
-// Flaky issue #19024
-var _ = Describe("ServiceAccounts [Flaky]", func() {
+var _ = Describe("ServiceAccounts", func() {
 	f := NewFramework("svcaccounts")
 
 	It("should mount an API token into pods [Conformance]", func() {


### PR DESCRIPTION
Was marked as flaky prior to #11291, 6 months ago.
Code has changed many times.
No flakes in last 28 runs, and no Jenkins
history before that.
Follow up in #19024 if you see a flake.
