### PR TITLE
Fix a small error comment in nodecondition type

### DIFF
--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -13560,7 +13560,7 @@
     "properties": {
      "type": {
       "type": "string",
-      "description": "Type of node condition, currently only Ready."
+      "description": "Type of node condition."
      },
      "status": {
       "type": "string",

--- a/docs/api-reference/v1/definitions.html
+++ b/docs/api-reference/v1/definitions.html
@@ -1457,7 +1457,7 @@ Examples:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">type</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Type of node condition, currently only Ready.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Type of node condition.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -7145,7 +7145,7 @@ The resulting set of endpoints can be viewed as:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2016-01-18 17:24:26 UTC
+Last updated 2016-01-22 02:17:17 UTC
 </div>
 </div>
 </body>

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -1971,7 +1971,7 @@ const (
 
 // NodeCondition contains condition infromation for a node.
 type NodeCondition struct {
-	// Type of node condition, currently only Ready.
+	// Type of node condition.
 	Type NodeConditionType `json:"type"`
 	// Status of the condition, one of True, False, Unknown.
 	Status ConditionStatus `json:"status"`

--- a/pkg/api/v1/types_swagger_doc_generated.go
+++ b/pkg/api/v1/types_swagger_doc_generated.go
@@ -701,7 +701,7 @@ func (NodeAddress) SwaggerDoc() map[string]string {
 
 var map_NodeCondition = map[string]string{
 	"":                   "NodeCondition contains condition infromation for a node.",
-	"type":               "Type of node condition, currently only Ready.",
+	"type":               "Type of node condition.",
 	"status":             "Status of the condition, one of True, False, Unknown.",
 	"lastHeartbeatTime":  "Last time we got an update on a given condition.",
 	"lastTransitionTime": "Last time the condition transit from one status to another.",


### PR DESCRIPTION
NodeConditionType has NodeReady and NodeOutOfDisk types, but the comment says `"//Type of node condition, currently only Ready"`, fix it.
