### PR TITLE
id is not valid for api v1

### DIFF
--- a/examples/glusterfs/glusterfs-pod.json
+++ b/examples/glusterfs/glusterfs-pod.json
@@ -1,6 +1,5 @@
 {
     "apiVersion": "v1",
-    "id": "glusterfs",
     "kind": "Pod",
     "metadata": {
         "name": "glusterfs"


### PR DESCRIPTION
Fixing the error below:
error validating "gfs-pod.json": error validating data: found invalid field id for v1.Pod; if you choose to ignore these errors, turn validation off with --validate=false
