### PR TITLE
Fix kubectl annotate and label to use versioned objects when operating

### DIFF
--- a/pkg/kubectl/cmd/annotate.go
+++ b/pkg/kubectl/cmd/annotate.go
@@ -201,7 +201,11 @@ func (o AnnotateOptions) RunAnnotate() error {
 			return err
 		}
 
-		name, namespace, obj := info.Name, info.Namespace, info.Object
+		obj, err := info.Mapping.ConvertToVersion(info.Object, info.Mapping.GroupVersionKind.GroupVersion().String())
+		if err != nil {
+			return err
+		}
+		name, namespace := info.Name, info.Namespace
 		oldData, err := json.Marshal(obj)
 		if err != nil {
 			return err

--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -238,7 +238,11 @@ func RunLabel(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []stri
 			}
 			outputObj = info.Object
 		} else {
-			name, namespace, obj := info.Name, info.Namespace, info.Object
+			obj, err := info.Mapping.ConvertToVersion(info.Object, info.Mapping.GroupVersionKind.GroupVersion().String())
+			if err != nil {
+				return err
+			}
+			name, namespace := info.Name, info.Namespace
 			oldData, err := json.Marshal(obj)
 			if err != nil {
 				return err


### PR DESCRIPTION
Currently `kubectl annotate` and `label` uses the internal representation when posting changes to the server. In the light of proposed changes (#3933) and the fact that in OpenShift we already don't have json tags in internal representation we need to update both commands to use versioned objects.

@kubernetes/kubectl 
