### PR TITLE
build: Use Go version in cross image tag

### DIFF
--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -14,7 +14,10 @@
 
 # This file creates a standard build environment for building Kubernetes
 
-FROM kube-build:cross
+# We replace KUBE_BUILD_IMAGE_CROSS in build/common.sh with the actual
+# cross-build image tag.
+FROM KUBE_BUILD_IMAGE_CROSS
+
 MAINTAINER  Joe Beda <jbeda@google.com>
 
 # (set an explicit GOARM of 5 for maximum compatibility)


### PR DESCRIPTION
The new tag format is `cross-<go version>-<cross version>`, starting
with `cross-1.5.3-1`.

Also bump the image we pre-pull / warn-on to 1.5.3

Fixes #19990
