### PR TITLE
Ubernetes-Lite GCE: Label volumes with zone information

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -107,7 +107,7 @@ if [[ "${ENABLE_NODE_AUTOSCALER}" == "true" ]]; then
 fi
 
 # Admission Controllers to invoke prior to persisting objects in cluster
-ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota
+ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,PersistentVolumeLabel
 
 # Optional: if set to true kube-up will automatically check for existing resources and clean them up.
 KUBE_UP_AUTOMATIC_CLEANUP=${KUBE_UP_AUTOMATIC_CLEANUP:-false}

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -120,7 +120,7 @@ if [[ "${ENABLE_NODE_AUTOSCALER}" == "true" ]]; then
   TARGET_NODE_UTILIZATION="${KUBE_TARGET_NODE_UTILIZATION:-0.7}"
 fi
 
-ADMISSION_CONTROL="${KUBE_ADMISSION_CONTROL:-NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota}"
+ADMISSION_CONTROL="${KUBE_ADMISSION_CONTROL:-NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota,PersistentVolumeLabel}"
 
 # Optional: if set to true kube-up will automatically check for existing resources and clean them up.
 KUBE_UP_AUTOMATIC_CLEANUP=${KUBE_UP_AUTOMATIC_CLEANUP:-false}

--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -1764,14 +1764,20 @@ func (gce *GCECloud) getDiskByNameUnknownZone(diskName string) (*gceDisk, error)
 	// "us-central1-a/mydisk".  We could do this for them as part of
 	// admission control, but that might be a little weird (values changing
 	// on create)
+
+	var found *gceDisk
 	for _, zone := range gce.managedZones {
 		disk, err := gce.findDiskByName(diskName, zone)
 		if err != nil {
 			return nil, err
 		}
-		if disk != nil {
-			return disk, nil
+		if found != nil {
+			return nil, fmt.Errorf("GCE persistent disk name was found in multiple zones: %q", diskName)
 		}
+		found = disk
+	}
+	if found != nil {
+		return found, nil
 	}
 	return nil, fmt.Errorf("GCE persistent disk not found: %q", diskName)
 }


### PR DESCRIPTION
I haven't yet had time to test this, but wanted to share with you asap @quinton-hoole 

This completes Ubernetes-Lite support for GCE, by labeling volumes with zones.  It also enforces non-ambiguousness when referring to volumes purely by name, which ends up having some very nice properties: from commit 8dbb5c90b1da68c6ed01c770beeceeeedd973907

```
    Ubernetes-Lite: Error if a PD name is ambiguous

    We don't cope well if a PD is in multiple zones, but this is actually
    fairly easy to detect.  This is probably justified purely on the basis
    that we never want to delete the wrong volume (DeleteDisk), but also
    because this means that we now warn on creation if a disk is in multiple
    zones (with the labeling admission controller).

    This also means that with the scheduling predicate in place, that many
    of our volume problems "go away" in practice: you still can't create or
    delete a volume when it is ambiguous, but thereafter the volume will be
    labeled with the zone, that will match it only to nodes with the same
    zone, and then we query for the volume in that zone when we
    attach/detach it.
```
