### PR TITLE
Move test (Pods should not back-off restarting a container on Livenes…

### DIFF
--- a/test/e2e/pods.go
+++ b/test/e2e/pods.go
@@ -897,8 +897,7 @@ var _ = Describe("Pods", func() {
 		}
 	})
 
-	// Flaky issue #18293
-	It("should not back-off restarting a container on LivenessProbe failure [Flaky]", func() {
+	It("should not back-off restarting a container on LivenessProbe failure [Serial]", func() {
 		podClient := framework.Client.Pods(framework.Namespace.Name)
 		podName := "pod-back-off-liveness"
 		containerName := "back-off-liveness"


### PR DESCRIPTION
…sProbe failure)

out of flaky test.

For last 100+ runs, the test never fail in kubernetes-e2e-gce-flaky build.
The only exception is build 10313, but the failure is caused by previous
flaky test, not this one itself.

Close #18293
