### PR TITLE
19848: Retry service IP repair on conflict

### DIFF
--- a/pkg/registry/service/ipallocator/controller/repair.go
+++ b/pkg/registry/service/ipallocator/controller/repair.go
@@ -22,6 +22,8 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/errors"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/registry/service"
 	"k8s.io/kubernetes/pkg/registry/service/ipallocator"
 	"k8s.io/kubernetes/pkg/util"
@@ -72,6 +74,11 @@ func (c *Repair) RunUntil(ch chan struct{}) {
 
 // RunOnce verifies the state of the cluster IP allocations and returns an error if an unrecoverable problem occurs.
 func (c *Repair) RunOnce() error {
+	return client.RetryOnConflict(client.DefaultBackoff, c.runOnce)
+}
+
+// runOnce verifies the state of the cluster IP allocations and returns an error if an unrecoverable problem occurs.
+func (c *Repair) runOnce() error {
 	// TODO: (per smarterclayton) if Get() or ListServices() is a weak consistency read,
 	// or if they are executed against different leaders,
 	// the ordering guarantee required to ensure no IP is allocated twice is violated.
@@ -127,12 +134,14 @@ func (c *Repair) RunOnce() error {
 		}
 	}
 
-	err = r.Snapshot(latest)
-	if err != nil {
-		return fmt.Errorf("unable to persist the updated service IP allocations: %v", err)
+	if err := r.Snapshot(latest); err != nil {
+		return fmt.Errorf("unable to snapshot the updated service IP allocations: %v", err)
 	}
 
 	if err := c.alloc.CreateOrUpdate(latest); err != nil {
+		if errors.IsConflict(err) {
+			return err
+		}
 		return fmt.Errorf("unable to persist the updated service IP allocations: %v", err)
 	}
 	return nil


### PR DESCRIPTION
Components can write services during startup, which results in the ip
allocator map being updated. Since core controllers _must_ succeed for
the masters to start, we should retry a few times in order to pass.

Fixes #19848, #19467
