### PR TITLE
Retry SSH connection for E2E log gathering.

### DIFF
--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package ssh
 
 import (
 	"fmt"
@@ -304,7 +304,7 @@ func TestSSHUser(t *testing.T) {
 	for _, item := range table {
 		dialer := &mockSSHDialer{}
 
-		_, _, _, err := runSSHCommand(dialer, item.command, item.user, item.host, item.signer)
+		_, _, _, err := runSSHCommand(dialer, item.command, item.user, item.host, item.signer, false)
 		if err == nil {
 			t.Errorf("expected error (as mock returns error); did not get one")
 		}

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -51,6 +51,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
+	sshutil "k8s.io/kubernetes/pkg/ssh"
 	"k8s.io/kubernetes/pkg/util"
 	deploymentutil "k8s.io/kubernetes/pkg/util/deployment"
 	"k8s.io/kubernetes/pkg/util/sets"
@@ -2219,7 +2220,7 @@ func SSH(cmd, host, provider string) (SSHResult, error) {
 		result.User = os.Getenv("USER")
 	}
 
-	stdout, stderr, code, err := util.RunSSHCommand(cmd, result.User, host, signer)
+	stdout, stderr, code, err := sshutil.RunSSHCommand(cmd, result.User, host, signer)
 	result.Stdout = stdout
 	result.Stderr = stderr
 	result.Code = code
@@ -2324,7 +2325,7 @@ func getSigner(provider string) (ssh.Signer, error) {
 		// If there is an env. variable override, use that.
 		aws_keyfile := os.Getenv("AWS_SSH_KEY")
 		if len(aws_keyfile) != 0 {
-			return util.MakePrivateKeySignerFromFile(aws_keyfile)
+			return sshutil.MakePrivateKeySignerFromFile(aws_keyfile)
 		}
 		// Otherwise revert to home dir
 		keyfile = "kube_aws_rsa"
@@ -2333,7 +2334,7 @@ func getSigner(provider string) (ssh.Signer, error) {
 	}
 	key := filepath.Join(keydir, keyfile)
 
-	return util.MakePrivateKeySignerFromFile(key)
+	return sshutil.MakePrivateKeySignerFromFile(key)
 }
 
 // checkPodsRunning returns whether all pods whose names are listed in podNames


### PR DESCRIPTION
We had some TCP connection flakes the other day, which led to missing logs as described in #19964. Several other tests rely on SSH and will flake due to a flaky connection, when a simple retry would fix them. This PR retries the SSH dial a few times with a few seconds in between each.

I'm new to go, so there might be a more idiomatic way to do this. I'm also leaning on PR Jenkins for testing this.
