### PR TITLE
kubelet: Update engine version parsing to handle semantic versioning

### DIFF
--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -275,7 +275,7 @@ func getDockerClient(dockerEndpoint string) (*docker.Client, error) {
 func ConnectToDockerOrDie(dockerEndpoint string) DockerInterface {
 	if dockerEndpoint == "fake://" {
 		return &FakeDockerClient{
-			VersionInfo: docker.Env{"ApiVersion=1.18"},
+			VersionInfo: docker.Env{"ApiVersion=1.18", "Version=1.6.0"},
 		}
 	}
 	client, err := getDockerClient(dockerEndpoint)

--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -31,6 +31,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/coreos/go-semver/semver"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/glog"
 	"github.com/golang/groupcache/lru"
@@ -944,18 +945,47 @@ func (dm *DockerManager) podInfraContainerChanged(pod *api.Pod, podInfraContaine
 	return podInfraContainerStatus.Hash != kubecontainer.HashContainer(expectedPodInfraContainer), nil
 }
 
-type dockerVersion docker.APIVersion
-
-func NewVersion(input string) (dockerVersion, error) {
-	version, err := docker.NewAPIVersion(input)
-	return dockerVersion(version), err
+// dockerVersion implementes kubecontainer.Version interface by implementing
+// Compare() and String() (which is implemented by the underlying semver.Version)
+// TODO: this code is the same as rktVersion and may make sense to be moved to
+// somewhere shared.
+type dockerVersion struct {
+	*semver.Version
 }
 
-func (dv dockerVersion) String() string {
+func newDockerVersion(version string) (dockerVersion, error) {
+	sem, err := semver.NewVersion(version)
+	if err != nil {
+		return dockerVersion{}, err
+	}
+	return dockerVersion{sem}, nil
+}
+
+func (r dockerVersion) Compare(other string) (int, error) {
+	v, err := semver.NewVersion(other)
+	if err != nil {
+		return -1, err
+	}
+
+	if r.LessThan(*v) {
+		return -1, nil
+	}
+	if v.LessThan(*r.Version) {
+		return 1, nil
+	}
+	return 0, nil
+}
+
+// dockerVersion implementes kubecontainer.Version interface by implementing
+// Compare() and String() on top og go-dockerclient's APIVersion. This version
+// string doesn't conform to semantic versioning, as it is only "x.y"
+type dockerAPIVersion docker.APIVersion
+
+func (dv dockerAPIVersion) String() string {
 	return docker.APIVersion(dv).String()
 }
 
-func (dv dockerVersion) Compare(other string) (int, error) {
+func (dv dockerAPIVersion) Compare(other string) (int, error) {
 	a := docker.APIVersion(dv)
 	b, err := docker.NewAPIVersion(other)
 	if err != nil {
@@ -981,12 +1011,12 @@ func (dm *DockerManager) Version() (kubecontainer.Version, error) {
 	}
 
 	engineVersion := env.Get("Version")
-	version, err := docker.NewAPIVersion(engineVersion)
+	version, err := newDockerVersion(engineVersion)
 	if err != nil {
 		glog.Errorf("docker: failed to parse docker server version %q: %v", engineVersion, err)
 		return nil, fmt.Errorf("docker: failed to parse docker server version %q: %v", engineVersion, err)
 	}
-	return dockerVersion(version), nil
+	return version, nil
 }
 
 func (dm *DockerManager) APIVersion() (kubecontainer.Version, error) {
@@ -1001,7 +1031,7 @@ func (dm *DockerManager) APIVersion() (kubecontainer.Version, error) {
 		glog.Errorf("docker: failed to parse docker api version %q: %v", apiVersion, err)
 		return nil, fmt.Errorf("docker: failed to parse docker api version %q: %v", apiVersion, err)
 	}
-	return dockerVersion(version), nil
+	return dockerAPIVersion(version), nil
 }
 
 // The first version of docker that supports exec natively is 1.3.0 == API 1.15


### PR DESCRIPTION
This updates the dockertools.dockerVersion to use a semantic versioning
library to more gracefully support engine versions which include
additional version fields.

Previously, go-dockerclient's APIVersion struct was use which only
handles plain numeric x.y.z version strings. With #19675, the library
was now used on the Docker engine string, however it is possible for the
engine string to include include additional information for beta, rc, or
distro specific builds.

This PR also enables the TestDockerRuntimeVersion test which was
previously just a FIXME and updates it to pass, and be used to test the
version string that cause #20005.

This negates the need for fsouza/go-dockerclient#451, since even with
that change, if a user was running Docker 1.10.0-rc1, this would cause
the kubelet to report it as simply 1.10.0.
