### PR TITLE
Updating heapster to the lastest stable release - v0.19.1

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -7,26 +7,26 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: heapster-v11
+  name: heapster-v12
   namespace: kube-system
   labels:
     k8s-app: heapster
-    version: v11
+    version: v12
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
   selector:
     k8s-app: heapster
-    version: v11
+    version: v12
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v11
+        version: v12
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v0.18.4
+        - image: gcr.io/google_containers/heapster:v0.19.1
           name: heapster
           resources:
             # keep request = limit to keep this container in guaranteed class

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -7,26 +7,26 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: heapster-v11
+  name: heapster-v12
   namespace: kube-system
   labels:
     k8s-app: heapster
-    version: v11
+    version: v12
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
   selector:
     k8s-app: heapster
-    version: v11
+    version: v12
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v11
+        version: v12
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v0.18.4
+        - image: gcr.io/google_containers/heapster:v0.19.1
           name: heapster
           resources:
             # keep request = limit to keep this container in guaranteed class

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -7,26 +7,26 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: heapster-v11
+  name: heapster-v12
   namespace: kube-system
   labels:
     k8s-app: heapster
-    version: v11
+    version: v12
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
   selector:
     k8s-app: heapster
-    version: v11
+    version: v12
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v11
+        version: v12
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v0.18.4
+        - image: gcr.io/google_containers/heapster:v0.19.1
           name: heapster
           resources:
             # keep request = limit to keep this container in guaranteed class

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -7,26 +7,26 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: heapster-v11
+  name: heapster-v12
   namespace: kube-system
   labels:
     k8s-app: heapster
-    version: v11
+    version: v12
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
   selector:
     k8s-app: heapster
-    version: v11
+    version: v12
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v11
+        version: v12
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v0.18.4
+        - image: gcr.io/google_containers/heapster:v0.19.1
           name: heapster
           resources:
             # keep request = limit to keep this container in guaranteed class


### PR DESCRIPTION
This update should prevent heapster from crashlooping whenever backend storage is unavailable.
This will help stabilize some of the e2e tests.
xref #19986
