### PR TITLE
Remove TestWatchEtcdError

### DIFF
--- a/pkg/storage/etcd/etcd_watcher_test.go
+++ b/pkg/storage/etcd/etcd_watcher_test.go
@@ -217,24 +217,6 @@ func TestWatchInterpretation_ResponseBadData(t *testing.T) {
 	}
 }
 
-/* re-Disabling due to flakes seen upstream #18914
-func TestWatchEtcdError(t *testing.T) {
-	codec := testapi.Default.Codec()
-	server := etcdtesting.NewEtcdTestClientServer(t)
-	h := newEtcdHelper(server.Client, codec, etcdtest.PathPrefix())
-	watching, err := h.Watch(context.TODO(), "/some/key", "4", storage.Everything)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	server.Terminate(t)
-
-	got, ok := <-watching.ResultChan()
-	if ok && got.Type != watch.Error {
-		t.Fatalf("Unexpected non-error")
-	}
-	watching.Stop()
-}*/
-
 func TestWatch(t *testing.T) {
 	codec := testapi.Default.Codec()
 	server := etcdtesting.NewEtcdTestClientServer(t)


### PR DESCRIPTION
We decided to remove this test, as there's no way to get an upper bound
on its running time. Etcd restart behavior should be tested in
integration or e2e tests.

Fixes #18914
