### PR TITLE
ResourceQuota controller improvements and e2e validation

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -225,9 +225,23 @@ func StartControllers(s *options.CMServer, kubeClient *client.Client, kubeconfig
 		glog.Infof("allocate-node-cidrs set to %v, node controller not creating routes", s.AllocateNodeCIDRs)
 	}
 
-	go resourcequotacontroller.NewResourceQuotaController(
-		clientForUserAgentOrDie(*kubeconfig, "resourcequota-controller"),
-		controller.StaticResyncPeriodFunc(s.ResourceQuotaSyncPeriod)).Run(s.ConcurrentResourceQuotaSyncs, util.NeverStop)
+	resourceQuotaControllerClient := clientForUserAgentOrDie(*kubeconfig, "resourcequota-controller")
+	resourceQuotaUsageRegistry := resourcequotacontroller.NewDefaultUsageFuncRegistry(resourceQuotaControllerClient)
+	resourceQuotaControllerFactory := resourcequotacontroller.NewMonitoringControllerFactory(resourceQuotaControllerClient)
+	groupKindsToMonitor := []unversioned.GroupKind{
+		unversioned.GroupKind{Group: "", Kind: "Pod"},
+		unversioned.GroupKind{Group: "", Kind: "Service"},
+		unversioned.GroupKind{Group: "", Kind: "ReplicationController"},
+		unversioned.GroupKind{Group: "", Kind: "PersistentVolumeClaim"},
+	}
+	resourceQuotaControllerOptions := &resourcequotacontroller.ResourceQuotaControllerOptions{
+		KubeClient:          resourceQuotaControllerClient,
+		ResyncPeriod:        controller.StaticResyncPeriodFunc(s.ResourceQuotaSyncPeriod),
+		UsageRegistry:       resourceQuotaUsageRegistry,
+		ControllerFactory:   resourceQuotaControllerFactory,
+		GroupKindsToMonitor: groupKindsToMonitor,
+	}
+	go resourcequotacontroller.NewResourceQuotaController(resourceQuotaControllerOptions).Run(s.ConcurrentResourceQuotaSyncs, util.NeverStop)
 
 	// If apiserver is not running we should wait for some time and fail only then. This is particularly
 	// important when we start apiserver and controller manager at the same time.

--- a/pkg/controller/resourcequota/resource_quota_controller.go
+++ b/pkg/controller/resourcequota/resource_quota_controller.go
@@ -17,12 +17,13 @@ limitations under the License.
 package resourcequota
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/golang/glog"
+
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/cache"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/controller"
@@ -33,6 +34,20 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+// ResourceQuotaControllerOptions holds options for creating a quota controller
+type ResourceQuotaControllerOptions struct {
+	// Must have authority to list all quotas, and update quota status
+	KubeClient client.Interface
+	// Controls full recalculation of quota usage
+	ResyncPeriod controller.ResyncPeriodFunc
+	// Knows how to calculate usage
+	UsageRegistry UsageFuncRegistry
+	// Knows how to build controllers that
+	ControllerFactory MonitoringControllerFactory
+	// List of GroupKind objects that should be monitored for deletion events
+	GroupKindsToMonitor []unversioned.GroupKind
+}
+
 // ResourceQuotaController is responsible for tracking quota usage status in the system
 type ResourceQuotaController struct {
 	// Must have authority to list all resources in the system, and update quota status
@@ -41,27 +56,33 @@ type ResourceQuotaController struct {
 	rqIndexer cache.Indexer
 	// Watches changes to all resource quota
 	rqController *framework.Controller
-	// A store of pods, populated by the podController
-	podStore cache.StoreToPodLister
-	// Watches changes to all pods (so we can optimize release of compute resources)
-	podController *framework.Controller
 	// ResourceQuota objects that need to be synchronized
 	queue *workqueue.Type
 	// To allow injection of syncUsage for testing.
 	syncHandler func(key string) error
 	// function that controls full recalculation of quota usage
 	resyncPeriod controller.ResyncPeriodFunc
+	// knows how to calculate usage
+	usageRegistry UsageFuncRegistry
+	// controllers monitoring various resources in the system
+	monitoringControllers []*framework.Controller
 }
 
 // NewResourceQuotaController creates a new ResourceQuotaController
-func NewResourceQuotaController(kubeClient client.Interface, resyncPeriod controller.ResyncPeriodFunc) *ResourceQuotaController {
-
+func NewResourceQuotaController(options *ResourceQuotaControllerOptions) *ResourceQuotaController {
+	// build the resource quota controller
 	rq := &ResourceQuotaController{
-		kubeClient:   kubeClient,
-		queue:        workqueue.New(),
-		resyncPeriod: resyncPeriod,
+		kubeClient:            options.KubeClient,
+		queue:                 workqueue.New(),
+		resyncPeriod:          options.ResyncPeriod,
+		usageRegistry:         options.UsageRegistry,
+		monitoringControllers: []*framework.Controller{},
 	}
 
+	// set the synchronization handler
+	rq.syncHandler = rq.syncResourceQuotaFromKey
+
+	// build the controller that observes quota
 	rq.rqIndexer, rq.rqController = framework.NewIndexerInformer(
 		&cache.ListWatch{
 			ListFunc: func(options api.ListOptions) (runtime.Object, error) {
@@ -72,7 +93,7 @@ func NewResourceQuotaController(kubeClient client.Interface, resyncPeriod contro
 			},
 		},
 		&api.ResourceQuota{},
-		resyncPeriod(),
+		rq.resyncPeriod(),
 		framework.ResourceEventHandlerFuncs{
 			AddFunc: rq.enqueueResourceQuota,
 			UpdateFunc: func(old, cur interface{}) {
@@ -100,26 +121,21 @@ func NewResourceQuotaController(kubeClient client.Interface, resyncPeriod contro
 		cache.Indexers{"namespace": cache.MetaNamespaceIndexFunc},
 	)
 
-	// We use this pod controller to rapidly observe when a pod deletion occurs in order to
-	// release compute resources from any associated quota.
-	rq.podStore.Store, rq.podController = framework.NewInformer(
-		&cache.ListWatch{
-			ListFunc: func(options api.ListOptions) (runtime.Object, error) {
-				return rq.kubeClient.Pods(api.NamespaceAll).List(options)
-			},
-			WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
-				return rq.kubeClient.Pods(api.NamespaceAll).Watch(options)
-			},
-		},
-		&api.Pod{},
-		resyncPeriod(),
-		framework.ResourceEventHandlerFuncs{
-			DeleteFunc: rq.deletePod,
-		},
-	)
-
-	// set the synchronization handler
-	rq.syncHandler = rq.syncResourceQuotaFromKey
+	// configure controllers that should monitor specific resource types
+	monitoringHandlerFuncs := framework.ResourceEventHandlerFuncs{DeleteFunc: rq.observeDelete}
+	for _, groupKindToMonitor := range options.GroupKindsToMonitor {
+		controllerOptions := &MonitoringControllerOptions{
+			GroupKind:                 groupKindToMonitor,
+			ResyncPeriod:              options.ResyncPeriod,
+			ResourceEventHandlerFuncs: monitoringHandlerFuncs,
+		}
+		monitorController, err := options.ControllerFactory.NewController(controllerOptions)
+		if err != nil {
+			glog.Warningf("quota controller unable to monitor %s due to %v, changes only accounted during full resync", groupKindToMonitor, err)
+		} else {
+			rq.monitoringControllers = append(rq.monitoringControllers, monitorController)
+		}
+	}
 	return rq
 }
 
@@ -162,44 +178,21 @@ func (rq *ResourceQuotaController) worker() {
 // Run begins quota controller using the specified number of workers
 func (rq *ResourceQuotaController) Run(workers int, stopCh <-chan struct{}) {
 	defer util.HandleCrash()
+	// the main quota controller
 	go rq.rqController.Run(stopCh)
-	go rq.podController.Run(stopCh)
+	// the controllers that monitor other resources to respond rapidly to deletions
+	for _, monitoringController := range rq.monitoringControllers {
+		go monitoringController.Run(stopCh)
+	}
+	// the workers that chug through the quota calculation backlog
 	for i := 0; i < workers; i++ {
 		go util.Until(rq.worker, time.Second, stopCh)
 	}
+	// the timer for how often we do a full recalculation across all quotas
 	go util.Until(func() { rq.enqueueAll() }, rq.resyncPeriod(), stopCh)
 	<-stopCh
 	glog.Infof("Shutting down ResourceQuotaController")
 	rq.queue.ShutDown()
-}
-
-// FilterQuotaPods eliminates pods that no longer have a cost against the quota
-// pods that have a restart policy of always are always returned
-// pods that are in a failed state, but have a restart policy of on failure are always returned
-// pods that are not in a success state or a failure state are included in quota
-func FilterQuotaPods(pods []api.Pod) []*api.Pod {
-	var result []*api.Pod
-	for i := range pods {
-		value := &pods[i]
-		// a pod that has a restart policy always no matter its state counts against usage
-		if value.Spec.RestartPolicy == api.RestartPolicyAlways {
-			result = append(result, value)
-			continue
-		}
-		// a failed pod with a restart policy of on failure will count against usage
-		if api.PodFailed == value.Status.Phase &&
-			value.Spec.RestartPolicy == api.RestartPolicyOnFailure {
-			result = append(result, value)
-			continue
-		}
-		// if the pod is not succeeded or failed, then we count it against quota
-		if api.PodSucceeded != value.Status.Phase &&
-			api.PodFailed != value.Status.Phase {
-			result = append(result, value)
-			continue
-		}
-	}
-	return result
 }
 
 // syncResourceQuotaFromKey syncs a quota key
@@ -249,7 +242,9 @@ func (rq *ResourceQuotaController) syncResourceQuota(quota api.ResourceQuota) (e
 	}
 
 	// set the hard values supported on the quota
+	resourceSet := ResourceSet{}
 	for k, v := range quota.Spec.Hard {
+		resourceSet[k] = struct{}{}
 		usage.Status.Hard[k] = *v.Copy()
 	}
 	// set any last known observed status values for usage
@@ -257,20 +252,21 @@ func (rq *ResourceQuotaController) syncResourceQuota(quota api.ResourceQuota) (e
 		usage.Status.Used[k] = *v.Copy()
 	}
 
-	set := map[api.ResourceName]bool{}
-	for k := range usage.Status.Hard {
-		set[k] = true
+	// recalculate usage
+	usageOptions := UsageOptions{
+		Namespace: quota.Namespace,
+		Resources: resourceSet,
 	}
-
-	pods := &api.PodList{}
-	if set[api.ResourcePods] || set[api.ResourceMemory] || set[api.ResourceCPU] {
-		pods, err = rq.kubeClient.Pods(usage.Namespace).List(api.ListOptions{})
+	latestUsage := api.ResourceList{}
+	for _, usageFunc := range rq.usageRegistry.UsageFuncs() {
+		usage, err := usageFunc(usageOptions)
 		if err != nil {
 			return err
 		}
+		for k, v := range usage.Used {
+			latestUsage[k] = v
+		}
 	}
-
-	filteredPods := FilterQuotaPods(pods.Items)
 
 	// iterate over each resource, and update observation
 	for k := range usage.Status.Hard {
@@ -281,53 +277,12 @@ func (rq *ResourceQuotaController) syncResourceQuota(quota api.ResourceQuota) (e
 			dirty = true
 		}
 
-		var value *resource.Quantity
-
-		switch k {
-		case api.ResourcePods:
-			value = resource.NewQuantity(int64(len(filteredPods)), resource.DecimalSI)
-		case api.ResourceServices:
-			items, err := rq.kubeClient.Services(usage.Namespace).List(api.ListOptions{})
-			if err != nil {
-				return err
-			}
-			value = resource.NewQuantity(int64(len(items.Items)), resource.DecimalSI)
-		case api.ResourceReplicationControllers:
-			items, err := rq.kubeClient.ReplicationControllers(usage.Namespace).List(api.ListOptions{})
-			if err != nil {
-				return err
-			}
-			value = resource.NewQuantity(int64(len(items.Items)), resource.DecimalSI)
-		case api.ResourceQuotas:
-			items, err := rq.kubeClient.ResourceQuotas(usage.Namespace).List(api.ListOptions{})
-			if err != nil {
-				return err
-			}
-			value = resource.NewQuantity(int64(len(items.Items)), resource.DecimalSI)
-		case api.ResourceSecrets:
-			items, err := rq.kubeClient.Secrets(usage.Namespace).List(api.ListOptions{})
-			if err != nil {
-				return err
-			}
-			value = resource.NewQuantity(int64(len(items.Items)), resource.DecimalSI)
-		case api.ResourcePersistentVolumeClaims:
-			items, err := rq.kubeClient.PersistentVolumeClaims(usage.Namespace).List(api.ListOptions{})
-			if err != nil {
-				return err
-			}
-			value = resource.NewQuantity(int64(len(items.Items)), resource.DecimalSI)
-		case api.ResourceMemory:
-			value = PodsRequests(filteredPods, api.ResourceMemory)
-		case api.ResourceCPU:
-			value = PodsRequests(filteredPods, api.ResourceCPU)
-		}
-
-		// ignore fields we do not understand (assume another controller is tracking it)
-		if value != nil {
-			// see if the value has changed
-			dirty = dirty || (value.Value() != prevQuantity.Value())
-			// just update the value
-			usage.Status.Used[k] = *value
+		// ignore updating fields this controller does not understand
+		// assume another controller is tracking it
+		newQuantity, found := latestUsage[k]
+		if found {
+			dirty = dirty || (newQuantity.Value() != prevQuantity.Value())
+			usage.Status.Used[k] = newQuantity
 		}
 	}
 
@@ -339,100 +294,38 @@ func (rq *ResourceQuotaController) syncResourceQuota(quota api.ResourceQuota) (e
 	return nil
 }
 
-// PodsRequests returns sum of each resource request for each pod in list
-// If a given pod in the list does not have a request for the named resource, we log the error
-// but still attempt to get the most representative count
-func PodsRequests(pods []*api.Pod, resourceName api.ResourceName) *resource.Quantity {
-	var sum *resource.Quantity
-	for i := range pods {
-		pod := pods[i]
-		podQuantity, err := PodRequests(pod, resourceName)
-		if err != nil {
-			// log the error, but try to keep the most accurate count possible in log
-			// rationale here is that you may have had pods in a namespace that did not have
-			// explicit requests prior to adding the quota
-			glog.Infof("No explicit request for resource, pod %s/%s, %s", pod.Namespace, pod.Name, resourceName)
-		} else {
-			if sum == nil {
-				sum = podQuantity
-			} else {
-				sum.Add(*podQuantity)
-			}
-		}
-	}
-	// if list is empty
-	if sum == nil {
-		q := resource.MustParse("0")
-		sum = &q
-	}
-	return sum
-}
-
-// PodRequests returns sum of each resource request across all containers in pod
-func PodRequests(pod *api.Pod, resourceName api.ResourceName) (*resource.Quantity, error) {
-	if !PodHasRequests(pod, resourceName) {
-		return nil, fmt.Errorf("Each container in pod %s/%s does not have an explicit request for resource %s.", pod.Namespace, pod.Name, resourceName)
-	}
-	var sum *resource.Quantity
-	for j := range pod.Spec.Containers {
-		value, _ := pod.Spec.Containers[j].Resources.Requests[resourceName]
-		if sum == nil {
-			sum = value.Copy()
-		} else {
-			err := sum.Add(value)
-			if err != nil {
-				return sum, err
-			}
-		}
-	}
-	// if list is empty
-	if sum == nil {
-		q := resource.MustParse("0")
-		sum = &q
-	}
-	return sum, nil
-}
-
-// PodHasRequests verifies that each container in the pod has an explicit request that is non-zero for a named resource
-func PodHasRequests(pod *api.Pod, resourceName api.ResourceName) bool {
-	for j := range pod.Spec.Containers {
-		value, valueSet := pod.Spec.Containers[j].Resources.Requests[resourceName]
-		if !valueSet || value.Value() == int64(0) {
-			return false
-		}
-	}
-	return true
-}
-
-// When a pod is deleted, enqueue the quota that manages the pod and update its expectations.
-// obj could be an *api.Pod, or a DeletionFinalStateUnknown marker item.
-func (rq *ResourceQuotaController) deletePod(obj interface{}) {
-	pod, ok := obj.(*api.Pod)
-	// When a delete is dropped, the relist will notice a pod in the store not
-	// in the list, leading to the insertion of a tombstone object which contains
-	// the deleted key/value. Note that this value might be stale. If the pod
-	// changed labels the new rc will not be woken up till the periodic resync.
-	if !ok {
+// When an object is deleted, enqueue the quota that manages the object.
+// obj could be a runtime.Object or a DeletionFinalStateUnknown marker item.
+func (rq *ResourceQuotaController) observeDelete(obj interface{}) {
+	metaObject, err := meta.Accessor(obj)
+	if err != nil {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			glog.Errorf("Couldn't get object from tombstone %+v, could take up to %v before a quota records the deletion", obj, rq.resyncPeriod())
+			glog.Errorf("quota controller could not get object from tombstone %+v, could take up to %v before a quota usage reflects the deletion", obj, rq.resyncPeriod())
 			return
 		}
-		pod, ok = tombstone.Obj.(*api.Pod)
-		if !ok {
-			glog.Errorf("Tombstone contained object that is not a pod %+v, could take up to %v before quota records the deletion", obj, rq.resyncPeriod())
+		metaObject, err = meta.Accessor(tombstone.Obj)
+		if err != nil {
+			glog.Errorf("quota controller tombstone contained object that is not a meta %+v, could take up to %v before quota records the deletion", tombstone.Obj, rq.resyncPeriod())
 			return
 		}
 	}
 
-	quotas, err := rq.rqIndexer.Index("namespace", pod)
+	// look up the quota documents that are impacted
+	namespace := metaObject.GetNamespace()
+	indexKey := &api.ResourceQuota{}
+	indexKey.Namespace = namespace
+	quotas, err := rq.rqIndexer.Index("namespace", indexKey)
+
 	if err != nil {
-		glog.Errorf("Couldn't find resource quota associated with pod %+v, could take up to %v before a quota records the deletion", obj, rq.resyncPeriod())
+		glog.Errorf("quota controller could not find ResourceQuota associated with namespace: %s, could take up to %v before a quota records the deletion", namespace, rq.resyncPeriod())
 	}
+
 	if len(quotas) == 0 {
-		glog.V(4).Infof("No resource quota associated with namespace %q", pod.Namespace)
+		glog.V(4).Infof("No resource quota associated with namespace %q", namespace)
 		return
 	}
+
 	for i := range quotas {
 		quota := quotas[i].(*api.ResourceQuota)
 		rq.enqueueResourceQuota(quota)

--- a/pkg/controller/resourcequota/resource_quota_framework.go
+++ b/pkg/controller/resourcequota/resource_quota_framework.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcequota
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/pkg/controller/framework"
+)
+
+// ResourceSet is a set of resource names
+type ResourceSet map[api.ResourceName]struct{}
+
+// UsageOptions is used as input for how to measure usage of a set of resources
+type UsageOptions struct {
+	// Namespace to measure
+	Namespace string
+	// Resources to measure
+	Resources ResourceSet
+}
+
+// Usage is result of measuring observed resource use in the system
+type Usage struct {
+	// Used maps resource to quantity used
+	Used api.ResourceList
+}
+
+// UsageFunc measures usage of a quota tracked resource
+type UsageFunc func(options UsageOptions) (Usage, error)
+
+// UsageFuncRegistry manages a set of functions that can calculate usage
+type UsageFuncRegistry interface {
+	// Map of internal group kind to a function that knows how to measure usage
+	UsageFuncs() map[unversioned.GroupKind]UsageFunc
+}
+
+// MonitoringControllerOptions is an options struct passed when instantiating
+// a controller that monitors resources tracked by quota that need to be
+// replenished faster than the default full resync interval.
+type MonitoringControllerOptions struct {
+	// The resource that should be monitored
+	GroupKind unversioned.GroupKind
+	// how often the monitoring controller does a full resync
+	ResyncPeriod controller.ResyncPeriodFunc
+	// ResourceEventHandlerFuncs that should be injected into the monitoring
+	// controller that enables interfacing with the quota controller
+	ResourceEventHandlerFuncs framework.ResourceEventHandlerFuncs
+}
+
+// MonitoringControllerFactory knows how to build monitoring controllers
+type MonitoringControllerFactory interface {
+	// NewController returns a controller configured with specified options
+	NewController(options *MonitoringControllerOptions) (*framework.Controller, error)
+}

--- a/pkg/controller/resourcequota/resource_quota_monitors.go
+++ b/pkg/controller/resourcequota/resource_quota_monitors.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcequota
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/client/cache"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/controller/framework"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+type monitoringControllerFactory struct {
+	kubeClient client.Interface
+}
+
+func (f *monitoringControllerFactory) NewController(options *MonitoringControllerOptions) (*framework.Controller, error) {
+	var result *framework.Controller
+
+	switch options.GroupKind {
+	case unversioned.GroupKind{Group: "", Kind: "Pod"}:
+		_, result = framework.NewInformer(
+			&cache.ListWatch{
+				ListFunc: func(options api.ListOptions) (runtime.Object, error) {
+					return f.kubeClient.Pods(api.NamespaceAll).List(options)
+				},
+				WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
+					return f.kubeClient.Pods(api.NamespaceAll).Watch(options)
+				},
+			},
+			&api.Pod{},
+			options.ResyncPeriod(),
+			options.ResourceEventHandlerFuncs,
+		)
+	case unversioned.GroupKind{Group: "", Kind: "Service"}:
+		_, result = framework.NewInformer(
+			&cache.ListWatch{
+				ListFunc: func(options api.ListOptions) (runtime.Object, error) {
+					return f.kubeClient.Services(api.NamespaceAll).List(options)
+				},
+				WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
+					return f.kubeClient.Services(api.NamespaceAll).Watch(options)
+				},
+			},
+			&api.Service{},
+			options.ResyncPeriod(),
+			options.ResourceEventHandlerFuncs,
+		)
+	case unversioned.GroupKind{Group: "", Kind: "ReplicationController"}:
+		_, result = framework.NewInformer(
+			&cache.ListWatch{
+				ListFunc: func(options api.ListOptions) (runtime.Object, error) {
+					return f.kubeClient.ReplicationControllers(api.NamespaceAll).List(options)
+				},
+				WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
+					return f.kubeClient.ReplicationControllers(api.NamespaceAll).Watch(options)
+				},
+			},
+			&api.ReplicationController{},
+			options.ResyncPeriod(),
+			options.ResourceEventHandlerFuncs,
+		)
+	case unversioned.GroupKind{Group: "", Kind: "PersistentVolumeClaim"}:
+		_, result = framework.NewInformer(
+			&cache.ListWatch{
+				ListFunc: func(options api.ListOptions) (runtime.Object, error) {
+					return f.kubeClient.PersistentVolumeClaims(api.NamespaceAll).List(options)
+				},
+				WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
+					return f.kubeClient.PersistentVolumeClaims(api.NamespaceAll).Watch(options)
+				},
+			},
+			&api.PersistentVolumeClaim{},
+			options.ResyncPeriod(),
+			options.ResourceEventHandlerFuncs,
+		)
+	default:
+		return nil, fmt.Errorf("No monitoring controller defined for %s", options.GroupKind)
+	}
+
+	return result, nil
+}
+
+// NewMonitoringControllerFactory returns factory that supports monitoring core kubernetes resources
+func NewMonitoringControllerFactory(kubeClient client.Interface) MonitoringControllerFactory {
+	return &monitoringControllerFactory{kubeClient: kubeClient}
+}

--- a/pkg/controller/resourcequota/resource_quota_usage_counters.go
+++ b/pkg/controller/resourcequota/resource_quota_usage_counters.go
@@ -1,0 +1,262 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcequota
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+)
+
+// usageFuncRegistry is an internal implementation of UsageFuncRegistry
+type usageFuncRegistry struct {
+	internalUsageFuncs map[unversioned.GroupKind]UsageFunc
+}
+
+func (u *usageFuncRegistry) UsageFuncs() map[unversioned.GroupKind]UsageFunc {
+	return u.internalUsageFuncs
+}
+
+// NewDefaultUsageFuncRegistry returns a UsageFuncRegistry that knows how to deal with core Kubernetes resources
+func NewDefaultUsageFuncRegistry(kubeClient client.Interface) UsageFuncRegistry {
+	return &usageFuncRegistry{
+		internalUsageFuncs: map[unversioned.GroupKind]UsageFunc{
+			unversioned.GroupKind{Group: "", Kind: "Pod"}:                   podUsageFunc(kubeClient),
+			unversioned.GroupKind{Group: "", Kind: "Service"}:               serviceUsageFunc(kubeClient),
+			unversioned.GroupKind{Group: "", Kind: "ReplicationController"}: replicationControllerUsageFunc(kubeClient),
+			unversioned.GroupKind{Group: "", Kind: "ResourceQuota"}:         resourceQuotaUsageFunc(kubeClient),
+			unversioned.GroupKind{Group: "", Kind: "Secret"}:                secretUsageFunc(kubeClient),
+			unversioned.GroupKind{Group: "", Kind: "PersistentVolumeClaim"}: persistentVolumeClaimUsageFunc(kubeClient),
+		},
+	}
+}
+
+func podUsageFunc(kubeClient client.Interface) UsageFunc {
+	return func(options UsageOptions) (Usage, error) {
+		usage := Usage{Used: api.ResourceList{}}
+
+		match := false
+		resourceMatches := []api.ResourceName{api.ResourcePods, api.ResourceCPU, api.ResourceMemory}
+		for _, resourceMatch := range resourceMatches {
+			if _, found := options.Resources[resourceMatch]; found {
+				match = true
+			}
+		}
+
+		if !match {
+			return usage, nil
+		}
+
+		pods, err := kubeClient.Pods(options.Namespace).List(api.ListOptions{})
+		if err != nil {
+			return usage, err
+		}
+		filteredPods := FilterQuotaPods(pods.Items)
+
+		if _, found := options.Resources[api.ResourcePods]; found {
+			value := resource.NewQuantity(int64(len(filteredPods)), resource.DecimalSI)
+			usage.Used[api.ResourcePods] = *value
+		}
+
+		computeResources := []api.ResourceName{api.ResourceMemory, api.ResourceCPU}
+		for _, computeResource := range computeResources {
+			value := PodsRequests(filteredPods, computeResource)
+			usage.Used[computeResource] = *value
+		}
+
+		return usage, nil
+	}
+}
+
+func serviceUsageFunc(kubeClient client.Interface) UsageFunc {
+	return func(options UsageOptions) (Usage, error) {
+		usage := Usage{Used: api.ResourceList{}}
+		resourceName := api.ResourceServices
+		if _, found := options.Resources[resourceName]; found {
+			itemList, err := kubeClient.Services(options.Namespace).List(api.ListOptions{})
+			if err != nil {
+				return usage, err
+			}
+			value := resource.NewQuantity(int64(len(itemList.Items)), resource.DecimalSI)
+			usage.Used[resourceName] = *value
+		}
+		return usage, nil
+	}
+}
+
+func replicationControllerUsageFunc(kubeClient client.Interface) UsageFunc {
+	return func(options UsageOptions) (Usage, error) {
+		usage := Usage{Used: api.ResourceList{}}
+		resourceName := api.ResourceReplicationControllers
+		if _, found := options.Resources[resourceName]; found {
+			itemList, err := kubeClient.ReplicationControllers(options.Namespace).List(api.ListOptions{})
+			if err != nil {
+				return usage, err
+			}
+			value := resource.NewQuantity(int64(len(itemList.Items)), resource.DecimalSI)
+			usage.Used[resourceName] = *value
+		}
+		return usage, nil
+	}
+}
+
+func resourceQuotaUsageFunc(kubeClient client.Interface) UsageFunc {
+	return func(options UsageOptions) (Usage, error) {
+		usage := Usage{Used: api.ResourceList{}}
+		resourceName := api.ResourceQuotas
+		if _, found := options.Resources[resourceName]; found {
+			itemList, err := kubeClient.ResourceQuotas(options.Namespace).List(api.ListOptions{})
+			if err != nil {
+				return usage, err
+			}
+			value := resource.NewQuantity(int64(len(itemList.Items)), resource.DecimalSI)
+			usage.Used[resourceName] = *value
+		}
+		return usage, nil
+	}
+}
+
+func secretUsageFunc(kubeClient client.Interface) UsageFunc {
+	return func(options UsageOptions) (Usage, error) {
+		usage := Usage{Used: api.ResourceList{}}
+		resourceName := api.ResourceSecrets
+		if _, found := options.Resources[resourceName]; found {
+			itemList, err := kubeClient.Secrets(options.Namespace).List(api.ListOptions{})
+			if err != nil {
+				return usage, err
+			}
+			value := resource.NewQuantity(int64(len(itemList.Items)), resource.DecimalSI)
+			usage.Used[resourceName] = *value
+		}
+		return usage, nil
+	}
+}
+
+func persistentVolumeClaimUsageFunc(kubeClient client.Interface) UsageFunc {
+	return func(options UsageOptions) (Usage, error) {
+		usage := Usage{Used: api.ResourceList{}}
+		resourceName := api.ResourcePersistentVolumeClaims
+		if _, found := options.Resources[resourceName]; found {
+			itemList, err := kubeClient.PersistentVolumeClaims(options.Namespace).List(api.ListOptions{})
+			if err != nil {
+				return usage, err
+			}
+			value := resource.NewQuantity(int64(len(itemList.Items)), resource.DecimalSI)
+			usage.Used[resourceName] = *value
+		}
+		return usage, nil
+	}
+}
+
+// FilterQuotaPods eliminates pods that no longer have a cost against the quota
+// pods that have a restart policy of always are always returned
+// pods that are in a failed state, but have a restart policy of on failure are always returned
+// pods that are not in a success state or a failure state are included in quota
+func FilterQuotaPods(pods []api.Pod) []*api.Pod {
+	var result []*api.Pod
+	for i := range pods {
+		value := &pods[i]
+		// a pod that has a restart policy always no matter its state counts against usage
+		if value.Spec.RestartPolicy == api.RestartPolicyAlways {
+			result = append(result, value)
+			continue
+		}
+		// a failed pod with a restart policy of on failure will count against usage
+		if api.PodFailed == value.Status.Phase &&
+			value.Spec.RestartPolicy == api.RestartPolicyOnFailure {
+			result = append(result, value)
+			continue
+		}
+		// if the pod is not succeeded or failed, then we count it against quota
+		if api.PodSucceeded != value.Status.Phase &&
+			api.PodFailed != value.Status.Phase {
+			result = append(result, value)
+			continue
+		}
+	}
+	return result
+}
+
+// PodsRequests returns sum of each resource request for each pod in list
+// If a given pod in the list does not have a request for the named resource, we log the error
+// but still attempt to get the most representative count
+func PodsRequests(pods []*api.Pod, resourceName api.ResourceName) *resource.Quantity {
+	var sum *resource.Quantity
+	for i := range pods {
+		pod := pods[i]
+		podQuantity, err := PodRequests(pod, resourceName)
+		if err != nil {
+			// log the error, but try to keep the most accurate count possible in log
+			// rationale here is that you may have had pods in a namespace that did not have
+			// explicit requests prior to adding the quota
+			glog.Infof("No explicit request for resource, pod %s/%s, %s", pod.Namespace, pod.Name, resourceName)
+		} else {
+			if sum == nil {
+				sum = podQuantity
+			} else {
+				sum.Add(*podQuantity)
+			}
+		}
+	}
+	// if list is empty
+	if sum == nil {
+		q := resource.MustParse("0")
+		sum = &q
+	}
+	return sum
+}
+
+// PodRequests returns sum of each resource request across all containers in pod
+func PodRequests(pod *api.Pod, resourceName api.ResourceName) (*resource.Quantity, error) {
+	if !PodHasRequests(pod, resourceName) {
+		return nil, fmt.Errorf("Each container in pod %s/%s does not have an explicit request for resource %s.", pod.Namespace, pod.Name, resourceName)
+	}
+	var sum *resource.Quantity
+	for j := range pod.Spec.Containers {
+		value, _ := pod.Spec.Containers[j].Resources.Requests[resourceName]
+		if sum == nil {
+			sum = value.Copy()
+		} else {
+			err := sum.Add(value)
+			if err != nil {
+				return sum, err
+			}
+		}
+	}
+	// if list is empty
+	if sum == nil {
+		q := resource.MustParse("0")
+		sum = &q
+	}
+	return sum, nil
+}
+
+// PodHasRequests verifies that each container in the pod has an explicit request that is non-zero for a named resource
+func PodHasRequests(pod *api.Pod, resourceName api.ResourceName) bool {
+	for j := range pod.Spec.Containers {
+		value, valueSet := pod.Spec.Containers[j].Resources.Requests[resourceName]
+		if !valueSet || value.Value() == int64(0) {
+			return false
+		}
+	}
+	return true
+}

--- a/test/e2e/resource_quota.go
+++ b/test/e2e/resource_quota.go
@@ -1,0 +1,217 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/util/intstr"
+	"k8s.io/kubernetes/pkg/util/wait"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	// how long to wait for a resource quota update to occur
+	resourceQuotaTimeout = 10 * time.Second
+)
+
+var _ = Describe("ResourceQuota [Conformance]", func() {
+	f := NewFramework("resourcequota")
+
+	It("should create a ResourceQuota and ensure its status is promptly calculated.", func() {
+		By("Creating a ResourceQuota")
+		quotaName := "test-quota"
+		resourceQuota := newTestResourceQuota(quotaName)
+		resourceQuota, err := createResourceQuota(f.Client, f.Namespace.Name, resourceQuota)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring resource quota status is calculated")
+		usedResources := api.ResourceList{}
+		usedResources[api.ResourceQuotas] = resource.MustParse("1")
+		err = waitForResourceQuota(f.Client, f.Namespace.Name, quotaName, usedResources)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should create a ResourceQuota and capture the life of a service.", func() {
+		By("Creating a ResourceQuota")
+		quotaName := "test-quota"
+		resourceQuota := newTestResourceQuota(quotaName)
+		resourceQuota, err := createResourceQuota(f.Client, f.Namespace.Name, resourceQuota)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating a Service")
+		service := newTestService("test-service")
+		service, err = f.Client.Services(f.Namespace.Name).Create(service)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring resource quota status captures service creation")
+		usedResources := api.ResourceList{}
+		usedResources[api.ResourceQuotas] = resource.MustParse("1")
+		usedResources[api.ResourceServices] = resource.MustParse("1")
+		err = waitForResourceQuota(f.Client, f.Namespace.Name, quotaName, usedResources)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Deleting a Service")
+		err = f.Client.Services(f.Namespace.Name).Delete(service.Name)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring resource quota status released usage")
+		usedResources[api.ResourceServices] = resource.MustParse("0")
+		err = waitForResourceQuota(f.Client, f.Namespace.Name, quotaName, usedResources)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should create a ResourceQuota and capture the life of a pod.", func() {
+		By("Creating a ResourceQuota")
+		quotaName := "test-quota"
+		resourceQuota := newTestResourceQuota(quotaName)
+		resourceQuota, err := createResourceQuota(f.Client, f.Namespace.Name, resourceQuota)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring resource quota status is calculated")
+		usedResources := api.ResourceList{}
+		usedResources[api.ResourceQuotas] = resource.MustParse("1")
+		err = waitForResourceQuota(f.Client, f.Namespace.Name, quotaName, usedResources)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating a Pod that fits quota")
+		podName := "test-pod"
+		requests := api.ResourceList{}
+		requests[api.ResourceCPU] = resource.MustParse("500m")
+		requests[api.ResourceMemory] = resource.MustParse("252Mi")
+		pod := newTestPod(podName, requests, api.ResourceList{})
+		pod, err = f.Client.Pods(f.Namespace.Name).Create(pod)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring resource quota status captures the pod usage")
+		usedResources[api.ResourceQuotas] = resource.MustParse("1")
+		usedResources[api.ResourcePods] = resource.MustParse("1")
+		usedResources[api.ResourceCPU] = requests[api.ResourceCPU]
+		usedResources[api.ResourceMemory] = requests[api.ResourceMemory]
+		err = waitForResourceQuota(f.Client, f.Namespace.Name, quotaName, usedResources)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Not allowing a pod to be created that exceeds remaining quota")
+		requests = api.ResourceList{}
+		requests[api.ResourceCPU] = resource.MustParse("600m")
+		requests[api.ResourceMemory] = resource.MustParse("100Mi")
+		pod = newTestPod("fail-pod", requests, api.ResourceList{})
+		pod, err = f.Client.Pods(f.Namespace.Name).Create(pod)
+		Expect(err).To(HaveOccurred())
+
+		By("Deleting the pod")
+		err = f.Client.Pods(f.Namespace.Name).Delete(podName, api.NewDeleteOptions(0))
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring resource quota status released the pod usage")
+		usedResources[api.ResourceQuotas] = resource.MustParse("1")
+		usedResources[api.ResourcePods] = resource.MustParse("0")
+		usedResources[api.ResourceCPU] = resource.MustParse("0")
+		usedResources[api.ResourceMemory] = resource.MustParse("0")
+		err = waitForResourceQuota(f.Client, f.Namespace.Name, quotaName, usedResources)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+})
+
+// newTestResourceQuota returns a quota that enforces default constraints for testing
+func newTestResourceQuota(name string) *api.ResourceQuota {
+	hard := api.ResourceList{}
+	hard[api.ResourcePods] = resource.MustParse("5")
+	hard[api.ResourceServices] = resource.MustParse("10")
+	hard[api.ResourceReplicationControllers] = resource.MustParse("10")
+	hard[api.ResourceQuotas] = resource.MustParse("1")
+	hard[api.ResourceCPU] = resource.MustParse("1")
+	hard[api.ResourceMemory] = resource.MustParse("500Mi")
+	return &api.ResourceQuota{
+		ObjectMeta: api.ObjectMeta{Name: name},
+		Spec:       api.ResourceQuotaSpec{Hard: hard},
+	}
+}
+
+// newTestPod returns a pod that has the specified requests and limits
+func newTestPod(name string, requests api.ResourceList, limits api.ResourceList) *api.Pod {
+	return &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Name: name,
+		},
+		Spec: api.PodSpec{
+			Containers: []api.Container{
+				{
+					Name:  "nginx",
+					Image: "gcr.io/google_containers/pause:2.0",
+					Resources: api.ResourceRequirements{
+						Requests: requests,
+						Limits:   limits,
+					},
+				},
+			},
+		},
+	}
+}
+
+// newTestService returns a simple service
+func newTestService(name string) *api.Service {
+	return &api.Service{
+		ObjectMeta: api.ObjectMeta{
+			Name: name,
+		},
+		Spec: api.ServiceSpec{
+			Ports: []api.ServicePort{{
+				Port:       80,
+				TargetPort: intstr.FromInt(80),
+			}},
+		},
+	}
+}
+
+// createResourceQuota in the specified namespace
+func createResourceQuota(c *client.Client, namespace string, resourceQuota *api.ResourceQuota) (*api.ResourceQuota, error) {
+	return c.ResourceQuotas(namespace).Create(resourceQuota)
+}
+
+// deleteResourceQuota with the specified name
+func deleteResourceQuota(c *client.Client, namespace, name string) error {
+	return c.ResourceQuotas(namespace).Delete(name)
+}
+
+// wait for resource quota status to show the expected used resources value
+func waitForResourceQuota(c *client.Client, ns, quotaName string, used api.ResourceList) error {
+	return wait.Poll(poll, resourceQuotaTimeout, func() (bool, error) {
+		resourceQuota, err := c.ResourceQuotas(ns).Get(quotaName)
+		if err != nil {
+			return false, err
+		}
+		// used may not yet be calculated
+		if resourceQuota.Status.Used == nil {
+			return false, nil
+		}
+		// verify that the quota shows the expected used resource values
+		for k, v := range used {
+			if actualValue, found := resourceQuota.Status.Used[k]; !found || (actualValue.Cmp(v) != 0) {
+				Logf("resource %s, expected %s, actual %s", k, v.String(), actualValue.String())
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+}


### PR DESCRIPTION
Refactors the `ResourceQuotaController` 
- all usage calculation logic is injected into the controller as a set of usage funcs
- all monitoring logic that runs outside of a full recalc is injected into the controller
- controller recalculates usage efficiently in response to a monitor telling it of a delete

Add e2e test that validates the improved latency in observing deletions.  It runs with a conservative 10s timeout, in practice, it takes < 1s, but it demonstrates that deletions are observed much faster than the full quota resync which defaults to a much higher value.

/cc @smarterclayton PTAL
