### PR TITLE
Don't add 'error: ' to messages if already there

### DIFF
--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -128,7 +128,10 @@ func checkErr(err error, handleErr func(string)) {
 
 	msg, ok := StandardErrorMessage(err)
 	if !ok {
-		msg = fmt.Sprintf("error: %s", err.Error())
+		msg = err.Error()
+		if !strings.HasPrefix(msg, "error: ") {
+			msg = fmt.Sprintf("error: %s", msg)
+		}
 	}
 	handleErr(msg)
 }


### PR DESCRIPTION
In some scenarios multiple errors may be aggregated or combined before being returned to CheckErr - when printing a simple message check whether an "error: " prefix already exists before appending.
