### PR TITLE
fix : openssl don't exist by default on CentOS docker image

### DIFF
--- a/cluster/saltbase/salt/generate-cert/init.sls
+++ b/cluster/saltbase/salt/generate-cert/init.sls
@@ -21,6 +21,9 @@
   {% set certgen="make-ca-cert.sh" %}
 {% endif %}
 
+openssl:
+  pkg.installed: []
+
 kube-cert:
   group.present:
     - system: True
@@ -38,3 +41,5 @@ kubernetes-cert:
     - user: root
     - group: root
     - shell: /bin/bash
+    - require:
+      - pkg: openssl


### PR DESCRIPTION
To fix it, I just add openssl depedency on "generate-cert" state. It
should work on Debian-like and RedHat-Like systems. (and, Archlinux,
Opensuse, etc)

Fixed error :
$ sudo salt 'kubernetes-master' state.apply

```
----------
          ID: kubernetes-cert
    Function: cmd.script
      Result: False
     Comment: Command 'kubernetes-cert' run
     Started: 06:57:06.634203
    Duration: 208.719 ms
     Changes:
              ----------
              pid:
                  793
              retcode:
                  1
              stderr:
                  /tmpm24T3R.sh: line 22: openssl: command not found
                  chgrp: cannot access '/srv/kubernetes/server.key': No such file or directory
                  chgrp: cannot access '/srv/kubernetes/server.cert': No such file or directory
                  chmod: cannot access '/srv/kubernetes/server.key': No such file or directory
                  chmod: cannot access '/srv/kubernetes/server.cert': No such file or directory
              stdout:
```

After applying my patch (success) :

```
----------
          ID: kubernetes-cert
    Function: cmd.script
      Result: True
     Comment: Command 'kubernetes-cert' run
     Started: 07:17:04.172384
    Duration: 1041.092 ms
     Changes:
              ----------
              pid:
                  1045
              retcode:
                  0
              stderr:
                  Generating a 4096 bit RSA private key
                  ......................................................................++
                  ...............................................................................++
                  writing new private key to '/srv/kubernetes/server.key'
                  -----
              stdout:
----------
```
