### PR TITLE
AWS: Call build-runtime-config where it is used

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -497,8 +497,6 @@ function create-dhcp-option-set () {
 
 # Verify prereqs
 function verify-prereqs {
-  build-runtime-config
-
   if [[ "$(which aws)" == "" ]]; then
     echo "Can't find aws in PATH, please fix and retry."
     exit 1
@@ -875,6 +873,9 @@ function kube-up {
 
 # Starts the master node
 function start-master() {
+  # Ensure RUNTIME_CONFIG is populated
+  build-runtime-config
+
   # Get or create master persistent volume
   ensure-master-pd
 
@@ -1054,6 +1055,9 @@ function start-master() {
 
 # Creates an ASG for the minion nodes
 function start-minions() {
+  # Minions don't currently use runtime config, but call it anyway for sanity
+  build-runtime-config
+
   echo "Creating minion configuration"
   generate-minion-user-data > "${KUBE_TEMP}/minion-user-data"
   local public_ip_option


### PR DESCRIPTION
build-runtime-config was being called in verify-prereqs, which didn't
match how GCE called it, and didn't seem to actually work.

Instead call it just before the master configuration is built.  Also
call it just before the node configuration is built, even though the
nodes don't _currently_ require the runtime_config.
