### PR TITLE
AWS: Change config-test defaults to match GCE

### DIFF
--- a/cluster/aws/config-test.sh
+++ b/cluster/aws/config-test.sh
@@ -82,8 +82,8 @@ MASTER_RESERVED_IP="${MASTER_RESERVED_IP:-}"
 RUNTIME_CONFIG="${KUBE_RUNTIME_CONFIG:-}"
 
 # Enable various v1beta1 features
-ENABLE_DEPLOYMENTS="${KUBE_ENABLE_DEPLOYMENTS:-}"
-ENABLE_DAEMONSETS="${KUBE_ENABLE_DAEMONSETS:-}"
+ENABLE_DEPLOYMENTS="${KUBE_ENABLE_DEPLOYMENTS:-true}"
+ENABLE_DAEMONSETS="${KUBE_ENABLE_DAEMONSETS:-true}"
 
 # Optional: Cluster monitoring to setup as part of the cluster bring up:
 #   none     - No cluster monitoring setup


### PR DESCRIPTION
KUBE_ENABLE_DAEMONSETS & KUBE_ENABLE_DEPLOYMENTS default to true in
config-test in GCE, so we should do the same in AWS for e2e sanity.
