### PR TITLE
Move the loader file log level to v(6)

### DIFF
--- a/pkg/client/unversioned/clientcmd/loader.go
+++ b/pkg/client/unversioned/clientcmd/loader.go
@@ -226,7 +226,7 @@ func LoadFromFile(filename string) (*clientcmdapi.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	glog.V(3).Infoln("Config loaded from file", filename)
+	glog.V(6).Infoln("Config loaded from file", filename)
 
 	// set LocationOfOrigin on every Cluster, User, and Context
 	for key, obj := range config.AuthInfos {


### PR DESCRIPTION
It's extremely rare that a user _must_ have this, and we typically test
and verify at V(5) to get debugging info, which clogs up e2e output.

Updated from #17239
