### PR TITLE
fix wrong db label

### DIFF
--- a/examples/rethinkdb/admin-service.yaml
+++ b/examples/rethinkdb/admin-service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    db: influxdb
+    db: rethinkdb
   name: rethinkdb-admin
 spec:
   ports:


### PR DESCRIPTION
The rethinkdb-admin service was labelled with `influxdb` instead of `rethinkdb`
