### PR TITLE
Handle deleted pods in status manager

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2434,6 +2434,7 @@ func (kl *Kubelet) HandlePodDeletions(pods []*api.Pod) {
 			glog.V(2).Infof("Failed to delete pod %q, err: %v", format.Pod(pod), err)
 		}
 		kl.probeManager.RemovePod(pod)
+		kl.statusManager.DeletePodStatus(pod.UID)
 	}
 }
 

--- a/pkg/kubelet/status/manager.go
+++ b/pkg/kubelet/status/manager.go
@@ -78,6 +78,8 @@ type Manager interface {
 	// SetPodStatus caches updates the cached status for the given pod, and triggers a status update.
 	SetPodStatus(pod *api.Pod, status api.PodStatus)
 
+	DeletePodStatus(uid types.UID)
+
 	// SetContainerReadiness updates the cached container status with the given readiness, and
 	// triggers a status update.
 	SetContainerReadiness(pod *api.Pod, containerID kubecontainer.ContainerID, ready bool)
@@ -129,7 +131,7 @@ func (m *manager) Start() {
 	go util.Forever(func() {
 		select {
 		case syncRequest := <-m.podStatusChannel:
-			m.syncPod(syncRequest.podUID, syncRequest.status)
+			m.syncPodCheckExistence(syncRequest.podUID, syncRequest.status)
 		case <-syncTicker:
 			m.syncBatch()
 		}
@@ -286,8 +288,8 @@ func (m *manager) updateStatusInternal(pod *api.Pod, status api.PodStatus) bool 
 	}
 }
 
-// deletePodStatus simply removes the given pod from the status cache.
-func (m *manager) deletePodStatus(uid types.UID) {
+// DeletePodStatus simply removes the given pod from the status cache.
+func (m *manager) DeletePodStatus(uid types.UID) {
 	m.podStatusesLock.Lock()
 	defer m.podStatusesLock.Unlock()
 	delete(m.podStatuses, uid)
@@ -338,6 +340,20 @@ func (m *manager) syncBatch() {
 	}
 }
 
+func (m *manager) podExists(uid types.UID) bool {
+	m.podStatusesLock.RLock()
+	defer m.podStatusesLock.RUnlock()
+	_, hasPod := m.podStatuses[uid]
+	return hasPod
+}
+
+func (m *manager) syncPodCheckExistence(uid types.UID, status versionedPodStatus) {
+	if !m.podExists(uid) {
+		return
+	}
+	m.syncPod(uid, status)
+}
+
 // syncPod syncs the given status with the API server. The caller must not hold the lock.
 func (m *manager) syncPod(uid types.UID, status versionedPodStatus) {
 	// TODO: make me easier to express from client code
@@ -352,7 +368,7 @@ func (m *manager) syncPod(uid types.UID, status versionedPodStatus) {
 		translatedUID := m.podManager.TranslatePodUID(pod.UID)
 		if len(translatedUID) > 0 && translatedUID != uid {
 			glog.V(3).Infof("Pod %q was deleted and then recreated, skipping status update", format.Pod(pod))
-			m.deletePodStatus(uid)
+			m.DeletePodStatus(uid)
 			return
 		}
 		if !m.needsUpdate(pod.UID, status) {
@@ -375,7 +391,7 @@ func (m *manager) syncPod(uid types.UID, status versionedPodStatus) {
 			}
 			if err := m.kubeClient.Pods(pod.Namespace).Delete(pod.Name, api.NewDeleteOptions(0)); err == nil {
 				glog.V(3).Infof("Pod %q fully terminated and removed from etcd", format.Pod(pod))
-				m.deletePodStatus(uid)
+				m.DeletePodStatus(uid)
 				return
 			}
 		}


### PR DESCRIPTION
When sending out an pod status update, kubelet
- GETs the pod from the apiserver
- Terminates if the apiserver returns an not found error; otherwise, proceed to
  to update.

Even after a pod has been deleted, there might still be queued up updates for
the pod. This leads to expensive, unncessary GET operations. The situation is
worse when there are batch creation/deletion of a significant number of pods
(e.g., E2E tests), leaving many updates in the queue.

This change checks whether a pod exists before GET the pod from the apiserver
to avoid redundant GETs. This is at the cost of the extra local check which requries
acquiring a lock, but it is an relatively inexpensive operation. This change also
deletes the pod entry in the status manager as soon as kubelet sees a pod
deletion.

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/20110)

<!-- Reviewable:end -->
