### PR TITLE
Add temp directory creation method for tests.

### DIFF
--- a/contrib/mesos/pkg/executor/executor_test.go
+++ b/contrib/mesos/pkg/executor/executor_test.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/dockertools"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
+	utiltesting "k8s.io/kubernetes/pkg/util/testing"
 	"k8s.io/kubernetes/pkg/watch"
 
 	"github.com/mesos/mesos-go/mesosproto"
@@ -288,7 +289,7 @@ func TestExecutorLaunchAndKillTask(t *testing.T) {
 // as a zip archive with pod definitions.
 func TestExecutorInitializeStaticPodsSource(t *testing.T) {
 	// create some zip with static pod definition
-	givenPodsDir, err := ioutil.TempDir("/tmp", "executor-givenpods")
+	givenPodsDir, err := utiltesting.MkTmpdir("executor-givenpods")
 	assert.NoError(t, err)
 	defer os.RemoveAll(givenPodsDir)
 
@@ -339,7 +340,7 @@ func TestExecutorInitializeStaticPodsSource(t *testing.T) {
 	expectedStaticPodsNum := 2 // subdirectories are ignored by FileSource, hence only 2
 
 	// temporary directory which is normally located in the executor sandbox
-	staticPodsConfigPath, err := ioutil.TempDir("/tmp", "executor-k8sm-archive")
+	staticPodsConfigPath, err := utiltesting.MkTmpdir("executor-k8sm-archive")
 	assert.NoError(t, err)
 	defer os.RemoveAll(staticPodsConfigPath)
 

--- a/docs/user-guide/persistent-volumes/volumes/local-01.yaml
+++ b/docs/user-guide/persistent-volumes/volumes/local-01.yaml
@@ -10,4 +10,4 @@ spec:
   accessModes:
     - ReadWriteOnce
   hostPath:
-    path: "/tmp/data01"
+    path: "/somepath/data01"

--- a/docs/user-guide/persistent-volumes/volumes/local-02.yaml
+++ b/docs/user-guide/persistent-volumes/volumes/local-02.yaml
@@ -10,5 +10,5 @@ spec:
   accessModes:
     - ReadWriteOnce
   hostPath:
-    path: "/tmp/data02"
+    path: "/somepath/data02"
   persistentVolumeReclaimPolicy: Recycle

--- a/docs/user-guide/persistent-volumes/volumes/nfs.yaml
+++ b/docs/user-guide/persistent-volumes/volumes/nfs.yaml
@@ -8,5 +8,5 @@ spec:
   accessModes:
     - ReadWriteOnce
   nfs:
-    path: /tmp
+    path: /somepath
     server: 172.17.0.2

--- a/pkg/cloudprovider/providers/mesos/client_test.go
+++ b/pkg/cloudprovider/providers/mesos/client_test.go
@@ -105,7 +105,7 @@ const (
 		"finished_tasks": 0,
 		"flags": {
 			"zk_session_timeout": "10secs",
-			"work_dir": "/tmp/mesos/local/Lc9arz",
+			"work_dir": "/somepath/mesos/local/Lc9arz",
 			"webui_dir": "/usr/local/share/mesos/webui",
 			"version": "false",
 			"user_sorter": "drf",

--- a/pkg/controller/persistentvolume/persistentvolume_provisioner_controller_test.go
+++ b/pkg/controller/persistentvolume/persistentvolume_provisioner_controller_test.go
@@ -66,7 +66,7 @@ func makeTestVolume() *api.PersistentVolume {
 			},
 			PersistentVolumeSource: api.PersistentVolumeSource{
 				HostPath: &api.HostPathVolumeSource{
-					Path: "/tmp/data01",
+					Path: "/somepath/data01",
 				},
 			},
 		},

--- a/pkg/controller/persistentvolume/persistentvolume_recycler_controller_test.go
+++ b/pkg/controller/persistentvolume/persistentvolume_recycler_controller_test.go
@@ -34,7 +34,7 @@ func TestFailedRecycling(t *testing.T) {
 			},
 			PersistentVolumeSource: api.PersistentVolumeSource{
 				HostPath: &api.HostPathVolumeSource{
-					Path: "/tmp/data02",
+					Path: "/somepath/data02",
 				},
 			},
 			PersistentVolumeReclaimPolicy: api.PersistentVolumeReclaimRecycle,

--- a/pkg/kubelet/config/file_test.go
+++ b/pkg/kubelet/config/file_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/securitycontext"
 	"k8s.io/kubernetes/pkg/util"
+	utiltesting "k8s.io/kubernetes/pkg/util/testing"
 )
 
 func TestExtractFromNonExistentFile(t *testing.T) {
@@ -174,7 +175,7 @@ func TestExtractFromBadDataFile(t *testing.T) {
 }
 
 func TestExtractFromEmptyDir(t *testing.T) {
-	dirName, err := ioutil.TempDir("", "foo")
+	dirName, err := utiltesting.MkTmpdir("file-test")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/pkg/kubelet/dockertools/labels_test.go
+++ b/pkg/kubelet/dockertools/labels_test.go
@@ -52,7 +52,7 @@ func TestLabels(t *testing.T) {
 	}
 	container := &api.Container{
 		Name: "test_container",
-		TerminationMessagePath: "/tmp",
+		TerminationMessagePath: "/somepath",
 		Lifecycle:              lifecycle,
 	}
 	pod := &api.Pod{

--- a/pkg/kubelet/network/cni/cni_test.go
+++ b/pkg/kubelet/network/cni/cni_test.go
@@ -39,16 +39,8 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/network"
 	proberesults "k8s.io/kubernetes/pkg/kubelet/prober/results"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
+	utiltesting "k8s.io/kubernetes/pkg/util/testing"
 )
-
-// The temp dir where test plugins will be stored.
-func tmpDirOrDie() string {
-	dir, err := ioutil.TempDir(os.TempDir(), "cni-test")
-	if err != nil {
-		panic(fmt.Sprintf("error creating tmp dir: %v", err))
-	}
-	return dir
-}
 
 func installPluginUnderTest(t *testing.T, testVendorCNIDirPrefix, testNetworkConfigPath, vendorName string, plugName string) {
 	pluginDir := path.Join(testNetworkConfigPath, plugName)
@@ -173,7 +165,7 @@ func TestCNIPlugin(t *testing.T) {
 	pluginName := fmt.Sprintf("test%d", rand.Intn(1000))
 	vendorName := fmt.Sprintf("test_vendor%d", rand.Intn(1000))
 
-	tmpDir := tmpDirOrDie()
+	tmpDir := utiltesting.MkTmpdirOrDie("cni-test")
 	testNetworkConfigPath := path.Join(tmpDir, "plugins", "net", "cni")
 	testVendorCNIDirPrefix := tmpDir
 	defer tearDownPlugin(tmpDir)

--- a/pkg/kubelet/network/exec/exec_test.go
+++ b/pkg/kubelet/network/exec/exec_test.go
@@ -31,10 +31,11 @@ import (
 
 	"k8s.io/kubernetes/pkg/kubelet/network"
 	"k8s.io/kubernetes/pkg/util/sets"
+	utiltesting "k8s.io/kubernetes/pkg/util/testing"
 )
 
 func tmpDirOrDie() string {
-	dir, err := ioutil.TempDir(os.TempDir(), "exec-test")
+	dir, err := utiltesting.MkTmpdir("exec-test")
 	if err != nil {
 		panic(fmt.Sprintf("error creating tmp dir: %v", err))
 	}

--- a/pkg/kubelet/rkt/rkt_test.go
+++ b/pkg/kubelet/rkt/rkt_test.go
@@ -19,6 +19,7 @@ package rkt
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"testing"
 	"time"
@@ -30,6 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	utiltesting "k8s.io/kubernetes/pkg/util/testing"
 )
 
 func mustMarshalPodManifest(man *appcschema.PodManifest) []byte {
@@ -755,6 +757,12 @@ func sortAppFields(app *appctypes.App) {
 }
 
 func TestSetApp(t *testing.T) {
+	tmpDir, err := utiltesting.MkTmpdir("rkt_test")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
 	rootUser := int64(0)
 	nonRootUser := int64(42)
 	runAsNonRootTrue := true
@@ -796,7 +804,7 @@ func TestSetApp(t *testing.T) {
 			container: &api.Container{
 				Command:    []string{"/bin/bar"},
 				Args:       []string{"hello", "world"},
-				WorkingDir: "/tmp",
+				WorkingDir: tmpDir,
 				Resources: api.ResourceRequirements{
 					Limits:   api.ResourceList{"cpu": resource.MustParse("50m"), "memory": resource.MustParse("50M")},
 					Requests: api.ResourceList{"cpu": resource.MustParse("5m"), "memory": resource.MustParse("5M")},
@@ -830,7 +838,7 @@ func TestSetApp(t *testing.T) {
 				User:              "42",
 				Group:             "22",
 				SupplementaryGIDs: []int{1, 2, 3},
-				WorkingDirectory:  "/tmp",
+				WorkingDirectory:  tmpDir,
 				Environment: []appctypes.EnvironmentVariable{
 					{"env-foo", "bar"},
 					{"env-bar", "foo"},
@@ -857,7 +865,7 @@ func TestSetApp(t *testing.T) {
 			container: &api.Container{
 				Command:    []string{"/bin/bar"},
 				Args:       []string{"hello", "world"},
-				WorkingDir: "/tmp",
+				WorkingDir: tmpDir,
 				Resources: api.ResourceRequirements{
 					Limits:   api.ResourceList{"cpu": resource.MustParse("50m"), "memory": resource.MustParse("50M")},
 					Requests: api.ResourceList{"cpu": resource.MustParse("5m"), "memory": resource.MustParse("5M")},
@@ -891,7 +899,7 @@ func TestSetApp(t *testing.T) {
 				User:              "42",
 				Group:             "22",
 				SupplementaryGIDs: []int{1, 2, 3},
-				WorkingDirectory:  "/tmp",
+				WorkingDirectory:  tmpDir,
 				Environment: []appctypes.EnvironmentVariable{
 					{"env-foo", "foo"},
 				},

--- a/pkg/kubelet/runonce_test.go
+++ b/pkg/kubelet/runonce_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package kubelet
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -32,6 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/network"
 	kubepod "k8s.io/kubernetes/pkg/kubelet/pod"
 	"k8s.io/kubernetes/pkg/kubelet/status"
+	utiltesting "k8s.io/kubernetes/pkg/util/testing"
 )
 
 func TestRunOnce(t *testing.T) {
@@ -49,7 +49,7 @@ func TestRunOnce(t *testing.T) {
 	podManager := kubepod.NewBasicPodManager(kubepod.NewFakeMirrorClient())
 	diskSpaceManager, _ := newDiskSpaceManager(cadvisor, DiskSpacePolicy{})
 	fakeRuntime := &kubecontainer.FakeRuntime{}
-	basePath, err := ioutil.TempDir(os.TempDir(), "kubelet")
+	basePath, err := utiltesting.MkTmpdir("kubelet")
 	if err != nil {
 		t.Fatalf("can't make a temp rootdir %v", err)
 	}

--- a/pkg/master/tunneler_test.go
+++ b/pkg/master/tunneler_test.go
@@ -74,7 +74,7 @@ func TestRefreshTunnels(t *testing.T) {
 	assert := assert.New(t)
 
 	// Fail case (no addresses associated with nodes)
-	assert.Error(tunneler.refreshTunnels("test", "/tmp/undefined"))
+	assert.Error(tunneler.refreshTunnels("test", "/somepath/undefined"))
 
 	// TODO: pass case without needing actual connections?
 }

--- a/pkg/util/io/io_test.go
+++ b/pkg/util/io/io_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/io"
+	utiltesting "k8s.io/kubernetes/pkg/util/testing"
 	"k8s.io/kubernetes/pkg/volume"
 )
 
@@ -37,8 +38,9 @@ func TestSavePodToFile(t *testing.T) {
 	encoded, err := runtime.Encode(codec, pod)
 	runtime.DecodeInto(codec, encoded, pod)
 
-	path := fmt.Sprintf("/tmp/kube-io-test-%s", uuid.New())
-	defer os.Remove(path)
+	tmpDir := utiltesting.MkTmpdirOrDie("kube-io-test")
+	defer os.RemoveAll(tmpDir)
+	path := fmt.Sprintf("/%s/kube-io-test-%s", tmpDir, uuid.New())
 
 	if err := io.SavePodToFile(pod, path, 777); err != nil {
 		t.Fatalf("failed to save pod to file: %v", err)

--- a/pkg/util/testing/tmpdir.go
+++ b/pkg/util/testing/tmpdir.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"io/ioutil"
+	"os"
+)
+
+// MkTmpdir creates a temporary directory based upon the prefix passed in.
+// If successful, it returns the temporary directory path. The directory can be
+// deleted with a call to "os.RemoveAll(...)".
+// In case of error, it'll return an empty string and the error.
+func MkTmpdir(prefix string) (string, error) {
+	tmpDir, err := ioutil.TempDir(os.TempDir(), prefix)
+	if err != nil {
+		return "", err
+	}
+	return tmpDir, nil
+}
+
+// MkTmpdir does the same work as "MkTmpdir", except in case of
+// errors, it'll trigger a panic.
+func MkTmpdirOrDie(prefix string) string {
+	tmpDir, err := MkTmpdir(prefix)
+	if err != nil {
+		panic(err)
+	}
+	return tmpDir
+}

--- a/pkg/volume/aws_ebs/aws_ebs_test.go
+++ b/pkg/volume/aws_ebs/aws_ebs_test.go
@@ -18,7 +18,6 @@ package aws_ebs
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -28,11 +27,12 @@ import (
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/mount"
+	utiltesting "k8s.io/kubernetes/pkg/util/testing"
 	"k8s.io/kubernetes/pkg/volume"
 )
 
 func TestCanSupport(t *testing.T) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "awsebsTest")
+	tmpDir, err := utiltesting.MkTmpdir("awsebsTest")
 	if err != nil {
 		t.Fatalf("can't make a temp dir: %v", err)
 	}
@@ -56,7 +56,7 @@ func TestCanSupport(t *testing.T) {
 }
 
 func TestGetAccessModes(t *testing.T) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "awsebsTest")
+	tmpDir, err := utiltesting.MkTmpdir("awsebsTest")
 	if err != nil {
 		t.Fatalf("can't make a temp dir: %v", err)
 	}
@@ -119,7 +119,7 @@ func (fake *fakePDManager) DeleteVolume(cd *awsElasticBlockStoreDeleter) error {
 }
 
 func TestPlugin(t *testing.T) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "awsebsTest")
+	tmpDir, err := utiltesting.MkTmpdir("awsebsTest")
 	if err != nil {
 		t.Fatalf("can't make a temp dir: %v")
 	}
@@ -260,7 +260,7 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 
 	client := testclient.NewSimpleFake(pv, claim)
 
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "awsebsTest")
+	tmpDir, err := utiltesting.MkTmpdir("awsebsTest")
 	if err != nil {
 		t.Fatalf("can't make a temp dir: %v", err)
 	}
@@ -280,7 +280,7 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 }
 
 func TestBuilderAndCleanerTypeAssert(t *testing.T) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "awsebsTest")
+	tmpDir, err := utiltesting.MkTmpdir("awsebsTest")
 	if err != nil {
 		t.Fatalf("can't make a temp dir: %v", err)
 	}

--- a/pkg/volume/cephfs/cephfs_test.go
+++ b/pkg/volume/cephfs/cephfs_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cephfs
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -25,11 +24,12 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/mount"
+	utiltesting "k8s.io/kubernetes/pkg/util/testing"
 	"k8s.io/kubernetes/pkg/volume"
 )
 
 func TestCanSupport(t *testing.T) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "cephTest")
+	tmpDir, err := utiltesting.MkTmpdir("cephTest")
 	if err != nil {
 		t.Fatalf("can't make a temp dir: %v", err)
 	}
@@ -52,7 +52,7 @@ func TestCanSupport(t *testing.T) {
 }
 
 func TestPlugin(t *testing.T) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "cephTest")
+	tmpDir, err := utiltesting.MkTmpdir("cephTest")
 	if err != nil {
 		t.Fatalf("can't make a temp dir: %v", err)
 	}

--- a/pkg/volume/cinder/cinder_test.go
+++ b/pkg/volume/cinder/cinder_test.go
@@ -18,7 +18,6 @@ package cinder
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -27,11 +26,12 @@ import (
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/mount"
+	utiltesting "k8s.io/kubernetes/pkg/util/testing"
 	"k8s.io/kubernetes/pkg/volume"
 )
 
 func TestCanSupport(t *testing.T) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "cinderTest")
+	tmpDir, err := utiltesting.MkTmpdir("cinderTest")
 	if err != nil {
 		t.Fatalf("can't make a temp dir: %v", err)
 	}
@@ -87,7 +87,7 @@ func (fake *fakePDManager) DeleteVolume(cd *cinderVolumeDeleter) error {
 }
 
 func TestPlugin(t *testing.T) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "cinderTest")
+	tmpDir, err := utiltesting.MkTmpdir("cinderTest")
 	if err != nil {
 		t.Fatalf("can't make a temp dir: %v", err)
 	}

--- a/pkg/volume/downwardapi/downwardapi_test.go
+++ b/pkg/volume/downwardapi/downwardapi_test.go
@@ -27,6 +27,7 @@ import (
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
 	"k8s.io/kubernetes/pkg/types"
+	utiltesting "k8s.io/kubernetes/pkg/util/testing"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/empty_dir"
 )
@@ -39,8 +40,8 @@ func formatMap(m map[string]string) (fmtstr string) {
 	return
 }
 
-func newTestHost(t *testing.T, client client.Interface, basePath string) (string, volume.VolumeHost) {
-	tempDir, err := ioutil.TempDir(basePath, "downwardApi_volume_test.")
+func newTestHost(t *testing.T, client client.Interface) (string, volume.VolumeHost) {
+	tempDir, err := utiltesting.MkTmpdir("downwardApi_volume_test.")
 	if err != nil {
 		t.Fatalf("can't make a temp rootdir: %v", err)
 	}
@@ -48,13 +49,9 @@ func newTestHost(t *testing.T, client client.Interface, basePath string) (string
 }
 
 func TestCanSupport(t *testing.T) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "downwardapiTest")
-	if err != nil {
-		t.Fatalf("can't make a temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
 	pluginMgr := volume.VolumePluginMgr{}
-	_, host := newTestHost(t, nil, tmpDir)
+	tmpDir, host := newTestHost(t, nil)
+	defer os.RemoveAll(tmpDir)
 	pluginMgr.InitPlugins(ProbeVolumePlugins(), host)
 
 	plugin, err := pluginMgr.FindPluginByName(downwardAPIPluginName)
@@ -105,13 +102,9 @@ func TestLabels(t *testing.T) {
 		},
 	})
 
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "downwardapiTest")
-	if err != nil {
-		t.Fatalf("can't make a temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
 	pluginMgr := volume.VolumePluginMgr{}
-	rootDir, host := newTestHost(t, fake, tmpDir)
+	rootDir, host := newTestHost(t, fake)
+	defer os.RemoveAll(rootDir)
 	pluginMgr.InitPlugins(ProbeVolumePlugins(), host)
 	plugin, err := pluginMgr.FindPluginByName(downwardAPIPluginName)
 	volumeSpec := &api.Volume{
@@ -196,13 +189,9 @@ func TestAnnotations(t *testing.T) {
 		},
 	})
 
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "downwardapiTest")
-	if err != nil {
-		t.Fatalf("can't make a temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
 	pluginMgr := volume.VolumePluginMgr{}
-	_, host := newTestHost(t, fake, tmpDir)
+	tmpDir, host := newTestHost(t, fake)
+	defer os.RemoveAll(tmpDir)
 	pluginMgr.InitPlugins(ProbeVolumePlugins(), host)
 	plugin, err := pluginMgr.FindPluginByName(downwardAPIPluginName)
 	if err != nil {
@@ -262,13 +251,9 @@ func TestName(t *testing.T) {
 		},
 	})
 
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "downwardapiTest")
-	if err != nil {
-		t.Fatalf("can't make a temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
 	pluginMgr := volume.VolumePluginMgr{}
-	_, host := newTestHost(t, fake, tmpDir)
+	tmpDir, host := newTestHost(t, fake)
+	defer os.RemoveAll(tmpDir)
 	pluginMgr.InitPlugins(ProbeVolumePlugins(), host)
 	plugin, err := pluginMgr.FindPluginByName(downwardAPIPluginName)
 	if err != nil {
@@ -329,13 +314,9 @@ func TestNamespace(t *testing.T) {
 		},
 	})
 
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "downwardapiTest")
-	if err != nil {
-		t.Fatalf("can't make a temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
 	pluginMgr := volume.VolumePluginMgr{}
-	_, host := newTestHost(t, fake, tmpDir)
+	tmpDir, host := newTestHost(t, fake)
+	defer os.RemoveAll(tmpDir)
 	pluginMgr.InitPlugins(ProbeVolumePlugins(), host)
 	plugin, err := pluginMgr.FindPluginByName(downwardAPIPluginName)
 	if err != nil {
@@ -389,13 +370,9 @@ func TestWriteTwiceNoUpdate(t *testing.T) {
 			Labels:    labels,
 		},
 	})
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "downwardapiTest")
-	if err != nil {
-		t.Fatalf("can't make a temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
 	pluginMgr := volume.VolumePluginMgr{}
-	_, host := newTestHost(t, fake, tmpDir)
+	tmpDir, host := newTestHost(t, fake)
+	defer os.RemoveAll(tmpDir)
 	pluginMgr.InitPlugins(ProbeVolumePlugins(), host)
 	plugin, err := pluginMgr.FindPluginByName(downwardAPIPluginName)
 	volumeSpec := &api.Volume{
@@ -479,13 +456,9 @@ func TestWriteTwiceWithUpdate(t *testing.T) {
 			Labels:    labels,
 		},
 	})
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "downwardapiTest")
-	if err != nil {
-		t.Fatalf("can't make a temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
 	pluginMgr := volume.VolumePluginMgr{}
-	_, host := newTestHost(t, fake, tmpDir)
+	tmpDir, host := newTestHost(t, fake)
+	defer os.RemoveAll(tmpDir)
 	pluginMgr.InitPlugins(ProbeVolumePlugins(), host)
 	plugin, err := pluginMgr.FindPluginByName(downwardAPIPluginName)
 	volumeSpec := &api.Volume{
@@ -589,13 +562,9 @@ func TestWriteWithUnixPath(t *testing.T) {
 		},
 	})
 
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "downwardapiTest")
-	if err != nil {
-		t.Fatalf("can't make a temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
 	pluginMgr := volume.VolumePluginMgr{}
-	_, host := newTestHost(t, fake, tmpDir)
+	tmpDir, host := newTestHost(t, fake)
+	defer os.RemoveAll(tmpDir)
 	pluginMgr.InitPlugins(ProbeVolumePlugins(), host)
 	plugin, err := pluginMgr.FindPluginByName(downwardAPIPluginName)
 	volumeSpec := &api.Volume{
@@ -669,13 +638,9 @@ func TestWriteWithUnixPathBadPath(t *testing.T) {
 		},
 	})
 
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "downwardapiTest")
-	if err != nil {
-		t.Fatalf("can't make a temp dir")
-	}
-	defer os.RemoveAll(tmpDir)
 	pluginMgr := volume.VolumePluginMgr{}
-	_, host := newTestHost(t, fake, tmpDir)
+	tmpDir, host := newTestHost(t, fake)
+	defer os.RemoveAll(tmpDir)
 	pluginMgr.InitPlugins(ProbeVolumePlugins(), host)
 	plugin, err := pluginMgr.FindPluginByName(downwardAPIPluginName)
 	if err != nil {

--- a/pkg/volume/empty_dir/empty_dir_test.go
+++ b/pkg/volume/empty_dir/empty_dir_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package empty_dir
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -27,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/mount"
+	utiltesting "k8s.io/kubernetes/pkg/util/testing"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/util"
 )
@@ -44,7 +44,7 @@ func makePluginUnderTest(t *testing.T, plugName, basePath string) volume.VolumeP
 }
 
 func TestCanSupport(t *testing.T) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "emptydirTest")
+	tmpDir, err := utiltesting.MkTmpdir("emptydirTest")
 	if err != nil {
 		t.Fatalf("can't make a temp dir: %v", err)
 	}
@@ -119,7 +119,7 @@ type pluginTestConfig struct {
 
 // doTestPlugin sets up a volume and tears it back down.
 func doTestPlugin(t *testing.T, config pluginTestConfig) {
-	basePath, err := ioutil.TempDir(os.TempDir(), "emptydir_volume_test")
+	basePath, err := utiltesting.MkTmpdir("emptydir_volume_test")
 	if err != nil {
 		t.Fatalf("can't make a temp rootdir: %v", err)
 	}
@@ -251,7 +251,7 @@ func doTestPlugin(t *testing.T, config pluginTestConfig) {
 }
 
 func TestPluginBackCompat(t *testing.T) {
-	basePath, err := ioutil.TempDir(os.TempDir(), "emptydirTest")
+	basePath, err := utiltesting.MkTmpdir("emptydirTest")
 	if err != nil {
 		t.Fatalf("can't make a temp dir： %v", err)
 	}
@@ -280,7 +280,7 @@ func TestPluginBackCompat(t *testing.T) {
 // TestMetrics tests that MetricProvider methods return sane values.
 func TestMetrics(t *testing.T) {
 	// Create an empty temp directory for the volume
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "empty_dir_test")
+	tmpDir, err := utiltesting.MkTmpdir("empty_dir_test")
 	if err != nil {
 		t.Fatalf("Can't make a tmp dir: %v", err)
 	}

--- a/pkg/volume/fc/fc_test.go
+++ b/pkg/volume/fc/fc_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package fc
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -24,12 +25,19 @@ import (
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/mount"
+	utiltesting "k8s.io/kubernetes/pkg/util/testing"
 	"k8s.io/kubernetes/pkg/volume"
 )
 
 func TestCanSupport(t *testing.T) {
+	tmpDir, err := utiltesting.MkTmpdir("fc_test")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
 	plugMgr := volume.VolumePluginMgr{}
-	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", nil, nil))
+	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, nil, nil))
 
 	plug, err := plugMgr.FindPluginByName("kubernetes.io/fc")
 	if err != nil {
@@ -44,8 +52,14 @@ func TestCanSupport(t *testing.T) {
 }
 
 func TestGetAccessModes(t *testing.T) {
+	tmpDir, err := utiltesting.MkTmpdir("fc_test")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
 	plugMgr := volume.VolumePluginMgr{}
-	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", nil, nil))
+	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, nil, nil))
 
 	plug, err := plugMgr.FindPersistentPluginByName("kubernetes.io/fc")
 	if err != nil {
@@ -66,12 +80,23 @@ func contains(modes []api.PersistentVolumeAccessMode, mode api.PersistentVolumeA
 }
 
 type fakeDiskManager struct {
+	tmpDir       string
 	attachCalled bool
 	detachCalled bool
 }
 
+func NewFakeDiskManager() *fakeDiskManager {
+	return &fakeDiskManager{
+		tmpDir: utiltesting.MkTmpdirOrDie("fc_test"),
+	}
+}
+
+func (fake *fakeDiskManager) Cleanup() {
+	os.RemoveAll(fake.tmpDir)
+}
+
 func (fake *fakeDiskManager) MakeGlobalPDName(disk fcDisk) string {
-	return "/tmp/fake_fc_path"
+	return fake.tmpDir
 }
 func (fake *fakeDiskManager) AttachDisk(b fcDiskBuilder) error {
 	globalPath := b.manager.MakeGlobalPDName(*b.fcDisk)
@@ -98,14 +123,21 @@ func (fake *fakeDiskManager) DetachDisk(c fcDiskCleaner, mntPath string) error {
 }
 
 func doTestPlugin(t *testing.T, spec *volume.Spec) {
+	tmpDir, err := utiltesting.MkTmpdir("fc_test")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
 	plugMgr := volume.VolumePluginMgr{}
-	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", nil, nil))
+	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, nil, nil))
 
 	plug, err := plugMgr.FindPluginByName("kubernetes.io/fc")
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}
-	fakeManager := &fakeDiskManager{}
+	fakeManager := NewFakeDiskManager()
+	defer fakeManager.Cleanup()
 	fakeMounter := &mount.FakeMounter{}
 	builder, err := plug.(*fcPlugin).newBuilderInternal(spec, types.UID("poduid"), fakeManager, fakeMounter)
 	if err != nil {
@@ -116,8 +148,9 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 	}
 
 	path := builder.GetPath()
-	if path != "/tmp/fake/pods/poduid/volumes/kubernetes.io~fc/vol1" {
-		t.Errorf("Got unexpected path: %s", path)
+	expectedPath := fmt.Sprintf("%s/pods/poduid/volumes/kubernetes.io~fc/vol1", tmpDir)
+	if path != expectedPath {
+		t.Errorf("Unexpected path, expected %q, got: %q", expectedPath, path)
 	}
 
 	if err := builder.SetUp(nil); err != nil {
@@ -141,8 +174,9 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 		t.Errorf("Attach was not called")
 	}
 
-	fakeManager = &fakeDiskManager{}
-	cleaner, err := plug.(*fcPlugin).newCleanerInternal("vol1", types.UID("poduid"), fakeManager, fakeMounter)
+	fakeManager2 := NewFakeDiskManager()
+	defer fakeManager2.Cleanup()
+	cleaner, err := plug.(*fcPlugin).newCleanerInternal("vol1", types.UID("poduid"), fakeManager2, fakeMounter)
 	if err != nil {
 		t.Errorf("Failed to make a new Cleaner: %v", err)
 	}
@@ -158,7 +192,7 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 	} else if !os.IsNotExist(err) {
 		t.Errorf("SetUp() failed: %v", err)
 	}
-	if !fakeManager.detachCalled {
+	if !fakeManager2.detachCalled {
 		t.Errorf("Detach was not called")
 	}
 }
@@ -198,6 +232,12 @@ func TestPluginPersistentVolume(t *testing.T) {
 }
 
 func TestPersistentClaimReadOnlyFlag(t *testing.T) {
+	tmpDir, err := utiltesting.MkTmpdir("fc_test")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
 	lun := 0
 	pv := &api.PersistentVolume{
 		ObjectMeta: api.ObjectMeta{
@@ -233,7 +273,7 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 	client := testclient.NewSimpleFake(pv, claim)
 
 	plugMgr := volume.VolumePluginMgr{}
-	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", client, nil))
+	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, client, nil))
 	plug, _ := plugMgr.FindPluginByName(fcPluginName)
 
 	// readOnly bool is supplied by persistent-claim volume source when its builder creates other volumes

--- a/pkg/volume/flocker/plugin_test.go
+++ b/pkg/volume/flocker/plugin_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package flocker
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -25,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/types"
+	utiltesting "k8s.io/kubernetes/pkg/util/testing"
 	"k8s.io/kubernetes/pkg/volume"
 )
 
@@ -32,7 +32,7 @@ const pluginName = "kubernetes.io/flocker"
 
 func newInitializedVolumePlugMgr(t *testing.T) (volume.VolumePluginMgr, string) {
 	plugMgr := volume.VolumePluginMgr{}
-	dir, err := ioutil.TempDir("", "flocker")
+	dir, err := utiltesting.MkTmpdir("flocker")
 	assert.NoError(t, err)
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(dir, nil, nil))
 	return plugMgr, dir

--- a/pkg/volume/gce_pd/gce_pd_test.go
+++ b/pkg/volume/gce_pd/gce_pd_test.go
@@ -18,7 +18,6 @@ package gce_pd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -28,11 +27,12 @@ import (
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/mount"
+	utiltesting "k8s.io/kubernetes/pkg/util/testing"
 	"k8s.io/kubernetes/pkg/volume"
 )
 
 func TestCanSupport(t *testing.T) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "gcepdTest")
+	tmpDir, err := utiltesting.MkTmpdir("gcepdTest")
 	if err != nil {
 		t.Fatalf("can't make a temp dir: %v", err)
 	}
@@ -56,7 +56,7 @@ func TestCanSupport(t *testing.T) {
 }
 
 func TestGetAccessModes(t *testing.T) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "gcepdTest")
+	tmpDir, err := utiltesting.MkTmpdir("gcepdTest")
 	if err != nil {
 		t.Fatalf("can't make a temp dir: %v", err)
 	}
@@ -124,7 +124,7 @@ func (fake *fakePDManager) DeleteVolume(cd *gcePersistentDiskDeleter) error {
 }
 
 func TestPlugin(t *testing.T) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "gcepdTest")
+	tmpDir, err := utiltesting.MkTmpdir("gcepdTest")
 	if err != nil {
 		t.Fatalf("can't make a temp dir: %v", err)
 	}
@@ -275,7 +275,7 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 
 	client := testclient.NewSimpleFake(pv, claim)
 
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "gcepdTest")
+	tmpDir, err := utiltesting.MkTmpdir("gcepdTest")
 	if err != nil {
 		t.Fatalf("can't make a temp dir: %v", err)
 	}

--- a/pkg/volume/glusterfs/glusterfs_test.go
+++ b/pkg/volume/glusterfs/glusterfs_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package glusterfs
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -25,12 +26,19 @@ import (
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/exec"
 	"k8s.io/kubernetes/pkg/util/mount"
+	utiltesting "k8s.io/kubernetes/pkg/util/testing"
 	"k8s.io/kubernetes/pkg/volume"
 )
 
 func TestCanSupport(t *testing.T) {
+	tmpDir, err := utiltesting.MkTmpdir("glusterfs_test")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
 	plugMgr := volume.VolumePluginMgr{}
-	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("fake", nil, nil))
+	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, nil, nil))
 	plug, err := plugMgr.FindPluginByName("kubernetes.io/glusterfs")
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
@@ -47,8 +55,14 @@ func TestCanSupport(t *testing.T) {
 }
 
 func TestGetAccessModes(t *testing.T) {
+	tmpDir, err := utiltesting.MkTmpdir("glusterfs_test")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
 	plugMgr := volume.VolumePluginMgr{}
-	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", nil, nil))
+	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, nil, nil))
 
 	plug, err := plugMgr.FindPersistentPluginByName("kubernetes.io/glusterfs")
 	if err != nil {
@@ -69,8 +83,14 @@ func contains(modes []api.PersistentVolumeAccessMode, mode api.PersistentVolumeA
 }
 
 func doTestPlugin(t *testing.T, spec *volume.Spec) {
+	tmpDir, err := utiltesting.MkTmpdir("glusterfs_test")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
 	plugMgr := volume.VolumePluginMgr{}
-	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", nil, nil))
+	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, nil, nil))
 	plug, err := plugMgr.FindPluginByName("kubernetes.io/glusterfs")
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
@@ -101,8 +121,9 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 		t.Error("Got a nil Builder")
 	}
 	path := builder.GetPath()
-	if path != "/tmp/fake/pods/poduid/volumes/kubernetes.io~glusterfs/vol1" {
-		t.Errorf("Got unexpected path: %s", path)
+	expectedPath := fmt.Sprintf("%s/pods/poduid/volumes/kubernetes.io~glusterfs/vol1", tmpDir)
+	if path != expectedPath {
+		t.Errorf("Unexpected path, expected %q, got: %q", expectedPath, path)
 	}
 	if err := builder.SetUp(nil); err != nil {
 		t.Errorf("Expected success, got: %v", err)
@@ -155,6 +176,12 @@ func TestPluginPersistentVolume(t *testing.T) {
 }
 
 func TestPersistentClaimReadOnlyFlag(t *testing.T) {
+	tmpDir, err := utiltesting.MkTmpdir("glusterfs_test")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
 	pv := &api.PersistentVolume{
 		ObjectMeta: api.ObjectMeta{
 			Name: "pvA",
@@ -195,7 +222,7 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 	client := testclient.NewSimpleFake(pv, claim, ep)
 
 	plugMgr := volume.VolumePluginMgr{}
-	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", client, nil))
+	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, client, nil))
 	plug, _ := plugMgr.FindPluginByName(glusterfsPluginName)
 
 	// readOnly bool is supplied by persistent-claim volume source when its builder creates other volumes

--- a/pkg/volume/host_path/host_path_test.go
+++ b/pkg/volume/host_path/host_path_test.go
@@ -90,6 +90,7 @@ func TestRecycler(t *testing.T) {
 }
 
 func TestDeleter(t *testing.T) {
+	// Deleter has a hard-coded regex for "/tmp".
 	tempPath := fmt.Sprintf("/tmp/hostpath/%s", util.NewUUID())
 	defer os.RemoveAll(tempPath)
 	err := os.MkdirAll(tempPath, 0750)
@@ -147,7 +148,7 @@ func TestDeleterTempDir(t *testing.T) {
 }
 
 func TestProvisioner(t *testing.T) {
-	tempPath := "/tmp/hostpath/"
+	tempPath := fmt.Sprintf("/tmp/hostpath/%s", util.NewUUID())
 	defer os.RemoveAll(tempPath)
 	err := os.MkdirAll(tempPath, 0750)
 

--- a/pkg/volume/iscsi/iscsi_test.go
+++ b/pkg/volume/iscsi/iscsi_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package iscsi
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -24,12 +25,19 @@ import (
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/mount"
+	utiltesting "k8s.io/kubernetes/pkg/util/testing"
 	"k8s.io/kubernetes/pkg/volume"
 )
 
 func TestCanSupport(t *testing.T) {
+	tmpDir, err := utiltesting.MkTmpdir("iscsi_test")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
 	plugMgr := volume.VolumePluginMgr{}
-	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", nil, nil))
+	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, nil, nil))
 
 	plug, err := plugMgr.FindPluginByName("kubernetes.io/iscsi")
 	if err != nil {
@@ -44,8 +52,14 @@ func TestCanSupport(t *testing.T) {
 }
 
 func TestGetAccessModes(t *testing.T) {
+	tmpDir, err := utiltesting.MkTmpdir("iscsi_test")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
 	plugMgr := volume.VolumePluginMgr{}
-	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", nil, nil))
+	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, nil, nil))
 
 	plug, err := plugMgr.FindPersistentPluginByName("kubernetes.io/iscsi")
 	if err != nil {
@@ -66,12 +80,23 @@ func contains(modes []api.PersistentVolumeAccessMode, mode api.PersistentVolumeA
 }
 
 type fakeDiskManager struct {
+	tmpDir       string
 	attachCalled bool
 	detachCalled bool
 }
 
+func NewFakeDiskManager() *fakeDiskManager {
+	return &fakeDiskManager{
+		tmpDir: utiltesting.MkTmpdirOrDie("fc_test"),
+	}
+}
+
+func (fake *fakeDiskManager) Cleanup() {
+	os.RemoveAll(fake.tmpDir)
+}
+
 func (fake *fakeDiskManager) MakeGlobalPDName(disk iscsiDisk) string {
-	return "/tmp/fake_iscsi_path"
+	return fake.tmpDir
 }
 func (fake *fakeDiskManager) AttachDisk(b iscsiDiskBuilder) error {
 	globalPath := b.manager.MakeGlobalPDName(*b.iscsiDisk)
@@ -98,14 +123,21 @@ func (fake *fakeDiskManager) DetachDisk(c iscsiDiskCleaner, mntPath string) erro
 }
 
 func doTestPlugin(t *testing.T, spec *volume.Spec) {
+	tmpDir, err := utiltesting.MkTmpdir("iscsi_test")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
 	plugMgr := volume.VolumePluginMgr{}
-	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", nil, nil))
+	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, nil, nil))
 
 	plug, err := plugMgr.FindPluginByName("kubernetes.io/iscsi")
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}
-	fakeManager := &fakeDiskManager{}
+	fakeManager := NewFakeDiskManager()
+	defer fakeManager.Cleanup()
 	fakeMounter := &mount.FakeMounter{}
 	builder, err := plug.(*iscsiPlugin).newBuilderInternal(spec, types.UID("poduid"), fakeManager, fakeMounter)
 	if err != nil {
@@ -116,8 +148,9 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 	}
 
 	path := builder.GetPath()
-	if path != "/tmp/fake/pods/poduid/volumes/kubernetes.io~iscsi/vol1" {
-		t.Errorf("Got unexpected path: %s", path)
+	expectedPath := fmt.Sprintf("%s/pods/poduid/volumes/kubernetes.io~iscsi/vol1", tmpDir)
+	if path != expectedPath {
+		t.Errorf("Unexpected path, expected %q, got: %q", expectedPath, path)
 	}
 
 	if err := builder.SetUp(nil); err != nil {
@@ -141,8 +174,9 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 		t.Errorf("Attach was not called")
 	}
 
-	fakeManager = &fakeDiskManager{}
-	cleaner, err := plug.(*iscsiPlugin).newCleanerInternal("vol1", types.UID("poduid"), fakeManager, fakeMounter)
+	fakeManager2 := NewFakeDiskManager()
+	defer fakeManager2.Cleanup()
+	cleaner, err := plug.(*iscsiPlugin).newCleanerInternal("vol1", types.UID("poduid"), fakeManager2, fakeMounter)
 	if err != nil {
 		t.Errorf("Failed to make a new Cleaner: %v", err)
 	}
@@ -158,7 +192,7 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 	} else if !os.IsNotExist(err) {
 		t.Errorf("SetUp() failed: %v", err)
 	}
-	if !fakeManager.detachCalled {
+	if !fakeManager2.detachCalled {
 		t.Errorf("Detach was not called")
 	}
 }
@@ -198,6 +232,12 @@ func TestPluginPersistentVolume(t *testing.T) {
 }
 
 func TestPersistentClaimReadOnlyFlag(t *testing.T) {
+	tmpDir, err := utiltesting.MkTmpdir("iscsi_test")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
 	pv := &api.PersistentVolume{
 		ObjectMeta: api.ObjectMeta{
 			Name: "pvA",
@@ -233,7 +273,7 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 	client := testclient.NewSimpleFake(pv, claim)
 
 	plugMgr := volume.VolumePluginMgr{}
-	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", client, nil))
+	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, client, nil))
 	plug, _ := plugMgr.FindPluginByName(iscsiPluginName)
 
 	// readOnly bool is supplied by persistent-claim volume source when its builder creates other volumes

--- a/pkg/volume/metrics_du_test.go
+++ b/pkg/volume/metrics_du_test.go
@@ -23,6 +23,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	utiltesting "k8s.io/kubernetes/pkg/util/testing"
 )
 
 const expectedBlockSize = 4096
@@ -30,7 +32,7 @@ const expectedBlockSize = 4096
 // TestMetricsDuGetCapacity tests that MetricsDu can read disk usage
 // for path
 func TestMetricsDuGetCapacity(t *testing.T) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "metrics_du_test")
+	tmpDir, err := utiltesting.MkTmpdir("metrics_du_test")
 	if err != nil {
 		t.Fatalf("Can't make a tmp dir: %v", err)
 	}

--- a/pkg/volume/nfs/nfs_test.go
+++ b/pkg/volume/nfs/nfs_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nfs
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -24,12 +25,19 @@ import (
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/mount"
+	utiltesting "k8s.io/kubernetes/pkg/util/testing"
 	"k8s.io/kubernetes/pkg/volume"
 )
 
 func TestCanSupport(t *testing.T) {
+	tmpDir, err := utiltesting.MkTmpdir("nfs_test")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
 	plugMgr := volume.VolumePluginMgr{}
-	plugMgr.InitPlugins(ProbeVolumePlugins(volume.VolumeConfig{}), volume.NewFakeVolumeHost("fake", nil, nil))
+	plugMgr.InitPlugins(ProbeVolumePlugins(volume.VolumeConfig{}), volume.NewFakeVolumeHost(tmpDir, nil, nil))
 	plug, err := plugMgr.FindPluginByName("kubernetes.io/nfs")
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
@@ -49,8 +57,14 @@ func TestCanSupport(t *testing.T) {
 }
 
 func TestGetAccessModes(t *testing.T) {
+	tmpDir, err := utiltesting.MkTmpdir("nfs_test")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
 	plugMgr := volume.VolumePluginMgr{}
-	plugMgr.InitPlugins(ProbeVolumePlugins(volume.VolumeConfig{}), volume.NewFakeVolumeHost("/tmp/fake", nil, nil))
+	plugMgr.InitPlugins(ProbeVolumePlugins(volume.VolumeConfig{}), volume.NewFakeVolumeHost(tmpDir, nil, nil))
 
 	plug, err := plugMgr.FindPersistentPluginByName("kubernetes.io/nfs")
 	if err != nil {
@@ -62,8 +76,14 @@ func TestGetAccessModes(t *testing.T) {
 }
 
 func TestRecycler(t *testing.T) {
+	tmpDir, err := utiltesting.MkTmpdir("nfs_test")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
 	plugMgr := volume.VolumePluginMgr{}
-	plugMgr.InitPlugins([]volume.VolumePlugin{&nfsPlugin{nil, newMockRecycler, volume.VolumeConfig{}}}, volume.NewFakeVolumeHost("/tmp/fake", nil, nil))
+	plugMgr.InitPlugins([]volume.VolumePlugin{&nfsPlugin{nil, newMockRecycler, volume.VolumeConfig{}}}, volume.NewFakeVolumeHost(tmpDir, nil, nil))
 
 	spec := &volume.Spec{PersistentVolume: &api.PersistentVolume{Spec: api.PersistentVolumeSpec{PersistentVolumeSource: api.PersistentVolumeSource{NFS: &api.NFSVolumeSource{Path: "/foo"}}}}}
 	plug, err := plugMgr.FindRecyclablePluginBySpec(spec)
@@ -113,8 +133,14 @@ func contains(modes []api.PersistentVolumeAccessMode, mode api.PersistentVolumeA
 }
 
 func doTestPlugin(t *testing.T, spec *volume.Spec) {
+	tmpDir, err := utiltesting.MkTmpdir("nfs_test")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
 	plugMgr := volume.VolumePluginMgr{}
-	plugMgr.InitPlugins(ProbeVolumePlugins(volume.VolumeConfig{}), volume.NewFakeVolumeHost("/tmp/fake", nil, nil))
+	plugMgr.InitPlugins(ProbeVolumePlugins(volume.VolumeConfig{}), volume.NewFakeVolumeHost(tmpDir, nil, nil))
 	plug, err := plugMgr.FindPluginByName("kubernetes.io/nfs")
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
@@ -130,8 +156,9 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 		t.Errorf("Got a nil Builder")
 	}
 	path := builder.GetPath()
-	if path != "/tmp/fake/pods/poduid/volumes/kubernetes.io~nfs/vol1" {
-		t.Errorf("Got unexpected path: %s", path)
+	expectedPath := fmt.Sprintf("%s/pods/poduid/volumes/kubernetes.io~nfs/vol1", tmpDir)
+	if path != expectedPath {
+		t.Errorf("Unexpected path, expected %q, got: %q", expectedPath, path)
 	}
 	if err := builder.SetUp(nil); err != nil {
 		t.Errorf("Expected success, got: %v", err)
@@ -184,7 +211,7 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 func TestPluginVolume(t *testing.T) {
 	vol := &api.Volume{
 		Name:         "vol1",
-		VolumeSource: api.VolumeSource{NFS: &api.NFSVolumeSource{Server: "localhost", Path: "/tmp", ReadOnly: false}},
+		VolumeSource: api.VolumeSource{NFS: &api.NFSVolumeSource{Server: "localhost", Path: "/somepath", ReadOnly: false}},
 	}
 	doTestPlugin(t, volume.NewSpecFromVolume(vol))
 }
@@ -196,7 +223,7 @@ func TestPluginPersistentVolume(t *testing.T) {
 		},
 		Spec: api.PersistentVolumeSpec{
 			PersistentVolumeSource: api.PersistentVolumeSource{
-				NFS: &api.NFSVolumeSource{Server: "localhost", Path: "/tmp", ReadOnly: false},
+				NFS: &api.NFSVolumeSource{Server: "localhost", Path: "/somepath", ReadOnly: false},
 			},
 		},
 	}
@@ -205,6 +232,12 @@ func TestPluginPersistentVolume(t *testing.T) {
 }
 
 func TestPersistentClaimReadOnlyFlag(t *testing.T) {
+	tmpDir, err := utiltesting.MkTmpdir("nfs_test")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
 	pv := &api.PersistentVolume{
 		ObjectMeta: api.ObjectMeta{
 			Name: "pvA",
@@ -235,7 +268,7 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 	client := testclient.NewSimpleFake(pv, claim)
 
 	plugMgr := volume.VolumePluginMgr{}
-	plugMgr.InitPlugins(ProbeVolumePlugins(volume.VolumeConfig{}), volume.NewFakeVolumeHost("/tmp/fake", client, nil))
+	plugMgr.InitPlugins(ProbeVolumePlugins(volume.VolumeConfig{}), volume.NewFakeVolumeHost(tmpDir, client, nil))
 	plug, _ := plugMgr.FindPluginByName(nfsPluginName)
 
 	// readOnly bool is supplied by persistent-claim volume source when its builder creates other volumes

--- a/pkg/volume/rbd/rbd_test.go
+++ b/pkg/volume/rbd/rbd_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rbd
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -24,12 +25,19 @@ import (
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/mount"
+	utiltesting "k8s.io/kubernetes/pkg/util/testing"
 	"k8s.io/kubernetes/pkg/volume"
 )
 
 func TestCanSupport(t *testing.T) {
+	tmpDir, err := utiltesting.MkTmpdir("rbd_test")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
 	plugMgr := volume.VolumePluginMgr{}
-	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", nil, nil))
+	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, nil, nil))
 
 	plug, err := plugMgr.FindPluginByName("kubernetes.io/rbd")
 	if err != nil {
@@ -43,10 +51,22 @@ func TestCanSupport(t *testing.T) {
 	}
 }
 
-type fakeDiskManager struct{}
+type fakeDiskManager struct {
+	tmpDir string
+}
+
+func NewFakeDiskManager() *fakeDiskManager {
+	return &fakeDiskManager{
+		tmpDir: utiltesting.MkTmpdirOrDie("rbd_test"),
+	}
+}
+
+func (fake *fakeDiskManager) Cleanup() {
+	os.RemoveAll(fake.tmpDir)
+}
 
 func (fake *fakeDiskManager) MakeGlobalPDName(disk rbd) string {
-	return "/tmp/fake_rbd_path"
+	return fake.tmpDir
 }
 func (fake *fakeDiskManager) AttachDisk(b rbdBuilder) error {
 	globalPath := b.manager.MakeGlobalPDName(*b.rbd)
@@ -67,14 +87,22 @@ func (fake *fakeDiskManager) DetachDisk(c rbdCleaner, mntPath string) error {
 }
 
 func doTestPlugin(t *testing.T, spec *volume.Spec) {
+	tmpDir, err := utiltesting.MkTmpdir("rbd_test")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
 	plugMgr := volume.VolumePluginMgr{}
-	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", nil, nil))
+	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, nil, nil))
 
 	plug, err := plugMgr.FindPluginByName("kubernetes.io/rbd")
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}
-	builder, err := plug.(*rbdPlugin).newBuilderInternal(spec, types.UID("poduid"), &fakeDiskManager{}, &mount.FakeMounter{}, "secrets")
+	fdm := NewFakeDiskManager()
+	defer fdm.Cleanup()
+	builder, err := plug.(*rbdPlugin).newBuilderInternal(spec, types.UID("poduid"), fdm, &mount.FakeMounter{}, "secrets")
 	if err != nil {
 		t.Errorf("Failed to make a new Builder: %v", err)
 	}
@@ -83,8 +111,9 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 	}
 
 	path := builder.GetPath()
-	if path != "/tmp/fake/pods/poduid/volumes/kubernetes.io~rbd/vol1" {
-		t.Errorf("Got unexpected path: %s", path)
+	expectedPath := fmt.Sprintf("%s/pods/poduid/volumes/kubernetes.io~rbd/vol1", tmpDir)
+	if path != expectedPath {
+		t.Errorf("Unexpected path, expected %q, got: %q", expectedPath, path)
 	}
 
 	if err := builder.SetUp(nil); err != nil {
@@ -105,7 +134,7 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 		}
 	}
 
-	cleaner, err := plug.(*rbdPlugin).newCleanerInternal("vol1", types.UID("poduid"), &fakeDiskManager{}, &mount.FakeMounter{})
+	cleaner, err := plug.(*rbdPlugin).newCleanerInternal("vol1", types.UID("poduid"), fdm, &mount.FakeMounter{})
 	if err != nil {
 		t.Errorf("Failed to make a new Cleaner: %v", err)
 	}
@@ -156,6 +185,12 @@ func TestPluginPersistentVolume(t *testing.T) {
 }
 
 func TestPersistentClaimReadOnlyFlag(t *testing.T) {
+	tmpDir, err := utiltesting.MkTmpdir("rbd_test")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
 	pv := &api.PersistentVolume{
 		ObjectMeta: api.ObjectMeta{
 			Name: "pvA",
@@ -190,7 +225,7 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 	client := testclient.NewSimpleFake(pv, claim)
 
 	plugMgr := volume.VolumePluginMgr{}
-	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", client, nil))
+	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, client, nil))
 	plug, _ := plugMgr.FindPluginByName(rbdPluginName)
 
 	// readOnly bool is supplied by persistent-claim volume source when its builder creates other volumes


### PR DESCRIPTION
Adding a single, unified temp directory creator to be used for tests. This is my first PR for issue #15176 (and reusing some of #16236). I'm working on fixing/changing tests to use this, but wanted to get the review going in case there are suggested changes.
