### PR TITLE
fix Version not found in docker.ENV in fakeDockerClient

### DIFF
--- a/cmd/kubemark/hollow-node.go
+++ b/cmd/kubemark/hollow-node.go
@@ -97,7 +97,7 @@ func main() {
 		containerManager := cm.NewStubContainerManager()
 
 		fakeDockerClient := dockertools.NewFakeDockerClient()
-		fakeDockerClient.VersionInfo = docker.Env{"ApiVersion=1.18"}
+		fakeDockerClient.VersionInfo = docker.Env{"Version=1.1.3", "ApiVersion=1.18"}
 		fakeDockerClient.EnableSleep = true
 
 		hollowKubelet := kubemark.NewHollowKubelet(


### PR DESCRIPTION
ref #20011 

I'm submitting a duct tape fix to the problem so that we could have Kubemark experiment recovered. More design   consideration should be taken so that such inconsistent change wouldn't happen again. Let's raise the discussion in sig scale and/or node.

@davidopp @gmarek @xiang90 @yifan-gu
