### PR TITLE
Register ECR credential plugin only when  AWS cloud instance is created

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -42,6 +42,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/cloudprovider"
+	"k8s.io/kubernetes/pkg/credentialprovider/aws"
 	"k8s.io/kubernetes/pkg/util/sets"
 
 	"github.com/golang/glog"
@@ -63,6 +64,9 @@ const MaxReadThenCreateRetries = 30
 // TODO: Remove when user/admin can configure volume types and thus we don't
 // need hardcoded defaults.
 const DefaultVolumeType = "gp2"
+
+// Used to call aws_credentials.Init() just once
+var once sync.Once
 
 // Abstraction over AWS, to allow mocking/other implementations
 type AWSServices interface {
@@ -590,6 +594,11 @@ func newAWSCloud(config io.Reader, awsServices AWSServices) (*AWSCloud, error) {
 	} else {
 		glog.Infof("AWS cloud - no tag filtering")
 	}
+
+	// Register handler for ECR credentials
+	once.Do(func() {
+		aws_credentials.Init()
+	})
 
 	return awsCloud, nil
 }

--- a/pkg/credentialprovider/aws/aws_credentials.go
+++ b/pkg/credentialprovider/aws/aws_credentials.go
@@ -27,7 +27,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/cloudprovider"
-	aws_cloud "k8s.io/kubernetes/pkg/cloudprovider/providers/aws"
 	"k8s.io/kubernetes/pkg/credentialprovider"
 )
 
@@ -66,9 +65,10 @@ type ecrProvider struct {
 	getter tokenGetter
 }
 
-// init registers the various means by which ECR credentials may
-// be resolved.
-func init() {
+// Not using the package init() function: this module should be initialized only
+// if using the AWS cloud provider. This way, we avoid timeouts waiting for a
+// non-existent provider.
+func Init() {
 	credentialprovider.RegisterCredentialProvider("aws-ecr-key",
 		&credentialprovider.CachingDockerConfigProvider{
 			Provider: &ecrProvider{},
@@ -82,7 +82,7 @@ func init() {
 // TODO: figure how to enable it manually for deployments that are not on AWS but still
 // use ECR somehow?
 func (p *ecrProvider) Enabled() bool {
-	provider, err := cloudprovider.GetCloudProvider(aws_cloud.ProviderName, nil)
+	provider, err := cloudprovider.GetCloudProvider("aws", nil)
 	if err != nil {
 		glog.Errorf("while initializing AWS cloud provider %v", err)
 		return false


### PR DESCRIPTION
Try to fix fallout from #19447.
