### PR TITLE
Increase initial delay for liveness probe test pod from 15s to 30s.

### DIFF
--- a/test/e2e/pods.go
+++ b/test/e2e/pods.go
@@ -689,7 +689,7 @@ var _ = Describe("Pods", func() {
 									Port: intstr.FromInt(8080),
 								},
 							},
-							InitialDelaySeconds: 15,
+							InitialDelaySeconds: 30,
 							FailureThreshold:    1,
 						},
 					},


### PR DESCRIPTION
For #18704
