### PR TITLE
Make listing deployment rcStore namespaced

### DIFF
--- a/pkg/client/cache/listers.go
+++ b/pkg/client/cache/listers.go
@@ -161,6 +161,25 @@ func (s *StoreToReplicationControllerLister) List() (controllers []api.Replicati
 	return controllers, nil
 }
 
+func (s *StoreToReplicationControllerLister) ReplicationControllers(namespace string) storeReplicationControllersNamespacer {
+	return storeReplicationControllersNamespacer{s.Store, namespace}
+}
+
+type storeReplicationControllersNamespacer struct {
+	store     Store
+	namespace string
+}
+
+func (s storeReplicationControllersNamespacer) List() (controllers []api.ReplicationController, err error) {
+	for _, c := range s.store.List() {
+		rc := *(c.(*api.ReplicationController))
+		if s.namespace == api.NamespaceAll || s.namespace == rc.Namespace {
+			controllers = append(controllers, rc)
+		}
+	}
+	return
+}
+
 // GetPodControllers returns a list of replication controllers managing a pod. Returns an error only if no matching controllers are found.
 func (s *StoreToReplicationControllerLister) GetPodControllers(pod *api.Pod) (controllers []api.ReplicationController, err error) {
 	var selector labels.Selector

--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -514,7 +514,7 @@ func (dc *DeploymentController) getOldRCs(deployment extensions.Deployment) ([]*
 			return &podList, err
 		},
 		func(namespace string, options api.ListOptions) ([]api.ReplicationController, error) {
-			return dc.rcStore.List()
+			return dc.rcStore.ReplicationControllers(namespace).List()
 		})
 }
 
@@ -523,7 +523,7 @@ func (dc *DeploymentController) getOldRCs(deployment extensions.Deployment) ([]*
 func (dc *DeploymentController) getNewRC(deployment extensions.Deployment) (*api.ReplicationController, error) {
 	existingNewRC, err := deploymentutil.GetNewRCFromList(deployment, dc.client,
 		func(namespace string, options api.ListOptions) ([]api.ReplicationController, error) {
-			return dc.rcStore.List()
+			return dc.rcStore.ReplicationControllers(namespace).List()
 		})
 	if err != nil || existingNewRC != nil {
 		return existingNewRC, err


### PR DESCRIPTION
When we list RCs from deployment rcStore, it should be namespaced. 

cc @bgrant0607 @nikhiljindal @ironcladlou @kargakis @kubernetes/sig-config
