### PR TITLE
Discover AWS ELB subnets from instances

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -1730,6 +1730,10 @@ func (s *AWSCloud) EnsureLoadBalancer(name, region string, publicIP net.IP, port
 		return nil, fmt.Errorf("publicIP cannot be specified for AWS ELB")
 	}
 
+	if len(hosts) == 0 {
+		return nil, fmt.Errorf("Load balancer cannot be created, there are no hosts to attach")
+	}
+
 	instances, err := s.getInstancesByNodeNames(hosts)
 	if err != nil {
 		return nil, err

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -43,7 +43,6 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/credentialprovider/aws"
-	"k8s.io/kubernetes/pkg/util/sets"
 
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api/unversioned"
@@ -1695,38 +1694,12 @@ func (s *AWSCloud) createTags(request *ec2.CreateTagsInput) (*ec2.CreateTagsOutp
 	}
 }
 
-func (s *AWSCloud) listSubnetIDsinVPC(vpcId string) ([]string, error) {
-
-	subnetIds := []string{}
-
-	request := &ec2.DescribeSubnetsInput{}
-	filters := []*ec2.Filter{}
-	filters = append(filters, newEc2Filter("vpc-id", vpcId))
-	// Note, this will only return subnets tagged with the cluster identifier for this Kubernetes cluster.
-	// In the case where an AZ has public & private subnets per AWS best practices, the deployment should ensure
-	// only the public subnet (where the ELB will go) is so tagged.
-	filters = s.addFilters(filters)
-	request.Filters = filters
-
-	subnets, err := s.ec2.DescribeSubnets(request)
-	if err != nil {
-		glog.Error("Error describing subnets: ", err)
-		return nil, err
+func findSubnetIDs(instances []*ec2.Instance) []string {
+	subnetIDs := []string{}
+	for _, instance := range instances {
+		subnetIDs = append(subnetIDs, *instance.SubnetId)
 	}
-
-	availabilityZones := sets.NewString()
-	for _, subnet := range subnets {
-		az := orEmpty(subnet.AvailabilityZone)
-		id := orEmpty(subnet.SubnetId)
-		if availabilityZones.Has(az) {
-			glog.Warning("Found multiple subnets per AZ '", az, "', ignoring subnet '", id, "'")
-			continue
-		}
-		subnetIds = append(subnetIds, id)
-		availabilityZones.Insert(az)
-	}
-
-	return subnetIds, nil
+	return subnetIDs
 }
 
 // EnsureLoadBalancer implements LoadBalancer.EnsureLoadBalancer
@@ -1769,11 +1742,7 @@ func (s *AWSCloud) EnsureLoadBalancer(name, region string, publicIP net.IP, port
 	}
 
 	// Construct list of configured subnets
-	subnetIDs, err := s.listSubnetIDsinVPC(vpcId)
-	if err != nil {
-		glog.Error("Error listing subnets in VPC", err)
-		return nil, err
-	}
+	subnetIDs := findSubnetIDs(instances)
 
 	// Create a security group for the load balancer
 	var securityGroupID string

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -714,90 +714,28 @@ func TestLoadBalancerMatchesClusterRegion(t *testing.T) {
 	}
 }
 
-func constructSubnets(subnetsIn map[int]map[string]string) (subnetsOut []*ec2.Subnet) {
-	for i := range subnetsIn {
-		subnetsOut = append(
-			subnetsOut,
-			constructSubnet(
-				subnetsIn[i]["id"],
-				subnetsIn[i]["az"],
-			),
-		)
-	}
-	return
-}
+func TestFindSubnetIDs(t *testing.T) {
 
-func constructSubnet(id string, az string) *ec2.Subnet {
-	return &ec2.Subnet{
-		SubnetId:         &id,
-		AvailabilityZone: &az,
-	}
-}
+	expectedIds := []string{"id1", "id2"}
 
-func TestSubnetIDsinVPC(t *testing.T) {
-	awsServices := NewFakeAWSServices()
-	c, err := newAWSCloud(strings.NewReader("[global]"), awsServices)
-	if err != nil {
-		t.Errorf("Error building aws cloud: %v", err)
+	instances := []*ec2.Instance{
+		{SubnetId: &expectedIds[0]},
+		{SubnetId: &expectedIds[1]},
+	}
+
+	subnetIds := findSubnetIDs(instances)
+
+	if len(expectedIds) != len(subnetIds) {
+		t.Errorf("Expected arrays to have same length")
 		return
 	}
 
-	vpcID := "vpc-deadbeef"
-
-	// test with 3 subnets from 3 different AZs
-	subnets := make(map[int]map[string]string)
-	subnets[0] = make(map[string]string)
-	subnets[0]["id"] = "subnet-a0000001"
-	subnets[0]["az"] = "af-south-1a"
-	subnets[1] = make(map[string]string)
-	subnets[1]["id"] = "subnet-b0000001"
-	subnets[1]["az"] = "af-south-1b"
-	subnets[2] = make(map[string]string)
-	subnets[2]["id"] = "subnet-c0000001"
-	subnets[2]["az"] = "af-south-1c"
-	awsServices.ec2.Subnets = constructSubnets(subnets)
-
-	result, err := c.listSubnetIDsinVPC(vpcID)
-	if err != nil {
-		t.Errorf("Error listing subnets: %v", err)
-		return
-	}
-
-	if len(result) != 3 {
-		t.Errorf("Expected 3 subnets but got %d", len(result))
-		return
-	}
-
-	result_set := make(map[string]bool)
-	for _, v := range result {
-		result_set[v] = true
-	}
-
-	for i := range subnets {
-		if !result_set[subnets[i]["id"]] {
-			t.Errorf("Expected subnet%d '%s' in result: %v", i, subnets[i]["id"], result)
+	for i, expectedId := range expectedIds {
+		if expectedId != subnetIds[i] {
+			t.Errorf("Expected subnet id %v to match %v", expectedId, subnetIds[i])
 			return
 		}
 	}
-
-	// test with 4 subnets from 3 different AZs
-	// add duplicate az subnet
-	subnets[3] = make(map[string]string)
-	subnets[3]["id"] = "subnet-c0000002"
-	subnets[3]["az"] = "af-south-1c"
-	awsServices.ec2.Subnets = constructSubnets(subnets)
-
-	result, err = c.listSubnetIDsinVPC(vpcID)
-	if err != nil {
-		t.Errorf("Error listing subnets: %v", err)
-		return
-	}
-
-	if len(result) != 3 {
-		t.Errorf("Expected 3 subnets but got %d", len(result))
-		return
-	}
-
 }
 
 func TestIpPermissionExistsHandlesMultipleGroupIds(t *testing.T) {


### PR DESCRIPTION
Change the aws elb mechanism to lookup subnet ids from the instances in
the cluster. This avoids the need to tag the subnet and simplifies the
lookup procedure.

The existing mechanism doesn't support multiple clusters in a single
subnet, as you can't tag a subnet with multiple clusters.
