### PR TITLE
Reenable Jenkins e2e jobs.

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-e2e.yaml
@@ -3,6 +3,7 @@
     description: '{description} Test owner: {test-owner}.'
     logrotate:
         daysToKeep: 7
+    disabled: false
     builders:
         - shell: |
             curl -fsS --retry 3  "https://raw.githubusercontent.com/kubernetes/kubernetes/{branch}/hack/jenkins/e2e.sh" | bash -


### PR DESCRIPTION
I've reenabled the critical builds manually. Two things went wrong with #19926. First, JJB was looking for a bool for disabled, and the string `'true'` and the string `'false'` both evaluate to `true`, so that's how it disabled them. Then, when we reverted, JJB knows that the default state is to not specify disabled at all, but Jenkins remembered that they were disabled so kept them disabled.

Oops.
