### PR TITLE
Use PR# rather than git sha1 for PR log path

### DIFF
--- a/hack/jenkins/upload-to-gcs.sh
+++ b/hack/jenkins/upload-to-gcs.sh
@@ -36,7 +36,7 @@ set -o pipefail
 set -o xtrace
 
 if [[ ${JOB_NAME} =~ -pull- ]]; then
-  : ${JENKINS_GCS_LOGS_PATH:="gs://kubernetes-jenkins/pr-logs/${ghprbActualCommit:-unknown}"}
+  : ${JENKINS_GCS_LOGS_PATH:="gs://kubernetes-jenkins/pr-logs/pull/${ghprbPullId:-unknown}"}
 else
   : ${JENKINS_GCS_LOGS_PATH:="gs://kubernetes-jenkins/logs"}
 fi


### PR DESCRIPTION
Per @lavalamp's suggestion.

This way, rather than staring at a long list of sha1s in  https://console.developers.google.com/storage/browser/kubernetes-jenkins/pr-logs/ to try to find relevant logs, you could instead just look for the pull number in https://console.developers.google.com/storage/browser/kubernetes-jenkins/pr-logs/pull/.

Assuming we're happy with this, I'd prefer to merge manually, since I'll need to update some configs in PR Jenkins simultaneously, as otherwise we'll break links. (Links in this PR will be somewhat broken, even.)

@kubernetes/goog-testing 
