### PR TITLE
Extend a timeout to reduce flakes.

### DIFF
--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -1240,7 +1240,7 @@ func startServeHostnameService(c *client.Client, ns, name string, port, replicas
 		Name:                 name,
 		Namespace:            ns,
 		PollInterval:         3 * time.Second,
-		Timeout:              30 * time.Second,
+		Timeout:              2 * time.Minute,
 		Replicas:             replicas,
 		CreatedPods:          &createdPods,
 		MaxContainerFailures: &maxContainerFailures,


### PR DESCRIPTION
@ihmccreery @spxtr @ixdy 

This is bringing the release-1.1 branch in line with the timeout that we use at HEAD.

This has flaked twice in the 1.1 CI recently.
