### PR TITLE
Change cluster_size_autoscaling.go to be [Feature:Autoscaling] rather than [Skipped]

### DIFF
--- a/test/e2e/cluster_size_autoscaling.go
+++ b/test/e2e/cluster_size_autoscaling.go
@@ -32,7 +32,7 @@ const (
 	scaleDownTimeout = 30 * time.Minute
 )
 
-var _ = Describe("Autoscaling [Skipped]", func() {
+var _ = Describe("Cluster size autoscaling [Feature:Autoscaling]", func() {
 	f := NewFramework("autoscaling")
 	var nodeCount int
 	var coresPerNode int


### PR DESCRIPTION
#20083 re-classified these as `[Skipped]` against policy cited in #19543.  `[Skipped]` is being phased out as a valid label.  I'm reclassifying these as a separate feature, since @piosz says they're alpha/different from `[Feature:Autoscaling]`.
