### PR TITLE
Classify initial resource as [Feature:Autoscaling]

### DIFF
--- a/test/e2e/initial_resources.go
+++ b/test/e2e/initial_resources.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 )
 
-var _ = Describe("Initial Resources [Skipped] ", func() {
+var _ = Describe("Initial Resources [Feature:Autoscaling]", func() {
 	f := NewFramework("initial-resources")
 
 	It("should set initial resources based on historical data", func() {


### PR DESCRIPTION
With #20109, is this test de-flaked?  If not, it should be labeled `[Feature:...]` and `[Flaky]` if it's still flaky; it should not remain as `[Skipped]`.
