### PR TITLE
Fix zone in cloudprovider method.

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -1368,21 +1368,28 @@ func (gce *GCECloud) RemoveInstancesFromInstanceGroup(name string, zone string, 
 func (gce *GCECloud) AddPortToInstanceGroup(ig *compute.InstanceGroup, port int64) (*compute.NamedPort, error) {
 	for _, np := range ig.NamedPorts {
 		if np.Port == port {
-			glog.Infof("Instance group %v already has named port %+v", ig.Name, np)
+			glog.V(3).Infof("Instance group %v already has named port %+v", ig.Name, np)
 			return np, nil
 		}
 	}
 	glog.Infof("Adding port %v to instance group %v with %d ports", port, ig.Name, len(ig.NamedPorts))
 	namedPort := compute.NamedPort{Name: fmt.Sprintf("port%v", port), Port: port}
 	ig.NamedPorts = append(ig.NamedPorts, &namedPort)
+
+	// setNamedPorts is a zonal endpoint, meaning we invoke it by re-creating a URL like:
+	// {project}/zones/{zone}/instanceGroups/{instanceGroup}/setNamedPorts, so the "zone"
+	// parameter given to SetNamedPorts must not be the entire zone URL.
+	zoneURLParts := strings.Split(ig.Zone, "/")
+	zone := zoneURLParts[len(zoneURLParts)-1]
+
 	op, err := gce.service.InstanceGroups.SetNamedPorts(
-		gce.projectID, ig.Zone, ig.Name,
+		gce.projectID, zone, ig.Name,
 		&compute.InstanceGroupsSetNamedPortsRequest{
 			NamedPorts: ig.NamedPorts}).Do()
 	if err != nil {
 		return nil, err
 	}
-	if err = gce.waitForZoneOp(op, ig.Zone); err != nil {
+	if err = gce.waitForZoneOp(op, zone); err != nil {
 		return nil, err
 	}
 	return &namedPort, nil


### PR DESCRIPTION
Previously we would hand the "zone" retrieved via getProjectAndZone (today's localZone) which was just a naked zone name. Now we given the Zone field of the instance group, which is a zone link, and breaks zonal endpoints like SetNamedPorts that aren't smart enough to know better.

@quinton-hoole @justinsb fyi, since there might've been other calls like this
