### PR TITLE
PoC - Example of a swagger 2.0 generation path

### DIFF
--- a/cmd/libs/go2idl/swagger/main.go
+++ b/cmd/libs/go2idl/swagger/main.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"log"
+	"os"
+	"strings"
+
+	"github.com/emicklei/go-restful"
+	"github.com/go-swagger/go-swagger/scan"
+	"github.com/go-swagger/go-swagger/spec"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/genericapiserver"
+	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
+	"k8s.io/kubernetes/pkg/master"
+	"k8s.io/kubernetes/pkg/storage/etcd"
+)
+
+func main() {
+	s := &spec.Swagger{}
+	if s.Paths == nil {
+		s.Paths = &spec.Paths{}
+		s.Paths.Paths = make(map[string]spec.PathItem)
+	}
+
+	storage, _ := (&etcd.EtcdConfig{}).NewStorage()
+	sd := genericapiserver.NewStorageDestinations()
+	sd.AddAPIGroup("", storage)
+	m := master.New(&master.Config{
+		Config: &genericapiserver.Config{
+			Serializer:               api.Codecs,
+			StorageDestinations:      sd,
+			APIGroupVersionOverrides: map[string]genericapiserver.APIGroupVersionOverride{"extensions/v1beta1": {Disable: true}},
+		},
+		KubeletClient: &kubeletclient.FakeKubeletClient{},
+	})
+	for _, ws := range m.HandlerContainer.RegisteredWebServices() {
+		for _, r := range ws.Routes() {
+			path := r.Path
+			if !strings.HasPrefix(path, "/") {
+				path = "/" + path
+			}
+			log.Printf("ws %s: route %s %s", ws.RootPath(), path, r.Method)
+			item := s.Paths.Paths[path]
+			switch r.Method {
+			case "GET":
+				op := (&spec.Operation{}).WithDescription(r.Doc).WithConsumes(r.Consumes...).WithProduces(r.Produces...)
+				item.Get = op
+				for _, p := range r.ParameterDocs {
+					switch p.Kind() {
+					case restful.PathParameterKind:
+						param := (&spec.Parameter{}).
+							WithLocation("path").
+							Named(p.Data().Name).
+							WithDescription(p.Data().Description)
+						if p.Data().Required {
+							param.AsRequired()
+						}
+						item.Get.AddParam(param)
+					}
+				}
+			}
+			s.Paths.Paths[path] = item
+		}
+	}
+	out, err := scan.Application(os.Args[1], s, nil, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	data, err := out.MarshalJSON()
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("%s", data)
+}


### PR DESCRIPTION
This generates swagger 2.0 using goswagger.io along with starting our master and walking
the registered routes. Run the command with:

```
GOPATH=$(pwd)/Godeps/_workspace:$GOPATH go run ./cmd/libs/go2idl/swagger/main.go "./cmd/kube-apiserver"
```

Example output:

```
{
  "swagger": "2.0",
  "paths": {
    "/": {
      "get": {
        "description": "get available API versions",
        "consumes": [
          "application/json",
          "application/yaml"
        ],
        "produces": [
          "application/json",
          "application/yaml"
        ]
      }
    },
    "/apis/": {
      "get": {
        "description": "get available API versions",
        "consumes": [
          "application/json",
          "application/yaml"
        ],
        "produces": [
          "application/json",
          "application/yaml"
        ]
      }
    },
    "/v1/": {
      "get": {
        "description": "get available resources",
        "consumes": [
          "application/json",
          "application/yaml"
        ],
        "produces": [
          "application/json",
          "application/yaml"
        ]
      }
    },
    "/v1/componentstatuses": {
      "get": {
        "description": "list objects of kind ComponentStatus",
        "consumes": [
          "*/*"
        ],
        "produces": [
          "application/json",
          "application/yaml"
        ]
      }
    },
    "/v1/componentstatuses/{name}": {
      "get": {
        "description": "read the specified ComponentStatus",
        "consumes": [
          "*/*"
        ],
        "produces": [
          "application/json",
          "application/yaml"
        ],
        "parameters": [
          {
            "description": "name of the ComponentStatus",
            "name": "name",
            "in": "path",
            "required": true
          }
        ]
      }
    },
```

This is not yet demonstrating the model loading of goswagger (which in theory can auto-annotate our schemas).
