### PR TITLE
Tag dynamically created GCE PD disks.

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gce
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -1617,12 +1618,36 @@ func (gce *GCECloud) GetZone() (cloudprovider.Zone, error) {
 	}, nil
 }
 
-// Create a new Persistent Disk, with the specified name & size, in the specified zone.
-func (gce *GCECloud) CreateDisk(name string, zone string, sizeGb int64) error {
-	diskToCreate := &compute.Disk{
-		Name:   name,
-		SizeGb: sizeGb,
+// encodeDiskTags encodes requested volume tags into JSON string, as GCE does
+// not support tags on GCE PDs and we use Description field as fallback.
+func (gce *GCECloud) encodeDiskTags(tags map[string]string) (string, error) {
+	if len(tags) == 0 {
+		// No tags -> empty JSON
+		return "", nil
 	}
+
+	enc, err := json.Marshal(tags)
+	if err != nil {
+		return "", err
+	}
+	return string(enc), nil
+}
+
+// CreateDisk creates a new Persistent Disk, with the specified name & size, in
+// the specified zone. It stores specified tags endoced in JSON in Description
+// field.
+func (gce *GCECloud) CreateDisk(name string, zone string, sizeGb int64, tags map[string]string) error {
+	tagsStr, err := gce.encodeDiskTags(tags)
+	if err != nil {
+		return err
+	}
+
+	diskToCreate := &compute.Disk{
+		Name:        name,
+		SizeGb:      sizeGb,
+		Description: tagsStr,
+	}
+
 	createOp, err := gce.service.Disks.Insert(gce.projectID, zone, diskToCreate).Do()
 	if err != nil {
 		return err

--- a/pkg/volume/gce_pd/gce_util.go
+++ b/pkg/volume/gce_pd/gce_util.go
@@ -146,7 +146,7 @@ func (gceutil *GCEDiskUtil) CreateVolume(c *gcePersistentDiskProvisioner) (volum
 		return "", 0, err
 	}
 
-	err = cloud.CreateDisk(name, zone.FailureDomain, int64(requestGB))
+	err = cloud.CreateDisk(name, zone.FailureDomain, int64(requestGB), *c.options.CloudTags)
 	if err != nil {
 		glog.V(2).Infof("Error creating GCE PD volume: %v", err)
 		return "", 0, err

--- a/test/e2e/pd.go
+++ b/test/e2e/pd.go
@@ -314,7 +314,8 @@ func createPD() (string, error) {
 			return "", err
 		}
 
-		err = gceCloud.CreateDisk(pdName, testContext.CloudConfig.Zone, 10 /* sizeGb */)
+		tags := map[string]string{}
+		err = gceCloud.CreateDisk(pdName, testContext.CloudConfig.Zone, 10 /* sizeGb */, tags)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
GCE disks don't have tags, we must encode the tags into Description field.
It's encoded as JSON, which is both human and machine readable:
description: '{"kubernetes.io/created-for/pv/name":"pv-gce-oxwts","kubernetes.io/created-for/pvc/name":"myclaim","kubernetes.io/created-for/pvc/namespace":"default"}'

This will allow cloud admin to detect why a PD was created and match it with Kubernetes namespace/project.
