### PR TITLE
Fix documentation formatting in `api_changes.md`

### DIFF
--- a/docs/devel/api_changes.md
+++ b/docs/devel/api_changes.md
@@ -415,12 +415,11 @@ Also note that you can (and for efficiency reasons should) use auto-generated
 conversion functions when writing your conversion functions.
 
 Once all the necessary manually written conversions are added, you need to
-regenerate auto-generated ones. To regenerate them:
-   - run
+regenerate auto-generated ones. To regenerate them, run:
 
-```sh
-hack/update-generated-conversions.sh
-```
+   ```sh
+   hack/update-generated-conversions.sh
+   ```
 
 If running the above script is impossible due to compile errors, the easiest
 workaround is to comment out the code causing errors and let the script to
@@ -441,12 +440,11 @@ The deep copy code resides with each versioned API:
    - `pkg/api/<version>/deep_copy_generated.go` containing auto-generated copy functions
    - `pkg/apis/extensions/<version>/deep_copy_generated.go` containing auto-generated copy functions
 
-To regenerate them:
-   - run
+To regenerate them, run:
 
-```sh
-hack/update-generated-deep-copies.sh
-```
+    ```sh
+    hack/update-generated-deep-copies.sh
+    ```
 
 ## Edit json (un)marshaling code
 
@@ -457,12 +455,11 @@ The auto-generated code resides with each versioned API:
    - `pkg/api/<version>/types.generated.go`
    - `pkg/apis/extensions/<version>/types.generated.go`
 
-To regenerate them:
-   - run
+To regenerate them, run:
 
-```sh
-hack/update-codecgen.sh
-```
+    ```sh
+    hack/update-codecgen.sh
+    ```
 
 ## Making a new API Group
 


### PR DESCRIPTION
The markdown formatting for the inline code seemed to start a new line
unnecessarily.

This may just be personal preference so no worries if it doesn't make sense as a change - I just thought it would make it easier to read.

Signed-off-by: mattjmcnaughton mattjmcnaughton@gmail.com
