### PR TITLE
Update the e2e-gce timeout to 3 hours, we've bumped up against it recently

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-e2e.yaml
@@ -37,7 +37,7 @@
     suffix:
         - 'gce':
             description: 'Run E2E tests on GCE using the latest successful build.'
-            timeout: 150
+            timeout: 180
         - 'gce-autoscaling':
             description: 'Run autoscaling E2E tests on GCE using the latest successful build.'
             timeout: 210


### PR DESCRIPTION
Mean runtime is 2:10, that's a little close for comfort.

@spxtr @ixdy @ihmccreery 
