### PR TITLE
PluginFactoryArgs: Expose explicit fields

### DIFF
--- a/plugin/pkg/scheduler/factory/plugins.go
+++ b/plugin/pkg/scheduler/factory/plugins.go
@@ -33,13 +33,13 @@ import (
 
 // PluginFactoryArgs are passed to all plugin factory functions.
 type PluginFactoryArgs struct {
-	algorithm.PodLister
-	algorithm.ServiceLister
-	algorithm.ControllerLister
-	NodeLister algorithm.NodeLister
-	NodeInfo   predicates.NodeInfo
-	PVInfo     predicates.PersistentVolumeInfo
-	PVCInfo    predicates.PersistentVolumeClaimInfo
+	PodLister        algorithm.PodLister
+	ServiceLister    algorithm.ServiceLister
+	ControllerLister algorithm.ControllerLister
+	NodeLister       algorithm.NodeLister
+	NodeInfo         predicates.NodeInfo
+	PVInfo           predicates.PersistentVolumeInfo
+	PVCInfo          predicates.PersistentVolumeClaimInfo
 }
 
 // A FitPredicateFactory produces a FitPredicate from the given args.


### PR DESCRIPTION
None of the embedded fields are used for inheritance methods. Expose
them for better code analysis.
