### PR TITLE
Fix #20088 Failed to run install_fedora_deps()!!! with Vagrant

### DIFF
--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -288,6 +288,10 @@ EOF
   #
   # -M installs the master
   # -N does not install the minion
+
+  # Temporary fix until salt-bootstrap merge this
+  # fix https://github.com/saltstack/salt-bootstrap/commit/4d4de1ec7488dc03afc3f1af980ff8b3d07c1c27 to stable
+  export BS_CURL_ARGS="-L"
   curl -sS -L --connect-timeout 20 --retry 6 --retry-delay 10 https://bootstrap.saltstack.com | sh -s -- -M -N
 
   # Install salt-api
@@ -305,6 +309,10 @@ fi
 if ! which salt-minion >/dev/null 2>&1; then
 
   # Install Salt minion
+
+  # Temporary fix until salt-bootstrap merge this
+  # fix https://github.com/saltstack/salt-bootstrap/commit/4d4de1ec7488dc03afc3f1af980ff8b3d07c1c27 to stable
+  export BS_CURL_ARGS="-L"
   curl -sS -L --connect-timeout 20 --retry 6 --retry-delay 10 https://bootstrap.saltstack.com | sh -s
 
   # Edit the Salt minion unit file to do restart always

--- a/cluster/vagrant/provision-minion.sh
+++ b/cluster/vagrant/provision-minion.sh
@@ -162,6 +162,10 @@ swapoff -a
 # we will run provision to update code each time we test, so we do not want to do salt install each time
 if ! which salt-minion >/dev/null 2>&1; then
   # Install Salt
+
+  # Temporary fix until salt-bootstrap merge this
+  # fix https://github.com/saltstack/salt-bootstrap/commit/4d4de1ec7488dc03afc3f1af980ff8b3d07c1c27 to stable
+  export BS_CURL_ARGS="-L"
   curl -sS -L --connect-timeout 20 --retry 6 --retry-delay 10 https://bootstrap.saltstack.com | sh -s
   
   # Edit the Salt minion unit file to do restart always


### PR DESCRIPTION
- Saltstack script https://bootstrap.saltstack.com using http://copr.fedoraproject.org/coprs/saltstack/salt/repo/fedora-21/saltstack-salt-fedora-21.repo at line no 2988
- Curl doesn't follow redirect
- `BS_CURL_ARGS` variable to override cURL arguments
- added BS_CURL_ARGS="-ksSL" in provision-master.sh and provission-minion.sh
