### PR TITLE
Move HPA e2es into the default slow suite, and add [Feature:ClusterSizeAutoscaling] and [Feature:InitialResources]

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -351,7 +351,8 @@ case ${JOB_NAME} in
   kubernetes-e2e-gce-autoscaling)
     : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-autoscaling"}
     : ${E2E_NETWORK:="e2e-autoscaling"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Feature:Autoscaling\]"}
+    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Feature:ClusterSizeAutoscaling\]|\[Feature:InitialResources\] \
+                           --ginkgo.skip=\[Flaky\]"}
     : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-autoscaling"}
     : ${PROJECT:="k8s-jnks-e2e-gce-autoscaling"}
     : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}

--- a/test/e2e/cluster_size_autoscaling.go
+++ b/test/e2e/cluster_size_autoscaling.go
@@ -32,7 +32,12 @@ const (
 	scaleDownTimeout = 30 * time.Minute
 )
 
-var _ = Describe("Autoscaling [Skipped]", func() {
+// [Feature:ClusterSizeAutoscaling]: Cluster size autoscaling is experimental
+// and require Google Cloud Monitoring to be enabled, so these tests are not
+// run by default.
+//
+// These tests take ~20 minutes to run each.
+var _ = Describe("Cluster size autoscaling [Feature:ClusterSizeAutoscaling] [Slow]", func() {
 	f := NewFramework("autoscaling")
 	var nodeCount int
 	var coresPerNode int

--- a/test/e2e/horizontal_pod_autoscaling.go
+++ b/test/e2e/horizontal_pod_autoscaling.go
@@ -31,7 +31,8 @@ const (
 	subresource    = "scale"
 )
 
-var _ = Describe("Horizontal pod autoscaling (scale resource: CPU) [Feature:Autoscaling]", func() {
+// These tests take ~20 minutes each.
+var _ = Describe("Horizontal pod autoscaling (scale resource: CPU) [Slow]", func() {
 	var rc *ResourceConsumer
 	f := NewFramework("horizontal-pod-autoscaling")
 

--- a/test/e2e/initial_resources.go
+++ b/test/e2e/initial_resources.go
@@ -26,7 +26,11 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 )
 
-var _ = Describe("Initial Resources [Skipped] ", func() {
+// [Feature:InitialResources]: Initial resources is an experimental feature, so
+// these tests are not run by default.
+//
+// Flaky issue #20272
+var _ = Describe("Initial Resources [Feature:InitialResources] [Flaky]", func() {
 	f := NewFramework("initial-resources")
 
 	It("should set initial resources based on historical data", func() {


### PR DESCRIPTION
Per our discussion earlier today:
- HPA tests should be run by default (though they are slow)
- "Cluster size autoscaling" and "Initial resources" tests should live in the autoscaling suite.

I labeled "Initial resources" `[Flaky]` per your comment and disabled flaky tests in the autoscaling suite; if you'd rather run them there, let me know.
