### PR TITLE
Make slow tests run in parallel, add gke-slow suite

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -418,9 +418,9 @@ case ${JOB_NAME} in
   kubernetes-e2e-gce-slow)
     : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-slow"}
     : ${E2E_NETWORK:="e2e-slow"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=$(join_regex_no_empty \
-          ${GCE_SLOW_TESTS[@]:+${GCE_SLOW_TESTS[@]}} \
-          )"}
+    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Slow\] \
+                           --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"}
+    : ${GINKGO_PARALLEL:="y"}
     : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-slow"}
     : ${PROJECT:="k8s-jkns-e2e-gce-slow"}
     : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
@@ -637,6 +637,17 @@ case ${JOB_NAME} in
           ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
           ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
           )"}
+    ;;
+
+  kubernetes-e2e-gke-slow)
+    : ${E2E_CLUSTER_NAME:="jkns-gke-e2e-slow"}
+    : ${E2E_NETWORK:="e2e-gke-slow"}
+    : ${E2E_SET_CLUSTER_API_VERSION:=y}
+    : ${PROJECT:="k8s-jkns-e2e-gke-slow"}
+    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
+    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Slow\] \
+                           --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"}
+    : ${GINKGO_PARALLEL:="y"}
     ;;
 
   # Run the GCE_PARALLEL_SKIP_TESTS on GKE.

--- a/hack/jenkins/job-configs/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-e2e.yaml
@@ -83,6 +83,9 @@
                 - cluster (k8s): ci/latest.txt<br>
                 - tests: ci/latest.txt
             timeout: 300
+        - 'gke-slow':
+            description: 'Run slow E2E tests on GKE using the latest successful build.'
+            timeout: 300
         - 'gke-ci-reboot':
             description: |
                 Run e2e tests using the following config:<br>


### PR DESCRIPTION
And another... this isn't blocked on anything.  The ACLs for the gke-slow project are pending, but it starting to run and failing shouldn't be an issue.

Work toward #10548.
