### PR TITLE
Fix `make release` on OS X

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -472,7 +472,7 @@ function kube::build::build_image() {
   kube::version::save_version_vars "${build_context_dir}/kube-version-defs"
 
   cp build/build-image/Dockerfile ${build_context_dir}/Dockerfile
-  sed -i "s/KUBE_BUILD_IMAGE_CROSS/${KUBE_BUILD_IMAGE_CROSS}/" ${build_context_dir}/Dockerfile
+  sed -i '' "s/KUBE_BUILD_IMAGE_CROSS/${KUBE_BUILD_IMAGE_CROSS}/" ${build_context_dir}/Dockerfile
   # We don't want to force-pull this image because it's based on a local image
   # (see kube::build::build_image_cross), not upstream.
   kube::build::docker_build "${KUBE_BUILD_IMAGE}" "${build_context_dir}" 'false'


### PR DESCRIPTION
Apparently the OS X version of sed -i requires a backup-extension to be specified.
Right now it is treating the sed command as the backup-extension, and then trying to parse the path as other args to sed, resulting in:

```
sed: 1: "/Users/cjcullen/go/src/ ...": command c expects \ followed by text
```

I haven't tested this on linux, but it _should_ have the exact same behavior as before.
