### PR TITLE
fixing docker -d deprecation

### DIFF
--- a/cluster/saltbase/salt/docker/docker.service
+++ b/cluster/saltbase/salt/docker/docker.service
@@ -6,7 +6,7 @@ Requires=docker.socket
 
 [Service]
 EnvironmentFile={{ environment_file }}
-ExecStart=/usr/bin/docker -d -H fd:// "$DOCKER_OPTS"
+ExecStart=/usr/bin/docker daemon -H fd:// "$DOCKER_OPTS"
 MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576

--- a/docs/getting-started-guides/coreos/bare_metal_offline.md
+++ b/docs/getting-started-guides/coreos/bare_metal_offline.md
@@ -557,7 +557,7 @@ On the PXE server make and fill in the variables `vi /var/www/html/coreos/pxe-cl
             EnvironmentFile=-/etc/default/docker
             EnvironmentFile=/run/flannel/subnet.env
             ExecStartPre=/bin/mount --make-rprivate /
-            ExecStart=/usr/bin/docker -d --bip=${FLANNEL_SUBNET} --mtu=${FLANNEL_MTU} -s=overlay -H fd:// ${DOCKER_EXTRA_OPTS}
+            ExecStart=/usr/bin/docker daemon --bip=${FLANNEL_SUBNET} --mtu=${FLANNEL_MTU} -s=overlay -H fd:// ${DOCKER_EXTRA_OPTS}
             [Install]
             WantedBy=multi-user.target
         - name: setup-network-environment.service

--- a/docs/getting-started-guides/docker-multinode/master.md
+++ b/docs/getting-started-guides/docker-multinode/master.md
@@ -70,6 +70,12 @@ Run:
 sudo sh -c 'docker -d -H unix:///var/run/docker-bootstrap.sock -p /var/run/docker-bootstrap.pid --iptables=false --ip-masq=false --bridge=none --graph=/var/lib/docker-bootstrap 2> /var/log/docker-bootstrap.log 1> /dev/null &'
 ```
 
+_If you have Docker 1.8.0 or higher run this instead_
+
+```sh
+sudo sh -c 'docker daemon -H unix:///var/run/docker-bootstrap.sock -p /var/run/docker-bootstrap.pid --iptables=false --ip-masq=false --bridge=none --graph=/var/lib/docker-bootstrap 2> /var/log/docker-bootstrap.log 1> /dev/null &'
+```
+
 _Important Note_:
 If you are running this on a long running system, rather than experimenting, you should run the bootstrap Docker instance under something like SysV init, upstart or systemd so that it is restarted
 across reboots and failures.

--- a/docs/getting-started-guides/docker-multinode/worker.md
+++ b/docs/getting-started-guides/docker-multinode/worker.md
@@ -72,6 +72,12 @@ Run:
 sudo sh -c 'docker -d -H unix:///var/run/docker-bootstrap.sock -p /var/run/docker-bootstrap.pid --iptables=false --ip-masq=false --bridge=none --graph=/var/lib/docker-bootstrap 2> /var/log/docker-bootstrap.log 1> /dev/null &'
 ```
 
+_If you have Docker 1.8.0 or higher run this instead_
+
+```sh
+sudo sh -c 'docker daemon -H unix:///var/run/docker-bootstrap.sock -p /var/run/docker-bootstrap.pid --iptables=false --ip-masq=false --bridge=none --graph=/var/lib/docker-bootstrap 2> /var/log/docker-bootstrap.log 1> /dev/null &'
+```
+
 _Important Note_:
 If you are running this on a long running system, rather than experimenting, you should run the bootstrap Docker instance under something like SysV init, upstart or systemd so that it is restarted
 across reboots and failures.
@@ -172,7 +178,7 @@ sudo docker run \
     --volume=/var/run:/var/run:rw \
     --net=host \
     --privileged=true \
-    --pid=host \ 
+    --pid=host \
     -d \
     gcr.io/google_containers/hyperkube:v${K8S_VERSION} \
     /hyperkube kubelet \

--- a/docs/getting-started-guides/docker-multinode/worker.sh
+++ b/docs/getting-started-guides/docker-multinode/worker.sh
@@ -60,7 +60,7 @@ detect_lsb() {
         *64)
             ;;
         *)
-	        echo "Error: We currently only support 64-bit platforms."	    
+	        echo "Error: We currently only support 64-bit platforms."
 	        exit 1
 	        ;;
     esac
@@ -96,7 +96,15 @@ detect_lsb() {
 
 # Start the bootstrap daemon
 bootstrap_daemon() {
-    docker -d \
+    # Detecting docker version so we could run proper docker_daemon command
+    [[ $(eval "docker --version") =~ ([0-9][.][0-9][.][0-9]*) ]] && version="${BASH_REMATCH[1]}"
+    local got=$(echo -e "${version}\n1.8.0" | sed '/^$/d' | sort -nr | head -1)
+    if [[ "${got}" = "${version}" ]]; then
+        docker_daemon="docker -d"
+    else
+        docker_daemon="docker daemon"
+    fi
+    ${docker_daemon} \
         -H unix:///var/run/docker-bootstrap.sock \
         -p /var/run/docker-bootstrap.pid \
         --iptables=false \
@@ -171,7 +179,7 @@ start_k8s() {
 
     # sleep a little bit
     sleep 5
-    
+
     # Start kubelet & proxy in container
     # TODO: Use secure port for communication
     docker run \
@@ -196,7 +204,7 @@ start_k8s() {
             --cluster-domain=cluster.local \
             --containerized \
             --v=2
-    
+
     docker run \
         -d \
         --net=host \


### PR DESCRIPTION
`docker -d` was removed on docker 1.10

I only did a grep "docker -d" in the repo. I hope there isn't a:

```
docker \
  -d
```

Signed-off-by: André Martins aanm90@gmail.com
