### PR TITLE
Log more information for ssh command.

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -2179,9 +2179,10 @@ func issueSSHCommand(cmd, provider string, node *api.Node) error {
 	if host == "" {
 		return fmt.Errorf("couldn't find external IP address for node %s", node.Name)
 	}
-	Logf("Calling %s on %s", cmd, node.Name)
-	if result, err := SSH(cmd, host, provider); result.Code != 0 || err != nil {
-		LogSSHResult(result)
+	Logf("Calling %s on %s(%s)", cmd, node.Name, host)
+	result, err := SSH(cmd, host, provider)
+	LogSSHResult(result)
+	if result.Code != 0 || err != nil {
 		return fmt.Errorf("failed running %q: %v (exit code %d)", cmd, err, result.Code)
 	}
 	return nil


### PR DESCRIPTION
Sometimes e2e test nodes are refused to reboot, but we didn't properly
catch the exit code. This one can give us more information on debugging.
#20179
