### PR TITLE
Reclassify Restart tests as [Disruptive] and skip [Feature:.+] tests in -serial jobs

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -511,8 +511,8 @@ case ${JOB_NAME} in
     : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-serial"}
     : ${E2E_NETWORK:="jenkins-gce-e2e-serial"}
     : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Serial\]|\[Disruptive\]|\[Feature:Restart\] \
-                           --ginkgo.skip=\[Flaky\]"}
+    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
+                           --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"}
     : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-serial"}
     : ${PROJECT:="kubernetes-jkns-e2e-gce-serial"}
     ;;
@@ -523,8 +523,8 @@ case ${JOB_NAME} in
     : ${E2E_NETWORK:="jenkins-gke-e2e-serial"}
     : ${E2E_SET_CLUSTER_API_VERSION:=y}
     : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Serial\]|\[Disruptive\]|\[Feature:Restart\] \
-                           --ginkgo.skip=\[Flaky\]"}
+    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
+                           --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"}
     : ${PROJECT:="jenkins-gke-e2e-serial"}
     ;;
 

--- a/test/e2e/restart.go
+++ b/test/e2e/restart.go
@@ -48,9 +48,7 @@ const (
 	restartPodReadyAgainTimeout = 5 * time.Minute
 )
 
-// TODO(ihmccreery): These tests haven't been run for a while, so until they're
-// known stable, consider them a non-core feature.
-var _ = Describe("Restart [Feature:Restart]", func() {
+var _ = Describe("Restart [Disruptive]", func() {
 	var c *client.Client
 	var ps *podStore
 	var skipped bool


### PR DESCRIPTION
These jobs were accidentally running `[Serial]` `[Feature:.+]` jobs, which they ought not to've been (namely, `[Feature:ExperimentalResourceUsageTracking]`).

cc @k8s-oncall
