### PR TITLE
Add spark-webui.json file to create spark master webui which is neede…

### DIFF
--- a/examples/spark/README.md
+++ b/examples/spark/README.md
@@ -43,8 +43,15 @@ Then, use the [`examples/spark/spark-master-service.json`](spark-master-service.
 create a logical service endpoint that Spark workers can use to access
 the Master pod.
 
+
 ```sh
 $ kubectl create -f examples/spark/spark-master-service.json
+```
+
+You can create a service for the Spark Master WebUI to monitor of the Spark cluster.
+
+```sh
+$ kubectl create -f examples/spark/spark-webui.json
 ```
 
 ### Check to see if Master is running and accessible

--- a/examples/spark/spark-webui.json
+++ b/examples/spark/spark-webui.json
@@ -1,0 +1,22 @@
+{
+  "kind": "Service",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "spark-webui",
+    "labels": {
+      "name": "spark-webui"
+    }
+  },
+  "spec": {
+    "ports": [
+      {
+        "port": 8080,
+        "targetPort": 8080
+      }
+    ],
+    "selector": {
+      "name": "spark-master"
+    }
+  }
+}
+


### PR DESCRIPTION
…d to monitor the spark cluster

Whenever I create the Spark cluster on Kube. using the example files of release-1.1 branch, I needed to monitor the Spark cluster and I always created the Spark WebUI. So, I think it will be useful to others who want to run the Spark cluster on Kube 1.1.
