### PR TITLE
Fix potential rounding problem

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -770,7 +770,10 @@ var _ = Describe("Kubectl client", func() {
 				}
 
 				By("restricting to a time range")
-				time.Sleep(1500 * time.Millisecond) // ensure that startup logs on the node are seen as older than 1s
+				// Note: we must wait at least two seconds,
+				// because the granularity is only 1 second and
+				// it could end up rounding the wrong way.
+				time.Sleep(2500 * time.Millisecond) // ensure that startup logs on the node are seen as older than 1s
 				recent_out := runKubectlOrDie("log", pod.Name, containerName, nsFlag, "--since=1s")
 				recent := len(strings.Split(recent_out, "\n"))
 				older_out := runKubectlOrDie("log", pod.Name, containerName, nsFlag, "--since=24h")


### PR DESCRIPTION
Fixes #20224.

If everything before this wait happened super fast (as it can on our Jenkins setup when the test machine is in the same project as the cluster), then integer truncation rounds the wrong way 50% of the time.
