### PR TITLE
Expand coding convention information on third party code

### DIFF
--- a/docs/devel/coding-conventions.md
+++ b/docs/devel/coding-conventions.md
@@ -77,8 +77,10 @@ Directory and file conventions
     - Examples should also illustrate
       [best practices for configuration and using the system](../user-guide/config-best-practices.md)
   - Third-party code
-    - Third-party Go code is managed using Godeps
-    - Other third-party code belongs in /third_party
+    - Go code for normal third-party dependencies is managed using [Godeps](https://github.com/tools/godep)
+    - Other third-party code belongs in `/third_party`
+      - forked third party Go code goes in `/third_party/forked`
+      - forked _golang stdlib_ code goes in `/third_party/golang`
     - Third-party code must include licenses
     - This includes modified third-party code and excerpts, as well
 


### PR DESCRIPTION
Expands the docs a little on third party deps re: forked / golang stdlib code.

@bgrant0607
