### PR TITLE
Include the unversioned.DiscoveryClient in the generated clientset

### DIFF
--- a/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_release_1_1/clientset.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_release_1_1/clientset.go
@@ -22,18 +22,25 @@ import (
 )
 
 type Interface interface {
+	Discovery() unversioned.DiscoveryInterface
 	Testgroup() testgroup_unversioned.TestgroupInterface
 }
 
 // Clientset contains the clients for groups. Each group has exactly one
 // version included in a Clientset.
 type Clientset struct {
+	*unversioned.DiscoveryClient
 	*testgroup_unversioned.TestgroupClient
 }
 
 // Testgroup retrieves the TestgroupClient
 func (c *Clientset) Testgroup() testgroup_unversioned.TestgroupInterface {
 	return c.TestgroupClient
+}
+
+// Discovery retrieves the DiscoveryClient
+func (c *Clientset) Discovery() unversioned.DiscoveryInterface {
+	return c.DiscoveryClient
 }
 
 // NewForConfig creates a new Clientset for the given config.
@@ -45,6 +52,10 @@ func NewForConfig(c *unversioned.Config) (*Clientset, error) {
 		return nil, err
 	}
 
+	clientset.DiscoveryClient, err = unversioned.NewDiscoveryClientForConfig(c)
+	if err != nil {
+		return nil, err
+	}
 	return &clientset, nil
 }
 
@@ -54,6 +65,7 @@ func NewForConfigOrDie(c *unversioned.Config) *Clientset {
 	var clientset Clientset
 	clientset.TestgroupClient = testgroup_unversioned.NewForConfigOrDie(c)
 
+	clientset.DiscoveryClient = unversioned.NewDiscoveryClientForConfigOrDie(c)
 	return &clientset
 }
 
@@ -62,5 +74,6 @@ func New(c *unversioned.RESTClient) *Clientset {
 	var clientset Clientset
 	clientset.TestgroupClient = testgroup_unversioned.New(c)
 
+	clientset.DiscoveryClient = unversioned.NewDiscoveryClient(c)
 	return &clientset
 }

--- a/pkg/client/clientset_generated/release_1_1/clientset.go
+++ b/pkg/client/clientset_generated/release_1_1/clientset.go
@@ -23,6 +23,7 @@ import (
 )
 
 type Interface interface {
+	Discovery() unversioned.DiscoveryInterface
 	Legacy() legacy_unversioned.LegacyInterface
 	Extensions() extensions_unversioned.ExtensionsInterface
 }
@@ -30,6 +31,7 @@ type Interface interface {
 // Clientset contains the clients for groups. Each group has exactly one
 // version included in a Clientset.
 type Clientset struct {
+	*unversioned.DiscoveryClient
 	*legacy_unversioned.LegacyClient
 	*extensions_unversioned.ExtensionsClient
 }
@@ -42,6 +44,11 @@ func (c *Clientset) Legacy() legacy_unversioned.LegacyInterface {
 // Extensions retrieves the ExtensionsClient
 func (c *Clientset) Extensions() extensions_unversioned.ExtensionsInterface {
 	return c.ExtensionsClient
+}
+
+// Discovery retrieves the DiscoveryClient
+func (c *Clientset) Discovery() unversioned.DiscoveryInterface {
+	return c.DiscoveryClient
 }
 
 // NewForConfig creates a new Clientset for the given config.
@@ -57,6 +64,10 @@ func NewForConfig(c *unversioned.Config) (*Clientset, error) {
 		return nil, err
 	}
 
+	clientset.DiscoveryClient, err = unversioned.NewDiscoveryClientForConfig(c)
+	if err != nil {
+		return nil, err
+	}
 	return &clientset, nil
 }
 
@@ -67,6 +78,7 @@ func NewForConfigOrDie(c *unversioned.Config) *Clientset {
 	clientset.LegacyClient = legacy_unversioned.NewForConfigOrDie(c)
 	clientset.ExtensionsClient = extensions_unversioned.NewForConfigOrDie(c)
 
+	clientset.DiscoveryClient = unversioned.NewDiscoveryClientForConfigOrDie(c)
 	return &clientset
 }
 
@@ -76,5 +88,6 @@ func New(c *unversioned.RESTClient) *Clientset {
 	clientset.LegacyClient = legacy_unversioned.New(c)
 	clientset.ExtensionsClient = extensions_unversioned.New(c)
 
+	clientset.DiscoveryClient = unversioned.NewDiscoveryClient(c)
 	return &clientset
 }

--- a/pkg/client/testing/fake/clientset.go
+++ b/pkg/client/testing/fake/clientset.go
@@ -24,6 +24,7 @@ import (
 	extensions_unversioned_fake "k8s.io/kubernetes/pkg/client/typed/generated/extensions/unversioned/fake"
 	legacy_unversioned "k8s.io/kubernetes/pkg/client/typed/generated/legacy/unversioned"
 	legacy_unversioned_fake "k8s.io/kubernetes/pkg/client/typed/generated/legacy/unversioned/fake"
+	"k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch"
 )
@@ -60,4 +61,8 @@ func (c *Clientset) Legacy() legacy_unversioned.LegacyInterface {
 
 func (c *Clientset) Extensions() extensions_unversioned.ExtensionsInterface {
 	return &extensions_unversioned_fake.FakeExtensions{&c.Fake}
+}
+
+func (c *Clientset) Discovery() unversioned.DiscoveryInterface {
+	return &FakeDiscovery{&c.Fake}
 }

--- a/pkg/client/testing/fake/discovery.go
+++ b/pkg/client/testing/fake/discovery.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"github.com/emicklei/go-restful/swagger"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/client/testing/core"
+	"k8s.io/kubernetes/pkg/version"
+)
+
+type FakeDiscovery struct {
+	*core.Fake
+}
+
+func (c *FakeDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*unversioned.APIResourceList, error) {
+	action := core.ActionImpl{
+		Verb:     "get",
+		Resource: "resource",
+	}
+	c.Invokes(action, nil)
+	return c.Resources[groupVersion], nil
+}
+
+func (c *FakeDiscovery) ServerResources() (map[string]*unversioned.APIResourceList, error) {
+	action := core.ActionImpl{
+		Verb:     "get",
+		Resource: "resource",
+	}
+	c.Invokes(action, nil)
+	return c.Resources, nil
+}
+
+func (c *FakeDiscovery) ServerGroups() (*unversioned.APIGroupList, error) {
+	return nil, nil
+}
+
+func (c *FakeDiscovery) ServerVersion() (*version.Info, error) {
+	action := core.ActionImpl{}
+	action.Verb = "get"
+	action.Resource = "version"
+
+	c.Invokes(action, nil)
+	versionInfo := version.Get()
+	return &versionInfo, nil
+}
+
+func (c *FakeDiscovery) SwaggerSchema(version unversioned.GroupVersion) (*swagger.ApiDeclaration, error) {
+	action := core.ActionImpl{}
+	action.Verb = "get"
+	if version == v1.SchemeGroupVersion {
+		action.Resource = "/swaggerapi/api/" + version.Version
+	} else {
+		action.Resource = "/swaggerapi/apis/" + version.Group + "/" + version.Version
+	}
+
+	c.Invokes(action, nil)
+	return &swagger.ApiDeclaration{}, nil
+}

--- a/pkg/client/unversioned/discovery_client.go
+++ b/pkg/client/unversioned/discovery_client.go
@@ -214,13 +214,29 @@ func setDiscoveryDefaults(config *Config) error {
 	return nil
 }
 
-// NewDiscoveryClient creates a new DiscoveryClient for the given config. This client
+// NewDiscoveryClientForConfig creates a new DiscoveryClient for the given config. This client
 // can be used to discover supported resources in the API server.
-func NewDiscoveryClient(c *Config) (*DiscoveryClient, error) {
+func NewDiscoveryClientForConfig(c *Config) (*DiscoveryClient, error) {
 	config := *c
 	if err := setDiscoveryDefaults(&config); err != nil {
 		return nil, err
 	}
 	client, err := UnversionedRESTClientFor(&config)
 	return &DiscoveryClient{client}, err
+}
+
+// NewDiscoveryClientForConfig creates a new DiscoveryClient for the given config. If
+// there is an error, it panics.
+func NewDiscoveryClientForConfigOrDie(c *Config) *DiscoveryClient {
+	client, err := NewDiscoveryClientForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return client
+
+}
+
+// New creates a new DiscoveryClient for the given RESTClient.
+func NewDiscoveryClient(c *RESTClient) *DiscoveryClient {
+	return &DiscoveryClient{c}
 }

--- a/pkg/client/unversioned/helper.go
+++ b/pkg/client/unversioned/helper.go
@@ -150,7 +150,7 @@ func New(c *Config) (*Client, error) {
 	}
 
 	discoveryConfig := *c
-	discoveryClient, err := NewDiscoveryClient(&discoveryConfig)
+	discoveryClient, err := NewDiscoveryClientForConfig(&discoveryConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Users can call clientset.Discovery() to get the unversioned.DiscoveryClientInterface.

This PR is needed by refactoring more controllers to use the clientset.
