### PR TITLE
Fix docker version errors in integration tests.

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -32,7 +32,6 @@ import (
 	"sync"
 	"time"
 
-	docker "github.com/fsouza/go-dockerclient"
 	kubeletapp "k8s.io/kubernetes/cmd/kubelet/app"
 	"k8s.io/kubernetes/pkg/api"
 	apierrors "k8s.io/kubernetes/pkg/api/errors"
@@ -201,7 +200,6 @@ func startComponents(firstManifestURL, secondManifestURL string) (string, string
 	testRootDir := integration.MakeTempDirOrDie("kubelet_integ_1.", "")
 	configFilePath := integration.MakeTempDirOrDie("config", testRootDir)
 	glog.Infof("Using %s as root dir for kubelet #1", testRootDir)
-	fakeDocker1.VersionInfo = docker.Env{"ApiVersion=1.20"}
 	cm := cm.NewStubContainerManager()
 	kcfg := kubeletapp.SimpleKubelet(
 		cl,
@@ -234,7 +232,6 @@ func startComponents(firstManifestURL, secondManifestURL string) (string, string
 	// have a place they can schedule.
 	testRootDir = integration.MakeTempDirOrDie("kubelet_integ_2.", "")
 	glog.Infof("Using %s as root dir for kubelet #2", testRootDir)
-	fakeDocker2.VersionInfo = docker.Env{"ApiVersion=1.20"}
 
 	kcfg = kubeletapp.SimpleKubelet(
 		cl,

--- a/pkg/kubelet/dockertools/fake_docker_client.go
+++ b/pkg/kubelet/dockertools/fake_docker_client.go
@@ -57,7 +57,7 @@ type FakeDockerClient struct {
 
 func NewFakeDockerClient() *FakeDockerClient {
 	return &FakeDockerClient{
-		VersionInfo:   docker.Env{"Version=1.1.3", "ApiVersion=1.15"},
+		VersionInfo:   docker.Env{"Version=1.8.1", "ApiVersion=1.20"},
 		Errors:        make(map[string]error),
 		RemovedImages: sets.String{},
 		ContainerMap:  make(map[string]*docker.Container),


### PR DESCRIPTION
When running integration tests (./hack/test-integration.sh) locally, logs are having several docker version errors:

```
E0129 11:33:48.661102    7935 manager.go:1017] docker: failed to parse docker server version "":  is not in dotted-tri format
E0129 11:33:48.661272    7935 kubelet.go:2573] Container runtime sanity check failed: docker: failed to parse docker server version "":  is not in dotted-tri format
E0129 11:33:48.667917    7935 manager.go:1017] docker: failed to parse docker server version "":  is not in dotted-tri format
E0129 11:33:48.668023    7935 kubelet.go:2573] Container runtime sanity check failed: docker: failed to parse docker server version "":  is not in dotted-tri format
```

The reason is that fake docker client is leaving docker's Version empty and causing these errors. One way is to fix as in this PR. Another way would be to remove setting VersionInfo as is currently done at 2 places in cmd/integration/integration.go as fake client anyway sets them in NewFakeDockerClient. 
