### PR TITLE
rkt: If resource's limit is empty, populate it with request,and vice versa

### DIFF
--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -262,17 +262,18 @@ func setIsolators(app *appctypes.App, c *api.Container, ctx *api.SecurityContext
 		request string
 	}
 
-	resources := make(map[api.ResourceName]resource)
+	// If limit is empty, populate it with request and vice versa.
+	resources := make(map[api.ResourceName]*resource)
 	for name, quantity := range c.Resources.Limits {
-		resources[name] = resource{limit: quantity.String()}
+		resources[name] = &resource{limit: quantity.String(), request: quantity.String()}
 	}
 	for name, quantity := range c.Resources.Requests {
 		r, ok := resources[name]
-		if !ok {
-			r = resource{}
+		if ok {
+			r.request = quantity.String()
+			continue
 		}
-		r.request = quantity.String()
-		resources[name] = r
+		resources[name] = &resource{limit: quantity.String(), request: quantity.String()}
 	}
 
 	for name, res := range resources {

--- a/pkg/kubelet/rkt/rkt_test.go
+++ b/pkg/kubelet/rkt/rkt_test.go
@@ -867,8 +867,8 @@ func TestSetApp(t *testing.T) {
 				Args:       []string{"hello", "world"},
 				WorkingDir: tmpDir,
 				Resources: api.ResourceRequirements{
-					Limits:   api.ResourceList{"cpu": resource.MustParse("50m"), "memory": resource.MustParse("50M")},
-					Requests: api.ResourceList{"cpu": resource.MustParse("5m"), "memory": resource.MustParse("5M")},
+					Limits:   api.ResourceList{"cpu": resource.MustParse("50m")},
+					Requests: api.ResourceList{"memory": resource.MustParse("5M")},
 				},
 			},
 			opts: &kubecontainer.RunContainerOptions{
@@ -912,8 +912,8 @@ func TestSetApp(t *testing.T) {
 				Isolators: []appctypes.Isolator{
 					generateCapRetainIsolator(t, "CAP_SYS_CHROOT", "CAP_SYS_BOOT"),
 					generateCapRevokeIsolator(t, "CAP_SETUID", "CAP_SETGID"),
-					generateCPUIsolator(t, "5m", "50m"),
-					generateMemoryIsolator(t, "5M", "50M"),
+					generateCPUIsolator(t, "50m", "50m"),
+					generateMemoryIsolator(t, "5M", "5M"),
 				},
 			},
 		},


### PR DESCRIPTION
This is previously fixed by https://github.com/kubernetes/kubernetes/pull/14173
But was introduced again by https://github.com/kubernetes/kubernetes/pull/19428

Also modified a test case to catch the issue in the future.

Also ref https://github.com/appc/spec/issues/562

cc @jonboulle @sjpotter @yujuhong @Random-Liu 
