### PR TITLE
Fix formatting errors when printing self signed cert paths.

### DIFF
--- a/pkg/genericapiserver/genericapiserver.go
+++ b/pkg/genericapiserver/genericapiserver.go
@@ -612,7 +612,7 @@ func (s *GenericAPIServer) Run(options *ServerRunOptions) {
 			if err := util.GenerateSelfSignedCert(s.ClusterIP.String(), options.TLSCertFile, options.TLSPrivateKeyFile, alternateIPs, alternateDNS); err != nil {
 				glog.Errorf("Unable to generate self signed cert: %v", err)
 			} else {
-				glog.Infof("Using self-signed cert (%options, %options)", options.TLSCertFile, options.TLSPrivateKeyFile)
+				glog.Infof("Using self-signed cert (%s, %s)", options.TLSCertFile, options.TLSPrivateKeyFile)
 			}
 		}
 


### PR DESCRIPTION
Running ./hack/test-update-storage-objects.sh shows some weird lines:

```
I0129 13:28:36.772434   18283 genericapiserver.go:615] Using self-signed cert (%!o(string=/tmp/apiserver.crt)ptions, %!o(string=/tmp/apiserver.key)ptions)
```

After this PR, it is shown as:

```
I0129 14:15:27.982534   30028 genericapiserver.go:615] Using self-signed cert (/tmp/apiserver.crt, /tmp/apiserver.key)
```
