### PR TITLE
Change ingress and componentstatus plural form

### DIFF
--- a/cmd/libs/go2idl/client-gen/generators/client-generator.go
+++ b/cmd/libs/go2idl/client-gen/generators/client-generator.go
@@ -55,9 +55,7 @@ type ClientGenArgs struct {
 // NameSystems returns the name system used by the generators in this package.
 func NameSystems() namer.NameSystems {
 	pluralExceptions := map[string]string{
-		"Endpoints":       "Endpoints",
-		"ComponentStatus": "ComponentStatus",
-		"Ingress":         "Ingress",
+		"Endpoints": "Endpoints",
 	}
 	return namer.NameSystems{
 		"public":             namer.NewPublicNamer(0),

--- a/pkg/client/typed/generated/extensions/unversioned/extensions_client.go
+++ b/pkg/client/typed/generated/extensions/unversioned/extensions_client.go
@@ -26,7 +26,7 @@ type ExtensionsInterface interface {
 	DaemonSetsGetter
 	DeploymentsGetter
 	HorizontalPodAutoscalersGetter
-	IngressGetter
+	IngressesGetter
 	JobsGetter
 	ScalesGetter
 	ThirdPartyResourcesGetter
@@ -49,8 +49,8 @@ func (c *ExtensionsClient) HorizontalPodAutoscalers(namespace string) Horizontal
 	return newHorizontalPodAutoscalers(c, namespace)
 }
 
-func (c *ExtensionsClient) Ingress(namespace string) IngressInterface {
-	return newIngress(c, namespace)
+func (c *ExtensionsClient) Ingresses(namespace string) IngressInterface {
+	return newIngresses(c, namespace)
 }
 
 func (c *ExtensionsClient) Jobs(namespace string) JobInterface {

--- a/pkg/client/typed/generated/extensions/unversioned/fake/fake_extensions_client.go
+++ b/pkg/client/typed/generated/extensions/unversioned/fake/fake_extensions_client.go
@@ -37,8 +37,8 @@ func (c *FakeExtensions) HorizontalPodAutoscalers(namespace string) unversioned.
 	return &FakeHorizontalPodAutoscalers{c, namespace}
 }
 
-func (c *FakeExtensions) Ingress(namespace string) unversioned.IngressInterface {
-	return &FakeIngress{c, namespace}
+func (c *FakeExtensions) Ingresses(namespace string) unversioned.IngressInterface {
+	return &FakeIngresses{c, namespace}
 }
 
 func (c *FakeExtensions) Jobs(namespace string) unversioned.JobInterface {

--- a/pkg/client/typed/generated/extensions/unversioned/fake/fake_ingress.go
+++ b/pkg/client/typed/generated/extensions/unversioned/fake/fake_ingress.go
@@ -24,15 +24,15 @@ import (
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
-// FakeIngress implements IngressInterface
-type FakeIngress struct {
+// FakeIngresses implements IngressInterface
+type FakeIngresses struct {
 	Fake *FakeExtensions
 	ns   string
 }
 
-func (c *FakeIngress) Create(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
+func (c *FakeIngresses) Create(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewCreateAction("ingress", c.ns, ingress), &extensions.Ingress{})
+		Invokes(core.NewCreateAction("ingresses", c.ns, ingress), &extensions.Ingress{})
 
 	if obj == nil {
 		return nil, err
@@ -40,9 +40,9 @@ func (c *FakeIngress) Create(ingress *extensions.Ingress) (result *extensions.In
 	return obj.(*extensions.Ingress), err
 }
 
-func (c *FakeIngress) Update(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
+func (c *FakeIngresses) Update(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewUpdateAction("ingress", c.ns, ingress), &extensions.Ingress{})
+		Invokes(core.NewUpdateAction("ingresses", c.ns, ingress), &extensions.Ingress{})
 
 	if obj == nil {
 		return nil, err
@@ -50,9 +50,9 @@ func (c *FakeIngress) Update(ingress *extensions.Ingress) (result *extensions.In
 	return obj.(*extensions.Ingress), err
 }
 
-func (c *FakeIngress) UpdateStatus(ingress *extensions.Ingress) (*extensions.Ingress, error) {
+func (c *FakeIngresses) UpdateStatus(ingress *extensions.Ingress) (*extensions.Ingress, error) {
 	obj, err := c.Fake.
-		Invokes(core.NewUpdateSubresourceAction("ingress", "status", c.ns, ingress), &extensions.Ingress{})
+		Invokes(core.NewUpdateSubresourceAction("ingresses", "status", c.ns, ingress), &extensions.Ingress{})
 
 	if obj == nil {
 		return nil, err
@@ -60,23 +60,23 @@ func (c *FakeIngress) UpdateStatus(ingress *extensions.Ingress) (*extensions.Ing
 	return obj.(*extensions.Ingress), err
 }
 
-func (c *FakeIngress) Delete(name string, options *api.DeleteOptions) error {
+func (c *FakeIngresses) Delete(name string, options *api.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(core.NewDeleteAction("ingress", c.ns, name), &extensions.Ingress{})
+		Invokes(core.NewDeleteAction("ingresses", c.ns, name), &extensions.Ingress{})
 
 	return err
 }
 
-func (c *FakeIngress) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+func (c *FakeIngresses) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
 
 	_, err := c.Fake.Invokes(action, &extensions.IngressList{})
 	return err
 }
 
-func (c *FakeIngress) Get(name string) (result *extensions.Ingress, err error) {
+func (c *FakeIngresses) Get(name string) (result *extensions.Ingress, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewGetAction("ingress", c.ns, name), &extensions.Ingress{})
+		Invokes(core.NewGetAction("ingresses", c.ns, name), &extensions.Ingress{})
 
 	if obj == nil {
 		return nil, err
@@ -84,9 +84,9 @@ func (c *FakeIngress) Get(name string) (result *extensions.Ingress, err error) {
 	return obj.(*extensions.Ingress), err
 }
 
-func (c *FakeIngress) List(opts api.ListOptions) (result *extensions.IngressList, err error) {
+func (c *FakeIngresses) List(opts api.ListOptions) (result *extensions.IngressList, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewListAction("ingress", c.ns, opts), &extensions.IngressList{})
+		Invokes(core.NewListAction("ingresses", c.ns, opts), &extensions.IngressList{})
 
 	if obj == nil {
 		return nil, err
@@ -105,9 +105,9 @@ func (c *FakeIngress) List(opts api.ListOptions) (result *extensions.IngressList
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested ingress.
-func (c *FakeIngress) Watch(opts api.ListOptions) (watch.Interface, error) {
+// Watch returns a watch.Interface that watches the requested ingresses.
+func (c *FakeIngresses) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(core.NewWatchAction("ingress", c.ns, opts))
+		InvokesWatch(core.NewWatchAction("ingresses", c.ns, opts))
 
 }

--- a/pkg/client/typed/generated/extensions/unversioned/ingress.go
+++ b/pkg/client/typed/generated/extensions/unversioned/ingress.go
@@ -22,10 +22,10 @@ import (
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
-// IngressGetter has a method to return a IngressInterface.
+// IngressesGetter has a method to return a IngressInterface.
 // A group's client should implement this interface.
-type IngressGetter interface {
-	Ingress(namespace string) IngressInterface
+type IngressesGetter interface {
+	Ingresses(namespace string) IngressInterface
 }
 
 // IngressInterface has methods to work with Ingress resources.
@@ -41,26 +41,26 @@ type IngressInterface interface {
 	IngressExpansion
 }
 
-// ingress implements IngressInterface
-type ingress struct {
+// ingresses implements IngressInterface
+type ingresses struct {
 	client *ExtensionsClient
 	ns     string
 }
 
-// newIngress returns a Ingress
-func newIngress(c *ExtensionsClient, namespace string) *ingress {
-	return &ingress{
+// newIngresses returns a Ingresses
+func newIngresses(c *ExtensionsClient, namespace string) *ingresses {
+	return &ingresses{
 		client: c,
 		ns:     namespace,
 	}
 }
 
 // Create takes the representation of a ingress and creates it.  Returns the server's representation of the ingress, and an error, if there is any.
-func (c *ingress) Create(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
+func (c *ingresses) Create(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
 	result = &extensions.Ingress{}
 	err = c.client.Post().
 		Namespace(c.ns).
-		Resource("ingress").
+		Resource("ingresses").
 		Body(ingress).
 		Do().
 		Into(result)
@@ -68,11 +68,11 @@ func (c *ingress) Create(ingress *extensions.Ingress) (result *extensions.Ingres
 }
 
 // Update takes the representation of a ingress and updates it. Returns the server's representation of the ingress, and an error, if there is any.
-func (c *ingress) Update(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
+func (c *ingresses) Update(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
 	result = &extensions.Ingress{}
 	err = c.client.Put().
 		Namespace(c.ns).
-		Resource("ingress").
+		Resource("ingresses").
 		Name(ingress.Name).
 		Body(ingress).
 		Do().
@@ -80,11 +80,11 @@ func (c *ingress) Update(ingress *extensions.Ingress) (result *extensions.Ingres
 	return
 }
 
-func (c *ingress) UpdateStatus(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
+func (c *ingresses) UpdateStatus(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
 	result = &extensions.Ingress{}
 	err = c.client.Put().
 		Namespace(c.ns).
-		Resource("ingress").
+		Resource("ingresses").
 		Name(ingress.Name).
 		SubResource("status").
 		Body(ingress).
@@ -94,10 +94,10 @@ func (c *ingress) UpdateStatus(ingress *extensions.Ingress) (result *extensions.
 }
 
 // Delete takes name of the ingress and deletes it. Returns an error if one occurs.
-func (c *ingress) Delete(name string, options *api.DeleteOptions) error {
+func (c *ingresses) Delete(name string, options *api.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("ingress").
+		Resource("ingresses").
 		Name(name).
 		Body(options).
 		Do().
@@ -105,10 +105,10 @@ func (c *ingress) Delete(name string, options *api.DeleteOptions) error {
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *ingress) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+func (c *ingresses) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("ingress").
+		Resource("ingresses").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).
 		Do().
@@ -116,35 +116,35 @@ func (c *ingress) DeleteCollection(options *api.DeleteOptions, listOptions api.L
 }
 
 // Get takes name of the ingress, and returns the corresponding ingress object, and an error if there is any.
-func (c *ingress) Get(name string) (result *extensions.Ingress, err error) {
+func (c *ingresses) Get(name string) (result *extensions.Ingress, err error) {
 	result = &extensions.Ingress{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("ingress").
+		Resource("ingresses").
 		Name(name).
 		Do().
 		Into(result)
 	return
 }
 
-// List takes label and field selectors, and returns the list of Ingress that match those selectors.
-func (c *ingress) List(opts api.ListOptions) (result *extensions.IngressList, err error) {
+// List takes label and field selectors, and returns the list of Ingresses that match those selectors.
+func (c *ingresses) List(opts api.ListOptions) (result *extensions.IngressList, err error) {
 	result = &extensions.IngressList{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("ingress").
+		Resource("ingresses").
 		VersionedParams(&opts, api.Scheme).
 		Do().
 		Into(result)
 	return
 }
 
-// Watch returns a watch.Interface that watches the requested ingress.
-func (c *ingress) Watch(opts api.ListOptions) (watch.Interface, error) {
+// Watch returns a watch.Interface that watches the requested ingresses.
+func (c *ingresses) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.client.Get().
 		Prefix("watch").
 		Namespace(c.ns).
-		Resource("ingress").
+		Resource("ingresses").
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }

--- a/pkg/client/typed/generated/legacy/unversioned/componentstatus.go
+++ b/pkg/client/typed/generated/legacy/unversioned/componentstatus.go
@@ -21,10 +21,10 @@ import (
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
-// ComponentStatusGetter has a method to return a ComponentStatusInterface.
+// ComponentStatusesGetter has a method to return a ComponentStatusInterface.
 // A group's client should implement this interface.
-type ComponentStatusGetter interface {
-	ComponentStatus() ComponentStatusInterface
+type ComponentStatusesGetter interface {
+	ComponentStatuses() ComponentStatusInterface
 }
 
 // ComponentStatusInterface has methods to work with ComponentStatus resources.
@@ -39,23 +39,23 @@ type ComponentStatusInterface interface {
 	ComponentStatusExpansion
 }
 
-// componentStatus implements ComponentStatusInterface
-type componentStatus struct {
+// componentStatuses implements ComponentStatusInterface
+type componentStatuses struct {
 	client *LegacyClient
 }
 
-// newComponentStatus returns a ComponentStatus
-func newComponentStatus(c *LegacyClient) *componentStatus {
-	return &componentStatus{
+// newComponentStatuses returns a ComponentStatuses
+func newComponentStatuses(c *LegacyClient) *componentStatuses {
+	return &componentStatuses{
 		client: c,
 	}
 }
 
 // Create takes the representation of a componentStatus and creates it.  Returns the server's representation of the componentStatus, and an error, if there is any.
-func (c *componentStatus) Create(componentStatus *api.ComponentStatus) (result *api.ComponentStatus, err error) {
+func (c *componentStatuses) Create(componentStatus *api.ComponentStatus) (result *api.ComponentStatus, err error) {
 	result = &api.ComponentStatus{}
 	err = c.client.Post().
-		Resource("componentstatus").
+		Resource("componentstatuses").
 		Body(componentStatus).
 		Do().
 		Into(result)
@@ -63,10 +63,10 @@ func (c *componentStatus) Create(componentStatus *api.ComponentStatus) (result *
 }
 
 // Update takes the representation of a componentStatus and updates it. Returns the server's representation of the componentStatus, and an error, if there is any.
-func (c *componentStatus) Update(componentStatus *api.ComponentStatus) (result *api.ComponentStatus, err error) {
+func (c *componentStatuses) Update(componentStatus *api.ComponentStatus) (result *api.ComponentStatus, err error) {
 	result = &api.ComponentStatus{}
 	err = c.client.Put().
-		Resource("componentstatus").
+		Resource("componentstatuses").
 		Name(componentStatus.Name).
 		Body(componentStatus).
 		Do().
@@ -75,9 +75,9 @@ func (c *componentStatus) Update(componentStatus *api.ComponentStatus) (result *
 }
 
 // Delete takes name of the componentStatus and deletes it. Returns an error if one occurs.
-func (c *componentStatus) Delete(name string, options *api.DeleteOptions) error {
+func (c *componentStatuses) Delete(name string, options *api.DeleteOptions) error {
 	return c.client.Delete().
-		Resource("componentstatus").
+		Resource("componentstatuses").
 		Name(name).
 		Body(options).
 		Do().
@@ -85,9 +85,9 @@ func (c *componentStatus) Delete(name string, options *api.DeleteOptions) error 
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *componentStatus) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+func (c *componentStatuses) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
-		Resource("componentstatus").
+		Resource("componentstatuses").
 		VersionedParams(&listOptions, api.Scheme).
 		Body(options).
 		Do().
@@ -95,32 +95,32 @@ func (c *componentStatus) DeleteCollection(options *api.DeleteOptions, listOptio
 }
 
 // Get takes name of the componentStatus, and returns the corresponding componentStatus object, and an error if there is any.
-func (c *componentStatus) Get(name string) (result *api.ComponentStatus, err error) {
+func (c *componentStatuses) Get(name string) (result *api.ComponentStatus, err error) {
 	result = &api.ComponentStatus{}
 	err = c.client.Get().
-		Resource("componentstatus").
+		Resource("componentstatuses").
 		Name(name).
 		Do().
 		Into(result)
 	return
 }
 
-// List takes label and field selectors, and returns the list of ComponentStatus that match those selectors.
-func (c *componentStatus) List(opts api.ListOptions) (result *api.ComponentStatusList, err error) {
+// List takes label and field selectors, and returns the list of ComponentStatuses that match those selectors.
+func (c *componentStatuses) List(opts api.ListOptions) (result *api.ComponentStatusList, err error) {
 	result = &api.ComponentStatusList{}
 	err = c.client.Get().
-		Resource("componentstatus").
+		Resource("componentstatuses").
 		VersionedParams(&opts, api.Scheme).
 		Do().
 		Into(result)
 	return
 }
 
-// Watch returns a watch.Interface that watches the requested componentStatus.
-func (c *componentStatus) Watch(opts api.ListOptions) (watch.Interface, error) {
+// Watch returns a watch.Interface that watches the requested componentStatuses.
+func (c *componentStatuses) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.client.Get().
 		Prefix("watch").
-		Resource("componentstatus").
+		Resource("componentstatuses").
 		VersionedParams(&opts, api.Scheme).
 		Watch()
 }

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_componentstatus.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_componentstatus.go
@@ -23,54 +23,54 @@ import (
 	watch "k8s.io/kubernetes/pkg/watch"
 )
 
-// FakeComponentStatus implements ComponentStatusInterface
-type FakeComponentStatus struct {
+// FakeComponentStatuses implements ComponentStatusInterface
+type FakeComponentStatuses struct {
 	Fake *FakeLegacy
 }
 
-func (c *FakeComponentStatus) Create(componentStatus *api.ComponentStatus) (result *api.ComponentStatus, err error) {
+func (c *FakeComponentStatuses) Create(componentStatus *api.ComponentStatus) (result *api.ComponentStatus, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewRootCreateAction("componentstatus", componentStatus), &api.ComponentStatus{})
+		Invokes(core.NewRootCreateAction("componentstatuses", componentStatus), &api.ComponentStatus{})
 	if obj == nil {
 		return nil, err
 	}
 	return obj.(*api.ComponentStatus), err
 }
 
-func (c *FakeComponentStatus) Update(componentStatus *api.ComponentStatus) (result *api.ComponentStatus, err error) {
+func (c *FakeComponentStatuses) Update(componentStatus *api.ComponentStatus) (result *api.ComponentStatus, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewRootUpdateAction("componentstatus", componentStatus), &api.ComponentStatus{})
+		Invokes(core.NewRootUpdateAction("componentstatuses", componentStatus), &api.ComponentStatus{})
 	if obj == nil {
 		return nil, err
 	}
 	return obj.(*api.ComponentStatus), err
 }
 
-func (c *FakeComponentStatus) Delete(name string, options *api.DeleteOptions) error {
+func (c *FakeComponentStatuses) Delete(name string, options *api.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(core.NewRootDeleteAction("componentstatus", name), &api.ComponentStatus{})
+		Invokes(core.NewRootDeleteAction("componentstatuses", name), &api.ComponentStatus{})
 	return err
 }
 
-func (c *FakeComponentStatus) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+func (c *FakeComponentStatuses) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	action := core.NewRootDeleteCollectionAction("events", listOptions)
 
 	_, err := c.Fake.Invokes(action, &api.ComponentStatusList{})
 	return err
 }
 
-func (c *FakeComponentStatus) Get(name string) (result *api.ComponentStatus, err error) {
+func (c *FakeComponentStatuses) Get(name string) (result *api.ComponentStatus, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewRootGetAction("componentstatus", name), &api.ComponentStatus{})
+		Invokes(core.NewRootGetAction("componentstatuses", name), &api.ComponentStatus{})
 	if obj == nil {
 		return nil, err
 	}
 	return obj.(*api.ComponentStatus), err
 }
 
-func (c *FakeComponentStatus) List(opts api.ListOptions) (result *api.ComponentStatusList, err error) {
+func (c *FakeComponentStatuses) List(opts api.ListOptions) (result *api.ComponentStatusList, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewRootListAction("componentstatus", opts), &api.ComponentStatusList{})
+		Invokes(core.NewRootListAction("componentstatuses", opts), &api.ComponentStatusList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -88,8 +88,8 @@ func (c *FakeComponentStatus) List(opts api.ListOptions) (result *api.ComponentS
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested componentStatus.
-func (c *FakeComponentStatus) Watch(opts api.ListOptions) (watch.Interface, error) {
+// Watch returns a watch.Interface that watches the requested componentStatuses.
+func (c *FakeComponentStatuses) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(core.NewRootWatchAction("componentstatus", opts))
+		InvokesWatch(core.NewRootWatchAction("componentstatuses", opts))
 }

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_legacy_client.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_legacy_client.go
@@ -25,8 +25,8 @@ type FakeLegacy struct {
 	*core.Fake
 }
 
-func (c *FakeLegacy) ComponentStatus() unversioned.ComponentStatusInterface {
-	return &FakeComponentStatus{c}
+func (c *FakeLegacy) ComponentStatuses() unversioned.ComponentStatusInterface {
+	return &FakeComponentStatuses{c}
 }
 
 func (c *FakeLegacy) Endpoints(namespace string) unversioned.EndpointsInterface {

--- a/pkg/client/typed/generated/legacy/unversioned/legacy_client.go
+++ b/pkg/client/typed/generated/legacy/unversioned/legacy_client.go
@@ -23,7 +23,7 @@ import (
 )
 
 type LegacyInterface interface {
-	ComponentStatusGetter
+	ComponentStatusesGetter
 	EndpointsGetter
 	EventsGetter
 	LimitRangesGetter
@@ -45,8 +45,8 @@ type LegacyClient struct {
 	*unversioned.RESTClient
 }
 
-func (c *LegacyClient) ComponentStatus() ComponentStatusInterface {
-	return newComponentStatus(c)
+func (c *LegacyClient) ComponentStatuses() ComponentStatusInterface {
+	return newComponentStatuses(c)
 }
 
 func (c *LegacyClient) Endpoints(namespace string) EndpointsInterface {


### PR DESCRIPTION
The plural form should respect whatever is encoded in the API server's service path, so we need "ingresses" and "componentstatuses".
