### PR TITLE
Extract On-Call docs out of wiki

### DIFF
--- a/docs/devel/README.md
+++ b/docs/devel/README.md
@@ -75,6 +75,9 @@ Guide](../admin/README.md).
 * **Coding Conventions** ([coding-conventions.md](coding-conventions.md)):
   Coding style advice for contributors.
 
+* **Document Conventions** ([how-to-doc.md](how-to-doc.md))
+  Document style advice for contributors.
+
 * **Running a cluster locally** ([running-locally.md](running-locally.md)):
   A fast and lightweight local cluster deployment for developement.
 

--- a/docs/devel/README.md
+++ b/docs/devel/README.md
@@ -48,6 +48,8 @@ Guide](../admin/README.md).
 
 * **Pull Request Process** ([pull-requests.md](pull-requests.md)): When and why pull requests are closed.
 
+* **Kubernetes On-Call Rotations** ([on-call-rotations.md](on-call-rotations.md)): Descriptions of on-call rotations for build and end-user support
+
 * **Faster PR reviews** ([faster_reviews.md](faster_reviews.md)): How to get faster PR reviews.
 
 * **Getting Recent Builds** ([getting-builds.md](getting-builds.md)): How to get recent builds including the latest builds that pass CI.

--- a/docs/devel/on-call-build-cop.md
+++ b/docs/devel/on-call-build-cop.md
@@ -1,0 +1,105 @@
+<!-- BEGIN MUNGE: UNVERSIONED_WARNING -->
+
+<!-- BEGIN STRIP_FOR_RELEASE -->
+
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+
+<h2>PLEASE NOTE: This document applies to the HEAD of the source tree</h2>
+
+If you are using a released version of Kubernetes, you should
+refer to the docs that go with that version.
+
+Documentation for other releases can be found at
+[releases.k8s.io](http://releases.k8s.io).
+</strong>
+--
+
+<!-- END STRIP_FOR_RELEASE -->
+
+<!-- END MUNGE: UNVERSIONED_WARNING -->
+Kubernetes "Github and Build-cop" Rotation
+==========================================
+
+Preqrequisites
+--------------
+
+* Ensure you have [write access to http://github.com/kubernetes/kubernetes](https://github.com/orgs/kubernetes/teams/kubernetes-maintainers)
+  * Test your admin access by e.g. adding a label to an issue.
+
+Traffic sources and responsibilities
+------------------------------------
+
+* GitHub [https://github.com/kubernetes/kubernetes/issues](https://github.com/kubernetes/kubernetes/issues) and [https://github.com/kubernetes/kubernetes/pulls](https://github.com/kubernetes/kubernetes/pulls):  Your job is to be the first responder to all new issues and PRs.  If you are not equipped to do this (which is fine!), it is your job to seek guidance!
+  * Support issues should be closed and redirected to Stackoverflow (see example response below).
+  * All incoming issues should be tagged with a team label (team/{api,ux,control-plane,node,cluster,csi,redhat,mesosphere,gke,release-infra,test-infra,none}); for issues that overlap teams, you can use multiple team labels
+    * There is a related concept of "Github teams" which allow you to @ mention a set of people; feel free to @ mention a Github team if you wish, but this is not a substitute for adding a team/* label, which is required
+      * [Google teams](https://github.com/orgs/kubernetes/teams?utf8=%E2%9C%93&query=goog-)
+      * [Redhat teams](https://github.com/orgs/kubernetes/teams?utf8=%E2%9C%93&query=rh-)
+      * [SIGs](https://github.com/orgs/kubernetes/teams?utf8=%E2%9C%93&query=sig-)
+    * If the issue is reporting broken builds, broken e2e tests, or other obvious P0 issues, label the issue with priority/P0 and assign it to someone. This is the only situation in which you should add a priority/* label
+      * non-P0 issues do not need a reviewer assigned initially
+    * Assign any issues related to Vagrant to @derekwaynecarr (and @mention him in the issue)
+  * All incoming PRs should be assigned a reviewer.
+    * unless it is a WIP (Work in Progress), RFC (Request for Comments), or design proposal.
+    * An auto-assigner [should do this for you] (https://github.com/kubernetes/kubernetes/pull/12365/files)
+    * When in doubt, choose a TL or team maintainer of the most relevant team; they can delegate
+  * Keep in mind that you can @ mention people in an issue/PR to bring it to their attention without assigning it to them. You can also @ mention github teams, such as @kubernetes/goog-ux or @kubernetes/kubectl
+  * If you need help triaging an issue or PR, consult with (or assign it to) @brendandburns, @thockin, @bgrant0607, @quinton-hoole, @davidopp, @dchen1107, @lavalamp (all U.S. Pacific Time) or @fgrzadkowski (Central European Time).
+  * At the beginning of your shift, please add team/* labels to any issues that have fallen through the cracks and don't have one. Likewise, be fair to the next person in rotation: try to ensure that every issue that gets filed while you are on duty is handled. The Github query to find issues with no team/* label is: [here](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+-label%3Ateam%2Fcontrol-plane+-label%3Ateam%2Fmesosphere+-label%3Ateam%2Fredhat+-label%3Ateam%2Frelease-infra+-label%3Ateam%2Fnone+-label%3Ateam%2Fnode+-label%3Ateam%2Fcluster+-label%3Ateam%2Fux+-label%3Ateam%2Fcsi+-label%3Ateam%2Fapi+-label%3Ateam%2Ftest-infra+).
+
+Example response for support issues:
+
+    Please re-post your question to [stackoverflow](http://stackoverflow.com/questions/tagged/kubernetes).
+
+    We are trying to consolidate the channels to which questions for help/support are posted so that we can improve our efficiency in responding to your requests, and to make it easier for you to find answers to frequently asked questions and how to address common use cases.
+
+    We regularly see messages posted in multiple forums, with the full response thread only in one place or, worse, spread across multiple forums. Also, the large volume of support issues on github is making it difficult for us to use issues to identify real bugs.
+
+    The Kubernetes team scans stackoverflow on a regular basis, and will try to ensure your questions don't go unanswered.
+
+    Before posting a new question, please search stackoverflow for answers to similar questions, and also familiarize yourself with:
+       * [the user guide](http://kubernetes.io/v1.0/)
+       * [the troubleshooting guide](http://kubernetes.io/v1.0/docs/troubleshooting.html)
+
+    Again, thanks for using Kubernetes.
+
+    The Kubernetes Team
+
+Build-copping
+-------------
+
+* The [merge-bot submit queue](http://submit-queue.k8s.io/) ([source](https://github.com/kubernetes/contrib/tree/master/submit-queue)) should auto-merge all eligible PRs for you once they've passed all the relevant checks mentioned below and all [critical e2e tests] (https://goto.google.com/k8s-test/view/Critical%20Builds/) are passing. If the merge-bot been disabled for some reason, or tests are failing, you might need to do some manual merging to get things back on track.
+* Once a day or so, look at the [flaky test builds](https://goto.google.com/k8s-test/view/Flaky/); if they are timing out, clusters are failing to start, or tests are consistently failing (instead of just flaking), file an issue to get things back on track.
+* Jobs that are not in [critical e2e tests] (https://goto.google.com/k8s-test/view/Critical%20Builds/) or [flaky test builds](https://goto.google.com/k8s-test/view/Flaky/) are not your responsibility to monitor. The `Test owner:` in the job description will be automatically emailed if the job is failing.
+* If you are a weekday oncall, ensure that PRs confirming to the following pre-requisites are being merged at a reasonable rate:
+  * [Have been LGTMd](https://github.com/kubernetes/kubernetes/labels/lgtm)
+  * Pass Travis and Shippable.
+  * Author has signed CLA if applicable.
+* If you are a weekend oncall, [never merge PRs manually](collab.md), instead add the label "lgtm" to the PRs once they have been LGTMd and passed Travis and Shippable; this will cause merge-bot to merge them automatically (or make them easy to find by the next oncall, who will merge them).
+* When the build is broken, roll back the PRs responsible ASAP
+* When E2E tests are unstable, a "merge freeze" may be instituted. During a merge freeze:
+  * Oncall should slowly merge LGTMd changes throughout the day while monitoring E2E to ensure stability.
+  * Ideally the E2E run should be green, but some tests are flaky and can fail randomly (not as a result of a particular change).
+    * If a large number of tests fail, or tests that normally pass fail, that is an indication that one or more of the PR(s) in that build might be problematic (and should be reverted).
+    * Use the Test Results Analyzer to see individual test history over time.
+* Flake mitigation
+  * Tests that flake (fail a small percentage of the time) need an issue filed against them. Please read [this](https://github.com/kubernetes/kubernetes/blob/doc-flaky-test/docs/devel/flaky-tests.md#filing-issues-for-flaky-tests); the build cop is expected to file issues for any flaky tests they encounter.
+  * It's reasonable to manually merge PRs that fix a flake or otherwise mitigate it.
+
+Contact information
+-------------------
+
+[@k8s-oncall](https://github.com/k8s-oncall) will reach the current person on call.
+
+<!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/devel/on-call-build-cop.md?pixel)]()
+<!-- END MUNGE: GENERATED_ANALYTICS -->

--- a/docs/devel/on-call-rotations.md
+++ b/docs/devel/on-call-rotations.md
@@ -1,0 +1,52 @@
+<!-- BEGIN MUNGE: UNVERSIONED_WARNING -->
+
+<!-- BEGIN STRIP_FOR_RELEASE -->
+
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+
+<h2>PLEASE NOTE: This document applies to the HEAD of the source tree</h2>
+
+If you are using a released version of Kubernetes, you should
+refer to the docs that go with that version.
+
+Documentation for other releases can be found at
+[releases.k8s.io](http://releases.k8s.io).
+</strong>
+--
+
+<!-- END STRIP_FOR_RELEASE -->
+
+<!-- END MUNGE: UNVERSIONED_WARNING -->
+Kubernetes On-Call Rotations
+====================
+
+Kubernetes "first responder" rotations
+--------------------------------------
+
+Kubernetes has generated a lot of public traffic: email, pull-requests, bugs, etc. So much traffic that it's becoming impossible to keep up with it all! This is a fantastic problem to have. In order to be sure that SOMEONE, but not EVERYONE on the team is paying attention to public traffic, we have instituted two "first responder" rotations, listed below. Please read this page before proceeding to the pages linked below, which are specific to each rotation.
+
+Please also read our [notes on OSS collaboration](collab.md), particularly the bits about hours. Specifically, each rotation is expected to be active primarily during work hours, less so off hours.
+
+During regular workday work hours of your shift, your primary responsibility is to monitor the traffic sources specific to your rotation. You can check traffic in the evenings if you feel so inclined, but it is not expected to be as highly focused as work hours. For weekends, you should check traffic very occasionally (e.g. once or twice a day). Again, it is not expected to be as highly focused as workdays. It is assumed that over time, everyone will get weekday and weekend shifts, so the workload will balance out.
+
+If you can not serve your shift, and you know this ahead of time, it is your responsibility to find someone to cover and to change the rotation. If you have an emergency, your responsibilities fall on the primary of the other rotation, who acts as your secondary. If you need help to cover all of the tasks, partners with oncall rotations (e.g., [Redhat](https://github.com/orgs/kubernetes/teams/rh-oncall)).
+
+If you are not on duty you DO NOT need to do these things. You are free to focus on "real work".
+
+Note that Kubernetes will occasionally enter code slush/freeze, prior to milestones. When it does, there might be changes in the instructions (assigning milestones, for instance).
+
+* [Github and Build Cop Rotation](on-call-build-cop.md)
+* [User Support Rotation](on-call-user-support.md)
+
+<!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/devel/on-call-rotations.md?pixel)]()
+<!-- END MUNGE: GENERATED_ANALYTICS -->

--- a/docs/devel/on-call-user-support.md
+++ b/docs/devel/on-call-user-support.md
@@ -1,0 +1,83 @@
+<!-- BEGIN MUNGE: UNVERSIONED_WARNING -->
+
+<!-- BEGIN STRIP_FOR_RELEASE -->
+
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+
+<h2>PLEASE NOTE: This document applies to the HEAD of the source tree</h2>
+
+If you are using a released version of Kubernetes, you should
+refer to the docs that go with that version.
+
+Documentation for other releases can be found at
+[releases.k8s.io](http://releases.k8s.io).
+</strong>
+--
+
+<!-- END STRIP_FOR_RELEASE -->
+
+<!-- END MUNGE: UNVERSIONED_WARNING -->
+Kubernetes "User Support" Rotation
+==================================
+
+Traffic sources and responsibilities
+------------------------------------
+
+* [StackOverflow](http://stackoverflow.com/questions/tagged/kubernetes) and [ServerFault](http://serverfault.com/questions/tagged/google-kubernetes): Respond to any thread that has no responses and is more than 6 hours old (over time we will lengthen this timeout to allow community responses). If you are not equipped to respond, it is your job to redirect to someone who can.
+  * [Query for unanswered Kubernetes StackOverflow questions](http://stackoverflow.com/search?q=%5Bkubernetes%5D+answers%3A0)
+  * [Query for unanswered Kubernetes ServerFault questions](http://serverfault.com/questions/tagged/google-kubernetes?sort=unanswered&pageSize=15)
+  * Direct poorly formulated questions to [stackoverflow's tips about how to ask](http://stackoverflow.com/help/how-to-ask)
+  * Direct off-topic questions to [stackoverflow's policy](http://stackoverflow.com/help/on-topic)
+* [Slack](https://kubernetes.slack.com) ([registration](http://slack.k8s.io)): Your job is to be on Slack, watching for questions and answering or redirecting as needed. Also check out the [Slack Archive](http://kubernetes.slackarchive.io/).
+* [Email/Groups](https://groups.google.com/forum/#!forum/google-containers): Respond to any thread that has no responses and is more than 6 hours old (over time we will lengthen this timeout to allow community responses). If you are not equipped to respond, it is your job to redirect to someone who can.
+* [Legacy] [IRC](irc://irc.freenode.net/#google-containers) (irc.freenode.net #google-containers): watch IRC for questions and try to redirect users to Slack. Also check out the [IRC logs](https://botbot.me/freenode/google-containers/).
+
+In general, try to direct support questions to:
+
+1. Documentation, such as the [user guide](../user-guide/README.md) and [troubleshooting guide](../troubleshooting.md)
+2. Stackoverflow
+
+If you see questions on a forum other than Stackoverflow, try to redirect them to Stackoverflow. Example response:
+
+    Please re-post your question to [stackoverflow](http://stackoverflow.com/questions/tagged/kubernetes).
+
+    We are trying to consolidate the channels to which questions for help/support are posted so that we can improve our efficiency in responding to your requests, and to make it easier for you to find answers to frequently asked questions and how to address common use cases.
+
+    We regularly see messages posted in multiple forums, with the full response thread only in one place or, worse, spread across multiple forums. Also, the large volume of support issues on github is making it difficult for us to use issues to identify real bugs.
+
+    The Kubernetes team scans stackoverflow on a regular basis, and will try to ensure your questions don't go unanswered.
+
+    Before posting a new question, please search stackoverflow for answers to similar questions, and also familiarize yourself with:
+      * [the user guide](http://kubernetes.io/v1.1/)
+      * [the troubleshooting guide](http://kubernetes.io/v1.1/docs/troubleshooting.html)
+
+    Again, thanks for using Kubernetes.
+
+    The Kubernetes Team
+
+If you answer a question (in any of the above forums) that you think might be useful for someone else in the future, *please add it to one of the FAQs in the wiki*:
+* [User FAQ](https://github.com/kubernetes/kubernetes/wiki/User-FAQ)
+* [Developer FAQ](https://github.com/kubernetes/kubernetes/wiki/Developer-FAQ)
+* [Debugging FAQ](https://github.com/kubernetes/kubernetes/wiki/Debugging-FAQ).
+
+Getting it into the FAQ is more important than polish. Please indicate the date it was added, so people can judge the likelihood that it is out-of-date (and please correct any FAQ entries that you see contain out-of-date information).
+
+Contact information
+-------------------
+
+[@k8s-support-oncall](https://github.com/k8s-support-oncall) will reach the current person on call.
+
+
+
+<!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/devel/on-call-user-support.md?pixel)]()
+<!-- END MUNGE: GENERATED_ANALYTICS -->

--- a/docs/devel/pull-requests.md
+++ b/docs/devel/pull-requests.md
@@ -53,7 +53,7 @@ Life of a Pull Request
 
 Unless in the last few weeks of a milestone when we need to reduce churn and stabilize, we aim to be always accepting pull requests.
 
-Either the [on call](https://github.com/kubernetes/kubernetes/wiki/Kubernetes-on-call-rotations) manually or the [github "munger"](https://github.com/kubernetes/contrib/tree/master/mungegithub) submit-queue plugin automatically will manage merging PRs.
+Either the [on call](on-call-rotations.md) manually or the [github "munger"](https://github.com/kubernetes/contrib/tree/master/mungegithub) submit-queue plugin automatically will manage merging PRs.
 
 There are several requirements for the submit-queue to work:
 * Author must have signed CLA ("cla: yes" label added to PR)


### PR DESCRIPTION
This came up during the most recent community meeting as step 1 of proposing changes to on-call policies.

No content changes aside from formatting/links.  Moved into `docs/devel/on-call-*.md`

Someone with edit rights to the wiki will need to remove these pages:
- https://github.com/kubernetes/kubernetes/wiki/Kubernetes-on-call-rotations
- https://github.com/kubernetes/kubernetes/wiki/Github-and-Build-Cop-Rotation
- https://github.com/kubernetes/kubernetes/wiki/User-Support-Rotation

This is my first docs PR so I'm not sure if this needs to be cherry-picked into release branches?

/cc @k8s-oncall @kubernetes/goog-testing @kubernetes/sig-testing
