### PR TITLE
Remove -reboot and -parallel test suites

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -410,24 +410,6 @@ case ${JOB_NAME} in
     NUM_NODES=${NUM_NODES_PARALLEL}
     ;;
 
-  # Runs all non-flaky tests on GCE in parallel.
-  kubernetes-e2e-gce-parallel)
-    : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-parallel"}
-    : ${E2E_NETWORK:="e2e-parallel"}
-    : ${GINKGO_PARALLEL:="y"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
-          ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
-          ${GCE_PARALLEL_SKIP_TESTS[@]:+${GCE_PARALLEL_SKIP_TESTS[@]}} \
-          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-          ${GCE_SLOW_TESTS[@]:+${GCE_SLOW_TESTS[@]}} \
-          )"}
-    : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-test-parallel"}
-    : ${PROJECT:="kubernetes-jenkins"}
-    : ${ENABLE_DEPLOYMENTS:=true}
-    # Override GCE defaults
-    NUM_NODES=${NUM_NODES_PARALLEL}
-    ;;
-
   # Runs all non-flaky tests on AWS in parallel.
   kubernetes-e2e-aws-parallel)
     : ${E2E_CLUSTER_NAME:="jenkins-aws-e2e-parallel"}

--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -461,15 +461,6 @@ case ${JOB_NAME} in
     NUM_NODES=${NUM_NODES_PARALLEL}
     ;;
 
-  # Run the Reboot tests on GCE. (#19681)
-  kubernetes-e2e-gce-reboot)
-    : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-reboot"}
-    : ${E2E_NETWORK:="e2e-reboot"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=Reboot"}
-    : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-reboot"}
-    : ${PROJECT:="kubernetes-jenkins"}
-    ;;
-
   # Run the [Serial], [Disruptive], and [Feature:Restart] tests on GCE.
   kubernetes-e2e-gce-serial)
     : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-serial"}
@@ -612,21 +603,6 @@ case ${JOB_NAME} in
     : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Slow\] \
                            --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[Skipped\]"}
     : ${GINKGO_PARALLEL:="y"}
-    ;;
-
-  # Run the GCE_PARALLEL_SKIP_TESTS on GKE.
-  kubernetes-e2e-gke-ci-reboot)
-    : ${E2E_CLUSTER_NAME:="jkns-gke-e2e-ci-reboot"}
-    : ${E2E_NETWORK:="e2e-gke-ci-reboot"}
-    : ${E2E_SET_CLUSTER_API_VERSION:=y}
-    : ${PROJECT:="k8s-jkns-e2e-gke-ci-reboot"}
-    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=$(join_regex_allow_empty \
-          ${GCE_PARALLEL_SKIP_TESTS[@]:+${GCE_PARALLEL_SKIP_TESTS[@]}} \
-          ) --ginkgo.skip=$(join_regex_no_empty \
-          ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
-          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-          )"}
     ;;
 
   kubernetes-e2e-gke-flaky)

--- a/hack/jenkins/job-configs/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-e2e.yaml
@@ -51,9 +51,6 @@
         - 'gce-parallel-flaky':
             description: 'Run E2E tests using Ginkgo''s parallel test runner on GCE using the latest successful build. Limit to known-flaky tests.'
             timeout: 90
-        - 'gce-reboot':
-            description: 'Run E2E reboot tests on GCE using the latest successful build. The reboot tests are currently flaky and causing other tests to fail, so we quarantine them into this project and dedicated test cluster.'
-            timeout: 300
         - 'gce-scalability':
             description: 'Run scalability E2E tests on GCE using the latest successful build.'
             timeout: 210
@@ -81,16 +78,6 @@
             timeout: 300
         - 'gke-slow':
             description: 'Run slow E2E tests on GKE using the latest successful build.'
-            timeout: 300
-        - 'gke-ci-reboot':
-            description: |
-                Run e2e tests using the following config:<br>
-                - provider: GKE<br>
-                - apiary: staging<br>
-                - borg job: test<br>
-                - client (kubectl): ci/latest.txt<br>
-                - cluster (k8s): ci/latest.txt<br>
-                - tests: ci/latest.txt
             timeout: 300
         - 'gke-flaky':
             description: |

--- a/hack/jenkins/job-configs/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-e2e.yaml
@@ -45,9 +45,6 @@
         - 'gce-flaky':
             description: 'Run E2E tests on GCE using the latest successful build. Limit to known-flaky tests.'
             timeout: 180
-        - 'gce-parallel':
-            description: 'Run E2E tests using Ginkgo''s parallel test runner on GCE using the latest successful build.'
-            timeout: 120
         - 'gce-parallel-flaky':
             description: 'Run E2E tests using Ginkgo''s parallel test runner on GCE using the latest successful build. Limit to known-flaky tests.'
             timeout: 90


### PR DESCRIPTION
Reboot tests are now all covered in `-gke-serial` and `-gce-serial`.

Parallel suite is now covered in `-gke` and `-gce`, since those are run in parallel.

(Work toward #10548)

@k8s-oncall; consider merging manually; I'll have to go delete the suites by hand once this goes in.

cc @kubernetes/goog-testing 
