### PR TITLE
Remove skip lists

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -331,16 +331,17 @@ case ${JOB_NAME} in
     ;;
 
   # AWS
-  #
-  # TODO(ihmccreery) configure these like GCE and GKE
 
-  # Runs all non-flaky, non-slow tests on AWS, sequentially.
+  # Runs all non-slow, non-serial, non-flaky, tests on AWS in parallel.
   kubernetes-e2e-aws)
     : ${E2E_PUBLISH_GREEN_VERSION:=true}
     : ${E2E_CLUSTER_NAME:="jenkins-aws-e2e"}
     : ${E2E_ZONE:="us-west-2a"}
     : ${ZONE:="us-west-2a"}
     : ${E2E_NETWORK:="e2e-aws"}
+    : ${GINKGO_PARALLEL:="y"}
+    # TODO(ihmccreery) remove [Skipped] once tests are relabeled
+    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[Skipped\]"}
     : ${KUBE_GCE_INSTANCE_PREFIX="e2e-aws"}
     : ${PROJECT:="k8s-jkns-e2e-aws"}
     : ${ENABLE_DEPLOYMENTS:=true}
@@ -349,16 +350,6 @@ case ${JOB_NAME} in
     : ${KUBE_SSH_USER:='ubuntu'}
     # This is needed to be able to create PD from the e2e test
     : ${AWS_SHARED_CREDENTIALS_FILE:='/var/lib/jenkins/.aws/credentials'}
-    ;;
-
-  # Runs all non-flaky tests on AWS in parallel.
-  kubernetes-e2e-aws-parallel)
-    : ${E2E_CLUSTER_NAME:="jenkins-aws-e2e-parallel"}
-    : ${E2E_NETWORK:="e2e-parallel"}
-    : ${GINKGO_PARALLEL:="y"}
-    # TODO(ihmccreery) remove [Skipped] once tests are relabeled
-    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[Skipped\]"}
-    : ${ENABLE_DEPLOYMENTS:=true}
     # Override AWS defaults.
     NUM_NODES=${NUM_NODES_PARALLEL}
     ;;

--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -54,9 +54,6 @@ function join_regex_no_empty() {
 # Assumes globals:
 #   $JOB_NAME
 #   $KUBERNETES_PROVIDER
-#   $GCE_DEFAULT_SKIP_TESTS
-#   $GCE_FLAKY_TESTS
-#   $GCE_SLOW_TESTS
 #
 # Args:
 #   $1 old_version:  the version to deploy a cluster at, and old e2e tests to run
@@ -79,17 +76,6 @@ function configure_upgrade_step() {
     exit 1
   }
   local -r step="${BASH_REMATCH[1]}"
-
-  local -r gce_test_args="--ginkgo.skip=$(join_regex_allow_empty \
-        ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
-        ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-        ${GCE_SLOW_TESTS[@]:+${GCE_SLOW_TESTS[@]}} \
-        )"
-  local -r gke_test_args="--ginkgo.skip=$(join_regex_allow_empty \
-        ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
-        ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-        ${GCE_SLOW_TESTS[@]:+${GCE_SLOW_TESTS[@]}} \
-        )"
 
   if [[ "${KUBERNETES_PROVIDER}" == "gce" ]]; then
     KUBE_GCE_INSTANCE_PREFIX="$cluster_name"
@@ -149,12 +135,6 @@ function configure_upgrade_step() {
       E2E_UP="false"
       E2E_TEST="true"
       E2E_DOWN="false"
-
-      if [[ "${KUBERNETES_PROVIDER}" == "gke" ]]; then
-        GINKGO_TEST_ARGS="${gke_test_args}"
-      else
-        GINKGO_TEST_ARGS="${gce_test_args}"
-      fi
       ;;
 
     step5)
@@ -178,12 +158,6 @@ function configure_upgrade_step() {
       E2E_UP="false"
       E2E_TEST="true"
       E2E_DOWN="false"
-
-      if [[ "${KUBERNETES_PROVIDER}" == "gke" ]]; then
-        GINKGO_TEST_ARGS="${gke_test_args}"
-      else
-        GINKGO_TEST_ARGS="${gce_test_args}"
-      fi
       ;;
 
     step7)
@@ -198,12 +172,6 @@ function configure_upgrade_step() {
       E2E_UP="false"
       E2E_TEST="true"
       E2E_DOWN="true"
-
-      if [[ "${KUBERNETES_PROVIDER}" == "gke" ]]; then
-        GINKGO_TEST_ARGS="${gke_test_args}"
-      else
-        GINKGO_TEST_ARGS="${gce_test_args}"
-      fi
       ;;
   esac
 }
@@ -263,41 +231,6 @@ fi
 # When 1.2.0-beta.0 comes out, e.g., this will become "ci/latest-1.2"
 CURRENT_RELEASE_PUBLISHED_VERSION="ci/latest-1.1"
 
-# Specialized tests which should be skipped by default for projects.
-GCE_DEFAULT_SKIP_TESTS=(
-    "\[Skipped\]"
-    "\[Feature:.+\]"
-    )
-
-# Tests which kills or restarts components and/or nodes.
-DISRUPTIVE_TESTS=(
-    "\[Disruptive\]"
-)
-
-# The following tests are known to be flaky, and are thus run only in their own
-# -flaky- build variants.
-GCE_FLAKY_TESTS=(
-    "\[Flaky\]"
-    )
-
-# The following tests are known to be slow running (> 2 min), and are
-# thus run only in their own -slow- build variants.  Note that tests
-# can be slow by explicit design (e.g. some soak tests), or slow
-# through poor implementation.  Please indicate which applies in the
-# comments below, and for poorly implemented tests, please quote the
-# issue number tracking speed improvements.
-GCE_SLOW_TESTS=(
-    "\[Slow\]"
-    )
-
-# Tests which are not able to be run in parallel.
-#
-# TODO(ihmccreery) I'd like to get these combined with DISRUPTIVE_TESTS.
-GCE_PARALLEL_SKIP_TESTS=(
-    "\[Serial\]"
-    "\[Disruptive\]"
-)
-
 # Define environment variables based on the Jenkins project name.
 # NOTE: Not all jobs are defined here. The hack/jenkins/e2e.sh in master and
 # release branches defines relevant jobs for that particular version of
@@ -311,13 +244,8 @@ case ${JOB_NAME} in
     : ${E2E_CLUSTER_NAME:="jnks-e2e-gce-${NODE_NAME}-${EXECUTOR_NUMBER}"}
     : ${E2E_NETWORK:="e2e-gce-${NODE_NAME}-${EXECUTOR_NUMBER}"}
     : ${GINKGO_PARALLEL:="y"}
-    # This list should match the list in kubernetes-e2e-gce-parallel.
-    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
-          ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
-          ${GCE_PARALLEL_SKIP_TESTS[@]:+${GCE_PARALLEL_SKIP_TESTS[@]}} \
-          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-          ${GCE_SLOW_TESTS[@]:+${GCE_SLOW_TESTS[@]}} \
-          )"}
+    # TODO(ihmccreery) remove [Skipped] once tests are relabeled
+    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[Skipped\]"}
     : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-gce-${NODE_NAME}-${EXECUTOR_NUMBER}"}
     : ${PROJECT:="kubernetes-jenkins-pull"}
     : ${ENABLE_DEPLOYMENTS:=true}
@@ -345,7 +273,7 @@ case ${JOB_NAME} in
   kubernetes-e2e-gce-slow)
     : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-slow"}
     : ${E2E_NETWORK:="e2e-slow"}
-    # TODO(ihmccreery) remove [Skipped] once tetss are relabeled
+    # TODO(ihmccreery) remove [Skipped] once tests are relabeled
     : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Slow\] \
                            --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[Skipped\]"}
     : ${GINKGO_PARALLEL:="y"}
@@ -385,7 +313,7 @@ case ${JOB_NAME} in
     : ${E2E_SET_CLUSTER_API_VERSION:=y}
     : ${PROJECT:="k8s-jkns-e2e-gke-slow"}
     : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
-    # TODO(ihmccreery) remove [Skipped] once tetss are relabeled
+    # TODO(ihmccreery) remove [Skipped] once tests are relabeled
     : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Slow\] \
                            --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[Skipped\]"}
     : ${GINKGO_PARALLEL:="y"}
@@ -413,11 +341,6 @@ case ${JOB_NAME} in
     : ${E2E_ZONE:="us-west-2a"}
     : ${ZONE:="us-west-2a"}
     : ${E2E_NETWORK:="e2e-aws"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
-          ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
-          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-          ${GCE_SLOW_TESTS[@]:+${GCE_SLOW_TESTS[@]}} \
-	  )"}
     : ${KUBE_GCE_INSTANCE_PREFIX="e2e-aws"}
     : ${PROJECT:="k8s-jkns-e2e-aws"}
     : ${ENABLE_DEPLOYMENTS:=true}
@@ -433,11 +356,8 @@ case ${JOB_NAME} in
     : ${E2E_CLUSTER_NAME:="jenkins-aws-e2e-parallel"}
     : ${E2E_NETWORK:="e2e-parallel"}
     : ${GINKGO_PARALLEL:="y"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
-          ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
-          ${GCE_PARALLEL_SKIP_TESTS[@]:+${GCE_PARALLEL_SKIP_TESTS[@]}} \
-          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-          )"}
+    # TODO(ihmccreery) remove [Skipped] once tests are relabeled
+    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[Skipped\]"}
     : ${ENABLE_DEPLOYMENTS:=true}
     # Override AWS defaults.
     NUM_NODES=${NUM_NODES_PARALLEL}
@@ -465,13 +385,11 @@ case ${JOB_NAME} in
     # Clear out any orphaned namespaces in case previous run was interrupted.
     : ${E2E_CLEAN_START:="true"}
     # We should be testing the reliability of a long-running cluster. The
-    # DISRUPTIVE_TESTS kill/restart components or nodes in the cluster,
+    # [Disruptive] tests kill/restart components or nodes in the cluster,
     # defeating the purpose of a soak cluster. (#15722)
-    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
-          ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
-          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-          ${DISRUPTIVE_TESTS[@]:+${DISRUPTIVE_TESTS[@]}} \
-          )"}
+    #
+    # TODO(ihmccreery) remove [Skipped] once tests are relabeled
+    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[Skipped\]"}
     : ${KUBE_GCE_INSTANCE_PREFIX:="gce-soak-weekly"}
     : ${PROJECT:="kubernetes-jenkins"}
     ;;
@@ -503,26 +421,24 @@ case ${JOB_NAME} in
     : ${PROJECT:="kubernetes-jenkins"}
     : ${E2E_OPT:="--check_version_skew=false"}
     # We should be testing the reliability of a long-running cluster. The
-    # DISRUPTIVE_TESTS kill/restart components or nodes in the cluster,
+    # [Disruptive] tests kill/restart components or nodes in the cluster,
     # defeating the purpose of a soak cluster. (#15722)
-    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
-          ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
-          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-          ${DISRUPTIVE_TESTS[@]:+${DISRUPTIVE_TESTS[@]}} \
-          )"}
+    #
+    # TODO(ihmccreery) remove [Skipped] once tests are relabeled
+    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[Skipped\]"}
     ;;
 
   # Flaky
+  #
+  # TODO(ihmccreery) Partition these in a sane way or get rid of them completely.
 
   # Runs the flaky tests on GCE, sequentially.
   kubernetes-e2e-gce-flaky)
     : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-flaky"}
     : ${E2E_NETWORK:="e2e-flaky"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
-          ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
-          ) --ginkgo.focus=$(join_regex_no_empty \
-          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-          )"}
+    # TODO(ihmccreery) remove [Skipped] once tests are relabeled
+    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Flaky\] \
+                           --ginkgo.skip=\[Feature:.+\]|\[Skipped\]"}
     : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-flaky"}
     : ${PROJECT:="k8s-jkns-e2e-gce-flaky"}
     : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
@@ -534,12 +450,9 @@ case ${JOB_NAME} in
     : ${E2E_CLUSTER_NAME:="parallel-flaky"}
     : ${E2E_NETWORK:="e2e-parallel-flaky"}
     : ${GINKGO_PARALLEL:="y"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
-          ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
-          ${GCE_PARALLEL_SKIP_TESTS[@]:+${GCE_PARALLEL_SKIP_TESTS[@]}} \
-          ) --ginkgo.focus=$(join_regex_no_empty \
-          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-          )"}
+    # TODO(ihmccreery) remove [Skipped] once tests are relabeled
+    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Flaky\] \
+                           --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Feature:.+\]|\[Skipped\]"}
     : ${KUBE_GCE_INSTANCE_PREFIX:="parallel-flaky"}
     : ${PROJECT:="k8s-jkns-e2e-gce-prl-flaky"}
     : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
@@ -553,9 +466,9 @@ case ${JOB_NAME} in
     : ${E2E_SET_CLUSTER_API_VERSION:=y}
     : ${PROJECT:="k8s-jkns-e2e-gke-ci-flaky"}
     : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=$(join_regex_no_empty \
-          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-          )"}
+    # TODO(ihmccreery) remove [Skipped] once tests are relabeled
+    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Flaky\] \
+                           --ginkgo.skip=\[Feature:.+\]|\[Skipped\]"}
     ;;
 
   # Features
@@ -699,12 +612,6 @@ case ${JOB_NAME} in
     : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-flannel"}
     : ${E2E_PUBLISH_GREEN_VERSION:="true"}
     : ${E2E_NETWORK:="e2e-gce-flannel"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
-          ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
-          ${GCE_PARALLEL_SKIP_TESTS[@]:+${GCE_PARALLEL_SKIP_TESTS[@]}} \
-          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-          ${GCE_SLOW_TESTS[@]:+${GCE_SLOW_TESTS[@]}} \
-          )"}
     : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-flannel"}
     : ${PROJECT:="kubernetes-flannel"}
     # Override GCE defaults.
@@ -833,10 +740,6 @@ case ${JOB_NAME} in
     : ${E2E_UP:="false"}
     : ${E2E_TEST:="true"}
     : ${E2E_DOWN:="false"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
-          ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
-          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-          )"}
     : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-upgrade-1-0"}
     : ${NUM_NODES:=5}
     ;;
@@ -870,10 +773,6 @@ case ${JOB_NAME} in
     : ${E2E_UP:="false"}
     : ${E2E_TEST:="true"}
     : ${E2E_DOWN:="false"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
-          ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
-          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-          )"}
     : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-upgrade-1-0"}
     : ${NUM_NODES:=5}
     ;;
@@ -890,11 +789,6 @@ case ${JOB_NAME} in
     : ${E2E_UP:="false"}
     : ${E2E_TEST:="true"}
     : ${E2E_DOWN:="true"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
-          ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
-          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-          ${GCE_SLOW_TESTS[@]:+${GCE_SLOW_TESTS[@]}} \
-          )"}
     : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-upgrade-1-0"}
     : ${NUM_NODES:=5}
     ;;

--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -303,6 +303,30 @@ GCE_PARALLEL_SKIP_TESTS=(
 # release branches defines relevant jobs for that particular version of
 # Kubernetes.
 case ${JOB_NAME} in
+
+  # PR builder
+
+  # Runs a subset of tests on GCE in parallel. Run against all pending PRs.
+  kubernetes-pull-build-test-e2e-gce)
+    : ${E2E_CLUSTER_NAME:="jnks-e2e-gce-${NODE_NAME}-${EXECUTOR_NUMBER}"}
+    : ${E2E_NETWORK:="e2e-gce-${NODE_NAME}-${EXECUTOR_NUMBER}"}
+    : ${GINKGO_PARALLEL:="y"}
+    # This list should match the list in kubernetes-e2e-gce-parallel.
+    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
+          ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
+          ${GCE_PARALLEL_SKIP_TESTS[@]:+${GCE_PARALLEL_SKIP_TESTS[@]}} \
+          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
+          ${GCE_SLOW_TESTS[@]:+${GCE_SLOW_TESTS[@]}} \
+          )"}
+    : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-gce-${NODE_NAME}-${EXECUTOR_NUMBER}"}
+    : ${PROJECT:="kubernetes-jenkins-pull"}
+    : ${ENABLE_DEPLOYMENTS:=true}
+    # Override GCE defaults
+    NUM_NODES=${NUM_NODES_PARALLEL}
+    ;;
+
+  # Core GCE
+
   # Runs all non-slow, non-serial, non-flaky, tests on GCE in parallel.
   kubernetes-e2e-gce)
     : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e"}
@@ -316,6 +340,71 @@ case ${JOB_NAME} in
     : ${ENABLE_DEPLOYMENTS:=true}
     : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
     ;;
+
+  # Runs slow tests on GCE, sequentially.
+  kubernetes-e2e-gce-slow)
+    : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-slow"}
+    : ${E2E_NETWORK:="e2e-slow"}
+    # TODO(ihmccreery) remove [Skipped] once tetss are relabeled
+    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Slow\] \
+                           --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[Skipped\]"}
+    : ${GINKGO_PARALLEL:="y"}
+    : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-slow"}
+    : ${PROJECT:="k8s-jkns-e2e-gce-slow"}
+    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
+    ;;
+
+  # Run the [Serial], [Disruptive], and [Feature:Restart] tests on GCE.
+  kubernetes-e2e-gce-serial)
+    : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-serial"}
+    : ${E2E_NETWORK:="jenkins-gce-e2e-serial"}
+    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
+    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
+                           --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"}
+    : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-serial"}
+    : ${PROJECT:="kubernetes-jkns-e2e-gce-serial"}
+    ;;
+
+  # Core GKE
+
+  # Runs all non-slow, non-serial, non-flaky, tests on GKE in parallel.
+  kubernetes-e2e-gke)
+    : ${E2E_CLUSTER_NAME:="jkns-gke-e2e-ci"}
+    : ${E2E_NETWORK:="e2e-gke-ci"}
+    : ${E2E_SET_CLUSTER_API_VERSION:=y}
+    : ${PROJECT:="k8s-jkns-e2e-gke-ci"}
+    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
+    # TODO(ihmccreery) remove [Skipped] once tests are relabeled
+    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[Skipped\]"}
+    : ${GINKGO_PARALLEL:="y"}
+    ;;
+
+  kubernetes-e2e-gke-slow)
+    : ${E2E_CLUSTER_NAME:="jkns-gke-e2e-slow"}
+    : ${E2E_NETWORK:="e2e-gke-slow"}
+    : ${E2E_SET_CLUSTER_API_VERSION:=y}
+    : ${PROJECT:="k8s-jkns-e2e-gke-slow"}
+    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
+    # TODO(ihmccreery) remove [Skipped] once tetss are relabeled
+    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Slow\] \
+                           --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[Skipped\]"}
+    : ${GINKGO_PARALLEL:="y"}
+    ;;
+
+  # Run the [Serial], [Disruptive], and [Feature:Restart] tests on GKE.
+  kubernetes-e2e-gke-serial)
+    : ${E2E_CLUSTER_NAME:="jenkins-gke-e2e-serial"}
+    : ${E2E_NETWORK:="jenkins-gke-e2e-serial"}
+    : ${E2E_SET_CLUSTER_API_VERSION:=y}
+    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
+    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
+                           --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"}
+    : ${PROJECT:="jenkins-gke-e2e-serial"}
+    ;;
+
+  # AWS
+  #
+  # TODO(ihmccreery) configure these like GCE and GKE
 
   # Runs all non-flaky, non-slow tests on AWS, sequentially.
   kubernetes-e2e-aws)
@@ -339,75 +428,6 @@ case ${JOB_NAME} in
     : ${AWS_SHARED_CREDENTIALS_FILE:='/var/lib/jenkins/.aws/credentials'}
     ;;
 
-  # Runs only the examples tests on GCE.
-  kubernetes-e2e-gce-examples)
-    : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-examples"}
-    : ${E2E_NETWORK:="e2e-examples"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Feature:Example\]"}
-    : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-examples"}
-    : ${PROJECT:="kubernetes-jenkins"}
-    ;;
-
-  # Runs only the autoscaling tests on GCE.
-  kubernetes-e2e-gce-autoscaling)
-    : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-autoscaling"}
-    : ${E2E_NETWORK:="e2e-autoscaling"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Feature:ClusterSizeAutoscaling\]|\[Feature:InitialResources\] \
-                           --ginkgo.skip=\[Flaky\]"}
-    : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-autoscaling"}
-    : ${PROJECT:="k8s-jnks-e2e-gce-autoscaling"}
-    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
-    : ${ENABLE_DEPLOYMENTS:=true}
-    ADMISSION_CONTROL="NamespaceLifecycle,InitialResources,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota"
-    ;;
-
-  # Runs the flaky tests on GCE, sequentially.
-  kubernetes-e2e-gce-flaky)
-    : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-flaky"}
-    : ${E2E_NETWORK:="e2e-flaky"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
-          ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
-          ) --ginkgo.focus=$(join_regex_no_empty \
-          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-          )"}
-    : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-flaky"}
-    : ${PROJECT:="k8s-jkns-e2e-gce-flaky"}
-    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
-    : ${E2E_DOWN:="true"}
-    ;;
-
-  # Runs slow tests on GCE, sequentially.
-  kubernetes-e2e-gce-slow)
-    : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-slow"}
-    : ${E2E_NETWORK:="e2e-slow"}
-    # TODO(ihmccreery) remove [Skipped] once tetss are relabeled
-    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Slow\] \
-                           --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[Skipped\]"}
-    : ${GINKGO_PARALLEL:="y"}
-    : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-slow"}
-    : ${PROJECT:="k8s-jkns-e2e-gce-slow"}
-    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
-    ;;
-
-  # Runs a subset of tests on GCE in parallel. Run against all pending PRs.
-  kubernetes-pull-build-test-e2e-gce)
-    : ${E2E_CLUSTER_NAME:="jnks-e2e-gce-${NODE_NAME}-${EXECUTOR_NUMBER}"}
-    : ${E2E_NETWORK:="e2e-gce-${NODE_NAME}-${EXECUTOR_NUMBER}"}
-    : ${GINKGO_PARALLEL:="y"}
-    # This list should match the list in kubernetes-e2e-gce-parallel.
-    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
-          ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
-          ${GCE_PARALLEL_SKIP_TESTS[@]:+${GCE_PARALLEL_SKIP_TESTS[@]}} \
-          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-          ${GCE_SLOW_TESTS[@]:+${GCE_SLOW_TESTS[@]}} \
-          )"}
-    : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-gce-${NODE_NAME}-${EXECUTOR_NUMBER}"}
-    : ${PROJECT:="kubernetes-jenkins-pull"}
-    : ${ENABLE_DEPLOYMENTS:=true}
-    # Override GCE defaults
-    NUM_NODES=${NUM_NODES_PARALLEL}
-    ;;
-
   # Runs all non-flaky tests on AWS in parallel.
   kubernetes-e2e-aws-parallel)
     : ${E2E_CLUSTER_NAME:="jenkins-aws-e2e-parallel"}
@@ -423,112 +443,7 @@ case ${JOB_NAME} in
     NUM_NODES=${NUM_NODES_PARALLEL}
     ;;
 
-  # Runs the flaky tests on GCE in parallel.
-  kubernetes-e2e-gce-parallel-flaky)
-    : ${E2E_CLUSTER_NAME:="parallel-flaky"}
-    : ${E2E_NETWORK:="e2e-parallel-flaky"}
-    : ${GINKGO_PARALLEL:="y"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
-          ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
-          ${GCE_PARALLEL_SKIP_TESTS[@]:+${GCE_PARALLEL_SKIP_TESTS[@]}} \
-          ) --ginkgo.focus=$(join_regex_no_empty \
-          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-          )"}
-    : ${KUBE_GCE_INSTANCE_PREFIX:="parallel-flaky"}
-    : ${PROJECT:="k8s-jkns-e2e-gce-prl-flaky"}
-    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
-    # Override GCE defaults.
-    NUM_NODES=${NUM_NODES_PARALLEL}
-    ;;
-
-  # Run the [Serial], [Disruptive], and [Feature:Restart] tests on GCE.
-  kubernetes-e2e-gce-serial)
-    : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-serial"}
-    : ${E2E_NETWORK:="jenkins-gce-e2e-serial"}
-    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
-                           --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"}
-    : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-serial"}
-    : ${PROJECT:="kubernetes-jkns-e2e-gce-serial"}
-    ;;
-
-  # Run the [Serial], [Disruptive], and [Feature:Restart] tests on GKE.
-  kubernetes-e2e-gke-serial)
-    : ${E2E_CLUSTER_NAME:="jenkins-gke-e2e-serial"}
-    : ${E2E_NETWORK:="jenkins-gke-e2e-serial"}
-    : ${E2E_SET_CLUSTER_API_VERSION:=y}
-    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
-                           --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"}
-    : ${PROJECT:="jenkins-gke-e2e-serial"}
-    ;;
-
-  # Runs the performance/scalability tests on GCE. A larger cluster is used.
-  kubernetes-e2e-gce-scalability)
-    : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-scalability"}
-    : ${E2E_NETWORK:="e2e-scalability"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Performance\] \
-        --gather-resource-usage=true \
-        --gather-metrics-at-teardown=true \
-        --gather-logs-sizes=true \
-        --output-print-type=json"}
-    : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-scalability"}
-    : ${PROJECT:="kubernetes-jenkins"}
-    # Override GCE defaults.
-    MASTER_SIZE="n1-standard-4"
-    NODE_SIZE="n1-standard-2"
-    NODE_DISK_SIZE="50GB"
-    NUM_NODES="100"
-    # Reduce logs verbosity
-    TEST_CLUSTER_LOG_LEVEL="--v=2"
-    # TODO: Remove when we figure out the reason for ocassional failures #19048
-    KUBELET_TEST_LOG_LEVEL="--v=4"
-    # Increase resync period to simulate production
-    TEST_CLUSTER_RESYNC_PERIOD="--min-resync-period=12h"
-    ;;
-
-  # Runs e2e on GCE with flannel and VXLAN.
-  kubernetes-e2e-gce-flannel)
-    : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-flannel"}
-    : ${E2E_PUBLISH_GREEN_VERSION:="true"}
-    : ${E2E_NETWORK:="e2e-gce-flannel"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
-          ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
-          ${GCE_PARALLEL_SKIP_TESTS[@]:+${GCE_PARALLEL_SKIP_TESTS[@]}} \
-          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-          ${GCE_SLOW_TESTS[@]:+${GCE_SLOW_TESTS[@]}} \
-          )"}
-    : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-flannel"}
-    : ${PROJECT:="kubernetes-flannel"}
-    # Override GCE defaults.
-    NETWORK_PROVIDER="flannel"
-    ;;
-
-  # Runs the performance/scalability test on huge 1000-node cluster on GCE.
-  # Flannel is used as network provider.
-  kubernetes-e2e-gce-enormous-cluster)
-    : ${E2E_CLUSTER_NAME:="jenkins-gce-enormous-cluster"}
-    : ${E2E_NETWORK:="e2e-enormous-cluster"}
-    # TODO: Currently run only density test.
-    # Once this is stable, run the whole [Performance] suite.
-    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=starting\s30\spods\sper\snode"}
-    : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-enormous-cluster"}
-    : ${PROJECT:="kubernetes-scale"}
-    # Override GCE defaults.
-    NETWORK_PROVIDER="flannel"
-    # Temporarily switch of Heapster, as this will not schedule anywhere.
-    # TODO: Think of a solution to enable it.
-    ENABLE_CLUSTER_MONITORING="none"
-    E2E_ZONE="asia-east1-a"
-    MASTER_SIZE="n1-standard-32"
-    NODE_SIZE="n1-standard-1"
-    NODE_DISK_SIZE="50GB"
-    NUM_NODES="1000"
-    # Reduce logs verbosity
-    TEST_CLUSTER_LOG_LEVEL="--v=1"
-    # Increase resync period to simulate production
-    TEST_CLUSTER_RESYNC_PERIOD="--min-resync-period=12h"
-    ;;
+  # GCE Soak
 
   # Sets up the GCE soak cluster weekly using the latest CI release.
   kubernetes-soak-weekly-deploy-gce)
@@ -561,40 +476,7 @@ case ${JOB_NAME} in
     : ${PROJECT:="kubernetes-jenkins"}
     ;;
 
-  # Runs all non-slow, non-serial, non-flaky, tests on GKE in parallel.
-  kubernetes-e2e-gke)
-    : ${E2E_CLUSTER_NAME:="jkns-gke-e2e-ci"}
-    : ${E2E_NETWORK:="e2e-gke-ci"}
-    : ${E2E_SET_CLUSTER_API_VERSION:=y}
-    : ${PROJECT:="k8s-jkns-e2e-gke-ci"}
-    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
-    # TODO(ihmccreery) remove [Skipped] once tests are relabeled
-    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[Skipped\]"}
-    : ${GINKGO_PARALLEL:="y"}
-    ;;
-
-  kubernetes-e2e-gke-slow)
-    : ${E2E_CLUSTER_NAME:="jkns-gke-e2e-slow"}
-    : ${E2E_NETWORK:="e2e-gke-slow"}
-    : ${E2E_SET_CLUSTER_API_VERSION:=y}
-    : ${PROJECT:="k8s-jkns-e2e-gke-slow"}
-    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
-    # TODO(ihmccreery) remove [Skipped] once tetss are relabeled
-    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Slow\] \
-                           --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[Skipped\]"}
-    : ${GINKGO_PARALLEL:="y"}
-    ;;
-
-  kubernetes-e2e-gke-flaky)
-    : ${E2E_CLUSTER_NAME:="kubernetes-gke-e2e-flaky"}
-    : ${E2E_NETWORK:="gke-e2e-flaky"}
-    : ${E2E_SET_CLUSTER_API_VERSION:=y}
-    : ${PROJECT:="k8s-jkns-e2e-gke-ci-flaky"}
-    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
-    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=$(join_regex_no_empty \
-          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
-          )"}
-    ;;
+  # GKE Soak
 
   # Sets up the GKE soak cluster weekly using the latest CI release.
   kubernetes-soak-weekly-deploy-gke)
@@ -629,6 +511,207 @@ case ${JOB_NAME} in
           ${DISRUPTIVE_TESTS[@]:+${DISRUPTIVE_TESTS[@]}} \
           )"}
     ;;
+
+  # Flaky
+
+  # Runs the flaky tests on GCE, sequentially.
+  kubernetes-e2e-gce-flaky)
+    : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-flaky"}
+    : ${E2E_NETWORK:="e2e-flaky"}
+    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
+          ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
+          ) --ginkgo.focus=$(join_regex_no_empty \
+          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
+          )"}
+    : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-flaky"}
+    : ${PROJECT:="k8s-jkns-e2e-gce-flaky"}
+    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
+    : ${E2E_DOWN:="true"}
+    ;;
+
+  # Runs the flaky tests on GCE in parallel.
+  kubernetes-e2e-gce-parallel-flaky)
+    : ${E2E_CLUSTER_NAME:="parallel-flaky"}
+    : ${E2E_NETWORK:="e2e-parallel-flaky"}
+    : ${GINKGO_PARALLEL:="y"}
+    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
+          ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
+          ${GCE_PARALLEL_SKIP_TESTS[@]:+${GCE_PARALLEL_SKIP_TESTS[@]}} \
+          ) --ginkgo.focus=$(join_regex_no_empty \
+          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
+          )"}
+    : ${KUBE_GCE_INSTANCE_PREFIX:="parallel-flaky"}
+    : ${PROJECT:="k8s-jkns-e2e-gce-prl-flaky"}
+    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
+    # Override GCE defaults.
+    NUM_NODES=${NUM_NODES_PARALLEL}
+    ;;
+
+  kubernetes-e2e-gke-flaky)
+    : ${E2E_CLUSTER_NAME:="kubernetes-gke-e2e-flaky"}
+    : ${E2E_NETWORK:="gke-e2e-flaky"}
+    : ${E2E_SET_CLUSTER_API_VERSION:=y}
+    : ${PROJECT:="k8s-jkns-e2e-gke-ci-flaky"}
+    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
+    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=$(join_regex_no_empty \
+          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
+          )"}
+    ;;
+
+  # Features
+
+  # Runs only the examples tests on GCE.
+  kubernetes-e2e-gce-examples)
+    : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-examples"}
+    : ${E2E_NETWORK:="e2e-examples"}
+    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Feature:Example\]"}
+    : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-examples"}
+    : ${PROJECT:="kubernetes-jenkins"}
+    ;;
+
+  # Runs only the autoscaling tests on GCE.
+  kubernetes-e2e-gce-autoscaling)
+    : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-autoscaling"}
+    : ${E2E_NETWORK:="e2e-autoscaling"}
+    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Feature:ClusterSizeAutoscaling\]|\[Feature:InitialResources\] \
+                           --ginkgo.skip=\[Flaky\]"}
+    : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-autoscaling"}
+    : ${PROJECT:="k8s-jnks-e2e-gce-autoscaling"}
+    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
+    : ${ENABLE_DEPLOYMENTS:=true}
+    ADMISSION_CONTROL="NamespaceLifecycle,InitialResources,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota"
+    ;;
+
+  # Runs the performance/scalability tests on GCE. A larger cluster is used.
+  kubernetes-e2e-gce-scalability)
+    : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-scalability"}
+    : ${E2E_NETWORK:="e2e-scalability"}
+    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Performance\] \
+        --gather-resource-usage=true \
+        --gather-metrics-at-teardown=true \
+        --gather-logs-sizes=true \
+        --output-print-type=json"}
+    : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-scalability"}
+    : ${PROJECT:="kubernetes-jenkins"}
+    # Override GCE defaults.
+    MASTER_SIZE="n1-standard-4"
+    NODE_SIZE="n1-standard-2"
+    NODE_DISK_SIZE="50GB"
+    NUM_NODES="100"
+    # Reduce logs verbosity
+    TEST_CLUSTER_LOG_LEVEL="--v=2"
+    # TODO: Remove when we figure out the reason for ocassional failures #19048
+    KUBELET_TEST_LOG_LEVEL="--v=4"
+    # Increase resync period to simulate production
+    TEST_CLUSTER_RESYNC_PERIOD="--min-resync-period=12h"
+    ;;
+
+  # Runs the performance/scalability test on huge 1000-node cluster on GCE.
+  # Flannel is used as network provider.
+  kubernetes-e2e-gce-enormous-cluster)
+    : ${E2E_CLUSTER_NAME:="jenkins-gce-enormous-cluster"}
+    : ${E2E_NETWORK:="e2e-enormous-cluster"}
+    # TODO: Currently run only density test.
+    # Once this is stable, run the whole [Performance] suite.
+    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=starting\s30\spods\sper\snode"}
+    : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-enormous-cluster"}
+    : ${PROJECT:="kubernetes-scale"}
+    # Override GCE defaults.
+    NETWORK_PROVIDER="flannel"
+    # Temporarily switch of Heapster, as this will not schedule anywhere.
+    # TODO: Think of a solution to enable it.
+    ENABLE_CLUSTER_MONITORING="none"
+    E2E_ZONE="asia-east1-a"
+    MASTER_SIZE="n1-standard-32"
+    NODE_SIZE="n1-standard-1"
+    NODE_DISK_SIZE="50GB"
+    NUM_NODES="1000"
+    # Reduce logs verbosity
+    TEST_CLUSTER_LOG_LEVEL="--v=1"
+    # Increase resync period to simulate production
+    TEST_CLUSTER_RESYNC_PERIOD="--min-resync-period=12h"
+    ;;
+
+  # Run Kubemark test on a fake 100 node cluster to have a comparison
+  # to the real results from scalability suite
+  kubernetes-kubemark-gce)
+    : ${E2E_CLUSTER_NAME:="kubernetes-kubemark"}
+    : ${E2E_NETWORK:="kubernetes-kubemark"}
+    : ${PROJECT:="k8s-jenkins-kubemark"}
+    : ${E2E_UP:="true"}
+    : ${E2E_DOWN:="true"}
+    : ${E2E_TEST:="false"}
+    : ${USE_KUBEMARK:="true"}
+    # Override defaults to be indpendent from GCE defaults and set kubemark parameters
+    KUBE_GCE_INSTANCE_PREFIX="kubemark100"
+    NUM_NODES="10"
+    MASTER_SIZE="n1-standard-2"
+    NODE_SIZE="n1-standard-1"
+    E2E_ZONE="asia-east1-a"
+    KUBEMARK_MASTER_SIZE="n1-standard-4"
+    KUBEMARK_NUM_NODES="100"
+    ;;
+
+  # Run Kubemark test on a fake 500 node cluster to test for regressions on
+  # bigger clusters
+  kubernetes-kubemark-500-gce)
+    : ${E2E_CLUSTER_NAME:="kubernetes-kubemark-500"}
+    : ${E2E_NETWORK:="kubernetes-kubemark-500"}
+    : ${PROJECT:="kubernetes-scale"}
+    : ${E2E_UP:="true"}
+    : ${E2E_DOWN:="true"}
+    : ${E2E_TEST:="false"}
+    : ${USE_KUBEMARK:="true"}
+    # Override defaults to be indpendent from GCE defaults and set kubemark parameters
+    NUM_NODES="6"
+    MASTER_SIZE="n1-standard-4"
+    NODE_SIZE="n1-standard-8"
+    KUBE_GCE_INSTANCE_PREFIX="kubemark500"
+    E2E_ZONE="us-east1-b"
+    KUBEMARK_MASTER_SIZE="n1-standard-16"
+    KUBEMARK_NUM_NODES="500"
+    ;;
+
+  # Run big Kubemark test, this currently means a 1000 node cluster and 16 core master
+  kubernetes-kubemark-gce-scale)
+    : ${E2E_CLUSTER_NAME:="kubernetes-kubemark-scale"}
+    : ${E2E_NETWORK:="kubernetes-kubemark-scale"}
+    : ${PROJECT:="kubernetes-scale"}
+    : ${E2E_UP:="true"}
+    : ${E2E_DOWN:="true"}
+    : ${E2E_TEST:="false"}
+    : ${USE_KUBEMARK:="true"}
+    # Override defaults to be indpendent from GCE defaults and set kubemark parameters
+    # We need 11 so that we won't hit max-pods limit (set to 100). TODO: do it in a nicer way.
+    NUM_NODES="11"
+    MASTER_SIZE="n1-standard-4"
+    NODE_SIZE="n1-standard-8"   # Note: can fit about 17 hollow nodes per core
+    #                                     so NUM_NODES x cores_per_node should
+    #                                     be set accordingly.
+    KUBE_GCE_INSTANCE_PREFIX="kubemark1000"
+    E2E_ZONE="us-east1-b"
+    KUBEMARK_MASTER_SIZE="n1-standard-16"
+    KUBEMARK_NUM_NODES="1000"
+    ;;
+
+  # Runs e2e on GCE with flannel and VXLAN.
+  kubernetes-e2e-gce-flannel)
+    : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-flannel"}
+    : ${E2E_PUBLISH_GREEN_VERSION:="true"}
+    : ${E2E_NETWORK:="e2e-gce-flannel"}
+    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
+          ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
+          ${GCE_PARALLEL_SKIP_TESTS[@]:+${GCE_PARALLEL_SKIP_TESTS[@]}} \
+          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
+          ${GCE_SLOW_TESTS[@]:+${GCE_SLOW_TESTS[@]}} \
+          )"}
+    : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-flannel"}
+    : ${PROJECT:="kubernetes-flannel"}
+    # Override GCE defaults.
+    NETWORK_PROVIDER="flannel"
+    ;;
+
+  # GKE Upgrades
 
   # kubernetes-upgrade-gke-1.0-master
   #
@@ -695,6 +778,8 @@ case ${JOB_NAME} in
   kubernetes-upgrade-gce-1.1-master-step7-e2e-new)
     configure_upgrade_step 'configured-in-release-1.1' 'ci/latest' 'upgrade-gce-1-1-master' 'k8s-jkns-gce-upgrade'
     ;;
+
+  # GCE Upgrades
 
   # kubernetes-upgrade-gce-1.0-current-release
   #
@@ -812,68 +897,6 @@ case ${JOB_NAME} in
           )"}
     : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-upgrade-1-0"}
     : ${NUM_NODES:=5}
-    ;;
-
-  # Run Kubemark test on a fake 100 node cluster to have a comparison
-  # to the real results from scalability suite
-  kubernetes-kubemark-gce)
-    : ${E2E_CLUSTER_NAME:="kubernetes-kubemark"}
-    : ${E2E_NETWORK:="kubernetes-kubemark"}
-    : ${PROJECT:="k8s-jenkins-kubemark"}
-    : ${E2E_UP:="true"}
-    : ${E2E_DOWN:="true"}
-    : ${E2E_TEST:="false"}
-    : ${USE_KUBEMARK:="true"}
-    # Override defaults to be indpendent from GCE defaults and set kubemark parameters
-    KUBE_GCE_INSTANCE_PREFIX="kubemark100"
-    NUM_NODES="10"
-    MASTER_SIZE="n1-standard-2"
-    NODE_SIZE="n1-standard-1"
-    E2E_ZONE="asia-east1-a"
-    KUBEMARK_MASTER_SIZE="n1-standard-4"
-    KUBEMARK_NUM_NODES="100"
-    ;;
-
-  # Run Kubemark test on a fake 500 node cluster to test for regressions on
-  # bigger clusters
-  kubernetes-kubemark-500-gce)
-    : ${E2E_CLUSTER_NAME:="kubernetes-kubemark-500"}
-    : ${E2E_NETWORK:="kubernetes-kubemark-500"}
-    : ${PROJECT:="kubernetes-scale"}
-    : ${E2E_UP:="true"}
-    : ${E2E_DOWN:="true"}
-    : ${E2E_TEST:="false"}
-    : ${USE_KUBEMARK:="true"}
-    # Override defaults to be indpendent from GCE defaults and set kubemark parameters
-    NUM_NODES="6"
-    MASTER_SIZE="n1-standard-4"
-    NODE_SIZE="n1-standard-8"
-    KUBE_GCE_INSTANCE_PREFIX="kubemark500"
-    E2E_ZONE="us-east1-b"
-    KUBEMARK_MASTER_SIZE="n1-standard-16"
-    KUBEMARK_NUM_NODES="500"
-    ;;
-
-  # Run big Kubemark test, this currently means a 1000 node cluster and 16 core master
-  kubernetes-kubemark-gce-scale)
-    : ${E2E_CLUSTER_NAME:="kubernetes-kubemark-scale"}
-    : ${E2E_NETWORK:="kubernetes-kubemark-scale"}
-    : ${PROJECT:="kubernetes-scale"}
-    : ${E2E_UP:="true"}
-    : ${E2E_DOWN:="true"}
-    : ${E2E_TEST:="false"}
-    : ${USE_KUBEMARK:="true"}
-    # Override defaults to be indpendent from GCE defaults and set kubemark parameters
-    # We need 11 so that we won't hit max-pods limit (set to 100). TODO: do it in a nicer way.
-    NUM_NODES="11"
-    MASTER_SIZE="n1-standard-4"
-    NODE_SIZE="n1-standard-8"   # Note: can fit about 17 hollow nodes per core
-    #                                     so NUM_NODES x cores_per_node should
-    #                                     be set accordingly.
-    KUBE_GCE_INSTANCE_PREFIX="kubemark1000"
-    E2E_ZONE="us-east1-b"
-    KUBEMARK_MASTER_SIZE="n1-standard-16"
-    KUBEMARK_NUM_NODES="1000"
     ;;
 esac
 

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -220,7 +220,7 @@ func RunE2ETests(t *testing.T) {
 	// Disable skipped tests unless they are explicitly requested.
 	if config.GinkgoConfig.FocusString == "" && config.GinkgoConfig.SkipString == "" {
 		// TODO(ihmccreery) Remove [Skipped] once all [Skipped] labels have been reclassified.
-		config.GinkgoConfig.SkipString = `\[Flaky\]|\[Skipped\]|\[Feature:.+\]`
+		config.GinkgoConfig.SkipString = `\[Flaky\]|\[Feature:.+\]|\[Skipped\]`
 	}
 
 	// Run tests through the Ginkgo runner with output to console + JUnit for Jenkins


### PR DESCRIPTION
The first commit in this PR just moves test suites into more sane groupings.  The second has much more in it:
- Remove all skip lists, and replace with label-based test arguments
- Flannel & upgrade tests all run the defaults according to `e2e.go`.

This PR should basically be a no-op, except:
- The upgrade suites will be running more tests
- AWS suites will be running more tests
- Flannel suite will be running more tests
- Soak tests will be running more tests

None of these are critical except soak tests, but those are unstable enough as it is.

This also configures the AWS job to run in parallel like the GCE and GKE jobs.

cc @kubernetes/goog-testing @k8s-oncall
