### PR TITLE
When running test-update-storage-objects, only build kube-apiserver.

### DIFF
--- a/hack/test-update-storage-objects.sh
+++ b/hack/test-update-storage-objects.sh
@@ -83,7 +83,7 @@ kube::etcd::start
 
 kube::log::status "Running test for update etcd object scenario"
 
-"${KUBE_ROOT}/hack/build-go.sh"
+"${KUBE_ROOT}/hack/build-go.sh" cmd/kube-apiserver
 
 
 #######################################################


### PR DESCRIPTION
Prior to this we built everything.  So slow!

Noticed this working on #19435
