### PR TITLE
Knock down the timeouts for gce, gce-slow, gke, and gke-slow

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-e2e.yaml
@@ -38,7 +38,10 @@
     suffix:
         - 'gce':
             description: 'Run E2E tests on GCE using the latest successful build.'
-            timeout: 150
+            timeout: 30
+        - 'gce-slow':
+            description: 'Run slow E2E tests on GCE using the latest successful build.'
+            timeout: 60
         - 'gce-autoscaling':
             description: 'Run autoscaling E2E tests on GCE using the latest successful build.'
             timeout: 210
@@ -51,9 +54,6 @@
         - 'gce-scalability':
             description: 'Run scalability E2E tests on GCE using the latest successful build.'
             timeout: 210
-        - 'gce-slow':
-            description: 'Run slow E2E tests on GCE using the latest successful build.'
-            timeout: 270
         - 'gce-flannel':
             description: 'Run E2E tests on GCE using Flannel and the latest successful build. This suite is quarantined in a dedicated project because Flannel integration is experimental.'
             timeout: 90
@@ -72,10 +72,10 @@
     suffix:
         - 'gke':
             description: Runs all non-slow, non-serial, non-flaky, tests on GKE in parallel (against GKE test endpoint)
-            timeout: 300
+            timeout: 30
         - 'gke-slow':
             description: 'Run slow E2E tests on GKE using the latest successful build.'
-            timeout: 300
+            timeout: 60
         - 'gke-flaky':
             description: |
                 Run flaky e2e tests using the following config:<br>


### PR DESCRIPTION
... now that they run in parallel.

@k8s-oncall this should be a no-op, but should prevent the hangs you saw earlier.

cc @kubernetes/goog-testing 
