### PR TITLE
Demote 'Pods should have their auto-restart back-off timer reset on image update' to [Slow]

### DIFF
--- a/test/e2e/pods.go
+++ b/test/e2e/pods.go
@@ -846,7 +846,7 @@ var _ = Describe("Pods", func() {
 		}
 	})
 
-	It("should have their auto-restart back-off timer reset on image update", func() {
+	It("should have their auto-restart back-off timer reset on image update [Slow]", func() {
 		podName := "pod-back-off-image"
 		containerName := "back-off"
 		podClient := framework.Client.Pods(framework.Namespace.Name)


### PR DESCRIPTION
This test took > 5 min in the last run of `kubernetes-e2e-gke`.

@spxtr there are another 5 tests that are taking > 2 min; we could consider dropping the threshold to 2 minutes to speed up the PR builder?

cc @kubernetes/goog-testing 
