### PR TITLE
Add basic doc on local cluster to dev guide

### DIFF
--- a/docs/devel/development.md
+++ b/docs/devel/development.md
@@ -46,7 +46,7 @@ branch, but release branches of Kubernetes should not change.
 
 ## Releases and Official Builds
 
-Official releases are built in Docker containers.  Details are [here](http://releases.k8s.io/HEAD/build/README.md).  You can do simple builds and development with just a local Docker installation.  If want to build go locally outside of docker, please continue below.
+Official releases are built in Docker containers.  Details are [here](http://releases.k8s.io/HEAD/build/README.md).  You can do simple builds and development with just a local Docker installation.  If you want to build go code locally outside of docker, please continue below.
 
 ## Go development environment
 
@@ -356,6 +356,34 @@ go run hack/e2e.go -build -pushup -test -down
 # kubectl output.
 go run hack/e2e.go -v -ctl='get events'
 go run hack/e2e.go -v -ctl='delete pod foobar'
+```
+
+## Local clusters
+
+It can be much faster to iterate on a local cluster instead of a cloud-based one.  To start a local cluster, you can run:
+
+```sh
+# The PATH construction is needed because PATH is one of the special-cased
+# environment variables not passed by sudo -E
+sudo PATH=$PATH hack/local-up-cluster.sh
+```
+
+This will start a single-node Kubernetes cluster than runs pods using the local docker daemon.  Press Control-C to stop the cluster.
+
+### E2E tests against local clusters
+
+In order to run an E2E test against a locally running cluster, use the `e2e.test` binary built by `hack/build-go.sh`
+directly:
+
+```sh
+export KUBECONFIG=/path/to/kubeconfig
+e2e.test --host=http://127.0.0.1:8080
+```
+
+To control the tests that are run:
+
+```sh
+e2e.test --host=http://127.0.0.1:8080 --ginkgo.focus="Secrets"
 ```
 
 ## Conformance testing


### PR DESCRIPTION
Add some basic docs about this, since it is truly the only way to fly on a slow link.

@eparis 
