### PR TITLE
Fix #11543 - use DescribeInstances API to retrieve the correct private DNS name

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -654,6 +654,7 @@ func (aws *AWSCloud) NodeAddresses(name string) ([]api.NodeAddress, error) {
 		}
 		return []api.NodeAddress{
 			{Type: api.NodeInternalIP, Address: internalIP},
+			{Type: api.NodeLegacyHostIP, Address: internalIP},
 			{Type: api.NodeExternalIP, Address: externalIP},
 		}, nil
 	}
@@ -1117,10 +1118,13 @@ func (s *AWSCloud) getSelfAWSInstance() (*awsInstance, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error fetching instance-id from ec2 metadata service: %v", err)
 		}
-		privateDnsName, err := s.metadata.GetMetadata("local-hostname")
+		// privateDnsName, err := s.metadata.GetMetadata("local-hostname")
+		// See #11543 - need to use ec2 API to get the privateDnsName in case of private dns zone e.g. mydomain.io
+		instance, err := s.getInstanceByID(instanceId)
 		if err != nil {
-			return nil, fmt.Errorf("error fetching local-hostname from ec2 metadata service: %v", err)
+			return nil, fmt.Errorf("error finding instance %s: %v", instanceId, err)
 		}
+		privateDnsName := aws.StringValue(instance.PrivateDnsName)
 		availabilityZone, err := getAvailabilityZone(s.metadata)
 		if err != nil {
 			return nil, fmt.Errorf("error fetching availability zone from ec2 metadata service: %v", err)
@@ -2137,7 +2141,6 @@ func (s *AWSCloud) UpdateLoadBalancer(name, region string, hosts []string) error
 }
 
 // Returns the instance with the specified ID
-// This function is currently unused, but seems very likely to be needed again
 func (a *AWSCloud) getInstanceByID(instanceID string) (*ec2.Instance, error) {
 	instances, err := a.getInstancesByIDs([]*string{&instanceID})
 	if err != nil {

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -133,6 +133,8 @@ func NewFakeAWSServices() *FakeAWSServices {
 
 	s.instanceId = "i-self"
 	s.privateDnsName = "ip-172-20-0-100.ec2.internal"
+	s.internalIP = "192.168.0.1"
+	s.externalIP = "1.2.3.4"
 	var selfInstance ec2.Instance
 	selfInstance.InstanceId = &s.instanceId
 	selfInstance.PrivateDnsName = &s.privateDnsName
@@ -587,9 +589,10 @@ func TestNodeAddresses(t *testing.T) {
 	// (we test that this produces an error)
 	var instance0 ec2.Instance
 	var instance1 ec2.Instance
+	var instance2 ec2.Instance
 
 	//0
-	instance0.InstanceId = aws.String("instance-same")
+	instance0.InstanceId = aws.String("i-self")
 	instance0.PrivateDnsName = aws.String("instance-same.ec2.internal")
 	instance0.PrivateIpAddress = aws.String("192.168.0.1")
 	instance0.PublicIpAddress = aws.String("1.2.3.4")
@@ -600,7 +603,7 @@ func TestNodeAddresses(t *testing.T) {
 	instance0.State = &state0
 
 	//1
-	instance1.InstanceId = aws.String("instance-same")
+	instance1.InstanceId = aws.String("i-self")
 	instance1.PrivateDnsName = aws.String("instance-same.ec2.internal")
 	instance1.PrivateIpAddress = aws.String("192.168.0.2")
 	instance1.InstanceType = aws.String("c3.large")
@@ -609,7 +612,18 @@ func TestNodeAddresses(t *testing.T) {
 	}
 	instance1.State = &state1
 
-	instances := []*ec2.Instance{&instance0, &instance1}
+	//2
+	instance2.InstanceId = aws.String("i-self")
+	instance2.PrivateDnsName = aws.String("instance-other.ec2.internal")
+	instance2.PrivateIpAddress = aws.String("192.168.0.1")
+	instance2.PublicIpAddress = aws.String("1.2.3.4")
+	instance2.InstanceType = aws.String("c3.large")
+	state2 := ec2.InstanceState{
+		Name: aws.String("running"),
+	}
+	instance2.State = &state2
+
+	instances := []*ec2.Instance{&instance0, &instance1, &instance2}
 
 	aws1, _ := mockInstancesResp([]*ec2.Instance{})
 	_, err1 := aws1.NodeAddresses("instance-mismatch.ec2.internal")


### PR DESCRIPTION
Following discussion on #17643, now retrieving the private DNS name via the `DescribeInstances` API as the one retrieved from the ec2 metadata can be incorrect in the case of private zones.

cc @justinsb 
