### PR TITLE
enable proxy settings for kubernetes build and update docs

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -73,17 +73,19 @@ When building final release tars, they are first staged into `_output/release-st
 ## Proxy Settings
 
 
-If you are behind a proxy, you need to edit `build/build-image/Dockerfile` and add proxy settings to execute command in that container correctly.
+If you are behind a proxy, you need to export proxy settings for kubernetes build, the following environment variables should be defined.
 
-example:
+```
+export KUBE_BUILD_HTTP_PROXY=http://username:password@proxyaddr:proxyport
+export KUBE_BUILD_HTTPS_PROXY=http://username:password@proxyaddr:proxyport
+```
 
-`ENV http_proxy http://username:password@proxyaddr:proxyport`
+Optionally, you can specify addresses of no proxy for kubernetes build, for example
 
-`ENV https_proxy http://username:password@proxyaddr:proxyport`
-
-Besides, to avoid integration test touch the proxy while connecting to local etcd service, you need to set
-
-`ENV no_proxy 127.0.0.1`
+```
+export KUBE_BUILD_NO_PROXY=127.0.0.1
+```
+If you are using sudo to make kubernetes build for example make quick-release, you need run `sudo -E make quick-release` to pass the environment variables.
 
 ## TODOs
 

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -24,6 +24,10 @@ MAINTAINER  Joe Beda <jbeda@google.com>
 ENV GOARM 5
 ENV GOOS    linux
 ENV GOARCH  amd64
+ENV http_proxy KUBE_BUILD_HTTP_PROXY
+ENV https_proxy KUBE_BUILD_HTTPS_PROXY
+ENV no_proxy KUBE_BUILD_NO_PROXY
+
 
 # work around 64MB tmpfs size in Docker 1.6
 ENV TMPDIR /tmp.k8s

--- a/build/common.sh
+++ b/build/common.sh
@@ -209,14 +209,14 @@ function kube::build::is_osx() {
 
 function kube::build::update_dockerfile() {
   if kube::build::is_osx; then
-    sed_arg=\"\"
+    sed_opts=("-i ''")
   else
-    sed_arg=""
+    sed_opts=(-i)
   fi
-  sed -i $sed_arg "s/KUBE_BUILD_IMAGE_CROSS/${KUBE_BUILD_IMAGE_CROSS}/" ${build_context_dir}/Dockerfile
-  sed -i $sed_arg "s#KUBE_BUILD_HTTP_PROXY#"`echo ${KUBE_BUILD_HTTP_PROXY:-\"\"}`"#" ${build_context_dir}/Dockerfile
-  sed -i $sed_arg "s#KUBE_BUILD_HTTPS_PROXY#"`echo ${KUBE_BUILD_HTTPS_PROXY:-\"\"}`"#" ${build_context_dir}/Dockerfile
-  sed -i $sed_arg "s#KUBE_BUILD_NO_PROXY#"`echo ${KUBE_BUILD_NO_PROXY:-127.0.0.1}`"#" ${build_context_dir}/Dockerfile
+  sed ${sed_opts[@]} "s/KUBE_BUILD_IMAGE_CROSS/${KUBE_BUILD_IMAGE_CROSS}/" ${build_context_dir}/Dockerfile
+  sed ${sed_opts[@]} "s#KUBE_BUILD_HTTP_PROXY#${KUBE_BUILD_HTTP_PROXY:-\"\"}#" ${build_context_dir}/Dockerfile
+  sed ${sed_opts[@]} "s#KUBE_BUILD_HTTPS_PROXY#${KUBE_BUILD_HTTPS_PROXY:-\"\"}#" ${build_context_dir}/Dockerfile
+  sed ${sed_opts[@]} "s#KUBE_BUILD_NO_PROXY#${KUBE_BUILD_NO_PROXY:-127.0.0.1}#" ${build_context_dir}/Dockerfile
 }
 
 function kube::build::ensure_docker_in_path() {


### PR DESCRIPTION
I am in China and badly gcr.io is blocked by GWF hence I need to setup my own proxy to make Kubernetes build, however when I refer build/README.md and follow the guideline to setup proxy in build/build-image/Dockerfile, I still cannot successfully make my own build.

Checking the build logs and source code, I see requires to connect to gcr.io to pull docker images during build time, hence this requires docker machine kube-dev having the capabilities of bypassing the proxy.

I updated the build/README.md to reflect this requirement, so that a user behind a proxy won't be blocked for k8s build. Please kindly review and suggest if this is fine to merge. Thanks.

------------error logs before setting proxy for kube-dev------------------
+++ [0128 11:21:08] Starting Docker build for image: kube-proxy
unable to ping registry endpoint https://gcr.io/v0/
v2 ping attempt failed with error: Get https://gcr.io/v2/: dial tcp 64.233.189.82:443: i/o timeout
v1 ping attempt failed with error: Get https://gcr.io/v1/_ping: dial tcp 64.233.189.82:443: i/o timeout
!!! Error in build/../build/common.sh:774
'"${DOCKER[@]}" build -q -t "${docker_image_tag}" ${docker_build_path} > /dev/null' exited with status 1
Call stack:
1: build/../build/common.sh:774 kube::release::create_docker_images_for_server(...)
2: build/../build/common.sh:727 kube::release::package_server_tarballs(...)
3: build/../build/common.sh:661 kube::release::package_tarballs(...)
4: build/release.sh:40 main(...)
Exiting with status 1
!!! [0128 11:22:24] previous tarball phase failed
!!! Error in build/release.sh:40
'return 1' exited with status 1
Call stack:
1: build/release.sh:40 main(...)
Exiting with status 1
make: **\* [quick-release] Error 1
