### PR TITLE
Docs docker multihost fix

### DIFF
--- a/docs/getting-started-guides/docker-multinode/master.md
+++ b/docs/getting-started-guides/docker-multinode/master.md
@@ -122,7 +122,7 @@ sudo docker -H unix:///var/run/docker-bootstrap.sock exec <really-long-hash-from
 
 You now need to edit the docker configuration to activate new flags.  Again, this is system specific.
 
-This may be in `/etc/default/docker` or `/etc/systemd/service/docker.service` or it may be elsewhere.
+This may be in `/etc/default/docker`, `/etc/sysconfig/docker` or `/etc/systemd/service/docker.service` or it may be elsewhere.
 
 Regardless, you need to add the following to the docker command line:
 

--- a/docs/getting-started-guides/docker-multinode/worker.md
+++ b/docs/getting-started-guides/docker-multinode/worker.md
@@ -106,7 +106,7 @@ sudo docker -H unix:///var/run/docker-bootstrap.sock exec <really-long-hash-from
 
 You now need to edit the docker configuration to activate new flags.  Again, this is system specific.
 
-This may be in `/etc/default/docker` or `/etc/systemd/service/docker.service` or it may be elsewhere.
+This may be in `/etc/default/docker`, `/etc/sysconfig/docker` or `/etc/systemd/service/docker.service` or it may be elsewhere.
 
 Regardless, you need to add the following to the docker command line:
 


### PR DESCRIPTION
As the Amazon Linux path is included as an option in the bootstrap script it is useful to also have it in the docs.
