### PR TITLE
Remove e2e global 'timeout'

### DIFF
--- a/test/e2e/cadvisor.go
+++ b/test/e2e/cadvisor.go
@@ -27,7 +27,6 @@ import (
 )
 
 const (
-	timeout       = 1 * time.Minute
 	maxRetries    = 6
 	sleepDuration = 10 * time.Second
 )

--- a/test/e2e/nodeoutofdisk.go
+++ b/test/e2e/nodeoutofdisk.go
@@ -218,7 +218,7 @@ func availCpu(c *client.Client, node *api.Node) (int64, error) {
 func availSize(c *client.Client, node *api.Node) (uint64, error) {
 	statsResource := fmt.Sprintf("api/v1/proxy/nodes/%s/stats/", node.Name)
 	Logf("Querying stats for node %s using url %s", node.Name, statsResource)
-	res, err := c.Get().AbsPath(statsResource).Timeout(timeout).Do().Raw()
+	res, err := c.Get().AbsPath(statsResource).Timeout(time.Minute).Do().Raw()
 	if err != nil {
 		return 0, fmt.Errorf("error querying cAdvisor API: %v", err)
 	}


### PR DESCRIPTION
A badly named global symbol.  One of many, but this one but me.
