### PR TITLE
Adjust the limits in the kubelet resource tracking test

### DIFF
--- a/test/e2e/kubelet_perf.go
+++ b/test/e2e/kubelet_perf.go
@@ -160,17 +160,25 @@ var _ = Describe("Kubelet [Serial] [Slow]", func() {
 		rm.Stop()
 	})
 	Describe("regular resource usage tracking", func() {
+		// We assume that the scheduler will make reasonable scheduling choices
+		// and assign ~N pods on the node.
+		// Although we want to track N pods per node, there are N + add-on pods
+		// in the cluster. The cluster add-on pods can be distributed unevenly
+		// among the nodes because they are created during the cluster
+		// initialization. This *noise* is obvious when N is small. We
+		// deliberately set higher resource usage limits to account for the
+		// noise.
 		rTests := []resourceTest{
 			{podsPerNode: 0,
 				limits: containersCPUSummary{
-					"/kubelet":       {0.50: 0.05, 0.95: 0.15},
-					"/docker-daemon": {0.50: 0.03, 0.95: 0.06},
+					"/kubelet":       {0.50: 0.06, 0.95: 0.08},
+					"/docker-daemon": {0.50: 0.05, 0.95: 0.06},
 				},
 			},
 			{podsPerNode: 35,
 				limits: containersCPUSummary{
-					"/kubelet":       {0.50: 0.15, 0.95: 0.35},
-					"/docker-daemon": {0.50: 0.06, 0.95: 0.30},
+					"/kubelet":       {0.50: 0.12, 0.95: 0.14},
+					"/docker-daemon": {0.50: 0.06, 0.95: 0.08},
 				},
 			},
 		}


### PR DESCRIPTION
The new limits reflect the recent changes in kubelet, and also account for
noise better.

The numbers are obtained based on the maximum cpu usage in the past 20
builds (starting at build 341) in kubernetes-e2e-gce-serial. Extra padding (>25%)
is added to account for noise in the cluster.

This fixes #19647 and #19482.
