### PR TITLE
Revert "Decrease request size in autoscaling suite"

### DIFF
--- a/test/e2e/autoscaling_utils.go
+++ b/test/e2e/autoscaling_utils.go
@@ -31,7 +31,7 @@ import (
 const (
 	dynamicConsumptionTimeInSeconds = 30
 	staticConsumptionTimeInSeconds  = 3600
-	dynamicRequestSizeInMillicores  = 20
+	dynamicRequestSizeInMillicores  = 100
 	dynamicRequestSizeInMegabytes   = 100
 	port                            = 80
 	targetPort                      = 8080


### PR DESCRIPTION
GCE autoscaling tests have been [failing permanently](http://kubekins.dls.corp.google.com/view/Critical%20Builds/job/kubernetes-e2e-gce-autoscaling/) since kubernetes/kubernetes#20405 was merged. Rolling Back to fix build.
