### PR TITLE
Make HPA Deployment tests [Feature:Deployment] until GKE has enabled them

### DIFF
--- a/test/e2e/horizontal_pod_autoscaling.go
+++ b/test/e2e/horizontal_pod_autoscaling.go
@@ -41,7 +41,7 @@ var _ = Describe("Horizontal pod autoscaling (scale resource: CPU) [Serial] [Slo
 	titleUp := "Should scale from 1 pod to 3 pods and from 3 to 5"
 	titleDown := "Should scale from 5 pods to 3 pods and from 3 to 1"
 
-	Describe("Deployment", func() {
+	Describe("Deployment [Feature:Deployment]", func() {
 		// CPU tests via deployments
 		It(titleUp, func() {
 			scaleUp("deployment", kindDeployment, rc, f)


### PR DESCRIPTION
These tests are failing right now in GKE because we haven't enabled deployments there.  I filed an internal bug for that, but until that's resolved, we can't run these tests in GKE.

When we enabled deployments in GKE, we should remove all `[Feature:Deployment]` labels and have those tests run by default.
