### PR TITLE
AWS: Fix e2e usage of find-tagged-master-ip

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -160,6 +160,7 @@ function get_security_group_id {
 # Finds the master ip, if it is saved (tagged on the master disk)
 # Sets KUBE_MASTER_IP
 function find-tagged-master-ip {
+  find-master-pd
   if [[ -n "${MASTER_DISK_ID:-}" ]]; then
     KUBE_MASTER_IP=$(get-tag ${MASTER_DISK_ID} ${TAG_KEY_MASTER_IP})
   fi
@@ -175,6 +176,7 @@ function get-tag {
 }
 
 # Gets an existing master, exiting if not found
+# Note that this is called directly by the e2e tests
 function detect-master() {
   find-tagged-master-ip
   KUBE_MASTER=${MASTER_NAME}


### PR DESCRIPTION
In the e2e tests detect-master is called directly.  In turn, it calls
find-tagged-master-ip, which assumed that find-master-pd has already already
been called.  But this wasn't true in the e2e case.

We add a call to find-master-pd; it is idempotent.
