### PR TITLE
conversion: add default conversion for {string,bool} ptr to {string,bool}

### DIFF
--- a/pkg/api/conversion.go
+++ b/pkg/api/conversion.go
@@ -43,10 +43,52 @@ func init() {
 		Convert_unversioned_Time_To_unversioned_Time,
 		Convert_string_To_labels_Selector,
 		Convert_string_To_fields_Selector,
+		Convert_bool_ref_To_bool,
+		Convert_bool_To_bool_ref,
+		Convert_string_ref_To_string,
+		Convert_string_To_string_ref,
 		Convert_labels_Selector_To_string,
 		Convert_fields_Selector_To_string,
 		Convert_resource_Quantity_To_resource_Quantity,
 	)
+}
+
+func Convert_string_ref_To_string(in **string, out *string, s conversion.Scope) error {
+	if *in == nil {
+		*out = ""
+		return nil
+	}
+	*out = **in
+	return nil
+}
+
+func Convert_string_To_string_ref(in *string, out **string, s conversion.Scope) error {
+	if in == nil {
+		stringVar := ""
+		*out = &stringVar
+		return nil
+	}
+	*out = in
+	return nil
+}
+
+func Convert_bool_ref_To_bool(in **bool, out *bool, s conversion.Scope) error {
+	if *in == nil {
+		*out = false
+		return nil
+	}
+	*out = **in
+	return nil
+}
+
+func Convert_bool_To_bool_ref(in *bool, out **bool, s conversion.Scope) error {
+	if in == nil {
+		boolVar := false
+		*out = &boolVar
+		return nil
+	}
+	*out = in
+	return nil
 }
 
 func Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(in, out *unversioned.TypeMeta, s conversion.Scope) error {

--- a/pkg/apis/extensions/v1beta1/conversion_generated.go
+++ b/pkg/apis/extensions/v1beta1/conversion_generated.go
@@ -2591,7 +2591,7 @@ func autoConvert_extensions_DaemonSetSpec_To_v1beta1_DaemonSetSpec(in *extension
 	if err := Convert_extensions_DaemonSetUpdateStrategy_To_v1beta1_DaemonSetUpdateStrategy(&in.UpdateStrategy, &out.UpdateStrategy, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.UniqueLabelKey, &out.UniqueLabelKey, 0); err != nil {
+	if err := api.Convert_string_To_string_ref(&in.UniqueLabelKey, &out.UniqueLabelKey, s); err != nil {
 		return err
 	}
 	return nil
@@ -2731,7 +2731,7 @@ func autoConvert_extensions_DeploymentSpec_To_v1beta1_DeploymentSpec(in *extensi
 	} else {
 		out.RevisionHistoryLimit = nil
 	}
-	if err := s.Convert(&in.UniqueLabelKey, &out.UniqueLabelKey, 0); err != nil {
+	if err := api.Convert_string_To_string_ref(&in.UniqueLabelKey, &out.UniqueLabelKey, s); err != nil {
 		return err
 	}
 	out.Paused = in.Paused
@@ -3768,7 +3768,9 @@ func autoConvert_v1beta1_DaemonSetSpec_To_extensions_DaemonSetSpec(in *DaemonSet
 	if err := Convert_v1beta1_DaemonSetUpdateStrategy_To_extensions_DaemonSetUpdateStrategy(&in.UpdateStrategy, &out.UpdateStrategy, s); err != nil {
 		return err
 	}
-	// in.UniqueLabelKey has no peer in out
+	if err := api.Convert_string_ref_To_string(&in.UniqueLabelKey, &out.UniqueLabelKey, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -3904,7 +3906,9 @@ func autoConvert_v1beta1_DeploymentSpec_To_extensions_DeploymentSpec(in *Deploym
 	} else {
 		out.RevisionHistoryLimit = nil
 	}
-	// in.UniqueLabelKey has no peer in out
+	if err := api.Convert_string_ref_To_string(&in.UniqueLabelKey, &out.UniqueLabelKey, s); err != nil {
+		return err
+	}
 	out.Paused = in.Paused
 	// unable to generate simple pointer conversion for v1beta1.RollbackConfig -> extensions.RollbackConfig
 	if in.RollbackTo != nil {


### PR DESCRIPTION
This is useful because it allows defaulting to infer whether a
string,bool value was provided by the user while still having the field
represented as a non pointer type in the internal representation.

cc @caesarxuchao @lavalamp @smarterclayton 
