### PR TITLE
Output details of current context when using current-context subcommand

### DIFF
--- a/pkg/kubectl/cmd/config/current_context.go
+++ b/pkg/kubectl/cmd/config/current_context.go
@@ -19,6 +19,8 @@ package config
 import (
 	"fmt"
 	"io"
+
+	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/spf13/cobra"
@@ -56,12 +58,22 @@ func RunCurrentContext(out io.Writer, args []string, options *CurrentContextOpti
 	if err != nil {
 		return err
 	}
+	return describeCurrentContext(out, config)
+}
 
+func describeCurrentContext(out io.Writer, config *clientcmdapi.Config) error {
 	if config.CurrentContext == "" {
-		err = fmt.Errorf("current-context is not set\n")
+		err := fmt.Errorf("current-context is not set\n")
 		return err
 	}
-
-	fmt.Fprintf(out, "%s\n", config.CurrentContext)
+	fmt.Fprintf(out, "Name:\t%s\n", config.CurrentContext)
+	currentContext := config.Contexts[config.CurrentContext]
+	if currentContext == nil {
+		err := fmt.Errorf("has no current-context named %s\n", config.CurrentContext)
+		return err
+	}
+	fmt.Fprintf(out, "  Cluster:\t%s\n", currentContext.Cluster)
+	fmt.Fprintf(out, "  User:\t%s\n", currentContext.AuthInfo)
+	fmt.Fprintf(out, "  Namespace:\t%s\n", currentContext.Namespace)
 	return nil
 }

--- a/pkg/kubectl/cmd/config/current_context_test.go
+++ b/pkg/kubectl/cmd/config/current_context_test.go
@@ -35,6 +35,8 @@ type currentContextTest struct {
 func newFederalContextConfig() clientcmdapi.Config {
 	return clientcmdapi.Config{
 		CurrentContext: "federal-context",
+		Contexts: map[string]*clientcmdapi.Context{
+			"federal-context": {AuthInfo: "some-user", Namespace: "different-namespace"}},
 	}
 }
 


### PR DESCRIPTION
Fixes #16085.

Before this PR:

```
# ./cluster/kubectl.sh config current-context
default
```

After this PR:

```
# ./cluster/kubectl.sh config current-context
  Name: default
    Cluster: 
    Namespace: default
    User:
```

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/20468)

<!-- Reviewable:end -->
