### PR TITLE
[WIP] Skip kubectl tests that don't work before v1.1 when running against a  pre-v1.1 cluster

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/pkg/version"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -72,7 +73,27 @@ const (
 	simplePodPort            = 80
 )
 
-var proxyRegexp = regexp.MustCompile("Starting to serve on 127.0.0.1:([0-9]+)")
+var (
+	proxyRegexp = regexp.MustCompile("Starting to serve on 127.0.0.1:([0-9]+)")
+
+	// Extended pod logging options were introduced in #13780 (v1.1.0) so we don't expect tests
+	// that rely on extended pod logging options to work on clusters before that.
+	//
+	// TODO(ihmccreery): remove once we don't care about v1.0 anymore, (tentatively in v1.3).
+	extendedPodLogFilterVersion = version.MustParse("v1.1.0")
+
+	// NodePorts were made optional in #12831 (v1.1.0) so we don't expect tests that used to
+	// require NodePorts but no longer include them to work on clusters before that.
+	//
+	// TODO(ihmccreery): remove once we don't care about v1.0 anymore, (tentatively in v1.3).
+	nodePortsOptionalVersion = version.MustParse("v1.1.0")
+
+	// Jobs were introduced in v1.1, so we don't expect tests that rely on jobs to work on
+	// clusters before that.
+	//
+	// TODO(ihmccreery): remove once we don't care about v1.0 anymore, (tentatively in v1.3).
+	jobsVersion = version.MustParse("v1.1.0")
+)
 
 var _ = Describe("Kubectl client", func() {
 	defer GinkgoRecover()
@@ -143,6 +164,8 @@ var _ = Describe("Kubectl client", func() {
 		})
 
 		It("should create and stop a working application [Conformance]", func() {
+			SkipUnlessServerVersionGTE(nodePortsOptionalVersion, c)
+
 			defer cleanup(guestbookPath, ns, frontendSelector, redisMasterSelector, redisSlaveSelector)
 
 			By("creating all guestbook components")
@@ -371,6 +394,8 @@ var _ = Describe("Kubectl client", func() {
 		})
 
 		It("should support inline execution and attach", func() {
+			SkipUnlessServerVersionGTE(jobsVersion, c)
+
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 
 			By("executing a command with run and attach with stdin")
@@ -482,6 +507,8 @@ var _ = Describe("Kubectl client", func() {
 
 	Describe("Kubectl describe", func() {
 		It("should check if kubectl describe prints relevant information for rc and pods [Conformance]", func() {
+			SkipUnlessServerVersionGTE(nodePortsOptionalVersion, c)
+
 			mkpath := func(file string) string {
 				return filepath.Join(testContext.RepoRoot, "examples/guestbook-go", file)
 			}
@@ -694,6 +721,8 @@ var _ = Describe("Kubectl client", func() {
 		})
 
 		It("should be able to retrieve and filter logs [Conformance]", func() {
+			SkipUnlessServerVersionGTE(extendedPodLogFilterVersion, c)
+
 			forEachPod(c, ns, "app", "redis", func(pod api.Pod) {
 				By("checking for a matching strings")
 				_, err := lookForStringInLog(ns, pod.Name, containerName, "The server is now ready to accept connections", podStartTimeout)

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -50,6 +50,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/watch"
 
+	"github.com/blang/semver"
 	"github.com/davecgh/go-spew/spew"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/net/websocket"
@@ -256,6 +257,16 @@ func providerIs(providers ...string) bool {
 		}
 	}
 	return false
+}
+
+func SkipUnlessServerVersionGTE(v semver.Version, c client.VersionInterface) {
+	gte, err := serverVersionGTE(v, c)
+	if err != nil {
+		Failf("Failed to get server version: %v", err)
+	}
+	if !gte {
+		Skipf("Not supported for server versions before %q", v)
+	}
 }
 
 type podCondition func(pod *api.Pod) (bool, error)


### PR DESCRIPTION
Backport of fix for #18581 to `release-1.1`.
