### PR TITLE
Change docker health checker to using `docker ps`

### DIFF
--- a/cluster/gce/trusty/node.yaml
+++ b/cluster/gce/trusty/node.yaml
@@ -258,7 +258,7 @@ script
 	# We simply kill the process when there is a failure. Another upstart job will automatically
 	# restart the process.
 	while [ 1 ]; do
-		if ! timeout 10 docker version > /dev/null; then
+		if ! timeout 20 docker ps > /dev/null; then
 			echo "Docker daemon failed!"
 			pkill docker
 		fi

--- a/cluster/saltbase/salt/supervisor/docker-checker.sh
+++ b/cluster/saltbase/salt/supervisor/docker-checker.sh
@@ -25,7 +25,7 @@ echo "waiting a minute for startup"
 sleep 60
 
 while true; do
-  if ! sudo timeout 10 docker version > /dev/null; then
+  if ! sudo timeout 20 docker ps > /dev/null; then
     echo "Docker failed!"
     exit 2
   fi


### PR DESCRIPTION
`docker ps` is a more reliable health check than docker version from past
experiences.
