### PR TITLE
let singularization handle non-conflicting ambiguity

### DIFF
--- a/pkg/api/unversioned/group_version.go
+++ b/pkg/api/unversioned/group_version.go
@@ -56,6 +56,10 @@ type GroupVersionResource struct {
 	Resource string
 }
 
+func (gvr GroupVersionResource) IsEmpty() bool {
+	return len(gvr.Group) == 0 && len(gvr.Version) == 0 && len(gvr.Resource) == 0
+}
+
 func (gvr GroupVersionResource) GroupResource() GroupResource {
 	return GroupResource{Group: gvr.Group, Resource: gvr.Resource}
 }


### PR DESCRIPTION
If you had two versions of group kube.io and both defined "pods", singularization would fail on ambiguity, but the answer was always "pod".  This allows non-conflicting ambiguity to be considered a success.
