### PR TITLE
[Client-gen] Generate fake clientset automatically

### DIFF
--- a/cmd/libs/go2idl/client-gen/generators/client-generator.go
+++ b/cmd/libs/go2idl/client-gen/generators/client-generator.go
@@ -193,6 +193,9 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 	var packageList []generator.Package
 
 	packageList = append(packageList, packageForClientset(customArgs, arguments.OutputPackagePath, boilerplate))
+	if customArgs.FakeClient {
+		packageList = append(packageList, fake.PackageForClientset(arguments.OutputPackagePath, customArgs.GroupVersions, boilerplate))
+	}
 
 	// If --clientset-only=true, we don't regenerate the individual typed clients.
 	if customArgs.ClientsetOnly {

--- a/cmd/libs/go2idl/client-gen/generators/fake/generator-fake-for-clientset.go
+++ b/cmd/libs/go2idl/client-gen/generators/fake/generator-fake-for-clientset.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"k8s.io/kubernetes/cmd/libs/go2idl/client-gen/generators/normalization"
+	"k8s.io/kubernetes/cmd/libs/go2idl/generator"
+	"k8s.io/kubernetes/cmd/libs/go2idl/namer"
+	"k8s.io/kubernetes/cmd/libs/go2idl/types"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+)
+
+// genClientset generates a package for a clientset.
+type genClientset struct {
+	generator.DefaultGen
+	groupVersions      []unversioned.GroupVersion
+	typedClientPath    string
+	outputPackage      string
+	imports            *generator.ImportTracker
+	clientsetGenerated bool
+}
+
+var _ generator.Generator = &genClientset{}
+
+func (g *genClientset) Namers(c *generator.Context) namer.NameSystems {
+	return namer.NameSystems{
+		"raw": namer.NewRawNamer(g.outputPackage, g.imports),
+	}
+}
+
+// We only want to call GenerateType() once.
+func (g *genClientset) Filter(c *generator.Context, t *types.Type) bool {
+	ret := !g.clientsetGenerated
+	g.clientsetGenerated = true
+	return ret
+}
+
+func (g *genClientset) Imports(c *generator.Context) (imports []string) {
+	imports = append(imports, g.imports.ImportLines()...)
+	for _, gv := range g.groupVersions {
+		group := normalization.Group(gv.Group)
+		version := normalization.Version(gv.Version)
+		typedClientPath := filepath.Join(g.typedClientPath, group, version)
+		imports = append(imports, fmt.Sprintf("%s_%s \"%s\"", group, version, typedClientPath))
+		fakeTypedClientPath := filepath.Join(typedClientPath, "fake")
+		imports = append(imports, fmt.Sprintf("%s_%s_fake \"%s\"", group, version, fakeTypedClientPath))
+	}
+	return
+}
+
+func (g *genClientset) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {
+	// TODO: We actually don't need any type information to generate the clientset,
+	// perhaps we can adapt the go2ild framework to this kind of usage.
+	sw := generator.NewSnippetWriter(w, c, "$", "$")
+
+	type arg struct {
+		Group       string
+		PackageName string
+	}
+	allGroups := []arg{}
+	for _, gv := range g.groupVersions {
+		group := normalization.Group(gv.Group)
+		version := normalization.Version(gv.Version)
+		allGroups = append(allGroups, arg{namer.IC(group), group + "_" + version})
+	}
+
+	for _, g := range allGroups {
+		sw.Do(clientsetInterfaceImplTemplate, g)
+	}
+
+	return sw.Error()
+}
+
+var clientsetInterfaceImplTemplate = `
+// $.Group$ retrieves the $.Group$Client
+func (c *Clientset) $.Group$() $.PackageName$.$.Group$Interface {
+	return &$.PackageName$_fake.Fake$.Group${&c.Fake}
+}
+`

--- a/cmd/libs/go2idl/client-gen/generators/normalization/normalization.go
+++ b/cmd/libs/go2idl/client-gen/generators/normalization/normalization.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package normalization
+
+func Group(group string) string {
+	if group == "api" {
+		return "legacy"
+	}
+	return group
+}
+
+func Version(version string) string {
+	if version == "" {
+		return "unversioned"
+	}
+	return version
+}

--- a/pkg/client/testing/fake/clientset.go
+++ b/pkg/client/testing/fake/clientset.go
@@ -20,10 +20,6 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_1"
 	"k8s.io/kubernetes/pkg/client/testing/core"
-	extensions_unversioned "k8s.io/kubernetes/pkg/client/typed/generated/extensions/unversioned"
-	extensions_unversioned_fake "k8s.io/kubernetes/pkg/client/typed/generated/extensions/unversioned/fake"
-	legacy_unversioned "k8s.io/kubernetes/pkg/client/typed/generated/legacy/unversioned"
-	legacy_unversioned_fake "k8s.io/kubernetes/pkg/client/typed/generated/legacy/unversioned/fake"
 	"k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch"
@@ -54,14 +50,6 @@ type Clientset struct {
 }
 
 var _ clientset.Interface = &Clientset{}
-
-func (c *Clientset) Legacy() legacy_unversioned.LegacyInterface {
-	return &legacy_unversioned_fake.FakeLegacy{&c.Fake}
-}
-
-func (c *Clientset) Extensions() extensions_unversioned.ExtensionsInterface {
-	return &extensions_unversioned_fake.FakeExtensions{&c.Fake}
-}
 
 func (c *Clientset) Discovery() unversioned.DiscoveryInterface {
 	return &FakeDiscovery{&c.Fake}

--- a/pkg/client/testing/fake/clientset_generated.go
+++ b/pkg/client/testing/fake/clientset_generated.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	extensions_unversioned "k8s.io/kubernetes/pkg/client/typed/generated/extensions/unversioned"
+	extensions_unversioned_fake "k8s.io/kubernetes/pkg/client/typed/generated/extensions/unversioned/fake"
+	legacy_unversioned "k8s.io/kubernetes/pkg/client/typed/generated/legacy/unversioned"
+	legacy_unversioned_fake "k8s.io/kubernetes/pkg/client/typed/generated/legacy/unversioned/fake"
+)
+
+// Legacy retrieves the LegacyClient
+func (c *Clientset) Legacy() legacy_unversioned.LegacyInterface {
+	return &legacy_unversioned_fake.FakeLegacy{&c.Fake}
+}
+
+// Extensions retrieves the ExtensionsClient
+func (c *Clientset) Extensions() extensions_unversioned.ExtensionsInterface {
+	return &extensions_unversioned_fake.FakeExtensions{&c.Fake}
+}


### PR DESCRIPTION
Fix #20414. This is a small improvement to client-gen, relieve the user from the burden of manually updating pkg/client/testing/fake/clientset.go every time they add a group.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/20523)

<!-- Reviewable:end -->
