### PR TITLE
Add AWS Jenkins jobs to source control.

### DIFF
--- a/hack/jenkins/job-configs/global.yaml
+++ b/hack/jenkins/job-configs/global.yaml
@@ -62,3 +62,4 @@
 - defaults:
     name: global
     emails: '$DEFAULT_RECIPIENTS'
+    cron-string: 'H/30 * * * *'

--- a/hack/jenkins/job-configs/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-e2e.yaml
@@ -20,7 +20,7 @@
         - reverse:
             jobs: '{trigger-job}'
             result: success
-        - timed: 'H/30 * * * *'
+        - timed: '{cron-string}'
     wrappers:
         - ansicolor:
             colormap: xterm
@@ -189,5 +189,23 @@
             timeout: 300
             emails: '$DEFAULT_RECIPIENTS, ihmccreery@google.com'
             test-owner: 'ihmccreery'
+    jobs:
+        - 'kubernetes-e2e-{suffix}'
+
+- project:
+    name: kubernetes-aws
+    test-owner: 'bburns'
+    emails: 'bburns@google.com'
+    cron-string: '@daily'
+    trigger-job: ''
+    suffix:
+        - 'aws':
+            description: 'Run e2e tests on AWS using the latest successful Kubernetes build.'
+            timeout: 240
+            branch: 'master'
+        - 'aws-release-1.1':
+            description: 'Run e2e tests on AWS using the latest successful 1.1 Kubernetes build.'
+            timeout: 240
+            branch: 'release-1.1'
     jobs:
         - 'kubernetes-e2e-{suffix}'


### PR DESCRIPTION
Ref: #18122

These aren't disabled, they just run daily. I forgot to ask you to do this last time, but please don't add the LGTM label, just state it. I'll merge manually.

That way I don't accidentally disable Jenkins at 4 AM :P
