### PR TITLE
add http handler to export configuration state

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -62,6 +62,7 @@ import (
 	"k8s.io/kubernetes/pkg/healthz"
 	"k8s.io/kubernetes/pkg/serviceaccount"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/configz"
 	"k8s.io/kubernetes/pkg/util/wait"
 
 	"github.com/golang/glog"
@@ -100,6 +101,11 @@ func ResyncPeriod(s *options.CMServer) func() time.Duration {
 
 // Run runs the CMServer.  This should never exit.
 func Run(s *options.CMServer) error {
+	if c, err := configz.New("componentconfig"); err == nil {
+		c.Set(s.KubeControllerManagerConfiguration)
+	} else {
+		glog.Errorf("unable to register configz: %s", err)
+	}
 	kubeconfig, err := clientcmd.BuildConfigFromFlags(s.Master, s.Kubeconfig)
 	if err != nil {
 		return err

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -58,6 +58,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/server"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/configz"
 	"k8s.io/kubernetes/pkg/util/flock"
 	"k8s.io/kubernetes/pkg/util/io"
 	"k8s.io/kubernetes/pkg/util/mount"
@@ -276,6 +277,11 @@ func run(s *options.KubeletServer, kcfg *KubeletConfig) (err error) {
 		if err := flock.Acquire(s.LockFilePath); err != nil {
 			return fmt.Errorf("unable to aquire file lock on %q: %v", s.LockFilePath, err)
 		}
+	}
+	if c, err := configz.New("componentconfig"); err == nil {
+		c.Set(s.KubeletConfiguration)
+	} else {
+		glog.Errorf("unable to register configz: %s", err)
 	}
 	if kcfg == nil {
 		cfg, err := UnsecuredKubeletConfig(s)

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -52,6 +52,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/server/stats"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/types"
+	"k8s.io/kubernetes/pkg/util/configz"
 	"k8s.io/kubernetes/pkg/util/flushwriter"
 	"k8s.io/kubernetes/pkg/util/httpstream"
 	"k8s.io/kubernetes/pkg/util/httpstream/spdy"
@@ -327,6 +328,8 @@ func (s *Server) InstallDebuggingHandlers() {
 		To(s.getContainerLogs).
 		Operation("getContainerLogs"))
 	s.restfulCont.Add(ws)
+
+	configz.InstallHandler(s.restfulCont)
 
 	handlePprofEndpoint := func(req *restful.Request, resp *restful.Response) {
 		name := strings.TrimPrefix(req.Request.URL.Path, pprofBasePath)

--- a/pkg/util/configz/configz.go
+++ b/pkg/util/configz/configz.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configz
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+)
+
+var (
+	configsGuard sync.RWMutex
+	configs      = map[string]*Config{}
+)
+
+type Config struct {
+	val interface{}
+}
+
+func InstallHandler(m mux) {
+	m.Handle("/configz", http.HandlerFunc(handle))
+}
+
+type mux interface {
+	Handle(string, http.Handler)
+}
+
+func New(name string) (*Config, error) {
+	configsGuard.Lock()
+	defer configsGuard.Unlock()
+	if _, found := configs[name]; found {
+		return nil, fmt.Errorf("register config %q twice", name)
+	}
+	newConfig := Config{}
+	configs[name] = &newConfig
+	return &newConfig, nil
+}
+
+func Delete(name string) {
+	configsGuard.Lock()
+	defer configsGuard.Unlock()
+	delete(configs, name)
+}
+
+func (v *Config) Set(val interface{}) {
+	configsGuard.Lock()
+	defer configsGuard.Unlock()
+	v.val = val
+}
+
+func (v *Config) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.val)
+}
+
+func handle(w http.ResponseWriter, r *http.Request) {
+	if err := write(w); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func write(w io.Writer) error {
+	configsGuard.Lock()
+	defer configsGuard.Unlock()
+	b, err := json.Marshal(configs)
+	if err != nil {
+		return fmt.Errorf("error marshaling json: %v", err)
+	}
+	_, err = w.Write(b)
+	return err
+}

--- a/pkg/util/configz/configz_test.go
+++ b/pkg/util/configz/configz_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configz
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestConfigz(t *testing.T) {
+	v, err := New("testing")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	v.Set("blah")
+
+	s := httptest.NewServer(http.HandlerFunc(handle))
+	// TODO: Uncomment when fix #19254
+	// defer s.Close()
+
+	resp, err := http.Get(s.URL + "/configz")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if string(body) != `{"testing":"blah"}` {
+		t.Fatalf("unexpected output: %v", err)
+	}
+
+	v.Set("bing")
+	resp, err = http.Get(s.URL + "/configz")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	body, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if string(body) != `{"testing":"bing"}` {
+		t.Fatalf("unexpected output: %v", err)
+	}
+
+	Delete("testing")
+	resp, err = http.Get(s.URL + "/configz")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	body, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if string(body) != `{}` {
+		t.Fatalf("unexpected output: %v", err)
+	}
+}


### PR DESCRIPTION
certain features of http://godoc.org/expvar make it difficult to use in k8s. Firstly it recieves a special interface expvar.Var so we would have to figure out how to marshal structs int expvar.Var. Second, it doesn't export the http handler so we would have to vendor the hander since we use non-default http.ServeMux's everywhere.
