### PR TITLE
WIP/MESOS: Revert "Skip kubectl tests that don't work before v1.1 when running a…

### DIFF
--- a/cluster/mesos/docker/test/Dockerfile
+++ b/cluster/mesos/docker/test/Dockerfile
@@ -47,4 +47,9 @@ COPY ./bin/* /usr/local/bin/
 
 RUN install-etcd.sh
 
+RUN mkdir -p /root/.ssh && chmod 700 /root/.ssh
+
+# avoid git/ssh prompts for host key acceptance
+RUN ssh-keyscan -t rsa github.com 2>&1 >> /root/.ssh/known_hosts
+
 ENTRYPOINT [ "bash" ]

--- a/cluster/mesos/docker/util.sh
+++ b/cluster/mesos/docker/util.sh
@@ -286,7 +286,7 @@ function kube-up {
 
   echo "Checking server version"
   local kubectl="${KUBE_ROOT}/cluster/kubectl.sh"
-  kubectl version
+  ${kubectl} version
 
   echo "Deploying Addons" 1>&2
   KUBE_SERVER=${KUBE_SERVER} "${provider_root}/deploy-addons.sh"

--- a/cluster/mesos/docker/util.sh
+++ b/cluster/mesos/docker/util.sh
@@ -284,6 +284,9 @@ function kube-up {
   detect-nodes
   create-kubeconfig
 
+  echo "Checking local directory"
+  ls -laF ${KUBE_ROOT}
+
   echo "Checking server version"
   local kubectl="${KUBE_ROOT}/cluster/kubectl.sh"
   ${kubectl} version

--- a/cluster/mesos/docker/util.sh
+++ b/cluster/mesos/docker/util.sh
@@ -284,6 +284,10 @@ function kube-up {
   detect-nodes
   create-kubeconfig
 
+  echo "Checking server version"
+  local kubectl="${KUBE_ROOT}/cluster/kubectl.sh"
+  kubectl version
+
   echo "Deploying Addons" 1>&2
   KUBE_SERVER=${KUBE_SERVER} "${provider_root}/deploy-addons.sh"
 

--- a/contrib/mesos/ci/run-with-cluster.sh
+++ b/contrib/mesos/ci/run-with-cluster.sh
@@ -78,7 +78,6 @@ docker run \
   -t $(tty &>/dev/null && echo "-i") \
   mesosphere/kubernetes-mesos-test \
   -ceux "\
-    git fetch --tags --verbose && \
     make clean all && \
     trap 'timeout 5m ./cluster/kube-down.sh' EXIT && \
     ./cluster/kube-down.sh && \

--- a/contrib/mesos/ci/run-with-cluster.sh
+++ b/contrib/mesos/ci/run-with-cluster.sh
@@ -77,6 +77,7 @@ docker run \
   -t $(tty &>/dev/null && echo "-i") \
   mesosphere/kubernetes-mesos-test \
   -ceux "\
+    git fetch --tags --verbose && \
     make clean all && \
     trap 'timeout 5m ./cluster/kube-down.sh' EXIT && \
     ./cluster/kube-down.sh && \

--- a/contrib/mesos/ci/run-with-cluster.sh
+++ b/contrib/mesos/ci/run-with-cluster.sh
@@ -67,6 +67,7 @@ docker run \
   -v "${MESOS_DOCKER_WORK_DIR}/mesosslave2/mesos:${MESOS_DOCKER_WORK_DIR}/mesosslave2/mesos" \
   -v "${MESOS_DOCKER_WORK_DIR}/overlay:${MESOS_DOCKER_WORK_DIR}/overlay" \
   -v "${MESOS_DOCKER_WORK_DIR}/reports:${MESOS_DOCKER_WORK_DIR}/reports" \
+  $(test -d /teamcity/system/git && echo "-v /teamcity/system/git:/teamcity/system/git" || true) \
   -e "MESOS_DOCKER_WORK_DIR=${MESOS_DOCKER_WORK_DIR}" \
   -e "MESOS_DOCKER_IMAGE_DIR=/var/tmp/kubernetes" \
   -e "MESOS_DOCKER_OVERLAY_DIR=${MESOS_DOCKER_WORK_DIR}/overlay" \


### PR DESCRIPTION
…gainst a pre-v1.1 cluster; fixes #18581"

This reverts commit 14e691036420a16e8bfbe1715624fc572849cf4b.

... testing whether reverting this change fixes our smoke tests
