### PR TITLE
centos_manual_config.md: fix etcd client port

### DIFF
--- a/docs/getting-started-guides/centos/centos_manual_config.md
+++ b/docs/getting-started-guides/centos/centos_manual_config.md
@@ -88,7 +88,7 @@ echo "192.168.121.9	centos-master
 
 ```sh
 # Comma separated list of nodes in the etcd cluster
-KUBE_ETCD_SERVERS="--etcd-servers=http://centos-master:4001"
+KUBE_ETCD_SERVERS="--etcd-servers=http://centos-master:2379"
 
 # logging to stderr means we get it in the systemd journal
 KUBE_LOGTOSTDERR="--logtostderr=true"


### PR DESCRIPTION
As per https://github.com/coreos/etcd/blob/master/Documentation/configuration.md

> The official etcd ports are 2379 for client requests, and 2380 for peer
> communication. Some legacy code and documentation still references
> ports 4001 and 7001, but all new etcd use and discussion should
> adopt the assigned ports.

Indeed, etcd-2.1.1-2.el7.x86_64 as comes in centos 7 "extras" repo is configured
to listen to clients at port 2379, not 4001.

Signed-off-by: Kirill Kolyshkin kolyshkin@gmail.com
