### PR TITLE
bump(ugorji/go): 4a79e5b7b21e51ae8d61641bca20399b79735a32

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -931,7 +931,7 @@
 		},
 		{
 			"ImportPath": "github.com/ugorji/go/codec",
-			"Rev": "f1f1a805ed361a0e078bb537e4ea78cd37dcf065"
+			"Rev": "4a79e5b7b21e51ae8d61641bca20399b79735a32"
 		},
 		{
 			"ImportPath": "github.com/vishvananda/netlink",

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/0doc.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/0doc.go
@@ -64,6 +64,7 @@ Rich Feature Set includes:
   - Never silently skip data when decoding.
     User decides whether to return an error or silently skip data when keys or indexes
     in the data stream do not map to fields in the struct.
+  - Detect and error when encoding a cyclic reference (instead of stack overflow shutdown)
   - Encode/Decode from/to chan types (for iterative streaming support)
   - Drop-in replacement for encoding/json. `json:` key in struct tag supported.
   - Provides a RPC Server and Client Codec for net/rpc communication protocol.
@@ -171,6 +172,8 @@ package codec
 
 // TODO:
 //
+//   - optimization for codecgen:
+//     if len of entity is <= 3 words, then support a value receiver for encode.
 //   - (En|De)coder should store an error when it occurs.
 //     Until reset, subsequent calls return that error that was stored.
 //     This means that free panics must go away.
@@ -190,4 +193,7 @@ package codec
 //    - Consider making Handle used AS-IS within the encoding/decoding session.
 //      This means that we don't cache Handle information within the (En|De)coder,
 //      except we really need it at Reset(...)
-//    - Handle recursive types during encoding/decoding?
+//    - Consider adding math/big support
+//    - Consider reducing the size of the generated functions:
+//      Maybe use one loop, and put the conditionals in the loop.
+//      for ... { if cLen > 0 { if j == cLen { break } } else if dd.CheckBreak() { break } }

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/binc.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/binc.go
@@ -908,10 +908,14 @@ func (h *BincHandle) newDecDriver(d *Decoder) decDriver {
 
 func (e *bincEncDriver) reset() {
 	e.w = e.e.w
+	e.s = 0
+	e.m = nil
 }
 
 func (d *bincDecDriver) reset() {
 	d.r = d.d.r
+	d.s = nil
+	d.bd, d.bdRead, d.vd, d.vs = 0, false, 0, 0
 }
 
 var _ decDriver = (*bincDecDriver)(nil)

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/cbor.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/cbor.go
@@ -578,6 +578,7 @@ func (e *cborEncDriver) reset() {
 
 func (d *cborDecDriver) reset() {
 	d.r = d.d.r
+	d.bd, d.bdRead = 0, false
 }
 
 var _ decDriver = (*cborDecDriver)(nil)

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/decode.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/decode.go
@@ -1862,6 +1862,7 @@ func (d *Decoder) intern(s string) {
 	}
 }
 
+// nextValueBytes returns the next value in the stream as a set of bytes.
 func (d *Decoder) nextValueBytes() []byte {
 	d.d.uncacheRead()
 	d.r.track()

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/encode.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/encode.go
@@ -110,6 +110,15 @@ type EncodeOptions struct {
 	//
 	Canonical bool
 
+	// CheckCircularRef controls whether we check for circular references
+	// and error fast during an encode.
+	//
+	// If enabled, an error is received if a pointer to a struct
+	// references itself either directly or through one of its fields (iteratively).
+	//
+	// This is opt-in, as there may be a performance hit to checking circular references.
+	CheckCircularRef bool
+
 	// AsSymbols defines what should be encoded as symbols.
 	//
 	// Encoding as symbols can reduce the encoded size significantly.
@@ -503,7 +512,7 @@ func (f *encFnInfo) kStruct(rv reflect.Value) {
 	newlen := len(fti.sfi)
 
 	// Use sync.Pool to reduce allocating slices unnecessarily.
-	// The cost of the occasional locking is less than the cost of new allocation.
+	// The cost of sync.Pool is less than the cost of new allocation.
 	pool, poolv, fkvs := encStructPoolGet(newlen)
 
 	// if toMap, use the sorted array. If toArray, use unsorted array (to match sequence in struct)
@@ -514,11 +523,6 @@ func (f *encFnInfo) kStruct(rv reflect.Value) {
 	var kv stringRv
 	for _, si := range tisfi {
 		kv.r = si.field(rv, false)
-		// if si.i != -1 {
-		// 	rvals[newlen] = rv.Field(int(si.i))
-		// } else {
-		// 	rvals[newlen] = rv.FieldByIndex(si.is)
-		// }
 		if toMap {
 			if si.omitEmpty && isEmptyValue(kv.r) {
 				continue
@@ -596,13 +600,15 @@ func (f *encFnInfo) kStruct(rv reflect.Value) {
 // 	f.e.encodeValue(rv.Elem())
 // }
 
-func (f *encFnInfo) kInterface(rv reflect.Value) {
-	if rv.IsNil() {
-		f.e.e.EncodeNil()
-		return
-	}
-	f.e.encodeValue(rv.Elem(), nil)
-}
+// func (f *encFnInfo) kInterface(rv reflect.Value) {
+// 	println("kInterface called")
+// 	debug.PrintStack()
+// 	if rv.IsNil() {
+// 		f.e.e.EncodeNil()
+// 		return
+// 	}
+// 	f.e.encodeValue(rv.Elem(), nil)
+// }
 
 func (f *encFnInfo) kMap(rv reflect.Value) {
 	ee := f.e.e
@@ -877,6 +883,7 @@ type Encoder struct {
 	// as the handler MAY need to do some coordination.
 	w  encWriter
 	s  []encRtidFn
+	ci set
 	be bool // is binary encoding
 	js bool // is json handle
 
@@ -1133,20 +1140,23 @@ func (e *Encoder) encode(iv interface{}) {
 	}
 }
 
-func (e *Encoder) encodeI(iv interface{}, checkFastpath, checkCodecSelfer bool) {
-	if rv, proceed := e.preEncodeValue(reflect.ValueOf(iv)); proceed {
-		rt := rv.Type()
-		rtid := reflect.ValueOf(rt).Pointer()
-		fn := e.getEncFn(rtid, rt, checkFastpath, checkCodecSelfer)
-		fn.f(&fn.i, rv)
-	}
-}
-
-func (e *Encoder) preEncodeValue(rv reflect.Value) (rv2 reflect.Value, proceed bool) {
+func (e *Encoder) preEncodeValue(rv reflect.Value) (rv2 reflect.Value, sptr uintptr, proceed bool) {
 	// use a goto statement instead of a recursive function for ptr/interface.
 TOP:
 	switch rv.Kind() {
-	case reflect.Ptr, reflect.Interface:
+	case reflect.Ptr:
+		if rv.IsNil() {
+			e.e.EncodeNil()
+			return
+		}
+		rv = rv.Elem()
+		if e.h.CheckCircularRef && rv.Kind() == reflect.Struct {
+			// TODO: Movable pointers will be an issue here. Future problem.
+			sptr = rv.UnsafeAddr()
+			break TOP
+		}
+		goto TOP
+	case reflect.Interface:
 		if rv.IsNil() {
 			e.e.EncodeNil()
 			return
@@ -1163,18 +1173,39 @@ TOP:
 		return
 	}
 
-	return rv, true
+	proceed = true
+	rv2 = rv
+	return
+}
+
+func (e *Encoder) doEncodeValue(rv reflect.Value, fn *encFn, sptr uintptr,
+	checkFastpath, checkCodecSelfer bool) {
+	if sptr != 0 {
+		if (&e.ci).add(sptr) {
+			e.errorf("circular reference found: # %d", sptr)
+		}
+	}
+	if fn == nil {
+		rt := rv.Type()
+		rtid := reflect.ValueOf(rt).Pointer()
+		fn = e.getEncFn(rtid, rt, true, true)
+	}
+	fn.f(&fn.i, rv)
+	if sptr != 0 {
+		(&e.ci).remove(sptr)
+	}
+}
+
+func (e *Encoder) encodeI(iv interface{}, checkFastpath, checkCodecSelfer bool) {
+	if rv, sptr, proceed := e.preEncodeValue(reflect.ValueOf(iv)); proceed {
+		e.doEncodeValue(rv, nil, sptr, checkFastpath, checkCodecSelfer)
+	}
 }
 
 func (e *Encoder) encodeValue(rv reflect.Value, fn *encFn) {
 	// if a valid fn is passed, it MUST BE for the dereferenced type of rv
-	if rv, proceed := e.preEncodeValue(rv); proceed {
-		if fn == nil {
-			rt := rv.Type()
-			rtid := reflect.ValueOf(rt).Pointer()
-			fn = e.getEncFn(rtid, rt, true, true)
-		}
-		fn.f(&fn.i, rv)
+	if rv, sptr, proceed := e.preEncodeValue(rv); proceed {
+		e.doEncodeValue(rv, fn, sptr, true, true)
 	}
 }
 
@@ -1284,10 +1315,11 @@ func (e *Encoder) getEncFn(rtid uintptr, rt reflect.Type, checkFastpath, checkCo
 				fn.f = (*encFnInfo).kSlice
 			case reflect.Struct:
 				fn.f = (*encFnInfo).kStruct
+				// reflect.Ptr and reflect.Interface are handled already by preEncodeValue
 				// case reflect.Ptr:
 				// 	fn.f = (*encFnInfo).kPtr
-			case reflect.Interface:
-				fn.f = (*encFnInfo).kInterface
+				// case reflect.Interface:
+				// 	fn.f = (*encFnInfo).kInterface
 			case reflect.Map:
 				fn.f = (*encFnInfo).kMap
 			default:
@@ -1353,25 +1385,6 @@ func encStructPoolGet(newlen int) (p *sync.Pool, v interface{}, s []stringRv) {
 	// 	panic(errors.New("encStructPoolLen must be equal to 4")) // defensive, in case it is changed
 	// }
 	// idxpool := newlen / 8
-
-	// if pool == nil {
-	// 	fkvs = make([]stringRv, newlen)
-	// } else {
-	// 	poolv = pool.Get()
-	// 	switch vv := poolv.(type) {
-	// 	case *[8]stringRv:
-	// 		fkvs = vv[:newlen]
-	// 	case *[16]stringRv:
-	// 		fkvs = vv[:newlen]
-	// 	case *[32]stringRv:
-	// 		fkvs = vv[:newlen]
-	// 	case *[64]stringRv:
-	// 		fkvs = vv[:newlen]
-	// 	case *[128]stringRv:
-	// 		fkvs = vv[:newlen]
-	// 	}
-	// }
-
 	if newlen <= 8 {
 		p = &encStructPool[0]
 		v = p.Get()

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/fast-path.generated.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/fast-path.generated.go
@@ -17712,7 +17712,7 @@ func (_ fastpathT) DecSliceIntfV(v []interface{}, checkNil bool, canChange bool,
 			changed = true
 		}
 		slh.End()
-		return
+		return v, changed
 	}
 
 	if containerLenS > 0 {
@@ -17771,7 +17771,7 @@ func (_ fastpathT) DecSliceIntfV(v []interface{}, checkNil bool, canChange bool,
 				changed = true
 			}
 			slh.End()
-			return
+			return v, changed
 		}
 		if cap(v) == 0 {
 			v = make([]interface{}, 1, 4)
@@ -17846,7 +17846,7 @@ func (_ fastpathT) DecSliceStringV(v []string, checkNil bool, canChange bool, d 
 			changed = true
 		}
 		slh.End()
-		return
+		return v, changed
 	}
 
 	if containerLenS > 0 {
@@ -17905,7 +17905,7 @@ func (_ fastpathT) DecSliceStringV(v []string, checkNil bool, canChange bool, d 
 				changed = true
 			}
 			slh.End()
-			return
+			return v, changed
 		}
 		if cap(v) == 0 {
 			v = make([]string, 1, 4)
@@ -17979,7 +17979,7 @@ func (_ fastpathT) DecSliceFloat32V(v []float32, checkNil bool, canChange bool, 
 			changed = true
 		}
 		slh.End()
-		return
+		return v, changed
 	}
 
 	if containerLenS > 0 {
@@ -18038,7 +18038,7 @@ func (_ fastpathT) DecSliceFloat32V(v []float32, checkNil bool, canChange bool, 
 				changed = true
 			}
 			slh.End()
-			return
+			return v, changed
 		}
 		if cap(v) == 0 {
 			v = make([]float32, 1, 4)
@@ -18112,7 +18112,7 @@ func (_ fastpathT) DecSliceFloat64V(v []float64, checkNil bool, canChange bool, 
 			changed = true
 		}
 		slh.End()
-		return
+		return v, changed
 	}
 
 	if containerLenS > 0 {
@@ -18171,7 +18171,7 @@ func (_ fastpathT) DecSliceFloat64V(v []float64, checkNil bool, canChange bool, 
 				changed = true
 			}
 			slh.End()
-			return
+			return v, changed
 		}
 		if cap(v) == 0 {
 			v = make([]float64, 1, 4)
@@ -18245,7 +18245,7 @@ func (_ fastpathT) DecSliceUintV(v []uint, checkNil bool, canChange bool, d *Dec
 			changed = true
 		}
 		slh.End()
-		return
+		return v, changed
 	}
 
 	if containerLenS > 0 {
@@ -18304,7 +18304,7 @@ func (_ fastpathT) DecSliceUintV(v []uint, checkNil bool, canChange bool, d *Dec
 				changed = true
 			}
 			slh.End()
-			return
+			return v, changed
 		}
 		if cap(v) == 0 {
 			v = make([]uint, 1, 4)
@@ -18378,7 +18378,7 @@ func (_ fastpathT) DecSliceUint16V(v []uint16, checkNil bool, canChange bool, d 
 			changed = true
 		}
 		slh.End()
-		return
+		return v, changed
 	}
 
 	if containerLenS > 0 {
@@ -18437,7 +18437,7 @@ func (_ fastpathT) DecSliceUint16V(v []uint16, checkNil bool, canChange bool, d 
 				changed = true
 			}
 			slh.End()
-			return
+			return v, changed
 		}
 		if cap(v) == 0 {
 			v = make([]uint16, 1, 4)
@@ -18511,7 +18511,7 @@ func (_ fastpathT) DecSliceUint32V(v []uint32, checkNil bool, canChange bool, d 
 			changed = true
 		}
 		slh.End()
-		return
+		return v, changed
 	}
 
 	if containerLenS > 0 {
@@ -18570,7 +18570,7 @@ func (_ fastpathT) DecSliceUint32V(v []uint32, checkNil bool, canChange bool, d 
 				changed = true
 			}
 			slh.End()
-			return
+			return v, changed
 		}
 		if cap(v) == 0 {
 			v = make([]uint32, 1, 4)
@@ -18644,7 +18644,7 @@ func (_ fastpathT) DecSliceUint64V(v []uint64, checkNil bool, canChange bool, d 
 			changed = true
 		}
 		slh.End()
-		return
+		return v, changed
 	}
 
 	if containerLenS > 0 {
@@ -18703,7 +18703,7 @@ func (_ fastpathT) DecSliceUint64V(v []uint64, checkNil bool, canChange bool, d 
 				changed = true
 			}
 			slh.End()
-			return
+			return v, changed
 		}
 		if cap(v) == 0 {
 			v = make([]uint64, 1, 4)
@@ -18777,7 +18777,7 @@ func (_ fastpathT) DecSliceUintptrV(v []uintptr, checkNil bool, canChange bool, 
 			changed = true
 		}
 		slh.End()
-		return
+		return v, changed
 	}
 
 	if containerLenS > 0 {
@@ -18836,7 +18836,7 @@ func (_ fastpathT) DecSliceUintptrV(v []uintptr, checkNil bool, canChange bool, 
 				changed = true
 			}
 			slh.End()
-			return
+			return v, changed
 		}
 		if cap(v) == 0 {
 			v = make([]uintptr, 1, 4)
@@ -18910,7 +18910,7 @@ func (_ fastpathT) DecSliceIntV(v []int, checkNil bool, canChange bool, d *Decod
 			changed = true
 		}
 		slh.End()
-		return
+		return v, changed
 	}
 
 	if containerLenS > 0 {
@@ -18969,7 +18969,7 @@ func (_ fastpathT) DecSliceIntV(v []int, checkNil bool, canChange bool, d *Decod
 				changed = true
 			}
 			slh.End()
-			return
+			return v, changed
 		}
 		if cap(v) == 0 {
 			v = make([]int, 1, 4)
@@ -19043,7 +19043,7 @@ func (_ fastpathT) DecSliceInt8V(v []int8, checkNil bool, canChange bool, d *Dec
 			changed = true
 		}
 		slh.End()
-		return
+		return v, changed
 	}
 
 	if containerLenS > 0 {
@@ -19102,7 +19102,7 @@ func (_ fastpathT) DecSliceInt8V(v []int8, checkNil bool, canChange bool, d *Dec
 				changed = true
 			}
 			slh.End()
-			return
+			return v, changed
 		}
 		if cap(v) == 0 {
 			v = make([]int8, 1, 4)
@@ -19176,7 +19176,7 @@ func (_ fastpathT) DecSliceInt16V(v []int16, checkNil bool, canChange bool, d *D
 			changed = true
 		}
 		slh.End()
-		return
+		return v, changed
 	}
 
 	if containerLenS > 0 {
@@ -19235,7 +19235,7 @@ func (_ fastpathT) DecSliceInt16V(v []int16, checkNil bool, canChange bool, d *D
 				changed = true
 			}
 			slh.End()
-			return
+			return v, changed
 		}
 		if cap(v) == 0 {
 			v = make([]int16, 1, 4)
@@ -19309,7 +19309,7 @@ func (_ fastpathT) DecSliceInt32V(v []int32, checkNil bool, canChange bool, d *D
 			changed = true
 		}
 		slh.End()
-		return
+		return v, changed
 	}
 
 	if containerLenS > 0 {
@@ -19368,7 +19368,7 @@ func (_ fastpathT) DecSliceInt32V(v []int32, checkNil bool, canChange bool, d *D
 				changed = true
 			}
 			slh.End()
-			return
+			return v, changed
 		}
 		if cap(v) == 0 {
 			v = make([]int32, 1, 4)
@@ -19442,7 +19442,7 @@ func (_ fastpathT) DecSliceInt64V(v []int64, checkNil bool, canChange bool, d *D
 			changed = true
 		}
 		slh.End()
-		return
+		return v, changed
 	}
 
 	if containerLenS > 0 {
@@ -19501,7 +19501,7 @@ func (_ fastpathT) DecSliceInt64V(v []int64, checkNil bool, canChange bool, d *D
 				changed = true
 			}
 			slh.End()
-			return
+			return v, changed
 		}
 		if cap(v) == 0 {
 			v = make([]int64, 1, 4)
@@ -19575,7 +19575,7 @@ func (_ fastpathT) DecSliceBoolV(v []bool, checkNil bool, canChange bool, d *Dec
 			changed = true
 		}
 		slh.End()
-		return
+		return v, changed
 	}
 
 	if containerLenS > 0 {
@@ -19634,7 +19634,7 @@ func (_ fastpathT) DecSliceBoolV(v []bool, checkNil bool, canChange bool, d *Dec
 				changed = true
 			}
 			slh.End()
-			return
+			return v, changed
 		}
 		if cap(v) == 0 {
 			v = make([]bool, 1, 4)

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/fast-path.go.tmpl
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/fast-path.go.tmpl
@@ -328,7 +328,7 @@ func (_ fastpathT) {{ .MethodNamePfx "Dec" false }}V(v []{{ .Elem }}, checkNil b
 			changed = true
 		}
 		slh.End()
-		return
+		return v, changed
 	}
 	
 	if containerLenS > 0 {
@@ -391,7 +391,7 @@ func (_ fastpathT) {{ .MethodNamePfx "Dec" false }}V(v []{{ .Elem }}, checkNil b
 				changed = true
 			}
 			slh.End()
-			return
+			return v, changed
 		}
 		if cap(v) == 0 {
 			v = make([]{{ .Elem }}, 1, 4)

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/helper.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/helper.go
@@ -155,8 +155,10 @@ const (
 	resetSliceElemToZeroValue bool = false
 )
 
-var oneByteArr = [1]byte{0}
-var zeroByteSlice = oneByteArr[:0:0]
+var (
+	oneByteArr    = [1]byte{0}
+	zeroByteSlice = oneByteArr[:0:0]
+)
 
 type charEncoding uint8
 
@@ -214,6 +216,24 @@ const (
 	containerArrayElem
 	containerArrayEnd
 )
+
+type rgetPoolT struct {
+	encNames [8]string
+	fNames   [8]string
+	etypes   [8]uintptr
+	sfis     [8]*structFieldInfo
+}
+
+var rgetPool = sync.Pool{
+	New: func() interface{} { return new(rgetPoolT) },
+}
+
+type rgetT struct {
+	fNames   []string
+	encNames []string
+	etypes   []uintptr
+	sfis     []*structFieldInfo
+}
 
 type containerStateRecv interface {
 	sendContainerState(containerState)
@@ -833,14 +853,17 @@ func (x *TypeInfos) get(rtid uintptr, rt reflect.Type) (pti *typeInfo) {
 			siInfo = parseStructFieldInfo(structInfoFieldName, x.structTag(f.Tag))
 			ti.toArray = siInfo.toArray
 		}
-		sfip := make([]*structFieldInfo, 0, rt.NumField())
-		x.rget(rt, nil, make(map[string]bool, 16), &sfip, siInfo)
-
-		ti.sfip = make([]*structFieldInfo, len(sfip))
-		ti.sfi = make([]*structFieldInfo, len(sfip))
-		copy(ti.sfip, sfip)
-		sort.Sort(sfiSortedByEncName(sfip))
-		copy(ti.sfi, sfip)
+		pi := rgetPool.Get()
+		pv := pi.(*rgetPoolT)
+		pv.etypes[0] = ti.baseId
+		vv := rgetT{pv.fNames[:0], pv.encNames[:0], pv.etypes[:1], pv.sfis[:0]}
+		x.rget(rt, rtid, nil, &vv, siInfo)
+		ti.sfip = make([]*structFieldInfo, len(vv.sfis))
+		ti.sfi = make([]*structFieldInfo, len(vv.sfis))
+		copy(ti.sfip, vv.sfis)
+		sort.Sort(sfiSortedByEncName(vv.sfis))
+		copy(ti.sfi, vv.sfis)
+		rgetPool.Put(pi)
 	}
 	// sfi = sfip
 
@@ -853,16 +876,37 @@ func (x *TypeInfos) get(rtid uintptr, rt reflect.Type) (pti *typeInfo) {
 	return
 }
 
-func (x *TypeInfos) rget(rt reflect.Type, indexstack []int, fnameToHastag map[string]bool,
-	sfi *[]*structFieldInfo, siInfo *structFieldInfo,
+func (x *TypeInfos) rget(rt reflect.Type, rtid uintptr,
+	indexstack []int, pv *rgetT, siInfo *structFieldInfo,
 ) {
-	for j := 0; j < rt.NumField(); j++ {
+	// This will read up the fields and store how to access the value.
+	// It uses the go language's rules for embedding, as below:
+	//   - if a field has been seen while traversing, skip it
+	//   - if an encName has been seen while traversing, skip it
+	//   - if an embedded type has been seen, skip it
+	//
+	// Also, per Go's rules, embedded fields must be analyzed AFTER all top-level fields.
+	//
+	// Note: we consciously use slices, not a map, to simulate a set.
+	//       Typically, types have < 16 fields, and iteration using equals is faster than maps there
+
+	type anonField struct {
+		ft  reflect.Type
+		idx int
+	}
+
+	var anonFields []anonField
+
+LOOP:
+	for j, jlen := 0, rt.NumField(); j < jlen; j++ {
 		f := rt.Field(j)
 		fkind := f.Type.Kind()
 		// skip if a func type, or is unexported, or structTag value == "-"
-		if fkind == reflect.Func {
-			continue
+		switch fkind {
+		case reflect.Func, reflect.Complex64, reflect.Complex128, reflect.UnsafePointer:
+			continue LOOP
 		}
+
 		// if r1, _ := utf8.DecodeRuneInString(f.Name); r1 == utf8.RuneError || !unicode.IsUpper(r1) {
 		if f.PkgPath != "" && !f.Anonymous { // unexported, not embedded
 			continue
@@ -886,11 +930,8 @@ func (x *TypeInfos) rget(rt reflect.Type, indexstack []int, fnameToHastag map[st
 					ft = ft.Elem()
 				}
 				if ft.Kind() == reflect.Struct {
-					indexstack2 := make([]int, len(indexstack)+1, len(indexstack)+4)
-					copy(indexstack2, indexstack)
-					indexstack2[len(indexstack)] = j
-					// indexstack2 := append(append(make([]int, 0, len(indexstack)+4), indexstack...), j)
-					x.rget(ft, indexstack2, fnameToHastag, sfi, siInfo)
+					// handle anonymous fields after handling all the non-anon fields
+					anonFields = append(anonFields, anonField{ft, j})
 					continue
 				}
 			}
@@ -901,26 +942,39 @@ func (x *TypeInfos) rget(rt reflect.Type, indexstack []int, fnameToHastag map[st
 			continue
 		}
 
-		// do not let fields with same name in embedded structs override field at higher level.
-		// this must be done after anonymous check, to allow anonymous field
-		// still include their child fields
-		if _, ok := fnameToHastag[f.Name]; ok {
-			continue
-		}
 		if f.Name == "" {
 			panic(noFieldNameToStructFieldInfoErr)
 		}
+
+		for _, k := range pv.fNames {
+			if k == f.Name {
+				continue LOOP
+			}
+		}
+		pv.fNames = append(pv.fNames, f.Name)
+
 		if si == nil {
 			si = parseStructFieldInfo(f.Name, stag)
 		} else if si.encName == "" {
 			si.encName = f.Name
 		}
+
+		for _, k := range pv.encNames {
+			if k == si.encName {
+				continue LOOP
+			}
+		}
+		pv.encNames = append(pv.encNames, si.encName)
+
 		// si.ikind = int(f.Type.Kind())
 		if len(indexstack) == 0 {
 			si.i = int16(j)
 		} else {
 			si.i = -1
-			si.is = append(append(make([]int, 0, len(indexstack)+4), indexstack...), j)
+			si.is = make([]int, len(indexstack)+1)
+			copy(si.is, indexstack)
+			si.is[len(indexstack)] = j
+			// si.is = append(append(make([]int, 0, len(indexstack)+4), indexstack...), j)
 		}
 
 		if siInfo != nil {
@@ -928,8 +982,26 @@ func (x *TypeInfos) rget(rt reflect.Type, indexstack []int, fnameToHastag map[st
 				si.omitEmpty = true
 			}
 		}
-		*sfi = append(*sfi, si)
-		fnameToHastag[f.Name] = stag != ""
+		pv.sfis = append(pv.sfis, si)
+	}
+
+	// now handle anonymous fields
+LOOP2:
+	for _, af := range anonFields {
+		// if etypes contains this, then do not call rget again (as the fields are already seen here)
+		ftid := reflect.ValueOf(af.ft).Pointer()
+		for _, k := range pv.etypes {
+			if k == ftid {
+				continue LOOP2
+			}
+		}
+		pv.etypes = append(pv.etypes, ftid)
+
+		indexstack2 := make([]int, len(indexstack)+1)
+		copy(indexstack2, indexstack)
+		indexstack2[len(indexstack)] = af.idx
+		// indexstack2 := append(append(make([]int, 0, len(indexstack)+4), indexstack...), j)
+		x.rget(af.ft, ftid, indexstack2, pv, siInfo)
 	}
 }
 
@@ -1127,3 +1199,73 @@ type bytesISlice []bytesI
 func (p bytesISlice) Len() int           { return len(p) }
 func (p bytesISlice) Less(i, j int) bool { return bytes.Compare(p[i].v, p[j].v) == -1 }
 func (p bytesISlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
+// -----------------
+
+type set []uintptr
+
+func (s *set) add(v uintptr) (exists bool) {
+	// e.ci is always nil, or len >= 1
+	// defer func() { fmt.Printf("$$$$$$$$$$$ cirRef Add: %v, exists: %v\n", v, exists) }()
+	x := *s
+	if x == nil {
+		x = make([]uintptr, 1, 8)
+		x[0] = v
+		*s = x
+		return
+	}
+	// typically, length will be 1. make this perform.
+	if len(x) == 1 {
+		if j := x[0]; j == 0 {
+			x[0] = v
+		} else if j == v {
+			exists = true
+		} else {
+			x = append(x, v)
+			*s = x
+		}
+		return
+	}
+	// check if it exists
+	for _, j := range x {
+		if j == v {
+			exists = true
+			return
+		}
+	}
+	// try to replace a "deleted" slot
+	for i, j := range x {
+		if j == 0 {
+			x[i] = v
+			return
+		}
+	}
+	// if unable to replace deleted slot, just append it.
+	x = append(x, v)
+	*s = x
+	return
+}
+
+func (s *set) remove(v uintptr) (exists bool) {
+	// defer func() { fmt.Printf("$$$$$$$$$$$ cirRef Rm: %v, exists: %v\n", v, exists) }()
+	x := *s
+	if len(x) == 0 {
+		return
+	}
+	if len(x) == 1 {
+		if x[0] == v {
+			x[0] = 0
+		}
+		return
+	}
+	for i, j := range x {
+		if j == v {
+			exists = true
+			x[i] = 0 // set it to 0, as way to delete it.
+			// copy(x[i:], x[i+1:])
+			// x = x[:len(x)-1]
+			return
+		}
+	}
+	return
+}

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/json.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/json.go
@@ -43,18 +43,23 @@ import (
 
 //--------------------------------
 
-var jsonLiterals = [...]byte{'t', 'r', 'u', 'e', 'f', 'a', 'l', 's', 'e', 'n', 'u', 'l', 'l'}
+var (
+	jsonLiterals = [...]byte{'t', 'r', 'u', 'e', 'f', 'a', 'l', 's', 'e', 'n', 'u', 'l', 'l'}
 
-var jsonFloat64Pow10 = [...]float64{
-	1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9,
-	1e10, 1e11, 1e12, 1e13, 1e14, 1e15, 1e16, 1e17, 1e18, 1e19,
-	1e20, 1e21, 1e22,
-}
+	jsonFloat64Pow10 = [...]float64{
+		1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9,
+		1e10, 1e11, 1e12, 1e13, 1e14, 1e15, 1e16, 1e17, 1e18, 1e19,
+		1e20, 1e21, 1e22,
+	}
 
-var jsonUint64Pow10 = [...]uint64{
-	1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9,
-	1e10, 1e11, 1e12, 1e13, 1e14, 1e15, 1e16, 1e17, 1e18, 1e19,
-}
+	jsonUint64Pow10 = [...]uint64{
+		1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9,
+		1e10, 1e11, 1e12, 1e13, 1e14, 1e15, 1e16, 1e17, 1e18, 1e19,
+	}
+
+	// jsonTabs and jsonSpaces are used as caches for indents
+	jsonTabs, jsonSpaces string
+)
 
 const (
 	// jsonUnreadAfterDecNum controls whether we unread after decoding a number.
@@ -85,7 +90,22 @@ const (
 	jsonNumUintMaxVal = 1<<uint64(64) - 1
 
 	// jsonNumDigitsUint64Largest = 19
+
+	jsonSpacesOrTabsLen = 128
 )
+
+func init() {
+	var bs [jsonSpacesOrTabsLen]byte
+	for i := 0; i < jsonSpacesOrTabsLen; i++ {
+		bs[i] = ' '
+	}
+	jsonSpaces = string(bs[:])
+
+	for i := 0; i < jsonSpacesOrTabsLen; i++ {
+		bs[i] = '\t'
+	}
+	jsonTabs = string(bs[:])
+}
 
 type jsonEncDriver struct {
 	e  *Encoder
@@ -94,9 +114,18 @@ type jsonEncDriver struct {
 	b  [64]byte // scratch
 	bs []byte   // scratch
 	se setExtWrapper
+	ds string // indent string
+	dl uint16 // indent level
+	dt bool   // indent using tabs
+	d  bool   // indent
 	c  containerState
 	noBuiltInTypes
 }
+
+// indent is done as below:
+//   - newline and indent are added before each mapKey or arrayElem
+//   - newline and indent are added before each ending,
+//     except there was no entry (so we can have {} or [])
 
 func (e *jsonEncDriver) sendContainerState(c containerState) {
 	// determine whether to output separators
@@ -104,18 +133,55 @@ func (e *jsonEncDriver) sendContainerState(c containerState) {
 		if e.c != containerMapStart {
 			e.w.writen1(',')
 		}
+		if e.d {
+			e.writeIndent()
+		}
 	} else if c == containerMapValue {
-		e.w.writen1(':')
+		if e.d {
+			e.w.writen2(':', ' ')
+		} else {
+			e.w.writen1(':')
+		}
 	} else if c == containerMapEnd {
+		if e.d {
+			e.dl--
+			if e.c != containerMapStart {
+				e.writeIndent()
+			}
+		}
 		e.w.writen1('}')
 	} else if c == containerArrayElem {
 		if e.c != containerArrayStart {
 			e.w.writen1(',')
 		}
+		if e.d {
+			e.writeIndent()
+		}
 	} else if c == containerArrayEnd {
+		if e.d {
+			e.dl--
+			if e.c != containerArrayStart {
+				e.writeIndent()
+			}
+		}
 		e.w.writen1(']')
 	}
 	e.c = c
+}
+
+func (e *jsonEncDriver) writeIndent() {
+	e.w.writen1('\n')
+	if x := len(e.ds) * int(e.dl); x <= jsonSpacesOrTabsLen {
+		if e.dt {
+			e.w.writestr(jsonTabs[:x])
+		} else {
+			e.w.writestr(jsonSpaces[:x])
+		}
+	} else {
+		for i := uint16(0); i < e.dl; i++ {
+			e.w.writestr(e.ds)
+		}
+	}
 }
 
 func (e *jsonEncDriver) EncodeNil() {
@@ -165,11 +231,17 @@ func (e *jsonEncDriver) EncodeRawExt(re *RawExt, en *Encoder) {
 }
 
 func (e *jsonEncDriver) EncodeArrayStart(length int) {
+	if e.d {
+		e.dl++
+	}
 	e.w.writen1('[')
 	e.c = containerArrayStart
 }
 
 func (e *jsonEncDriver) EncodeMapStart(length int) {
+	if e.d {
+		e.dl++
+	}
 	e.w.writen1('{')
 	e.c = containerMapStart
 }
@@ -1033,6 +1105,11 @@ type JsonHandle struct {
 	// RawBytesExt, if configured, is used to encode and decode raw bytes in a custom way.
 	// If not configured, raw bytes are encoded to/from base64 text.
 	RawBytesExt InterfaceExt
+
+	// Indent indicates how a value is encoded.
+	//   - If positive, indent by that number of spaces.
+	//   - If negative, indent by that number of tabs.
+	Indent int8
 }
 
 func (h *JsonHandle) SetInterfaceExt(rt reflect.Type, tag uint64, ext InterfaceExt) (err error) {
@@ -1040,26 +1117,48 @@ func (h *JsonHandle) SetInterfaceExt(rt reflect.Type, tag uint64, ext InterfaceE
 }
 
 func (h *JsonHandle) newEncDriver(e *Encoder) encDriver {
-	hd := jsonEncDriver{e: e, w: e.w, h: h}
+	hd := jsonEncDriver{e: e, h: h}
 	hd.bs = hd.b[:0]
-	hd.se.i = h.RawBytesExt
+
+	hd.reset()
+
 	return &hd
 }
 
 func (h *JsonHandle) newDecDriver(d *Decoder) decDriver {
 	// d := jsonDecDriver{r: r.(*bytesDecReader), h: h}
-	hd := jsonDecDriver{d: d, r: d.r, h: h}
+	hd := jsonDecDriver{d: d, h: h}
 	hd.bs = hd.b[:0]
-	hd.se.i = h.RawBytesExt
+	hd.reset()
 	return &hd
 }
 
 func (e *jsonEncDriver) reset() {
 	e.w = e.e.w
+	e.se.i = e.h.RawBytesExt
+	if e.bs != nil {
+		e.bs = e.bs[:0]
+	}
+	e.d, e.dt, e.dl, e.ds = false, false, 0, ""
+	e.c = 0
+	if e.h.Indent > 0 {
+		e.d = true
+		e.ds = jsonSpaces[:e.h.Indent]
+	} else if e.h.Indent < 0 {
+		e.d = true
+		e.dt = true
+		e.ds = jsonTabs[:-(e.h.Indent)]
+	}
 }
 
 func (d *jsonDecDriver) reset() {
 	d.r = d.d.r
+	d.se.i = d.h.RawBytesExt
+	if d.bs != nil {
+		d.bs = d.bs[:0]
+	}
+	d.c, d.tok = 0, 0
+	d.n.reset()
 }
 
 var jsonEncodeTerminate = []byte{' '}

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/msgpack.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/msgpack.go
@@ -374,7 +374,7 @@ func (d *msgpackDecDriver) DecodeNaked() {
 	}
 	if n.v == valueTypeUint && d.h.SignedInteger {
 		n.v = valueTypeInt
-		n.i = int64(n.v)
+		n.i = int64(n.u)
 	}
 	return
 }
@@ -729,6 +729,7 @@ func (e *msgpackEncDriver) reset() {
 
 func (d *msgpackDecDriver) reset() {
 	d.r = d.d.r
+	d.bd, d.bdRead = 0, false
 }
 
 //--------------------------------------------------

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/simple.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/simple.go
@@ -512,6 +512,7 @@ func (e *simpleEncDriver) reset() {
 
 func (d *simpleDecDriver) reset() {
 	d.r = d.d.r
+	d.bd, d.bdRead = 0, false
 }
 
 var _ decDriver = (*simpleDecDriver)(nil)

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/tests.sh
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/tests.sh
@@ -6,6 +6,7 @@
 _run() {
     # 1. VARIATIONS: regular (t), canonical (c), IO R/W (i),
     #                binc-nosymbols (n), struct2array (s), intern string (e),
+    #                json-indent (d), circular (l)
     # 2. MODE: reflection (r), external (x), codecgen (g), unsafe (u), notfastpath (f)
     # 3. OPTIONS: verbose (v), reset (z), must (m),
     # 
@@ -16,7 +17,7 @@ _run() {
     zargs=""
     local OPTIND 
     OPTIND=1
-    while getopts "xurtcinsvgzmef" flag
+    while getopts "_xurtcinsvgzmefdl" flag
     do
         case "x$flag" in 
             'xr')  ;;
@@ -27,6 +28,7 @@ _run() {
             'xv') zargs="$zargs -tv" ;;
             'xz') zargs="$zargs -tr" ;;
             'xm') zargs="$zargs -tm" ;;
+            'xl') zargs="$zargs -tl" ;;
             *) ;;
         esac
     done
@@ -35,15 +37,19 @@ _run() {
     # echo ">>>>>>> TAGS: $ztags"
     
     OPTIND=1
-    while getopts "xurtcinsvgzmef" flag
+    while getopts "_xurtcinsvgzmefdl" flag
     do
         case "x$flag" in 
             'xt') printf ">>>>>>> REGULAR    : "; go test "-tags=$ztags" $zargs ; sleep 2 ;;
             'xc') printf ">>>>>>> CANONICAL  : "; go test "-tags=$ztags" $zargs -tc; sleep 2 ;;
             'xi') printf ">>>>>>> I/O        : "; go test "-tags=$ztags" $zargs -ti; sleep 2 ;;
-            'xn') printf ">>>>>>> NO_SYMBOLS : "; go test "-tags=$ztags" $zargs -tn; sleep 2 ;;
+            'xn') printf ">>>>>>> NO_SYMBOLS : "; go test "-tags=$ztags" -run=Binc $zargs -tn; sleep 2 ;;
             'xs') printf ">>>>>>> TO_ARRAY   : "; go test "-tags=$ztags" $zargs -ts; sleep 2 ;;
             'xe') printf ">>>>>>> INTERN     : "; go test "-tags=$ztags" $zargs -te; sleep 2 ;;
+            'xd') printf ">>>>>>> INDENT     : ";
+                  go test "-tags=$ztags" -run=JsonCodecsTable -td=-1 $zargs;
+                  go test "-tags=$ztags" -run=JsonCodecsTable -td=8 $zargs;
+                  sleep 2 ;;
             *) ;;
         esac
     done
@@ -55,20 +61,20 @@ _run() {
 # echo ">>>>>>> RUNNING VARIATIONS OF TESTS"    
 if [[ "x$@" = "x" ]]; then
     # All: r, x, g, gu
-    _run "-rtcinsm"  # regular
-    _run "-rtcinsmz" # regular with reset
-    _run "-rtcinsmf" # regular with no fastpath (notfastpath)
-    _run "-xtcinsm" # external
-    _run "-gxtcinsm" # codecgen: requires external
-    _run "-gxutcinsm" # codecgen + unsafe
+    _run "-_tcinsed_ml"  # regular
+    _run "-_tcinsed_ml_z" # regular with reset
+    _run "-_tcinsed_ml_f" # regular with no fastpath (notfastpath)
+    _run "-x_tcinsed_ml" # external
+    _run "-gx_tcinsed_ml" # codecgen: requires external
+    _run "-gxu_tcinsed_ml" # codecgen + unsafe
 elif [[ "x$@" = "x-Z" ]]; then
     # Regular
-    _run "-rtcinsm"  # regular
-    _run "-rtcinsmz" # regular with reset
+    _run "-_tcinsed_ml"  # regular
+    _run "-_tcinsed_ml_z" # regular with reset
 elif [[ "x$@" = "x-F" ]]; then
     # regular with notfastpath
-    _run "-rtcinsmf"  # regular
-    _run "-rtcinsmzf" # regular with reset
+    _run "-_tcinsed_ml_f"  # regular
+    _run "-_tcinsed_ml_zf" # regular with reset
 else
     _run "$@"
 fi

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/time.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/time.go
@@ -5,11 +5,22 @@ package codec
 
 import (
 	"fmt"
+	"reflect"
 	"time"
 )
 
 var (
-	timeDigits = [...]byte{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'}
+	timeDigits   = [...]byte{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'}
+	timeExtEncFn = func(rv reflect.Value) (bs []byte, err error) {
+		defer panicToErr(&err)
+		bs = timeExt{}.WriteExt(rv.Interface())
+		return
+	}
+	timeExtDecFn = func(rv reflect.Value, bs []byte) (err error) {
+		defer panicToErr(&err)
+		timeExt{}.ReadExt(rv.Interface(), bs)
+		return
+	}
 )
 
 type timeExt struct{}

--- a/cmd/libs/go2idl/client-gen/testdata/apis/testgroup/types.generated.go
+++ b/cmd/libs/go2idl/client-gen/testdata/apis/testgroup/types.generated.go
@@ -88,10 +88,10 @@ func (x *TestType) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2 [4]bool
 			_, _, _ = yysep2, yyq2, yy2arr2
 			const yyr2 bool = false
-			yyq2[0] = x.Kind != ""
-			yyq2[1] = x.APIVersion != ""
-			yyq2[2] = true
-			yyq2[3] = true
+			yyq2[0] = true
+			yyq2[1] = true
+			yyq2[2] = x.Kind != ""
+			yyq2[3] = x.APIVersion != ""
 			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(4)
@@ -108,22 +108,56 @@ func (x *TestType) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[0] {
-					yym4 := z.EncBinary()
-					_ = yym4
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy4 := &x.ObjectMeta
+					yy4.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq2[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy5 := &x.ObjectMeta
+					yy5.CodecEncodeSelf(e)
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2[1] {
+					yy7 := &x.Status
+					yy7.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy8 := &x.Status
+					yy8.CodecEncodeSelf(e)
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2[2] {
+					yym10 := z.EncBinary()
+					_ = yym10
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym5 := z.EncBinary()
-					_ = yym5
+					yym11 := z.EncBinary()
+					_ = yym11
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -132,9 +166,9 @@ func (x *TestType) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[1] {
-					yym7 := z.EncBinary()
-					_ = yym7
+				if yyq2[3] {
+					yym13 := z.EncBinary()
+					_ = yym13
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -143,50 +177,16 @@ func (x *TestType) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2[1] {
+				if yyq2[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym8 := z.EncBinary()
-					_ = yym8
+					yym14 := z.EncBinary()
+					_ = yym14
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
-				}
-			}
-			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[2] {
-					yy10 := &x.ObjectMeta
-					yy10.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2[2] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy11 := &x.ObjectMeta
-					yy11.CodecEncodeSelf(e)
-				}
-			}
-			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[3] {
-					yy13 := &x.Status
-					yy13.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2[3] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy14 := &x.Status
-					yy14.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2 || yy2arr2 {
@@ -250,6 +250,20 @@ func (x *TestType) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys17 := string(yys17Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys17 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_api.ObjectMeta{}
+			} else {
+				yyv18 := &x.ObjectMeta
+				yyv18.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = TestTypeStatus{}
+			} else {
+				yyv19 := &x.Status
+				yyv19.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -261,20 +275,6 @@ func (x *TestType) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = pkg2_api.ObjectMeta{}
-			} else {
-				yyv20 := &x.ObjectMeta
-				yyv20.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = TestTypeStatus{}
-			} else {
-				yyv21 := &x.Status
-				yyv21.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys17)
@@ -290,6 +290,40 @@ func (x *TestType) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj22 int
 	var yyb22 bool
 	var yyhl22 bool = l >= 0
+	yyj22++
+	if yyhl22 {
+		yyb22 = yyj22 > l
+	} else {
+		yyb22 = r.CheckBreak()
+	}
+	if yyb22 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_api.ObjectMeta{}
+	} else {
+		yyv23 := &x.ObjectMeta
+		yyv23.CodecDecodeSelf(d)
+	}
+	yyj22++
+	if yyhl22 {
+		yyb22 = yyj22 > l
+	} else {
+		yyb22 = r.CheckBreak()
+	}
+	if yyb22 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = TestTypeStatus{}
+	} else {
+		yyv24 := &x.Status
+		yyv24.CodecDecodeSelf(d)
+	}
 	yyj22++
 	if yyhl22 {
 		yyb22 = yyj22 > l
@@ -321,40 +355,6 @@ func (x *TestType) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj22++
-	if yyhl22 {
-		yyb22 = yyj22 > l
-	} else {
-		yyb22 = r.CheckBreak()
-	}
-	if yyb22 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = pkg2_api.ObjectMeta{}
-	} else {
-		yyv25 := &x.ObjectMeta
-		yyv25.CodecDecodeSelf(d)
-	}
-	yyj22++
-	if yyhl22 {
-		yyb22 = yyj22 > l
-	} else {
-		yyb22 = r.CheckBreak()
-	}
-	if yyb22 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = TestTypeStatus{}
-	} else {
-		yyv26 := &x.Status
-		yyv26.CodecDecodeSelf(d)
 	}
 	for {
 		yyj22++
@@ -389,9 +389,9 @@ func (x *TestTypeList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq28 [4]bool
 			_, _, _ = yysep28, yyq28, yy2arr28
 			const yyr28 bool = false
-			yyq28[0] = x.Kind != ""
-			yyq28[1] = x.APIVersion != ""
-			yyq28[2] = true
+			yyq28[0] = true
+			yyq28[2] = x.Kind != ""
+			yyq28[3] = x.APIVersion != ""
 			var yynn28 int
 			if yyr28 || yy2arr28 {
 				r.EncodeArrayStart(4)
@@ -408,79 +408,29 @@ func (x *TestTypeList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr28 || yy2arr28 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq28[0] {
-					yym30 := z.EncBinary()
-					_ = yym30
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq28[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy30 := &x.ListMeta
 					yym31 := z.EncBinary()
 					_ = yym31
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy30) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr28 || yy2arr28 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq28[1] {
-					yym33 := z.EncBinary()
-					_ = yym33
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq28[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym34 := z.EncBinary()
-					_ = yym34
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr28 || yy2arr28 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq28[2] {
-					yy36 := &x.ListMeta
-					yym37 := z.EncBinary()
-					_ = yym37
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy36) {
-					} else {
-						z.EncFallback(yy36)
+						z.EncFallback(yy30)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq28[2] {
+				if yyq28[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy38 := &x.ListMeta
-					yym39 := z.EncBinary()
-					_ = yym39
+					yy32 := &x.ListMeta
+					yym33 := z.EncBinary()
+					_ = yym33
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy38) {
+					} else if z.HasExtensions() && z.EncExt(yy32) {
 					} else {
-						z.EncFallback(yy38)
+						z.EncFallback(yy32)
 					}
 				}
 			}
@@ -489,8 +439,8 @@ func (x *TestTypeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym41 := z.EncBinary()
-					_ = yym41
+					yym35 := z.EncBinary()
+					_ = yym35
 					if false {
 					} else {
 						h.encSliceTestType(([]TestType)(x.Items), e)
@@ -503,11 +453,61 @@ func (x *TestTypeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym36 := z.EncBinary()
+					_ = yym36
+					if false {
+					} else {
+						h.encSliceTestType(([]TestType)(x.Items), e)
+					}
+				}
+			}
+			if yyr28 || yy2arr28 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq28[2] {
+					yym38 := z.EncBinary()
+					_ = yym38
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq28[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym39 := z.EncBinary()
+					_ = yym39
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr28 || yy2arr28 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq28[3] {
+					yym41 := z.EncBinary()
+					_ = yym41
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq28[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym42 := z.EncBinary()
 					_ = yym42
 					if false {
 					} else {
-						h.encSliceTestType(([]TestType)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -572,6 +572,31 @@ func (x *TestTypeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys45 := string(yys45Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys45 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv46 := &x.ListMeta
+				yym47 := z.DecBinary()
+				_ = yym47
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv46) {
+				} else {
+					z.DecFallback(yyv46, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv48 := &x.Items
+				yym49 := z.DecBinary()
+				_ = yym49
+				if false {
+				} else {
+					h.decSliceTestType((*[]TestType)(yyv48), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -583,31 +608,6 @@ func (x *TestTypeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg1_unversioned.ListMeta{}
-			} else {
-				yyv48 := &x.ListMeta
-				yym49 := z.DecBinary()
-				_ = yym49
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv48) {
-				} else {
-					z.DecFallback(yyv48, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv50 := &x.Items
-				yym51 := z.DecBinary()
-				_ = yym51
-				if false {
-				} else {
-					h.decSliceTestType((*[]TestType)(yyv50), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys45)
@@ -623,6 +623,51 @@ func (x *TestTypeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj52 int
 	var yyb52 bool
 	var yyhl52 bool = l >= 0
+	yyj52++
+	if yyhl52 {
+		yyb52 = yyj52 > l
+	} else {
+		yyb52 = r.CheckBreak()
+	}
+	if yyb52 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv53 := &x.ListMeta
+		yym54 := z.DecBinary()
+		_ = yym54
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv53) {
+		} else {
+			z.DecFallback(yyv53, false)
+		}
+	}
+	yyj52++
+	if yyhl52 {
+		yyb52 = yyj52 > l
+	} else {
+		yyb52 = r.CheckBreak()
+	}
+	if yyb52 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv55 := &x.Items
+		yym56 := z.DecBinary()
+		_ = yym56
+		if false {
+		} else {
+			h.decSliceTestType((*[]TestType)(yyv55), d)
+		}
+	}
 	yyj52++
 	if yyhl52 {
 		yyb52 = yyj52 > l
@@ -654,51 +699,6 @@ func (x *TestTypeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj52++
-	if yyhl52 {
-		yyb52 = yyj52 > l
-	} else {
-		yyb52 = r.CheckBreak()
-	}
-	if yyb52 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg1_unversioned.ListMeta{}
-	} else {
-		yyv55 := &x.ListMeta
-		yym56 := z.DecBinary()
-		_ = yym56
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv55) {
-		} else {
-			z.DecFallback(yyv55, false)
-		}
-	}
-	yyj52++
-	if yyhl52 {
-		yyb52 = yyj52 > l
-	} else {
-		yyb52 = r.CheckBreak()
-	}
-	if yyb52 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv57 := &x.Items
-		yym58 := z.DecBinary()
-		_ = yym58
-		if false {
-		} else {
-			h.decSliceTestType((*[]TestType)(yyv57), d)
-		}
 	}
 	for {
 		yyj52++

--- a/cmd/libs/go2idl/client-gen/testdata/apis/testgroup/v1/types.generated.go
+++ b/cmd/libs/go2idl/client-gen/testdata/apis/testgroup/v1/types.generated.go
@@ -88,10 +88,10 @@ func (x *TestType) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2 [4]bool
 			_, _, _ = yysep2, yyq2, yy2arr2
 			const yyr2 bool = false
-			yyq2[0] = x.Kind != ""
-			yyq2[1] = x.APIVersion != ""
-			yyq2[2] = true
-			yyq2[3] = true
+			yyq2[0] = true
+			yyq2[1] = true
+			yyq2[2] = x.Kind != ""
+			yyq2[3] = x.APIVersion != ""
 			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(4)
@@ -108,22 +108,56 @@ func (x *TestType) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[0] {
-					yym4 := z.EncBinary()
-					_ = yym4
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy4 := &x.ObjectMeta
+					yy4.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq2[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy5 := &x.ObjectMeta
+					yy5.CodecEncodeSelf(e)
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2[1] {
+					yy7 := &x.Status
+					yy7.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy8 := &x.Status
+					yy8.CodecEncodeSelf(e)
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2[2] {
+					yym10 := z.EncBinary()
+					_ = yym10
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym5 := z.EncBinary()
-					_ = yym5
+					yym11 := z.EncBinary()
+					_ = yym11
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -132,9 +166,9 @@ func (x *TestType) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[1] {
-					yym7 := z.EncBinary()
-					_ = yym7
+				if yyq2[3] {
+					yym13 := z.EncBinary()
+					_ = yym13
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -143,50 +177,16 @@ func (x *TestType) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2[1] {
+				if yyq2[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym8 := z.EncBinary()
-					_ = yym8
+					yym14 := z.EncBinary()
+					_ = yym14
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
-				}
-			}
-			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[2] {
-					yy10 := &x.ObjectMeta
-					yy10.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2[2] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy11 := &x.ObjectMeta
-					yy11.CodecEncodeSelf(e)
-				}
-			}
-			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[3] {
-					yy13 := &x.Status
-					yy13.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2[3] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy14 := &x.Status
-					yy14.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2 || yy2arr2 {
@@ -250,6 +250,20 @@ func (x *TestType) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys17 := string(yys17Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys17 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_api.ObjectMeta{}
+			} else {
+				yyv18 := &x.ObjectMeta
+				yyv18.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = TestTypeStatus{}
+			} else {
+				yyv19 := &x.Status
+				yyv19.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -261,20 +275,6 @@ func (x *TestType) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = pkg2_api.ObjectMeta{}
-			} else {
-				yyv20 := &x.ObjectMeta
-				yyv20.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = TestTypeStatus{}
-			} else {
-				yyv21 := &x.Status
-				yyv21.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys17)
@@ -290,6 +290,40 @@ func (x *TestType) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj22 int
 	var yyb22 bool
 	var yyhl22 bool = l >= 0
+	yyj22++
+	if yyhl22 {
+		yyb22 = yyj22 > l
+	} else {
+		yyb22 = r.CheckBreak()
+	}
+	if yyb22 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_api.ObjectMeta{}
+	} else {
+		yyv23 := &x.ObjectMeta
+		yyv23.CodecDecodeSelf(d)
+	}
+	yyj22++
+	if yyhl22 {
+		yyb22 = yyj22 > l
+	} else {
+		yyb22 = r.CheckBreak()
+	}
+	if yyb22 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = TestTypeStatus{}
+	} else {
+		yyv24 := &x.Status
+		yyv24.CodecDecodeSelf(d)
+	}
 	yyj22++
 	if yyhl22 {
 		yyb22 = yyj22 > l
@@ -321,40 +355,6 @@ func (x *TestType) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj22++
-	if yyhl22 {
-		yyb22 = yyj22 > l
-	} else {
-		yyb22 = r.CheckBreak()
-	}
-	if yyb22 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = pkg2_api.ObjectMeta{}
-	} else {
-		yyv25 := &x.ObjectMeta
-		yyv25.CodecDecodeSelf(d)
-	}
-	yyj22++
-	if yyhl22 {
-		yyb22 = yyj22 > l
-	} else {
-		yyb22 = r.CheckBreak()
-	}
-	if yyb22 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = TestTypeStatus{}
-	} else {
-		yyv26 := &x.Status
-		yyv26.CodecDecodeSelf(d)
 	}
 	for {
 		yyj22++
@@ -389,9 +389,9 @@ func (x *TestTypeList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq28 [4]bool
 			_, _, _ = yysep28, yyq28, yy2arr28
 			const yyr28 bool = false
-			yyq28[0] = x.Kind != ""
-			yyq28[1] = x.APIVersion != ""
-			yyq28[2] = true
+			yyq28[0] = true
+			yyq28[2] = x.Kind != ""
+			yyq28[3] = x.APIVersion != ""
 			var yynn28 int
 			if yyr28 || yy2arr28 {
 				r.EncodeArrayStart(4)
@@ -408,79 +408,29 @@ func (x *TestTypeList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr28 || yy2arr28 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq28[0] {
-					yym30 := z.EncBinary()
-					_ = yym30
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq28[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy30 := &x.ListMeta
 					yym31 := z.EncBinary()
 					_ = yym31
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy30) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr28 || yy2arr28 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq28[1] {
-					yym33 := z.EncBinary()
-					_ = yym33
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq28[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym34 := z.EncBinary()
-					_ = yym34
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr28 || yy2arr28 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq28[2] {
-					yy36 := &x.ListMeta
-					yym37 := z.EncBinary()
-					_ = yym37
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy36) {
-					} else {
-						z.EncFallback(yy36)
+						z.EncFallback(yy30)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq28[2] {
+				if yyq28[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy38 := &x.ListMeta
-					yym39 := z.EncBinary()
-					_ = yym39
+					yy32 := &x.ListMeta
+					yym33 := z.EncBinary()
+					_ = yym33
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy38) {
+					} else if z.HasExtensions() && z.EncExt(yy32) {
 					} else {
-						z.EncFallback(yy38)
+						z.EncFallback(yy32)
 					}
 				}
 			}
@@ -489,8 +439,8 @@ func (x *TestTypeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym41 := z.EncBinary()
-					_ = yym41
+					yym35 := z.EncBinary()
+					_ = yym35
 					if false {
 					} else {
 						h.encSliceTestType(([]TestType)(x.Items), e)
@@ -503,11 +453,61 @@ func (x *TestTypeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym36 := z.EncBinary()
+					_ = yym36
+					if false {
+					} else {
+						h.encSliceTestType(([]TestType)(x.Items), e)
+					}
+				}
+			}
+			if yyr28 || yy2arr28 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq28[2] {
+					yym38 := z.EncBinary()
+					_ = yym38
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq28[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym39 := z.EncBinary()
+					_ = yym39
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr28 || yy2arr28 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq28[3] {
+					yym41 := z.EncBinary()
+					_ = yym41
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq28[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym42 := z.EncBinary()
 					_ = yym42
 					if false {
 					} else {
-						h.encSliceTestType(([]TestType)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -572,6 +572,31 @@ func (x *TestTypeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys45 := string(yys45Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys45 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv46 := &x.ListMeta
+				yym47 := z.DecBinary()
+				_ = yym47
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv46) {
+				} else {
+					z.DecFallback(yyv46, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv48 := &x.Items
+				yym49 := z.DecBinary()
+				_ = yym49
+				if false {
+				} else {
+					h.decSliceTestType((*[]TestType)(yyv48), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -583,31 +608,6 @@ func (x *TestTypeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg1_unversioned.ListMeta{}
-			} else {
-				yyv48 := &x.ListMeta
-				yym49 := z.DecBinary()
-				_ = yym49
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv48) {
-				} else {
-					z.DecFallback(yyv48, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv50 := &x.Items
-				yym51 := z.DecBinary()
-				_ = yym51
-				if false {
-				} else {
-					h.decSliceTestType((*[]TestType)(yyv50), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys45)
@@ -623,6 +623,51 @@ func (x *TestTypeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj52 int
 	var yyb52 bool
 	var yyhl52 bool = l >= 0
+	yyj52++
+	if yyhl52 {
+		yyb52 = yyj52 > l
+	} else {
+		yyb52 = r.CheckBreak()
+	}
+	if yyb52 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv53 := &x.ListMeta
+		yym54 := z.DecBinary()
+		_ = yym54
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv53) {
+		} else {
+			z.DecFallback(yyv53, false)
+		}
+	}
+	yyj52++
+	if yyhl52 {
+		yyb52 = yyj52 > l
+	} else {
+		yyb52 = r.CheckBreak()
+	}
+	if yyb52 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv55 := &x.Items
+		yym56 := z.DecBinary()
+		_ = yym56
+		if false {
+		} else {
+			h.decSliceTestType((*[]TestType)(yyv55), d)
+		}
+	}
 	yyj52++
 	if yyhl52 {
 		yyb52 = yyj52 > l
@@ -654,51 +699,6 @@ func (x *TestTypeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj52++
-	if yyhl52 {
-		yyb52 = yyj52 > l
-	} else {
-		yyb52 = r.CheckBreak()
-	}
-	if yyb52 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg1_unversioned.ListMeta{}
-	} else {
-		yyv55 := &x.ListMeta
-		yym56 := z.DecBinary()
-		_ = yym56
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv55) {
-		} else {
-			z.DecFallback(yyv55, false)
-		}
-	}
-	yyj52++
-	if yyhl52 {
-		yyb52 = yyj52 > l
-	} else {
-		yyb52 = r.CheckBreak()
-	}
-	if yyb52 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv57 := &x.Items
-		yym58 := z.DecBinary()
-		_ = yym58
-		if false {
-		} else {
-			h.decSliceTestType((*[]TestType)(yyv57), d)
-		}
 	}
 	for {
 		yyj52++

--- a/pkg/api/types.generated.go
+++ b/pkg/api/types.generated.go
@@ -4479,11 +4479,11 @@ func (x *PersistentVolume) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq259 [5]bool
 			_, _, _ = yysep259, yyq259, yy2arr259
 			const yyr259 bool = false
-			yyq259[0] = x.Kind != ""
-			yyq259[1] = x.APIVersion != ""
+			yyq259[0] = true
+			yyq259[1] = true
 			yyq259[2] = true
-			yyq259[3] = true
-			yyq259[4] = true
+			yyq259[3] = x.Kind != ""
+			yyq259[4] = x.APIVersion != ""
 			var yynn259 int
 			if yyr259 || yy2arr259 {
 				r.EncodeArrayStart(5)
@@ -4500,57 +4500,41 @@ func (x *PersistentVolume) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr259 || yy2arr259 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq259[0] {
-					yym261 := z.EncBinary()
-					_ = yym261
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy261 := &x.ObjectMeta
+					yy261.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq259[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym262 := z.EncBinary()
-					_ = yym262
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy262 := &x.ObjectMeta
+					yy262.CodecEncodeSelf(e)
 				}
 			}
 			if yyr259 || yy2arr259 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq259[1] {
-					yym264 := z.EncBinary()
-					_ = yym264
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy264 := &x.Spec
+					yy264.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq259[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym265 := z.EncBinary()
-					_ = yym265
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy265 := &x.Spec
+					yy265.CodecEncodeSelf(e)
 				}
 			}
 			if yyr259 || yy2arr259 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq259[2] {
-					yy267 := &x.ObjectMeta
+					yy267 := &x.Status
 					yy267.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
@@ -4558,44 +4542,60 @@ func (x *PersistentVolume) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq259[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy268 := &x.ObjectMeta
+					yy268 := &x.Status
 					yy268.CodecEncodeSelf(e)
 				}
 			}
 			if yyr259 || yy2arr259 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq259[3] {
-					yy270 := &x.Spec
-					yy270.CodecEncodeSelf(e)
+					yym270 := z.EncBinary()
+					_ = yym270
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq259[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy271 := &x.Spec
-					yy271.CodecEncodeSelf(e)
+					yym271 := z.EncBinary()
+					_ = yym271
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				}
 			}
 			if yyr259 || yy2arr259 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq259[4] {
-					yy273 := &x.Status
-					yy273.CodecEncodeSelf(e)
+					yym273 := z.EncBinary()
+					_ = yym273
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq259[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy274 := &x.Status
-					yy274.CodecEncodeSelf(e)
+					yym274 := z.EncBinary()
+					_ = yym274
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr259 || yy2arr259 {
@@ -4659,6 +4659,27 @@ func (x *PersistentVolume) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys277 := string(yys277Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys277 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv278 := &x.ObjectMeta
+				yyv278.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = PersistentVolumeSpec{}
+			} else {
+				yyv279 := &x.Spec
+				yyv279.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = PersistentVolumeStatus{}
+			} else {
+				yyv280 := &x.Status
+				yyv280.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -4670,27 +4691,6 @@ func (x *PersistentVolume) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv280 := &x.ObjectMeta
-				yyv280.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = PersistentVolumeSpec{}
-			} else {
-				yyv281 := &x.Spec
-				yyv281.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = PersistentVolumeStatus{}
-			} else {
-				yyv282 := &x.Status
-				yyv282.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys277)
@@ -4706,6 +4706,57 @@ func (x *PersistentVolume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	var yyj283 int
 	var yyb283 bool
 	var yyhl283 bool = l >= 0
+	yyj283++
+	if yyhl283 {
+		yyb283 = yyj283 > l
+	} else {
+		yyb283 = r.CheckBreak()
+	}
+	if yyb283 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv284 := &x.ObjectMeta
+		yyv284.CodecDecodeSelf(d)
+	}
+	yyj283++
+	if yyhl283 {
+		yyb283 = yyj283 > l
+	} else {
+		yyb283 = r.CheckBreak()
+	}
+	if yyb283 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = PersistentVolumeSpec{}
+	} else {
+		yyv285 := &x.Spec
+		yyv285.CodecDecodeSelf(d)
+	}
+	yyj283++
+	if yyhl283 {
+		yyb283 = yyj283 > l
+	} else {
+		yyb283 = r.CheckBreak()
+	}
+	if yyb283 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = PersistentVolumeStatus{}
+	} else {
+		yyv286 := &x.Status
+		yyv286.CodecDecodeSelf(d)
+	}
 	yyj283++
 	if yyhl283 {
 		yyb283 = yyj283 > l
@@ -4737,57 +4788,6 @@ func (x *PersistentVolume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj283++
-	if yyhl283 {
-		yyb283 = yyj283 > l
-	} else {
-		yyb283 = r.CheckBreak()
-	}
-	if yyb283 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv286 := &x.ObjectMeta
-		yyv286.CodecDecodeSelf(d)
-	}
-	yyj283++
-	if yyhl283 {
-		yyb283 = yyj283 > l
-	} else {
-		yyb283 = r.CheckBreak()
-	}
-	if yyb283 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = PersistentVolumeSpec{}
-	} else {
-		yyv287 := &x.Spec
-		yyv287.CodecDecodeSelf(d)
-	}
-	yyj283++
-	if yyhl283 {
-		yyb283 = yyj283 > l
-	} else {
-		yyb283 = r.CheckBreak()
-	}
-	if yyb283 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = PersistentVolumeStatus{}
-	} else {
-		yyv288 := &x.Status
-		yyv288.CodecDecodeSelf(d)
 	}
 	for {
 		yyj283++
@@ -4822,21 +4822,21 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq290 [16]bool
 			_, _, _ = yysep290, yyq290, yy2arr290
 			const yyr290 bool = false
-			yyq290[1] = x.PersistentVolumeSource.GCEPersistentDisk != nil && x.GCEPersistentDisk != nil
-			yyq290[2] = x.PersistentVolumeSource.AWSElasticBlockStore != nil && x.AWSElasticBlockStore != nil
-			yyq290[3] = x.PersistentVolumeSource.HostPath != nil && x.HostPath != nil
-			yyq290[4] = x.PersistentVolumeSource.Glusterfs != nil && x.Glusterfs != nil
-			yyq290[5] = x.PersistentVolumeSource.NFS != nil && x.NFS != nil
-			yyq290[6] = x.PersistentVolumeSource.RBD != nil && x.RBD != nil
-			yyq290[7] = x.PersistentVolumeSource.ISCSI != nil && x.ISCSI != nil
-			yyq290[8] = x.PersistentVolumeSource.FlexVolume != nil && x.FlexVolume != nil
-			yyq290[9] = x.PersistentVolumeSource.Cinder != nil && x.Cinder != nil
-			yyq290[10] = x.PersistentVolumeSource.CephFS != nil && x.CephFS != nil
-			yyq290[11] = x.PersistentVolumeSource.FC != nil && x.FC != nil
-			yyq290[12] = x.PersistentVolumeSource.Flocker != nil && x.Flocker != nil
-			yyq290[13] = len(x.AccessModes) != 0
-			yyq290[14] = x.ClaimRef != nil
-			yyq290[15] = x.PersistentVolumeReclaimPolicy != ""
+			yyq290[1] = len(x.AccessModes) != 0
+			yyq290[2] = x.ClaimRef != nil
+			yyq290[3] = x.PersistentVolumeReclaimPolicy != ""
+			yyq290[4] = x.PersistentVolumeSource.GCEPersistentDisk != nil && x.GCEPersistentDisk != nil
+			yyq290[5] = x.PersistentVolumeSource.AWSElasticBlockStore != nil && x.AWSElasticBlockStore != nil
+			yyq290[6] = x.PersistentVolumeSource.HostPath != nil && x.HostPath != nil
+			yyq290[7] = x.PersistentVolumeSource.Glusterfs != nil && x.Glusterfs != nil
+			yyq290[8] = x.PersistentVolumeSource.NFS != nil && x.NFS != nil
+			yyq290[9] = x.PersistentVolumeSource.RBD != nil && x.RBD != nil
+			yyq290[10] = x.PersistentVolumeSource.ISCSI != nil && x.ISCSI != nil
+			yyq290[11] = x.PersistentVolumeSource.FlexVolume != nil && x.FlexVolume != nil
+			yyq290[12] = x.PersistentVolumeSource.Cinder != nil && x.Cinder != nil
+			yyq290[13] = x.PersistentVolumeSource.CephFS != nil && x.CephFS != nil
+			yyq290[14] = x.PersistentVolumeSource.FC != nil && x.FC != nil
+			yyq290[15] = x.PersistentVolumeSource.Flocker != nil && x.Flocker != nil
 			var yynn290 int
 			if yyr290 || yy2arr290 {
 				r.EncodeArrayStart(16)
@@ -4867,458 +4867,14 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					x.Capacity.CodecEncodeSelf(e)
 				}
 			}
-			var yyn292 bool
-			if x.PersistentVolumeSource.GCEPersistentDisk == nil {
-				yyn292 = true
-				goto LABEL292
-			}
-		LABEL292:
-			if yyr290 || yy2arr290 {
-				if yyn292 {
-					r.EncodeNil()
-				} else {
-					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq290[1] {
-						if x.GCEPersistentDisk == nil {
-							r.EncodeNil()
-						} else {
-							x.GCEPersistentDisk.CodecEncodeSelf(e)
-						}
-					} else {
-						r.EncodeNil()
-					}
-				}
-			} else {
-				if yyq290[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("gcePersistentDisk"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn292 {
-						r.EncodeNil()
-					} else {
-						if x.GCEPersistentDisk == nil {
-							r.EncodeNil()
-						} else {
-							x.GCEPersistentDisk.CodecEncodeSelf(e)
-						}
-					}
-				}
-			}
-			var yyn293 bool
-			if x.PersistentVolumeSource.AWSElasticBlockStore == nil {
-				yyn293 = true
-				goto LABEL293
-			}
-		LABEL293:
-			if yyr290 || yy2arr290 {
-				if yyn293 {
-					r.EncodeNil()
-				} else {
-					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq290[2] {
-						if x.AWSElasticBlockStore == nil {
-							r.EncodeNil()
-						} else {
-							x.AWSElasticBlockStore.CodecEncodeSelf(e)
-						}
-					} else {
-						r.EncodeNil()
-					}
-				}
-			} else {
-				if yyq290[2] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("awsElasticBlockStore"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn293 {
-						r.EncodeNil()
-					} else {
-						if x.AWSElasticBlockStore == nil {
-							r.EncodeNil()
-						} else {
-							x.AWSElasticBlockStore.CodecEncodeSelf(e)
-						}
-					}
-				}
-			}
-			var yyn294 bool
-			if x.PersistentVolumeSource.HostPath == nil {
-				yyn294 = true
-				goto LABEL294
-			}
-		LABEL294:
-			if yyr290 || yy2arr290 {
-				if yyn294 {
-					r.EncodeNil()
-				} else {
-					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq290[3] {
-						if x.HostPath == nil {
-							r.EncodeNil()
-						} else {
-							x.HostPath.CodecEncodeSelf(e)
-						}
-					} else {
-						r.EncodeNil()
-					}
-				}
-			} else {
-				if yyq290[3] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("hostPath"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn294 {
-						r.EncodeNil()
-					} else {
-						if x.HostPath == nil {
-							r.EncodeNil()
-						} else {
-							x.HostPath.CodecEncodeSelf(e)
-						}
-					}
-				}
-			}
-			var yyn295 bool
-			if x.PersistentVolumeSource.Glusterfs == nil {
-				yyn295 = true
-				goto LABEL295
-			}
-		LABEL295:
-			if yyr290 || yy2arr290 {
-				if yyn295 {
-					r.EncodeNil()
-				} else {
-					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq290[4] {
-						if x.Glusterfs == nil {
-							r.EncodeNil()
-						} else {
-							x.Glusterfs.CodecEncodeSelf(e)
-						}
-					} else {
-						r.EncodeNil()
-					}
-				}
-			} else {
-				if yyq290[4] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("glusterfs"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn295 {
-						r.EncodeNil()
-					} else {
-						if x.Glusterfs == nil {
-							r.EncodeNil()
-						} else {
-							x.Glusterfs.CodecEncodeSelf(e)
-						}
-					}
-				}
-			}
-			var yyn296 bool
-			if x.PersistentVolumeSource.NFS == nil {
-				yyn296 = true
-				goto LABEL296
-			}
-		LABEL296:
-			if yyr290 || yy2arr290 {
-				if yyn296 {
-					r.EncodeNil()
-				} else {
-					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq290[5] {
-						if x.NFS == nil {
-							r.EncodeNil()
-						} else {
-							x.NFS.CodecEncodeSelf(e)
-						}
-					} else {
-						r.EncodeNil()
-					}
-				}
-			} else {
-				if yyq290[5] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("nfs"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn296 {
-						r.EncodeNil()
-					} else {
-						if x.NFS == nil {
-							r.EncodeNil()
-						} else {
-							x.NFS.CodecEncodeSelf(e)
-						}
-					}
-				}
-			}
-			var yyn297 bool
-			if x.PersistentVolumeSource.RBD == nil {
-				yyn297 = true
-				goto LABEL297
-			}
-		LABEL297:
-			if yyr290 || yy2arr290 {
-				if yyn297 {
-					r.EncodeNil()
-				} else {
-					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq290[6] {
-						if x.RBD == nil {
-							r.EncodeNil()
-						} else {
-							x.RBD.CodecEncodeSelf(e)
-						}
-					} else {
-						r.EncodeNil()
-					}
-				}
-			} else {
-				if yyq290[6] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("rbd"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn297 {
-						r.EncodeNil()
-					} else {
-						if x.RBD == nil {
-							r.EncodeNil()
-						} else {
-							x.RBD.CodecEncodeSelf(e)
-						}
-					}
-				}
-			}
-			var yyn298 bool
-			if x.PersistentVolumeSource.ISCSI == nil {
-				yyn298 = true
-				goto LABEL298
-			}
-		LABEL298:
-			if yyr290 || yy2arr290 {
-				if yyn298 {
-					r.EncodeNil()
-				} else {
-					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq290[7] {
-						if x.ISCSI == nil {
-							r.EncodeNil()
-						} else {
-							x.ISCSI.CodecEncodeSelf(e)
-						}
-					} else {
-						r.EncodeNil()
-					}
-				}
-			} else {
-				if yyq290[7] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("iscsi"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn298 {
-						r.EncodeNil()
-					} else {
-						if x.ISCSI == nil {
-							r.EncodeNil()
-						} else {
-							x.ISCSI.CodecEncodeSelf(e)
-						}
-					}
-				}
-			}
-			var yyn299 bool
-			if x.PersistentVolumeSource.FlexVolume == nil {
-				yyn299 = true
-				goto LABEL299
-			}
-		LABEL299:
-			if yyr290 || yy2arr290 {
-				if yyn299 {
-					r.EncodeNil()
-				} else {
-					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq290[8] {
-						if x.FlexVolume == nil {
-							r.EncodeNil()
-						} else {
-							x.FlexVolume.CodecEncodeSelf(e)
-						}
-					} else {
-						r.EncodeNil()
-					}
-				}
-			} else {
-				if yyq290[8] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("flexVolume"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn299 {
-						r.EncodeNil()
-					} else {
-						if x.FlexVolume == nil {
-							r.EncodeNil()
-						} else {
-							x.FlexVolume.CodecEncodeSelf(e)
-						}
-					}
-				}
-			}
-			var yyn300 bool
-			if x.PersistentVolumeSource.Cinder == nil {
-				yyn300 = true
-				goto LABEL300
-			}
-		LABEL300:
-			if yyr290 || yy2arr290 {
-				if yyn300 {
-					r.EncodeNil()
-				} else {
-					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq290[9] {
-						if x.Cinder == nil {
-							r.EncodeNil()
-						} else {
-							x.Cinder.CodecEncodeSelf(e)
-						}
-					} else {
-						r.EncodeNil()
-					}
-				}
-			} else {
-				if yyq290[9] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("cinder"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn300 {
-						r.EncodeNil()
-					} else {
-						if x.Cinder == nil {
-							r.EncodeNil()
-						} else {
-							x.Cinder.CodecEncodeSelf(e)
-						}
-					}
-				}
-			}
-			var yyn301 bool
-			if x.PersistentVolumeSource.CephFS == nil {
-				yyn301 = true
-				goto LABEL301
-			}
-		LABEL301:
-			if yyr290 || yy2arr290 {
-				if yyn301 {
-					r.EncodeNil()
-				} else {
-					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq290[10] {
-						if x.CephFS == nil {
-							r.EncodeNil()
-						} else {
-							x.CephFS.CodecEncodeSelf(e)
-						}
-					} else {
-						r.EncodeNil()
-					}
-				}
-			} else {
-				if yyq290[10] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("cephfs"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn301 {
-						r.EncodeNil()
-					} else {
-						if x.CephFS == nil {
-							r.EncodeNil()
-						} else {
-							x.CephFS.CodecEncodeSelf(e)
-						}
-					}
-				}
-			}
-			var yyn302 bool
-			if x.PersistentVolumeSource.FC == nil {
-				yyn302 = true
-				goto LABEL302
-			}
-		LABEL302:
-			if yyr290 || yy2arr290 {
-				if yyn302 {
-					r.EncodeNil()
-				} else {
-					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq290[11] {
-						if x.FC == nil {
-							r.EncodeNil()
-						} else {
-							x.FC.CodecEncodeSelf(e)
-						}
-					} else {
-						r.EncodeNil()
-					}
-				}
-			} else {
-				if yyq290[11] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("fc"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn302 {
-						r.EncodeNil()
-					} else {
-						if x.FC == nil {
-							r.EncodeNil()
-						} else {
-							x.FC.CodecEncodeSelf(e)
-						}
-					}
-				}
-			}
-			var yyn303 bool
-			if x.PersistentVolumeSource.Flocker == nil {
-				yyn303 = true
-				goto LABEL303
-			}
-		LABEL303:
-			if yyr290 || yy2arr290 {
-				if yyn303 {
-					r.EncodeNil()
-				} else {
-					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq290[12] {
-						if x.Flocker == nil {
-							r.EncodeNil()
-						} else {
-							x.Flocker.CodecEncodeSelf(e)
-						}
-					} else {
-						r.EncodeNil()
-					}
-				}
-			} else {
-				if yyq290[12] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("flocker"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn303 {
-						r.EncodeNil()
-					} else {
-						if x.Flocker == nil {
-							r.EncodeNil()
-						} else {
-							x.Flocker.CodecEncodeSelf(e)
-						}
-					}
-				}
-			}
 			if yyr290 || yy2arr290 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq290[13] {
+				if yyq290[1] {
 					if x.AccessModes == nil {
 						r.EncodeNil()
 					} else {
-						yym305 := z.EncBinary()
-						_ = yym305
+						yym293 := z.EncBinary()
+						_ = yym293
 						if false {
 						} else {
 							h.encSlicePersistentVolumeAccessMode(([]PersistentVolumeAccessMode)(x.AccessModes), e)
@@ -5328,15 +4884,15 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq290[13] {
+				if yyq290[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("accessModes"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.AccessModes == nil {
 						r.EncodeNil()
 					} else {
-						yym306 := z.EncBinary()
-						_ = yym306
+						yym294 := z.EncBinary()
+						_ = yym294
 						if false {
 						} else {
 							h.encSlicePersistentVolumeAccessMode(([]PersistentVolumeAccessMode)(x.AccessModes), e)
@@ -5346,7 +4902,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr290 || yy2arr290 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq290[14] {
+				if yyq290[2] {
 					if x.ClaimRef == nil {
 						r.EncodeNil()
 					} else {
@@ -5356,7 +4912,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq290[14] {
+				if yyq290[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("claimRef"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
@@ -5369,17 +4925,461 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr290 || yy2arr290 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq290[15] {
+				if yyq290[3] {
 					x.PersistentVolumeReclaimPolicy.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq290[15] {
+				if yyq290[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("persistentVolumeReclaimPolicy"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.PersistentVolumeReclaimPolicy.CodecEncodeSelf(e)
+				}
+			}
+			var yyn297 bool
+			if x.PersistentVolumeSource.GCEPersistentDisk == nil {
+				yyn297 = true
+				goto LABEL297
+			}
+		LABEL297:
+			if yyr290 || yy2arr290 {
+				if yyn297 {
+					r.EncodeNil()
+				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+					if yyq290[4] {
+						if x.GCEPersistentDisk == nil {
+							r.EncodeNil()
+						} else {
+							x.GCEPersistentDisk.CodecEncodeSelf(e)
+						}
+					} else {
+						r.EncodeNil()
+					}
+				}
+			} else {
+				if yyq290[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("gcePersistentDisk"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if yyn297 {
+						r.EncodeNil()
+					} else {
+						if x.GCEPersistentDisk == nil {
+							r.EncodeNil()
+						} else {
+							x.GCEPersistentDisk.CodecEncodeSelf(e)
+						}
+					}
+				}
+			}
+			var yyn298 bool
+			if x.PersistentVolumeSource.AWSElasticBlockStore == nil {
+				yyn298 = true
+				goto LABEL298
+			}
+		LABEL298:
+			if yyr290 || yy2arr290 {
+				if yyn298 {
+					r.EncodeNil()
+				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+					if yyq290[5] {
+						if x.AWSElasticBlockStore == nil {
+							r.EncodeNil()
+						} else {
+							x.AWSElasticBlockStore.CodecEncodeSelf(e)
+						}
+					} else {
+						r.EncodeNil()
+					}
+				}
+			} else {
+				if yyq290[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("awsElasticBlockStore"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if yyn298 {
+						r.EncodeNil()
+					} else {
+						if x.AWSElasticBlockStore == nil {
+							r.EncodeNil()
+						} else {
+							x.AWSElasticBlockStore.CodecEncodeSelf(e)
+						}
+					}
+				}
+			}
+			var yyn299 bool
+			if x.PersistentVolumeSource.HostPath == nil {
+				yyn299 = true
+				goto LABEL299
+			}
+		LABEL299:
+			if yyr290 || yy2arr290 {
+				if yyn299 {
+					r.EncodeNil()
+				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+					if yyq290[6] {
+						if x.HostPath == nil {
+							r.EncodeNil()
+						} else {
+							x.HostPath.CodecEncodeSelf(e)
+						}
+					} else {
+						r.EncodeNil()
+					}
+				}
+			} else {
+				if yyq290[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("hostPath"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if yyn299 {
+						r.EncodeNil()
+					} else {
+						if x.HostPath == nil {
+							r.EncodeNil()
+						} else {
+							x.HostPath.CodecEncodeSelf(e)
+						}
+					}
+				}
+			}
+			var yyn300 bool
+			if x.PersistentVolumeSource.Glusterfs == nil {
+				yyn300 = true
+				goto LABEL300
+			}
+		LABEL300:
+			if yyr290 || yy2arr290 {
+				if yyn300 {
+					r.EncodeNil()
+				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+					if yyq290[7] {
+						if x.Glusterfs == nil {
+							r.EncodeNil()
+						} else {
+							x.Glusterfs.CodecEncodeSelf(e)
+						}
+					} else {
+						r.EncodeNil()
+					}
+				}
+			} else {
+				if yyq290[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("glusterfs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if yyn300 {
+						r.EncodeNil()
+					} else {
+						if x.Glusterfs == nil {
+							r.EncodeNil()
+						} else {
+							x.Glusterfs.CodecEncodeSelf(e)
+						}
+					}
+				}
+			}
+			var yyn301 bool
+			if x.PersistentVolumeSource.NFS == nil {
+				yyn301 = true
+				goto LABEL301
+			}
+		LABEL301:
+			if yyr290 || yy2arr290 {
+				if yyn301 {
+					r.EncodeNil()
+				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+					if yyq290[8] {
+						if x.NFS == nil {
+							r.EncodeNil()
+						} else {
+							x.NFS.CodecEncodeSelf(e)
+						}
+					} else {
+						r.EncodeNil()
+					}
+				}
+			} else {
+				if yyq290[8] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("nfs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if yyn301 {
+						r.EncodeNil()
+					} else {
+						if x.NFS == nil {
+							r.EncodeNil()
+						} else {
+							x.NFS.CodecEncodeSelf(e)
+						}
+					}
+				}
+			}
+			var yyn302 bool
+			if x.PersistentVolumeSource.RBD == nil {
+				yyn302 = true
+				goto LABEL302
+			}
+		LABEL302:
+			if yyr290 || yy2arr290 {
+				if yyn302 {
+					r.EncodeNil()
+				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+					if yyq290[9] {
+						if x.RBD == nil {
+							r.EncodeNil()
+						} else {
+							x.RBD.CodecEncodeSelf(e)
+						}
+					} else {
+						r.EncodeNil()
+					}
+				}
+			} else {
+				if yyq290[9] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("rbd"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if yyn302 {
+						r.EncodeNil()
+					} else {
+						if x.RBD == nil {
+							r.EncodeNil()
+						} else {
+							x.RBD.CodecEncodeSelf(e)
+						}
+					}
+				}
+			}
+			var yyn303 bool
+			if x.PersistentVolumeSource.ISCSI == nil {
+				yyn303 = true
+				goto LABEL303
+			}
+		LABEL303:
+			if yyr290 || yy2arr290 {
+				if yyn303 {
+					r.EncodeNil()
+				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+					if yyq290[10] {
+						if x.ISCSI == nil {
+							r.EncodeNil()
+						} else {
+							x.ISCSI.CodecEncodeSelf(e)
+						}
+					} else {
+						r.EncodeNil()
+					}
+				}
+			} else {
+				if yyq290[10] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("iscsi"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if yyn303 {
+						r.EncodeNil()
+					} else {
+						if x.ISCSI == nil {
+							r.EncodeNil()
+						} else {
+							x.ISCSI.CodecEncodeSelf(e)
+						}
+					}
+				}
+			}
+			var yyn304 bool
+			if x.PersistentVolumeSource.FlexVolume == nil {
+				yyn304 = true
+				goto LABEL304
+			}
+		LABEL304:
+			if yyr290 || yy2arr290 {
+				if yyn304 {
+					r.EncodeNil()
+				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+					if yyq290[11] {
+						if x.FlexVolume == nil {
+							r.EncodeNil()
+						} else {
+							x.FlexVolume.CodecEncodeSelf(e)
+						}
+					} else {
+						r.EncodeNil()
+					}
+				}
+			} else {
+				if yyq290[11] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("flexVolume"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if yyn304 {
+						r.EncodeNil()
+					} else {
+						if x.FlexVolume == nil {
+							r.EncodeNil()
+						} else {
+							x.FlexVolume.CodecEncodeSelf(e)
+						}
+					}
+				}
+			}
+			var yyn305 bool
+			if x.PersistentVolumeSource.Cinder == nil {
+				yyn305 = true
+				goto LABEL305
+			}
+		LABEL305:
+			if yyr290 || yy2arr290 {
+				if yyn305 {
+					r.EncodeNil()
+				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+					if yyq290[12] {
+						if x.Cinder == nil {
+							r.EncodeNil()
+						} else {
+							x.Cinder.CodecEncodeSelf(e)
+						}
+					} else {
+						r.EncodeNil()
+					}
+				}
+			} else {
+				if yyq290[12] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("cinder"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if yyn305 {
+						r.EncodeNil()
+					} else {
+						if x.Cinder == nil {
+							r.EncodeNil()
+						} else {
+							x.Cinder.CodecEncodeSelf(e)
+						}
+					}
+				}
+			}
+			var yyn306 bool
+			if x.PersistentVolumeSource.CephFS == nil {
+				yyn306 = true
+				goto LABEL306
+			}
+		LABEL306:
+			if yyr290 || yy2arr290 {
+				if yyn306 {
+					r.EncodeNil()
+				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+					if yyq290[13] {
+						if x.CephFS == nil {
+							r.EncodeNil()
+						} else {
+							x.CephFS.CodecEncodeSelf(e)
+						}
+					} else {
+						r.EncodeNil()
+					}
+				}
+			} else {
+				if yyq290[13] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("cephfs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if yyn306 {
+						r.EncodeNil()
+					} else {
+						if x.CephFS == nil {
+							r.EncodeNil()
+						} else {
+							x.CephFS.CodecEncodeSelf(e)
+						}
+					}
+				}
+			}
+			var yyn307 bool
+			if x.PersistentVolumeSource.FC == nil {
+				yyn307 = true
+				goto LABEL307
+			}
+		LABEL307:
+			if yyr290 || yy2arr290 {
+				if yyn307 {
+					r.EncodeNil()
+				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+					if yyq290[14] {
+						if x.FC == nil {
+							r.EncodeNil()
+						} else {
+							x.FC.CodecEncodeSelf(e)
+						}
+					} else {
+						r.EncodeNil()
+					}
+				}
+			} else {
+				if yyq290[14] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("fc"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if yyn307 {
+						r.EncodeNil()
+					} else {
+						if x.FC == nil {
+							r.EncodeNil()
+						} else {
+							x.FC.CodecEncodeSelf(e)
+						}
+					}
+				}
+			}
+			var yyn308 bool
+			if x.PersistentVolumeSource.Flocker == nil {
+				yyn308 = true
+				goto LABEL308
+			}
+		LABEL308:
+			if yyr290 || yy2arr290 {
+				if yyn308 {
+					r.EncodeNil()
+				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+					if yyq290[15] {
+						if x.Flocker == nil {
+							r.EncodeNil()
+						} else {
+							x.Flocker.CodecEncodeSelf(e)
+						}
+					} else {
+						r.EncodeNil()
+					}
+				}
+			} else {
+				if yyq290[15] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("flocker"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if yyn308 {
+						r.EncodeNil()
+					} else {
+						if x.Flocker == nil {
+							r.EncodeNil()
+						} else {
+							x.Flocker.CodecEncodeSelf(e)
+						}
+					}
 				}
 			}
 			if yyr290 || yy2arr290 {
@@ -5449,6 +5449,35 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			} else {
 				yyv312 := &x.Capacity
 				yyv312.CodecDecodeSelf(d)
+			}
+		case "accessModes":
+			if r.TryDecodeAsNil() {
+				x.AccessModes = nil
+			} else {
+				yyv313 := &x.AccessModes
+				yym314 := z.DecBinary()
+				_ = yym314
+				if false {
+				} else {
+					h.decSlicePersistentVolumeAccessMode((*[]PersistentVolumeAccessMode)(yyv313), d)
+				}
+			}
+		case "claimRef":
+			if r.TryDecodeAsNil() {
+				if x.ClaimRef != nil {
+					x.ClaimRef = nil
+				}
+			} else {
+				if x.ClaimRef == nil {
+					x.ClaimRef = new(ObjectReference)
+				}
+				x.ClaimRef.CodecDecodeSelf(d)
+			}
+		case "persistentVolumeReclaimPolicy":
+			if r.TryDecodeAsNil() {
+				x.PersistentVolumeReclaimPolicy = ""
+			} else {
+				x.PersistentVolumeReclaimPolicy = PersistentVolumeReclaimPolicy(r.DecodeString())
 			}
 		case "gcePersistentDisk":
 			if x.PersistentVolumeSource.GCEPersistentDisk == nil {
@@ -5618,35 +5647,6 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				}
 				x.Flocker.CodecDecodeSelf(d)
 			}
-		case "accessModes":
-			if r.TryDecodeAsNil() {
-				x.AccessModes = nil
-			} else {
-				yyv325 := &x.AccessModes
-				yym326 := z.DecBinary()
-				_ = yym326
-				if false {
-				} else {
-					h.decSlicePersistentVolumeAccessMode((*[]PersistentVolumeAccessMode)(yyv325), d)
-				}
-			}
-		case "claimRef":
-			if r.TryDecodeAsNil() {
-				if x.ClaimRef != nil {
-					x.ClaimRef = nil
-				}
-			} else {
-				if x.ClaimRef == nil {
-					x.ClaimRef = new(ObjectReference)
-				}
-				x.ClaimRef.CodecDecodeSelf(d)
-			}
-		case "persistentVolumeReclaimPolicy":
-			if r.TryDecodeAsNil() {
-				x.PersistentVolumeReclaimPolicy = ""
-			} else {
-				x.PersistentVolumeReclaimPolicy = PersistentVolumeReclaimPolicy(r.DecodeString())
-			}
 		default:
 			z.DecStructFieldNotFound(-1, yys311)
 		} // end switch yys311
@@ -5677,6 +5677,65 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		yyv330 := &x.Capacity
 		yyv330.CodecDecodeSelf(d)
+	}
+	yyj329++
+	if yyhl329 {
+		yyb329 = yyj329 > l
+	} else {
+		yyb329 = r.CheckBreak()
+	}
+	if yyb329 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.AccessModes = nil
+	} else {
+		yyv331 := &x.AccessModes
+		yym332 := z.DecBinary()
+		_ = yym332
+		if false {
+		} else {
+			h.decSlicePersistentVolumeAccessMode((*[]PersistentVolumeAccessMode)(yyv331), d)
+		}
+	}
+	yyj329++
+	if yyhl329 {
+		yyb329 = yyj329 > l
+	} else {
+		yyb329 = r.CheckBreak()
+	}
+	if yyb329 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		if x.ClaimRef != nil {
+			x.ClaimRef = nil
+		}
+	} else {
+		if x.ClaimRef == nil {
+			x.ClaimRef = new(ObjectReference)
+		}
+		x.ClaimRef.CodecDecodeSelf(d)
+	}
+	yyj329++
+	if yyhl329 {
+		yyb329 = yyj329 > l
+	} else {
+		yyb329 = r.CheckBreak()
+	}
+	if yyb329 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.PersistentVolumeReclaimPolicy = ""
+	} else {
+		x.PersistentVolumeReclaimPolicy = PersistentVolumeReclaimPolicy(r.DecodeString())
 	}
 	if x.PersistentVolumeSource.GCEPersistentDisk == nil {
 		x.PersistentVolumeSource.GCEPersistentDisk = new(GCEPersistentDiskVolumeSource)
@@ -5965,65 +6024,6 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 			x.Flocker = new(FlockerVolumeSource)
 		}
 		x.Flocker.CodecDecodeSelf(d)
-	}
-	yyj329++
-	if yyhl329 {
-		yyb329 = yyj329 > l
-	} else {
-		yyb329 = r.CheckBreak()
-	}
-	if yyb329 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.AccessModes = nil
-	} else {
-		yyv343 := &x.AccessModes
-		yym344 := z.DecBinary()
-		_ = yym344
-		if false {
-		} else {
-			h.decSlicePersistentVolumeAccessMode((*[]PersistentVolumeAccessMode)(yyv343), d)
-		}
-	}
-	yyj329++
-	if yyhl329 {
-		yyb329 = yyj329 > l
-	} else {
-		yyb329 = r.CheckBreak()
-	}
-	if yyb329 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		if x.ClaimRef != nil {
-			x.ClaimRef = nil
-		}
-	} else {
-		if x.ClaimRef == nil {
-			x.ClaimRef = new(ObjectReference)
-		}
-		x.ClaimRef.CodecDecodeSelf(d)
-	}
-	yyj329++
-	if yyhl329 {
-		yyb329 = yyj329 > l
-	} else {
-		yyb329 = r.CheckBreak()
-	}
-	if yyb329 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.PersistentVolumeReclaimPolicy = ""
-	} else {
-		x.PersistentVolumeReclaimPolicy = PersistentVolumeReclaimPolicy(r.DecodeString())
 	}
 	for {
 		yyj329++
@@ -6339,9 +6339,9 @@ func (x *PersistentVolumeList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq369 [4]bool
 			_, _, _ = yysep369, yyq369, yy2arr369
 			const yyr369 bool = false
-			yyq369[0] = x.Kind != ""
-			yyq369[1] = x.APIVersion != ""
-			yyq369[2] = true
+			yyq369[0] = true
+			yyq369[2] = x.Kind != ""
+			yyq369[3] = x.APIVersion != ""
 			var yynn369 int
 			if yyr369 || yy2arr369 {
 				r.EncodeArrayStart(4)
@@ -6358,79 +6358,29 @@ func (x *PersistentVolumeList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr369 || yy2arr369 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq369[0] {
-					yym371 := z.EncBinary()
-					_ = yym371
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq369[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy371 := &x.ListMeta
 					yym372 := z.EncBinary()
 					_ = yym372
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy371) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr369 || yy2arr369 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq369[1] {
-					yym374 := z.EncBinary()
-					_ = yym374
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq369[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym375 := z.EncBinary()
-					_ = yym375
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr369 || yy2arr369 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq369[2] {
-					yy377 := &x.ListMeta
-					yym378 := z.EncBinary()
-					_ = yym378
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy377) {
-					} else {
-						z.EncFallback(yy377)
+						z.EncFallback(yy371)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq369[2] {
+				if yyq369[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy379 := &x.ListMeta
-					yym380 := z.EncBinary()
-					_ = yym380
+					yy373 := &x.ListMeta
+					yym374 := z.EncBinary()
+					_ = yym374
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy379) {
+					} else if z.HasExtensions() && z.EncExt(yy373) {
 					} else {
-						z.EncFallback(yy379)
+						z.EncFallback(yy373)
 					}
 				}
 			}
@@ -6439,8 +6389,8 @@ func (x *PersistentVolumeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym382 := z.EncBinary()
-					_ = yym382
+					yym376 := z.EncBinary()
+					_ = yym376
 					if false {
 					} else {
 						h.encSlicePersistentVolume(([]PersistentVolume)(x.Items), e)
@@ -6453,11 +6403,61 @@ func (x *PersistentVolumeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym377 := z.EncBinary()
+					_ = yym377
+					if false {
+					} else {
+						h.encSlicePersistentVolume(([]PersistentVolume)(x.Items), e)
+					}
+				}
+			}
+			if yyr369 || yy2arr369 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq369[2] {
+					yym379 := z.EncBinary()
+					_ = yym379
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq369[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym380 := z.EncBinary()
+					_ = yym380
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr369 || yy2arr369 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq369[3] {
+					yym382 := z.EncBinary()
+					_ = yym382
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq369[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym383 := z.EncBinary()
 					_ = yym383
 					if false {
 					} else {
-						h.encSlicePersistentVolume(([]PersistentVolume)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -6522,6 +6522,31 @@ func (x *PersistentVolumeList) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 		yys386 := string(yys386Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys386 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv387 := &x.ListMeta
+				yym388 := z.DecBinary()
+				_ = yym388
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv387) {
+				} else {
+					z.DecFallback(yyv387, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv389 := &x.Items
+				yym390 := z.DecBinary()
+				_ = yym390
+				if false {
+				} else {
+					h.decSlicePersistentVolume((*[]PersistentVolume)(yyv389), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -6533,31 +6558,6 @@ func (x *PersistentVolumeList) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv389 := &x.ListMeta
-				yym390 := z.DecBinary()
-				_ = yym390
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv389) {
-				} else {
-					z.DecFallback(yyv389, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv391 := &x.Items
-				yym392 := z.DecBinary()
-				_ = yym392
-				if false {
-				} else {
-					h.decSlicePersistentVolume((*[]PersistentVolume)(yyv391), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys386)
@@ -6573,6 +6573,51 @@ func (x *PersistentVolumeList) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	var yyj393 int
 	var yyb393 bool
 	var yyhl393 bool = l >= 0
+	yyj393++
+	if yyhl393 {
+		yyb393 = yyj393 > l
+	} else {
+		yyb393 = r.CheckBreak()
+	}
+	if yyb393 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv394 := &x.ListMeta
+		yym395 := z.DecBinary()
+		_ = yym395
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv394) {
+		} else {
+			z.DecFallback(yyv394, false)
+		}
+	}
+	yyj393++
+	if yyhl393 {
+		yyb393 = yyj393 > l
+	} else {
+		yyb393 = r.CheckBreak()
+	}
+	if yyb393 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv396 := &x.Items
+		yym397 := z.DecBinary()
+		_ = yym397
+		if false {
+		} else {
+			h.decSlicePersistentVolume((*[]PersistentVolume)(yyv396), d)
+		}
+	}
 	yyj393++
 	if yyhl393 {
 		yyb393 = yyj393 > l
@@ -6604,51 +6649,6 @@ func (x *PersistentVolumeList) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj393++
-	if yyhl393 {
-		yyb393 = yyj393 > l
-	} else {
-		yyb393 = r.CheckBreak()
-	}
-	if yyb393 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv396 := &x.ListMeta
-		yym397 := z.DecBinary()
-		_ = yym397
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv396) {
-		} else {
-			z.DecFallback(yyv396, false)
-		}
-	}
-	yyj393++
-	if yyhl393 {
-		yyb393 = yyj393 > l
-	} else {
-		yyb393 = r.CheckBreak()
-	}
-	if yyb393 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv398 := &x.Items
-		yym399 := z.DecBinary()
-		_ = yym399
-		if false {
-		} else {
-			h.decSlicePersistentVolume((*[]PersistentVolume)(yyv398), d)
-		}
 	}
 	for {
 		yyj393++
@@ -6683,11 +6683,11 @@ func (x *PersistentVolumeClaim) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq401 [5]bool
 			_, _, _ = yysep401, yyq401, yy2arr401
 			const yyr401 bool = false
-			yyq401[0] = x.Kind != ""
-			yyq401[1] = x.APIVersion != ""
+			yyq401[0] = true
+			yyq401[1] = true
 			yyq401[2] = true
-			yyq401[3] = true
-			yyq401[4] = true
+			yyq401[3] = x.Kind != ""
+			yyq401[4] = x.APIVersion != ""
 			var yynn401 int
 			if yyr401 || yy2arr401 {
 				r.EncodeArrayStart(5)
@@ -6704,57 +6704,41 @@ func (x *PersistentVolumeClaim) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr401 || yy2arr401 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq401[0] {
-					yym403 := z.EncBinary()
-					_ = yym403
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy403 := &x.ObjectMeta
+					yy403.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq401[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym404 := z.EncBinary()
-					_ = yym404
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy404 := &x.ObjectMeta
+					yy404.CodecEncodeSelf(e)
 				}
 			}
 			if yyr401 || yy2arr401 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq401[1] {
-					yym406 := z.EncBinary()
-					_ = yym406
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy406 := &x.Spec
+					yy406.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq401[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym407 := z.EncBinary()
-					_ = yym407
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy407 := &x.Spec
+					yy407.CodecEncodeSelf(e)
 				}
 			}
 			if yyr401 || yy2arr401 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq401[2] {
-					yy409 := &x.ObjectMeta
+					yy409 := &x.Status
 					yy409.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
@@ -6762,44 +6746,60 @@ func (x *PersistentVolumeClaim) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq401[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy410 := &x.ObjectMeta
+					yy410 := &x.Status
 					yy410.CodecEncodeSelf(e)
 				}
 			}
 			if yyr401 || yy2arr401 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq401[3] {
-					yy412 := &x.Spec
-					yy412.CodecEncodeSelf(e)
+					yym412 := z.EncBinary()
+					_ = yym412
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq401[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy413 := &x.Spec
-					yy413.CodecEncodeSelf(e)
+					yym413 := z.EncBinary()
+					_ = yym413
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				}
 			}
 			if yyr401 || yy2arr401 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq401[4] {
-					yy415 := &x.Status
-					yy415.CodecEncodeSelf(e)
+					yym415 := z.EncBinary()
+					_ = yym415
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq401[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy416 := &x.Status
-					yy416.CodecEncodeSelf(e)
+					yym416 := z.EncBinary()
+					_ = yym416
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr401 || yy2arr401 {
@@ -6863,6 +6863,27 @@ func (x *PersistentVolumeClaim) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 		yys419 := string(yys419Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys419 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv420 := &x.ObjectMeta
+				yyv420.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = PersistentVolumeClaimSpec{}
+			} else {
+				yyv421 := &x.Spec
+				yyv421.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = PersistentVolumeClaimStatus{}
+			} else {
+				yyv422 := &x.Status
+				yyv422.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -6874,27 +6895,6 @@ func (x *PersistentVolumeClaim) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv422 := &x.ObjectMeta
-				yyv422.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = PersistentVolumeClaimSpec{}
-			} else {
-				yyv423 := &x.Spec
-				yyv423.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = PersistentVolumeClaimStatus{}
-			} else {
-				yyv424 := &x.Status
-				yyv424.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys419)
@@ -6910,6 +6910,57 @@ func (x *PersistentVolumeClaim) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var yyj425 int
 	var yyb425 bool
 	var yyhl425 bool = l >= 0
+	yyj425++
+	if yyhl425 {
+		yyb425 = yyj425 > l
+	} else {
+		yyb425 = r.CheckBreak()
+	}
+	if yyb425 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv426 := &x.ObjectMeta
+		yyv426.CodecDecodeSelf(d)
+	}
+	yyj425++
+	if yyhl425 {
+		yyb425 = yyj425 > l
+	} else {
+		yyb425 = r.CheckBreak()
+	}
+	if yyb425 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = PersistentVolumeClaimSpec{}
+	} else {
+		yyv427 := &x.Spec
+		yyv427.CodecDecodeSelf(d)
+	}
+	yyj425++
+	if yyhl425 {
+		yyb425 = yyj425 > l
+	} else {
+		yyb425 = r.CheckBreak()
+	}
+	if yyb425 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = PersistentVolumeClaimStatus{}
+	} else {
+		yyv428 := &x.Status
+		yyv428.CodecDecodeSelf(d)
+	}
 	yyj425++
 	if yyhl425 {
 		yyb425 = yyj425 > l
@@ -6941,57 +6992,6 @@ func (x *PersistentVolumeClaim) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj425++
-	if yyhl425 {
-		yyb425 = yyj425 > l
-	} else {
-		yyb425 = r.CheckBreak()
-	}
-	if yyb425 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv428 := &x.ObjectMeta
-		yyv428.CodecDecodeSelf(d)
-	}
-	yyj425++
-	if yyhl425 {
-		yyb425 = yyj425 > l
-	} else {
-		yyb425 = r.CheckBreak()
-	}
-	if yyb425 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = PersistentVolumeClaimSpec{}
-	} else {
-		yyv429 := &x.Spec
-		yyv429.CodecDecodeSelf(d)
-	}
-	yyj425++
-	if yyhl425 {
-		yyb425 = yyj425 > l
-	} else {
-		yyb425 = r.CheckBreak()
-	}
-	if yyb425 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = PersistentVolumeClaimStatus{}
-	} else {
-		yyv430 := &x.Status
-		yyv430.CodecDecodeSelf(d)
 	}
 	for {
 		yyj425++
@@ -7026,9 +7026,9 @@ func (x *PersistentVolumeClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq432 [4]bool
 			_, _, _ = yysep432, yyq432, yy2arr432
 			const yyr432 bool = false
-			yyq432[0] = x.Kind != ""
-			yyq432[1] = x.APIVersion != ""
-			yyq432[2] = true
+			yyq432[0] = true
+			yyq432[2] = x.Kind != ""
+			yyq432[3] = x.APIVersion != ""
 			var yynn432 int
 			if yyr432 || yy2arr432 {
 				r.EncodeArrayStart(4)
@@ -7045,79 +7045,29 @@ func (x *PersistentVolumeClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr432 || yy2arr432 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq432[0] {
-					yym434 := z.EncBinary()
-					_ = yym434
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq432[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy434 := &x.ListMeta
 					yym435 := z.EncBinary()
 					_ = yym435
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy434) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr432 || yy2arr432 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq432[1] {
-					yym437 := z.EncBinary()
-					_ = yym437
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq432[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym438 := z.EncBinary()
-					_ = yym438
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr432 || yy2arr432 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq432[2] {
-					yy440 := &x.ListMeta
-					yym441 := z.EncBinary()
-					_ = yym441
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy440) {
-					} else {
-						z.EncFallback(yy440)
+						z.EncFallback(yy434)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq432[2] {
+				if yyq432[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy442 := &x.ListMeta
-					yym443 := z.EncBinary()
-					_ = yym443
+					yy436 := &x.ListMeta
+					yym437 := z.EncBinary()
+					_ = yym437
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy442) {
+					} else if z.HasExtensions() && z.EncExt(yy436) {
 					} else {
-						z.EncFallback(yy442)
+						z.EncFallback(yy436)
 					}
 				}
 			}
@@ -7126,8 +7076,8 @@ func (x *PersistentVolumeClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym445 := z.EncBinary()
-					_ = yym445
+					yym439 := z.EncBinary()
+					_ = yym439
 					if false {
 					} else {
 						h.encSlicePersistentVolumeClaim(([]PersistentVolumeClaim)(x.Items), e)
@@ -7140,11 +7090,61 @@ func (x *PersistentVolumeClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym440 := z.EncBinary()
+					_ = yym440
+					if false {
+					} else {
+						h.encSlicePersistentVolumeClaim(([]PersistentVolumeClaim)(x.Items), e)
+					}
+				}
+			}
+			if yyr432 || yy2arr432 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq432[2] {
+					yym442 := z.EncBinary()
+					_ = yym442
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq432[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym443 := z.EncBinary()
+					_ = yym443
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr432 || yy2arr432 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq432[3] {
+					yym445 := z.EncBinary()
+					_ = yym445
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq432[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym446 := z.EncBinary()
 					_ = yym446
 					if false {
 					} else {
-						h.encSlicePersistentVolumeClaim(([]PersistentVolumeClaim)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -7209,6 +7209,31 @@ func (x *PersistentVolumeClaimList) codecDecodeSelfFromMap(l int, d *codec1978.D
 		yys449 := string(yys449Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys449 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv450 := &x.ListMeta
+				yym451 := z.DecBinary()
+				_ = yym451
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv450) {
+				} else {
+					z.DecFallback(yyv450, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv452 := &x.Items
+				yym453 := z.DecBinary()
+				_ = yym453
+				if false {
+				} else {
+					h.decSlicePersistentVolumeClaim((*[]PersistentVolumeClaim)(yyv452), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -7220,31 +7245,6 @@ func (x *PersistentVolumeClaimList) codecDecodeSelfFromMap(l int, d *codec1978.D
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv452 := &x.ListMeta
-				yym453 := z.DecBinary()
-				_ = yym453
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv452) {
-				} else {
-					z.DecFallback(yyv452, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv454 := &x.Items
-				yym455 := z.DecBinary()
-				_ = yym455
-				if false {
-				} else {
-					h.decSlicePersistentVolumeClaim((*[]PersistentVolumeClaim)(yyv454), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys449)
@@ -7260,6 +7260,51 @@ func (x *PersistentVolumeClaimList) codecDecodeSelfFromArray(l int, d *codec1978
 	var yyj456 int
 	var yyb456 bool
 	var yyhl456 bool = l >= 0
+	yyj456++
+	if yyhl456 {
+		yyb456 = yyj456 > l
+	} else {
+		yyb456 = r.CheckBreak()
+	}
+	if yyb456 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv457 := &x.ListMeta
+		yym458 := z.DecBinary()
+		_ = yym458
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv457) {
+		} else {
+			z.DecFallback(yyv457, false)
+		}
+	}
+	yyj456++
+	if yyhl456 {
+		yyb456 = yyj456 > l
+	} else {
+		yyb456 = r.CheckBreak()
+	}
+	if yyb456 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv459 := &x.Items
+		yym460 := z.DecBinary()
+		_ = yym460
+		if false {
+		} else {
+			h.decSlicePersistentVolumeClaim((*[]PersistentVolumeClaim)(yyv459), d)
+		}
+	}
 	yyj456++
 	if yyhl456 {
 		yyb456 = yyj456 > l
@@ -7291,51 +7336,6 @@ func (x *PersistentVolumeClaimList) codecDecodeSelfFromArray(l int, d *codec1978
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj456++
-	if yyhl456 {
-		yyb456 = yyj456 > l
-	} else {
-		yyb456 = r.CheckBreak()
-	}
-	if yyb456 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv459 := &x.ListMeta
-		yym460 := z.DecBinary()
-		_ = yym460
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv459) {
-		} else {
-			z.DecFallback(yyv459, false)
-		}
-	}
-	yyj456++
-	if yyhl456 {
-		yyb456 = yyj456 > l
-	} else {
-		yyb456 = r.CheckBreak()
-	}
-	if yyb456 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv461 := &x.Items
-		yym462 := z.DecBinary()
-		_ = yym462
-		if false {
-		} else {
-			h.decSlicePersistentVolumeClaim((*[]PersistentVolumeClaim)(yyv461), d)
-		}
 	}
 	for {
 		yyj456++
@@ -14148,17 +14148,17 @@ func (x *ConfigMapKeySelector) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym1006
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("Name"))
+				r.EncodeString(codecSelferC_UTF81234, string("key"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1007 := z.EncBinary()
 				_ = yym1007
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
 				}
 			}
 			if yyr1004 || yy2arr1004 {
@@ -14167,17 +14167,17 @@ func (x *ConfigMapKeySelector) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym1009
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
+					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("key"))
+				r.EncodeString(codecSelferC_UTF81234, string("Name"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1010 := z.EncBinary()
 				_ = yym1010
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
+					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			}
 			if yyr1004 || yy2arr1004 {
@@ -14241,17 +14241,17 @@ func (x *ConfigMapKeySelector) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 		yys1013 := string(yys1013Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1013 {
-		case "Name":
-			if r.TryDecodeAsNil() {
-				x.Name = ""
-			} else {
-				x.Name = string(r.DecodeString())
-			}
 		case "key":
 			if r.TryDecodeAsNil() {
 				x.Key = ""
 			} else {
 				x.Key = string(r.DecodeString())
+			}
+		case "Name":
+			if r.TryDecodeAsNil() {
+				x.Name = ""
+			} else {
+				x.Name = string(r.DecodeString())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1013)
@@ -14279,9 +14279,9 @@ func (x *ConfigMapKeySelector) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.Name = ""
+		x.Key = ""
 	} else {
-		x.Name = string(r.DecodeString())
+		x.Key = string(r.DecodeString())
 	}
 	yyj1016++
 	if yyhl1016 {
@@ -14295,9 +14295,9 @@ func (x *ConfigMapKeySelector) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.Key = ""
+		x.Name = ""
 	} else {
-		x.Key = string(r.DecodeString())
+		x.Name = string(r.DecodeString())
 	}
 	for {
 		yyj1016++
@@ -14351,17 +14351,17 @@ func (x *SecretKeySelector) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym1022
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("Name"))
+				r.EncodeString(codecSelferC_UTF81234, string("key"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1023 := z.EncBinary()
 				_ = yym1023
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
 				}
 			}
 			if yyr1020 || yy2arr1020 {
@@ -14370,17 +14370,17 @@ func (x *SecretKeySelector) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym1025
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
+					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("key"))
+				r.EncodeString(codecSelferC_UTF81234, string("Name"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym1026 := z.EncBinary()
 				_ = yym1026
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
+					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			}
 			if yyr1020 || yy2arr1020 {
@@ -14444,17 +14444,17 @@ func (x *SecretKeySelector) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 		yys1029 := string(yys1029Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1029 {
-		case "Name":
-			if r.TryDecodeAsNil() {
-				x.Name = ""
-			} else {
-				x.Name = string(r.DecodeString())
-			}
 		case "key":
 			if r.TryDecodeAsNil() {
 				x.Key = ""
 			} else {
 				x.Key = string(r.DecodeString())
+			}
+		case "Name":
+			if r.TryDecodeAsNil() {
+				x.Name = ""
+			} else {
+				x.Name = string(r.DecodeString())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1029)
@@ -14482,9 +14482,9 @@ func (x *SecretKeySelector) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.Name = ""
+		x.Key = ""
 	} else {
-		x.Name = string(r.DecodeString())
+		x.Key = string(r.DecodeString())
 	}
 	yyj1032++
 	if yyhl1032 {
@@ -14498,9 +14498,9 @@ func (x *SecretKeySelector) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.Key = ""
+		x.Name = ""
 	} else {
-		x.Key = string(r.DecodeString())
+		x.Name = string(r.DecodeString())
 	}
 	for {
 		yyj1032++
@@ -15545,14 +15545,14 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1117 [8]bool
 			_, _, _ = yysep1117, yyq1117, yy2arr1117
 			const yyr1117 bool = false
-			yyq1117[0] = x.Handler.Exec != nil && x.Exec != nil
-			yyq1117[1] = x.Handler.HTTPGet != nil && x.HTTPGet != nil
-			yyq1117[2] = x.Handler.TCPSocket != nil && x.TCPSocket != nil
-			yyq1117[3] = x.InitialDelaySeconds != 0
-			yyq1117[4] = x.TimeoutSeconds != 0
-			yyq1117[5] = x.PeriodSeconds != 0
-			yyq1117[6] = x.SuccessThreshold != 0
-			yyq1117[7] = x.FailureThreshold != 0
+			yyq1117[0] = x.InitialDelaySeconds != 0
+			yyq1117[1] = x.TimeoutSeconds != 0
+			yyq1117[2] = x.PeriodSeconds != 0
+			yyq1117[3] = x.SuccessThreshold != 0
+			yyq1117[4] = x.FailureThreshold != 0
+			yyq1117[5] = x.Handler.Exec != nil && x.Exec != nil
+			yyq1117[6] = x.Handler.HTTPGet != nil && x.HTTPGet != nil
+			yyq1117[7] = x.Handler.TCPSocket != nil && x.TCPSocket != nil
 			var yynn1117 int
 			if yyr1117 || yy2arr1117 {
 				r.EncodeArrayStart(8)
@@ -15566,122 +15566,11 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				r.EncodeMapStart(yynn1117)
 				yynn1117 = 0
 			}
-			var yyn1118 bool
-			if x.Handler.Exec == nil {
-				yyn1118 = true
-				goto LABEL1118
-			}
-		LABEL1118:
-			if yyr1117 || yy2arr1117 {
-				if yyn1118 {
-					r.EncodeNil()
-				} else {
-					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq1117[0] {
-						if x.Exec == nil {
-							r.EncodeNil()
-						} else {
-							x.Exec.CodecEncodeSelf(e)
-						}
-					} else {
-						r.EncodeNil()
-					}
-				}
-			} else {
-				if yyq1117[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("exec"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn1118 {
-						r.EncodeNil()
-					} else {
-						if x.Exec == nil {
-							r.EncodeNil()
-						} else {
-							x.Exec.CodecEncodeSelf(e)
-						}
-					}
-				}
-			}
-			var yyn1119 bool
-			if x.Handler.HTTPGet == nil {
-				yyn1119 = true
-				goto LABEL1119
-			}
-		LABEL1119:
-			if yyr1117 || yy2arr1117 {
-				if yyn1119 {
-					r.EncodeNil()
-				} else {
-					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq1117[1] {
-						if x.HTTPGet == nil {
-							r.EncodeNil()
-						} else {
-							x.HTTPGet.CodecEncodeSelf(e)
-						}
-					} else {
-						r.EncodeNil()
-					}
-				}
-			} else {
-				if yyq1117[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("httpGet"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn1119 {
-						r.EncodeNil()
-					} else {
-						if x.HTTPGet == nil {
-							r.EncodeNil()
-						} else {
-							x.HTTPGet.CodecEncodeSelf(e)
-						}
-					}
-				}
-			}
-			var yyn1120 bool
-			if x.Handler.TCPSocket == nil {
-				yyn1120 = true
-				goto LABEL1120
-			}
-		LABEL1120:
-			if yyr1117 || yy2arr1117 {
-				if yyn1120 {
-					r.EncodeNil()
-				} else {
-					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq1117[2] {
-						if x.TCPSocket == nil {
-							r.EncodeNil()
-						} else {
-							x.TCPSocket.CodecEncodeSelf(e)
-						}
-					} else {
-						r.EncodeNil()
-					}
-				}
-			} else {
-				if yyq1117[2] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("tcpSocket"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn1120 {
-						r.EncodeNil()
-					} else {
-						if x.TCPSocket == nil {
-							r.EncodeNil()
-						} else {
-							x.TCPSocket.CodecEncodeSelf(e)
-						}
-					}
-				}
-			}
 			if yyr1117 || yy2arr1117 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1117[3] {
-					yym1122 := z.EncBinary()
-					_ = yym1122
+				if yyq1117[0] {
+					yym1119 := z.EncBinary()
+					_ = yym1119
 					if false {
 					} else {
 						r.EncodeInt(int64(x.InitialDelaySeconds))
@@ -15690,115 +15579,226 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq1117[3] {
+				if yyq1117[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("initialDelaySeconds"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1120 := z.EncBinary()
+					_ = yym1120
+					if false {
+					} else {
+						r.EncodeInt(int64(x.InitialDelaySeconds))
+					}
+				}
+			}
+			if yyr1117 || yy2arr1117 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1117[1] {
+					yym1122 := z.EncBinary()
+					_ = yym1122
+					if false {
+					} else {
+						r.EncodeInt(int64(x.TimeoutSeconds))
+					}
+				} else {
+					r.EncodeInt(0)
+				}
+			} else {
+				if yyq1117[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("timeoutSeconds"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1123 := z.EncBinary()
 					_ = yym1123
 					if false {
 					} else {
-						r.EncodeInt(int64(x.InitialDelaySeconds))
+						r.EncodeInt(int64(x.TimeoutSeconds))
 					}
 				}
 			}
 			if yyr1117 || yy2arr1117 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1117[4] {
+				if yyq1117[2] {
 					yym1125 := z.EncBinary()
 					_ = yym1125
 					if false {
 					} else {
-						r.EncodeInt(int64(x.TimeoutSeconds))
+						r.EncodeInt(int64(x.PeriodSeconds))
 					}
 				} else {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq1117[4] {
+				if yyq1117[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("timeoutSeconds"))
+					r.EncodeString(codecSelferC_UTF81234, string("periodSeconds"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1126 := z.EncBinary()
 					_ = yym1126
 					if false {
 					} else {
-						r.EncodeInt(int64(x.TimeoutSeconds))
+						r.EncodeInt(int64(x.PeriodSeconds))
 					}
 				}
 			}
 			if yyr1117 || yy2arr1117 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1117[5] {
+				if yyq1117[3] {
 					yym1128 := z.EncBinary()
 					_ = yym1128
 					if false {
 					} else {
-						r.EncodeInt(int64(x.PeriodSeconds))
+						r.EncodeInt(int64(x.SuccessThreshold))
 					}
 				} else {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq1117[5] {
+				if yyq1117[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("periodSeconds"))
+					r.EncodeString(codecSelferC_UTF81234, string("successThreshold"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1129 := z.EncBinary()
 					_ = yym1129
 					if false {
 					} else {
-						r.EncodeInt(int64(x.PeriodSeconds))
+						r.EncodeInt(int64(x.SuccessThreshold))
 					}
 				}
 			}
 			if yyr1117 || yy2arr1117 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1117[6] {
+				if yyq1117[4] {
 					yym1131 := z.EncBinary()
 					_ = yym1131
 					if false {
 					} else {
-						r.EncodeInt(int64(x.SuccessThreshold))
+						r.EncodeInt(int64(x.FailureThreshold))
 					}
 				} else {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq1117[6] {
+				if yyq1117[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("successThreshold"))
+					r.EncodeString(codecSelferC_UTF81234, string("failureThreshold"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1132 := z.EncBinary()
 					_ = yym1132
 					if false {
 					} else {
-						r.EncodeInt(int64(x.SuccessThreshold))
+						r.EncodeInt(int64(x.FailureThreshold))
 					}
 				}
 			}
+			var yyn1133 bool
+			if x.Handler.Exec == nil {
+				yyn1133 = true
+				goto LABEL1133
+			}
+		LABEL1133:
 			if yyr1117 || yy2arr1117 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1117[7] {
-					yym1134 := z.EncBinary()
-					_ = yym1134
-					if false {
-					} else {
-						r.EncodeInt(int64(x.FailureThreshold))
-					}
+				if yyn1133 {
+					r.EncodeNil()
 				} else {
-					r.EncodeInt(0)
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+					if yyq1117[5] {
+						if x.Exec == nil {
+							r.EncodeNil()
+						} else {
+							x.Exec.CodecEncodeSelf(e)
+						}
+					} else {
+						r.EncodeNil()
+					}
+				}
+			} else {
+				if yyq1117[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("exec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if yyn1133 {
+						r.EncodeNil()
+					} else {
+						if x.Exec == nil {
+							r.EncodeNil()
+						} else {
+							x.Exec.CodecEncodeSelf(e)
+						}
+					}
+				}
+			}
+			var yyn1134 bool
+			if x.Handler.HTTPGet == nil {
+				yyn1134 = true
+				goto LABEL1134
+			}
+		LABEL1134:
+			if yyr1117 || yy2arr1117 {
+				if yyn1134 {
+					r.EncodeNil()
+				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+					if yyq1117[6] {
+						if x.HTTPGet == nil {
+							r.EncodeNil()
+						} else {
+							x.HTTPGet.CodecEncodeSelf(e)
+						}
+					} else {
+						r.EncodeNil()
+					}
+				}
+			} else {
+				if yyq1117[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("httpGet"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if yyn1134 {
+						r.EncodeNil()
+					} else {
+						if x.HTTPGet == nil {
+							r.EncodeNil()
+						} else {
+							x.HTTPGet.CodecEncodeSelf(e)
+						}
+					}
+				}
+			}
+			var yyn1135 bool
+			if x.Handler.TCPSocket == nil {
+				yyn1135 = true
+				goto LABEL1135
+			}
+		LABEL1135:
+			if yyr1117 || yy2arr1117 {
+				if yyn1135 {
+					r.EncodeNil()
+				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+					if yyq1117[7] {
+						if x.TCPSocket == nil {
+							r.EncodeNil()
+						} else {
+							x.TCPSocket.CodecEncodeSelf(e)
+						}
+					} else {
+						r.EncodeNil()
+					}
 				}
 			} else {
 				if yyq1117[7] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("failureThreshold"))
+					r.EncodeString(codecSelferC_UTF81234, string("tcpSocket"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1135 := z.EncBinary()
-					_ = yym1135
-					if false {
+					if yyn1135 {
+						r.EncodeNil()
 					} else {
-						r.EncodeInt(int64(x.FailureThreshold))
+						if x.TCPSocket == nil {
+							r.EncodeNil()
+						} else {
+							x.TCPSocket.CodecEncodeSelf(e)
+						}
 					}
 				}
 			}
@@ -15863,6 +15863,36 @@ func (x *Probe) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys1138 := string(yys1138Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1138 {
+		case "initialDelaySeconds":
+			if r.TryDecodeAsNil() {
+				x.InitialDelaySeconds = 0
+			} else {
+				x.InitialDelaySeconds = int(r.DecodeInt(codecSelferBitsize1234))
+			}
+		case "timeoutSeconds":
+			if r.TryDecodeAsNil() {
+				x.TimeoutSeconds = 0
+			} else {
+				x.TimeoutSeconds = int(r.DecodeInt(codecSelferBitsize1234))
+			}
+		case "periodSeconds":
+			if r.TryDecodeAsNil() {
+				x.PeriodSeconds = 0
+			} else {
+				x.PeriodSeconds = int(r.DecodeInt(codecSelferBitsize1234))
+			}
+		case "successThreshold":
+			if r.TryDecodeAsNil() {
+				x.SuccessThreshold = 0
+			} else {
+				x.SuccessThreshold = int(r.DecodeInt(codecSelferBitsize1234))
+			}
+		case "failureThreshold":
+			if r.TryDecodeAsNil() {
+				x.FailureThreshold = 0
+			} else {
+				x.FailureThreshold = int(r.DecodeInt(codecSelferBitsize1234))
+			}
 		case "exec":
 			if x.Handler.Exec == nil {
 				x.Handler.Exec = new(ExecAction)
@@ -15905,36 +15935,6 @@ func (x *Probe) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				}
 				x.TCPSocket.CodecDecodeSelf(d)
 			}
-		case "initialDelaySeconds":
-			if r.TryDecodeAsNil() {
-				x.InitialDelaySeconds = 0
-			} else {
-				x.InitialDelaySeconds = int(r.DecodeInt(codecSelferBitsize1234))
-			}
-		case "timeoutSeconds":
-			if r.TryDecodeAsNil() {
-				x.TimeoutSeconds = 0
-			} else {
-				x.TimeoutSeconds = int(r.DecodeInt(codecSelferBitsize1234))
-			}
-		case "periodSeconds":
-			if r.TryDecodeAsNil() {
-				x.PeriodSeconds = 0
-			} else {
-				x.PeriodSeconds = int(r.DecodeInt(codecSelferBitsize1234))
-			}
-		case "successThreshold":
-			if r.TryDecodeAsNil() {
-				x.SuccessThreshold = 0
-			} else {
-				x.SuccessThreshold = int(r.DecodeInt(codecSelferBitsize1234))
-			}
-		case "failureThreshold":
-			if r.TryDecodeAsNil() {
-				x.FailureThreshold = 0
-			} else {
-				x.FailureThreshold = int(r.DecodeInt(codecSelferBitsize1234))
-			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1138)
 		} // end switch yys1138
@@ -15949,78 +15949,6 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj1147 int
 	var yyb1147 bool
 	var yyhl1147 bool = l >= 0
-	if x.Handler.Exec == nil {
-		x.Handler.Exec = new(ExecAction)
-	}
-	yyj1147++
-	if yyhl1147 {
-		yyb1147 = yyj1147 > l
-	} else {
-		yyb1147 = r.CheckBreak()
-	}
-	if yyb1147 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		if x.Exec != nil {
-			x.Exec = nil
-		}
-	} else {
-		if x.Exec == nil {
-			x.Exec = new(ExecAction)
-		}
-		x.Exec.CodecDecodeSelf(d)
-	}
-	if x.Handler.HTTPGet == nil {
-		x.Handler.HTTPGet = new(HTTPGetAction)
-	}
-	yyj1147++
-	if yyhl1147 {
-		yyb1147 = yyj1147 > l
-	} else {
-		yyb1147 = r.CheckBreak()
-	}
-	if yyb1147 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		if x.HTTPGet != nil {
-			x.HTTPGet = nil
-		}
-	} else {
-		if x.HTTPGet == nil {
-			x.HTTPGet = new(HTTPGetAction)
-		}
-		x.HTTPGet.CodecDecodeSelf(d)
-	}
-	if x.Handler.TCPSocket == nil {
-		x.Handler.TCPSocket = new(TCPSocketAction)
-	}
-	yyj1147++
-	if yyhl1147 {
-		yyb1147 = yyj1147 > l
-	} else {
-		yyb1147 = r.CheckBreak()
-	}
-	if yyb1147 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		if x.TCPSocket != nil {
-			x.TCPSocket = nil
-		}
-	} else {
-		if x.TCPSocket == nil {
-			x.TCPSocket = new(TCPSocketAction)
-		}
-		x.TCPSocket.CodecDecodeSelf(d)
-	}
 	yyj1147++
 	if yyhl1147 {
 		yyb1147 = yyj1147 > l
@@ -16100,6 +16028,78 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.FailureThreshold = 0
 	} else {
 		x.FailureThreshold = int(r.DecodeInt(codecSelferBitsize1234))
+	}
+	if x.Handler.Exec == nil {
+		x.Handler.Exec = new(ExecAction)
+	}
+	yyj1147++
+	if yyhl1147 {
+		yyb1147 = yyj1147 > l
+	} else {
+		yyb1147 = r.CheckBreak()
+	}
+	if yyb1147 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		if x.Exec != nil {
+			x.Exec = nil
+		}
+	} else {
+		if x.Exec == nil {
+			x.Exec = new(ExecAction)
+		}
+		x.Exec.CodecDecodeSelf(d)
+	}
+	if x.Handler.HTTPGet == nil {
+		x.Handler.HTTPGet = new(HTTPGetAction)
+	}
+	yyj1147++
+	if yyhl1147 {
+		yyb1147 = yyj1147 > l
+	} else {
+		yyb1147 = r.CheckBreak()
+	}
+	if yyb1147 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		if x.HTTPGet != nil {
+			x.HTTPGet = nil
+		}
+	} else {
+		if x.HTTPGet == nil {
+			x.HTTPGet = new(HTTPGetAction)
+		}
+		x.HTTPGet.CodecDecodeSelf(d)
+	}
+	if x.Handler.TCPSocket == nil {
+		x.Handler.TCPSocket = new(TCPSocketAction)
+	}
+	yyj1147++
+	if yyhl1147 {
+		yyb1147 = yyj1147 > l
+	} else {
+		yyb1147 = r.CheckBreak()
+	}
+	if yyb1147 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		if x.TCPSocket != nil {
+			x.TCPSocket = nil
+		}
+	} else {
+		if x.TCPSocket == nil {
+			x.TCPSocket = new(TCPSocketAction)
+		}
+		x.TCPSocket.CodecDecodeSelf(d)
 	}
 	for {
 		yyj1147++
@@ -20494,9 +20494,9 @@ func (x *PodList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1505 [4]bool
 			_, _, _ = yysep1505, yyq1505, yy2arr1505
 			const yyr1505 bool = false
-			yyq1505[0] = x.Kind != ""
-			yyq1505[1] = x.APIVersion != ""
-			yyq1505[2] = true
+			yyq1505[0] = true
+			yyq1505[2] = x.Kind != ""
+			yyq1505[3] = x.APIVersion != ""
 			var yynn1505 int
 			if yyr1505 || yy2arr1505 {
 				r.EncodeArrayStart(4)
@@ -20513,79 +20513,29 @@ func (x *PodList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr1505 || yy2arr1505 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1505[0] {
-					yym1507 := z.EncBinary()
-					_ = yym1507
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1505[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1507 := &x.ListMeta
 					yym1508 := z.EncBinary()
 					_ = yym1508
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1507) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr1505 || yy2arr1505 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1505[1] {
-					yym1510 := z.EncBinary()
-					_ = yym1510
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1505[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1511 := z.EncBinary()
-					_ = yym1511
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr1505 || yy2arr1505 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1505[2] {
-					yy1513 := &x.ListMeta
-					yym1514 := z.EncBinary()
-					_ = yym1514
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1513) {
-					} else {
-						z.EncFallback(yy1513)
+						z.EncFallback(yy1507)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1505[2] {
+				if yyq1505[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1515 := &x.ListMeta
-					yym1516 := z.EncBinary()
-					_ = yym1516
+					yy1509 := &x.ListMeta
+					yym1510 := z.EncBinary()
+					_ = yym1510
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1515) {
+					} else if z.HasExtensions() && z.EncExt(yy1509) {
 					} else {
-						z.EncFallback(yy1515)
+						z.EncFallback(yy1509)
 					}
 				}
 			}
@@ -20594,8 +20544,8 @@ func (x *PodList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1518 := z.EncBinary()
-					_ = yym1518
+					yym1512 := z.EncBinary()
+					_ = yym1512
 					if false {
 					} else {
 						h.encSlicePod(([]Pod)(x.Items), e)
@@ -20608,11 +20558,61 @@ func (x *PodList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym1513 := z.EncBinary()
+					_ = yym1513
+					if false {
+					} else {
+						h.encSlicePod(([]Pod)(x.Items), e)
+					}
+				}
+			}
+			if yyr1505 || yy2arr1505 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1505[2] {
+					yym1515 := z.EncBinary()
+					_ = yym1515
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1505[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1516 := z.EncBinary()
+					_ = yym1516
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr1505 || yy2arr1505 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1505[3] {
+					yym1518 := z.EncBinary()
+					_ = yym1518
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1505[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1519 := z.EncBinary()
 					_ = yym1519
 					if false {
 					} else {
-						h.encSlicePod(([]Pod)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -20677,6 +20677,31 @@ func (x *PodList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys1522 := string(yys1522Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1522 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv1523 := &x.ListMeta
+				yym1524 := z.DecBinary()
+				_ = yym1524
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv1523) {
+				} else {
+					z.DecFallback(yyv1523, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv1525 := &x.Items
+				yym1526 := z.DecBinary()
+				_ = yym1526
+				if false {
+				} else {
+					h.decSlicePod((*[]Pod)(yyv1525), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -20688,31 +20713,6 @@ func (x *PodList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv1525 := &x.ListMeta
-				yym1526 := z.DecBinary()
-				_ = yym1526
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1525) {
-				} else {
-					z.DecFallback(yyv1525, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv1527 := &x.Items
-				yym1528 := z.DecBinary()
-				_ = yym1528
-				if false {
-				} else {
-					h.decSlicePod((*[]Pod)(yyv1527), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1522)
@@ -20728,6 +20728,51 @@ func (x *PodList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj1529 int
 	var yyb1529 bool
 	var yyhl1529 bool = l >= 0
+	yyj1529++
+	if yyhl1529 {
+		yyb1529 = yyj1529 > l
+	} else {
+		yyb1529 = r.CheckBreak()
+	}
+	if yyb1529 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv1530 := &x.ListMeta
+		yym1531 := z.DecBinary()
+		_ = yym1531
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1530) {
+		} else {
+			z.DecFallback(yyv1530, false)
+		}
+	}
+	yyj1529++
+	if yyhl1529 {
+		yyb1529 = yyj1529 > l
+	} else {
+		yyb1529 = r.CheckBreak()
+	}
+	if yyb1529 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv1532 := &x.Items
+		yym1533 := z.DecBinary()
+		_ = yym1533
+		if false {
+		} else {
+			h.decSlicePod((*[]Pod)(yyv1532), d)
+		}
+	}
 	yyj1529++
 	if yyhl1529 {
 		yyb1529 = yyj1529 > l
@@ -20759,51 +20804,6 @@ func (x *PodList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj1529++
-	if yyhl1529 {
-		yyb1529 = yyj1529 > l
-	} else {
-		yyb1529 = r.CheckBreak()
-	}
-	if yyb1529 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv1532 := &x.ListMeta
-		yym1533 := z.DecBinary()
-		_ = yym1533
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1532) {
-		} else {
-			z.DecFallback(yyv1532, false)
-		}
-	}
-	yyj1529++
-	if yyhl1529 {
-		yyb1529 = yyj1529 > l
-	} else {
-		yyb1529 = r.CheckBreak()
-	}
-	if yyb1529 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv1534 := &x.Items
-		yym1535 := z.DecBinary()
-		_ = yym1535
-		if false {
-		} else {
-			h.decSlicePod((*[]Pod)(yyv1534), d)
-		}
 	}
 	for {
 		yyj1529++
@@ -24152,10 +24152,10 @@ func (x *PodStatusResult) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1811 [4]bool
 			_, _, _ = yysep1811, yyq1811, yy2arr1811
 			const yyr1811 bool = false
-			yyq1811[0] = x.Kind != ""
-			yyq1811[1] = x.APIVersion != ""
-			yyq1811[2] = true
-			yyq1811[3] = true
+			yyq1811[0] = true
+			yyq1811[1] = true
+			yyq1811[2] = x.Kind != ""
+			yyq1811[3] = x.APIVersion != ""
 			var yynn1811 int
 			if yyr1811 || yy2arr1811 {
 				r.EncodeArrayStart(4)
@@ -24172,22 +24172,56 @@ func (x *PodStatusResult) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr1811 || yy2arr1811 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1811[0] {
-					yym1813 := z.EncBinary()
-					_ = yym1813
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy1813 := &x.ObjectMeta
+					yy1813.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq1811[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1814 := &x.ObjectMeta
+					yy1814.CodecEncodeSelf(e)
+				}
+			}
+			if yyr1811 || yy2arr1811 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1811[1] {
+					yy1816 := &x.Status
+					yy1816.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1811[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1817 := &x.Status
+					yy1817.CodecEncodeSelf(e)
+				}
+			}
+			if yyr1811 || yy2arr1811 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1811[2] {
+					yym1819 := z.EncBinary()
+					_ = yym1819
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1811[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1814 := z.EncBinary()
-					_ = yym1814
+					yym1820 := z.EncBinary()
+					_ = yym1820
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -24196,9 +24230,9 @@ func (x *PodStatusResult) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr1811 || yy2arr1811 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1811[1] {
-					yym1816 := z.EncBinary()
-					_ = yym1816
+				if yyq1811[3] {
+					yym1822 := z.EncBinary()
+					_ = yym1822
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -24207,50 +24241,16 @@ func (x *PodStatusResult) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1811[1] {
+				if yyq1811[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1817 := z.EncBinary()
-					_ = yym1817
+					yym1823 := z.EncBinary()
+					_ = yym1823
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
-				}
-			}
-			if yyr1811 || yy2arr1811 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1811[2] {
-					yy1819 := &x.ObjectMeta
-					yy1819.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1811[2] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1820 := &x.ObjectMeta
-					yy1820.CodecEncodeSelf(e)
-				}
-			}
-			if yyr1811 || yy2arr1811 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1811[3] {
-					yy1822 := &x.Status
-					yy1822.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1811[3] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1823 := &x.Status
-					yy1823.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1811 || yy2arr1811 {
@@ -24314,6 +24314,20 @@ func (x *PodStatusResult) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys1826 := string(yys1826Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1826 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv1827 := &x.ObjectMeta
+				yyv1827.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = PodStatus{}
+			} else {
+				yyv1828 := &x.Status
+				yyv1828.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -24325,20 +24339,6 @@ func (x *PodStatusResult) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv1829 := &x.ObjectMeta
-				yyv1829.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = PodStatus{}
-			} else {
-				yyv1830 := &x.Status
-				yyv1830.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1826)
@@ -24354,6 +24354,40 @@ func (x *PodStatusResult) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var yyj1831 int
 	var yyb1831 bool
 	var yyhl1831 bool = l >= 0
+	yyj1831++
+	if yyhl1831 {
+		yyb1831 = yyj1831 > l
+	} else {
+		yyb1831 = r.CheckBreak()
+	}
+	if yyb1831 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv1832 := &x.ObjectMeta
+		yyv1832.CodecDecodeSelf(d)
+	}
+	yyj1831++
+	if yyhl1831 {
+		yyb1831 = yyj1831 > l
+	} else {
+		yyb1831 = r.CheckBreak()
+	}
+	if yyb1831 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = PodStatus{}
+	} else {
+		yyv1833 := &x.Status
+		yyv1833.CodecDecodeSelf(d)
+	}
 	yyj1831++
 	if yyhl1831 {
 		yyb1831 = yyj1831 > l
@@ -24385,40 +24419,6 @@ func (x *PodStatusResult) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj1831++
-	if yyhl1831 {
-		yyb1831 = yyj1831 > l
-	} else {
-		yyb1831 = r.CheckBreak()
-	}
-	if yyb1831 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv1834 := &x.ObjectMeta
-		yyv1834.CodecDecodeSelf(d)
-	}
-	yyj1831++
-	if yyhl1831 {
-		yyb1831 = yyj1831 > l
-	} else {
-		yyb1831 = r.CheckBreak()
-	}
-	if yyb1831 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = PodStatus{}
-	} else {
-		yyv1835 := &x.Status
-		yyv1835.CodecDecodeSelf(d)
 	}
 	for {
 		yyj1831++
@@ -24453,11 +24453,11 @@ func (x *Pod) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1837 [5]bool
 			_, _, _ = yysep1837, yyq1837, yy2arr1837
 			const yyr1837 bool = false
-			yyq1837[0] = x.Kind != ""
-			yyq1837[1] = x.APIVersion != ""
+			yyq1837[0] = true
+			yyq1837[1] = true
 			yyq1837[2] = true
-			yyq1837[3] = true
-			yyq1837[4] = true
+			yyq1837[3] = x.Kind != ""
+			yyq1837[4] = x.APIVersion != ""
 			var yynn1837 int
 			if yyr1837 || yy2arr1837 {
 				r.EncodeArrayStart(5)
@@ -24474,57 +24474,41 @@ func (x *Pod) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr1837 || yy2arr1837 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1837[0] {
-					yym1839 := z.EncBinary()
-					_ = yym1839
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy1839 := &x.ObjectMeta
+					yy1839.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq1837[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1840 := z.EncBinary()
-					_ = yym1840
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy1840 := &x.ObjectMeta
+					yy1840.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1837 || yy2arr1837 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1837[1] {
-					yym1842 := z.EncBinary()
-					_ = yym1842
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy1842 := &x.Spec
+					yy1842.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq1837[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1843 := z.EncBinary()
-					_ = yym1843
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy1843 := &x.Spec
+					yy1843.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1837 || yy2arr1837 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1837[2] {
-					yy1845 := &x.ObjectMeta
+					yy1845 := &x.Status
 					yy1845.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
@@ -24532,44 +24516,60 @@ func (x *Pod) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq1837[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1846 := &x.ObjectMeta
+					yy1846 := &x.Status
 					yy1846.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1837 || yy2arr1837 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1837[3] {
-					yy1848 := &x.Spec
-					yy1848.CodecEncodeSelf(e)
+					yym1848 := z.EncBinary()
+					_ = yym1848
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq1837[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1849 := &x.Spec
-					yy1849.CodecEncodeSelf(e)
+					yym1849 := z.EncBinary()
+					_ = yym1849
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				}
 			}
 			if yyr1837 || yy2arr1837 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1837[4] {
-					yy1851 := &x.Status
-					yy1851.CodecEncodeSelf(e)
+					yym1851 := z.EncBinary()
+					_ = yym1851
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq1837[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1852 := &x.Status
-					yy1852.CodecEncodeSelf(e)
+					yym1852 := z.EncBinary()
+					_ = yym1852
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr1837 || yy2arr1837 {
@@ -24633,6 +24633,27 @@ func (x *Pod) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys1855 := string(yys1855Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1855 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv1856 := &x.ObjectMeta
+				yyv1856.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = PodSpec{}
+			} else {
+				yyv1857 := &x.Spec
+				yyv1857.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = PodStatus{}
+			} else {
+				yyv1858 := &x.Status
+				yyv1858.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -24644,27 +24665,6 @@ func (x *Pod) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv1858 := &x.ObjectMeta
-				yyv1858.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = PodSpec{}
-			} else {
-				yyv1859 := &x.Spec
-				yyv1859.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = PodStatus{}
-			} else {
-				yyv1860 := &x.Status
-				yyv1860.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1855)
@@ -24680,6 +24680,57 @@ func (x *Pod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj1861 int
 	var yyb1861 bool
 	var yyhl1861 bool = l >= 0
+	yyj1861++
+	if yyhl1861 {
+		yyb1861 = yyj1861 > l
+	} else {
+		yyb1861 = r.CheckBreak()
+	}
+	if yyb1861 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv1862 := &x.ObjectMeta
+		yyv1862.CodecDecodeSelf(d)
+	}
+	yyj1861++
+	if yyhl1861 {
+		yyb1861 = yyj1861 > l
+	} else {
+		yyb1861 = r.CheckBreak()
+	}
+	if yyb1861 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = PodSpec{}
+	} else {
+		yyv1863 := &x.Spec
+		yyv1863.CodecDecodeSelf(d)
+	}
+	yyj1861++
+	if yyhl1861 {
+		yyb1861 = yyj1861 > l
+	} else {
+		yyb1861 = r.CheckBreak()
+	}
+	if yyb1861 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = PodStatus{}
+	} else {
+		yyv1864 := &x.Status
+		yyv1864.CodecDecodeSelf(d)
+	}
 	yyj1861++
 	if yyhl1861 {
 		yyb1861 = yyj1861 > l
@@ -24711,57 +24762,6 @@ func (x *Pod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj1861++
-	if yyhl1861 {
-		yyb1861 = yyj1861 > l
-	} else {
-		yyb1861 = r.CheckBreak()
-	}
-	if yyb1861 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv1864 := &x.ObjectMeta
-		yyv1864.CodecDecodeSelf(d)
-	}
-	yyj1861++
-	if yyhl1861 {
-		yyb1861 = yyj1861 > l
-	} else {
-		yyb1861 = r.CheckBreak()
-	}
-	if yyb1861 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = PodSpec{}
-	} else {
-		yyv1865 := &x.Spec
-		yyv1865.CodecDecodeSelf(d)
-	}
-	yyj1861++
-	if yyhl1861 {
-		yyb1861 = yyj1861 > l
-	} else {
-		yyb1861 = r.CheckBreak()
-	}
-	if yyb1861 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = PodStatus{}
-	} else {
-		yyv1866 := &x.Status
-		yyv1866.CodecDecodeSelf(d)
 	}
 	for {
 		yyj1861++
@@ -25001,10 +25001,10 @@ func (x *PodTemplate) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1884 [4]bool
 			_, _, _ = yysep1884, yyq1884, yy2arr1884
 			const yyr1884 bool = false
-			yyq1884[0] = x.Kind != ""
-			yyq1884[1] = x.APIVersion != ""
-			yyq1884[2] = true
-			yyq1884[3] = true
+			yyq1884[0] = true
+			yyq1884[1] = true
+			yyq1884[2] = x.Kind != ""
+			yyq1884[3] = x.APIVersion != ""
 			var yynn1884 int
 			if yyr1884 || yy2arr1884 {
 				r.EncodeArrayStart(4)
@@ -25021,22 +25021,56 @@ func (x *PodTemplate) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr1884 || yy2arr1884 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1884[0] {
-					yym1886 := z.EncBinary()
-					_ = yym1886
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy1886 := &x.ObjectMeta
+					yy1886.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq1884[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1887 := &x.ObjectMeta
+					yy1887.CodecEncodeSelf(e)
+				}
+			}
+			if yyr1884 || yy2arr1884 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1884[1] {
+					yy1889 := &x.Template
+					yy1889.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1884[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("template"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1890 := &x.Template
+					yy1890.CodecEncodeSelf(e)
+				}
+			}
+			if yyr1884 || yy2arr1884 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1884[2] {
+					yym1892 := z.EncBinary()
+					_ = yym1892
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1884[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1887 := z.EncBinary()
-					_ = yym1887
+					yym1893 := z.EncBinary()
+					_ = yym1893
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -25045,9 +25079,9 @@ func (x *PodTemplate) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr1884 || yy2arr1884 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1884[1] {
-					yym1889 := z.EncBinary()
-					_ = yym1889
+				if yyq1884[3] {
+					yym1895 := z.EncBinary()
+					_ = yym1895
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -25056,50 +25090,16 @@ func (x *PodTemplate) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1884[1] {
+				if yyq1884[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1890 := z.EncBinary()
-					_ = yym1890
+					yym1896 := z.EncBinary()
+					_ = yym1896
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
-				}
-			}
-			if yyr1884 || yy2arr1884 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1884[2] {
-					yy1892 := &x.ObjectMeta
-					yy1892.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1884[2] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1893 := &x.ObjectMeta
-					yy1893.CodecEncodeSelf(e)
-				}
-			}
-			if yyr1884 || yy2arr1884 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1884[3] {
-					yy1895 := &x.Template
-					yy1895.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1884[3] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("template"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1896 := &x.Template
-					yy1896.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1884 || yy2arr1884 {
@@ -25163,6 +25163,20 @@ func (x *PodTemplate) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys1899 := string(yys1899Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1899 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv1900 := &x.ObjectMeta
+				yyv1900.CodecDecodeSelf(d)
+			}
+		case "template":
+			if r.TryDecodeAsNil() {
+				x.Template = PodTemplateSpec{}
+			} else {
+				yyv1901 := &x.Template
+				yyv1901.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -25174,20 +25188,6 @@ func (x *PodTemplate) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv1902 := &x.ObjectMeta
-				yyv1902.CodecDecodeSelf(d)
-			}
-		case "template":
-			if r.TryDecodeAsNil() {
-				x.Template = PodTemplateSpec{}
-			} else {
-				yyv1903 := &x.Template
-				yyv1903.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1899)
@@ -25203,6 +25203,40 @@ func (x *PodTemplate) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj1904 int
 	var yyb1904 bool
 	var yyhl1904 bool = l >= 0
+	yyj1904++
+	if yyhl1904 {
+		yyb1904 = yyj1904 > l
+	} else {
+		yyb1904 = r.CheckBreak()
+	}
+	if yyb1904 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv1905 := &x.ObjectMeta
+		yyv1905.CodecDecodeSelf(d)
+	}
+	yyj1904++
+	if yyhl1904 {
+		yyb1904 = yyj1904 > l
+	} else {
+		yyb1904 = r.CheckBreak()
+	}
+	if yyb1904 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Template = PodTemplateSpec{}
+	} else {
+		yyv1906 := &x.Template
+		yyv1906.CodecDecodeSelf(d)
+	}
 	yyj1904++
 	if yyhl1904 {
 		yyb1904 = yyj1904 > l
@@ -25234,40 +25268,6 @@ func (x *PodTemplate) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj1904++
-	if yyhl1904 {
-		yyb1904 = yyj1904 > l
-	} else {
-		yyb1904 = r.CheckBreak()
-	}
-	if yyb1904 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv1907 := &x.ObjectMeta
-		yyv1907.CodecDecodeSelf(d)
-	}
-	yyj1904++
-	if yyhl1904 {
-		yyb1904 = yyj1904 > l
-	} else {
-		yyb1904 = r.CheckBreak()
-	}
-	if yyb1904 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Template = PodTemplateSpec{}
-	} else {
-		yyv1908 := &x.Template
-		yyv1908.CodecDecodeSelf(d)
 	}
 	for {
 		yyj1904++
@@ -25302,9 +25302,9 @@ func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1910 [4]bool
 			_, _, _ = yysep1910, yyq1910, yy2arr1910
 			const yyr1910 bool = false
-			yyq1910[0] = x.Kind != ""
-			yyq1910[1] = x.APIVersion != ""
-			yyq1910[2] = true
+			yyq1910[0] = true
+			yyq1910[2] = x.Kind != ""
+			yyq1910[3] = x.APIVersion != ""
 			var yynn1910 int
 			if yyr1910 || yy2arr1910 {
 				r.EncodeArrayStart(4)
@@ -25321,79 +25321,29 @@ func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr1910 || yy2arr1910 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1910[0] {
-					yym1912 := z.EncBinary()
-					_ = yym1912
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1910[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1912 := &x.ListMeta
 					yym1913 := z.EncBinary()
 					_ = yym1913
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1912) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr1910 || yy2arr1910 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1910[1] {
-					yym1915 := z.EncBinary()
-					_ = yym1915
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1910[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1916 := z.EncBinary()
-					_ = yym1916
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr1910 || yy2arr1910 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1910[2] {
-					yy1918 := &x.ListMeta
-					yym1919 := z.EncBinary()
-					_ = yym1919
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1918) {
-					} else {
-						z.EncFallback(yy1918)
+						z.EncFallback(yy1912)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1910[2] {
+				if yyq1910[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1920 := &x.ListMeta
-					yym1921 := z.EncBinary()
-					_ = yym1921
+					yy1914 := &x.ListMeta
+					yym1915 := z.EncBinary()
+					_ = yym1915
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1920) {
+					} else if z.HasExtensions() && z.EncExt(yy1914) {
 					} else {
-						z.EncFallback(yy1920)
+						z.EncFallback(yy1914)
 					}
 				}
 			}
@@ -25402,8 +25352,8 @@ func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1923 := z.EncBinary()
-					_ = yym1923
+					yym1917 := z.EncBinary()
+					_ = yym1917
 					if false {
 					} else {
 						h.encSlicePodTemplate(([]PodTemplate)(x.Items), e)
@@ -25416,11 +25366,61 @@ func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym1918 := z.EncBinary()
+					_ = yym1918
+					if false {
+					} else {
+						h.encSlicePodTemplate(([]PodTemplate)(x.Items), e)
+					}
+				}
+			}
+			if yyr1910 || yy2arr1910 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1910[2] {
+					yym1920 := z.EncBinary()
+					_ = yym1920
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1910[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1921 := z.EncBinary()
+					_ = yym1921
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr1910 || yy2arr1910 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1910[3] {
+					yym1923 := z.EncBinary()
+					_ = yym1923
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1910[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1924 := z.EncBinary()
 					_ = yym1924
 					if false {
 					} else {
-						h.encSlicePodTemplate(([]PodTemplate)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -25485,6 +25485,31 @@ func (x *PodTemplateList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys1927 := string(yys1927Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1927 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv1928 := &x.ListMeta
+				yym1929 := z.DecBinary()
+				_ = yym1929
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv1928) {
+				} else {
+					z.DecFallback(yyv1928, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv1930 := &x.Items
+				yym1931 := z.DecBinary()
+				_ = yym1931
+				if false {
+				} else {
+					h.decSlicePodTemplate((*[]PodTemplate)(yyv1930), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -25496,31 +25521,6 @@ func (x *PodTemplateList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv1930 := &x.ListMeta
-				yym1931 := z.DecBinary()
-				_ = yym1931
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1930) {
-				} else {
-					z.DecFallback(yyv1930, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv1932 := &x.Items
-				yym1933 := z.DecBinary()
-				_ = yym1933
-				if false {
-				} else {
-					h.decSlicePodTemplate((*[]PodTemplate)(yyv1932), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1927)
@@ -25536,6 +25536,51 @@ func (x *PodTemplateList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var yyj1934 int
 	var yyb1934 bool
 	var yyhl1934 bool = l >= 0
+	yyj1934++
+	if yyhl1934 {
+		yyb1934 = yyj1934 > l
+	} else {
+		yyb1934 = r.CheckBreak()
+	}
+	if yyb1934 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv1935 := &x.ListMeta
+		yym1936 := z.DecBinary()
+		_ = yym1936
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1935) {
+		} else {
+			z.DecFallback(yyv1935, false)
+		}
+	}
+	yyj1934++
+	if yyhl1934 {
+		yyb1934 = yyj1934 > l
+	} else {
+		yyb1934 = r.CheckBreak()
+	}
+	if yyb1934 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv1937 := &x.Items
+		yym1938 := z.DecBinary()
+		_ = yym1938
+		if false {
+		} else {
+			h.decSlicePodTemplate((*[]PodTemplate)(yyv1937), d)
+		}
+	}
 	yyj1934++
 	if yyhl1934 {
 		yyb1934 = yyj1934 > l
@@ -25567,51 +25612,6 @@ func (x *PodTemplateList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj1934++
-	if yyhl1934 {
-		yyb1934 = yyj1934 > l
-	} else {
-		yyb1934 = r.CheckBreak()
-	}
-	if yyb1934 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv1937 := &x.ListMeta
-		yym1938 := z.DecBinary()
-		_ = yym1938
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1937) {
-		} else {
-			z.DecFallback(yyv1937, false)
-		}
-	}
-	yyj1934++
-	if yyhl1934 {
-		yyb1934 = yyj1934 > l
-	} else {
-		yyb1934 = r.CheckBreak()
-	}
-	if yyb1934 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv1939 := &x.Items
-		yym1940 := z.DecBinary()
-		_ = yym1940
-		if false {
-		} else {
-			h.decSlicePodTemplate((*[]PodTemplate)(yyv1939), d)
-		}
 	}
 	for {
 		yyj1934++
@@ -26135,11 +26135,11 @@ func (x *ReplicationController) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1979 [5]bool
 			_, _, _ = yysep1979, yyq1979, yy2arr1979
 			const yyr1979 bool = false
-			yyq1979[0] = x.Kind != ""
-			yyq1979[1] = x.APIVersion != ""
+			yyq1979[0] = true
+			yyq1979[1] = true
 			yyq1979[2] = true
-			yyq1979[3] = true
-			yyq1979[4] = true
+			yyq1979[3] = x.Kind != ""
+			yyq1979[4] = x.APIVersion != ""
 			var yynn1979 int
 			if yyr1979 || yy2arr1979 {
 				r.EncodeArrayStart(5)
@@ -26156,57 +26156,41 @@ func (x *ReplicationController) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr1979 || yy2arr1979 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1979[0] {
-					yym1981 := z.EncBinary()
-					_ = yym1981
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy1981 := &x.ObjectMeta
+					yy1981.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq1979[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1982 := z.EncBinary()
-					_ = yym1982
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy1982 := &x.ObjectMeta
+					yy1982.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1979 || yy2arr1979 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1979[1] {
-					yym1984 := z.EncBinary()
-					_ = yym1984
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy1984 := &x.Spec
+					yy1984.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq1979[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1985 := z.EncBinary()
-					_ = yym1985
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy1985 := &x.Spec
+					yy1985.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1979 || yy2arr1979 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1979[2] {
-					yy1987 := &x.ObjectMeta
+					yy1987 := &x.Status
 					yy1987.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
@@ -26214,44 +26198,60 @@ func (x *ReplicationController) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq1979[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1988 := &x.ObjectMeta
+					yy1988 := &x.Status
 					yy1988.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1979 || yy2arr1979 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1979[3] {
-					yy1990 := &x.Spec
-					yy1990.CodecEncodeSelf(e)
+					yym1990 := z.EncBinary()
+					_ = yym1990
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq1979[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1991 := &x.Spec
-					yy1991.CodecEncodeSelf(e)
+					yym1991 := z.EncBinary()
+					_ = yym1991
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				}
 			}
 			if yyr1979 || yy2arr1979 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1979[4] {
-					yy1993 := &x.Status
-					yy1993.CodecEncodeSelf(e)
+					yym1993 := z.EncBinary()
+					_ = yym1993
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq1979[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1994 := &x.Status
-					yy1994.CodecEncodeSelf(e)
+					yym1994 := z.EncBinary()
+					_ = yym1994
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr1979 || yy2arr1979 {
@@ -26315,6 +26315,27 @@ func (x *ReplicationController) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 		yys1997 := string(yys1997Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1997 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv1998 := &x.ObjectMeta
+				yyv1998.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = ReplicationControllerSpec{}
+			} else {
+				yyv1999 := &x.Spec
+				yyv1999.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = ReplicationControllerStatus{}
+			} else {
+				yyv2000 := &x.Status
+				yyv2000.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -26326,27 +26347,6 @@ func (x *ReplicationController) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv2000 := &x.ObjectMeta
-				yyv2000.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = ReplicationControllerSpec{}
-			} else {
-				yyv2001 := &x.Spec
-				yyv2001.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = ReplicationControllerStatus{}
-			} else {
-				yyv2002 := &x.Status
-				yyv2002.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1997)
@@ -26362,6 +26362,57 @@ func (x *ReplicationController) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var yyj2003 int
 	var yyb2003 bool
 	var yyhl2003 bool = l >= 0
+	yyj2003++
+	if yyhl2003 {
+		yyb2003 = yyj2003 > l
+	} else {
+		yyb2003 = r.CheckBreak()
+	}
+	if yyb2003 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv2004 := &x.ObjectMeta
+		yyv2004.CodecDecodeSelf(d)
+	}
+	yyj2003++
+	if yyhl2003 {
+		yyb2003 = yyj2003 > l
+	} else {
+		yyb2003 = r.CheckBreak()
+	}
+	if yyb2003 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = ReplicationControllerSpec{}
+	} else {
+		yyv2005 := &x.Spec
+		yyv2005.CodecDecodeSelf(d)
+	}
+	yyj2003++
+	if yyhl2003 {
+		yyb2003 = yyj2003 > l
+	} else {
+		yyb2003 = r.CheckBreak()
+	}
+	if yyb2003 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = ReplicationControllerStatus{}
+	} else {
+		yyv2006 := &x.Status
+		yyv2006.CodecDecodeSelf(d)
+	}
 	yyj2003++
 	if yyhl2003 {
 		yyb2003 = yyj2003 > l
@@ -26393,57 +26444,6 @@ func (x *ReplicationController) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj2003++
-	if yyhl2003 {
-		yyb2003 = yyj2003 > l
-	} else {
-		yyb2003 = r.CheckBreak()
-	}
-	if yyb2003 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv2006 := &x.ObjectMeta
-		yyv2006.CodecDecodeSelf(d)
-	}
-	yyj2003++
-	if yyhl2003 {
-		yyb2003 = yyj2003 > l
-	} else {
-		yyb2003 = r.CheckBreak()
-	}
-	if yyb2003 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = ReplicationControllerSpec{}
-	} else {
-		yyv2007 := &x.Spec
-		yyv2007.CodecDecodeSelf(d)
-	}
-	yyj2003++
-	if yyhl2003 {
-		yyb2003 = yyj2003 > l
-	} else {
-		yyb2003 = r.CheckBreak()
-	}
-	if yyb2003 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = ReplicationControllerStatus{}
-	} else {
-		yyv2008 := &x.Status
-		yyv2008.CodecDecodeSelf(d)
 	}
 	for {
 		yyj2003++
@@ -26478,9 +26478,9 @@ func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2010 [4]bool
 			_, _, _ = yysep2010, yyq2010, yy2arr2010
 			const yyr2010 bool = false
-			yyq2010[0] = x.Kind != ""
-			yyq2010[1] = x.APIVersion != ""
-			yyq2010[2] = true
+			yyq2010[0] = true
+			yyq2010[2] = x.Kind != ""
+			yyq2010[3] = x.APIVersion != ""
 			var yynn2010 int
 			if yyr2010 || yy2arr2010 {
 				r.EncodeArrayStart(4)
@@ -26497,79 +26497,29 @@ func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2010 || yy2arr2010 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2010[0] {
-					yym2012 := z.EncBinary()
-					_ = yym2012
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2010[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy2012 := &x.ListMeta
 					yym2013 := z.EncBinary()
 					_ = yym2013
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2012) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2010 || yy2arr2010 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2010[1] {
-					yym2015 := z.EncBinary()
-					_ = yym2015
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2010[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2016 := z.EncBinary()
-					_ = yym2016
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2010 || yy2arr2010 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2010[2] {
-					yy2018 := &x.ListMeta
-					yym2019 := z.EncBinary()
-					_ = yym2019
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2018) {
-					} else {
-						z.EncFallback(yy2018)
+						z.EncFallback(yy2012)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2010[2] {
+				if yyq2010[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2020 := &x.ListMeta
-					yym2021 := z.EncBinary()
-					_ = yym2021
+					yy2014 := &x.ListMeta
+					yym2015 := z.EncBinary()
+					_ = yym2015
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2020) {
+					} else if z.HasExtensions() && z.EncExt(yy2014) {
 					} else {
-						z.EncFallback(yy2020)
+						z.EncFallback(yy2014)
 					}
 				}
 			}
@@ -26578,8 +26528,8 @@ func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2023 := z.EncBinary()
-					_ = yym2023
+					yym2017 := z.EncBinary()
+					_ = yym2017
 					if false {
 					} else {
 						h.encSliceReplicationController(([]ReplicationController)(x.Items), e)
@@ -26592,11 +26542,61 @@ func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym2018 := z.EncBinary()
+					_ = yym2018
+					if false {
+					} else {
+						h.encSliceReplicationController(([]ReplicationController)(x.Items), e)
+					}
+				}
+			}
+			if yyr2010 || yy2arr2010 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2010[2] {
+					yym2020 := z.EncBinary()
+					_ = yym2020
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2010[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2021 := z.EncBinary()
+					_ = yym2021
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2010 || yy2arr2010 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2010[3] {
+					yym2023 := z.EncBinary()
+					_ = yym2023
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2010[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2024 := z.EncBinary()
 					_ = yym2024
 					if false {
 					} else {
-						h.encSliceReplicationController(([]ReplicationController)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -26661,6 +26661,31 @@ func (x *ReplicationControllerList) codecDecodeSelfFromMap(l int, d *codec1978.D
 		yys2027 := string(yys2027Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2027 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv2028 := &x.ListMeta
+				yym2029 := z.DecBinary()
+				_ = yym2029
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv2028) {
+				} else {
+					z.DecFallback(yyv2028, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv2030 := &x.Items
+				yym2031 := z.DecBinary()
+				_ = yym2031
+				if false {
+				} else {
+					h.decSliceReplicationController((*[]ReplicationController)(yyv2030), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -26672,31 +26697,6 @@ func (x *ReplicationControllerList) codecDecodeSelfFromMap(l int, d *codec1978.D
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv2030 := &x.ListMeta
-				yym2031 := z.DecBinary()
-				_ = yym2031
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2030) {
-				} else {
-					z.DecFallback(yyv2030, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv2032 := &x.Items
-				yym2033 := z.DecBinary()
-				_ = yym2033
-				if false {
-				} else {
-					h.decSliceReplicationController((*[]ReplicationController)(yyv2032), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2027)
@@ -26712,6 +26712,51 @@ func (x *ReplicationControllerList) codecDecodeSelfFromArray(l int, d *codec1978
 	var yyj2034 int
 	var yyb2034 bool
 	var yyhl2034 bool = l >= 0
+	yyj2034++
+	if yyhl2034 {
+		yyb2034 = yyj2034 > l
+	} else {
+		yyb2034 = r.CheckBreak()
+	}
+	if yyb2034 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv2035 := &x.ListMeta
+		yym2036 := z.DecBinary()
+		_ = yym2036
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv2035) {
+		} else {
+			z.DecFallback(yyv2035, false)
+		}
+	}
+	yyj2034++
+	if yyhl2034 {
+		yyb2034 = yyj2034 > l
+	} else {
+		yyb2034 = r.CheckBreak()
+	}
+	if yyb2034 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv2037 := &x.Items
+		yym2038 := z.DecBinary()
+		_ = yym2038
+		if false {
+		} else {
+			h.decSliceReplicationController((*[]ReplicationController)(yyv2037), d)
+		}
+	}
 	yyj2034++
 	if yyhl2034 {
 		yyb2034 = yyj2034 > l
@@ -26743,51 +26788,6 @@ func (x *ReplicationControllerList) codecDecodeSelfFromArray(l int, d *codec1978
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj2034++
-	if yyhl2034 {
-		yyb2034 = yyj2034 > l
-	} else {
-		yyb2034 = r.CheckBreak()
-	}
-	if yyb2034 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv2037 := &x.ListMeta
-		yym2038 := z.DecBinary()
-		_ = yym2038
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2037) {
-		} else {
-			z.DecFallback(yyv2037, false)
-		}
-	}
-	yyj2034++
-	if yyhl2034 {
-		yyb2034 = yyj2034 > l
-	} else {
-		yyb2034 = r.CheckBreak()
-	}
-	if yyb2034 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv2039 := &x.Items
-		yym2040 := z.DecBinary()
-		_ = yym2040
-		if false {
-		} else {
-			h.decSliceReplicationController((*[]ReplicationController)(yyv2039), d)
-		}
 	}
 	for {
 		yyj2034++
@@ -26822,9 +26822,9 @@ func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2042 [4]bool
 			_, _, _ = yysep2042, yyq2042, yy2arr2042
 			const yyr2042 bool = false
-			yyq2042[0] = x.Kind != ""
-			yyq2042[1] = x.APIVersion != ""
-			yyq2042[2] = true
+			yyq2042[0] = true
+			yyq2042[2] = x.Kind != ""
+			yyq2042[3] = x.APIVersion != ""
 			var yynn2042 int
 			if yyr2042 || yy2arr2042 {
 				r.EncodeArrayStart(4)
@@ -26841,79 +26841,29 @@ func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2042 || yy2arr2042 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2042[0] {
-					yym2044 := z.EncBinary()
-					_ = yym2044
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2042[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy2044 := &x.ListMeta
 					yym2045 := z.EncBinary()
 					_ = yym2045
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2044) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2042 || yy2arr2042 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2042[1] {
-					yym2047 := z.EncBinary()
-					_ = yym2047
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2042[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2048 := z.EncBinary()
-					_ = yym2048
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2042 || yy2arr2042 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2042[2] {
-					yy2050 := &x.ListMeta
-					yym2051 := z.EncBinary()
-					_ = yym2051
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2050) {
-					} else {
-						z.EncFallback(yy2050)
+						z.EncFallback(yy2044)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2042[2] {
+				if yyq2042[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2052 := &x.ListMeta
-					yym2053 := z.EncBinary()
-					_ = yym2053
+					yy2046 := &x.ListMeta
+					yym2047 := z.EncBinary()
+					_ = yym2047
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2052) {
+					} else if z.HasExtensions() && z.EncExt(yy2046) {
 					} else {
-						z.EncFallback(yy2052)
+						z.EncFallback(yy2046)
 					}
 				}
 			}
@@ -26922,8 +26872,8 @@ func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2055 := z.EncBinary()
-					_ = yym2055
+					yym2049 := z.EncBinary()
+					_ = yym2049
 					if false {
 					} else {
 						h.encSliceService(([]Service)(x.Items), e)
@@ -26936,11 +26886,61 @@ func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym2050 := z.EncBinary()
+					_ = yym2050
+					if false {
+					} else {
+						h.encSliceService(([]Service)(x.Items), e)
+					}
+				}
+			}
+			if yyr2042 || yy2arr2042 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2042[2] {
+					yym2052 := z.EncBinary()
+					_ = yym2052
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2042[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2053 := z.EncBinary()
+					_ = yym2053
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2042 || yy2arr2042 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2042[3] {
+					yym2055 := z.EncBinary()
+					_ = yym2055
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2042[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2056 := z.EncBinary()
 					_ = yym2056
 					if false {
 					} else {
-						h.encSliceService(([]Service)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -27005,6 +27005,31 @@ func (x *ServiceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys2059 := string(yys2059Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2059 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv2060 := &x.ListMeta
+				yym2061 := z.DecBinary()
+				_ = yym2061
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv2060) {
+				} else {
+					z.DecFallback(yyv2060, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv2062 := &x.Items
+				yym2063 := z.DecBinary()
+				_ = yym2063
+				if false {
+				} else {
+					h.decSliceService((*[]Service)(yyv2062), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -27016,31 +27041,6 @@ func (x *ServiceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv2062 := &x.ListMeta
-				yym2063 := z.DecBinary()
-				_ = yym2063
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2062) {
-				} else {
-					z.DecFallback(yyv2062, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv2064 := &x.Items
-				yym2065 := z.DecBinary()
-				_ = yym2065
-				if false {
-				} else {
-					h.decSliceService((*[]Service)(yyv2064), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2059)
@@ -27056,6 +27056,51 @@ func (x *ServiceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj2066 int
 	var yyb2066 bool
 	var yyhl2066 bool = l >= 0
+	yyj2066++
+	if yyhl2066 {
+		yyb2066 = yyj2066 > l
+	} else {
+		yyb2066 = r.CheckBreak()
+	}
+	if yyb2066 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv2067 := &x.ListMeta
+		yym2068 := z.DecBinary()
+		_ = yym2068
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv2067) {
+		} else {
+			z.DecFallback(yyv2067, false)
+		}
+	}
+	yyj2066++
+	if yyhl2066 {
+		yyb2066 = yyj2066 > l
+	} else {
+		yyb2066 = r.CheckBreak()
+	}
+	if yyb2066 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv2069 := &x.Items
+		yym2070 := z.DecBinary()
+		_ = yym2070
+		if false {
+		} else {
+			h.decSliceService((*[]Service)(yyv2069), d)
+		}
+	}
 	yyj2066++
 	if yyhl2066 {
 		yyb2066 = yyj2066 > l
@@ -27087,51 +27132,6 @@ func (x *ServiceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj2066++
-	if yyhl2066 {
-		yyb2066 = yyj2066 > l
-	} else {
-		yyb2066 = r.CheckBreak()
-	}
-	if yyb2066 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv2069 := &x.ListMeta
-		yym2070 := z.DecBinary()
-		_ = yym2070
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2069) {
-		} else {
-			z.DecFallback(yyv2069, false)
-		}
-	}
-	yyj2066++
-	if yyhl2066 {
-		yyb2066 = yyj2066 > l
-	} else {
-		yyb2066 = r.CheckBreak()
-	}
-	if yyb2066 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv2071 := &x.Items
-		yym2072 := z.DecBinary()
-		_ = yym2072
-		if false {
-		} else {
-			h.decSliceService((*[]Service)(yyv2071), d)
-		}
 	}
 	for {
 		yyj2066++
@@ -28612,11 +28612,11 @@ func (x *Service) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2194 [5]bool
 			_, _, _ = yysep2194, yyq2194, yy2arr2194
 			const yyr2194 bool = false
-			yyq2194[0] = x.Kind != ""
-			yyq2194[1] = x.APIVersion != ""
+			yyq2194[0] = true
+			yyq2194[1] = true
 			yyq2194[2] = true
-			yyq2194[3] = true
-			yyq2194[4] = true
+			yyq2194[3] = x.Kind != ""
+			yyq2194[4] = x.APIVersion != ""
 			var yynn2194 int
 			if yyr2194 || yy2arr2194 {
 				r.EncodeArrayStart(5)
@@ -28633,57 +28633,41 @@ func (x *Service) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2194 || yy2arr2194 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2194[0] {
-					yym2196 := z.EncBinary()
-					_ = yym2196
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy2196 := &x.ObjectMeta
+					yy2196.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq2194[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2197 := z.EncBinary()
-					_ = yym2197
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy2197 := &x.ObjectMeta
+					yy2197.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2194 || yy2arr2194 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2194[1] {
-					yym2199 := z.EncBinary()
-					_ = yym2199
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy2199 := &x.Spec
+					yy2199.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq2194[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2200 := z.EncBinary()
-					_ = yym2200
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy2200 := &x.Spec
+					yy2200.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2194 || yy2arr2194 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2194[2] {
-					yy2202 := &x.ObjectMeta
+					yy2202 := &x.Status
 					yy2202.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
@@ -28691,44 +28675,60 @@ func (x *Service) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq2194[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2203 := &x.ObjectMeta
+					yy2203 := &x.Status
 					yy2203.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2194 || yy2arr2194 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2194[3] {
-					yy2205 := &x.Spec
-					yy2205.CodecEncodeSelf(e)
+					yym2205 := z.EncBinary()
+					_ = yym2205
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq2194[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2206 := &x.Spec
-					yy2206.CodecEncodeSelf(e)
+					yym2206 := z.EncBinary()
+					_ = yym2206
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				}
 			}
 			if yyr2194 || yy2arr2194 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2194[4] {
-					yy2208 := &x.Status
-					yy2208.CodecEncodeSelf(e)
+					yym2208 := z.EncBinary()
+					_ = yym2208
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq2194[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2209 := &x.Status
-					yy2209.CodecEncodeSelf(e)
+					yym2209 := z.EncBinary()
+					_ = yym2209
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr2194 || yy2arr2194 {
@@ -28792,6 +28792,27 @@ func (x *Service) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys2212 := string(yys2212Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2212 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv2213 := &x.ObjectMeta
+				yyv2213.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = ServiceSpec{}
+			} else {
+				yyv2214 := &x.Spec
+				yyv2214.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = ServiceStatus{}
+			} else {
+				yyv2215 := &x.Status
+				yyv2215.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -28803,27 +28824,6 @@ func (x *Service) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv2215 := &x.ObjectMeta
-				yyv2215.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = ServiceSpec{}
-			} else {
-				yyv2216 := &x.Spec
-				yyv2216.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = ServiceStatus{}
-			} else {
-				yyv2217 := &x.Status
-				yyv2217.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2212)
@@ -28839,6 +28839,57 @@ func (x *Service) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj2218 int
 	var yyb2218 bool
 	var yyhl2218 bool = l >= 0
+	yyj2218++
+	if yyhl2218 {
+		yyb2218 = yyj2218 > l
+	} else {
+		yyb2218 = r.CheckBreak()
+	}
+	if yyb2218 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv2219 := &x.ObjectMeta
+		yyv2219.CodecDecodeSelf(d)
+	}
+	yyj2218++
+	if yyhl2218 {
+		yyb2218 = yyj2218 > l
+	} else {
+		yyb2218 = r.CheckBreak()
+	}
+	if yyb2218 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = ServiceSpec{}
+	} else {
+		yyv2220 := &x.Spec
+		yyv2220.CodecDecodeSelf(d)
+	}
+	yyj2218++
+	if yyhl2218 {
+		yyb2218 = yyj2218 > l
+	} else {
+		yyb2218 = r.CheckBreak()
+	}
+	if yyb2218 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = ServiceStatus{}
+	} else {
+		yyv2221 := &x.Status
+		yyv2221.CodecDecodeSelf(d)
+	}
 	yyj2218++
 	if yyhl2218 {
 		yyb2218 = yyj2218 > l
@@ -28870,57 +28921,6 @@ func (x *Service) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj2218++
-	if yyhl2218 {
-		yyb2218 = yyj2218 > l
-	} else {
-		yyb2218 = r.CheckBreak()
-	}
-	if yyb2218 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv2221 := &x.ObjectMeta
-		yyv2221.CodecDecodeSelf(d)
-	}
-	yyj2218++
-	if yyhl2218 {
-		yyb2218 = yyj2218 > l
-	} else {
-		yyb2218 = r.CheckBreak()
-	}
-	if yyb2218 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = ServiceSpec{}
-	} else {
-		yyv2222 := &x.Spec
-		yyv2222.CodecDecodeSelf(d)
-	}
-	yyj2218++
-	if yyhl2218 {
-		yyb2218 = yyj2218 > l
-	} else {
-		yyb2218 = r.CheckBreak()
-	}
-	if yyb2218 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = ServiceStatus{}
-	} else {
-		yyv2223 := &x.Status
-		yyv2223.CodecDecodeSelf(d)
 	}
 	for {
 		yyj2218++
@@ -28955,10 +28955,10 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2225 [5]bool
 			_, _, _ = yysep2225, yyq2225, yy2arr2225
 			const yyr2225 bool = false
-			yyq2225[0] = x.Kind != ""
-			yyq2225[1] = x.APIVersion != ""
-			yyq2225[2] = true
-			yyq2225[4] = len(x.ImagePullSecrets) != 0
+			yyq2225[0] = true
+			yyq2225[2] = len(x.ImagePullSecrets) != 0
+			yyq2225[3] = x.Kind != ""
+			yyq2225[4] = x.APIVersion != ""
 			var yynn2225 int
 			if yyr2225 || yy2arr2225 {
 				r.EncodeArrayStart(5)
@@ -28975,68 +28975,18 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2225 || yy2arr2225 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2225[0] {
-					yym2227 := z.EncBinary()
-					_ = yym2227
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2225[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2228 := z.EncBinary()
-					_ = yym2228
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2225 || yy2arr2225 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2225[1] {
-					yym2230 := z.EncBinary()
-					_ = yym2230
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2225[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2231 := z.EncBinary()
-					_ = yym2231
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2225 || yy2arr2225 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2225[2] {
-					yy2233 := &x.ObjectMeta
-					yy2233.CodecEncodeSelf(e)
+					yy2227 := &x.ObjectMeta
+					yy2227.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2225[2] {
+				if yyq2225[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2234 := &x.ObjectMeta
-					yy2234.CodecEncodeSelf(e)
+					yy2228 := &x.ObjectMeta
+					yy2228.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2225 || yy2arr2225 {
@@ -29044,8 +28994,8 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Secrets == nil {
 					r.EncodeNil()
 				} else {
-					yym2236 := z.EncBinary()
-					_ = yym2236
+					yym2230 := z.EncBinary()
+					_ = yym2230
 					if false {
 					} else {
 						h.encSliceObjectReference(([]ObjectReference)(x.Secrets), e)
@@ -29058,8 +29008,8 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Secrets == nil {
 					r.EncodeNil()
 				} else {
-					yym2237 := z.EncBinary()
-					_ = yym2237
+					yym2231 := z.EncBinary()
+					_ = yym2231
 					if false {
 					} else {
 						h.encSliceObjectReference(([]ObjectReference)(x.Secrets), e)
@@ -29068,12 +29018,12 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2225 || yy2arr2225 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2225[4] {
+				if yyq2225[2] {
 					if x.ImagePullSecrets == nil {
 						r.EncodeNil()
 					} else {
-						yym2239 := z.EncBinary()
-						_ = yym2239
+						yym2233 := z.EncBinary()
+						_ = yym2233
 						if false {
 						} else {
 							h.encSliceLocalObjectReference(([]LocalObjectReference)(x.ImagePullSecrets), e)
@@ -29083,19 +29033,69 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2225[4] {
+				if yyq2225[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("imagePullSecrets"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.ImagePullSecrets == nil {
 						r.EncodeNil()
 					} else {
-						yym2240 := z.EncBinary()
-						_ = yym2240
+						yym2234 := z.EncBinary()
+						_ = yym2234
 						if false {
 						} else {
 							h.encSliceLocalObjectReference(([]LocalObjectReference)(x.ImagePullSecrets), e)
 						}
+					}
+				}
+			}
+			if yyr2225 || yy2arr2225 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2225[3] {
+					yym2236 := z.EncBinary()
+					_ = yym2236
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2225[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2237 := z.EncBinary()
+					_ = yym2237
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2225 || yy2arr2225 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2225[4] {
+					yym2239 := z.EncBinary()
+					_ = yym2239
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2225[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2240 := z.EncBinary()
+					_ = yym2240
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -29160,6 +29160,37 @@ func (x *ServiceAccount) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys2243 := string(yys2243Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2243 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv2244 := &x.ObjectMeta
+				yyv2244.CodecDecodeSelf(d)
+			}
+		case "secrets":
+			if r.TryDecodeAsNil() {
+				x.Secrets = nil
+			} else {
+				yyv2245 := &x.Secrets
+				yym2246 := z.DecBinary()
+				_ = yym2246
+				if false {
+				} else {
+					h.decSliceObjectReference((*[]ObjectReference)(yyv2245), d)
+				}
+			}
+		case "imagePullSecrets":
+			if r.TryDecodeAsNil() {
+				x.ImagePullSecrets = nil
+			} else {
+				yyv2247 := &x.ImagePullSecrets
+				yym2248 := z.DecBinary()
+				_ = yym2248
+				if false {
+				} else {
+					h.decSliceLocalObjectReference((*[]LocalObjectReference)(yyv2247), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -29171,37 +29202,6 @@ func (x *ServiceAccount) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv2246 := &x.ObjectMeta
-				yyv2246.CodecDecodeSelf(d)
-			}
-		case "secrets":
-			if r.TryDecodeAsNil() {
-				x.Secrets = nil
-			} else {
-				yyv2247 := &x.Secrets
-				yym2248 := z.DecBinary()
-				_ = yym2248
-				if false {
-				} else {
-					h.decSliceObjectReference((*[]ObjectReference)(yyv2247), d)
-				}
-			}
-		case "imagePullSecrets":
-			if r.TryDecodeAsNil() {
-				x.ImagePullSecrets = nil
-			} else {
-				yyv2249 := &x.ImagePullSecrets
-				yym2250 := z.DecBinary()
-				_ = yym2250
-				if false {
-				} else {
-					h.decSliceLocalObjectReference((*[]LocalObjectReference)(yyv2249), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2243)
@@ -29217,6 +29217,67 @@ func (x *ServiceAccount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj2251 int
 	var yyb2251 bool
 	var yyhl2251 bool = l >= 0
+	yyj2251++
+	if yyhl2251 {
+		yyb2251 = yyj2251 > l
+	} else {
+		yyb2251 = r.CheckBreak()
+	}
+	if yyb2251 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv2252 := &x.ObjectMeta
+		yyv2252.CodecDecodeSelf(d)
+	}
+	yyj2251++
+	if yyhl2251 {
+		yyb2251 = yyj2251 > l
+	} else {
+		yyb2251 = r.CheckBreak()
+	}
+	if yyb2251 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Secrets = nil
+	} else {
+		yyv2253 := &x.Secrets
+		yym2254 := z.DecBinary()
+		_ = yym2254
+		if false {
+		} else {
+			h.decSliceObjectReference((*[]ObjectReference)(yyv2253), d)
+		}
+	}
+	yyj2251++
+	if yyhl2251 {
+		yyb2251 = yyj2251 > l
+	} else {
+		yyb2251 = r.CheckBreak()
+	}
+	if yyb2251 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ImagePullSecrets = nil
+	} else {
+		yyv2255 := &x.ImagePullSecrets
+		yym2256 := z.DecBinary()
+		_ = yym2256
+		if false {
+		} else {
+			h.decSliceLocalObjectReference((*[]LocalObjectReference)(yyv2255), d)
+		}
+	}
 	yyj2251++
 	if yyhl2251 {
 		yyb2251 = yyj2251 > l
@@ -29248,67 +29309,6 @@ func (x *ServiceAccount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj2251++
-	if yyhl2251 {
-		yyb2251 = yyj2251 > l
-	} else {
-		yyb2251 = r.CheckBreak()
-	}
-	if yyb2251 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv2254 := &x.ObjectMeta
-		yyv2254.CodecDecodeSelf(d)
-	}
-	yyj2251++
-	if yyhl2251 {
-		yyb2251 = yyj2251 > l
-	} else {
-		yyb2251 = r.CheckBreak()
-	}
-	if yyb2251 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Secrets = nil
-	} else {
-		yyv2255 := &x.Secrets
-		yym2256 := z.DecBinary()
-		_ = yym2256
-		if false {
-		} else {
-			h.decSliceObjectReference((*[]ObjectReference)(yyv2255), d)
-		}
-	}
-	yyj2251++
-	if yyhl2251 {
-		yyb2251 = yyj2251 > l
-	} else {
-		yyb2251 = r.CheckBreak()
-	}
-	if yyb2251 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ImagePullSecrets = nil
-	} else {
-		yyv2257 := &x.ImagePullSecrets
-		yym2258 := z.DecBinary()
-		_ = yym2258
-		if false {
-		} else {
-			h.decSliceLocalObjectReference((*[]LocalObjectReference)(yyv2257), d)
-		}
 	}
 	for {
 		yyj2251++
@@ -29343,9 +29343,9 @@ func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2260 [4]bool
 			_, _, _ = yysep2260, yyq2260, yy2arr2260
 			const yyr2260 bool = false
-			yyq2260[0] = x.Kind != ""
-			yyq2260[1] = x.APIVersion != ""
-			yyq2260[2] = true
+			yyq2260[0] = true
+			yyq2260[2] = x.Kind != ""
+			yyq2260[3] = x.APIVersion != ""
 			var yynn2260 int
 			if yyr2260 || yy2arr2260 {
 				r.EncodeArrayStart(4)
@@ -29362,79 +29362,29 @@ func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2260 || yy2arr2260 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2260[0] {
-					yym2262 := z.EncBinary()
-					_ = yym2262
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2260[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy2262 := &x.ListMeta
 					yym2263 := z.EncBinary()
 					_ = yym2263
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2262) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2260 || yy2arr2260 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2260[1] {
-					yym2265 := z.EncBinary()
-					_ = yym2265
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2260[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2266 := z.EncBinary()
-					_ = yym2266
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2260 || yy2arr2260 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2260[2] {
-					yy2268 := &x.ListMeta
-					yym2269 := z.EncBinary()
-					_ = yym2269
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2268) {
-					} else {
-						z.EncFallback(yy2268)
+						z.EncFallback(yy2262)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2260[2] {
+				if yyq2260[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2270 := &x.ListMeta
-					yym2271 := z.EncBinary()
-					_ = yym2271
+					yy2264 := &x.ListMeta
+					yym2265 := z.EncBinary()
+					_ = yym2265
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2270) {
+					} else if z.HasExtensions() && z.EncExt(yy2264) {
 					} else {
-						z.EncFallback(yy2270)
+						z.EncFallback(yy2264)
 					}
 				}
 			}
@@ -29443,8 +29393,8 @@ func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2273 := z.EncBinary()
-					_ = yym2273
+					yym2267 := z.EncBinary()
+					_ = yym2267
 					if false {
 					} else {
 						h.encSliceServiceAccount(([]ServiceAccount)(x.Items), e)
@@ -29457,11 +29407,61 @@ func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym2268 := z.EncBinary()
+					_ = yym2268
+					if false {
+					} else {
+						h.encSliceServiceAccount(([]ServiceAccount)(x.Items), e)
+					}
+				}
+			}
+			if yyr2260 || yy2arr2260 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2260[2] {
+					yym2270 := z.EncBinary()
+					_ = yym2270
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2260[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2271 := z.EncBinary()
+					_ = yym2271
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2260 || yy2arr2260 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2260[3] {
+					yym2273 := z.EncBinary()
+					_ = yym2273
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2260[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2274 := z.EncBinary()
 					_ = yym2274
 					if false {
 					} else {
-						h.encSliceServiceAccount(([]ServiceAccount)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -29526,6 +29526,31 @@ func (x *ServiceAccountList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 		yys2277 := string(yys2277Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2277 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv2278 := &x.ListMeta
+				yym2279 := z.DecBinary()
+				_ = yym2279
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv2278) {
+				} else {
+					z.DecFallback(yyv2278, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv2280 := &x.Items
+				yym2281 := z.DecBinary()
+				_ = yym2281
+				if false {
+				} else {
+					h.decSliceServiceAccount((*[]ServiceAccount)(yyv2280), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -29537,31 +29562,6 @@ func (x *ServiceAccountList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv2280 := &x.ListMeta
-				yym2281 := z.DecBinary()
-				_ = yym2281
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2280) {
-				} else {
-					z.DecFallback(yyv2280, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv2282 := &x.Items
-				yym2283 := z.DecBinary()
-				_ = yym2283
-				if false {
-				} else {
-					h.decSliceServiceAccount((*[]ServiceAccount)(yyv2282), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2277)
@@ -29577,6 +29577,51 @@ func (x *ServiceAccountList) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	var yyj2284 int
 	var yyb2284 bool
 	var yyhl2284 bool = l >= 0
+	yyj2284++
+	if yyhl2284 {
+		yyb2284 = yyj2284 > l
+	} else {
+		yyb2284 = r.CheckBreak()
+	}
+	if yyb2284 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv2285 := &x.ListMeta
+		yym2286 := z.DecBinary()
+		_ = yym2286
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv2285) {
+		} else {
+			z.DecFallback(yyv2285, false)
+		}
+	}
+	yyj2284++
+	if yyhl2284 {
+		yyb2284 = yyj2284 > l
+	} else {
+		yyb2284 = r.CheckBreak()
+	}
+	if yyb2284 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv2287 := &x.Items
+		yym2288 := z.DecBinary()
+		_ = yym2288
+		if false {
+		} else {
+			h.decSliceServiceAccount((*[]ServiceAccount)(yyv2287), d)
+		}
+	}
 	yyj2284++
 	if yyhl2284 {
 		yyb2284 = yyj2284 > l
@@ -29608,51 +29653,6 @@ func (x *ServiceAccountList) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj2284++
-	if yyhl2284 {
-		yyb2284 = yyj2284 > l
-	} else {
-		yyb2284 = r.CheckBreak()
-	}
-	if yyb2284 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv2287 := &x.ListMeta
-		yym2288 := z.DecBinary()
-		_ = yym2288
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2287) {
-		} else {
-			z.DecFallback(yyv2287, false)
-		}
-	}
-	yyj2284++
-	if yyhl2284 {
-		yyb2284 = yyj2284 > l
-	} else {
-		yyb2284 = r.CheckBreak()
-	}
-	if yyb2284 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv2289 := &x.Items
-		yym2290 := z.DecBinary()
-		_ = yym2290
-		if false {
-		} else {
-			h.decSliceServiceAccount((*[]ServiceAccount)(yyv2289), d)
-		}
 	}
 	for {
 		yyj2284++
@@ -29687,9 +29687,9 @@ func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2292 [4]bool
 			_, _, _ = yysep2292, yyq2292, yy2arr2292
 			const yyr2292 bool = false
-			yyq2292[0] = x.Kind != ""
-			yyq2292[1] = x.APIVersion != ""
-			yyq2292[2] = true
+			yyq2292[0] = true
+			yyq2292[2] = x.Kind != ""
+			yyq2292[3] = x.APIVersion != ""
 			var yynn2292 int
 			if yyr2292 || yy2arr2292 {
 				r.EncodeArrayStart(4)
@@ -29706,68 +29706,18 @@ func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2292 || yy2arr2292 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2292[0] {
-					yym2294 := z.EncBinary()
-					_ = yym2294
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2292[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2295 := z.EncBinary()
-					_ = yym2295
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2292 || yy2arr2292 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2292[1] {
-					yym2297 := z.EncBinary()
-					_ = yym2297
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2292[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2298 := z.EncBinary()
-					_ = yym2298
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2292 || yy2arr2292 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2292[2] {
-					yy2300 := &x.ObjectMeta
-					yy2300.CodecEncodeSelf(e)
+					yy2294 := &x.ObjectMeta
+					yy2294.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2292[2] {
+				if yyq2292[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2301 := &x.ObjectMeta
-					yy2301.CodecEncodeSelf(e)
+					yy2295 := &x.ObjectMeta
+					yy2295.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2292 || yy2arr2292 {
@@ -29775,8 +29725,8 @@ func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Subsets == nil {
 					r.EncodeNil()
 				} else {
-					yym2303 := z.EncBinary()
-					_ = yym2303
+					yym2297 := z.EncBinary()
+					_ = yym2297
 					if false {
 					} else {
 						h.encSliceEndpointSubset(([]EndpointSubset)(x.Subsets), e)
@@ -29789,11 +29739,61 @@ func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Subsets == nil {
 					r.EncodeNil()
 				} else {
+					yym2298 := z.EncBinary()
+					_ = yym2298
+					if false {
+					} else {
+						h.encSliceEndpointSubset(([]EndpointSubset)(x.Subsets), e)
+					}
+				}
+			}
+			if yyr2292 || yy2arr2292 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2292[2] {
+					yym2300 := z.EncBinary()
+					_ = yym2300
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2292[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2301 := z.EncBinary()
+					_ = yym2301
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2292 || yy2arr2292 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2292[3] {
+					yym2303 := z.EncBinary()
+					_ = yym2303
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2292[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2304 := z.EncBinary()
 					_ = yym2304
 					if false {
 					} else {
-						h.encSliceEndpointSubset(([]EndpointSubset)(x.Subsets), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -29858,6 +29858,25 @@ func (x *Endpoints) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys2307 := string(yys2307Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2307 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv2308 := &x.ObjectMeta
+				yyv2308.CodecDecodeSelf(d)
+			}
+		case "Subsets":
+			if r.TryDecodeAsNil() {
+				x.Subsets = nil
+			} else {
+				yyv2309 := &x.Subsets
+				yym2310 := z.DecBinary()
+				_ = yym2310
+				if false {
+				} else {
+					h.decSliceEndpointSubset((*[]EndpointSubset)(yyv2309), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -29869,25 +29888,6 @@ func (x *Endpoints) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv2310 := &x.ObjectMeta
-				yyv2310.CodecDecodeSelf(d)
-			}
-		case "Subsets":
-			if r.TryDecodeAsNil() {
-				x.Subsets = nil
-			} else {
-				yyv2311 := &x.Subsets
-				yym2312 := z.DecBinary()
-				_ = yym2312
-				if false {
-				} else {
-					h.decSliceEndpointSubset((*[]EndpointSubset)(yyv2311), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2307)
@@ -29903,6 +29903,45 @@ func (x *Endpoints) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj2313 int
 	var yyb2313 bool
 	var yyhl2313 bool = l >= 0
+	yyj2313++
+	if yyhl2313 {
+		yyb2313 = yyj2313 > l
+	} else {
+		yyb2313 = r.CheckBreak()
+	}
+	if yyb2313 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv2314 := &x.ObjectMeta
+		yyv2314.CodecDecodeSelf(d)
+	}
+	yyj2313++
+	if yyhl2313 {
+		yyb2313 = yyj2313 > l
+	} else {
+		yyb2313 = r.CheckBreak()
+	}
+	if yyb2313 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Subsets = nil
+	} else {
+		yyv2315 := &x.Subsets
+		yym2316 := z.DecBinary()
+		_ = yym2316
+		if false {
+		} else {
+			h.decSliceEndpointSubset((*[]EndpointSubset)(yyv2315), d)
+		}
+	}
 	yyj2313++
 	if yyhl2313 {
 		yyb2313 = yyj2313 > l
@@ -29934,45 +29973,6 @@ func (x *Endpoints) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj2313++
-	if yyhl2313 {
-		yyb2313 = yyj2313 > l
-	} else {
-		yyb2313 = r.CheckBreak()
-	}
-	if yyb2313 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv2316 := &x.ObjectMeta
-		yyv2316.CodecDecodeSelf(d)
-	}
-	yyj2313++
-	if yyhl2313 {
-		yyb2313 = yyj2313 > l
-	} else {
-		yyb2313 = r.CheckBreak()
-	}
-	if yyb2313 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Subsets = nil
-	} else {
-		yyv2317 := &x.Subsets
-		yym2318 := z.DecBinary()
-		_ = yym2318
-		if false {
-		} else {
-			h.decSliceEndpointSubset((*[]EndpointSubset)(yyv2317), d)
-		}
 	}
 	for {
 		yyj2313++
@@ -30756,9 +30756,9 @@ func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2380 [4]bool
 			_, _, _ = yysep2380, yyq2380, yy2arr2380
 			const yyr2380 bool = false
-			yyq2380[0] = x.Kind != ""
-			yyq2380[1] = x.APIVersion != ""
-			yyq2380[2] = true
+			yyq2380[0] = true
+			yyq2380[2] = x.Kind != ""
+			yyq2380[3] = x.APIVersion != ""
 			var yynn2380 int
 			if yyr2380 || yy2arr2380 {
 				r.EncodeArrayStart(4)
@@ -30775,79 +30775,29 @@ func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2380 || yy2arr2380 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2380[0] {
-					yym2382 := z.EncBinary()
-					_ = yym2382
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2380[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy2382 := &x.ListMeta
 					yym2383 := z.EncBinary()
 					_ = yym2383
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2382) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2380 || yy2arr2380 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2380[1] {
-					yym2385 := z.EncBinary()
-					_ = yym2385
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2380[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2386 := z.EncBinary()
-					_ = yym2386
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2380 || yy2arr2380 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2380[2] {
-					yy2388 := &x.ListMeta
-					yym2389 := z.EncBinary()
-					_ = yym2389
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2388) {
-					} else {
-						z.EncFallback(yy2388)
+						z.EncFallback(yy2382)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2380[2] {
+				if yyq2380[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2390 := &x.ListMeta
-					yym2391 := z.EncBinary()
-					_ = yym2391
+					yy2384 := &x.ListMeta
+					yym2385 := z.EncBinary()
+					_ = yym2385
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2390) {
+					} else if z.HasExtensions() && z.EncExt(yy2384) {
 					} else {
-						z.EncFallback(yy2390)
+						z.EncFallback(yy2384)
 					}
 				}
 			}
@@ -30856,8 +30806,8 @@ func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2393 := z.EncBinary()
-					_ = yym2393
+					yym2387 := z.EncBinary()
+					_ = yym2387
 					if false {
 					} else {
 						h.encSliceEndpoints(([]Endpoints)(x.Items), e)
@@ -30870,11 +30820,61 @@ func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym2388 := z.EncBinary()
+					_ = yym2388
+					if false {
+					} else {
+						h.encSliceEndpoints(([]Endpoints)(x.Items), e)
+					}
+				}
+			}
+			if yyr2380 || yy2arr2380 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2380[2] {
+					yym2390 := z.EncBinary()
+					_ = yym2390
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2380[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2391 := z.EncBinary()
+					_ = yym2391
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2380 || yy2arr2380 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2380[3] {
+					yym2393 := z.EncBinary()
+					_ = yym2393
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2380[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2394 := z.EncBinary()
 					_ = yym2394
 					if false {
 					} else {
-						h.encSliceEndpoints(([]Endpoints)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -30939,6 +30939,31 @@ func (x *EndpointsList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys2397 := string(yys2397Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2397 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv2398 := &x.ListMeta
+				yym2399 := z.DecBinary()
+				_ = yym2399
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv2398) {
+				} else {
+					z.DecFallback(yyv2398, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv2400 := &x.Items
+				yym2401 := z.DecBinary()
+				_ = yym2401
+				if false {
+				} else {
+					h.decSliceEndpoints((*[]Endpoints)(yyv2400), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -30950,31 +30975,6 @@ func (x *EndpointsList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv2400 := &x.ListMeta
-				yym2401 := z.DecBinary()
-				_ = yym2401
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2400) {
-				} else {
-					z.DecFallback(yyv2400, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv2402 := &x.Items
-				yym2403 := z.DecBinary()
-				_ = yym2403
-				if false {
-				} else {
-					h.decSliceEndpoints((*[]Endpoints)(yyv2402), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2397)
@@ -30990,6 +30990,51 @@ func (x *EndpointsList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj2404 int
 	var yyb2404 bool
 	var yyhl2404 bool = l >= 0
+	yyj2404++
+	if yyhl2404 {
+		yyb2404 = yyj2404 > l
+	} else {
+		yyb2404 = r.CheckBreak()
+	}
+	if yyb2404 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv2405 := &x.ListMeta
+		yym2406 := z.DecBinary()
+		_ = yym2406
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv2405) {
+		} else {
+			z.DecFallback(yyv2405, false)
+		}
+	}
+	yyj2404++
+	if yyhl2404 {
+		yyb2404 = yyj2404 > l
+	} else {
+		yyb2404 = r.CheckBreak()
+	}
+	if yyb2404 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv2407 := &x.Items
+		yym2408 := z.DecBinary()
+		_ = yym2408
+		if false {
+		} else {
+			h.decSliceEndpoints((*[]Endpoints)(yyv2407), d)
+		}
+	}
 	yyj2404++
 	if yyhl2404 {
 		yyb2404 = yyj2404 > l
@@ -31021,51 +31066,6 @@ func (x *EndpointsList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj2404++
-	if yyhl2404 {
-		yyb2404 = yyj2404 > l
-	} else {
-		yyb2404 = r.CheckBreak()
-	}
-	if yyb2404 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv2407 := &x.ListMeta
-		yym2408 := z.DecBinary()
-		_ = yym2408
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2407) {
-		} else {
-			z.DecFallback(yyv2407, false)
-		}
-	}
-	yyj2404++
-	if yyhl2404 {
-		yyb2404 = yyj2404 > l
-	} else {
-		yyb2404 = r.CheckBreak()
-	}
-	if yyb2404 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv2409 := &x.Items
-		yym2410 := z.DecBinary()
-		_ = yym2410
-		if false {
-		} else {
-			h.decSliceEndpoints((*[]Endpoints)(yyv2409), d)
-		}
 	}
 	for {
 		yyj2404++
@@ -33892,11 +33892,11 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2643 [5]bool
 			_, _, _ = yysep2643, yyq2643, yy2arr2643
 			const yyr2643 bool = false
-			yyq2643[0] = x.Kind != ""
-			yyq2643[1] = x.APIVersion != ""
+			yyq2643[0] = true
+			yyq2643[1] = true
 			yyq2643[2] = true
-			yyq2643[3] = true
-			yyq2643[4] = true
+			yyq2643[3] = x.Kind != ""
+			yyq2643[4] = x.APIVersion != ""
 			var yynn2643 int
 			if yyr2643 || yy2arr2643 {
 				r.EncodeArrayStart(5)
@@ -33913,57 +33913,41 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2643 || yy2arr2643 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2643[0] {
-					yym2645 := z.EncBinary()
-					_ = yym2645
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy2645 := &x.ObjectMeta
+					yy2645.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq2643[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2646 := z.EncBinary()
-					_ = yym2646
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy2646 := &x.ObjectMeta
+					yy2646.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2643 || yy2arr2643 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2643[1] {
-					yym2648 := z.EncBinary()
-					_ = yym2648
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy2648 := &x.Spec
+					yy2648.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq2643[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2649 := z.EncBinary()
-					_ = yym2649
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy2649 := &x.Spec
+					yy2649.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2643 || yy2arr2643 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2643[2] {
-					yy2651 := &x.ObjectMeta
+					yy2651 := &x.Status
 					yy2651.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
@@ -33971,44 +33955,60 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq2643[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2652 := &x.ObjectMeta
+					yy2652 := &x.Status
 					yy2652.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2643 || yy2arr2643 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2643[3] {
-					yy2654 := &x.Spec
-					yy2654.CodecEncodeSelf(e)
+					yym2654 := z.EncBinary()
+					_ = yym2654
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq2643[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2655 := &x.Spec
-					yy2655.CodecEncodeSelf(e)
+					yym2655 := z.EncBinary()
+					_ = yym2655
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				}
 			}
 			if yyr2643 || yy2arr2643 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2643[4] {
-					yy2657 := &x.Status
-					yy2657.CodecEncodeSelf(e)
+					yym2657 := z.EncBinary()
+					_ = yym2657
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq2643[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2658 := &x.Status
-					yy2658.CodecEncodeSelf(e)
+					yym2658 := z.EncBinary()
+					_ = yym2658
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr2643 || yy2arr2643 {
@@ -34072,6 +34072,27 @@ func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys2661 := string(yys2661Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2661 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv2662 := &x.ObjectMeta
+				yyv2662.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = NodeSpec{}
+			} else {
+				yyv2663 := &x.Spec
+				yyv2663.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = NodeStatus{}
+			} else {
+				yyv2664 := &x.Status
+				yyv2664.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -34083,27 +34104,6 @@ func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv2664 := &x.ObjectMeta
-				yyv2664.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = NodeSpec{}
-			} else {
-				yyv2665 := &x.Spec
-				yyv2665.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = NodeStatus{}
-			} else {
-				yyv2666 := &x.Status
-				yyv2666.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2661)
@@ -34119,6 +34119,57 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj2667 int
 	var yyb2667 bool
 	var yyhl2667 bool = l >= 0
+	yyj2667++
+	if yyhl2667 {
+		yyb2667 = yyj2667 > l
+	} else {
+		yyb2667 = r.CheckBreak()
+	}
+	if yyb2667 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv2668 := &x.ObjectMeta
+		yyv2668.CodecDecodeSelf(d)
+	}
+	yyj2667++
+	if yyhl2667 {
+		yyb2667 = yyj2667 > l
+	} else {
+		yyb2667 = r.CheckBreak()
+	}
+	if yyb2667 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = NodeSpec{}
+	} else {
+		yyv2669 := &x.Spec
+		yyv2669.CodecDecodeSelf(d)
+	}
+	yyj2667++
+	if yyhl2667 {
+		yyb2667 = yyj2667 > l
+	} else {
+		yyb2667 = r.CheckBreak()
+	}
+	if yyb2667 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = NodeStatus{}
+	} else {
+		yyv2670 := &x.Status
+		yyv2670.CodecDecodeSelf(d)
+	}
 	yyj2667++
 	if yyhl2667 {
 		yyb2667 = yyj2667 > l
@@ -34150,57 +34201,6 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj2667++
-	if yyhl2667 {
-		yyb2667 = yyj2667 > l
-	} else {
-		yyb2667 = r.CheckBreak()
-	}
-	if yyb2667 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv2670 := &x.ObjectMeta
-		yyv2670.CodecDecodeSelf(d)
-	}
-	yyj2667++
-	if yyhl2667 {
-		yyb2667 = yyj2667 > l
-	} else {
-		yyb2667 = r.CheckBreak()
-	}
-	if yyb2667 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = NodeSpec{}
-	} else {
-		yyv2671 := &x.Spec
-		yyv2671.CodecDecodeSelf(d)
-	}
-	yyj2667++
-	if yyhl2667 {
-		yyb2667 = yyj2667 > l
-	} else {
-		yyb2667 = r.CheckBreak()
-	}
-	if yyb2667 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = NodeStatus{}
-	} else {
-		yyv2672 := &x.Status
-		yyv2672.CodecDecodeSelf(d)
 	}
 	for {
 		yyj2667++
@@ -34235,9 +34235,9 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2674 [4]bool
 			_, _, _ = yysep2674, yyq2674, yy2arr2674
 			const yyr2674 bool = false
-			yyq2674[0] = x.Kind != ""
-			yyq2674[1] = x.APIVersion != ""
-			yyq2674[2] = true
+			yyq2674[0] = true
+			yyq2674[2] = x.Kind != ""
+			yyq2674[3] = x.APIVersion != ""
 			var yynn2674 int
 			if yyr2674 || yy2arr2674 {
 				r.EncodeArrayStart(4)
@@ -34254,79 +34254,29 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2674 || yy2arr2674 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2674[0] {
-					yym2676 := z.EncBinary()
-					_ = yym2676
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2674[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy2676 := &x.ListMeta
 					yym2677 := z.EncBinary()
 					_ = yym2677
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2676) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2674 || yy2arr2674 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2674[1] {
-					yym2679 := z.EncBinary()
-					_ = yym2679
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2674[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2680 := z.EncBinary()
-					_ = yym2680
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2674 || yy2arr2674 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2674[2] {
-					yy2682 := &x.ListMeta
-					yym2683 := z.EncBinary()
-					_ = yym2683
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2682) {
-					} else {
-						z.EncFallback(yy2682)
+						z.EncFallback(yy2676)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2674[2] {
+				if yyq2674[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2684 := &x.ListMeta
-					yym2685 := z.EncBinary()
-					_ = yym2685
+					yy2678 := &x.ListMeta
+					yym2679 := z.EncBinary()
+					_ = yym2679
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2684) {
+					} else if z.HasExtensions() && z.EncExt(yy2678) {
 					} else {
-						z.EncFallback(yy2684)
+						z.EncFallback(yy2678)
 					}
 				}
 			}
@@ -34335,8 +34285,8 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2687 := z.EncBinary()
-					_ = yym2687
+					yym2681 := z.EncBinary()
+					_ = yym2681
 					if false {
 					} else {
 						h.encSliceNode(([]Node)(x.Items), e)
@@ -34349,11 +34299,61 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym2682 := z.EncBinary()
+					_ = yym2682
+					if false {
+					} else {
+						h.encSliceNode(([]Node)(x.Items), e)
+					}
+				}
+			}
+			if yyr2674 || yy2arr2674 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2674[2] {
+					yym2684 := z.EncBinary()
+					_ = yym2684
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2674[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2685 := z.EncBinary()
+					_ = yym2685
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2674 || yy2arr2674 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2674[3] {
+					yym2687 := z.EncBinary()
+					_ = yym2687
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2674[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2688 := z.EncBinary()
 					_ = yym2688
 					if false {
 					} else {
-						h.encSliceNode(([]Node)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -34418,6 +34418,31 @@ func (x *NodeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys2691 := string(yys2691Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2691 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv2692 := &x.ListMeta
+				yym2693 := z.DecBinary()
+				_ = yym2693
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv2692) {
+				} else {
+					z.DecFallback(yyv2692, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv2694 := &x.Items
+				yym2695 := z.DecBinary()
+				_ = yym2695
+				if false {
+				} else {
+					h.decSliceNode((*[]Node)(yyv2694), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -34429,31 +34454,6 @@ func (x *NodeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv2694 := &x.ListMeta
-				yym2695 := z.DecBinary()
-				_ = yym2695
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2694) {
-				} else {
-					z.DecFallback(yyv2694, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv2696 := &x.Items
-				yym2697 := z.DecBinary()
-				_ = yym2697
-				if false {
-				} else {
-					h.decSliceNode((*[]Node)(yyv2696), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2691)
@@ -34469,6 +34469,51 @@ func (x *NodeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj2698 int
 	var yyb2698 bool
 	var yyhl2698 bool = l >= 0
+	yyj2698++
+	if yyhl2698 {
+		yyb2698 = yyj2698 > l
+	} else {
+		yyb2698 = r.CheckBreak()
+	}
+	if yyb2698 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv2699 := &x.ListMeta
+		yym2700 := z.DecBinary()
+		_ = yym2700
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv2699) {
+		} else {
+			z.DecFallback(yyv2699, false)
+		}
+	}
+	yyj2698++
+	if yyhl2698 {
+		yyb2698 = yyj2698 > l
+	} else {
+		yyb2698 = r.CheckBreak()
+	}
+	if yyb2698 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv2701 := &x.Items
+		yym2702 := z.DecBinary()
+		_ = yym2702
+		if false {
+		} else {
+			h.decSliceNode((*[]Node)(yyv2701), d)
+		}
+	}
 	yyj2698++
 	if yyhl2698 {
 		yyb2698 = yyj2698 > l
@@ -34500,51 +34545,6 @@ func (x *NodeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj2698++
-	if yyhl2698 {
-		yyb2698 = yyj2698 > l
-	} else {
-		yyb2698 = r.CheckBreak()
-	}
-	if yyb2698 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv2701 := &x.ListMeta
-		yym2702 := z.DecBinary()
-		_ = yym2702
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2701) {
-		} else {
-			z.DecFallback(yyv2701, false)
-		}
-	}
-	yyj2698++
-	if yyhl2698 {
-		yyb2698 = yyj2698 > l
-	} else {
-		yyb2698 = r.CheckBreak()
-	}
-	if yyb2698 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv2703 := &x.Items
-		yym2704 := z.DecBinary()
-		_ = yym2704
-		if false {
-		} else {
-			h.decSliceNode((*[]Node)(yyv2703), d)
-		}
 	}
 	for {
 		yyj2698++
@@ -34972,11 +34972,11 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2732 [5]bool
 			_, _, _ = yysep2732, yyq2732, yy2arr2732
 			const yyr2732 bool = false
-			yyq2732[0] = x.Kind != ""
-			yyq2732[1] = x.APIVersion != ""
+			yyq2732[0] = true
+			yyq2732[1] = true
 			yyq2732[2] = true
-			yyq2732[3] = true
-			yyq2732[4] = true
+			yyq2732[3] = x.Kind != ""
+			yyq2732[4] = x.APIVersion != ""
 			var yynn2732 int
 			if yyr2732 || yy2arr2732 {
 				r.EncodeArrayStart(5)
@@ -34993,57 +34993,41 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2732 || yy2arr2732 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2732[0] {
-					yym2734 := z.EncBinary()
-					_ = yym2734
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy2734 := &x.ObjectMeta
+					yy2734.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq2732[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2735 := z.EncBinary()
-					_ = yym2735
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy2735 := &x.ObjectMeta
+					yy2735.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2732 || yy2arr2732 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2732[1] {
-					yym2737 := z.EncBinary()
-					_ = yym2737
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy2737 := &x.Spec
+					yy2737.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq2732[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2738 := z.EncBinary()
-					_ = yym2738
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy2738 := &x.Spec
+					yy2738.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2732 || yy2arr2732 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2732[2] {
-					yy2740 := &x.ObjectMeta
+					yy2740 := &x.Status
 					yy2740.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
@@ -35051,44 +35035,60 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq2732[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2741 := &x.ObjectMeta
+					yy2741 := &x.Status
 					yy2741.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2732 || yy2arr2732 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2732[3] {
-					yy2743 := &x.Spec
-					yy2743.CodecEncodeSelf(e)
+					yym2743 := z.EncBinary()
+					_ = yym2743
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq2732[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2744 := &x.Spec
-					yy2744.CodecEncodeSelf(e)
+					yym2744 := z.EncBinary()
+					_ = yym2744
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				}
 			}
 			if yyr2732 || yy2arr2732 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2732[4] {
-					yy2746 := &x.Status
-					yy2746.CodecEncodeSelf(e)
+					yym2746 := z.EncBinary()
+					_ = yym2746
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq2732[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2747 := &x.Status
-					yy2747.CodecEncodeSelf(e)
+					yym2747 := z.EncBinary()
+					_ = yym2747
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr2732 || yy2arr2732 {
@@ -35152,6 +35152,27 @@ func (x *Namespace) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys2750 := string(yys2750Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2750 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv2751 := &x.ObjectMeta
+				yyv2751.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = NamespaceSpec{}
+			} else {
+				yyv2752 := &x.Spec
+				yyv2752.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = NamespaceStatus{}
+			} else {
+				yyv2753 := &x.Status
+				yyv2753.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -35163,27 +35184,6 @@ func (x *Namespace) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv2753 := &x.ObjectMeta
-				yyv2753.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = NamespaceSpec{}
-			} else {
-				yyv2754 := &x.Spec
-				yyv2754.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = NamespaceStatus{}
-			} else {
-				yyv2755 := &x.Status
-				yyv2755.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2750)
@@ -35199,6 +35199,57 @@ func (x *Namespace) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj2756 int
 	var yyb2756 bool
 	var yyhl2756 bool = l >= 0
+	yyj2756++
+	if yyhl2756 {
+		yyb2756 = yyj2756 > l
+	} else {
+		yyb2756 = r.CheckBreak()
+	}
+	if yyb2756 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv2757 := &x.ObjectMeta
+		yyv2757.CodecDecodeSelf(d)
+	}
+	yyj2756++
+	if yyhl2756 {
+		yyb2756 = yyj2756 > l
+	} else {
+		yyb2756 = r.CheckBreak()
+	}
+	if yyb2756 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = NamespaceSpec{}
+	} else {
+		yyv2758 := &x.Spec
+		yyv2758.CodecDecodeSelf(d)
+	}
+	yyj2756++
+	if yyhl2756 {
+		yyb2756 = yyj2756 > l
+	} else {
+		yyb2756 = r.CheckBreak()
+	}
+	if yyb2756 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = NamespaceStatus{}
+	} else {
+		yyv2759 := &x.Status
+		yyv2759.CodecDecodeSelf(d)
+	}
 	yyj2756++
 	if yyhl2756 {
 		yyb2756 = yyj2756 > l
@@ -35230,57 +35281,6 @@ func (x *Namespace) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj2756++
-	if yyhl2756 {
-		yyb2756 = yyj2756 > l
-	} else {
-		yyb2756 = r.CheckBreak()
-	}
-	if yyb2756 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv2759 := &x.ObjectMeta
-		yyv2759.CodecDecodeSelf(d)
-	}
-	yyj2756++
-	if yyhl2756 {
-		yyb2756 = yyj2756 > l
-	} else {
-		yyb2756 = r.CheckBreak()
-	}
-	if yyb2756 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = NamespaceSpec{}
-	} else {
-		yyv2760 := &x.Spec
-		yyv2760.CodecDecodeSelf(d)
-	}
-	yyj2756++
-	if yyhl2756 {
-		yyb2756 = yyj2756 > l
-	} else {
-		yyb2756 = r.CheckBreak()
-	}
-	if yyb2756 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = NamespaceStatus{}
-	} else {
-		yyv2761 := &x.Status
-		yyv2761.CodecDecodeSelf(d)
 	}
 	for {
 		yyj2756++
@@ -35315,9 +35315,9 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2763 [4]bool
 			_, _, _ = yysep2763, yyq2763, yy2arr2763
 			const yyr2763 bool = false
-			yyq2763[0] = x.Kind != ""
-			yyq2763[1] = x.APIVersion != ""
-			yyq2763[2] = true
+			yyq2763[0] = true
+			yyq2763[2] = x.Kind != ""
+			yyq2763[3] = x.APIVersion != ""
 			var yynn2763 int
 			if yyr2763 || yy2arr2763 {
 				r.EncodeArrayStart(4)
@@ -35334,79 +35334,29 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2763 || yy2arr2763 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2763[0] {
-					yym2765 := z.EncBinary()
-					_ = yym2765
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2763[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy2765 := &x.ListMeta
 					yym2766 := z.EncBinary()
 					_ = yym2766
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2765) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2763 || yy2arr2763 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2763[1] {
-					yym2768 := z.EncBinary()
-					_ = yym2768
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2763[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2769 := z.EncBinary()
-					_ = yym2769
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2763 || yy2arr2763 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2763[2] {
-					yy2771 := &x.ListMeta
-					yym2772 := z.EncBinary()
-					_ = yym2772
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2771) {
-					} else {
-						z.EncFallback(yy2771)
+						z.EncFallback(yy2765)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2763[2] {
+				if yyq2763[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2773 := &x.ListMeta
-					yym2774 := z.EncBinary()
-					_ = yym2774
+					yy2767 := &x.ListMeta
+					yym2768 := z.EncBinary()
+					_ = yym2768
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2773) {
+					} else if z.HasExtensions() && z.EncExt(yy2767) {
 					} else {
-						z.EncFallback(yy2773)
+						z.EncFallback(yy2767)
 					}
 				}
 			}
@@ -35415,8 +35365,8 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2776 := z.EncBinary()
-					_ = yym2776
+					yym2770 := z.EncBinary()
+					_ = yym2770
 					if false {
 					} else {
 						h.encSliceNamespace(([]Namespace)(x.Items), e)
@@ -35429,11 +35379,61 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym2771 := z.EncBinary()
+					_ = yym2771
+					if false {
+					} else {
+						h.encSliceNamespace(([]Namespace)(x.Items), e)
+					}
+				}
+			}
+			if yyr2763 || yy2arr2763 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2763[2] {
+					yym2773 := z.EncBinary()
+					_ = yym2773
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2763[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2774 := z.EncBinary()
+					_ = yym2774
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2763 || yy2arr2763 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2763[3] {
+					yym2776 := z.EncBinary()
+					_ = yym2776
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2763[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2777 := z.EncBinary()
 					_ = yym2777
 					if false {
 					} else {
-						h.encSliceNamespace(([]Namespace)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -35498,6 +35498,31 @@ func (x *NamespaceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys2780 := string(yys2780Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2780 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv2781 := &x.ListMeta
+				yym2782 := z.DecBinary()
+				_ = yym2782
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv2781) {
+				} else {
+					z.DecFallback(yyv2781, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv2783 := &x.Items
+				yym2784 := z.DecBinary()
+				_ = yym2784
+				if false {
+				} else {
+					h.decSliceNamespace((*[]Namespace)(yyv2783), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -35509,31 +35534,6 @@ func (x *NamespaceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv2783 := &x.ListMeta
-				yym2784 := z.DecBinary()
-				_ = yym2784
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2783) {
-				} else {
-					z.DecFallback(yyv2783, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv2785 := &x.Items
-				yym2786 := z.DecBinary()
-				_ = yym2786
-				if false {
-				} else {
-					h.decSliceNamespace((*[]Namespace)(yyv2785), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2780)
@@ -35549,6 +35549,51 @@ func (x *NamespaceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj2787 int
 	var yyb2787 bool
 	var yyhl2787 bool = l >= 0
+	yyj2787++
+	if yyhl2787 {
+		yyb2787 = yyj2787 > l
+	} else {
+		yyb2787 = r.CheckBreak()
+	}
+	if yyb2787 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv2788 := &x.ListMeta
+		yym2789 := z.DecBinary()
+		_ = yym2789
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv2788) {
+		} else {
+			z.DecFallback(yyv2788, false)
+		}
+	}
+	yyj2787++
+	if yyhl2787 {
+		yyb2787 = yyj2787 > l
+	} else {
+		yyb2787 = r.CheckBreak()
+	}
+	if yyb2787 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv2790 := &x.Items
+		yym2791 := z.DecBinary()
+		_ = yym2791
+		if false {
+		} else {
+			h.decSliceNamespace((*[]Namespace)(yyv2790), d)
+		}
+	}
 	yyj2787++
 	if yyhl2787 {
 		yyb2787 = yyj2787 > l
@@ -35580,51 +35625,6 @@ func (x *NamespaceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj2787++
-	if yyhl2787 {
-		yyb2787 = yyj2787 > l
-	} else {
-		yyb2787 = r.CheckBreak()
-	}
-	if yyb2787 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv2790 := &x.ListMeta
-		yym2791 := z.DecBinary()
-		_ = yym2791
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2790) {
-		} else {
-			z.DecFallback(yyv2790, false)
-		}
-	}
-	yyj2787++
-	if yyhl2787 {
-		yyb2787 = yyj2787 > l
-	} else {
-		yyb2787 = r.CheckBreak()
-	}
-	if yyb2787 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv2792 := &x.Items
-		yym2793 := z.DecBinary()
-		_ = yym2793
-		if false {
-		} else {
-			h.decSliceNamespace((*[]Namespace)(yyv2792), d)
-		}
 	}
 	for {
 		yyj2787++
@@ -35659,9 +35659,9 @@ func (x *Binding) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2795 [4]bool
 			_, _, _ = yysep2795, yyq2795, yy2arr2795
 			const yyr2795 bool = false
-			yyq2795[0] = x.Kind != ""
-			yyq2795[1] = x.APIVersion != ""
-			yyq2795[2] = true
+			yyq2795[0] = true
+			yyq2795[2] = x.Kind != ""
+			yyq2795[3] = x.APIVersion != ""
 			var yynn2795 int
 			if yyr2795 || yy2arr2795 {
 				r.EncodeArrayStart(4)
@@ -35678,80 +35678,80 @@ func (x *Binding) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2795 || yy2arr2795 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2795[0] {
-					yym2797 := z.EncBinary()
-					_ = yym2797
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2795[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2798 := z.EncBinary()
-					_ = yym2798
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2795 || yy2arr2795 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2795[1] {
-					yym2800 := z.EncBinary()
-					_ = yym2800
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2795[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2801 := z.EncBinary()
-					_ = yym2801
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2795 || yy2arr2795 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2795[2] {
-					yy2803 := &x.ObjectMeta
-					yy2803.CodecEncodeSelf(e)
+					yy2797 := &x.ObjectMeta
+					yy2797.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2795[2] {
+				if yyq2795[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2804 := &x.ObjectMeta
-					yy2804.CodecEncodeSelf(e)
+					yy2798 := &x.ObjectMeta
+					yy2798.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2795 || yy2arr2795 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy2806 := &x.Target
-				yy2806.CodecEncodeSelf(e)
+				yy2800 := &x.Target
+				yy2800.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("target"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy2807 := &x.Target
-				yy2807.CodecEncodeSelf(e)
+				yy2801 := &x.Target
+				yy2801.CodecEncodeSelf(e)
+			}
+			if yyr2795 || yy2arr2795 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2795[2] {
+					yym2803 := z.EncBinary()
+					_ = yym2803
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2795[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2804 := z.EncBinary()
+					_ = yym2804
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2795 || yy2arr2795 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2795[3] {
+					yym2806 := z.EncBinary()
+					_ = yym2806
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2795[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2807 := z.EncBinary()
+					_ = yym2807
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
 			}
 			if yyr2795 || yy2arr2795 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
@@ -35814,6 +35814,20 @@ func (x *Binding) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys2810 := string(yys2810Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2810 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv2811 := &x.ObjectMeta
+				yyv2811.CodecDecodeSelf(d)
+			}
+		case "target":
+			if r.TryDecodeAsNil() {
+				x.Target = ObjectReference{}
+			} else {
+				yyv2812 := &x.Target
+				yyv2812.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -35825,20 +35839,6 @@ func (x *Binding) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv2813 := &x.ObjectMeta
-				yyv2813.CodecDecodeSelf(d)
-			}
-		case "target":
-			if r.TryDecodeAsNil() {
-				x.Target = ObjectReference{}
-			} else {
-				yyv2814 := &x.Target
-				yyv2814.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2810)
@@ -35854,6 +35854,40 @@ func (x *Binding) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj2815 int
 	var yyb2815 bool
 	var yyhl2815 bool = l >= 0
+	yyj2815++
+	if yyhl2815 {
+		yyb2815 = yyj2815 > l
+	} else {
+		yyb2815 = r.CheckBreak()
+	}
+	if yyb2815 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv2816 := &x.ObjectMeta
+		yyv2816.CodecDecodeSelf(d)
+	}
+	yyj2815++
+	if yyhl2815 {
+		yyb2815 = yyj2815 > l
+	} else {
+		yyb2815 = r.CheckBreak()
+	}
+	if yyb2815 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Target = ObjectReference{}
+	} else {
+		yyv2817 := &x.Target
+		yyv2817.CodecDecodeSelf(d)
+	}
 	yyj2815++
 	if yyhl2815 {
 		yyb2815 = yyj2815 > l
@@ -35885,40 +35919,6 @@ func (x *Binding) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj2815++
-	if yyhl2815 {
-		yyb2815 = yyj2815 > l
-	} else {
-		yyb2815 = r.CheckBreak()
-	}
-	if yyb2815 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv2818 := &x.ObjectMeta
-		yyv2818.CodecDecodeSelf(d)
-	}
-	yyj2815++
-	if yyhl2815 {
-		yyb2815 = yyj2815 > l
-	} else {
-		yyb2815 = r.CheckBreak()
-	}
-	if yyb2815 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Target = ObjectReference{}
-	} else {
-		yyv2819 := &x.Target
-		yyv2819.CodecDecodeSelf(d)
 	}
 	for {
 		yyj2815++
@@ -35953,8 +35953,8 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2821 [3]bool
 			_, _, _ = yysep2821, yyq2821, yy2arr2821
 			const yyr2821 bool = false
-			yyq2821[0] = x.Kind != ""
-			yyq2821[1] = x.APIVersion != ""
+			yyq2821[1] = x.Kind != ""
+			yyq2821[2] = x.APIVersion != ""
 			var yynn2821 int
 			if yyr2821 || yy2arr2821 {
 				r.EncodeArrayStart(3)
@@ -35970,65 +35970,15 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2821 || yy2arr2821 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2821[0] {
-					yym2823 := z.EncBinary()
-					_ = yym2823
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+				if x.GracePeriodSeconds == nil {
+					r.EncodeNil()
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2821[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy2823 := *x.GracePeriodSeconds
 					yym2824 := z.EncBinary()
 					_ = yym2824
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2821 || yy2arr2821 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2821[1] {
-					yym2826 := z.EncBinary()
-					_ = yym2826
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2821[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2827 := z.EncBinary()
-					_ = yym2827
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2821 || yy2arr2821 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if x.GracePeriodSeconds == nil {
-					r.EncodeNil()
-				} else {
-					yy2829 := *x.GracePeriodSeconds
-					yym2830 := z.EncBinary()
-					_ = yym2830
-					if false {
-					} else {
-						r.EncodeInt(int64(yy2829))
+						r.EncodeInt(int64(yy2823))
 					}
 				}
 			} else {
@@ -36038,12 +35988,62 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.GracePeriodSeconds == nil {
 					r.EncodeNil()
 				} else {
-					yy2831 := *x.GracePeriodSeconds
+					yy2825 := *x.GracePeriodSeconds
+					yym2826 := z.EncBinary()
+					_ = yym2826
+					if false {
+					} else {
+						r.EncodeInt(int64(yy2825))
+					}
+				}
+			}
+			if yyr2821 || yy2arr2821 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2821[1] {
+					yym2828 := z.EncBinary()
+					_ = yym2828
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2821[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2829 := z.EncBinary()
+					_ = yym2829
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2821 || yy2arr2821 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2821[2] {
+					yym2831 := z.EncBinary()
+					_ = yym2831
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2821[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2832 := z.EncBinary()
 					_ = yym2832
 					if false {
 					} else {
-						r.EncodeInt(int64(yy2831))
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -36108,6 +36108,22 @@ func (x *DeleteOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys2835 := string(yys2835Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2835 {
+		case "gracePeriodSeconds":
+			if r.TryDecodeAsNil() {
+				if x.GracePeriodSeconds != nil {
+					x.GracePeriodSeconds = nil
+				}
+			} else {
+				if x.GracePeriodSeconds == nil {
+					x.GracePeriodSeconds = new(int64)
+				}
+				yym2837 := z.DecBinary()
+				_ = yym2837
+				if false {
+				} else {
+					*((*int64)(x.GracePeriodSeconds)) = int64(r.DecodeInt(64))
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -36119,22 +36135,6 @@ func (x *DeleteOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "gracePeriodSeconds":
-			if r.TryDecodeAsNil() {
-				if x.GracePeriodSeconds != nil {
-					x.GracePeriodSeconds = nil
-				}
-			} else {
-				if x.GracePeriodSeconds == nil {
-					x.GracePeriodSeconds = new(int64)
-				}
-				yym2839 := z.DecBinary()
-				_ = yym2839
-				if false {
-				} else {
-					*((*int64)(x.GracePeriodSeconds)) = int64(r.DecodeInt(64))
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2835)
@@ -36150,6 +36150,32 @@ func (x *DeleteOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj2840 int
 	var yyb2840 bool
 	var yyhl2840 bool = l >= 0
+	yyj2840++
+	if yyhl2840 {
+		yyb2840 = yyj2840 > l
+	} else {
+		yyb2840 = r.CheckBreak()
+	}
+	if yyb2840 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		if x.GracePeriodSeconds != nil {
+			x.GracePeriodSeconds = nil
+		}
+	} else {
+		if x.GracePeriodSeconds == nil {
+			x.GracePeriodSeconds = new(int64)
+		}
+		yym2842 := z.DecBinary()
+		_ = yym2842
+		if false {
+		} else {
+			*((*int64)(x.GracePeriodSeconds)) = int64(r.DecodeInt(64))
+		}
+	}
 	yyj2840++
 	if yyhl2840 {
 		yyb2840 = yyj2840 > l
@@ -36181,32 +36207,6 @@ func (x *DeleteOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj2840++
-	if yyhl2840 {
-		yyb2840 = yyj2840 > l
-	} else {
-		yyb2840 = r.CheckBreak()
-	}
-	if yyb2840 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		if x.GracePeriodSeconds != nil {
-			x.GracePeriodSeconds = nil
-		}
-	} else {
-		if x.GracePeriodSeconds == nil {
-			x.GracePeriodSeconds = new(int64)
-		}
-		yym2844 := z.DecBinary()
-		_ = yym2844
-		if false {
-		} else {
-			*((*int64)(x.GracePeriodSeconds)) = int64(r.DecodeInt(64))
-		}
 	}
 	for {
 		yyj2840++
@@ -36241,8 +36241,8 @@ func (x *ExportOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2846 [4]bool
 			_, _, _ = yysep2846, yyq2846, yy2arr2846
 			const yyr2846 bool = false
-			yyq2846[0] = x.Kind != ""
-			yyq2846[1] = x.APIVersion != ""
+			yyq2846[2] = x.Kind != ""
+			yyq2846[3] = x.APIVersion != ""
 			var yynn2846 int
 			if yyr2846 || yy2arr2846 {
 				r.EncodeArrayStart(4)
@@ -36258,58 +36258,8 @@ func (x *ExportOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2846 || yy2arr2846 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2846[0] {
-					yym2848 := z.EncBinary()
-					_ = yym2848
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2846[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2849 := z.EncBinary()
-					_ = yym2849
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2846 || yy2arr2846 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2846[1] {
-					yym2851 := z.EncBinary()
-					_ = yym2851
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2846[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2852 := z.EncBinary()
-					_ = yym2852
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2846 || yy2arr2846 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym2854 := z.EncBinary()
-				_ = yym2854
+				yym2848 := z.EncBinary()
+				_ = yym2848
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Export))
@@ -36318,8 +36268,8 @@ func (x *ExportOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("export"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym2855 := z.EncBinary()
-				_ = yym2855
+				yym2849 := z.EncBinary()
+				_ = yym2849
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Export))
@@ -36327,8 +36277,8 @@ func (x *ExportOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2846 || yy2arr2846 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym2857 := z.EncBinary()
-				_ = yym2857
+				yym2851 := z.EncBinary()
+				_ = yym2851
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Exact))
@@ -36337,11 +36287,61 @@ func (x *ExportOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("exact"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym2858 := z.EncBinary()
-				_ = yym2858
+				yym2852 := z.EncBinary()
+				_ = yym2852
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Exact))
+				}
+			}
+			if yyr2846 || yy2arr2846 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2846[2] {
+					yym2854 := z.EncBinary()
+					_ = yym2854
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2846[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2855 := z.EncBinary()
+					_ = yym2855
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2846 || yy2arr2846 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2846[3] {
+					yym2857 := z.EncBinary()
+					_ = yym2857
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2846[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2858 := z.EncBinary()
+					_ = yym2858
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr2846 || yy2arr2846 {
@@ -36405,18 +36405,6 @@ func (x *ExportOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys2861 := string(yys2861Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2861 {
-		case "kind":
-			if r.TryDecodeAsNil() {
-				x.Kind = ""
-			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
-			}
 		case "export":
 			if r.TryDecodeAsNil() {
 				x.Export = false
@@ -36428,6 +36416,18 @@ func (x *ExportOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Exact = false
 			} else {
 				x.Exact = bool(r.DecodeBool())
+			}
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2861)
@@ -36443,38 +36443,6 @@ func (x *ExportOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj2866 int
 	var yyb2866 bool
 	var yyhl2866 bool = l >= 0
-	yyj2866++
-	if yyhl2866 {
-		yyb2866 = yyj2866 > l
-	} else {
-		yyb2866 = r.CheckBreak()
-	}
-	if yyb2866 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Kind = ""
-	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj2866++
-	if yyhl2866 {
-		yyb2866 = yyj2866 > l
-	} else {
-		yyb2866 = r.CheckBreak()
-	}
-	if yyb2866 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
-	}
 	yyj2866++
 	if yyhl2866 {
 		yyb2866 = yyj2866 > l
@@ -36506,6 +36474,38 @@ func (x *ExportOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Exact = false
 	} else {
 		x.Exact = bool(r.DecodeBool())
+	}
+	yyj2866++
+	if yyhl2866 {
+		yyb2866 = yyj2866 > l
+	} else {
+		yyb2866 = r.CheckBreak()
+	}
+	if yyb2866 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj2866++
+	if yyhl2866 {
+		yyb2866 = yyj2866 > l
+	} else {
+		yyb2866 = r.CheckBreak()
+	}
+	if yyb2866 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
 	}
 	for {
 		yyj2866++
@@ -36540,8 +36540,8 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2872 [7]bool
 			_, _, _ = yysep2872, yyq2872, yy2arr2872
 			const yyr2872 bool = false
-			yyq2872[0] = x.Kind != ""
-			yyq2872[1] = x.APIVersion != ""
+			yyq2872[5] = x.Kind != ""
+			yyq2872[6] = x.APIVersion != ""
 			var yynn2872 int
 			if yyr2872 || yy2arr2872 {
 				r.EncodeArrayStart(7)
@@ -36557,61 +36557,11 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2872 || yy2arr2872 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2872[0] {
-					yym2874 := z.EncBinary()
-					_ = yym2874
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2872[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2875 := z.EncBinary()
-					_ = yym2875
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2872 || yy2arr2872 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2872[1] {
-					yym2877 := z.EncBinary()
-					_ = yym2877
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2872[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2878 := z.EncBinary()
-					_ = yym2878
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2872 || yy2arr2872 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.LabelSelector == nil {
 					r.EncodeNil()
 				} else {
-					yym2880 := z.EncBinary()
-					_ = yym2880
+					yym2874 := z.EncBinary()
+					_ = yym2874
 					if false {
 					} else if z.HasExtensions() && z.EncExt(x.LabelSelector) {
 					} else {
@@ -36625,8 +36575,8 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.LabelSelector == nil {
 					r.EncodeNil()
 				} else {
-					yym2881 := z.EncBinary()
-					_ = yym2881
+					yym2875 := z.EncBinary()
+					_ = yym2875
 					if false {
 					} else if z.HasExtensions() && z.EncExt(x.LabelSelector) {
 					} else {
@@ -36639,8 +36589,8 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.FieldSelector == nil {
 					r.EncodeNil()
 				} else {
-					yym2883 := z.EncBinary()
-					_ = yym2883
+					yym2877 := z.EncBinary()
+					_ = yym2877
 					if false {
 					} else if z.HasExtensions() && z.EncExt(x.FieldSelector) {
 					} else {
@@ -36654,8 +36604,8 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.FieldSelector == nil {
 					r.EncodeNil()
 				} else {
-					yym2884 := z.EncBinary()
-					_ = yym2884
+					yym2878 := z.EncBinary()
+					_ = yym2878
 					if false {
 					} else if z.HasExtensions() && z.EncExt(x.FieldSelector) {
 					} else {
@@ -36665,8 +36615,8 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2872 || yy2arr2872 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym2886 := z.EncBinary()
-				_ = yym2886
+				yym2880 := z.EncBinary()
+				_ = yym2880
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Watch))
@@ -36675,8 +36625,8 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Watch"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym2887 := z.EncBinary()
-				_ = yym2887
+				yym2881 := z.EncBinary()
+				_ = yym2881
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Watch))
@@ -36684,8 +36634,8 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2872 || yy2arr2872 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym2889 := z.EncBinary()
-				_ = yym2889
+				yym2883 := z.EncBinary()
+				_ = yym2883
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
@@ -36694,8 +36644,8 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("ResourceVersion"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym2890 := z.EncBinary()
-				_ = yym2890
+				yym2884 := z.EncBinary()
+				_ = yym2884
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
@@ -36706,12 +36656,12 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.TimeoutSeconds == nil {
 					r.EncodeNil()
 				} else {
-					yy2892 := *x.TimeoutSeconds
-					yym2893 := z.EncBinary()
-					_ = yym2893
+					yy2886 := *x.TimeoutSeconds
+					yym2887 := z.EncBinary()
+					_ = yym2887
 					if false {
 					} else {
-						r.EncodeInt(int64(yy2892))
+						r.EncodeInt(int64(yy2886))
 					}
 				}
 			} else {
@@ -36721,12 +36671,62 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.TimeoutSeconds == nil {
 					r.EncodeNil()
 				} else {
-					yy2894 := *x.TimeoutSeconds
+					yy2888 := *x.TimeoutSeconds
+					yym2889 := z.EncBinary()
+					_ = yym2889
+					if false {
+					} else {
+						r.EncodeInt(int64(yy2888))
+					}
+				}
+			}
+			if yyr2872 || yy2arr2872 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2872[5] {
+					yym2891 := z.EncBinary()
+					_ = yym2891
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2872[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2892 := z.EncBinary()
+					_ = yym2892
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2872 || yy2arr2872 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2872[6] {
+					yym2894 := z.EncBinary()
+					_ = yym2894
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2872[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2895 := z.EncBinary()
 					_ = yym2895
 					if false {
 					} else {
-						r.EncodeInt(int64(yy2894))
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -36791,42 +36791,30 @@ func (x *ListOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys2898 := string(yys2898Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2898 {
-		case "kind":
-			if r.TryDecodeAsNil() {
-				x.Kind = ""
-			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
-			}
 		case "LabelSelector":
 			if r.TryDecodeAsNil() {
 				x.LabelSelector = nil
 			} else {
-				yyv2901 := &x.LabelSelector
-				yym2902 := z.DecBinary()
-				_ = yym2902
+				yyv2899 := &x.LabelSelector
+				yym2900 := z.DecBinary()
+				_ = yym2900
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2901) {
+				} else if z.HasExtensions() && z.DecExt(yyv2899) {
 				} else {
-					z.DecFallback(yyv2901, true)
+					z.DecFallback(yyv2899, true)
 				}
 			}
 		case "FieldSelector":
 			if r.TryDecodeAsNil() {
 				x.FieldSelector = nil
 			} else {
-				yyv2903 := &x.FieldSelector
-				yym2904 := z.DecBinary()
-				_ = yym2904
+				yyv2901 := &x.FieldSelector
+				yym2902 := z.DecBinary()
+				_ = yym2902
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2903) {
+				} else if z.HasExtensions() && z.DecExt(yyv2901) {
 				} else {
-					z.DecFallback(yyv2903, true)
+					z.DecFallback(yyv2901, true)
 				}
 			}
 		case "Watch":
@@ -36850,12 +36838,24 @@ func (x *ListOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TimeoutSeconds == nil {
 					x.TimeoutSeconds = new(int64)
 				}
-				yym2908 := z.DecBinary()
-				_ = yym2908
+				yym2906 := z.DecBinary()
+				_ = yym2906
 				if false {
 				} else {
 					*((*int64)(x.TimeoutSeconds)) = int64(r.DecodeInt(64))
 				}
+			}
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2898)
@@ -36883,47 +36883,15 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.Kind = ""
-	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj2909++
-	if yyhl2909 {
-		yyb2909 = yyj2909 > l
-	} else {
-		yyb2909 = r.CheckBreak()
-	}
-	if yyb2909 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
-	}
-	yyj2909++
-	if yyhl2909 {
-		yyb2909 = yyj2909 > l
-	} else {
-		yyb2909 = r.CheckBreak()
-	}
-	if yyb2909 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
 		x.LabelSelector = nil
 	} else {
-		yyv2912 := &x.LabelSelector
-		yym2913 := z.DecBinary()
-		_ = yym2913
+		yyv2910 := &x.LabelSelector
+		yym2911 := z.DecBinary()
+		_ = yym2911
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2912) {
+		} else if z.HasExtensions() && z.DecExt(yyv2910) {
 		} else {
-			z.DecFallback(yyv2912, true)
+			z.DecFallback(yyv2910, true)
 		}
 	}
 	yyj2909++
@@ -36940,13 +36908,13 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.FieldSelector = nil
 	} else {
-		yyv2914 := &x.FieldSelector
-		yym2915 := z.DecBinary()
-		_ = yym2915
+		yyv2912 := &x.FieldSelector
+		yym2913 := z.DecBinary()
+		_ = yym2913
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2914) {
+		} else if z.HasExtensions() && z.DecExt(yyv2912) {
 		} else {
-			z.DecFallback(yyv2914, true)
+			z.DecFallback(yyv2912, true)
 		}
 	}
 	yyj2909++
@@ -37000,12 +36968,44 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TimeoutSeconds == nil {
 			x.TimeoutSeconds = new(int64)
 		}
-		yym2919 := z.DecBinary()
-		_ = yym2919
+		yym2917 := z.DecBinary()
+		_ = yym2917
 		if false {
 		} else {
 			*((*int64)(x.TimeoutSeconds)) = int64(r.DecodeInt(64))
 		}
+	}
+	yyj2909++
+	if yyhl2909 {
+		yyb2909 = yyj2909 > l
+	} else {
+		yyb2909 = r.CheckBreak()
+	}
+	if yyb2909 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj2909++
+	if yyhl2909 {
+		yyb2909 = yyj2909 > l
+	} else {
+		yyb2909 = r.CheckBreak()
+	}
+	if yyb2909 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
 	}
 	for {
 		yyj2909++
@@ -37040,8 +37040,8 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2921 [10]bool
 			_, _, _ = yysep2921, yyq2921, yy2arr2921
 			const yyr2921 bool = false
-			yyq2921[0] = x.Kind != ""
-			yyq2921[1] = x.APIVersion != ""
+			yyq2921[8] = x.Kind != ""
+			yyq2921[9] = x.APIVersion != ""
 			var yynn2921 int
 			if yyr2921 || yy2arr2921 {
 				r.EncodeArrayStart(10)
@@ -37057,58 +37057,8 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2921 || yy2arr2921 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2921[0] {
-					yym2923 := z.EncBinary()
-					_ = yym2923
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2921[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2924 := z.EncBinary()
-					_ = yym2924
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2921 || yy2arr2921 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2921[1] {
-					yym2926 := z.EncBinary()
-					_ = yym2926
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2921[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2927 := z.EncBinary()
-					_ = yym2927
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2921 || yy2arr2921 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym2929 := z.EncBinary()
-				_ = yym2929
+				yym2923 := z.EncBinary()
+				_ = yym2923
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Container))
@@ -37117,8 +37067,8 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Container"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym2930 := z.EncBinary()
-				_ = yym2930
+				yym2924 := z.EncBinary()
+				_ = yym2924
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Container))
@@ -37126,8 +37076,8 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2921 || yy2arr2921 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym2932 := z.EncBinary()
-				_ = yym2932
+				yym2926 := z.EncBinary()
+				_ = yym2926
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Follow))
@@ -37136,8 +37086,8 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Follow"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym2933 := z.EncBinary()
-				_ = yym2933
+				yym2927 := z.EncBinary()
+				_ = yym2927
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Follow))
@@ -37145,8 +37095,8 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2921 || yy2arr2921 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym2935 := z.EncBinary()
-				_ = yym2935
+				yym2929 := z.EncBinary()
+				_ = yym2929
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Previous))
@@ -37155,8 +37105,8 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Previous"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym2936 := z.EncBinary()
-				_ = yym2936
+				yym2930 := z.EncBinary()
+				_ = yym2930
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Previous))
@@ -37167,12 +37117,12 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.SinceSeconds == nil {
 					r.EncodeNil()
 				} else {
-					yy2938 := *x.SinceSeconds
-					yym2939 := z.EncBinary()
-					_ = yym2939
+					yy2932 := *x.SinceSeconds
+					yym2933 := z.EncBinary()
+					_ = yym2933
 					if false {
 					} else {
-						r.EncodeInt(int64(yy2938))
+						r.EncodeInt(int64(yy2932))
 					}
 				}
 			} else {
@@ -37182,12 +37132,12 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.SinceSeconds == nil {
 					r.EncodeNil()
 				} else {
-					yy2940 := *x.SinceSeconds
-					yym2941 := z.EncBinary()
-					_ = yym2941
+					yy2934 := *x.SinceSeconds
+					yym2935 := z.EncBinary()
+					_ = yym2935
 					if false {
 					} else {
-						r.EncodeInt(int64(yy2940))
+						r.EncodeInt(int64(yy2934))
 					}
 				}
 			}
@@ -37196,13 +37146,13 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.SinceTime == nil {
 					r.EncodeNil()
 				} else {
-					yym2943 := z.EncBinary()
-					_ = yym2943
+					yym2937 := z.EncBinary()
+					_ = yym2937
 					if false {
 					} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
-					} else if yym2943 {
+					} else if yym2937 {
 						z.EncBinaryMarshal(x.SinceTime)
-					} else if !yym2943 && z.IsJSONHandle() {
+					} else if !yym2937 && z.IsJSONHandle() {
 						z.EncJSONMarshal(x.SinceTime)
 					} else {
 						z.EncFallback(x.SinceTime)
@@ -37215,13 +37165,13 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.SinceTime == nil {
 					r.EncodeNil()
 				} else {
-					yym2944 := z.EncBinary()
-					_ = yym2944
+					yym2938 := z.EncBinary()
+					_ = yym2938
 					if false {
 					} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
-					} else if yym2944 {
+					} else if yym2938 {
 						z.EncBinaryMarshal(x.SinceTime)
-					} else if !yym2944 && z.IsJSONHandle() {
+					} else if !yym2938 && z.IsJSONHandle() {
 						z.EncJSONMarshal(x.SinceTime)
 					} else {
 						z.EncFallback(x.SinceTime)
@@ -37230,8 +37180,8 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2921 || yy2arr2921 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym2946 := z.EncBinary()
-				_ = yym2946
+				yym2940 := z.EncBinary()
+				_ = yym2940
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Timestamps))
@@ -37240,8 +37190,8 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Timestamps"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym2947 := z.EncBinary()
-				_ = yym2947
+				yym2941 := z.EncBinary()
+				_ = yym2941
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Timestamps))
@@ -37252,12 +37202,12 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.TailLines == nil {
 					r.EncodeNil()
 				} else {
-					yy2949 := *x.TailLines
-					yym2950 := z.EncBinary()
-					_ = yym2950
+					yy2943 := *x.TailLines
+					yym2944 := z.EncBinary()
+					_ = yym2944
 					if false {
 					} else {
-						r.EncodeInt(int64(yy2949))
+						r.EncodeInt(int64(yy2943))
 					}
 				}
 			} else {
@@ -37267,12 +37217,12 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.TailLines == nil {
 					r.EncodeNil()
 				} else {
-					yy2951 := *x.TailLines
-					yym2952 := z.EncBinary()
-					_ = yym2952
+					yy2945 := *x.TailLines
+					yym2946 := z.EncBinary()
+					_ = yym2946
 					if false {
 					} else {
-						r.EncodeInt(int64(yy2951))
+						r.EncodeInt(int64(yy2945))
 					}
 				}
 			}
@@ -37281,12 +37231,12 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.LimitBytes == nil {
 					r.EncodeNil()
 				} else {
-					yy2954 := *x.LimitBytes
-					yym2955 := z.EncBinary()
-					_ = yym2955
+					yy2948 := *x.LimitBytes
+					yym2949 := z.EncBinary()
+					_ = yym2949
 					if false {
 					} else {
-						r.EncodeInt(int64(yy2954))
+						r.EncodeInt(int64(yy2948))
 					}
 				}
 			} else {
@@ -37296,12 +37246,62 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.LimitBytes == nil {
 					r.EncodeNil()
 				} else {
-					yy2956 := *x.LimitBytes
+					yy2950 := *x.LimitBytes
+					yym2951 := z.EncBinary()
+					_ = yym2951
+					if false {
+					} else {
+						r.EncodeInt(int64(yy2950))
+					}
+				}
+			}
+			if yyr2921 || yy2arr2921 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2921[8] {
+					yym2953 := z.EncBinary()
+					_ = yym2953
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2921[8] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2954 := z.EncBinary()
+					_ = yym2954
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2921 || yy2arr2921 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2921[9] {
+					yym2956 := z.EncBinary()
+					_ = yym2956
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2921[9] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2957 := z.EncBinary()
 					_ = yym2957
 					if false {
 					} else {
-						r.EncodeInt(int64(yy2956))
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -37366,18 +37366,6 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys2960 := string(yys2960Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2960 {
-		case "kind":
-			if r.TryDecodeAsNil() {
-				x.Kind = ""
-			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
-			}
 		case "Container":
 			if r.TryDecodeAsNil() {
 				x.Container = ""
@@ -37405,8 +37393,8 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.SinceSeconds == nil {
 					x.SinceSeconds = new(int64)
 				}
-				yym2967 := z.DecBinary()
-				_ = yym2967
+				yym2965 := z.DecBinary()
+				_ = yym2965
 				if false {
 				} else {
 					*((*int64)(x.SinceSeconds)) = int64(r.DecodeInt(64))
@@ -37421,13 +37409,13 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.SinceTime == nil {
 					x.SinceTime = new(pkg2_unversioned.Time)
 				}
-				yym2969 := z.DecBinary()
-				_ = yym2969
+				yym2967 := z.DecBinary()
+				_ = yym2967
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
-				} else if yym2969 {
+				} else if yym2967 {
 					z.DecBinaryUnmarshal(x.SinceTime)
-				} else if !yym2969 && z.IsJSONHandle() {
+				} else if !yym2967 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.SinceTime)
 				} else {
 					z.DecFallback(x.SinceTime, false)
@@ -37448,8 +37436,8 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TailLines == nil {
 					x.TailLines = new(int64)
 				}
-				yym2972 := z.DecBinary()
-				_ = yym2972
+				yym2970 := z.DecBinary()
+				_ = yym2970
 				if false {
 				} else {
 					*((*int64)(x.TailLines)) = int64(r.DecodeInt(64))
@@ -37464,12 +37452,24 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.LimitBytes == nil {
 					x.LimitBytes = new(int64)
 				}
-				yym2974 := z.DecBinary()
-				_ = yym2974
+				yym2972 := z.DecBinary()
+				_ = yym2972
 				if false {
 				} else {
 					*((*int64)(x.LimitBytes)) = int64(r.DecodeInt(64))
 				}
+			}
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2960)
@@ -37485,38 +37485,6 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj2975 int
 	var yyb2975 bool
 	var yyhl2975 bool = l >= 0
-	yyj2975++
-	if yyhl2975 {
-		yyb2975 = yyj2975 > l
-	} else {
-		yyb2975 = r.CheckBreak()
-	}
-	if yyb2975 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Kind = ""
-	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj2975++
-	if yyhl2975 {
-		yyb2975 = yyj2975 > l
-	} else {
-		yyb2975 = r.CheckBreak()
-	}
-	if yyb2975 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
-	}
 	yyj2975++
 	if yyhl2975 {
 		yyb2975 = yyj2975 > l
@@ -37584,8 +37552,8 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.SinceSeconds == nil {
 			x.SinceSeconds = new(int64)
 		}
-		yym2982 := z.DecBinary()
-		_ = yym2982
+		yym2980 := z.DecBinary()
+		_ = yym2980
 		if false {
 		} else {
 			*((*int64)(x.SinceSeconds)) = int64(r.DecodeInt(64))
@@ -37610,13 +37578,13 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.SinceTime == nil {
 			x.SinceTime = new(pkg2_unversioned.Time)
 		}
-		yym2984 := z.DecBinary()
-		_ = yym2984
+		yym2982 := z.DecBinary()
+		_ = yym2982
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
-		} else if yym2984 {
+		} else if yym2982 {
 			z.DecBinaryUnmarshal(x.SinceTime)
-		} else if !yym2984 && z.IsJSONHandle() {
+		} else if !yym2982 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.SinceTime)
 		} else {
 			z.DecFallback(x.SinceTime, false)
@@ -37657,8 +37625,8 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TailLines == nil {
 			x.TailLines = new(int64)
 		}
-		yym2987 := z.DecBinary()
-		_ = yym2987
+		yym2985 := z.DecBinary()
+		_ = yym2985
 		if false {
 		} else {
 			*((*int64)(x.TailLines)) = int64(r.DecodeInt(64))
@@ -37683,12 +37651,44 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.LimitBytes == nil {
 			x.LimitBytes = new(int64)
 		}
-		yym2989 := z.DecBinary()
-		_ = yym2989
+		yym2987 := z.DecBinary()
+		_ = yym2987
 		if false {
 		} else {
 			*((*int64)(x.LimitBytes)) = int64(r.DecodeInt(64))
 		}
+	}
+	yyj2975++
+	if yyhl2975 {
+		yyb2975 = yyj2975 > l
+	} else {
+		yyb2975 = r.CheckBreak()
+	}
+	if yyb2975 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj2975++
+	if yyhl2975 {
+		yyb2975 = yyj2975 > l
+	} else {
+		yyb2975 = r.CheckBreak()
+	}
+	if yyb2975 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
 	}
 	for {
 		yyj2975++
@@ -37723,13 +37723,13 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2991 [7]bool
 			_, _, _ = yysep2991, yyq2991, yy2arr2991
 			const yyr2991 bool = false
-			yyq2991[0] = x.Kind != ""
-			yyq2991[1] = x.APIVersion != ""
-			yyq2991[2] = x.Stdin != false
-			yyq2991[3] = x.Stdout != false
-			yyq2991[4] = x.Stderr != false
-			yyq2991[5] = x.TTY != false
-			yyq2991[6] = x.Container != ""
+			yyq2991[0] = x.Stdin != false
+			yyq2991[1] = x.Stdout != false
+			yyq2991[2] = x.Stderr != false
+			yyq2991[3] = x.TTY != false
+			yyq2991[4] = x.Container != ""
+			yyq2991[5] = x.Kind != ""
+			yyq2991[6] = x.APIVersion != ""
 			var yynn2991 int
 			if yyr2991 || yy2arr2991 {
 				r.EncodeArrayStart(7)
@@ -37750,21 +37750,21 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym2993
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+						r.EncodeBool(bool(x.Stdin))
 					}
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeBool(false)
 				}
 			} else {
 				if yyq2991[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("stdin"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2994 := z.EncBinary()
 					_ = yym2994
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+						r.EncodeBool(bool(x.Stdin))
 					}
 				}
 			}
@@ -37775,21 +37775,21 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym2996
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeBool(bool(x.Stdout))
 					}
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeBool(false)
 				}
 			} else {
 				if yyq2991[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("stdout"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2997 := z.EncBinary()
 					_ = yym2997
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeBool(bool(x.Stdout))
 					}
 				}
 			}
@@ -37800,7 +37800,7 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym2999
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stdin))
+						r.EncodeBool(bool(x.Stderr))
 					}
 				} else {
 					r.EncodeBool(false)
@@ -37808,13 +37808,13 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq2991[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("stdin"))
+					r.EncodeString(codecSelferC_UTF81234, string("stderr"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3000 := z.EncBinary()
 					_ = yym3000
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stdin))
+						r.EncodeBool(bool(x.Stderr))
 					}
 				}
 			}
@@ -37825,7 +37825,7 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym3002
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stdout))
+						r.EncodeBool(bool(x.TTY))
 					}
 				} else {
 					r.EncodeBool(false)
@@ -37833,13 +37833,13 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq2991[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("stdout"))
+					r.EncodeString(codecSelferC_UTF81234, string("tty"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3003 := z.EncBinary()
 					_ = yym3003
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stdout))
+						r.EncodeBool(bool(x.TTY))
 					}
 				}
 			}
@@ -37850,21 +37850,21 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym3005
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stderr))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
 					}
 				} else {
-					r.EncodeBool(false)
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq2991[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("stderr"))
+					r.EncodeString(codecSelferC_UTF81234, string("container"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3006 := z.EncBinary()
 					_ = yym3006
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stderr))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
 					}
 				}
 			}
@@ -37875,21 +37875,21 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym3008
 					if false {
 					} else {
-						r.EncodeBool(bool(x.TTY))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				} else {
-					r.EncodeBool(false)
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq2991[5] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("tty"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3009 := z.EncBinary()
 					_ = yym3009
 					if false {
 					} else {
-						r.EncodeBool(bool(x.TTY))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
@@ -37900,7 +37900,7 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym3011
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -37908,13 +37908,13 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq2991[6] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("container"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3012 := z.EncBinary()
 					_ = yym3012
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -37979,18 +37979,6 @@ func (x *PodAttachOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys3015 := string(yys3015Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3015 {
-		case "kind":
-			if r.TryDecodeAsNil() {
-				x.Kind = ""
-			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
-			}
 		case "stdin":
 			if r.TryDecodeAsNil() {
 				x.Stdin = false
@@ -38021,6 +38009,18 @@ func (x *PodAttachOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			} else {
 				x.Container = string(r.DecodeString())
 			}
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
+			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3015)
 		} // end switch yys3015
@@ -38035,38 +38035,6 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	var yyj3023 int
 	var yyb3023 bool
 	var yyhl3023 bool = l >= 0
-	yyj3023++
-	if yyhl3023 {
-		yyb3023 = yyj3023 > l
-	} else {
-		yyb3023 = r.CheckBreak()
-	}
-	if yyb3023 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Kind = ""
-	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj3023++
-	if yyhl3023 {
-		yyb3023 = yyj3023 > l
-	} else {
-		yyb3023 = r.CheckBreak()
-	}
-	if yyb3023 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
-	}
 	yyj3023++
 	if yyhl3023 {
 		yyb3023 = yyj3023 > l
@@ -38147,6 +38115,38 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Container = string(r.DecodeString())
 	}
+	yyj3023++
+	if yyhl3023 {
+		yyb3023 = yyj3023 > l
+	} else {
+		yyb3023 = r.CheckBreak()
+	}
+	if yyb3023 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj3023++
+	if yyhl3023 {
+		yyb3023 = yyj3023 > l
+	} else {
+		yyb3023 = r.CheckBreak()
+	}
+	if yyb3023 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
+	}
 	for {
 		yyj3023++
 		if yyhl3023 {
@@ -38180,8 +38180,8 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3032 [8]bool
 			_, _, _ = yysep3032, yyq3032, yy2arr3032
 			const yyr3032 bool = false
-			yyq3032[0] = x.Kind != ""
-			yyq3032[1] = x.APIVersion != ""
+			yyq3032[6] = x.Kind != ""
+			yyq3032[7] = x.APIVersion != ""
 			var yynn3032 int
 			if yyr3032 || yy2arr3032 {
 				r.EncodeArrayStart(8)
@@ -38197,58 +38197,8 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr3032 || yy2arr3032 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3032[0] {
-					yym3034 := z.EncBinary()
-					_ = yym3034
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3032[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3035 := z.EncBinary()
-					_ = yym3035
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3032 || yy2arr3032 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3032[1] {
-					yym3037 := z.EncBinary()
-					_ = yym3037
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3032[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3038 := z.EncBinary()
-					_ = yym3038
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3032 || yy2arr3032 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym3040 := z.EncBinary()
-				_ = yym3040
+				yym3034 := z.EncBinary()
+				_ = yym3034
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Stdin))
@@ -38257,8 +38207,8 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Stdin"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym3041 := z.EncBinary()
-				_ = yym3041
+				yym3035 := z.EncBinary()
+				_ = yym3035
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Stdin))
@@ -38266,8 +38216,8 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr3032 || yy2arr3032 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym3043 := z.EncBinary()
-				_ = yym3043
+				yym3037 := z.EncBinary()
+				_ = yym3037
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Stdout))
@@ -38276,8 +38226,8 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Stdout"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym3044 := z.EncBinary()
-				_ = yym3044
+				yym3038 := z.EncBinary()
+				_ = yym3038
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Stdout))
@@ -38285,8 +38235,8 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr3032 || yy2arr3032 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym3046 := z.EncBinary()
-				_ = yym3046
+				yym3040 := z.EncBinary()
+				_ = yym3040
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Stderr))
@@ -38295,8 +38245,8 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Stderr"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym3047 := z.EncBinary()
-				_ = yym3047
+				yym3041 := z.EncBinary()
+				_ = yym3041
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Stderr))
@@ -38304,8 +38254,8 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr3032 || yy2arr3032 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym3049 := z.EncBinary()
-				_ = yym3049
+				yym3043 := z.EncBinary()
+				_ = yym3043
 				if false {
 				} else {
 					r.EncodeBool(bool(x.TTY))
@@ -38314,8 +38264,8 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("TTY"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym3050 := z.EncBinary()
-				_ = yym3050
+				yym3044 := z.EncBinary()
+				_ = yym3044
 				if false {
 				} else {
 					r.EncodeBool(bool(x.TTY))
@@ -38323,8 +38273,8 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr3032 || yy2arr3032 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym3052 := z.EncBinary()
-				_ = yym3052
+				yym3046 := z.EncBinary()
+				_ = yym3046
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Container))
@@ -38333,8 +38283,8 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Container"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym3053 := z.EncBinary()
-				_ = yym3053
+				yym3047 := z.EncBinary()
+				_ = yym3047
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Container))
@@ -38345,8 +38295,8 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Command == nil {
 					r.EncodeNil()
 				} else {
-					yym3055 := z.EncBinary()
-					_ = yym3055
+					yym3049 := z.EncBinary()
+					_ = yym3049
 					if false {
 					} else {
 						z.F.EncSliceStringV(x.Command, false, e)
@@ -38359,11 +38309,61 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Command == nil {
 					r.EncodeNil()
 				} else {
+					yym3050 := z.EncBinary()
+					_ = yym3050
+					if false {
+					} else {
+						z.F.EncSliceStringV(x.Command, false, e)
+					}
+				}
+			}
+			if yyr3032 || yy2arr3032 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3032[6] {
+					yym3052 := z.EncBinary()
+					_ = yym3052
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3032[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3053 := z.EncBinary()
+					_ = yym3053
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3032 || yy2arr3032 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3032[7] {
+					yym3055 := z.EncBinary()
+					_ = yym3055
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3032[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3056 := z.EncBinary()
 					_ = yym3056
 					if false {
 					} else {
-						z.F.EncSliceStringV(x.Command, false, e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -38428,18 +38428,6 @@ func (x *PodExecOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys3059 := string(yys3059Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3059 {
-		case "kind":
-			if r.TryDecodeAsNil() {
-				x.Kind = ""
-			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
-			}
 		case "Stdin":
 			if r.TryDecodeAsNil() {
 				x.Stdin = false
@@ -38474,13 +38462,25 @@ func (x *PodExecOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Command = nil
 			} else {
-				yyv3067 := &x.Command
-				yym3068 := z.DecBinary()
-				_ = yym3068
+				yyv3065 := &x.Command
+				yym3066 := z.DecBinary()
+				_ = yym3066
 				if false {
 				} else {
-					z.F.DecSliceStringX(yyv3067, false, d)
+					z.F.DecSliceStringX(yyv3065, false, d)
 				}
+			}
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3059)
@@ -38496,38 +38496,6 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj3069 int
 	var yyb3069 bool
 	var yyhl3069 bool = l >= 0
-	yyj3069++
-	if yyhl3069 {
-		yyb3069 = yyj3069 > l
-	} else {
-		yyb3069 = r.CheckBreak()
-	}
-	if yyb3069 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Kind = ""
-	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj3069++
-	if yyhl3069 {
-		yyb3069 = yyj3069 > l
-	} else {
-		yyb3069 = r.CheckBreak()
-	}
-	if yyb3069 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
-	}
 	yyj3069++
 	if yyhl3069 {
 		yyb3069 = yyj3069 > l
@@ -38622,13 +38590,45 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Command = nil
 	} else {
-		yyv3077 := &x.Command
-		yym3078 := z.DecBinary()
-		_ = yym3078
+		yyv3075 := &x.Command
+		yym3076 := z.DecBinary()
+		_ = yym3076
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv3077, false, d)
+			z.F.DecSliceStringX(yyv3075, false, d)
 		}
+	}
+	yyj3069++
+	if yyhl3069 {
+		yyb3069 = yyj3069 > l
+	} else {
+		yyb3069 = r.CheckBreak()
+	}
+	if yyb3069 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj3069++
+	if yyhl3069 {
+		yyb3069 = yyj3069 > l
+	} else {
+		yyb3069 = r.CheckBreak()
+	}
+	if yyb3069 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
 	}
 	for {
 		yyj3069++
@@ -38663,8 +38663,8 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3080 [3]bool
 			_, _, _ = yysep3080, yyq3080, yy2arr3080
 			const yyr3080 bool = false
-			yyq3080[0] = x.Kind != ""
-			yyq3080[1] = x.APIVersion != ""
+			yyq3080[1] = x.Kind != ""
+			yyq3080[2] = x.APIVersion != ""
 			var yynn3080 int
 			if yyr3080 || yy2arr3080 {
 				r.EncodeArrayStart(3)
@@ -38680,27 +38680,21 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr3080 || yy2arr3080 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3080[0] {
-					yym3082 := z.EncBinary()
-					_ = yym3082
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+				yym3082 := z.EncBinary()
+				_ = yym3082
+				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 				}
 			} else {
-				if yyq3080[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3083 := z.EncBinary()
-					_ = yym3083
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("Path"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym3083 := z.EncBinary()
+				_ = yym3083
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 				}
 			}
 			if yyr3080 || yy2arr3080 {
@@ -38710,7 +38704,7 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym3085
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -38718,33 +38712,39 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq3080[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3086 := z.EncBinary()
 					_ = yym3086
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
 			if yyr3080 || yy2arr3080 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym3088 := z.EncBinary()
-				_ = yym3088
-				if false {
+				if yyq3080[2] {
+					yym3088 := z.EncBinary()
+					_ = yym3088
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("Path"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym3089 := z.EncBinary()
-				_ = yym3089
-				if false {
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
+				if yyq3080[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3089 := z.EncBinary()
+					_ = yym3089
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr3080 || yy2arr3080 {
@@ -38808,6 +38808,12 @@ func (x *PodProxyOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys3092 := string(yys3092Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3092 {
+		case "Path":
+			if r.TryDecodeAsNil() {
+				x.Path = ""
+			} else {
+				x.Path = string(r.DecodeString())
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -38819,12 +38825,6 @@ func (x *PodProxyOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "Path":
-			if r.TryDecodeAsNil() {
-				x.Path = ""
-			} else {
-				x.Path = string(r.DecodeString())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3092)
@@ -38840,6 +38840,22 @@ func (x *PodProxyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var yyj3096 int
 	var yyb3096 bool
 	var yyhl3096 bool = l >= 0
+	yyj3096++
+	if yyhl3096 {
+		yyb3096 = yyj3096 > l
+	} else {
+		yyb3096 = r.CheckBreak()
+	}
+	if yyb3096 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Path = ""
+	} else {
+		x.Path = string(r.DecodeString())
+	}
 	yyj3096++
 	if yyhl3096 {
 		yyb3096 = yyj3096 > l
@@ -38871,22 +38887,6 @@ func (x *PodProxyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3096++
-	if yyhl3096 {
-		yyb3096 = yyj3096 > l
-	} else {
-		yyb3096 = r.CheckBreak()
-	}
-	if yyb3096 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Path = ""
-	} else {
-		x.Path = string(r.DecodeString())
 	}
 	for {
 		yyj3096++
@@ -39542,9 +39542,9 @@ func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3153 [3]bool
 			_, _, _ = yysep3153, yyq3153, yy2arr3153
 			const yyr3153 bool = false
-			yyq3153[0] = x.Kind != ""
-			yyq3153[1] = x.APIVersion != ""
-			yyq3153[2] = true
+			yyq3153[0] = true
+			yyq3153[1] = x.Kind != ""
+			yyq3153[2] = x.APIVersion != ""
 			var yynn3153 int
 			if yyr3153 || yy2arr3153 {
 				r.EncodeArrayStart(3)
@@ -39561,26 +39561,18 @@ func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr3153 || yy2arr3153 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3153[0] {
-					yym3155 := z.EncBinary()
-					_ = yym3155
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy3155 := &x.Reference
+					yy3155.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq3153[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("reference"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3156 := z.EncBinary()
-					_ = yym3156
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy3156 := &x.Reference
+					yy3156.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3153 || yy2arr3153 {
@@ -39590,7 +39582,7 @@ func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym3158
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -39598,31 +39590,39 @@ func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq3153[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3159 := z.EncBinary()
 					_ = yym3159
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
 			if yyr3153 || yy2arr3153 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3153[2] {
-					yy3161 := &x.Reference
-					yy3161.CodecEncodeSelf(e)
+					yym3161 := z.EncBinary()
+					_ = yym3161
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq3153[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("reference"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3162 := &x.Reference
-					yy3162.CodecEncodeSelf(e)
+					yym3162 := z.EncBinary()
+					_ = yym3162
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr3153 || yy2arr3153 {
@@ -39686,6 +39686,13 @@ func (x *SerializedReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 		yys3165 := string(yys3165Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3165 {
+		case "reference":
+			if r.TryDecodeAsNil() {
+				x.Reference = ObjectReference{}
+			} else {
+				yyv3166 := &x.Reference
+				yyv3166.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -39697,13 +39704,6 @@ func (x *SerializedReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "reference":
-			if r.TryDecodeAsNil() {
-				x.Reference = ObjectReference{}
-			} else {
-				yyv3168 := &x.Reference
-				yyv3168.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3165)
@@ -39719,6 +39719,23 @@ func (x *SerializedReference) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	var yyj3169 int
 	var yyb3169 bool
 	var yyhl3169 bool = l >= 0
+	yyj3169++
+	if yyhl3169 {
+		yyb3169 = yyj3169 > l
+	} else {
+		yyb3169 = r.CheckBreak()
+	}
+	if yyb3169 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Reference = ObjectReference{}
+	} else {
+		yyv3170 := &x.Reference
+		yyv3170.CodecDecodeSelf(d)
+	}
 	yyj3169++
 	if yyhl3169 {
 		yyb3169 = yyj3169 > l
@@ -39750,23 +39767,6 @@ func (x *SerializedReference) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3169++
-	if yyhl3169 {
-		yyb3169 = yyj3169 > l
-	} else {
-		yyb3169 = r.CheckBreak()
-	}
-	if yyb3169 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Reference = ObjectReference{}
-	} else {
-		yyv3172 := &x.Reference
-		yyv3172.CodecDecodeSelf(d)
 	}
 	for {
 		yyj3169++
@@ -40018,17 +40018,17 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3190 [11]bool
 			_, _, _ = yysep3190, yyq3190, yy2arr3190
 			const yyr3190 bool = false
-			yyq3190[0] = x.Kind != ""
-			yyq3190[1] = x.APIVersion != ""
-			yyq3190[2] = true
-			yyq3190[3] = true
-			yyq3190[4] = x.Reason != ""
-			yyq3190[5] = x.Message != ""
+			yyq3190[0] = true
+			yyq3190[1] = true
+			yyq3190[2] = x.Reason != ""
+			yyq3190[3] = x.Message != ""
+			yyq3190[4] = true
+			yyq3190[5] = true
 			yyq3190[6] = true
-			yyq3190[7] = true
-			yyq3190[8] = true
-			yyq3190[9] = x.Count != 0
-			yyq3190[10] = x.Type != ""
+			yyq3190[7] = x.Count != 0
+			yyq3190[8] = x.Type != ""
+			yyq3190[9] = x.Kind != ""
+			yyq3190[10] = x.APIVersion != ""
 			var yynn3190 int
 			if yyr3190 || yy2arr3190 {
 				r.EncodeArrayStart(11)
@@ -40045,92 +40045,42 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr3190 || yy2arr3190 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3190[0] {
-					yym3192 := z.EncBinary()
-					_ = yym3192
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy3192 := &x.ObjectMeta
+					yy3192.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq3190[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3193 := z.EncBinary()
-					_ = yym3193
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3190 || yy2arr3190 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3190[1] {
-					yym3195 := z.EncBinary()
-					_ = yym3195
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3190[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3196 := z.EncBinary()
-					_ = yym3196
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3190 || yy2arr3190 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3190[2] {
-					yy3198 := &x.ObjectMeta
-					yy3198.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq3190[2] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3199 := &x.ObjectMeta
-					yy3199.CodecEncodeSelf(e)
+					yy3193 := &x.ObjectMeta
+					yy3193.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3190 || yy2arr3190 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3190[3] {
-					yy3201 := &x.InvolvedObject
-					yy3201.CodecEncodeSelf(e)
+				if yyq3190[1] {
+					yy3195 := &x.InvolvedObject
+					yy3195.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3190[3] {
+				if yyq3190[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("involvedObject"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3202 := &x.InvolvedObject
-					yy3202.CodecEncodeSelf(e)
+					yy3196 := &x.InvolvedObject
+					yy3196.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3190 || yy2arr3190 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3190[4] {
-					yym3204 := z.EncBinary()
-					_ = yym3204
+				if yyq3190[2] {
+					yym3198 := z.EncBinary()
+					_ = yym3198
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
@@ -40139,12 +40089,12 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3190[4] {
+				if yyq3190[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("reason"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3205 := z.EncBinary()
-					_ = yym3205
+					yym3199 := z.EncBinary()
+					_ = yym3199
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
@@ -40153,9 +40103,9 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr3190 || yy2arr3190 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3190[5] {
-					yym3207 := z.EncBinary()
-					_ = yym3207
+				if yyq3190[3] {
+					yym3201 := z.EncBinary()
+					_ = yym3201
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
@@ -40164,12 +40114,12 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3190[5] {
+				if yyq3190[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3208 := z.EncBinary()
-					_ = yym3208
+					yym3202 := z.EncBinary()
+					_ = yym3202
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
@@ -40178,92 +40128,142 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr3190 || yy2arr3190 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3190[6] {
-					yy3210 := &x.Source
-					yy3210.CodecEncodeSelf(e)
+				if yyq3190[4] {
+					yy3204 := &x.Source
+					yy3204.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3190[6] {
+				if yyq3190[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("source"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3211 := &x.Source
-					yy3211.CodecEncodeSelf(e)
+					yy3205 := &x.Source
+					yy3205.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3190 || yy2arr3190 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3190[7] {
-					yy3213 := &x.FirstTimestamp
-					yym3214 := z.EncBinary()
-					_ = yym3214
+				if yyq3190[5] {
+					yy3207 := &x.FirstTimestamp
+					yym3208 := z.EncBinary()
+					_ = yym3208
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3213) {
-					} else if yym3214 {
-						z.EncBinaryMarshal(yy3213)
-					} else if !yym3214 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy3213)
+					} else if z.HasExtensions() && z.EncExt(yy3207) {
+					} else if yym3208 {
+						z.EncBinaryMarshal(yy3207)
+					} else if !yym3208 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy3207)
 					} else {
-						z.EncFallback(yy3213)
+						z.EncFallback(yy3207)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3190[7] {
+				if yyq3190[5] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("firstTimestamp"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3215 := &x.FirstTimestamp
-					yym3216 := z.EncBinary()
-					_ = yym3216
+					yy3209 := &x.FirstTimestamp
+					yym3210 := z.EncBinary()
+					_ = yym3210
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3215) {
-					} else if yym3216 {
-						z.EncBinaryMarshal(yy3215)
-					} else if !yym3216 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy3215)
+					} else if z.HasExtensions() && z.EncExt(yy3209) {
+					} else if yym3210 {
+						z.EncBinaryMarshal(yy3209)
+					} else if !yym3210 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy3209)
 					} else {
-						z.EncFallback(yy3215)
+						z.EncFallback(yy3209)
+					}
+				}
+			}
+			if yyr3190 || yy2arr3190 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3190[6] {
+					yy3212 := &x.LastTimestamp
+					yym3213 := z.EncBinary()
+					_ = yym3213
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3212) {
+					} else if yym3213 {
+						z.EncBinaryMarshal(yy3212)
+					} else if !yym3213 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy3212)
+					} else {
+						z.EncFallback(yy3212)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq3190[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("lastTimestamp"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy3214 := &x.LastTimestamp
+					yym3215 := z.EncBinary()
+					_ = yym3215
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3214) {
+					} else if yym3215 {
+						z.EncBinaryMarshal(yy3214)
+					} else if !yym3215 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy3214)
+					} else {
+						z.EncFallback(yy3214)
+					}
+				}
+			}
+			if yyr3190 || yy2arr3190 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3190[7] {
+					yym3217 := z.EncBinary()
+					_ = yym3217
+					if false {
+					} else {
+						r.EncodeInt(int64(x.Count))
+					}
+				} else {
+					r.EncodeInt(0)
+				}
+			} else {
+				if yyq3190[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("count"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3218 := z.EncBinary()
+					_ = yym3218
+					if false {
+					} else {
+						r.EncodeInt(int64(x.Count))
 					}
 				}
 			}
 			if yyr3190 || yy2arr3190 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3190[8] {
-					yy3218 := &x.LastTimestamp
-					yym3219 := z.EncBinary()
-					_ = yym3219
+					yym3220 := z.EncBinary()
+					_ = yym3220
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3218) {
-					} else if yym3219 {
-						z.EncBinaryMarshal(yy3218)
-					} else if !yym3219 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy3218)
 					} else {
-						z.EncFallback(yy3218)
+						r.EncodeString(codecSelferC_UTF81234, string(x.Type))
 					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq3190[8] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("lastTimestamp"))
+					r.EncodeString(codecSelferC_UTF81234, string("type"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3220 := &x.LastTimestamp
 					yym3221 := z.EncBinary()
 					_ = yym3221
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3220) {
-					} else if yym3221 {
-						z.EncBinaryMarshal(yy3220)
-					} else if !yym3221 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy3220)
 					} else {
-						z.EncFallback(yy3220)
+						r.EncodeString(codecSelferC_UTF81234, string(x.Type))
 					}
 				}
 			}
@@ -40274,21 +40274,21 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym3223
 					if false {
 					} else {
-						r.EncodeInt(int64(x.Count))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				} else {
-					r.EncodeInt(0)
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq3190[9] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("count"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3224 := z.EncBinary()
 					_ = yym3224
 					if false {
 					} else {
-						r.EncodeInt(int64(x.Count))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
@@ -40299,7 +40299,7 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym3226
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Type))
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -40307,13 +40307,13 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq3190[10] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("type"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3227 := z.EncBinary()
 					_ = yym3227
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Type))
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -40378,31 +40378,19 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys3230 := string(yys3230Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3230 {
-		case "kind":
-			if r.TryDecodeAsNil() {
-				x.Kind = ""
-			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
-			}
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv3233 := &x.ObjectMeta
-				yyv3233.CodecDecodeSelf(d)
+				yyv3231 := &x.ObjectMeta
+				yyv3231.CodecDecodeSelf(d)
 			}
 		case "involvedObject":
 			if r.TryDecodeAsNil() {
 				x.InvolvedObject = ObjectReference{}
 			} else {
-				yyv3234 := &x.InvolvedObject
-				yyv3234.CodecDecodeSelf(d)
+				yyv3232 := &x.InvolvedObject
+				yyv3232.CodecDecodeSelf(d)
 			}
 		case "reason":
 			if r.TryDecodeAsNil() {
@@ -40420,14 +40408,31 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Source = EventSource{}
 			} else {
-				yyv3237 := &x.Source
-				yyv3237.CodecDecodeSelf(d)
+				yyv3235 := &x.Source
+				yyv3235.CodecDecodeSelf(d)
 			}
 		case "firstTimestamp":
 			if r.TryDecodeAsNil() {
 				x.FirstTimestamp = pkg2_unversioned.Time{}
 			} else {
-				yyv3238 := &x.FirstTimestamp
+				yyv3236 := &x.FirstTimestamp
+				yym3237 := z.DecBinary()
+				_ = yym3237
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv3236) {
+				} else if yym3237 {
+					z.DecBinaryUnmarshal(yyv3236)
+				} else if !yym3237 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv3236)
+				} else {
+					z.DecFallback(yyv3236, false)
+				}
+			}
+		case "lastTimestamp":
+			if r.TryDecodeAsNil() {
+				x.LastTimestamp = pkg2_unversioned.Time{}
+			} else {
+				yyv3238 := &x.LastTimestamp
 				yym3239 := z.DecBinary()
 				_ = yym3239
 				if false {
@@ -40438,23 +40443,6 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 					z.DecJSONUnmarshal(yyv3238)
 				} else {
 					z.DecFallback(yyv3238, false)
-				}
-			}
-		case "lastTimestamp":
-			if r.TryDecodeAsNil() {
-				x.LastTimestamp = pkg2_unversioned.Time{}
-			} else {
-				yyv3240 := &x.LastTimestamp
-				yym3241 := z.DecBinary()
-				_ = yym3241
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3240) {
-				} else if yym3241 {
-					z.DecBinaryUnmarshal(yyv3240)
-				} else if !yym3241 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv3240)
-				} else {
-					z.DecFallback(yyv3240, false)
 				}
 			}
 		case "count":
@@ -40468,6 +40456,18 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Type = ""
 			} else {
 				x.Type = string(r.DecodeString())
+			}
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3230)
@@ -40495,42 +40495,10 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.Kind = ""
-	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj3244++
-	if yyhl3244 {
-		yyb3244 = yyj3244 > l
-	} else {
-		yyb3244 = r.CheckBreak()
-	}
-	if yyb3244 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3244++
-	if yyhl3244 {
-		yyb3244 = yyj3244 > l
-	} else {
-		yyb3244 = r.CheckBreak()
-	}
-	if yyb3244 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv3247 := &x.ObjectMeta
-		yyv3247.CodecDecodeSelf(d)
+		yyv3245 := &x.ObjectMeta
+		yyv3245.CodecDecodeSelf(d)
 	}
 	yyj3244++
 	if yyhl3244 {
@@ -40546,8 +40514,8 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.InvolvedObject = ObjectReference{}
 	} else {
-		yyv3248 := &x.InvolvedObject
-		yyv3248.CodecDecodeSelf(d)
+		yyv3246 := &x.InvolvedObject
+		yyv3246.CodecDecodeSelf(d)
 	}
 	yyj3244++
 	if yyhl3244 {
@@ -40595,8 +40563,8 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Source = EventSource{}
 	} else {
-		yyv3251 := &x.Source
-		yyv3251.CodecDecodeSelf(d)
+		yyv3249 := &x.Source
+		yyv3249.CodecDecodeSelf(d)
 	}
 	yyj3244++
 	if yyhl3244 {
@@ -40612,17 +40580,17 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.FirstTimestamp = pkg2_unversioned.Time{}
 	} else {
-		yyv3252 := &x.FirstTimestamp
-		yym3253 := z.DecBinary()
-		_ = yym3253
+		yyv3250 := &x.FirstTimestamp
+		yym3251 := z.DecBinary()
+		_ = yym3251
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3252) {
-		} else if yym3253 {
-			z.DecBinaryUnmarshal(yyv3252)
-		} else if !yym3253 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv3252)
+		} else if z.HasExtensions() && z.DecExt(yyv3250) {
+		} else if yym3251 {
+			z.DecBinaryUnmarshal(yyv3250)
+		} else if !yym3251 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv3250)
 		} else {
-			z.DecFallback(yyv3252, false)
+			z.DecFallback(yyv3250, false)
 		}
 	}
 	yyj3244++
@@ -40639,17 +40607,17 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.LastTimestamp = pkg2_unversioned.Time{}
 	} else {
-		yyv3254 := &x.LastTimestamp
-		yym3255 := z.DecBinary()
-		_ = yym3255
+		yyv3252 := &x.LastTimestamp
+		yym3253 := z.DecBinary()
+		_ = yym3253
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3254) {
-		} else if yym3255 {
-			z.DecBinaryUnmarshal(yyv3254)
-		} else if !yym3255 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv3254)
+		} else if z.HasExtensions() && z.DecExt(yyv3252) {
+		} else if yym3253 {
+			z.DecBinaryUnmarshal(yyv3252)
+		} else if !yym3253 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv3252)
 		} else {
-			z.DecFallback(yyv3254, false)
+			z.DecFallback(yyv3252, false)
 		}
 	}
 	yyj3244++
@@ -40684,6 +40652,38 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Type = string(r.DecodeString())
 	}
+	yyj3244++
+	if yyhl3244 {
+		yyb3244 = yyj3244 > l
+	} else {
+		yyb3244 = r.CheckBreak()
+	}
+	if yyb3244 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj3244++
+	if yyhl3244 {
+		yyb3244 = yyj3244 > l
+	} else {
+		yyb3244 = r.CheckBreak()
+	}
+	if yyb3244 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
+	}
 	for {
 		yyj3244++
 		if yyhl3244 {
@@ -40717,9 +40717,9 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3259 [4]bool
 			_, _, _ = yysep3259, yyq3259, yy2arr3259
 			const yyr3259 bool = false
-			yyq3259[0] = x.Kind != ""
-			yyq3259[1] = x.APIVersion != ""
-			yyq3259[2] = true
+			yyq3259[0] = true
+			yyq3259[2] = x.Kind != ""
+			yyq3259[3] = x.APIVersion != ""
 			var yynn3259 int
 			if yyr3259 || yy2arr3259 {
 				r.EncodeArrayStart(4)
@@ -40736,79 +40736,29 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr3259 || yy2arr3259 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3259[0] {
-					yym3261 := z.EncBinary()
-					_ = yym3261
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3259[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy3261 := &x.ListMeta
 					yym3262 := z.EncBinary()
 					_ = yym3262
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3261) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3259 || yy2arr3259 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3259[1] {
-					yym3264 := z.EncBinary()
-					_ = yym3264
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3259[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3265 := z.EncBinary()
-					_ = yym3265
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3259 || yy2arr3259 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3259[2] {
-					yy3267 := &x.ListMeta
-					yym3268 := z.EncBinary()
-					_ = yym3268
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3267) {
-					} else {
-						z.EncFallback(yy3267)
+						z.EncFallback(yy3261)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3259[2] {
+				if yyq3259[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3269 := &x.ListMeta
-					yym3270 := z.EncBinary()
-					_ = yym3270
+					yy3263 := &x.ListMeta
+					yym3264 := z.EncBinary()
+					_ = yym3264
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3269) {
+					} else if z.HasExtensions() && z.EncExt(yy3263) {
 					} else {
-						z.EncFallback(yy3269)
+						z.EncFallback(yy3263)
 					}
 				}
 			}
@@ -40817,8 +40767,8 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3272 := z.EncBinary()
-					_ = yym3272
+					yym3266 := z.EncBinary()
+					_ = yym3266
 					if false {
 					} else {
 						h.encSliceEvent(([]Event)(x.Items), e)
@@ -40831,11 +40781,61 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym3267 := z.EncBinary()
+					_ = yym3267
+					if false {
+					} else {
+						h.encSliceEvent(([]Event)(x.Items), e)
+					}
+				}
+			}
+			if yyr3259 || yy2arr3259 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3259[2] {
+					yym3269 := z.EncBinary()
+					_ = yym3269
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3259[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3270 := z.EncBinary()
+					_ = yym3270
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3259 || yy2arr3259 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3259[3] {
+					yym3272 := z.EncBinary()
+					_ = yym3272
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3259[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3273 := z.EncBinary()
 					_ = yym3273
 					if false {
 					} else {
-						h.encSliceEvent(([]Event)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -40900,6 +40900,31 @@ func (x *EventList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys3276 := string(yys3276Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3276 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv3277 := &x.ListMeta
+				yym3278 := z.DecBinary()
+				_ = yym3278
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv3277) {
+				} else {
+					z.DecFallback(yyv3277, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv3279 := &x.Items
+				yym3280 := z.DecBinary()
+				_ = yym3280
+				if false {
+				} else {
+					h.decSliceEvent((*[]Event)(yyv3279), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -40911,31 +40936,6 @@ func (x *EventList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv3279 := &x.ListMeta
-				yym3280 := z.DecBinary()
-				_ = yym3280
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3279) {
-				} else {
-					z.DecFallback(yyv3279, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv3281 := &x.Items
-				yym3282 := z.DecBinary()
-				_ = yym3282
-				if false {
-				} else {
-					h.decSliceEvent((*[]Event)(yyv3281), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3276)
@@ -40951,6 +40951,51 @@ func (x *EventList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj3283 int
 	var yyb3283 bool
 	var yyhl3283 bool = l >= 0
+	yyj3283++
+	if yyhl3283 {
+		yyb3283 = yyj3283 > l
+	} else {
+		yyb3283 = r.CheckBreak()
+	}
+	if yyb3283 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv3284 := &x.ListMeta
+		yym3285 := z.DecBinary()
+		_ = yym3285
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv3284) {
+		} else {
+			z.DecFallback(yyv3284, false)
+		}
+	}
+	yyj3283++
+	if yyhl3283 {
+		yyb3283 = yyj3283 > l
+	} else {
+		yyb3283 = r.CheckBreak()
+	}
+	if yyb3283 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv3286 := &x.Items
+		yym3287 := z.DecBinary()
+		_ = yym3287
+		if false {
+		} else {
+			h.decSliceEvent((*[]Event)(yyv3286), d)
+		}
+	}
 	yyj3283++
 	if yyhl3283 {
 		yyb3283 = yyj3283 > l
@@ -40982,51 +41027,6 @@ func (x *EventList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3283++
-	if yyhl3283 {
-		yyb3283 = yyj3283 > l
-	} else {
-		yyb3283 = r.CheckBreak()
-	}
-	if yyb3283 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv3286 := &x.ListMeta
-		yym3287 := z.DecBinary()
-		_ = yym3287
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3286) {
-		} else {
-			z.DecFallback(yyv3286, false)
-		}
-	}
-	yyj3283++
-	if yyhl3283 {
-		yyb3283 = yyj3283 > l
-	} else {
-		yyb3283 = r.CheckBreak()
-	}
-	if yyb3283 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv3288 := &x.Items
-		yym3289 := z.DecBinary()
-		_ = yym3289
-		if false {
-		} else {
-			h.decSliceEvent((*[]Event)(yyv3288), d)
-		}
 	}
 	for {
 		yyj3283++
@@ -41061,9 +41061,9 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3291 [4]bool
 			_, _, _ = yysep3291, yyq3291, yy2arr3291
 			const yyr3291 bool = false
-			yyq3291[0] = x.Kind != ""
-			yyq3291[1] = x.APIVersion != ""
-			yyq3291[2] = true
+			yyq3291[0] = true
+			yyq3291[2] = x.Kind != ""
+			yyq3291[3] = x.APIVersion != ""
 			var yynn3291 int
 			if yyr3291 || yy2arr3291 {
 				r.EncodeArrayStart(4)
@@ -41080,79 +41080,29 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr3291 || yy2arr3291 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3291[0] {
-					yym3293 := z.EncBinary()
-					_ = yym3293
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3291[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy3293 := &x.ListMeta
 					yym3294 := z.EncBinary()
 					_ = yym3294
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3293) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3291 || yy2arr3291 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3291[1] {
-					yym3296 := z.EncBinary()
-					_ = yym3296
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3291[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3297 := z.EncBinary()
-					_ = yym3297
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3291 || yy2arr3291 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3291[2] {
-					yy3299 := &x.ListMeta
-					yym3300 := z.EncBinary()
-					_ = yym3300
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3299) {
-					} else {
-						z.EncFallback(yy3299)
+						z.EncFallback(yy3293)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3291[2] {
+				if yyq3291[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3301 := &x.ListMeta
-					yym3302 := z.EncBinary()
-					_ = yym3302
+					yy3295 := &x.ListMeta
+					yym3296 := z.EncBinary()
+					_ = yym3296
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3301) {
+					} else if z.HasExtensions() && z.EncExt(yy3295) {
 					} else {
-						z.EncFallback(yy3301)
+						z.EncFallback(yy3295)
 					}
 				}
 			}
@@ -41161,8 +41111,8 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3304 := z.EncBinary()
-					_ = yym3304
+					yym3298 := z.EncBinary()
+					_ = yym3298
 					if false {
 					} else {
 						h.encSliceruntime_Object(([]pkg8_runtime.Object)(x.Items), e)
@@ -41175,11 +41125,61 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym3299 := z.EncBinary()
+					_ = yym3299
+					if false {
+					} else {
+						h.encSliceruntime_Object(([]pkg8_runtime.Object)(x.Items), e)
+					}
+				}
+			}
+			if yyr3291 || yy2arr3291 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3291[2] {
+					yym3301 := z.EncBinary()
+					_ = yym3301
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3291[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3302 := z.EncBinary()
+					_ = yym3302
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3291 || yy2arr3291 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3291[3] {
+					yym3304 := z.EncBinary()
+					_ = yym3304
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3291[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3305 := z.EncBinary()
 					_ = yym3305
 					if false {
 					} else {
-						h.encSliceruntime_Object(([]pkg8_runtime.Object)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -41244,6 +41244,31 @@ func (x *List) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys3308 := string(yys3308Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3308 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv3309 := &x.ListMeta
+				yym3310 := z.DecBinary()
+				_ = yym3310
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv3309) {
+				} else {
+					z.DecFallback(yyv3309, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv3311 := &x.Items
+				yym3312 := z.DecBinary()
+				_ = yym3312
+				if false {
+				} else {
+					h.decSliceruntime_Object((*[]pkg8_runtime.Object)(yyv3311), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -41255,31 +41280,6 @@ func (x *List) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv3311 := &x.ListMeta
-				yym3312 := z.DecBinary()
-				_ = yym3312
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3311) {
-				} else {
-					z.DecFallback(yyv3311, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv3313 := &x.Items
-				yym3314 := z.DecBinary()
-				_ = yym3314
-				if false {
-				} else {
-					h.decSliceruntime_Object((*[]pkg8_runtime.Object)(yyv3313), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3308)
@@ -41295,6 +41295,51 @@ func (x *List) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj3315 int
 	var yyb3315 bool
 	var yyhl3315 bool = l >= 0
+	yyj3315++
+	if yyhl3315 {
+		yyb3315 = yyj3315 > l
+	} else {
+		yyb3315 = r.CheckBreak()
+	}
+	if yyb3315 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv3316 := &x.ListMeta
+		yym3317 := z.DecBinary()
+		_ = yym3317
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv3316) {
+		} else {
+			z.DecFallback(yyv3316, false)
+		}
+	}
+	yyj3315++
+	if yyhl3315 {
+		yyb3315 = yyj3315 > l
+	} else {
+		yyb3315 = r.CheckBreak()
+	}
+	if yyb3315 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv3318 := &x.Items
+		yym3319 := z.DecBinary()
+		_ = yym3319
+		if false {
+		} else {
+			h.decSliceruntime_Object((*[]pkg8_runtime.Object)(yyv3318), d)
+		}
+	}
 	yyj3315++
 	if yyhl3315 {
 		yyb3315 = yyj3315 > l
@@ -41326,51 +41371,6 @@ func (x *List) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3315++
-	if yyhl3315 {
-		yyb3315 = yyj3315 > l
-	} else {
-		yyb3315 = r.CheckBreak()
-	}
-	if yyb3315 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv3318 := &x.ListMeta
-		yym3319 := z.DecBinary()
-		_ = yym3319
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3318) {
-		} else {
-			z.DecFallback(yyv3318, false)
-		}
-	}
-	yyj3315++
-	if yyhl3315 {
-		yyb3315 = yyj3315 > l
-	} else {
-		yyb3315 = r.CheckBreak()
-	}
-	if yyb3315 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv3320 := &x.Items
-		yym3321 := z.DecBinary()
-		_ = yym3321
-		if false {
-		} else {
-			h.decSliceruntime_Object((*[]pkg8_runtime.Object)(yyv3320), d)
-		}
 	}
 	for {
 		yyj3315++
@@ -42012,10 +42012,10 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3362 [4]bool
 			_, _, _ = yysep3362, yyq3362, yy2arr3362
 			const yyr3362 bool = false
-			yyq3362[0] = x.Kind != ""
-			yyq3362[1] = x.APIVersion != ""
-			yyq3362[2] = true
-			yyq3362[3] = true
+			yyq3362[0] = true
+			yyq3362[1] = true
+			yyq3362[2] = x.Kind != ""
+			yyq3362[3] = x.APIVersion != ""
 			var yynn3362 int
 			if yyr3362 || yy2arr3362 {
 				r.EncodeArrayStart(4)
@@ -42032,22 +42032,56 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr3362 || yy2arr3362 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3362[0] {
-					yym3364 := z.EncBinary()
-					_ = yym3364
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy3364 := &x.ObjectMeta
+					yy3364.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq3362[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy3365 := &x.ObjectMeta
+					yy3365.CodecEncodeSelf(e)
+				}
+			}
+			if yyr3362 || yy2arr3362 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3362[1] {
+					yy3367 := &x.Spec
+					yy3367.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq3362[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy3368 := &x.Spec
+					yy3368.CodecEncodeSelf(e)
+				}
+			}
+			if yyr3362 || yy2arr3362 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3362[2] {
+					yym3370 := z.EncBinary()
+					_ = yym3370
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3362[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3365 := z.EncBinary()
-					_ = yym3365
+					yym3371 := z.EncBinary()
+					_ = yym3371
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -42056,9 +42090,9 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr3362 || yy2arr3362 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3362[1] {
-					yym3367 := z.EncBinary()
-					_ = yym3367
+				if yyq3362[3] {
+					yym3373 := z.EncBinary()
+					_ = yym3373
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -42067,50 +42101,16 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3362[1] {
+				if yyq3362[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3368 := z.EncBinary()
-					_ = yym3368
+					yym3374 := z.EncBinary()
+					_ = yym3374
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
-				}
-			}
-			if yyr3362 || yy2arr3362 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3362[2] {
-					yy3370 := &x.ObjectMeta
-					yy3370.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq3362[2] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3371 := &x.ObjectMeta
-					yy3371.CodecEncodeSelf(e)
-				}
-			}
-			if yyr3362 || yy2arr3362 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3362[3] {
-					yy3373 := &x.Spec
-					yy3373.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq3362[3] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3374 := &x.Spec
-					yy3374.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3362 || yy2arr3362 {
@@ -42174,6 +42174,20 @@ func (x *LimitRange) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys3377 := string(yys3377Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3377 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv3378 := &x.ObjectMeta
+				yyv3378.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = LimitRangeSpec{}
+			} else {
+				yyv3379 := &x.Spec
+				yyv3379.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -42185,20 +42199,6 @@ func (x *LimitRange) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv3380 := &x.ObjectMeta
-				yyv3380.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = LimitRangeSpec{}
-			} else {
-				yyv3381 := &x.Spec
-				yyv3381.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3377)
@@ -42214,6 +42214,40 @@ func (x *LimitRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj3382 int
 	var yyb3382 bool
 	var yyhl3382 bool = l >= 0
+	yyj3382++
+	if yyhl3382 {
+		yyb3382 = yyj3382 > l
+	} else {
+		yyb3382 = r.CheckBreak()
+	}
+	if yyb3382 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv3383 := &x.ObjectMeta
+		yyv3383.CodecDecodeSelf(d)
+	}
+	yyj3382++
+	if yyhl3382 {
+		yyb3382 = yyj3382 > l
+	} else {
+		yyb3382 = r.CheckBreak()
+	}
+	if yyb3382 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = LimitRangeSpec{}
+	} else {
+		yyv3384 := &x.Spec
+		yyv3384.CodecDecodeSelf(d)
+	}
 	yyj3382++
 	if yyhl3382 {
 		yyb3382 = yyj3382 > l
@@ -42245,40 +42279,6 @@ func (x *LimitRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3382++
-	if yyhl3382 {
-		yyb3382 = yyj3382 > l
-	} else {
-		yyb3382 = r.CheckBreak()
-	}
-	if yyb3382 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv3385 := &x.ObjectMeta
-		yyv3385.CodecDecodeSelf(d)
-	}
-	yyj3382++
-	if yyhl3382 {
-		yyb3382 = yyj3382 > l
-	} else {
-		yyb3382 = r.CheckBreak()
-	}
-	if yyb3382 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = LimitRangeSpec{}
-	} else {
-		yyv3386 := &x.Spec
-		yyv3386.CodecDecodeSelf(d)
 	}
 	for {
 		yyj3382++
@@ -42313,9 +42313,9 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3388 [4]bool
 			_, _, _ = yysep3388, yyq3388, yy2arr3388
 			const yyr3388 bool = false
-			yyq3388[0] = x.Kind != ""
-			yyq3388[1] = x.APIVersion != ""
-			yyq3388[2] = true
+			yyq3388[0] = true
+			yyq3388[2] = x.Kind != ""
+			yyq3388[3] = x.APIVersion != ""
 			var yynn3388 int
 			if yyr3388 || yy2arr3388 {
 				r.EncodeArrayStart(4)
@@ -42332,79 +42332,29 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr3388 || yy2arr3388 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3388[0] {
-					yym3390 := z.EncBinary()
-					_ = yym3390
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3388[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy3390 := &x.ListMeta
 					yym3391 := z.EncBinary()
 					_ = yym3391
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3390) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3388 || yy2arr3388 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3388[1] {
-					yym3393 := z.EncBinary()
-					_ = yym3393
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3388[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3394 := z.EncBinary()
-					_ = yym3394
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3388 || yy2arr3388 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3388[2] {
-					yy3396 := &x.ListMeta
-					yym3397 := z.EncBinary()
-					_ = yym3397
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3396) {
-					} else {
-						z.EncFallback(yy3396)
+						z.EncFallback(yy3390)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3388[2] {
+				if yyq3388[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3398 := &x.ListMeta
-					yym3399 := z.EncBinary()
-					_ = yym3399
+					yy3392 := &x.ListMeta
+					yym3393 := z.EncBinary()
+					_ = yym3393
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3398) {
+					} else if z.HasExtensions() && z.EncExt(yy3392) {
 					} else {
-						z.EncFallback(yy3398)
+						z.EncFallback(yy3392)
 					}
 				}
 			}
@@ -42413,8 +42363,8 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3401 := z.EncBinary()
-					_ = yym3401
+					yym3395 := z.EncBinary()
+					_ = yym3395
 					if false {
 					} else {
 						h.encSliceLimitRange(([]LimitRange)(x.Items), e)
@@ -42427,11 +42377,61 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym3396 := z.EncBinary()
+					_ = yym3396
+					if false {
+					} else {
+						h.encSliceLimitRange(([]LimitRange)(x.Items), e)
+					}
+				}
+			}
+			if yyr3388 || yy2arr3388 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3388[2] {
+					yym3398 := z.EncBinary()
+					_ = yym3398
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3388[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3399 := z.EncBinary()
+					_ = yym3399
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3388 || yy2arr3388 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3388[3] {
+					yym3401 := z.EncBinary()
+					_ = yym3401
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3388[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3402 := z.EncBinary()
 					_ = yym3402
 					if false {
 					} else {
-						h.encSliceLimitRange(([]LimitRange)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -42496,6 +42496,31 @@ func (x *LimitRangeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys3405 := string(yys3405Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3405 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv3406 := &x.ListMeta
+				yym3407 := z.DecBinary()
+				_ = yym3407
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv3406) {
+				} else {
+					z.DecFallback(yyv3406, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv3408 := &x.Items
+				yym3409 := z.DecBinary()
+				_ = yym3409
+				if false {
+				} else {
+					h.decSliceLimitRange((*[]LimitRange)(yyv3408), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -42507,31 +42532,6 @@ func (x *LimitRangeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv3408 := &x.ListMeta
-				yym3409 := z.DecBinary()
-				_ = yym3409
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3408) {
-				} else {
-					z.DecFallback(yyv3408, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv3410 := &x.Items
-				yym3411 := z.DecBinary()
-				_ = yym3411
-				if false {
-				} else {
-					h.decSliceLimitRange((*[]LimitRange)(yyv3410), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3405)
@@ -42547,6 +42547,51 @@ func (x *LimitRangeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj3412 int
 	var yyb3412 bool
 	var yyhl3412 bool = l >= 0
+	yyj3412++
+	if yyhl3412 {
+		yyb3412 = yyj3412 > l
+	} else {
+		yyb3412 = r.CheckBreak()
+	}
+	if yyb3412 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv3413 := &x.ListMeta
+		yym3414 := z.DecBinary()
+		_ = yym3414
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv3413) {
+		} else {
+			z.DecFallback(yyv3413, false)
+		}
+	}
+	yyj3412++
+	if yyhl3412 {
+		yyb3412 = yyj3412 > l
+	} else {
+		yyb3412 = r.CheckBreak()
+	}
+	if yyb3412 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv3415 := &x.Items
+		yym3416 := z.DecBinary()
+		_ = yym3416
+		if false {
+		} else {
+			h.decSliceLimitRange((*[]LimitRange)(yyv3415), d)
+		}
+	}
 	yyj3412++
 	if yyhl3412 {
 		yyb3412 = yyj3412 > l
@@ -42578,51 +42623,6 @@ func (x *LimitRangeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3412++
-	if yyhl3412 {
-		yyb3412 = yyj3412 > l
-	} else {
-		yyb3412 = r.CheckBreak()
-	}
-	if yyb3412 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv3415 := &x.ListMeta
-		yym3416 := z.DecBinary()
-		_ = yym3416
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3415) {
-		} else {
-			z.DecFallback(yyv3415, false)
-		}
-	}
-	yyj3412++
-	if yyhl3412 {
-		yyb3412 = yyj3412 > l
-	} else {
-		yyb3412 = r.CheckBreak()
-	}
-	if yyb3412 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv3417 := &x.Items
-		yym3418 := z.DecBinary()
-		_ = yym3418
-		if false {
-		} else {
-			h.decSliceLimitRange((*[]LimitRange)(yyv3417), d)
-		}
 	}
 	for {
 		yyj3412++
@@ -43043,11 +43043,11 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3441 [5]bool
 			_, _, _ = yysep3441, yyq3441, yy2arr3441
 			const yyr3441 bool = false
-			yyq3441[0] = x.Kind != ""
-			yyq3441[1] = x.APIVersion != ""
+			yyq3441[0] = true
+			yyq3441[1] = true
 			yyq3441[2] = true
-			yyq3441[3] = true
-			yyq3441[4] = true
+			yyq3441[3] = x.Kind != ""
+			yyq3441[4] = x.APIVersion != ""
 			var yynn3441 int
 			if yyr3441 || yy2arr3441 {
 				r.EncodeArrayStart(5)
@@ -43064,57 +43064,41 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr3441 || yy2arr3441 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3441[0] {
-					yym3443 := z.EncBinary()
-					_ = yym3443
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy3443 := &x.ObjectMeta
+					yy3443.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq3441[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3444 := z.EncBinary()
-					_ = yym3444
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy3444 := &x.ObjectMeta
+					yy3444.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3441 || yy2arr3441 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3441[1] {
-					yym3446 := z.EncBinary()
-					_ = yym3446
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy3446 := &x.Spec
+					yy3446.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq3441[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3447 := z.EncBinary()
-					_ = yym3447
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy3447 := &x.Spec
+					yy3447.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3441 || yy2arr3441 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3441[2] {
-					yy3449 := &x.ObjectMeta
+					yy3449 := &x.Status
 					yy3449.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
@@ -43122,44 +43106,60 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq3441[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3450 := &x.ObjectMeta
+					yy3450 := &x.Status
 					yy3450.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3441 || yy2arr3441 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3441[3] {
-					yy3452 := &x.Spec
-					yy3452.CodecEncodeSelf(e)
+					yym3452 := z.EncBinary()
+					_ = yym3452
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq3441[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3453 := &x.Spec
-					yy3453.CodecEncodeSelf(e)
+					yym3453 := z.EncBinary()
+					_ = yym3453
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				}
 			}
 			if yyr3441 || yy2arr3441 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3441[4] {
-					yy3455 := &x.Status
-					yy3455.CodecEncodeSelf(e)
+					yym3455 := z.EncBinary()
+					_ = yym3455
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq3441[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3456 := &x.Status
-					yy3456.CodecEncodeSelf(e)
+					yym3456 := z.EncBinary()
+					_ = yym3456
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr3441 || yy2arr3441 {
@@ -43223,6 +43223,27 @@ func (x *ResourceQuota) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys3459 := string(yys3459Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3459 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv3460 := &x.ObjectMeta
+				yyv3460.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = ResourceQuotaSpec{}
+			} else {
+				yyv3461 := &x.Spec
+				yyv3461.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = ResourceQuotaStatus{}
+			} else {
+				yyv3462 := &x.Status
+				yyv3462.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -43234,27 +43255,6 @@ func (x *ResourceQuota) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv3462 := &x.ObjectMeta
-				yyv3462.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = ResourceQuotaSpec{}
-			} else {
-				yyv3463 := &x.Spec
-				yyv3463.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = ResourceQuotaStatus{}
-			} else {
-				yyv3464 := &x.Status
-				yyv3464.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3459)
@@ -43270,6 +43270,57 @@ func (x *ResourceQuota) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj3465 int
 	var yyb3465 bool
 	var yyhl3465 bool = l >= 0
+	yyj3465++
+	if yyhl3465 {
+		yyb3465 = yyj3465 > l
+	} else {
+		yyb3465 = r.CheckBreak()
+	}
+	if yyb3465 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv3466 := &x.ObjectMeta
+		yyv3466.CodecDecodeSelf(d)
+	}
+	yyj3465++
+	if yyhl3465 {
+		yyb3465 = yyj3465 > l
+	} else {
+		yyb3465 = r.CheckBreak()
+	}
+	if yyb3465 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = ResourceQuotaSpec{}
+	} else {
+		yyv3467 := &x.Spec
+		yyv3467.CodecDecodeSelf(d)
+	}
+	yyj3465++
+	if yyhl3465 {
+		yyb3465 = yyj3465 > l
+	} else {
+		yyb3465 = r.CheckBreak()
+	}
+	if yyb3465 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = ResourceQuotaStatus{}
+	} else {
+		yyv3468 := &x.Status
+		yyv3468.CodecDecodeSelf(d)
+	}
 	yyj3465++
 	if yyhl3465 {
 		yyb3465 = yyj3465 > l
@@ -43301,57 +43352,6 @@ func (x *ResourceQuota) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3465++
-	if yyhl3465 {
-		yyb3465 = yyj3465 > l
-	} else {
-		yyb3465 = r.CheckBreak()
-	}
-	if yyb3465 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv3468 := &x.ObjectMeta
-		yyv3468.CodecDecodeSelf(d)
-	}
-	yyj3465++
-	if yyhl3465 {
-		yyb3465 = yyj3465 > l
-	} else {
-		yyb3465 = r.CheckBreak()
-	}
-	if yyb3465 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = ResourceQuotaSpec{}
-	} else {
-		yyv3469 := &x.Spec
-		yyv3469.CodecDecodeSelf(d)
-	}
-	yyj3465++
-	if yyhl3465 {
-		yyb3465 = yyj3465 > l
-	} else {
-		yyb3465 = r.CheckBreak()
-	}
-	if yyb3465 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = ResourceQuotaStatus{}
-	} else {
-		yyv3470 := &x.Status
-		yyv3470.CodecDecodeSelf(d)
 	}
 	for {
 		yyj3465++
@@ -43386,9 +43386,9 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3472 [4]bool
 			_, _, _ = yysep3472, yyq3472, yy2arr3472
 			const yyr3472 bool = false
-			yyq3472[0] = x.Kind != ""
-			yyq3472[1] = x.APIVersion != ""
-			yyq3472[2] = true
+			yyq3472[0] = true
+			yyq3472[2] = x.Kind != ""
+			yyq3472[3] = x.APIVersion != ""
 			var yynn3472 int
 			if yyr3472 || yy2arr3472 {
 				r.EncodeArrayStart(4)
@@ -43405,79 +43405,29 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr3472 || yy2arr3472 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3472[0] {
-					yym3474 := z.EncBinary()
-					_ = yym3474
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3472[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy3474 := &x.ListMeta
 					yym3475 := z.EncBinary()
 					_ = yym3475
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3474) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3472 || yy2arr3472 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3472[1] {
-					yym3477 := z.EncBinary()
-					_ = yym3477
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3472[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3478 := z.EncBinary()
-					_ = yym3478
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3472 || yy2arr3472 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3472[2] {
-					yy3480 := &x.ListMeta
-					yym3481 := z.EncBinary()
-					_ = yym3481
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3480) {
-					} else {
-						z.EncFallback(yy3480)
+						z.EncFallback(yy3474)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3472[2] {
+				if yyq3472[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3482 := &x.ListMeta
-					yym3483 := z.EncBinary()
-					_ = yym3483
+					yy3476 := &x.ListMeta
+					yym3477 := z.EncBinary()
+					_ = yym3477
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3482) {
+					} else if z.HasExtensions() && z.EncExt(yy3476) {
 					} else {
-						z.EncFallback(yy3482)
+						z.EncFallback(yy3476)
 					}
 				}
 			}
@@ -43486,8 +43436,8 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3485 := z.EncBinary()
-					_ = yym3485
+					yym3479 := z.EncBinary()
+					_ = yym3479
 					if false {
 					} else {
 						h.encSliceResourceQuota(([]ResourceQuota)(x.Items), e)
@@ -43500,11 +43450,61 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym3480 := z.EncBinary()
+					_ = yym3480
+					if false {
+					} else {
+						h.encSliceResourceQuota(([]ResourceQuota)(x.Items), e)
+					}
+				}
+			}
+			if yyr3472 || yy2arr3472 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3472[2] {
+					yym3482 := z.EncBinary()
+					_ = yym3482
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3472[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3483 := z.EncBinary()
+					_ = yym3483
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3472 || yy2arr3472 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3472[3] {
+					yym3485 := z.EncBinary()
+					_ = yym3485
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3472[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3486 := z.EncBinary()
 					_ = yym3486
 					if false {
 					} else {
-						h.encSliceResourceQuota(([]ResourceQuota)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -43569,6 +43569,31 @@ func (x *ResourceQuotaList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 		yys3489 := string(yys3489Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3489 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv3490 := &x.ListMeta
+				yym3491 := z.DecBinary()
+				_ = yym3491
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv3490) {
+				} else {
+					z.DecFallback(yyv3490, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv3492 := &x.Items
+				yym3493 := z.DecBinary()
+				_ = yym3493
+				if false {
+				} else {
+					h.decSliceResourceQuota((*[]ResourceQuota)(yyv3492), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -43580,31 +43605,6 @@ func (x *ResourceQuotaList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv3492 := &x.ListMeta
-				yym3493 := z.DecBinary()
-				_ = yym3493
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3492) {
-				} else {
-					z.DecFallback(yyv3492, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv3494 := &x.Items
-				yym3495 := z.DecBinary()
-				_ = yym3495
-				if false {
-				} else {
-					h.decSliceResourceQuota((*[]ResourceQuota)(yyv3494), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3489)
@@ -43620,6 +43620,51 @@ func (x *ResourceQuotaList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var yyj3496 int
 	var yyb3496 bool
 	var yyhl3496 bool = l >= 0
+	yyj3496++
+	if yyhl3496 {
+		yyb3496 = yyj3496 > l
+	} else {
+		yyb3496 = r.CheckBreak()
+	}
+	if yyb3496 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv3497 := &x.ListMeta
+		yym3498 := z.DecBinary()
+		_ = yym3498
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv3497) {
+		} else {
+			z.DecFallback(yyv3497, false)
+		}
+	}
+	yyj3496++
+	if yyhl3496 {
+		yyb3496 = yyj3496 > l
+	} else {
+		yyb3496 = r.CheckBreak()
+	}
+	if yyb3496 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv3499 := &x.Items
+		yym3500 := z.DecBinary()
+		_ = yym3500
+		if false {
+		} else {
+			h.decSliceResourceQuota((*[]ResourceQuota)(yyv3499), d)
+		}
+	}
 	yyj3496++
 	if yyhl3496 {
 		yyb3496 = yyj3496 > l
@@ -43651,51 +43696,6 @@ func (x *ResourceQuotaList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3496++
-	if yyhl3496 {
-		yyb3496 = yyj3496 > l
-	} else {
-		yyb3496 = r.CheckBreak()
-	}
-	if yyb3496 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv3499 := &x.ListMeta
-		yym3500 := z.DecBinary()
-		_ = yym3500
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3499) {
-		} else {
-			z.DecFallback(yyv3499, false)
-		}
-	}
-	yyj3496++
-	if yyhl3496 {
-		yyb3496 = yyj3496 > l
-	} else {
-		yyb3496 = r.CheckBreak()
-	}
-	if yyb3496 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv3501 := &x.Items
-		yym3502 := z.DecBinary()
-		_ = yym3502
-		if false {
-		} else {
-			h.decSliceResourceQuota((*[]ResourceQuota)(yyv3501), d)
-		}
 	}
 	for {
 		yyj3496++
@@ -43730,11 +43730,11 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3504 [5]bool
 			_, _, _ = yysep3504, yyq3504, yy2arr3504
 			const yyr3504 bool = false
-			yyq3504[0] = x.Kind != ""
-			yyq3504[1] = x.APIVersion != ""
-			yyq3504[2] = true
-			yyq3504[3] = len(x.Data) != 0
-			yyq3504[4] = x.Type != ""
+			yyq3504[0] = true
+			yyq3504[1] = len(x.Data) != 0
+			yyq3504[2] = x.Type != ""
+			yyq3504[3] = x.Kind != ""
+			yyq3504[4] = x.APIVersion != ""
 			var yynn3504 int
 			if yyr3504 || yy2arr3504 {
 				r.EncodeArrayStart(5)
@@ -43751,78 +43751,28 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr3504 || yy2arr3504 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3504[0] {
-					yym3506 := z.EncBinary()
-					_ = yym3506
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3504[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3507 := z.EncBinary()
-					_ = yym3507
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3504 || yy2arr3504 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3504[1] {
-					yym3509 := z.EncBinary()
-					_ = yym3509
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3504[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3510 := z.EncBinary()
-					_ = yym3510
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3504 || yy2arr3504 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3504[2] {
-					yy3512 := &x.ObjectMeta
-					yy3512.CodecEncodeSelf(e)
+					yy3506 := &x.ObjectMeta
+					yy3506.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3504[2] {
+				if yyq3504[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3513 := &x.ObjectMeta
-					yy3513.CodecEncodeSelf(e)
+					yy3507 := &x.ObjectMeta
+					yy3507.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3504 || yy2arr3504 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3504[3] {
+				if yyq3504[1] {
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
-						yym3515 := z.EncBinary()
-						_ = yym3515
+						yym3509 := z.EncBinary()
+						_ = yym3509
 						if false {
 						} else {
 							h.encMapstringSliceuint8((map[string][]uint8)(x.Data), e)
@@ -43832,15 +43782,15 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3504[3] {
+				if yyq3504[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("data"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
-						yym3516 := z.EncBinary()
-						_ = yym3516
+						yym3510 := z.EncBinary()
+						_ = yym3510
 						if false {
 						} else {
 							h.encMapstringSliceuint8((map[string][]uint8)(x.Data), e)
@@ -43850,17 +43800,67 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr3504 || yy2arr3504 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3504[4] {
+				if yyq3504[2] {
 					x.Type.CodecEncodeSelf(e)
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3504[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("type"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					x.Type.CodecEncodeSelf(e)
+				}
+			}
+			if yyr3504 || yy2arr3504 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3504[3] {
+					yym3513 := z.EncBinary()
+					_ = yym3513
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3504[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3514 := z.EncBinary()
+					_ = yym3514
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3504 || yy2arr3504 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3504[4] {
+					yym3516 := z.EncBinary()
+					_ = yym3516
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq3504[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("type"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					x.Type.CodecEncodeSelf(e)
+					yym3517 := z.EncBinary()
+					_ = yym3517
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr3504 || yy2arr3504 {
@@ -43924,6 +43924,31 @@ func (x *Secret) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys3520 := string(yys3520Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3520 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv3521 := &x.ObjectMeta
+				yyv3521.CodecDecodeSelf(d)
+			}
+		case "data":
+			if r.TryDecodeAsNil() {
+				x.Data = nil
+			} else {
+				yyv3522 := &x.Data
+				yym3523 := z.DecBinary()
+				_ = yym3523
+				if false {
+				} else {
+					h.decMapstringSliceuint8((*map[string][]uint8)(yyv3522), d)
+				}
+			}
+		case "type":
+			if r.TryDecodeAsNil() {
+				x.Type = ""
+			} else {
+				x.Type = SecretType(r.DecodeString())
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -43935,31 +43960,6 @@ func (x *Secret) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv3523 := &x.ObjectMeta
-				yyv3523.CodecDecodeSelf(d)
-			}
-		case "data":
-			if r.TryDecodeAsNil() {
-				x.Data = nil
-			} else {
-				yyv3524 := &x.Data
-				yym3525 := z.DecBinary()
-				_ = yym3525
-				if false {
-				} else {
-					h.decMapstringSliceuint8((*map[string][]uint8)(yyv3524), d)
-				}
-			}
-		case "type":
-			if r.TryDecodeAsNil() {
-				x.Type = ""
-			} else {
-				x.Type = SecretType(r.DecodeString())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3520)
@@ -43975,6 +43975,61 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj3527 int
 	var yyb3527 bool
 	var yyhl3527 bool = l >= 0
+	yyj3527++
+	if yyhl3527 {
+		yyb3527 = yyj3527 > l
+	} else {
+		yyb3527 = r.CheckBreak()
+	}
+	if yyb3527 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv3528 := &x.ObjectMeta
+		yyv3528.CodecDecodeSelf(d)
+	}
+	yyj3527++
+	if yyhl3527 {
+		yyb3527 = yyj3527 > l
+	} else {
+		yyb3527 = r.CheckBreak()
+	}
+	if yyb3527 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Data = nil
+	} else {
+		yyv3529 := &x.Data
+		yym3530 := z.DecBinary()
+		_ = yym3530
+		if false {
+		} else {
+			h.decMapstringSliceuint8((*map[string][]uint8)(yyv3529), d)
+		}
+	}
+	yyj3527++
+	if yyhl3527 {
+		yyb3527 = yyj3527 > l
+	} else {
+		yyb3527 = r.CheckBreak()
+	}
+	if yyb3527 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Type = ""
+	} else {
+		x.Type = SecretType(r.DecodeString())
+	}
 	yyj3527++
 	if yyhl3527 {
 		yyb3527 = yyj3527 > l
@@ -44006,61 +44061,6 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3527++
-	if yyhl3527 {
-		yyb3527 = yyj3527 > l
-	} else {
-		yyb3527 = r.CheckBreak()
-	}
-	if yyb3527 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv3530 := &x.ObjectMeta
-		yyv3530.CodecDecodeSelf(d)
-	}
-	yyj3527++
-	if yyhl3527 {
-		yyb3527 = yyj3527 > l
-	} else {
-		yyb3527 = r.CheckBreak()
-	}
-	if yyb3527 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Data = nil
-	} else {
-		yyv3531 := &x.Data
-		yym3532 := z.DecBinary()
-		_ = yym3532
-		if false {
-		} else {
-			h.decMapstringSliceuint8((*map[string][]uint8)(yyv3531), d)
-		}
-	}
-	yyj3527++
-	if yyhl3527 {
-		yyb3527 = yyj3527 > l
-	} else {
-		yyb3527 = r.CheckBreak()
-	}
-	if yyb3527 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Type = ""
-	} else {
-		x.Type = SecretType(r.DecodeString())
 	}
 	for {
 		yyj3527++
@@ -44121,9 +44121,9 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3537 [4]bool
 			_, _, _ = yysep3537, yyq3537, yy2arr3537
 			const yyr3537 bool = false
-			yyq3537[0] = x.Kind != ""
-			yyq3537[1] = x.APIVersion != ""
-			yyq3537[2] = true
+			yyq3537[0] = true
+			yyq3537[2] = x.Kind != ""
+			yyq3537[3] = x.APIVersion != ""
 			var yynn3537 int
 			if yyr3537 || yy2arr3537 {
 				r.EncodeArrayStart(4)
@@ -44140,79 +44140,29 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr3537 || yy2arr3537 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3537[0] {
-					yym3539 := z.EncBinary()
-					_ = yym3539
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3537[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy3539 := &x.ListMeta
 					yym3540 := z.EncBinary()
 					_ = yym3540
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3539) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3537 || yy2arr3537 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3537[1] {
-					yym3542 := z.EncBinary()
-					_ = yym3542
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3537[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3543 := z.EncBinary()
-					_ = yym3543
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3537 || yy2arr3537 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3537[2] {
-					yy3545 := &x.ListMeta
-					yym3546 := z.EncBinary()
-					_ = yym3546
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3545) {
-					} else {
-						z.EncFallback(yy3545)
+						z.EncFallback(yy3539)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3537[2] {
+				if yyq3537[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3547 := &x.ListMeta
-					yym3548 := z.EncBinary()
-					_ = yym3548
+					yy3541 := &x.ListMeta
+					yym3542 := z.EncBinary()
+					_ = yym3542
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3547) {
+					} else if z.HasExtensions() && z.EncExt(yy3541) {
 					} else {
-						z.EncFallback(yy3547)
+						z.EncFallback(yy3541)
 					}
 				}
 			}
@@ -44221,8 +44171,8 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3550 := z.EncBinary()
-					_ = yym3550
+					yym3544 := z.EncBinary()
+					_ = yym3544
 					if false {
 					} else {
 						h.encSliceSecret(([]Secret)(x.Items), e)
@@ -44235,11 +44185,61 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym3545 := z.EncBinary()
+					_ = yym3545
+					if false {
+					} else {
+						h.encSliceSecret(([]Secret)(x.Items), e)
+					}
+				}
+			}
+			if yyr3537 || yy2arr3537 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3537[2] {
+					yym3547 := z.EncBinary()
+					_ = yym3547
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3537[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3548 := z.EncBinary()
+					_ = yym3548
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3537 || yy2arr3537 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3537[3] {
+					yym3550 := z.EncBinary()
+					_ = yym3550
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3537[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3551 := z.EncBinary()
 					_ = yym3551
 					if false {
 					} else {
-						h.encSliceSecret(([]Secret)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -44304,6 +44304,31 @@ func (x *SecretList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys3554 := string(yys3554Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3554 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv3555 := &x.ListMeta
+				yym3556 := z.DecBinary()
+				_ = yym3556
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv3555) {
+				} else {
+					z.DecFallback(yyv3555, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv3557 := &x.Items
+				yym3558 := z.DecBinary()
+				_ = yym3558
+				if false {
+				} else {
+					h.decSliceSecret((*[]Secret)(yyv3557), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -44315,31 +44340,6 @@ func (x *SecretList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv3557 := &x.ListMeta
-				yym3558 := z.DecBinary()
-				_ = yym3558
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3557) {
-				} else {
-					z.DecFallback(yyv3557, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv3559 := &x.Items
-				yym3560 := z.DecBinary()
-				_ = yym3560
-				if false {
-				} else {
-					h.decSliceSecret((*[]Secret)(yyv3559), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3554)
@@ -44355,6 +44355,51 @@ func (x *SecretList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj3561 int
 	var yyb3561 bool
 	var yyhl3561 bool = l >= 0
+	yyj3561++
+	if yyhl3561 {
+		yyb3561 = yyj3561 > l
+	} else {
+		yyb3561 = r.CheckBreak()
+	}
+	if yyb3561 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv3562 := &x.ListMeta
+		yym3563 := z.DecBinary()
+		_ = yym3563
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv3562) {
+		} else {
+			z.DecFallback(yyv3562, false)
+		}
+	}
+	yyj3561++
+	if yyhl3561 {
+		yyb3561 = yyj3561 > l
+	} else {
+		yyb3561 = r.CheckBreak()
+	}
+	if yyb3561 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv3564 := &x.Items
+		yym3565 := z.DecBinary()
+		_ = yym3565
+		if false {
+		} else {
+			h.decSliceSecret((*[]Secret)(yyv3564), d)
+		}
+	}
 	yyj3561++
 	if yyhl3561 {
 		yyb3561 = yyj3561 > l
@@ -44386,51 +44431,6 @@ func (x *SecretList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3561++
-	if yyhl3561 {
-		yyb3561 = yyj3561 > l
-	} else {
-		yyb3561 = r.CheckBreak()
-	}
-	if yyb3561 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv3564 := &x.ListMeta
-		yym3565 := z.DecBinary()
-		_ = yym3565
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3564) {
-		} else {
-			z.DecFallback(yyv3564, false)
-		}
-	}
-	yyj3561++
-	if yyhl3561 {
-		yyb3561 = yyj3561 > l
-	} else {
-		yyb3561 = r.CheckBreak()
-	}
-	if yyb3561 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv3566 := &x.Items
-		yym3567 := z.DecBinary()
-		_ = yym3567
-		if false {
-		} else {
-			h.decSliceSecret((*[]Secret)(yyv3566), d)
-		}
 	}
 	for {
 		yyj3561++
@@ -44465,10 +44465,10 @@ func (x *ConfigMap) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3569 [4]bool
 			_, _, _ = yysep3569, yyq3569, yy2arr3569
 			const yyr3569 bool = false
-			yyq3569[0] = x.Kind != ""
-			yyq3569[1] = x.APIVersion != ""
-			yyq3569[2] = true
-			yyq3569[3] = len(x.Data) != 0
+			yyq3569[0] = true
+			yyq3569[1] = len(x.Data) != 0
+			yyq3569[2] = x.Kind != ""
+			yyq3569[3] = x.APIVersion != ""
 			var yynn3569 int
 			if yyr3569 || yy2arr3569 {
 				r.EncodeArrayStart(4)
@@ -44485,78 +44485,28 @@ func (x *ConfigMap) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr3569 || yy2arr3569 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3569[0] {
-					yym3571 := z.EncBinary()
-					_ = yym3571
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3569[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3572 := z.EncBinary()
-					_ = yym3572
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3569 || yy2arr3569 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3569[1] {
-					yym3574 := z.EncBinary()
-					_ = yym3574
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3569[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3575 := z.EncBinary()
-					_ = yym3575
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3569 || yy2arr3569 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3569[2] {
-					yy3577 := &x.ObjectMeta
-					yy3577.CodecEncodeSelf(e)
+					yy3571 := &x.ObjectMeta
+					yy3571.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3569[2] {
+				if yyq3569[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3578 := &x.ObjectMeta
-					yy3578.CodecEncodeSelf(e)
+					yy3572 := &x.ObjectMeta
+					yy3572.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3569 || yy2arr3569 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3569[3] {
+				if yyq3569[1] {
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
-						yym3580 := z.EncBinary()
-						_ = yym3580
+						yym3574 := z.EncBinary()
+						_ = yym3574
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Data, false, e)
@@ -44566,19 +44516,69 @@ func (x *ConfigMap) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3569[3] {
+				if yyq3569[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("data"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
-						yym3581 := z.EncBinary()
-						_ = yym3581
+						yym3575 := z.EncBinary()
+						_ = yym3575
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Data, false, e)
 						}
+					}
+				}
+			}
+			if yyr3569 || yy2arr3569 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3569[2] {
+					yym3577 := z.EncBinary()
+					_ = yym3577
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3569[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3578 := z.EncBinary()
+					_ = yym3578
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3569 || yy2arr3569 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3569[3] {
+					yym3580 := z.EncBinary()
+					_ = yym3580
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3569[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3581 := z.EncBinary()
+					_ = yym3581
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -44643,6 +44643,25 @@ func (x *ConfigMap) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys3584 := string(yys3584Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3584 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv3585 := &x.ObjectMeta
+				yyv3585.CodecDecodeSelf(d)
+			}
+		case "data":
+			if r.TryDecodeAsNil() {
+				x.Data = nil
+			} else {
+				yyv3586 := &x.Data
+				yym3587 := z.DecBinary()
+				_ = yym3587
+				if false {
+				} else {
+					z.F.DecMapStringStringX(yyv3586, false, d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -44654,25 +44673,6 @@ func (x *ConfigMap) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv3587 := &x.ObjectMeta
-				yyv3587.CodecDecodeSelf(d)
-			}
-		case "data":
-			if r.TryDecodeAsNil() {
-				x.Data = nil
-			} else {
-				yyv3588 := &x.Data
-				yym3589 := z.DecBinary()
-				_ = yym3589
-				if false {
-				} else {
-					z.F.DecMapStringStringX(yyv3588, false, d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3584)
@@ -44688,6 +44688,45 @@ func (x *ConfigMap) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj3590 int
 	var yyb3590 bool
 	var yyhl3590 bool = l >= 0
+	yyj3590++
+	if yyhl3590 {
+		yyb3590 = yyj3590 > l
+	} else {
+		yyb3590 = r.CheckBreak()
+	}
+	if yyb3590 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv3591 := &x.ObjectMeta
+		yyv3591.CodecDecodeSelf(d)
+	}
+	yyj3590++
+	if yyhl3590 {
+		yyb3590 = yyj3590 > l
+	} else {
+		yyb3590 = r.CheckBreak()
+	}
+	if yyb3590 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Data = nil
+	} else {
+		yyv3592 := &x.Data
+		yym3593 := z.DecBinary()
+		_ = yym3593
+		if false {
+		} else {
+			z.F.DecMapStringStringX(yyv3592, false, d)
+		}
+	}
 	yyj3590++
 	if yyhl3590 {
 		yyb3590 = yyj3590 > l
@@ -44719,45 +44758,6 @@ func (x *ConfigMap) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3590++
-	if yyhl3590 {
-		yyb3590 = yyj3590 > l
-	} else {
-		yyb3590 = r.CheckBreak()
-	}
-	if yyb3590 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv3593 := &x.ObjectMeta
-		yyv3593.CodecDecodeSelf(d)
-	}
-	yyj3590++
-	if yyhl3590 {
-		yyb3590 = yyj3590 > l
-	} else {
-		yyb3590 = r.CheckBreak()
-	}
-	if yyb3590 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Data = nil
-	} else {
-		yyv3594 := &x.Data
-		yym3595 := z.DecBinary()
-		_ = yym3595
-		if false {
-		} else {
-			z.F.DecMapStringStringX(yyv3594, false, d)
-		}
 	}
 	for {
 		yyj3590++
@@ -44792,10 +44792,10 @@ func (x *ConfigMapList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3597 [4]bool
 			_, _, _ = yysep3597, yyq3597, yy2arr3597
 			const yyr3597 bool = false
-			yyq3597[0] = x.Kind != ""
-			yyq3597[1] = x.APIVersion != ""
-			yyq3597[2] = true
-			yyq3597[3] = len(x.Items) != 0
+			yyq3597[0] = true
+			yyq3597[1] = len(x.Items) != 0
+			yyq3597[2] = x.Kind != ""
+			yyq3597[3] = x.APIVersion != ""
 			var yynn3597 int
 			if yyr3597 || yy2arr3597 {
 				r.EncodeArrayStart(4)
@@ -44812,90 +44812,40 @@ func (x *ConfigMapList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr3597 || yy2arr3597 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3597[0] {
-					yym3599 := z.EncBinary()
-					_ = yym3599
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3597[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy3599 := &x.ListMeta
 					yym3600 := z.EncBinary()
 					_ = yym3600
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3599) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3597 || yy2arr3597 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3597[1] {
-					yym3602 := z.EncBinary()
-					_ = yym3602
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3597[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3603 := z.EncBinary()
-					_ = yym3603
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3597 || yy2arr3597 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3597[2] {
-					yy3605 := &x.ListMeta
-					yym3606 := z.EncBinary()
-					_ = yym3606
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3605) {
-					} else {
-						z.EncFallback(yy3605)
+						z.EncFallback(yy3599)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3597[2] {
+				if yyq3597[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3607 := &x.ListMeta
-					yym3608 := z.EncBinary()
-					_ = yym3608
+					yy3601 := &x.ListMeta
+					yym3602 := z.EncBinary()
+					_ = yym3602
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3607) {
+					} else if z.HasExtensions() && z.EncExt(yy3601) {
 					} else {
-						z.EncFallback(yy3607)
+						z.EncFallback(yy3601)
 					}
 				}
 			}
 			if yyr3597 || yy2arr3597 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3597[3] {
+				if yyq3597[1] {
 					if x.Items == nil {
 						r.EncodeNil()
 					} else {
-						yym3610 := z.EncBinary()
-						_ = yym3610
+						yym3604 := z.EncBinary()
+						_ = yym3604
 						if false {
 						} else {
 							h.encSliceConfigMap(([]ConfigMap)(x.Items), e)
@@ -44905,19 +44855,69 @@ func (x *ConfigMapList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3597[3] {
+				if yyq3597[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("items"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Items == nil {
 						r.EncodeNil()
 					} else {
-						yym3611 := z.EncBinary()
-						_ = yym3611
+						yym3605 := z.EncBinary()
+						_ = yym3605
 						if false {
 						} else {
 							h.encSliceConfigMap(([]ConfigMap)(x.Items), e)
 						}
+					}
+				}
+			}
+			if yyr3597 || yy2arr3597 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3597[2] {
+					yym3607 := z.EncBinary()
+					_ = yym3607
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3597[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3608 := z.EncBinary()
+					_ = yym3608
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3597 || yy2arr3597 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3597[3] {
+					yym3610 := z.EncBinary()
+					_ = yym3610
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3597[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3611 := z.EncBinary()
+					_ = yym3611
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -44982,6 +44982,31 @@ func (x *ConfigMapList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys3614 := string(yys3614Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3614 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv3615 := &x.ListMeta
+				yym3616 := z.DecBinary()
+				_ = yym3616
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv3615) {
+				} else {
+					z.DecFallback(yyv3615, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv3617 := &x.Items
+				yym3618 := z.DecBinary()
+				_ = yym3618
+				if false {
+				} else {
+					h.decSliceConfigMap((*[]ConfigMap)(yyv3617), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -44993,31 +45018,6 @@ func (x *ConfigMapList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv3617 := &x.ListMeta
-				yym3618 := z.DecBinary()
-				_ = yym3618
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3617) {
-				} else {
-					z.DecFallback(yyv3617, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv3619 := &x.Items
-				yym3620 := z.DecBinary()
-				_ = yym3620
-				if false {
-				} else {
-					h.decSliceConfigMap((*[]ConfigMap)(yyv3619), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3614)
@@ -45033,6 +45033,51 @@ func (x *ConfigMapList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj3621 int
 	var yyb3621 bool
 	var yyhl3621 bool = l >= 0
+	yyj3621++
+	if yyhl3621 {
+		yyb3621 = yyj3621 > l
+	} else {
+		yyb3621 = r.CheckBreak()
+	}
+	if yyb3621 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv3622 := &x.ListMeta
+		yym3623 := z.DecBinary()
+		_ = yym3623
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv3622) {
+		} else {
+			z.DecFallback(yyv3622, false)
+		}
+	}
+	yyj3621++
+	if yyhl3621 {
+		yyb3621 = yyj3621 > l
+	} else {
+		yyb3621 = r.CheckBreak()
+	}
+	if yyb3621 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv3624 := &x.Items
+		yym3625 := z.DecBinary()
+		_ = yym3625
+		if false {
+		} else {
+			h.decSliceConfigMap((*[]ConfigMap)(yyv3624), d)
+		}
+	}
 	yyj3621++
 	if yyhl3621 {
 		yyb3621 = yyj3621 > l
@@ -45064,51 +45109,6 @@ func (x *ConfigMapList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3621++
-	if yyhl3621 {
-		yyb3621 = yyj3621 > l
-	} else {
-		yyb3621 = r.CheckBreak()
-	}
-	if yyb3621 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv3624 := &x.ListMeta
-		yym3625 := z.DecBinary()
-		_ = yym3625
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3624) {
-		} else {
-			z.DecFallback(yyv3624, false)
-		}
-	}
-	yyj3621++
-	if yyhl3621 {
-		yyb3621 = yyj3621 > l
-	} else {
-		yyb3621 = r.CheckBreak()
-	}
-	if yyb3621 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv3626 := &x.Items
-		yym3627 := z.DecBinary()
-		_ = yym3627
-		if false {
-		} else {
-			h.decSliceConfigMap((*[]ConfigMap)(yyv3626), d)
-		}
 	}
 	for {
 		yyj3621++
@@ -45474,10 +45474,10 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3655 [4]bool
 			_, _, _ = yysep3655, yyq3655, yy2arr3655
 			const yyr3655 bool = false
-			yyq3655[0] = x.Kind != ""
-			yyq3655[1] = x.APIVersion != ""
-			yyq3655[2] = true
-			yyq3655[3] = len(x.Conditions) != 0
+			yyq3655[0] = true
+			yyq3655[1] = len(x.Conditions) != 0
+			yyq3655[2] = x.Kind != ""
+			yyq3655[3] = x.APIVersion != ""
 			var yynn3655 int
 			if yyr3655 || yy2arr3655 {
 				r.EncodeArrayStart(4)
@@ -45494,78 +45494,28 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr3655 || yy2arr3655 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3655[0] {
-					yym3657 := z.EncBinary()
-					_ = yym3657
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3655[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3658 := z.EncBinary()
-					_ = yym3658
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3655 || yy2arr3655 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3655[1] {
-					yym3660 := z.EncBinary()
-					_ = yym3660
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3655[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3661 := z.EncBinary()
-					_ = yym3661
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3655 || yy2arr3655 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3655[2] {
-					yy3663 := &x.ObjectMeta
-					yy3663.CodecEncodeSelf(e)
+					yy3657 := &x.ObjectMeta
+					yy3657.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3655[2] {
+				if yyq3655[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3664 := &x.ObjectMeta
-					yy3664.CodecEncodeSelf(e)
+					yy3658 := &x.ObjectMeta
+					yy3658.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3655 || yy2arr3655 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3655[3] {
+				if yyq3655[1] {
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym3666 := z.EncBinary()
-						_ = yym3666
+						yym3660 := z.EncBinary()
+						_ = yym3660
 						if false {
 						} else {
 							h.encSliceComponentCondition(([]ComponentCondition)(x.Conditions), e)
@@ -45575,19 +45525,69 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3655[3] {
+				if yyq3655[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("conditions"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym3667 := z.EncBinary()
-						_ = yym3667
+						yym3661 := z.EncBinary()
+						_ = yym3661
 						if false {
 						} else {
 							h.encSliceComponentCondition(([]ComponentCondition)(x.Conditions), e)
 						}
+					}
+				}
+			}
+			if yyr3655 || yy2arr3655 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3655[2] {
+					yym3663 := z.EncBinary()
+					_ = yym3663
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3655[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3664 := z.EncBinary()
+					_ = yym3664
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3655 || yy2arr3655 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3655[3] {
+					yym3666 := z.EncBinary()
+					_ = yym3666
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3655[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3667 := z.EncBinary()
+					_ = yym3667
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -45652,6 +45652,25 @@ func (x *ComponentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys3670 := string(yys3670Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3670 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv3671 := &x.ObjectMeta
+				yyv3671.CodecDecodeSelf(d)
+			}
+		case "conditions":
+			if r.TryDecodeAsNil() {
+				x.Conditions = nil
+			} else {
+				yyv3672 := &x.Conditions
+				yym3673 := z.DecBinary()
+				_ = yym3673
+				if false {
+				} else {
+					h.decSliceComponentCondition((*[]ComponentCondition)(yyv3672), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -45663,25 +45682,6 @@ func (x *ComponentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv3673 := &x.ObjectMeta
-				yyv3673.CodecDecodeSelf(d)
-			}
-		case "conditions":
-			if r.TryDecodeAsNil() {
-				x.Conditions = nil
-			} else {
-				yyv3674 := &x.Conditions
-				yym3675 := z.DecBinary()
-				_ = yym3675
-				if false {
-				} else {
-					h.decSliceComponentCondition((*[]ComponentCondition)(yyv3674), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3670)
@@ -45697,6 +45697,45 @@ func (x *ComponentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var yyj3676 int
 	var yyb3676 bool
 	var yyhl3676 bool = l >= 0
+	yyj3676++
+	if yyhl3676 {
+		yyb3676 = yyj3676 > l
+	} else {
+		yyb3676 = r.CheckBreak()
+	}
+	if yyb3676 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv3677 := &x.ObjectMeta
+		yyv3677.CodecDecodeSelf(d)
+	}
+	yyj3676++
+	if yyhl3676 {
+		yyb3676 = yyj3676 > l
+	} else {
+		yyb3676 = r.CheckBreak()
+	}
+	if yyb3676 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Conditions = nil
+	} else {
+		yyv3678 := &x.Conditions
+		yym3679 := z.DecBinary()
+		_ = yym3679
+		if false {
+		} else {
+			h.decSliceComponentCondition((*[]ComponentCondition)(yyv3678), d)
+		}
+	}
 	yyj3676++
 	if yyhl3676 {
 		yyb3676 = yyj3676 > l
@@ -45728,45 +45767,6 @@ func (x *ComponentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3676++
-	if yyhl3676 {
-		yyb3676 = yyj3676 > l
-	} else {
-		yyb3676 = r.CheckBreak()
-	}
-	if yyb3676 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv3679 := &x.ObjectMeta
-		yyv3679.CodecDecodeSelf(d)
-	}
-	yyj3676++
-	if yyhl3676 {
-		yyb3676 = yyj3676 > l
-	} else {
-		yyb3676 = r.CheckBreak()
-	}
-	if yyb3676 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Conditions = nil
-	} else {
-		yyv3680 := &x.Conditions
-		yym3681 := z.DecBinary()
-		_ = yym3681
-		if false {
-		} else {
-			h.decSliceComponentCondition((*[]ComponentCondition)(yyv3680), d)
-		}
 	}
 	for {
 		yyj3676++
@@ -45801,9 +45801,9 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3683 [4]bool
 			_, _, _ = yysep3683, yyq3683, yy2arr3683
 			const yyr3683 bool = false
-			yyq3683[0] = x.Kind != ""
-			yyq3683[1] = x.APIVersion != ""
-			yyq3683[2] = true
+			yyq3683[0] = true
+			yyq3683[2] = x.Kind != ""
+			yyq3683[3] = x.APIVersion != ""
 			var yynn3683 int
 			if yyr3683 || yy2arr3683 {
 				r.EncodeArrayStart(4)
@@ -45820,79 +45820,29 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr3683 || yy2arr3683 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3683[0] {
-					yym3685 := z.EncBinary()
-					_ = yym3685
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3683[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy3685 := &x.ListMeta
 					yym3686 := z.EncBinary()
 					_ = yym3686
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3685) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3683 || yy2arr3683 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3683[1] {
-					yym3688 := z.EncBinary()
-					_ = yym3688
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3683[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3689 := z.EncBinary()
-					_ = yym3689
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3683 || yy2arr3683 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3683[2] {
-					yy3691 := &x.ListMeta
-					yym3692 := z.EncBinary()
-					_ = yym3692
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3691) {
-					} else {
-						z.EncFallback(yy3691)
+						z.EncFallback(yy3685)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3683[2] {
+				if yyq3683[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3693 := &x.ListMeta
-					yym3694 := z.EncBinary()
-					_ = yym3694
+					yy3687 := &x.ListMeta
+					yym3688 := z.EncBinary()
+					_ = yym3688
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3693) {
+					} else if z.HasExtensions() && z.EncExt(yy3687) {
 					} else {
-						z.EncFallback(yy3693)
+						z.EncFallback(yy3687)
 					}
 				}
 			}
@@ -45901,8 +45851,8 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3696 := z.EncBinary()
-					_ = yym3696
+					yym3690 := z.EncBinary()
+					_ = yym3690
 					if false {
 					} else {
 						h.encSliceComponentStatus(([]ComponentStatus)(x.Items), e)
@@ -45915,11 +45865,61 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym3691 := z.EncBinary()
+					_ = yym3691
+					if false {
+					} else {
+						h.encSliceComponentStatus(([]ComponentStatus)(x.Items), e)
+					}
+				}
+			}
+			if yyr3683 || yy2arr3683 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3683[2] {
+					yym3693 := z.EncBinary()
+					_ = yym3693
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3683[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3694 := z.EncBinary()
+					_ = yym3694
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3683 || yy2arr3683 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3683[3] {
+					yym3696 := z.EncBinary()
+					_ = yym3696
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3683[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3697 := z.EncBinary()
 					_ = yym3697
 					if false {
 					} else {
-						h.encSliceComponentStatus(([]ComponentStatus)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -45984,6 +45984,31 @@ func (x *ComponentStatusList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 		yys3700 := string(yys3700Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3700 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv3701 := &x.ListMeta
+				yym3702 := z.DecBinary()
+				_ = yym3702
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv3701) {
+				} else {
+					z.DecFallback(yyv3701, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv3703 := &x.Items
+				yym3704 := z.DecBinary()
+				_ = yym3704
+				if false {
+				} else {
+					h.decSliceComponentStatus((*[]ComponentStatus)(yyv3703), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -45995,31 +46020,6 @@ func (x *ComponentStatusList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv3703 := &x.ListMeta
-				yym3704 := z.DecBinary()
-				_ = yym3704
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3703) {
-				} else {
-					z.DecFallback(yyv3703, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv3705 := &x.Items
-				yym3706 := z.DecBinary()
-				_ = yym3706
-				if false {
-				} else {
-					h.decSliceComponentStatus((*[]ComponentStatus)(yyv3705), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3700)
@@ -46035,6 +46035,51 @@ func (x *ComponentStatusList) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	var yyj3707 int
 	var yyb3707 bool
 	var yyhl3707 bool = l >= 0
+	yyj3707++
+	if yyhl3707 {
+		yyb3707 = yyj3707 > l
+	} else {
+		yyb3707 = r.CheckBreak()
+	}
+	if yyb3707 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv3708 := &x.ListMeta
+		yym3709 := z.DecBinary()
+		_ = yym3709
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv3708) {
+		} else {
+			z.DecFallback(yyv3708, false)
+		}
+	}
+	yyj3707++
+	if yyhl3707 {
+		yyb3707 = yyj3707 > l
+	} else {
+		yyb3707 = r.CheckBreak()
+	}
+	if yyb3707 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv3710 := &x.Items
+		yym3711 := z.DecBinary()
+		_ = yym3711
+		if false {
+		} else {
+			h.decSliceComponentStatus((*[]ComponentStatus)(yyv3710), d)
+		}
+	}
 	yyj3707++
 	if yyhl3707 {
 		yyb3707 = yyj3707 > l
@@ -46066,51 +46111,6 @@ func (x *ComponentStatusList) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3707++
-	if yyhl3707 {
-		yyb3707 = yyj3707 > l
-	} else {
-		yyb3707 = r.CheckBreak()
-	}
-	if yyb3707 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv3710 := &x.ListMeta
-		yym3711 := z.DecBinary()
-		_ = yym3711
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3710) {
-		} else {
-			z.DecFallback(yyv3710, false)
-		}
-	}
-	yyj3707++
-	if yyhl3707 {
-		yyb3707 = yyj3707 > l
-	} else {
-		yyb3707 = r.CheckBreak()
-	}
-	if yyb3707 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv3712 := &x.Items
-		yym3713 := z.DecBinary()
-		_ = yym3713
-		if false {
-		} else {
-			h.decSliceComponentStatus((*[]ComponentStatus)(yyv3712), d)
-		}
 	}
 	for {
 		yyj3707++
@@ -46925,9 +46925,9 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3780 [5]bool
 			_, _, _ = yysep3780, yyq3780, yy2arr3780
 			const yyr3780 bool = false
-			yyq3780[0] = x.Kind != ""
-			yyq3780[1] = x.APIVersion != ""
-			yyq3780[2] = true
+			yyq3780[0] = true
+			yyq3780[3] = x.Kind != ""
+			yyq3780[4] = x.APIVersion != ""
 			var yynn3780 int
 			if yyr3780 || yy2arr3780 {
 				r.EncodeArrayStart(5)
@@ -46944,74 +46944,24 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr3780 || yy2arr3780 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3780[0] {
-					yym3782 := z.EncBinary()
-					_ = yym3782
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3780[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3783 := z.EncBinary()
-					_ = yym3783
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3780 || yy2arr3780 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3780[1] {
-					yym3785 := z.EncBinary()
-					_ = yym3785
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3780[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3786 := z.EncBinary()
-					_ = yym3786
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3780 || yy2arr3780 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3780[2] {
-					yy3788 := &x.ObjectMeta
-					yy3788.CodecEncodeSelf(e)
+					yy3782 := &x.ObjectMeta
+					yy3782.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3780[2] {
+				if yyq3780[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3789 := &x.ObjectMeta
-					yy3789.CodecEncodeSelf(e)
+					yy3783 := &x.ObjectMeta
+					yy3783.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3780 || yy2arr3780 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym3791 := z.EncBinary()
-				_ = yym3791
+				yym3785 := z.EncBinary()
+				_ = yym3785
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Range))
@@ -47020,8 +46970,8 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("range"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym3792 := z.EncBinary()
-				_ = yym3792
+				yym3786 := z.EncBinary()
+				_ = yym3786
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Range))
@@ -47032,8 +46982,8 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Data == nil {
 					r.EncodeNil()
 				} else {
-					yym3794 := z.EncBinary()
-					_ = yym3794
+					yym3788 := z.EncBinary()
+					_ = yym3788
 					if false {
 					} else {
 						r.EncodeStringBytes(codecSelferC_RAW1234, []byte(x.Data))
@@ -47046,11 +46996,61 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Data == nil {
 					r.EncodeNil()
 				} else {
+					yym3789 := z.EncBinary()
+					_ = yym3789
+					if false {
+					} else {
+						r.EncodeStringBytes(codecSelferC_RAW1234, []byte(x.Data))
+					}
+				}
+			}
+			if yyr3780 || yy2arr3780 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3780[3] {
+					yym3791 := z.EncBinary()
+					_ = yym3791
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3780[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3792 := z.EncBinary()
+					_ = yym3792
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3780 || yy2arr3780 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3780[4] {
+					yym3794 := z.EncBinary()
+					_ = yym3794
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3780[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3795 := z.EncBinary()
 					_ = yym3795
 					if false {
 					} else {
-						r.EncodeStringBytes(codecSelferC_RAW1234, []byte(x.Data))
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -47115,24 +47115,12 @@ func (x *RangeAllocation) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys3798 := string(yys3798Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3798 {
-		case "kind":
-			if r.TryDecodeAsNil() {
-				x.Kind = ""
-			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
-			}
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv3801 := &x.ObjectMeta
-				yyv3801.CodecDecodeSelf(d)
+				yyv3799 := &x.ObjectMeta
+				yyv3799.CodecDecodeSelf(d)
 			}
 		case "range":
 			if r.TryDecodeAsNil() {
@@ -47144,13 +47132,25 @@ func (x *RangeAllocation) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Data = nil
 			} else {
-				yyv3803 := &x.Data
-				yym3804 := z.DecBinary()
-				_ = yym3804
+				yyv3801 := &x.Data
+				yym3802 := z.DecBinary()
+				_ = yym3802
 				if false {
 				} else {
-					*yyv3803 = r.DecodeBytes(*(*[]byte)(yyv3803), false, false)
+					*yyv3801 = r.DecodeBytes(*(*[]byte)(yyv3801), false, false)
 				}
+			}
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3798)
@@ -47178,42 +47178,10 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.Kind = ""
-	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj3805++
-	if yyhl3805 {
-		yyb3805 = yyj3805 > l
-	} else {
-		yyb3805 = r.CheckBreak()
-	}
-	if yyb3805 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3805++
-	if yyhl3805 {
-		yyb3805 = yyj3805 > l
-	} else {
-		yyb3805 = r.CheckBreak()
-	}
-	if yyb3805 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv3808 := &x.ObjectMeta
-		yyv3808.CodecDecodeSelf(d)
+		yyv3806 := &x.ObjectMeta
+		yyv3806.CodecDecodeSelf(d)
 	}
 	yyj3805++
 	if yyhl3805 {
@@ -47245,13 +47213,45 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	if r.TryDecodeAsNil() {
 		x.Data = nil
 	} else {
-		yyv3810 := &x.Data
-		yym3811 := z.DecBinary()
-		_ = yym3811
+		yyv3808 := &x.Data
+		yym3809 := z.DecBinary()
+		_ = yym3809
 		if false {
 		} else {
-			*yyv3810 = r.DecodeBytes(*(*[]byte)(yyv3810), false, false)
+			*yyv3808 = r.DecodeBytes(*(*[]byte)(yyv3808), false, false)
 		}
+	}
+	yyj3805++
+	if yyhl3805 {
+		yyb3805 = yyj3805 > l
+	} else {
+		yyb3805 = r.CheckBreak()
+	}
+	if yyb3805 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj3805++
+	if yyhl3805 {
+		yyb3805 = yyj3805 > l
+	} else {
+		yyb3805 = r.CheckBreak()
+	}
+	if yyb3805 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
 	}
 	for {
 		yyj3805++

--- a/pkg/api/v1/types.generated.go
+++ b/pkg/api/v1/types.generated.go
@@ -4475,11 +4475,11 @@ func (x *PersistentVolume) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq259 [5]bool
 			_, _, _ = yysep259, yyq259, yy2arr259
 			const yyr259 bool = false
-			yyq259[0] = x.Kind != ""
-			yyq259[1] = x.APIVersion != ""
+			yyq259[0] = true
+			yyq259[1] = true
 			yyq259[2] = true
-			yyq259[3] = true
-			yyq259[4] = true
+			yyq259[3] = x.Kind != ""
+			yyq259[4] = x.APIVersion != ""
 			var yynn259 int
 			if yyr259 || yy2arr259 {
 				r.EncodeArrayStart(5)
@@ -4496,57 +4496,41 @@ func (x *PersistentVolume) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr259 || yy2arr259 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq259[0] {
-					yym261 := z.EncBinary()
-					_ = yym261
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy261 := &x.ObjectMeta
+					yy261.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq259[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym262 := z.EncBinary()
-					_ = yym262
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy262 := &x.ObjectMeta
+					yy262.CodecEncodeSelf(e)
 				}
 			}
 			if yyr259 || yy2arr259 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq259[1] {
-					yym264 := z.EncBinary()
-					_ = yym264
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy264 := &x.Spec
+					yy264.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq259[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym265 := z.EncBinary()
-					_ = yym265
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy265 := &x.Spec
+					yy265.CodecEncodeSelf(e)
 				}
 			}
 			if yyr259 || yy2arr259 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq259[2] {
-					yy267 := &x.ObjectMeta
+					yy267 := &x.Status
 					yy267.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
@@ -4554,44 +4538,60 @@ func (x *PersistentVolume) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq259[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy268 := &x.ObjectMeta
+					yy268 := &x.Status
 					yy268.CodecEncodeSelf(e)
 				}
 			}
 			if yyr259 || yy2arr259 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq259[3] {
-					yy270 := &x.Spec
-					yy270.CodecEncodeSelf(e)
+					yym270 := z.EncBinary()
+					_ = yym270
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq259[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy271 := &x.Spec
-					yy271.CodecEncodeSelf(e)
+					yym271 := z.EncBinary()
+					_ = yym271
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				}
 			}
 			if yyr259 || yy2arr259 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq259[4] {
-					yy273 := &x.Status
-					yy273.CodecEncodeSelf(e)
+					yym273 := z.EncBinary()
+					_ = yym273
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq259[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy274 := &x.Status
-					yy274.CodecEncodeSelf(e)
+					yym274 := z.EncBinary()
+					_ = yym274
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr259 || yy2arr259 {
@@ -4655,6 +4655,27 @@ func (x *PersistentVolume) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys277 := string(yys277Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys277 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv278 := &x.ObjectMeta
+				yyv278.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = PersistentVolumeSpec{}
+			} else {
+				yyv279 := &x.Spec
+				yyv279.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = PersistentVolumeStatus{}
+			} else {
+				yyv280 := &x.Status
+				yyv280.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -4666,27 +4687,6 @@ func (x *PersistentVolume) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv280 := &x.ObjectMeta
-				yyv280.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = PersistentVolumeSpec{}
-			} else {
-				yyv281 := &x.Spec
-				yyv281.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = PersistentVolumeStatus{}
-			} else {
-				yyv282 := &x.Status
-				yyv282.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys277)
@@ -4702,6 +4702,57 @@ func (x *PersistentVolume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	var yyj283 int
 	var yyb283 bool
 	var yyhl283 bool = l >= 0
+	yyj283++
+	if yyhl283 {
+		yyb283 = yyj283 > l
+	} else {
+		yyb283 = r.CheckBreak()
+	}
+	if yyb283 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv284 := &x.ObjectMeta
+		yyv284.CodecDecodeSelf(d)
+	}
+	yyj283++
+	if yyhl283 {
+		yyb283 = yyj283 > l
+	} else {
+		yyb283 = r.CheckBreak()
+	}
+	if yyb283 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = PersistentVolumeSpec{}
+	} else {
+		yyv285 := &x.Spec
+		yyv285.CodecDecodeSelf(d)
+	}
+	yyj283++
+	if yyhl283 {
+		yyb283 = yyj283 > l
+	} else {
+		yyb283 = r.CheckBreak()
+	}
+	if yyb283 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = PersistentVolumeStatus{}
+	} else {
+		yyv286 := &x.Status
+		yyv286.CodecDecodeSelf(d)
+	}
 	yyj283++
 	if yyhl283 {
 		yyb283 = yyj283 > l
@@ -4733,57 +4784,6 @@ func (x *PersistentVolume) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj283++
-	if yyhl283 {
-		yyb283 = yyj283 > l
-	} else {
-		yyb283 = r.CheckBreak()
-	}
-	if yyb283 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv286 := &x.ObjectMeta
-		yyv286.CodecDecodeSelf(d)
-	}
-	yyj283++
-	if yyhl283 {
-		yyb283 = yyj283 > l
-	} else {
-		yyb283 = r.CheckBreak()
-	}
-	if yyb283 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = PersistentVolumeSpec{}
-	} else {
-		yyv287 := &x.Spec
-		yyv287.CodecDecodeSelf(d)
-	}
-	yyj283++
-	if yyhl283 {
-		yyb283 = yyj283 > l
-	} else {
-		yyb283 = r.CheckBreak()
-	}
-	if yyb283 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = PersistentVolumeStatus{}
-	} else {
-		yyv288 := &x.Status
-		yyv288.CodecDecodeSelf(d)
 	}
 	for {
 		yyj283++
@@ -4819,21 +4819,21 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep290, yyq290, yy2arr290
 			const yyr290 bool = false
 			yyq290[0] = len(x.Capacity) != 0
-			yyq290[1] = x.PersistentVolumeSource.GCEPersistentDisk != nil && x.GCEPersistentDisk != nil
-			yyq290[2] = x.PersistentVolumeSource.AWSElasticBlockStore != nil && x.AWSElasticBlockStore != nil
-			yyq290[3] = x.PersistentVolumeSource.HostPath != nil && x.HostPath != nil
-			yyq290[4] = x.PersistentVolumeSource.Glusterfs != nil && x.Glusterfs != nil
-			yyq290[5] = x.PersistentVolumeSource.NFS != nil && x.NFS != nil
-			yyq290[6] = x.PersistentVolumeSource.RBD != nil && x.RBD != nil
-			yyq290[7] = x.PersistentVolumeSource.ISCSI != nil && x.ISCSI != nil
-			yyq290[8] = x.PersistentVolumeSource.Cinder != nil && x.Cinder != nil
-			yyq290[9] = x.PersistentVolumeSource.CephFS != nil && x.CephFS != nil
-			yyq290[10] = x.PersistentVolumeSource.FC != nil && x.FC != nil
-			yyq290[11] = x.PersistentVolumeSource.Flocker != nil && x.Flocker != nil
-			yyq290[12] = x.PersistentVolumeSource.FlexVolume != nil && x.FlexVolume != nil
-			yyq290[13] = len(x.AccessModes) != 0
-			yyq290[14] = x.ClaimRef != nil
-			yyq290[15] = x.PersistentVolumeReclaimPolicy != ""
+			yyq290[1] = len(x.AccessModes) != 0
+			yyq290[2] = x.ClaimRef != nil
+			yyq290[3] = x.PersistentVolumeReclaimPolicy != ""
+			yyq290[4] = x.PersistentVolumeSource.GCEPersistentDisk != nil && x.GCEPersistentDisk != nil
+			yyq290[5] = x.PersistentVolumeSource.AWSElasticBlockStore != nil && x.AWSElasticBlockStore != nil
+			yyq290[6] = x.PersistentVolumeSource.HostPath != nil && x.HostPath != nil
+			yyq290[7] = x.PersistentVolumeSource.Glusterfs != nil && x.Glusterfs != nil
+			yyq290[8] = x.PersistentVolumeSource.NFS != nil && x.NFS != nil
+			yyq290[9] = x.PersistentVolumeSource.RBD != nil && x.RBD != nil
+			yyq290[10] = x.PersistentVolumeSource.ISCSI != nil && x.ISCSI != nil
+			yyq290[11] = x.PersistentVolumeSource.Cinder != nil && x.Cinder != nil
+			yyq290[12] = x.PersistentVolumeSource.CephFS != nil && x.CephFS != nil
+			yyq290[13] = x.PersistentVolumeSource.FC != nil && x.FC != nil
+			yyq290[14] = x.PersistentVolumeSource.Flocker != nil && x.Flocker != nil
+			yyq290[15] = x.PersistentVolumeSource.FlexVolume != nil && x.FlexVolume != nil
 			var yynn290 int
 			if yyr290 || yy2arr290 {
 				r.EncodeArrayStart(16)
@@ -4870,458 +4870,14 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			var yyn292 bool
-			if x.PersistentVolumeSource.GCEPersistentDisk == nil {
-				yyn292 = true
-				goto LABEL292
-			}
-		LABEL292:
-			if yyr290 || yy2arr290 {
-				if yyn292 {
-					r.EncodeNil()
-				} else {
-					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq290[1] {
-						if x.GCEPersistentDisk == nil {
-							r.EncodeNil()
-						} else {
-							x.GCEPersistentDisk.CodecEncodeSelf(e)
-						}
-					} else {
-						r.EncodeNil()
-					}
-				}
-			} else {
-				if yyq290[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("gcePersistentDisk"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn292 {
-						r.EncodeNil()
-					} else {
-						if x.GCEPersistentDisk == nil {
-							r.EncodeNil()
-						} else {
-							x.GCEPersistentDisk.CodecEncodeSelf(e)
-						}
-					}
-				}
-			}
-			var yyn293 bool
-			if x.PersistentVolumeSource.AWSElasticBlockStore == nil {
-				yyn293 = true
-				goto LABEL293
-			}
-		LABEL293:
-			if yyr290 || yy2arr290 {
-				if yyn293 {
-					r.EncodeNil()
-				} else {
-					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq290[2] {
-						if x.AWSElasticBlockStore == nil {
-							r.EncodeNil()
-						} else {
-							x.AWSElasticBlockStore.CodecEncodeSelf(e)
-						}
-					} else {
-						r.EncodeNil()
-					}
-				}
-			} else {
-				if yyq290[2] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("awsElasticBlockStore"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn293 {
-						r.EncodeNil()
-					} else {
-						if x.AWSElasticBlockStore == nil {
-							r.EncodeNil()
-						} else {
-							x.AWSElasticBlockStore.CodecEncodeSelf(e)
-						}
-					}
-				}
-			}
-			var yyn294 bool
-			if x.PersistentVolumeSource.HostPath == nil {
-				yyn294 = true
-				goto LABEL294
-			}
-		LABEL294:
-			if yyr290 || yy2arr290 {
-				if yyn294 {
-					r.EncodeNil()
-				} else {
-					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq290[3] {
-						if x.HostPath == nil {
-							r.EncodeNil()
-						} else {
-							x.HostPath.CodecEncodeSelf(e)
-						}
-					} else {
-						r.EncodeNil()
-					}
-				}
-			} else {
-				if yyq290[3] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("hostPath"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn294 {
-						r.EncodeNil()
-					} else {
-						if x.HostPath == nil {
-							r.EncodeNil()
-						} else {
-							x.HostPath.CodecEncodeSelf(e)
-						}
-					}
-				}
-			}
-			var yyn295 bool
-			if x.PersistentVolumeSource.Glusterfs == nil {
-				yyn295 = true
-				goto LABEL295
-			}
-		LABEL295:
-			if yyr290 || yy2arr290 {
-				if yyn295 {
-					r.EncodeNil()
-				} else {
-					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq290[4] {
-						if x.Glusterfs == nil {
-							r.EncodeNil()
-						} else {
-							x.Glusterfs.CodecEncodeSelf(e)
-						}
-					} else {
-						r.EncodeNil()
-					}
-				}
-			} else {
-				if yyq290[4] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("glusterfs"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn295 {
-						r.EncodeNil()
-					} else {
-						if x.Glusterfs == nil {
-							r.EncodeNil()
-						} else {
-							x.Glusterfs.CodecEncodeSelf(e)
-						}
-					}
-				}
-			}
-			var yyn296 bool
-			if x.PersistentVolumeSource.NFS == nil {
-				yyn296 = true
-				goto LABEL296
-			}
-		LABEL296:
-			if yyr290 || yy2arr290 {
-				if yyn296 {
-					r.EncodeNil()
-				} else {
-					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq290[5] {
-						if x.NFS == nil {
-							r.EncodeNil()
-						} else {
-							x.NFS.CodecEncodeSelf(e)
-						}
-					} else {
-						r.EncodeNil()
-					}
-				}
-			} else {
-				if yyq290[5] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("nfs"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn296 {
-						r.EncodeNil()
-					} else {
-						if x.NFS == nil {
-							r.EncodeNil()
-						} else {
-							x.NFS.CodecEncodeSelf(e)
-						}
-					}
-				}
-			}
-			var yyn297 bool
-			if x.PersistentVolumeSource.RBD == nil {
-				yyn297 = true
-				goto LABEL297
-			}
-		LABEL297:
-			if yyr290 || yy2arr290 {
-				if yyn297 {
-					r.EncodeNil()
-				} else {
-					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq290[6] {
-						if x.RBD == nil {
-							r.EncodeNil()
-						} else {
-							x.RBD.CodecEncodeSelf(e)
-						}
-					} else {
-						r.EncodeNil()
-					}
-				}
-			} else {
-				if yyq290[6] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("rbd"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn297 {
-						r.EncodeNil()
-					} else {
-						if x.RBD == nil {
-							r.EncodeNil()
-						} else {
-							x.RBD.CodecEncodeSelf(e)
-						}
-					}
-				}
-			}
-			var yyn298 bool
-			if x.PersistentVolumeSource.ISCSI == nil {
-				yyn298 = true
-				goto LABEL298
-			}
-		LABEL298:
-			if yyr290 || yy2arr290 {
-				if yyn298 {
-					r.EncodeNil()
-				} else {
-					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq290[7] {
-						if x.ISCSI == nil {
-							r.EncodeNil()
-						} else {
-							x.ISCSI.CodecEncodeSelf(e)
-						}
-					} else {
-						r.EncodeNil()
-					}
-				}
-			} else {
-				if yyq290[7] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("iscsi"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn298 {
-						r.EncodeNil()
-					} else {
-						if x.ISCSI == nil {
-							r.EncodeNil()
-						} else {
-							x.ISCSI.CodecEncodeSelf(e)
-						}
-					}
-				}
-			}
-			var yyn299 bool
-			if x.PersistentVolumeSource.Cinder == nil {
-				yyn299 = true
-				goto LABEL299
-			}
-		LABEL299:
-			if yyr290 || yy2arr290 {
-				if yyn299 {
-					r.EncodeNil()
-				} else {
-					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq290[8] {
-						if x.Cinder == nil {
-							r.EncodeNil()
-						} else {
-							x.Cinder.CodecEncodeSelf(e)
-						}
-					} else {
-						r.EncodeNil()
-					}
-				}
-			} else {
-				if yyq290[8] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("cinder"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn299 {
-						r.EncodeNil()
-					} else {
-						if x.Cinder == nil {
-							r.EncodeNil()
-						} else {
-							x.Cinder.CodecEncodeSelf(e)
-						}
-					}
-				}
-			}
-			var yyn300 bool
-			if x.PersistentVolumeSource.CephFS == nil {
-				yyn300 = true
-				goto LABEL300
-			}
-		LABEL300:
-			if yyr290 || yy2arr290 {
-				if yyn300 {
-					r.EncodeNil()
-				} else {
-					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq290[9] {
-						if x.CephFS == nil {
-							r.EncodeNil()
-						} else {
-							x.CephFS.CodecEncodeSelf(e)
-						}
-					} else {
-						r.EncodeNil()
-					}
-				}
-			} else {
-				if yyq290[9] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("cephfs"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn300 {
-						r.EncodeNil()
-					} else {
-						if x.CephFS == nil {
-							r.EncodeNil()
-						} else {
-							x.CephFS.CodecEncodeSelf(e)
-						}
-					}
-				}
-			}
-			var yyn301 bool
-			if x.PersistentVolumeSource.FC == nil {
-				yyn301 = true
-				goto LABEL301
-			}
-		LABEL301:
-			if yyr290 || yy2arr290 {
-				if yyn301 {
-					r.EncodeNil()
-				} else {
-					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq290[10] {
-						if x.FC == nil {
-							r.EncodeNil()
-						} else {
-							x.FC.CodecEncodeSelf(e)
-						}
-					} else {
-						r.EncodeNil()
-					}
-				}
-			} else {
-				if yyq290[10] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("fc"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn301 {
-						r.EncodeNil()
-					} else {
-						if x.FC == nil {
-							r.EncodeNil()
-						} else {
-							x.FC.CodecEncodeSelf(e)
-						}
-					}
-				}
-			}
-			var yyn302 bool
-			if x.PersistentVolumeSource.Flocker == nil {
-				yyn302 = true
-				goto LABEL302
-			}
-		LABEL302:
-			if yyr290 || yy2arr290 {
-				if yyn302 {
-					r.EncodeNil()
-				} else {
-					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq290[11] {
-						if x.Flocker == nil {
-							r.EncodeNil()
-						} else {
-							x.Flocker.CodecEncodeSelf(e)
-						}
-					} else {
-						r.EncodeNil()
-					}
-				}
-			} else {
-				if yyq290[11] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("flocker"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn302 {
-						r.EncodeNil()
-					} else {
-						if x.Flocker == nil {
-							r.EncodeNil()
-						} else {
-							x.Flocker.CodecEncodeSelf(e)
-						}
-					}
-				}
-			}
-			var yyn303 bool
-			if x.PersistentVolumeSource.FlexVolume == nil {
-				yyn303 = true
-				goto LABEL303
-			}
-		LABEL303:
-			if yyr290 || yy2arr290 {
-				if yyn303 {
-					r.EncodeNil()
-				} else {
-					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq290[12] {
-						if x.FlexVolume == nil {
-							r.EncodeNil()
-						} else {
-							x.FlexVolume.CodecEncodeSelf(e)
-						}
-					} else {
-						r.EncodeNil()
-					}
-				}
-			} else {
-				if yyq290[12] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("flexVolume"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn303 {
-						r.EncodeNil()
-					} else {
-						if x.FlexVolume == nil {
-							r.EncodeNil()
-						} else {
-							x.FlexVolume.CodecEncodeSelf(e)
-						}
-					}
-				}
-			}
 			if yyr290 || yy2arr290 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq290[13] {
+				if yyq290[1] {
 					if x.AccessModes == nil {
 						r.EncodeNil()
 					} else {
-						yym305 := z.EncBinary()
-						_ = yym305
+						yym293 := z.EncBinary()
+						_ = yym293
 						if false {
 						} else {
 							h.encSlicePersistentVolumeAccessMode(([]PersistentVolumeAccessMode)(x.AccessModes), e)
@@ -5331,15 +4887,15 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq290[13] {
+				if yyq290[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("accessModes"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.AccessModes == nil {
 						r.EncodeNil()
 					} else {
-						yym306 := z.EncBinary()
-						_ = yym306
+						yym294 := z.EncBinary()
+						_ = yym294
 						if false {
 						} else {
 							h.encSlicePersistentVolumeAccessMode(([]PersistentVolumeAccessMode)(x.AccessModes), e)
@@ -5349,7 +4905,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr290 || yy2arr290 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq290[14] {
+				if yyq290[2] {
 					if x.ClaimRef == nil {
 						r.EncodeNil()
 					} else {
@@ -5359,7 +4915,7 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq290[14] {
+				if yyq290[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("claimRef"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
@@ -5372,17 +4928,461 @@ func (x *PersistentVolumeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr290 || yy2arr290 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq290[15] {
+				if yyq290[3] {
 					x.PersistentVolumeReclaimPolicy.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq290[15] {
+				if yyq290[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("persistentVolumeReclaimPolicy"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					x.PersistentVolumeReclaimPolicy.CodecEncodeSelf(e)
+				}
+			}
+			var yyn297 bool
+			if x.PersistentVolumeSource.GCEPersistentDisk == nil {
+				yyn297 = true
+				goto LABEL297
+			}
+		LABEL297:
+			if yyr290 || yy2arr290 {
+				if yyn297 {
+					r.EncodeNil()
+				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+					if yyq290[4] {
+						if x.GCEPersistentDisk == nil {
+							r.EncodeNil()
+						} else {
+							x.GCEPersistentDisk.CodecEncodeSelf(e)
+						}
+					} else {
+						r.EncodeNil()
+					}
+				}
+			} else {
+				if yyq290[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("gcePersistentDisk"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if yyn297 {
+						r.EncodeNil()
+					} else {
+						if x.GCEPersistentDisk == nil {
+							r.EncodeNil()
+						} else {
+							x.GCEPersistentDisk.CodecEncodeSelf(e)
+						}
+					}
+				}
+			}
+			var yyn298 bool
+			if x.PersistentVolumeSource.AWSElasticBlockStore == nil {
+				yyn298 = true
+				goto LABEL298
+			}
+		LABEL298:
+			if yyr290 || yy2arr290 {
+				if yyn298 {
+					r.EncodeNil()
+				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+					if yyq290[5] {
+						if x.AWSElasticBlockStore == nil {
+							r.EncodeNil()
+						} else {
+							x.AWSElasticBlockStore.CodecEncodeSelf(e)
+						}
+					} else {
+						r.EncodeNil()
+					}
+				}
+			} else {
+				if yyq290[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("awsElasticBlockStore"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if yyn298 {
+						r.EncodeNil()
+					} else {
+						if x.AWSElasticBlockStore == nil {
+							r.EncodeNil()
+						} else {
+							x.AWSElasticBlockStore.CodecEncodeSelf(e)
+						}
+					}
+				}
+			}
+			var yyn299 bool
+			if x.PersistentVolumeSource.HostPath == nil {
+				yyn299 = true
+				goto LABEL299
+			}
+		LABEL299:
+			if yyr290 || yy2arr290 {
+				if yyn299 {
+					r.EncodeNil()
+				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+					if yyq290[6] {
+						if x.HostPath == nil {
+							r.EncodeNil()
+						} else {
+							x.HostPath.CodecEncodeSelf(e)
+						}
+					} else {
+						r.EncodeNil()
+					}
+				}
+			} else {
+				if yyq290[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("hostPath"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if yyn299 {
+						r.EncodeNil()
+					} else {
+						if x.HostPath == nil {
+							r.EncodeNil()
+						} else {
+							x.HostPath.CodecEncodeSelf(e)
+						}
+					}
+				}
+			}
+			var yyn300 bool
+			if x.PersistentVolumeSource.Glusterfs == nil {
+				yyn300 = true
+				goto LABEL300
+			}
+		LABEL300:
+			if yyr290 || yy2arr290 {
+				if yyn300 {
+					r.EncodeNil()
+				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+					if yyq290[7] {
+						if x.Glusterfs == nil {
+							r.EncodeNil()
+						} else {
+							x.Glusterfs.CodecEncodeSelf(e)
+						}
+					} else {
+						r.EncodeNil()
+					}
+				}
+			} else {
+				if yyq290[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("glusterfs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if yyn300 {
+						r.EncodeNil()
+					} else {
+						if x.Glusterfs == nil {
+							r.EncodeNil()
+						} else {
+							x.Glusterfs.CodecEncodeSelf(e)
+						}
+					}
+				}
+			}
+			var yyn301 bool
+			if x.PersistentVolumeSource.NFS == nil {
+				yyn301 = true
+				goto LABEL301
+			}
+		LABEL301:
+			if yyr290 || yy2arr290 {
+				if yyn301 {
+					r.EncodeNil()
+				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+					if yyq290[8] {
+						if x.NFS == nil {
+							r.EncodeNil()
+						} else {
+							x.NFS.CodecEncodeSelf(e)
+						}
+					} else {
+						r.EncodeNil()
+					}
+				}
+			} else {
+				if yyq290[8] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("nfs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if yyn301 {
+						r.EncodeNil()
+					} else {
+						if x.NFS == nil {
+							r.EncodeNil()
+						} else {
+							x.NFS.CodecEncodeSelf(e)
+						}
+					}
+				}
+			}
+			var yyn302 bool
+			if x.PersistentVolumeSource.RBD == nil {
+				yyn302 = true
+				goto LABEL302
+			}
+		LABEL302:
+			if yyr290 || yy2arr290 {
+				if yyn302 {
+					r.EncodeNil()
+				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+					if yyq290[9] {
+						if x.RBD == nil {
+							r.EncodeNil()
+						} else {
+							x.RBD.CodecEncodeSelf(e)
+						}
+					} else {
+						r.EncodeNil()
+					}
+				}
+			} else {
+				if yyq290[9] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("rbd"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if yyn302 {
+						r.EncodeNil()
+					} else {
+						if x.RBD == nil {
+							r.EncodeNil()
+						} else {
+							x.RBD.CodecEncodeSelf(e)
+						}
+					}
+				}
+			}
+			var yyn303 bool
+			if x.PersistentVolumeSource.ISCSI == nil {
+				yyn303 = true
+				goto LABEL303
+			}
+		LABEL303:
+			if yyr290 || yy2arr290 {
+				if yyn303 {
+					r.EncodeNil()
+				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+					if yyq290[10] {
+						if x.ISCSI == nil {
+							r.EncodeNil()
+						} else {
+							x.ISCSI.CodecEncodeSelf(e)
+						}
+					} else {
+						r.EncodeNil()
+					}
+				}
+			} else {
+				if yyq290[10] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("iscsi"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if yyn303 {
+						r.EncodeNil()
+					} else {
+						if x.ISCSI == nil {
+							r.EncodeNil()
+						} else {
+							x.ISCSI.CodecEncodeSelf(e)
+						}
+					}
+				}
+			}
+			var yyn304 bool
+			if x.PersistentVolumeSource.Cinder == nil {
+				yyn304 = true
+				goto LABEL304
+			}
+		LABEL304:
+			if yyr290 || yy2arr290 {
+				if yyn304 {
+					r.EncodeNil()
+				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+					if yyq290[11] {
+						if x.Cinder == nil {
+							r.EncodeNil()
+						} else {
+							x.Cinder.CodecEncodeSelf(e)
+						}
+					} else {
+						r.EncodeNil()
+					}
+				}
+			} else {
+				if yyq290[11] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("cinder"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if yyn304 {
+						r.EncodeNil()
+					} else {
+						if x.Cinder == nil {
+							r.EncodeNil()
+						} else {
+							x.Cinder.CodecEncodeSelf(e)
+						}
+					}
+				}
+			}
+			var yyn305 bool
+			if x.PersistentVolumeSource.CephFS == nil {
+				yyn305 = true
+				goto LABEL305
+			}
+		LABEL305:
+			if yyr290 || yy2arr290 {
+				if yyn305 {
+					r.EncodeNil()
+				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+					if yyq290[12] {
+						if x.CephFS == nil {
+							r.EncodeNil()
+						} else {
+							x.CephFS.CodecEncodeSelf(e)
+						}
+					} else {
+						r.EncodeNil()
+					}
+				}
+			} else {
+				if yyq290[12] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("cephfs"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if yyn305 {
+						r.EncodeNil()
+					} else {
+						if x.CephFS == nil {
+							r.EncodeNil()
+						} else {
+							x.CephFS.CodecEncodeSelf(e)
+						}
+					}
+				}
+			}
+			var yyn306 bool
+			if x.PersistentVolumeSource.FC == nil {
+				yyn306 = true
+				goto LABEL306
+			}
+		LABEL306:
+			if yyr290 || yy2arr290 {
+				if yyn306 {
+					r.EncodeNil()
+				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+					if yyq290[13] {
+						if x.FC == nil {
+							r.EncodeNil()
+						} else {
+							x.FC.CodecEncodeSelf(e)
+						}
+					} else {
+						r.EncodeNil()
+					}
+				}
+			} else {
+				if yyq290[13] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("fc"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if yyn306 {
+						r.EncodeNil()
+					} else {
+						if x.FC == nil {
+							r.EncodeNil()
+						} else {
+							x.FC.CodecEncodeSelf(e)
+						}
+					}
+				}
+			}
+			var yyn307 bool
+			if x.PersistentVolumeSource.Flocker == nil {
+				yyn307 = true
+				goto LABEL307
+			}
+		LABEL307:
+			if yyr290 || yy2arr290 {
+				if yyn307 {
+					r.EncodeNil()
+				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+					if yyq290[14] {
+						if x.Flocker == nil {
+							r.EncodeNil()
+						} else {
+							x.Flocker.CodecEncodeSelf(e)
+						}
+					} else {
+						r.EncodeNil()
+					}
+				}
+			} else {
+				if yyq290[14] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("flocker"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if yyn307 {
+						r.EncodeNil()
+					} else {
+						if x.Flocker == nil {
+							r.EncodeNil()
+						} else {
+							x.Flocker.CodecEncodeSelf(e)
+						}
+					}
+				}
+			}
+			var yyn308 bool
+			if x.PersistentVolumeSource.FlexVolume == nil {
+				yyn308 = true
+				goto LABEL308
+			}
+		LABEL308:
+			if yyr290 || yy2arr290 {
+				if yyn308 {
+					r.EncodeNil()
+				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+					if yyq290[15] {
+						if x.FlexVolume == nil {
+							r.EncodeNil()
+						} else {
+							x.FlexVolume.CodecEncodeSelf(e)
+						}
+					} else {
+						r.EncodeNil()
+					}
+				}
+			} else {
+				if yyq290[15] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("flexVolume"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if yyn308 {
+						r.EncodeNil()
+					} else {
+						if x.FlexVolume == nil {
+							r.EncodeNil()
+						} else {
+							x.FlexVolume.CodecEncodeSelf(e)
+						}
+					}
 				}
 			}
 			if yyr290 || yy2arr290 {
@@ -5452,6 +5452,35 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			} else {
 				yyv312 := &x.Capacity
 				yyv312.CodecDecodeSelf(d)
+			}
+		case "accessModes":
+			if r.TryDecodeAsNil() {
+				x.AccessModes = nil
+			} else {
+				yyv313 := &x.AccessModes
+				yym314 := z.DecBinary()
+				_ = yym314
+				if false {
+				} else {
+					h.decSlicePersistentVolumeAccessMode((*[]PersistentVolumeAccessMode)(yyv313), d)
+				}
+			}
+		case "claimRef":
+			if r.TryDecodeAsNil() {
+				if x.ClaimRef != nil {
+					x.ClaimRef = nil
+				}
+			} else {
+				if x.ClaimRef == nil {
+					x.ClaimRef = new(ObjectReference)
+				}
+				x.ClaimRef.CodecDecodeSelf(d)
+			}
+		case "persistentVolumeReclaimPolicy":
+			if r.TryDecodeAsNil() {
+				x.PersistentVolumeReclaimPolicy = ""
+			} else {
+				x.PersistentVolumeReclaimPolicy = PersistentVolumeReclaimPolicy(r.DecodeString())
 			}
 		case "gcePersistentDisk":
 			if x.PersistentVolumeSource.GCEPersistentDisk == nil {
@@ -5621,35 +5650,6 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				}
 				x.FlexVolume.CodecDecodeSelf(d)
 			}
-		case "accessModes":
-			if r.TryDecodeAsNil() {
-				x.AccessModes = nil
-			} else {
-				yyv325 := &x.AccessModes
-				yym326 := z.DecBinary()
-				_ = yym326
-				if false {
-				} else {
-					h.decSlicePersistentVolumeAccessMode((*[]PersistentVolumeAccessMode)(yyv325), d)
-				}
-			}
-		case "claimRef":
-			if r.TryDecodeAsNil() {
-				if x.ClaimRef != nil {
-					x.ClaimRef = nil
-				}
-			} else {
-				if x.ClaimRef == nil {
-					x.ClaimRef = new(ObjectReference)
-				}
-				x.ClaimRef.CodecDecodeSelf(d)
-			}
-		case "persistentVolumeReclaimPolicy":
-			if r.TryDecodeAsNil() {
-				x.PersistentVolumeReclaimPolicy = ""
-			} else {
-				x.PersistentVolumeReclaimPolicy = PersistentVolumeReclaimPolicy(r.DecodeString())
-			}
 		default:
 			z.DecStructFieldNotFound(-1, yys311)
 		} // end switch yys311
@@ -5680,6 +5680,65 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		yyv330 := &x.Capacity
 		yyv330.CodecDecodeSelf(d)
+	}
+	yyj329++
+	if yyhl329 {
+		yyb329 = yyj329 > l
+	} else {
+		yyb329 = r.CheckBreak()
+	}
+	if yyb329 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.AccessModes = nil
+	} else {
+		yyv331 := &x.AccessModes
+		yym332 := z.DecBinary()
+		_ = yym332
+		if false {
+		} else {
+			h.decSlicePersistentVolumeAccessMode((*[]PersistentVolumeAccessMode)(yyv331), d)
+		}
+	}
+	yyj329++
+	if yyhl329 {
+		yyb329 = yyj329 > l
+	} else {
+		yyb329 = r.CheckBreak()
+	}
+	if yyb329 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		if x.ClaimRef != nil {
+			x.ClaimRef = nil
+		}
+	} else {
+		if x.ClaimRef == nil {
+			x.ClaimRef = new(ObjectReference)
+		}
+		x.ClaimRef.CodecDecodeSelf(d)
+	}
+	yyj329++
+	if yyhl329 {
+		yyb329 = yyj329 > l
+	} else {
+		yyb329 = r.CheckBreak()
+	}
+	if yyb329 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.PersistentVolumeReclaimPolicy = ""
+	} else {
+		x.PersistentVolumeReclaimPolicy = PersistentVolumeReclaimPolicy(r.DecodeString())
 	}
 	if x.PersistentVolumeSource.GCEPersistentDisk == nil {
 		x.PersistentVolumeSource.GCEPersistentDisk = new(GCEPersistentDiskVolumeSource)
@@ -5968,65 +6027,6 @@ func (x *PersistentVolumeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 			x.FlexVolume = new(FlexVolumeSource)
 		}
 		x.FlexVolume.CodecDecodeSelf(d)
-	}
-	yyj329++
-	if yyhl329 {
-		yyb329 = yyj329 > l
-	} else {
-		yyb329 = r.CheckBreak()
-	}
-	if yyb329 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.AccessModes = nil
-	} else {
-		yyv343 := &x.AccessModes
-		yym344 := z.DecBinary()
-		_ = yym344
-		if false {
-		} else {
-			h.decSlicePersistentVolumeAccessMode((*[]PersistentVolumeAccessMode)(yyv343), d)
-		}
-	}
-	yyj329++
-	if yyhl329 {
-		yyb329 = yyj329 > l
-	} else {
-		yyb329 = r.CheckBreak()
-	}
-	if yyb329 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		if x.ClaimRef != nil {
-			x.ClaimRef = nil
-		}
-	} else {
-		if x.ClaimRef == nil {
-			x.ClaimRef = new(ObjectReference)
-		}
-		x.ClaimRef.CodecDecodeSelf(d)
-	}
-	yyj329++
-	if yyhl329 {
-		yyb329 = yyj329 > l
-	} else {
-		yyb329 = r.CheckBreak()
-	}
-	if yyb329 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.PersistentVolumeReclaimPolicy = ""
-	} else {
-		x.PersistentVolumeReclaimPolicy = PersistentVolumeReclaimPolicy(r.DecodeString())
 	}
 	for {
 		yyj329++
@@ -6342,9 +6342,9 @@ func (x *PersistentVolumeList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq369 [4]bool
 			_, _, _ = yysep369, yyq369, yy2arr369
 			const yyr369 bool = false
-			yyq369[0] = x.Kind != ""
-			yyq369[1] = x.APIVersion != ""
-			yyq369[2] = true
+			yyq369[0] = true
+			yyq369[2] = x.Kind != ""
+			yyq369[3] = x.APIVersion != ""
 			var yynn369 int
 			if yyr369 || yy2arr369 {
 				r.EncodeArrayStart(4)
@@ -6361,79 +6361,29 @@ func (x *PersistentVolumeList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr369 || yy2arr369 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq369[0] {
-					yym371 := z.EncBinary()
-					_ = yym371
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq369[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy371 := &x.ListMeta
 					yym372 := z.EncBinary()
 					_ = yym372
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy371) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr369 || yy2arr369 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq369[1] {
-					yym374 := z.EncBinary()
-					_ = yym374
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq369[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym375 := z.EncBinary()
-					_ = yym375
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr369 || yy2arr369 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq369[2] {
-					yy377 := &x.ListMeta
-					yym378 := z.EncBinary()
-					_ = yym378
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy377) {
-					} else {
-						z.EncFallback(yy377)
+						z.EncFallback(yy371)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq369[2] {
+				if yyq369[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy379 := &x.ListMeta
-					yym380 := z.EncBinary()
-					_ = yym380
+					yy373 := &x.ListMeta
+					yym374 := z.EncBinary()
+					_ = yym374
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy379) {
+					} else if z.HasExtensions() && z.EncExt(yy373) {
 					} else {
-						z.EncFallback(yy379)
+						z.EncFallback(yy373)
 					}
 				}
 			}
@@ -6442,8 +6392,8 @@ func (x *PersistentVolumeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym382 := z.EncBinary()
-					_ = yym382
+					yym376 := z.EncBinary()
+					_ = yym376
 					if false {
 					} else {
 						h.encSlicePersistentVolume(([]PersistentVolume)(x.Items), e)
@@ -6456,11 +6406,61 @@ func (x *PersistentVolumeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym377 := z.EncBinary()
+					_ = yym377
+					if false {
+					} else {
+						h.encSlicePersistentVolume(([]PersistentVolume)(x.Items), e)
+					}
+				}
+			}
+			if yyr369 || yy2arr369 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq369[2] {
+					yym379 := z.EncBinary()
+					_ = yym379
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq369[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym380 := z.EncBinary()
+					_ = yym380
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr369 || yy2arr369 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq369[3] {
+					yym382 := z.EncBinary()
+					_ = yym382
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq369[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym383 := z.EncBinary()
 					_ = yym383
 					if false {
 					} else {
-						h.encSlicePersistentVolume(([]PersistentVolume)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -6525,6 +6525,31 @@ func (x *PersistentVolumeList) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 		yys386 := string(yys386Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys386 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv387 := &x.ListMeta
+				yym388 := z.DecBinary()
+				_ = yym388
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv387) {
+				} else {
+					z.DecFallback(yyv387, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv389 := &x.Items
+				yym390 := z.DecBinary()
+				_ = yym390
+				if false {
+				} else {
+					h.decSlicePersistentVolume((*[]PersistentVolume)(yyv389), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -6536,31 +6561,6 @@ func (x *PersistentVolumeList) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv389 := &x.ListMeta
-				yym390 := z.DecBinary()
-				_ = yym390
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv389) {
-				} else {
-					z.DecFallback(yyv389, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv391 := &x.Items
-				yym392 := z.DecBinary()
-				_ = yym392
-				if false {
-				} else {
-					h.decSlicePersistentVolume((*[]PersistentVolume)(yyv391), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys386)
@@ -6576,6 +6576,51 @@ func (x *PersistentVolumeList) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	var yyj393 int
 	var yyb393 bool
 	var yyhl393 bool = l >= 0
+	yyj393++
+	if yyhl393 {
+		yyb393 = yyj393 > l
+	} else {
+		yyb393 = r.CheckBreak()
+	}
+	if yyb393 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv394 := &x.ListMeta
+		yym395 := z.DecBinary()
+		_ = yym395
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv394) {
+		} else {
+			z.DecFallback(yyv394, false)
+		}
+	}
+	yyj393++
+	if yyhl393 {
+		yyb393 = yyj393 > l
+	} else {
+		yyb393 = r.CheckBreak()
+	}
+	if yyb393 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv396 := &x.Items
+		yym397 := z.DecBinary()
+		_ = yym397
+		if false {
+		} else {
+			h.decSlicePersistentVolume((*[]PersistentVolume)(yyv396), d)
+		}
+	}
 	yyj393++
 	if yyhl393 {
 		yyb393 = yyj393 > l
@@ -6607,51 +6652,6 @@ func (x *PersistentVolumeList) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj393++
-	if yyhl393 {
-		yyb393 = yyj393 > l
-	} else {
-		yyb393 = r.CheckBreak()
-	}
-	if yyb393 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv396 := &x.ListMeta
-		yym397 := z.DecBinary()
-		_ = yym397
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv396) {
-		} else {
-			z.DecFallback(yyv396, false)
-		}
-	}
-	yyj393++
-	if yyhl393 {
-		yyb393 = yyj393 > l
-	} else {
-		yyb393 = r.CheckBreak()
-	}
-	if yyb393 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv398 := &x.Items
-		yym399 := z.DecBinary()
-		_ = yym399
-		if false {
-		} else {
-			h.decSlicePersistentVolume((*[]PersistentVolume)(yyv398), d)
-		}
 	}
 	for {
 		yyj393++
@@ -6686,11 +6686,11 @@ func (x *PersistentVolumeClaim) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq401 [5]bool
 			_, _, _ = yysep401, yyq401, yy2arr401
 			const yyr401 bool = false
-			yyq401[0] = x.Kind != ""
-			yyq401[1] = x.APIVersion != ""
+			yyq401[0] = true
+			yyq401[1] = true
 			yyq401[2] = true
-			yyq401[3] = true
-			yyq401[4] = true
+			yyq401[3] = x.Kind != ""
+			yyq401[4] = x.APIVersion != ""
 			var yynn401 int
 			if yyr401 || yy2arr401 {
 				r.EncodeArrayStart(5)
@@ -6707,57 +6707,41 @@ func (x *PersistentVolumeClaim) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr401 || yy2arr401 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq401[0] {
-					yym403 := z.EncBinary()
-					_ = yym403
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy403 := &x.ObjectMeta
+					yy403.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq401[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym404 := z.EncBinary()
-					_ = yym404
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy404 := &x.ObjectMeta
+					yy404.CodecEncodeSelf(e)
 				}
 			}
 			if yyr401 || yy2arr401 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq401[1] {
-					yym406 := z.EncBinary()
-					_ = yym406
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy406 := &x.Spec
+					yy406.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq401[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym407 := z.EncBinary()
-					_ = yym407
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy407 := &x.Spec
+					yy407.CodecEncodeSelf(e)
 				}
 			}
 			if yyr401 || yy2arr401 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq401[2] {
-					yy409 := &x.ObjectMeta
+					yy409 := &x.Status
 					yy409.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
@@ -6765,44 +6749,60 @@ func (x *PersistentVolumeClaim) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq401[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy410 := &x.ObjectMeta
+					yy410 := &x.Status
 					yy410.CodecEncodeSelf(e)
 				}
 			}
 			if yyr401 || yy2arr401 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq401[3] {
-					yy412 := &x.Spec
-					yy412.CodecEncodeSelf(e)
+					yym412 := z.EncBinary()
+					_ = yym412
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq401[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy413 := &x.Spec
-					yy413.CodecEncodeSelf(e)
+					yym413 := z.EncBinary()
+					_ = yym413
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				}
 			}
 			if yyr401 || yy2arr401 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq401[4] {
-					yy415 := &x.Status
-					yy415.CodecEncodeSelf(e)
+					yym415 := z.EncBinary()
+					_ = yym415
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq401[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy416 := &x.Status
-					yy416.CodecEncodeSelf(e)
+					yym416 := z.EncBinary()
+					_ = yym416
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr401 || yy2arr401 {
@@ -6866,6 +6866,27 @@ func (x *PersistentVolumeClaim) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 		yys419 := string(yys419Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys419 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv420 := &x.ObjectMeta
+				yyv420.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = PersistentVolumeClaimSpec{}
+			} else {
+				yyv421 := &x.Spec
+				yyv421.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = PersistentVolumeClaimStatus{}
+			} else {
+				yyv422 := &x.Status
+				yyv422.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -6877,27 +6898,6 @@ func (x *PersistentVolumeClaim) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv422 := &x.ObjectMeta
-				yyv422.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = PersistentVolumeClaimSpec{}
-			} else {
-				yyv423 := &x.Spec
-				yyv423.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = PersistentVolumeClaimStatus{}
-			} else {
-				yyv424 := &x.Status
-				yyv424.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys419)
@@ -6913,6 +6913,57 @@ func (x *PersistentVolumeClaim) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var yyj425 int
 	var yyb425 bool
 	var yyhl425 bool = l >= 0
+	yyj425++
+	if yyhl425 {
+		yyb425 = yyj425 > l
+	} else {
+		yyb425 = r.CheckBreak()
+	}
+	if yyb425 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv426 := &x.ObjectMeta
+		yyv426.CodecDecodeSelf(d)
+	}
+	yyj425++
+	if yyhl425 {
+		yyb425 = yyj425 > l
+	} else {
+		yyb425 = r.CheckBreak()
+	}
+	if yyb425 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = PersistentVolumeClaimSpec{}
+	} else {
+		yyv427 := &x.Spec
+		yyv427.CodecDecodeSelf(d)
+	}
+	yyj425++
+	if yyhl425 {
+		yyb425 = yyj425 > l
+	} else {
+		yyb425 = r.CheckBreak()
+	}
+	if yyb425 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = PersistentVolumeClaimStatus{}
+	} else {
+		yyv428 := &x.Status
+		yyv428.CodecDecodeSelf(d)
+	}
 	yyj425++
 	if yyhl425 {
 		yyb425 = yyj425 > l
@@ -6944,57 +6995,6 @@ func (x *PersistentVolumeClaim) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj425++
-	if yyhl425 {
-		yyb425 = yyj425 > l
-	} else {
-		yyb425 = r.CheckBreak()
-	}
-	if yyb425 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv428 := &x.ObjectMeta
-		yyv428.CodecDecodeSelf(d)
-	}
-	yyj425++
-	if yyhl425 {
-		yyb425 = yyj425 > l
-	} else {
-		yyb425 = r.CheckBreak()
-	}
-	if yyb425 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = PersistentVolumeClaimSpec{}
-	} else {
-		yyv429 := &x.Spec
-		yyv429.CodecDecodeSelf(d)
-	}
-	yyj425++
-	if yyhl425 {
-		yyb425 = yyj425 > l
-	} else {
-		yyb425 = r.CheckBreak()
-	}
-	if yyb425 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = PersistentVolumeClaimStatus{}
-	} else {
-		yyv430 := &x.Status
-		yyv430.CodecDecodeSelf(d)
 	}
 	for {
 		yyj425++
@@ -7029,9 +7029,9 @@ func (x *PersistentVolumeClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq432 [4]bool
 			_, _, _ = yysep432, yyq432, yy2arr432
 			const yyr432 bool = false
-			yyq432[0] = x.Kind != ""
-			yyq432[1] = x.APIVersion != ""
-			yyq432[2] = true
+			yyq432[0] = true
+			yyq432[2] = x.Kind != ""
+			yyq432[3] = x.APIVersion != ""
 			var yynn432 int
 			if yyr432 || yy2arr432 {
 				r.EncodeArrayStart(4)
@@ -7048,79 +7048,29 @@ func (x *PersistentVolumeClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr432 || yy2arr432 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq432[0] {
-					yym434 := z.EncBinary()
-					_ = yym434
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq432[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy434 := &x.ListMeta
 					yym435 := z.EncBinary()
 					_ = yym435
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy434) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr432 || yy2arr432 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq432[1] {
-					yym437 := z.EncBinary()
-					_ = yym437
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq432[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym438 := z.EncBinary()
-					_ = yym438
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr432 || yy2arr432 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq432[2] {
-					yy440 := &x.ListMeta
-					yym441 := z.EncBinary()
-					_ = yym441
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy440) {
-					} else {
-						z.EncFallback(yy440)
+						z.EncFallback(yy434)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq432[2] {
+				if yyq432[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy442 := &x.ListMeta
-					yym443 := z.EncBinary()
-					_ = yym443
+					yy436 := &x.ListMeta
+					yym437 := z.EncBinary()
+					_ = yym437
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy442) {
+					} else if z.HasExtensions() && z.EncExt(yy436) {
 					} else {
-						z.EncFallback(yy442)
+						z.EncFallback(yy436)
 					}
 				}
 			}
@@ -7129,8 +7079,8 @@ func (x *PersistentVolumeClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym445 := z.EncBinary()
-					_ = yym445
+					yym439 := z.EncBinary()
+					_ = yym439
 					if false {
 					} else {
 						h.encSlicePersistentVolumeClaim(([]PersistentVolumeClaim)(x.Items), e)
@@ -7143,11 +7093,61 @@ func (x *PersistentVolumeClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym440 := z.EncBinary()
+					_ = yym440
+					if false {
+					} else {
+						h.encSlicePersistentVolumeClaim(([]PersistentVolumeClaim)(x.Items), e)
+					}
+				}
+			}
+			if yyr432 || yy2arr432 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq432[2] {
+					yym442 := z.EncBinary()
+					_ = yym442
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq432[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym443 := z.EncBinary()
+					_ = yym443
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr432 || yy2arr432 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq432[3] {
+					yym445 := z.EncBinary()
+					_ = yym445
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq432[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym446 := z.EncBinary()
 					_ = yym446
 					if false {
 					} else {
-						h.encSlicePersistentVolumeClaim(([]PersistentVolumeClaim)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -7212,6 +7212,31 @@ func (x *PersistentVolumeClaimList) codecDecodeSelfFromMap(l int, d *codec1978.D
 		yys449 := string(yys449Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys449 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv450 := &x.ListMeta
+				yym451 := z.DecBinary()
+				_ = yym451
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv450) {
+				} else {
+					z.DecFallback(yyv450, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv452 := &x.Items
+				yym453 := z.DecBinary()
+				_ = yym453
+				if false {
+				} else {
+					h.decSlicePersistentVolumeClaim((*[]PersistentVolumeClaim)(yyv452), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -7223,31 +7248,6 @@ func (x *PersistentVolumeClaimList) codecDecodeSelfFromMap(l int, d *codec1978.D
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv452 := &x.ListMeta
-				yym453 := z.DecBinary()
-				_ = yym453
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv452) {
-				} else {
-					z.DecFallback(yyv452, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv454 := &x.Items
-				yym455 := z.DecBinary()
-				_ = yym455
-				if false {
-				} else {
-					h.decSlicePersistentVolumeClaim((*[]PersistentVolumeClaim)(yyv454), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys449)
@@ -7263,6 +7263,51 @@ func (x *PersistentVolumeClaimList) codecDecodeSelfFromArray(l int, d *codec1978
 	var yyj456 int
 	var yyb456 bool
 	var yyhl456 bool = l >= 0
+	yyj456++
+	if yyhl456 {
+		yyb456 = yyj456 > l
+	} else {
+		yyb456 = r.CheckBreak()
+	}
+	if yyb456 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv457 := &x.ListMeta
+		yym458 := z.DecBinary()
+		_ = yym458
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv457) {
+		} else {
+			z.DecFallback(yyv457, false)
+		}
+	}
+	yyj456++
+	if yyhl456 {
+		yyb456 = yyj456 > l
+	} else {
+		yyb456 = r.CheckBreak()
+	}
+	if yyb456 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv459 := &x.Items
+		yym460 := z.DecBinary()
+		_ = yym460
+		if false {
+		} else {
+			h.decSlicePersistentVolumeClaim((*[]PersistentVolumeClaim)(yyv459), d)
+		}
+	}
 	yyj456++
 	if yyhl456 {
 		yyb456 = yyj456 > l
@@ -7294,51 +7339,6 @@ func (x *PersistentVolumeClaimList) codecDecodeSelfFromArray(l int, d *codec1978
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj456++
-	if yyhl456 {
-		yyb456 = yyj456 > l
-	} else {
-		yyb456 = r.CheckBreak()
-	}
-	if yyb456 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv459 := &x.ListMeta
-		yym460 := z.DecBinary()
-		_ = yym460
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv459) {
-		} else {
-			z.DecFallback(yyv459, false)
-		}
-	}
-	yyj456++
-	if yyhl456 {
-		yyb456 = yyj456 > l
-	} else {
-		yyb456 = r.CheckBreak()
-	}
-	if yyb456 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv461 := &x.Items
-		yym462 := z.DecBinary()
-		_ = yym462
-		if false {
-		} else {
-			h.decSlicePersistentVolumeClaim((*[]PersistentVolumeClaim)(yyv461), d)
-		}
 	}
 	for {
 		yyj456++
@@ -13711,7 +13711,7 @@ func (x *ConfigMapKeySelector) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq975 [2]bool
 			_, _, _ = yysep975, yyq975, yy2arr975
 			const yyr975 bool = false
-			yyq975[0] = x.Name != ""
+			yyq975[1] = x.Name != ""
 			var yynn975 int
 			if yyr975 || yy2arr975 {
 				r.EncodeArrayStart(2)
@@ -13727,33 +13727,8 @@ func (x *ConfigMapKeySelector) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr975 || yy2arr975 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq975[0] {
-					yym977 := z.EncBinary()
-					_ = yym977
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq975[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("name"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym978 := z.EncBinary()
-					_ = yym978
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
-					}
-				}
-			}
-			if yyr975 || yy2arr975 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym980 := z.EncBinary()
-				_ = yym980
+				yym977 := z.EncBinary()
+				_ = yym977
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
@@ -13762,11 +13737,36 @@ func (x *ConfigMapKeySelector) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("key"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym981 := z.EncBinary()
-				_ = yym981
+				yym978 := z.EncBinary()
+				_ = yym978
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
+				}
+			}
+			if yyr975 || yy2arr975 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq975[1] {
+					yym980 := z.EncBinary()
+					_ = yym980
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq975[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("name"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym981 := z.EncBinary()
+					_ = yym981
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+					}
 				}
 			}
 			if yyr975 || yy2arr975 {
@@ -13830,17 +13830,17 @@ func (x *ConfigMapKeySelector) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 		yys984 := string(yys984Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys984 {
-		case "name":
-			if r.TryDecodeAsNil() {
-				x.Name = ""
-			} else {
-				x.Name = string(r.DecodeString())
-			}
 		case "key":
 			if r.TryDecodeAsNil() {
 				x.Key = ""
 			} else {
 				x.Key = string(r.DecodeString())
+			}
+		case "name":
+			if r.TryDecodeAsNil() {
+				x.Name = ""
+			} else {
+				x.Name = string(r.DecodeString())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys984)
@@ -13868,9 +13868,9 @@ func (x *ConfigMapKeySelector) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.Name = ""
+		x.Key = ""
 	} else {
-		x.Name = string(r.DecodeString())
+		x.Key = string(r.DecodeString())
 	}
 	yyj987++
 	if yyhl987 {
@@ -13884,9 +13884,9 @@ func (x *ConfigMapKeySelector) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.Key = ""
+		x.Name = ""
 	} else {
-		x.Key = string(r.DecodeString())
+		x.Name = string(r.DecodeString())
 	}
 	for {
 		yyj987++
@@ -13921,7 +13921,7 @@ func (x *SecretKeySelector) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq991 [2]bool
 			_, _, _ = yysep991, yyq991, yy2arr991
 			const yyr991 bool = false
-			yyq991[0] = x.Name != ""
+			yyq991[1] = x.Name != ""
 			var yynn991 int
 			if yyr991 || yy2arr991 {
 				r.EncodeArrayStart(2)
@@ -13937,33 +13937,8 @@ func (x *SecretKeySelector) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr991 || yy2arr991 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq991[0] {
-					yym993 := z.EncBinary()
-					_ = yym993
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq991[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("name"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym994 := z.EncBinary()
-					_ = yym994
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
-					}
-				}
-			}
-			if yyr991 || yy2arr991 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym996 := z.EncBinary()
-				_ = yym996
+				yym993 := z.EncBinary()
+				_ = yym993
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
@@ -13972,11 +13947,36 @@ func (x *SecretKeySelector) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("key"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym997 := z.EncBinary()
-				_ = yym997
+				yym994 := z.EncBinary()
+				_ = yym994
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
+				}
+			}
+			if yyr991 || yy2arr991 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq991[1] {
+					yym996 := z.EncBinary()
+					_ = yym996
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq991[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("name"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym997 := z.EncBinary()
+					_ = yym997
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+					}
 				}
 			}
 			if yyr991 || yy2arr991 {
@@ -14040,17 +14040,17 @@ func (x *SecretKeySelector) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 		yys1000 := string(yys1000Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1000 {
-		case "name":
-			if r.TryDecodeAsNil() {
-				x.Name = ""
-			} else {
-				x.Name = string(r.DecodeString())
-			}
 		case "key":
 			if r.TryDecodeAsNil() {
 				x.Key = ""
 			} else {
 				x.Key = string(r.DecodeString())
+			}
+		case "name":
+			if r.TryDecodeAsNil() {
+				x.Name = ""
+			} else {
+				x.Name = string(r.DecodeString())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1000)
@@ -14078,9 +14078,9 @@ func (x *SecretKeySelector) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.Name = ""
+		x.Key = ""
 	} else {
-		x.Name = string(r.DecodeString())
+		x.Key = string(r.DecodeString())
 	}
 	yyj1003++
 	if yyhl1003 {
@@ -14094,9 +14094,9 @@ func (x *SecretKeySelector) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.Key = ""
+		x.Name = ""
 	} else {
-		x.Key = string(r.DecodeString())
+		x.Name = string(r.DecodeString())
 	}
 	for {
 		yyj1003++
@@ -15127,14 +15127,14 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1088 [8]bool
 			_, _, _ = yysep1088, yyq1088, yy2arr1088
 			const yyr1088 bool = false
-			yyq1088[0] = x.Handler.Exec != nil && x.Exec != nil
-			yyq1088[1] = x.Handler.HTTPGet != nil && x.HTTPGet != nil
-			yyq1088[2] = x.Handler.TCPSocket != nil && x.TCPSocket != nil
-			yyq1088[3] = x.InitialDelaySeconds != 0
-			yyq1088[4] = x.TimeoutSeconds != 0
-			yyq1088[5] = x.PeriodSeconds != 0
-			yyq1088[6] = x.SuccessThreshold != 0
-			yyq1088[7] = x.FailureThreshold != 0
+			yyq1088[0] = x.InitialDelaySeconds != 0
+			yyq1088[1] = x.TimeoutSeconds != 0
+			yyq1088[2] = x.PeriodSeconds != 0
+			yyq1088[3] = x.SuccessThreshold != 0
+			yyq1088[4] = x.FailureThreshold != 0
+			yyq1088[5] = x.Handler.Exec != nil && x.Exec != nil
+			yyq1088[6] = x.Handler.HTTPGet != nil && x.HTTPGet != nil
+			yyq1088[7] = x.Handler.TCPSocket != nil && x.TCPSocket != nil
 			var yynn1088 int
 			if yyr1088 || yy2arr1088 {
 				r.EncodeArrayStart(8)
@@ -15148,122 +15148,11 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 				r.EncodeMapStart(yynn1088)
 				yynn1088 = 0
 			}
-			var yyn1089 bool
-			if x.Handler.Exec == nil {
-				yyn1089 = true
-				goto LABEL1089
-			}
-		LABEL1089:
-			if yyr1088 || yy2arr1088 {
-				if yyn1089 {
-					r.EncodeNil()
-				} else {
-					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq1088[0] {
-						if x.Exec == nil {
-							r.EncodeNil()
-						} else {
-							x.Exec.CodecEncodeSelf(e)
-						}
-					} else {
-						r.EncodeNil()
-					}
-				}
-			} else {
-				if yyq1088[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("exec"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn1089 {
-						r.EncodeNil()
-					} else {
-						if x.Exec == nil {
-							r.EncodeNil()
-						} else {
-							x.Exec.CodecEncodeSelf(e)
-						}
-					}
-				}
-			}
-			var yyn1090 bool
-			if x.Handler.HTTPGet == nil {
-				yyn1090 = true
-				goto LABEL1090
-			}
-		LABEL1090:
-			if yyr1088 || yy2arr1088 {
-				if yyn1090 {
-					r.EncodeNil()
-				} else {
-					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq1088[1] {
-						if x.HTTPGet == nil {
-							r.EncodeNil()
-						} else {
-							x.HTTPGet.CodecEncodeSelf(e)
-						}
-					} else {
-						r.EncodeNil()
-					}
-				}
-			} else {
-				if yyq1088[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("httpGet"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn1090 {
-						r.EncodeNil()
-					} else {
-						if x.HTTPGet == nil {
-							r.EncodeNil()
-						} else {
-							x.HTTPGet.CodecEncodeSelf(e)
-						}
-					}
-				}
-			}
-			var yyn1091 bool
-			if x.Handler.TCPSocket == nil {
-				yyn1091 = true
-				goto LABEL1091
-			}
-		LABEL1091:
-			if yyr1088 || yy2arr1088 {
-				if yyn1091 {
-					r.EncodeNil()
-				} else {
-					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq1088[2] {
-						if x.TCPSocket == nil {
-							r.EncodeNil()
-						} else {
-							x.TCPSocket.CodecEncodeSelf(e)
-						}
-					} else {
-						r.EncodeNil()
-					}
-				}
-			} else {
-				if yyq1088[2] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("tcpSocket"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn1091 {
-						r.EncodeNil()
-					} else {
-						if x.TCPSocket == nil {
-							r.EncodeNil()
-						} else {
-							x.TCPSocket.CodecEncodeSelf(e)
-						}
-					}
-				}
-			}
 			if yyr1088 || yy2arr1088 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1088[3] {
-					yym1093 := z.EncBinary()
-					_ = yym1093
+				if yyq1088[0] {
+					yym1090 := z.EncBinary()
+					_ = yym1090
 					if false {
 					} else {
 						r.EncodeInt(int64(x.InitialDelaySeconds))
@@ -15272,115 +15161,226 @@ func (x *Probe) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq1088[3] {
+				if yyq1088[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("initialDelaySeconds"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1091 := z.EncBinary()
+					_ = yym1091
+					if false {
+					} else {
+						r.EncodeInt(int64(x.InitialDelaySeconds))
+					}
+				}
+			}
+			if yyr1088 || yy2arr1088 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1088[1] {
+					yym1093 := z.EncBinary()
+					_ = yym1093
+					if false {
+					} else {
+						r.EncodeInt(int64(x.TimeoutSeconds))
+					}
+				} else {
+					r.EncodeInt(0)
+				}
+			} else {
+				if yyq1088[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("timeoutSeconds"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1094 := z.EncBinary()
 					_ = yym1094
 					if false {
 					} else {
-						r.EncodeInt(int64(x.InitialDelaySeconds))
+						r.EncodeInt(int64(x.TimeoutSeconds))
 					}
 				}
 			}
 			if yyr1088 || yy2arr1088 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1088[4] {
+				if yyq1088[2] {
 					yym1096 := z.EncBinary()
 					_ = yym1096
 					if false {
 					} else {
-						r.EncodeInt(int64(x.TimeoutSeconds))
+						r.EncodeInt(int64(x.PeriodSeconds))
 					}
 				} else {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq1088[4] {
+				if yyq1088[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("timeoutSeconds"))
+					r.EncodeString(codecSelferC_UTF81234, string("periodSeconds"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1097 := z.EncBinary()
 					_ = yym1097
 					if false {
 					} else {
-						r.EncodeInt(int64(x.TimeoutSeconds))
+						r.EncodeInt(int64(x.PeriodSeconds))
 					}
 				}
 			}
 			if yyr1088 || yy2arr1088 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1088[5] {
+				if yyq1088[3] {
 					yym1099 := z.EncBinary()
 					_ = yym1099
 					if false {
 					} else {
-						r.EncodeInt(int64(x.PeriodSeconds))
+						r.EncodeInt(int64(x.SuccessThreshold))
 					}
 				} else {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq1088[5] {
+				if yyq1088[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("periodSeconds"))
+					r.EncodeString(codecSelferC_UTF81234, string("successThreshold"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1100 := z.EncBinary()
 					_ = yym1100
 					if false {
 					} else {
-						r.EncodeInt(int64(x.PeriodSeconds))
+						r.EncodeInt(int64(x.SuccessThreshold))
 					}
 				}
 			}
 			if yyr1088 || yy2arr1088 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1088[6] {
+				if yyq1088[4] {
 					yym1102 := z.EncBinary()
 					_ = yym1102
 					if false {
 					} else {
-						r.EncodeInt(int64(x.SuccessThreshold))
+						r.EncodeInt(int64(x.FailureThreshold))
 					}
 				} else {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq1088[6] {
+				if yyq1088[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("successThreshold"))
+					r.EncodeString(codecSelferC_UTF81234, string("failureThreshold"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1103 := z.EncBinary()
 					_ = yym1103
 					if false {
 					} else {
-						r.EncodeInt(int64(x.SuccessThreshold))
+						r.EncodeInt(int64(x.FailureThreshold))
 					}
 				}
 			}
+			var yyn1104 bool
+			if x.Handler.Exec == nil {
+				yyn1104 = true
+				goto LABEL1104
+			}
+		LABEL1104:
 			if yyr1088 || yy2arr1088 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1088[7] {
-					yym1105 := z.EncBinary()
-					_ = yym1105
-					if false {
-					} else {
-						r.EncodeInt(int64(x.FailureThreshold))
-					}
+				if yyn1104 {
+					r.EncodeNil()
 				} else {
-					r.EncodeInt(0)
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+					if yyq1088[5] {
+						if x.Exec == nil {
+							r.EncodeNil()
+						} else {
+							x.Exec.CodecEncodeSelf(e)
+						}
+					} else {
+						r.EncodeNil()
+					}
+				}
+			} else {
+				if yyq1088[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("exec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if yyn1104 {
+						r.EncodeNil()
+					} else {
+						if x.Exec == nil {
+							r.EncodeNil()
+						} else {
+							x.Exec.CodecEncodeSelf(e)
+						}
+					}
+				}
+			}
+			var yyn1105 bool
+			if x.Handler.HTTPGet == nil {
+				yyn1105 = true
+				goto LABEL1105
+			}
+		LABEL1105:
+			if yyr1088 || yy2arr1088 {
+				if yyn1105 {
+					r.EncodeNil()
+				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+					if yyq1088[6] {
+						if x.HTTPGet == nil {
+							r.EncodeNil()
+						} else {
+							x.HTTPGet.CodecEncodeSelf(e)
+						}
+					} else {
+						r.EncodeNil()
+					}
+				}
+			} else {
+				if yyq1088[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("httpGet"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if yyn1105 {
+						r.EncodeNil()
+					} else {
+						if x.HTTPGet == nil {
+							r.EncodeNil()
+						} else {
+							x.HTTPGet.CodecEncodeSelf(e)
+						}
+					}
+				}
+			}
+			var yyn1106 bool
+			if x.Handler.TCPSocket == nil {
+				yyn1106 = true
+				goto LABEL1106
+			}
+		LABEL1106:
+			if yyr1088 || yy2arr1088 {
+				if yyn1106 {
+					r.EncodeNil()
+				} else {
+					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+					if yyq1088[7] {
+						if x.TCPSocket == nil {
+							r.EncodeNil()
+						} else {
+							x.TCPSocket.CodecEncodeSelf(e)
+						}
+					} else {
+						r.EncodeNil()
+					}
 				}
 			} else {
 				if yyq1088[7] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("failureThreshold"))
+					r.EncodeString(codecSelferC_UTF81234, string("tcpSocket"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1106 := z.EncBinary()
-					_ = yym1106
-					if false {
+					if yyn1106 {
+						r.EncodeNil()
 					} else {
-						r.EncodeInt(int64(x.FailureThreshold))
+						if x.TCPSocket == nil {
+							r.EncodeNil()
+						} else {
+							x.TCPSocket.CodecEncodeSelf(e)
+						}
 					}
 				}
 			}
@@ -15445,6 +15445,36 @@ func (x *Probe) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys1109 := string(yys1109Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1109 {
+		case "initialDelaySeconds":
+			if r.TryDecodeAsNil() {
+				x.InitialDelaySeconds = 0
+			} else {
+				x.InitialDelaySeconds = int32(r.DecodeInt(32))
+			}
+		case "timeoutSeconds":
+			if r.TryDecodeAsNil() {
+				x.TimeoutSeconds = 0
+			} else {
+				x.TimeoutSeconds = int32(r.DecodeInt(32))
+			}
+		case "periodSeconds":
+			if r.TryDecodeAsNil() {
+				x.PeriodSeconds = 0
+			} else {
+				x.PeriodSeconds = int32(r.DecodeInt(32))
+			}
+		case "successThreshold":
+			if r.TryDecodeAsNil() {
+				x.SuccessThreshold = 0
+			} else {
+				x.SuccessThreshold = int32(r.DecodeInt(32))
+			}
+		case "failureThreshold":
+			if r.TryDecodeAsNil() {
+				x.FailureThreshold = 0
+			} else {
+				x.FailureThreshold = int32(r.DecodeInt(32))
+			}
 		case "exec":
 			if x.Handler.Exec == nil {
 				x.Handler.Exec = new(ExecAction)
@@ -15487,36 +15517,6 @@ func (x *Probe) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				}
 				x.TCPSocket.CodecDecodeSelf(d)
 			}
-		case "initialDelaySeconds":
-			if r.TryDecodeAsNil() {
-				x.InitialDelaySeconds = 0
-			} else {
-				x.InitialDelaySeconds = int32(r.DecodeInt(32))
-			}
-		case "timeoutSeconds":
-			if r.TryDecodeAsNil() {
-				x.TimeoutSeconds = 0
-			} else {
-				x.TimeoutSeconds = int32(r.DecodeInt(32))
-			}
-		case "periodSeconds":
-			if r.TryDecodeAsNil() {
-				x.PeriodSeconds = 0
-			} else {
-				x.PeriodSeconds = int32(r.DecodeInt(32))
-			}
-		case "successThreshold":
-			if r.TryDecodeAsNil() {
-				x.SuccessThreshold = 0
-			} else {
-				x.SuccessThreshold = int32(r.DecodeInt(32))
-			}
-		case "failureThreshold":
-			if r.TryDecodeAsNil() {
-				x.FailureThreshold = 0
-			} else {
-				x.FailureThreshold = int32(r.DecodeInt(32))
-			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1109)
 		} // end switch yys1109
@@ -15531,78 +15531,6 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj1118 int
 	var yyb1118 bool
 	var yyhl1118 bool = l >= 0
-	if x.Handler.Exec == nil {
-		x.Handler.Exec = new(ExecAction)
-	}
-	yyj1118++
-	if yyhl1118 {
-		yyb1118 = yyj1118 > l
-	} else {
-		yyb1118 = r.CheckBreak()
-	}
-	if yyb1118 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		if x.Exec != nil {
-			x.Exec = nil
-		}
-	} else {
-		if x.Exec == nil {
-			x.Exec = new(ExecAction)
-		}
-		x.Exec.CodecDecodeSelf(d)
-	}
-	if x.Handler.HTTPGet == nil {
-		x.Handler.HTTPGet = new(HTTPGetAction)
-	}
-	yyj1118++
-	if yyhl1118 {
-		yyb1118 = yyj1118 > l
-	} else {
-		yyb1118 = r.CheckBreak()
-	}
-	if yyb1118 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		if x.HTTPGet != nil {
-			x.HTTPGet = nil
-		}
-	} else {
-		if x.HTTPGet == nil {
-			x.HTTPGet = new(HTTPGetAction)
-		}
-		x.HTTPGet.CodecDecodeSelf(d)
-	}
-	if x.Handler.TCPSocket == nil {
-		x.Handler.TCPSocket = new(TCPSocketAction)
-	}
-	yyj1118++
-	if yyhl1118 {
-		yyb1118 = yyj1118 > l
-	} else {
-		yyb1118 = r.CheckBreak()
-	}
-	if yyb1118 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		if x.TCPSocket != nil {
-			x.TCPSocket = nil
-		}
-	} else {
-		if x.TCPSocket == nil {
-			x.TCPSocket = new(TCPSocketAction)
-		}
-		x.TCPSocket.CodecDecodeSelf(d)
-	}
 	yyj1118++
 	if yyhl1118 {
 		yyb1118 = yyj1118 > l
@@ -15682,6 +15610,78 @@ func (x *Probe) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.FailureThreshold = 0
 	} else {
 		x.FailureThreshold = int32(r.DecodeInt(32))
+	}
+	if x.Handler.Exec == nil {
+		x.Handler.Exec = new(ExecAction)
+	}
+	yyj1118++
+	if yyhl1118 {
+		yyb1118 = yyj1118 > l
+	} else {
+		yyb1118 = r.CheckBreak()
+	}
+	if yyb1118 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		if x.Exec != nil {
+			x.Exec = nil
+		}
+	} else {
+		if x.Exec == nil {
+			x.Exec = new(ExecAction)
+		}
+		x.Exec.CodecDecodeSelf(d)
+	}
+	if x.Handler.HTTPGet == nil {
+		x.Handler.HTTPGet = new(HTTPGetAction)
+	}
+	yyj1118++
+	if yyhl1118 {
+		yyb1118 = yyj1118 > l
+	} else {
+		yyb1118 = r.CheckBreak()
+	}
+	if yyb1118 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		if x.HTTPGet != nil {
+			x.HTTPGet = nil
+		}
+	} else {
+		if x.HTTPGet == nil {
+			x.HTTPGet = new(HTTPGetAction)
+		}
+		x.HTTPGet.CodecDecodeSelf(d)
+	}
+	if x.Handler.TCPSocket == nil {
+		x.Handler.TCPSocket = new(TCPSocketAction)
+	}
+	yyj1118++
+	if yyhl1118 {
+		yyb1118 = yyj1118 > l
+	} else {
+		yyb1118 = r.CheckBreak()
+	}
+	if yyb1118 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		if x.TCPSocket != nil {
+			x.TCPSocket = nil
+		}
+	} else {
+		if x.TCPSocket == nil {
+			x.TCPSocket = new(TCPSocketAction)
+		}
+		x.TCPSocket.CodecDecodeSelf(d)
 	}
 	for {
 		yyj1118++
@@ -23466,10 +23466,10 @@ func (x *PodStatusResult) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1755 [4]bool
 			_, _, _ = yysep1755, yyq1755, yy2arr1755
 			const yyr1755 bool = false
-			yyq1755[0] = x.Kind != ""
-			yyq1755[1] = x.APIVersion != ""
-			yyq1755[2] = true
-			yyq1755[3] = true
+			yyq1755[0] = true
+			yyq1755[1] = true
+			yyq1755[2] = x.Kind != ""
+			yyq1755[3] = x.APIVersion != ""
 			var yynn1755 int
 			if yyr1755 || yy2arr1755 {
 				r.EncodeArrayStart(4)
@@ -23486,22 +23486,56 @@ func (x *PodStatusResult) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr1755 || yy2arr1755 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1755[0] {
-					yym1757 := z.EncBinary()
-					_ = yym1757
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy1757 := &x.ObjectMeta
+					yy1757.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq1755[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1758 := &x.ObjectMeta
+					yy1758.CodecEncodeSelf(e)
+				}
+			}
+			if yyr1755 || yy2arr1755 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1755[1] {
+					yy1760 := &x.Status
+					yy1760.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1755[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1761 := &x.Status
+					yy1761.CodecEncodeSelf(e)
+				}
+			}
+			if yyr1755 || yy2arr1755 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1755[2] {
+					yym1763 := z.EncBinary()
+					_ = yym1763
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1755[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1758 := z.EncBinary()
-					_ = yym1758
+					yym1764 := z.EncBinary()
+					_ = yym1764
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -23510,9 +23544,9 @@ func (x *PodStatusResult) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr1755 || yy2arr1755 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1755[1] {
-					yym1760 := z.EncBinary()
-					_ = yym1760
+				if yyq1755[3] {
+					yym1766 := z.EncBinary()
+					_ = yym1766
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -23521,50 +23555,16 @@ func (x *PodStatusResult) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1755[1] {
+				if yyq1755[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1761 := z.EncBinary()
-					_ = yym1761
+					yym1767 := z.EncBinary()
+					_ = yym1767
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
-				}
-			}
-			if yyr1755 || yy2arr1755 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1755[2] {
-					yy1763 := &x.ObjectMeta
-					yy1763.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1755[2] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1764 := &x.ObjectMeta
-					yy1764.CodecEncodeSelf(e)
-				}
-			}
-			if yyr1755 || yy2arr1755 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1755[3] {
-					yy1766 := &x.Status
-					yy1766.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1755[3] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1767 := &x.Status
-					yy1767.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1755 || yy2arr1755 {
@@ -23628,6 +23628,20 @@ func (x *PodStatusResult) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys1770 := string(yys1770Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1770 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv1771 := &x.ObjectMeta
+				yyv1771.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = PodStatus{}
+			} else {
+				yyv1772 := &x.Status
+				yyv1772.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -23639,20 +23653,6 @@ func (x *PodStatusResult) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv1773 := &x.ObjectMeta
-				yyv1773.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = PodStatus{}
-			} else {
-				yyv1774 := &x.Status
-				yyv1774.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1770)
@@ -23668,6 +23668,40 @@ func (x *PodStatusResult) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var yyj1775 int
 	var yyb1775 bool
 	var yyhl1775 bool = l >= 0
+	yyj1775++
+	if yyhl1775 {
+		yyb1775 = yyj1775 > l
+	} else {
+		yyb1775 = r.CheckBreak()
+	}
+	if yyb1775 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv1776 := &x.ObjectMeta
+		yyv1776.CodecDecodeSelf(d)
+	}
+	yyj1775++
+	if yyhl1775 {
+		yyb1775 = yyj1775 > l
+	} else {
+		yyb1775 = r.CheckBreak()
+	}
+	if yyb1775 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = PodStatus{}
+	} else {
+		yyv1777 := &x.Status
+		yyv1777.CodecDecodeSelf(d)
+	}
 	yyj1775++
 	if yyhl1775 {
 		yyb1775 = yyj1775 > l
@@ -23699,40 +23733,6 @@ func (x *PodStatusResult) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj1775++
-	if yyhl1775 {
-		yyb1775 = yyj1775 > l
-	} else {
-		yyb1775 = r.CheckBreak()
-	}
-	if yyb1775 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv1778 := &x.ObjectMeta
-		yyv1778.CodecDecodeSelf(d)
-	}
-	yyj1775++
-	if yyhl1775 {
-		yyb1775 = yyj1775 > l
-	} else {
-		yyb1775 = r.CheckBreak()
-	}
-	if yyb1775 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = PodStatus{}
-	} else {
-		yyv1779 := &x.Status
-		yyv1779.CodecDecodeSelf(d)
 	}
 	for {
 		yyj1775++
@@ -23767,11 +23767,11 @@ func (x *Pod) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1781 [5]bool
 			_, _, _ = yysep1781, yyq1781, yy2arr1781
 			const yyr1781 bool = false
-			yyq1781[0] = x.Kind != ""
-			yyq1781[1] = x.APIVersion != ""
+			yyq1781[0] = true
+			yyq1781[1] = true
 			yyq1781[2] = true
-			yyq1781[3] = true
-			yyq1781[4] = true
+			yyq1781[3] = x.Kind != ""
+			yyq1781[4] = x.APIVersion != ""
 			var yynn1781 int
 			if yyr1781 || yy2arr1781 {
 				r.EncodeArrayStart(5)
@@ -23788,57 +23788,41 @@ func (x *Pod) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr1781 || yy2arr1781 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1781[0] {
-					yym1783 := z.EncBinary()
-					_ = yym1783
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy1783 := &x.ObjectMeta
+					yy1783.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq1781[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1784 := z.EncBinary()
-					_ = yym1784
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy1784 := &x.ObjectMeta
+					yy1784.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1781 || yy2arr1781 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1781[1] {
-					yym1786 := z.EncBinary()
-					_ = yym1786
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy1786 := &x.Spec
+					yy1786.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq1781[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1787 := z.EncBinary()
-					_ = yym1787
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy1787 := &x.Spec
+					yy1787.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1781 || yy2arr1781 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1781[2] {
-					yy1789 := &x.ObjectMeta
+					yy1789 := &x.Status
 					yy1789.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
@@ -23846,44 +23830,60 @@ func (x *Pod) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq1781[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1790 := &x.ObjectMeta
+					yy1790 := &x.Status
 					yy1790.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1781 || yy2arr1781 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1781[3] {
-					yy1792 := &x.Spec
-					yy1792.CodecEncodeSelf(e)
+					yym1792 := z.EncBinary()
+					_ = yym1792
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq1781[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1793 := &x.Spec
-					yy1793.CodecEncodeSelf(e)
+					yym1793 := z.EncBinary()
+					_ = yym1793
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				}
 			}
 			if yyr1781 || yy2arr1781 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1781[4] {
-					yy1795 := &x.Status
-					yy1795.CodecEncodeSelf(e)
+					yym1795 := z.EncBinary()
+					_ = yym1795
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq1781[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1796 := &x.Status
-					yy1796.CodecEncodeSelf(e)
+					yym1796 := z.EncBinary()
+					_ = yym1796
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr1781 || yy2arr1781 {
@@ -23947,6 +23947,27 @@ func (x *Pod) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys1799 := string(yys1799Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1799 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv1800 := &x.ObjectMeta
+				yyv1800.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = PodSpec{}
+			} else {
+				yyv1801 := &x.Spec
+				yyv1801.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = PodStatus{}
+			} else {
+				yyv1802 := &x.Status
+				yyv1802.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -23958,27 +23979,6 @@ func (x *Pod) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv1802 := &x.ObjectMeta
-				yyv1802.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = PodSpec{}
-			} else {
-				yyv1803 := &x.Spec
-				yyv1803.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = PodStatus{}
-			} else {
-				yyv1804 := &x.Status
-				yyv1804.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1799)
@@ -23994,6 +23994,57 @@ func (x *Pod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj1805 int
 	var yyb1805 bool
 	var yyhl1805 bool = l >= 0
+	yyj1805++
+	if yyhl1805 {
+		yyb1805 = yyj1805 > l
+	} else {
+		yyb1805 = r.CheckBreak()
+	}
+	if yyb1805 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv1806 := &x.ObjectMeta
+		yyv1806.CodecDecodeSelf(d)
+	}
+	yyj1805++
+	if yyhl1805 {
+		yyb1805 = yyj1805 > l
+	} else {
+		yyb1805 = r.CheckBreak()
+	}
+	if yyb1805 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = PodSpec{}
+	} else {
+		yyv1807 := &x.Spec
+		yyv1807.CodecDecodeSelf(d)
+	}
+	yyj1805++
+	if yyhl1805 {
+		yyb1805 = yyj1805 > l
+	} else {
+		yyb1805 = r.CheckBreak()
+	}
+	if yyb1805 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = PodStatus{}
+	} else {
+		yyv1808 := &x.Status
+		yyv1808.CodecDecodeSelf(d)
+	}
 	yyj1805++
 	if yyhl1805 {
 		yyb1805 = yyj1805 > l
@@ -24025,57 +24076,6 @@ func (x *Pod) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj1805++
-	if yyhl1805 {
-		yyb1805 = yyj1805 > l
-	} else {
-		yyb1805 = r.CheckBreak()
-	}
-	if yyb1805 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv1808 := &x.ObjectMeta
-		yyv1808.CodecDecodeSelf(d)
-	}
-	yyj1805++
-	if yyhl1805 {
-		yyb1805 = yyj1805 > l
-	} else {
-		yyb1805 = r.CheckBreak()
-	}
-	if yyb1805 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = PodSpec{}
-	} else {
-		yyv1809 := &x.Spec
-		yyv1809.CodecDecodeSelf(d)
-	}
-	yyj1805++
-	if yyhl1805 {
-		yyb1805 = yyj1805 > l
-	} else {
-		yyb1805 = r.CheckBreak()
-	}
-	if yyb1805 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = PodStatus{}
-	} else {
-		yyv1810 := &x.Status
-		yyv1810.CodecDecodeSelf(d)
 	}
 	for {
 		yyj1805++
@@ -24110,9 +24110,9 @@ func (x *PodList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1812 [4]bool
 			_, _, _ = yysep1812, yyq1812, yy2arr1812
 			const yyr1812 bool = false
-			yyq1812[0] = x.Kind != ""
-			yyq1812[1] = x.APIVersion != ""
-			yyq1812[2] = true
+			yyq1812[0] = true
+			yyq1812[2] = x.Kind != ""
+			yyq1812[3] = x.APIVersion != ""
 			var yynn1812 int
 			if yyr1812 || yy2arr1812 {
 				r.EncodeArrayStart(4)
@@ -24129,79 +24129,29 @@ func (x *PodList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr1812 || yy2arr1812 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1812[0] {
-					yym1814 := z.EncBinary()
-					_ = yym1814
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1812[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1814 := &x.ListMeta
 					yym1815 := z.EncBinary()
 					_ = yym1815
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1814) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr1812 || yy2arr1812 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1812[1] {
-					yym1817 := z.EncBinary()
-					_ = yym1817
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1812[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1818 := z.EncBinary()
-					_ = yym1818
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr1812 || yy2arr1812 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1812[2] {
-					yy1820 := &x.ListMeta
-					yym1821 := z.EncBinary()
-					_ = yym1821
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1820) {
-					} else {
-						z.EncFallback(yy1820)
+						z.EncFallback(yy1814)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1812[2] {
+				if yyq1812[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1822 := &x.ListMeta
-					yym1823 := z.EncBinary()
-					_ = yym1823
+					yy1816 := &x.ListMeta
+					yym1817 := z.EncBinary()
+					_ = yym1817
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1822) {
+					} else if z.HasExtensions() && z.EncExt(yy1816) {
 					} else {
-						z.EncFallback(yy1822)
+						z.EncFallback(yy1816)
 					}
 				}
 			}
@@ -24210,8 +24160,8 @@ func (x *PodList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1825 := z.EncBinary()
-					_ = yym1825
+					yym1819 := z.EncBinary()
+					_ = yym1819
 					if false {
 					} else {
 						h.encSlicePod(([]Pod)(x.Items), e)
@@ -24224,11 +24174,61 @@ func (x *PodList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym1820 := z.EncBinary()
+					_ = yym1820
+					if false {
+					} else {
+						h.encSlicePod(([]Pod)(x.Items), e)
+					}
+				}
+			}
+			if yyr1812 || yy2arr1812 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1812[2] {
+					yym1822 := z.EncBinary()
+					_ = yym1822
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1812[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1823 := z.EncBinary()
+					_ = yym1823
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr1812 || yy2arr1812 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1812[3] {
+					yym1825 := z.EncBinary()
+					_ = yym1825
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1812[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1826 := z.EncBinary()
 					_ = yym1826
 					if false {
 					} else {
-						h.encSlicePod(([]Pod)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -24293,6 +24293,31 @@ func (x *PodList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys1829 := string(yys1829Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1829 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv1830 := &x.ListMeta
+				yym1831 := z.DecBinary()
+				_ = yym1831
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv1830) {
+				} else {
+					z.DecFallback(yyv1830, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv1832 := &x.Items
+				yym1833 := z.DecBinary()
+				_ = yym1833
+				if false {
+				} else {
+					h.decSlicePod((*[]Pod)(yyv1832), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -24304,31 +24329,6 @@ func (x *PodList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv1832 := &x.ListMeta
-				yym1833 := z.DecBinary()
-				_ = yym1833
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1832) {
-				} else {
-					z.DecFallback(yyv1832, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv1834 := &x.Items
-				yym1835 := z.DecBinary()
-				_ = yym1835
-				if false {
-				} else {
-					h.decSlicePod((*[]Pod)(yyv1834), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1829)
@@ -24344,6 +24344,51 @@ func (x *PodList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj1836 int
 	var yyb1836 bool
 	var yyhl1836 bool = l >= 0
+	yyj1836++
+	if yyhl1836 {
+		yyb1836 = yyj1836 > l
+	} else {
+		yyb1836 = r.CheckBreak()
+	}
+	if yyb1836 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv1837 := &x.ListMeta
+		yym1838 := z.DecBinary()
+		_ = yym1838
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1837) {
+		} else {
+			z.DecFallback(yyv1837, false)
+		}
+	}
+	yyj1836++
+	if yyhl1836 {
+		yyb1836 = yyj1836 > l
+	} else {
+		yyb1836 = r.CheckBreak()
+	}
+	if yyb1836 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv1839 := &x.Items
+		yym1840 := z.DecBinary()
+		_ = yym1840
+		if false {
+		} else {
+			h.decSlicePod((*[]Pod)(yyv1839), d)
+		}
+	}
 	yyj1836++
 	if yyhl1836 {
 		yyb1836 = yyj1836 > l
@@ -24375,51 +24420,6 @@ func (x *PodList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj1836++
-	if yyhl1836 {
-		yyb1836 = yyj1836 > l
-	} else {
-		yyb1836 = r.CheckBreak()
-	}
-	if yyb1836 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv1839 := &x.ListMeta
-		yym1840 := z.DecBinary()
-		_ = yym1840
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1839) {
-		} else {
-			z.DecFallback(yyv1839, false)
-		}
-	}
-	yyj1836++
-	if yyhl1836 {
-		yyb1836 = yyj1836 > l
-	} else {
-		yyb1836 = r.CheckBreak()
-	}
-	if yyb1836 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv1841 := &x.Items
-		yym1842 := z.DecBinary()
-		_ = yym1842
-		if false {
-		} else {
-			h.decSlicePod((*[]Pod)(yyv1841), d)
-		}
 	}
 	for {
 		yyj1836++
@@ -24659,10 +24659,10 @@ func (x *PodTemplate) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1860 [4]bool
 			_, _, _ = yysep1860, yyq1860, yy2arr1860
 			const yyr1860 bool = false
-			yyq1860[0] = x.Kind != ""
-			yyq1860[1] = x.APIVersion != ""
-			yyq1860[2] = true
-			yyq1860[3] = true
+			yyq1860[0] = true
+			yyq1860[1] = true
+			yyq1860[2] = x.Kind != ""
+			yyq1860[3] = x.APIVersion != ""
 			var yynn1860 int
 			if yyr1860 || yy2arr1860 {
 				r.EncodeArrayStart(4)
@@ -24679,22 +24679,56 @@ func (x *PodTemplate) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr1860 || yy2arr1860 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1860[0] {
-					yym1862 := z.EncBinary()
-					_ = yym1862
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy1862 := &x.ObjectMeta
+					yy1862.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq1860[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1863 := &x.ObjectMeta
+					yy1863.CodecEncodeSelf(e)
+				}
+			}
+			if yyr1860 || yy2arr1860 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1860[1] {
+					yy1865 := &x.Template
+					yy1865.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1860[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("template"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1866 := &x.Template
+					yy1866.CodecEncodeSelf(e)
+				}
+			}
+			if yyr1860 || yy2arr1860 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1860[2] {
+					yym1868 := z.EncBinary()
+					_ = yym1868
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1860[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1863 := z.EncBinary()
-					_ = yym1863
+					yym1869 := z.EncBinary()
+					_ = yym1869
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -24703,9 +24737,9 @@ func (x *PodTemplate) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr1860 || yy2arr1860 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1860[1] {
-					yym1865 := z.EncBinary()
-					_ = yym1865
+				if yyq1860[3] {
+					yym1871 := z.EncBinary()
+					_ = yym1871
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -24714,50 +24748,16 @@ func (x *PodTemplate) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1860[1] {
+				if yyq1860[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1866 := z.EncBinary()
-					_ = yym1866
+					yym1872 := z.EncBinary()
+					_ = yym1872
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
-				}
-			}
-			if yyr1860 || yy2arr1860 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1860[2] {
-					yy1868 := &x.ObjectMeta
-					yy1868.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1860[2] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1869 := &x.ObjectMeta
-					yy1869.CodecEncodeSelf(e)
-				}
-			}
-			if yyr1860 || yy2arr1860 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1860[3] {
-					yy1871 := &x.Template
-					yy1871.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1860[3] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("template"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1872 := &x.Template
-					yy1872.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1860 || yy2arr1860 {
@@ -24821,6 +24821,20 @@ func (x *PodTemplate) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys1875 := string(yys1875Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1875 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv1876 := &x.ObjectMeta
+				yyv1876.CodecDecodeSelf(d)
+			}
+		case "template":
+			if r.TryDecodeAsNil() {
+				x.Template = PodTemplateSpec{}
+			} else {
+				yyv1877 := &x.Template
+				yyv1877.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -24832,20 +24846,6 @@ func (x *PodTemplate) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv1878 := &x.ObjectMeta
-				yyv1878.CodecDecodeSelf(d)
-			}
-		case "template":
-			if r.TryDecodeAsNil() {
-				x.Template = PodTemplateSpec{}
-			} else {
-				yyv1879 := &x.Template
-				yyv1879.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1875)
@@ -24861,6 +24861,40 @@ func (x *PodTemplate) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj1880 int
 	var yyb1880 bool
 	var yyhl1880 bool = l >= 0
+	yyj1880++
+	if yyhl1880 {
+		yyb1880 = yyj1880 > l
+	} else {
+		yyb1880 = r.CheckBreak()
+	}
+	if yyb1880 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv1881 := &x.ObjectMeta
+		yyv1881.CodecDecodeSelf(d)
+	}
+	yyj1880++
+	if yyhl1880 {
+		yyb1880 = yyj1880 > l
+	} else {
+		yyb1880 = r.CheckBreak()
+	}
+	if yyb1880 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Template = PodTemplateSpec{}
+	} else {
+		yyv1882 := &x.Template
+		yyv1882.CodecDecodeSelf(d)
+	}
 	yyj1880++
 	if yyhl1880 {
 		yyb1880 = yyj1880 > l
@@ -24892,40 +24926,6 @@ func (x *PodTemplate) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj1880++
-	if yyhl1880 {
-		yyb1880 = yyj1880 > l
-	} else {
-		yyb1880 = r.CheckBreak()
-	}
-	if yyb1880 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv1883 := &x.ObjectMeta
-		yyv1883.CodecDecodeSelf(d)
-	}
-	yyj1880++
-	if yyhl1880 {
-		yyb1880 = yyj1880 > l
-	} else {
-		yyb1880 = r.CheckBreak()
-	}
-	if yyb1880 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Template = PodTemplateSpec{}
-	} else {
-		yyv1884 := &x.Template
-		yyv1884.CodecDecodeSelf(d)
 	}
 	for {
 		yyj1880++
@@ -24960,9 +24960,9 @@ func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1886 [4]bool
 			_, _, _ = yysep1886, yyq1886, yy2arr1886
 			const yyr1886 bool = false
-			yyq1886[0] = x.Kind != ""
-			yyq1886[1] = x.APIVersion != ""
-			yyq1886[2] = true
+			yyq1886[0] = true
+			yyq1886[2] = x.Kind != ""
+			yyq1886[3] = x.APIVersion != ""
 			var yynn1886 int
 			if yyr1886 || yy2arr1886 {
 				r.EncodeArrayStart(4)
@@ -24979,79 +24979,29 @@ func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr1886 || yy2arr1886 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1886[0] {
-					yym1888 := z.EncBinary()
-					_ = yym1888
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1886[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1888 := &x.ListMeta
 					yym1889 := z.EncBinary()
 					_ = yym1889
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1888) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr1886 || yy2arr1886 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1886[1] {
-					yym1891 := z.EncBinary()
-					_ = yym1891
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1886[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1892 := z.EncBinary()
-					_ = yym1892
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr1886 || yy2arr1886 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1886[2] {
-					yy1894 := &x.ListMeta
-					yym1895 := z.EncBinary()
-					_ = yym1895
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1894) {
-					} else {
-						z.EncFallback(yy1894)
+						z.EncFallback(yy1888)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1886[2] {
+				if yyq1886[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1896 := &x.ListMeta
-					yym1897 := z.EncBinary()
-					_ = yym1897
+					yy1890 := &x.ListMeta
+					yym1891 := z.EncBinary()
+					_ = yym1891
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1896) {
+					} else if z.HasExtensions() && z.EncExt(yy1890) {
 					} else {
-						z.EncFallback(yy1896)
+						z.EncFallback(yy1890)
 					}
 				}
 			}
@@ -25060,8 +25010,8 @@ func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1899 := z.EncBinary()
-					_ = yym1899
+					yym1893 := z.EncBinary()
+					_ = yym1893
 					if false {
 					} else {
 						h.encSlicePodTemplate(([]PodTemplate)(x.Items), e)
@@ -25074,11 +25024,61 @@ func (x *PodTemplateList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym1894 := z.EncBinary()
+					_ = yym1894
+					if false {
+					} else {
+						h.encSlicePodTemplate(([]PodTemplate)(x.Items), e)
+					}
+				}
+			}
+			if yyr1886 || yy2arr1886 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1886[2] {
+					yym1896 := z.EncBinary()
+					_ = yym1896
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1886[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1897 := z.EncBinary()
+					_ = yym1897
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr1886 || yy2arr1886 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1886[3] {
+					yym1899 := z.EncBinary()
+					_ = yym1899
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1886[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1900 := z.EncBinary()
 					_ = yym1900
 					if false {
 					} else {
-						h.encSlicePodTemplate(([]PodTemplate)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -25143,6 +25143,31 @@ func (x *PodTemplateList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys1903 := string(yys1903Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1903 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv1904 := &x.ListMeta
+				yym1905 := z.DecBinary()
+				_ = yym1905
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv1904) {
+				} else {
+					z.DecFallback(yyv1904, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv1906 := &x.Items
+				yym1907 := z.DecBinary()
+				_ = yym1907
+				if false {
+				} else {
+					h.decSlicePodTemplate((*[]PodTemplate)(yyv1906), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -25154,31 +25179,6 @@ func (x *PodTemplateList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv1906 := &x.ListMeta
-				yym1907 := z.DecBinary()
-				_ = yym1907
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1906) {
-				} else {
-					z.DecFallback(yyv1906, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv1908 := &x.Items
-				yym1909 := z.DecBinary()
-				_ = yym1909
-				if false {
-				} else {
-					h.decSlicePodTemplate((*[]PodTemplate)(yyv1908), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1903)
@@ -25194,6 +25194,51 @@ func (x *PodTemplateList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var yyj1910 int
 	var yyb1910 bool
 	var yyhl1910 bool = l >= 0
+	yyj1910++
+	if yyhl1910 {
+		yyb1910 = yyj1910 > l
+	} else {
+		yyb1910 = r.CheckBreak()
+	}
+	if yyb1910 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv1911 := &x.ListMeta
+		yym1912 := z.DecBinary()
+		_ = yym1912
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1911) {
+		} else {
+			z.DecFallback(yyv1911, false)
+		}
+	}
+	yyj1910++
+	if yyhl1910 {
+		yyb1910 = yyj1910 > l
+	} else {
+		yyb1910 = r.CheckBreak()
+	}
+	if yyb1910 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv1913 := &x.Items
+		yym1914 := z.DecBinary()
+		_ = yym1914
+		if false {
+		} else {
+			h.decSlicePodTemplate((*[]PodTemplate)(yyv1913), d)
+		}
+	}
 	yyj1910++
 	if yyhl1910 {
 		yyb1910 = yyj1910 > l
@@ -25225,51 +25270,6 @@ func (x *PodTemplateList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj1910++
-	if yyhl1910 {
-		yyb1910 = yyj1910 > l
-	} else {
-		yyb1910 = r.CheckBreak()
-	}
-	if yyb1910 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv1913 := &x.ListMeta
-		yym1914 := z.DecBinary()
-		_ = yym1914
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1913) {
-		} else {
-			z.DecFallback(yyv1913, false)
-		}
-	}
-	yyj1910++
-	if yyhl1910 {
-		yyb1910 = yyj1910 > l
-	} else {
-		yyb1910 = r.CheckBreak()
-	}
-	if yyb1910 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv1915 := &x.Items
-		yym1916 := z.DecBinary()
-		_ = yym1916
-		if false {
-		} else {
-			h.decSlicePodTemplate((*[]PodTemplate)(yyv1915), d)
-		}
 	}
 	for {
 		yyj1910++
@@ -25837,11 +25837,11 @@ func (x *ReplicationController) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1959 [5]bool
 			_, _, _ = yysep1959, yyq1959, yy2arr1959
 			const yyr1959 bool = false
-			yyq1959[0] = x.Kind != ""
-			yyq1959[1] = x.APIVersion != ""
+			yyq1959[0] = true
+			yyq1959[1] = true
 			yyq1959[2] = true
-			yyq1959[3] = true
-			yyq1959[4] = true
+			yyq1959[3] = x.Kind != ""
+			yyq1959[4] = x.APIVersion != ""
 			var yynn1959 int
 			if yyr1959 || yy2arr1959 {
 				r.EncodeArrayStart(5)
@@ -25858,57 +25858,41 @@ func (x *ReplicationController) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr1959 || yy2arr1959 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1959[0] {
-					yym1961 := z.EncBinary()
-					_ = yym1961
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy1961 := &x.ObjectMeta
+					yy1961.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq1959[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1962 := z.EncBinary()
-					_ = yym1962
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy1962 := &x.ObjectMeta
+					yy1962.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1959 || yy2arr1959 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1959[1] {
-					yym1964 := z.EncBinary()
-					_ = yym1964
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy1964 := &x.Spec
+					yy1964.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq1959[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1965 := z.EncBinary()
-					_ = yym1965
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy1965 := &x.Spec
+					yy1965.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1959 || yy2arr1959 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1959[2] {
-					yy1967 := &x.ObjectMeta
+					yy1967 := &x.Status
 					yy1967.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
@@ -25916,44 +25900,60 @@ func (x *ReplicationController) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq1959[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1968 := &x.ObjectMeta
+					yy1968 := &x.Status
 					yy1968.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1959 || yy2arr1959 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1959[3] {
-					yy1970 := &x.Spec
-					yy1970.CodecEncodeSelf(e)
+					yym1970 := z.EncBinary()
+					_ = yym1970
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq1959[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1971 := &x.Spec
-					yy1971.CodecEncodeSelf(e)
+					yym1971 := z.EncBinary()
+					_ = yym1971
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				}
 			}
 			if yyr1959 || yy2arr1959 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1959[4] {
-					yy1973 := &x.Status
-					yy1973.CodecEncodeSelf(e)
+					yym1973 := z.EncBinary()
+					_ = yym1973
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq1959[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1974 := &x.Status
-					yy1974.CodecEncodeSelf(e)
+					yym1974 := z.EncBinary()
+					_ = yym1974
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr1959 || yy2arr1959 {
@@ -26017,6 +26017,27 @@ func (x *ReplicationController) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 		yys1977 := string(yys1977Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1977 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv1978 := &x.ObjectMeta
+				yyv1978.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = ReplicationControllerSpec{}
+			} else {
+				yyv1979 := &x.Spec
+				yyv1979.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = ReplicationControllerStatus{}
+			} else {
+				yyv1980 := &x.Status
+				yyv1980.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -26028,27 +26049,6 @@ func (x *ReplicationController) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv1980 := &x.ObjectMeta
-				yyv1980.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = ReplicationControllerSpec{}
-			} else {
-				yyv1981 := &x.Spec
-				yyv1981.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = ReplicationControllerStatus{}
-			} else {
-				yyv1982 := &x.Status
-				yyv1982.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1977)
@@ -26064,6 +26064,57 @@ func (x *ReplicationController) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var yyj1983 int
 	var yyb1983 bool
 	var yyhl1983 bool = l >= 0
+	yyj1983++
+	if yyhl1983 {
+		yyb1983 = yyj1983 > l
+	} else {
+		yyb1983 = r.CheckBreak()
+	}
+	if yyb1983 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv1984 := &x.ObjectMeta
+		yyv1984.CodecDecodeSelf(d)
+	}
+	yyj1983++
+	if yyhl1983 {
+		yyb1983 = yyj1983 > l
+	} else {
+		yyb1983 = r.CheckBreak()
+	}
+	if yyb1983 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = ReplicationControllerSpec{}
+	} else {
+		yyv1985 := &x.Spec
+		yyv1985.CodecDecodeSelf(d)
+	}
+	yyj1983++
+	if yyhl1983 {
+		yyb1983 = yyj1983 > l
+	} else {
+		yyb1983 = r.CheckBreak()
+	}
+	if yyb1983 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = ReplicationControllerStatus{}
+	} else {
+		yyv1986 := &x.Status
+		yyv1986.CodecDecodeSelf(d)
+	}
 	yyj1983++
 	if yyhl1983 {
 		yyb1983 = yyj1983 > l
@@ -26095,57 +26146,6 @@ func (x *ReplicationController) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj1983++
-	if yyhl1983 {
-		yyb1983 = yyj1983 > l
-	} else {
-		yyb1983 = r.CheckBreak()
-	}
-	if yyb1983 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv1986 := &x.ObjectMeta
-		yyv1986.CodecDecodeSelf(d)
-	}
-	yyj1983++
-	if yyhl1983 {
-		yyb1983 = yyj1983 > l
-	} else {
-		yyb1983 = r.CheckBreak()
-	}
-	if yyb1983 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = ReplicationControllerSpec{}
-	} else {
-		yyv1987 := &x.Spec
-		yyv1987.CodecDecodeSelf(d)
-	}
-	yyj1983++
-	if yyhl1983 {
-		yyb1983 = yyj1983 > l
-	} else {
-		yyb1983 = r.CheckBreak()
-	}
-	if yyb1983 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = ReplicationControllerStatus{}
-	} else {
-		yyv1988 := &x.Status
-		yyv1988.CodecDecodeSelf(d)
 	}
 	for {
 		yyj1983++
@@ -26180,9 +26180,9 @@ func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1990 [4]bool
 			_, _, _ = yysep1990, yyq1990, yy2arr1990
 			const yyr1990 bool = false
-			yyq1990[0] = x.Kind != ""
-			yyq1990[1] = x.APIVersion != ""
-			yyq1990[2] = true
+			yyq1990[0] = true
+			yyq1990[2] = x.Kind != ""
+			yyq1990[3] = x.APIVersion != ""
 			var yynn1990 int
 			if yyr1990 || yy2arr1990 {
 				r.EncodeArrayStart(4)
@@ -26199,79 +26199,29 @@ func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr1990 || yy2arr1990 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1990[0] {
-					yym1992 := z.EncBinary()
-					_ = yym1992
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1990[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1992 := &x.ListMeta
 					yym1993 := z.EncBinary()
 					_ = yym1993
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1992) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr1990 || yy2arr1990 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1990[1] {
-					yym1995 := z.EncBinary()
-					_ = yym1995
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1990[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1996 := z.EncBinary()
-					_ = yym1996
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr1990 || yy2arr1990 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1990[2] {
-					yy1998 := &x.ListMeta
-					yym1999 := z.EncBinary()
-					_ = yym1999
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1998) {
-					} else {
-						z.EncFallback(yy1998)
+						z.EncFallback(yy1992)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1990[2] {
+				if yyq1990[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2000 := &x.ListMeta
-					yym2001 := z.EncBinary()
-					_ = yym2001
+					yy1994 := &x.ListMeta
+					yym1995 := z.EncBinary()
+					_ = yym1995
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2000) {
+					} else if z.HasExtensions() && z.EncExt(yy1994) {
 					} else {
-						z.EncFallback(yy2000)
+						z.EncFallback(yy1994)
 					}
 				}
 			}
@@ -26280,8 +26230,8 @@ func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2003 := z.EncBinary()
-					_ = yym2003
+					yym1997 := z.EncBinary()
+					_ = yym1997
 					if false {
 					} else {
 						h.encSliceReplicationController(([]ReplicationController)(x.Items), e)
@@ -26294,11 +26244,61 @@ func (x *ReplicationControllerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym1998 := z.EncBinary()
+					_ = yym1998
+					if false {
+					} else {
+						h.encSliceReplicationController(([]ReplicationController)(x.Items), e)
+					}
+				}
+			}
+			if yyr1990 || yy2arr1990 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1990[2] {
+					yym2000 := z.EncBinary()
+					_ = yym2000
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1990[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2001 := z.EncBinary()
+					_ = yym2001
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr1990 || yy2arr1990 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1990[3] {
+					yym2003 := z.EncBinary()
+					_ = yym2003
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1990[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2004 := z.EncBinary()
 					_ = yym2004
 					if false {
 					} else {
-						h.encSliceReplicationController(([]ReplicationController)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -26363,6 +26363,31 @@ func (x *ReplicationControllerList) codecDecodeSelfFromMap(l int, d *codec1978.D
 		yys2007 := string(yys2007Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2007 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv2008 := &x.ListMeta
+				yym2009 := z.DecBinary()
+				_ = yym2009
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv2008) {
+				} else {
+					z.DecFallback(yyv2008, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv2010 := &x.Items
+				yym2011 := z.DecBinary()
+				_ = yym2011
+				if false {
+				} else {
+					h.decSliceReplicationController((*[]ReplicationController)(yyv2010), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -26374,31 +26399,6 @@ func (x *ReplicationControllerList) codecDecodeSelfFromMap(l int, d *codec1978.D
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv2010 := &x.ListMeta
-				yym2011 := z.DecBinary()
-				_ = yym2011
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2010) {
-				} else {
-					z.DecFallback(yyv2010, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv2012 := &x.Items
-				yym2013 := z.DecBinary()
-				_ = yym2013
-				if false {
-				} else {
-					h.decSliceReplicationController((*[]ReplicationController)(yyv2012), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2007)
@@ -26414,6 +26414,51 @@ func (x *ReplicationControllerList) codecDecodeSelfFromArray(l int, d *codec1978
 	var yyj2014 int
 	var yyb2014 bool
 	var yyhl2014 bool = l >= 0
+	yyj2014++
+	if yyhl2014 {
+		yyb2014 = yyj2014 > l
+	} else {
+		yyb2014 = r.CheckBreak()
+	}
+	if yyb2014 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv2015 := &x.ListMeta
+		yym2016 := z.DecBinary()
+		_ = yym2016
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv2015) {
+		} else {
+			z.DecFallback(yyv2015, false)
+		}
+	}
+	yyj2014++
+	if yyhl2014 {
+		yyb2014 = yyj2014 > l
+	} else {
+		yyb2014 = r.CheckBreak()
+	}
+	if yyb2014 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv2017 := &x.Items
+		yym2018 := z.DecBinary()
+		_ = yym2018
+		if false {
+		} else {
+			h.decSliceReplicationController((*[]ReplicationController)(yyv2017), d)
+		}
+	}
 	yyj2014++
 	if yyhl2014 {
 		yyb2014 = yyj2014 > l
@@ -26445,51 +26490,6 @@ func (x *ReplicationControllerList) codecDecodeSelfFromArray(l int, d *codec1978
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj2014++
-	if yyhl2014 {
-		yyb2014 = yyj2014 > l
-	} else {
-		yyb2014 = r.CheckBreak()
-	}
-	if yyb2014 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv2017 := &x.ListMeta
-		yym2018 := z.DecBinary()
-		_ = yym2018
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2017) {
-		} else {
-			z.DecFallback(yyv2017, false)
-		}
-	}
-	yyj2014++
-	if yyhl2014 {
-		yyb2014 = yyj2014 > l
-	} else {
-		yyb2014 = r.CheckBreak()
-	}
-	if yyb2014 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv2019 := &x.Items
-		yym2020 := z.DecBinary()
-		_ = yym2020
-		if false {
-		} else {
-			h.decSliceReplicationController((*[]ReplicationController)(yyv2019), d)
-		}
 	}
 	for {
 		yyj2014++
@@ -28073,11 +28073,11 @@ func (x *Service) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2149 [5]bool
 			_, _, _ = yysep2149, yyq2149, yy2arr2149
 			const yyr2149 bool = false
-			yyq2149[0] = x.Kind != ""
-			yyq2149[1] = x.APIVersion != ""
+			yyq2149[0] = true
+			yyq2149[1] = true
 			yyq2149[2] = true
-			yyq2149[3] = true
-			yyq2149[4] = true
+			yyq2149[3] = x.Kind != ""
+			yyq2149[4] = x.APIVersion != ""
 			var yynn2149 int
 			if yyr2149 || yy2arr2149 {
 				r.EncodeArrayStart(5)
@@ -28094,57 +28094,41 @@ func (x *Service) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2149 || yy2arr2149 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2149[0] {
-					yym2151 := z.EncBinary()
-					_ = yym2151
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy2151 := &x.ObjectMeta
+					yy2151.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq2149[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2152 := z.EncBinary()
-					_ = yym2152
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy2152 := &x.ObjectMeta
+					yy2152.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2149 || yy2arr2149 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2149[1] {
-					yym2154 := z.EncBinary()
-					_ = yym2154
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy2154 := &x.Spec
+					yy2154.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq2149[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2155 := z.EncBinary()
-					_ = yym2155
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy2155 := &x.Spec
+					yy2155.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2149 || yy2arr2149 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2149[2] {
-					yy2157 := &x.ObjectMeta
+					yy2157 := &x.Status
 					yy2157.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
@@ -28152,44 +28136,60 @@ func (x *Service) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq2149[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2158 := &x.ObjectMeta
+					yy2158 := &x.Status
 					yy2158.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2149 || yy2arr2149 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2149[3] {
-					yy2160 := &x.Spec
-					yy2160.CodecEncodeSelf(e)
+					yym2160 := z.EncBinary()
+					_ = yym2160
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq2149[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2161 := &x.Spec
-					yy2161.CodecEncodeSelf(e)
+					yym2161 := z.EncBinary()
+					_ = yym2161
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				}
 			}
 			if yyr2149 || yy2arr2149 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2149[4] {
-					yy2163 := &x.Status
-					yy2163.CodecEncodeSelf(e)
+					yym2163 := z.EncBinary()
+					_ = yym2163
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq2149[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2164 := &x.Status
-					yy2164.CodecEncodeSelf(e)
+					yym2164 := z.EncBinary()
+					_ = yym2164
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr2149 || yy2arr2149 {
@@ -28253,6 +28253,27 @@ func (x *Service) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys2167 := string(yys2167Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2167 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv2168 := &x.ObjectMeta
+				yyv2168.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = ServiceSpec{}
+			} else {
+				yyv2169 := &x.Spec
+				yyv2169.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = ServiceStatus{}
+			} else {
+				yyv2170 := &x.Status
+				yyv2170.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -28264,27 +28285,6 @@ func (x *Service) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv2170 := &x.ObjectMeta
-				yyv2170.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = ServiceSpec{}
-			} else {
-				yyv2171 := &x.Spec
-				yyv2171.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = ServiceStatus{}
-			} else {
-				yyv2172 := &x.Status
-				yyv2172.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2167)
@@ -28300,6 +28300,57 @@ func (x *Service) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj2173 int
 	var yyb2173 bool
 	var yyhl2173 bool = l >= 0
+	yyj2173++
+	if yyhl2173 {
+		yyb2173 = yyj2173 > l
+	} else {
+		yyb2173 = r.CheckBreak()
+	}
+	if yyb2173 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv2174 := &x.ObjectMeta
+		yyv2174.CodecDecodeSelf(d)
+	}
+	yyj2173++
+	if yyhl2173 {
+		yyb2173 = yyj2173 > l
+	} else {
+		yyb2173 = r.CheckBreak()
+	}
+	if yyb2173 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = ServiceSpec{}
+	} else {
+		yyv2175 := &x.Spec
+		yyv2175.CodecDecodeSelf(d)
+	}
+	yyj2173++
+	if yyhl2173 {
+		yyb2173 = yyj2173 > l
+	} else {
+		yyb2173 = r.CheckBreak()
+	}
+	if yyb2173 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = ServiceStatus{}
+	} else {
+		yyv2176 := &x.Status
+		yyv2176.CodecDecodeSelf(d)
+	}
 	yyj2173++
 	if yyhl2173 {
 		yyb2173 = yyj2173 > l
@@ -28331,57 +28382,6 @@ func (x *Service) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj2173++
-	if yyhl2173 {
-		yyb2173 = yyj2173 > l
-	} else {
-		yyb2173 = r.CheckBreak()
-	}
-	if yyb2173 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv2176 := &x.ObjectMeta
-		yyv2176.CodecDecodeSelf(d)
-	}
-	yyj2173++
-	if yyhl2173 {
-		yyb2173 = yyj2173 > l
-	} else {
-		yyb2173 = r.CheckBreak()
-	}
-	if yyb2173 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = ServiceSpec{}
-	} else {
-		yyv2177 := &x.Spec
-		yyv2177.CodecDecodeSelf(d)
-	}
-	yyj2173++
-	if yyhl2173 {
-		yyb2173 = yyj2173 > l
-	} else {
-		yyb2173 = r.CheckBreak()
-	}
-	if yyb2173 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = ServiceStatus{}
-	} else {
-		yyv2178 := &x.Status
-		yyv2178.CodecDecodeSelf(d)
 	}
 	for {
 		yyj2173++
@@ -28416,9 +28416,9 @@ func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2180 [4]bool
 			_, _, _ = yysep2180, yyq2180, yy2arr2180
 			const yyr2180 bool = false
-			yyq2180[0] = x.Kind != ""
-			yyq2180[1] = x.APIVersion != ""
-			yyq2180[2] = true
+			yyq2180[0] = true
+			yyq2180[2] = x.Kind != ""
+			yyq2180[3] = x.APIVersion != ""
 			var yynn2180 int
 			if yyr2180 || yy2arr2180 {
 				r.EncodeArrayStart(4)
@@ -28435,79 +28435,29 @@ func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2180 || yy2arr2180 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2180[0] {
-					yym2182 := z.EncBinary()
-					_ = yym2182
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2180[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy2182 := &x.ListMeta
 					yym2183 := z.EncBinary()
 					_ = yym2183
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2182) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2180 || yy2arr2180 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2180[1] {
-					yym2185 := z.EncBinary()
-					_ = yym2185
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2180[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2186 := z.EncBinary()
-					_ = yym2186
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2180 || yy2arr2180 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2180[2] {
-					yy2188 := &x.ListMeta
-					yym2189 := z.EncBinary()
-					_ = yym2189
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2188) {
-					} else {
-						z.EncFallback(yy2188)
+						z.EncFallback(yy2182)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2180[2] {
+				if yyq2180[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2190 := &x.ListMeta
-					yym2191 := z.EncBinary()
-					_ = yym2191
+					yy2184 := &x.ListMeta
+					yym2185 := z.EncBinary()
+					_ = yym2185
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2190) {
+					} else if z.HasExtensions() && z.EncExt(yy2184) {
 					} else {
-						z.EncFallback(yy2190)
+						z.EncFallback(yy2184)
 					}
 				}
 			}
@@ -28516,8 +28466,8 @@ func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2193 := z.EncBinary()
-					_ = yym2193
+					yym2187 := z.EncBinary()
+					_ = yym2187
 					if false {
 					} else {
 						h.encSliceService(([]Service)(x.Items), e)
@@ -28530,11 +28480,61 @@ func (x *ServiceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym2188 := z.EncBinary()
+					_ = yym2188
+					if false {
+					} else {
+						h.encSliceService(([]Service)(x.Items), e)
+					}
+				}
+			}
+			if yyr2180 || yy2arr2180 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2180[2] {
+					yym2190 := z.EncBinary()
+					_ = yym2190
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2180[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2191 := z.EncBinary()
+					_ = yym2191
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2180 || yy2arr2180 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2180[3] {
+					yym2193 := z.EncBinary()
+					_ = yym2193
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2180[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2194 := z.EncBinary()
 					_ = yym2194
 					if false {
 					} else {
-						h.encSliceService(([]Service)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -28599,6 +28599,31 @@ func (x *ServiceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys2197 := string(yys2197Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2197 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv2198 := &x.ListMeta
+				yym2199 := z.DecBinary()
+				_ = yym2199
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv2198) {
+				} else {
+					z.DecFallback(yyv2198, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv2200 := &x.Items
+				yym2201 := z.DecBinary()
+				_ = yym2201
+				if false {
+				} else {
+					h.decSliceService((*[]Service)(yyv2200), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -28610,31 +28635,6 @@ func (x *ServiceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv2200 := &x.ListMeta
-				yym2201 := z.DecBinary()
-				_ = yym2201
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2200) {
-				} else {
-					z.DecFallback(yyv2200, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv2202 := &x.Items
-				yym2203 := z.DecBinary()
-				_ = yym2203
-				if false {
-				} else {
-					h.decSliceService((*[]Service)(yyv2202), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2197)
@@ -28650,6 +28650,51 @@ func (x *ServiceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj2204 int
 	var yyb2204 bool
 	var yyhl2204 bool = l >= 0
+	yyj2204++
+	if yyhl2204 {
+		yyb2204 = yyj2204 > l
+	} else {
+		yyb2204 = r.CheckBreak()
+	}
+	if yyb2204 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv2205 := &x.ListMeta
+		yym2206 := z.DecBinary()
+		_ = yym2206
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv2205) {
+		} else {
+			z.DecFallback(yyv2205, false)
+		}
+	}
+	yyj2204++
+	if yyhl2204 {
+		yyb2204 = yyj2204 > l
+	} else {
+		yyb2204 = r.CheckBreak()
+	}
+	if yyb2204 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv2207 := &x.Items
+		yym2208 := z.DecBinary()
+		_ = yym2208
+		if false {
+		} else {
+			h.decSliceService((*[]Service)(yyv2207), d)
+		}
+	}
 	yyj2204++
 	if yyhl2204 {
 		yyb2204 = yyj2204 > l
@@ -28681,51 +28726,6 @@ func (x *ServiceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj2204++
-	if yyhl2204 {
-		yyb2204 = yyj2204 > l
-	} else {
-		yyb2204 = r.CheckBreak()
-	}
-	if yyb2204 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv2207 := &x.ListMeta
-		yym2208 := z.DecBinary()
-		_ = yym2208
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2207) {
-		} else {
-			z.DecFallback(yyv2207, false)
-		}
-	}
-	yyj2204++
-	if yyhl2204 {
-		yyb2204 = yyj2204 > l
-	} else {
-		yyb2204 = r.CheckBreak()
-	}
-	if yyb2204 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv2209 := &x.Items
-		yym2210 := z.DecBinary()
-		_ = yym2210
-		if false {
-		} else {
-			h.decSliceService((*[]Service)(yyv2209), d)
-		}
 	}
 	for {
 		yyj2204++
@@ -28760,11 +28760,11 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2212 [5]bool
 			_, _, _ = yysep2212, yyq2212, yy2arr2212
 			const yyr2212 bool = false
-			yyq2212[0] = x.Kind != ""
-			yyq2212[1] = x.APIVersion != ""
-			yyq2212[2] = true
-			yyq2212[3] = len(x.Secrets) != 0
-			yyq2212[4] = len(x.ImagePullSecrets) != 0
+			yyq2212[0] = true
+			yyq2212[1] = len(x.Secrets) != 0
+			yyq2212[2] = len(x.ImagePullSecrets) != 0
+			yyq2212[3] = x.Kind != ""
+			yyq2212[4] = x.APIVersion != ""
 			var yynn2212 int
 			if yyr2212 || yy2arr2212 {
 				r.EncodeArrayStart(5)
@@ -28781,78 +28781,28 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2212 || yy2arr2212 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2212[0] {
-					yym2214 := z.EncBinary()
-					_ = yym2214
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2212[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2215 := z.EncBinary()
-					_ = yym2215
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2212 || yy2arr2212 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2212[1] {
-					yym2217 := z.EncBinary()
-					_ = yym2217
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2212[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2218 := z.EncBinary()
-					_ = yym2218
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2212 || yy2arr2212 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2212[2] {
-					yy2220 := &x.ObjectMeta
-					yy2220.CodecEncodeSelf(e)
+					yy2214 := &x.ObjectMeta
+					yy2214.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2212[2] {
+				if yyq2212[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2221 := &x.ObjectMeta
-					yy2221.CodecEncodeSelf(e)
+					yy2215 := &x.ObjectMeta
+					yy2215.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2212 || yy2arr2212 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2212[3] {
+				if yyq2212[1] {
 					if x.Secrets == nil {
 						r.EncodeNil()
 					} else {
-						yym2223 := z.EncBinary()
-						_ = yym2223
+						yym2217 := z.EncBinary()
+						_ = yym2217
 						if false {
 						} else {
 							h.encSliceObjectReference(([]ObjectReference)(x.Secrets), e)
@@ -28862,15 +28812,15 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2212[3] {
+				if yyq2212[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("secrets"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Secrets == nil {
 						r.EncodeNil()
 					} else {
-						yym2224 := z.EncBinary()
-						_ = yym2224
+						yym2218 := z.EncBinary()
+						_ = yym2218
 						if false {
 						} else {
 							h.encSliceObjectReference(([]ObjectReference)(x.Secrets), e)
@@ -28880,12 +28830,12 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2212 || yy2arr2212 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2212[4] {
+				if yyq2212[2] {
 					if x.ImagePullSecrets == nil {
 						r.EncodeNil()
 					} else {
-						yym2226 := z.EncBinary()
-						_ = yym2226
+						yym2220 := z.EncBinary()
+						_ = yym2220
 						if false {
 						} else {
 							h.encSliceLocalObjectReference(([]LocalObjectReference)(x.ImagePullSecrets), e)
@@ -28895,19 +28845,69 @@ func (x *ServiceAccount) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2212[4] {
+				if yyq2212[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("imagePullSecrets"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.ImagePullSecrets == nil {
 						r.EncodeNil()
 					} else {
-						yym2227 := z.EncBinary()
-						_ = yym2227
+						yym2221 := z.EncBinary()
+						_ = yym2221
 						if false {
 						} else {
 							h.encSliceLocalObjectReference(([]LocalObjectReference)(x.ImagePullSecrets), e)
 						}
+					}
+				}
+			}
+			if yyr2212 || yy2arr2212 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2212[3] {
+					yym2223 := z.EncBinary()
+					_ = yym2223
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2212[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2224 := z.EncBinary()
+					_ = yym2224
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2212 || yy2arr2212 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2212[4] {
+					yym2226 := z.EncBinary()
+					_ = yym2226
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2212[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2227 := z.EncBinary()
+					_ = yym2227
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -28972,6 +28972,37 @@ func (x *ServiceAccount) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys2230 := string(yys2230Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2230 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv2231 := &x.ObjectMeta
+				yyv2231.CodecDecodeSelf(d)
+			}
+		case "secrets":
+			if r.TryDecodeAsNil() {
+				x.Secrets = nil
+			} else {
+				yyv2232 := &x.Secrets
+				yym2233 := z.DecBinary()
+				_ = yym2233
+				if false {
+				} else {
+					h.decSliceObjectReference((*[]ObjectReference)(yyv2232), d)
+				}
+			}
+		case "imagePullSecrets":
+			if r.TryDecodeAsNil() {
+				x.ImagePullSecrets = nil
+			} else {
+				yyv2234 := &x.ImagePullSecrets
+				yym2235 := z.DecBinary()
+				_ = yym2235
+				if false {
+				} else {
+					h.decSliceLocalObjectReference((*[]LocalObjectReference)(yyv2234), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -28983,37 +29014,6 @@ func (x *ServiceAccount) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv2233 := &x.ObjectMeta
-				yyv2233.CodecDecodeSelf(d)
-			}
-		case "secrets":
-			if r.TryDecodeAsNil() {
-				x.Secrets = nil
-			} else {
-				yyv2234 := &x.Secrets
-				yym2235 := z.DecBinary()
-				_ = yym2235
-				if false {
-				} else {
-					h.decSliceObjectReference((*[]ObjectReference)(yyv2234), d)
-				}
-			}
-		case "imagePullSecrets":
-			if r.TryDecodeAsNil() {
-				x.ImagePullSecrets = nil
-			} else {
-				yyv2236 := &x.ImagePullSecrets
-				yym2237 := z.DecBinary()
-				_ = yym2237
-				if false {
-				} else {
-					h.decSliceLocalObjectReference((*[]LocalObjectReference)(yyv2236), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2230)
@@ -29029,6 +29029,67 @@ func (x *ServiceAccount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj2238 int
 	var yyb2238 bool
 	var yyhl2238 bool = l >= 0
+	yyj2238++
+	if yyhl2238 {
+		yyb2238 = yyj2238 > l
+	} else {
+		yyb2238 = r.CheckBreak()
+	}
+	if yyb2238 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv2239 := &x.ObjectMeta
+		yyv2239.CodecDecodeSelf(d)
+	}
+	yyj2238++
+	if yyhl2238 {
+		yyb2238 = yyj2238 > l
+	} else {
+		yyb2238 = r.CheckBreak()
+	}
+	if yyb2238 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Secrets = nil
+	} else {
+		yyv2240 := &x.Secrets
+		yym2241 := z.DecBinary()
+		_ = yym2241
+		if false {
+		} else {
+			h.decSliceObjectReference((*[]ObjectReference)(yyv2240), d)
+		}
+	}
+	yyj2238++
+	if yyhl2238 {
+		yyb2238 = yyj2238 > l
+	} else {
+		yyb2238 = r.CheckBreak()
+	}
+	if yyb2238 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ImagePullSecrets = nil
+	} else {
+		yyv2242 := &x.ImagePullSecrets
+		yym2243 := z.DecBinary()
+		_ = yym2243
+		if false {
+		} else {
+			h.decSliceLocalObjectReference((*[]LocalObjectReference)(yyv2242), d)
+		}
+	}
 	yyj2238++
 	if yyhl2238 {
 		yyb2238 = yyj2238 > l
@@ -29060,67 +29121,6 @@ func (x *ServiceAccount) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj2238++
-	if yyhl2238 {
-		yyb2238 = yyj2238 > l
-	} else {
-		yyb2238 = r.CheckBreak()
-	}
-	if yyb2238 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv2241 := &x.ObjectMeta
-		yyv2241.CodecDecodeSelf(d)
-	}
-	yyj2238++
-	if yyhl2238 {
-		yyb2238 = yyj2238 > l
-	} else {
-		yyb2238 = r.CheckBreak()
-	}
-	if yyb2238 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Secrets = nil
-	} else {
-		yyv2242 := &x.Secrets
-		yym2243 := z.DecBinary()
-		_ = yym2243
-		if false {
-		} else {
-			h.decSliceObjectReference((*[]ObjectReference)(yyv2242), d)
-		}
-	}
-	yyj2238++
-	if yyhl2238 {
-		yyb2238 = yyj2238 > l
-	} else {
-		yyb2238 = r.CheckBreak()
-	}
-	if yyb2238 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ImagePullSecrets = nil
-	} else {
-		yyv2244 := &x.ImagePullSecrets
-		yym2245 := z.DecBinary()
-		_ = yym2245
-		if false {
-		} else {
-			h.decSliceLocalObjectReference((*[]LocalObjectReference)(yyv2244), d)
-		}
 	}
 	for {
 		yyj2238++
@@ -29155,9 +29155,9 @@ func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2247 [4]bool
 			_, _, _ = yysep2247, yyq2247, yy2arr2247
 			const yyr2247 bool = false
-			yyq2247[0] = x.Kind != ""
-			yyq2247[1] = x.APIVersion != ""
-			yyq2247[2] = true
+			yyq2247[0] = true
+			yyq2247[2] = x.Kind != ""
+			yyq2247[3] = x.APIVersion != ""
 			var yynn2247 int
 			if yyr2247 || yy2arr2247 {
 				r.EncodeArrayStart(4)
@@ -29174,79 +29174,29 @@ func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2247 || yy2arr2247 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2247[0] {
-					yym2249 := z.EncBinary()
-					_ = yym2249
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2247[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy2249 := &x.ListMeta
 					yym2250 := z.EncBinary()
 					_ = yym2250
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2249) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2247 || yy2arr2247 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2247[1] {
-					yym2252 := z.EncBinary()
-					_ = yym2252
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2247[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2253 := z.EncBinary()
-					_ = yym2253
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2247 || yy2arr2247 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2247[2] {
-					yy2255 := &x.ListMeta
-					yym2256 := z.EncBinary()
-					_ = yym2256
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2255) {
-					} else {
-						z.EncFallback(yy2255)
+						z.EncFallback(yy2249)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2247[2] {
+				if yyq2247[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2257 := &x.ListMeta
-					yym2258 := z.EncBinary()
-					_ = yym2258
+					yy2251 := &x.ListMeta
+					yym2252 := z.EncBinary()
+					_ = yym2252
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2257) {
+					} else if z.HasExtensions() && z.EncExt(yy2251) {
 					} else {
-						z.EncFallback(yy2257)
+						z.EncFallback(yy2251)
 					}
 				}
 			}
@@ -29255,8 +29205,8 @@ func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2260 := z.EncBinary()
-					_ = yym2260
+					yym2254 := z.EncBinary()
+					_ = yym2254
 					if false {
 					} else {
 						h.encSliceServiceAccount(([]ServiceAccount)(x.Items), e)
@@ -29269,11 +29219,61 @@ func (x *ServiceAccountList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym2255 := z.EncBinary()
+					_ = yym2255
+					if false {
+					} else {
+						h.encSliceServiceAccount(([]ServiceAccount)(x.Items), e)
+					}
+				}
+			}
+			if yyr2247 || yy2arr2247 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2247[2] {
+					yym2257 := z.EncBinary()
+					_ = yym2257
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2247[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2258 := z.EncBinary()
+					_ = yym2258
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2247 || yy2arr2247 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2247[3] {
+					yym2260 := z.EncBinary()
+					_ = yym2260
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2247[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2261 := z.EncBinary()
 					_ = yym2261
 					if false {
 					} else {
-						h.encSliceServiceAccount(([]ServiceAccount)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -29338,6 +29338,31 @@ func (x *ServiceAccountList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 		yys2264 := string(yys2264Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2264 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv2265 := &x.ListMeta
+				yym2266 := z.DecBinary()
+				_ = yym2266
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv2265) {
+				} else {
+					z.DecFallback(yyv2265, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv2267 := &x.Items
+				yym2268 := z.DecBinary()
+				_ = yym2268
+				if false {
+				} else {
+					h.decSliceServiceAccount((*[]ServiceAccount)(yyv2267), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -29349,31 +29374,6 @@ func (x *ServiceAccountList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv2267 := &x.ListMeta
-				yym2268 := z.DecBinary()
-				_ = yym2268
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2267) {
-				} else {
-					z.DecFallback(yyv2267, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv2269 := &x.Items
-				yym2270 := z.DecBinary()
-				_ = yym2270
-				if false {
-				} else {
-					h.decSliceServiceAccount((*[]ServiceAccount)(yyv2269), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2264)
@@ -29389,6 +29389,51 @@ func (x *ServiceAccountList) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	var yyj2271 int
 	var yyb2271 bool
 	var yyhl2271 bool = l >= 0
+	yyj2271++
+	if yyhl2271 {
+		yyb2271 = yyj2271 > l
+	} else {
+		yyb2271 = r.CheckBreak()
+	}
+	if yyb2271 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv2272 := &x.ListMeta
+		yym2273 := z.DecBinary()
+		_ = yym2273
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv2272) {
+		} else {
+			z.DecFallback(yyv2272, false)
+		}
+	}
+	yyj2271++
+	if yyhl2271 {
+		yyb2271 = yyj2271 > l
+	} else {
+		yyb2271 = r.CheckBreak()
+	}
+	if yyb2271 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv2274 := &x.Items
+		yym2275 := z.DecBinary()
+		_ = yym2275
+		if false {
+		} else {
+			h.decSliceServiceAccount((*[]ServiceAccount)(yyv2274), d)
+		}
+	}
 	yyj2271++
 	if yyhl2271 {
 		yyb2271 = yyj2271 > l
@@ -29420,51 +29465,6 @@ func (x *ServiceAccountList) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj2271++
-	if yyhl2271 {
-		yyb2271 = yyj2271 > l
-	} else {
-		yyb2271 = r.CheckBreak()
-	}
-	if yyb2271 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv2274 := &x.ListMeta
-		yym2275 := z.DecBinary()
-		_ = yym2275
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2274) {
-		} else {
-			z.DecFallback(yyv2274, false)
-		}
-	}
-	yyj2271++
-	if yyhl2271 {
-		yyb2271 = yyj2271 > l
-	} else {
-		yyb2271 = r.CheckBreak()
-	}
-	if yyb2271 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv2276 := &x.Items
-		yym2277 := z.DecBinary()
-		_ = yym2277
-		if false {
-		} else {
-			h.decSliceServiceAccount((*[]ServiceAccount)(yyv2276), d)
-		}
 	}
 	for {
 		yyj2271++
@@ -29499,9 +29499,9 @@ func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2279 [4]bool
 			_, _, _ = yysep2279, yyq2279, yy2arr2279
 			const yyr2279 bool = false
-			yyq2279[0] = x.Kind != ""
-			yyq2279[1] = x.APIVersion != ""
-			yyq2279[2] = true
+			yyq2279[0] = true
+			yyq2279[2] = x.Kind != ""
+			yyq2279[3] = x.APIVersion != ""
 			var yynn2279 int
 			if yyr2279 || yy2arr2279 {
 				r.EncodeArrayStart(4)
@@ -29518,68 +29518,18 @@ func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2279 || yy2arr2279 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2279[0] {
-					yym2281 := z.EncBinary()
-					_ = yym2281
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2279[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2282 := z.EncBinary()
-					_ = yym2282
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2279 || yy2arr2279 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2279[1] {
-					yym2284 := z.EncBinary()
-					_ = yym2284
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2279[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2285 := z.EncBinary()
-					_ = yym2285
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2279 || yy2arr2279 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2279[2] {
-					yy2287 := &x.ObjectMeta
-					yy2287.CodecEncodeSelf(e)
+					yy2281 := &x.ObjectMeta
+					yy2281.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2279[2] {
+				if yyq2279[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2288 := &x.ObjectMeta
-					yy2288.CodecEncodeSelf(e)
+					yy2282 := &x.ObjectMeta
+					yy2282.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2279 || yy2arr2279 {
@@ -29587,8 +29537,8 @@ func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Subsets == nil {
 					r.EncodeNil()
 				} else {
-					yym2290 := z.EncBinary()
-					_ = yym2290
+					yym2284 := z.EncBinary()
+					_ = yym2284
 					if false {
 					} else {
 						h.encSliceEndpointSubset(([]EndpointSubset)(x.Subsets), e)
@@ -29601,11 +29551,61 @@ func (x *Endpoints) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Subsets == nil {
 					r.EncodeNil()
 				} else {
+					yym2285 := z.EncBinary()
+					_ = yym2285
+					if false {
+					} else {
+						h.encSliceEndpointSubset(([]EndpointSubset)(x.Subsets), e)
+					}
+				}
+			}
+			if yyr2279 || yy2arr2279 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2279[2] {
+					yym2287 := z.EncBinary()
+					_ = yym2287
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2279[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2288 := z.EncBinary()
+					_ = yym2288
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2279 || yy2arr2279 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2279[3] {
+					yym2290 := z.EncBinary()
+					_ = yym2290
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2279[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2291 := z.EncBinary()
 					_ = yym2291
 					if false {
 					} else {
-						h.encSliceEndpointSubset(([]EndpointSubset)(x.Subsets), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -29670,6 +29670,25 @@ func (x *Endpoints) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys2294 := string(yys2294Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2294 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv2295 := &x.ObjectMeta
+				yyv2295.CodecDecodeSelf(d)
+			}
+		case "subsets":
+			if r.TryDecodeAsNil() {
+				x.Subsets = nil
+			} else {
+				yyv2296 := &x.Subsets
+				yym2297 := z.DecBinary()
+				_ = yym2297
+				if false {
+				} else {
+					h.decSliceEndpointSubset((*[]EndpointSubset)(yyv2296), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -29681,25 +29700,6 @@ func (x *Endpoints) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv2297 := &x.ObjectMeta
-				yyv2297.CodecDecodeSelf(d)
-			}
-		case "subsets":
-			if r.TryDecodeAsNil() {
-				x.Subsets = nil
-			} else {
-				yyv2298 := &x.Subsets
-				yym2299 := z.DecBinary()
-				_ = yym2299
-				if false {
-				} else {
-					h.decSliceEndpointSubset((*[]EndpointSubset)(yyv2298), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2294)
@@ -29715,6 +29715,45 @@ func (x *Endpoints) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj2300 int
 	var yyb2300 bool
 	var yyhl2300 bool = l >= 0
+	yyj2300++
+	if yyhl2300 {
+		yyb2300 = yyj2300 > l
+	} else {
+		yyb2300 = r.CheckBreak()
+	}
+	if yyb2300 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv2301 := &x.ObjectMeta
+		yyv2301.CodecDecodeSelf(d)
+	}
+	yyj2300++
+	if yyhl2300 {
+		yyb2300 = yyj2300 > l
+	} else {
+		yyb2300 = r.CheckBreak()
+	}
+	if yyb2300 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Subsets = nil
+	} else {
+		yyv2302 := &x.Subsets
+		yym2303 := z.DecBinary()
+		_ = yym2303
+		if false {
+		} else {
+			h.decSliceEndpointSubset((*[]EndpointSubset)(yyv2302), d)
+		}
+	}
 	yyj2300++
 	if yyhl2300 {
 		yyb2300 = yyj2300 > l
@@ -29746,45 +29785,6 @@ func (x *Endpoints) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj2300++
-	if yyhl2300 {
-		yyb2300 = yyj2300 > l
-	} else {
-		yyb2300 = r.CheckBreak()
-	}
-	if yyb2300 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv2303 := &x.ObjectMeta
-		yyv2303.CodecDecodeSelf(d)
-	}
-	yyj2300++
-	if yyhl2300 {
-		yyb2300 = yyj2300 > l
-	} else {
-		yyb2300 = r.CheckBreak()
-	}
-	if yyb2300 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Subsets = nil
-	} else {
-		yyv2304 := &x.Subsets
-		yym2305 := z.DecBinary()
-		_ = yym2305
-		if false {
-		} else {
-			h.decSliceEndpointSubset((*[]EndpointSubset)(yyv2304), d)
-		}
 	}
 	for {
 		yyj2300++
@@ -30610,9 +30610,9 @@ func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2367 [4]bool
 			_, _, _ = yysep2367, yyq2367, yy2arr2367
 			const yyr2367 bool = false
-			yyq2367[0] = x.Kind != ""
-			yyq2367[1] = x.APIVersion != ""
-			yyq2367[2] = true
+			yyq2367[0] = true
+			yyq2367[2] = x.Kind != ""
+			yyq2367[3] = x.APIVersion != ""
 			var yynn2367 int
 			if yyr2367 || yy2arr2367 {
 				r.EncodeArrayStart(4)
@@ -30629,79 +30629,29 @@ func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2367 || yy2arr2367 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2367[0] {
-					yym2369 := z.EncBinary()
-					_ = yym2369
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2367[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy2369 := &x.ListMeta
 					yym2370 := z.EncBinary()
 					_ = yym2370
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2369) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2367 || yy2arr2367 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2367[1] {
-					yym2372 := z.EncBinary()
-					_ = yym2372
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2367[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2373 := z.EncBinary()
-					_ = yym2373
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2367 || yy2arr2367 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2367[2] {
-					yy2375 := &x.ListMeta
-					yym2376 := z.EncBinary()
-					_ = yym2376
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2375) {
-					} else {
-						z.EncFallback(yy2375)
+						z.EncFallback(yy2369)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2367[2] {
+				if yyq2367[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2377 := &x.ListMeta
-					yym2378 := z.EncBinary()
-					_ = yym2378
+					yy2371 := &x.ListMeta
+					yym2372 := z.EncBinary()
+					_ = yym2372
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2377) {
+					} else if z.HasExtensions() && z.EncExt(yy2371) {
 					} else {
-						z.EncFallback(yy2377)
+						z.EncFallback(yy2371)
 					}
 				}
 			}
@@ -30710,8 +30660,8 @@ func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2380 := z.EncBinary()
-					_ = yym2380
+					yym2374 := z.EncBinary()
+					_ = yym2374
 					if false {
 					} else {
 						h.encSliceEndpoints(([]Endpoints)(x.Items), e)
@@ -30724,11 +30674,61 @@ func (x *EndpointsList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym2375 := z.EncBinary()
+					_ = yym2375
+					if false {
+					} else {
+						h.encSliceEndpoints(([]Endpoints)(x.Items), e)
+					}
+				}
+			}
+			if yyr2367 || yy2arr2367 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2367[2] {
+					yym2377 := z.EncBinary()
+					_ = yym2377
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2367[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2378 := z.EncBinary()
+					_ = yym2378
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2367 || yy2arr2367 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2367[3] {
+					yym2380 := z.EncBinary()
+					_ = yym2380
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2367[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2381 := z.EncBinary()
 					_ = yym2381
 					if false {
 					} else {
-						h.encSliceEndpoints(([]Endpoints)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -30793,6 +30793,31 @@ func (x *EndpointsList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys2384 := string(yys2384Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2384 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv2385 := &x.ListMeta
+				yym2386 := z.DecBinary()
+				_ = yym2386
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv2385) {
+				} else {
+					z.DecFallback(yyv2385, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv2387 := &x.Items
+				yym2388 := z.DecBinary()
+				_ = yym2388
+				if false {
+				} else {
+					h.decSliceEndpoints((*[]Endpoints)(yyv2387), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -30804,31 +30829,6 @@ func (x *EndpointsList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv2387 := &x.ListMeta
-				yym2388 := z.DecBinary()
-				_ = yym2388
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2387) {
-				} else {
-					z.DecFallback(yyv2387, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv2389 := &x.Items
-				yym2390 := z.DecBinary()
-				_ = yym2390
-				if false {
-				} else {
-					h.decSliceEndpoints((*[]Endpoints)(yyv2389), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2384)
@@ -30844,6 +30844,51 @@ func (x *EndpointsList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj2391 int
 	var yyb2391 bool
 	var yyhl2391 bool = l >= 0
+	yyj2391++
+	if yyhl2391 {
+		yyb2391 = yyj2391 > l
+	} else {
+		yyb2391 = r.CheckBreak()
+	}
+	if yyb2391 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv2392 := &x.ListMeta
+		yym2393 := z.DecBinary()
+		_ = yym2393
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv2392) {
+		} else {
+			z.DecFallback(yyv2392, false)
+		}
+	}
+	yyj2391++
+	if yyhl2391 {
+		yyb2391 = yyj2391 > l
+	} else {
+		yyb2391 = r.CheckBreak()
+	}
+	if yyb2391 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv2394 := &x.Items
+		yym2395 := z.DecBinary()
+		_ = yym2395
+		if false {
+		} else {
+			h.decSliceEndpoints((*[]Endpoints)(yyv2394), d)
+		}
+	}
 	yyj2391++
 	if yyhl2391 {
 		yyb2391 = yyj2391 > l
@@ -30875,51 +30920,6 @@ func (x *EndpointsList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj2391++
-	if yyhl2391 {
-		yyb2391 = yyj2391 > l
-	} else {
-		yyb2391 = r.CheckBreak()
-	}
-	if yyb2391 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv2394 := &x.ListMeta
-		yym2395 := z.DecBinary()
-		_ = yym2395
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2394) {
-		} else {
-			z.DecFallback(yyv2394, false)
-		}
-	}
-	yyj2391++
-	if yyhl2391 {
-		yyb2391 = yyj2391 > l
-	} else {
-		yyb2391 = r.CheckBreak()
-	}
-	if yyb2391 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv2396 := &x.Items
-		yym2397 := z.DecBinary()
-		_ = yym2397
-		if false {
-		} else {
-			h.decSliceEndpoints((*[]Endpoints)(yyv2396), d)
-		}
 	}
 	for {
 		yyj2391++
@@ -33577,11 +33577,11 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2621 [5]bool
 			_, _, _ = yysep2621, yyq2621, yy2arr2621
 			const yyr2621 bool = false
-			yyq2621[0] = x.Kind != ""
-			yyq2621[1] = x.APIVersion != ""
+			yyq2621[0] = true
+			yyq2621[1] = true
 			yyq2621[2] = true
-			yyq2621[3] = true
-			yyq2621[4] = true
+			yyq2621[3] = x.Kind != ""
+			yyq2621[4] = x.APIVersion != ""
 			var yynn2621 int
 			if yyr2621 || yy2arr2621 {
 				r.EncodeArrayStart(5)
@@ -33598,57 +33598,41 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2621 || yy2arr2621 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2621[0] {
-					yym2623 := z.EncBinary()
-					_ = yym2623
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy2623 := &x.ObjectMeta
+					yy2623.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq2621[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2624 := z.EncBinary()
-					_ = yym2624
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy2624 := &x.ObjectMeta
+					yy2624.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2621 || yy2arr2621 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2621[1] {
-					yym2626 := z.EncBinary()
-					_ = yym2626
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy2626 := &x.Spec
+					yy2626.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq2621[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2627 := z.EncBinary()
-					_ = yym2627
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy2627 := &x.Spec
+					yy2627.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2621 || yy2arr2621 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2621[2] {
-					yy2629 := &x.ObjectMeta
+					yy2629 := &x.Status
 					yy2629.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
@@ -33656,44 +33640,60 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq2621[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2630 := &x.ObjectMeta
+					yy2630 := &x.Status
 					yy2630.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2621 || yy2arr2621 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2621[3] {
-					yy2632 := &x.Spec
-					yy2632.CodecEncodeSelf(e)
+					yym2632 := z.EncBinary()
+					_ = yym2632
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq2621[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2633 := &x.Spec
-					yy2633.CodecEncodeSelf(e)
+					yym2633 := z.EncBinary()
+					_ = yym2633
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				}
 			}
 			if yyr2621 || yy2arr2621 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2621[4] {
-					yy2635 := &x.Status
-					yy2635.CodecEncodeSelf(e)
+					yym2635 := z.EncBinary()
+					_ = yym2635
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq2621[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2636 := &x.Status
-					yy2636.CodecEncodeSelf(e)
+					yym2636 := z.EncBinary()
+					_ = yym2636
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr2621 || yy2arr2621 {
@@ -33757,6 +33757,27 @@ func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys2639 := string(yys2639Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2639 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv2640 := &x.ObjectMeta
+				yyv2640.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = NodeSpec{}
+			} else {
+				yyv2641 := &x.Spec
+				yyv2641.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = NodeStatus{}
+			} else {
+				yyv2642 := &x.Status
+				yyv2642.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -33768,27 +33789,6 @@ func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv2642 := &x.ObjectMeta
-				yyv2642.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = NodeSpec{}
-			} else {
-				yyv2643 := &x.Spec
-				yyv2643.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = NodeStatus{}
-			} else {
-				yyv2644 := &x.Status
-				yyv2644.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2639)
@@ -33804,6 +33804,57 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj2645 int
 	var yyb2645 bool
 	var yyhl2645 bool = l >= 0
+	yyj2645++
+	if yyhl2645 {
+		yyb2645 = yyj2645 > l
+	} else {
+		yyb2645 = r.CheckBreak()
+	}
+	if yyb2645 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv2646 := &x.ObjectMeta
+		yyv2646.CodecDecodeSelf(d)
+	}
+	yyj2645++
+	if yyhl2645 {
+		yyb2645 = yyj2645 > l
+	} else {
+		yyb2645 = r.CheckBreak()
+	}
+	if yyb2645 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = NodeSpec{}
+	} else {
+		yyv2647 := &x.Spec
+		yyv2647.CodecDecodeSelf(d)
+	}
+	yyj2645++
+	if yyhl2645 {
+		yyb2645 = yyj2645 > l
+	} else {
+		yyb2645 = r.CheckBreak()
+	}
+	if yyb2645 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = NodeStatus{}
+	} else {
+		yyv2648 := &x.Status
+		yyv2648.CodecDecodeSelf(d)
+	}
 	yyj2645++
 	if yyhl2645 {
 		yyb2645 = yyj2645 > l
@@ -33835,57 +33886,6 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj2645++
-	if yyhl2645 {
-		yyb2645 = yyj2645 > l
-	} else {
-		yyb2645 = r.CheckBreak()
-	}
-	if yyb2645 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv2648 := &x.ObjectMeta
-		yyv2648.CodecDecodeSelf(d)
-	}
-	yyj2645++
-	if yyhl2645 {
-		yyb2645 = yyj2645 > l
-	} else {
-		yyb2645 = r.CheckBreak()
-	}
-	if yyb2645 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = NodeSpec{}
-	} else {
-		yyv2649 := &x.Spec
-		yyv2649.CodecDecodeSelf(d)
-	}
-	yyj2645++
-	if yyhl2645 {
-		yyb2645 = yyj2645 > l
-	} else {
-		yyb2645 = r.CheckBreak()
-	}
-	if yyb2645 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = NodeStatus{}
-	} else {
-		yyv2650 := &x.Status
-		yyv2650.CodecDecodeSelf(d)
 	}
 	for {
 		yyj2645++
@@ -33920,9 +33920,9 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2652 [4]bool
 			_, _, _ = yysep2652, yyq2652, yy2arr2652
 			const yyr2652 bool = false
-			yyq2652[0] = x.Kind != ""
-			yyq2652[1] = x.APIVersion != ""
-			yyq2652[2] = true
+			yyq2652[0] = true
+			yyq2652[2] = x.Kind != ""
+			yyq2652[3] = x.APIVersion != ""
 			var yynn2652 int
 			if yyr2652 || yy2arr2652 {
 				r.EncodeArrayStart(4)
@@ -33939,79 +33939,29 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2652 || yy2arr2652 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2652[0] {
-					yym2654 := z.EncBinary()
-					_ = yym2654
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2652[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy2654 := &x.ListMeta
 					yym2655 := z.EncBinary()
 					_ = yym2655
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2654) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2652 || yy2arr2652 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2652[1] {
-					yym2657 := z.EncBinary()
-					_ = yym2657
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2652[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2658 := z.EncBinary()
-					_ = yym2658
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2652 || yy2arr2652 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2652[2] {
-					yy2660 := &x.ListMeta
-					yym2661 := z.EncBinary()
-					_ = yym2661
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2660) {
-					} else {
-						z.EncFallback(yy2660)
+						z.EncFallback(yy2654)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2652[2] {
+				if yyq2652[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2662 := &x.ListMeta
-					yym2663 := z.EncBinary()
-					_ = yym2663
+					yy2656 := &x.ListMeta
+					yym2657 := z.EncBinary()
+					_ = yym2657
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2662) {
+					} else if z.HasExtensions() && z.EncExt(yy2656) {
 					} else {
-						z.EncFallback(yy2662)
+						z.EncFallback(yy2656)
 					}
 				}
 			}
@@ -34020,8 +33970,8 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2665 := z.EncBinary()
-					_ = yym2665
+					yym2659 := z.EncBinary()
+					_ = yym2659
 					if false {
 					} else {
 						h.encSliceNode(([]Node)(x.Items), e)
@@ -34034,11 +33984,61 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym2660 := z.EncBinary()
+					_ = yym2660
+					if false {
+					} else {
+						h.encSliceNode(([]Node)(x.Items), e)
+					}
+				}
+			}
+			if yyr2652 || yy2arr2652 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2652[2] {
+					yym2662 := z.EncBinary()
+					_ = yym2662
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2652[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2663 := z.EncBinary()
+					_ = yym2663
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2652 || yy2arr2652 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2652[3] {
+					yym2665 := z.EncBinary()
+					_ = yym2665
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2652[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2666 := z.EncBinary()
 					_ = yym2666
 					if false {
 					} else {
-						h.encSliceNode(([]Node)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -34103,6 +34103,31 @@ func (x *NodeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys2669 := string(yys2669Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2669 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv2670 := &x.ListMeta
+				yym2671 := z.DecBinary()
+				_ = yym2671
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv2670) {
+				} else {
+					z.DecFallback(yyv2670, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv2672 := &x.Items
+				yym2673 := z.DecBinary()
+				_ = yym2673
+				if false {
+				} else {
+					h.decSliceNode((*[]Node)(yyv2672), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -34114,31 +34139,6 @@ func (x *NodeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv2672 := &x.ListMeta
-				yym2673 := z.DecBinary()
-				_ = yym2673
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2672) {
-				} else {
-					z.DecFallback(yyv2672, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv2674 := &x.Items
-				yym2675 := z.DecBinary()
-				_ = yym2675
-				if false {
-				} else {
-					h.decSliceNode((*[]Node)(yyv2674), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2669)
@@ -34154,6 +34154,51 @@ func (x *NodeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj2676 int
 	var yyb2676 bool
 	var yyhl2676 bool = l >= 0
+	yyj2676++
+	if yyhl2676 {
+		yyb2676 = yyj2676 > l
+	} else {
+		yyb2676 = r.CheckBreak()
+	}
+	if yyb2676 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv2677 := &x.ListMeta
+		yym2678 := z.DecBinary()
+		_ = yym2678
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv2677) {
+		} else {
+			z.DecFallback(yyv2677, false)
+		}
+	}
+	yyj2676++
+	if yyhl2676 {
+		yyb2676 = yyj2676 > l
+	} else {
+		yyb2676 = r.CheckBreak()
+	}
+	if yyb2676 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv2679 := &x.Items
+		yym2680 := z.DecBinary()
+		_ = yym2680
+		if false {
+		} else {
+			h.decSliceNode((*[]Node)(yyv2679), d)
+		}
+	}
 	yyj2676++
 	if yyhl2676 {
 		yyb2676 = yyj2676 > l
@@ -34185,51 +34230,6 @@ func (x *NodeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj2676++
-	if yyhl2676 {
-		yyb2676 = yyj2676 > l
-	} else {
-		yyb2676 = r.CheckBreak()
-	}
-	if yyb2676 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv2679 := &x.ListMeta
-		yym2680 := z.DecBinary()
-		_ = yym2680
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2679) {
-		} else {
-			z.DecFallback(yyv2679, false)
-		}
-	}
-	yyj2676++
-	if yyhl2676 {
-		yyb2676 = yyj2676 > l
-	} else {
-		yyb2676 = r.CheckBreak()
-	}
-	if yyb2676 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv2681 := &x.Items
-		yym2682 := z.DecBinary()
-		_ = yym2682
-		if false {
-		} else {
-			h.decSliceNode((*[]Node)(yyv2681), d)
-		}
 	}
 	for {
 		yyj2676++
@@ -34664,11 +34664,11 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2710 [5]bool
 			_, _, _ = yysep2710, yyq2710, yy2arr2710
 			const yyr2710 bool = false
-			yyq2710[0] = x.Kind != ""
-			yyq2710[1] = x.APIVersion != ""
+			yyq2710[0] = true
+			yyq2710[1] = true
 			yyq2710[2] = true
-			yyq2710[3] = true
-			yyq2710[4] = true
+			yyq2710[3] = x.Kind != ""
+			yyq2710[4] = x.APIVersion != ""
 			var yynn2710 int
 			if yyr2710 || yy2arr2710 {
 				r.EncodeArrayStart(5)
@@ -34685,57 +34685,41 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2710 || yy2arr2710 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2710[0] {
-					yym2712 := z.EncBinary()
-					_ = yym2712
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy2712 := &x.ObjectMeta
+					yy2712.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq2710[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2713 := z.EncBinary()
-					_ = yym2713
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy2713 := &x.ObjectMeta
+					yy2713.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2710 || yy2arr2710 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2710[1] {
-					yym2715 := z.EncBinary()
-					_ = yym2715
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy2715 := &x.Spec
+					yy2715.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq2710[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2716 := z.EncBinary()
-					_ = yym2716
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy2716 := &x.Spec
+					yy2716.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2710 || yy2arr2710 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2710[2] {
-					yy2718 := &x.ObjectMeta
+					yy2718 := &x.Status
 					yy2718.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
@@ -34743,44 +34727,60 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq2710[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2719 := &x.ObjectMeta
+					yy2719 := &x.Status
 					yy2719.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2710 || yy2arr2710 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2710[3] {
-					yy2721 := &x.Spec
-					yy2721.CodecEncodeSelf(e)
+					yym2721 := z.EncBinary()
+					_ = yym2721
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq2710[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2722 := &x.Spec
-					yy2722.CodecEncodeSelf(e)
+					yym2722 := z.EncBinary()
+					_ = yym2722
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				}
 			}
 			if yyr2710 || yy2arr2710 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2710[4] {
-					yy2724 := &x.Status
-					yy2724.CodecEncodeSelf(e)
+					yym2724 := z.EncBinary()
+					_ = yym2724
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq2710[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2725 := &x.Status
-					yy2725.CodecEncodeSelf(e)
+					yym2725 := z.EncBinary()
+					_ = yym2725
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr2710 || yy2arr2710 {
@@ -34844,6 +34844,27 @@ func (x *Namespace) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys2728 := string(yys2728Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2728 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv2729 := &x.ObjectMeta
+				yyv2729.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = NamespaceSpec{}
+			} else {
+				yyv2730 := &x.Spec
+				yyv2730.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = NamespaceStatus{}
+			} else {
+				yyv2731 := &x.Status
+				yyv2731.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -34855,27 +34876,6 @@ func (x *Namespace) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv2731 := &x.ObjectMeta
-				yyv2731.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = NamespaceSpec{}
-			} else {
-				yyv2732 := &x.Spec
-				yyv2732.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = NamespaceStatus{}
-			} else {
-				yyv2733 := &x.Status
-				yyv2733.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2728)
@@ -34891,6 +34891,57 @@ func (x *Namespace) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj2734 int
 	var yyb2734 bool
 	var yyhl2734 bool = l >= 0
+	yyj2734++
+	if yyhl2734 {
+		yyb2734 = yyj2734 > l
+	} else {
+		yyb2734 = r.CheckBreak()
+	}
+	if yyb2734 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv2735 := &x.ObjectMeta
+		yyv2735.CodecDecodeSelf(d)
+	}
+	yyj2734++
+	if yyhl2734 {
+		yyb2734 = yyj2734 > l
+	} else {
+		yyb2734 = r.CheckBreak()
+	}
+	if yyb2734 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = NamespaceSpec{}
+	} else {
+		yyv2736 := &x.Spec
+		yyv2736.CodecDecodeSelf(d)
+	}
+	yyj2734++
+	if yyhl2734 {
+		yyb2734 = yyj2734 > l
+	} else {
+		yyb2734 = r.CheckBreak()
+	}
+	if yyb2734 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = NamespaceStatus{}
+	} else {
+		yyv2737 := &x.Status
+		yyv2737.CodecDecodeSelf(d)
+	}
 	yyj2734++
 	if yyhl2734 {
 		yyb2734 = yyj2734 > l
@@ -34922,57 +34973,6 @@ func (x *Namespace) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj2734++
-	if yyhl2734 {
-		yyb2734 = yyj2734 > l
-	} else {
-		yyb2734 = r.CheckBreak()
-	}
-	if yyb2734 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv2737 := &x.ObjectMeta
-		yyv2737.CodecDecodeSelf(d)
-	}
-	yyj2734++
-	if yyhl2734 {
-		yyb2734 = yyj2734 > l
-	} else {
-		yyb2734 = r.CheckBreak()
-	}
-	if yyb2734 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = NamespaceSpec{}
-	} else {
-		yyv2738 := &x.Spec
-		yyv2738.CodecDecodeSelf(d)
-	}
-	yyj2734++
-	if yyhl2734 {
-		yyb2734 = yyj2734 > l
-	} else {
-		yyb2734 = r.CheckBreak()
-	}
-	if yyb2734 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = NamespaceStatus{}
-	} else {
-		yyv2739 := &x.Status
-		yyv2739.CodecDecodeSelf(d)
 	}
 	for {
 		yyj2734++
@@ -35007,9 +35007,9 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2741 [4]bool
 			_, _, _ = yysep2741, yyq2741, yy2arr2741
 			const yyr2741 bool = false
-			yyq2741[0] = x.Kind != ""
-			yyq2741[1] = x.APIVersion != ""
-			yyq2741[2] = true
+			yyq2741[0] = true
+			yyq2741[2] = x.Kind != ""
+			yyq2741[3] = x.APIVersion != ""
 			var yynn2741 int
 			if yyr2741 || yy2arr2741 {
 				r.EncodeArrayStart(4)
@@ -35026,79 +35026,29 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2741 || yy2arr2741 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2741[0] {
-					yym2743 := z.EncBinary()
-					_ = yym2743
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2741[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy2743 := &x.ListMeta
 					yym2744 := z.EncBinary()
 					_ = yym2744
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2743) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2741 || yy2arr2741 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2741[1] {
-					yym2746 := z.EncBinary()
-					_ = yym2746
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2741[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2747 := z.EncBinary()
-					_ = yym2747
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2741 || yy2arr2741 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2741[2] {
-					yy2749 := &x.ListMeta
-					yym2750 := z.EncBinary()
-					_ = yym2750
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2749) {
-					} else {
-						z.EncFallback(yy2749)
+						z.EncFallback(yy2743)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2741[2] {
+				if yyq2741[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2751 := &x.ListMeta
-					yym2752 := z.EncBinary()
-					_ = yym2752
+					yy2745 := &x.ListMeta
+					yym2746 := z.EncBinary()
+					_ = yym2746
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2751) {
+					} else if z.HasExtensions() && z.EncExt(yy2745) {
 					} else {
-						z.EncFallback(yy2751)
+						z.EncFallback(yy2745)
 					}
 				}
 			}
@@ -35107,8 +35057,8 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2754 := z.EncBinary()
-					_ = yym2754
+					yym2748 := z.EncBinary()
+					_ = yym2748
 					if false {
 					} else {
 						h.encSliceNamespace(([]Namespace)(x.Items), e)
@@ -35121,11 +35071,61 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym2749 := z.EncBinary()
+					_ = yym2749
+					if false {
+					} else {
+						h.encSliceNamespace(([]Namespace)(x.Items), e)
+					}
+				}
+			}
+			if yyr2741 || yy2arr2741 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2741[2] {
+					yym2751 := z.EncBinary()
+					_ = yym2751
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2741[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2752 := z.EncBinary()
+					_ = yym2752
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2741 || yy2arr2741 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2741[3] {
+					yym2754 := z.EncBinary()
+					_ = yym2754
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2741[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2755 := z.EncBinary()
 					_ = yym2755
 					if false {
 					} else {
-						h.encSliceNamespace(([]Namespace)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -35190,6 +35190,31 @@ func (x *NamespaceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys2758 := string(yys2758Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2758 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv2759 := &x.ListMeta
+				yym2760 := z.DecBinary()
+				_ = yym2760
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv2759) {
+				} else {
+					z.DecFallback(yyv2759, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv2761 := &x.Items
+				yym2762 := z.DecBinary()
+				_ = yym2762
+				if false {
+				} else {
+					h.decSliceNamespace((*[]Namespace)(yyv2761), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -35201,31 +35226,6 @@ func (x *NamespaceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv2761 := &x.ListMeta
-				yym2762 := z.DecBinary()
-				_ = yym2762
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2761) {
-				} else {
-					z.DecFallback(yyv2761, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv2763 := &x.Items
-				yym2764 := z.DecBinary()
-				_ = yym2764
-				if false {
-				} else {
-					h.decSliceNamespace((*[]Namespace)(yyv2763), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2758)
@@ -35241,6 +35241,51 @@ func (x *NamespaceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj2765 int
 	var yyb2765 bool
 	var yyhl2765 bool = l >= 0
+	yyj2765++
+	if yyhl2765 {
+		yyb2765 = yyj2765 > l
+	} else {
+		yyb2765 = r.CheckBreak()
+	}
+	if yyb2765 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv2766 := &x.ListMeta
+		yym2767 := z.DecBinary()
+		_ = yym2767
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv2766) {
+		} else {
+			z.DecFallback(yyv2766, false)
+		}
+	}
+	yyj2765++
+	if yyhl2765 {
+		yyb2765 = yyj2765 > l
+	} else {
+		yyb2765 = r.CheckBreak()
+	}
+	if yyb2765 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv2768 := &x.Items
+		yym2769 := z.DecBinary()
+		_ = yym2769
+		if false {
+		} else {
+			h.decSliceNamespace((*[]Namespace)(yyv2768), d)
+		}
+	}
 	yyj2765++
 	if yyhl2765 {
 		yyb2765 = yyj2765 > l
@@ -35272,51 +35317,6 @@ func (x *NamespaceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj2765++
-	if yyhl2765 {
-		yyb2765 = yyj2765 > l
-	} else {
-		yyb2765 = r.CheckBreak()
-	}
-	if yyb2765 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv2768 := &x.ListMeta
-		yym2769 := z.DecBinary()
-		_ = yym2769
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2768) {
-		} else {
-			z.DecFallback(yyv2768, false)
-		}
-	}
-	yyj2765++
-	if yyhl2765 {
-		yyb2765 = yyj2765 > l
-	} else {
-		yyb2765 = r.CheckBreak()
-	}
-	if yyb2765 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv2770 := &x.Items
-		yym2771 := z.DecBinary()
-		_ = yym2771
-		if false {
-		} else {
-			h.decSliceNamespace((*[]Namespace)(yyv2770), d)
-		}
 	}
 	for {
 		yyj2765++
@@ -35351,9 +35351,9 @@ func (x *Binding) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2773 [4]bool
 			_, _, _ = yysep2773, yyq2773, yy2arr2773
 			const yyr2773 bool = false
-			yyq2773[0] = x.Kind != ""
-			yyq2773[1] = x.APIVersion != ""
-			yyq2773[2] = true
+			yyq2773[0] = true
+			yyq2773[2] = x.Kind != ""
+			yyq2773[3] = x.APIVersion != ""
 			var yynn2773 int
 			if yyr2773 || yy2arr2773 {
 				r.EncodeArrayStart(4)
@@ -35370,80 +35370,80 @@ func (x *Binding) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2773 || yy2arr2773 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2773[0] {
-					yym2775 := z.EncBinary()
-					_ = yym2775
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2773[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2776 := z.EncBinary()
-					_ = yym2776
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2773 || yy2arr2773 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2773[1] {
-					yym2778 := z.EncBinary()
-					_ = yym2778
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2773[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2779 := z.EncBinary()
-					_ = yym2779
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2773 || yy2arr2773 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2773[2] {
-					yy2781 := &x.ObjectMeta
-					yy2781.CodecEncodeSelf(e)
+					yy2775 := &x.ObjectMeta
+					yy2775.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2773[2] {
+				if yyq2773[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy2782 := &x.ObjectMeta
-					yy2782.CodecEncodeSelf(e)
+					yy2776 := &x.ObjectMeta
+					yy2776.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2773 || yy2arr2773 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy2784 := &x.Target
-				yy2784.CodecEncodeSelf(e)
+				yy2778 := &x.Target
+				yy2778.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("target"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy2785 := &x.Target
-				yy2785.CodecEncodeSelf(e)
+				yy2779 := &x.Target
+				yy2779.CodecEncodeSelf(e)
+			}
+			if yyr2773 || yy2arr2773 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2773[2] {
+					yym2781 := z.EncBinary()
+					_ = yym2781
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2773[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2782 := z.EncBinary()
+					_ = yym2782
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2773 || yy2arr2773 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2773[3] {
+					yym2784 := z.EncBinary()
+					_ = yym2784
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2773[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2785 := z.EncBinary()
+					_ = yym2785
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
 			}
 			if yyr2773 || yy2arr2773 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
@@ -35506,6 +35506,20 @@ func (x *Binding) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys2788 := string(yys2788Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2788 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv2789 := &x.ObjectMeta
+				yyv2789.CodecDecodeSelf(d)
+			}
+		case "target":
+			if r.TryDecodeAsNil() {
+				x.Target = ObjectReference{}
+			} else {
+				yyv2790 := &x.Target
+				yyv2790.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -35517,20 +35531,6 @@ func (x *Binding) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv2791 := &x.ObjectMeta
-				yyv2791.CodecDecodeSelf(d)
-			}
-		case "target":
-			if r.TryDecodeAsNil() {
-				x.Target = ObjectReference{}
-			} else {
-				yyv2792 := &x.Target
-				yyv2792.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2788)
@@ -35546,6 +35546,40 @@ func (x *Binding) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj2793 int
 	var yyb2793 bool
 	var yyhl2793 bool = l >= 0
+	yyj2793++
+	if yyhl2793 {
+		yyb2793 = yyj2793 > l
+	} else {
+		yyb2793 = r.CheckBreak()
+	}
+	if yyb2793 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv2794 := &x.ObjectMeta
+		yyv2794.CodecDecodeSelf(d)
+	}
+	yyj2793++
+	if yyhl2793 {
+		yyb2793 = yyj2793 > l
+	} else {
+		yyb2793 = r.CheckBreak()
+	}
+	if yyb2793 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Target = ObjectReference{}
+	} else {
+		yyv2795 := &x.Target
+		yyv2795.CodecDecodeSelf(d)
+	}
 	yyj2793++
 	if yyhl2793 {
 		yyb2793 = yyj2793 > l
@@ -35577,40 +35611,6 @@ func (x *Binding) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj2793++
-	if yyhl2793 {
-		yyb2793 = yyj2793 > l
-	} else {
-		yyb2793 = r.CheckBreak()
-	}
-	if yyb2793 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv2796 := &x.ObjectMeta
-		yyv2796.CodecDecodeSelf(d)
-	}
-	yyj2793++
-	if yyhl2793 {
-		yyb2793 = yyj2793 > l
-	} else {
-		yyb2793 = r.CheckBreak()
-	}
-	if yyb2793 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Target = ObjectReference{}
-	} else {
-		yyv2797 := &x.Target
-		yyv2797.CodecDecodeSelf(d)
 	}
 	for {
 		yyj2793++
@@ -35645,8 +35645,8 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2799 [3]bool
 			_, _, _ = yysep2799, yyq2799, yy2arr2799
 			const yyr2799 bool = false
-			yyq2799[0] = x.Kind != ""
-			yyq2799[1] = x.APIVersion != ""
+			yyq2799[1] = x.Kind != ""
+			yyq2799[2] = x.APIVersion != ""
 			var yynn2799 int
 			if yyr2799 || yy2arr2799 {
 				r.EncodeArrayStart(3)
@@ -35662,65 +35662,15 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2799 || yy2arr2799 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2799[0] {
-					yym2801 := z.EncBinary()
-					_ = yym2801
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+				if x.GracePeriodSeconds == nil {
+					r.EncodeNil()
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2799[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy2801 := *x.GracePeriodSeconds
 					yym2802 := z.EncBinary()
 					_ = yym2802
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2799 || yy2arr2799 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2799[1] {
-					yym2804 := z.EncBinary()
-					_ = yym2804
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2799[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2805 := z.EncBinary()
-					_ = yym2805
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2799 || yy2arr2799 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if x.GracePeriodSeconds == nil {
-					r.EncodeNil()
-				} else {
-					yy2807 := *x.GracePeriodSeconds
-					yym2808 := z.EncBinary()
-					_ = yym2808
-					if false {
-					} else {
-						r.EncodeInt(int64(yy2807))
+						r.EncodeInt(int64(yy2801))
 					}
 				}
 			} else {
@@ -35730,12 +35680,62 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.GracePeriodSeconds == nil {
 					r.EncodeNil()
 				} else {
-					yy2809 := *x.GracePeriodSeconds
+					yy2803 := *x.GracePeriodSeconds
+					yym2804 := z.EncBinary()
+					_ = yym2804
+					if false {
+					} else {
+						r.EncodeInt(int64(yy2803))
+					}
+				}
+			}
+			if yyr2799 || yy2arr2799 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2799[1] {
+					yym2806 := z.EncBinary()
+					_ = yym2806
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2799[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2807 := z.EncBinary()
+					_ = yym2807
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2799 || yy2arr2799 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2799[2] {
+					yym2809 := z.EncBinary()
+					_ = yym2809
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2799[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2810 := z.EncBinary()
 					_ = yym2810
 					if false {
 					} else {
-						r.EncodeInt(int64(yy2809))
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -35800,6 +35800,22 @@ func (x *DeleteOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys2813 := string(yys2813Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2813 {
+		case "gracePeriodSeconds":
+			if r.TryDecodeAsNil() {
+				if x.GracePeriodSeconds != nil {
+					x.GracePeriodSeconds = nil
+				}
+			} else {
+				if x.GracePeriodSeconds == nil {
+					x.GracePeriodSeconds = new(int64)
+				}
+				yym2815 := z.DecBinary()
+				_ = yym2815
+				if false {
+				} else {
+					*((*int64)(x.GracePeriodSeconds)) = int64(r.DecodeInt(64))
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -35811,22 +35827,6 @@ func (x *DeleteOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "gracePeriodSeconds":
-			if r.TryDecodeAsNil() {
-				if x.GracePeriodSeconds != nil {
-					x.GracePeriodSeconds = nil
-				}
-			} else {
-				if x.GracePeriodSeconds == nil {
-					x.GracePeriodSeconds = new(int64)
-				}
-				yym2817 := z.DecBinary()
-				_ = yym2817
-				if false {
-				} else {
-					*((*int64)(x.GracePeriodSeconds)) = int64(r.DecodeInt(64))
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2813)
@@ -35842,6 +35842,32 @@ func (x *DeleteOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj2818 int
 	var yyb2818 bool
 	var yyhl2818 bool = l >= 0
+	yyj2818++
+	if yyhl2818 {
+		yyb2818 = yyj2818 > l
+	} else {
+		yyb2818 = r.CheckBreak()
+	}
+	if yyb2818 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		if x.GracePeriodSeconds != nil {
+			x.GracePeriodSeconds = nil
+		}
+	} else {
+		if x.GracePeriodSeconds == nil {
+			x.GracePeriodSeconds = new(int64)
+		}
+		yym2820 := z.DecBinary()
+		_ = yym2820
+		if false {
+		} else {
+			*((*int64)(x.GracePeriodSeconds)) = int64(r.DecodeInt(64))
+		}
+	}
 	yyj2818++
 	if yyhl2818 {
 		yyb2818 = yyj2818 > l
@@ -35873,32 +35899,6 @@ func (x *DeleteOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj2818++
-	if yyhl2818 {
-		yyb2818 = yyj2818 > l
-	} else {
-		yyb2818 = r.CheckBreak()
-	}
-	if yyb2818 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		if x.GracePeriodSeconds != nil {
-			x.GracePeriodSeconds = nil
-		}
-	} else {
-		if x.GracePeriodSeconds == nil {
-			x.GracePeriodSeconds = new(int64)
-		}
-		yym2822 := z.DecBinary()
-		_ = yym2822
-		if false {
-		} else {
-			*((*int64)(x.GracePeriodSeconds)) = int64(r.DecodeInt(64))
-		}
 	}
 	for {
 		yyj2818++
@@ -35933,8 +35933,8 @@ func (x *ExportOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2824 [4]bool
 			_, _, _ = yysep2824, yyq2824, yy2arr2824
 			const yyr2824 bool = false
-			yyq2824[0] = x.Kind != ""
-			yyq2824[1] = x.APIVersion != ""
+			yyq2824[2] = x.Kind != ""
+			yyq2824[3] = x.APIVersion != ""
 			var yynn2824 int
 			if yyr2824 || yy2arr2824 {
 				r.EncodeArrayStart(4)
@@ -35950,58 +35950,8 @@ func (x *ExportOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2824 || yy2arr2824 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2824[0] {
-					yym2826 := z.EncBinary()
-					_ = yym2826
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2824[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2827 := z.EncBinary()
-					_ = yym2827
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2824 || yy2arr2824 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2824[1] {
-					yym2829 := z.EncBinary()
-					_ = yym2829
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2824[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2830 := z.EncBinary()
-					_ = yym2830
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2824 || yy2arr2824 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym2832 := z.EncBinary()
-				_ = yym2832
+				yym2826 := z.EncBinary()
+				_ = yym2826
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Export))
@@ -36010,8 +35960,8 @@ func (x *ExportOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("export"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym2833 := z.EncBinary()
-				_ = yym2833
+				yym2827 := z.EncBinary()
+				_ = yym2827
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Export))
@@ -36019,8 +35969,8 @@ func (x *ExportOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2824 || yy2arr2824 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym2835 := z.EncBinary()
-				_ = yym2835
+				yym2829 := z.EncBinary()
+				_ = yym2829
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Exact))
@@ -36029,11 +35979,61 @@ func (x *ExportOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("exact"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym2836 := z.EncBinary()
-				_ = yym2836
+				yym2830 := z.EncBinary()
+				_ = yym2830
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Exact))
+				}
+			}
+			if yyr2824 || yy2arr2824 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2824[2] {
+					yym2832 := z.EncBinary()
+					_ = yym2832
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2824[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2833 := z.EncBinary()
+					_ = yym2833
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2824 || yy2arr2824 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2824[3] {
+					yym2835 := z.EncBinary()
+					_ = yym2835
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2824[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2836 := z.EncBinary()
+					_ = yym2836
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr2824 || yy2arr2824 {
@@ -36097,18 +36097,6 @@ func (x *ExportOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys2839 := string(yys2839Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2839 {
-		case "kind":
-			if r.TryDecodeAsNil() {
-				x.Kind = ""
-			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
-			}
 		case "export":
 			if r.TryDecodeAsNil() {
 				x.Export = false
@@ -36120,6 +36108,18 @@ func (x *ExportOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Exact = false
 			} else {
 				x.Exact = bool(r.DecodeBool())
+			}
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2839)
@@ -36135,38 +36135,6 @@ func (x *ExportOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj2844 int
 	var yyb2844 bool
 	var yyhl2844 bool = l >= 0
-	yyj2844++
-	if yyhl2844 {
-		yyb2844 = yyj2844 > l
-	} else {
-		yyb2844 = r.CheckBreak()
-	}
-	if yyb2844 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Kind = ""
-	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj2844++
-	if yyhl2844 {
-		yyb2844 = yyj2844 > l
-	} else {
-		yyb2844 = r.CheckBreak()
-	}
-	if yyb2844 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
-	}
 	yyj2844++
 	if yyhl2844 {
 		yyb2844 = yyj2844 > l
@@ -36198,6 +36166,38 @@ func (x *ExportOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Exact = false
 	} else {
 		x.Exact = bool(r.DecodeBool())
+	}
+	yyj2844++
+	if yyhl2844 {
+		yyb2844 = yyj2844 > l
+	} else {
+		yyb2844 = r.CheckBreak()
+	}
+	if yyb2844 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj2844++
+	if yyhl2844 {
+		yyb2844 = yyj2844 > l
+	} else {
+		yyb2844 = r.CheckBreak()
+	}
+	if yyb2844 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
 	}
 	for {
 		yyj2844++
@@ -36232,13 +36232,13 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2850 [7]bool
 			_, _, _ = yysep2850, yyq2850, yy2arr2850
 			const yyr2850 bool = false
-			yyq2850[0] = x.Kind != ""
-			yyq2850[1] = x.APIVersion != ""
-			yyq2850[2] = x.LabelSelector != ""
-			yyq2850[3] = x.FieldSelector != ""
-			yyq2850[4] = x.Watch != false
-			yyq2850[5] = x.ResourceVersion != ""
-			yyq2850[6] = x.TimeoutSeconds != nil
+			yyq2850[0] = x.LabelSelector != ""
+			yyq2850[1] = x.FieldSelector != ""
+			yyq2850[2] = x.Watch != false
+			yyq2850[3] = x.ResourceVersion != ""
+			yyq2850[4] = x.TimeoutSeconds != nil
+			yyq2850[5] = x.Kind != ""
+			yyq2850[6] = x.APIVersion != ""
 			var yynn2850 int
 			if yyr2850 || yy2arr2850 {
 				r.EncodeArrayStart(7)
@@ -36259,7 +36259,7 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym2852
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+						r.EncodeString(codecSelferC_UTF81234, string(x.LabelSelector))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -36267,13 +36267,13 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq2850[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("labelSelector"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2853 := z.EncBinary()
 					_ = yym2853
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+						r.EncodeString(codecSelferC_UTF81234, string(x.LabelSelector))
 					}
 				}
 			}
@@ -36284,7 +36284,7 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym2855
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.FieldSelector))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -36292,13 +36292,13 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq2850[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("fieldSelector"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2856 := z.EncBinary()
 					_ = yym2856
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.FieldSelector))
 					}
 				}
 			}
@@ -36309,21 +36309,21 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym2858
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.LabelSelector))
+						r.EncodeBool(bool(x.Watch))
 					}
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeBool(false)
 				}
 			} else {
 				if yyq2850[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("labelSelector"))
+					r.EncodeString(codecSelferC_UTF81234, string("watch"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2859 := z.EncBinary()
 					_ = yym2859
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.LabelSelector))
+						r.EncodeBool(bool(x.Watch))
 					}
 				}
 			}
@@ -36334,7 +36334,7 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym2861
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.FieldSelector))
+						r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -36342,49 +36342,59 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq2850[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("fieldSelector"))
+					r.EncodeString(codecSelferC_UTF81234, string("resourceVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2862 := z.EncBinary()
 					_ = yym2862
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.FieldSelector))
+						r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
 					}
 				}
 			}
 			if yyr2850 || yy2arr2850 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2850[4] {
-					yym2864 := z.EncBinary()
-					_ = yym2864
-					if false {
+					if x.TimeoutSeconds == nil {
+						r.EncodeNil()
 					} else {
-						r.EncodeBool(bool(x.Watch))
+						yy2864 := *x.TimeoutSeconds
+						yym2865 := z.EncBinary()
+						_ = yym2865
+						if false {
+						} else {
+							r.EncodeInt(int64(yy2864))
+						}
 					}
 				} else {
-					r.EncodeBool(false)
+					r.EncodeNil()
 				}
 			} else {
 				if yyq2850[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("watch"))
+					r.EncodeString(codecSelferC_UTF81234, string("timeoutSeconds"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2865 := z.EncBinary()
-					_ = yym2865
-					if false {
+					if x.TimeoutSeconds == nil {
+						r.EncodeNil()
 					} else {
-						r.EncodeBool(bool(x.Watch))
+						yy2866 := *x.TimeoutSeconds
+						yym2867 := z.EncBinary()
+						_ = yym2867
+						if false {
+						} else {
+							r.EncodeInt(int64(yy2866))
+						}
 					}
 				}
 			}
 			if yyr2850 || yy2arr2850 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2850[5] {
-					yym2867 := z.EncBinary()
-					_ = yym2867
+					yym2869 := z.EncBinary()
+					_ = yym2869
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -36392,48 +36402,38 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq2850[5] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("resourceVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2868 := z.EncBinary()
-					_ = yym2868
+					yym2870 := z.EncBinary()
+					_ = yym2870
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
 			if yyr2850 || yy2arr2850 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2850[6] {
-					if x.TimeoutSeconds == nil {
-						r.EncodeNil()
+					yym2872 := z.EncBinary()
+					_ = yym2872
+					if false {
 					} else {
-						yy2870 := *x.TimeoutSeconds
-						yym2871 := z.EncBinary()
-						_ = yym2871
-						if false {
-						} else {
-							r.EncodeInt(int64(yy2870))
-						}
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq2850[6] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("timeoutSeconds"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if x.TimeoutSeconds == nil {
-						r.EncodeNil()
+					yym2873 := z.EncBinary()
+					_ = yym2873
+					if false {
 					} else {
-						yy2872 := *x.TimeoutSeconds
-						yym2873 := z.EncBinary()
-						_ = yym2873
-						if false {
-						} else {
-							r.EncodeInt(int64(yy2872))
-						}
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -36498,18 +36498,6 @@ func (x *ListOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys2876 := string(yys2876Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2876 {
-		case "kind":
-			if r.TryDecodeAsNil() {
-				x.Kind = ""
-			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
-			}
 		case "labelSelector":
 			if r.TryDecodeAsNil() {
 				x.LabelSelector = ""
@@ -36543,12 +36531,24 @@ func (x *ListOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TimeoutSeconds == nil {
 					x.TimeoutSeconds = new(int64)
 				}
-				yym2884 := z.DecBinary()
-				_ = yym2884
+				yym2882 := z.DecBinary()
+				_ = yym2882
 				if false {
 				} else {
 					*((*int64)(x.TimeoutSeconds)) = int64(r.DecodeInt(64))
 				}
+			}
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2876)
@@ -36564,38 +36564,6 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj2885 int
 	var yyb2885 bool
 	var yyhl2885 bool = l >= 0
-	yyj2885++
-	if yyhl2885 {
-		yyb2885 = yyj2885 > l
-	} else {
-		yyb2885 = r.CheckBreak()
-	}
-	if yyb2885 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Kind = ""
-	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj2885++
-	if yyhl2885 {
-		yyb2885 = yyj2885 > l
-	} else {
-		yyb2885 = r.CheckBreak()
-	}
-	if yyb2885 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
-	}
 	yyj2885++
 	if yyhl2885 {
 		yyb2885 = yyj2885 > l
@@ -36679,12 +36647,44 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TimeoutSeconds == nil {
 			x.TimeoutSeconds = new(int64)
 		}
-		yym2893 := z.DecBinary()
-		_ = yym2893
+		yym2891 := z.DecBinary()
+		_ = yym2891
 		if false {
 		} else {
 			*((*int64)(x.TimeoutSeconds)) = int64(r.DecodeInt(64))
 		}
+	}
+	yyj2885++
+	if yyhl2885 {
+		yyb2885 = yyj2885 > l
+	} else {
+		yyb2885 = r.CheckBreak()
+	}
+	if yyb2885 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj2885++
+	if yyhl2885 {
+		yyb2885 = yyj2885 > l
+	} else {
+		yyb2885 = r.CheckBreak()
+	}
+	if yyb2885 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
 	}
 	for {
 		yyj2885++
@@ -36719,16 +36719,16 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2895 [10]bool
 			_, _, _ = yysep2895, yyq2895, yy2arr2895
 			const yyr2895 bool = false
-			yyq2895[0] = x.Kind != ""
-			yyq2895[1] = x.APIVersion != ""
-			yyq2895[2] = x.Container != ""
-			yyq2895[3] = x.Follow != false
-			yyq2895[4] = x.Previous != false
-			yyq2895[5] = x.SinceSeconds != nil
-			yyq2895[6] = x.SinceTime != nil
-			yyq2895[7] = x.Timestamps != false
-			yyq2895[8] = x.TailLines != nil
-			yyq2895[9] = x.LimitBytes != nil
+			yyq2895[0] = x.Container != ""
+			yyq2895[1] = x.Follow != false
+			yyq2895[2] = x.Previous != false
+			yyq2895[3] = x.SinceSeconds != nil
+			yyq2895[4] = x.SinceTime != nil
+			yyq2895[5] = x.Timestamps != false
+			yyq2895[6] = x.TailLines != nil
+			yyq2895[7] = x.LimitBytes != nil
+			yyq2895[8] = x.Kind != ""
+			yyq2895[9] = x.APIVersion != ""
 			var yynn2895 int
 			if yyr2895 || yy2arr2895 {
 				r.EncodeArrayStart(10)
@@ -36749,7 +36749,7 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym2897
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -36757,13 +36757,13 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq2895[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("container"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2898 := z.EncBinary()
 					_ = yym2898
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
 					}
 				}
 			}
@@ -36774,21 +36774,21 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym2900
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeBool(bool(x.Follow))
 					}
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeBool(false)
 				}
 			} else {
 				if yyq2895[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("follow"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2901 := z.EncBinary()
 					_ = yym2901
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeBool(bool(x.Follow))
 					}
 				}
 			}
@@ -36799,122 +36799,72 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym2903
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
+						r.EncodeBool(bool(x.Previous))
 					}
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeBool(false)
 				}
 			} else {
 				if yyq2895[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("container"))
+					r.EncodeString(codecSelferC_UTF81234, string("previous"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2904 := z.EncBinary()
 					_ = yym2904
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
-					}
-				}
-			}
-			if yyr2895 || yy2arr2895 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2895[3] {
-					yym2906 := z.EncBinary()
-					_ = yym2906
-					if false {
-					} else {
-						r.EncodeBool(bool(x.Follow))
-					}
-				} else {
-					r.EncodeBool(false)
-				}
-			} else {
-				if yyq2895[3] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("follow"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2907 := z.EncBinary()
-					_ = yym2907
-					if false {
-					} else {
-						r.EncodeBool(bool(x.Follow))
-					}
-				}
-			}
-			if yyr2895 || yy2arr2895 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2895[4] {
-					yym2909 := z.EncBinary()
-					_ = yym2909
-					if false {
-					} else {
-						r.EncodeBool(bool(x.Previous))
-					}
-				} else {
-					r.EncodeBool(false)
-				}
-			} else {
-				if yyq2895[4] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("previous"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2910 := z.EncBinary()
-					_ = yym2910
-					if false {
-					} else {
 						r.EncodeBool(bool(x.Previous))
 					}
 				}
 			}
 			if yyr2895 || yy2arr2895 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2895[5] {
+				if yyq2895[3] {
 					if x.SinceSeconds == nil {
 						r.EncodeNil()
 					} else {
-						yy2912 := *x.SinceSeconds
-						yym2913 := z.EncBinary()
-						_ = yym2913
+						yy2906 := *x.SinceSeconds
+						yym2907 := z.EncBinary()
+						_ = yym2907
 						if false {
 						} else {
-							r.EncodeInt(int64(yy2912))
+							r.EncodeInt(int64(yy2906))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2895[5] {
+				if yyq2895[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("sinceSeconds"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.SinceSeconds == nil {
 						r.EncodeNil()
 					} else {
-						yy2914 := *x.SinceSeconds
-						yym2915 := z.EncBinary()
-						_ = yym2915
+						yy2908 := *x.SinceSeconds
+						yym2909 := z.EncBinary()
+						_ = yym2909
 						if false {
 						} else {
-							r.EncodeInt(int64(yy2914))
+							r.EncodeInt(int64(yy2908))
 						}
 					}
 				}
 			}
 			if yyr2895 || yy2arr2895 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2895[6] {
+				if yyq2895[4] {
 					if x.SinceTime == nil {
 						r.EncodeNil()
 					} else {
-						yym2917 := z.EncBinary()
-						_ = yym2917
+						yym2911 := z.EncBinary()
+						_ = yym2911
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
-						} else if yym2917 {
+						} else if yym2911 {
 							z.EncBinaryMarshal(x.SinceTime)
-						} else if !yym2917 && z.IsJSONHandle() {
+						} else if !yym2911 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.SinceTime)
 						} else {
 							z.EncFallback(x.SinceTime)
@@ -36924,20 +36874,20 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2895[6] {
+				if yyq2895[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("sinceTime"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.SinceTime == nil {
 						r.EncodeNil()
 					} else {
-						yym2918 := z.EncBinary()
-						_ = yym2918
+						yym2912 := z.EncBinary()
+						_ = yym2912
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
-						} else if yym2918 {
+						} else if yym2912 {
 							z.EncBinaryMarshal(x.SinceTime)
-						} else if !yym2918 && z.IsJSONHandle() {
+						} else if !yym2912 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.SinceTime)
 						} else {
 							z.EncFallback(x.SinceTime)
@@ -36947,9 +36897,9 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2895 || yy2arr2895 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2895[7] {
-					yym2920 := z.EncBinary()
-					_ = yym2920
+				if yyq2895[5] {
+					yym2914 := z.EncBinary()
+					_ = yym2914
 					if false {
 					} else {
 						r.EncodeBool(bool(x.Timestamps))
@@ -36958,12 +36908,12 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq2895[7] {
+				if yyq2895[5] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("timestamps"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym2921 := z.EncBinary()
-					_ = yym2921
+					yym2915 := z.EncBinary()
+					_ = yym2915
 					if false {
 					} else {
 						r.EncodeBool(bool(x.Timestamps))
@@ -36972,71 +36922,121 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2895 || yy2arr2895 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2895[8] {
+				if yyq2895[6] {
 					if x.TailLines == nil {
 						r.EncodeNil()
 					} else {
-						yy2923 := *x.TailLines
-						yym2924 := z.EncBinary()
-						_ = yym2924
+						yy2917 := *x.TailLines
+						yym2918 := z.EncBinary()
+						_ = yym2918
 						if false {
 						} else {
-							r.EncodeInt(int64(yy2923))
+							r.EncodeInt(int64(yy2917))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2895[8] {
+				if yyq2895[6] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("tailLines"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.TailLines == nil {
 						r.EncodeNil()
 					} else {
-						yy2925 := *x.TailLines
-						yym2926 := z.EncBinary()
-						_ = yym2926
+						yy2919 := *x.TailLines
+						yym2920 := z.EncBinary()
+						_ = yym2920
 						if false {
 						} else {
-							r.EncodeInt(int64(yy2925))
+							r.EncodeInt(int64(yy2919))
 						}
 					}
 				}
 			}
 			if yyr2895 || yy2arr2895 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2895[9] {
+				if yyq2895[7] {
 					if x.LimitBytes == nil {
 						r.EncodeNil()
 					} else {
-						yy2928 := *x.LimitBytes
-						yym2929 := z.EncBinary()
-						_ = yym2929
+						yy2922 := *x.LimitBytes
+						yym2923 := z.EncBinary()
+						_ = yym2923
 						if false {
 						} else {
-							r.EncodeInt(int64(yy2928))
+							r.EncodeInt(int64(yy2922))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2895[9] {
+				if yyq2895[7] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("limitBytes"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.LimitBytes == nil {
 						r.EncodeNil()
 					} else {
-						yy2930 := *x.LimitBytes
-						yym2931 := z.EncBinary()
-						_ = yym2931
+						yy2924 := *x.LimitBytes
+						yym2925 := z.EncBinary()
+						_ = yym2925
 						if false {
 						} else {
-							r.EncodeInt(int64(yy2930))
+							r.EncodeInt(int64(yy2924))
 						}
+					}
+				}
+			}
+			if yyr2895 || yy2arr2895 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2895[8] {
+					yym2927 := z.EncBinary()
+					_ = yym2927
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2895[8] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2928 := z.EncBinary()
+					_ = yym2928
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2895 || yy2arr2895 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2895[9] {
+					yym2930 := z.EncBinary()
+					_ = yym2930
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2895[9] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym2931 := z.EncBinary()
+					_ = yym2931
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -37101,18 +37101,6 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys2934 := string(yys2934Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2934 {
-		case "kind":
-			if r.TryDecodeAsNil() {
-				x.Kind = ""
-			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
-			}
 		case "container":
 			if r.TryDecodeAsNil() {
 				x.Container = ""
@@ -37140,8 +37128,8 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.SinceSeconds == nil {
 					x.SinceSeconds = new(int64)
 				}
-				yym2941 := z.DecBinary()
-				_ = yym2941
+				yym2939 := z.DecBinary()
+				_ = yym2939
 				if false {
 				} else {
 					*((*int64)(x.SinceSeconds)) = int64(r.DecodeInt(64))
@@ -37156,13 +37144,13 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.SinceTime == nil {
 					x.SinceTime = new(pkg2_unversioned.Time)
 				}
-				yym2943 := z.DecBinary()
-				_ = yym2943
+				yym2941 := z.DecBinary()
+				_ = yym2941
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
-				} else if yym2943 {
+				} else if yym2941 {
 					z.DecBinaryUnmarshal(x.SinceTime)
-				} else if !yym2943 && z.IsJSONHandle() {
+				} else if !yym2941 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.SinceTime)
 				} else {
 					z.DecFallback(x.SinceTime, false)
@@ -37183,8 +37171,8 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TailLines == nil {
 					x.TailLines = new(int64)
 				}
-				yym2946 := z.DecBinary()
-				_ = yym2946
+				yym2944 := z.DecBinary()
+				_ = yym2944
 				if false {
 				} else {
 					*((*int64)(x.TailLines)) = int64(r.DecodeInt(64))
@@ -37199,12 +37187,24 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.LimitBytes == nil {
 					x.LimitBytes = new(int64)
 				}
-				yym2948 := z.DecBinary()
-				_ = yym2948
+				yym2946 := z.DecBinary()
+				_ = yym2946
 				if false {
 				} else {
 					*((*int64)(x.LimitBytes)) = int64(r.DecodeInt(64))
 				}
+			}
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2934)
@@ -37220,38 +37220,6 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj2949 int
 	var yyb2949 bool
 	var yyhl2949 bool = l >= 0
-	yyj2949++
-	if yyhl2949 {
-		yyb2949 = yyj2949 > l
-	} else {
-		yyb2949 = r.CheckBreak()
-	}
-	if yyb2949 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Kind = ""
-	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj2949++
-	if yyhl2949 {
-		yyb2949 = yyj2949 > l
-	} else {
-		yyb2949 = r.CheckBreak()
-	}
-	if yyb2949 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
-	}
 	yyj2949++
 	if yyhl2949 {
 		yyb2949 = yyj2949 > l
@@ -37319,8 +37287,8 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.SinceSeconds == nil {
 			x.SinceSeconds = new(int64)
 		}
-		yym2956 := z.DecBinary()
-		_ = yym2956
+		yym2954 := z.DecBinary()
+		_ = yym2954
 		if false {
 		} else {
 			*((*int64)(x.SinceSeconds)) = int64(r.DecodeInt(64))
@@ -37345,13 +37313,13 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.SinceTime == nil {
 			x.SinceTime = new(pkg2_unversioned.Time)
 		}
-		yym2958 := z.DecBinary()
-		_ = yym2958
+		yym2956 := z.DecBinary()
+		_ = yym2956
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
-		} else if yym2958 {
+		} else if yym2956 {
 			z.DecBinaryUnmarshal(x.SinceTime)
-		} else if !yym2958 && z.IsJSONHandle() {
+		} else if !yym2956 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.SinceTime)
 		} else {
 			z.DecFallback(x.SinceTime, false)
@@ -37392,8 +37360,8 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TailLines == nil {
 			x.TailLines = new(int64)
 		}
-		yym2961 := z.DecBinary()
-		_ = yym2961
+		yym2959 := z.DecBinary()
+		_ = yym2959
 		if false {
 		} else {
 			*((*int64)(x.TailLines)) = int64(r.DecodeInt(64))
@@ -37418,12 +37386,44 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.LimitBytes == nil {
 			x.LimitBytes = new(int64)
 		}
-		yym2963 := z.DecBinary()
-		_ = yym2963
+		yym2961 := z.DecBinary()
+		_ = yym2961
 		if false {
 		} else {
 			*((*int64)(x.LimitBytes)) = int64(r.DecodeInt(64))
 		}
+	}
+	yyj2949++
+	if yyhl2949 {
+		yyb2949 = yyj2949 > l
+	} else {
+		yyb2949 = r.CheckBreak()
+	}
+	if yyb2949 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj2949++
+	if yyhl2949 {
+		yyb2949 = yyj2949 > l
+	} else {
+		yyb2949 = r.CheckBreak()
+	}
+	if yyb2949 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
 	}
 	for {
 		yyj2949++
@@ -37458,13 +37458,13 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2965 [7]bool
 			_, _, _ = yysep2965, yyq2965, yy2arr2965
 			const yyr2965 bool = false
-			yyq2965[0] = x.Kind != ""
-			yyq2965[1] = x.APIVersion != ""
-			yyq2965[2] = x.Stdin != false
-			yyq2965[3] = x.Stdout != false
-			yyq2965[4] = x.Stderr != false
-			yyq2965[5] = x.TTY != false
-			yyq2965[6] = x.Container != ""
+			yyq2965[0] = x.Stdin != false
+			yyq2965[1] = x.Stdout != false
+			yyq2965[2] = x.Stderr != false
+			yyq2965[3] = x.TTY != false
+			yyq2965[4] = x.Container != ""
+			yyq2965[5] = x.Kind != ""
+			yyq2965[6] = x.APIVersion != ""
 			var yynn2965 int
 			if yyr2965 || yy2arr2965 {
 				r.EncodeArrayStart(7)
@@ -37485,21 +37485,21 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym2967
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+						r.EncodeBool(bool(x.Stdin))
 					}
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeBool(false)
 				}
 			} else {
 				if yyq2965[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("stdin"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2968 := z.EncBinary()
 					_ = yym2968
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+						r.EncodeBool(bool(x.Stdin))
 					}
 				}
 			}
@@ -37510,21 +37510,21 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym2970
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeBool(bool(x.Stdout))
 					}
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeBool(false)
 				}
 			} else {
 				if yyq2965[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("stdout"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2971 := z.EncBinary()
 					_ = yym2971
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeBool(bool(x.Stdout))
 					}
 				}
 			}
@@ -37535,7 +37535,7 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym2973
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stdin))
+						r.EncodeBool(bool(x.Stderr))
 					}
 				} else {
 					r.EncodeBool(false)
@@ -37543,13 +37543,13 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq2965[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("stdin"))
+					r.EncodeString(codecSelferC_UTF81234, string("stderr"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2974 := z.EncBinary()
 					_ = yym2974
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stdin))
+						r.EncodeBool(bool(x.Stderr))
 					}
 				}
 			}
@@ -37560,7 +37560,7 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym2976
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stdout))
+						r.EncodeBool(bool(x.TTY))
 					}
 				} else {
 					r.EncodeBool(false)
@@ -37568,13 +37568,13 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq2965[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("stdout"))
+					r.EncodeString(codecSelferC_UTF81234, string("tty"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2977 := z.EncBinary()
 					_ = yym2977
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stdout))
+						r.EncodeBool(bool(x.TTY))
 					}
 				}
 			}
@@ -37585,21 +37585,21 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym2979
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stderr))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
 					}
 				} else {
-					r.EncodeBool(false)
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq2965[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("stderr"))
+					r.EncodeString(codecSelferC_UTF81234, string("container"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2980 := z.EncBinary()
 					_ = yym2980
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stderr))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
 					}
 				}
 			}
@@ -37610,21 +37610,21 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym2982
 					if false {
 					} else {
-						r.EncodeBool(bool(x.TTY))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				} else {
-					r.EncodeBool(false)
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq2965[5] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("tty"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2983 := z.EncBinary()
 					_ = yym2983
 					if false {
 					} else {
-						r.EncodeBool(bool(x.TTY))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
@@ -37635,7 +37635,7 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym2985
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -37643,13 +37643,13 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq2965[6] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("container"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym2986 := z.EncBinary()
 					_ = yym2986
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -37714,18 +37714,6 @@ func (x *PodAttachOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys2989 := string(yys2989Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys2989 {
-		case "kind":
-			if r.TryDecodeAsNil() {
-				x.Kind = ""
-			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
-			}
 		case "stdin":
 			if r.TryDecodeAsNil() {
 				x.Stdin = false
@@ -37756,6 +37744,18 @@ func (x *PodAttachOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			} else {
 				x.Container = string(r.DecodeString())
 			}
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
+			}
 		default:
 			z.DecStructFieldNotFound(-1, yys2989)
 		} // end switch yys2989
@@ -37770,38 +37770,6 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	var yyj2997 int
 	var yyb2997 bool
 	var yyhl2997 bool = l >= 0
-	yyj2997++
-	if yyhl2997 {
-		yyb2997 = yyj2997 > l
-	} else {
-		yyb2997 = r.CheckBreak()
-	}
-	if yyb2997 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Kind = ""
-	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj2997++
-	if yyhl2997 {
-		yyb2997 = yyj2997 > l
-	} else {
-		yyb2997 = r.CheckBreak()
-	}
-	if yyb2997 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
-	}
 	yyj2997++
 	if yyhl2997 {
 		yyb2997 = yyj2997 > l
@@ -37882,6 +37850,38 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Container = string(r.DecodeString())
 	}
+	yyj2997++
+	if yyhl2997 {
+		yyb2997 = yyj2997 > l
+	} else {
+		yyb2997 = r.CheckBreak()
+	}
+	if yyb2997 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj2997++
+	if yyhl2997 {
+		yyb2997 = yyj2997 > l
+	} else {
+		yyb2997 = r.CheckBreak()
+	}
+	if yyb2997 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
+	}
 	for {
 		yyj2997++
 		if yyhl2997 {
@@ -37915,13 +37915,13 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3006 [8]bool
 			_, _, _ = yysep3006, yyq3006, yy2arr3006
 			const yyr3006 bool = false
-			yyq3006[0] = x.Kind != ""
-			yyq3006[1] = x.APIVersion != ""
-			yyq3006[2] = x.Stdin != false
-			yyq3006[3] = x.Stdout != false
-			yyq3006[4] = x.Stderr != false
-			yyq3006[5] = x.TTY != false
-			yyq3006[6] = x.Container != ""
+			yyq3006[0] = x.Stdin != false
+			yyq3006[1] = x.Stdout != false
+			yyq3006[2] = x.Stderr != false
+			yyq3006[3] = x.TTY != false
+			yyq3006[4] = x.Container != ""
+			yyq3006[6] = x.Kind != ""
+			yyq3006[7] = x.APIVersion != ""
 			var yynn3006 int
 			if yyr3006 || yy2arr3006 {
 				r.EncodeArrayStart(8)
@@ -37942,21 +37942,21 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym3008
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+						r.EncodeBool(bool(x.Stdin))
 					}
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeBool(false)
 				}
 			} else {
 				if yyq3006[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("stdin"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3009 := z.EncBinary()
 					_ = yym3009
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+						r.EncodeBool(bool(x.Stdin))
 					}
 				}
 			}
@@ -37967,21 +37967,21 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym3011
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeBool(bool(x.Stdout))
 					}
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeBool(false)
 				}
 			} else {
 				if yyq3006[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("stdout"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3012 := z.EncBinary()
 					_ = yym3012
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeBool(bool(x.Stdout))
 					}
 				}
 			}
@@ -37992,7 +37992,7 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym3014
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stdin))
+						r.EncodeBool(bool(x.Stderr))
 					}
 				} else {
 					r.EncodeBool(false)
@@ -38000,13 +38000,13 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq3006[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("stdin"))
+					r.EncodeString(codecSelferC_UTF81234, string("stderr"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3015 := z.EncBinary()
 					_ = yym3015
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stdin))
+						r.EncodeBool(bool(x.Stderr))
 					}
 				}
 			}
@@ -38017,7 +38017,7 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym3017
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stdout))
+						r.EncodeBool(bool(x.TTY))
 					}
 				} else {
 					r.EncodeBool(false)
@@ -38025,13 +38025,13 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq3006[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("stdout"))
+					r.EncodeString(codecSelferC_UTF81234, string("tty"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3018 := z.EncBinary()
 					_ = yym3018
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stdout))
+						r.EncodeBool(bool(x.TTY))
 					}
 				}
 			}
@@ -38042,68 +38042,18 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym3020
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stderr))
-					}
-				} else {
-					r.EncodeBool(false)
-				}
-			} else {
-				if yyq3006[4] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("stderr"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3021 := z.EncBinary()
-					_ = yym3021
-					if false {
-					} else {
-						r.EncodeBool(bool(x.Stderr))
-					}
-				}
-			}
-			if yyr3006 || yy2arr3006 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3006[5] {
-					yym3023 := z.EncBinary()
-					_ = yym3023
-					if false {
-					} else {
-						r.EncodeBool(bool(x.TTY))
-					}
-				} else {
-					r.EncodeBool(false)
-				}
-			} else {
-				if yyq3006[5] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("tty"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3024 := z.EncBinary()
-					_ = yym3024
-					if false {
-					} else {
-						r.EncodeBool(bool(x.TTY))
-					}
-				}
-			}
-			if yyr3006 || yy2arr3006 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3006[6] {
-					yym3026 := z.EncBinary()
-					_ = yym3026
-					if false {
-					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3006[6] {
+				if yyq3006[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("container"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3027 := z.EncBinary()
-					_ = yym3027
+					yym3021 := z.EncBinary()
+					_ = yym3021
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
@@ -38115,8 +38065,8 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Command == nil {
 					r.EncodeNil()
 				} else {
-					yym3029 := z.EncBinary()
-					_ = yym3029
+					yym3023 := z.EncBinary()
+					_ = yym3023
 					if false {
 					} else {
 						z.F.EncSliceStringV(x.Command, false, e)
@@ -38129,11 +38079,61 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Command == nil {
 					r.EncodeNil()
 				} else {
+					yym3024 := z.EncBinary()
+					_ = yym3024
+					if false {
+					} else {
+						z.F.EncSliceStringV(x.Command, false, e)
+					}
+				}
+			}
+			if yyr3006 || yy2arr3006 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3006[6] {
+					yym3026 := z.EncBinary()
+					_ = yym3026
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3006[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3027 := z.EncBinary()
+					_ = yym3027
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3006 || yy2arr3006 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3006[7] {
+					yym3029 := z.EncBinary()
+					_ = yym3029
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3006[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3030 := z.EncBinary()
 					_ = yym3030
 					if false {
 					} else {
-						z.F.EncSliceStringV(x.Command, false, e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -38198,18 +38198,6 @@ func (x *PodExecOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys3033 := string(yys3033Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3033 {
-		case "kind":
-			if r.TryDecodeAsNil() {
-				x.Kind = ""
-			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
-			}
 		case "stdin":
 			if r.TryDecodeAsNil() {
 				x.Stdin = false
@@ -38244,13 +38232,25 @@ func (x *PodExecOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Command = nil
 			} else {
-				yyv3041 := &x.Command
-				yym3042 := z.DecBinary()
-				_ = yym3042
+				yyv3039 := &x.Command
+				yym3040 := z.DecBinary()
+				_ = yym3040
 				if false {
 				} else {
-					z.F.DecSliceStringX(yyv3041, false, d)
+					z.F.DecSliceStringX(yyv3039, false, d)
 				}
+			}
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3033)
@@ -38266,38 +38266,6 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj3043 int
 	var yyb3043 bool
 	var yyhl3043 bool = l >= 0
-	yyj3043++
-	if yyhl3043 {
-		yyb3043 = yyj3043 > l
-	} else {
-		yyb3043 = r.CheckBreak()
-	}
-	if yyb3043 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Kind = ""
-	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj3043++
-	if yyhl3043 {
-		yyb3043 = yyj3043 > l
-	} else {
-		yyb3043 = r.CheckBreak()
-	}
-	if yyb3043 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
-	}
 	yyj3043++
 	if yyhl3043 {
 		yyb3043 = yyj3043 > l
@@ -38392,13 +38360,45 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Command = nil
 	} else {
-		yyv3051 := &x.Command
-		yym3052 := z.DecBinary()
-		_ = yym3052
+		yyv3049 := &x.Command
+		yym3050 := z.DecBinary()
+		_ = yym3050
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv3051, false, d)
+			z.F.DecSliceStringX(yyv3049, false, d)
 		}
+	}
+	yyj3043++
+	if yyhl3043 {
+		yyb3043 = yyj3043 > l
+	} else {
+		yyb3043 = r.CheckBreak()
+	}
+	if yyb3043 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj3043++
+	if yyhl3043 {
+		yyb3043 = yyj3043 > l
+	} else {
+		yyb3043 = r.CheckBreak()
+	}
+	if yyb3043 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
 	}
 	for {
 		yyj3043++
@@ -38433,9 +38433,9 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3054 [3]bool
 			_, _, _ = yysep3054, yyq3054, yy2arr3054
 			const yyr3054 bool = false
-			yyq3054[0] = x.Kind != ""
-			yyq3054[1] = x.APIVersion != ""
-			yyq3054[2] = x.Path != ""
+			yyq3054[0] = x.Path != ""
+			yyq3054[1] = x.Kind != ""
+			yyq3054[2] = x.APIVersion != ""
 			var yynn3054 int
 			if yyr3054 || yy2arr3054 {
 				r.EncodeArrayStart(3)
@@ -38456,7 +38456,7 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym3056
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -38464,13 +38464,13 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq3054[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("path"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3057 := z.EncBinary()
 					_ = yym3057
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 					}
 				}
 			}
@@ -38481,7 +38481,7 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym3059
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -38489,13 +38489,13 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq3054[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3060 := z.EncBinary()
 					_ = yym3060
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
@@ -38506,7 +38506,7 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym3062
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Path))
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -38514,13 +38514,13 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq3054[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("path"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3063 := z.EncBinary()
 					_ = yym3063
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Path))
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -38585,6 +38585,12 @@ func (x *PodProxyOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys3066 := string(yys3066Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3066 {
+		case "path":
+			if r.TryDecodeAsNil() {
+				x.Path = ""
+			} else {
+				x.Path = string(r.DecodeString())
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -38596,12 +38602,6 @@ func (x *PodProxyOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "path":
-			if r.TryDecodeAsNil() {
-				x.Path = ""
-			} else {
-				x.Path = string(r.DecodeString())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3066)
@@ -38617,6 +38617,22 @@ func (x *PodProxyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var yyj3070 int
 	var yyb3070 bool
 	var yyhl3070 bool = l >= 0
+	yyj3070++
+	if yyhl3070 {
+		yyb3070 = yyj3070 > l
+	} else {
+		yyb3070 = r.CheckBreak()
+	}
+	if yyb3070 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Path = ""
+	} else {
+		x.Path = string(r.DecodeString())
+	}
 	yyj3070++
 	if yyhl3070 {
 		yyb3070 = yyj3070 > l
@@ -38648,22 +38664,6 @@ func (x *PodProxyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3070++
-	if yyhl3070 {
-		yyb3070 = yyj3070 > l
-	} else {
-		yyb3070 = r.CheckBreak()
-	}
-	if yyb3070 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Path = ""
-	} else {
-		x.Path = string(r.DecodeString())
 	}
 	for {
 		yyj3070++
@@ -39326,9 +39326,9 @@ func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3127 [3]bool
 			_, _, _ = yysep3127, yyq3127, yy2arr3127
 			const yyr3127 bool = false
-			yyq3127[0] = x.Kind != ""
-			yyq3127[1] = x.APIVersion != ""
-			yyq3127[2] = true
+			yyq3127[0] = true
+			yyq3127[1] = x.Kind != ""
+			yyq3127[2] = x.APIVersion != ""
 			var yynn3127 int
 			if yyr3127 || yy2arr3127 {
 				r.EncodeArrayStart(3)
@@ -39345,26 +39345,18 @@ func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr3127 || yy2arr3127 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3127[0] {
-					yym3129 := z.EncBinary()
-					_ = yym3129
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy3129 := &x.Reference
+					yy3129.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq3127[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("reference"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3130 := z.EncBinary()
-					_ = yym3130
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy3130 := &x.Reference
+					yy3130.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3127 || yy2arr3127 {
@@ -39374,7 +39366,7 @@ func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym3132
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -39382,31 +39374,39 @@ func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq3127[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3133 := z.EncBinary()
 					_ = yym3133
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
 			if yyr3127 || yy2arr3127 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3127[2] {
-					yy3135 := &x.Reference
-					yy3135.CodecEncodeSelf(e)
+					yym3135 := z.EncBinary()
+					_ = yym3135
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq3127[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("reference"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3136 := &x.Reference
-					yy3136.CodecEncodeSelf(e)
+					yym3136 := z.EncBinary()
+					_ = yym3136
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr3127 || yy2arr3127 {
@@ -39470,6 +39470,13 @@ func (x *SerializedReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 		yys3139 := string(yys3139Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3139 {
+		case "reference":
+			if r.TryDecodeAsNil() {
+				x.Reference = ObjectReference{}
+			} else {
+				yyv3140 := &x.Reference
+				yyv3140.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -39481,13 +39488,6 @@ func (x *SerializedReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "reference":
-			if r.TryDecodeAsNil() {
-				x.Reference = ObjectReference{}
-			} else {
-				yyv3142 := &x.Reference
-				yyv3142.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3139)
@@ -39503,6 +39503,23 @@ func (x *SerializedReference) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	var yyj3143 int
 	var yyb3143 bool
 	var yyhl3143 bool = l >= 0
+	yyj3143++
+	if yyhl3143 {
+		yyb3143 = yyj3143 > l
+	} else {
+		yyb3143 = r.CheckBreak()
+	}
+	if yyb3143 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Reference = ObjectReference{}
+	} else {
+		yyv3144 := &x.Reference
+		yyv3144.CodecDecodeSelf(d)
+	}
 	yyj3143++
 	if yyhl3143 {
 		yyb3143 = yyj3143 > l
@@ -39534,23 +39551,6 @@ func (x *SerializedReference) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3143++
-	if yyhl3143 {
-		yyb3143 = yyj3143 > l
-	} else {
-		yyb3143 = r.CheckBreak()
-	}
-	if yyb3143 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Reference = ObjectReference{}
-	} else {
-		yyv3146 := &x.Reference
-		yyv3146.CodecDecodeSelf(d)
 	}
 	for {
 		yyj3143++
@@ -39802,15 +39802,15 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3164 [11]bool
 			_, _, _ = yysep3164, yyq3164, yy2arr3164
 			const yyr3164 bool = false
-			yyq3164[0] = x.Kind != ""
-			yyq3164[1] = x.APIVersion != ""
-			yyq3164[4] = x.Reason != ""
-			yyq3164[5] = x.Message != ""
+			yyq3164[2] = x.Reason != ""
+			yyq3164[3] = x.Message != ""
+			yyq3164[4] = true
+			yyq3164[5] = true
 			yyq3164[6] = true
-			yyq3164[7] = true
-			yyq3164[8] = true
-			yyq3164[9] = x.Count != 0
-			yyq3164[10] = x.Type != ""
+			yyq3164[7] = x.Count != 0
+			yyq3164[8] = x.Type != ""
+			yyq3164[9] = x.Kind != ""
+			yyq3164[10] = x.APIVersion != ""
 			var yynn3164 int
 			if yyr3164 || yy2arr3164 {
 				r.EncodeArrayStart(11)
@@ -39826,81 +39826,31 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr3164 || yy2arr3164 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3164[0] {
-					yym3166 := z.EncBinary()
-					_ = yym3166
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3164[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3167 := z.EncBinary()
-					_ = yym3167
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3164 || yy2arr3164 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3164[1] {
-					yym3169 := z.EncBinary()
-					_ = yym3169
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3164[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3170 := z.EncBinary()
-					_ = yym3170
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3164 || yy2arr3164 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy3172 := &x.ObjectMeta
-				yy3172.CodecEncodeSelf(e)
+				yy3166 := &x.ObjectMeta
+				yy3166.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy3173 := &x.ObjectMeta
-				yy3173.CodecEncodeSelf(e)
+				yy3167 := &x.ObjectMeta
+				yy3167.CodecEncodeSelf(e)
 			}
 			if yyr3164 || yy2arr3164 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy3175 := &x.InvolvedObject
-				yy3175.CodecEncodeSelf(e)
+				yy3169 := &x.InvolvedObject
+				yy3169.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("involvedObject"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy3176 := &x.InvolvedObject
-				yy3176.CodecEncodeSelf(e)
+				yy3170 := &x.InvolvedObject
+				yy3170.CodecEncodeSelf(e)
 			}
 			if yyr3164 || yy2arr3164 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3164[4] {
-					yym3178 := z.EncBinary()
-					_ = yym3178
+				if yyq3164[2] {
+					yym3172 := z.EncBinary()
+					_ = yym3172
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
@@ -39909,12 +39859,12 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3164[4] {
+				if yyq3164[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("reason"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3179 := z.EncBinary()
-					_ = yym3179
+					yym3173 := z.EncBinary()
+					_ = yym3173
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
@@ -39923,9 +39873,9 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr3164 || yy2arr3164 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3164[5] {
-					yym3181 := z.EncBinary()
-					_ = yym3181
+				if yyq3164[3] {
+					yym3175 := z.EncBinary()
+					_ = yym3175
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
@@ -39934,12 +39884,12 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3164[5] {
+				if yyq3164[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3182 := z.EncBinary()
-					_ = yym3182
+					yym3176 := z.EncBinary()
+					_ = yym3176
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
@@ -39948,92 +39898,142 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr3164 || yy2arr3164 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3164[6] {
-					yy3184 := &x.Source
-					yy3184.CodecEncodeSelf(e)
+				if yyq3164[4] {
+					yy3178 := &x.Source
+					yy3178.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3164[6] {
+				if yyq3164[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("source"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3185 := &x.Source
-					yy3185.CodecEncodeSelf(e)
+					yy3179 := &x.Source
+					yy3179.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3164 || yy2arr3164 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3164[7] {
-					yy3187 := &x.FirstTimestamp
-					yym3188 := z.EncBinary()
-					_ = yym3188
+				if yyq3164[5] {
+					yy3181 := &x.FirstTimestamp
+					yym3182 := z.EncBinary()
+					_ = yym3182
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3187) {
-					} else if yym3188 {
-						z.EncBinaryMarshal(yy3187)
-					} else if !yym3188 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy3187)
+					} else if z.HasExtensions() && z.EncExt(yy3181) {
+					} else if yym3182 {
+						z.EncBinaryMarshal(yy3181)
+					} else if !yym3182 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy3181)
 					} else {
-						z.EncFallback(yy3187)
+						z.EncFallback(yy3181)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3164[7] {
+				if yyq3164[5] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("firstTimestamp"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3189 := &x.FirstTimestamp
-					yym3190 := z.EncBinary()
-					_ = yym3190
+					yy3183 := &x.FirstTimestamp
+					yym3184 := z.EncBinary()
+					_ = yym3184
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3189) {
-					} else if yym3190 {
-						z.EncBinaryMarshal(yy3189)
-					} else if !yym3190 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy3189)
+					} else if z.HasExtensions() && z.EncExt(yy3183) {
+					} else if yym3184 {
+						z.EncBinaryMarshal(yy3183)
+					} else if !yym3184 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy3183)
 					} else {
-						z.EncFallback(yy3189)
+						z.EncFallback(yy3183)
+					}
+				}
+			}
+			if yyr3164 || yy2arr3164 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3164[6] {
+					yy3186 := &x.LastTimestamp
+					yym3187 := z.EncBinary()
+					_ = yym3187
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3186) {
+					} else if yym3187 {
+						z.EncBinaryMarshal(yy3186)
+					} else if !yym3187 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy3186)
+					} else {
+						z.EncFallback(yy3186)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq3164[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("lastTimestamp"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy3188 := &x.LastTimestamp
+					yym3189 := z.EncBinary()
+					_ = yym3189
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3188) {
+					} else if yym3189 {
+						z.EncBinaryMarshal(yy3188)
+					} else if !yym3189 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy3188)
+					} else {
+						z.EncFallback(yy3188)
+					}
+				}
+			}
+			if yyr3164 || yy2arr3164 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3164[7] {
+					yym3191 := z.EncBinary()
+					_ = yym3191
+					if false {
+					} else {
+						r.EncodeInt(int64(x.Count))
+					}
+				} else {
+					r.EncodeInt(0)
+				}
+			} else {
+				if yyq3164[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("count"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3192 := z.EncBinary()
+					_ = yym3192
+					if false {
+					} else {
+						r.EncodeInt(int64(x.Count))
 					}
 				}
 			}
 			if yyr3164 || yy2arr3164 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3164[8] {
-					yy3192 := &x.LastTimestamp
-					yym3193 := z.EncBinary()
-					_ = yym3193
+					yym3194 := z.EncBinary()
+					_ = yym3194
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3192) {
-					} else if yym3193 {
-						z.EncBinaryMarshal(yy3192)
-					} else if !yym3193 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy3192)
 					} else {
-						z.EncFallback(yy3192)
+						r.EncodeString(codecSelferC_UTF81234, string(x.Type))
 					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq3164[8] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("lastTimestamp"))
+					r.EncodeString(codecSelferC_UTF81234, string("type"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3194 := &x.LastTimestamp
 					yym3195 := z.EncBinary()
 					_ = yym3195
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3194) {
-					} else if yym3195 {
-						z.EncBinaryMarshal(yy3194)
-					} else if !yym3195 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy3194)
 					} else {
-						z.EncFallback(yy3194)
+						r.EncodeString(codecSelferC_UTF81234, string(x.Type))
 					}
 				}
 			}
@@ -40044,21 +40044,21 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym3197
 					if false {
 					} else {
-						r.EncodeInt(int64(x.Count))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				} else {
-					r.EncodeInt(0)
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq3164[9] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("count"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3198 := z.EncBinary()
 					_ = yym3198
 					if false {
 					} else {
-						r.EncodeInt(int64(x.Count))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
@@ -40069,7 +40069,7 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym3200
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Type))
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -40077,13 +40077,13 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq3164[10] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("type"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3201 := z.EncBinary()
 					_ = yym3201
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Type))
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -40148,31 +40148,19 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys3204 := string(yys3204Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3204 {
-		case "kind":
-			if r.TryDecodeAsNil() {
-				x.Kind = ""
-			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
-			}
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv3207 := &x.ObjectMeta
-				yyv3207.CodecDecodeSelf(d)
+				yyv3205 := &x.ObjectMeta
+				yyv3205.CodecDecodeSelf(d)
 			}
 		case "involvedObject":
 			if r.TryDecodeAsNil() {
 				x.InvolvedObject = ObjectReference{}
 			} else {
-				yyv3208 := &x.InvolvedObject
-				yyv3208.CodecDecodeSelf(d)
+				yyv3206 := &x.InvolvedObject
+				yyv3206.CodecDecodeSelf(d)
 			}
 		case "reason":
 			if r.TryDecodeAsNil() {
@@ -40190,14 +40178,31 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Source = EventSource{}
 			} else {
-				yyv3211 := &x.Source
-				yyv3211.CodecDecodeSelf(d)
+				yyv3209 := &x.Source
+				yyv3209.CodecDecodeSelf(d)
 			}
 		case "firstTimestamp":
 			if r.TryDecodeAsNil() {
 				x.FirstTimestamp = pkg2_unversioned.Time{}
 			} else {
-				yyv3212 := &x.FirstTimestamp
+				yyv3210 := &x.FirstTimestamp
+				yym3211 := z.DecBinary()
+				_ = yym3211
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv3210) {
+				} else if yym3211 {
+					z.DecBinaryUnmarshal(yyv3210)
+				} else if !yym3211 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv3210)
+				} else {
+					z.DecFallback(yyv3210, false)
+				}
+			}
+		case "lastTimestamp":
+			if r.TryDecodeAsNil() {
+				x.LastTimestamp = pkg2_unversioned.Time{}
+			} else {
+				yyv3212 := &x.LastTimestamp
 				yym3213 := z.DecBinary()
 				_ = yym3213
 				if false {
@@ -40208,23 +40213,6 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 					z.DecJSONUnmarshal(yyv3212)
 				} else {
 					z.DecFallback(yyv3212, false)
-				}
-			}
-		case "lastTimestamp":
-			if r.TryDecodeAsNil() {
-				x.LastTimestamp = pkg2_unversioned.Time{}
-			} else {
-				yyv3214 := &x.LastTimestamp
-				yym3215 := z.DecBinary()
-				_ = yym3215
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3214) {
-				} else if yym3215 {
-					z.DecBinaryUnmarshal(yyv3214)
-				} else if !yym3215 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv3214)
-				} else {
-					z.DecFallback(yyv3214, false)
 				}
 			}
 		case "count":
@@ -40238,6 +40226,18 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Type = ""
 			} else {
 				x.Type = string(r.DecodeString())
+			}
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3204)
@@ -40265,42 +40265,10 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.Kind = ""
-	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj3218++
-	if yyhl3218 {
-		yyb3218 = yyj3218 > l
-	} else {
-		yyb3218 = r.CheckBreak()
-	}
-	if yyb3218 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3218++
-	if yyhl3218 {
-		yyb3218 = yyj3218 > l
-	} else {
-		yyb3218 = r.CheckBreak()
-	}
-	if yyb3218 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv3221 := &x.ObjectMeta
-		yyv3221.CodecDecodeSelf(d)
+		yyv3219 := &x.ObjectMeta
+		yyv3219.CodecDecodeSelf(d)
 	}
 	yyj3218++
 	if yyhl3218 {
@@ -40316,8 +40284,8 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.InvolvedObject = ObjectReference{}
 	} else {
-		yyv3222 := &x.InvolvedObject
-		yyv3222.CodecDecodeSelf(d)
+		yyv3220 := &x.InvolvedObject
+		yyv3220.CodecDecodeSelf(d)
 	}
 	yyj3218++
 	if yyhl3218 {
@@ -40365,8 +40333,8 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Source = EventSource{}
 	} else {
-		yyv3225 := &x.Source
-		yyv3225.CodecDecodeSelf(d)
+		yyv3223 := &x.Source
+		yyv3223.CodecDecodeSelf(d)
 	}
 	yyj3218++
 	if yyhl3218 {
@@ -40382,17 +40350,17 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.FirstTimestamp = pkg2_unversioned.Time{}
 	} else {
-		yyv3226 := &x.FirstTimestamp
-		yym3227 := z.DecBinary()
-		_ = yym3227
+		yyv3224 := &x.FirstTimestamp
+		yym3225 := z.DecBinary()
+		_ = yym3225
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3226) {
-		} else if yym3227 {
-			z.DecBinaryUnmarshal(yyv3226)
-		} else if !yym3227 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv3226)
+		} else if z.HasExtensions() && z.DecExt(yyv3224) {
+		} else if yym3225 {
+			z.DecBinaryUnmarshal(yyv3224)
+		} else if !yym3225 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv3224)
 		} else {
-			z.DecFallback(yyv3226, false)
+			z.DecFallback(yyv3224, false)
 		}
 	}
 	yyj3218++
@@ -40409,17 +40377,17 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.LastTimestamp = pkg2_unversioned.Time{}
 	} else {
-		yyv3228 := &x.LastTimestamp
-		yym3229 := z.DecBinary()
-		_ = yym3229
+		yyv3226 := &x.LastTimestamp
+		yym3227 := z.DecBinary()
+		_ = yym3227
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3228) {
-		} else if yym3229 {
-			z.DecBinaryUnmarshal(yyv3228)
-		} else if !yym3229 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv3228)
+		} else if z.HasExtensions() && z.DecExt(yyv3226) {
+		} else if yym3227 {
+			z.DecBinaryUnmarshal(yyv3226)
+		} else if !yym3227 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv3226)
 		} else {
-			z.DecFallback(yyv3228, false)
+			z.DecFallback(yyv3226, false)
 		}
 	}
 	yyj3218++
@@ -40454,6 +40422,38 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Type = string(r.DecodeString())
 	}
+	yyj3218++
+	if yyhl3218 {
+		yyb3218 = yyj3218 > l
+	} else {
+		yyb3218 = r.CheckBreak()
+	}
+	if yyb3218 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj3218++
+	if yyhl3218 {
+		yyb3218 = yyj3218 > l
+	} else {
+		yyb3218 = r.CheckBreak()
+	}
+	if yyb3218 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
+	}
 	for {
 		yyj3218++
 		if yyhl3218 {
@@ -40487,9 +40487,9 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3233 [4]bool
 			_, _, _ = yysep3233, yyq3233, yy2arr3233
 			const yyr3233 bool = false
-			yyq3233[0] = x.Kind != ""
-			yyq3233[1] = x.APIVersion != ""
-			yyq3233[2] = true
+			yyq3233[0] = true
+			yyq3233[2] = x.Kind != ""
+			yyq3233[3] = x.APIVersion != ""
 			var yynn3233 int
 			if yyr3233 || yy2arr3233 {
 				r.EncodeArrayStart(4)
@@ -40506,79 +40506,29 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr3233 || yy2arr3233 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3233[0] {
-					yym3235 := z.EncBinary()
-					_ = yym3235
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3233[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy3235 := &x.ListMeta
 					yym3236 := z.EncBinary()
 					_ = yym3236
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3235) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3233 || yy2arr3233 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3233[1] {
-					yym3238 := z.EncBinary()
-					_ = yym3238
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3233[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3239 := z.EncBinary()
-					_ = yym3239
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3233 || yy2arr3233 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3233[2] {
-					yy3241 := &x.ListMeta
-					yym3242 := z.EncBinary()
-					_ = yym3242
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3241) {
-					} else {
-						z.EncFallback(yy3241)
+						z.EncFallback(yy3235)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3233[2] {
+				if yyq3233[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3243 := &x.ListMeta
-					yym3244 := z.EncBinary()
-					_ = yym3244
+					yy3237 := &x.ListMeta
+					yym3238 := z.EncBinary()
+					_ = yym3238
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3243) {
+					} else if z.HasExtensions() && z.EncExt(yy3237) {
 					} else {
-						z.EncFallback(yy3243)
+						z.EncFallback(yy3237)
 					}
 				}
 			}
@@ -40587,8 +40537,8 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3246 := z.EncBinary()
-					_ = yym3246
+					yym3240 := z.EncBinary()
+					_ = yym3240
 					if false {
 					} else {
 						h.encSliceEvent(([]Event)(x.Items), e)
@@ -40601,11 +40551,61 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym3241 := z.EncBinary()
+					_ = yym3241
+					if false {
+					} else {
+						h.encSliceEvent(([]Event)(x.Items), e)
+					}
+				}
+			}
+			if yyr3233 || yy2arr3233 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3233[2] {
+					yym3243 := z.EncBinary()
+					_ = yym3243
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3233[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3244 := z.EncBinary()
+					_ = yym3244
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3233 || yy2arr3233 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3233[3] {
+					yym3246 := z.EncBinary()
+					_ = yym3246
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3233[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3247 := z.EncBinary()
 					_ = yym3247
 					if false {
 					} else {
-						h.encSliceEvent(([]Event)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -40670,6 +40670,31 @@ func (x *EventList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys3250 := string(yys3250Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3250 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv3251 := &x.ListMeta
+				yym3252 := z.DecBinary()
+				_ = yym3252
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv3251) {
+				} else {
+					z.DecFallback(yyv3251, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv3253 := &x.Items
+				yym3254 := z.DecBinary()
+				_ = yym3254
+				if false {
+				} else {
+					h.decSliceEvent((*[]Event)(yyv3253), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -40681,31 +40706,6 @@ func (x *EventList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv3253 := &x.ListMeta
-				yym3254 := z.DecBinary()
-				_ = yym3254
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3253) {
-				} else {
-					z.DecFallback(yyv3253, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv3255 := &x.Items
-				yym3256 := z.DecBinary()
-				_ = yym3256
-				if false {
-				} else {
-					h.decSliceEvent((*[]Event)(yyv3255), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3250)
@@ -40721,6 +40721,51 @@ func (x *EventList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj3257 int
 	var yyb3257 bool
 	var yyhl3257 bool = l >= 0
+	yyj3257++
+	if yyhl3257 {
+		yyb3257 = yyj3257 > l
+	} else {
+		yyb3257 = r.CheckBreak()
+	}
+	if yyb3257 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv3258 := &x.ListMeta
+		yym3259 := z.DecBinary()
+		_ = yym3259
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv3258) {
+		} else {
+			z.DecFallback(yyv3258, false)
+		}
+	}
+	yyj3257++
+	if yyhl3257 {
+		yyb3257 = yyj3257 > l
+	} else {
+		yyb3257 = r.CheckBreak()
+	}
+	if yyb3257 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv3260 := &x.Items
+		yym3261 := z.DecBinary()
+		_ = yym3261
+		if false {
+		} else {
+			h.decSliceEvent((*[]Event)(yyv3260), d)
+		}
+	}
 	yyj3257++
 	if yyhl3257 {
 		yyb3257 = yyj3257 > l
@@ -40752,51 +40797,6 @@ func (x *EventList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3257++
-	if yyhl3257 {
-		yyb3257 = yyj3257 > l
-	} else {
-		yyb3257 = r.CheckBreak()
-	}
-	if yyb3257 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv3260 := &x.ListMeta
-		yym3261 := z.DecBinary()
-		_ = yym3261
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3260) {
-		} else {
-			z.DecFallback(yyv3260, false)
-		}
-	}
-	yyj3257++
-	if yyhl3257 {
-		yyb3257 = yyj3257 > l
-	} else {
-		yyb3257 = r.CheckBreak()
-	}
-	if yyb3257 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv3262 := &x.Items
-		yym3263 := z.DecBinary()
-		_ = yym3263
-		if false {
-		} else {
-			h.decSliceEvent((*[]Event)(yyv3262), d)
-		}
 	}
 	for {
 		yyj3257++
@@ -40831,9 +40831,9 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3265 [4]bool
 			_, _, _ = yysep3265, yyq3265, yy2arr3265
 			const yyr3265 bool = false
-			yyq3265[0] = x.Kind != ""
-			yyq3265[1] = x.APIVersion != ""
-			yyq3265[2] = true
+			yyq3265[0] = true
+			yyq3265[2] = x.Kind != ""
+			yyq3265[3] = x.APIVersion != ""
 			var yynn3265 int
 			if yyr3265 || yy2arr3265 {
 				r.EncodeArrayStart(4)
@@ -40850,79 +40850,29 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr3265 || yy2arr3265 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3265[0] {
-					yym3267 := z.EncBinary()
-					_ = yym3267
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3265[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy3267 := &x.ListMeta
 					yym3268 := z.EncBinary()
 					_ = yym3268
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3267) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3265 || yy2arr3265 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3265[1] {
-					yym3270 := z.EncBinary()
-					_ = yym3270
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3265[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3271 := z.EncBinary()
-					_ = yym3271
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3265 || yy2arr3265 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3265[2] {
-					yy3273 := &x.ListMeta
-					yym3274 := z.EncBinary()
-					_ = yym3274
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3273) {
-					} else {
-						z.EncFallback(yy3273)
+						z.EncFallback(yy3267)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3265[2] {
+				if yyq3265[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3275 := &x.ListMeta
-					yym3276 := z.EncBinary()
-					_ = yym3276
+					yy3269 := &x.ListMeta
+					yym3270 := z.EncBinary()
+					_ = yym3270
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3275) {
+					} else if z.HasExtensions() && z.EncExt(yy3269) {
 					} else {
-						z.EncFallback(yy3275)
+						z.EncFallback(yy3269)
 					}
 				}
 			}
@@ -40931,8 +40881,8 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3278 := z.EncBinary()
-					_ = yym3278
+					yym3272 := z.EncBinary()
+					_ = yym3272
 					if false {
 					} else {
 						h.encSliceruntime_RawExtension(([]pkg6_runtime.RawExtension)(x.Items), e)
@@ -40945,11 +40895,61 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym3273 := z.EncBinary()
+					_ = yym3273
+					if false {
+					} else {
+						h.encSliceruntime_RawExtension(([]pkg6_runtime.RawExtension)(x.Items), e)
+					}
+				}
+			}
+			if yyr3265 || yy2arr3265 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3265[2] {
+					yym3275 := z.EncBinary()
+					_ = yym3275
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3265[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3276 := z.EncBinary()
+					_ = yym3276
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3265 || yy2arr3265 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3265[3] {
+					yym3278 := z.EncBinary()
+					_ = yym3278
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3265[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3279 := z.EncBinary()
 					_ = yym3279
 					if false {
 					} else {
-						h.encSliceruntime_RawExtension(([]pkg6_runtime.RawExtension)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -41014,6 +41014,31 @@ func (x *List) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys3282 := string(yys3282Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3282 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv3283 := &x.ListMeta
+				yym3284 := z.DecBinary()
+				_ = yym3284
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv3283) {
+				} else {
+					z.DecFallback(yyv3283, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv3285 := &x.Items
+				yym3286 := z.DecBinary()
+				_ = yym3286
+				if false {
+				} else {
+					h.decSliceruntime_RawExtension((*[]pkg6_runtime.RawExtension)(yyv3285), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -41025,31 +41050,6 @@ func (x *List) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv3285 := &x.ListMeta
-				yym3286 := z.DecBinary()
-				_ = yym3286
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3285) {
-				} else {
-					z.DecFallback(yyv3285, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv3287 := &x.Items
-				yym3288 := z.DecBinary()
-				_ = yym3288
-				if false {
-				} else {
-					h.decSliceruntime_RawExtension((*[]pkg6_runtime.RawExtension)(yyv3287), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3282)
@@ -41065,6 +41065,51 @@ func (x *List) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj3289 int
 	var yyb3289 bool
 	var yyhl3289 bool = l >= 0
+	yyj3289++
+	if yyhl3289 {
+		yyb3289 = yyj3289 > l
+	} else {
+		yyb3289 = r.CheckBreak()
+	}
+	if yyb3289 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv3290 := &x.ListMeta
+		yym3291 := z.DecBinary()
+		_ = yym3291
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv3290) {
+		} else {
+			z.DecFallback(yyv3290, false)
+		}
+	}
+	yyj3289++
+	if yyhl3289 {
+		yyb3289 = yyj3289 > l
+	} else {
+		yyb3289 = r.CheckBreak()
+	}
+	if yyb3289 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv3292 := &x.Items
+		yym3293 := z.DecBinary()
+		_ = yym3293
+		if false {
+		} else {
+			h.decSliceruntime_RawExtension((*[]pkg6_runtime.RawExtension)(yyv3292), d)
+		}
+	}
 	yyj3289++
 	if yyhl3289 {
 		yyb3289 = yyj3289 > l
@@ -41096,51 +41141,6 @@ func (x *List) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3289++
-	if yyhl3289 {
-		yyb3289 = yyj3289 > l
-	} else {
-		yyb3289 = r.CheckBreak()
-	}
-	if yyb3289 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv3292 := &x.ListMeta
-		yym3293 := z.DecBinary()
-		_ = yym3293
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3292) {
-		} else {
-			z.DecFallback(yyv3292, false)
-		}
-	}
-	yyj3289++
-	if yyhl3289 {
-		yyb3289 = yyj3289 > l
-	} else {
-		yyb3289 = r.CheckBreak()
-	}
-	if yyb3289 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv3294 := &x.Items
-		yym3295 := z.DecBinary()
-		_ = yym3295
-		if false {
-		} else {
-			h.decSliceruntime_RawExtension((*[]pkg6_runtime.RawExtension)(yyv3294), d)
-		}
 	}
 	for {
 		yyj3289++
@@ -41782,10 +41782,10 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3336 [4]bool
 			_, _, _ = yysep3336, yyq3336, yy2arr3336
 			const yyr3336 bool = false
-			yyq3336[0] = x.Kind != ""
-			yyq3336[1] = x.APIVersion != ""
-			yyq3336[2] = true
-			yyq3336[3] = true
+			yyq3336[0] = true
+			yyq3336[1] = true
+			yyq3336[2] = x.Kind != ""
+			yyq3336[3] = x.APIVersion != ""
 			var yynn3336 int
 			if yyr3336 || yy2arr3336 {
 				r.EncodeArrayStart(4)
@@ -41802,22 +41802,56 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr3336 || yy2arr3336 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3336[0] {
-					yym3338 := z.EncBinary()
-					_ = yym3338
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy3338 := &x.ObjectMeta
+					yy3338.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq3336[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy3339 := &x.ObjectMeta
+					yy3339.CodecEncodeSelf(e)
+				}
+			}
+			if yyr3336 || yy2arr3336 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3336[1] {
+					yy3341 := &x.Spec
+					yy3341.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq3336[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy3342 := &x.Spec
+					yy3342.CodecEncodeSelf(e)
+				}
+			}
+			if yyr3336 || yy2arr3336 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3336[2] {
+					yym3344 := z.EncBinary()
+					_ = yym3344
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3336[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3339 := z.EncBinary()
-					_ = yym3339
+					yym3345 := z.EncBinary()
+					_ = yym3345
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -41826,9 +41860,9 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr3336 || yy2arr3336 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3336[1] {
-					yym3341 := z.EncBinary()
-					_ = yym3341
+				if yyq3336[3] {
+					yym3347 := z.EncBinary()
+					_ = yym3347
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -41837,50 +41871,16 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3336[1] {
+				if yyq3336[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3342 := z.EncBinary()
-					_ = yym3342
+					yym3348 := z.EncBinary()
+					_ = yym3348
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
-				}
-			}
-			if yyr3336 || yy2arr3336 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3336[2] {
-					yy3344 := &x.ObjectMeta
-					yy3344.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq3336[2] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3345 := &x.ObjectMeta
-					yy3345.CodecEncodeSelf(e)
-				}
-			}
-			if yyr3336 || yy2arr3336 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3336[3] {
-					yy3347 := &x.Spec
-					yy3347.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq3336[3] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3348 := &x.Spec
-					yy3348.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3336 || yy2arr3336 {
@@ -41944,6 +41944,20 @@ func (x *LimitRange) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys3351 := string(yys3351Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3351 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv3352 := &x.ObjectMeta
+				yyv3352.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = LimitRangeSpec{}
+			} else {
+				yyv3353 := &x.Spec
+				yyv3353.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -41955,20 +41969,6 @@ func (x *LimitRange) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv3354 := &x.ObjectMeta
-				yyv3354.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = LimitRangeSpec{}
-			} else {
-				yyv3355 := &x.Spec
-				yyv3355.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3351)
@@ -41984,6 +41984,40 @@ func (x *LimitRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj3356 int
 	var yyb3356 bool
 	var yyhl3356 bool = l >= 0
+	yyj3356++
+	if yyhl3356 {
+		yyb3356 = yyj3356 > l
+	} else {
+		yyb3356 = r.CheckBreak()
+	}
+	if yyb3356 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv3357 := &x.ObjectMeta
+		yyv3357.CodecDecodeSelf(d)
+	}
+	yyj3356++
+	if yyhl3356 {
+		yyb3356 = yyj3356 > l
+	} else {
+		yyb3356 = r.CheckBreak()
+	}
+	if yyb3356 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = LimitRangeSpec{}
+	} else {
+		yyv3358 := &x.Spec
+		yyv3358.CodecDecodeSelf(d)
+	}
 	yyj3356++
 	if yyhl3356 {
 		yyb3356 = yyj3356 > l
@@ -42015,40 +42049,6 @@ func (x *LimitRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3356++
-	if yyhl3356 {
-		yyb3356 = yyj3356 > l
-	} else {
-		yyb3356 = r.CheckBreak()
-	}
-	if yyb3356 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv3359 := &x.ObjectMeta
-		yyv3359.CodecDecodeSelf(d)
-	}
-	yyj3356++
-	if yyhl3356 {
-		yyb3356 = yyj3356 > l
-	} else {
-		yyb3356 = r.CheckBreak()
-	}
-	if yyb3356 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = LimitRangeSpec{}
-	} else {
-		yyv3360 := &x.Spec
-		yyv3360.CodecDecodeSelf(d)
 	}
 	for {
 		yyj3356++
@@ -42083,9 +42083,9 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3362 [4]bool
 			_, _, _ = yysep3362, yyq3362, yy2arr3362
 			const yyr3362 bool = false
-			yyq3362[0] = x.Kind != ""
-			yyq3362[1] = x.APIVersion != ""
-			yyq3362[2] = true
+			yyq3362[0] = true
+			yyq3362[2] = x.Kind != ""
+			yyq3362[3] = x.APIVersion != ""
 			var yynn3362 int
 			if yyr3362 || yy2arr3362 {
 				r.EncodeArrayStart(4)
@@ -42102,79 +42102,29 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr3362 || yy2arr3362 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3362[0] {
-					yym3364 := z.EncBinary()
-					_ = yym3364
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3362[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy3364 := &x.ListMeta
 					yym3365 := z.EncBinary()
 					_ = yym3365
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3364) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3362 || yy2arr3362 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3362[1] {
-					yym3367 := z.EncBinary()
-					_ = yym3367
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3362[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3368 := z.EncBinary()
-					_ = yym3368
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3362 || yy2arr3362 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3362[2] {
-					yy3370 := &x.ListMeta
-					yym3371 := z.EncBinary()
-					_ = yym3371
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3370) {
-					} else {
-						z.EncFallback(yy3370)
+						z.EncFallback(yy3364)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3362[2] {
+				if yyq3362[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3372 := &x.ListMeta
-					yym3373 := z.EncBinary()
-					_ = yym3373
+					yy3366 := &x.ListMeta
+					yym3367 := z.EncBinary()
+					_ = yym3367
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3372) {
+					} else if z.HasExtensions() && z.EncExt(yy3366) {
 					} else {
-						z.EncFallback(yy3372)
+						z.EncFallback(yy3366)
 					}
 				}
 			}
@@ -42183,8 +42133,8 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3375 := z.EncBinary()
-					_ = yym3375
+					yym3369 := z.EncBinary()
+					_ = yym3369
 					if false {
 					} else {
 						h.encSliceLimitRange(([]LimitRange)(x.Items), e)
@@ -42197,11 +42147,61 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym3370 := z.EncBinary()
+					_ = yym3370
+					if false {
+					} else {
+						h.encSliceLimitRange(([]LimitRange)(x.Items), e)
+					}
+				}
+			}
+			if yyr3362 || yy2arr3362 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3362[2] {
+					yym3372 := z.EncBinary()
+					_ = yym3372
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3362[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3373 := z.EncBinary()
+					_ = yym3373
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3362 || yy2arr3362 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3362[3] {
+					yym3375 := z.EncBinary()
+					_ = yym3375
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3362[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3376 := z.EncBinary()
 					_ = yym3376
 					if false {
 					} else {
-						h.encSliceLimitRange(([]LimitRange)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -42266,6 +42266,31 @@ func (x *LimitRangeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys3379 := string(yys3379Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3379 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv3380 := &x.ListMeta
+				yym3381 := z.DecBinary()
+				_ = yym3381
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv3380) {
+				} else {
+					z.DecFallback(yyv3380, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv3382 := &x.Items
+				yym3383 := z.DecBinary()
+				_ = yym3383
+				if false {
+				} else {
+					h.decSliceLimitRange((*[]LimitRange)(yyv3382), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -42277,31 +42302,6 @@ func (x *LimitRangeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv3382 := &x.ListMeta
-				yym3383 := z.DecBinary()
-				_ = yym3383
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3382) {
-				} else {
-					z.DecFallback(yyv3382, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv3384 := &x.Items
-				yym3385 := z.DecBinary()
-				_ = yym3385
-				if false {
-				} else {
-					h.decSliceLimitRange((*[]LimitRange)(yyv3384), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3379)
@@ -42317,6 +42317,51 @@ func (x *LimitRangeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj3386 int
 	var yyb3386 bool
 	var yyhl3386 bool = l >= 0
+	yyj3386++
+	if yyhl3386 {
+		yyb3386 = yyj3386 > l
+	} else {
+		yyb3386 = r.CheckBreak()
+	}
+	if yyb3386 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv3387 := &x.ListMeta
+		yym3388 := z.DecBinary()
+		_ = yym3388
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv3387) {
+		} else {
+			z.DecFallback(yyv3387, false)
+		}
+	}
+	yyj3386++
+	if yyhl3386 {
+		yyb3386 = yyj3386 > l
+	} else {
+		yyb3386 = r.CheckBreak()
+	}
+	if yyb3386 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv3389 := &x.Items
+		yym3390 := z.DecBinary()
+		_ = yym3390
+		if false {
+		} else {
+			h.decSliceLimitRange((*[]LimitRange)(yyv3389), d)
+		}
+	}
 	yyj3386++
 	if yyhl3386 {
 		yyb3386 = yyj3386 > l
@@ -42348,51 +42393,6 @@ func (x *LimitRangeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3386++
-	if yyhl3386 {
-		yyb3386 = yyj3386 > l
-	} else {
-		yyb3386 = r.CheckBreak()
-	}
-	if yyb3386 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv3389 := &x.ListMeta
-		yym3390 := z.DecBinary()
-		_ = yym3390
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3389) {
-		} else {
-			z.DecFallback(yyv3389, false)
-		}
-	}
-	yyj3386++
-	if yyhl3386 {
-		yyb3386 = yyj3386 > l
-	} else {
-		yyb3386 = r.CheckBreak()
-	}
-	if yyb3386 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv3391 := &x.Items
-		yym3392 := z.DecBinary()
-		_ = yym3392
-		if false {
-		} else {
-			h.decSliceLimitRange((*[]LimitRange)(yyv3391), d)
-		}
 	}
 	for {
 		yyj3386++
@@ -42813,11 +42813,11 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3415 [5]bool
 			_, _, _ = yysep3415, yyq3415, yy2arr3415
 			const yyr3415 bool = false
-			yyq3415[0] = x.Kind != ""
-			yyq3415[1] = x.APIVersion != ""
+			yyq3415[0] = true
+			yyq3415[1] = true
 			yyq3415[2] = true
-			yyq3415[3] = true
-			yyq3415[4] = true
+			yyq3415[3] = x.Kind != ""
+			yyq3415[4] = x.APIVersion != ""
 			var yynn3415 int
 			if yyr3415 || yy2arr3415 {
 				r.EncodeArrayStart(5)
@@ -42834,57 +42834,41 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr3415 || yy2arr3415 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3415[0] {
-					yym3417 := z.EncBinary()
-					_ = yym3417
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy3417 := &x.ObjectMeta
+					yy3417.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq3415[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3418 := z.EncBinary()
-					_ = yym3418
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy3418 := &x.ObjectMeta
+					yy3418.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3415 || yy2arr3415 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3415[1] {
-					yym3420 := z.EncBinary()
-					_ = yym3420
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy3420 := &x.Spec
+					yy3420.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq3415[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3421 := z.EncBinary()
-					_ = yym3421
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy3421 := &x.Spec
+					yy3421.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3415 || yy2arr3415 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3415[2] {
-					yy3423 := &x.ObjectMeta
+					yy3423 := &x.Status
 					yy3423.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
@@ -42892,44 +42876,60 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq3415[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3424 := &x.ObjectMeta
+					yy3424 := &x.Status
 					yy3424.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3415 || yy2arr3415 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3415[3] {
-					yy3426 := &x.Spec
-					yy3426.CodecEncodeSelf(e)
+					yym3426 := z.EncBinary()
+					_ = yym3426
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq3415[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3427 := &x.Spec
-					yy3427.CodecEncodeSelf(e)
+					yym3427 := z.EncBinary()
+					_ = yym3427
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				}
 			}
 			if yyr3415 || yy2arr3415 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3415[4] {
-					yy3429 := &x.Status
-					yy3429.CodecEncodeSelf(e)
+					yym3429 := z.EncBinary()
+					_ = yym3429
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq3415[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3430 := &x.Status
-					yy3430.CodecEncodeSelf(e)
+					yym3430 := z.EncBinary()
+					_ = yym3430
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr3415 || yy2arr3415 {
@@ -42993,6 +42993,27 @@ func (x *ResourceQuota) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys3433 := string(yys3433Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3433 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv3434 := &x.ObjectMeta
+				yyv3434.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = ResourceQuotaSpec{}
+			} else {
+				yyv3435 := &x.Spec
+				yyv3435.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = ResourceQuotaStatus{}
+			} else {
+				yyv3436 := &x.Status
+				yyv3436.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -43004,27 +43025,6 @@ func (x *ResourceQuota) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv3436 := &x.ObjectMeta
-				yyv3436.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = ResourceQuotaSpec{}
-			} else {
-				yyv3437 := &x.Spec
-				yyv3437.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = ResourceQuotaStatus{}
-			} else {
-				yyv3438 := &x.Status
-				yyv3438.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3433)
@@ -43040,6 +43040,57 @@ func (x *ResourceQuota) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj3439 int
 	var yyb3439 bool
 	var yyhl3439 bool = l >= 0
+	yyj3439++
+	if yyhl3439 {
+		yyb3439 = yyj3439 > l
+	} else {
+		yyb3439 = r.CheckBreak()
+	}
+	if yyb3439 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv3440 := &x.ObjectMeta
+		yyv3440.CodecDecodeSelf(d)
+	}
+	yyj3439++
+	if yyhl3439 {
+		yyb3439 = yyj3439 > l
+	} else {
+		yyb3439 = r.CheckBreak()
+	}
+	if yyb3439 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = ResourceQuotaSpec{}
+	} else {
+		yyv3441 := &x.Spec
+		yyv3441.CodecDecodeSelf(d)
+	}
+	yyj3439++
+	if yyhl3439 {
+		yyb3439 = yyj3439 > l
+	} else {
+		yyb3439 = r.CheckBreak()
+	}
+	if yyb3439 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = ResourceQuotaStatus{}
+	} else {
+		yyv3442 := &x.Status
+		yyv3442.CodecDecodeSelf(d)
+	}
 	yyj3439++
 	if yyhl3439 {
 		yyb3439 = yyj3439 > l
@@ -43071,57 +43122,6 @@ func (x *ResourceQuota) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3439++
-	if yyhl3439 {
-		yyb3439 = yyj3439 > l
-	} else {
-		yyb3439 = r.CheckBreak()
-	}
-	if yyb3439 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv3442 := &x.ObjectMeta
-		yyv3442.CodecDecodeSelf(d)
-	}
-	yyj3439++
-	if yyhl3439 {
-		yyb3439 = yyj3439 > l
-	} else {
-		yyb3439 = r.CheckBreak()
-	}
-	if yyb3439 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = ResourceQuotaSpec{}
-	} else {
-		yyv3443 := &x.Spec
-		yyv3443.CodecDecodeSelf(d)
-	}
-	yyj3439++
-	if yyhl3439 {
-		yyb3439 = yyj3439 > l
-	} else {
-		yyb3439 = r.CheckBreak()
-	}
-	if yyb3439 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = ResourceQuotaStatus{}
-	} else {
-		yyv3444 := &x.Status
-		yyv3444.CodecDecodeSelf(d)
 	}
 	for {
 		yyj3439++
@@ -43156,9 +43156,9 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3446 [4]bool
 			_, _, _ = yysep3446, yyq3446, yy2arr3446
 			const yyr3446 bool = false
-			yyq3446[0] = x.Kind != ""
-			yyq3446[1] = x.APIVersion != ""
-			yyq3446[2] = true
+			yyq3446[0] = true
+			yyq3446[2] = x.Kind != ""
+			yyq3446[3] = x.APIVersion != ""
 			var yynn3446 int
 			if yyr3446 || yy2arr3446 {
 				r.EncodeArrayStart(4)
@@ -43175,79 +43175,29 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr3446 || yy2arr3446 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3446[0] {
-					yym3448 := z.EncBinary()
-					_ = yym3448
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3446[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy3448 := &x.ListMeta
 					yym3449 := z.EncBinary()
 					_ = yym3449
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3448) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3446 || yy2arr3446 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3446[1] {
-					yym3451 := z.EncBinary()
-					_ = yym3451
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3446[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3452 := z.EncBinary()
-					_ = yym3452
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3446 || yy2arr3446 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3446[2] {
-					yy3454 := &x.ListMeta
-					yym3455 := z.EncBinary()
-					_ = yym3455
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3454) {
-					} else {
-						z.EncFallback(yy3454)
+						z.EncFallback(yy3448)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3446[2] {
+				if yyq3446[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3456 := &x.ListMeta
-					yym3457 := z.EncBinary()
-					_ = yym3457
+					yy3450 := &x.ListMeta
+					yym3451 := z.EncBinary()
+					_ = yym3451
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3456) {
+					} else if z.HasExtensions() && z.EncExt(yy3450) {
 					} else {
-						z.EncFallback(yy3456)
+						z.EncFallback(yy3450)
 					}
 				}
 			}
@@ -43256,8 +43206,8 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3459 := z.EncBinary()
-					_ = yym3459
+					yym3453 := z.EncBinary()
+					_ = yym3453
 					if false {
 					} else {
 						h.encSliceResourceQuota(([]ResourceQuota)(x.Items), e)
@@ -43270,11 +43220,61 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym3454 := z.EncBinary()
+					_ = yym3454
+					if false {
+					} else {
+						h.encSliceResourceQuota(([]ResourceQuota)(x.Items), e)
+					}
+				}
+			}
+			if yyr3446 || yy2arr3446 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3446[2] {
+					yym3456 := z.EncBinary()
+					_ = yym3456
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3446[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3457 := z.EncBinary()
+					_ = yym3457
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3446 || yy2arr3446 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3446[3] {
+					yym3459 := z.EncBinary()
+					_ = yym3459
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3446[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3460 := z.EncBinary()
 					_ = yym3460
 					if false {
 					} else {
-						h.encSliceResourceQuota(([]ResourceQuota)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -43339,6 +43339,31 @@ func (x *ResourceQuotaList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 		yys3463 := string(yys3463Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3463 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv3464 := &x.ListMeta
+				yym3465 := z.DecBinary()
+				_ = yym3465
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv3464) {
+				} else {
+					z.DecFallback(yyv3464, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv3466 := &x.Items
+				yym3467 := z.DecBinary()
+				_ = yym3467
+				if false {
+				} else {
+					h.decSliceResourceQuota((*[]ResourceQuota)(yyv3466), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -43350,31 +43375,6 @@ func (x *ResourceQuotaList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv3466 := &x.ListMeta
-				yym3467 := z.DecBinary()
-				_ = yym3467
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3466) {
-				} else {
-					z.DecFallback(yyv3466, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv3468 := &x.Items
-				yym3469 := z.DecBinary()
-				_ = yym3469
-				if false {
-				} else {
-					h.decSliceResourceQuota((*[]ResourceQuota)(yyv3468), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3463)
@@ -43390,6 +43390,51 @@ func (x *ResourceQuotaList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var yyj3470 int
 	var yyb3470 bool
 	var yyhl3470 bool = l >= 0
+	yyj3470++
+	if yyhl3470 {
+		yyb3470 = yyj3470 > l
+	} else {
+		yyb3470 = r.CheckBreak()
+	}
+	if yyb3470 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv3471 := &x.ListMeta
+		yym3472 := z.DecBinary()
+		_ = yym3472
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv3471) {
+		} else {
+			z.DecFallback(yyv3471, false)
+		}
+	}
+	yyj3470++
+	if yyhl3470 {
+		yyb3470 = yyj3470 > l
+	} else {
+		yyb3470 = r.CheckBreak()
+	}
+	if yyb3470 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv3473 := &x.Items
+		yym3474 := z.DecBinary()
+		_ = yym3474
+		if false {
+		} else {
+			h.decSliceResourceQuota((*[]ResourceQuota)(yyv3473), d)
+		}
+	}
 	yyj3470++
 	if yyhl3470 {
 		yyb3470 = yyj3470 > l
@@ -43421,51 +43466,6 @@ func (x *ResourceQuotaList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3470++
-	if yyhl3470 {
-		yyb3470 = yyj3470 > l
-	} else {
-		yyb3470 = r.CheckBreak()
-	}
-	if yyb3470 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv3473 := &x.ListMeta
-		yym3474 := z.DecBinary()
-		_ = yym3474
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3473) {
-		} else {
-			z.DecFallback(yyv3473, false)
-		}
-	}
-	yyj3470++
-	if yyhl3470 {
-		yyb3470 = yyj3470 > l
-	} else {
-		yyb3470 = r.CheckBreak()
-	}
-	if yyb3470 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv3475 := &x.Items
-		yym3476 := z.DecBinary()
-		_ = yym3476
-		if false {
-		} else {
-			h.decSliceResourceQuota((*[]ResourceQuota)(yyv3475), d)
-		}
 	}
 	for {
 		yyj3470++
@@ -43500,11 +43500,11 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3478 [5]bool
 			_, _, _ = yysep3478, yyq3478, yy2arr3478
 			const yyr3478 bool = false
-			yyq3478[0] = x.Kind != ""
-			yyq3478[1] = x.APIVersion != ""
-			yyq3478[2] = true
-			yyq3478[3] = len(x.Data) != 0
-			yyq3478[4] = x.Type != ""
+			yyq3478[0] = true
+			yyq3478[1] = len(x.Data) != 0
+			yyq3478[2] = x.Type != ""
+			yyq3478[3] = x.Kind != ""
+			yyq3478[4] = x.APIVersion != ""
 			var yynn3478 int
 			if yyr3478 || yy2arr3478 {
 				r.EncodeArrayStart(5)
@@ -43521,78 +43521,28 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr3478 || yy2arr3478 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3478[0] {
-					yym3480 := z.EncBinary()
-					_ = yym3480
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3478[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3481 := z.EncBinary()
-					_ = yym3481
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3478 || yy2arr3478 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3478[1] {
-					yym3483 := z.EncBinary()
-					_ = yym3483
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3478[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3484 := z.EncBinary()
-					_ = yym3484
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3478 || yy2arr3478 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3478[2] {
-					yy3486 := &x.ObjectMeta
-					yy3486.CodecEncodeSelf(e)
+					yy3480 := &x.ObjectMeta
+					yy3480.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3478[2] {
+				if yyq3478[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3487 := &x.ObjectMeta
-					yy3487.CodecEncodeSelf(e)
+					yy3481 := &x.ObjectMeta
+					yy3481.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3478 || yy2arr3478 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3478[3] {
+				if yyq3478[1] {
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
-						yym3489 := z.EncBinary()
-						_ = yym3489
+						yym3483 := z.EncBinary()
+						_ = yym3483
 						if false {
 						} else {
 							h.encMapstringSliceuint8((map[string][]uint8)(x.Data), e)
@@ -43602,15 +43552,15 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3478[3] {
+				if yyq3478[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("data"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
-						yym3490 := z.EncBinary()
-						_ = yym3490
+						yym3484 := z.EncBinary()
+						_ = yym3484
 						if false {
 						} else {
 							h.encMapstringSliceuint8((map[string][]uint8)(x.Data), e)
@@ -43620,17 +43570,67 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr3478 || yy2arr3478 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3478[4] {
+				if yyq3478[2] {
 					x.Type.CodecEncodeSelf(e)
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3478[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("type"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					x.Type.CodecEncodeSelf(e)
+				}
+			}
+			if yyr3478 || yy2arr3478 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3478[3] {
+					yym3487 := z.EncBinary()
+					_ = yym3487
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3478[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3488 := z.EncBinary()
+					_ = yym3488
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3478 || yy2arr3478 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3478[4] {
+					yym3490 := z.EncBinary()
+					_ = yym3490
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq3478[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("type"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					x.Type.CodecEncodeSelf(e)
+					yym3491 := z.EncBinary()
+					_ = yym3491
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr3478 || yy2arr3478 {
@@ -43694,6 +43694,31 @@ func (x *Secret) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys3494 := string(yys3494Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3494 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv3495 := &x.ObjectMeta
+				yyv3495.CodecDecodeSelf(d)
+			}
+		case "data":
+			if r.TryDecodeAsNil() {
+				x.Data = nil
+			} else {
+				yyv3496 := &x.Data
+				yym3497 := z.DecBinary()
+				_ = yym3497
+				if false {
+				} else {
+					h.decMapstringSliceuint8((*map[string][]uint8)(yyv3496), d)
+				}
+			}
+		case "type":
+			if r.TryDecodeAsNil() {
+				x.Type = ""
+			} else {
+				x.Type = SecretType(r.DecodeString())
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -43705,31 +43730,6 @@ func (x *Secret) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv3497 := &x.ObjectMeta
-				yyv3497.CodecDecodeSelf(d)
-			}
-		case "data":
-			if r.TryDecodeAsNil() {
-				x.Data = nil
-			} else {
-				yyv3498 := &x.Data
-				yym3499 := z.DecBinary()
-				_ = yym3499
-				if false {
-				} else {
-					h.decMapstringSliceuint8((*map[string][]uint8)(yyv3498), d)
-				}
-			}
-		case "type":
-			if r.TryDecodeAsNil() {
-				x.Type = ""
-			} else {
-				x.Type = SecretType(r.DecodeString())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3494)
@@ -43745,6 +43745,61 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj3501 int
 	var yyb3501 bool
 	var yyhl3501 bool = l >= 0
+	yyj3501++
+	if yyhl3501 {
+		yyb3501 = yyj3501 > l
+	} else {
+		yyb3501 = r.CheckBreak()
+	}
+	if yyb3501 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv3502 := &x.ObjectMeta
+		yyv3502.CodecDecodeSelf(d)
+	}
+	yyj3501++
+	if yyhl3501 {
+		yyb3501 = yyj3501 > l
+	} else {
+		yyb3501 = r.CheckBreak()
+	}
+	if yyb3501 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Data = nil
+	} else {
+		yyv3503 := &x.Data
+		yym3504 := z.DecBinary()
+		_ = yym3504
+		if false {
+		} else {
+			h.decMapstringSliceuint8((*map[string][]uint8)(yyv3503), d)
+		}
+	}
+	yyj3501++
+	if yyhl3501 {
+		yyb3501 = yyj3501 > l
+	} else {
+		yyb3501 = r.CheckBreak()
+	}
+	if yyb3501 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Type = ""
+	} else {
+		x.Type = SecretType(r.DecodeString())
+	}
 	yyj3501++
 	if yyhl3501 {
 		yyb3501 = yyj3501 > l
@@ -43776,61 +43831,6 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3501++
-	if yyhl3501 {
-		yyb3501 = yyj3501 > l
-	} else {
-		yyb3501 = r.CheckBreak()
-	}
-	if yyb3501 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv3504 := &x.ObjectMeta
-		yyv3504.CodecDecodeSelf(d)
-	}
-	yyj3501++
-	if yyhl3501 {
-		yyb3501 = yyj3501 > l
-	} else {
-		yyb3501 = r.CheckBreak()
-	}
-	if yyb3501 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Data = nil
-	} else {
-		yyv3505 := &x.Data
-		yym3506 := z.DecBinary()
-		_ = yym3506
-		if false {
-		} else {
-			h.decMapstringSliceuint8((*map[string][]uint8)(yyv3505), d)
-		}
-	}
-	yyj3501++
-	if yyhl3501 {
-		yyb3501 = yyj3501 > l
-	} else {
-		yyb3501 = r.CheckBreak()
-	}
-	if yyb3501 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Type = ""
-	} else {
-		x.Type = SecretType(r.DecodeString())
 	}
 	for {
 		yyj3501++
@@ -43891,9 +43891,9 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3511 [4]bool
 			_, _, _ = yysep3511, yyq3511, yy2arr3511
 			const yyr3511 bool = false
-			yyq3511[0] = x.Kind != ""
-			yyq3511[1] = x.APIVersion != ""
-			yyq3511[2] = true
+			yyq3511[0] = true
+			yyq3511[2] = x.Kind != ""
+			yyq3511[3] = x.APIVersion != ""
 			var yynn3511 int
 			if yyr3511 || yy2arr3511 {
 				r.EncodeArrayStart(4)
@@ -43910,79 +43910,29 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr3511 || yy2arr3511 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3511[0] {
-					yym3513 := z.EncBinary()
-					_ = yym3513
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3511[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy3513 := &x.ListMeta
 					yym3514 := z.EncBinary()
 					_ = yym3514
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3513) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3511 || yy2arr3511 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3511[1] {
-					yym3516 := z.EncBinary()
-					_ = yym3516
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3511[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3517 := z.EncBinary()
-					_ = yym3517
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3511 || yy2arr3511 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3511[2] {
-					yy3519 := &x.ListMeta
-					yym3520 := z.EncBinary()
-					_ = yym3520
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3519) {
-					} else {
-						z.EncFallback(yy3519)
+						z.EncFallback(yy3513)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3511[2] {
+				if yyq3511[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3521 := &x.ListMeta
-					yym3522 := z.EncBinary()
-					_ = yym3522
+					yy3515 := &x.ListMeta
+					yym3516 := z.EncBinary()
+					_ = yym3516
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3521) {
+					} else if z.HasExtensions() && z.EncExt(yy3515) {
 					} else {
-						z.EncFallback(yy3521)
+						z.EncFallback(yy3515)
 					}
 				}
 			}
@@ -43991,8 +43941,8 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3524 := z.EncBinary()
-					_ = yym3524
+					yym3518 := z.EncBinary()
+					_ = yym3518
 					if false {
 					} else {
 						h.encSliceSecret(([]Secret)(x.Items), e)
@@ -44005,11 +43955,61 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym3519 := z.EncBinary()
+					_ = yym3519
+					if false {
+					} else {
+						h.encSliceSecret(([]Secret)(x.Items), e)
+					}
+				}
+			}
+			if yyr3511 || yy2arr3511 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3511[2] {
+					yym3521 := z.EncBinary()
+					_ = yym3521
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3511[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3522 := z.EncBinary()
+					_ = yym3522
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3511 || yy2arr3511 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3511[3] {
+					yym3524 := z.EncBinary()
+					_ = yym3524
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3511[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3525 := z.EncBinary()
 					_ = yym3525
 					if false {
 					} else {
-						h.encSliceSecret(([]Secret)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -44074,6 +44074,31 @@ func (x *SecretList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys3528 := string(yys3528Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3528 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv3529 := &x.ListMeta
+				yym3530 := z.DecBinary()
+				_ = yym3530
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv3529) {
+				} else {
+					z.DecFallback(yyv3529, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv3531 := &x.Items
+				yym3532 := z.DecBinary()
+				_ = yym3532
+				if false {
+				} else {
+					h.decSliceSecret((*[]Secret)(yyv3531), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -44085,31 +44110,6 @@ func (x *SecretList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv3531 := &x.ListMeta
-				yym3532 := z.DecBinary()
-				_ = yym3532
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3531) {
-				} else {
-					z.DecFallback(yyv3531, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv3533 := &x.Items
-				yym3534 := z.DecBinary()
-				_ = yym3534
-				if false {
-				} else {
-					h.decSliceSecret((*[]Secret)(yyv3533), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3528)
@@ -44125,6 +44125,51 @@ func (x *SecretList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj3535 int
 	var yyb3535 bool
 	var yyhl3535 bool = l >= 0
+	yyj3535++
+	if yyhl3535 {
+		yyb3535 = yyj3535 > l
+	} else {
+		yyb3535 = r.CheckBreak()
+	}
+	if yyb3535 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv3536 := &x.ListMeta
+		yym3537 := z.DecBinary()
+		_ = yym3537
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv3536) {
+		} else {
+			z.DecFallback(yyv3536, false)
+		}
+	}
+	yyj3535++
+	if yyhl3535 {
+		yyb3535 = yyj3535 > l
+	} else {
+		yyb3535 = r.CheckBreak()
+	}
+	if yyb3535 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv3538 := &x.Items
+		yym3539 := z.DecBinary()
+		_ = yym3539
+		if false {
+		} else {
+			h.decSliceSecret((*[]Secret)(yyv3538), d)
+		}
+	}
 	yyj3535++
 	if yyhl3535 {
 		yyb3535 = yyj3535 > l
@@ -44156,51 +44201,6 @@ func (x *SecretList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3535++
-	if yyhl3535 {
-		yyb3535 = yyj3535 > l
-	} else {
-		yyb3535 = r.CheckBreak()
-	}
-	if yyb3535 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv3538 := &x.ListMeta
-		yym3539 := z.DecBinary()
-		_ = yym3539
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3538) {
-		} else {
-			z.DecFallback(yyv3538, false)
-		}
-	}
-	yyj3535++
-	if yyhl3535 {
-		yyb3535 = yyj3535 > l
-	} else {
-		yyb3535 = r.CheckBreak()
-	}
-	if yyb3535 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv3540 := &x.Items
-		yym3541 := z.DecBinary()
-		_ = yym3541
-		if false {
-		} else {
-			h.decSliceSecret((*[]Secret)(yyv3540), d)
-		}
 	}
 	for {
 		yyj3535++
@@ -44235,10 +44235,10 @@ func (x *ConfigMap) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3543 [4]bool
 			_, _, _ = yysep3543, yyq3543, yy2arr3543
 			const yyr3543 bool = false
-			yyq3543[0] = x.Kind != ""
-			yyq3543[1] = x.APIVersion != ""
-			yyq3543[2] = true
-			yyq3543[3] = len(x.Data) != 0
+			yyq3543[0] = true
+			yyq3543[1] = len(x.Data) != 0
+			yyq3543[2] = x.Kind != ""
+			yyq3543[3] = x.APIVersion != ""
 			var yynn3543 int
 			if yyr3543 || yy2arr3543 {
 				r.EncodeArrayStart(4)
@@ -44255,78 +44255,28 @@ func (x *ConfigMap) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr3543 || yy2arr3543 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3543[0] {
-					yym3545 := z.EncBinary()
-					_ = yym3545
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3543[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3546 := z.EncBinary()
-					_ = yym3546
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3543 || yy2arr3543 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3543[1] {
-					yym3548 := z.EncBinary()
-					_ = yym3548
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3543[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3549 := z.EncBinary()
-					_ = yym3549
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3543 || yy2arr3543 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3543[2] {
-					yy3551 := &x.ObjectMeta
-					yy3551.CodecEncodeSelf(e)
+					yy3545 := &x.ObjectMeta
+					yy3545.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3543[2] {
+				if yyq3543[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3552 := &x.ObjectMeta
-					yy3552.CodecEncodeSelf(e)
+					yy3546 := &x.ObjectMeta
+					yy3546.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3543 || yy2arr3543 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3543[3] {
+				if yyq3543[1] {
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
-						yym3554 := z.EncBinary()
-						_ = yym3554
+						yym3548 := z.EncBinary()
+						_ = yym3548
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Data, false, e)
@@ -44336,19 +44286,69 @@ func (x *ConfigMap) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3543[3] {
+				if yyq3543[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("data"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
-						yym3555 := z.EncBinary()
-						_ = yym3555
+						yym3549 := z.EncBinary()
+						_ = yym3549
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Data, false, e)
 						}
+					}
+				}
+			}
+			if yyr3543 || yy2arr3543 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3543[2] {
+					yym3551 := z.EncBinary()
+					_ = yym3551
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3543[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3552 := z.EncBinary()
+					_ = yym3552
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3543 || yy2arr3543 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3543[3] {
+					yym3554 := z.EncBinary()
+					_ = yym3554
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3543[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3555 := z.EncBinary()
+					_ = yym3555
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -44413,6 +44413,25 @@ func (x *ConfigMap) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys3558 := string(yys3558Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3558 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv3559 := &x.ObjectMeta
+				yyv3559.CodecDecodeSelf(d)
+			}
+		case "data":
+			if r.TryDecodeAsNil() {
+				x.Data = nil
+			} else {
+				yyv3560 := &x.Data
+				yym3561 := z.DecBinary()
+				_ = yym3561
+				if false {
+				} else {
+					z.F.DecMapStringStringX(yyv3560, false, d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -44424,25 +44443,6 @@ func (x *ConfigMap) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv3561 := &x.ObjectMeta
-				yyv3561.CodecDecodeSelf(d)
-			}
-		case "data":
-			if r.TryDecodeAsNil() {
-				x.Data = nil
-			} else {
-				yyv3562 := &x.Data
-				yym3563 := z.DecBinary()
-				_ = yym3563
-				if false {
-				} else {
-					z.F.DecMapStringStringX(yyv3562, false, d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3558)
@@ -44458,6 +44458,45 @@ func (x *ConfigMap) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj3564 int
 	var yyb3564 bool
 	var yyhl3564 bool = l >= 0
+	yyj3564++
+	if yyhl3564 {
+		yyb3564 = yyj3564 > l
+	} else {
+		yyb3564 = r.CheckBreak()
+	}
+	if yyb3564 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv3565 := &x.ObjectMeta
+		yyv3565.CodecDecodeSelf(d)
+	}
+	yyj3564++
+	if yyhl3564 {
+		yyb3564 = yyj3564 > l
+	} else {
+		yyb3564 = r.CheckBreak()
+	}
+	if yyb3564 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Data = nil
+	} else {
+		yyv3566 := &x.Data
+		yym3567 := z.DecBinary()
+		_ = yym3567
+		if false {
+		} else {
+			z.F.DecMapStringStringX(yyv3566, false, d)
+		}
+	}
 	yyj3564++
 	if yyhl3564 {
 		yyb3564 = yyj3564 > l
@@ -44489,45 +44528,6 @@ func (x *ConfigMap) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3564++
-	if yyhl3564 {
-		yyb3564 = yyj3564 > l
-	} else {
-		yyb3564 = r.CheckBreak()
-	}
-	if yyb3564 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv3567 := &x.ObjectMeta
-		yyv3567.CodecDecodeSelf(d)
-	}
-	yyj3564++
-	if yyhl3564 {
-		yyb3564 = yyj3564 > l
-	} else {
-		yyb3564 = r.CheckBreak()
-	}
-	if yyb3564 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Data = nil
-	} else {
-		yyv3568 := &x.Data
-		yym3569 := z.DecBinary()
-		_ = yym3569
-		if false {
-		} else {
-			z.F.DecMapStringStringX(yyv3568, false, d)
-		}
 	}
 	for {
 		yyj3564++
@@ -44562,10 +44562,10 @@ func (x *ConfigMapList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3571 [4]bool
 			_, _, _ = yysep3571, yyq3571, yy2arr3571
 			const yyr3571 bool = false
-			yyq3571[0] = x.Kind != ""
-			yyq3571[1] = x.APIVersion != ""
-			yyq3571[2] = true
-			yyq3571[3] = len(x.Items) != 0
+			yyq3571[0] = true
+			yyq3571[1] = len(x.Items) != 0
+			yyq3571[2] = x.Kind != ""
+			yyq3571[3] = x.APIVersion != ""
 			var yynn3571 int
 			if yyr3571 || yy2arr3571 {
 				r.EncodeArrayStart(4)
@@ -44582,90 +44582,40 @@ func (x *ConfigMapList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr3571 || yy2arr3571 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3571[0] {
-					yym3573 := z.EncBinary()
-					_ = yym3573
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3571[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy3573 := &x.ListMeta
 					yym3574 := z.EncBinary()
 					_ = yym3574
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3573) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3571 || yy2arr3571 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3571[1] {
-					yym3576 := z.EncBinary()
-					_ = yym3576
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3571[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3577 := z.EncBinary()
-					_ = yym3577
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3571 || yy2arr3571 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3571[2] {
-					yy3579 := &x.ListMeta
-					yym3580 := z.EncBinary()
-					_ = yym3580
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3579) {
-					} else {
-						z.EncFallback(yy3579)
+						z.EncFallback(yy3573)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3571[2] {
+				if yyq3571[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3581 := &x.ListMeta
-					yym3582 := z.EncBinary()
-					_ = yym3582
+					yy3575 := &x.ListMeta
+					yym3576 := z.EncBinary()
+					_ = yym3576
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3581) {
+					} else if z.HasExtensions() && z.EncExt(yy3575) {
 					} else {
-						z.EncFallback(yy3581)
+						z.EncFallback(yy3575)
 					}
 				}
 			}
 			if yyr3571 || yy2arr3571 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3571[3] {
+				if yyq3571[1] {
 					if x.Items == nil {
 						r.EncodeNil()
 					} else {
-						yym3584 := z.EncBinary()
-						_ = yym3584
+						yym3578 := z.EncBinary()
+						_ = yym3578
 						if false {
 						} else {
 							h.encSliceConfigMap(([]ConfigMap)(x.Items), e)
@@ -44675,19 +44625,69 @@ func (x *ConfigMapList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3571[3] {
+				if yyq3571[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("items"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Items == nil {
 						r.EncodeNil()
 					} else {
-						yym3585 := z.EncBinary()
-						_ = yym3585
+						yym3579 := z.EncBinary()
+						_ = yym3579
 						if false {
 						} else {
 							h.encSliceConfigMap(([]ConfigMap)(x.Items), e)
 						}
+					}
+				}
+			}
+			if yyr3571 || yy2arr3571 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3571[2] {
+					yym3581 := z.EncBinary()
+					_ = yym3581
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3571[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3582 := z.EncBinary()
+					_ = yym3582
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3571 || yy2arr3571 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3571[3] {
+					yym3584 := z.EncBinary()
+					_ = yym3584
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3571[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3585 := z.EncBinary()
+					_ = yym3585
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -44752,6 +44752,31 @@ func (x *ConfigMapList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys3588 := string(yys3588Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3588 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv3589 := &x.ListMeta
+				yym3590 := z.DecBinary()
+				_ = yym3590
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv3589) {
+				} else {
+					z.DecFallback(yyv3589, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv3591 := &x.Items
+				yym3592 := z.DecBinary()
+				_ = yym3592
+				if false {
+				} else {
+					h.decSliceConfigMap((*[]ConfigMap)(yyv3591), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -44763,31 +44788,6 @@ func (x *ConfigMapList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv3591 := &x.ListMeta
-				yym3592 := z.DecBinary()
-				_ = yym3592
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3591) {
-				} else {
-					z.DecFallback(yyv3591, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv3593 := &x.Items
-				yym3594 := z.DecBinary()
-				_ = yym3594
-				if false {
-				} else {
-					h.decSliceConfigMap((*[]ConfigMap)(yyv3593), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3588)
@@ -44803,6 +44803,51 @@ func (x *ConfigMapList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj3595 int
 	var yyb3595 bool
 	var yyhl3595 bool = l >= 0
+	yyj3595++
+	if yyhl3595 {
+		yyb3595 = yyj3595 > l
+	} else {
+		yyb3595 = r.CheckBreak()
+	}
+	if yyb3595 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv3596 := &x.ListMeta
+		yym3597 := z.DecBinary()
+		_ = yym3597
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv3596) {
+		} else {
+			z.DecFallback(yyv3596, false)
+		}
+	}
+	yyj3595++
+	if yyhl3595 {
+		yyb3595 = yyj3595 > l
+	} else {
+		yyb3595 = r.CheckBreak()
+	}
+	if yyb3595 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv3598 := &x.Items
+		yym3599 := z.DecBinary()
+		_ = yym3599
+		if false {
+		} else {
+			h.decSliceConfigMap((*[]ConfigMap)(yyv3598), d)
+		}
+	}
 	yyj3595++
 	if yyhl3595 {
 		yyb3595 = yyj3595 > l
@@ -44834,51 +44879,6 @@ func (x *ConfigMapList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3595++
-	if yyhl3595 {
-		yyb3595 = yyj3595 > l
-	} else {
-		yyb3595 = r.CheckBreak()
-	}
-	if yyb3595 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv3598 := &x.ListMeta
-		yym3599 := z.DecBinary()
-		_ = yym3599
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3598) {
-		} else {
-			z.DecFallback(yyv3598, false)
-		}
-	}
-	yyj3595++
-	if yyhl3595 {
-		yyb3595 = yyj3595 > l
-	} else {
-		yyb3595 = r.CheckBreak()
-	}
-	if yyb3595 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv3600 := &x.Items
-		yym3601 := z.DecBinary()
-		_ = yym3601
-		if false {
-		} else {
-			h.decSliceConfigMap((*[]ConfigMap)(yyv3600), d)
-		}
 	}
 	for {
 		yyj3595++
@@ -45218,10 +45218,10 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3627 [4]bool
 			_, _, _ = yysep3627, yyq3627, yy2arr3627
 			const yyr3627 bool = false
-			yyq3627[0] = x.Kind != ""
-			yyq3627[1] = x.APIVersion != ""
-			yyq3627[2] = true
-			yyq3627[3] = len(x.Conditions) != 0
+			yyq3627[0] = true
+			yyq3627[1] = len(x.Conditions) != 0
+			yyq3627[2] = x.Kind != ""
+			yyq3627[3] = x.APIVersion != ""
 			var yynn3627 int
 			if yyr3627 || yy2arr3627 {
 				r.EncodeArrayStart(4)
@@ -45238,78 +45238,28 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr3627 || yy2arr3627 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3627[0] {
-					yym3629 := z.EncBinary()
-					_ = yym3629
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3627[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3630 := z.EncBinary()
-					_ = yym3630
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3627 || yy2arr3627 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3627[1] {
-					yym3632 := z.EncBinary()
-					_ = yym3632
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3627[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3633 := z.EncBinary()
-					_ = yym3633
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3627 || yy2arr3627 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3627[2] {
-					yy3635 := &x.ObjectMeta
-					yy3635.CodecEncodeSelf(e)
+					yy3629 := &x.ObjectMeta
+					yy3629.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3627[2] {
+				if yyq3627[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3636 := &x.ObjectMeta
-					yy3636.CodecEncodeSelf(e)
+					yy3630 := &x.ObjectMeta
+					yy3630.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3627 || yy2arr3627 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3627[3] {
+				if yyq3627[1] {
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym3638 := z.EncBinary()
-						_ = yym3638
+						yym3632 := z.EncBinary()
+						_ = yym3632
 						if false {
 						} else {
 							h.encSliceComponentCondition(([]ComponentCondition)(x.Conditions), e)
@@ -45319,19 +45269,69 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3627[3] {
+				if yyq3627[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("conditions"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym3639 := z.EncBinary()
-						_ = yym3639
+						yym3633 := z.EncBinary()
+						_ = yym3633
 						if false {
 						} else {
 							h.encSliceComponentCondition(([]ComponentCondition)(x.Conditions), e)
 						}
+					}
+				}
+			}
+			if yyr3627 || yy2arr3627 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3627[2] {
+					yym3635 := z.EncBinary()
+					_ = yym3635
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3627[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3636 := z.EncBinary()
+					_ = yym3636
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3627 || yy2arr3627 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3627[3] {
+					yym3638 := z.EncBinary()
+					_ = yym3638
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3627[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3639 := z.EncBinary()
+					_ = yym3639
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -45396,6 +45396,25 @@ func (x *ComponentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys3642 := string(yys3642Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3642 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = ObjectMeta{}
+			} else {
+				yyv3643 := &x.ObjectMeta
+				yyv3643.CodecDecodeSelf(d)
+			}
+		case "conditions":
+			if r.TryDecodeAsNil() {
+				x.Conditions = nil
+			} else {
+				yyv3644 := &x.Conditions
+				yym3645 := z.DecBinary()
+				_ = yym3645
+				if false {
+				} else {
+					h.decSliceComponentCondition((*[]ComponentCondition)(yyv3644), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -45407,25 +45426,6 @@ func (x *ComponentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = ObjectMeta{}
-			} else {
-				yyv3645 := &x.ObjectMeta
-				yyv3645.CodecDecodeSelf(d)
-			}
-		case "conditions":
-			if r.TryDecodeAsNil() {
-				x.Conditions = nil
-			} else {
-				yyv3646 := &x.Conditions
-				yym3647 := z.DecBinary()
-				_ = yym3647
-				if false {
-				} else {
-					h.decSliceComponentCondition((*[]ComponentCondition)(yyv3646), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3642)
@@ -45441,6 +45441,45 @@ func (x *ComponentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var yyj3648 int
 	var yyb3648 bool
 	var yyhl3648 bool = l >= 0
+	yyj3648++
+	if yyhl3648 {
+		yyb3648 = yyj3648 > l
+	} else {
+		yyb3648 = r.CheckBreak()
+	}
+	if yyb3648 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = ObjectMeta{}
+	} else {
+		yyv3649 := &x.ObjectMeta
+		yyv3649.CodecDecodeSelf(d)
+	}
+	yyj3648++
+	if yyhl3648 {
+		yyb3648 = yyj3648 > l
+	} else {
+		yyb3648 = r.CheckBreak()
+	}
+	if yyb3648 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Conditions = nil
+	} else {
+		yyv3650 := &x.Conditions
+		yym3651 := z.DecBinary()
+		_ = yym3651
+		if false {
+		} else {
+			h.decSliceComponentCondition((*[]ComponentCondition)(yyv3650), d)
+		}
+	}
 	yyj3648++
 	if yyhl3648 {
 		yyb3648 = yyj3648 > l
@@ -45472,45 +45511,6 @@ func (x *ComponentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3648++
-	if yyhl3648 {
-		yyb3648 = yyj3648 > l
-	} else {
-		yyb3648 = r.CheckBreak()
-	}
-	if yyb3648 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = ObjectMeta{}
-	} else {
-		yyv3651 := &x.ObjectMeta
-		yyv3651.CodecDecodeSelf(d)
-	}
-	yyj3648++
-	if yyhl3648 {
-		yyb3648 = yyj3648 > l
-	} else {
-		yyb3648 = r.CheckBreak()
-	}
-	if yyb3648 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Conditions = nil
-	} else {
-		yyv3652 := &x.Conditions
-		yym3653 := z.DecBinary()
-		_ = yym3653
-		if false {
-		} else {
-			h.decSliceComponentCondition((*[]ComponentCondition)(yyv3652), d)
-		}
 	}
 	for {
 		yyj3648++
@@ -45545,9 +45545,9 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3655 [4]bool
 			_, _, _ = yysep3655, yyq3655, yy2arr3655
 			const yyr3655 bool = false
-			yyq3655[0] = x.Kind != ""
-			yyq3655[1] = x.APIVersion != ""
-			yyq3655[2] = true
+			yyq3655[0] = true
+			yyq3655[2] = x.Kind != ""
+			yyq3655[3] = x.APIVersion != ""
 			var yynn3655 int
 			if yyr3655 || yy2arr3655 {
 				r.EncodeArrayStart(4)
@@ -45564,79 +45564,29 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr3655 || yy2arr3655 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3655[0] {
-					yym3657 := z.EncBinary()
-					_ = yym3657
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3655[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy3657 := &x.ListMeta
 					yym3658 := z.EncBinary()
 					_ = yym3658
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3657) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3655 || yy2arr3655 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3655[1] {
-					yym3660 := z.EncBinary()
-					_ = yym3660
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3655[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3661 := z.EncBinary()
-					_ = yym3661
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3655 || yy2arr3655 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3655[2] {
-					yy3663 := &x.ListMeta
-					yym3664 := z.EncBinary()
-					_ = yym3664
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3663) {
-					} else {
-						z.EncFallback(yy3663)
+						z.EncFallback(yy3657)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3655[2] {
+				if yyq3655[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3665 := &x.ListMeta
-					yym3666 := z.EncBinary()
-					_ = yym3666
+					yy3659 := &x.ListMeta
+					yym3660 := z.EncBinary()
+					_ = yym3660
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3665) {
+					} else if z.HasExtensions() && z.EncExt(yy3659) {
 					} else {
-						z.EncFallback(yy3665)
+						z.EncFallback(yy3659)
 					}
 				}
 			}
@@ -45645,8 +45595,8 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3668 := z.EncBinary()
-					_ = yym3668
+					yym3662 := z.EncBinary()
+					_ = yym3662
 					if false {
 					} else {
 						h.encSliceComponentStatus(([]ComponentStatus)(x.Items), e)
@@ -45659,11 +45609,61 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym3663 := z.EncBinary()
+					_ = yym3663
+					if false {
+					} else {
+						h.encSliceComponentStatus(([]ComponentStatus)(x.Items), e)
+					}
+				}
+			}
+			if yyr3655 || yy2arr3655 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3655[2] {
+					yym3665 := z.EncBinary()
+					_ = yym3665
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3655[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3666 := z.EncBinary()
+					_ = yym3666
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3655 || yy2arr3655 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3655[3] {
+					yym3668 := z.EncBinary()
+					_ = yym3668
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3655[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3669 := z.EncBinary()
 					_ = yym3669
 					if false {
 					} else {
-						h.encSliceComponentStatus(([]ComponentStatus)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -45728,6 +45728,31 @@ func (x *ComponentStatusList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 		yys3672 := string(yys3672Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3672 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg2_unversioned.ListMeta{}
+			} else {
+				yyv3673 := &x.ListMeta
+				yym3674 := z.DecBinary()
+				_ = yym3674
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv3673) {
+				} else {
+					z.DecFallback(yyv3673, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv3675 := &x.Items
+				yym3676 := z.DecBinary()
+				_ = yym3676
+				if false {
+				} else {
+					h.decSliceComponentStatus((*[]ComponentStatus)(yyv3675), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -45739,31 +45764,6 @@ func (x *ComponentStatusList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg2_unversioned.ListMeta{}
-			} else {
-				yyv3675 := &x.ListMeta
-				yym3676 := z.DecBinary()
-				_ = yym3676
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3675) {
-				} else {
-					z.DecFallback(yyv3675, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv3677 := &x.Items
-				yym3678 := z.DecBinary()
-				_ = yym3678
-				if false {
-				} else {
-					h.decSliceComponentStatus((*[]ComponentStatus)(yyv3677), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3672)
@@ -45779,6 +45779,51 @@ func (x *ComponentStatusList) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	var yyj3679 int
 	var yyb3679 bool
 	var yyhl3679 bool = l >= 0
+	yyj3679++
+	if yyhl3679 {
+		yyb3679 = yyj3679 > l
+	} else {
+		yyb3679 = r.CheckBreak()
+	}
+	if yyb3679 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg2_unversioned.ListMeta{}
+	} else {
+		yyv3680 := &x.ListMeta
+		yym3681 := z.DecBinary()
+		_ = yym3681
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv3680) {
+		} else {
+			z.DecFallback(yyv3680, false)
+		}
+	}
+	yyj3679++
+	if yyhl3679 {
+		yyb3679 = yyj3679 > l
+	} else {
+		yyb3679 = r.CheckBreak()
+	}
+	if yyb3679 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv3682 := &x.Items
+		yym3683 := z.DecBinary()
+		_ = yym3683
+		if false {
+		} else {
+			h.decSliceComponentStatus((*[]ComponentStatus)(yyv3682), d)
+		}
+	}
 	yyj3679++
 	if yyhl3679 {
 		yyb3679 = yyj3679 > l
@@ -45810,51 +45855,6 @@ func (x *ComponentStatusList) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3679++
-	if yyhl3679 {
-		yyb3679 = yyj3679 > l
-	} else {
-		yyb3679 = r.CheckBreak()
-	}
-	if yyb3679 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg2_unversioned.ListMeta{}
-	} else {
-		yyv3682 := &x.ListMeta
-		yym3683 := z.DecBinary()
-		_ = yym3683
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3682) {
-		} else {
-			z.DecFallback(yyv3682, false)
-		}
-	}
-	yyj3679++
-	if yyhl3679 {
-		yyb3679 = yyj3679 > l
-	} else {
-		yyb3679 = r.CheckBreak()
-	}
-	if yyb3679 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv3684 := &x.Items
-		yym3685 := z.DecBinary()
-		_ = yym3685
-		if false {
-		} else {
-			h.decSliceComponentStatus((*[]ComponentStatus)(yyv3684), d)
-		}
 	}
 	for {
 		yyj3679++
@@ -47055,9 +47055,9 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq3781 [5]bool
 			_, _, _ = yysep3781, yyq3781, yy2arr3781
 			const yyr3781 bool = false
-			yyq3781[0] = x.Kind != ""
-			yyq3781[1] = x.APIVersion != ""
-			yyq3781[2] = true
+			yyq3781[0] = true
+			yyq3781[3] = x.Kind != ""
+			yyq3781[4] = x.APIVersion != ""
 			var yynn3781 int
 			if yyr3781 || yy2arr3781 {
 				r.EncodeArrayStart(5)
@@ -47074,74 +47074,24 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr3781 || yy2arr3781 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq3781[0] {
-					yym3783 := z.EncBinary()
-					_ = yym3783
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3781[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3784 := z.EncBinary()
-					_ = yym3784
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr3781 || yy2arr3781 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3781[1] {
-					yym3786 := z.EncBinary()
-					_ = yym3786
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3781[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym3787 := z.EncBinary()
-					_ = yym3787
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3781 || yy2arr3781 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq3781[2] {
-					yy3789 := &x.ObjectMeta
-					yy3789.CodecEncodeSelf(e)
+					yy3783 := &x.ObjectMeta
+					yy3783.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3781[2] {
+				if yyq3781[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy3790 := &x.ObjectMeta
-					yy3790.CodecEncodeSelf(e)
+					yy3784 := &x.ObjectMeta
+					yy3784.CodecEncodeSelf(e)
 				}
 			}
 			if yyr3781 || yy2arr3781 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym3792 := z.EncBinary()
-				_ = yym3792
+				yym3786 := z.EncBinary()
+				_ = yym3786
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Range))
@@ -47150,8 +47100,8 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("range"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym3793 := z.EncBinary()
-				_ = yym3793
+				yym3787 := z.EncBinary()
+				_ = yym3787
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Range))
@@ -47162,8 +47112,8 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Data == nil {
 					r.EncodeNil()
 				} else {
-					yym3795 := z.EncBinary()
-					_ = yym3795
+					yym3789 := z.EncBinary()
+					_ = yym3789
 					if false {
 					} else {
 						r.EncodeStringBytes(codecSelferC_RAW1234, []byte(x.Data))
@@ -47176,11 +47126,61 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Data == nil {
 					r.EncodeNil()
 				} else {
+					yym3790 := z.EncBinary()
+					_ = yym3790
+					if false {
+					} else {
+						r.EncodeStringBytes(codecSelferC_RAW1234, []byte(x.Data))
+					}
+				}
+			}
+			if yyr3781 || yy2arr3781 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3781[3] {
+					yym3792 := z.EncBinary()
+					_ = yym3792
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3781[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym3793 := z.EncBinary()
+					_ = yym3793
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr3781 || yy2arr3781 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq3781[4] {
+					yym3795 := z.EncBinary()
+					_ = yym3795
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3781[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym3796 := z.EncBinary()
 					_ = yym3796
 					if false {
 					} else {
-						r.EncodeStringBytes(codecSelferC_RAW1234, []byte(x.Data))
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -47245,24 +47245,12 @@ func (x *RangeAllocation) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys3799 := string(yys3799Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys3799 {
-		case "kind":
-			if r.TryDecodeAsNil() {
-				x.Kind = ""
-			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
-			}
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv3802 := &x.ObjectMeta
-				yyv3802.CodecDecodeSelf(d)
+				yyv3800 := &x.ObjectMeta
+				yyv3800.CodecDecodeSelf(d)
 			}
 		case "range":
 			if r.TryDecodeAsNil() {
@@ -47274,13 +47262,25 @@ func (x *RangeAllocation) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Data = nil
 			} else {
-				yyv3804 := &x.Data
-				yym3805 := z.DecBinary()
-				_ = yym3805
+				yyv3802 := &x.Data
+				yym3803 := z.DecBinary()
+				_ = yym3803
 				if false {
 				} else {
-					*yyv3804 = r.DecodeBytes(*(*[]byte)(yyv3804), false, false)
+					*yyv3802 = r.DecodeBytes(*(*[]byte)(yyv3802), false, false)
 				}
+			}
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3799)
@@ -47308,42 +47308,10 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.Kind = ""
-	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj3806++
-	if yyhl3806 {
-		yyb3806 = yyj3806 > l
-	} else {
-		yyb3806 = r.CheckBreak()
-	}
-	if yyb3806 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
-	}
-	yyj3806++
-	if yyhl3806 {
-		yyb3806 = yyj3806 > l
-	} else {
-		yyb3806 = r.CheckBreak()
-	}
-	if yyb3806 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv3809 := &x.ObjectMeta
-		yyv3809.CodecDecodeSelf(d)
+		yyv3807 := &x.ObjectMeta
+		yyv3807.CodecDecodeSelf(d)
 	}
 	yyj3806++
 	if yyhl3806 {
@@ -47375,13 +47343,45 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	if r.TryDecodeAsNil() {
 		x.Data = nil
 	} else {
-		yyv3811 := &x.Data
-		yym3812 := z.DecBinary()
-		_ = yym3812
+		yyv3809 := &x.Data
+		yym3810 := z.DecBinary()
+		_ = yym3810
 		if false {
 		} else {
-			*yyv3811 = r.DecodeBytes(*(*[]byte)(yyv3811), false, false)
+			*yyv3809 = r.DecodeBytes(*(*[]byte)(yyv3809), false, false)
 		}
+	}
+	yyj3806++
+	if yyhl3806 {
+		yyb3806 = yyj3806 > l
+	} else {
+		yyb3806 = r.CheckBreak()
+	}
+	if yyb3806 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj3806++
+	if yyhl3806 {
+		yyb3806 = yyj3806 > l
+	} else {
+		yyb3806 = r.CheckBreak()
+	}
+	if yyb3806 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
 	}
 	for {
 		yyj3806++

--- a/pkg/apis/authorization/types.generated.go
+++ b/pkg/apis/authorization/types.generated.go
@@ -82,8 +82,8 @@ func (x *SubjectAccessReview) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2 [4]bool
 			_, _, _ = yysep2, yyq2, yy2arr2
 			const yyr2 bool = false
-			yyq2[0] = x.Kind != ""
-			yyq2[1] = x.APIVersion != ""
+			yyq2[2] = x.Kind != ""
+			yyq2[3] = x.APIVersion != ""
 			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(4)
@@ -99,75 +99,75 @@ func (x *SubjectAccessReview) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[0] {
-					yym4 := z.EncBinary()
-					_ = yym4
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym5 := z.EncBinary()
-					_ = yym5
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[1] {
-					yym7 := z.EncBinary()
-					_ = yym7
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym8 := z.EncBinary()
-					_ = yym8
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy10 := &x.Spec
-				yy10.CodecEncodeSelf(e)
+				yy4 := &x.Spec
+				yy4.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Spec"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy11 := &x.Spec
-				yy11.CodecEncodeSelf(e)
+				yy5 := &x.Spec
+				yy5.CodecEncodeSelf(e)
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy13 := &x.Status
-				yy13.CodecEncodeSelf(e)
+				yy7 := &x.Status
+				yy7.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Status"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy14 := &x.Status
-				yy14.CodecEncodeSelf(e)
+				yy8 := &x.Status
+				yy8.CodecEncodeSelf(e)
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2[2] {
+					yym10 := z.EncBinary()
+					_ = yym10
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym11 := z.EncBinary()
+					_ = yym11
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2[3] {
+					yym13 := z.EncBinary()
+					_ = yym13
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym14 := z.EncBinary()
+					_ = yym14
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
@@ -230,6 +230,20 @@ func (x *SubjectAccessReview) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 		yys17 := string(yys17Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys17 {
+		case "Spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = SubjectAccessReviewSpec{}
+			} else {
+				yyv18 := &x.Spec
+				yyv18.CodecDecodeSelf(d)
+			}
+		case "Status":
+			if r.TryDecodeAsNil() {
+				x.Status = SubjectAccessReviewStatus{}
+			} else {
+				yyv19 := &x.Status
+				yyv19.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -241,20 +255,6 @@ func (x *SubjectAccessReview) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "Spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = SubjectAccessReviewSpec{}
-			} else {
-				yyv20 := &x.Spec
-				yyv20.CodecDecodeSelf(d)
-			}
-		case "Status":
-			if r.TryDecodeAsNil() {
-				x.Status = SubjectAccessReviewStatus{}
-			} else {
-				yyv21 := &x.Status
-				yyv21.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys17)
@@ -270,6 +270,40 @@ func (x *SubjectAccessReview) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	var yyj22 int
 	var yyb22 bool
 	var yyhl22 bool = l >= 0
+	yyj22++
+	if yyhl22 {
+		yyb22 = yyj22 > l
+	} else {
+		yyb22 = r.CheckBreak()
+	}
+	if yyb22 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = SubjectAccessReviewSpec{}
+	} else {
+		yyv23 := &x.Spec
+		yyv23.CodecDecodeSelf(d)
+	}
+	yyj22++
+	if yyhl22 {
+		yyb22 = yyj22 > l
+	} else {
+		yyb22 = r.CheckBreak()
+	}
+	if yyb22 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = SubjectAccessReviewStatus{}
+	} else {
+		yyv24 := &x.Status
+		yyv24.CodecDecodeSelf(d)
+	}
 	yyj22++
 	if yyhl22 {
 		yyb22 = yyj22 > l
@@ -301,40 +335,6 @@ func (x *SubjectAccessReview) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj22++
-	if yyhl22 {
-		yyb22 = yyj22 > l
-	} else {
-		yyb22 = r.CheckBreak()
-	}
-	if yyb22 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = SubjectAccessReviewSpec{}
-	} else {
-		yyv25 := &x.Spec
-		yyv25.CodecDecodeSelf(d)
-	}
-	yyj22++
-	if yyhl22 {
-		yyb22 = yyj22 > l
-	} else {
-		yyb22 = r.CheckBreak()
-	}
-	if yyb22 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = SubjectAccessReviewStatus{}
-	} else {
-		yyv26 := &x.Status
-		yyv26.CodecDecodeSelf(d)
 	}
 	for {
 		yyj22++
@@ -369,8 +369,8 @@ func (x *SelfSubjectAccessReview) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq28 [4]bool
 			_, _, _ = yysep28, yyq28, yy2arr28
 			const yyr28 bool = false
-			yyq28[0] = x.Kind != ""
-			yyq28[1] = x.APIVersion != ""
+			yyq28[2] = x.Kind != ""
+			yyq28[3] = x.APIVersion != ""
 			var yynn28 int
 			if yyr28 || yy2arr28 {
 				r.EncodeArrayStart(4)
@@ -386,75 +386,75 @@ func (x *SelfSubjectAccessReview) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr28 || yy2arr28 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq28[0] {
-					yym30 := z.EncBinary()
-					_ = yym30
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq28[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym31 := z.EncBinary()
-					_ = yym31
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr28 || yy2arr28 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq28[1] {
-					yym33 := z.EncBinary()
-					_ = yym33
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq28[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym34 := z.EncBinary()
-					_ = yym34
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr28 || yy2arr28 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy36 := &x.Spec
-				yy36.CodecEncodeSelf(e)
+				yy30 := &x.Spec
+				yy30.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Spec"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy37 := &x.Spec
-				yy37.CodecEncodeSelf(e)
+				yy31 := &x.Spec
+				yy31.CodecEncodeSelf(e)
 			}
 			if yyr28 || yy2arr28 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy39 := &x.Status
-				yy39.CodecEncodeSelf(e)
+				yy33 := &x.Status
+				yy33.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Status"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy40 := &x.Status
-				yy40.CodecEncodeSelf(e)
+				yy34 := &x.Status
+				yy34.CodecEncodeSelf(e)
+			}
+			if yyr28 || yy2arr28 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq28[2] {
+					yym36 := z.EncBinary()
+					_ = yym36
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq28[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym37 := z.EncBinary()
+					_ = yym37
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr28 || yy2arr28 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq28[3] {
+					yym39 := z.EncBinary()
+					_ = yym39
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq28[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym40 := z.EncBinary()
+					_ = yym40
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
 			}
 			if yyr28 || yy2arr28 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
@@ -517,6 +517,20 @@ func (x *SelfSubjectAccessReview) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 		yys43 := string(yys43Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys43 {
+		case "Spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = SelfSubjectAccessReviewSpec{}
+			} else {
+				yyv44 := &x.Spec
+				yyv44.CodecDecodeSelf(d)
+			}
+		case "Status":
+			if r.TryDecodeAsNil() {
+				x.Status = SubjectAccessReviewStatus{}
+			} else {
+				yyv45 := &x.Status
+				yyv45.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -528,20 +542,6 @@ func (x *SelfSubjectAccessReview) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "Spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = SelfSubjectAccessReviewSpec{}
-			} else {
-				yyv46 := &x.Spec
-				yyv46.CodecDecodeSelf(d)
-			}
-		case "Status":
-			if r.TryDecodeAsNil() {
-				x.Status = SubjectAccessReviewStatus{}
-			} else {
-				yyv47 := &x.Status
-				yyv47.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys43)
@@ -557,6 +557,40 @@ func (x *SelfSubjectAccessReview) codecDecodeSelfFromArray(l int, d *codec1978.D
 	var yyj48 int
 	var yyb48 bool
 	var yyhl48 bool = l >= 0
+	yyj48++
+	if yyhl48 {
+		yyb48 = yyj48 > l
+	} else {
+		yyb48 = r.CheckBreak()
+	}
+	if yyb48 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = SelfSubjectAccessReviewSpec{}
+	} else {
+		yyv49 := &x.Spec
+		yyv49.CodecDecodeSelf(d)
+	}
+	yyj48++
+	if yyhl48 {
+		yyb48 = yyj48 > l
+	} else {
+		yyb48 = r.CheckBreak()
+	}
+	if yyb48 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = SubjectAccessReviewStatus{}
+	} else {
+		yyv50 := &x.Status
+		yyv50.CodecDecodeSelf(d)
+	}
 	yyj48++
 	if yyhl48 {
 		yyb48 = yyj48 > l
@@ -588,40 +622,6 @@ func (x *SelfSubjectAccessReview) codecDecodeSelfFromArray(l int, d *codec1978.D
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj48++
-	if yyhl48 {
-		yyb48 = yyj48 > l
-	} else {
-		yyb48 = r.CheckBreak()
-	}
-	if yyb48 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = SelfSubjectAccessReviewSpec{}
-	} else {
-		yyv51 := &x.Spec
-		yyv51.CodecDecodeSelf(d)
-	}
-	yyj48++
-	if yyhl48 {
-		yyb48 = yyj48 > l
-	} else {
-		yyb48 = r.CheckBreak()
-	}
-	if yyb48 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = SubjectAccessReviewStatus{}
-	} else {
-		yyv52 := &x.Status
-		yyv52.CodecDecodeSelf(d)
 	}
 	for {
 		yyj48++
@@ -656,8 +656,8 @@ func (x *LocalSubjectAccessReview) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq54 [4]bool
 			_, _, _ = yysep54, yyq54, yy2arr54
 			const yyr54 bool = false
-			yyq54[0] = x.Kind != ""
-			yyq54[1] = x.APIVersion != ""
+			yyq54[2] = x.Kind != ""
+			yyq54[3] = x.APIVersion != ""
 			var yynn54 int
 			if yyr54 || yy2arr54 {
 				r.EncodeArrayStart(4)
@@ -673,75 +673,75 @@ func (x *LocalSubjectAccessReview) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr54 || yy2arr54 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq54[0] {
-					yym56 := z.EncBinary()
-					_ = yym56
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq54[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym57 := z.EncBinary()
-					_ = yym57
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr54 || yy2arr54 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq54[1] {
-					yym59 := z.EncBinary()
-					_ = yym59
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq54[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym60 := z.EncBinary()
-					_ = yym60
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr54 || yy2arr54 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy62 := &x.Spec
-				yy62.CodecEncodeSelf(e)
+				yy56 := &x.Spec
+				yy56.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Spec"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy63 := &x.Spec
-				yy63.CodecEncodeSelf(e)
+				yy57 := &x.Spec
+				yy57.CodecEncodeSelf(e)
 			}
 			if yyr54 || yy2arr54 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy65 := &x.Status
-				yy65.CodecEncodeSelf(e)
+				yy59 := &x.Status
+				yy59.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Status"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy66 := &x.Status
-				yy66.CodecEncodeSelf(e)
+				yy60 := &x.Status
+				yy60.CodecEncodeSelf(e)
+			}
+			if yyr54 || yy2arr54 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq54[2] {
+					yym62 := z.EncBinary()
+					_ = yym62
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq54[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym63 := z.EncBinary()
+					_ = yym63
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr54 || yy2arr54 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq54[3] {
+					yym65 := z.EncBinary()
+					_ = yym65
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq54[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym66 := z.EncBinary()
+					_ = yym66
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
 			}
 			if yyr54 || yy2arr54 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
@@ -804,6 +804,20 @@ func (x *LocalSubjectAccessReview) codecDecodeSelfFromMap(l int, d *codec1978.De
 		yys69 := string(yys69Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys69 {
+		case "Spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = SubjectAccessReviewSpec{}
+			} else {
+				yyv70 := &x.Spec
+				yyv70.CodecDecodeSelf(d)
+			}
+		case "Status":
+			if r.TryDecodeAsNil() {
+				x.Status = SubjectAccessReviewStatus{}
+			} else {
+				yyv71 := &x.Status
+				yyv71.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -815,20 +829,6 @@ func (x *LocalSubjectAccessReview) codecDecodeSelfFromMap(l int, d *codec1978.De
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "Spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = SubjectAccessReviewSpec{}
-			} else {
-				yyv72 := &x.Spec
-				yyv72.CodecDecodeSelf(d)
-			}
-		case "Status":
-			if r.TryDecodeAsNil() {
-				x.Status = SubjectAccessReviewStatus{}
-			} else {
-				yyv73 := &x.Status
-				yyv73.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys69)
@@ -844,6 +844,40 @@ func (x *LocalSubjectAccessReview) codecDecodeSelfFromArray(l int, d *codec1978.
 	var yyj74 int
 	var yyb74 bool
 	var yyhl74 bool = l >= 0
+	yyj74++
+	if yyhl74 {
+		yyb74 = yyj74 > l
+	} else {
+		yyb74 = r.CheckBreak()
+	}
+	if yyb74 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = SubjectAccessReviewSpec{}
+	} else {
+		yyv75 := &x.Spec
+		yyv75.CodecDecodeSelf(d)
+	}
+	yyj74++
+	if yyhl74 {
+		yyb74 = yyj74 > l
+	} else {
+		yyb74 = r.CheckBreak()
+	}
+	if yyb74 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = SubjectAccessReviewStatus{}
+	} else {
+		yyv76 := &x.Status
+		yyv76.CodecDecodeSelf(d)
+	}
 	yyj74++
 	if yyhl74 {
 		yyb74 = yyj74 > l
@@ -875,40 +909,6 @@ func (x *LocalSubjectAccessReview) codecDecodeSelfFromArray(l int, d *codec1978.
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj74++
-	if yyhl74 {
-		yyb74 = yyj74 > l
-	} else {
-		yyb74 = r.CheckBreak()
-	}
-	if yyb74 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = SubjectAccessReviewSpec{}
-	} else {
-		yyv77 := &x.Spec
-		yyv77.CodecDecodeSelf(d)
-	}
-	yyj74++
-	if yyhl74 {
-		yyb74 = yyj74 > l
-	} else {
-		yyb74 = r.CheckBreak()
-	}
-	if yyb74 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = SubjectAccessReviewStatus{}
-	} else {
-		yyv78 := &x.Status
-		yyv78.CodecDecodeSelf(d)
 	}
 	for {
 		yyj74++

--- a/pkg/apis/authorization/v1beta1/types.generated.go
+++ b/pkg/apis/authorization/v1beta1/types.generated.go
@@ -82,9 +82,9 @@ func (x *SubjectAccessReview) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2 [4]bool
 			_, _, _ = yysep2, yyq2, yy2arr2
 			const yyr2 bool = false
-			yyq2[0] = x.Kind != ""
-			yyq2[1] = x.APIVersion != ""
-			yyq2[3] = true
+			yyq2[1] = true
+			yyq2[2] = x.Kind != ""
+			yyq2[3] = x.APIVersion != ""
 			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(4)
@@ -100,80 +100,80 @@ func (x *SubjectAccessReview) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[0] {
-					yym4 := z.EncBinary()
-					_ = yym4
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym5 := z.EncBinary()
-					_ = yym5
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[1] {
-					yym7 := z.EncBinary()
-					_ = yym7
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym8 := z.EncBinary()
-					_ = yym8
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy10 := &x.Spec
-				yy10.CodecEncodeSelf(e)
+				yy4 := &x.Spec
+				yy4.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("spec"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy11 := &x.Spec
-				yy11.CodecEncodeSelf(e)
+				yy5 := &x.Spec
+				yy5.CodecEncodeSelf(e)
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[3] {
-					yy13 := &x.Status
-					yy13.CodecEncodeSelf(e)
+				if yyq2[1] {
+					yy7 := &x.Status
+					yy7.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2[3] {
+				if yyq2[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy14 := &x.Status
-					yy14.CodecEncodeSelf(e)
+					yy8 := &x.Status
+					yy8.CodecEncodeSelf(e)
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2[2] {
+					yym10 := z.EncBinary()
+					_ = yym10
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym11 := z.EncBinary()
+					_ = yym11
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2[3] {
+					yym13 := z.EncBinary()
+					_ = yym13
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym14 := z.EncBinary()
+					_ = yym14
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr2 || yy2arr2 {
@@ -237,6 +237,20 @@ func (x *SubjectAccessReview) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 		yys17 := string(yys17Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys17 {
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = SubjectAccessReviewSpec{}
+			} else {
+				yyv18 := &x.Spec
+				yyv18.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = SubjectAccessReviewStatus{}
+			} else {
+				yyv19 := &x.Status
+				yyv19.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -248,20 +262,6 @@ func (x *SubjectAccessReview) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = SubjectAccessReviewSpec{}
-			} else {
-				yyv20 := &x.Spec
-				yyv20.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = SubjectAccessReviewStatus{}
-			} else {
-				yyv21 := &x.Status
-				yyv21.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys17)
@@ -277,6 +277,40 @@ func (x *SubjectAccessReview) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	var yyj22 int
 	var yyb22 bool
 	var yyhl22 bool = l >= 0
+	yyj22++
+	if yyhl22 {
+		yyb22 = yyj22 > l
+	} else {
+		yyb22 = r.CheckBreak()
+	}
+	if yyb22 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = SubjectAccessReviewSpec{}
+	} else {
+		yyv23 := &x.Spec
+		yyv23.CodecDecodeSelf(d)
+	}
+	yyj22++
+	if yyhl22 {
+		yyb22 = yyj22 > l
+	} else {
+		yyb22 = r.CheckBreak()
+	}
+	if yyb22 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = SubjectAccessReviewStatus{}
+	} else {
+		yyv24 := &x.Status
+		yyv24.CodecDecodeSelf(d)
+	}
 	yyj22++
 	if yyhl22 {
 		yyb22 = yyj22 > l
@@ -308,40 +342,6 @@ func (x *SubjectAccessReview) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj22++
-	if yyhl22 {
-		yyb22 = yyj22 > l
-	} else {
-		yyb22 = r.CheckBreak()
-	}
-	if yyb22 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = SubjectAccessReviewSpec{}
-	} else {
-		yyv25 := &x.Spec
-		yyv25.CodecDecodeSelf(d)
-	}
-	yyj22++
-	if yyhl22 {
-		yyb22 = yyj22 > l
-	} else {
-		yyb22 = r.CheckBreak()
-	}
-	if yyb22 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = SubjectAccessReviewStatus{}
-	} else {
-		yyv26 := &x.Status
-		yyv26.CodecDecodeSelf(d)
 	}
 	for {
 		yyj22++
@@ -376,9 +376,9 @@ func (x *SelfSubjectAccessReview) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq28 [4]bool
 			_, _, _ = yysep28, yyq28, yy2arr28
 			const yyr28 bool = false
-			yyq28[0] = x.Kind != ""
-			yyq28[1] = x.APIVersion != ""
-			yyq28[3] = true
+			yyq28[1] = true
+			yyq28[2] = x.Kind != ""
+			yyq28[3] = x.APIVersion != ""
 			var yynn28 int
 			if yyr28 || yy2arr28 {
 				r.EncodeArrayStart(4)
@@ -394,80 +394,80 @@ func (x *SelfSubjectAccessReview) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr28 || yy2arr28 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq28[0] {
-					yym30 := z.EncBinary()
-					_ = yym30
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq28[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym31 := z.EncBinary()
-					_ = yym31
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr28 || yy2arr28 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq28[1] {
-					yym33 := z.EncBinary()
-					_ = yym33
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq28[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym34 := z.EncBinary()
-					_ = yym34
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr28 || yy2arr28 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy36 := &x.Spec
-				yy36.CodecEncodeSelf(e)
+				yy30 := &x.Spec
+				yy30.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("spec"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy37 := &x.Spec
-				yy37.CodecEncodeSelf(e)
+				yy31 := &x.Spec
+				yy31.CodecEncodeSelf(e)
 			}
 			if yyr28 || yy2arr28 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq28[3] {
-					yy39 := &x.Status
-					yy39.CodecEncodeSelf(e)
+				if yyq28[1] {
+					yy33 := &x.Status
+					yy33.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq28[3] {
+				if yyq28[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy40 := &x.Status
-					yy40.CodecEncodeSelf(e)
+					yy34 := &x.Status
+					yy34.CodecEncodeSelf(e)
+				}
+			}
+			if yyr28 || yy2arr28 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq28[2] {
+					yym36 := z.EncBinary()
+					_ = yym36
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq28[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym37 := z.EncBinary()
+					_ = yym37
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr28 || yy2arr28 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq28[3] {
+					yym39 := z.EncBinary()
+					_ = yym39
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq28[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym40 := z.EncBinary()
+					_ = yym40
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr28 || yy2arr28 {
@@ -531,6 +531,20 @@ func (x *SelfSubjectAccessReview) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 		yys43 := string(yys43Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys43 {
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = SelfSubjectAccessReviewSpec{}
+			} else {
+				yyv44 := &x.Spec
+				yyv44.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = SubjectAccessReviewStatus{}
+			} else {
+				yyv45 := &x.Status
+				yyv45.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -542,20 +556,6 @@ func (x *SelfSubjectAccessReview) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = SelfSubjectAccessReviewSpec{}
-			} else {
-				yyv46 := &x.Spec
-				yyv46.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = SubjectAccessReviewStatus{}
-			} else {
-				yyv47 := &x.Status
-				yyv47.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys43)
@@ -571,6 +571,40 @@ func (x *SelfSubjectAccessReview) codecDecodeSelfFromArray(l int, d *codec1978.D
 	var yyj48 int
 	var yyb48 bool
 	var yyhl48 bool = l >= 0
+	yyj48++
+	if yyhl48 {
+		yyb48 = yyj48 > l
+	} else {
+		yyb48 = r.CheckBreak()
+	}
+	if yyb48 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = SelfSubjectAccessReviewSpec{}
+	} else {
+		yyv49 := &x.Spec
+		yyv49.CodecDecodeSelf(d)
+	}
+	yyj48++
+	if yyhl48 {
+		yyb48 = yyj48 > l
+	} else {
+		yyb48 = r.CheckBreak()
+	}
+	if yyb48 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = SubjectAccessReviewStatus{}
+	} else {
+		yyv50 := &x.Status
+		yyv50.CodecDecodeSelf(d)
+	}
 	yyj48++
 	if yyhl48 {
 		yyb48 = yyj48 > l
@@ -602,40 +636,6 @@ func (x *SelfSubjectAccessReview) codecDecodeSelfFromArray(l int, d *codec1978.D
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj48++
-	if yyhl48 {
-		yyb48 = yyj48 > l
-	} else {
-		yyb48 = r.CheckBreak()
-	}
-	if yyb48 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = SelfSubjectAccessReviewSpec{}
-	} else {
-		yyv51 := &x.Spec
-		yyv51.CodecDecodeSelf(d)
-	}
-	yyj48++
-	if yyhl48 {
-		yyb48 = yyj48 > l
-	} else {
-		yyb48 = r.CheckBreak()
-	}
-	if yyb48 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = SubjectAccessReviewStatus{}
-	} else {
-		yyv52 := &x.Status
-		yyv52.CodecDecodeSelf(d)
 	}
 	for {
 		yyj48++
@@ -670,9 +670,9 @@ func (x *LocalSubjectAccessReview) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq54 [4]bool
 			_, _, _ = yysep54, yyq54, yy2arr54
 			const yyr54 bool = false
-			yyq54[0] = x.Kind != ""
-			yyq54[1] = x.APIVersion != ""
-			yyq54[3] = true
+			yyq54[1] = true
+			yyq54[2] = x.Kind != ""
+			yyq54[3] = x.APIVersion != ""
 			var yynn54 int
 			if yyr54 || yy2arr54 {
 				r.EncodeArrayStart(4)
@@ -688,80 +688,80 @@ func (x *LocalSubjectAccessReview) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr54 || yy2arr54 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq54[0] {
-					yym56 := z.EncBinary()
-					_ = yym56
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq54[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym57 := z.EncBinary()
-					_ = yym57
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr54 || yy2arr54 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq54[1] {
-					yym59 := z.EncBinary()
-					_ = yym59
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq54[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym60 := z.EncBinary()
-					_ = yym60
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr54 || yy2arr54 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy62 := &x.Spec
-				yy62.CodecEncodeSelf(e)
+				yy56 := &x.Spec
+				yy56.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("spec"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy63 := &x.Spec
-				yy63.CodecEncodeSelf(e)
+				yy57 := &x.Spec
+				yy57.CodecEncodeSelf(e)
 			}
 			if yyr54 || yy2arr54 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq54[3] {
-					yy65 := &x.Status
-					yy65.CodecEncodeSelf(e)
+				if yyq54[1] {
+					yy59 := &x.Status
+					yy59.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq54[3] {
+				if yyq54[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy66 := &x.Status
-					yy66.CodecEncodeSelf(e)
+					yy60 := &x.Status
+					yy60.CodecEncodeSelf(e)
+				}
+			}
+			if yyr54 || yy2arr54 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq54[2] {
+					yym62 := z.EncBinary()
+					_ = yym62
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq54[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym63 := z.EncBinary()
+					_ = yym63
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr54 || yy2arr54 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq54[3] {
+					yym65 := z.EncBinary()
+					_ = yym65
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq54[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym66 := z.EncBinary()
+					_ = yym66
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr54 || yy2arr54 {
@@ -825,6 +825,20 @@ func (x *LocalSubjectAccessReview) codecDecodeSelfFromMap(l int, d *codec1978.De
 		yys69 := string(yys69Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys69 {
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = SubjectAccessReviewSpec{}
+			} else {
+				yyv70 := &x.Spec
+				yyv70.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = SubjectAccessReviewStatus{}
+			} else {
+				yyv71 := &x.Status
+				yyv71.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -836,20 +850,6 @@ func (x *LocalSubjectAccessReview) codecDecodeSelfFromMap(l int, d *codec1978.De
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = SubjectAccessReviewSpec{}
-			} else {
-				yyv72 := &x.Spec
-				yyv72.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = SubjectAccessReviewStatus{}
-			} else {
-				yyv73 := &x.Status
-				yyv73.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys69)
@@ -865,6 +865,40 @@ func (x *LocalSubjectAccessReview) codecDecodeSelfFromArray(l int, d *codec1978.
 	var yyj74 int
 	var yyb74 bool
 	var yyhl74 bool = l >= 0
+	yyj74++
+	if yyhl74 {
+		yyb74 = yyj74 > l
+	} else {
+		yyb74 = r.CheckBreak()
+	}
+	if yyb74 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = SubjectAccessReviewSpec{}
+	} else {
+		yyv75 := &x.Spec
+		yyv75.CodecDecodeSelf(d)
+	}
+	yyj74++
+	if yyhl74 {
+		yyb74 = yyj74 > l
+	} else {
+		yyb74 = r.CheckBreak()
+	}
+	if yyb74 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = SubjectAccessReviewStatus{}
+	} else {
+		yyv76 := &x.Status
+		yyv76.CodecDecodeSelf(d)
+	}
 	yyj74++
 	if yyhl74 {
 		yyb74 = yyj74 > l
@@ -896,40 +930,6 @@ func (x *LocalSubjectAccessReview) codecDecodeSelfFromArray(l int, d *codec1978.
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj74++
-	if yyhl74 {
-		yyb74 = yyj74 > l
-	} else {
-		yyb74 = r.CheckBreak()
-	}
-	if yyb74 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = SubjectAccessReviewSpec{}
-	} else {
-		yyv77 := &x.Spec
-		yyv77.CodecDecodeSelf(d)
-	}
-	yyj74++
-	if yyhl74 {
-		yyb74 = yyj74 > l
-	} else {
-		yyb74 = r.CheckBreak()
-	}
-	if yyb74 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = SubjectAccessReviewStatus{}
-	} else {
-		yyv78 := &x.Status
-		yyv78.CodecDecodeSelf(d)
 	}
 	for {
 		yyj74++

--- a/pkg/apis/componentconfig/types.generated.go
+++ b/pkg/apis/componentconfig/types.generated.go
@@ -84,8 +84,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2 [18]bool
 			_, _, _ = yysep2, yyq2, yy2arr2
 			const yyr2 bool = false
-			yyq2[0] = x.Kind != ""
-			yyq2[1] = x.APIVersion != ""
+			yyq2[16] = x.Kind != ""
+			yyq2[17] = x.APIVersion != ""
 			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(18)
@@ -101,58 +101,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[0] {
-					yym4 := z.EncBinary()
-					_ = yym4
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym5 := z.EncBinary()
-					_ = yym5
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[1] {
-					yym7 := z.EncBinary()
-					_ = yym7
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym8 := z.EncBinary()
-					_ = yym8
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym10 := z.EncBinary()
-				_ = yym10
+				yym4 := z.EncBinary()
+				_ = yym4
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.BindAddress))
@@ -161,8 +111,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("bindAddress"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym11 := z.EncBinary()
-				_ = yym11
+				yym5 := z.EncBinary()
+				_ = yym5
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.BindAddress))
@@ -170,8 +120,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym13 := z.EncBinary()
-				_ = yym13
+				yym7 := z.EncBinary()
+				_ = yym7
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.HealthzBindAddress))
@@ -180,8 +130,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("healthzBindAddress"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym14 := z.EncBinary()
-				_ = yym14
+				yym8 := z.EncBinary()
+				_ = yym8
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.HealthzBindAddress))
@@ -189,8 +139,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym16 := z.EncBinary()
-				_ = yym16
+				yym10 := z.EncBinary()
+				_ = yym10
 				if false {
 				} else {
 					r.EncodeInt(int64(x.HealthzPort))
@@ -199,8 +149,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("healthzPort"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym17 := z.EncBinary()
-				_ = yym17
+				yym11 := z.EncBinary()
+				_ = yym11
 				if false {
 				} else {
 					r.EncodeInt(int64(x.HealthzPort))
@@ -208,8 +158,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym19 := z.EncBinary()
-				_ = yym19
+				yym13 := z.EncBinary()
+				_ = yym13
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.HostnameOverride))
@@ -218,8 +168,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("hostnameOverride"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym20 := z.EncBinary()
-				_ = yym20
+				yym14 := z.EncBinary()
+				_ = yym14
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.HostnameOverride))
@@ -230,12 +180,12 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.IPTablesMasqueradeBit == nil {
 					r.EncodeNil()
 				} else {
-					yy22 := *x.IPTablesMasqueradeBit
-					yym23 := z.EncBinary()
-					_ = yym23
+					yy16 := *x.IPTablesMasqueradeBit
+					yym17 := z.EncBinary()
+					_ = yym17
 					if false {
 					} else {
-						r.EncodeInt(int64(yy22))
+						r.EncodeInt(int64(yy16))
 					}
 				}
 			} else {
@@ -245,46 +195,46 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.IPTablesMasqueradeBit == nil {
 					r.EncodeNil()
 				} else {
-					yy24 := *x.IPTablesMasqueradeBit
-					yym25 := z.EncBinary()
-					_ = yym25
+					yy18 := *x.IPTablesMasqueradeBit
+					yym19 := z.EncBinary()
+					_ = yym19
 					if false {
 					} else {
-						r.EncodeInt(int64(yy24))
+						r.EncodeInt(int64(yy18))
 					}
 				}
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy27 := &x.IPTablesSyncPeriod
-				yym28 := z.EncBinary()
-				_ = yym28
+				yy21 := &x.IPTablesSyncPeriod
+				yym22 := z.EncBinary()
+				_ = yym22
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy27) {
-				} else if !yym28 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy27)
+				} else if z.HasExtensions() && z.EncExt(yy21) {
+				} else if !yym22 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy21)
 				} else {
-					z.EncFallback(yy27)
+					z.EncFallback(yy21)
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("iptablesSyncPeriodSeconds"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy29 := &x.IPTablesSyncPeriod
-				yym30 := z.EncBinary()
-				_ = yym30
+				yy23 := &x.IPTablesSyncPeriod
+				yym24 := z.EncBinary()
+				_ = yym24
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy29) {
-				} else if !yym30 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy29)
+				} else if z.HasExtensions() && z.EncExt(yy23) {
+				} else if !yym24 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy23)
 				} else {
-					z.EncFallback(yy29)
+					z.EncFallback(yy23)
 				}
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym32 := z.EncBinary()
-				_ = yym32
+				yym26 := z.EncBinary()
+				_ = yym26
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.KubeconfigPath))
@@ -293,8 +243,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("kubeconfigPath"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym33 := z.EncBinary()
-				_ = yym33
+				yym27 := z.EncBinary()
+				_ = yym27
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.KubeconfigPath))
@@ -302,8 +252,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym35 := z.EncBinary()
-				_ = yym35
+				yym29 := z.EncBinary()
+				_ = yym29
 				if false {
 				} else {
 					r.EncodeBool(bool(x.MasqueradeAll))
@@ -312,8 +262,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("masqueradeAll"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym36 := z.EncBinary()
-				_ = yym36
+				yym30 := z.EncBinary()
+				_ = yym30
 				if false {
 				} else {
 					r.EncodeBool(bool(x.MasqueradeAll))
@@ -321,8 +271,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym38 := z.EncBinary()
-				_ = yym38
+				yym32 := z.EncBinary()
+				_ = yym32
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Master))
@@ -331,8 +281,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("master"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym39 := z.EncBinary()
-				_ = yym39
+				yym33 := z.EncBinary()
+				_ = yym33
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Master))
@@ -343,12 +293,12 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.OOMScoreAdj == nil {
 					r.EncodeNil()
 				} else {
-					yy41 := *x.OOMScoreAdj
-					yym42 := z.EncBinary()
-					_ = yym42
+					yy35 := *x.OOMScoreAdj
+					yym36 := z.EncBinary()
+					_ = yym36
 					if false {
 					} else {
-						r.EncodeInt(int64(yy41))
+						r.EncodeInt(int64(yy35))
 					}
 				}
 			} else {
@@ -358,12 +308,12 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.OOMScoreAdj == nil {
 					r.EncodeNil()
 				} else {
-					yy43 := *x.OOMScoreAdj
-					yym44 := z.EncBinary()
-					_ = yym44
+					yy37 := *x.OOMScoreAdj
+					yym38 := z.EncBinary()
+					_ = yym38
 					if false {
 					} else {
-						r.EncodeInt(int64(yy43))
+						r.EncodeInt(int64(yy37))
 					}
 				}
 			}
@@ -378,8 +328,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym47 := z.EncBinary()
-				_ = yym47
+				yym41 := z.EncBinary()
+				_ = yym41
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.PortRange))
@@ -388,8 +338,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("portRange"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym48 := z.EncBinary()
-				_ = yym48
+				yym42 := z.EncBinary()
+				_ = yym42
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.PortRange))
@@ -397,8 +347,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym50 := z.EncBinary()
-				_ = yym50
+				yym44 := z.EncBinary()
+				_ = yym44
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ResourceContainer))
@@ -407,8 +357,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("resourceContainer"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym51 := z.EncBinary()
-				_ = yym51
+				yym45 := z.EncBinary()
+				_ = yym45
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ResourceContainer))
@@ -416,21 +366,53 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy53 := &x.UDPIdleTimeout
-				yym54 := z.EncBinary()
-				_ = yym54
+				yy47 := &x.UDPIdleTimeout
+				yym48 := z.EncBinary()
+				_ = yym48
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy53) {
-				} else if !yym54 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy53)
+				} else if z.HasExtensions() && z.EncExt(yy47) {
+				} else if !yym48 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy47)
 				} else {
-					z.EncFallback(yy53)
+					z.EncFallback(yy47)
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("udpTimeoutMilliseconds"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy55 := &x.UDPIdleTimeout
+				yy49 := &x.UDPIdleTimeout
+				yym50 := z.EncBinary()
+				_ = yym50
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy49) {
+				} else if !yym50 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy49)
+				} else {
+					z.EncFallback(yy49)
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym52 := z.EncBinary()
+				_ = yym52
+				if false {
+				} else {
+					r.EncodeInt(int64(x.ConntrackMax))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("conntrackMax"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym53 := z.EncBinary()
+				_ = yym53
+				if false {
+				} else {
+					r.EncodeInt(int64(x.ConntrackMax))
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yy55 := &x.ConntrackTCPEstablishedTimeout
 				yym56 := z.EncBinary()
 				_ = yym56
 				if false {
@@ -440,51 +422,69 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				} else {
 					z.EncFallback(yy55)
 				}
-			}
-			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym58 := z.EncBinary()
-				_ = yym58
-				if false {
-				} else {
-					r.EncodeInt(int64(x.ConntrackMax))
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("conntrackMax"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym59 := z.EncBinary()
-				_ = yym59
-				if false {
-				} else {
-					r.EncodeInt(int64(x.ConntrackMax))
-				}
-			}
-			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy61 := &x.ConntrackTCPEstablishedTimeout
-				yym62 := z.EncBinary()
-				_ = yym62
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy61) {
-				} else if !yym62 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy61)
-				} else {
-					z.EncFallback(yy61)
-				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("conntrackTCPEstablishedTimeout"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy63 := &x.ConntrackTCPEstablishedTimeout
-				yym64 := z.EncBinary()
-				_ = yym64
+				yy57 := &x.ConntrackTCPEstablishedTimeout
+				yym58 := z.EncBinary()
+				_ = yym58
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy63) {
-				} else if !yym64 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy63)
+				} else if z.HasExtensions() && z.EncExt(yy57) {
+				} else if !yym58 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy57)
 				} else {
-					z.EncFallback(yy63)
+					z.EncFallback(yy57)
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2[16] {
+					yym60 := z.EncBinary()
+					_ = yym60
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2[16] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym61 := z.EncBinary()
+					_ = yym61
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2[17] {
+					yym63 := z.EncBinary()
+					_ = yym63
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2[17] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym64 := z.EncBinary()
+					_ = yym64
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr2 || yy2arr2 {
@@ -548,18 +548,6 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 		yys67 := string(yys67Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys67 {
-		case "kind":
-			if r.TryDecodeAsNil() {
-				x.Kind = ""
-			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
-			}
 		case "bindAddress":
 			if r.TryDecodeAsNil() {
 				x.BindAddress = ""
@@ -593,8 +581,8 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				if x.IPTablesMasqueradeBit == nil {
 					x.IPTablesMasqueradeBit = new(int)
 				}
-				yym75 := z.DecBinary()
-				_ = yym75
+				yym73 := z.DecBinary()
+				_ = yym73
 				if false {
 				} else {
 					*((*int)(x.IPTablesMasqueradeBit)) = int(r.DecodeInt(codecSelferBitsize1234))
@@ -604,15 +592,15 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			if r.TryDecodeAsNil() {
 				x.IPTablesSyncPeriod = pkg1_unversioned.Duration{}
 			} else {
-				yyv76 := &x.IPTablesSyncPeriod
-				yym77 := z.DecBinary()
-				_ = yym77
+				yyv74 := &x.IPTablesSyncPeriod
+				yym75 := z.DecBinary()
+				_ = yym75
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv76) {
-				} else if !yym77 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv76)
+				} else if z.HasExtensions() && z.DecExt(yyv74) {
+				} else if !yym75 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv74)
 				} else {
-					z.DecFallback(yyv76, false)
+					z.DecFallback(yyv74, false)
 				}
 			}
 		case "kubeconfigPath":
@@ -642,8 +630,8 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				if x.OOMScoreAdj == nil {
 					x.OOMScoreAdj = new(int)
 				}
-				yym82 := z.DecBinary()
-				_ = yym82
+				yym80 := z.DecBinary()
+				_ = yym80
 				if false {
 				} else {
 					*((*int)(x.OOMScoreAdj)) = int(r.DecodeInt(codecSelferBitsize1234))
@@ -671,15 +659,15 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			if r.TryDecodeAsNil() {
 				x.UDPIdleTimeout = pkg1_unversioned.Duration{}
 			} else {
-				yyv86 := &x.UDPIdleTimeout
-				yym87 := z.DecBinary()
-				_ = yym87
+				yyv84 := &x.UDPIdleTimeout
+				yym85 := z.DecBinary()
+				_ = yym85
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv86) {
-				} else if !yym87 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv86)
+				} else if z.HasExtensions() && z.DecExt(yyv84) {
+				} else if !yym85 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv84)
 				} else {
-					z.DecFallback(yyv86, false)
+					z.DecFallback(yyv84, false)
 				}
 			}
 		case "conntrackMax":
@@ -692,16 +680,28 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			if r.TryDecodeAsNil() {
 				x.ConntrackTCPEstablishedTimeout = pkg1_unversioned.Duration{}
 			} else {
-				yyv89 := &x.ConntrackTCPEstablishedTimeout
-				yym90 := z.DecBinary()
-				_ = yym90
+				yyv87 := &x.ConntrackTCPEstablishedTimeout
+				yym88 := z.DecBinary()
+				_ = yym88
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv89) {
-				} else if !yym90 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv89)
+				} else if z.HasExtensions() && z.DecExt(yyv87) {
+				} else if !yym88 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv87)
 				} else {
-					z.DecFallback(yyv89, false)
+					z.DecFallback(yyv87, false)
 				}
+			}
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys67)
@@ -717,38 +717,6 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 	var yyj91 int
 	var yyb91 bool
 	var yyhl91 bool = l >= 0
-	yyj91++
-	if yyhl91 {
-		yyb91 = yyj91 > l
-	} else {
-		yyb91 = r.CheckBreak()
-	}
-	if yyb91 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Kind = ""
-	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj91++
-	if yyhl91 {
-		yyb91 = yyj91 > l
-	} else {
-		yyb91 = r.CheckBreak()
-	}
-	if yyb91 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
-	}
 	yyj91++
 	if yyhl91 {
 		yyb91 = yyj91 > l
@@ -832,8 +800,8 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		if x.IPTablesMasqueradeBit == nil {
 			x.IPTablesMasqueradeBit = new(int)
 		}
-		yym99 := z.DecBinary()
-		_ = yym99
+		yym97 := z.DecBinary()
+		_ = yym97
 		if false {
 		} else {
 			*((*int)(x.IPTablesMasqueradeBit)) = int(r.DecodeInt(codecSelferBitsize1234))
@@ -853,15 +821,15 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 	if r.TryDecodeAsNil() {
 		x.IPTablesSyncPeriod = pkg1_unversioned.Duration{}
 	} else {
-		yyv100 := &x.IPTablesSyncPeriod
-		yym101 := z.DecBinary()
-		_ = yym101
+		yyv98 := &x.IPTablesSyncPeriod
+		yym99 := z.DecBinary()
+		_ = yym99
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv100) {
-		} else if !yym101 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv100)
+		} else if z.HasExtensions() && z.DecExt(yyv98) {
+		} else if !yym99 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv98)
 		} else {
-			z.DecFallback(yyv100, false)
+			z.DecFallback(yyv98, false)
 		}
 	}
 	yyj91++
@@ -931,8 +899,8 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		if x.OOMScoreAdj == nil {
 			x.OOMScoreAdj = new(int)
 		}
-		yym106 := z.DecBinary()
-		_ = yym106
+		yym104 := z.DecBinary()
+		_ = yym104
 		if false {
 		} else {
 			*((*int)(x.OOMScoreAdj)) = int(r.DecodeInt(codecSelferBitsize1234))
@@ -1000,15 +968,15 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 	if r.TryDecodeAsNil() {
 		x.UDPIdleTimeout = pkg1_unversioned.Duration{}
 	} else {
-		yyv110 := &x.UDPIdleTimeout
-		yym111 := z.DecBinary()
-		_ = yym111
+		yyv108 := &x.UDPIdleTimeout
+		yym109 := z.DecBinary()
+		_ = yym109
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv110) {
-		} else if !yym111 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv110)
+		} else if z.HasExtensions() && z.DecExt(yyv108) {
+		} else if !yym109 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv108)
 		} else {
-			z.DecFallback(yyv110, false)
+			z.DecFallback(yyv108, false)
 		}
 	}
 	yyj91++
@@ -1041,16 +1009,48 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 	if r.TryDecodeAsNil() {
 		x.ConntrackTCPEstablishedTimeout = pkg1_unversioned.Duration{}
 	} else {
-		yyv113 := &x.ConntrackTCPEstablishedTimeout
-		yym114 := z.DecBinary()
-		_ = yym114
+		yyv111 := &x.ConntrackTCPEstablishedTimeout
+		yym112 := z.DecBinary()
+		_ = yym112
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv113) {
-		} else if !yym114 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv113)
+		} else if z.HasExtensions() && z.DecExt(yyv111) {
+		} else if !yym112 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv111)
 		} else {
-			z.DecFallback(yyv113, false)
+			z.DecFallback(yyv111, false)
 		}
+	}
+	yyj91++
+	if yyhl91 {
+		yyb91 = yyj91 > l
+	} else {
+		yyb91 = r.CheckBreak()
+	}
+	if yyb91 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj91++
+	if yyhl91 {
+		yyb91 = yyj91 > l
+	} else {
+		yyb91 = r.CheckBreak()
+	}
+	if yyb91 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
 	}
 	for {
 		yyj91++
@@ -4509,8 +4509,8 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq523 [11]bool
 			_, _, _ = yysep523, yyq523, yy2arr523
 			const yyr523 bool = false
-			yyq523[0] = x.Kind != ""
-			yyq523[1] = x.APIVersion != ""
+			yyq523[9] = x.Kind != ""
+			yyq523[10] = x.APIVersion != ""
 			var yynn523 int
 			if yyr523 || yy2arr523 {
 				r.EncodeArrayStart(11)
@@ -4526,58 +4526,8 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr523 || yy2arr523 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq523[0] {
-					yym525 := z.EncBinary()
-					_ = yym525
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq523[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym526 := z.EncBinary()
-					_ = yym526
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr523 || yy2arr523 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq523[1] {
-					yym528 := z.EncBinary()
-					_ = yym528
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq523[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym529 := z.EncBinary()
-					_ = yym529
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr523 || yy2arr523 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym531 := z.EncBinary()
-				_ = yym531
+				yym525 := z.EncBinary()
+				_ = yym525
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Port))
@@ -4586,8 +4536,8 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("port"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym532 := z.EncBinary()
-				_ = yym532
+				yym526 := z.EncBinary()
+				_ = yym526
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Port))
@@ -4595,8 +4545,8 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr523 || yy2arr523 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym534 := z.EncBinary()
-				_ = yym534
+				yym528 := z.EncBinary()
+				_ = yym528
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Address))
@@ -4605,8 +4555,8 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("address"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym535 := z.EncBinary()
-				_ = yym535
+				yym529 := z.EncBinary()
+				_ = yym529
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Address))
@@ -4614,8 +4564,8 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr523 || yy2arr523 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym537 := z.EncBinary()
-				_ = yym537
+				yym531 := z.EncBinary()
+				_ = yym531
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.AlgorithmProvider))
@@ -4624,8 +4574,8 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("algorithmProvider"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym538 := z.EncBinary()
-				_ = yym538
+				yym532 := z.EncBinary()
+				_ = yym532
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.AlgorithmProvider))
@@ -4633,8 +4583,8 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr523 || yy2arr523 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym540 := z.EncBinary()
-				_ = yym540
+				yym534 := z.EncBinary()
+				_ = yym534
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.PolicyConfigFile))
@@ -4643,8 +4593,8 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("policyConfigFile"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym541 := z.EncBinary()
-				_ = yym541
+				yym535 := z.EncBinary()
+				_ = yym535
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.PolicyConfigFile))
@@ -4652,8 +4602,8 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr523 || yy2arr523 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym543 := z.EncBinary()
-				_ = yym543
+				yym537 := z.EncBinary()
+				_ = yym537
 				if false {
 				} else {
 					r.EncodeBool(bool(x.EnableProfiling))
@@ -4662,8 +4612,8 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("enableProfiling"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym544 := z.EncBinary()
-				_ = yym544
+				yym538 := z.EncBinary()
+				_ = yym538
 				if false {
 				} else {
 					r.EncodeBool(bool(x.EnableProfiling))
@@ -4671,8 +4621,8 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr523 || yy2arr523 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym546 := z.EncBinary()
-				_ = yym546
+				yym540 := z.EncBinary()
+				_ = yym540
 				if false {
 				} else {
 					r.EncodeFloat32(float32(x.KubeAPIQPS))
@@ -4681,8 +4631,8 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("kubeAPIQPS"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym547 := z.EncBinary()
-				_ = yym547
+				yym541 := z.EncBinary()
+				_ = yym541
 				if false {
 				} else {
 					r.EncodeFloat32(float32(x.KubeAPIQPS))
@@ -4690,8 +4640,8 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr523 || yy2arr523 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym549 := z.EncBinary()
-				_ = yym549
+				yym543 := z.EncBinary()
+				_ = yym543
 				if false {
 				} else {
 					r.EncodeInt(int64(x.KubeAPIBurst))
@@ -4700,8 +4650,8 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("kubeAPIBurst"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym550 := z.EncBinary()
-				_ = yym550
+				yym544 := z.EncBinary()
+				_ = yym544
 				if false {
 				} else {
 					r.EncodeInt(int64(x.KubeAPIBurst))
@@ -4709,8 +4659,8 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr523 || yy2arr523 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym552 := z.EncBinary()
-				_ = yym552
+				yym546 := z.EncBinary()
+				_ = yym546
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.SchedulerName))
@@ -4719,8 +4669,8 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("schedulerName"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym553 := z.EncBinary()
-				_ = yym553
+				yym547 := z.EncBinary()
+				_ = yym547
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.SchedulerName))
@@ -4728,14 +4678,64 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr523 || yy2arr523 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy555 := &x.LeaderElection
-				yy555.CodecEncodeSelf(e)
+				yy549 := &x.LeaderElection
+				yy549.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("leaderElection"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy556 := &x.LeaderElection
-				yy556.CodecEncodeSelf(e)
+				yy550 := &x.LeaderElection
+				yy550.CodecEncodeSelf(e)
+			}
+			if yyr523 || yy2arr523 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq523[9] {
+					yym552 := z.EncBinary()
+					_ = yym552
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq523[9] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym553 := z.EncBinary()
+					_ = yym553
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr523 || yy2arr523 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq523[10] {
+					yym555 := z.EncBinary()
+					_ = yym555
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq523[10] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym556 := z.EncBinary()
+					_ = yym556
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
 			}
 			if yyr523 || yy2arr523 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
@@ -4798,18 +4798,6 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.
 		yys559 := string(yys559Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys559 {
-		case "kind":
-			if r.TryDecodeAsNil() {
-				x.Kind = ""
-			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
-			}
 		case "port":
 			if r.TryDecodeAsNil() {
 				x.Port = 0
@@ -4862,8 +4850,20 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.
 			if r.TryDecodeAsNil() {
 				x.LeaderElection = LeaderElectionConfiguration{}
 			} else {
-				yyv570 := &x.LeaderElection
-				yyv570.CodecDecodeSelf(d)
+				yyv568 := &x.LeaderElection
+				yyv568.CodecDecodeSelf(d)
+			}
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys559)
@@ -4879,38 +4879,6 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	var yyj571 int
 	var yyb571 bool
 	var yyhl571 bool = l >= 0
-	yyj571++
-	if yyhl571 {
-		yyb571 = yyj571 > l
-	} else {
-		yyb571 = r.CheckBreak()
-	}
-	if yyb571 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Kind = ""
-	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj571++
-	if yyhl571 {
-		yyb571 = yyj571 > l
-	} else {
-		yyb571 = r.CheckBreak()
-	}
-	if yyb571 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
-	}
 	yyj571++
 	if yyhl571 {
 		yyb571 = yyj571 > l
@@ -5053,8 +5021,40 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	if r.TryDecodeAsNil() {
 		x.LeaderElection = LeaderElectionConfiguration{}
 	} else {
-		yyv582 := &x.LeaderElection
-		yyv582.CodecDecodeSelf(d)
+		yyv580 := &x.LeaderElection
+		yyv580.CodecDecodeSelf(d)
+	}
+	yyj571++
+	if yyhl571 {
+		yyb571 = yyj571 > l
+	} else {
+		yyb571 = r.CheckBreak()
+	}
+	if yyb571 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj571++
+	if yyhl571 {
+		yyb571 = yyj571 > l
+	} else {
+		yyb571 = r.CheckBreak()
+	}
+	if yyb571 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
 	}
 	for {
 		yyj571++

--- a/pkg/apis/componentconfig/v1alpha1/types.generated.go
+++ b/pkg/apis/componentconfig/v1alpha1/types.generated.go
@@ -84,8 +84,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2 [18]bool
 			_, _, _ = yysep2, yyq2, yy2arr2
 			const yyr2 bool = false
-			yyq2[0] = x.Kind != ""
-			yyq2[1] = x.APIVersion != ""
+			yyq2[16] = x.Kind != ""
+			yyq2[17] = x.APIVersion != ""
 			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(18)
@@ -101,58 +101,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[0] {
-					yym4 := z.EncBinary()
-					_ = yym4
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym5 := z.EncBinary()
-					_ = yym5
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[1] {
-					yym7 := z.EncBinary()
-					_ = yym7
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym8 := z.EncBinary()
-					_ = yym8
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym10 := z.EncBinary()
-				_ = yym10
+				yym4 := z.EncBinary()
+				_ = yym4
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.BindAddress))
@@ -161,8 +111,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("bindAddress"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym11 := z.EncBinary()
-				_ = yym11
+				yym5 := z.EncBinary()
+				_ = yym5
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.BindAddress))
@@ -170,8 +120,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym13 := z.EncBinary()
-				_ = yym13
+				yym7 := z.EncBinary()
+				_ = yym7
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.HealthzBindAddress))
@@ -180,8 +130,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("healthzBindAddress"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym14 := z.EncBinary()
-				_ = yym14
+				yym8 := z.EncBinary()
+				_ = yym8
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.HealthzBindAddress))
@@ -189,8 +139,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym16 := z.EncBinary()
-				_ = yym16
+				yym10 := z.EncBinary()
+				_ = yym10
 				if false {
 				} else {
 					r.EncodeInt(int64(x.HealthzPort))
@@ -199,8 +149,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("healthzPort"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym17 := z.EncBinary()
-				_ = yym17
+				yym11 := z.EncBinary()
+				_ = yym11
 				if false {
 				} else {
 					r.EncodeInt(int64(x.HealthzPort))
@@ -208,8 +158,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym19 := z.EncBinary()
-				_ = yym19
+				yym13 := z.EncBinary()
+				_ = yym13
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.HostnameOverride))
@@ -218,8 +168,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("hostnameOverride"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym20 := z.EncBinary()
-				_ = yym20
+				yym14 := z.EncBinary()
+				_ = yym14
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.HostnameOverride))
@@ -230,12 +180,12 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.IPTablesMasqueradeBit == nil {
 					r.EncodeNil()
 				} else {
-					yy22 := *x.IPTablesMasqueradeBit
-					yym23 := z.EncBinary()
-					_ = yym23
+					yy16 := *x.IPTablesMasqueradeBit
+					yym17 := z.EncBinary()
+					_ = yym17
 					if false {
 					} else {
-						r.EncodeInt(int64(yy22))
+						r.EncodeInt(int64(yy16))
 					}
 				}
 			} else {
@@ -245,46 +195,46 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.IPTablesMasqueradeBit == nil {
 					r.EncodeNil()
 				} else {
-					yy24 := *x.IPTablesMasqueradeBit
-					yym25 := z.EncBinary()
-					_ = yym25
+					yy18 := *x.IPTablesMasqueradeBit
+					yym19 := z.EncBinary()
+					_ = yym19
 					if false {
 					} else {
-						r.EncodeInt(int64(yy24))
+						r.EncodeInt(int64(yy18))
 					}
 				}
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy27 := &x.IPTablesSyncPeriod
-				yym28 := z.EncBinary()
-				_ = yym28
+				yy21 := &x.IPTablesSyncPeriod
+				yym22 := z.EncBinary()
+				_ = yym22
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy27) {
-				} else if !yym28 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy27)
+				} else if z.HasExtensions() && z.EncExt(yy21) {
+				} else if !yym22 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy21)
 				} else {
-					z.EncFallback(yy27)
+					z.EncFallback(yy21)
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("iptablesSyncPeriodSeconds"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy29 := &x.IPTablesSyncPeriod
-				yym30 := z.EncBinary()
-				_ = yym30
+				yy23 := &x.IPTablesSyncPeriod
+				yym24 := z.EncBinary()
+				_ = yym24
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy29) {
-				} else if !yym30 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy29)
+				} else if z.HasExtensions() && z.EncExt(yy23) {
+				} else if !yym24 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy23)
 				} else {
-					z.EncFallback(yy29)
+					z.EncFallback(yy23)
 				}
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym32 := z.EncBinary()
-				_ = yym32
+				yym26 := z.EncBinary()
+				_ = yym26
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.KubeconfigPath))
@@ -293,8 +243,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("kubeconfigPath"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym33 := z.EncBinary()
-				_ = yym33
+				yym27 := z.EncBinary()
+				_ = yym27
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.KubeconfigPath))
@@ -302,8 +252,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym35 := z.EncBinary()
-				_ = yym35
+				yym29 := z.EncBinary()
+				_ = yym29
 				if false {
 				} else {
 					r.EncodeBool(bool(x.MasqueradeAll))
@@ -312,8 +262,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("masqueradeAll"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym36 := z.EncBinary()
-				_ = yym36
+				yym30 := z.EncBinary()
+				_ = yym30
 				if false {
 				} else {
 					r.EncodeBool(bool(x.MasqueradeAll))
@@ -321,8 +271,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym38 := z.EncBinary()
-				_ = yym38
+				yym32 := z.EncBinary()
+				_ = yym32
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Master))
@@ -331,8 +281,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("master"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym39 := z.EncBinary()
-				_ = yym39
+				yym33 := z.EncBinary()
+				_ = yym33
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Master))
@@ -343,12 +293,12 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.OOMScoreAdj == nil {
 					r.EncodeNil()
 				} else {
-					yy41 := *x.OOMScoreAdj
-					yym42 := z.EncBinary()
-					_ = yym42
+					yy35 := *x.OOMScoreAdj
+					yym36 := z.EncBinary()
+					_ = yym36
 					if false {
 					} else {
-						r.EncodeInt(int64(yy41))
+						r.EncodeInt(int64(yy35))
 					}
 				}
 			} else {
@@ -358,12 +308,12 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.OOMScoreAdj == nil {
 					r.EncodeNil()
 				} else {
-					yy43 := *x.OOMScoreAdj
-					yym44 := z.EncBinary()
-					_ = yym44
+					yy37 := *x.OOMScoreAdj
+					yym38 := z.EncBinary()
+					_ = yym38
 					if false {
 					} else {
-						r.EncodeInt(int64(yy43))
+						r.EncodeInt(int64(yy37))
 					}
 				}
 			}
@@ -378,8 +328,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym47 := z.EncBinary()
-				_ = yym47
+				yym41 := z.EncBinary()
+				_ = yym41
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.PortRange))
@@ -388,8 +338,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("portRange"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym48 := z.EncBinary()
-				_ = yym48
+				yym42 := z.EncBinary()
+				_ = yym42
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.PortRange))
@@ -397,8 +347,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym50 := z.EncBinary()
-				_ = yym50
+				yym44 := z.EncBinary()
+				_ = yym44
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ResourceContainer))
@@ -407,8 +357,8 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("resourceContainer"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym51 := z.EncBinary()
-				_ = yym51
+				yym45 := z.EncBinary()
+				_ = yym45
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ResourceContainer))
@@ -416,21 +366,53 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy53 := &x.UDPIdleTimeout
-				yym54 := z.EncBinary()
-				_ = yym54
+				yy47 := &x.UDPIdleTimeout
+				yym48 := z.EncBinary()
+				_ = yym48
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy53) {
-				} else if !yym54 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy53)
+				} else if z.HasExtensions() && z.EncExt(yy47) {
+				} else if !yym48 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy47)
 				} else {
-					z.EncFallback(yy53)
+					z.EncFallback(yy47)
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("udpTimeoutMilliseconds"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy55 := &x.UDPIdleTimeout
+				yy49 := &x.UDPIdleTimeout
+				yym50 := z.EncBinary()
+				_ = yym50
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy49) {
+				} else if !yym50 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy49)
+				} else {
+					z.EncFallback(yy49)
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym52 := z.EncBinary()
+				_ = yym52
+				if false {
+				} else {
+					r.EncodeInt(int64(x.ConntrackMax))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("conntrackMax"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym53 := z.EncBinary()
+				_ = yym53
+				if false {
+				} else {
+					r.EncodeInt(int64(x.ConntrackMax))
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yy55 := &x.ConntrackTCPEstablishedTimeout
 				yym56 := z.EncBinary()
 				_ = yym56
 				if false {
@@ -440,51 +422,69 @@ func (x *KubeProxyConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				} else {
 					z.EncFallback(yy55)
 				}
-			}
-			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym58 := z.EncBinary()
-				_ = yym58
-				if false {
-				} else {
-					r.EncodeInt(int64(x.ConntrackMax))
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("conntrackMax"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym59 := z.EncBinary()
-				_ = yym59
-				if false {
-				} else {
-					r.EncodeInt(int64(x.ConntrackMax))
-				}
-			}
-			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy61 := &x.ConntrackTCPEstablishedTimeout
-				yym62 := z.EncBinary()
-				_ = yym62
-				if false {
-				} else if z.HasExtensions() && z.EncExt(yy61) {
-				} else if !yym62 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy61)
-				} else {
-					z.EncFallback(yy61)
-				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("conntrackTCPEstablishedTimeout"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy63 := &x.ConntrackTCPEstablishedTimeout
-				yym64 := z.EncBinary()
-				_ = yym64
+				yy57 := &x.ConntrackTCPEstablishedTimeout
+				yym58 := z.EncBinary()
+				_ = yym58
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy63) {
-				} else if !yym64 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy63)
+				} else if z.HasExtensions() && z.EncExt(yy57) {
+				} else if !yym58 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy57)
 				} else {
-					z.EncFallback(yy63)
+					z.EncFallback(yy57)
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2[16] {
+					yym60 := z.EncBinary()
+					_ = yym60
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2[16] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym61 := z.EncBinary()
+					_ = yym61
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2[17] {
+					yym63 := z.EncBinary()
+					_ = yym63
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2[17] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym64 := z.EncBinary()
+					_ = yym64
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr2 || yy2arr2 {
@@ -548,18 +548,6 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 		yys67 := string(yys67Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys67 {
-		case "kind":
-			if r.TryDecodeAsNil() {
-				x.Kind = ""
-			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
-			}
 		case "bindAddress":
 			if r.TryDecodeAsNil() {
 				x.BindAddress = ""
@@ -593,8 +581,8 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				if x.IPTablesMasqueradeBit == nil {
 					x.IPTablesMasqueradeBit = new(int32)
 				}
-				yym75 := z.DecBinary()
-				_ = yym75
+				yym73 := z.DecBinary()
+				_ = yym73
 				if false {
 				} else {
 					*((*int32)(x.IPTablesMasqueradeBit)) = int32(r.DecodeInt(32))
@@ -604,15 +592,15 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			if r.TryDecodeAsNil() {
 				x.IPTablesSyncPeriod = pkg1_unversioned.Duration{}
 			} else {
-				yyv76 := &x.IPTablesSyncPeriod
-				yym77 := z.DecBinary()
-				_ = yym77
+				yyv74 := &x.IPTablesSyncPeriod
+				yym75 := z.DecBinary()
+				_ = yym75
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv76) {
-				} else if !yym77 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv76)
+				} else if z.HasExtensions() && z.DecExt(yyv74) {
+				} else if !yym75 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv74)
 				} else {
-					z.DecFallback(yyv76, false)
+					z.DecFallback(yyv74, false)
 				}
 			}
 		case "kubeconfigPath":
@@ -642,8 +630,8 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				if x.OOMScoreAdj == nil {
 					x.OOMScoreAdj = new(int32)
 				}
-				yym82 := z.DecBinary()
-				_ = yym82
+				yym80 := z.DecBinary()
+				_ = yym80
 				if false {
 				} else {
 					*((*int32)(x.OOMScoreAdj)) = int32(r.DecodeInt(32))
@@ -671,15 +659,15 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			if r.TryDecodeAsNil() {
 				x.UDPIdleTimeout = pkg1_unversioned.Duration{}
 			} else {
-				yyv86 := &x.UDPIdleTimeout
-				yym87 := z.DecBinary()
-				_ = yym87
+				yyv84 := &x.UDPIdleTimeout
+				yym85 := z.DecBinary()
+				_ = yym85
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv86) {
-				} else if !yym87 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv86)
+				} else if z.HasExtensions() && z.DecExt(yyv84) {
+				} else if !yym85 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv84)
 				} else {
-					z.DecFallback(yyv86, false)
+					z.DecFallback(yyv84, false)
 				}
 			}
 		case "conntrackMax":
@@ -692,16 +680,28 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			if r.TryDecodeAsNil() {
 				x.ConntrackTCPEstablishedTimeout = pkg1_unversioned.Duration{}
 			} else {
-				yyv89 := &x.ConntrackTCPEstablishedTimeout
-				yym90 := z.DecBinary()
-				_ = yym90
+				yyv87 := &x.ConntrackTCPEstablishedTimeout
+				yym88 := z.DecBinary()
+				_ = yym88
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv89) {
-				} else if !yym90 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv89)
+				} else if z.HasExtensions() && z.DecExt(yyv87) {
+				} else if !yym88 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv87)
 				} else {
-					z.DecFallback(yyv89, false)
+					z.DecFallback(yyv87, false)
 				}
+			}
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys67)
@@ -717,38 +717,6 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 	var yyj91 int
 	var yyb91 bool
 	var yyhl91 bool = l >= 0
-	yyj91++
-	if yyhl91 {
-		yyb91 = yyj91 > l
-	} else {
-		yyb91 = r.CheckBreak()
-	}
-	if yyb91 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Kind = ""
-	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj91++
-	if yyhl91 {
-		yyb91 = yyj91 > l
-	} else {
-		yyb91 = r.CheckBreak()
-	}
-	if yyb91 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
-	}
 	yyj91++
 	if yyhl91 {
 		yyb91 = yyj91 > l
@@ -832,8 +800,8 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		if x.IPTablesMasqueradeBit == nil {
 			x.IPTablesMasqueradeBit = new(int32)
 		}
-		yym99 := z.DecBinary()
-		_ = yym99
+		yym97 := z.DecBinary()
+		_ = yym97
 		if false {
 		} else {
 			*((*int32)(x.IPTablesMasqueradeBit)) = int32(r.DecodeInt(32))
@@ -853,15 +821,15 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 	if r.TryDecodeAsNil() {
 		x.IPTablesSyncPeriod = pkg1_unversioned.Duration{}
 	} else {
-		yyv100 := &x.IPTablesSyncPeriod
-		yym101 := z.DecBinary()
-		_ = yym101
+		yyv98 := &x.IPTablesSyncPeriod
+		yym99 := z.DecBinary()
+		_ = yym99
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv100) {
-		} else if !yym101 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv100)
+		} else if z.HasExtensions() && z.DecExt(yyv98) {
+		} else if !yym99 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv98)
 		} else {
-			z.DecFallback(yyv100, false)
+			z.DecFallback(yyv98, false)
 		}
 	}
 	yyj91++
@@ -931,8 +899,8 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 		if x.OOMScoreAdj == nil {
 			x.OOMScoreAdj = new(int32)
 		}
-		yym106 := z.DecBinary()
-		_ = yym106
+		yym104 := z.DecBinary()
+		_ = yym104
 		if false {
 		} else {
 			*((*int32)(x.OOMScoreAdj)) = int32(r.DecodeInt(32))
@@ -1000,15 +968,15 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 	if r.TryDecodeAsNil() {
 		x.UDPIdleTimeout = pkg1_unversioned.Duration{}
 	} else {
-		yyv110 := &x.UDPIdleTimeout
-		yym111 := z.DecBinary()
-		_ = yym111
+		yyv108 := &x.UDPIdleTimeout
+		yym109 := z.DecBinary()
+		_ = yym109
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv110) {
-		} else if !yym111 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv110)
+		} else if z.HasExtensions() && z.DecExt(yyv108) {
+		} else if !yym109 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv108)
 		} else {
-			z.DecFallback(yyv110, false)
+			z.DecFallback(yyv108, false)
 		}
 	}
 	yyj91++
@@ -1041,16 +1009,48 @@ func (x *KubeProxyConfiguration) codecDecodeSelfFromArray(l int, d *codec1978.De
 	if r.TryDecodeAsNil() {
 		x.ConntrackTCPEstablishedTimeout = pkg1_unversioned.Duration{}
 	} else {
-		yyv113 := &x.ConntrackTCPEstablishedTimeout
-		yym114 := z.DecBinary()
-		_ = yym114
+		yyv111 := &x.ConntrackTCPEstablishedTimeout
+		yym112 := z.DecBinary()
+		_ = yym112
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv113) {
-		} else if !yym114 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv113)
+		} else if z.HasExtensions() && z.DecExt(yyv111) {
+		} else if !yym112 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv111)
 		} else {
-			z.DecFallback(yyv113, false)
+			z.DecFallback(yyv111, false)
 		}
+	}
+	yyj91++
+	if yyhl91 {
+		yyb91 = yyj91 > l
+	} else {
+		yyb91 = r.CheckBreak()
+	}
+	if yyb91 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj91++
+	if yyhl91 {
+		yyb91 = yyj91 > l
+	} else {
+		yyb91 = r.CheckBreak()
+	}
+	if yyb91 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
 	}
 	for {
 		yyj91++
@@ -1111,8 +1111,8 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq118 [11]bool
 			_, _, _ = yysep118, yyq118, yy2arr118
 			const yyr118 bool = false
-			yyq118[0] = x.Kind != ""
-			yyq118[1] = x.APIVersion != ""
+			yyq118[9] = x.Kind != ""
+			yyq118[10] = x.APIVersion != ""
 			var yynn118 int
 			if yyr118 || yy2arr118 {
 				r.EncodeArrayStart(11)
@@ -1128,58 +1128,8 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr118 || yy2arr118 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq118[0] {
-					yym120 := z.EncBinary()
-					_ = yym120
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq118[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym121 := z.EncBinary()
-					_ = yym121
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr118 || yy2arr118 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq118[1] {
-					yym123 := z.EncBinary()
-					_ = yym123
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq118[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym124 := z.EncBinary()
-					_ = yym124
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr118 || yy2arr118 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym126 := z.EncBinary()
-				_ = yym126
+				yym120 := z.EncBinary()
+				_ = yym120
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Port))
@@ -1188,8 +1138,8 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("port"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym127 := z.EncBinary()
-				_ = yym127
+				yym121 := z.EncBinary()
+				_ = yym121
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Port))
@@ -1197,8 +1147,8 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr118 || yy2arr118 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym129 := z.EncBinary()
-				_ = yym129
+				yym123 := z.EncBinary()
+				_ = yym123
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Address))
@@ -1207,8 +1157,8 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("address"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym130 := z.EncBinary()
-				_ = yym130
+				yym124 := z.EncBinary()
+				_ = yym124
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Address))
@@ -1216,8 +1166,8 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr118 || yy2arr118 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym132 := z.EncBinary()
-				_ = yym132
+				yym126 := z.EncBinary()
+				_ = yym126
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.AlgorithmProvider))
@@ -1226,8 +1176,8 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("algorithmProvider"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym133 := z.EncBinary()
-				_ = yym133
+				yym127 := z.EncBinary()
+				_ = yym127
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.AlgorithmProvider))
@@ -1235,8 +1185,8 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr118 || yy2arr118 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym135 := z.EncBinary()
-				_ = yym135
+				yym129 := z.EncBinary()
+				_ = yym129
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.PolicyConfigFile))
@@ -1245,8 +1195,8 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("policyConfigFile"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym136 := z.EncBinary()
-				_ = yym136
+				yym130 := z.EncBinary()
+				_ = yym130
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.PolicyConfigFile))
@@ -1257,12 +1207,12 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.EnableProfiling == nil {
 					r.EncodeNil()
 				} else {
-					yy138 := *x.EnableProfiling
-					yym139 := z.EncBinary()
-					_ = yym139
+					yy132 := *x.EnableProfiling
+					yym133 := z.EncBinary()
+					_ = yym133
 					if false {
 					} else {
-						r.EncodeBool(bool(yy138))
+						r.EncodeBool(bool(yy132))
 					}
 				}
 			} else {
@@ -1272,19 +1222,19 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.EnableProfiling == nil {
 					r.EncodeNil()
 				} else {
-					yy140 := *x.EnableProfiling
-					yym141 := z.EncBinary()
-					_ = yym141
+					yy134 := *x.EnableProfiling
+					yym135 := z.EncBinary()
+					_ = yym135
 					if false {
 					} else {
-						r.EncodeBool(bool(yy140))
+						r.EncodeBool(bool(yy134))
 					}
 				}
 			}
 			if yyr118 || yy2arr118 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym143 := z.EncBinary()
-				_ = yym143
+				yym137 := z.EncBinary()
+				_ = yym137
 				if false {
 				} else {
 					r.EncodeFloat32(float32(x.KubeAPIQPS))
@@ -1293,8 +1243,8 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("kubeAPIQPS"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym144 := z.EncBinary()
-				_ = yym144
+				yym138 := z.EncBinary()
+				_ = yym138
 				if false {
 				} else {
 					r.EncodeFloat32(float32(x.KubeAPIQPS))
@@ -1302,8 +1252,8 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr118 || yy2arr118 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym146 := z.EncBinary()
-				_ = yym146
+				yym140 := z.EncBinary()
+				_ = yym140
 				if false {
 				} else {
 					r.EncodeInt(int64(x.KubeAPIBurst))
@@ -1312,8 +1262,8 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("kubeAPIBurst"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym147 := z.EncBinary()
-				_ = yym147
+				yym141 := z.EncBinary()
+				_ = yym141
 				if false {
 				} else {
 					r.EncodeInt(int64(x.KubeAPIBurst))
@@ -1321,8 +1271,8 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr118 || yy2arr118 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym149 := z.EncBinary()
-				_ = yym149
+				yym143 := z.EncBinary()
+				_ = yym143
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.SchedulerName))
@@ -1331,8 +1281,8 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("schedulerName"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym150 := z.EncBinary()
-				_ = yym150
+				yym144 := z.EncBinary()
+				_ = yym144
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.SchedulerName))
@@ -1340,14 +1290,64 @@ func (x *KubeSchedulerConfiguration) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr118 || yy2arr118 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy152 := &x.LeaderElection
-				yy152.CodecEncodeSelf(e)
+				yy146 := &x.LeaderElection
+				yy146.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("leaderElection"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy153 := &x.LeaderElection
-				yy153.CodecEncodeSelf(e)
+				yy147 := &x.LeaderElection
+				yy147.CodecEncodeSelf(e)
+			}
+			if yyr118 || yy2arr118 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq118[9] {
+					yym149 := z.EncBinary()
+					_ = yym149
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq118[9] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym150 := z.EncBinary()
+					_ = yym150
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr118 || yy2arr118 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq118[10] {
+					yym152 := z.EncBinary()
+					_ = yym152
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq118[10] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym153 := z.EncBinary()
+					_ = yym153
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
 			}
 			if yyr118 || yy2arr118 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
@@ -1410,18 +1410,6 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.
 		yys156 := string(yys156Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys156 {
-		case "kind":
-			if r.TryDecodeAsNil() {
-				x.Kind = ""
-			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
-			}
 		case "port":
 			if r.TryDecodeAsNil() {
 				x.Port = 0
@@ -1455,8 +1443,8 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.
 				if x.EnableProfiling == nil {
 					x.EnableProfiling = new(bool)
 				}
-				yym164 := z.DecBinary()
-				_ = yym164
+				yym162 := z.DecBinary()
+				_ = yym162
 				if false {
 				} else {
 					*((*bool)(x.EnableProfiling)) = r.DecodeBool()
@@ -1484,8 +1472,20 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromMap(l int, d *codec1978.
 			if r.TryDecodeAsNil() {
 				x.LeaderElection = LeaderElectionConfiguration{}
 			} else {
-				yyv168 := &x.LeaderElection
-				yyv168.CodecDecodeSelf(d)
+				yyv166 := &x.LeaderElection
+				yyv166.CodecDecodeSelf(d)
+			}
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys156)
@@ -1501,38 +1501,6 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	var yyj169 int
 	var yyb169 bool
 	var yyhl169 bool = l >= 0
-	yyj169++
-	if yyhl169 {
-		yyb169 = yyj169 > l
-	} else {
-		yyb169 = r.CheckBreak()
-	}
-	if yyb169 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Kind = ""
-	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj169++
-	if yyhl169 {
-		yyb169 = yyj169 > l
-	} else {
-		yyb169 = r.CheckBreak()
-	}
-	if yyb169 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
-	}
 	yyj169++
 	if yyhl169 {
 		yyb169 = yyj169 > l
@@ -1616,8 +1584,8 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 		if x.EnableProfiling == nil {
 			x.EnableProfiling = new(bool)
 		}
-		yym177 := z.DecBinary()
-		_ = yym177
+		yym175 := z.DecBinary()
+		_ = yym175
 		if false {
 		} else {
 			*((*bool)(x.EnableProfiling)) = r.DecodeBool()
@@ -1685,8 +1653,40 @@ func (x *KubeSchedulerConfiguration) codecDecodeSelfFromArray(l int, d *codec197
 	if r.TryDecodeAsNil() {
 		x.LeaderElection = LeaderElectionConfiguration{}
 	} else {
-		yyv181 := &x.LeaderElection
-		yyv181.CodecDecodeSelf(d)
+		yyv179 := &x.LeaderElection
+		yyv179.CodecDecodeSelf(d)
+	}
+	yyj169++
+	if yyhl169 {
+		yyb169 = yyj169 > l
+	} else {
+		yyb169 = r.CheckBreak()
+	}
+	if yyb169 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj169++
+	if yyhl169 {
+		yyb169 = yyj169 > l
+	} else {
+		yyb169 = r.CheckBreak()
+	}
+	if yyb169 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
 	}
 	for {
 		yyj169++

--- a/pkg/apis/extensions/types.generated.go
+++ b/pkg/apis/extensions/types.generated.go
@@ -493,11 +493,11 @@ func (x *Scale) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq31 [5]bool
 			_, _, _ = yysep31, yyq31, yy2arr31
 			const yyr31 bool = false
-			yyq31[0] = x.Kind != ""
-			yyq31[1] = x.APIVersion != ""
+			yyq31[0] = true
+			yyq31[1] = true
 			yyq31[2] = true
-			yyq31[3] = true
-			yyq31[4] = true
+			yyq31[3] = x.Kind != ""
+			yyq31[4] = x.APIVersion != ""
 			var yynn31 int
 			if yyr31 || yy2arr31 {
 				r.EncodeArrayStart(5)
@@ -514,57 +514,41 @@ func (x *Scale) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr31 || yy2arr31 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq31[0] {
-					yym33 := z.EncBinary()
-					_ = yym33
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy33 := &x.ObjectMeta
+					yy33.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq31[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym34 := z.EncBinary()
-					_ = yym34
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy34 := &x.ObjectMeta
+					yy34.CodecEncodeSelf(e)
 				}
 			}
 			if yyr31 || yy2arr31 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq31[1] {
-					yym36 := z.EncBinary()
-					_ = yym36
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy36 := &x.Spec
+					yy36.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq31[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym37 := z.EncBinary()
-					_ = yym37
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy37 := &x.Spec
+					yy37.CodecEncodeSelf(e)
 				}
 			}
 			if yyr31 || yy2arr31 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq31[2] {
-					yy39 := &x.ObjectMeta
+					yy39 := &x.Status
 					yy39.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
@@ -572,44 +556,60 @@ func (x *Scale) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq31[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy40 := &x.ObjectMeta
+					yy40 := &x.Status
 					yy40.CodecEncodeSelf(e)
 				}
 			}
 			if yyr31 || yy2arr31 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq31[3] {
-					yy42 := &x.Spec
-					yy42.CodecEncodeSelf(e)
+					yym42 := z.EncBinary()
+					_ = yym42
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq31[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy43 := &x.Spec
-					yy43.CodecEncodeSelf(e)
+					yym43 := z.EncBinary()
+					_ = yym43
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				}
 			}
 			if yyr31 || yy2arr31 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq31[4] {
-					yy45 := &x.Status
-					yy45.CodecEncodeSelf(e)
+					yym45 := z.EncBinary()
+					_ = yym45
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq31[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy46 := &x.Status
-					yy46.CodecEncodeSelf(e)
+					yym46 := z.EncBinary()
+					_ = yym46
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr31 || yy2arr31 {
@@ -673,6 +673,27 @@ func (x *Scale) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys49 := string(yys49Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys49 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_api.ObjectMeta{}
+			} else {
+				yyv50 := &x.ObjectMeta
+				yyv50.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = ScaleSpec{}
+			} else {
+				yyv51 := &x.Spec
+				yyv51.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = ScaleStatus{}
+			} else {
+				yyv52 := &x.Status
+				yyv52.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -684,27 +705,6 @@ func (x *Scale) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = pkg2_api.ObjectMeta{}
-			} else {
-				yyv52 := &x.ObjectMeta
-				yyv52.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = ScaleSpec{}
-			} else {
-				yyv53 := &x.Spec
-				yyv53.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = ScaleStatus{}
-			} else {
-				yyv54 := &x.Status
-				yyv54.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys49)
@@ -720,6 +720,57 @@ func (x *Scale) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj55 int
 	var yyb55 bool
 	var yyhl55 bool = l >= 0
+	yyj55++
+	if yyhl55 {
+		yyb55 = yyj55 > l
+	} else {
+		yyb55 = r.CheckBreak()
+	}
+	if yyb55 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_api.ObjectMeta{}
+	} else {
+		yyv56 := &x.ObjectMeta
+		yyv56.CodecDecodeSelf(d)
+	}
+	yyj55++
+	if yyhl55 {
+		yyb55 = yyj55 > l
+	} else {
+		yyb55 = r.CheckBreak()
+	}
+	if yyb55 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = ScaleSpec{}
+	} else {
+		yyv57 := &x.Spec
+		yyv57.CodecDecodeSelf(d)
+	}
+	yyj55++
+	if yyhl55 {
+		yyb55 = yyj55 > l
+	} else {
+		yyb55 = r.CheckBreak()
+	}
+	if yyb55 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = ScaleStatus{}
+	} else {
+		yyv58 := &x.Status
+		yyv58.CodecDecodeSelf(d)
+	}
 	yyj55++
 	if yyhl55 {
 		yyb55 = yyj55 > l
@@ -751,57 +802,6 @@ func (x *Scale) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj55++
-	if yyhl55 {
-		yyb55 = yyj55 > l
-	} else {
-		yyb55 = r.CheckBreak()
-	}
-	if yyb55 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = pkg2_api.ObjectMeta{}
-	} else {
-		yyv58 := &x.ObjectMeta
-		yyv58.CodecDecodeSelf(d)
-	}
-	yyj55++
-	if yyhl55 {
-		yyb55 = yyj55 > l
-	} else {
-		yyb55 = r.CheckBreak()
-	}
-	if yyb55 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = ScaleSpec{}
-	} else {
-		yyv59 := &x.Spec
-		yyv59.CodecDecodeSelf(d)
-	}
-	yyj55++
-	if yyhl55 {
-		yyb55 = yyj55 > l
-	} else {
-		yyb55 = r.CheckBreak()
-	}
-	if yyb55 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = ScaleStatus{}
-	} else {
-		yyv60 := &x.Status
-		yyv60.CodecDecodeSelf(d)
 	}
 	for {
 		yyj55++
@@ -3136,11 +3136,11 @@ func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq250 [5]bool
 			_, _, _ = yysep250, yyq250, yy2arr250
 			const yyr250 bool = false
-			yyq250[0] = x.Kind != ""
-			yyq250[1] = x.APIVersion != ""
+			yyq250[0] = true
+			yyq250[1] = true
 			yyq250[2] = true
-			yyq250[3] = true
-			yyq250[4] = true
+			yyq250[3] = x.Kind != ""
+			yyq250[4] = x.APIVersion != ""
 			var yynn250 int
 			if yyr250 || yy2arr250 {
 				r.EncodeArrayStart(5)
@@ -3157,57 +3157,41 @@ func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr250 || yy2arr250 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq250[0] {
-					yym252 := z.EncBinary()
-					_ = yym252
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy252 := &x.ObjectMeta
+					yy252.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq250[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym253 := z.EncBinary()
-					_ = yym253
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy253 := &x.ObjectMeta
+					yy253.CodecEncodeSelf(e)
 				}
 			}
 			if yyr250 || yy2arr250 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq250[1] {
-					yym255 := z.EncBinary()
-					_ = yym255
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy255 := &x.Spec
+					yy255.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq250[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym256 := z.EncBinary()
-					_ = yym256
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy256 := &x.Spec
+					yy256.CodecEncodeSelf(e)
 				}
 			}
 			if yyr250 || yy2arr250 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq250[2] {
-					yy258 := &x.ObjectMeta
+					yy258 := &x.Status
 					yy258.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
@@ -3215,44 +3199,60 @@ func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq250[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy259 := &x.ObjectMeta
+					yy259 := &x.Status
 					yy259.CodecEncodeSelf(e)
 				}
 			}
 			if yyr250 || yy2arr250 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq250[3] {
-					yy261 := &x.Spec
-					yy261.CodecEncodeSelf(e)
+					yym261 := z.EncBinary()
+					_ = yym261
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq250[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy262 := &x.Spec
-					yy262.CodecEncodeSelf(e)
+					yym262 := z.EncBinary()
+					_ = yym262
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				}
 			}
 			if yyr250 || yy2arr250 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq250[4] {
-					yy264 := &x.Status
-					yy264.CodecEncodeSelf(e)
+					yym264 := z.EncBinary()
+					_ = yym264
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq250[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy265 := &x.Status
-					yy265.CodecEncodeSelf(e)
+					yym265 := z.EncBinary()
+					_ = yym265
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr250 || yy2arr250 {
@@ -3316,6 +3316,27 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 		yys268 := string(yys268Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys268 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_api.ObjectMeta{}
+			} else {
+				yyv269 := &x.ObjectMeta
+				yyv269.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = HorizontalPodAutoscalerSpec{}
+			} else {
+				yyv270 := &x.Spec
+				yyv270.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = HorizontalPodAutoscalerStatus{}
+			} else {
+				yyv271 := &x.Status
+				yyv271.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -3327,27 +3348,6 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = pkg2_api.ObjectMeta{}
-			} else {
-				yyv271 := &x.ObjectMeta
-				yyv271.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = HorizontalPodAutoscalerSpec{}
-			} else {
-				yyv272 := &x.Spec
-				yyv272.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = HorizontalPodAutoscalerStatus{}
-			} else {
-				yyv273 := &x.Status
-				yyv273.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys268)
@@ -3363,6 +3363,57 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.D
 	var yyj274 int
 	var yyb274 bool
 	var yyhl274 bool = l >= 0
+	yyj274++
+	if yyhl274 {
+		yyb274 = yyj274 > l
+	} else {
+		yyb274 = r.CheckBreak()
+	}
+	if yyb274 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_api.ObjectMeta{}
+	} else {
+		yyv275 := &x.ObjectMeta
+		yyv275.CodecDecodeSelf(d)
+	}
+	yyj274++
+	if yyhl274 {
+		yyb274 = yyj274 > l
+	} else {
+		yyb274 = r.CheckBreak()
+	}
+	if yyb274 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = HorizontalPodAutoscalerSpec{}
+	} else {
+		yyv276 := &x.Spec
+		yyv276.CodecDecodeSelf(d)
+	}
+	yyj274++
+	if yyhl274 {
+		yyb274 = yyj274 > l
+	} else {
+		yyb274 = r.CheckBreak()
+	}
+	if yyb274 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = HorizontalPodAutoscalerStatus{}
+	} else {
+		yyv277 := &x.Status
+		yyv277.CodecDecodeSelf(d)
+	}
 	yyj274++
 	if yyhl274 {
 		yyb274 = yyj274 > l
@@ -3394,57 +3445,6 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.D
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj274++
-	if yyhl274 {
-		yyb274 = yyj274 > l
-	} else {
-		yyb274 = r.CheckBreak()
-	}
-	if yyb274 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = pkg2_api.ObjectMeta{}
-	} else {
-		yyv277 := &x.ObjectMeta
-		yyv277.CodecDecodeSelf(d)
-	}
-	yyj274++
-	if yyhl274 {
-		yyb274 = yyj274 > l
-	} else {
-		yyb274 = r.CheckBreak()
-	}
-	if yyb274 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = HorizontalPodAutoscalerSpec{}
-	} else {
-		yyv278 := &x.Spec
-		yyv278.CodecDecodeSelf(d)
-	}
-	yyj274++
-	if yyhl274 {
-		yyb274 = yyj274 > l
-	} else {
-		yyb274 = r.CheckBreak()
-	}
-	if yyb274 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = HorizontalPodAutoscalerStatus{}
-	} else {
-		yyv279 := &x.Status
-		yyv279.CodecDecodeSelf(d)
 	}
 	for {
 		yyj274++
@@ -3479,9 +3479,9 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq281 [4]bool
 			_, _, _ = yysep281, yyq281, yy2arr281
 			const yyr281 bool = false
-			yyq281[0] = x.Kind != ""
-			yyq281[1] = x.APIVersion != ""
-			yyq281[2] = true
+			yyq281[0] = true
+			yyq281[2] = x.Kind != ""
+			yyq281[3] = x.APIVersion != ""
 			var yynn281 int
 			if yyr281 || yy2arr281 {
 				r.EncodeArrayStart(4)
@@ -3498,79 +3498,29 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr281 || yy2arr281 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq281[0] {
-					yym283 := z.EncBinary()
-					_ = yym283
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq281[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy283 := &x.ListMeta
 					yym284 := z.EncBinary()
 					_ = yym284
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy283) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr281 || yy2arr281 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq281[1] {
-					yym286 := z.EncBinary()
-					_ = yym286
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq281[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym287 := z.EncBinary()
-					_ = yym287
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr281 || yy2arr281 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq281[2] {
-					yy289 := &x.ListMeta
-					yym290 := z.EncBinary()
-					_ = yym290
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy289) {
-					} else {
-						z.EncFallback(yy289)
+						z.EncFallback(yy283)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq281[2] {
+				if yyq281[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy291 := &x.ListMeta
-					yym292 := z.EncBinary()
-					_ = yym292
+					yy285 := &x.ListMeta
+					yym286 := z.EncBinary()
+					_ = yym286
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy291) {
+					} else if z.HasExtensions() && z.EncExt(yy285) {
 					} else {
-						z.EncFallback(yy291)
+						z.EncFallback(yy285)
 					}
 				}
 			}
@@ -3579,8 +3529,8 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym294 := z.EncBinary()
-					_ = yym294
+					yym288 := z.EncBinary()
+					_ = yym288
 					if false {
 					} else {
 						h.encSliceHorizontalPodAutoscaler(([]HorizontalPodAutoscaler)(x.Items), e)
@@ -3593,11 +3543,61 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym289 := z.EncBinary()
+					_ = yym289
+					if false {
+					} else {
+						h.encSliceHorizontalPodAutoscaler(([]HorizontalPodAutoscaler)(x.Items), e)
+					}
+				}
+			}
+			if yyr281 || yy2arr281 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq281[2] {
+					yym291 := z.EncBinary()
+					_ = yym291
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq281[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym292 := z.EncBinary()
+					_ = yym292
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr281 || yy2arr281 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq281[3] {
+					yym294 := z.EncBinary()
+					_ = yym294
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq281[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym295 := z.EncBinary()
 					_ = yym295
 					if false {
 					} else {
-						h.encSliceHorizontalPodAutoscaler(([]HorizontalPodAutoscaler)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -3662,6 +3662,31 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978
 		yys298 := string(yys298Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys298 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv299 := &x.ListMeta
+				yym300 := z.DecBinary()
+				_ = yym300
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv299) {
+				} else {
+					z.DecFallback(yyv299, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv301 := &x.Items
+				yym302 := z.DecBinary()
+				_ = yym302
+				if false {
+				} else {
+					h.decSliceHorizontalPodAutoscaler((*[]HorizontalPodAutoscaler)(yyv301), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -3673,31 +3698,6 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg1_unversioned.ListMeta{}
-			} else {
-				yyv301 := &x.ListMeta
-				yym302 := z.DecBinary()
-				_ = yym302
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv301) {
-				} else {
-					z.DecFallback(yyv301, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv303 := &x.Items
-				yym304 := z.DecBinary()
-				_ = yym304
-				if false {
-				} else {
-					h.decSliceHorizontalPodAutoscaler((*[]HorizontalPodAutoscaler)(yyv303), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys298)
@@ -3713,6 +3713,51 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromArray(l int, d *codec19
 	var yyj305 int
 	var yyb305 bool
 	var yyhl305 bool = l >= 0
+	yyj305++
+	if yyhl305 {
+		yyb305 = yyj305 > l
+	} else {
+		yyb305 = r.CheckBreak()
+	}
+	if yyb305 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv306 := &x.ListMeta
+		yym307 := z.DecBinary()
+		_ = yym307
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv306) {
+		} else {
+			z.DecFallback(yyv306, false)
+		}
+	}
+	yyj305++
+	if yyhl305 {
+		yyb305 = yyj305 > l
+	} else {
+		yyb305 = r.CheckBreak()
+	}
+	if yyb305 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv308 := &x.Items
+		yym309 := z.DecBinary()
+		_ = yym309
+		if false {
+		} else {
+			h.decSliceHorizontalPodAutoscaler((*[]HorizontalPodAutoscaler)(yyv308), d)
+		}
+	}
 	yyj305++
 	if yyhl305 {
 		yyb305 = yyj305 > l
@@ -3744,51 +3789,6 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromArray(l int, d *codec19
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj305++
-	if yyhl305 {
-		yyb305 = yyj305 > l
-	} else {
-		yyb305 = r.CheckBreak()
-	}
-	if yyb305 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg1_unversioned.ListMeta{}
-	} else {
-		yyv308 := &x.ListMeta
-		yym309 := z.DecBinary()
-		_ = yym309
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv308) {
-		} else {
-			z.DecFallback(yyv308, false)
-		}
-	}
-	yyj305++
-	if yyhl305 {
-		yyb305 = yyj305 > l
-	} else {
-		yyb305 = r.CheckBreak()
-	}
-	if yyb305 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv310 := &x.Items
-		yym311 := z.DecBinary()
-		_ = yym311
-		if false {
-		} else {
-			h.decSliceHorizontalPodAutoscaler((*[]HorizontalPodAutoscaler)(yyv310), d)
-		}
 	}
 	for {
 		yyj305++
@@ -3823,11 +3823,11 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq313 [5]bool
 			_, _, _ = yysep313, yyq313, yy2arr313
 			const yyr313 bool = false
-			yyq313[0] = x.Kind != ""
-			yyq313[1] = x.APIVersion != ""
-			yyq313[2] = true
-			yyq313[3] = x.Description != ""
-			yyq313[4] = len(x.Versions) != 0
+			yyq313[0] = true
+			yyq313[1] = x.Description != ""
+			yyq313[2] = len(x.Versions) != 0
+			yyq313[3] = x.Kind != ""
+			yyq313[4] = x.APIVersion != ""
 			var yynn313 int
 			if yyr313 || yy2arr313 {
 				r.EncodeArrayStart(5)
@@ -3844,26 +3844,18 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr313 || yy2arr313 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq313[0] {
-					yym315 := z.EncBinary()
-					_ = yym315
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy315 := &x.ObjectMeta
+					yy315.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq313[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym316 := z.EncBinary()
-					_ = yym316
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy316 := &x.ObjectMeta
+					yy316.CodecEncodeSelf(e)
 				}
 			}
 			if yyr313 || yy2arr313 {
@@ -3873,7 +3865,7 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym318
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Description))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -3881,31 +3873,47 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq313[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("description"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym319 := z.EncBinary()
 					_ = yym319
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Description))
 					}
 				}
 			}
 			if yyr313 || yy2arr313 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq313[2] {
-					yy321 := &x.ObjectMeta
-					yy321.CodecEncodeSelf(e)
+					if x.Versions == nil {
+						r.EncodeNil()
+					} else {
+						yym321 := z.EncBinary()
+						_ = yym321
+						if false {
+						} else {
+							h.encSliceAPIVersion(([]APIVersion)(x.Versions), e)
+						}
+					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
 				if yyq313[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("versions"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy322 := &x.ObjectMeta
-					yy322.CodecEncodeSelf(e)
+					if x.Versions == nil {
+						r.EncodeNil()
+					} else {
+						yym322 := z.EncBinary()
+						_ = yym322
+						if false {
+						} else {
+							h.encSliceAPIVersion(([]APIVersion)(x.Versions), e)
+						}
+					}
 				}
 			}
 			if yyr313 || yy2arr313 {
@@ -3915,7 +3923,7 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym324
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Description))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -3923,46 +3931,38 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq313[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("description"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym325 := z.EncBinary()
 					_ = yym325
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Description))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
 			if yyr313 || yy2arr313 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq313[4] {
-					if x.Versions == nil {
-						r.EncodeNil()
+					yym327 := z.EncBinary()
+					_ = yym327
+					if false {
 					} else {
-						yym327 := z.EncBinary()
-						_ = yym327
-						if false {
-						} else {
-							h.encSliceAPIVersion(([]APIVersion)(x.Versions), e)
-						}
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq313[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("versions"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if x.Versions == nil {
-						r.EncodeNil()
+					yym328 := z.EncBinary()
+					_ = yym328
+					if false {
 					} else {
-						yym328 := z.EncBinary()
-						_ = yym328
-						if false {
-						} else {
-							h.encSliceAPIVersion(([]APIVersion)(x.Versions), e)
-						}
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -4027,24 +4027,12 @@ func (x *ThirdPartyResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 		yys331 := string(yys331Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys331 {
-		case "kind":
-			if r.TryDecodeAsNil() {
-				x.Kind = ""
-			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
-			}
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv334 := &x.ObjectMeta
-				yyv334.CodecDecodeSelf(d)
+				yyv332 := &x.ObjectMeta
+				yyv332.CodecDecodeSelf(d)
 			}
 		case "description":
 			if r.TryDecodeAsNil() {
@@ -4056,13 +4044,25 @@ func (x *ThirdPartyResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			if r.TryDecodeAsNil() {
 				x.Versions = nil
 			} else {
-				yyv336 := &x.Versions
-				yym337 := z.DecBinary()
-				_ = yym337
+				yyv334 := &x.Versions
+				yym335 := z.DecBinary()
+				_ = yym335
 				if false {
 				} else {
-					h.decSliceAPIVersion((*[]APIVersion)(yyv336), d)
+					h.decSliceAPIVersion((*[]APIVersion)(yyv334), d)
 				}
+			}
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys331)
@@ -4090,42 +4090,10 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.Kind = ""
-	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj338++
-	if yyhl338 {
-		yyb338 = yyj338 > l
-	} else {
-		yyb338 = r.CheckBreak()
-	}
-	if yyb338 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
-	}
-	yyj338++
-	if yyhl338 {
-		yyb338 = yyj338 > l
-	} else {
-		yyb338 = r.CheckBreak()
-	}
-	if yyb338 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv341 := &x.ObjectMeta
-		yyv341.CodecDecodeSelf(d)
+		yyv339 := &x.ObjectMeta
+		yyv339.CodecDecodeSelf(d)
 	}
 	yyj338++
 	if yyhl338 {
@@ -4157,13 +4125,45 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	if r.TryDecodeAsNil() {
 		x.Versions = nil
 	} else {
-		yyv343 := &x.Versions
-		yym344 := z.DecBinary()
-		_ = yym344
+		yyv341 := &x.Versions
+		yym342 := z.DecBinary()
+		_ = yym342
 		if false {
 		} else {
-			h.decSliceAPIVersion((*[]APIVersion)(yyv343), d)
+			h.decSliceAPIVersion((*[]APIVersion)(yyv341), d)
 		}
+	}
+	yyj338++
+	if yyhl338 {
+		yyb338 = yyj338 > l
+	} else {
+		yyb338 = r.CheckBreak()
+	}
+	if yyb338 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj338++
+	if yyhl338 {
+		yyb338 = yyj338 > l
+	} else {
+		yyb338 = r.CheckBreak()
+	}
+	if yyb338 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
 	}
 	for {
 		yyj338++
@@ -4198,9 +4198,9 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq346 [4]bool
 			_, _, _ = yysep346, yyq346, yy2arr346
 			const yyr346 bool = false
-			yyq346[0] = x.Kind != ""
-			yyq346[1] = x.APIVersion != ""
-			yyq346[2] = true
+			yyq346[0] = true
+			yyq346[2] = x.Kind != ""
+			yyq346[3] = x.APIVersion != ""
 			var yynn346 int
 			if yyr346 || yy2arr346 {
 				r.EncodeArrayStart(4)
@@ -4217,79 +4217,29 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr346 || yy2arr346 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq346[0] {
-					yym348 := z.EncBinary()
-					_ = yym348
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq346[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy348 := &x.ListMeta
 					yym349 := z.EncBinary()
 					_ = yym349
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy348) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr346 || yy2arr346 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq346[1] {
-					yym351 := z.EncBinary()
-					_ = yym351
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq346[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym352 := z.EncBinary()
-					_ = yym352
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr346 || yy2arr346 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq346[2] {
-					yy354 := &x.ListMeta
-					yym355 := z.EncBinary()
-					_ = yym355
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy354) {
-					} else {
-						z.EncFallback(yy354)
+						z.EncFallback(yy348)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq346[2] {
+				if yyq346[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy356 := &x.ListMeta
-					yym357 := z.EncBinary()
-					_ = yym357
+					yy350 := &x.ListMeta
+					yym351 := z.EncBinary()
+					_ = yym351
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy356) {
+					} else if z.HasExtensions() && z.EncExt(yy350) {
 					} else {
-						z.EncFallback(yy356)
+						z.EncFallback(yy350)
 					}
 				}
 			}
@@ -4298,8 +4248,8 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym359 := z.EncBinary()
-					_ = yym359
+					yym353 := z.EncBinary()
+					_ = yym353
 					if false {
 					} else {
 						h.encSliceThirdPartyResource(([]ThirdPartyResource)(x.Items), e)
@@ -4312,11 +4262,61 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym354 := z.EncBinary()
+					_ = yym354
+					if false {
+					} else {
+						h.encSliceThirdPartyResource(([]ThirdPartyResource)(x.Items), e)
+					}
+				}
+			}
+			if yyr346 || yy2arr346 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq346[2] {
+					yym356 := z.EncBinary()
+					_ = yym356
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq346[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym357 := z.EncBinary()
+					_ = yym357
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr346 || yy2arr346 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq346[3] {
+					yym359 := z.EncBinary()
+					_ = yym359
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq346[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym360 := z.EncBinary()
 					_ = yym360
 					if false {
 					} else {
-						h.encSliceThirdPartyResource(([]ThirdPartyResource)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -4381,6 +4381,31 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 		yys363 := string(yys363Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys363 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv364 := &x.ListMeta
+				yym365 := z.DecBinary()
+				_ = yym365
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv364) {
+				} else {
+					z.DecFallback(yyv364, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv366 := &x.Items
+				yym367 := z.DecBinary()
+				_ = yym367
+				if false {
+				} else {
+					h.decSliceThirdPartyResource((*[]ThirdPartyResource)(yyv366), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -4392,31 +4417,6 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg1_unversioned.ListMeta{}
-			} else {
-				yyv366 := &x.ListMeta
-				yym367 := z.DecBinary()
-				_ = yym367
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv366) {
-				} else {
-					z.DecFallback(yyv366, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv368 := &x.Items
-				yym369 := z.DecBinary()
-				_ = yym369
-				if false {
-				} else {
-					h.decSliceThirdPartyResource((*[]ThirdPartyResource)(yyv368), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys363)
@@ -4432,6 +4432,51 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromArray(l int, d *codec1978.De
 	var yyj370 int
 	var yyb370 bool
 	var yyhl370 bool = l >= 0
+	yyj370++
+	if yyhl370 {
+		yyb370 = yyj370 > l
+	} else {
+		yyb370 = r.CheckBreak()
+	}
+	if yyb370 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv371 := &x.ListMeta
+		yym372 := z.DecBinary()
+		_ = yym372
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv371) {
+		} else {
+			z.DecFallback(yyv371, false)
+		}
+	}
+	yyj370++
+	if yyhl370 {
+		yyb370 = yyj370 > l
+	} else {
+		yyb370 = r.CheckBreak()
+	}
+	if yyb370 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv373 := &x.Items
+		yym374 := z.DecBinary()
+		_ = yym374
+		if false {
+		} else {
+			h.decSliceThirdPartyResource((*[]ThirdPartyResource)(yyv373), d)
+		}
+	}
 	yyj370++
 	if yyhl370 {
 		yyb370 = yyj370 > l
@@ -4463,51 +4508,6 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromArray(l int, d *codec1978.De
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj370++
-	if yyhl370 {
-		yyb370 = yyj370 > l
-	} else {
-		yyb370 = r.CheckBreak()
-	}
-	if yyb370 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg1_unversioned.ListMeta{}
-	} else {
-		yyv373 := &x.ListMeta
-		yym374 := z.DecBinary()
-		_ = yym374
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv373) {
-		} else {
-			z.DecFallback(yyv373, false)
-		}
-	}
-	yyj370++
-	if yyhl370 {
-		yyb370 = yyj370 > l
-	} else {
-		yyb370 = r.CheckBreak()
-	}
-	if yyb370 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv375 := &x.Items
-		yym376 := z.DecBinary()
-		_ = yym376
-		if false {
-		} else {
-			h.decSliceThirdPartyResource((*[]ThirdPartyResource)(yyv375), d)
-		}
 	}
 	for {
 		yyj370++
@@ -4759,10 +4759,10 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq394 [4]bool
 			_, _, _ = yysep394, yyq394, yy2arr394
 			const yyr394 bool = false
-			yyq394[0] = x.Kind != ""
-			yyq394[1] = x.APIVersion != ""
-			yyq394[2] = true
-			yyq394[3] = len(x.Data) != 0
+			yyq394[0] = true
+			yyq394[1] = len(x.Data) != 0
+			yyq394[2] = x.Kind != ""
+			yyq394[3] = x.APIVersion != ""
 			var yynn394 int
 			if yyr394 || yy2arr394 {
 				r.EncodeArrayStart(4)
@@ -4779,78 +4779,28 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr394 || yy2arr394 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq394[0] {
-					yym396 := z.EncBinary()
-					_ = yym396
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq394[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym397 := z.EncBinary()
-					_ = yym397
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr394 || yy2arr394 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq394[1] {
-					yym399 := z.EncBinary()
-					_ = yym399
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq394[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym400 := z.EncBinary()
-					_ = yym400
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr394 || yy2arr394 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq394[2] {
-					yy402 := &x.ObjectMeta
-					yy402.CodecEncodeSelf(e)
+					yy396 := &x.ObjectMeta
+					yy396.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq394[2] {
+				if yyq394[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy403 := &x.ObjectMeta
-					yy403.CodecEncodeSelf(e)
+					yy397 := &x.ObjectMeta
+					yy397.CodecEncodeSelf(e)
 				}
 			}
 			if yyr394 || yy2arr394 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq394[3] {
+				if yyq394[1] {
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
-						yym405 := z.EncBinary()
-						_ = yym405
+						yym399 := z.EncBinary()
+						_ = yym399
 						if false {
 						} else {
 							r.EncodeStringBytes(codecSelferC_RAW1234, []byte(x.Data))
@@ -4860,19 +4810,69 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq394[3] {
+				if yyq394[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("data"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
-						yym406 := z.EncBinary()
-						_ = yym406
+						yym400 := z.EncBinary()
+						_ = yym400
 						if false {
 						} else {
 							r.EncodeStringBytes(codecSelferC_RAW1234, []byte(x.Data))
 						}
+					}
+				}
+			}
+			if yyr394 || yy2arr394 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq394[2] {
+					yym402 := z.EncBinary()
+					_ = yym402
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq394[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym403 := z.EncBinary()
+					_ = yym403
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr394 || yy2arr394 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq394[3] {
+					yym405 := z.EncBinary()
+					_ = yym405
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq394[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym406 := z.EncBinary()
+					_ = yym406
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -4937,6 +4937,25 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 		yys409 := string(yys409Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys409 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_api.ObjectMeta{}
+			} else {
+				yyv410 := &x.ObjectMeta
+				yyv410.CodecDecodeSelf(d)
+			}
+		case "data":
+			if r.TryDecodeAsNil() {
+				x.Data = nil
+			} else {
+				yyv411 := &x.Data
+				yym412 := z.DecBinary()
+				_ = yym412
+				if false {
+				} else {
+					*yyv411 = r.DecodeBytes(*(*[]byte)(yyv411), false, false)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -4948,25 +4967,6 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = pkg2_api.ObjectMeta{}
-			} else {
-				yyv412 := &x.ObjectMeta
-				yyv412.CodecDecodeSelf(d)
-			}
-		case "data":
-			if r.TryDecodeAsNil() {
-				x.Data = nil
-			} else {
-				yyv413 := &x.Data
-				yym414 := z.DecBinary()
-				_ = yym414
-				if false {
-				} else {
-					*yyv413 = r.DecodeBytes(*(*[]byte)(yyv413), false, false)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys409)
@@ -4982,6 +4982,45 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromArray(l int, d *codec1978.De
 	var yyj415 int
 	var yyb415 bool
 	var yyhl415 bool = l >= 0
+	yyj415++
+	if yyhl415 {
+		yyb415 = yyj415 > l
+	} else {
+		yyb415 = r.CheckBreak()
+	}
+	if yyb415 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_api.ObjectMeta{}
+	} else {
+		yyv416 := &x.ObjectMeta
+		yyv416.CodecDecodeSelf(d)
+	}
+	yyj415++
+	if yyhl415 {
+		yyb415 = yyj415 > l
+	} else {
+		yyb415 = r.CheckBreak()
+	}
+	if yyb415 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Data = nil
+	} else {
+		yyv417 := &x.Data
+		yym418 := z.DecBinary()
+		_ = yym418
+		if false {
+		} else {
+			*yyv417 = r.DecodeBytes(*(*[]byte)(yyv417), false, false)
+		}
+	}
 	yyj415++
 	if yyhl415 {
 		yyb415 = yyj415 > l
@@ -5013,45 +5052,6 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromArray(l int, d *codec1978.De
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj415++
-	if yyhl415 {
-		yyb415 = yyj415 > l
-	} else {
-		yyb415 = r.CheckBreak()
-	}
-	if yyb415 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = pkg2_api.ObjectMeta{}
-	} else {
-		yyv418 := &x.ObjectMeta
-		yyv418.CodecDecodeSelf(d)
-	}
-	yyj415++
-	if yyhl415 {
-		yyb415 = yyj415 > l
-	} else {
-		yyb415 = r.CheckBreak()
-	}
-	if yyb415 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Data = nil
-	} else {
-		yyv419 := &x.Data
-		yym420 := z.DecBinary()
-		_ = yym420
-		if false {
-		} else {
-			*yyv419 = r.DecodeBytes(*(*[]byte)(yyv419), false, false)
-		}
 	}
 	for {
 		yyj415++
@@ -5086,11 +5086,11 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq422 [5]bool
 			_, _, _ = yysep422, yyq422, yy2arr422
 			const yyr422 bool = false
-			yyq422[0] = x.Kind != ""
-			yyq422[1] = x.APIVersion != ""
+			yyq422[0] = true
+			yyq422[1] = true
 			yyq422[2] = true
-			yyq422[3] = true
-			yyq422[4] = true
+			yyq422[3] = x.Kind != ""
+			yyq422[4] = x.APIVersion != ""
 			var yynn422 int
 			if yyr422 || yy2arr422 {
 				r.EncodeArrayStart(5)
@@ -5107,57 +5107,41 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr422 || yy2arr422 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq422[0] {
-					yym424 := z.EncBinary()
-					_ = yym424
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy424 := &x.ObjectMeta
+					yy424.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq422[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym425 := z.EncBinary()
-					_ = yym425
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy425 := &x.ObjectMeta
+					yy425.CodecEncodeSelf(e)
 				}
 			}
 			if yyr422 || yy2arr422 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq422[1] {
-					yym427 := z.EncBinary()
-					_ = yym427
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy427 := &x.Spec
+					yy427.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq422[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym428 := z.EncBinary()
-					_ = yym428
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy428 := &x.Spec
+					yy428.CodecEncodeSelf(e)
 				}
 			}
 			if yyr422 || yy2arr422 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq422[2] {
-					yy430 := &x.ObjectMeta
+					yy430 := &x.Status
 					yy430.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
@@ -5165,44 +5149,60 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq422[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy431 := &x.ObjectMeta
+					yy431 := &x.Status
 					yy431.CodecEncodeSelf(e)
 				}
 			}
 			if yyr422 || yy2arr422 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq422[3] {
-					yy433 := &x.Spec
-					yy433.CodecEncodeSelf(e)
+					yym433 := z.EncBinary()
+					_ = yym433
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq422[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy434 := &x.Spec
-					yy434.CodecEncodeSelf(e)
+					yym434 := z.EncBinary()
+					_ = yym434
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				}
 			}
 			if yyr422 || yy2arr422 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq422[4] {
-					yy436 := &x.Status
-					yy436.CodecEncodeSelf(e)
+					yym436 := z.EncBinary()
+					_ = yym436
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq422[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy437 := &x.Status
-					yy437.CodecEncodeSelf(e)
+					yym437 := z.EncBinary()
+					_ = yym437
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr422 || yy2arr422 {
@@ -5266,6 +5266,27 @@ func (x *Deployment) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys440 := string(yys440Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys440 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_api.ObjectMeta{}
+			} else {
+				yyv441 := &x.ObjectMeta
+				yyv441.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = DeploymentSpec{}
+			} else {
+				yyv442 := &x.Spec
+				yyv442.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = DeploymentStatus{}
+			} else {
+				yyv443 := &x.Status
+				yyv443.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -5277,27 +5298,6 @@ func (x *Deployment) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = pkg2_api.ObjectMeta{}
-			} else {
-				yyv443 := &x.ObjectMeta
-				yyv443.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = DeploymentSpec{}
-			} else {
-				yyv444 := &x.Spec
-				yyv444.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = DeploymentStatus{}
-			} else {
-				yyv445 := &x.Status
-				yyv445.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys440)
@@ -5313,6 +5313,57 @@ func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj446 int
 	var yyb446 bool
 	var yyhl446 bool = l >= 0
+	yyj446++
+	if yyhl446 {
+		yyb446 = yyj446 > l
+	} else {
+		yyb446 = r.CheckBreak()
+	}
+	if yyb446 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_api.ObjectMeta{}
+	} else {
+		yyv447 := &x.ObjectMeta
+		yyv447.CodecDecodeSelf(d)
+	}
+	yyj446++
+	if yyhl446 {
+		yyb446 = yyj446 > l
+	} else {
+		yyb446 = r.CheckBreak()
+	}
+	if yyb446 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = DeploymentSpec{}
+	} else {
+		yyv448 := &x.Spec
+		yyv448.CodecDecodeSelf(d)
+	}
+	yyj446++
+	if yyhl446 {
+		yyb446 = yyj446 > l
+	} else {
+		yyb446 = r.CheckBreak()
+	}
+	if yyb446 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = DeploymentStatus{}
+	} else {
+		yyv449 := &x.Status
+		yyv449.CodecDecodeSelf(d)
+	}
 	yyj446++
 	if yyhl446 {
 		yyb446 = yyj446 > l
@@ -5344,57 +5395,6 @@ func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj446++
-	if yyhl446 {
-		yyb446 = yyj446 > l
-	} else {
-		yyb446 = r.CheckBreak()
-	}
-	if yyb446 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = pkg2_api.ObjectMeta{}
-	} else {
-		yyv449 := &x.ObjectMeta
-		yyv449.CodecDecodeSelf(d)
-	}
-	yyj446++
-	if yyhl446 {
-		yyb446 = yyj446 > l
-	} else {
-		yyb446 = r.CheckBreak()
-	}
-	if yyb446 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = DeploymentSpec{}
-	} else {
-		yyv450 := &x.Spec
-		yyv450.CodecDecodeSelf(d)
-	}
-	yyj446++
-	if yyhl446 {
-		yyb446 = yyj446 > l
-	} else {
-		yyb446 = r.CheckBreak()
-	}
-	if yyb446 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = DeploymentStatus{}
-	} else {
-		yyv451 := &x.Status
-		yyv451.CodecDecodeSelf(d)
 	}
 	for {
 		yyj446++
@@ -5973,9 +5973,9 @@ func (x *DeploymentRollback) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq503 [5]bool
 			_, _, _ = yysep503, yyq503, yy2arr503
 			const yyr503 bool = false
-			yyq503[0] = x.Kind != ""
-			yyq503[1] = x.APIVersion != ""
-			yyq503[3] = len(x.UpdatedAnnotations) != 0
+			yyq503[1] = len(x.UpdatedAnnotations) != 0
+			yyq503[3] = x.Kind != ""
+			yyq503[4] = x.APIVersion != ""
 			var yynn503 int
 			if yyr503 || yy2arr503 {
 				r.EncodeArrayStart(5)
@@ -5991,58 +5991,8 @@ func (x *DeploymentRollback) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr503 || yy2arr503 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq503[0] {
-					yym505 := z.EncBinary()
-					_ = yym505
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq503[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym506 := z.EncBinary()
-					_ = yym506
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr503 || yy2arr503 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq503[1] {
-					yym508 := z.EncBinary()
-					_ = yym508
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq503[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym509 := z.EncBinary()
-					_ = yym509
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr503 || yy2arr503 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym511 := z.EncBinary()
-				_ = yym511
+				yym505 := z.EncBinary()
+				_ = yym505
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
@@ -6051,8 +6001,8 @@ func (x *DeploymentRollback) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("name"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym512 := z.EncBinary()
-				_ = yym512
+				yym506 := z.EncBinary()
+				_ = yym506
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
@@ -6060,12 +6010,12 @@ func (x *DeploymentRollback) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr503 || yy2arr503 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq503[3] {
+				if yyq503[1] {
 					if x.UpdatedAnnotations == nil {
 						r.EncodeNil()
 					} else {
-						yym514 := z.EncBinary()
-						_ = yym514
+						yym508 := z.EncBinary()
+						_ = yym508
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.UpdatedAnnotations, false, e)
@@ -6075,15 +6025,15 @@ func (x *DeploymentRollback) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq503[3] {
+				if yyq503[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("updatedAnnotations"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.UpdatedAnnotations == nil {
 						r.EncodeNil()
 					} else {
-						yym515 := z.EncBinary()
-						_ = yym515
+						yym509 := z.EncBinary()
+						_ = yym509
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.UpdatedAnnotations, false, e)
@@ -6093,14 +6043,64 @@ func (x *DeploymentRollback) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr503 || yy2arr503 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy517 := &x.RollbackTo
-				yy517.CodecEncodeSelf(e)
+				yy511 := &x.RollbackTo
+				yy511.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("rollbackTo"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy518 := &x.RollbackTo
-				yy518.CodecEncodeSelf(e)
+				yy512 := &x.RollbackTo
+				yy512.CodecEncodeSelf(e)
+			}
+			if yyr503 || yy2arr503 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq503[3] {
+					yym514 := z.EncBinary()
+					_ = yym514
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq503[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym515 := z.EncBinary()
+					_ = yym515
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr503 || yy2arr503 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq503[4] {
+					yym517 := z.EncBinary()
+					_ = yym517
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq503[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym518 := z.EncBinary()
+					_ = yym518
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
 			}
 			if yyr503 || yy2arr503 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
@@ -6163,6 +6163,31 @@ func (x *DeploymentRollback) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 		yys521 := string(yys521Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys521 {
+		case "name":
+			if r.TryDecodeAsNil() {
+				x.Name = ""
+			} else {
+				x.Name = string(r.DecodeString())
+			}
+		case "updatedAnnotations":
+			if r.TryDecodeAsNil() {
+				x.UpdatedAnnotations = nil
+			} else {
+				yyv523 := &x.UpdatedAnnotations
+				yym524 := z.DecBinary()
+				_ = yym524
+				if false {
+				} else {
+					z.F.DecMapStringStringX(yyv523, false, d)
+				}
+			}
+		case "rollbackTo":
+			if r.TryDecodeAsNil() {
+				x.RollbackTo = RollbackConfig{}
+			} else {
+				yyv525 := &x.RollbackTo
+				yyv525.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -6174,31 +6199,6 @@ func (x *DeploymentRollback) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "name":
-			if r.TryDecodeAsNil() {
-				x.Name = ""
-			} else {
-				x.Name = string(r.DecodeString())
-			}
-		case "updatedAnnotations":
-			if r.TryDecodeAsNil() {
-				x.UpdatedAnnotations = nil
-			} else {
-				yyv525 := &x.UpdatedAnnotations
-				yym526 := z.DecBinary()
-				_ = yym526
-				if false {
-				} else {
-					z.F.DecMapStringStringX(yyv525, false, d)
-				}
-			}
-		case "rollbackTo":
-			if r.TryDecodeAsNil() {
-				x.RollbackTo = RollbackConfig{}
-			} else {
-				yyv527 := &x.RollbackTo
-				yyv527.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys521)
@@ -6214,6 +6214,61 @@ func (x *DeploymentRollback) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	var yyj528 int
 	var yyb528 bool
 	var yyhl528 bool = l >= 0
+	yyj528++
+	if yyhl528 {
+		yyb528 = yyj528 > l
+	} else {
+		yyb528 = r.CheckBreak()
+	}
+	if yyb528 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Name = ""
+	} else {
+		x.Name = string(r.DecodeString())
+	}
+	yyj528++
+	if yyhl528 {
+		yyb528 = yyj528 > l
+	} else {
+		yyb528 = r.CheckBreak()
+	}
+	if yyb528 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.UpdatedAnnotations = nil
+	} else {
+		yyv530 := &x.UpdatedAnnotations
+		yym531 := z.DecBinary()
+		_ = yym531
+		if false {
+		} else {
+			z.F.DecMapStringStringX(yyv530, false, d)
+		}
+	}
+	yyj528++
+	if yyhl528 {
+		yyb528 = yyj528 > l
+	} else {
+		yyb528 = r.CheckBreak()
+	}
+	if yyb528 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.RollbackTo = RollbackConfig{}
+	} else {
+		yyv532 := &x.RollbackTo
+		yyv532.CodecDecodeSelf(d)
+	}
 	yyj528++
 	if yyhl528 {
 		yyb528 = yyj528 > l
@@ -6245,61 +6300,6 @@ func (x *DeploymentRollback) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj528++
-	if yyhl528 {
-		yyb528 = yyj528 > l
-	} else {
-		yyb528 = r.CheckBreak()
-	}
-	if yyb528 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Name = ""
-	} else {
-		x.Name = string(r.DecodeString())
-	}
-	yyj528++
-	if yyhl528 {
-		yyb528 = yyj528 > l
-	} else {
-		yyb528 = r.CheckBreak()
-	}
-	if yyb528 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.UpdatedAnnotations = nil
-	} else {
-		yyv532 := &x.UpdatedAnnotations
-		yym533 := z.DecBinary()
-		_ = yym533
-		if false {
-		} else {
-			z.F.DecMapStringStringX(yyv532, false, d)
-		}
-	}
-	yyj528++
-	if yyhl528 {
-		yyb528 = yyj528 > l
-	} else {
-		yyb528 = r.CheckBreak()
-	}
-	if yyb528 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.RollbackTo = RollbackConfig{}
-	} else {
-		yyv534 := &x.RollbackTo
-		yyv534.CodecDecodeSelf(d)
 	}
 	for {
 		yyj528++
@@ -7326,9 +7326,9 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq611 [4]bool
 			_, _, _ = yysep611, yyq611, yy2arr611
 			const yyr611 bool = false
-			yyq611[0] = x.Kind != ""
-			yyq611[1] = x.APIVersion != ""
-			yyq611[2] = true
+			yyq611[0] = true
+			yyq611[2] = x.Kind != ""
+			yyq611[3] = x.APIVersion != ""
 			var yynn611 int
 			if yyr611 || yy2arr611 {
 				r.EncodeArrayStart(4)
@@ -7345,79 +7345,29 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr611 || yy2arr611 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq611[0] {
-					yym613 := z.EncBinary()
-					_ = yym613
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq611[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy613 := &x.ListMeta
 					yym614 := z.EncBinary()
 					_ = yym614
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy613) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr611 || yy2arr611 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq611[1] {
-					yym616 := z.EncBinary()
-					_ = yym616
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq611[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym617 := z.EncBinary()
-					_ = yym617
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr611 || yy2arr611 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq611[2] {
-					yy619 := &x.ListMeta
-					yym620 := z.EncBinary()
-					_ = yym620
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy619) {
-					} else {
-						z.EncFallback(yy619)
+						z.EncFallback(yy613)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq611[2] {
+				if yyq611[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy621 := &x.ListMeta
-					yym622 := z.EncBinary()
-					_ = yym622
+					yy615 := &x.ListMeta
+					yym616 := z.EncBinary()
+					_ = yym616
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy621) {
+					} else if z.HasExtensions() && z.EncExt(yy615) {
 					} else {
-						z.EncFallback(yy621)
+						z.EncFallback(yy615)
 					}
 				}
 			}
@@ -7426,8 +7376,8 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym624 := z.EncBinary()
-					_ = yym624
+					yym618 := z.EncBinary()
+					_ = yym618
 					if false {
 					} else {
 						h.encSliceDeployment(([]Deployment)(x.Items), e)
@@ -7440,11 +7390,61 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym619 := z.EncBinary()
+					_ = yym619
+					if false {
+					} else {
+						h.encSliceDeployment(([]Deployment)(x.Items), e)
+					}
+				}
+			}
+			if yyr611 || yy2arr611 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq611[2] {
+					yym621 := z.EncBinary()
+					_ = yym621
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq611[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym622 := z.EncBinary()
+					_ = yym622
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr611 || yy2arr611 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq611[3] {
+					yym624 := z.EncBinary()
+					_ = yym624
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq611[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym625 := z.EncBinary()
 					_ = yym625
 					if false {
 					} else {
-						h.encSliceDeployment(([]Deployment)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -7509,6 +7509,31 @@ func (x *DeploymentList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys628 := string(yys628Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys628 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv629 := &x.ListMeta
+				yym630 := z.DecBinary()
+				_ = yym630
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv629) {
+				} else {
+					z.DecFallback(yyv629, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv631 := &x.Items
+				yym632 := z.DecBinary()
+				_ = yym632
+				if false {
+				} else {
+					h.decSliceDeployment((*[]Deployment)(yyv631), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -7520,31 +7545,6 @@ func (x *DeploymentList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg1_unversioned.ListMeta{}
-			} else {
-				yyv631 := &x.ListMeta
-				yym632 := z.DecBinary()
-				_ = yym632
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv631) {
-				} else {
-					z.DecFallback(yyv631, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv633 := &x.Items
-				yym634 := z.DecBinary()
-				_ = yym634
-				if false {
-				} else {
-					h.decSliceDeployment((*[]Deployment)(yyv633), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys628)
@@ -7560,6 +7560,51 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj635 int
 	var yyb635 bool
 	var yyhl635 bool = l >= 0
+	yyj635++
+	if yyhl635 {
+		yyb635 = yyj635 > l
+	} else {
+		yyb635 = r.CheckBreak()
+	}
+	if yyb635 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv636 := &x.ListMeta
+		yym637 := z.DecBinary()
+		_ = yym637
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv636) {
+		} else {
+			z.DecFallback(yyv636, false)
+		}
+	}
+	yyj635++
+	if yyhl635 {
+		yyb635 = yyj635 > l
+	} else {
+		yyb635 = r.CheckBreak()
+	}
+	if yyb635 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv638 := &x.Items
+		yym639 := z.DecBinary()
+		_ = yym639
+		if false {
+		} else {
+			h.decSliceDeployment((*[]Deployment)(yyv638), d)
+		}
+	}
 	yyj635++
 	if yyhl635 {
 		yyb635 = yyj635 > l
@@ -7591,51 +7636,6 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj635++
-	if yyhl635 {
-		yyb635 = yyj635 > l
-	} else {
-		yyb635 = r.CheckBreak()
-	}
-	if yyb635 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg1_unversioned.ListMeta{}
-	} else {
-		yyv638 := &x.ListMeta
-		yym639 := z.DecBinary()
-		_ = yym639
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv638) {
-		} else {
-			z.DecFallback(yyv638, false)
-		}
-	}
-	yyj635++
-	if yyhl635 {
-		yyb635 = yyj635 > l
-	} else {
-		yyb635 = r.CheckBreak()
-	}
-	if yyb635 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv640 := &x.Items
-		yym641 := z.DecBinary()
-		_ = yym641
-		if false {
-		} else {
-			h.decSliceDeployment((*[]Deployment)(yyv640), d)
-		}
 	}
 	for {
 		yyj635++
@@ -8724,11 +8724,11 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq726 [5]bool
 			_, _, _ = yysep726, yyq726, yy2arr726
 			const yyr726 bool = false
-			yyq726[0] = x.Kind != ""
-			yyq726[1] = x.APIVersion != ""
+			yyq726[0] = true
+			yyq726[1] = true
 			yyq726[2] = true
-			yyq726[3] = true
-			yyq726[4] = true
+			yyq726[3] = x.Kind != ""
+			yyq726[4] = x.APIVersion != ""
 			var yynn726 int
 			if yyr726 || yy2arr726 {
 				r.EncodeArrayStart(5)
@@ -8745,57 +8745,41 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr726 || yy2arr726 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq726[0] {
-					yym728 := z.EncBinary()
-					_ = yym728
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy728 := &x.ObjectMeta
+					yy728.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq726[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym729 := z.EncBinary()
-					_ = yym729
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy729 := &x.ObjectMeta
+					yy729.CodecEncodeSelf(e)
 				}
 			}
 			if yyr726 || yy2arr726 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq726[1] {
-					yym731 := z.EncBinary()
-					_ = yym731
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy731 := &x.Spec
+					yy731.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq726[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym732 := z.EncBinary()
-					_ = yym732
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy732 := &x.Spec
+					yy732.CodecEncodeSelf(e)
 				}
 			}
 			if yyr726 || yy2arr726 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq726[2] {
-					yy734 := &x.ObjectMeta
+					yy734 := &x.Status
 					yy734.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
@@ -8803,44 +8787,60 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq726[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy735 := &x.ObjectMeta
+					yy735 := &x.Status
 					yy735.CodecEncodeSelf(e)
 				}
 			}
 			if yyr726 || yy2arr726 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq726[3] {
-					yy737 := &x.Spec
-					yy737.CodecEncodeSelf(e)
+					yym737 := z.EncBinary()
+					_ = yym737
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq726[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy738 := &x.Spec
-					yy738.CodecEncodeSelf(e)
+					yym738 := z.EncBinary()
+					_ = yym738
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				}
 			}
 			if yyr726 || yy2arr726 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq726[4] {
-					yy740 := &x.Status
-					yy740.CodecEncodeSelf(e)
+					yym740 := z.EncBinary()
+					_ = yym740
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq726[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy741 := &x.Status
-					yy741.CodecEncodeSelf(e)
+					yym741 := z.EncBinary()
+					_ = yym741
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr726 || yy2arr726 {
@@ -8904,6 +8904,27 @@ func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys744 := string(yys744Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys744 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_api.ObjectMeta{}
+			} else {
+				yyv745 := &x.ObjectMeta
+				yyv745.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = DaemonSetSpec{}
+			} else {
+				yyv746 := &x.Spec
+				yyv746.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = DaemonSetStatus{}
+			} else {
+				yyv747 := &x.Status
+				yyv747.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -8915,27 +8936,6 @@ func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = pkg2_api.ObjectMeta{}
-			} else {
-				yyv747 := &x.ObjectMeta
-				yyv747.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = DaemonSetSpec{}
-			} else {
-				yyv748 := &x.Spec
-				yyv748.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = DaemonSetStatus{}
-			} else {
-				yyv749 := &x.Status
-				yyv749.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys744)
@@ -8951,6 +8951,57 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj750 int
 	var yyb750 bool
 	var yyhl750 bool = l >= 0
+	yyj750++
+	if yyhl750 {
+		yyb750 = yyj750 > l
+	} else {
+		yyb750 = r.CheckBreak()
+	}
+	if yyb750 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_api.ObjectMeta{}
+	} else {
+		yyv751 := &x.ObjectMeta
+		yyv751.CodecDecodeSelf(d)
+	}
+	yyj750++
+	if yyhl750 {
+		yyb750 = yyj750 > l
+	} else {
+		yyb750 = r.CheckBreak()
+	}
+	if yyb750 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = DaemonSetSpec{}
+	} else {
+		yyv752 := &x.Spec
+		yyv752.CodecDecodeSelf(d)
+	}
+	yyj750++
+	if yyhl750 {
+		yyb750 = yyj750 > l
+	} else {
+		yyb750 = r.CheckBreak()
+	}
+	if yyb750 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = DaemonSetStatus{}
+	} else {
+		yyv753 := &x.Status
+		yyv753.CodecDecodeSelf(d)
+	}
 	yyj750++
 	if yyhl750 {
 		yyb750 = yyj750 > l
@@ -8982,57 +9033,6 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj750++
-	if yyhl750 {
-		yyb750 = yyj750 > l
-	} else {
-		yyb750 = r.CheckBreak()
-	}
-	if yyb750 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = pkg2_api.ObjectMeta{}
-	} else {
-		yyv753 := &x.ObjectMeta
-		yyv753.CodecDecodeSelf(d)
-	}
-	yyj750++
-	if yyhl750 {
-		yyb750 = yyj750 > l
-	} else {
-		yyb750 = r.CheckBreak()
-	}
-	if yyb750 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = DaemonSetSpec{}
-	} else {
-		yyv754 := &x.Spec
-		yyv754.CodecDecodeSelf(d)
-	}
-	yyj750++
-	if yyhl750 {
-		yyb750 = yyj750 > l
-	} else {
-		yyb750 = r.CheckBreak()
-	}
-	if yyb750 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = DaemonSetStatus{}
-	} else {
-		yyv755 := &x.Status
-		yyv755.CodecDecodeSelf(d)
 	}
 	for {
 		yyj750++
@@ -9067,9 +9067,9 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq757 [4]bool
 			_, _, _ = yysep757, yyq757, yy2arr757
 			const yyr757 bool = false
-			yyq757[0] = x.Kind != ""
-			yyq757[1] = x.APIVersion != ""
-			yyq757[2] = true
+			yyq757[0] = true
+			yyq757[2] = x.Kind != ""
+			yyq757[3] = x.APIVersion != ""
 			var yynn757 int
 			if yyr757 || yy2arr757 {
 				r.EncodeArrayStart(4)
@@ -9086,79 +9086,29 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr757 || yy2arr757 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq757[0] {
-					yym759 := z.EncBinary()
-					_ = yym759
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq757[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy759 := &x.ListMeta
 					yym760 := z.EncBinary()
 					_ = yym760
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy759) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr757 || yy2arr757 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq757[1] {
-					yym762 := z.EncBinary()
-					_ = yym762
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq757[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym763 := z.EncBinary()
-					_ = yym763
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr757 || yy2arr757 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq757[2] {
-					yy765 := &x.ListMeta
-					yym766 := z.EncBinary()
-					_ = yym766
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy765) {
-					} else {
-						z.EncFallback(yy765)
+						z.EncFallback(yy759)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq757[2] {
+				if yyq757[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy767 := &x.ListMeta
-					yym768 := z.EncBinary()
-					_ = yym768
+					yy761 := &x.ListMeta
+					yym762 := z.EncBinary()
+					_ = yym762
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy767) {
+					} else if z.HasExtensions() && z.EncExt(yy761) {
 					} else {
-						z.EncFallback(yy767)
+						z.EncFallback(yy761)
 					}
 				}
 			}
@@ -9167,8 +9117,8 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym770 := z.EncBinary()
-					_ = yym770
+					yym764 := z.EncBinary()
+					_ = yym764
 					if false {
 					} else {
 						h.encSliceDaemonSet(([]DaemonSet)(x.Items), e)
@@ -9181,11 +9131,61 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym765 := z.EncBinary()
+					_ = yym765
+					if false {
+					} else {
+						h.encSliceDaemonSet(([]DaemonSet)(x.Items), e)
+					}
+				}
+			}
+			if yyr757 || yy2arr757 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq757[2] {
+					yym767 := z.EncBinary()
+					_ = yym767
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq757[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym768 := z.EncBinary()
+					_ = yym768
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr757 || yy2arr757 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq757[3] {
+					yym770 := z.EncBinary()
+					_ = yym770
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq757[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym771 := z.EncBinary()
 					_ = yym771
 					if false {
 					} else {
-						h.encSliceDaemonSet(([]DaemonSet)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -9250,6 +9250,31 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys774 := string(yys774Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys774 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv775 := &x.ListMeta
+				yym776 := z.DecBinary()
+				_ = yym776
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv775) {
+				} else {
+					z.DecFallback(yyv775, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv777 := &x.Items
+				yym778 := z.DecBinary()
+				_ = yym778
+				if false {
+				} else {
+					h.decSliceDaemonSet((*[]DaemonSet)(yyv777), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -9261,31 +9286,6 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg1_unversioned.ListMeta{}
-			} else {
-				yyv777 := &x.ListMeta
-				yym778 := z.DecBinary()
-				_ = yym778
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv777) {
-				} else {
-					z.DecFallback(yyv777, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv779 := &x.Items
-				yym780 := z.DecBinary()
-				_ = yym780
-				if false {
-				} else {
-					h.decSliceDaemonSet((*[]DaemonSet)(yyv779), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys774)
@@ -9301,6 +9301,51 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj781 int
 	var yyb781 bool
 	var yyhl781 bool = l >= 0
+	yyj781++
+	if yyhl781 {
+		yyb781 = yyj781 > l
+	} else {
+		yyb781 = r.CheckBreak()
+	}
+	if yyb781 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv782 := &x.ListMeta
+		yym783 := z.DecBinary()
+		_ = yym783
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv782) {
+		} else {
+			z.DecFallback(yyv782, false)
+		}
+	}
+	yyj781++
+	if yyhl781 {
+		yyb781 = yyj781 > l
+	} else {
+		yyb781 = r.CheckBreak()
+	}
+	if yyb781 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv784 := &x.Items
+		yym785 := z.DecBinary()
+		_ = yym785
+		if false {
+		} else {
+			h.decSliceDaemonSet((*[]DaemonSet)(yyv784), d)
+		}
+	}
 	yyj781++
 	if yyhl781 {
 		yyb781 = yyj781 > l
@@ -9332,51 +9377,6 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj781++
-	if yyhl781 {
-		yyb781 = yyj781 > l
-	} else {
-		yyb781 = r.CheckBreak()
-	}
-	if yyb781 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg1_unversioned.ListMeta{}
-	} else {
-		yyv784 := &x.ListMeta
-		yym785 := z.DecBinary()
-		_ = yym785
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv784) {
-		} else {
-			z.DecFallback(yyv784, false)
-		}
-	}
-	yyj781++
-	if yyhl781 {
-		yyb781 = yyj781 > l
-	} else {
-		yyb781 = r.CheckBreak()
-	}
-	if yyb781 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv786 := &x.Items
-		yym787 := z.DecBinary()
-		_ = yym787
-		if false {
-		} else {
-			h.decSliceDaemonSet((*[]DaemonSet)(yyv786), d)
-		}
 	}
 	for {
 		yyj781++
@@ -9411,9 +9411,9 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq789 [4]bool
 			_, _, _ = yysep789, yyq789, yy2arr789
 			const yyr789 bool = false
-			yyq789[0] = x.Kind != ""
-			yyq789[1] = x.APIVersion != ""
-			yyq789[2] = true
+			yyq789[0] = true
+			yyq789[2] = x.Kind != ""
+			yyq789[3] = x.APIVersion != ""
 			var yynn789 int
 			if yyr789 || yy2arr789 {
 				r.EncodeArrayStart(4)
@@ -9430,79 +9430,29 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr789 || yy2arr789 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq789[0] {
-					yym791 := z.EncBinary()
-					_ = yym791
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq789[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy791 := &x.ListMeta
 					yym792 := z.EncBinary()
 					_ = yym792
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy791) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr789 || yy2arr789 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq789[1] {
-					yym794 := z.EncBinary()
-					_ = yym794
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq789[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym795 := z.EncBinary()
-					_ = yym795
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr789 || yy2arr789 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq789[2] {
-					yy797 := &x.ListMeta
-					yym798 := z.EncBinary()
-					_ = yym798
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy797) {
-					} else {
-						z.EncFallback(yy797)
+						z.EncFallback(yy791)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq789[2] {
+				if yyq789[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy799 := &x.ListMeta
-					yym800 := z.EncBinary()
-					_ = yym800
+					yy793 := &x.ListMeta
+					yym794 := z.EncBinary()
+					_ = yym794
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy799) {
+					} else if z.HasExtensions() && z.EncExt(yy793) {
 					} else {
-						z.EncFallback(yy799)
+						z.EncFallback(yy793)
 					}
 				}
 			}
@@ -9511,8 +9461,8 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym802 := z.EncBinary()
-					_ = yym802
+					yym796 := z.EncBinary()
+					_ = yym796
 					if false {
 					} else {
 						h.encSliceThirdPartyResourceData(([]ThirdPartyResourceData)(x.Items), e)
@@ -9525,11 +9475,61 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym797 := z.EncBinary()
+					_ = yym797
+					if false {
+					} else {
+						h.encSliceThirdPartyResourceData(([]ThirdPartyResourceData)(x.Items), e)
+					}
+				}
+			}
+			if yyr789 || yy2arr789 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq789[2] {
+					yym799 := z.EncBinary()
+					_ = yym799
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq789[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym800 := z.EncBinary()
+					_ = yym800
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr789 || yy2arr789 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq789[3] {
+					yym802 := z.EncBinary()
+					_ = yym802
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq789[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym803 := z.EncBinary()
 					_ = yym803
 					if false {
 					} else {
-						h.encSliceThirdPartyResourceData(([]ThirdPartyResourceData)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -9594,6 +9594,31 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 		yys806 := string(yys806Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys806 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv807 := &x.ListMeta
+				yym808 := z.DecBinary()
+				_ = yym808
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv807) {
+				} else {
+					z.DecFallback(yyv807, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv809 := &x.Items
+				yym810 := z.DecBinary()
+				_ = yym810
+				if false {
+				} else {
+					h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv809), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -9605,31 +9630,6 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg1_unversioned.ListMeta{}
-			} else {
-				yyv809 := &x.ListMeta
-				yym810 := z.DecBinary()
-				_ = yym810
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv809) {
-				} else {
-					z.DecFallback(yyv809, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv811 := &x.Items
-				yym812 := z.DecBinary()
-				_ = yym812
-				if false {
-				} else {
-					h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv811), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys806)
@@ -9645,6 +9645,51 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 	var yyj813 int
 	var yyb813 bool
 	var yyhl813 bool = l >= 0
+	yyj813++
+	if yyhl813 {
+		yyb813 = yyj813 > l
+	} else {
+		yyb813 = r.CheckBreak()
+	}
+	if yyb813 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv814 := &x.ListMeta
+		yym815 := z.DecBinary()
+		_ = yym815
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv814) {
+		} else {
+			z.DecFallback(yyv814, false)
+		}
+	}
+	yyj813++
+	if yyhl813 {
+		yyb813 = yyj813 > l
+	} else {
+		yyb813 = r.CheckBreak()
+	}
+	if yyb813 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv816 := &x.Items
+		yym817 := z.DecBinary()
+		_ = yym817
+		if false {
+		} else {
+			h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv816), d)
+		}
+	}
 	yyj813++
 	if yyhl813 {
 		yyb813 = yyj813 > l
@@ -9676,51 +9721,6 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj813++
-	if yyhl813 {
-		yyb813 = yyj813 > l
-	} else {
-		yyb813 = r.CheckBreak()
-	}
-	if yyb813 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg1_unversioned.ListMeta{}
-	} else {
-		yyv816 := &x.ListMeta
-		yym817 := z.DecBinary()
-		_ = yym817
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv816) {
-		} else {
-			z.DecFallback(yyv816, false)
-		}
-	}
-	yyj813++
-	if yyhl813 {
-		yyb813 = yyj813 > l
-	} else {
-		yyb813 = r.CheckBreak()
-	}
-	if yyb813 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv818 := &x.Items
-		yym819 := z.DecBinary()
-		_ = yym819
-		if false {
-		} else {
-			h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv818), d)
-		}
 	}
 	for {
 		yyj813++
@@ -9755,11 +9755,11 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq821 [5]bool
 			_, _, _ = yysep821, yyq821, yy2arr821
 			const yyr821 bool = false
-			yyq821[0] = x.Kind != ""
-			yyq821[1] = x.APIVersion != ""
+			yyq821[0] = true
+			yyq821[1] = true
 			yyq821[2] = true
-			yyq821[3] = true
-			yyq821[4] = true
+			yyq821[3] = x.Kind != ""
+			yyq821[4] = x.APIVersion != ""
 			var yynn821 int
 			if yyr821 || yy2arr821 {
 				r.EncodeArrayStart(5)
@@ -9776,57 +9776,41 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr821 || yy2arr821 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq821[0] {
-					yym823 := z.EncBinary()
-					_ = yym823
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy823 := &x.ObjectMeta
+					yy823.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq821[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym824 := z.EncBinary()
-					_ = yym824
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy824 := &x.ObjectMeta
+					yy824.CodecEncodeSelf(e)
 				}
 			}
 			if yyr821 || yy2arr821 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq821[1] {
-					yym826 := z.EncBinary()
-					_ = yym826
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy826 := &x.Spec
+					yy826.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq821[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym827 := z.EncBinary()
-					_ = yym827
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy827 := &x.Spec
+					yy827.CodecEncodeSelf(e)
 				}
 			}
 			if yyr821 || yy2arr821 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq821[2] {
-					yy829 := &x.ObjectMeta
+					yy829 := &x.Status
 					yy829.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
@@ -9834,44 +9818,60 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq821[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy830 := &x.ObjectMeta
+					yy830 := &x.Status
 					yy830.CodecEncodeSelf(e)
 				}
 			}
 			if yyr821 || yy2arr821 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq821[3] {
-					yy832 := &x.Spec
-					yy832.CodecEncodeSelf(e)
+					yym832 := z.EncBinary()
+					_ = yym832
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq821[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy833 := &x.Spec
-					yy833.CodecEncodeSelf(e)
+					yym833 := z.EncBinary()
+					_ = yym833
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				}
 			}
 			if yyr821 || yy2arr821 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq821[4] {
-					yy835 := &x.Status
-					yy835.CodecEncodeSelf(e)
+					yym835 := z.EncBinary()
+					_ = yym835
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq821[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy836 := &x.Status
-					yy836.CodecEncodeSelf(e)
+					yym836 := z.EncBinary()
+					_ = yym836
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr821 || yy2arr821 {
@@ -9935,6 +9935,27 @@ func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys839 := string(yys839Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys839 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_api.ObjectMeta{}
+			} else {
+				yyv840 := &x.ObjectMeta
+				yyv840.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = JobSpec{}
+			} else {
+				yyv841 := &x.Spec
+				yyv841.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = JobStatus{}
+			} else {
+				yyv842 := &x.Status
+				yyv842.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -9946,27 +9967,6 @@ func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = pkg2_api.ObjectMeta{}
-			} else {
-				yyv842 := &x.ObjectMeta
-				yyv842.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = JobSpec{}
-			} else {
-				yyv843 := &x.Spec
-				yyv843.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = JobStatus{}
-			} else {
-				yyv844 := &x.Status
-				yyv844.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys839)
@@ -9982,6 +9982,57 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj845 int
 	var yyb845 bool
 	var yyhl845 bool = l >= 0
+	yyj845++
+	if yyhl845 {
+		yyb845 = yyj845 > l
+	} else {
+		yyb845 = r.CheckBreak()
+	}
+	if yyb845 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_api.ObjectMeta{}
+	} else {
+		yyv846 := &x.ObjectMeta
+		yyv846.CodecDecodeSelf(d)
+	}
+	yyj845++
+	if yyhl845 {
+		yyb845 = yyj845 > l
+	} else {
+		yyb845 = r.CheckBreak()
+	}
+	if yyb845 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = JobSpec{}
+	} else {
+		yyv847 := &x.Spec
+		yyv847.CodecDecodeSelf(d)
+	}
+	yyj845++
+	if yyhl845 {
+		yyb845 = yyj845 > l
+	} else {
+		yyb845 = r.CheckBreak()
+	}
+	if yyb845 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = JobStatus{}
+	} else {
+		yyv848 := &x.Status
+		yyv848.CodecDecodeSelf(d)
+	}
 	yyj845++
 	if yyhl845 {
 		yyb845 = yyj845 > l
@@ -10013,57 +10064,6 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj845++
-	if yyhl845 {
-		yyb845 = yyj845 > l
-	} else {
-		yyb845 = r.CheckBreak()
-	}
-	if yyb845 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = pkg2_api.ObjectMeta{}
-	} else {
-		yyv848 := &x.ObjectMeta
-		yyv848.CodecDecodeSelf(d)
-	}
-	yyj845++
-	if yyhl845 {
-		yyb845 = yyj845 > l
-	} else {
-		yyb845 = r.CheckBreak()
-	}
-	if yyb845 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = JobSpec{}
-	} else {
-		yyv849 := &x.Spec
-		yyv849.CodecDecodeSelf(d)
-	}
-	yyj845++
-	if yyhl845 {
-		yyb845 = yyj845 > l
-	} else {
-		yyb845 = r.CheckBreak()
-	}
-	if yyb845 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = JobStatus{}
-	} else {
-		yyv850 := &x.Status
-		yyv850.CodecDecodeSelf(d)
 	}
 	for {
 		yyj845++
@@ -10098,9 +10098,9 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq852 [4]bool
 			_, _, _ = yysep852, yyq852, yy2arr852
 			const yyr852 bool = false
-			yyq852[0] = x.Kind != ""
-			yyq852[1] = x.APIVersion != ""
-			yyq852[2] = true
+			yyq852[0] = true
+			yyq852[2] = x.Kind != ""
+			yyq852[3] = x.APIVersion != ""
 			var yynn852 int
 			if yyr852 || yy2arr852 {
 				r.EncodeArrayStart(4)
@@ -10117,79 +10117,29 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr852 || yy2arr852 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq852[0] {
-					yym854 := z.EncBinary()
-					_ = yym854
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq852[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy854 := &x.ListMeta
 					yym855 := z.EncBinary()
 					_ = yym855
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy854) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr852 || yy2arr852 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq852[1] {
-					yym857 := z.EncBinary()
-					_ = yym857
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq852[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym858 := z.EncBinary()
-					_ = yym858
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr852 || yy2arr852 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq852[2] {
-					yy860 := &x.ListMeta
-					yym861 := z.EncBinary()
-					_ = yym861
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy860) {
-					} else {
-						z.EncFallback(yy860)
+						z.EncFallback(yy854)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq852[2] {
+				if yyq852[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy862 := &x.ListMeta
-					yym863 := z.EncBinary()
-					_ = yym863
+					yy856 := &x.ListMeta
+					yym857 := z.EncBinary()
+					_ = yym857
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy862) {
+					} else if z.HasExtensions() && z.EncExt(yy856) {
 					} else {
-						z.EncFallback(yy862)
+						z.EncFallback(yy856)
 					}
 				}
 			}
@@ -10198,8 +10148,8 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym865 := z.EncBinary()
-					_ = yym865
+					yym859 := z.EncBinary()
+					_ = yym859
 					if false {
 					} else {
 						h.encSliceJob(([]Job)(x.Items), e)
@@ -10212,11 +10162,61 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym860 := z.EncBinary()
+					_ = yym860
+					if false {
+					} else {
+						h.encSliceJob(([]Job)(x.Items), e)
+					}
+				}
+			}
+			if yyr852 || yy2arr852 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq852[2] {
+					yym862 := z.EncBinary()
+					_ = yym862
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq852[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym863 := z.EncBinary()
+					_ = yym863
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr852 || yy2arr852 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq852[3] {
+					yym865 := z.EncBinary()
+					_ = yym865
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq852[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym866 := z.EncBinary()
 					_ = yym866
 					if false {
 					} else {
-						h.encSliceJob(([]Job)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -10281,6 +10281,31 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys869 := string(yys869Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys869 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv870 := &x.ListMeta
+				yym871 := z.DecBinary()
+				_ = yym871
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv870) {
+				} else {
+					z.DecFallback(yyv870, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv872 := &x.Items
+				yym873 := z.DecBinary()
+				_ = yym873
+				if false {
+				} else {
+					h.decSliceJob((*[]Job)(yyv872), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -10292,31 +10317,6 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg1_unversioned.ListMeta{}
-			} else {
-				yyv872 := &x.ListMeta
-				yym873 := z.DecBinary()
-				_ = yym873
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv872) {
-				} else {
-					z.DecFallback(yyv872, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv874 := &x.Items
-				yym875 := z.DecBinary()
-				_ = yym875
-				if false {
-				} else {
-					h.decSliceJob((*[]Job)(yyv874), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys869)
@@ -10332,6 +10332,51 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj876 int
 	var yyb876 bool
 	var yyhl876 bool = l >= 0
+	yyj876++
+	if yyhl876 {
+		yyb876 = yyj876 > l
+	} else {
+		yyb876 = r.CheckBreak()
+	}
+	if yyb876 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv877 := &x.ListMeta
+		yym878 := z.DecBinary()
+		_ = yym878
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv877) {
+		} else {
+			z.DecFallback(yyv877, false)
+		}
+	}
+	yyj876++
+	if yyhl876 {
+		yyb876 = yyj876 > l
+	} else {
+		yyb876 = r.CheckBreak()
+	}
+	if yyb876 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv879 := &x.Items
+		yym880 := z.DecBinary()
+		_ = yym880
+		if false {
+		} else {
+			h.decSliceJob((*[]Job)(yyv879), d)
+		}
+	}
 	yyj876++
 	if yyhl876 {
 		yyb876 = yyj876 > l
@@ -10363,51 +10408,6 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj876++
-	if yyhl876 {
-		yyb876 = yyj876 > l
-	} else {
-		yyb876 = r.CheckBreak()
-	}
-	if yyb876 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg1_unversioned.ListMeta{}
-	} else {
-		yyv879 := &x.ListMeta
-		yym880 := z.DecBinary()
-		_ = yym880
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv879) {
-		} else {
-			z.DecFallback(yyv879, false)
-		}
-	}
-	yyj876++
-	if yyhl876 {
-		yyb876 = yyj876 > l
-	} else {
-		yyb876 = r.CheckBreak()
-	}
-	if yyb876 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv881 := &x.Items
-		yym882 := z.DecBinary()
-		_ = yym882
-		if false {
-		} else {
-			h.decSliceJob((*[]Job)(yyv881), d)
-		}
 	}
 	for {
 		yyj876++
@@ -11918,11 +11918,11 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1015 [5]bool
 			_, _, _ = yysep1015, yyq1015, yy2arr1015
 			const yyr1015 bool = false
-			yyq1015[0] = x.Kind != ""
-			yyq1015[1] = x.APIVersion != ""
+			yyq1015[0] = true
+			yyq1015[1] = true
 			yyq1015[2] = true
-			yyq1015[3] = true
-			yyq1015[4] = true
+			yyq1015[3] = x.Kind != ""
+			yyq1015[4] = x.APIVersion != ""
 			var yynn1015 int
 			if yyr1015 || yy2arr1015 {
 				r.EncodeArrayStart(5)
@@ -11939,57 +11939,41 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr1015 || yy2arr1015 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1015[0] {
-					yym1017 := z.EncBinary()
-					_ = yym1017
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy1017 := &x.ObjectMeta
+					yy1017.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq1015[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1018 := z.EncBinary()
-					_ = yym1018
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy1018 := &x.ObjectMeta
+					yy1018.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1015 || yy2arr1015 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1015[1] {
-					yym1020 := z.EncBinary()
-					_ = yym1020
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy1020 := &x.Spec
+					yy1020.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq1015[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1021 := z.EncBinary()
-					_ = yym1021
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy1021 := &x.Spec
+					yy1021.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1015 || yy2arr1015 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1015[2] {
-					yy1023 := &x.ObjectMeta
+					yy1023 := &x.Status
 					yy1023.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
@@ -11997,44 +11981,60 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq1015[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1024 := &x.ObjectMeta
+					yy1024 := &x.Status
 					yy1024.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1015 || yy2arr1015 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1015[3] {
-					yy1026 := &x.Spec
-					yy1026.CodecEncodeSelf(e)
+					yym1026 := z.EncBinary()
+					_ = yym1026
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq1015[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1027 := &x.Spec
-					yy1027.CodecEncodeSelf(e)
+					yym1027 := z.EncBinary()
+					_ = yym1027
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				}
 			}
 			if yyr1015 || yy2arr1015 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1015[4] {
-					yy1029 := &x.Status
-					yy1029.CodecEncodeSelf(e)
+					yym1029 := z.EncBinary()
+					_ = yym1029
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq1015[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1030 := &x.Status
-					yy1030.CodecEncodeSelf(e)
+					yym1030 := z.EncBinary()
+					_ = yym1030
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr1015 || yy2arr1015 {
@@ -12098,6 +12098,27 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys1033 := string(yys1033Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1033 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_api.ObjectMeta{}
+			} else {
+				yyv1034 := &x.ObjectMeta
+				yyv1034.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = IngressSpec{}
+			} else {
+				yyv1035 := &x.Spec
+				yyv1035.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = IngressStatus{}
+			} else {
+				yyv1036 := &x.Status
+				yyv1036.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -12109,27 +12130,6 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = pkg2_api.ObjectMeta{}
-			} else {
-				yyv1036 := &x.ObjectMeta
-				yyv1036.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = IngressSpec{}
-			} else {
-				yyv1037 := &x.Spec
-				yyv1037.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = IngressStatus{}
-			} else {
-				yyv1038 := &x.Status
-				yyv1038.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1033)
@@ -12145,6 +12145,57 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj1039 int
 	var yyb1039 bool
 	var yyhl1039 bool = l >= 0
+	yyj1039++
+	if yyhl1039 {
+		yyb1039 = yyj1039 > l
+	} else {
+		yyb1039 = r.CheckBreak()
+	}
+	if yyb1039 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_api.ObjectMeta{}
+	} else {
+		yyv1040 := &x.ObjectMeta
+		yyv1040.CodecDecodeSelf(d)
+	}
+	yyj1039++
+	if yyhl1039 {
+		yyb1039 = yyj1039 > l
+	} else {
+		yyb1039 = r.CheckBreak()
+	}
+	if yyb1039 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = IngressSpec{}
+	} else {
+		yyv1041 := &x.Spec
+		yyv1041.CodecDecodeSelf(d)
+	}
+	yyj1039++
+	if yyhl1039 {
+		yyb1039 = yyj1039 > l
+	} else {
+		yyb1039 = r.CheckBreak()
+	}
+	if yyb1039 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = IngressStatus{}
+	} else {
+		yyv1042 := &x.Status
+		yyv1042.CodecDecodeSelf(d)
+	}
 	yyj1039++
 	if yyhl1039 {
 		yyb1039 = yyj1039 > l
@@ -12176,57 +12227,6 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj1039++
-	if yyhl1039 {
-		yyb1039 = yyj1039 > l
-	} else {
-		yyb1039 = r.CheckBreak()
-	}
-	if yyb1039 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = pkg2_api.ObjectMeta{}
-	} else {
-		yyv1042 := &x.ObjectMeta
-		yyv1042.CodecDecodeSelf(d)
-	}
-	yyj1039++
-	if yyhl1039 {
-		yyb1039 = yyj1039 > l
-	} else {
-		yyb1039 = r.CheckBreak()
-	}
-	if yyb1039 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = IngressSpec{}
-	} else {
-		yyv1043 := &x.Spec
-		yyv1043.CodecDecodeSelf(d)
-	}
-	yyj1039++
-	if yyhl1039 {
-		yyb1039 = yyj1039 > l
-	} else {
-		yyb1039 = r.CheckBreak()
-	}
-	if yyb1039 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = IngressStatus{}
-	} else {
-		yyv1044 := &x.Status
-		yyv1044.CodecDecodeSelf(d)
 	}
 	for {
 		yyj1039++
@@ -12261,9 +12261,9 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1046 [4]bool
 			_, _, _ = yysep1046, yyq1046, yy2arr1046
 			const yyr1046 bool = false
-			yyq1046[0] = x.Kind != ""
-			yyq1046[1] = x.APIVersion != ""
-			yyq1046[2] = true
+			yyq1046[0] = true
+			yyq1046[2] = x.Kind != ""
+			yyq1046[3] = x.APIVersion != ""
 			var yynn1046 int
 			if yyr1046 || yy2arr1046 {
 				r.EncodeArrayStart(4)
@@ -12280,79 +12280,29 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr1046 || yy2arr1046 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1046[0] {
-					yym1048 := z.EncBinary()
-					_ = yym1048
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1046[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1048 := &x.ListMeta
 					yym1049 := z.EncBinary()
 					_ = yym1049
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1048) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr1046 || yy2arr1046 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1046[1] {
-					yym1051 := z.EncBinary()
-					_ = yym1051
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1046[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1052 := z.EncBinary()
-					_ = yym1052
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr1046 || yy2arr1046 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1046[2] {
-					yy1054 := &x.ListMeta
-					yym1055 := z.EncBinary()
-					_ = yym1055
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1054) {
-					} else {
-						z.EncFallback(yy1054)
+						z.EncFallback(yy1048)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1046[2] {
+				if yyq1046[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1056 := &x.ListMeta
-					yym1057 := z.EncBinary()
-					_ = yym1057
+					yy1050 := &x.ListMeta
+					yym1051 := z.EncBinary()
+					_ = yym1051
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1056) {
+					} else if z.HasExtensions() && z.EncExt(yy1050) {
 					} else {
-						z.EncFallback(yy1056)
+						z.EncFallback(yy1050)
 					}
 				}
 			}
@@ -12361,8 +12311,8 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1059 := z.EncBinary()
-					_ = yym1059
+					yym1053 := z.EncBinary()
+					_ = yym1053
 					if false {
 					} else {
 						h.encSliceIngress(([]Ingress)(x.Items), e)
@@ -12375,11 +12325,61 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym1054 := z.EncBinary()
+					_ = yym1054
+					if false {
+					} else {
+						h.encSliceIngress(([]Ingress)(x.Items), e)
+					}
+				}
+			}
+			if yyr1046 || yy2arr1046 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1046[2] {
+					yym1056 := z.EncBinary()
+					_ = yym1056
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1046[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1057 := z.EncBinary()
+					_ = yym1057
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr1046 || yy2arr1046 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1046[3] {
+					yym1059 := z.EncBinary()
+					_ = yym1059
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1046[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1060 := z.EncBinary()
 					_ = yym1060
 					if false {
 					} else {
-						h.encSliceIngress(([]Ingress)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -12444,6 +12444,31 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys1063 := string(yys1063Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1063 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv1064 := &x.ListMeta
+				yym1065 := z.DecBinary()
+				_ = yym1065
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv1064) {
+				} else {
+					z.DecFallback(yyv1064, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv1066 := &x.Items
+				yym1067 := z.DecBinary()
+				_ = yym1067
+				if false {
+				} else {
+					h.decSliceIngress((*[]Ingress)(yyv1066), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -12455,31 +12480,6 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg1_unversioned.ListMeta{}
-			} else {
-				yyv1066 := &x.ListMeta
-				yym1067 := z.DecBinary()
-				_ = yym1067
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1066) {
-				} else {
-					z.DecFallback(yyv1066, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv1068 := &x.Items
-				yym1069 := z.DecBinary()
-				_ = yym1069
-				if false {
-				} else {
-					h.decSliceIngress((*[]Ingress)(yyv1068), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1063)
@@ -12495,6 +12495,51 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj1070 int
 	var yyb1070 bool
 	var yyhl1070 bool = l >= 0
+	yyj1070++
+	if yyhl1070 {
+		yyb1070 = yyj1070 > l
+	} else {
+		yyb1070 = r.CheckBreak()
+	}
+	if yyb1070 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv1071 := &x.ListMeta
+		yym1072 := z.DecBinary()
+		_ = yym1072
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1071) {
+		} else {
+			z.DecFallback(yyv1071, false)
+		}
+	}
+	yyj1070++
+	if yyhl1070 {
+		yyb1070 = yyj1070 > l
+	} else {
+		yyb1070 = r.CheckBreak()
+	}
+	if yyb1070 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv1073 := &x.Items
+		yym1074 := z.DecBinary()
+		_ = yym1074
+		if false {
+		} else {
+			h.decSliceIngress((*[]Ingress)(yyv1073), d)
+		}
+	}
 	yyj1070++
 	if yyhl1070 {
 		yyb1070 = yyj1070 > l
@@ -12526,51 +12571,6 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj1070++
-	if yyhl1070 {
-		yyb1070 = yyj1070 > l
-	} else {
-		yyb1070 = r.CheckBreak()
-	}
-	if yyb1070 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg1_unversioned.ListMeta{}
-	} else {
-		yyv1073 := &x.ListMeta
-		yym1074 := z.DecBinary()
-		_ = yym1074
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1073) {
-		} else {
-			z.DecFallback(yyv1073, false)
-		}
-	}
-	yyj1070++
-	if yyhl1070 {
-		yyb1070 = yyj1070 > l
-	} else {
-		yyb1070 = r.CheckBreak()
-	}
-	if yyb1070 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv1075 := &x.Items
-		yym1076 := z.DecBinary()
-		_ = yym1076
-		if false {
-		} else {
-			h.decSliceIngress((*[]Ingress)(yyv1075), d)
-		}
 	}
 	for {
 		yyj1070++
@@ -14838,10 +14838,10 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1241 [4]bool
 			_, _, _ = yysep1241, yyq1241, yy2arr1241
 			const yyr1241 bool = false
-			yyq1241[0] = x.Kind != ""
-			yyq1241[1] = x.APIVersion != ""
-			yyq1241[2] = true
-			yyq1241[3] = true
+			yyq1241[0] = true
+			yyq1241[1] = true
+			yyq1241[2] = x.Kind != ""
+			yyq1241[3] = x.APIVersion != ""
 			var yynn1241 int
 			if yyr1241 || yy2arr1241 {
 				r.EncodeArrayStart(4)
@@ -14858,22 +14858,56 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr1241 || yy2arr1241 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1241[0] {
-					yym1243 := z.EncBinary()
-					_ = yym1243
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy1243 := &x.ObjectMeta
+					yy1243.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq1241[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1244 := &x.ObjectMeta
+					yy1244.CodecEncodeSelf(e)
+				}
+			}
+			if yyr1241 || yy2arr1241 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1241[1] {
+					yy1246 := &x.Spec
+					yy1246.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1241[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1247 := &x.Spec
+					yy1247.CodecEncodeSelf(e)
+				}
+			}
+			if yyr1241 || yy2arr1241 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1241[2] {
+					yym1249 := z.EncBinary()
+					_ = yym1249
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1241[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1244 := z.EncBinary()
-					_ = yym1244
+					yym1250 := z.EncBinary()
+					_ = yym1250
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -14882,9 +14916,9 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr1241 || yy2arr1241 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1241[1] {
-					yym1246 := z.EncBinary()
-					_ = yym1246
+				if yyq1241[3] {
+					yym1252 := z.EncBinary()
+					_ = yym1252
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -14893,50 +14927,16 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1241[1] {
+				if yyq1241[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1247 := z.EncBinary()
-					_ = yym1247
+					yym1253 := z.EncBinary()
+					_ = yym1253
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
-				}
-			}
-			if yyr1241 || yy2arr1241 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1241[2] {
-					yy1249 := &x.ObjectMeta
-					yy1249.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1241[2] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1250 := &x.ObjectMeta
-					yy1250.CodecEncodeSelf(e)
-				}
-			}
-			if yyr1241 || yy2arr1241 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1241[3] {
-					yy1252 := &x.Spec
-					yy1252.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1241[3] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1253 := &x.Spec
-					yy1253.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1241 || yy2arr1241 {
@@ -15000,6 +15000,20 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 		yys1256 := string(yys1256Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1256 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_api.ObjectMeta{}
+			} else {
+				yyv1257 := &x.ObjectMeta
+				yyv1257.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = ClusterAutoscalerSpec{}
+			} else {
+				yyv1258 := &x.Spec
+				yyv1258.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -15011,20 +15025,6 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = pkg2_api.ObjectMeta{}
-			} else {
-				yyv1259 := &x.ObjectMeta
-				yyv1259.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = ClusterAutoscalerSpec{}
-			} else {
-				yyv1260 := &x.Spec
-				yyv1260.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1256)
@@ -15040,6 +15040,40 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var yyj1261 int
 	var yyb1261 bool
 	var yyhl1261 bool = l >= 0
+	yyj1261++
+	if yyhl1261 {
+		yyb1261 = yyj1261 > l
+	} else {
+		yyb1261 = r.CheckBreak()
+	}
+	if yyb1261 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_api.ObjectMeta{}
+	} else {
+		yyv1262 := &x.ObjectMeta
+		yyv1262.CodecDecodeSelf(d)
+	}
+	yyj1261++
+	if yyhl1261 {
+		yyb1261 = yyj1261 > l
+	} else {
+		yyb1261 = r.CheckBreak()
+	}
+	if yyb1261 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = ClusterAutoscalerSpec{}
+	} else {
+		yyv1263 := &x.Spec
+		yyv1263.CodecDecodeSelf(d)
+	}
 	yyj1261++
 	if yyhl1261 {
 		yyb1261 = yyj1261 > l
@@ -15071,40 +15105,6 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj1261++
-	if yyhl1261 {
-		yyb1261 = yyj1261 > l
-	} else {
-		yyb1261 = r.CheckBreak()
-	}
-	if yyb1261 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = pkg2_api.ObjectMeta{}
-	} else {
-		yyv1264 := &x.ObjectMeta
-		yyv1264.CodecDecodeSelf(d)
-	}
-	yyj1261++
-	if yyhl1261 {
-		yyb1261 = yyj1261 > l
-	} else {
-		yyb1261 = r.CheckBreak()
-	}
-	if yyb1261 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = ClusterAutoscalerSpec{}
-	} else {
-		yyv1265 := &x.Spec
-		yyv1265.CodecDecodeSelf(d)
 	}
 	for {
 		yyj1261++
@@ -15139,9 +15139,9 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1267 [4]bool
 			_, _, _ = yysep1267, yyq1267, yy2arr1267
 			const yyr1267 bool = false
-			yyq1267[0] = x.Kind != ""
-			yyq1267[1] = x.APIVersion != ""
-			yyq1267[2] = true
+			yyq1267[0] = true
+			yyq1267[2] = x.Kind != ""
+			yyq1267[3] = x.APIVersion != ""
 			var yynn1267 int
 			if yyr1267 || yy2arr1267 {
 				r.EncodeArrayStart(4)
@@ -15158,79 +15158,29 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr1267 || yy2arr1267 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1267[0] {
-					yym1269 := z.EncBinary()
-					_ = yym1269
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1267[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1269 := &x.ListMeta
 					yym1270 := z.EncBinary()
 					_ = yym1270
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1269) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr1267 || yy2arr1267 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1267[1] {
-					yym1272 := z.EncBinary()
-					_ = yym1272
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1267[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1273 := z.EncBinary()
-					_ = yym1273
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr1267 || yy2arr1267 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1267[2] {
-					yy1275 := &x.ListMeta
-					yym1276 := z.EncBinary()
-					_ = yym1276
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1275) {
-					} else {
-						z.EncFallback(yy1275)
+						z.EncFallback(yy1269)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1267[2] {
+				if yyq1267[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1277 := &x.ListMeta
-					yym1278 := z.EncBinary()
-					_ = yym1278
+					yy1271 := &x.ListMeta
+					yym1272 := z.EncBinary()
+					_ = yym1272
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1277) {
+					} else if z.HasExtensions() && z.EncExt(yy1271) {
 					} else {
-						z.EncFallback(yy1277)
+						z.EncFallback(yy1271)
 					}
 				}
 			}
@@ -15239,8 +15189,8 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1280 := z.EncBinary()
-					_ = yym1280
+					yym1274 := z.EncBinary()
+					_ = yym1274
 					if false {
 					} else {
 						h.encSliceClusterAutoscaler(([]ClusterAutoscaler)(x.Items), e)
@@ -15253,11 +15203,61 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym1275 := z.EncBinary()
+					_ = yym1275
+					if false {
+					} else {
+						h.encSliceClusterAutoscaler(([]ClusterAutoscaler)(x.Items), e)
+					}
+				}
+			}
+			if yyr1267 || yy2arr1267 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1267[2] {
+					yym1277 := z.EncBinary()
+					_ = yym1277
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1267[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1278 := z.EncBinary()
+					_ = yym1278
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr1267 || yy2arr1267 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1267[3] {
+					yym1280 := z.EncBinary()
+					_ = yym1280
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1267[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1281 := z.EncBinary()
 					_ = yym1281
 					if false {
 					} else {
-						h.encSliceClusterAutoscaler(([]ClusterAutoscaler)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -15322,6 +15322,31 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 		yys1284 := string(yys1284Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1284 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv1285 := &x.ListMeta
+				yym1286 := z.DecBinary()
+				_ = yym1286
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv1285) {
+				} else {
+					z.DecFallback(yyv1285, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv1287 := &x.Items
+				yym1288 := z.DecBinary()
+				_ = yym1288
+				if false {
+				} else {
+					h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1287), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -15333,31 +15358,6 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg1_unversioned.ListMeta{}
-			} else {
-				yyv1287 := &x.ListMeta
-				yym1288 := z.DecBinary()
-				_ = yym1288
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1287) {
-				} else {
-					z.DecFallback(yyv1287, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv1289 := &x.Items
-				yym1290 := z.DecBinary()
-				_ = yym1290
-				if false {
-				} else {
-					h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1289), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1284)
@@ -15373,6 +15373,51 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var yyj1291 int
 	var yyb1291 bool
 	var yyhl1291 bool = l >= 0
+	yyj1291++
+	if yyhl1291 {
+		yyb1291 = yyj1291 > l
+	} else {
+		yyb1291 = r.CheckBreak()
+	}
+	if yyb1291 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv1292 := &x.ListMeta
+		yym1293 := z.DecBinary()
+		_ = yym1293
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1292) {
+		} else {
+			z.DecFallback(yyv1292, false)
+		}
+	}
+	yyj1291++
+	if yyhl1291 {
+		yyb1291 = yyj1291 > l
+	} else {
+		yyb1291 = r.CheckBreak()
+	}
+	if yyb1291 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv1294 := &x.Items
+		yym1295 := z.DecBinary()
+		_ = yym1295
+		if false {
+		} else {
+			h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1294), d)
+		}
+	}
 	yyj1291++
 	if yyhl1291 {
 		yyb1291 = yyj1291 > l
@@ -15404,51 +15449,6 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj1291++
-	if yyhl1291 {
-		yyb1291 = yyj1291 > l
-	} else {
-		yyb1291 = r.CheckBreak()
-	}
-	if yyb1291 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg1_unversioned.ListMeta{}
-	} else {
-		yyv1294 := &x.ListMeta
-		yym1295 := z.DecBinary()
-		_ = yym1295
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1294) {
-		} else {
-			z.DecFallback(yyv1294, false)
-		}
-	}
-	yyj1291++
-	if yyhl1291 {
-		yyb1291 = yyj1291 > l
-	} else {
-		yyb1291 = r.CheckBreak()
-	}
-	if yyb1291 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv1296 := &x.Items
-		yym1297 := z.DecBinary()
-		_ = yym1297
-		if false {
-		} else {
-			h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1296), d)
-		}
 	}
 	for {
 		yyj1291++
@@ -15483,11 +15483,11 @@ func (x *ReplicaSet) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1299 [5]bool
 			_, _, _ = yysep1299, yyq1299, yy2arr1299
 			const yyr1299 bool = false
-			yyq1299[0] = x.Kind != ""
-			yyq1299[1] = x.APIVersion != ""
+			yyq1299[0] = true
+			yyq1299[1] = true
 			yyq1299[2] = true
-			yyq1299[3] = true
-			yyq1299[4] = true
+			yyq1299[3] = x.Kind != ""
+			yyq1299[4] = x.APIVersion != ""
 			var yynn1299 int
 			if yyr1299 || yy2arr1299 {
 				r.EncodeArrayStart(5)
@@ -15504,57 +15504,41 @@ func (x *ReplicaSet) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr1299 || yy2arr1299 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1299[0] {
-					yym1301 := z.EncBinary()
-					_ = yym1301
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy1301 := &x.ObjectMeta
+					yy1301.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq1299[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1302 := z.EncBinary()
-					_ = yym1302
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy1302 := &x.ObjectMeta
+					yy1302.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1299 || yy2arr1299 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1299[1] {
-					yym1304 := z.EncBinary()
-					_ = yym1304
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy1304 := &x.Spec
+					yy1304.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq1299[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1305 := z.EncBinary()
-					_ = yym1305
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy1305 := &x.Spec
+					yy1305.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1299 || yy2arr1299 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1299[2] {
-					yy1307 := &x.ObjectMeta
+					yy1307 := &x.Status
 					yy1307.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
@@ -15562,44 +15546,60 @@ func (x *ReplicaSet) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq1299[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1308 := &x.ObjectMeta
+					yy1308 := &x.Status
 					yy1308.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1299 || yy2arr1299 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1299[3] {
-					yy1310 := &x.Spec
-					yy1310.CodecEncodeSelf(e)
+					yym1310 := z.EncBinary()
+					_ = yym1310
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq1299[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1311 := &x.Spec
-					yy1311.CodecEncodeSelf(e)
+					yym1311 := z.EncBinary()
+					_ = yym1311
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				}
 			}
 			if yyr1299 || yy2arr1299 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1299[4] {
-					yy1313 := &x.Status
-					yy1313.CodecEncodeSelf(e)
+					yym1313 := z.EncBinary()
+					_ = yym1313
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq1299[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1314 := &x.Status
-					yy1314.CodecEncodeSelf(e)
+					yym1314 := z.EncBinary()
+					_ = yym1314
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr1299 || yy2arr1299 {
@@ -15663,6 +15663,27 @@ func (x *ReplicaSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys1317 := string(yys1317Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1317 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_api.ObjectMeta{}
+			} else {
+				yyv1318 := &x.ObjectMeta
+				yyv1318.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = ReplicaSetSpec{}
+			} else {
+				yyv1319 := &x.Spec
+				yyv1319.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = ReplicaSetStatus{}
+			} else {
+				yyv1320 := &x.Status
+				yyv1320.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -15674,27 +15695,6 @@ func (x *ReplicaSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = pkg2_api.ObjectMeta{}
-			} else {
-				yyv1320 := &x.ObjectMeta
-				yyv1320.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = ReplicaSetSpec{}
-			} else {
-				yyv1321 := &x.Spec
-				yyv1321.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = ReplicaSetStatus{}
-			} else {
-				yyv1322 := &x.Status
-				yyv1322.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1317)
@@ -15710,6 +15710,57 @@ func (x *ReplicaSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj1323 int
 	var yyb1323 bool
 	var yyhl1323 bool = l >= 0
+	yyj1323++
+	if yyhl1323 {
+		yyb1323 = yyj1323 > l
+	} else {
+		yyb1323 = r.CheckBreak()
+	}
+	if yyb1323 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_api.ObjectMeta{}
+	} else {
+		yyv1324 := &x.ObjectMeta
+		yyv1324.CodecDecodeSelf(d)
+	}
+	yyj1323++
+	if yyhl1323 {
+		yyb1323 = yyj1323 > l
+	} else {
+		yyb1323 = r.CheckBreak()
+	}
+	if yyb1323 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = ReplicaSetSpec{}
+	} else {
+		yyv1325 := &x.Spec
+		yyv1325.CodecDecodeSelf(d)
+	}
+	yyj1323++
+	if yyhl1323 {
+		yyb1323 = yyj1323 > l
+	} else {
+		yyb1323 = r.CheckBreak()
+	}
+	if yyb1323 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = ReplicaSetStatus{}
+	} else {
+		yyv1326 := &x.Status
+		yyv1326.CodecDecodeSelf(d)
+	}
 	yyj1323++
 	if yyhl1323 {
 		yyb1323 = yyj1323 > l
@@ -15741,57 +15792,6 @@ func (x *ReplicaSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj1323++
-	if yyhl1323 {
-		yyb1323 = yyj1323 > l
-	} else {
-		yyb1323 = r.CheckBreak()
-	}
-	if yyb1323 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = pkg2_api.ObjectMeta{}
-	} else {
-		yyv1326 := &x.ObjectMeta
-		yyv1326.CodecDecodeSelf(d)
-	}
-	yyj1323++
-	if yyhl1323 {
-		yyb1323 = yyj1323 > l
-	} else {
-		yyb1323 = r.CheckBreak()
-	}
-	if yyb1323 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = ReplicaSetSpec{}
-	} else {
-		yyv1327 := &x.Spec
-		yyv1327.CodecDecodeSelf(d)
-	}
-	yyj1323++
-	if yyhl1323 {
-		yyb1323 = yyj1323 > l
-	} else {
-		yyb1323 = r.CheckBreak()
-	}
-	if yyb1323 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = ReplicaSetStatus{}
-	} else {
-		yyv1328 := &x.Status
-		yyv1328.CodecDecodeSelf(d)
 	}
 	for {
 		yyj1323++
@@ -15826,9 +15826,9 @@ func (x *ReplicaSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1330 [4]bool
 			_, _, _ = yysep1330, yyq1330, yy2arr1330
 			const yyr1330 bool = false
-			yyq1330[0] = x.Kind != ""
-			yyq1330[1] = x.APIVersion != ""
-			yyq1330[2] = true
+			yyq1330[0] = true
+			yyq1330[2] = x.Kind != ""
+			yyq1330[3] = x.APIVersion != ""
 			var yynn1330 int
 			if yyr1330 || yy2arr1330 {
 				r.EncodeArrayStart(4)
@@ -15845,79 +15845,29 @@ func (x *ReplicaSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr1330 || yy2arr1330 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1330[0] {
-					yym1332 := z.EncBinary()
-					_ = yym1332
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1330[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1332 := &x.ListMeta
 					yym1333 := z.EncBinary()
 					_ = yym1333
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1332) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr1330 || yy2arr1330 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1330[1] {
-					yym1335 := z.EncBinary()
-					_ = yym1335
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1330[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1336 := z.EncBinary()
-					_ = yym1336
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr1330 || yy2arr1330 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1330[2] {
-					yy1338 := &x.ListMeta
-					yym1339 := z.EncBinary()
-					_ = yym1339
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1338) {
-					} else {
-						z.EncFallback(yy1338)
+						z.EncFallback(yy1332)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1330[2] {
+				if yyq1330[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1340 := &x.ListMeta
-					yym1341 := z.EncBinary()
-					_ = yym1341
+					yy1334 := &x.ListMeta
+					yym1335 := z.EncBinary()
+					_ = yym1335
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1340) {
+					} else if z.HasExtensions() && z.EncExt(yy1334) {
 					} else {
-						z.EncFallback(yy1340)
+						z.EncFallback(yy1334)
 					}
 				}
 			}
@@ -15926,8 +15876,8 @@ func (x *ReplicaSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1343 := z.EncBinary()
-					_ = yym1343
+					yym1337 := z.EncBinary()
+					_ = yym1337
 					if false {
 					} else {
 						h.encSliceReplicaSet(([]ReplicaSet)(x.Items), e)
@@ -15940,11 +15890,61 @@ func (x *ReplicaSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym1338 := z.EncBinary()
+					_ = yym1338
+					if false {
+					} else {
+						h.encSliceReplicaSet(([]ReplicaSet)(x.Items), e)
+					}
+				}
+			}
+			if yyr1330 || yy2arr1330 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1330[2] {
+					yym1340 := z.EncBinary()
+					_ = yym1340
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1330[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1341 := z.EncBinary()
+					_ = yym1341
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr1330 || yy2arr1330 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1330[3] {
+					yym1343 := z.EncBinary()
+					_ = yym1343
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1330[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1344 := z.EncBinary()
 					_ = yym1344
 					if false {
 					} else {
-						h.encSliceReplicaSet(([]ReplicaSet)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -16009,6 +16009,31 @@ func (x *ReplicaSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys1347 := string(yys1347Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1347 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv1348 := &x.ListMeta
+				yym1349 := z.DecBinary()
+				_ = yym1349
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv1348) {
+				} else {
+					z.DecFallback(yyv1348, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv1350 := &x.Items
+				yym1351 := z.DecBinary()
+				_ = yym1351
+				if false {
+				} else {
+					h.decSliceReplicaSet((*[]ReplicaSet)(yyv1350), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -16020,31 +16045,6 @@ func (x *ReplicaSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg1_unversioned.ListMeta{}
-			} else {
-				yyv1350 := &x.ListMeta
-				yym1351 := z.DecBinary()
-				_ = yym1351
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1350) {
-				} else {
-					z.DecFallback(yyv1350, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv1352 := &x.Items
-				yym1353 := z.DecBinary()
-				_ = yym1353
-				if false {
-				} else {
-					h.decSliceReplicaSet((*[]ReplicaSet)(yyv1352), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1347)
@@ -16060,6 +16060,51 @@ func (x *ReplicaSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj1354 int
 	var yyb1354 bool
 	var yyhl1354 bool = l >= 0
+	yyj1354++
+	if yyhl1354 {
+		yyb1354 = yyj1354 > l
+	} else {
+		yyb1354 = r.CheckBreak()
+	}
+	if yyb1354 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv1355 := &x.ListMeta
+		yym1356 := z.DecBinary()
+		_ = yym1356
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1355) {
+		} else {
+			z.DecFallback(yyv1355, false)
+		}
+	}
+	yyj1354++
+	if yyhl1354 {
+		yyb1354 = yyj1354 > l
+	} else {
+		yyb1354 = r.CheckBreak()
+	}
+	if yyb1354 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv1357 := &x.Items
+		yym1358 := z.DecBinary()
+		_ = yym1358
+		if false {
+		} else {
+			h.decSliceReplicaSet((*[]ReplicaSet)(yyv1357), d)
+		}
+	}
 	yyj1354++
 	if yyhl1354 {
 		yyb1354 = yyj1354 > l
@@ -16091,51 +16136,6 @@ func (x *ReplicaSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj1354++
-	if yyhl1354 {
-		yyb1354 = yyj1354 > l
-	} else {
-		yyb1354 = r.CheckBreak()
-	}
-	if yyb1354 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg1_unversioned.ListMeta{}
-	} else {
-		yyv1357 := &x.ListMeta
-		yym1358 := z.DecBinary()
-		_ = yym1358
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1357) {
-		} else {
-			z.DecFallback(yyv1357, false)
-		}
-	}
-	yyj1354++
-	if yyhl1354 {
-		yyb1354 = yyj1354 > l
-	} else {
-		yyb1354 = r.CheckBreak()
-	}
-	if yyb1354 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv1359 := &x.Items
-		yym1360 := z.DecBinary()
-		_ = yym1360
-		if false {
-		} else {
-			h.decSliceReplicaSet((*[]ReplicaSet)(yyv1359), d)
-		}
 	}
 	for {
 		yyj1354++
@@ -16678,10 +16678,10 @@ func (x *PodSecurityPolicy) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1399 [4]bool
 			_, _, _ = yysep1399, yyq1399, yy2arr1399
 			const yyr1399 bool = false
-			yyq1399[0] = x.Kind != ""
-			yyq1399[1] = x.APIVersion != ""
-			yyq1399[2] = true
-			yyq1399[3] = true
+			yyq1399[0] = true
+			yyq1399[1] = true
+			yyq1399[2] = x.Kind != ""
+			yyq1399[3] = x.APIVersion != ""
 			var yynn1399 int
 			if yyr1399 || yy2arr1399 {
 				r.EncodeArrayStart(4)
@@ -16698,22 +16698,56 @@ func (x *PodSecurityPolicy) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr1399 || yy2arr1399 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1399[0] {
-					yym1401 := z.EncBinary()
-					_ = yym1401
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy1401 := &x.ObjectMeta
+					yy1401.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq1399[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1402 := &x.ObjectMeta
+					yy1402.CodecEncodeSelf(e)
+				}
+			}
+			if yyr1399 || yy2arr1399 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1399[1] {
+					yy1404 := &x.Spec
+					yy1404.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1399[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1405 := &x.Spec
+					yy1405.CodecEncodeSelf(e)
+				}
+			}
+			if yyr1399 || yy2arr1399 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1399[2] {
+					yym1407 := z.EncBinary()
+					_ = yym1407
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1399[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1402 := z.EncBinary()
-					_ = yym1402
+					yym1408 := z.EncBinary()
+					_ = yym1408
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -16722,9 +16756,9 @@ func (x *PodSecurityPolicy) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr1399 || yy2arr1399 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1399[1] {
-					yym1404 := z.EncBinary()
-					_ = yym1404
+				if yyq1399[3] {
+					yym1410 := z.EncBinary()
+					_ = yym1410
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -16733,50 +16767,16 @@ func (x *PodSecurityPolicy) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1399[1] {
+				if yyq1399[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1405 := z.EncBinary()
-					_ = yym1405
+					yym1411 := z.EncBinary()
+					_ = yym1411
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
-				}
-			}
-			if yyr1399 || yy2arr1399 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1399[2] {
-					yy1407 := &x.ObjectMeta
-					yy1407.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1399[2] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1408 := &x.ObjectMeta
-					yy1408.CodecEncodeSelf(e)
-				}
-			}
-			if yyr1399 || yy2arr1399 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1399[3] {
-					yy1410 := &x.Spec
-					yy1410.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1399[3] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1411 := &x.Spec
-					yy1411.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1399 || yy2arr1399 {
@@ -16840,6 +16840,20 @@ func (x *PodSecurityPolicy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 		yys1414 := string(yys1414Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1414 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_api.ObjectMeta{}
+			} else {
+				yyv1415 := &x.ObjectMeta
+				yyv1415.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = PodSecurityPolicySpec{}
+			} else {
+				yyv1416 := &x.Spec
+				yyv1416.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -16851,20 +16865,6 @@ func (x *PodSecurityPolicy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = pkg2_api.ObjectMeta{}
-			} else {
-				yyv1417 := &x.ObjectMeta
-				yyv1417.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = PodSecurityPolicySpec{}
-			} else {
-				yyv1418 := &x.Spec
-				yyv1418.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1414)
@@ -16880,6 +16880,40 @@ func (x *PodSecurityPolicy) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var yyj1419 int
 	var yyb1419 bool
 	var yyhl1419 bool = l >= 0
+	yyj1419++
+	if yyhl1419 {
+		yyb1419 = yyj1419 > l
+	} else {
+		yyb1419 = r.CheckBreak()
+	}
+	if yyb1419 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_api.ObjectMeta{}
+	} else {
+		yyv1420 := &x.ObjectMeta
+		yyv1420.CodecDecodeSelf(d)
+	}
+	yyj1419++
+	if yyhl1419 {
+		yyb1419 = yyj1419 > l
+	} else {
+		yyb1419 = r.CheckBreak()
+	}
+	if yyb1419 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = PodSecurityPolicySpec{}
+	} else {
+		yyv1421 := &x.Spec
+		yyv1421.CodecDecodeSelf(d)
+	}
 	yyj1419++
 	if yyhl1419 {
 		yyb1419 = yyj1419 > l
@@ -16911,40 +16945,6 @@ func (x *PodSecurityPolicy) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj1419++
-	if yyhl1419 {
-		yyb1419 = yyj1419 > l
-	} else {
-		yyb1419 = r.CheckBreak()
-	}
-	if yyb1419 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = pkg2_api.ObjectMeta{}
-	} else {
-		yyv1422 := &x.ObjectMeta
-		yyv1422.CodecDecodeSelf(d)
-	}
-	yyj1419++
-	if yyhl1419 {
-		yyb1419 = yyj1419 > l
-	} else {
-		yyb1419 = r.CheckBreak()
-	}
-	if yyb1419 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = PodSecurityPolicySpec{}
-	} else {
-		yyv1423 := &x.Spec
-		yyv1423.CodecDecodeSelf(d)
 	}
 	for {
 		yyj1419++
@@ -18492,9 +18492,9 @@ func (x *PodSecurityPolicyList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1548 [4]bool
 			_, _, _ = yysep1548, yyq1548, yy2arr1548
 			const yyr1548 bool = false
-			yyq1548[0] = x.Kind != ""
-			yyq1548[1] = x.APIVersion != ""
-			yyq1548[2] = true
+			yyq1548[0] = true
+			yyq1548[2] = x.Kind != ""
+			yyq1548[3] = x.APIVersion != ""
 			var yynn1548 int
 			if yyr1548 || yy2arr1548 {
 				r.EncodeArrayStart(4)
@@ -18511,79 +18511,29 @@ func (x *PodSecurityPolicyList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr1548 || yy2arr1548 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1548[0] {
-					yym1550 := z.EncBinary()
-					_ = yym1550
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1548[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1550 := &x.ListMeta
 					yym1551 := z.EncBinary()
 					_ = yym1551
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1550) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr1548 || yy2arr1548 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1548[1] {
-					yym1553 := z.EncBinary()
-					_ = yym1553
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1548[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1554 := z.EncBinary()
-					_ = yym1554
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr1548 || yy2arr1548 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1548[2] {
-					yy1556 := &x.ListMeta
-					yym1557 := z.EncBinary()
-					_ = yym1557
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1556) {
-					} else {
-						z.EncFallback(yy1556)
+						z.EncFallback(yy1550)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1548[2] {
+				if yyq1548[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1558 := &x.ListMeta
-					yym1559 := z.EncBinary()
-					_ = yym1559
+					yy1552 := &x.ListMeta
+					yym1553 := z.EncBinary()
+					_ = yym1553
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1558) {
+					} else if z.HasExtensions() && z.EncExt(yy1552) {
 					} else {
-						z.EncFallback(yy1558)
+						z.EncFallback(yy1552)
 					}
 				}
 			}
@@ -18592,8 +18542,8 @@ func (x *PodSecurityPolicyList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1561 := z.EncBinary()
-					_ = yym1561
+					yym1555 := z.EncBinary()
+					_ = yym1555
 					if false {
 					} else {
 						h.encSlicePodSecurityPolicy(([]PodSecurityPolicy)(x.Items), e)
@@ -18606,11 +18556,61 @@ func (x *PodSecurityPolicyList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym1556 := z.EncBinary()
+					_ = yym1556
+					if false {
+					} else {
+						h.encSlicePodSecurityPolicy(([]PodSecurityPolicy)(x.Items), e)
+					}
+				}
+			}
+			if yyr1548 || yy2arr1548 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1548[2] {
+					yym1558 := z.EncBinary()
+					_ = yym1558
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1548[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1559 := z.EncBinary()
+					_ = yym1559
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr1548 || yy2arr1548 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1548[3] {
+					yym1561 := z.EncBinary()
+					_ = yym1561
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1548[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1562 := z.EncBinary()
 					_ = yym1562
 					if false {
 					} else {
-						h.encSlicePodSecurityPolicy(([]PodSecurityPolicy)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -18675,6 +18675,31 @@ func (x *PodSecurityPolicyList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 		yys1565 := string(yys1565Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1565 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv1566 := &x.ListMeta
+				yym1567 := z.DecBinary()
+				_ = yym1567
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv1566) {
+				} else {
+					z.DecFallback(yyv1566, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv1568 := &x.Items
+				yym1569 := z.DecBinary()
+				_ = yym1569
+				if false {
+				} else {
+					h.decSlicePodSecurityPolicy((*[]PodSecurityPolicy)(yyv1568), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -18686,31 +18711,6 @@ func (x *PodSecurityPolicyList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg1_unversioned.ListMeta{}
-			} else {
-				yyv1568 := &x.ListMeta
-				yym1569 := z.DecBinary()
-				_ = yym1569
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1568) {
-				} else {
-					z.DecFallback(yyv1568, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv1570 := &x.Items
-				yym1571 := z.DecBinary()
-				_ = yym1571
-				if false {
-				} else {
-					h.decSlicePodSecurityPolicy((*[]PodSecurityPolicy)(yyv1570), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1565)
@@ -18726,6 +18726,51 @@ func (x *PodSecurityPolicyList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var yyj1572 int
 	var yyb1572 bool
 	var yyhl1572 bool = l >= 0
+	yyj1572++
+	if yyhl1572 {
+		yyb1572 = yyj1572 > l
+	} else {
+		yyb1572 = r.CheckBreak()
+	}
+	if yyb1572 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv1573 := &x.ListMeta
+		yym1574 := z.DecBinary()
+		_ = yym1574
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1573) {
+		} else {
+			z.DecFallback(yyv1573, false)
+		}
+	}
+	yyj1572++
+	if yyhl1572 {
+		yyb1572 = yyj1572 > l
+	} else {
+		yyb1572 = r.CheckBreak()
+	}
+	if yyb1572 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv1575 := &x.Items
+		yym1576 := z.DecBinary()
+		_ = yym1576
+		if false {
+		} else {
+			h.decSlicePodSecurityPolicy((*[]PodSecurityPolicy)(yyv1575), d)
+		}
+	}
 	yyj1572++
 	if yyhl1572 {
 		yyb1572 = yyj1572 > l
@@ -18757,51 +18802,6 @@ func (x *PodSecurityPolicyList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj1572++
-	if yyhl1572 {
-		yyb1572 = yyj1572 > l
-	} else {
-		yyb1572 = r.CheckBreak()
-	}
-	if yyb1572 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg1_unversioned.ListMeta{}
-	} else {
-		yyv1575 := &x.ListMeta
-		yym1576 := z.DecBinary()
-		_ = yym1576
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1575) {
-		} else {
-			z.DecFallback(yyv1575, false)
-		}
-	}
-	yyj1572++
-	if yyhl1572 {
-		yyb1572 = yyj1572 > l
-	} else {
-		yyb1572 = r.CheckBreak()
-	}
-	if yyb1572 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv1577 := &x.Items
-		yym1578 := z.DecBinary()
-		_ = yym1578
-		if false {
-		} else {
-			h.decSlicePodSecurityPolicy((*[]PodSecurityPolicy)(yyv1577), d)
-		}
 	}
 	for {
 		yyj1572++

--- a/pkg/apis/extensions/v1beta1/types.generated.go
+++ b/pkg/apis/extensions/v1beta1/types.generated.go
@@ -493,11 +493,11 @@ func (x *Scale) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq31 [5]bool
 			_, _, _ = yysep31, yyq31, yy2arr31
 			const yyr31 bool = false
-			yyq31[0] = x.Kind != ""
-			yyq31[1] = x.APIVersion != ""
+			yyq31[0] = true
+			yyq31[1] = true
 			yyq31[2] = true
-			yyq31[3] = true
-			yyq31[4] = true
+			yyq31[3] = x.Kind != ""
+			yyq31[4] = x.APIVersion != ""
 			var yynn31 int
 			if yyr31 || yy2arr31 {
 				r.EncodeArrayStart(5)
@@ -514,57 +514,41 @@ func (x *Scale) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr31 || yy2arr31 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq31[0] {
-					yym33 := z.EncBinary()
-					_ = yym33
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy33 := &x.ObjectMeta
+					yy33.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq31[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym34 := z.EncBinary()
-					_ = yym34
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy34 := &x.ObjectMeta
+					yy34.CodecEncodeSelf(e)
 				}
 			}
 			if yyr31 || yy2arr31 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq31[1] {
-					yym36 := z.EncBinary()
-					_ = yym36
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy36 := &x.Spec
+					yy36.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq31[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym37 := z.EncBinary()
-					_ = yym37
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy37 := &x.Spec
+					yy37.CodecEncodeSelf(e)
 				}
 			}
 			if yyr31 || yy2arr31 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq31[2] {
-					yy39 := &x.ObjectMeta
+					yy39 := &x.Status
 					yy39.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
@@ -572,44 +556,60 @@ func (x *Scale) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq31[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy40 := &x.ObjectMeta
+					yy40 := &x.Status
 					yy40.CodecEncodeSelf(e)
 				}
 			}
 			if yyr31 || yy2arr31 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq31[3] {
-					yy42 := &x.Spec
-					yy42.CodecEncodeSelf(e)
+					yym42 := z.EncBinary()
+					_ = yym42
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq31[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy43 := &x.Spec
-					yy43.CodecEncodeSelf(e)
+					yym43 := z.EncBinary()
+					_ = yym43
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				}
 			}
 			if yyr31 || yy2arr31 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq31[4] {
-					yy45 := &x.Status
-					yy45.CodecEncodeSelf(e)
+					yym45 := z.EncBinary()
+					_ = yym45
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq31[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy46 := &x.Status
-					yy46.CodecEncodeSelf(e)
+					yym46 := z.EncBinary()
+					_ = yym46
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr31 || yy2arr31 {
@@ -673,6 +673,27 @@ func (x *Scale) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys49 := string(yys49Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys49 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_v1.ObjectMeta{}
+			} else {
+				yyv50 := &x.ObjectMeta
+				yyv50.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = ScaleSpec{}
+			} else {
+				yyv51 := &x.Spec
+				yyv51.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = ScaleStatus{}
+			} else {
+				yyv52 := &x.Status
+				yyv52.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -684,27 +705,6 @@ func (x *Scale) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = pkg2_v1.ObjectMeta{}
-			} else {
-				yyv52 := &x.ObjectMeta
-				yyv52.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = ScaleSpec{}
-			} else {
-				yyv53 := &x.Spec
-				yyv53.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = ScaleStatus{}
-			} else {
-				yyv54 := &x.Status
-				yyv54.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys49)
@@ -720,6 +720,57 @@ func (x *Scale) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj55 int
 	var yyb55 bool
 	var yyhl55 bool = l >= 0
+	yyj55++
+	if yyhl55 {
+		yyb55 = yyj55 > l
+	} else {
+		yyb55 = r.CheckBreak()
+	}
+	if yyb55 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_v1.ObjectMeta{}
+	} else {
+		yyv56 := &x.ObjectMeta
+		yyv56.CodecDecodeSelf(d)
+	}
+	yyj55++
+	if yyhl55 {
+		yyb55 = yyj55 > l
+	} else {
+		yyb55 = r.CheckBreak()
+	}
+	if yyb55 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = ScaleSpec{}
+	} else {
+		yyv57 := &x.Spec
+		yyv57.CodecDecodeSelf(d)
+	}
+	yyj55++
+	if yyhl55 {
+		yyb55 = yyj55 > l
+	} else {
+		yyb55 = r.CheckBreak()
+	}
+	if yyb55 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = ScaleStatus{}
+	} else {
+		yyv58 := &x.Status
+		yyv58.CodecDecodeSelf(d)
+	}
 	yyj55++
 	if yyhl55 {
 		yyb55 = yyj55 > l
@@ -751,57 +802,6 @@ func (x *Scale) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj55++
-	if yyhl55 {
-		yyb55 = yyj55 > l
-	} else {
-		yyb55 = r.CheckBreak()
-	}
-	if yyb55 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = pkg2_v1.ObjectMeta{}
-	} else {
-		yyv58 := &x.ObjectMeta
-		yyv58.CodecDecodeSelf(d)
-	}
-	yyj55++
-	if yyhl55 {
-		yyb55 = yyj55 > l
-	} else {
-		yyb55 = r.CheckBreak()
-	}
-	if yyb55 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = ScaleSpec{}
-	} else {
-		yyv59 := &x.Spec
-		yyv59.CodecDecodeSelf(d)
-	}
-	yyj55++
-	if yyhl55 {
-		yyb55 = yyj55 > l
-	} else {
-		yyb55 = r.CheckBreak()
-	}
-	if yyb55 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = ScaleStatus{}
-	} else {
-		yyv60 := &x.Status
-		yyv60.CodecDecodeSelf(d)
 	}
 	for {
 		yyj55++
@@ -3136,11 +3136,11 @@ func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq250 [5]bool
 			_, _, _ = yysep250, yyq250, yy2arr250
 			const yyr250 bool = false
-			yyq250[0] = x.Kind != ""
-			yyq250[1] = x.APIVersion != ""
+			yyq250[0] = true
+			yyq250[1] = true
 			yyq250[2] = true
-			yyq250[3] = true
-			yyq250[4] = true
+			yyq250[3] = x.Kind != ""
+			yyq250[4] = x.APIVersion != ""
 			var yynn250 int
 			if yyr250 || yy2arr250 {
 				r.EncodeArrayStart(5)
@@ -3157,57 +3157,41 @@ func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr250 || yy2arr250 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq250[0] {
-					yym252 := z.EncBinary()
-					_ = yym252
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy252 := &x.ObjectMeta
+					yy252.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq250[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym253 := z.EncBinary()
-					_ = yym253
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy253 := &x.ObjectMeta
+					yy253.CodecEncodeSelf(e)
 				}
 			}
 			if yyr250 || yy2arr250 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq250[1] {
-					yym255 := z.EncBinary()
-					_ = yym255
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy255 := &x.Spec
+					yy255.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq250[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym256 := z.EncBinary()
-					_ = yym256
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy256 := &x.Spec
+					yy256.CodecEncodeSelf(e)
 				}
 			}
 			if yyr250 || yy2arr250 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq250[2] {
-					yy258 := &x.ObjectMeta
+					yy258 := &x.Status
 					yy258.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
@@ -3215,44 +3199,60 @@ func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq250[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy259 := &x.ObjectMeta
+					yy259 := &x.Status
 					yy259.CodecEncodeSelf(e)
 				}
 			}
 			if yyr250 || yy2arr250 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq250[3] {
-					yy261 := &x.Spec
-					yy261.CodecEncodeSelf(e)
+					yym261 := z.EncBinary()
+					_ = yym261
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq250[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy262 := &x.Spec
-					yy262.CodecEncodeSelf(e)
+					yym262 := z.EncBinary()
+					_ = yym262
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				}
 			}
 			if yyr250 || yy2arr250 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq250[4] {
-					yy264 := &x.Status
-					yy264.CodecEncodeSelf(e)
+					yym264 := z.EncBinary()
+					_ = yym264
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq250[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy265 := &x.Status
-					yy265.CodecEncodeSelf(e)
+					yym265 := z.EncBinary()
+					_ = yym265
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr250 || yy2arr250 {
@@ -3316,6 +3316,27 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 		yys268 := string(yys268Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys268 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_v1.ObjectMeta{}
+			} else {
+				yyv269 := &x.ObjectMeta
+				yyv269.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = HorizontalPodAutoscalerSpec{}
+			} else {
+				yyv270 := &x.Spec
+				yyv270.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = HorizontalPodAutoscalerStatus{}
+			} else {
+				yyv271 := &x.Status
+				yyv271.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -3327,27 +3348,6 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = pkg2_v1.ObjectMeta{}
-			} else {
-				yyv271 := &x.ObjectMeta
-				yyv271.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = HorizontalPodAutoscalerSpec{}
-			} else {
-				yyv272 := &x.Spec
-				yyv272.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = HorizontalPodAutoscalerStatus{}
-			} else {
-				yyv273 := &x.Status
-				yyv273.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys268)
@@ -3363,6 +3363,57 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.D
 	var yyj274 int
 	var yyb274 bool
 	var yyhl274 bool = l >= 0
+	yyj274++
+	if yyhl274 {
+		yyb274 = yyj274 > l
+	} else {
+		yyb274 = r.CheckBreak()
+	}
+	if yyb274 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_v1.ObjectMeta{}
+	} else {
+		yyv275 := &x.ObjectMeta
+		yyv275.CodecDecodeSelf(d)
+	}
+	yyj274++
+	if yyhl274 {
+		yyb274 = yyj274 > l
+	} else {
+		yyb274 = r.CheckBreak()
+	}
+	if yyb274 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = HorizontalPodAutoscalerSpec{}
+	} else {
+		yyv276 := &x.Spec
+		yyv276.CodecDecodeSelf(d)
+	}
+	yyj274++
+	if yyhl274 {
+		yyb274 = yyj274 > l
+	} else {
+		yyb274 = r.CheckBreak()
+	}
+	if yyb274 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = HorizontalPodAutoscalerStatus{}
+	} else {
+		yyv277 := &x.Status
+		yyv277.CodecDecodeSelf(d)
+	}
 	yyj274++
 	if yyhl274 {
 		yyb274 = yyj274 > l
@@ -3394,57 +3445,6 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.D
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj274++
-	if yyhl274 {
-		yyb274 = yyj274 > l
-	} else {
-		yyb274 = r.CheckBreak()
-	}
-	if yyb274 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = pkg2_v1.ObjectMeta{}
-	} else {
-		yyv277 := &x.ObjectMeta
-		yyv277.CodecDecodeSelf(d)
-	}
-	yyj274++
-	if yyhl274 {
-		yyb274 = yyj274 > l
-	} else {
-		yyb274 = r.CheckBreak()
-	}
-	if yyb274 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = HorizontalPodAutoscalerSpec{}
-	} else {
-		yyv278 := &x.Spec
-		yyv278.CodecDecodeSelf(d)
-	}
-	yyj274++
-	if yyhl274 {
-		yyb274 = yyj274 > l
-	} else {
-		yyb274 = r.CheckBreak()
-	}
-	if yyb274 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = HorizontalPodAutoscalerStatus{}
-	} else {
-		yyv279 := &x.Status
-		yyv279.CodecDecodeSelf(d)
 	}
 	for {
 		yyj274++
@@ -3479,9 +3479,9 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq281 [4]bool
 			_, _, _ = yysep281, yyq281, yy2arr281
 			const yyr281 bool = false
-			yyq281[0] = x.Kind != ""
-			yyq281[1] = x.APIVersion != ""
-			yyq281[2] = true
+			yyq281[0] = true
+			yyq281[2] = x.Kind != ""
+			yyq281[3] = x.APIVersion != ""
 			var yynn281 int
 			if yyr281 || yy2arr281 {
 				r.EncodeArrayStart(4)
@@ -3498,79 +3498,29 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr281 || yy2arr281 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq281[0] {
-					yym283 := z.EncBinary()
-					_ = yym283
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq281[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy283 := &x.ListMeta
 					yym284 := z.EncBinary()
 					_ = yym284
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy283) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr281 || yy2arr281 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq281[1] {
-					yym286 := z.EncBinary()
-					_ = yym286
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq281[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym287 := z.EncBinary()
-					_ = yym287
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr281 || yy2arr281 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq281[2] {
-					yy289 := &x.ListMeta
-					yym290 := z.EncBinary()
-					_ = yym290
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy289) {
-					} else {
-						z.EncFallback(yy289)
+						z.EncFallback(yy283)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq281[2] {
+				if yyq281[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy291 := &x.ListMeta
-					yym292 := z.EncBinary()
-					_ = yym292
+					yy285 := &x.ListMeta
+					yym286 := z.EncBinary()
+					_ = yym286
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy291) {
+					} else if z.HasExtensions() && z.EncExt(yy285) {
 					} else {
-						z.EncFallback(yy291)
+						z.EncFallback(yy285)
 					}
 				}
 			}
@@ -3579,8 +3529,8 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym294 := z.EncBinary()
-					_ = yym294
+					yym288 := z.EncBinary()
+					_ = yym288
 					if false {
 					} else {
 						h.encSliceHorizontalPodAutoscaler(([]HorizontalPodAutoscaler)(x.Items), e)
@@ -3593,11 +3543,61 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym289 := z.EncBinary()
+					_ = yym289
+					if false {
+					} else {
+						h.encSliceHorizontalPodAutoscaler(([]HorizontalPodAutoscaler)(x.Items), e)
+					}
+				}
+			}
+			if yyr281 || yy2arr281 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq281[2] {
+					yym291 := z.EncBinary()
+					_ = yym291
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq281[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym292 := z.EncBinary()
+					_ = yym292
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr281 || yy2arr281 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq281[3] {
+					yym294 := z.EncBinary()
+					_ = yym294
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq281[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym295 := z.EncBinary()
 					_ = yym295
 					if false {
 					} else {
-						h.encSliceHorizontalPodAutoscaler(([]HorizontalPodAutoscaler)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -3662,6 +3662,31 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978
 		yys298 := string(yys298Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys298 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv299 := &x.ListMeta
+				yym300 := z.DecBinary()
+				_ = yym300
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv299) {
+				} else {
+					z.DecFallback(yyv299, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv301 := &x.Items
+				yym302 := z.DecBinary()
+				_ = yym302
+				if false {
+				} else {
+					h.decSliceHorizontalPodAutoscaler((*[]HorizontalPodAutoscaler)(yyv301), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -3673,31 +3698,6 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg1_unversioned.ListMeta{}
-			} else {
-				yyv301 := &x.ListMeta
-				yym302 := z.DecBinary()
-				_ = yym302
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv301) {
-				} else {
-					z.DecFallback(yyv301, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv303 := &x.Items
-				yym304 := z.DecBinary()
-				_ = yym304
-				if false {
-				} else {
-					h.decSliceHorizontalPodAutoscaler((*[]HorizontalPodAutoscaler)(yyv303), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys298)
@@ -3713,6 +3713,51 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromArray(l int, d *codec19
 	var yyj305 int
 	var yyb305 bool
 	var yyhl305 bool = l >= 0
+	yyj305++
+	if yyhl305 {
+		yyb305 = yyj305 > l
+	} else {
+		yyb305 = r.CheckBreak()
+	}
+	if yyb305 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv306 := &x.ListMeta
+		yym307 := z.DecBinary()
+		_ = yym307
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv306) {
+		} else {
+			z.DecFallback(yyv306, false)
+		}
+	}
+	yyj305++
+	if yyhl305 {
+		yyb305 = yyj305 > l
+	} else {
+		yyb305 = r.CheckBreak()
+	}
+	if yyb305 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv308 := &x.Items
+		yym309 := z.DecBinary()
+		_ = yym309
+		if false {
+		} else {
+			h.decSliceHorizontalPodAutoscaler((*[]HorizontalPodAutoscaler)(yyv308), d)
+		}
+	}
 	yyj305++
 	if yyhl305 {
 		yyb305 = yyj305 > l
@@ -3744,51 +3789,6 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromArray(l int, d *codec19
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj305++
-	if yyhl305 {
-		yyb305 = yyj305 > l
-	} else {
-		yyb305 = r.CheckBreak()
-	}
-	if yyb305 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg1_unversioned.ListMeta{}
-	} else {
-		yyv308 := &x.ListMeta
-		yym309 := z.DecBinary()
-		_ = yym309
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv308) {
-		} else {
-			z.DecFallback(yyv308, false)
-		}
-	}
-	yyj305++
-	if yyhl305 {
-		yyb305 = yyj305 > l
-	} else {
-		yyb305 = r.CheckBreak()
-	}
-	if yyb305 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv310 := &x.Items
-		yym311 := z.DecBinary()
-		_ = yym311
-		if false {
-		} else {
-			h.decSliceHorizontalPodAutoscaler((*[]HorizontalPodAutoscaler)(yyv310), d)
-		}
 	}
 	for {
 		yyj305++
@@ -3823,11 +3823,11 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq313 [5]bool
 			_, _, _ = yysep313, yyq313, yy2arr313
 			const yyr313 bool = false
-			yyq313[0] = x.Kind != ""
-			yyq313[1] = x.APIVersion != ""
-			yyq313[2] = true
-			yyq313[3] = x.Description != ""
-			yyq313[4] = len(x.Versions) != 0
+			yyq313[0] = true
+			yyq313[1] = x.Description != ""
+			yyq313[2] = len(x.Versions) != 0
+			yyq313[3] = x.Kind != ""
+			yyq313[4] = x.APIVersion != ""
 			var yynn313 int
 			if yyr313 || yy2arr313 {
 				r.EncodeArrayStart(5)
@@ -3844,26 +3844,18 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr313 || yy2arr313 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq313[0] {
-					yym315 := z.EncBinary()
-					_ = yym315
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy315 := &x.ObjectMeta
+					yy315.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq313[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym316 := z.EncBinary()
-					_ = yym316
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy316 := &x.ObjectMeta
+					yy316.CodecEncodeSelf(e)
 				}
 			}
 			if yyr313 || yy2arr313 {
@@ -3873,7 +3865,7 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym318
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Description))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -3881,31 +3873,47 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq313[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("description"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym319 := z.EncBinary()
 					_ = yym319
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Description))
 					}
 				}
 			}
 			if yyr313 || yy2arr313 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq313[2] {
-					yy321 := &x.ObjectMeta
-					yy321.CodecEncodeSelf(e)
+					if x.Versions == nil {
+						r.EncodeNil()
+					} else {
+						yym321 := z.EncBinary()
+						_ = yym321
+						if false {
+						} else {
+							h.encSliceAPIVersion(([]APIVersion)(x.Versions), e)
+						}
+					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
 				if yyq313[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("versions"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy322 := &x.ObjectMeta
-					yy322.CodecEncodeSelf(e)
+					if x.Versions == nil {
+						r.EncodeNil()
+					} else {
+						yym322 := z.EncBinary()
+						_ = yym322
+						if false {
+						} else {
+							h.encSliceAPIVersion(([]APIVersion)(x.Versions), e)
+						}
+					}
 				}
 			}
 			if yyr313 || yy2arr313 {
@@ -3915,7 +3923,7 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym324
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Description))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -3923,46 +3931,38 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq313[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("description"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym325 := z.EncBinary()
 					_ = yym325
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Description))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
 			if yyr313 || yy2arr313 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq313[4] {
-					if x.Versions == nil {
-						r.EncodeNil()
+					yym327 := z.EncBinary()
+					_ = yym327
+					if false {
 					} else {
-						yym327 := z.EncBinary()
-						_ = yym327
-						if false {
-						} else {
-							h.encSliceAPIVersion(([]APIVersion)(x.Versions), e)
-						}
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq313[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("versions"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if x.Versions == nil {
-						r.EncodeNil()
+					yym328 := z.EncBinary()
+					_ = yym328
+					if false {
 					} else {
-						yym328 := z.EncBinary()
-						_ = yym328
-						if false {
-						} else {
-							h.encSliceAPIVersion(([]APIVersion)(x.Versions), e)
-						}
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -4027,24 +4027,12 @@ func (x *ThirdPartyResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 		yys331 := string(yys331Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys331 {
-		case "kind":
-			if r.TryDecodeAsNil() {
-				x.Kind = ""
-			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
-			}
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_v1.ObjectMeta{}
 			} else {
-				yyv334 := &x.ObjectMeta
-				yyv334.CodecDecodeSelf(d)
+				yyv332 := &x.ObjectMeta
+				yyv332.CodecDecodeSelf(d)
 			}
 		case "description":
 			if r.TryDecodeAsNil() {
@@ -4056,13 +4044,25 @@ func (x *ThirdPartyResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			if r.TryDecodeAsNil() {
 				x.Versions = nil
 			} else {
-				yyv336 := &x.Versions
-				yym337 := z.DecBinary()
-				_ = yym337
+				yyv334 := &x.Versions
+				yym335 := z.DecBinary()
+				_ = yym335
 				if false {
 				} else {
-					h.decSliceAPIVersion((*[]APIVersion)(yyv336), d)
+					h.decSliceAPIVersion((*[]APIVersion)(yyv334), d)
 				}
+			}
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys331)
@@ -4090,42 +4090,10 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.Kind = ""
-	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj338++
-	if yyhl338 {
-		yyb338 = yyj338 > l
-	} else {
-		yyb338 = r.CheckBreak()
-	}
-	if yyb338 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
-	}
-	yyj338++
-	if yyhl338 {
-		yyb338 = yyj338 > l
-	} else {
-		yyb338 = r.CheckBreak()
-	}
-	if yyb338 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_v1.ObjectMeta{}
 	} else {
-		yyv341 := &x.ObjectMeta
-		yyv341.CodecDecodeSelf(d)
+		yyv339 := &x.ObjectMeta
+		yyv339.CodecDecodeSelf(d)
 	}
 	yyj338++
 	if yyhl338 {
@@ -4157,13 +4125,45 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	if r.TryDecodeAsNil() {
 		x.Versions = nil
 	} else {
-		yyv343 := &x.Versions
-		yym344 := z.DecBinary()
-		_ = yym344
+		yyv341 := &x.Versions
+		yym342 := z.DecBinary()
+		_ = yym342
 		if false {
 		} else {
-			h.decSliceAPIVersion((*[]APIVersion)(yyv343), d)
+			h.decSliceAPIVersion((*[]APIVersion)(yyv341), d)
 		}
+	}
+	yyj338++
+	if yyhl338 {
+		yyb338 = yyj338 > l
+	} else {
+		yyb338 = r.CheckBreak()
+	}
+	if yyb338 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj338++
+	if yyhl338 {
+		yyb338 = yyj338 > l
+	} else {
+		yyb338 = r.CheckBreak()
+	}
+	if yyb338 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
 	}
 	for {
 		yyj338++
@@ -4198,9 +4198,9 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq346 [4]bool
 			_, _, _ = yysep346, yyq346, yy2arr346
 			const yyr346 bool = false
-			yyq346[0] = x.Kind != ""
-			yyq346[1] = x.APIVersion != ""
-			yyq346[2] = true
+			yyq346[0] = true
+			yyq346[2] = x.Kind != ""
+			yyq346[3] = x.APIVersion != ""
 			var yynn346 int
 			if yyr346 || yy2arr346 {
 				r.EncodeArrayStart(4)
@@ -4217,79 +4217,29 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr346 || yy2arr346 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq346[0] {
-					yym348 := z.EncBinary()
-					_ = yym348
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq346[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy348 := &x.ListMeta
 					yym349 := z.EncBinary()
 					_ = yym349
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy348) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr346 || yy2arr346 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq346[1] {
-					yym351 := z.EncBinary()
-					_ = yym351
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq346[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym352 := z.EncBinary()
-					_ = yym352
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr346 || yy2arr346 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq346[2] {
-					yy354 := &x.ListMeta
-					yym355 := z.EncBinary()
-					_ = yym355
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy354) {
-					} else {
-						z.EncFallback(yy354)
+						z.EncFallback(yy348)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq346[2] {
+				if yyq346[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy356 := &x.ListMeta
-					yym357 := z.EncBinary()
-					_ = yym357
+					yy350 := &x.ListMeta
+					yym351 := z.EncBinary()
+					_ = yym351
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy356) {
+					} else if z.HasExtensions() && z.EncExt(yy350) {
 					} else {
-						z.EncFallback(yy356)
+						z.EncFallback(yy350)
 					}
 				}
 			}
@@ -4298,8 +4248,8 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym359 := z.EncBinary()
-					_ = yym359
+					yym353 := z.EncBinary()
+					_ = yym353
 					if false {
 					} else {
 						h.encSliceThirdPartyResource(([]ThirdPartyResource)(x.Items), e)
@@ -4312,11 +4262,61 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym354 := z.EncBinary()
+					_ = yym354
+					if false {
+					} else {
+						h.encSliceThirdPartyResource(([]ThirdPartyResource)(x.Items), e)
+					}
+				}
+			}
+			if yyr346 || yy2arr346 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq346[2] {
+					yym356 := z.EncBinary()
+					_ = yym356
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq346[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym357 := z.EncBinary()
+					_ = yym357
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr346 || yy2arr346 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq346[3] {
+					yym359 := z.EncBinary()
+					_ = yym359
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq346[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym360 := z.EncBinary()
 					_ = yym360
 					if false {
 					} else {
-						h.encSliceThirdPartyResource(([]ThirdPartyResource)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -4381,6 +4381,31 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 		yys363 := string(yys363Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys363 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv364 := &x.ListMeta
+				yym365 := z.DecBinary()
+				_ = yym365
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv364) {
+				} else {
+					z.DecFallback(yyv364, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv366 := &x.Items
+				yym367 := z.DecBinary()
+				_ = yym367
+				if false {
+				} else {
+					h.decSliceThirdPartyResource((*[]ThirdPartyResource)(yyv366), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -4392,31 +4417,6 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg1_unversioned.ListMeta{}
-			} else {
-				yyv366 := &x.ListMeta
-				yym367 := z.DecBinary()
-				_ = yym367
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv366) {
-				} else {
-					z.DecFallback(yyv366, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv368 := &x.Items
-				yym369 := z.DecBinary()
-				_ = yym369
-				if false {
-				} else {
-					h.decSliceThirdPartyResource((*[]ThirdPartyResource)(yyv368), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys363)
@@ -4432,6 +4432,51 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromArray(l int, d *codec1978.De
 	var yyj370 int
 	var yyb370 bool
 	var yyhl370 bool = l >= 0
+	yyj370++
+	if yyhl370 {
+		yyb370 = yyj370 > l
+	} else {
+		yyb370 = r.CheckBreak()
+	}
+	if yyb370 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv371 := &x.ListMeta
+		yym372 := z.DecBinary()
+		_ = yym372
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv371) {
+		} else {
+			z.DecFallback(yyv371, false)
+		}
+	}
+	yyj370++
+	if yyhl370 {
+		yyb370 = yyj370 > l
+	} else {
+		yyb370 = r.CheckBreak()
+	}
+	if yyb370 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv373 := &x.Items
+		yym374 := z.DecBinary()
+		_ = yym374
+		if false {
+		} else {
+			h.decSliceThirdPartyResource((*[]ThirdPartyResource)(yyv373), d)
+		}
+	}
 	yyj370++
 	if yyhl370 {
 		yyb370 = yyj370 > l
@@ -4463,51 +4508,6 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromArray(l int, d *codec1978.De
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj370++
-	if yyhl370 {
-		yyb370 = yyj370 > l
-	} else {
-		yyb370 = r.CheckBreak()
-	}
-	if yyb370 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg1_unversioned.ListMeta{}
-	} else {
-		yyv373 := &x.ListMeta
-		yym374 := z.DecBinary()
-		_ = yym374
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv373) {
-		} else {
-			z.DecFallback(yyv373, false)
-		}
-	}
-	yyj370++
-	if yyhl370 {
-		yyb370 = yyj370 > l
-	} else {
-		yyb370 = r.CheckBreak()
-	}
-	if yyb370 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv375 := &x.Items
-		yym376 := z.DecBinary()
-		_ = yym376
-		if false {
-		} else {
-			h.decSliceThirdPartyResource((*[]ThirdPartyResource)(yyv375), d)
-		}
 	}
 	for {
 		yyj370++
@@ -4759,10 +4759,10 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq394 [4]bool
 			_, _, _ = yysep394, yyq394, yy2arr394
 			const yyr394 bool = false
-			yyq394[0] = x.Kind != ""
-			yyq394[1] = x.APIVersion != ""
-			yyq394[2] = true
-			yyq394[3] = len(x.Data) != 0
+			yyq394[0] = true
+			yyq394[1] = len(x.Data) != 0
+			yyq394[2] = x.Kind != ""
+			yyq394[3] = x.APIVersion != ""
 			var yynn394 int
 			if yyr394 || yy2arr394 {
 				r.EncodeArrayStart(4)
@@ -4779,78 +4779,28 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr394 || yy2arr394 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq394[0] {
-					yym396 := z.EncBinary()
-					_ = yym396
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq394[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym397 := z.EncBinary()
-					_ = yym397
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr394 || yy2arr394 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq394[1] {
-					yym399 := z.EncBinary()
-					_ = yym399
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq394[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym400 := z.EncBinary()
-					_ = yym400
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr394 || yy2arr394 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq394[2] {
-					yy402 := &x.ObjectMeta
-					yy402.CodecEncodeSelf(e)
+					yy396 := &x.ObjectMeta
+					yy396.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq394[2] {
+				if yyq394[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy403 := &x.ObjectMeta
-					yy403.CodecEncodeSelf(e)
+					yy397 := &x.ObjectMeta
+					yy397.CodecEncodeSelf(e)
 				}
 			}
 			if yyr394 || yy2arr394 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq394[3] {
+				if yyq394[1] {
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
-						yym405 := z.EncBinary()
-						_ = yym405
+						yym399 := z.EncBinary()
+						_ = yym399
 						if false {
 						} else {
 							r.EncodeStringBytes(codecSelferC_RAW1234, []byte(x.Data))
@@ -4860,19 +4810,69 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq394[3] {
+				if yyq394[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("data"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
-						yym406 := z.EncBinary()
-						_ = yym406
+						yym400 := z.EncBinary()
+						_ = yym400
 						if false {
 						} else {
 							r.EncodeStringBytes(codecSelferC_RAW1234, []byte(x.Data))
 						}
+					}
+				}
+			}
+			if yyr394 || yy2arr394 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq394[2] {
+					yym402 := z.EncBinary()
+					_ = yym402
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq394[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym403 := z.EncBinary()
+					_ = yym403
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr394 || yy2arr394 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq394[3] {
+					yym405 := z.EncBinary()
+					_ = yym405
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq394[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym406 := z.EncBinary()
+					_ = yym406
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -4937,6 +4937,25 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 		yys409 := string(yys409Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys409 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_v1.ObjectMeta{}
+			} else {
+				yyv410 := &x.ObjectMeta
+				yyv410.CodecDecodeSelf(d)
+			}
+		case "data":
+			if r.TryDecodeAsNil() {
+				x.Data = nil
+			} else {
+				yyv411 := &x.Data
+				yym412 := z.DecBinary()
+				_ = yym412
+				if false {
+				} else {
+					*yyv411 = r.DecodeBytes(*(*[]byte)(yyv411), false, false)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -4948,25 +4967,6 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = pkg2_v1.ObjectMeta{}
-			} else {
-				yyv412 := &x.ObjectMeta
-				yyv412.CodecDecodeSelf(d)
-			}
-		case "data":
-			if r.TryDecodeAsNil() {
-				x.Data = nil
-			} else {
-				yyv413 := &x.Data
-				yym414 := z.DecBinary()
-				_ = yym414
-				if false {
-				} else {
-					*yyv413 = r.DecodeBytes(*(*[]byte)(yyv413), false, false)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys409)
@@ -4982,6 +4982,45 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromArray(l int, d *codec1978.De
 	var yyj415 int
 	var yyb415 bool
 	var yyhl415 bool = l >= 0
+	yyj415++
+	if yyhl415 {
+		yyb415 = yyj415 > l
+	} else {
+		yyb415 = r.CheckBreak()
+	}
+	if yyb415 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_v1.ObjectMeta{}
+	} else {
+		yyv416 := &x.ObjectMeta
+		yyv416.CodecDecodeSelf(d)
+	}
+	yyj415++
+	if yyhl415 {
+		yyb415 = yyj415 > l
+	} else {
+		yyb415 = r.CheckBreak()
+	}
+	if yyb415 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Data = nil
+	} else {
+		yyv417 := &x.Data
+		yym418 := z.DecBinary()
+		_ = yym418
+		if false {
+		} else {
+			*yyv417 = r.DecodeBytes(*(*[]byte)(yyv417), false, false)
+		}
+	}
 	yyj415++
 	if yyhl415 {
 		yyb415 = yyj415 > l
@@ -5013,45 +5052,6 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromArray(l int, d *codec1978.De
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj415++
-	if yyhl415 {
-		yyb415 = yyj415 > l
-	} else {
-		yyb415 = r.CheckBreak()
-	}
-	if yyb415 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = pkg2_v1.ObjectMeta{}
-	} else {
-		yyv418 := &x.ObjectMeta
-		yyv418.CodecDecodeSelf(d)
-	}
-	yyj415++
-	if yyhl415 {
-		yyb415 = yyj415 > l
-	} else {
-		yyb415 = r.CheckBreak()
-	}
-	if yyb415 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Data = nil
-	} else {
-		yyv419 := &x.Data
-		yym420 := z.DecBinary()
-		_ = yym420
-		if false {
-		} else {
-			*yyv419 = r.DecodeBytes(*(*[]byte)(yyv419), false, false)
-		}
 	}
 	for {
 		yyj415++
@@ -5086,11 +5086,11 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq422 [5]bool
 			_, _, _ = yysep422, yyq422, yy2arr422
 			const yyr422 bool = false
-			yyq422[0] = x.Kind != ""
-			yyq422[1] = x.APIVersion != ""
+			yyq422[0] = true
+			yyq422[1] = true
 			yyq422[2] = true
-			yyq422[3] = true
-			yyq422[4] = true
+			yyq422[3] = x.Kind != ""
+			yyq422[4] = x.APIVersion != ""
 			var yynn422 int
 			if yyr422 || yy2arr422 {
 				r.EncodeArrayStart(5)
@@ -5107,57 +5107,41 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr422 || yy2arr422 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq422[0] {
-					yym424 := z.EncBinary()
-					_ = yym424
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy424 := &x.ObjectMeta
+					yy424.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq422[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym425 := z.EncBinary()
-					_ = yym425
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy425 := &x.ObjectMeta
+					yy425.CodecEncodeSelf(e)
 				}
 			}
 			if yyr422 || yy2arr422 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq422[1] {
-					yym427 := z.EncBinary()
-					_ = yym427
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy427 := &x.Spec
+					yy427.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq422[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym428 := z.EncBinary()
-					_ = yym428
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy428 := &x.Spec
+					yy428.CodecEncodeSelf(e)
 				}
 			}
 			if yyr422 || yy2arr422 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq422[2] {
-					yy430 := &x.ObjectMeta
+					yy430 := &x.Status
 					yy430.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
@@ -5165,44 +5149,60 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq422[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy431 := &x.ObjectMeta
+					yy431 := &x.Status
 					yy431.CodecEncodeSelf(e)
 				}
 			}
 			if yyr422 || yy2arr422 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq422[3] {
-					yy433 := &x.Spec
-					yy433.CodecEncodeSelf(e)
+					yym433 := z.EncBinary()
+					_ = yym433
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq422[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy434 := &x.Spec
-					yy434.CodecEncodeSelf(e)
+					yym434 := z.EncBinary()
+					_ = yym434
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				}
 			}
 			if yyr422 || yy2arr422 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq422[4] {
-					yy436 := &x.Status
-					yy436.CodecEncodeSelf(e)
+					yym436 := z.EncBinary()
+					_ = yym436
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq422[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy437 := &x.Status
-					yy437.CodecEncodeSelf(e)
+					yym437 := z.EncBinary()
+					_ = yym437
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr422 || yy2arr422 {
@@ -5266,6 +5266,27 @@ func (x *Deployment) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys440 := string(yys440Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys440 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_v1.ObjectMeta{}
+			} else {
+				yyv441 := &x.ObjectMeta
+				yyv441.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = DeploymentSpec{}
+			} else {
+				yyv442 := &x.Spec
+				yyv442.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = DeploymentStatus{}
+			} else {
+				yyv443 := &x.Status
+				yyv443.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -5277,27 +5298,6 @@ func (x *Deployment) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = pkg2_v1.ObjectMeta{}
-			} else {
-				yyv443 := &x.ObjectMeta
-				yyv443.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = DeploymentSpec{}
-			} else {
-				yyv444 := &x.Spec
-				yyv444.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = DeploymentStatus{}
-			} else {
-				yyv445 := &x.Status
-				yyv445.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys440)
@@ -5313,6 +5313,57 @@ func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj446 int
 	var yyb446 bool
 	var yyhl446 bool = l >= 0
+	yyj446++
+	if yyhl446 {
+		yyb446 = yyj446 > l
+	} else {
+		yyb446 = r.CheckBreak()
+	}
+	if yyb446 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_v1.ObjectMeta{}
+	} else {
+		yyv447 := &x.ObjectMeta
+		yyv447.CodecDecodeSelf(d)
+	}
+	yyj446++
+	if yyhl446 {
+		yyb446 = yyj446 > l
+	} else {
+		yyb446 = r.CheckBreak()
+	}
+	if yyb446 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = DeploymentSpec{}
+	} else {
+		yyv448 := &x.Spec
+		yyv448.CodecDecodeSelf(d)
+	}
+	yyj446++
+	if yyhl446 {
+		yyb446 = yyj446 > l
+	} else {
+		yyb446 = r.CheckBreak()
+	}
+	if yyb446 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = DeploymentStatus{}
+	} else {
+		yyv449 := &x.Status
+		yyv449.CodecDecodeSelf(d)
+	}
 	yyj446++
 	if yyhl446 {
 		yyb446 = yyj446 > l
@@ -5344,57 +5395,6 @@ func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj446++
-	if yyhl446 {
-		yyb446 = yyj446 > l
-	} else {
-		yyb446 = r.CheckBreak()
-	}
-	if yyb446 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = pkg2_v1.ObjectMeta{}
-	} else {
-		yyv449 := &x.ObjectMeta
-		yyv449.CodecDecodeSelf(d)
-	}
-	yyj446++
-	if yyhl446 {
-		yyb446 = yyj446 > l
-	} else {
-		yyb446 = r.CheckBreak()
-	}
-	if yyb446 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = DeploymentSpec{}
-	} else {
-		yyv450 := &x.Spec
-		yyv450.CodecDecodeSelf(d)
-	}
-	yyj446++
-	if yyhl446 {
-		yyb446 = yyj446 > l
-	} else {
-		yyb446 = r.CheckBreak()
-	}
-	if yyb446 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = DeploymentStatus{}
-	} else {
-		yyv451 := &x.Status
-		yyv451.CodecDecodeSelf(d)
 	}
 	for {
 		yyj446++
@@ -6003,9 +6003,9 @@ func (x *DeploymentRollback) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq507 [5]bool
 			_, _, _ = yysep507, yyq507, yy2arr507
 			const yyr507 bool = false
-			yyq507[0] = x.Kind != ""
-			yyq507[1] = x.APIVersion != ""
-			yyq507[3] = len(x.UpdatedAnnotations) != 0
+			yyq507[1] = len(x.UpdatedAnnotations) != 0
+			yyq507[3] = x.Kind != ""
+			yyq507[4] = x.APIVersion != ""
 			var yynn507 int
 			if yyr507 || yy2arr507 {
 				r.EncodeArrayStart(5)
@@ -6021,58 +6021,8 @@ func (x *DeploymentRollback) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr507 || yy2arr507 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq507[0] {
-					yym509 := z.EncBinary()
-					_ = yym509
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq507[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym510 := z.EncBinary()
-					_ = yym510
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr507 || yy2arr507 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq507[1] {
-					yym512 := z.EncBinary()
-					_ = yym512
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq507[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym513 := z.EncBinary()
-					_ = yym513
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr507 || yy2arr507 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym515 := z.EncBinary()
-				_ = yym515
+				yym509 := z.EncBinary()
+				_ = yym509
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
@@ -6081,8 +6031,8 @@ func (x *DeploymentRollback) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("name"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym516 := z.EncBinary()
-				_ = yym516
+				yym510 := z.EncBinary()
+				_ = yym510
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
@@ -6090,12 +6040,12 @@ func (x *DeploymentRollback) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr507 || yy2arr507 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq507[3] {
+				if yyq507[1] {
 					if x.UpdatedAnnotations == nil {
 						r.EncodeNil()
 					} else {
-						yym518 := z.EncBinary()
-						_ = yym518
+						yym512 := z.EncBinary()
+						_ = yym512
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.UpdatedAnnotations, false, e)
@@ -6105,15 +6055,15 @@ func (x *DeploymentRollback) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq507[3] {
+				if yyq507[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("updatedAnnotations"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.UpdatedAnnotations == nil {
 						r.EncodeNil()
 					} else {
-						yym519 := z.EncBinary()
-						_ = yym519
+						yym513 := z.EncBinary()
+						_ = yym513
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.UpdatedAnnotations, false, e)
@@ -6123,14 +6073,64 @@ func (x *DeploymentRollback) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr507 || yy2arr507 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy521 := &x.RollbackTo
-				yy521.CodecEncodeSelf(e)
+				yy515 := &x.RollbackTo
+				yy515.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("rollbackTo"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy522 := &x.RollbackTo
-				yy522.CodecEncodeSelf(e)
+				yy516 := &x.RollbackTo
+				yy516.CodecEncodeSelf(e)
+			}
+			if yyr507 || yy2arr507 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq507[3] {
+					yym518 := z.EncBinary()
+					_ = yym518
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq507[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym519 := z.EncBinary()
+					_ = yym519
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr507 || yy2arr507 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq507[4] {
+					yym521 := z.EncBinary()
+					_ = yym521
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq507[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym522 := z.EncBinary()
+					_ = yym522
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
 			}
 			if yyr507 || yy2arr507 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
@@ -6193,6 +6193,31 @@ func (x *DeploymentRollback) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 		yys525 := string(yys525Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys525 {
+		case "name":
+			if r.TryDecodeAsNil() {
+				x.Name = ""
+			} else {
+				x.Name = string(r.DecodeString())
+			}
+		case "updatedAnnotations":
+			if r.TryDecodeAsNil() {
+				x.UpdatedAnnotations = nil
+			} else {
+				yyv527 := &x.UpdatedAnnotations
+				yym528 := z.DecBinary()
+				_ = yym528
+				if false {
+				} else {
+					z.F.DecMapStringStringX(yyv527, false, d)
+				}
+			}
+		case "rollbackTo":
+			if r.TryDecodeAsNil() {
+				x.RollbackTo = RollbackConfig{}
+			} else {
+				yyv529 := &x.RollbackTo
+				yyv529.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -6204,31 +6229,6 @@ func (x *DeploymentRollback) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "name":
-			if r.TryDecodeAsNil() {
-				x.Name = ""
-			} else {
-				x.Name = string(r.DecodeString())
-			}
-		case "updatedAnnotations":
-			if r.TryDecodeAsNil() {
-				x.UpdatedAnnotations = nil
-			} else {
-				yyv529 := &x.UpdatedAnnotations
-				yym530 := z.DecBinary()
-				_ = yym530
-				if false {
-				} else {
-					z.F.DecMapStringStringX(yyv529, false, d)
-				}
-			}
-		case "rollbackTo":
-			if r.TryDecodeAsNil() {
-				x.RollbackTo = RollbackConfig{}
-			} else {
-				yyv531 := &x.RollbackTo
-				yyv531.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys525)
@@ -6244,6 +6244,61 @@ func (x *DeploymentRollback) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	var yyj532 int
 	var yyb532 bool
 	var yyhl532 bool = l >= 0
+	yyj532++
+	if yyhl532 {
+		yyb532 = yyj532 > l
+	} else {
+		yyb532 = r.CheckBreak()
+	}
+	if yyb532 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Name = ""
+	} else {
+		x.Name = string(r.DecodeString())
+	}
+	yyj532++
+	if yyhl532 {
+		yyb532 = yyj532 > l
+	} else {
+		yyb532 = r.CheckBreak()
+	}
+	if yyb532 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.UpdatedAnnotations = nil
+	} else {
+		yyv534 := &x.UpdatedAnnotations
+		yym535 := z.DecBinary()
+		_ = yym535
+		if false {
+		} else {
+			z.F.DecMapStringStringX(yyv534, false, d)
+		}
+	}
+	yyj532++
+	if yyhl532 {
+		yyb532 = yyj532 > l
+	} else {
+		yyb532 = r.CheckBreak()
+	}
+	if yyb532 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.RollbackTo = RollbackConfig{}
+	} else {
+		yyv536 := &x.RollbackTo
+		yyv536.CodecDecodeSelf(d)
+	}
 	yyj532++
 	if yyhl532 {
 		yyb532 = yyj532 > l
@@ -6275,61 +6330,6 @@ func (x *DeploymentRollback) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj532++
-	if yyhl532 {
-		yyb532 = yyj532 > l
-	} else {
-		yyb532 = r.CheckBreak()
-	}
-	if yyb532 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Name = ""
-	} else {
-		x.Name = string(r.DecodeString())
-	}
-	yyj532++
-	if yyhl532 {
-		yyb532 = yyj532 > l
-	} else {
-		yyb532 = r.CheckBreak()
-	}
-	if yyb532 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.UpdatedAnnotations = nil
-	} else {
-		yyv536 := &x.UpdatedAnnotations
-		yym537 := z.DecBinary()
-		_ = yym537
-		if false {
-		} else {
-			z.F.DecMapStringStringX(yyv536, false, d)
-		}
-	}
-	yyj532++
-	if yyhl532 {
-		yyb532 = yyj532 > l
-	} else {
-		yyb532 = r.CheckBreak()
-	}
-	if yyb532 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.RollbackTo = RollbackConfig{}
-	} else {
-		yyv538 := &x.RollbackTo
-		yyv538.CodecDecodeSelf(d)
 	}
 	for {
 		yyj532++
@@ -7384,9 +7384,9 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq611 [4]bool
 			_, _, _ = yysep611, yyq611, yy2arr611
 			const yyr611 bool = false
-			yyq611[0] = x.Kind != ""
-			yyq611[1] = x.APIVersion != ""
-			yyq611[2] = true
+			yyq611[0] = true
+			yyq611[2] = x.Kind != ""
+			yyq611[3] = x.APIVersion != ""
 			var yynn611 int
 			if yyr611 || yy2arr611 {
 				r.EncodeArrayStart(4)
@@ -7403,79 +7403,29 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr611 || yy2arr611 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq611[0] {
-					yym613 := z.EncBinary()
-					_ = yym613
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq611[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy613 := &x.ListMeta
 					yym614 := z.EncBinary()
 					_ = yym614
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy613) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr611 || yy2arr611 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq611[1] {
-					yym616 := z.EncBinary()
-					_ = yym616
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq611[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym617 := z.EncBinary()
-					_ = yym617
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr611 || yy2arr611 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq611[2] {
-					yy619 := &x.ListMeta
-					yym620 := z.EncBinary()
-					_ = yym620
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy619) {
-					} else {
-						z.EncFallback(yy619)
+						z.EncFallback(yy613)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq611[2] {
+				if yyq611[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy621 := &x.ListMeta
-					yym622 := z.EncBinary()
-					_ = yym622
+					yy615 := &x.ListMeta
+					yym616 := z.EncBinary()
+					_ = yym616
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy621) {
+					} else if z.HasExtensions() && z.EncExt(yy615) {
 					} else {
-						z.EncFallback(yy621)
+						z.EncFallback(yy615)
 					}
 				}
 			}
@@ -7484,8 +7434,8 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym624 := z.EncBinary()
-					_ = yym624
+					yym618 := z.EncBinary()
+					_ = yym618
 					if false {
 					} else {
 						h.encSliceDeployment(([]Deployment)(x.Items), e)
@@ -7498,11 +7448,61 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym619 := z.EncBinary()
+					_ = yym619
+					if false {
+					} else {
+						h.encSliceDeployment(([]Deployment)(x.Items), e)
+					}
+				}
+			}
+			if yyr611 || yy2arr611 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq611[2] {
+					yym621 := z.EncBinary()
+					_ = yym621
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq611[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym622 := z.EncBinary()
+					_ = yym622
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr611 || yy2arr611 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq611[3] {
+					yym624 := z.EncBinary()
+					_ = yym624
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq611[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym625 := z.EncBinary()
 					_ = yym625
 					if false {
 					} else {
-						h.encSliceDeployment(([]Deployment)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -7567,6 +7567,31 @@ func (x *DeploymentList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys628 := string(yys628Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys628 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv629 := &x.ListMeta
+				yym630 := z.DecBinary()
+				_ = yym630
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv629) {
+				} else {
+					z.DecFallback(yyv629, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv631 := &x.Items
+				yym632 := z.DecBinary()
+				_ = yym632
+				if false {
+				} else {
+					h.decSliceDeployment((*[]Deployment)(yyv631), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -7578,31 +7603,6 @@ func (x *DeploymentList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg1_unversioned.ListMeta{}
-			} else {
-				yyv631 := &x.ListMeta
-				yym632 := z.DecBinary()
-				_ = yym632
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv631) {
-				} else {
-					z.DecFallback(yyv631, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv633 := &x.Items
-				yym634 := z.DecBinary()
-				_ = yym634
-				if false {
-				} else {
-					h.decSliceDeployment((*[]Deployment)(yyv633), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys628)
@@ -7618,6 +7618,51 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj635 int
 	var yyb635 bool
 	var yyhl635 bool = l >= 0
+	yyj635++
+	if yyhl635 {
+		yyb635 = yyj635 > l
+	} else {
+		yyb635 = r.CheckBreak()
+	}
+	if yyb635 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv636 := &x.ListMeta
+		yym637 := z.DecBinary()
+		_ = yym637
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv636) {
+		} else {
+			z.DecFallback(yyv636, false)
+		}
+	}
+	yyj635++
+	if yyhl635 {
+		yyb635 = yyj635 > l
+	} else {
+		yyb635 = r.CheckBreak()
+	}
+	if yyb635 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv638 := &x.Items
+		yym639 := z.DecBinary()
+		_ = yym639
+		if false {
+		} else {
+			h.decSliceDeployment((*[]Deployment)(yyv638), d)
+		}
+	}
 	yyj635++
 	if yyhl635 {
 		yyb635 = yyj635 > l
@@ -7649,51 +7694,6 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj635++
-	if yyhl635 {
-		yyb635 = yyj635 > l
-	} else {
-		yyb635 = r.CheckBreak()
-	}
-	if yyb635 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg1_unversioned.ListMeta{}
-	} else {
-		yyv638 := &x.ListMeta
-		yym639 := z.DecBinary()
-		_ = yym639
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv638) {
-		} else {
-			z.DecFallback(yyv638, false)
-		}
-	}
-	yyj635++
-	if yyhl635 {
-		yyb635 = yyj635 > l
-	} else {
-		yyb635 = r.CheckBreak()
-	}
-	if yyb635 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv640 := &x.Items
-		yym641 := z.DecBinary()
-		_ = yym641
-		if false {
-		} else {
-			h.decSliceDeployment((*[]Deployment)(yyv640), d)
-		}
 	}
 	for {
 		yyj635++
@@ -8802,11 +8802,11 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq724 [5]bool
 			_, _, _ = yysep724, yyq724, yy2arr724
 			const yyr724 bool = false
-			yyq724[0] = x.Kind != ""
-			yyq724[1] = x.APIVersion != ""
+			yyq724[0] = true
+			yyq724[1] = true
 			yyq724[2] = true
-			yyq724[3] = true
-			yyq724[4] = true
+			yyq724[3] = x.Kind != ""
+			yyq724[4] = x.APIVersion != ""
 			var yynn724 int
 			if yyr724 || yy2arr724 {
 				r.EncodeArrayStart(5)
@@ -8823,57 +8823,41 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr724 || yy2arr724 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq724[0] {
-					yym726 := z.EncBinary()
-					_ = yym726
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy726 := &x.ObjectMeta
+					yy726.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq724[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym727 := z.EncBinary()
-					_ = yym727
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy727 := &x.ObjectMeta
+					yy727.CodecEncodeSelf(e)
 				}
 			}
 			if yyr724 || yy2arr724 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq724[1] {
-					yym729 := z.EncBinary()
-					_ = yym729
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy729 := &x.Spec
+					yy729.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq724[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym730 := z.EncBinary()
-					_ = yym730
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy730 := &x.Spec
+					yy730.CodecEncodeSelf(e)
 				}
 			}
 			if yyr724 || yy2arr724 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq724[2] {
-					yy732 := &x.ObjectMeta
+					yy732 := &x.Status
 					yy732.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
@@ -8881,44 +8865,60 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq724[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy733 := &x.ObjectMeta
+					yy733 := &x.Status
 					yy733.CodecEncodeSelf(e)
 				}
 			}
 			if yyr724 || yy2arr724 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq724[3] {
-					yy735 := &x.Spec
-					yy735.CodecEncodeSelf(e)
+					yym735 := z.EncBinary()
+					_ = yym735
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq724[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy736 := &x.Spec
-					yy736.CodecEncodeSelf(e)
+					yym736 := z.EncBinary()
+					_ = yym736
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				}
 			}
 			if yyr724 || yy2arr724 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq724[4] {
-					yy738 := &x.Status
-					yy738.CodecEncodeSelf(e)
+					yym738 := z.EncBinary()
+					_ = yym738
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq724[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy739 := &x.Status
-					yy739.CodecEncodeSelf(e)
+					yym739 := z.EncBinary()
+					_ = yym739
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr724 || yy2arr724 {
@@ -8982,6 +8982,27 @@ func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys742 := string(yys742Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys742 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_v1.ObjectMeta{}
+			} else {
+				yyv743 := &x.ObjectMeta
+				yyv743.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = DaemonSetSpec{}
+			} else {
+				yyv744 := &x.Spec
+				yyv744.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = DaemonSetStatus{}
+			} else {
+				yyv745 := &x.Status
+				yyv745.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -8993,27 +9014,6 @@ func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = pkg2_v1.ObjectMeta{}
-			} else {
-				yyv745 := &x.ObjectMeta
-				yyv745.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = DaemonSetSpec{}
-			} else {
-				yyv746 := &x.Spec
-				yyv746.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = DaemonSetStatus{}
-			} else {
-				yyv747 := &x.Status
-				yyv747.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys742)
@@ -9029,6 +9029,57 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj748 int
 	var yyb748 bool
 	var yyhl748 bool = l >= 0
+	yyj748++
+	if yyhl748 {
+		yyb748 = yyj748 > l
+	} else {
+		yyb748 = r.CheckBreak()
+	}
+	if yyb748 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_v1.ObjectMeta{}
+	} else {
+		yyv749 := &x.ObjectMeta
+		yyv749.CodecDecodeSelf(d)
+	}
+	yyj748++
+	if yyhl748 {
+		yyb748 = yyj748 > l
+	} else {
+		yyb748 = r.CheckBreak()
+	}
+	if yyb748 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = DaemonSetSpec{}
+	} else {
+		yyv750 := &x.Spec
+		yyv750.CodecDecodeSelf(d)
+	}
+	yyj748++
+	if yyhl748 {
+		yyb748 = yyj748 > l
+	} else {
+		yyb748 = r.CheckBreak()
+	}
+	if yyb748 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = DaemonSetStatus{}
+	} else {
+		yyv751 := &x.Status
+		yyv751.CodecDecodeSelf(d)
+	}
 	yyj748++
 	if yyhl748 {
 		yyb748 = yyj748 > l
@@ -9060,57 +9111,6 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj748++
-	if yyhl748 {
-		yyb748 = yyj748 > l
-	} else {
-		yyb748 = r.CheckBreak()
-	}
-	if yyb748 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = pkg2_v1.ObjectMeta{}
-	} else {
-		yyv751 := &x.ObjectMeta
-		yyv751.CodecDecodeSelf(d)
-	}
-	yyj748++
-	if yyhl748 {
-		yyb748 = yyj748 > l
-	} else {
-		yyb748 = r.CheckBreak()
-	}
-	if yyb748 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = DaemonSetSpec{}
-	} else {
-		yyv752 := &x.Spec
-		yyv752.CodecDecodeSelf(d)
-	}
-	yyj748++
-	if yyhl748 {
-		yyb748 = yyj748 > l
-	} else {
-		yyb748 = r.CheckBreak()
-	}
-	if yyb748 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = DaemonSetStatus{}
-	} else {
-		yyv753 := &x.Status
-		yyv753.CodecDecodeSelf(d)
 	}
 	for {
 		yyj748++
@@ -9145,9 +9145,9 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq755 [4]bool
 			_, _, _ = yysep755, yyq755, yy2arr755
 			const yyr755 bool = false
-			yyq755[0] = x.Kind != ""
-			yyq755[1] = x.APIVersion != ""
-			yyq755[2] = true
+			yyq755[0] = true
+			yyq755[2] = x.Kind != ""
+			yyq755[3] = x.APIVersion != ""
 			var yynn755 int
 			if yyr755 || yy2arr755 {
 				r.EncodeArrayStart(4)
@@ -9164,79 +9164,29 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr755 || yy2arr755 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq755[0] {
-					yym757 := z.EncBinary()
-					_ = yym757
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq755[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy757 := &x.ListMeta
 					yym758 := z.EncBinary()
 					_ = yym758
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy757) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr755 || yy2arr755 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq755[1] {
-					yym760 := z.EncBinary()
-					_ = yym760
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq755[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym761 := z.EncBinary()
-					_ = yym761
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr755 || yy2arr755 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq755[2] {
-					yy763 := &x.ListMeta
-					yym764 := z.EncBinary()
-					_ = yym764
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy763) {
-					} else {
-						z.EncFallback(yy763)
+						z.EncFallback(yy757)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq755[2] {
+				if yyq755[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy765 := &x.ListMeta
-					yym766 := z.EncBinary()
-					_ = yym766
+					yy759 := &x.ListMeta
+					yym760 := z.EncBinary()
+					_ = yym760
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy765) {
+					} else if z.HasExtensions() && z.EncExt(yy759) {
 					} else {
-						z.EncFallback(yy765)
+						z.EncFallback(yy759)
 					}
 				}
 			}
@@ -9245,8 +9195,8 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym768 := z.EncBinary()
-					_ = yym768
+					yym762 := z.EncBinary()
+					_ = yym762
 					if false {
 					} else {
 						h.encSliceDaemonSet(([]DaemonSet)(x.Items), e)
@@ -9259,11 +9209,61 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym763 := z.EncBinary()
+					_ = yym763
+					if false {
+					} else {
+						h.encSliceDaemonSet(([]DaemonSet)(x.Items), e)
+					}
+				}
+			}
+			if yyr755 || yy2arr755 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq755[2] {
+					yym765 := z.EncBinary()
+					_ = yym765
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq755[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym766 := z.EncBinary()
+					_ = yym766
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr755 || yy2arr755 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq755[3] {
+					yym768 := z.EncBinary()
+					_ = yym768
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq755[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym769 := z.EncBinary()
 					_ = yym769
 					if false {
 					} else {
-						h.encSliceDaemonSet(([]DaemonSet)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -9328,6 +9328,31 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys772 := string(yys772Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys772 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv773 := &x.ListMeta
+				yym774 := z.DecBinary()
+				_ = yym774
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv773) {
+				} else {
+					z.DecFallback(yyv773, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv775 := &x.Items
+				yym776 := z.DecBinary()
+				_ = yym776
+				if false {
+				} else {
+					h.decSliceDaemonSet((*[]DaemonSet)(yyv775), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -9339,31 +9364,6 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg1_unversioned.ListMeta{}
-			} else {
-				yyv775 := &x.ListMeta
-				yym776 := z.DecBinary()
-				_ = yym776
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv775) {
-				} else {
-					z.DecFallback(yyv775, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv777 := &x.Items
-				yym778 := z.DecBinary()
-				_ = yym778
-				if false {
-				} else {
-					h.decSliceDaemonSet((*[]DaemonSet)(yyv777), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys772)
@@ -9379,6 +9379,51 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj779 int
 	var yyb779 bool
 	var yyhl779 bool = l >= 0
+	yyj779++
+	if yyhl779 {
+		yyb779 = yyj779 > l
+	} else {
+		yyb779 = r.CheckBreak()
+	}
+	if yyb779 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv780 := &x.ListMeta
+		yym781 := z.DecBinary()
+		_ = yym781
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv780) {
+		} else {
+			z.DecFallback(yyv780, false)
+		}
+	}
+	yyj779++
+	if yyhl779 {
+		yyb779 = yyj779 > l
+	} else {
+		yyb779 = r.CheckBreak()
+	}
+	if yyb779 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv782 := &x.Items
+		yym783 := z.DecBinary()
+		_ = yym783
+		if false {
+		} else {
+			h.decSliceDaemonSet((*[]DaemonSet)(yyv782), d)
+		}
+	}
 	yyj779++
 	if yyhl779 {
 		yyb779 = yyj779 > l
@@ -9410,51 +9455,6 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj779++
-	if yyhl779 {
-		yyb779 = yyj779 > l
-	} else {
-		yyb779 = r.CheckBreak()
-	}
-	if yyb779 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg1_unversioned.ListMeta{}
-	} else {
-		yyv782 := &x.ListMeta
-		yym783 := z.DecBinary()
-		_ = yym783
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv782) {
-		} else {
-			z.DecFallback(yyv782, false)
-		}
-	}
-	yyj779++
-	if yyhl779 {
-		yyb779 = yyj779 > l
-	} else {
-		yyb779 = r.CheckBreak()
-	}
-	if yyb779 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv784 := &x.Items
-		yym785 := z.DecBinary()
-		_ = yym785
-		if false {
-		} else {
-			h.decSliceDaemonSet((*[]DaemonSet)(yyv784), d)
-		}
 	}
 	for {
 		yyj779++
@@ -9489,9 +9489,9 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq787 [4]bool
 			_, _, _ = yysep787, yyq787, yy2arr787
 			const yyr787 bool = false
-			yyq787[0] = x.Kind != ""
-			yyq787[1] = x.APIVersion != ""
-			yyq787[2] = true
+			yyq787[0] = true
+			yyq787[2] = x.Kind != ""
+			yyq787[3] = x.APIVersion != ""
 			var yynn787 int
 			if yyr787 || yy2arr787 {
 				r.EncodeArrayStart(4)
@@ -9508,79 +9508,29 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr787 || yy2arr787 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq787[0] {
-					yym789 := z.EncBinary()
-					_ = yym789
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq787[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy789 := &x.ListMeta
 					yym790 := z.EncBinary()
 					_ = yym790
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy789) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr787 || yy2arr787 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq787[1] {
-					yym792 := z.EncBinary()
-					_ = yym792
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq787[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym793 := z.EncBinary()
-					_ = yym793
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr787 || yy2arr787 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq787[2] {
-					yy795 := &x.ListMeta
-					yym796 := z.EncBinary()
-					_ = yym796
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy795) {
-					} else {
-						z.EncFallback(yy795)
+						z.EncFallback(yy789)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq787[2] {
+				if yyq787[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy797 := &x.ListMeta
-					yym798 := z.EncBinary()
-					_ = yym798
+					yy791 := &x.ListMeta
+					yym792 := z.EncBinary()
+					_ = yym792
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy797) {
+					} else if z.HasExtensions() && z.EncExt(yy791) {
 					} else {
-						z.EncFallback(yy797)
+						z.EncFallback(yy791)
 					}
 				}
 			}
@@ -9589,8 +9539,8 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym800 := z.EncBinary()
-					_ = yym800
+					yym794 := z.EncBinary()
+					_ = yym794
 					if false {
 					} else {
 						h.encSliceThirdPartyResourceData(([]ThirdPartyResourceData)(x.Items), e)
@@ -9603,11 +9553,61 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym795 := z.EncBinary()
+					_ = yym795
+					if false {
+					} else {
+						h.encSliceThirdPartyResourceData(([]ThirdPartyResourceData)(x.Items), e)
+					}
+				}
+			}
+			if yyr787 || yy2arr787 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq787[2] {
+					yym797 := z.EncBinary()
+					_ = yym797
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq787[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym798 := z.EncBinary()
+					_ = yym798
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr787 || yy2arr787 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq787[3] {
+					yym800 := z.EncBinary()
+					_ = yym800
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq787[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym801 := z.EncBinary()
 					_ = yym801
 					if false {
 					} else {
-						h.encSliceThirdPartyResourceData(([]ThirdPartyResourceData)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -9672,6 +9672,31 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 		yys804 := string(yys804Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys804 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv805 := &x.ListMeta
+				yym806 := z.DecBinary()
+				_ = yym806
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv805) {
+				} else {
+					z.DecFallback(yyv805, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv807 := &x.Items
+				yym808 := z.DecBinary()
+				_ = yym808
+				if false {
+				} else {
+					h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv807), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -9683,31 +9708,6 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg1_unversioned.ListMeta{}
-			} else {
-				yyv807 := &x.ListMeta
-				yym808 := z.DecBinary()
-				_ = yym808
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv807) {
-				} else {
-					z.DecFallback(yyv807, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv809 := &x.Items
-				yym810 := z.DecBinary()
-				_ = yym810
-				if false {
-				} else {
-					h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv809), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys804)
@@ -9723,6 +9723,51 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 	var yyj811 int
 	var yyb811 bool
 	var yyhl811 bool = l >= 0
+	yyj811++
+	if yyhl811 {
+		yyb811 = yyj811 > l
+	} else {
+		yyb811 = r.CheckBreak()
+	}
+	if yyb811 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv812 := &x.ListMeta
+		yym813 := z.DecBinary()
+		_ = yym813
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv812) {
+		} else {
+			z.DecFallback(yyv812, false)
+		}
+	}
+	yyj811++
+	if yyhl811 {
+		yyb811 = yyj811 > l
+	} else {
+		yyb811 = r.CheckBreak()
+	}
+	if yyb811 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv814 := &x.Items
+		yym815 := z.DecBinary()
+		_ = yym815
+		if false {
+		} else {
+			h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv814), d)
+		}
+	}
 	yyj811++
 	if yyhl811 {
 		yyb811 = yyj811 > l
@@ -9754,51 +9799,6 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj811++
-	if yyhl811 {
-		yyb811 = yyj811 > l
-	} else {
-		yyb811 = r.CheckBreak()
-	}
-	if yyb811 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg1_unversioned.ListMeta{}
-	} else {
-		yyv814 := &x.ListMeta
-		yym815 := z.DecBinary()
-		_ = yym815
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv814) {
-		} else {
-			z.DecFallback(yyv814, false)
-		}
-	}
-	yyj811++
-	if yyhl811 {
-		yyb811 = yyj811 > l
-	} else {
-		yyb811 = r.CheckBreak()
-	}
-	if yyb811 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv816 := &x.Items
-		yym817 := z.DecBinary()
-		_ = yym817
-		if false {
-		} else {
-			h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv816), d)
-		}
 	}
 	for {
 		yyj811++
@@ -9833,11 +9833,11 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq819 [5]bool
 			_, _, _ = yysep819, yyq819, yy2arr819
 			const yyr819 bool = false
-			yyq819[0] = x.Kind != ""
-			yyq819[1] = x.APIVersion != ""
+			yyq819[0] = true
+			yyq819[1] = true
 			yyq819[2] = true
-			yyq819[3] = true
-			yyq819[4] = true
+			yyq819[3] = x.Kind != ""
+			yyq819[4] = x.APIVersion != ""
 			var yynn819 int
 			if yyr819 || yy2arr819 {
 				r.EncodeArrayStart(5)
@@ -9854,57 +9854,41 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr819 || yy2arr819 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq819[0] {
-					yym821 := z.EncBinary()
-					_ = yym821
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy821 := &x.ObjectMeta
+					yy821.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq819[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym822 := z.EncBinary()
-					_ = yym822
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy822 := &x.ObjectMeta
+					yy822.CodecEncodeSelf(e)
 				}
 			}
 			if yyr819 || yy2arr819 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq819[1] {
-					yym824 := z.EncBinary()
-					_ = yym824
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy824 := &x.Spec
+					yy824.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq819[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym825 := z.EncBinary()
-					_ = yym825
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy825 := &x.Spec
+					yy825.CodecEncodeSelf(e)
 				}
 			}
 			if yyr819 || yy2arr819 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq819[2] {
-					yy827 := &x.ObjectMeta
+					yy827 := &x.Status
 					yy827.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
@@ -9912,44 +9896,60 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq819[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy828 := &x.ObjectMeta
+					yy828 := &x.Status
 					yy828.CodecEncodeSelf(e)
 				}
 			}
 			if yyr819 || yy2arr819 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq819[3] {
-					yy830 := &x.Spec
-					yy830.CodecEncodeSelf(e)
+					yym830 := z.EncBinary()
+					_ = yym830
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq819[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy831 := &x.Spec
-					yy831.CodecEncodeSelf(e)
+					yym831 := z.EncBinary()
+					_ = yym831
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				}
 			}
 			if yyr819 || yy2arr819 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq819[4] {
-					yy833 := &x.Status
-					yy833.CodecEncodeSelf(e)
+					yym833 := z.EncBinary()
+					_ = yym833
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq819[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy834 := &x.Status
-					yy834.CodecEncodeSelf(e)
+					yym834 := z.EncBinary()
+					_ = yym834
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr819 || yy2arr819 {
@@ -10013,6 +10013,27 @@ func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys837 := string(yys837Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys837 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_v1.ObjectMeta{}
+			} else {
+				yyv838 := &x.ObjectMeta
+				yyv838.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = JobSpec{}
+			} else {
+				yyv839 := &x.Spec
+				yyv839.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = JobStatus{}
+			} else {
+				yyv840 := &x.Status
+				yyv840.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -10024,27 +10045,6 @@ func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = pkg2_v1.ObjectMeta{}
-			} else {
-				yyv840 := &x.ObjectMeta
-				yyv840.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = JobSpec{}
-			} else {
-				yyv841 := &x.Spec
-				yyv841.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = JobStatus{}
-			} else {
-				yyv842 := &x.Status
-				yyv842.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys837)
@@ -10060,6 +10060,57 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj843 int
 	var yyb843 bool
 	var yyhl843 bool = l >= 0
+	yyj843++
+	if yyhl843 {
+		yyb843 = yyj843 > l
+	} else {
+		yyb843 = r.CheckBreak()
+	}
+	if yyb843 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_v1.ObjectMeta{}
+	} else {
+		yyv844 := &x.ObjectMeta
+		yyv844.CodecDecodeSelf(d)
+	}
+	yyj843++
+	if yyhl843 {
+		yyb843 = yyj843 > l
+	} else {
+		yyb843 = r.CheckBreak()
+	}
+	if yyb843 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = JobSpec{}
+	} else {
+		yyv845 := &x.Spec
+		yyv845.CodecDecodeSelf(d)
+	}
+	yyj843++
+	if yyhl843 {
+		yyb843 = yyj843 > l
+	} else {
+		yyb843 = r.CheckBreak()
+	}
+	if yyb843 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = JobStatus{}
+	} else {
+		yyv846 := &x.Status
+		yyv846.CodecDecodeSelf(d)
+	}
 	yyj843++
 	if yyhl843 {
 		yyb843 = yyj843 > l
@@ -10091,57 +10142,6 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj843++
-	if yyhl843 {
-		yyb843 = yyj843 > l
-	} else {
-		yyb843 = r.CheckBreak()
-	}
-	if yyb843 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = pkg2_v1.ObjectMeta{}
-	} else {
-		yyv846 := &x.ObjectMeta
-		yyv846.CodecDecodeSelf(d)
-	}
-	yyj843++
-	if yyhl843 {
-		yyb843 = yyj843 > l
-	} else {
-		yyb843 = r.CheckBreak()
-	}
-	if yyb843 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = JobSpec{}
-	} else {
-		yyv847 := &x.Spec
-		yyv847.CodecDecodeSelf(d)
-	}
-	yyj843++
-	if yyhl843 {
-		yyb843 = yyj843 > l
-	} else {
-		yyb843 = r.CheckBreak()
-	}
-	if yyb843 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = JobStatus{}
-	} else {
-		yyv848 := &x.Status
-		yyv848.CodecDecodeSelf(d)
 	}
 	for {
 		yyj843++
@@ -10176,9 +10176,9 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq850 [4]bool
 			_, _, _ = yysep850, yyq850, yy2arr850
 			const yyr850 bool = false
-			yyq850[0] = x.Kind != ""
-			yyq850[1] = x.APIVersion != ""
-			yyq850[2] = true
+			yyq850[0] = true
+			yyq850[2] = x.Kind != ""
+			yyq850[3] = x.APIVersion != ""
 			var yynn850 int
 			if yyr850 || yy2arr850 {
 				r.EncodeArrayStart(4)
@@ -10195,79 +10195,29 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr850 || yy2arr850 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq850[0] {
-					yym852 := z.EncBinary()
-					_ = yym852
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq850[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy852 := &x.ListMeta
 					yym853 := z.EncBinary()
 					_ = yym853
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy852) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr850 || yy2arr850 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq850[1] {
-					yym855 := z.EncBinary()
-					_ = yym855
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq850[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym856 := z.EncBinary()
-					_ = yym856
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr850 || yy2arr850 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq850[2] {
-					yy858 := &x.ListMeta
-					yym859 := z.EncBinary()
-					_ = yym859
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy858) {
-					} else {
-						z.EncFallback(yy858)
+						z.EncFallback(yy852)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq850[2] {
+				if yyq850[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy860 := &x.ListMeta
-					yym861 := z.EncBinary()
-					_ = yym861
+					yy854 := &x.ListMeta
+					yym855 := z.EncBinary()
+					_ = yym855
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy860) {
+					} else if z.HasExtensions() && z.EncExt(yy854) {
 					} else {
-						z.EncFallback(yy860)
+						z.EncFallback(yy854)
 					}
 				}
 			}
@@ -10276,8 +10226,8 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym863 := z.EncBinary()
-					_ = yym863
+					yym857 := z.EncBinary()
+					_ = yym857
 					if false {
 					} else {
 						h.encSliceJob(([]Job)(x.Items), e)
@@ -10290,11 +10240,61 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym858 := z.EncBinary()
+					_ = yym858
+					if false {
+					} else {
+						h.encSliceJob(([]Job)(x.Items), e)
+					}
+				}
+			}
+			if yyr850 || yy2arr850 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq850[2] {
+					yym860 := z.EncBinary()
+					_ = yym860
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq850[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym861 := z.EncBinary()
+					_ = yym861
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr850 || yy2arr850 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq850[3] {
+					yym863 := z.EncBinary()
+					_ = yym863
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq850[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym864 := z.EncBinary()
 					_ = yym864
 					if false {
 					} else {
-						h.encSliceJob(([]Job)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -10359,6 +10359,31 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys867 := string(yys867Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys867 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv868 := &x.ListMeta
+				yym869 := z.DecBinary()
+				_ = yym869
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv868) {
+				} else {
+					z.DecFallback(yyv868, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv870 := &x.Items
+				yym871 := z.DecBinary()
+				_ = yym871
+				if false {
+				} else {
+					h.decSliceJob((*[]Job)(yyv870), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -10370,31 +10395,6 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg1_unversioned.ListMeta{}
-			} else {
-				yyv870 := &x.ListMeta
-				yym871 := z.DecBinary()
-				_ = yym871
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv870) {
-				} else {
-					z.DecFallback(yyv870, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv872 := &x.Items
-				yym873 := z.DecBinary()
-				_ = yym873
-				if false {
-				} else {
-					h.decSliceJob((*[]Job)(yyv872), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys867)
@@ -10410,6 +10410,51 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj874 int
 	var yyb874 bool
 	var yyhl874 bool = l >= 0
+	yyj874++
+	if yyhl874 {
+		yyb874 = yyj874 > l
+	} else {
+		yyb874 = r.CheckBreak()
+	}
+	if yyb874 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv875 := &x.ListMeta
+		yym876 := z.DecBinary()
+		_ = yym876
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv875) {
+		} else {
+			z.DecFallback(yyv875, false)
+		}
+	}
+	yyj874++
+	if yyhl874 {
+		yyb874 = yyj874 > l
+	} else {
+		yyb874 = r.CheckBreak()
+	}
+	if yyb874 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv877 := &x.Items
+		yym878 := z.DecBinary()
+		_ = yym878
+		if false {
+		} else {
+			h.decSliceJob((*[]Job)(yyv877), d)
+		}
+	}
 	yyj874++
 	if yyhl874 {
 		yyb874 = yyj874 > l
@@ -10441,51 +10486,6 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj874++
-	if yyhl874 {
-		yyb874 = yyj874 > l
-	} else {
-		yyb874 = r.CheckBreak()
-	}
-	if yyb874 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg1_unversioned.ListMeta{}
-	} else {
-		yyv877 := &x.ListMeta
-		yym878 := z.DecBinary()
-		_ = yym878
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv877) {
-		} else {
-			z.DecFallback(yyv877, false)
-		}
-	}
-	yyj874++
-	if yyhl874 {
-		yyb874 = yyj874 > l
-	} else {
-		yyb874 = r.CheckBreak()
-	}
-	if yyb874 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv879 := &x.Items
-		yym880 := z.DecBinary()
-		_ = yym880
-		if false {
-		} else {
-			h.decSliceJob((*[]Job)(yyv879), d)
-		}
 	}
 	for {
 		yyj874++
@@ -11972,11 +11972,11 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1009 [5]bool
 			_, _, _ = yysep1009, yyq1009, yy2arr1009
 			const yyr1009 bool = false
-			yyq1009[0] = x.Kind != ""
-			yyq1009[1] = x.APIVersion != ""
+			yyq1009[0] = true
+			yyq1009[1] = true
 			yyq1009[2] = true
-			yyq1009[3] = true
-			yyq1009[4] = true
+			yyq1009[3] = x.Kind != ""
+			yyq1009[4] = x.APIVersion != ""
 			var yynn1009 int
 			if yyr1009 || yy2arr1009 {
 				r.EncodeArrayStart(5)
@@ -11993,57 +11993,41 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr1009 || yy2arr1009 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1009[0] {
-					yym1011 := z.EncBinary()
-					_ = yym1011
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy1011 := &x.ObjectMeta
+					yy1011.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq1009[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1012 := z.EncBinary()
-					_ = yym1012
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy1012 := &x.ObjectMeta
+					yy1012.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1009 || yy2arr1009 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1009[1] {
-					yym1014 := z.EncBinary()
-					_ = yym1014
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy1014 := &x.Spec
+					yy1014.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq1009[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1015 := z.EncBinary()
-					_ = yym1015
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy1015 := &x.Spec
+					yy1015.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1009 || yy2arr1009 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1009[2] {
-					yy1017 := &x.ObjectMeta
+					yy1017 := &x.Status
 					yy1017.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
@@ -12051,44 +12035,60 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq1009[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1018 := &x.ObjectMeta
+					yy1018 := &x.Status
 					yy1018.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1009 || yy2arr1009 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1009[3] {
-					yy1020 := &x.Spec
-					yy1020.CodecEncodeSelf(e)
+					yym1020 := z.EncBinary()
+					_ = yym1020
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq1009[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1021 := &x.Spec
-					yy1021.CodecEncodeSelf(e)
+					yym1021 := z.EncBinary()
+					_ = yym1021
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				}
 			}
 			if yyr1009 || yy2arr1009 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1009[4] {
-					yy1023 := &x.Status
-					yy1023.CodecEncodeSelf(e)
+					yym1023 := z.EncBinary()
+					_ = yym1023
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq1009[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1024 := &x.Status
-					yy1024.CodecEncodeSelf(e)
+					yym1024 := z.EncBinary()
+					_ = yym1024
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr1009 || yy2arr1009 {
@@ -12152,6 +12152,27 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys1027 := string(yys1027Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1027 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_v1.ObjectMeta{}
+			} else {
+				yyv1028 := &x.ObjectMeta
+				yyv1028.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = IngressSpec{}
+			} else {
+				yyv1029 := &x.Spec
+				yyv1029.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = IngressStatus{}
+			} else {
+				yyv1030 := &x.Status
+				yyv1030.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -12163,27 +12184,6 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = pkg2_v1.ObjectMeta{}
-			} else {
-				yyv1030 := &x.ObjectMeta
-				yyv1030.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = IngressSpec{}
-			} else {
-				yyv1031 := &x.Spec
-				yyv1031.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = IngressStatus{}
-			} else {
-				yyv1032 := &x.Status
-				yyv1032.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1027)
@@ -12199,6 +12199,57 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj1033 int
 	var yyb1033 bool
 	var yyhl1033 bool = l >= 0
+	yyj1033++
+	if yyhl1033 {
+		yyb1033 = yyj1033 > l
+	} else {
+		yyb1033 = r.CheckBreak()
+	}
+	if yyb1033 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_v1.ObjectMeta{}
+	} else {
+		yyv1034 := &x.ObjectMeta
+		yyv1034.CodecDecodeSelf(d)
+	}
+	yyj1033++
+	if yyhl1033 {
+		yyb1033 = yyj1033 > l
+	} else {
+		yyb1033 = r.CheckBreak()
+	}
+	if yyb1033 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = IngressSpec{}
+	} else {
+		yyv1035 := &x.Spec
+		yyv1035.CodecDecodeSelf(d)
+	}
+	yyj1033++
+	if yyhl1033 {
+		yyb1033 = yyj1033 > l
+	} else {
+		yyb1033 = r.CheckBreak()
+	}
+	if yyb1033 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = IngressStatus{}
+	} else {
+		yyv1036 := &x.Status
+		yyv1036.CodecDecodeSelf(d)
+	}
 	yyj1033++
 	if yyhl1033 {
 		yyb1033 = yyj1033 > l
@@ -12230,57 +12281,6 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj1033++
-	if yyhl1033 {
-		yyb1033 = yyj1033 > l
-	} else {
-		yyb1033 = r.CheckBreak()
-	}
-	if yyb1033 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = pkg2_v1.ObjectMeta{}
-	} else {
-		yyv1036 := &x.ObjectMeta
-		yyv1036.CodecDecodeSelf(d)
-	}
-	yyj1033++
-	if yyhl1033 {
-		yyb1033 = yyj1033 > l
-	} else {
-		yyb1033 = r.CheckBreak()
-	}
-	if yyb1033 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = IngressSpec{}
-	} else {
-		yyv1037 := &x.Spec
-		yyv1037.CodecDecodeSelf(d)
-	}
-	yyj1033++
-	if yyhl1033 {
-		yyb1033 = yyj1033 > l
-	} else {
-		yyb1033 = r.CheckBreak()
-	}
-	if yyb1033 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = IngressStatus{}
-	} else {
-		yyv1038 := &x.Status
-		yyv1038.CodecDecodeSelf(d)
 	}
 	for {
 		yyj1033++
@@ -12315,9 +12315,9 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1040 [4]bool
 			_, _, _ = yysep1040, yyq1040, yy2arr1040
 			const yyr1040 bool = false
-			yyq1040[0] = x.Kind != ""
-			yyq1040[1] = x.APIVersion != ""
-			yyq1040[2] = true
+			yyq1040[0] = true
+			yyq1040[2] = x.Kind != ""
+			yyq1040[3] = x.APIVersion != ""
 			var yynn1040 int
 			if yyr1040 || yy2arr1040 {
 				r.EncodeArrayStart(4)
@@ -12334,79 +12334,29 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr1040 || yy2arr1040 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1040[0] {
-					yym1042 := z.EncBinary()
-					_ = yym1042
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1040[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1042 := &x.ListMeta
 					yym1043 := z.EncBinary()
 					_ = yym1043
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1042) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr1040 || yy2arr1040 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1040[1] {
-					yym1045 := z.EncBinary()
-					_ = yym1045
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1040[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1046 := z.EncBinary()
-					_ = yym1046
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr1040 || yy2arr1040 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1040[2] {
-					yy1048 := &x.ListMeta
-					yym1049 := z.EncBinary()
-					_ = yym1049
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1048) {
-					} else {
-						z.EncFallback(yy1048)
+						z.EncFallback(yy1042)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1040[2] {
+				if yyq1040[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1050 := &x.ListMeta
-					yym1051 := z.EncBinary()
-					_ = yym1051
+					yy1044 := &x.ListMeta
+					yym1045 := z.EncBinary()
+					_ = yym1045
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1050) {
+					} else if z.HasExtensions() && z.EncExt(yy1044) {
 					} else {
-						z.EncFallback(yy1050)
+						z.EncFallback(yy1044)
 					}
 				}
 			}
@@ -12415,8 +12365,8 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1053 := z.EncBinary()
-					_ = yym1053
+					yym1047 := z.EncBinary()
+					_ = yym1047
 					if false {
 					} else {
 						h.encSliceIngress(([]Ingress)(x.Items), e)
@@ -12429,11 +12379,61 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym1048 := z.EncBinary()
+					_ = yym1048
+					if false {
+					} else {
+						h.encSliceIngress(([]Ingress)(x.Items), e)
+					}
+				}
+			}
+			if yyr1040 || yy2arr1040 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1040[2] {
+					yym1050 := z.EncBinary()
+					_ = yym1050
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1040[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1051 := z.EncBinary()
+					_ = yym1051
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr1040 || yy2arr1040 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1040[3] {
+					yym1053 := z.EncBinary()
+					_ = yym1053
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1040[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1054 := z.EncBinary()
 					_ = yym1054
 					if false {
 					} else {
-						h.encSliceIngress(([]Ingress)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -12498,6 +12498,31 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys1057 := string(yys1057Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1057 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv1058 := &x.ListMeta
+				yym1059 := z.DecBinary()
+				_ = yym1059
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv1058) {
+				} else {
+					z.DecFallback(yyv1058, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv1060 := &x.Items
+				yym1061 := z.DecBinary()
+				_ = yym1061
+				if false {
+				} else {
+					h.decSliceIngress((*[]Ingress)(yyv1060), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -12509,31 +12534,6 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg1_unversioned.ListMeta{}
-			} else {
-				yyv1060 := &x.ListMeta
-				yym1061 := z.DecBinary()
-				_ = yym1061
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1060) {
-				} else {
-					z.DecFallback(yyv1060, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv1062 := &x.Items
-				yym1063 := z.DecBinary()
-				_ = yym1063
-				if false {
-				} else {
-					h.decSliceIngress((*[]Ingress)(yyv1062), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1057)
@@ -12549,6 +12549,51 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj1064 int
 	var yyb1064 bool
 	var yyhl1064 bool = l >= 0
+	yyj1064++
+	if yyhl1064 {
+		yyb1064 = yyj1064 > l
+	} else {
+		yyb1064 = r.CheckBreak()
+	}
+	if yyb1064 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv1065 := &x.ListMeta
+		yym1066 := z.DecBinary()
+		_ = yym1066
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1065) {
+		} else {
+			z.DecFallback(yyv1065, false)
+		}
+	}
+	yyj1064++
+	if yyhl1064 {
+		yyb1064 = yyj1064 > l
+	} else {
+		yyb1064 = r.CheckBreak()
+	}
+	if yyb1064 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv1067 := &x.Items
+		yym1068 := z.DecBinary()
+		_ = yym1068
+		if false {
+		} else {
+			h.decSliceIngress((*[]Ingress)(yyv1067), d)
+		}
+	}
 	yyj1064++
 	if yyhl1064 {
 		yyb1064 = yyj1064 > l
@@ -12580,51 +12625,6 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj1064++
-	if yyhl1064 {
-		yyb1064 = yyj1064 > l
-	} else {
-		yyb1064 = r.CheckBreak()
-	}
-	if yyb1064 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg1_unversioned.ListMeta{}
-	} else {
-		yyv1067 := &x.ListMeta
-		yym1068 := z.DecBinary()
-		_ = yym1068
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1067) {
-		} else {
-			z.DecFallback(yyv1067, false)
-		}
-	}
-	yyj1064++
-	if yyhl1064 {
-		yyb1064 = yyj1064 > l
-	} else {
-		yyb1064 = r.CheckBreak()
-	}
-	if yyb1064 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv1069 := &x.Items
-		yym1070 := z.DecBinary()
-		_ = yym1070
-		if false {
-		} else {
-			h.decSliceIngress((*[]Ingress)(yyv1069), d)
-		}
 	}
 	for {
 		yyj1064++
@@ -14892,10 +14892,10 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1235 [4]bool
 			_, _, _ = yysep1235, yyq1235, yy2arr1235
 			const yyr1235 bool = false
-			yyq1235[0] = x.Kind != ""
-			yyq1235[1] = x.APIVersion != ""
-			yyq1235[2] = true
-			yyq1235[3] = true
+			yyq1235[0] = true
+			yyq1235[1] = true
+			yyq1235[2] = x.Kind != ""
+			yyq1235[3] = x.APIVersion != ""
 			var yynn1235 int
 			if yyr1235 || yy2arr1235 {
 				r.EncodeArrayStart(4)
@@ -14912,22 +14912,56 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr1235 || yy2arr1235 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1235[0] {
-					yym1237 := z.EncBinary()
-					_ = yym1237
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy1237 := &x.ObjectMeta
+					yy1237.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq1235[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1238 := &x.ObjectMeta
+					yy1238.CodecEncodeSelf(e)
+				}
+			}
+			if yyr1235 || yy2arr1235 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1235[1] {
+					yy1240 := &x.Spec
+					yy1240.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1235[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1241 := &x.Spec
+					yy1241.CodecEncodeSelf(e)
+				}
+			}
+			if yyr1235 || yy2arr1235 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1235[2] {
+					yym1243 := z.EncBinary()
+					_ = yym1243
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1235[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1238 := z.EncBinary()
-					_ = yym1238
+					yym1244 := z.EncBinary()
+					_ = yym1244
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -14936,9 +14970,9 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr1235 || yy2arr1235 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1235[1] {
-					yym1240 := z.EncBinary()
-					_ = yym1240
+				if yyq1235[3] {
+					yym1246 := z.EncBinary()
+					_ = yym1246
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -14947,50 +14981,16 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1235[1] {
+				if yyq1235[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1241 := z.EncBinary()
-					_ = yym1241
+					yym1247 := z.EncBinary()
+					_ = yym1247
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
-				}
-			}
-			if yyr1235 || yy2arr1235 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1235[2] {
-					yy1243 := &x.ObjectMeta
-					yy1243.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1235[2] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1244 := &x.ObjectMeta
-					yy1244.CodecEncodeSelf(e)
-				}
-			}
-			if yyr1235 || yy2arr1235 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1235[3] {
-					yy1246 := &x.Spec
-					yy1246.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1235[3] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1247 := &x.Spec
-					yy1247.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1235 || yy2arr1235 {
@@ -15054,6 +15054,20 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 		yys1250 := string(yys1250Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1250 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_v1.ObjectMeta{}
+			} else {
+				yyv1251 := &x.ObjectMeta
+				yyv1251.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = ClusterAutoscalerSpec{}
+			} else {
+				yyv1252 := &x.Spec
+				yyv1252.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -15065,20 +15079,6 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = pkg2_v1.ObjectMeta{}
-			} else {
-				yyv1253 := &x.ObjectMeta
-				yyv1253.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = ClusterAutoscalerSpec{}
-			} else {
-				yyv1254 := &x.Spec
-				yyv1254.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1250)
@@ -15094,6 +15094,40 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var yyj1255 int
 	var yyb1255 bool
 	var yyhl1255 bool = l >= 0
+	yyj1255++
+	if yyhl1255 {
+		yyb1255 = yyj1255 > l
+	} else {
+		yyb1255 = r.CheckBreak()
+	}
+	if yyb1255 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_v1.ObjectMeta{}
+	} else {
+		yyv1256 := &x.ObjectMeta
+		yyv1256.CodecDecodeSelf(d)
+	}
+	yyj1255++
+	if yyhl1255 {
+		yyb1255 = yyj1255 > l
+	} else {
+		yyb1255 = r.CheckBreak()
+	}
+	if yyb1255 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = ClusterAutoscalerSpec{}
+	} else {
+		yyv1257 := &x.Spec
+		yyv1257.CodecDecodeSelf(d)
+	}
 	yyj1255++
 	if yyhl1255 {
 		yyb1255 = yyj1255 > l
@@ -15125,40 +15159,6 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj1255++
-	if yyhl1255 {
-		yyb1255 = yyj1255 > l
-	} else {
-		yyb1255 = r.CheckBreak()
-	}
-	if yyb1255 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = pkg2_v1.ObjectMeta{}
-	} else {
-		yyv1258 := &x.ObjectMeta
-		yyv1258.CodecDecodeSelf(d)
-	}
-	yyj1255++
-	if yyhl1255 {
-		yyb1255 = yyj1255 > l
-	} else {
-		yyb1255 = r.CheckBreak()
-	}
-	if yyb1255 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = ClusterAutoscalerSpec{}
-	} else {
-		yyv1259 := &x.Spec
-		yyv1259.CodecDecodeSelf(d)
 	}
 	for {
 		yyj1255++
@@ -15193,9 +15193,9 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1261 [4]bool
 			_, _, _ = yysep1261, yyq1261, yy2arr1261
 			const yyr1261 bool = false
-			yyq1261[0] = x.Kind != ""
-			yyq1261[1] = x.APIVersion != ""
-			yyq1261[2] = true
+			yyq1261[0] = true
+			yyq1261[2] = x.Kind != ""
+			yyq1261[3] = x.APIVersion != ""
 			var yynn1261 int
 			if yyr1261 || yy2arr1261 {
 				r.EncodeArrayStart(4)
@@ -15212,79 +15212,29 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr1261 || yy2arr1261 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1261[0] {
-					yym1263 := z.EncBinary()
-					_ = yym1263
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1261[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1263 := &x.ListMeta
 					yym1264 := z.EncBinary()
 					_ = yym1264
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1263) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr1261 || yy2arr1261 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1261[1] {
-					yym1266 := z.EncBinary()
-					_ = yym1266
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1261[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1267 := z.EncBinary()
-					_ = yym1267
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr1261 || yy2arr1261 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1261[2] {
-					yy1269 := &x.ListMeta
-					yym1270 := z.EncBinary()
-					_ = yym1270
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1269) {
-					} else {
-						z.EncFallback(yy1269)
+						z.EncFallback(yy1263)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1261[2] {
+				if yyq1261[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1271 := &x.ListMeta
-					yym1272 := z.EncBinary()
-					_ = yym1272
+					yy1265 := &x.ListMeta
+					yym1266 := z.EncBinary()
+					_ = yym1266
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1271) {
+					} else if z.HasExtensions() && z.EncExt(yy1265) {
 					} else {
-						z.EncFallback(yy1271)
+						z.EncFallback(yy1265)
 					}
 				}
 			}
@@ -15293,8 +15243,8 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1274 := z.EncBinary()
-					_ = yym1274
+					yym1268 := z.EncBinary()
+					_ = yym1268
 					if false {
 					} else {
 						h.encSliceClusterAutoscaler(([]ClusterAutoscaler)(x.Items), e)
@@ -15307,11 +15257,61 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym1269 := z.EncBinary()
+					_ = yym1269
+					if false {
+					} else {
+						h.encSliceClusterAutoscaler(([]ClusterAutoscaler)(x.Items), e)
+					}
+				}
+			}
+			if yyr1261 || yy2arr1261 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1261[2] {
+					yym1271 := z.EncBinary()
+					_ = yym1271
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1261[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1272 := z.EncBinary()
+					_ = yym1272
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr1261 || yy2arr1261 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1261[3] {
+					yym1274 := z.EncBinary()
+					_ = yym1274
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1261[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1275 := z.EncBinary()
 					_ = yym1275
 					if false {
 					} else {
-						h.encSliceClusterAutoscaler(([]ClusterAutoscaler)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -15376,6 +15376,31 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 		yys1278 := string(yys1278Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1278 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv1279 := &x.ListMeta
+				yym1280 := z.DecBinary()
+				_ = yym1280
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv1279) {
+				} else {
+					z.DecFallback(yyv1279, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv1281 := &x.Items
+				yym1282 := z.DecBinary()
+				_ = yym1282
+				if false {
+				} else {
+					h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1281), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -15387,31 +15412,6 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg1_unversioned.ListMeta{}
-			} else {
-				yyv1281 := &x.ListMeta
-				yym1282 := z.DecBinary()
-				_ = yym1282
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1281) {
-				} else {
-					z.DecFallback(yyv1281, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv1283 := &x.Items
-				yym1284 := z.DecBinary()
-				_ = yym1284
-				if false {
-				} else {
-					h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1283), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1278)
@@ -15427,6 +15427,51 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var yyj1285 int
 	var yyb1285 bool
 	var yyhl1285 bool = l >= 0
+	yyj1285++
+	if yyhl1285 {
+		yyb1285 = yyj1285 > l
+	} else {
+		yyb1285 = r.CheckBreak()
+	}
+	if yyb1285 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv1286 := &x.ListMeta
+		yym1287 := z.DecBinary()
+		_ = yym1287
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1286) {
+		} else {
+			z.DecFallback(yyv1286, false)
+		}
+	}
+	yyj1285++
+	if yyhl1285 {
+		yyb1285 = yyj1285 > l
+	} else {
+		yyb1285 = r.CheckBreak()
+	}
+	if yyb1285 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv1288 := &x.Items
+		yym1289 := z.DecBinary()
+		_ = yym1289
+		if false {
+		} else {
+			h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1288), d)
+		}
+	}
 	yyj1285++
 	if yyhl1285 {
 		yyb1285 = yyj1285 > l
@@ -15458,51 +15503,6 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj1285++
-	if yyhl1285 {
-		yyb1285 = yyj1285 > l
-	} else {
-		yyb1285 = r.CheckBreak()
-	}
-	if yyb1285 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg1_unversioned.ListMeta{}
-	} else {
-		yyv1288 := &x.ListMeta
-		yym1289 := z.DecBinary()
-		_ = yym1289
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1288) {
-		} else {
-			z.DecFallback(yyv1288, false)
-		}
-	}
-	yyj1285++
-	if yyhl1285 {
-		yyb1285 = yyj1285 > l
-	} else {
-		yyb1285 = r.CheckBreak()
-	}
-	if yyb1285 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv1290 := &x.Items
-		yym1291 := z.DecBinary()
-		_ = yym1291
-		if false {
-		} else {
-			h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1290), d)
-		}
 	}
 	for {
 		yyj1285++
@@ -15537,8 +15537,8 @@ func (x *ExportOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1293 [4]bool
 			_, _, _ = yysep1293, yyq1293, yy2arr1293
 			const yyr1293 bool = false
-			yyq1293[0] = x.Kind != ""
-			yyq1293[1] = x.APIVersion != ""
+			yyq1293[2] = x.Kind != ""
+			yyq1293[3] = x.APIVersion != ""
 			var yynn1293 int
 			if yyr1293 || yy2arr1293 {
 				r.EncodeArrayStart(4)
@@ -15554,58 +15554,8 @@ func (x *ExportOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr1293 || yy2arr1293 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1293[0] {
-					yym1295 := z.EncBinary()
-					_ = yym1295
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1293[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1296 := z.EncBinary()
-					_ = yym1296
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr1293 || yy2arr1293 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1293[1] {
-					yym1298 := z.EncBinary()
-					_ = yym1298
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1293[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1299 := z.EncBinary()
-					_ = yym1299
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr1293 || yy2arr1293 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1301 := z.EncBinary()
-				_ = yym1301
+				yym1295 := z.EncBinary()
+				_ = yym1295
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Export))
@@ -15614,8 +15564,8 @@ func (x *ExportOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("export"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1302 := z.EncBinary()
-				_ = yym1302
+				yym1296 := z.EncBinary()
+				_ = yym1296
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Export))
@@ -15623,8 +15573,8 @@ func (x *ExportOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr1293 || yy2arr1293 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1304 := z.EncBinary()
-				_ = yym1304
+				yym1298 := z.EncBinary()
+				_ = yym1298
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Exact))
@@ -15633,11 +15583,61 @@ func (x *ExportOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("exact"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1305 := z.EncBinary()
-				_ = yym1305
+				yym1299 := z.EncBinary()
+				_ = yym1299
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Exact))
+				}
+			}
+			if yyr1293 || yy2arr1293 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1293[2] {
+					yym1301 := z.EncBinary()
+					_ = yym1301
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1293[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1302 := z.EncBinary()
+					_ = yym1302
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr1293 || yy2arr1293 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1293[3] {
+					yym1304 := z.EncBinary()
+					_ = yym1304
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1293[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1305 := z.EncBinary()
+					_ = yym1305
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr1293 || yy2arr1293 {
@@ -15701,18 +15701,6 @@ func (x *ExportOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys1308 := string(yys1308Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1308 {
-		case "kind":
-			if r.TryDecodeAsNil() {
-				x.Kind = ""
-			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
-			}
 		case "export":
 			if r.TryDecodeAsNil() {
 				x.Export = false
@@ -15724,6 +15712,18 @@ func (x *ExportOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Exact = false
 			} else {
 				x.Exact = bool(r.DecodeBool())
+			}
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1308)
@@ -15739,38 +15739,6 @@ func (x *ExportOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj1313 int
 	var yyb1313 bool
 	var yyhl1313 bool = l >= 0
-	yyj1313++
-	if yyhl1313 {
-		yyb1313 = yyj1313 > l
-	} else {
-		yyb1313 = r.CheckBreak()
-	}
-	if yyb1313 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Kind = ""
-	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj1313++
-	if yyhl1313 {
-		yyb1313 = yyj1313 > l
-	} else {
-		yyb1313 = r.CheckBreak()
-	}
-	if yyb1313 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
-	}
 	yyj1313++
 	if yyhl1313 {
 		yyb1313 = yyj1313 > l
@@ -15802,6 +15770,38 @@ func (x *ExportOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Exact = false
 	} else {
 		x.Exact = bool(r.DecodeBool())
+	}
+	yyj1313++
+	if yyhl1313 {
+		yyb1313 = yyj1313 > l
+	} else {
+		yyb1313 = r.CheckBreak()
+	}
+	if yyb1313 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj1313++
+	if yyhl1313 {
+		yyb1313 = yyj1313 > l
+	} else {
+		yyb1313 = r.CheckBreak()
+	}
+	if yyb1313 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
 	}
 	for {
 		yyj1313++
@@ -15836,13 +15836,13 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1319 [7]bool
 			_, _, _ = yysep1319, yyq1319, yy2arr1319
 			const yyr1319 bool = false
-			yyq1319[0] = x.Kind != ""
-			yyq1319[1] = x.APIVersion != ""
-			yyq1319[2] = x.LabelSelector != ""
-			yyq1319[3] = x.FieldSelector != ""
-			yyq1319[4] = x.Watch != false
-			yyq1319[5] = x.ResourceVersion != ""
-			yyq1319[6] = x.TimeoutSeconds != nil
+			yyq1319[0] = x.LabelSelector != ""
+			yyq1319[1] = x.FieldSelector != ""
+			yyq1319[2] = x.Watch != false
+			yyq1319[3] = x.ResourceVersion != ""
+			yyq1319[4] = x.TimeoutSeconds != nil
+			yyq1319[5] = x.Kind != ""
+			yyq1319[6] = x.APIVersion != ""
 			var yynn1319 int
 			if yyr1319 || yy2arr1319 {
 				r.EncodeArrayStart(7)
@@ -15863,7 +15863,7 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym1321
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+						r.EncodeString(codecSelferC_UTF81234, string(x.LabelSelector))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -15871,13 +15871,13 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq1319[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("labelSelector"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1322 := z.EncBinary()
 					_ = yym1322
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+						r.EncodeString(codecSelferC_UTF81234, string(x.LabelSelector))
 					}
 				}
 			}
@@ -15888,7 +15888,7 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym1324
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.FieldSelector))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -15896,13 +15896,13 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq1319[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("fieldSelector"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1325 := z.EncBinary()
 					_ = yym1325
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.FieldSelector))
 					}
 				}
 			}
@@ -15913,21 +15913,21 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym1327
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.LabelSelector))
+						r.EncodeBool(bool(x.Watch))
 					}
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeBool(false)
 				}
 			} else {
 				if yyq1319[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("labelSelector"))
+					r.EncodeString(codecSelferC_UTF81234, string("watch"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1328 := z.EncBinary()
 					_ = yym1328
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.LabelSelector))
+						r.EncodeBool(bool(x.Watch))
 					}
 				}
 			}
@@ -15938,7 +15938,7 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym1330
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.FieldSelector))
+						r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -15946,49 +15946,59 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq1319[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("fieldSelector"))
+					r.EncodeString(codecSelferC_UTF81234, string("resourceVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1331 := z.EncBinary()
 					_ = yym1331
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.FieldSelector))
+						r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
 					}
 				}
 			}
 			if yyr1319 || yy2arr1319 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1319[4] {
-					yym1333 := z.EncBinary()
-					_ = yym1333
-					if false {
+					if x.TimeoutSeconds == nil {
+						r.EncodeNil()
 					} else {
-						r.EncodeBool(bool(x.Watch))
+						yy1333 := *x.TimeoutSeconds
+						yym1334 := z.EncBinary()
+						_ = yym1334
+						if false {
+						} else {
+							r.EncodeInt(int64(yy1333))
+						}
 					}
 				} else {
-					r.EncodeBool(false)
+					r.EncodeNil()
 				}
 			} else {
 				if yyq1319[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("watch"))
+					r.EncodeString(codecSelferC_UTF81234, string("timeoutSeconds"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1334 := z.EncBinary()
-					_ = yym1334
-					if false {
+					if x.TimeoutSeconds == nil {
+						r.EncodeNil()
 					} else {
-						r.EncodeBool(bool(x.Watch))
+						yy1335 := *x.TimeoutSeconds
+						yym1336 := z.EncBinary()
+						_ = yym1336
+						if false {
+						} else {
+							r.EncodeInt(int64(yy1335))
+						}
 					}
 				}
 			}
 			if yyr1319 || yy2arr1319 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1319[5] {
-					yym1336 := z.EncBinary()
-					_ = yym1336
+					yym1338 := z.EncBinary()
+					_ = yym1338
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -15996,48 +16006,38 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq1319[5] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("resourceVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1337 := z.EncBinary()
-					_ = yym1337
+					yym1339 := z.EncBinary()
+					_ = yym1339
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
 			if yyr1319 || yy2arr1319 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1319[6] {
-					if x.TimeoutSeconds == nil {
-						r.EncodeNil()
+					yym1341 := z.EncBinary()
+					_ = yym1341
+					if false {
 					} else {
-						yy1339 := *x.TimeoutSeconds
-						yym1340 := z.EncBinary()
-						_ = yym1340
-						if false {
-						} else {
-							r.EncodeInt(int64(yy1339))
-						}
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq1319[6] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("timeoutSeconds"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if x.TimeoutSeconds == nil {
-						r.EncodeNil()
+					yym1342 := z.EncBinary()
+					_ = yym1342
+					if false {
 					} else {
-						yy1341 := *x.TimeoutSeconds
-						yym1342 := z.EncBinary()
-						_ = yym1342
-						if false {
-						} else {
-							r.EncodeInt(int64(yy1341))
-						}
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -16102,18 +16102,6 @@ func (x *ListOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys1345 := string(yys1345Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1345 {
-		case "kind":
-			if r.TryDecodeAsNil() {
-				x.Kind = ""
-			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
-			}
 		case "labelSelector":
 			if r.TryDecodeAsNil() {
 				x.LabelSelector = ""
@@ -16147,12 +16135,24 @@ func (x *ListOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TimeoutSeconds == nil {
 					x.TimeoutSeconds = new(int64)
 				}
-				yym1353 := z.DecBinary()
-				_ = yym1353
+				yym1351 := z.DecBinary()
+				_ = yym1351
 				if false {
 				} else {
 					*((*int64)(x.TimeoutSeconds)) = int64(r.DecodeInt(64))
 				}
+			}
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1345)
@@ -16168,38 +16168,6 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj1354 int
 	var yyb1354 bool
 	var yyhl1354 bool = l >= 0
-	yyj1354++
-	if yyhl1354 {
-		yyb1354 = yyj1354 > l
-	} else {
-		yyb1354 = r.CheckBreak()
-	}
-	if yyb1354 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Kind = ""
-	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj1354++
-	if yyhl1354 {
-		yyb1354 = yyj1354 > l
-	} else {
-		yyb1354 = r.CheckBreak()
-	}
-	if yyb1354 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
-	}
 	yyj1354++
 	if yyhl1354 {
 		yyb1354 = yyj1354 > l
@@ -16283,12 +16251,44 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TimeoutSeconds == nil {
 			x.TimeoutSeconds = new(int64)
 		}
-		yym1362 := z.DecBinary()
-		_ = yym1362
+		yym1360 := z.DecBinary()
+		_ = yym1360
 		if false {
 		} else {
 			*((*int64)(x.TimeoutSeconds)) = int64(r.DecodeInt(64))
 		}
+	}
+	yyj1354++
+	if yyhl1354 {
+		yyb1354 = yyj1354 > l
+	} else {
+		yyb1354 = r.CheckBreak()
+	}
+	if yyb1354 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj1354++
+	if yyhl1354 {
+		yyb1354 = yyj1354 > l
+	} else {
+		yyb1354 = r.CheckBreak()
+	}
+	if yyb1354 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
 	}
 	for {
 		yyj1354++
@@ -16867,11 +16867,11 @@ func (x *ReplicaSet) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1407 [5]bool
 			_, _, _ = yysep1407, yyq1407, yy2arr1407
 			const yyr1407 bool = false
-			yyq1407[0] = x.Kind != ""
-			yyq1407[1] = x.APIVersion != ""
+			yyq1407[0] = true
+			yyq1407[1] = true
 			yyq1407[2] = true
-			yyq1407[3] = true
-			yyq1407[4] = true
+			yyq1407[3] = x.Kind != ""
+			yyq1407[4] = x.APIVersion != ""
 			var yynn1407 int
 			if yyr1407 || yy2arr1407 {
 				r.EncodeArrayStart(5)
@@ -16888,57 +16888,41 @@ func (x *ReplicaSet) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr1407 || yy2arr1407 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1407[0] {
-					yym1409 := z.EncBinary()
-					_ = yym1409
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy1409 := &x.ObjectMeta
+					yy1409.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq1407[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1410 := z.EncBinary()
-					_ = yym1410
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy1410 := &x.ObjectMeta
+					yy1410.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1407 || yy2arr1407 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1407[1] {
-					yym1412 := z.EncBinary()
-					_ = yym1412
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy1412 := &x.Spec
+					yy1412.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq1407[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1413 := z.EncBinary()
-					_ = yym1413
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
+					yy1413 := &x.Spec
+					yy1413.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1407 || yy2arr1407 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1407[2] {
-					yy1415 := &x.ObjectMeta
+					yy1415 := &x.Status
 					yy1415.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
@@ -16946,44 +16930,60 @@ func (x *ReplicaSet) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq1407[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1416 := &x.ObjectMeta
+					yy1416 := &x.Status
 					yy1416.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1407 || yy2arr1407 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1407[3] {
-					yy1418 := &x.Spec
-					yy1418.CodecEncodeSelf(e)
+					yym1418 := z.EncBinary()
+					_ = yym1418
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq1407[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1419 := &x.Spec
-					yy1419.CodecEncodeSelf(e)
+					yym1419 := z.EncBinary()
+					_ = yym1419
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
 				}
 			}
 			if yyr1407 || yy2arr1407 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1407[4] {
-					yy1421 := &x.Status
-					yy1421.CodecEncodeSelf(e)
+					yym1421 := z.EncBinary()
+					_ = yym1421
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				} else {
-					r.EncodeNil()
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq1407[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1422 := &x.Status
-					yy1422.CodecEncodeSelf(e)
+					yym1422 := z.EncBinary()
+					_ = yym1422
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr1407 || yy2arr1407 {
@@ -17047,6 +17047,27 @@ func (x *ReplicaSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys1425 := string(yys1425Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1425 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_v1.ObjectMeta{}
+			} else {
+				yyv1426 := &x.ObjectMeta
+				yyv1426.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = ReplicaSetSpec{}
+			} else {
+				yyv1427 := &x.Spec
+				yyv1427.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = ReplicaSetStatus{}
+			} else {
+				yyv1428 := &x.Status
+				yyv1428.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -17058,27 +17079,6 @@ func (x *ReplicaSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = pkg2_v1.ObjectMeta{}
-			} else {
-				yyv1428 := &x.ObjectMeta
-				yyv1428.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = ReplicaSetSpec{}
-			} else {
-				yyv1429 := &x.Spec
-				yyv1429.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = ReplicaSetStatus{}
-			} else {
-				yyv1430 := &x.Status
-				yyv1430.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1425)
@@ -17094,6 +17094,57 @@ func (x *ReplicaSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj1431 int
 	var yyb1431 bool
 	var yyhl1431 bool = l >= 0
+	yyj1431++
+	if yyhl1431 {
+		yyb1431 = yyj1431 > l
+	} else {
+		yyb1431 = r.CheckBreak()
+	}
+	if yyb1431 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_v1.ObjectMeta{}
+	} else {
+		yyv1432 := &x.ObjectMeta
+		yyv1432.CodecDecodeSelf(d)
+	}
+	yyj1431++
+	if yyhl1431 {
+		yyb1431 = yyj1431 > l
+	} else {
+		yyb1431 = r.CheckBreak()
+	}
+	if yyb1431 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = ReplicaSetSpec{}
+	} else {
+		yyv1433 := &x.Spec
+		yyv1433.CodecDecodeSelf(d)
+	}
+	yyj1431++
+	if yyhl1431 {
+		yyb1431 = yyj1431 > l
+	} else {
+		yyb1431 = r.CheckBreak()
+	}
+	if yyb1431 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Status = ReplicaSetStatus{}
+	} else {
+		yyv1434 := &x.Status
+		yyv1434.CodecDecodeSelf(d)
+	}
 	yyj1431++
 	if yyhl1431 {
 		yyb1431 = yyj1431 > l
@@ -17125,57 +17176,6 @@ func (x *ReplicaSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj1431++
-	if yyhl1431 {
-		yyb1431 = yyj1431 > l
-	} else {
-		yyb1431 = r.CheckBreak()
-	}
-	if yyb1431 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = pkg2_v1.ObjectMeta{}
-	} else {
-		yyv1434 := &x.ObjectMeta
-		yyv1434.CodecDecodeSelf(d)
-	}
-	yyj1431++
-	if yyhl1431 {
-		yyb1431 = yyj1431 > l
-	} else {
-		yyb1431 = r.CheckBreak()
-	}
-	if yyb1431 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = ReplicaSetSpec{}
-	} else {
-		yyv1435 := &x.Spec
-		yyv1435.CodecDecodeSelf(d)
-	}
-	yyj1431++
-	if yyhl1431 {
-		yyb1431 = yyj1431 > l
-	} else {
-		yyb1431 = r.CheckBreak()
-	}
-	if yyb1431 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Status = ReplicaSetStatus{}
-	} else {
-		yyv1436 := &x.Status
-		yyv1436.CodecDecodeSelf(d)
 	}
 	for {
 		yyj1431++
@@ -17210,9 +17210,9 @@ func (x *ReplicaSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1438 [4]bool
 			_, _, _ = yysep1438, yyq1438, yy2arr1438
 			const yyr1438 bool = false
-			yyq1438[0] = x.Kind != ""
-			yyq1438[1] = x.APIVersion != ""
-			yyq1438[2] = true
+			yyq1438[0] = true
+			yyq1438[2] = x.Kind != ""
+			yyq1438[3] = x.APIVersion != ""
 			var yynn1438 int
 			if yyr1438 || yy2arr1438 {
 				r.EncodeArrayStart(4)
@@ -17229,79 +17229,29 @@ func (x *ReplicaSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr1438 || yy2arr1438 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1438[0] {
-					yym1440 := z.EncBinary()
-					_ = yym1440
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1438[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1440 := &x.ListMeta
 					yym1441 := z.EncBinary()
 					_ = yym1441
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1440) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr1438 || yy2arr1438 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1438[1] {
-					yym1443 := z.EncBinary()
-					_ = yym1443
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1438[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1444 := z.EncBinary()
-					_ = yym1444
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr1438 || yy2arr1438 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1438[2] {
-					yy1446 := &x.ListMeta
-					yym1447 := z.EncBinary()
-					_ = yym1447
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1446) {
-					} else {
-						z.EncFallback(yy1446)
+						z.EncFallback(yy1440)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1438[2] {
+				if yyq1438[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1448 := &x.ListMeta
-					yym1449 := z.EncBinary()
-					_ = yym1449
+					yy1442 := &x.ListMeta
+					yym1443 := z.EncBinary()
+					_ = yym1443
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1448) {
+					} else if z.HasExtensions() && z.EncExt(yy1442) {
 					} else {
-						z.EncFallback(yy1448)
+						z.EncFallback(yy1442)
 					}
 				}
 			}
@@ -17310,8 +17260,8 @@ func (x *ReplicaSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1451 := z.EncBinary()
-					_ = yym1451
+					yym1445 := z.EncBinary()
+					_ = yym1445
 					if false {
 					} else {
 						h.encSliceReplicaSet(([]ReplicaSet)(x.Items), e)
@@ -17324,11 +17274,61 @@ func (x *ReplicaSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym1446 := z.EncBinary()
+					_ = yym1446
+					if false {
+					} else {
+						h.encSliceReplicaSet(([]ReplicaSet)(x.Items), e)
+					}
+				}
+			}
+			if yyr1438 || yy2arr1438 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1438[2] {
+					yym1448 := z.EncBinary()
+					_ = yym1448
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1438[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1449 := z.EncBinary()
+					_ = yym1449
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr1438 || yy2arr1438 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1438[3] {
+					yym1451 := z.EncBinary()
+					_ = yym1451
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1438[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1452 := z.EncBinary()
 					_ = yym1452
 					if false {
 					} else {
-						h.encSliceReplicaSet(([]ReplicaSet)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -17393,6 +17393,31 @@ func (x *ReplicaSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys1455 := string(yys1455Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1455 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv1456 := &x.ListMeta
+				yym1457 := z.DecBinary()
+				_ = yym1457
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv1456) {
+				} else {
+					z.DecFallback(yyv1456, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv1458 := &x.Items
+				yym1459 := z.DecBinary()
+				_ = yym1459
+				if false {
+				} else {
+					h.decSliceReplicaSet((*[]ReplicaSet)(yyv1458), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -17404,31 +17429,6 @@ func (x *ReplicaSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg1_unversioned.ListMeta{}
-			} else {
-				yyv1458 := &x.ListMeta
-				yym1459 := z.DecBinary()
-				_ = yym1459
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1458) {
-				} else {
-					z.DecFallback(yyv1458, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv1460 := &x.Items
-				yym1461 := z.DecBinary()
-				_ = yym1461
-				if false {
-				} else {
-					h.decSliceReplicaSet((*[]ReplicaSet)(yyv1460), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1455)
@@ -17444,6 +17444,51 @@ func (x *ReplicaSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj1462 int
 	var yyb1462 bool
 	var yyhl1462 bool = l >= 0
+	yyj1462++
+	if yyhl1462 {
+		yyb1462 = yyj1462 > l
+	} else {
+		yyb1462 = r.CheckBreak()
+	}
+	if yyb1462 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv1463 := &x.ListMeta
+		yym1464 := z.DecBinary()
+		_ = yym1464
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1463) {
+		} else {
+			z.DecFallback(yyv1463, false)
+		}
+	}
+	yyj1462++
+	if yyhl1462 {
+		yyb1462 = yyj1462 > l
+	} else {
+		yyb1462 = r.CheckBreak()
+	}
+	if yyb1462 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv1465 := &x.Items
+		yym1466 := z.DecBinary()
+		_ = yym1466
+		if false {
+		} else {
+			h.decSliceReplicaSet((*[]ReplicaSet)(yyv1465), d)
+		}
+	}
 	yyj1462++
 	if yyhl1462 {
 		yyb1462 = yyj1462 > l
@@ -17475,51 +17520,6 @@ func (x *ReplicaSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj1462++
-	if yyhl1462 {
-		yyb1462 = yyj1462 > l
-	} else {
-		yyb1462 = r.CheckBreak()
-	}
-	if yyb1462 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg1_unversioned.ListMeta{}
-	} else {
-		yyv1465 := &x.ListMeta
-		yym1466 := z.DecBinary()
-		_ = yym1466
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1465) {
-		} else {
-			z.DecFallback(yyv1465, false)
-		}
-	}
-	yyj1462++
-	if yyhl1462 {
-		yyb1462 = yyj1462 > l
-	} else {
-		yyb1462 = r.CheckBreak()
-	}
-	if yyb1462 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv1467 := &x.Items
-		yym1468 := z.DecBinary()
-		_ = yym1468
-		if false {
-		} else {
-			h.decSliceReplicaSet((*[]ReplicaSet)(yyv1467), d)
-		}
 	}
 	for {
 		yyj1462++
@@ -18075,10 +18075,10 @@ func (x *PodSecurityPolicy) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1507 [4]bool
 			_, _, _ = yysep1507, yyq1507, yy2arr1507
 			const yyr1507 bool = false
-			yyq1507[0] = x.Kind != ""
-			yyq1507[1] = x.APIVersion != ""
-			yyq1507[2] = true
-			yyq1507[3] = true
+			yyq1507[0] = true
+			yyq1507[1] = true
+			yyq1507[2] = x.Kind != ""
+			yyq1507[3] = x.APIVersion != ""
 			var yynn1507 int
 			if yyr1507 || yy2arr1507 {
 				r.EncodeArrayStart(4)
@@ -18095,22 +18095,56 @@ func (x *PodSecurityPolicy) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr1507 || yy2arr1507 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1507[0] {
-					yym1509 := z.EncBinary()
-					_ = yym1509
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
+					yy1509 := &x.ObjectMeta
+					yy1509.CodecEncodeSelf(e)
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					r.EncodeNil()
 				}
 			} else {
 				if yyq1507[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1510 := &x.ObjectMeta
+					yy1510.CodecEncodeSelf(e)
+				}
+			}
+			if yyr1507 || yy2arr1507 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1507[1] {
+					yy1512 := &x.Spec
+					yy1512.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1507[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1513 := &x.Spec
+					yy1513.CodecEncodeSelf(e)
+				}
+			}
+			if yyr1507 || yy2arr1507 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1507[2] {
+					yym1515 := z.EncBinary()
+					_ = yym1515
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1507[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1510 := z.EncBinary()
-					_ = yym1510
+					yym1516 := z.EncBinary()
+					_ = yym1516
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -18119,9 +18153,9 @@ func (x *PodSecurityPolicy) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr1507 || yy2arr1507 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1507[1] {
-					yym1512 := z.EncBinary()
-					_ = yym1512
+				if yyq1507[3] {
+					yym1518 := z.EncBinary()
+					_ = yym1518
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -18130,50 +18164,16 @@ func (x *PodSecurityPolicy) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1507[1] {
+				if yyq1507[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1513 := z.EncBinary()
-					_ = yym1513
+					yym1519 := z.EncBinary()
+					_ = yym1519
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
-				}
-			}
-			if yyr1507 || yy2arr1507 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1507[2] {
-					yy1515 := &x.ObjectMeta
-					yy1515.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1507[2] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1516 := &x.ObjectMeta
-					yy1516.CodecEncodeSelf(e)
-				}
-			}
-			if yyr1507 || yy2arr1507 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1507[3] {
-					yy1518 := &x.Spec
-					yy1518.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1507[3] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1519 := &x.Spec
-					yy1519.CodecEncodeSelf(e)
 				}
 			}
 			if yyr1507 || yy2arr1507 {
@@ -18237,6 +18237,20 @@ func (x *PodSecurityPolicy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 		yys1522 := string(yys1522Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1522 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_v1.ObjectMeta{}
+			} else {
+				yyv1523 := &x.ObjectMeta
+				yyv1523.CodecDecodeSelf(d)
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = PodSecurityPolicySpec{}
+			} else {
+				yyv1524 := &x.Spec
+				yyv1524.CodecDecodeSelf(d)
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -18248,20 +18262,6 @@ func (x *PodSecurityPolicy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = pkg2_v1.ObjectMeta{}
-			} else {
-				yyv1525 := &x.ObjectMeta
-				yyv1525.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = PodSecurityPolicySpec{}
-			} else {
-				yyv1526 := &x.Spec
-				yyv1526.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1522)
@@ -18277,6 +18277,40 @@ func (x *PodSecurityPolicy) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var yyj1527 int
 	var yyb1527 bool
 	var yyhl1527 bool = l >= 0
+	yyj1527++
+	if yyhl1527 {
+		yyb1527 = yyj1527 > l
+	} else {
+		yyb1527 = r.CheckBreak()
+	}
+	if yyb1527 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_v1.ObjectMeta{}
+	} else {
+		yyv1528 := &x.ObjectMeta
+		yyv1528.CodecDecodeSelf(d)
+	}
+	yyj1527++
+	if yyhl1527 {
+		yyb1527 = yyj1527 > l
+	} else {
+		yyb1527 = r.CheckBreak()
+	}
+	if yyb1527 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Spec = PodSecurityPolicySpec{}
+	} else {
+		yyv1529 := &x.Spec
+		yyv1529.CodecDecodeSelf(d)
+	}
 	yyj1527++
 	if yyhl1527 {
 		yyb1527 = yyj1527 > l
@@ -18308,40 +18342,6 @@ func (x *PodSecurityPolicy) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj1527++
-	if yyhl1527 {
-		yyb1527 = yyj1527 > l
-	} else {
-		yyb1527 = r.CheckBreak()
-	}
-	if yyb1527 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = pkg2_v1.ObjectMeta{}
-	} else {
-		yyv1530 := &x.ObjectMeta
-		yyv1530.CodecDecodeSelf(d)
-	}
-	yyj1527++
-	if yyhl1527 {
-		yyb1527 = yyj1527 > l
-	} else {
-		yyb1527 = r.CheckBreak()
-	}
-	if yyb1527 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Spec = PodSecurityPolicySpec{}
-	} else {
-		yyv1531 := &x.Spec
-		yyv1531.CodecDecodeSelf(d)
 	}
 	for {
 		yyj1527++
@@ -19889,9 +19889,9 @@ func (x *PodSecurityPolicyList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq1656 [4]bool
 			_, _, _ = yysep1656, yyq1656, yy2arr1656
 			const yyr1656 bool = false
-			yyq1656[0] = x.Kind != ""
-			yyq1656[1] = x.APIVersion != ""
-			yyq1656[2] = true
+			yyq1656[0] = true
+			yyq1656[2] = x.Kind != ""
+			yyq1656[3] = x.APIVersion != ""
 			var yynn1656 int
 			if yyr1656 || yy2arr1656 {
 				r.EncodeArrayStart(4)
@@ -19908,79 +19908,29 @@ func (x *PodSecurityPolicyList) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr1656 || yy2arr1656 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq1656[0] {
-					yym1658 := z.EncBinary()
-					_ = yym1658
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1656[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1658 := &x.ListMeta
 					yym1659 := z.EncBinary()
 					_ = yym1659
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1658) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr1656 || yy2arr1656 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1656[1] {
-					yym1661 := z.EncBinary()
-					_ = yym1661
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1656[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1662 := z.EncBinary()
-					_ = yym1662
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr1656 || yy2arr1656 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1656[2] {
-					yy1664 := &x.ListMeta
-					yym1665 := z.EncBinary()
-					_ = yym1665
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1664) {
-					} else {
-						z.EncFallback(yy1664)
+						z.EncFallback(yy1658)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1656[2] {
+				if yyq1656[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1666 := &x.ListMeta
-					yym1667 := z.EncBinary()
-					_ = yym1667
+					yy1660 := &x.ListMeta
+					yym1661 := z.EncBinary()
+					_ = yym1661
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1666) {
+					} else if z.HasExtensions() && z.EncExt(yy1660) {
 					} else {
-						z.EncFallback(yy1666)
+						z.EncFallback(yy1660)
 					}
 				}
 			}
@@ -19989,8 +19939,8 @@ func (x *PodSecurityPolicyList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1669 := z.EncBinary()
-					_ = yym1669
+					yym1663 := z.EncBinary()
+					_ = yym1663
 					if false {
 					} else {
 						h.encSlicePodSecurityPolicy(([]PodSecurityPolicy)(x.Items), e)
@@ -20003,11 +19953,61 @@ func (x *PodSecurityPolicyList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
+					yym1664 := z.EncBinary()
+					_ = yym1664
+					if false {
+					} else {
+						h.encSlicePodSecurityPolicy(([]PodSecurityPolicy)(x.Items), e)
+					}
+				}
+			}
+			if yyr1656 || yy2arr1656 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1656[2] {
+					yym1666 := z.EncBinary()
+					_ = yym1666
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1656[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1667 := z.EncBinary()
+					_ = yym1667
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr1656 || yy2arr1656 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1656[3] {
+					yym1669 := z.EncBinary()
+					_ = yym1669
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1656[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym1670 := z.EncBinary()
 					_ = yym1670
 					if false {
 					} else {
-						h.encSlicePodSecurityPolicy(([]PodSecurityPolicy)(x.Items), e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -20072,6 +20072,31 @@ func (x *PodSecurityPolicyList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 		yys1673 := string(yys1673Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1673 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv1674 := &x.ListMeta
+				yym1675 := z.DecBinary()
+				_ = yym1675
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv1674) {
+				} else {
+					z.DecFallback(yyv1674, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv1676 := &x.Items
+				yym1677 := z.DecBinary()
+				_ = yym1677
+				if false {
+				} else {
+					h.decSlicePodSecurityPolicy((*[]PodSecurityPolicy)(yyv1676), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -20083,31 +20108,6 @@ func (x *PodSecurityPolicyList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg1_unversioned.ListMeta{}
-			} else {
-				yyv1676 := &x.ListMeta
-				yym1677 := z.DecBinary()
-				_ = yym1677
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1676) {
-				} else {
-					z.DecFallback(yyv1676, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv1678 := &x.Items
-				yym1679 := z.DecBinary()
-				_ = yym1679
-				if false {
-				} else {
-					h.decSlicePodSecurityPolicy((*[]PodSecurityPolicy)(yyv1678), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1673)
@@ -20123,6 +20123,51 @@ func (x *PodSecurityPolicyList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var yyj1680 int
 	var yyb1680 bool
 	var yyhl1680 bool = l >= 0
+	yyj1680++
+	if yyhl1680 {
+		yyb1680 = yyj1680 > l
+	} else {
+		yyb1680 = r.CheckBreak()
+	}
+	if yyb1680 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv1681 := &x.ListMeta
+		yym1682 := z.DecBinary()
+		_ = yym1682
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1681) {
+		} else {
+			z.DecFallback(yyv1681, false)
+		}
+	}
+	yyj1680++
+	if yyhl1680 {
+		yyb1680 = yyj1680 > l
+	} else {
+		yyb1680 = r.CheckBreak()
+	}
+	if yyb1680 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv1683 := &x.Items
+		yym1684 := z.DecBinary()
+		_ = yym1684
+		if false {
+		} else {
+			h.decSlicePodSecurityPolicy((*[]PodSecurityPolicy)(yyv1683), d)
+		}
+	}
 	yyj1680++
 	if yyhl1680 {
 		yyb1680 = yyj1680 > l
@@ -20154,51 +20199,6 @@ func (x *PodSecurityPolicyList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj1680++
-	if yyhl1680 {
-		yyb1680 = yyj1680 > l
-	} else {
-		yyb1680 = r.CheckBreak()
-	}
-	if yyb1680 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg1_unversioned.ListMeta{}
-	} else {
-		yyv1683 := &x.ListMeta
-		yym1684 := z.DecBinary()
-		_ = yym1684
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1683) {
-		} else {
-			z.DecFallback(yyv1683, false)
-		}
-	}
-	yyj1680++
-	if yyhl1680 {
-		yyb1680 = yyj1680 > l
-	} else {
-		yyb1680 = r.CheckBreak()
-	}
-	if yyb1680 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv1685 := &x.Items
-		yym1686 := z.DecBinary()
-		_ = yym1686
-		if false {
-		} else {
-			h.decSlicePodSecurityPolicy((*[]PodSecurityPolicy)(yyv1685), d)
-		}
 	}
 	for {
 		yyj1680++

--- a/pkg/apiserver/testing/types.generated.go
+++ b/pkg/apiserver/testing/types.generated.go
@@ -88,10 +88,10 @@ func (x *Simple) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2 [5]bool
 			_, _, _ = yysep2, yyq2, yy2arr2
 			const yyr2 bool = false
-			yyq2[0] = x.Kind != ""
-			yyq2[1] = x.APIVersion != ""
-			yyq2[3] = x.Other != ""
-			yyq2[4] = len(x.Labels) != 0
+			yyq2[1] = x.Other != ""
+			yyq2[2] = len(x.Labels) != 0
+			yyq2[3] = x.Kind != ""
+			yyq2[4] = x.APIVersion != ""
 			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(5)
@@ -107,28 +107,14 @@ func (x *Simple) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[0] {
-					yym4 := z.EncBinary()
-					_ = yym4
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
+				yy4 := &x.ObjectMeta
+				yy4.CodecEncodeSelf(e)
 			} else {
-				if yyq2[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym5 := z.EncBinary()
-					_ = yym5
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yy5 := &x.ObjectMeta
+				yy5.CodecEncodeSelf(e)
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
@@ -137,7 +123,7 @@ func (x *Simple) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym7
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Other))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -145,60 +131,24 @@ func (x *Simple) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq2[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("other"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym8 := z.EncBinary()
 					_ = yym8
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy10 := &x.ObjectMeta
-				yy10.CodecEncodeSelf(e)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy11 := &x.ObjectMeta
-				yy11.CodecEncodeSelf(e)
-			}
-			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[3] {
-					yym13 := z.EncBinary()
-					_ = yym13
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Other))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2[3] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("other"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym14 := z.EncBinary()
-					_ = yym14
-					if false {
-					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Other))
 					}
 				}
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[4] {
+				if yyq2[2] {
 					if x.Labels == nil {
 						r.EncodeNil()
 					} else {
-						yym16 := z.EncBinary()
-						_ = yym16
+						yym10 := z.EncBinary()
+						_ = yym10
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Labels, false, e)
@@ -208,19 +158,69 @@ func (x *Simple) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2[4] {
+				if yyq2[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("labels"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Labels == nil {
 						r.EncodeNil()
 					} else {
-						yym17 := z.EncBinary()
-						_ = yym17
+						yym11 := z.EncBinary()
+						_ = yym11
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Labels, false, e)
 						}
+					}
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2[3] {
+					yym13 := z.EncBinary()
+					_ = yym13
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym14 := z.EncBinary()
+					_ = yym14
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2[4] {
+					yym16 := z.EncBinary()
+					_ = yym16
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym17 := z.EncBinary()
+					_ = yym17
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -285,24 +285,12 @@ func (x *Simple) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys20 := string(yys20Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys20 {
-		case "kind":
-			if r.TryDecodeAsNil() {
-				x.Kind = ""
-			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
-			}
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv23 := &x.ObjectMeta
-				yyv23.CodecDecodeSelf(d)
+				yyv21 := &x.ObjectMeta
+				yyv21.CodecDecodeSelf(d)
 			}
 		case "other":
 			if r.TryDecodeAsNil() {
@@ -314,13 +302,25 @@ func (x *Simple) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Labels = nil
 			} else {
-				yyv25 := &x.Labels
-				yym26 := z.DecBinary()
-				_ = yym26
+				yyv23 := &x.Labels
+				yym24 := z.DecBinary()
+				_ = yym24
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv25, false, d)
+					z.F.DecMapStringStringX(yyv23, false, d)
 				}
+			}
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys20)
@@ -348,42 +348,10 @@ func (x *Simple) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.Kind = ""
-	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj27++
-	if yyhl27 {
-		yyb27 = yyj27 > l
-	} else {
-		yyb27 = r.CheckBreak()
-	}
-	if yyb27 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
-	}
-	yyj27++
-	if yyhl27 {
-		yyb27 = yyj27 > l
-	} else {
-		yyb27 = r.CheckBreak()
-	}
-	if yyb27 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv30 := &x.ObjectMeta
-		yyv30.CodecDecodeSelf(d)
+		yyv28 := &x.ObjectMeta
+		yyv28.CodecDecodeSelf(d)
 	}
 	yyj27++
 	if yyhl27 {
@@ -415,13 +383,45 @@ func (x *Simple) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Labels = nil
 	} else {
-		yyv32 := &x.Labels
-		yym33 := z.DecBinary()
-		_ = yym33
+		yyv30 := &x.Labels
+		yym31 := z.DecBinary()
+		_ = yym31
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv32, false, d)
+			z.F.DecMapStringStringX(yyv30, false, d)
 		}
+	}
+	yyj27++
+	if yyhl27 {
+		yyb27 = yyj27 > l
+	} else {
+		yyb27 = r.CheckBreak()
+	}
+	if yyb27 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj27++
+	if yyhl27 {
+		yyb27 = yyj27 > l
+	} else {
+		yyb27 = r.CheckBreak()
+	}
+	if yyb27 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
 	}
 	for {
 		yyj27++
@@ -456,10 +456,10 @@ func (x *SimpleRoot) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq35 [5]bool
 			_, _, _ = yysep35, yyq35, yy2arr35
 			const yyr35 bool = false
-			yyq35[0] = x.Kind != ""
-			yyq35[1] = x.APIVersion != ""
-			yyq35[3] = x.Other != ""
-			yyq35[4] = len(x.Labels) != 0
+			yyq35[1] = x.Other != ""
+			yyq35[2] = len(x.Labels) != 0
+			yyq35[3] = x.Kind != ""
+			yyq35[4] = x.APIVersion != ""
 			var yynn35 int
 			if yyr35 || yy2arr35 {
 				r.EncodeArrayStart(5)
@@ -475,28 +475,14 @@ func (x *SimpleRoot) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr35 || yy2arr35 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq35[0] {
-					yym37 := z.EncBinary()
-					_ = yym37
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
+				yy37 := &x.ObjectMeta
+				yy37.CodecEncodeSelf(e)
 			} else {
-				if yyq35[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym38 := z.EncBinary()
-					_ = yym38
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yy38 := &x.ObjectMeta
+				yy38.CodecEncodeSelf(e)
 			}
 			if yyr35 || yy2arr35 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
@@ -505,7 +491,7 @@ func (x *SimpleRoot) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym40
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Other))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
@@ -513,60 +499,24 @@ func (x *SimpleRoot) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq35[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					r.EncodeString(codecSelferC_UTF81234, string("other"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym41 := z.EncBinary()
 					_ = yym41
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr35 || yy2arr35 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy43 := &x.ObjectMeta
-				yy43.CodecEncodeSelf(e)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy44 := &x.ObjectMeta
-				yy44.CodecEncodeSelf(e)
-			}
-			if yyr35 || yy2arr35 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq35[3] {
-					yym46 := z.EncBinary()
-					_ = yym46
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Other))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq35[3] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("other"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym47 := z.EncBinary()
-					_ = yym47
-					if false {
-					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Other))
 					}
 				}
 			}
 			if yyr35 || yy2arr35 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq35[4] {
+				if yyq35[2] {
 					if x.Labels == nil {
 						r.EncodeNil()
 					} else {
-						yym49 := z.EncBinary()
-						_ = yym49
+						yym43 := z.EncBinary()
+						_ = yym43
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Labels, false, e)
@@ -576,19 +526,69 @@ func (x *SimpleRoot) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq35[4] {
+				if yyq35[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("labels"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Labels == nil {
 						r.EncodeNil()
 					} else {
-						yym50 := z.EncBinary()
-						_ = yym50
+						yym44 := z.EncBinary()
+						_ = yym44
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Labels, false, e)
 						}
+					}
+				}
+			}
+			if yyr35 || yy2arr35 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq35[3] {
+					yym46 := z.EncBinary()
+					_ = yym46
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq35[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym47 := z.EncBinary()
+					_ = yym47
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr35 || yy2arr35 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq35[4] {
+					yym49 := z.EncBinary()
+					_ = yym49
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq35[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym50 := z.EncBinary()
+					_ = yym50
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -653,24 +653,12 @@ func (x *SimpleRoot) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys53 := string(yys53Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys53 {
-		case "kind":
-			if r.TryDecodeAsNil() {
-				x.Kind = ""
-			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
-			}
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv56 := &x.ObjectMeta
-				yyv56.CodecDecodeSelf(d)
+				yyv54 := &x.ObjectMeta
+				yyv54.CodecDecodeSelf(d)
 			}
 		case "other":
 			if r.TryDecodeAsNil() {
@@ -682,13 +670,25 @@ func (x *SimpleRoot) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Labels = nil
 			} else {
-				yyv58 := &x.Labels
-				yym59 := z.DecBinary()
-				_ = yym59
+				yyv56 := &x.Labels
+				yym57 := z.DecBinary()
+				_ = yym57
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv58, false, d)
+					z.F.DecMapStringStringX(yyv56, false, d)
 				}
+			}
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys53)
@@ -716,42 +716,10 @@ func (x *SimpleRoot) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.Kind = ""
-	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj60++
-	if yyhl60 {
-		yyb60 = yyj60 > l
-	} else {
-		yyb60 = r.CheckBreak()
-	}
-	if yyb60 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
-	}
-	yyj60++
-	if yyhl60 {
-		yyb60 = yyj60 > l
-	} else {
-		yyb60 = r.CheckBreak()
-	}
-	if yyb60 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv63 := &x.ObjectMeta
-		yyv63.CodecDecodeSelf(d)
+		yyv61 := &x.ObjectMeta
+		yyv61.CodecDecodeSelf(d)
 	}
 	yyj60++
 	if yyhl60 {
@@ -783,13 +751,45 @@ func (x *SimpleRoot) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Labels = nil
 	} else {
-		yyv65 := &x.Labels
-		yym66 := z.DecBinary()
-		_ = yym66
+		yyv63 := &x.Labels
+		yym64 := z.DecBinary()
+		_ = yym64
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv65, false, d)
+			z.F.DecMapStringStringX(yyv63, false, d)
 		}
+	}
+	yyj60++
+	if yyhl60 {
+		yyb60 = yyj60 > l
+	} else {
+		yyb60 = r.CheckBreak()
+	}
+	if yyb60 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj60++
+	if yyhl60 {
+		yyb60 = yyj60 > l
+	} else {
+		yyb60 = r.CheckBreak()
+	}
+	if yyb60 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
 	}
 	for {
 		yyj60++
@@ -824,8 +824,8 @@ func (x *SimpleGetOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq68 [5]bool
 			_, _, _ = yysep68, yyq68, yy2arr68
 			const yyr68 bool = false
-			yyq68[0] = x.Kind != ""
-			yyq68[1] = x.APIVersion != ""
+			yyq68[3] = x.Kind != ""
+			yyq68[4] = x.APIVersion != ""
 			var yynn68 int
 			if yyr68 || yy2arr68 {
 				r.EncodeArrayStart(5)
@@ -841,58 +841,8 @@ func (x *SimpleGetOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr68 || yy2arr68 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq68[0] {
-					yym70 := z.EncBinary()
-					_ = yym70
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq68[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym71 := z.EncBinary()
-					_ = yym71
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr68 || yy2arr68 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq68[1] {
-					yym73 := z.EncBinary()
-					_ = yym73
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq68[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym74 := z.EncBinary()
-					_ = yym74
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr68 || yy2arr68 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym76 := z.EncBinary()
-				_ = yym76
+				yym70 := z.EncBinary()
+				_ = yym70
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Param1))
@@ -901,8 +851,8 @@ func (x *SimpleGetOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("param1"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym77 := z.EncBinary()
-				_ = yym77
+				yym71 := z.EncBinary()
+				_ = yym71
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Param1))
@@ -910,8 +860,8 @@ func (x *SimpleGetOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr68 || yy2arr68 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym79 := z.EncBinary()
-				_ = yym79
+				yym73 := z.EncBinary()
+				_ = yym73
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Param2))
@@ -920,8 +870,8 @@ func (x *SimpleGetOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("param2"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym80 := z.EncBinary()
-				_ = yym80
+				yym74 := z.EncBinary()
+				_ = yym74
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Param2))
@@ -929,8 +879,8 @@ func (x *SimpleGetOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr68 || yy2arr68 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym82 := z.EncBinary()
-				_ = yym82
+				yym76 := z.EncBinary()
+				_ = yym76
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
@@ -939,11 +889,61 @@ func (x *SimpleGetOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("atAPath"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym83 := z.EncBinary()
-				_ = yym83
+				yym77 := z.EncBinary()
+				_ = yym77
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
+				}
+			}
+			if yyr68 || yy2arr68 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq68[3] {
+					yym79 := z.EncBinary()
+					_ = yym79
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq68[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym80 := z.EncBinary()
+					_ = yym80
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr68 || yy2arr68 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq68[4] {
+					yym82 := z.EncBinary()
+					_ = yym82
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq68[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym83 := z.EncBinary()
+					_ = yym83
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr68 || yy2arr68 {
@@ -1007,18 +1007,6 @@ func (x *SimpleGetOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys86 := string(yys86Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys86 {
-		case "kind":
-			if r.TryDecodeAsNil() {
-				x.Kind = ""
-			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
-			}
 		case "param1":
 			if r.TryDecodeAsNil() {
 				x.Param1 = ""
@@ -1037,6 +1025,18 @@ func (x *SimpleGetOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			} else {
 				x.Path = string(r.DecodeString())
 			}
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
+			}
 		default:
 			z.DecStructFieldNotFound(-1, yys86)
 		} // end switch yys86
@@ -1051,38 +1051,6 @@ func (x *SimpleGetOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	var yyj92 int
 	var yyb92 bool
 	var yyhl92 bool = l >= 0
-	yyj92++
-	if yyhl92 {
-		yyb92 = yyj92 > l
-	} else {
-		yyb92 = r.CheckBreak()
-	}
-	if yyb92 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Kind = ""
-	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj92++
-	if yyhl92 {
-		yyb92 = yyj92 > l
-	} else {
-		yyb92 = r.CheckBreak()
-	}
-	if yyb92 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
-	}
 	yyj92++
 	if yyhl92 {
 		yyb92 = yyj92 > l
@@ -1131,6 +1099,38 @@ func (x *SimpleGetOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Path = string(r.DecodeString())
 	}
+	yyj92++
+	if yyhl92 {
+		yyb92 = yyj92 > l
+	} else {
+		yyb92 = r.CheckBreak()
+	}
+	if yyb92 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj92++
+	if yyhl92 {
+		yyb92 = yyj92 > l
+	} else {
+		yyb92 = r.CheckBreak()
+	}
+	if yyb92 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
+	}
 	for {
 		yyj92++
 		if yyhl92 {
@@ -1164,9 +1164,9 @@ func (x *SimpleList) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq99 [4]bool
 			_, _, _ = yysep99, yyq99, yy2arr99
 			const yyr99 bool = false
-			yyq99[0] = x.Kind != ""
-			yyq99[1] = x.APIVersion != ""
-			yyq99[3] = len(x.Items) != 0
+			yyq99[1] = len(x.Items) != 0
+			yyq99[2] = x.Kind != ""
+			yyq99[3] = x.APIVersion != ""
 			var yynn99 int
 			if yyr99 || yy2arr99 {
 				r.EncodeArrayStart(4)
@@ -1182,85 +1182,35 @@ func (x *SimpleList) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr99 || yy2arr99 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq99[0] {
-					yym101 := z.EncBinary()
-					_ = yym101
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq99[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym102 := z.EncBinary()
-					_ = yym102
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr99 || yy2arr99 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq99[1] {
-					yym104 := z.EncBinary()
-					_ = yym104
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq99[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym105 := z.EncBinary()
-					_ = yym105
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr99 || yy2arr99 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy107 := &x.ListMeta
-				yym108 := z.EncBinary()
-				_ = yym108
+				yy101 := &x.ListMeta
+				yym102 := z.EncBinary()
+				_ = yym102
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy107) {
+				} else if z.HasExtensions() && z.EncExt(yy101) {
 				} else {
-					z.EncFallback(yy107)
+					z.EncFallback(yy101)
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy109 := &x.ListMeta
-				yym110 := z.EncBinary()
-				_ = yym110
+				yy103 := &x.ListMeta
+				yym104 := z.EncBinary()
+				_ = yym104
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy109) {
+				} else if z.HasExtensions() && z.EncExt(yy103) {
 				} else {
-					z.EncFallback(yy109)
+					z.EncFallback(yy103)
 				}
 			}
 			if yyr99 || yy2arr99 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq99[3] {
+				if yyq99[1] {
 					if x.Items == nil {
 						r.EncodeNil()
 					} else {
-						yym112 := z.EncBinary()
-						_ = yym112
+						yym106 := z.EncBinary()
+						_ = yym106
 						if false {
 						} else {
 							h.encSliceSimple(([]Simple)(x.Items), e)
@@ -1270,19 +1220,69 @@ func (x *SimpleList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq99[3] {
+				if yyq99[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("items"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Items == nil {
 						r.EncodeNil()
 					} else {
-						yym113 := z.EncBinary()
-						_ = yym113
+						yym107 := z.EncBinary()
+						_ = yym107
 						if false {
 						} else {
 							h.encSliceSimple(([]Simple)(x.Items), e)
 						}
+					}
+				}
+			}
+			if yyr99 || yy2arr99 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq99[2] {
+					yym109 := z.EncBinary()
+					_ = yym109
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq99[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym110 := z.EncBinary()
+					_ = yym110
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr99 || yy2arr99 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq99[3] {
+					yym112 := z.EncBinary()
+					_ = yym112
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq99[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym113 := z.EncBinary()
+					_ = yym113
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -1347,6 +1347,31 @@ func (x *SimpleList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys116 := string(yys116Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys116 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ListMeta = pkg1_unversioned.ListMeta{}
+			} else {
+				yyv117 := &x.ListMeta
+				yym118 := z.DecBinary()
+				_ = yym118
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv117) {
+				} else {
+					z.DecFallback(yyv117, false)
+				}
+			}
+		case "items":
+			if r.TryDecodeAsNil() {
+				x.Items = nil
+			} else {
+				yyv119 := &x.Items
+				yym120 := z.DecBinary()
+				_ = yym120
+				if false {
+				} else {
+					h.decSliceSimple((*[]Simple)(yyv119), d)
+				}
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -1358,31 +1383,6 @@ func (x *SimpleList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg1_unversioned.ListMeta{}
-			} else {
-				yyv119 := &x.ListMeta
-				yym120 := z.DecBinary()
-				_ = yym120
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv119) {
-				} else {
-					z.DecFallback(yyv119, false)
-				}
-			}
-		case "items":
-			if r.TryDecodeAsNil() {
-				x.Items = nil
-			} else {
-				yyv121 := &x.Items
-				yym122 := z.DecBinary()
-				_ = yym122
-				if false {
-				} else {
-					h.decSliceSimple((*[]Simple)(yyv121), d)
-				}
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys116)
@@ -1398,6 +1398,51 @@ func (x *SimpleList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj123 int
 	var yyb123 bool
 	var yyhl123 bool = l >= 0
+	yyj123++
+	if yyhl123 {
+		yyb123 = yyj123 > l
+	} else {
+		yyb123 = r.CheckBreak()
+	}
+	if yyb123 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv124 := &x.ListMeta
+		yym125 := z.DecBinary()
+		_ = yym125
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv124) {
+		} else {
+			z.DecFallback(yyv124, false)
+		}
+	}
+	yyj123++
+	if yyhl123 {
+		yyb123 = yyj123 > l
+	} else {
+		yyb123 = r.CheckBreak()
+	}
+	if yyb123 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv126 := &x.Items
+		yym127 := z.DecBinary()
+		_ = yym127
+		if false {
+		} else {
+			h.decSliceSimple((*[]Simple)(yyv126), d)
+		}
+	}
 	yyj123++
 	if yyhl123 {
 		yyb123 = yyj123 > l
@@ -1429,51 +1474,6 @@ func (x *SimpleList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj123++
-	if yyhl123 {
-		yyb123 = yyj123 > l
-	} else {
-		yyb123 = r.CheckBreak()
-	}
-	if yyb123 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg1_unversioned.ListMeta{}
-	} else {
-		yyv126 := &x.ListMeta
-		yym127 := z.DecBinary()
-		_ = yym127
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv126) {
-		} else {
-			z.DecFallback(yyv126, false)
-		}
-	}
-	yyj123++
-	if yyhl123 {
-		yyb123 = yyj123 > l
-	} else {
-		yyb123 = r.CheckBreak()
-	}
-	if yyb123 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Items = nil
-	} else {
-		yyv128 := &x.Items
-		yym129 := z.DecBinary()
-		_ = yym129
-		if false {
-		} else {
-			h.decSliceSimple((*[]Simple)(yyv128), d)
-		}
 	}
 	for {
 		yyj123++

--- a/pkg/kubectl/testing/types.generated.go
+++ b/pkg/kubectl/testing/types.generated.go
@@ -88,9 +88,9 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2 [7]bool
 			_, _, _ = yysep2, yyq2, yy2arr2
 			const yyr2 bool = false
-			yyq2[0] = x.Kind != ""
-			yyq2[1] = x.APIVersion != ""
-			yyq2[2] = true
+			yyq2[0] = true
+			yyq2[5] = x.Kind != ""
+			yyq2[6] = x.APIVersion != ""
 			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(7)
@@ -107,74 +107,24 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[0] {
-					yym4 := z.EncBinary()
-					_ = yym4
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym5 := z.EncBinary()
-					_ = yym5
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[1] {
-					yym7 := z.EncBinary()
-					_ = yym7
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym8 := z.EncBinary()
-					_ = yym8
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[2] {
-					yy10 := &x.ObjectMeta
-					yy10.CodecEncodeSelf(e)
+					yy4 := &x.ObjectMeta
+					yy4.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2[2] {
+				if yyq2[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy11 := &x.ObjectMeta
-					yy11.CodecEncodeSelf(e)
+					yy5 := &x.ObjectMeta
+					yy5.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym13 := z.EncBinary()
-				_ = yym13
+				yym7 := z.EncBinary()
+				_ = yym7
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
@@ -183,8 +133,8 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("Key"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym14 := z.EncBinary()
-				_ = yym14
+				yym8 := z.EncBinary()
+				_ = yym8
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
@@ -195,8 +145,8 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Map == nil {
 					r.EncodeNil()
 				} else {
-					yym16 := z.EncBinary()
-					_ = yym16
+					yym10 := z.EncBinary()
+					_ = yym10
 					if false {
 					} else {
 						z.F.EncMapStringIntV(x.Map, false, e)
@@ -209,8 +159,8 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Map == nil {
 					r.EncodeNil()
 				} else {
-					yym17 := z.EncBinary()
-					_ = yym17
+					yym11 := z.EncBinary()
+					_ = yym11
 					if false {
 					} else {
 						z.F.EncMapStringIntV(x.Map, false, e)
@@ -222,8 +172,8 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.StringList == nil {
 					r.EncodeNil()
 				} else {
-					yym19 := z.EncBinary()
-					_ = yym19
+					yym13 := z.EncBinary()
+					_ = yym13
 					if false {
 					} else {
 						z.F.EncSliceStringV(x.StringList, false, e)
@@ -236,8 +186,8 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.StringList == nil {
 					r.EncodeNil()
 				} else {
-					yym20 := z.EncBinary()
-					_ = yym20
+					yym14 := z.EncBinary()
+					_ = yym14
 					if false {
 					} else {
 						z.F.EncSliceStringV(x.StringList, false, e)
@@ -249,8 +199,8 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.IntList == nil {
 					r.EncodeNil()
 				} else {
-					yym22 := z.EncBinary()
-					_ = yym22
+					yym16 := z.EncBinary()
+					_ = yym16
 					if false {
 					} else {
 						z.F.EncSliceIntV(x.IntList, false, e)
@@ -263,11 +213,61 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.IntList == nil {
 					r.EncodeNil()
 				} else {
+					yym17 := z.EncBinary()
+					_ = yym17
+					if false {
+					} else {
+						z.F.EncSliceIntV(x.IntList, false, e)
+					}
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2[5] {
+					yym19 := z.EncBinary()
+					_ = yym19
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym20 := z.EncBinary()
+					_ = yym20
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2[6] {
+					yym22 := z.EncBinary()
+					_ = yym22
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					yym23 := z.EncBinary()
 					_ = yym23
 					if false {
 					} else {
-						z.F.EncSliceIntV(x.IntList, false, e)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -332,24 +332,12 @@ func (x *TestStruct) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys26 := string(yys26Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys26 {
-		case "kind":
-			if r.TryDecodeAsNil() {
-				x.Kind = ""
-			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
-			}
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv29 := &x.ObjectMeta
-				yyv29.CodecDecodeSelf(d)
+				yyv27 := &x.ObjectMeta
+				yyv27.CodecDecodeSelf(d)
 			}
 		case "Key":
 			if r.TryDecodeAsNil() {
@@ -361,37 +349,49 @@ func (x *TestStruct) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Map = nil
 			} else {
-				yyv31 := &x.Map
-				yym32 := z.DecBinary()
-				_ = yym32
+				yyv29 := &x.Map
+				yym30 := z.DecBinary()
+				_ = yym30
 				if false {
 				} else {
-					z.F.DecMapStringIntX(yyv31, false, d)
+					z.F.DecMapStringIntX(yyv29, false, d)
 				}
 			}
 		case "StringList":
 			if r.TryDecodeAsNil() {
 				x.StringList = nil
 			} else {
-				yyv33 := &x.StringList
-				yym34 := z.DecBinary()
-				_ = yym34
+				yyv31 := &x.StringList
+				yym32 := z.DecBinary()
+				_ = yym32
 				if false {
 				} else {
-					z.F.DecSliceStringX(yyv33, false, d)
+					z.F.DecSliceStringX(yyv31, false, d)
 				}
 			}
 		case "IntList":
 			if r.TryDecodeAsNil() {
 				x.IntList = nil
 			} else {
-				yyv35 := &x.IntList
-				yym36 := z.DecBinary()
-				_ = yym36
+				yyv33 := &x.IntList
+				yym34 := z.DecBinary()
+				_ = yym34
 				if false {
 				} else {
-					z.F.DecSliceIntX(yyv35, false, d)
+					z.F.DecSliceIntX(yyv33, false, d)
 				}
+			}
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys26)
@@ -419,42 +419,10 @@ func (x *TestStruct) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.Kind = ""
-	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj37++
-	if yyhl37 {
-		yyb37 = yyj37 > l
-	} else {
-		yyb37 = r.CheckBreak()
-	}
-	if yyb37 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
-	}
-	yyj37++
-	if yyhl37 {
-		yyb37 = yyj37 > l
-	} else {
-		yyb37 = r.CheckBreak()
-	}
-	if yyb37 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv40 := &x.ObjectMeta
-		yyv40.CodecDecodeSelf(d)
+		yyv38 := &x.ObjectMeta
+		yyv38.CodecDecodeSelf(d)
 	}
 	yyj37++
 	if yyhl37 {
@@ -486,12 +454,12 @@ func (x *TestStruct) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Map = nil
 	} else {
-		yyv42 := &x.Map
-		yym43 := z.DecBinary()
-		_ = yym43
+		yyv40 := &x.Map
+		yym41 := z.DecBinary()
+		_ = yym41
 		if false {
 		} else {
-			z.F.DecMapStringIntX(yyv42, false, d)
+			z.F.DecMapStringIntX(yyv40, false, d)
 		}
 	}
 	yyj37++
@@ -508,12 +476,12 @@ func (x *TestStruct) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.StringList = nil
 	} else {
-		yyv44 := &x.StringList
-		yym45 := z.DecBinary()
-		_ = yym45
+		yyv42 := &x.StringList
+		yym43 := z.DecBinary()
+		_ = yym43
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv44, false, d)
+			z.F.DecSliceStringX(yyv42, false, d)
 		}
 	}
 	yyj37++
@@ -530,13 +498,45 @@ func (x *TestStruct) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.IntList = nil
 	} else {
-		yyv46 := &x.IntList
-		yym47 := z.DecBinary()
-		_ = yym47
+		yyv44 := &x.IntList
+		yym45 := z.DecBinary()
+		_ = yym45
 		if false {
 		} else {
-			z.F.DecSliceIntX(yyv46, false, d)
+			z.F.DecSliceIntX(yyv44, false, d)
 		}
+	}
+	yyj37++
+	if yyhl37 {
+		yyb37 = yyj37 > l
+	} else {
+		yyb37 = r.CheckBreak()
+	}
+	if yyb37 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj37++
+	if yyhl37 {
+		yyb37 = yyj37 > l
+	} else {
+		yyb37 = r.CheckBreak()
+	}
+	if yyb37 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
 	}
 	for {
 		yyj37++

--- a/pkg/storage/testing/types.generated.go
+++ b/pkg/storage/testing/types.generated.go
@@ -88,8 +88,8 @@ func (x *TestResource) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2 [4]bool
 			_, _, _ = yysep2, yyq2, yy2arr2
 			const yyr2 bool = false
-			yyq2[0] = x.Kind != ""
-			yyq2[1] = x.APIVersion != ""
+			yyq2[2] = x.Kind != ""
+			yyq2[3] = x.APIVersion != ""
 			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(4)
@@ -105,69 +105,19 @@ func (x *TestResource) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[0] {
-					yym4 := z.EncBinary()
-					_ = yym4
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym5 := z.EncBinary()
-					_ = yym5
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[1] {
-					yym7 := z.EncBinary()
-					_ = yym7
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym8 := z.EncBinary()
-					_ = yym8
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy10 := &x.ObjectMeta
-				yy10.CodecEncodeSelf(e)
+				yy4 := &x.ObjectMeta
+				yy4.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy11 := &x.ObjectMeta
-				yy11.CodecEncodeSelf(e)
+				yy5 := &x.ObjectMeta
+				yy5.CodecEncodeSelf(e)
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym13 := z.EncBinary()
-				_ = yym13
+				yym7 := z.EncBinary()
+				_ = yym7
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Value))
@@ -176,11 +126,61 @@ func (x *TestResource) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("value"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym14 := z.EncBinary()
-				_ = yym14
+				yym8 := z.EncBinary()
+				_ = yym8
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Value))
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2[2] {
+					yym10 := z.EncBinary()
+					_ = yym10
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym11 := z.EncBinary()
+					_ = yym11
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2[3] {
+					yym13 := z.EncBinary()
+					_ = yym13
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym14 := z.EncBinary()
+					_ = yym14
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
 				}
 			}
 			if yyr2 || yy2arr2 {
@@ -244,6 +244,19 @@ func (x *TestResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys17 := string(yys17Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys17 {
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_api.ObjectMeta{}
+			} else {
+				yyv18 := &x.ObjectMeta
+				yyv18.CodecDecodeSelf(d)
+			}
+		case "value":
+			if r.TryDecodeAsNil() {
+				x.Value = 0
+			} else {
+				x.Value = int(r.DecodeInt(codecSelferBitsize1234))
+			}
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -255,19 +268,6 @@ func (x *TestResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = ""
 			} else {
 				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = pkg2_api.ObjectMeta{}
-			} else {
-				yyv20 := &x.ObjectMeta
-				yyv20.CodecDecodeSelf(d)
-			}
-		case "value":
-			if r.TryDecodeAsNil() {
-				x.Value = 0
-			} else {
-				x.Value = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys17)
@@ -283,6 +283,39 @@ func (x *TestResource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var yyj22 int
 	var yyb22 bool
 	var yyhl22 bool = l >= 0
+	yyj22++
+	if yyhl22 {
+		yyb22 = yyj22 > l
+	} else {
+		yyb22 = r.CheckBreak()
+	}
+	if yyb22 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_api.ObjectMeta{}
+	} else {
+		yyv23 := &x.ObjectMeta
+		yyv23.CodecDecodeSelf(d)
+	}
+	yyj22++
+	if yyhl22 {
+		yyb22 = yyj22 > l
+	} else {
+		yyb22 = r.CheckBreak()
+	}
+	if yyb22 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Value = 0
+	} else {
+		x.Value = int(r.DecodeInt(codecSelferBitsize1234))
+	}
 	yyj22++
 	if yyhl22 {
 		yyb22 = yyj22 > l
@@ -314,39 +347,6 @@ func (x *TestResource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = ""
 	} else {
 		x.APIVersion = string(r.DecodeString())
-	}
-	yyj22++
-	if yyhl22 {
-		yyb22 = yyj22 > l
-	} else {
-		yyb22 = r.CheckBreak()
-	}
-	if yyb22 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = pkg2_api.ObjectMeta{}
-	} else {
-		yyv25 := &x.ObjectMeta
-		yyv25.CodecDecodeSelf(d)
-	}
-	yyj22++
-	if yyhl22 {
-		yyb22 = yyj22 > l
-	} else {
-		yyb22 = r.CheckBreak()
-	}
-	if yyb22 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Value = 0
-	} else {
-		x.Value = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
 		yyj22++


### PR DESCRIPTION
Picks up fix for https://github.com/ugorji/go/issues/119 where `{"foo":[]}` would be decoded as `{"foo":nil}` for fast path decodes.
