### PR TITLE
Up timeout on serial jobs

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-e2e.yaml
@@ -181,12 +181,12 @@
     suffix:
         - 'gce-serial':
             description: 'Run [Serial], [Disruptive], and [Feature:Restart] tests on GCE using the latest successful build.'
-            timeout: 300
+            timeout: 600
             emails: '$DEFAULT_RECIPIENTS, ihmccreery@google.com'
             test-owner: 'ihmccreery'
         - 'gke-serial':
             description: 'Run [Serial], [Disruptive], and [Feature:Restart] tests on GKE using the latest successful build.'
-            timeout: 300
+            timeout: 600
             emails: '$DEFAULT_RECIPIENTS, ihmccreery@google.com'
             test-owner: 'ihmccreery'
     jobs:


### PR DESCRIPTION
`gke-serial` is failing due to timeout now.  I'm giving ~100% leniency; happy to debate, but I'd like to get this in asap so the tests stop failing.
