### PR TITLE
Don't label the UI e2e test as part of the conformance suite

### DIFF
--- a/test/e2e/kube-ui.go
+++ b/test/e2e/kube-ui.go
@@ -39,7 +39,7 @@ var _ = Describe("kube-ui", func() {
 
 	f := NewFramework("kube-ui")
 
-	It("should check that the kube-ui instance is alive [Conformance]", func() {
+	It("should check that the kube-ui instance is alive", func() {
 		By("Checking the kube-ui service exists.")
 		err := waitForService(f.Client, uiNamespace, uiServiceName, true, poll, serviceStartTimeout)
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
It's a test to ensure that an _optional_ cluster addon is working.

/cc @erictune 
