### PR TITLE
[WIP] replace kubectl describe client

### DIFF
--- a/pkg/client/unversioned/restclient.go
+++ b/pkg/client/unversioned/restclient.go
@@ -17,6 +17,7 @@ limitations under the License.
 package unversioned
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"os"
@@ -26,6 +27,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
 )
 
@@ -57,6 +59,27 @@ type RESTClient struct {
 
 	// Set specific behavior of the client.  If not set http.DefaultClient will be used.
 	Client *http.Client
+}
+
+// ChangeTargetVersion changes the versioned API path the RESTClient targets at.
+func (c *RESTClient) ChangeTargetVersion(gv unversioned.GroupVersion) error {
+	fmt.Println("CHAO: before change, c.versionedAPIPath=", c.versionedAPIPath)
+	segments := strings.Split(c.versionedAPIPath, "/")
+	if gv.Group != "" && gv.Group != segments[len(segments)-2] {
+		return fmt.Errorf("cannot switch from group %v to group %v", segments[len(segments)-2], gv.Group)
+	}
+	if gv.Group() != "" {
+		c.versionedAPIPath = strings.Join(append(segments[:len(segments)-2], gv.Group, gv.Version))
+	} else {
+		c.versionedAPIPath = strings.Join(append(segments[:len(segments)-1], gv.Version))
+	}
+	fmt.Println("CHAO: after change, c.versionedAPIPath=", c.versionedAPIPath)
+	return nil
+}
+
+// SwitchCodec changes the codec the RESTClient uses.
+func (c *RESTClient) SwitchCodec(codec runtime.Codec) error {
+	c.contentConfig.Codec = codec
 }
 
 // NewRESTClient creates a new RESTClient. This client performs generic REST functions

--- a/pkg/client/unversioned/restclient.go
+++ b/pkg/client/unversioned/restclient.go
@@ -68,17 +68,17 @@ func (c *RESTClient) ChangeTargetVersion(gv unversioned.GroupVersion) error {
 	if gv.Group != "" && gv.Group != segments[len(segments)-2] {
 		return fmt.Errorf("cannot switch from group %v to group %v", segments[len(segments)-2], gv.Group)
 	}
-	if gv.Group() != "" {
-		c.versionedAPIPath = strings.Join(append(segments[:len(segments)-2], gv.Group, gv.Version))
+	if gv.Group != "" {
+		c.versionedAPIPath = strings.Join(append(segments[:len(segments)-2], gv.Group, gv.Version), "/")
 	} else {
-		c.versionedAPIPath = strings.Join(append(segments[:len(segments)-1], gv.Version))
+		c.versionedAPIPath = strings.Join(append(segments[:len(segments)-1], gv.Version), "/")
 	}
 	fmt.Println("CHAO: after change, c.versionedAPIPath=", c.versionedAPIPath)
 	return nil
 }
 
 // SwitchCodec changes the codec the RESTClient uses.
-func (c *RESTClient) SwitchCodec(codec runtime.Codec) error {
+func (c *RESTClient) SwitchCodec(codec runtime.Codec) {
 	c.contentConfig.Codec = codec
 }
 

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -60,9 +60,8 @@ const (
 // TODO: pass the various interfaces on the factory directly into the command constructors (so the
 // commands are decoupled from the factory).
 type Factory struct {
-	clients   *ClientCache
-	clientset clientset.Clientset
-	flags     *pflag.FlagSet
+	clients *ClientCache
+	flags   *pflag.FlagSet
 
 	// Returns interfaces for dealing with arbitrary runtime.Objects.
 	Object func() (meta.RESTMapper, runtime.ObjectTyper)
@@ -179,12 +178,11 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 	}
 
 	clients := NewClientCache(clientConfig)
-	clientset := clientset.NewForConfigOrDie(clientConfig)
+	var clientsetPtr *clientset.Clientset
 
 	return &Factory{
-		clients:   clients,
-		clientset: clientset,
-		flags:     flags,
+		clients: clients,
+		flags:   flags,
 
 		Object: func() (meta.RESTMapper, runtime.ObjectTyper) {
 			cfg, err := clientConfig.ClientConfig()
@@ -217,9 +215,18 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 			return nil, fmt.Errorf("unable to get RESTClient for resource '%s'", mapping.Resource)
 		},
 		Describer: func(mapping *meta.RESTMapping) (kubectl.Describer, error) {
-			mappingVersion := mapping.GroupVersionKind.GroupVersion()
-			client, err := clients.ClientForVersion(&mappingVersion)
-			copyClientset := clientset
+			if clientsetPtr == nil {
+				config, err := clients.ClientConfigForVersion(nil)
+				if err != nil {
+					return nil, fmt.Errorf("failed to get config: %v", err)
+				}
+				clientsetPtr, err = clientset.NewForConfig(config)
+				if err != nil {
+					return nil, fmt.Errorf("failed to initialize a clientset: %v", err)
+				}
+			}
+			// TODO: we need a clientset cache
+			copyClientset := *clientsetPtr
 			// TODO: we should add a Group("groupName") function to clientset
 			serializer, ok := api.Codecs.SerializerForFileExtension("json")
 			if !ok {
@@ -229,14 +236,14 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 			switch mapping.GroupVersionKind.Group {
 			case api.GroupName:
 				// TODO: we need to add a method to typed group client to tell us what version it supports in default
-				copyClientset.LegacyClient.RESTClient.SwitchCodec(api.Codecs.CodecForVersions(serializer, gv, unversioned.GroupVersion{api.GroupName, runtime.APIVersionInternal}))
+				copyClientset.LegacyClient.RESTClient.SwitchCodec(api.Codecs.CodecForVersions(serializer, []unversioned.GroupVersion{gv}, []unversioned.GroupVersion{{api.GroupName, runtime.APIVersionInternal}}))
 				copyClientset.LegacyClient.RESTClient.ChangeTargetVersion(mapping.GroupVersionKind.GroupVersion())
 			case extensions.GroupName:
-				copyClientset.ExtensionsClient.RESTClient.SwitchCodec(api.Codecs.CodecForVersions(serializer, gv, unversioned.GroupVersion{extensions.GroupName, runtime.APIVersionInternal}))
+				copyClientset.ExtensionsClient.RESTClient.SwitchCodec(api.Codecs.CodecForVersions(serializer, []unversioned.GroupVersion{gv}, []unversioned.GroupVersion{{extensions.GroupName, runtime.APIVersionInternal}}))
 				copyClientset.ExtensionsClient.RESTClient.ChangeTargetVersion(mapping.GroupVersionKind.GroupVersion())
 			}
 
-			if describer, ok := kubectl.DescriberFor(mapping.GroupVersionKind.GroupKind(), copyClientset); ok {
+			if describer, ok := kubectl.DescriberFor(mapping.GroupVersionKind.GroupKind(), &copyClientset); ok {
 				return describer, nil
 			}
 			return nil, fmt.Errorf("no description has been implemented for %q", mapping.GroupVersionKind.Kind)

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -60,8 +60,9 @@ const (
 // TODO: pass the various interfaces on the factory directly into the command constructors (so the
 // commands are decoupled from the factory).
 type Factory struct {
-	clients *ClientCache
-	flags   *pflag.FlagSet
+	clients   *ClientCache
+	clientset clientset.Clientset
+	flags     *pflag.FlagSet
 
 	// Returns interfaces for dealing with arbitrary runtime.Objects.
 	Object func() (meta.RESTMapper, runtime.ObjectTyper)
@@ -180,8 +181,9 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 	clients := NewClientCache(clientConfig)
 
 	return &Factory{
-		clients: clients,
-		flags:   flags,
+		clients:   clients,
+		clientset: clientset.NewForConfigOrDie(clientConfig),
+		flags:     flags,
 
 		Object: func() (meta.RESTMapper, runtime.ObjectTyper) {
 			cfg, err := clientConfig.ClientConfig()

--- a/pkg/kubectl/describe_test.go
+++ b/pkg/kubectl/describe_test.go
@@ -28,20 +28,19 @@ import (
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/extensions"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_1"
 	"k8s.io/kubernetes/pkg/client/testing/fake"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
-	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
 )
 
 type describeClient struct {
 	T         *testing.T
 	Namespace string
 	Err       error
-	client.Interface
+	clientset.Interface
 }
 
 func TestDescribePod(t *testing.T) {
-	fake := testclient.NewSimpleFake(&api.Pod{
+	fake := fake.NewSimpleClientset(&api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Name:      "bar",
 			Namespace: "foo",
@@ -59,7 +58,7 @@ func TestDescribePod(t *testing.T) {
 }
 
 func TestDescribeService(t *testing.T) {
-	fake := testclient.NewSimpleFake(&api.Service{
+	fake := fake.NewSimpleClientset(&api.Service{
 		ObjectMeta: api.ObjectMeta{
 			Name:      "bar",
 			Namespace: "foo",
@@ -78,7 +77,7 @@ func TestDescribeService(t *testing.T) {
 
 func TestPodDescribeResultsSorted(t *testing.T) {
 	// Arrange
-	fake := testclient.NewSimpleFake(&api.EventList{
+	fake := fake.NewSimpleClientset(&api.EventList{
 		Items: []api.Event{
 			{
 				Source:         api.EventSource{Component: "kubelet"},
@@ -490,7 +489,7 @@ func TestPersistentVolumeDescriber(t *testing.T) {
 	}
 
 	for name, pv := range tests {
-		fake := testclient.NewSimpleFake(pv)
+		fake := fake.NewSimpleClientset(pv)
 		c := PersistentVolumeDescriber{fake}
 		str, err := c.Describe("foo", "bar")
 		if err != nil {


### PR DESCRIPTION
This is part of the attempt to replace the unversioned client with the generated clientset.

Using clientset in kubectl is tricky, because kubectl should support multiple versions, while a clientset is targeted a one version. To support multiple version, we modify the target URL and Codec of RESTClient embedded in the clientset on the fly.

This PR is intended as a proof of concept.
