### PR TITLE
Fix DeleteCollection in FakeClient

### DIFF
--- a/cmd/libs/go2idl/client-gen/generators/fake/generator-fake-for-type.go
+++ b/cmd/libs/go2idl/client-gen/generators/fake/generator-fake-for-type.go
@@ -212,8 +212,8 @@ func (c *Fake$.type|publicPlural$) Delete(name string, options *$.apiDeleteOptio
 
 var deleteCollectionTemplate = `
 func (c *Fake$.type|publicPlural$) DeleteCollection(options *$.apiDeleteOptions|raw$, listOptions $.apiListOptions|raw$) error {
-	$if .namespaced$action := $.NewDeleteCollectionAction|raw$("events", c.ns, listOptions)
-	$else$action := $.NewRootDeleteCollectionAction|raw$("events", listOptions)
+	$if .namespaced$action := $.NewDeleteCollectionAction|raw$("$.type|allLowercasePlural$", c.ns, listOptions)
+	$else$action := $.NewRootDeleteCollectionAction|raw$("$.type|allLowercasePlural$", listOptions)
 	$end$
 	_, err := c.Fake.Invokes(action, &$.type|raw$List{})
 	return err

--- a/pkg/client/typed/generated/extensions/unversioned/fake/fake_daemonset.go
+++ b/pkg/client/typed/generated/extensions/unversioned/fake/fake_daemonset.go
@@ -68,7 +68,7 @@ func (c *FakeDaemonSets) Delete(name string, options *api.DeleteOptions) error {
 }
 
 func (c *FakeDaemonSets) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+	action := core.NewDeleteCollectionAction("daemonsets", c.ns, listOptions)
 
 	_, err := c.Fake.Invokes(action, &extensions.DaemonSetList{})
 	return err

--- a/pkg/client/typed/generated/extensions/unversioned/fake/fake_deployment.go
+++ b/pkg/client/typed/generated/extensions/unversioned/fake/fake_deployment.go
@@ -68,7 +68,7 @@ func (c *FakeDeployments) Delete(name string, options *api.DeleteOptions) error 
 }
 
 func (c *FakeDeployments) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+	action := core.NewDeleteCollectionAction("deployments", c.ns, listOptions)
 
 	_, err := c.Fake.Invokes(action, &extensions.DeploymentList{})
 	return err

--- a/pkg/client/typed/generated/extensions/unversioned/fake/fake_horizontalpodautoscaler.go
+++ b/pkg/client/typed/generated/extensions/unversioned/fake/fake_horizontalpodautoscaler.go
@@ -68,7 +68,7 @@ func (c *FakeHorizontalPodAutoscalers) Delete(name string, options *api.DeleteOp
 }
 
 func (c *FakeHorizontalPodAutoscalers) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+	action := core.NewDeleteCollectionAction("horizontalpodautoscalers", c.ns, listOptions)
 
 	_, err := c.Fake.Invokes(action, &extensions.HorizontalPodAutoscalerList{})
 	return err

--- a/pkg/client/typed/generated/extensions/unversioned/fake/fake_ingress.go
+++ b/pkg/client/typed/generated/extensions/unversioned/fake/fake_ingress.go
@@ -68,7 +68,7 @@ func (c *FakeIngresses) Delete(name string, options *api.DeleteOptions) error {
 }
 
 func (c *FakeIngresses) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+	action := core.NewDeleteCollectionAction("ingresses", c.ns, listOptions)
 
 	_, err := c.Fake.Invokes(action, &extensions.IngressList{})
 	return err

--- a/pkg/client/typed/generated/extensions/unversioned/fake/fake_job.go
+++ b/pkg/client/typed/generated/extensions/unversioned/fake/fake_job.go
@@ -68,7 +68,7 @@ func (c *FakeJobs) Delete(name string, options *api.DeleteOptions) error {
 }
 
 func (c *FakeJobs) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+	action := core.NewDeleteCollectionAction("jobs", c.ns, listOptions)
 
 	_, err := c.Fake.Invokes(action, &extensions.JobList{})
 	return err

--- a/pkg/client/typed/generated/extensions/unversioned/fake/fake_replicaset.go
+++ b/pkg/client/typed/generated/extensions/unversioned/fake/fake_replicaset.go
@@ -68,7 +68,7 @@ func (c *FakeReplicaSets) Delete(name string, options *api.DeleteOptions) error 
 }
 
 func (c *FakeReplicaSets) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+	action := core.NewDeleteCollectionAction("replicasets", c.ns, listOptions)
 
 	_, err := c.Fake.Invokes(action, &extensions.ReplicaSetList{})
 	return err

--- a/pkg/client/typed/generated/extensions/unversioned/fake/fake_thirdpartyresource.go
+++ b/pkg/client/typed/generated/extensions/unversioned/fake/fake_thirdpartyresource.go
@@ -58,7 +58,7 @@ func (c *FakeThirdPartyResources) Delete(name string, options *api.DeleteOptions
 }
 
 func (c *FakeThirdPartyResources) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+	action := core.NewDeleteCollectionAction("thirdpartyresources", c.ns, listOptions)
 
 	_, err := c.Fake.Invokes(action, &extensions.ThirdPartyResourceList{})
 	return err

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_componentstatus.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_componentstatus.go
@@ -53,7 +53,7 @@ func (c *FakeComponentStatuses) Delete(name string, options *api.DeleteOptions) 
 }
 
 func (c *FakeComponentStatuses) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	action := core.NewRootDeleteCollectionAction("events", listOptions)
+	action := core.NewRootDeleteCollectionAction("componentstatuses", listOptions)
 
 	_, err := c.Fake.Invokes(action, &api.ComponentStatusList{})
 	return err

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_configmap.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_configmap.go
@@ -57,7 +57,7 @@ func (c *FakeConfigMaps) Delete(name string, options *api.DeleteOptions) error {
 }
 
 func (c *FakeConfigMaps) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+	action := core.NewDeleteCollectionAction("configmaps", c.ns, listOptions)
 
 	_, err := c.Fake.Invokes(action, &api.ConfigMapList{})
 	return err

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_endpoints.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_endpoints.go
@@ -57,7 +57,7 @@ func (c *FakeEndpoints) Delete(name string, options *api.DeleteOptions) error {
 }
 
 func (c *FakeEndpoints) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+	action := core.NewDeleteCollectionAction("endpoints", c.ns, listOptions)
 
 	_, err := c.Fake.Invokes(action, &api.EndpointsList{})
 	return err

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_limitrange.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_limitrange.go
@@ -57,7 +57,7 @@ func (c *FakeLimitRanges) Delete(name string, options *api.DeleteOptions) error 
 }
 
 func (c *FakeLimitRanges) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+	action := core.NewDeleteCollectionAction("limitranges", c.ns, listOptions)
 
 	_, err := c.Fake.Invokes(action, &api.LimitRangeList{})
 	return err

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_namespace.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_namespace.go
@@ -62,7 +62,7 @@ func (c *FakeNamespaces) Delete(name string, options *api.DeleteOptions) error {
 }
 
 func (c *FakeNamespaces) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	action := core.NewRootDeleteCollectionAction("events", listOptions)
+	action := core.NewRootDeleteCollectionAction("namespaces", listOptions)
 
 	_, err := c.Fake.Invokes(action, &api.NamespaceList{})
 	return err

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_node.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_node.go
@@ -62,7 +62,7 @@ func (c *FakeNodes) Delete(name string, options *api.DeleteOptions) error {
 }
 
 func (c *FakeNodes) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	action := core.NewRootDeleteCollectionAction("events", listOptions)
+	action := core.NewRootDeleteCollectionAction("nodes", listOptions)
 
 	_, err := c.Fake.Invokes(action, &api.NodeList{})
 	return err

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_persistentvolume.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_persistentvolume.go
@@ -62,7 +62,7 @@ func (c *FakePersistentVolumes) Delete(name string, options *api.DeleteOptions) 
 }
 
 func (c *FakePersistentVolumes) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	action := core.NewRootDeleteCollectionAction("events", listOptions)
+	action := core.NewRootDeleteCollectionAction("persistentvolumes", listOptions)
 
 	_, err := c.Fake.Invokes(action, &api.PersistentVolumeList{})
 	return err

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_persistentvolumeclaim.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_persistentvolumeclaim.go
@@ -67,7 +67,7 @@ func (c *FakePersistentVolumeClaims) Delete(name string, options *api.DeleteOpti
 }
 
 func (c *FakePersistentVolumeClaims) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+	action := core.NewDeleteCollectionAction("persistentvolumeclaims", c.ns, listOptions)
 
 	_, err := c.Fake.Invokes(action, &api.PersistentVolumeClaimList{})
 	return err

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_pod.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_pod.go
@@ -67,7 +67,7 @@ func (c *FakePods) Delete(name string, options *api.DeleteOptions) error {
 }
 
 func (c *FakePods) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+	action := core.NewDeleteCollectionAction("pods", c.ns, listOptions)
 
 	_, err := c.Fake.Invokes(action, &api.PodList{})
 	return err

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_podtemplate.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_podtemplate.go
@@ -57,7 +57,7 @@ func (c *FakePodTemplates) Delete(name string, options *api.DeleteOptions) error
 }
 
 func (c *FakePodTemplates) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+	action := core.NewDeleteCollectionAction("podtemplates", c.ns, listOptions)
 
 	_, err := c.Fake.Invokes(action, &api.PodTemplateList{})
 	return err

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_replicationcontroller.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_replicationcontroller.go
@@ -67,7 +67,7 @@ func (c *FakeReplicationControllers) Delete(name string, options *api.DeleteOpti
 }
 
 func (c *FakeReplicationControllers) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+	action := core.NewDeleteCollectionAction("replicationcontrollers", c.ns, listOptions)
 
 	_, err := c.Fake.Invokes(action, &api.ReplicationControllerList{})
 	return err

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_resourcequota.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_resourcequota.go
@@ -67,7 +67,7 @@ func (c *FakeResourceQuotas) Delete(name string, options *api.DeleteOptions) err
 }
 
 func (c *FakeResourceQuotas) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+	action := core.NewDeleteCollectionAction("resourcequotas", c.ns, listOptions)
 
 	_, err := c.Fake.Invokes(action, &api.ResourceQuotaList{})
 	return err

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_secret.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_secret.go
@@ -57,7 +57,7 @@ func (c *FakeSecrets) Delete(name string, options *api.DeleteOptions) error {
 }
 
 func (c *FakeSecrets) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+	action := core.NewDeleteCollectionAction("secrets", c.ns, listOptions)
 
 	_, err := c.Fake.Invokes(action, &api.SecretList{})
 	return err

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_service.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_service.go
@@ -67,7 +67,7 @@ func (c *FakeServices) Delete(name string, options *api.DeleteOptions) error {
 }
 
 func (c *FakeServices) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+	action := core.NewDeleteCollectionAction("services", c.ns, listOptions)
 
 	_, err := c.Fake.Invokes(action, &api.ServiceList{})
 	return err

--- a/pkg/client/typed/generated/legacy/unversioned/fake/fake_serviceaccount.go
+++ b/pkg/client/typed/generated/legacy/unversioned/fake/fake_serviceaccount.go
@@ -57,7 +57,7 @@ func (c *FakeServiceAccounts) Delete(name string, options *api.DeleteOptions) er
 }
 
 func (c *FakeServiceAccounts) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	action := core.NewDeleteCollectionAction("events", c.ns, listOptions)
+	action := core.NewDeleteCollectionAction("serviceaccounts", c.ns, listOptions)
 
 	_, err := c.Fake.Invokes(action, &api.ServiceAccountList{})
 	return err


### PR DESCRIPTION
There was an error in the generator client that hardcoded "events"

This blocks other PRs as it fails their unit tests.

/cc @lavalamp @caesarxuchao @smarterclayton @pmorie 

quick review appreciated ;-)

Fixes https://github.com/kubernetes/kubernetes/issues/20568
