### PR TITLE
Removing unused var in etcd_failure.go

### DIFF
--- a/test/e2e/etcd_failure.go
+++ b/test/e2e/etcd_failure.go
@@ -29,7 +29,6 @@ import (
 
 var _ = Describe("Etcd failure [Disruptive]", func() {
 
-	var skipped bool
 	framework := NewFramework("etcd-failure")
 
 	BeforeEach(func() {
@@ -38,9 +37,7 @@ var _ = Describe("Etcd failure [Disruptive]", func() {
 		// - master access
 		// ... so the provider check should be identical to the intersection of
 		// providers that provide those capabilities.
-		skipped = true
 		SkipUnlessProviderIs("gce")
-		skipped = false
 
 		Expect(RunRC(RCConfig{
 			Client:    framework.Client,


### PR DESCRIPTION
Found the following in all logs on jenkins:

```
type checker error: k8s.io/kubernetes/test/e2e/etcd_failure.go:32:6: skipped declared but not used
type checking encountered some errors in "k8s.io/kubernetes/test/e2e", but ignoring.
```

We stopped using the variable after https://github.com/kubernetes/kubernetes/pull/16084

cc @smarterclayton 
