### PR TITLE
Move Trusty e2e testing jobs to job-configs

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-e2e-trusty.yaml
+++ b/hack/jenkins/job-configs/kubernetes-e2e-trusty.yaml
@@ -1,0 +1,69 @@
+- job-template:
+    name: 'kubernetes-e2e-gce-trusty-{suffix}'
+    description: '{description} Test owner: {test-owner}.'
+    logrotate:
+        daysToKeep: 7
+    builders:
+        - shell: |
+            curl -fsS --retry 3  "https://raw.githubusercontent.com/kubernetes/kubernetes/{branch}/hack/jenkins/e2e.sh" | bash -
+    properties:
+        - mail-watcher
+    publishers:
+        - claim-build
+        - junit-publisher
+        - log-parser
+        - email-ext:
+            recipients: "{emails}"
+        - description-setter:
+            regexp: KUBE_GCE_MINION_IMAGE=(.*)
+        - groovy-postbuild:
+            script: |
+                def trustyImageMatcher = manager.getLogMatcher("KUBE_GCE_MINION_IMAGE=(.*)")
+                if(trustyImageMatcher?.matches()) manager.addShortText("<b>Trusty Image: " + trustyImageMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
+                def k8sVersionMatcher = manager.getLogMatcher("Using\\spublished\\sversion\\s(.*)\\s\\(from.*")
+                if(k8sVersionMatcher?.matches()) manager.addShortText("<br><b>Kubernetes version: " + k8sVersionMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
+
+    triggers:
+        - timed: 'H H/8 * * *'
+    wrappers:
+        - ansicolor:
+            colormap: xterm
+        - timeout:
+            timeout: '{timeout}'
+            fail: true
+        - timestamps
+        - workspace-cleanup
+
+- project:
+    name: kubernetes-e2e-gce-trusty
+    test-owner: 'wonderfly@google.com'
+    branch: 'release-1.1'
+    emails:
+        adityakali@google.com,ameyd@google.com,andryeu@google.com,gwells@google.com,qzheng@google.com,saied@google.com,wonderfly@google.com,yinghan@google.com
+    suffix:
+        - 'head-release':
+            description: 'Continuously test Trusty build against latest k8s release.'
+            timeout: 150
+        - 'dev-release':
+            description: 'Continuously test Trusty dev build against latest k8s release.'
+            timeout: 150
+        - 'beta-release':
+            description: 'Continuously test Trusty beta build against latest k8s release.'
+            timeout: 150
+        - 'stable-release':
+            description: 'Continuously test Trusty stable build against latest k8s release.'
+            timeout: 150
+        - 'head-slow':
+            description: 'Run slow E2E tests on latest Trusty build.'
+            timeout: 270
+        - 'dev-slow':
+            description: 'Run slow E2E tests on latest Trusty dev build.'
+            timeout: 270
+        - 'beta-slow':
+            description: 'Run slow E2E tests on latest Trusty beta build.'
+            timeout: 270
+        - 'stable-slow':
+            description: 'Run slow E2E tests on latest Trusty stable build.'
+            timeout: 270
+    jobs:
+        - 'kubernetes-e2e-gce-trusty-{suffix}'


### PR DESCRIPTION
@spxtr jenkins-jobs test job-configs/ spits out the XML and it looks sane. How do I test it works on Jenkins before merging it in?

cc @ihmccreery @ixdy @andyzheng0831 
