### PR TITLE
Add explicit test case for old mergo.Merge behavior

### DIFF
--- a/pkg/client/unversioned/clientcmd/client_config.go
+++ b/pkg/client/unversioned/clientcmd/client_config.go
@@ -111,6 +111,8 @@ func (config DirectClientConfig) ClientConfig() (*client.Config, error) {
 		var err error
 
 		// mergo is a first write wins for map value and a last writing wins for interface values
+		// NOTE: This behavior changed with https://github.com/imdario/mergo/commit/d304790b2ed594794496464fadd89d2bb266600a.
+		//       Our mergo.Merge version is older than this change.
 		userAuthPartialConfig, err := getUserIdentificationPartialConfig(configAuthInfo, config.fallbackReader)
 		if err != nil {
 			return nil, err

--- a/pkg/client/unversioned/clientcmd/client_config_test.go
+++ b/pkg/client/unversioned/clientcmd/client_config_test.go
@@ -20,10 +20,29 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/imdario/mergo"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
 )
+
+func TestOldMergoLib(t *testing.T) {
+	type T struct {
+		X string
+	}
+	dst := T{X: "one"}
+	src := T{X: "two"}
+	mergo.Merge(&dst, &src)
+	if dst.X != "two" {
+		// mergo.Merge changed in an incompatible way with
+		//
+		//   https://github.com/imdario/mergo/commit/d304790b2ed594794496464fadd89d2bb266600a
+		//
+		// We have to stay with the old version which still does eager
+		// copying from src to dst in structs.
+		t.Errorf("mergo.Merge library found with incompatible, new behavior")
+	}
+}
 
 func createValidTestConfig() *clientcmdapi.Config {
 	const (


### PR DESCRIPTION
Follow-up of https://github.com/kubernetes/kubernetes/pull/20579.

mergo.Merge changed in an incompatible way with https://github.com/imdario/mergo/commit/d304790b2ed594794496464fadd89d2bb266600a. We have to stay with the old version which still does eager copying from src to dst in structs.
