### PR TITLE
[Discussion] Quarantine reboot tests as [Feature:Reboot] due to instability?

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -514,6 +514,24 @@ case ${JOB_NAME} in
 
   # Feature jobs
 
+  # Runs only the reboot tests on GCE.
+  kubernetes-e2e-gce-reboot)
+    : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-reboot"}
+    : ${E2E_NETWORK:="e2e-reboot"}
+    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Feature:Reboot\]"}
+    : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-reboot"}
+    : ${PROJECT:="kubernetes-jenkins"}
+  ;;
+
+  kubernetes-e2e-gke-reboot)
+    : ${E2E_CLUSTER_NAME:="jkns-gke-e2e-ci-reboot"}
+    : ${E2E_NETWORK:="e2e-gke-ci-reboot"}
+    : ${E2E_SET_CLUSTER_API_VERSION:=y}
+    : ${PROJECT:="k8s-jkns-e2e-gke-ci-reboot"}
+    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
+    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Feature:Reboot\]"}
+  ;;
+
   # Runs only the examples tests on GCE.
   kubernetes-e2e-gce-examples)
     : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-examples"}

--- a/hack/jenkins/job-configs/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-e2e.yaml
@@ -189,13 +189,23 @@
             timeout: 300
             emails: '$DEFAULT_RECIPIENTS, ihmccreery@google.com'
             test-owner: 'ihmccreery'
-        - 'gke-ingress':
-            description: 'Run [Feature:Ingress] tests on GKE using the latest successful build.'
+        - 'gce-reboot':
+            description: 'Run [Feature:Reboot] tests on GCE using the latest successful build.'
+            timeout: 120
+            emails: '$DEFAULT_RECIPIENTS, ihmccreery@google.com'
+            test-owner: 'ihmccreery'
+        - 'gke-reboot':
+            description: 'Run [Feature:Reboot] tests on GKE using the latest successful build.'
+            timeout: 120
+            emails: '$DEFAULT_RECIPIENTS, ihmccreery@google.com'
+            test-owner: 'ihmccreery'
+        - 'gce-ingress':
+            description: 'Run [Feature:Ingress] tests on GCE using the latest successful build.'
             timeout: 90
             emails: '$DEFAULT_RECIPIENTS, beeps@google.com'
             test-owner: 'beeps'
-        - 'gce-ingress':
-            description: 'Run [Feature:Ingress] tests on GCE using the latest successful build.'
+        - 'gke-ingress':
+            description: 'Run [Feature:Ingress] tests on GKE using the latest successful build.'
             timeout: 90
             emails: '$DEFAULT_RECIPIENTS, beeps@google.com'
             test-owner: 'beeps'

--- a/test/e2e/reboot.go
+++ b/test/e2e/reboot.go
@@ -45,7 +45,9 @@ const (
 	rebootPodReadyAgainTimeout = 5 * time.Minute
 )
 
-var _ = Describe("Reboot [Disruptive]", func() {
+// Reboot tests are flaky, and when they break, they break the whole cluster.
+// They need to run in a separate suite until we can make them better.
+var _ = Describe("Reboot [Disruptive] [Feature:Reboot]", func() {
 	var f *Framework
 
 	BeforeEach(func() {


### PR DESCRIPTION
These tests are flaky and making it very difficult to debug other tests.  I'm proposing we consider reboot an unstable feature that we should dedicate some serious engineering time to.

@dchen1107 we talked about this last week and you said you didn't want to do this, but the jobs running reboot tests are really ugly right now, and it's hard to see why.

cc @quinton-hoole and @ixdy so they can say I-told-you-so.  :blush: 
