### PR TITLE
Enable deployment e2e tests

### DIFF
--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -32,7 +32,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Deployment [Feature:Deployment]", func() {
+var _ = Describe("Deployment", func() {
 	f := NewFramework("deployment")
 
 	It("deployment should create new pods", func() {

--- a/test/e2e/horizontal_pod_autoscaling.go
+++ b/test/e2e/horizontal_pod_autoscaling.go
@@ -42,7 +42,7 @@ var _ = Describe("Horizontal pod autoscaling (scale resource: CPU) [Serial] [Slo
 	titleDown := "Should scale from 5 pods to 3 pods and from 3 to 1"
 
 	// TODO(madhusudancs): Fix this when Scale group issues are resolved (see issue #18528).
-	// Describe("Deployment [Feature:Deployment]", func() {
+	// Describe("Deployment", func() {
 	// 	// CPU tests via deployments
 	// 	It(titleUp, func() {
 	// 		scaleUp("deployment", kindDeployment, rc, f)


### PR DESCRIPTION
#20441 #20597

After deployment is enabled by default (i.e. #20517 is merged), remove `[Feature:Deployment]` to enable deployment e2e tests. 
cc @ihmccreery @roberthbailey 
