### PR TITLE
Added support for using PAM with basic-auth. 

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -96,6 +96,7 @@ type APIServer struct {
 	SSHKeyfile                 string
 	MaxConnectionBytesPerSec   int64
 	KubernetesServiceNodePort  int
+	PamPassword                bool
 }
 
 // NewAPIServer creates a new APIServer object with default parameters
@@ -229,4 +230,5 @@ func (s *APIServer) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&s.KubernetesServiceNodePort, "kubernetes-service-node-port", 0, "If non-zero, the Kubernetes master service (which apiserver creates/maintains) will be of type NodePort, using this as the value of the port. If zero, the Kubernetes master service will be of type ClusterIP.")
 	// TODO: delete this flag as soon as we identify and fix all clients that send malformed updates, like #14126.
 	fs.BoolVar(&validation.RepairMalformedUpdates, "repair-malformed-updates", true, "If true, server will do its best to fix the update request to pass the validation, e.g., setting empty UID in update request to its existing value. This flag can be turned off after we fix all the clients that send malformed updates.")
+	fs.BoolVar(&s.PamPassword, "pam-password", false, "Enable use of PAM authentication for validating user credentials.")
 }

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -318,6 +318,7 @@ func Run(s *options.APIServer) error {
 		ServiceAccountLookup:      s.ServiceAccountLookup,
 		ServiceAccountTokenGetter: serviceAccountGetter,
 		KeystoneURL:               s.KeystoneURL,
+		PamPassword:               s.PamPassword,
 	})
 
 	if err != nil {
@@ -374,7 +375,7 @@ func Run(s *options.APIServer) error {
 			ReadWritePort:             s.SecurePort,
 			PublicAddress:             s.AdvertiseAddress,
 			Authenticator:             authenticator,
-			SupportsBasicAuth:         len(s.BasicAuthFile) > 0,
+			SupportsBasicAuth:         len(s.BasicAuthFile) > 0 || s.PamPassword,
 			Authorizer:                authorizer,
 			AdmissionControl:          admissionController,
 			APIGroupVersionOverrides:  apiGroupVersionOverrides,

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -397,7 +397,7 @@ kube::golang::build_binaries_for_platform() {
         "${nonstatics[@]:+${nonstatics[@]}}"
     fi
     if [[ "${#statics[@]}" != 0 ]]; then
-      CGO_ENABLED=0 go install -installsuffix cgo "${goflags[@]:+${goflags[@]}}" \
+      CGO_ENABLED=1 go install -installsuffix cgo "${goflags[@]:+${goflags[@]}}" \
         -ldflags "${goldflags}" \
         "${statics[@]:+${statics[@]}}"
     fi

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -354,3 +354,4 @@ watch-only
 whitelist-override-label
 windows-line-endings
 www-prefix
+pam-password

--- a/plugin/pkg/auth/authenticator/password/pampassword/pampassword.go
+++ b/plugin/pkg/auth/authenticator/password/pampassword/pampassword.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pampassword
+
+import (
+	"errors"
+	"github.com/golang/glog"
+	"github.com/msteinert/pam"
+	"k8s.io/kubernetes/pkg/auth/authenticator"
+	"k8s.io/kubernetes/pkg/auth/user"
+	"os"
+)
+
+type pamPaswdAuthenticator struct{}
+
+type Credentials struct {
+	User     string
+	Password string
+}
+
+func (c Credentials) RespondPAM(s pam.Style, msg string) (string, error) {
+	switch s {
+	case pam.PromptEchoOn:
+		return c.User, nil
+	case pam.PromptEchoOff:
+		return c.Password, nil
+	}
+	return "", errors.New("unexpected")
+}
+
+// NewAllow returns a password authenticator that allows any non-empty username
+func NewPamPassword() authenticator.Password {
+	return pamPaswdAuthenticator{}
+}
+
+// AuthenticatePassword implements authenticator.Password to allow any non-empty username,
+// using the specified username as the name and UID
+func (pamPaswdAuthenticator) AuthenticatePassword(username, password string) (user.Info, bool, error) {
+	c := Credentials{
+		Password: password,
+	}
+
+	module := os.Getenv("KUBE_PAM_MODULE_NAME")
+	if module == "" {
+		module = "kubepam"
+	}
+
+	tx, err := pam.Start(module, username, c)
+	if err != nil {
+		glog.Errorf("basicauth PAM start #error: %v", err)
+		return nil, false, nil
+	}
+
+	err = tx.Authenticate(0)
+	if err != nil {
+		glog.Errorf("basicauth PAM #error: %v  failed auth for %s", err, username)
+		return nil, false, nil
+	}
+
+	glog.Infof("basicauth PAM auth success for %s", username)
+	return &user.DefaultInfo{Name: username}, true, nil
+}

--- a/plugin/pkg/auth/authenticator/request/basicauth/basicauth.go
+++ b/plugin/pkg/auth/authenticator/request/basicauth/basicauth.go
@@ -17,13 +17,9 @@ limitations under the License.
 package basicauth
 
 import (
-	"errors"
-	"github.com/golang/glog"
-	"github.com/msteinert/pam"
 	"k8s.io/kubernetes/pkg/auth/authenticator"
 	"k8s.io/kubernetes/pkg/auth/user"
 	"net/http"
-	"os"
 )
 
 // Authenticator authenticates requests using basic auth
@@ -36,52 +32,11 @@ func New(auth authenticator.Password) *Authenticator {
 	return &Authenticator{auth}
 }
 
-type Credentials struct {
-	User     string
-	Password string
-}
-
-func (c Credentials) RespondPAM(s pam.Style, msg string) (string, error) {
-	switch s {
-	case pam.PromptEchoOn:
-		return c.User, nil
-	case pam.PromptEchoOff:
-		return c.Password, nil
-	}
-	return "", errors.New("unexpected")
-}
-
 // AuthenticateRequest authenticates the request using the "Authorization: Basic" header in the request
 func (a *Authenticator) AuthenticateRequest(req *http.Request) (user.Info, bool, error) {
 	username, password, found := req.BasicAuth()
 	if !found {
 		return nil, false, nil
-	}
-
-	if os.Getenv("BASIC_AUTH_PAM") == "1" {
-		c := Credentials{
-			Password: password,
-		}
-
-		module := os.Getenv("KUBE_PAM_MODULE_NAME")
-		if module == "" {
-			module = "kubepam"
-		}
-
-		tx, err := pam.Start(module, username, c)
-		if err != nil {
-			glog.Errorf("basicauth PAM start #error: %v", err)
-			return nil, false, nil
-		}
-
-		err = tx.Authenticate(0)
-		if err != nil {
-			glog.Errorf("basicauth PAM #error: %v  failed auth for %s", err, username)
-			return nil, false, nil
-		}
-
-		glog.Infof("basicauth PAM auth success for %s", username)
-		return nil, true, nil
 	}
 	return a.auth.AuthenticatePassword(username, password)
 }

--- a/plugin/pkg/auth/authenticator/request/basicauth/basicauth.go
+++ b/plugin/pkg/auth/authenticator/request/basicauth/basicauth.go
@@ -17,10 +17,13 @@ limitations under the License.
 package basicauth
 
 import (
-	"net/http"
-
+	"errors"
+	"github.com/golang/glog"
+	"github.com/msteinert/pam"
 	"k8s.io/kubernetes/pkg/auth/authenticator"
 	"k8s.io/kubernetes/pkg/auth/user"
+	"net/http"
+	"os"
 )
 
 // Authenticator authenticates requests using basic auth
@@ -33,11 +36,52 @@ func New(auth authenticator.Password) *Authenticator {
 	return &Authenticator{auth}
 }
 
+type Credentials struct {
+	User     string
+	Password string
+}
+
+func (c Credentials) RespondPAM(s pam.Style, msg string) (string, error) {
+	switch s {
+	case pam.PromptEchoOn:
+		return c.User, nil
+	case pam.PromptEchoOff:
+		return c.Password, nil
+	}
+	return "", errors.New("unexpected")
+}
+
 // AuthenticateRequest authenticates the request using the "Authorization: Basic" header in the request
 func (a *Authenticator) AuthenticateRequest(req *http.Request) (user.Info, bool, error) {
 	username, password, found := req.BasicAuth()
 	if !found {
 		return nil, false, nil
+	}
+
+	if os.Getenv("BASIC_AUTH_PAM") == "1" {
+		c := Credentials{
+			Password: password,
+		}
+
+		module := os.Getenv("KUBE_PAM_MODULE_NAME")
+		if module == "" {
+			module = "kubepam"
+		}
+
+		tx, err := pam.Start(module, username, c)
+		if err != nil {
+			glog.Errorf("basicauth PAM start #error: %v", err)
+			return nil, false, nil
+		}
+
+		err = tx.Authenticate(0)
+		if err != nil {
+			glog.Errorf("basicauth PAM #error: %v  failed auth for %s", err, username)
+			return nil, false, nil
+		}
+
+		glog.Infof("basicauth PAM auth success for %s", username)
+		return nil, true, nil
 	}
 	return a.auth.AuthenticatePassword(username, password)
 }


### PR DESCRIPTION
@erictune If basic-auth is used for authentication when a client communicates with the api server
and the BASIC_AUTH_PAM env var is on, then the configured PAM module is used to validate the
user name/password pair.  For example the local PAM module may be configured to lookup the user name/password in Active Directory.
