### PR TITLE
[wip] drop rlock before timing out watch

### DIFF
--- a/pkg/registry/service/portallocator/controller/repair.go
+++ b/pkg/registry/service/portallocator/controller/repair.go
@@ -86,10 +86,8 @@ func (c *Repair) runOnce() error {
 	if err != nil {
 		return fmt.Errorf("unable to refresh the port block: %v", err)
 	}
-
 	ctx := api.WithNamespace(api.NewDefaultContext(), api.NamespaceAll)
-	options := &api.ListOptions{ResourceVersion: latest.ObjectMeta.ResourceVersion}
-	list, err := c.registry.ListServices(ctx, options)
+	list, err := c.registry.ListServices(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("unable to refresh the port block: %v", err)
 	}

--- a/pkg/storage/watch_cache.go
+++ b/pkg/storage/watch_cache.go
@@ -220,13 +220,13 @@ func (w *watchCache) WaitUntilFreshAndList(resourceVersion uint64) ([]interface{
 	}()
 
 	w.RLock()
+	defer w.RUnlock()
 	for w.resourceVersion < resourceVersion {
 		if w.clock.Since(startTime) >= MaximumListWait {
 			return nil, 0, fmt.Errorf("time limit exceeded while waiting for resource version %v (current value: %v)", resourceVersion, w.resourceVersion)
 		}
 		w.cond.Wait()
 	}
-	defer w.RUnlock()
 	return w.store.List(), w.resourceVersion, nil
 }
 


### PR DESCRIPTION
So the running theory is we deadlock when we hit the watch timeout, and we hit the watch timeout because the node port allocator requests a resource version in the future. If this is right, https://github.com/kubernetes/kubernetes/issues/20652 will only affect Services, not pods, and is also what's cauing https://github.com/kubernetes/kubernetes/issues/20547

Still a wip because it's been a while since I've looked at this code. Hopefully @kubernetes/goog-cluster will shout if this is nuts.
