### PR TITLE
Capability to specify mount propagation mode of per volume with docker

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -403,10 +403,22 @@ const (
 	ClaimBound PersistentVolumeClaimPhase = "Bound"
 )
 
+type PropagationMode string
+
+const (
+	PropagationPrivate  PropagationMode = "private"
+	PropagationRPrivate PropagationMode = "rprivate"
+	PropagationSlave    PropagationMode = "slave"
+	PropagationRSlave   PropagationMode = "rslave"
+	PropagationShared   PropagationMode = "shared"
+	PropagationRShared  PropagationMode = "rshared"
+)
+
 // Represents a host path mapped into a pod.
 // Host path volumes do not support ownership management or SELinux relabeling.
 type HostPathVolumeSource struct {
-	Path string `json:"path"`
+	Path        string          `json:"path"`
+	Propagation PropagationMode `json:"propagation,omitempty"`
 }
 
 // Represents an empty directory for a pod.

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -498,12 +498,24 @@ const (
 	ClaimBound PersistentVolumeClaimPhase = "Bound"
 )
 
+type PropagationMode string
+
+const (
+	PropagationPrivate  PropagationMode = "private"
+	PropagationRPrivate PropagationMode = "rprivate"
+	PropagationSlave    PropagationMode = "slave"
+	PropagationRSlave   PropagationMode = "rslave"
+	PropagationShared   PropagationMode = "shared"
+	PropagationRShared  PropagationMode = "rshared"
+)
+
 // Represents a host path mapped into a pod.
 // Host path volumes do not support ownership management or SELinux relabeling.
 type HostPathVolumeSource struct {
 	// Path of the directory on the host.
 	// More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#hostpath
-	Path string `json:"path" protobuf:"bytes,1,opt,name=path"`
+	Path        string          `json:"path" protobuf:"bytes,1,opt,name=path"`
+	Propagation PropagationMode `json:"propagation,omitempty"`
 }
 
 // Represents an empty directory for a pod.

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -336,6 +336,8 @@ type Mount struct {
 	ReadOnly bool
 	// Whether the mount needs SELinux relabeling
 	SELinuxRelabel bool
+	// Mount propagation mode of the volume
+	Propagation api.PropagationMode
 }
 
 type PortMapping struct {

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -33,6 +33,9 @@ type Volume interface {
 
 	// MetricsProvider embeds methods for exposing metrics (e.g. used,available space).
 	MetricsProvider
+
+	// GetPropagationMode returns the propagation mode the volume is mounted to.
+	GetPropagationMode() api.PropagationMode
 }
 
 // MetricsProvider exposes metrics (e.g. used,available space) related to a Volume.


### PR DESCRIPTION
Volume mount propagation mode has been supported since docker 1.10.0, but this function is absent in current kubelet.
This patch set allows one to specify mount propagation setting of a volume. Allowed values are "shared" or "slave" or "private", via introducing a new filed called `"Propagation"` in type `VolumeMount` in `api/types`

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/20698)

<!-- Reviewable:end -->
