### PR TITLE
Add CentOS to SaltStack configuration for Kubernetes

### DIFF
--- a/cluster/saltbase/salt/docker/init.sls
+++ b/cluster/saltbase/salt/docker/init.sls
@@ -18,7 +18,7 @@ bridge-utils:
     - mode: 644
     - makedirs: true
 
-{% if grains.os == 'Fedora' and grains.osrelease_info[0] >= 22 %}
+{% if (grains.os == 'Fedora' and grains.osrelease_info[0] >= 22) or (grains.os == 'CentOS' and grains.osrelease_info[0] >= 7) %}
 
 docker:
   pkg:


### PR DESCRIPTION
As a Fujitsu we are interested to add support for CentOS distribution. Currently we have patch for this file but the best approach is adding this to repository.
