### PR TITLE
allow older fedora docker versions

### DIFF
--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -946,7 +947,14 @@ type dockerVersion struct {
 	*semver.Version
 }
 
+// oldFedoraDockerVersion matches the suffix that old levesl of docker were built with on fedora
+// For example, "1.8.2.fc21".  This is a very simple expression to allow us to strip it.
+var oldFedoraDockerVersion = regexp.MustCompile(`.*\.fc[\d][\d]$`)
+
 func newDockerVersion(version string) (dockerVersion, error) {
+	if oldFedoraDockerVersion.MatchString(version) {
+		version = version[0 : len(version)-5]
+	}
 	sem, err := semver.NewVersion(version)
 	if err != nil {
 		return dockerVersion{}, err


### PR DESCRIPTION
Fedora packaging of docker used to include suffixes: `1.8.2.fc21`.  I'm pretty sure that 1.8 is still valid for use on kubernetes, but you get complaints with that old version.

@eparis Is our packaging going to keep doing this?  I haven't sorted out why `dnf` doesn't want to upgrade my `docker-io` package, but if 1.8 is valid we shouldn't puke on it.
