### PR TITLE
Make #19601 backward compatible.

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -667,6 +667,13 @@ function kube::release::clean_cruft() {
   find ${RELEASE_STAGE} -name '.DS*' -exec rm {} \;
 }
 
+function kube::release::package_hyperkube() {
+  # If we have these variables set then we want to build all docker images.
+  if [[ -n "${KUBE_DOCKER_IMAGE_TAG-}" && -n "${KUBE_DOCKER_REGISTRY-}" ]]; then
+    REGISTRY="${KUBE_DOCKER_REGISTRY}" VERSION="${KUBE_DOCKER_IMAGE_TAG}" make -C cluster/images/hyperkube/ build
+  fi
+}
+
 function kube::release::package_tarballs() {
   # Clean out any old releases
   rm -rf "${RELEASE_DIR}"

--- a/build/release.sh
+++ b/build/release.sh
@@ -39,3 +39,4 @@ fi
 
 kube::build::copy_output
 kube::release::package_tarballs
+kube::release::package_hyperkube

--- a/release/build-official-release.sh
+++ b/release/build-official-release.sh
@@ -91,8 +91,6 @@ export KUBE_DOCKER_REGISTRY="gcr.io/google_containers"
 export KUBE_DOCKER_IMAGE_TAG="${KUBE_RELEASE_VERSION}"
 
 make release
-# We don't want to include this in 'make release' as it'd slow down every day development cycle.
-REGISTRY="${KUBE_DOCKER_REGISTRY}" VERSION="${KUBE_DOCKER_IMAGE_TAG}" make -C cluster/images/hyperkube/ build
 
 if ${KUBE_BUILD_DIR}/cluster/kubectl.sh version | grep Client | grep dirty; then
   echo "!!! Tag at invalid point, or something else is bad. Build is dirty. Don't push this build." >&2


### PR DESCRIPTION
Move building `hyperkube` image to `make release` to make it backward compatible in release process.

Fixes #20047
