### PR TITLE
support optional envvars for pod-infra-container

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -733,6 +733,7 @@ type KubeletConfig struct {
 
 	ExperimentalFlannelOverlay bool
 	NodeIP                     net.IP
+	ContainerRuntimeOptions    []kubecontainer.Option
 }
 
 func CreateAndInitKubelet(kc *KubeletConfig) (k KubeletBootstrap, pc *config.PodConfig, err error) {
@@ -820,6 +821,7 @@ func CreateAndInitKubelet(kc *KubeletConfig) (k KubeletBootstrap, pc *config.Pod
 		kc.Reservation,
 		kc.EnableCustomMetrics,
 		kc.VolumeStatsAggPeriod,
+		kc.ContainerRuntimeOptions,
 	)
 
 	if err != nil {

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -464,3 +464,7 @@ func ParsePodFullName(podFullName string) (string, string, error) {
 	}
 	return parts[0], parts[1], nil
 }
+
+// Option is a functional option type for Runtime, useful for
+// completely optional settings.
+type Option func(Runtime)

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -206,6 +206,7 @@ func NewMainKubelet(
 	reservation kubetypes.Reservation,
 	enableCustomMetrics bool,
 	volumeStatsAggPeriod time.Duration,
+	containerRuntimeOptions []kubecontainer.Option,
 ) (*Kubelet, error) {
 	if rootDirectory == "" {
 		return nil, fmt.Errorf("invalid root directory %q", rootDirectory)
@@ -387,6 +388,7 @@ func NewMainKubelet(
 			imageBackOff,
 			serializeImagePulls,
 			enableCustomMetrics,
+			containerRuntimeOptions...,
 		)
 	case "rkt":
 		conf := &rkt.Config{


### PR DESCRIPTION
This PR adds support for tweaking the environment variables of a pod's infra container, as discussed per #19881.

required for https://github.com/mesosphere/kubernetes-mesos/issues/739

/cc @dchen1107 @vishh 
