### PR TITLE
Downcase invalid ACIdentifier rkt.kubernetes.io/terminationMessagePath

### DIFF
--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -81,7 +81,7 @@ const (
 	k8sRktCreationTimeAnno           = "rkt.kubernetes.io/created"
 	k8sRktContainerHashAnno          = "rkt.kubernetes.io/containerhash"
 	k8sRktRestartCountAnno           = "rkt.kubernetes.io/restartcount"
-	k8sRktTerminationMessagePathAnno = "rkt.kubernetes.io/terminationMessagePath"
+	k8sRktTerminationMessagePathAnno = "rkt.kubernetes.io/terminationmessagepath"
 	dockerPrefix                     = "docker://"
 
 	authDir            = "auth.d"

--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -79,9 +79,9 @@ const (
 	k8sRktNamespaceAnno    = "rkt.kubernetes.io/namespace"
 	//TODO: remove the creation time annotation once this is closed: https://github.com/coreos/rkt/issues/1789
 	k8sRktCreationTimeAnno           = "rkt.kubernetes.io/created"
-	k8sRktContainerHashAnno          = "rkt.kubernetes.io/containerhash"
-	k8sRktRestartCountAnno           = "rkt.kubernetes.io/restartcount"
-	k8sRktTerminationMessagePathAnno = "rkt.kubernetes.io/terminationmessagepath"
+	k8sRktContainerHashAnno          = "rkt.kubernetes.io/container-hash"
+	k8sRktRestartCountAnno           = "rkt.kubernetes.io/restart-count"
+	k8sRktTerminationMessagePathAnno = "rkt.kubernetes.io/termination-message-path"
 	dockerPrefix                     = "docker://"
 
 	authDir            = "auth.d"


### PR DESCRIPTION
Conform to the ACI spec at [acidentifier.go](https://github.com/appc/spec/blob/3972f6a1b657f38e30100d2a7ef377cc8690c8db/schema/types/acidentifier.go#L25-L29).
