### PR TITLE
clear env var check for unit test

### DIFF
--- a/pkg/kubectl/cmd/config/current_context_test.go
+++ b/pkg/kubectl/cmd/config/current_context_test.go
@@ -66,6 +66,7 @@ func (test currentContextTest) run(t *testing.T) {
 
 	pathOptions := NewDefaultPathOptions()
 	pathOptions.GlobalFile = fakeKubeFile.Name()
+	pathOptions.EnvVar = ""
 	options := CurrentContextOptions{
 		ConfigAccess: pathOptions,
 	}


### PR DESCRIPTION
If `KUBECONFIG` is set when running unit tests, this one will fail.  Clear the env var, so you get a clean test.
