### PR TITLE
Fix 1.1 e2e's to work with 1.2 clusters with scheduler named "default-scheduler"

### DIFF
--- a/pkg/version/semver.go
+++ b/pkg/version/semver.go
@@ -44,7 +44,7 @@ func Parse(gitversion string) (semver.Version, error) {
 func MustParse(gitversion string) semver.Version {
 	v, err := Parse(gitversion)
 	if err != nil {
-		glog.Fatalf("failed to parse semver from giversion %q: %v", gitversion, err)
+		glog.Fatalf("failed to parse semver from gitversion %q: %v", gitversion, err)
 	}
 	return v
 }

--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -335,7 +335,7 @@ var _ = Describe("Density", func() {
 					fields.Set{
 						"involvedObject.kind":      "Pod",
 						"involvedObject.namespace": ns,
-						"source":                   "scheduler",
+						"source":                   getSchedulerName(c),
 					}.AsSelector())
 				expectNoError(err)
 				for k := range createTimes {

--- a/test/e2e/events.go
+++ b/test/e2e/events.go
@@ -91,7 +91,7 @@ var _ = Describe("Events", func() {
 					"involvedObject.kind":      "Pod",
 					"involvedObject.uid":       string(podWithUid.UID),
 					"involvedObject.namespace": framework.Namespace.Name,
-					"source":                   "scheduler",
+					"source":                   getSchedulerName(framework.Client),
 				}.AsSelector(),
 			)
 			if err != nil {

--- a/test/e2e/scheduler_predicates.go
+++ b/test/e2e/scheduler_predicates.go
@@ -99,14 +99,13 @@ func verifyResult(c *client.Client, podName string, ns string, oldNotRunning int
 	allPods, err := c.Pods(api.NamespaceAll).List(labels.Everything(), fields.Everything())
 	expectNoError(err)
 	_, notRunningPods := getPodsNumbers(allPods)
-
 	schedEvents, err := c.Events(ns).List(
 		labels.Everything(),
 		fields.Set{
 			"involvedObject.kind":      "Pod",
 			"involvedObject.name":      podName,
 			"involvedObject.namespace": ns,
-			"source":                   "scheduler",
+			"source":                   getSchedulerName(c),
 			"reason":                   "FailedScheduling",
 		}.AsSelector())
 	expectNoError(err)
@@ -121,7 +120,7 @@ func verifyResult(c *client.Client, podName string, ns string, oldNotRunning int
 				"involvedObject.kind":      "Pod",
 				"involvedObject.name":      podName,
 				"involvedObject.namespace": ns,
-				"source":                   "scheduler",
+				"source":                   getSchedulerName(c),
 				"reason":                   "failedScheduling",
 			}.AsSelector())
 		expectNoError(err)


### PR DESCRIPTION
Fixes #19724.

Includes a partial cherry-pick of #19608.
