### PR TITLE
Fix #19098 - misplaced cassandra-controller in cassandra example

### DIFF
--- a/examples/cassandra/cassandra-controller.yaml
+++ b/examples/cassandra/cassandra-controller.yaml
@@ -26,7 +26,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: gcr.io/google_containers/cassandra:v7
+          image: gcr.io/google_containers/cassandra:v6
           name: cassandra
           ports:
             - containerPort: 9042

--- a/examples/cassandra/cassandra-daemonset.yaml
+++ b/examples/cassandra/cassandra-daemonset.yaml
@@ -25,7 +25,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: "gcr.io/google_containers/cassandra:v7"
+          image: "gcr.io/google_containers/cassandra:v6"
           name: cassandra
           ports:
             - containerPort: 9042

--- a/examples/cassandra/cassandra.yaml
+++ b/examples/cassandra/cassandra.yaml
@@ -11,7 +11,7 @@ spec:
     resources:
       limits:
         cpu: "0.1"
-    image: gcr.io/google_containers/cassandra:v7
+    image: gcr.io/google_containers/cassandra:v6
     name: cassandra
     ports:
     - name: cql


### PR DESCRIPTION
- Fix #19098 - use cassandra pod example instead of cassandra-controller example as per examples instructions
- use `gcr.io/google_containers/cassandra:v6` instead of `v7` due to #19071 (`Permission denied` error) with v7
