### PR TITLE
Fix another instance of golang #12262

### DIFF
--- a/plugin/pkg/auth/authenticator/token/oidc/oidc_test.go
+++ b/plugin/pkg/auth/authenticator/token/oidc/oidc_test.go
@@ -309,7 +309,8 @@ func TestOIDCAuthentication(t *testing.T) {
 		t.Fatalf("Cannot load cert/key pair: %v", err)
 	}
 	srv.StartTLS()
-	defer srv.Close()
+	// TODO: Uncomment when fix #19254
+	// defer srv.Close()
 
 	op.pcfg = oidc.ProviderConfig{
 		Issuer:       srv.URL,


### PR DESCRIPTION
Reliably reproducible on two up-to-date Fedora 23 machines using
go 1.5.3, both one Core i7-4770R and a Core i7-4790.

https://github.com/golang/go/issues/12262

TestOIDCAuthentication times out because the server has a couple pending open connections.
