### PR TITLE
adding back the update when grace-period=0

### DIFF
--- a/pkg/api/rest/resttest/resttest.go
+++ b/pkg/api/rest/resttest/resttest.go
@@ -673,8 +673,7 @@ func (t *Tester) testDeleteGracefulImmediate(obj runtime.Object, setFn SetFunc, 
 		t.Errorf("unexpected error, object should be deleted immediately: %v", err)
 	}
 	objectMeta = t.getObjectMetaOrFail(out)
-	// the second delete shouldn't update the object, so the objectMeta.DeletionGracePeriodSeconds should eqaul to the value set in the first delete.
-	if objectMeta.DeletionTimestamp == nil || objectMeta.DeletionGracePeriodSeconds == nil || *objectMeta.DeletionGracePeriodSeconds != expectedGrace {
+	if objectMeta.DeletionTimestamp == nil || objectMeta.DeletionGracePeriodSeconds == nil || *objectMeta.DeletionGracePeriodSeconds != 0 {
 		t.Errorf("unexpected deleted meta: %#v", objectMeta)
 	}
 }

--- a/pkg/controller/node/nodecontroller.go
+++ b/pkg/controller/node/nodecontroller.go
@@ -325,6 +325,12 @@ func (nc *NodeController) maybeDeleteTerminatingPod(obj interface{}) {
 		return
 	}
 
+	// API server will delete the pod. To avoid a race condition, node controller
+	// shouldn't try to delete the pod.
+	if pod.DeletionGracePeriodSeconds != nil && *pod.DeletionGracePeriodSeconds == 0 {
+		return
+	}
+
 	// delete terminating pods that have not yet been scheduled
 	if len(pod.Spec.NodeName) == 0 {
 		nc.forcefullyDeletePod(pod)

--- a/pkg/registry/generic/etcd/etcd.go
+++ b/pkg/registry/generic/etcd/etcd.go
@@ -387,7 +387,7 @@ func (e *Etcd) Delete(ctx api.Context, name string, options *api.DeleteOptions) 
 	if pendingGraceful {
 		return e.finalizeDelete(obj, false)
 	}
-	if graceful && *options.GracePeriodSeconds > 0 {
+	if graceful {
 		out := e.NewFunc()
 		lastGraceful := int64(0)
 		err := e.Storage.GuaranteedUpdate(


### PR DESCRIPTION
#20202 skips the update when a pod is deleted with grace period = 0. That breaks the non-graceful deletion, pods will get a default deletion grace period even if the grace period is set to 0.

This PR adds back the update. To avoid the race condition #20202 trying to solve, this PR adds checks in node controller and kubelet before issuing a Delete request to API server. Specifically, it checks if the grace period is 0, if so, they will leave API server to delete the pod from etcd.

I've verified that the `grace-period=0` does take effect.
