### PR TITLE
E2E framework cleanups

### DIFF
--- a/test/e2e/example_cluster_dns.go
+++ b/test/e2e/example_cluster_dns.go
@@ -75,15 +75,8 @@ var _ = Describe("ClusterDns [Feature:Example]", func() {
 		namespaces := []*api.Namespace{nil, nil}
 		for i := range namespaces {
 			var err error
-			namespaces[i], err = createTestingNS(fmt.Sprintf("dnsexample%d", i), c, nil)
-			if testContext.DeleteNamespace {
-				if namespaces[i] != nil {
-					defer deleteNS(c, namespaces[i].Name, 5*time.Minute /* namespace deletion timeout */)
-				}
-				Expect(err).NotTo(HaveOccurred())
-			} else {
-				Logf("Found DeleteNamespace=false, skipping namespace deletion!")
-			}
+			namespaces[i], err = framework.CreateNamespace(fmt.Sprintf("dnsexample%d", i), nil)
+			Expect(err).NotTo(HaveOccurred())
 		}
 
 		for _, ns := range namespaces {

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -54,9 +54,6 @@ const loadBalancerLagTimeout = 2 * time.Minute
 //TODO: once support ticket 21807001 is resolved, reduce this timeout back to something reasonable
 const loadBalancerCreateTimeout = 20 * time.Minute
 
-// How long to wait for a namespace to be deleted.
-const namespaceDeleteTimeout = 5 * time.Minute
-
 // This should match whatever the default/configured range is
 var ServiceNodePortRange = utilnet.PortRange{Base: 30000, Size: 2768}
 
@@ -64,26 +61,11 @@ var _ = Describe("Services", func() {
 	f := NewFramework("services")
 
 	var c *client.Client
-	var extraNamespaces []string
 
 	BeforeEach(func() {
 		var err error
 		c, err = loadClient()
 		Expect(err).NotTo(HaveOccurred())
-	})
-
-	AfterEach(func() {
-		if testContext.DeleteNamespace {
-			for _, ns := range extraNamespaces {
-				By(fmt.Sprintf("Destroying namespace %v", ns))
-				if err := deleteNS(c, ns, namespaceDeleteTimeout); err != nil {
-					Failf("Couldn't delete namespace %s: %s", ns, err)
-				}
-			}
-			extraNamespaces = nil
-		} else {
-			Logf("Found DeleteNamespace=false, skipping namespace deletion!")
-		}
 	})
 
 	// TODO: We get coverage of TCP/UDP and multi-port services through the DNS test. We should have a simpler test for multi-port TCP here.
@@ -429,11 +411,10 @@ var _ = Describe("Services", func() {
 		Logf("namespace for TCP test: %s", ns1)
 
 		By("creating a second namespace")
-		namespacePtr, err := createTestingNS("services", c, nil)
+		namespacePtr, err := f.CreateNamespace("services", nil)
 		Expect(err).NotTo(HaveOccurred())
 		ns2 := namespacePtr.Name // LB2 in ns2 on UDP
 		Logf("namespace for UDP test: %s", ns2)
-		extraNamespaces = append(extraNamespaces, ns2)
 
 		jig := NewServiceTestJig(c, serviceName)
 		nodeIP := pickNodeIP(jig.Client) // for later

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -54,6 +54,9 @@ const loadBalancerLagTimeout = 2 * time.Minute
 //TODO: once support ticket 21807001 is resolved, reduce this timeout back to something reasonable
 const loadBalancerCreateTimeout = 20 * time.Minute
 
+// How long to wait for a namespace to be deleted.
+const namespaceDeleteTimeout = 5 * time.Minute
+
 // This should match whatever the default/configured range is
 var ServiceNodePortRange = utilnet.PortRange{Base: 30000, Size: 2768}
 
@@ -73,7 +76,7 @@ var _ = Describe("Services", func() {
 		if testContext.DeleteNamespace {
 			for _, ns := range extraNamespaces {
 				By(fmt.Sprintf("Destroying namespace %v", ns))
-				if err := deleteNS(c, ns, 5*time.Minute /* namespace deletion timeout */); err != nil {
+				if err := deleteNS(c, ns, namespaceDeleteTimeout); err != nil {
 					Failf("Couldn't delete namespace %s: %s", ns, err)
 				}
 			}
@@ -327,9 +330,9 @@ var _ = Describe("Services", func() {
 
 		By("Removing iptable rules")
 		result, err := SSH(`
-					sudo iptables -t nat -F KUBE-SERVICES || true;
-					sudo iptables -t nat -F KUBE-PORTALS-HOST || true;
-					sudo iptables -t nat -F KUBE-PORTALS-CONTAINER || true`, host, testContext.Provider)
+			sudo iptables -t nat -F KUBE-SERVICES || true;
+			sudo iptables -t nat -F KUBE-PORTALS-HOST || true;
+			sudo iptables -t nat -F KUBE-PORTALS-CONTAINER || true`, host, testContext.Provider)
 		if err != nil || result.Code != 0 {
 			LogSSHResult(result)
 			Failf("couldn't remove iptable rules: %v", err)


### PR DESCRIPTION
A few things have always bugged me about our framework.  Specifically the guarantees about cleanup are almost useless in the face of test timeouts or manual ^C (I assume a timeout == SIGINT, but I guess we'll see?).

Now this tries harder to always clean up. 

Fixes #14944
