### PR TITLE
Take GVK in SwaggerSchema()

### DIFF
--- a/pkg/kubectl/cmd/explain.go
+++ b/pkg/kubectl/cmd/explain.go
@@ -98,7 +98,7 @@ func RunExplain(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []st
 		}
 	}
 
-	schema, err := f.SwaggerSchema(apiVersion)
+	schema, err := f.SwaggerSchema(apiVersion.WithKind(gvk.Kind))
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -106,8 +106,8 @@ type Factory struct {
 	ResumeObject func(object runtime.Object) (bool, error)
 	// Returns a schema that can validate objects stored on disk.
 	Validator func(validate bool, cacheDir string) (validation.Schema, error)
-	// SwaggerSchema returns the schema declaration for the provided group version.
-	SwaggerSchema func(unversioned.GroupVersion) (*swagger.ApiDeclaration, error)
+	// SwaggerSchema returns the schema declaration for the provided group version kind.
+	SwaggerSchema func(unversioned.GroupVersionKind) (*swagger.ApiDeclaration, error)
 	// Returns the default namespace to use in cases where no
 	// other namespace is specified and whether the namespace was
 	// overriden.
@@ -408,7 +408,8 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 			}
 			return validation.NullSchema{}, nil
 		},
-		SwaggerSchema: func(version unversioned.GroupVersion) (*swagger.ApiDeclaration, error) {
+		SwaggerSchema: func(gvk unversioned.GroupVersionKind) (*swagger.ApiDeclaration, error) {
+			version := gvk.GroupVersion()
 			client, err := clients.ClientForVersion(&version)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
This is needed for the legacy OpenShift API group (oapi) which is also
group: "", version: "v1", but needs to return a different swagger
schema.  Will in the future be replaced by group defaulting.

@kargakis
