### PR TITLE
Sanitize flannel config

### DIFF
--- a/cluster/saltbase/salt/flannel-server/flannel-server.manifest
+++ b/cluster/saltbase/salt/flannel-server/flannel-server.manifest
@@ -35,7 +35,7 @@
                 "args": [
                     "--network-config=/etc/kubernetes/network.json",
                     "--etcd-prefix=/kubernetes.io/network",
-                    "--etcd-server=http://127.0.0.1:4001"
+                    "--etcd-server=http://127.0.0.1:{{ etcd_port }}"
                 ],
                 "volumeMounts": [
                     {
@@ -51,7 +51,7 @@
                 "command": [
                     "/bin/sh",
                     "-c",
-                    "/opt/bin/flanneld -listen 0.0.0.0:10253 -etcd-endpoints http://127.0.0.1:4001 -etcd-prefix /kubernetes.io/network 1>>/var/log/flannel_server.log 2>&1"
+                    "/opt/bin/flanneld -listen 0.0.0.0:10253 -etcd-endpoints http://127.0.0.1:{{ etcd_port }} -etcd-prefix /kubernetes.io/network 1>>/var/log/flannel_server.log 2>&1"
                 ],
                 "ports": [
                     {
@@ -77,15 +77,28 @@
                 "command": [
                     "/bin/sh",
                     "-c",
-                    "/opt/bin/etcd --listen-peer-urls http://127.0.0.1:4001 --addr http://127.0.0.1:4001 --bind-addr 127.0.0.1:4001 --data-dir /var/etcd/data 1>>/var/log/etcd_flannel.log 2>&1"
+                    "/usr/local/bin/etcd --listen-peer-urls http://127.0.0.1:{{ etcd_peer_port }} --addr 127.0.0.1:{{ etcd_port }} --bind-addr 127.0.0.1:{{ etcd_port }} --data-dir /var/etcd/data 1>>/var/log/etcd_flannel.log 2>&1"
                 ],
+                "livenessProbe": {
+                    "httpGet": {
+                        "host": "127.0.0.1",
+                        "port": {{ etcd_port }},
+                        "path": "/health"
+                    },
+                    "initialDelaySeconds": 15,
+                    "timeoutSeconds": 15
+                },
                 "resources": {
                     "limits": {
-                        "cpu": "100m",
-                        "memory": "50Mi"
+                        "cpu": {{ cpulimit }},
+                        "memory": {{ memlimit }}
                     }
                 },
                 "volumeMounts": [
+                    {
+                        "name": "varlog",
+                        "mountPath": "/var/log"
+                    },
                     {
                         "name": "etcdstorage",
                         "mountPath": "/var/etcd/data"
@@ -96,4 +109,3 @@
         "hostNetwork": true
     }
 }
-

--- a/cluster/saltbase/salt/flannel-server/init.sls
+++ b/cluster/saltbase/salt/flannel-server/init.sls
@@ -22,3 +22,10 @@ touch /var/log/etcd_flannel.log:
     - mode: 644
     - makedirs: true
     - dir_mode: 755
+    - template: jinja
+    - context:
+        etcd_port: 4003
+        etcd_peer_port: 2382
+        cpulimit: '"100m"'
+        memlimit: '"50Mi"'
+


### PR DESCRIPTION
No excuses for my inability to write salt. Why the flannel builder is straight green is left as an exercise for the reader (http://kubekins.dls.corp.google.com/job/kubernetes-e2e-gce-flannel/).
