### PR TITLE
e2e SecurityContext tests wrong volume dir

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -364,6 +364,7 @@ upgrade-target
 use-kubernetes-cluster-service
 user-whitelist
 verify-only
+volume-dir
 volume-plugin-dir
 volume-stats-agg-period
 watch-cache

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -63,6 +63,7 @@ func RegisterFlags() {
 
 	flag.StringVar(&testContext.KubeConfig, clientcmd.RecommendedConfigPathFlag, "", "Path to kubeconfig containing embedded authinfo.")
 	flag.StringVar(&testContext.KubeContext, clientcmd.FlagContext, "", "kubeconfig context to use/override. If unset, will use value from 'current-context'")
+	flag.StringVar(&testContext.KubeVolumeDir, "volume-dir", "/var/lib/kubelet", "Path to the directory containing the kubelet volumes.")
 	flag.StringVar(&testContext.CertDir, "cert-dir", "", "Path to the directory containing the certs. Default is empty, which doesn't use certs.")
 	flag.StringVar(&testContext.Host, "host", "", "The host, or apiserver, to connect to")
 	flag.StringVar(&testContext.RepoRoot, "repo-root", "../../", "Root directory of kubernetes repository, for finding test files.")

--- a/test/e2e/security_context.go
+++ b/test/e2e/security_context.go
@@ -154,8 +154,8 @@ func testPodSELinuxLabeling(framework *Framework, hostIPC bool, hostPID bool) {
 
 	// Confirm that the file can be accessed from a second
 	// pod using host_path with the same MCS label
-	volumeHostPath := fmt.Sprintf("/var/lib/kubelet/pods/%s/volumes/kubernetes.io~empty-dir/%s", foundPod.UID, volumeName)
-	By("confirming a container with the same label can read the file")
+	volumeHostPath := fmt.Sprintf("%s/pods/%s/volumes/kubernetes.io~empty-dir/%s", testContext.KubeVolumeDir, foundPod.UID, volumeName)
+	By(fmt.Sprintf("confirming a container with the same label can read the file under --volume-dir=%s", testContext.KubeVolumeDir))
 	pod = scTestPod(hostIPC, hostPID)
 	pod.Spec.NodeName = foundPod.Spec.NodeName
 	volumeMounts := []api.VolumeMount{

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -139,6 +139,7 @@ var runId = util.NewUUID()
 type TestContextType struct {
 	KubeConfig            string
 	KubeContext           string
+	KubeVolumeDir         string
 	CertDir               string
 	Host                  string
 	RepoRoot              string


### PR DESCRIPTION
The volume directory is not guaranteed to be /var/lib/kubelet
for a conforming implementation of Kubernetes.  Add --volume-dir
and an internal shim
