### PR TITLE
Fix sort-by indentation issue.

### DIFF
--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -276,7 +276,7 @@ func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string
 			}
 			continue
 		}
-		if err := printer.PrintObj(objs[ix], out); err != nil {
+		if err := printer.PrintObj(objs[ix], w); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
With kubectl get --sort-by, the output formatting is incorrectly indented:

```
FIRSTSEEN   LASTSEEN   COUNT     NAME        KIND      SUBOBJECT   TYPE      REASON     SOURCE                   MESSAGE
44s         44s        1         127.0.0.1   Node                  Normal    Starting   {kube-proxy 127.0.0.1}   Starting kube-proxy.
43s       43s       1         127.0.0.1   Node                Normal    Starting   {kubelet 127.0.0.1}   Starting kubelet.
43s       43s       1         127.0.0.1   Node                Normal    NodeHasSufficientDisk   {kubelet 127.0.0.1}   Node 127.0.0.1 status is now: NodeHasSufficientDisk
39s       39s       1         127.0.0.1   Node                Normal    RegisteredNode   {controllermanager }   Node 127.0.0.1 event: Registered Node 127.0.0.1 in NodeController
```

This commit fixes this issue.
