### PR TITLE
Allow custom namespace creation in e2e framework

### DIFF
--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -225,6 +225,10 @@ func (f *Framework) afterEach() {
 }
 
 func (f *Framework) CreateNamespace(baseName string, labels map[string]string) (*api.Namespace, error) {
+	createTestingNS := testContext.CreateTestingNS
+	if createTestingNS == nil {
+		createTestingNS = CreateTestingNS
+	}
 	ns, err := createTestingNS(baseName, f.Client, labels)
 	if err == nil {
 		f.namespacesToDelete = append(f.namespacesToDelete, ns)

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -152,6 +152,8 @@ type CloudConfig struct {
 // unique identifier of the e2e run
 var runId = util.NewUUID()
 
+type CreateTestingNSFn func(baseName string, c *client.Client, labels map[string]string) (*api.Namespace, error)
+
 type TestContextType struct {
 	KubeConfig            string
 	KubeContext           string
@@ -178,6 +180,10 @@ type TestContextType struct {
 	GatherMetricsAfterTest            bool
 	// Currently supported values are 'hr' for human-readable and 'json'. It's a comma separated list.
 	OutputPrintType string
+	// CreateTestingNS is responsible for creating namespace used for executing e2e tests.
+	// It accepts namespace base name, which will be prepended with e2e prefix, kube client
+	// and labels to be applied to a namespace.
+	CreateTestingNS CreateTestingNSFn
 }
 
 var testContext TestContextType
@@ -652,9 +658,9 @@ func waitForPersistentVolumePhase(phase api.PersistentVolumePhase, c *client.Cli
 	return fmt.Errorf("PersistentVolume %s not in phase %s within %v", pvName, phase, timeout)
 }
 
-// createTestingNS should be used by every test, note that we append a common prefix to the provided test name.
+// CreateTestingNS should be used by every test, note that we append a common prefix to the provided test name.
 // Please see NewFramework instead of using this directly.
-func createTestingNS(baseName string, c *client.Client, labels map[string]string) (*api.Namespace, error) {
+func CreateTestingNS(baseName string, c *client.Client, labels map[string]string) (*api.Namespace, error) {
 	if labels == nil {
 		labels = map[string]string{}
 	}


### PR DESCRIPTION
Supersedes  #12221.

Previously we allowed setting NsCreateFunc on a framework, which in certain OpenShift usecases is sufficient. We need a way to inject our security constraints at the namespace creation. To address that I've added a parameter in `TestContextType` which will allow replacing default ns creation function. 
If such is not provided I'm using the default one from `test/e2e/util.go`, which I've also made public with this PR for reuse inside OpenShift.

@ixdy @mfojtik @deads2k @liggitt ptal
