### PR TITLE
Fix Vagrant issue with Salt

### DIFF
--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -56,6 +56,8 @@ done
 echo "127.0.0.1 localhost" >> /etc/hosts # enables cmds like 'kubectl get pods' on master.
 echo "$MASTER_IP $MASTER_NAME" >> /etc/hosts
 
+prepare-package-manager
+
 # Configure the master network
 if [ "${NETWORK_PROVIDER}" != "kubenet" ]; then
   provision-network-master

--- a/cluster/vagrant/provision-node.sh
+++ b/cluster/vagrant/provision-node.sh
@@ -52,6 +52,8 @@ for (( i=0; i<${#NODE_NAMES[@]}; i++)); do
   fi
 done
 
+prepare-package-manager
+
 # Configure network
 if [ "${NETWORK_PROVIDER}" != "kubenet" ]; then
   provision-network-node

--- a/cluster/vagrant/provision-utils.sh
+++ b/cluster/vagrant/provision-utils.sh
@@ -14,6 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+function prepare-package-manager() {
+  echo "Prepare package manager"
+
+  # Useful if a mirror is broken or slow
+  echo "fastestmirror=True" >> /etc/dnf/dnf.conf
+
+  # In Fedora 23, installed version does not work with Salt
+  # Cf. https://github.com/saltstack/salt/issues/31001
+  dnf update -y dnf dnf-plugins-core
+}
+
 function write-salt-config() {
   local role="$1"
 


### PR DESCRIPTION
Package manager "dnf" does not work correctly with Salt
(cf https://github.com/saltstack/salt/issues/31001)

It causes Salt to consider that some packages (python, git, curl, etc.) are not
installed, which breaks the Vagrant Kubernetes setup.

Updating dnf and dnf-plugins-core to their latest version solves the issue.

Additionally, I've added the "fastestmirror" to dnf, which is useful if a
RPM mirror is broken or very slow. (In my case, dnf used a broken mirror which
froze the Kubernetes setup).
