### PR TITLE
Make 1.1 kube-ui test forward-compatible with 1.2

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -905,7 +905,7 @@ var multiSchedulerVersion = version.MustParse("v1.2.0-alpha.6")
 
 func getSchedulerName(c client.VersionInterface) string {
 	serverVersionGTEMultiSchedulerVersion, err := serverVersionGTE(multiSchedulerVersion, c)
-	if err != nil && serverVersionGTEMultiSchedulerVersion {
+	if err == nil && serverVersionGTEMultiSchedulerVersion {
 		return "default-scheduler"
 	}
 	return "scheduler"


### PR DESCRIPTION
Make v1.1 tests compatible with #20563.

Backport #20563, this test should never have been part of conformance.  cc @kubernetes/sig-testing.

Diffbased off of #20740; WIP until that goes in.
