### PR TITLE
e2e: use the tagged busybox image to avoid unnecessary pulling

### DIFF
--- a/test/e2e/configmap.go
+++ b/test/e2e/configmap.go
@@ -62,7 +62,7 @@ var _ = Describe("ConfigMap", func() {
 				Containers: []api.Container{
 					{
 						Name:    "env-test",
-						Image:   "gcr.io/google_containers/busybox",
+						Image:   "gcr.io/google_containers/busybox:1.24",
 						Command: []string{"sh", "-c", "env"},
 						Env: []api.EnvVar{
 							{

--- a/test/e2e/downward_api.go
+++ b/test/e2e/downward_api.go
@@ -91,7 +91,7 @@ func testDownwardAPI(framework *Framework, podName string, env []api.EnvVar, exp
 			Containers: []api.Container{
 				{
 					Name:    "dapi-container",
-					Image:   "gcr.io/google_containers/busybox",
+					Image:   "gcr.io/google_containers/busybox:1.24",
 					Command: []string{"sh", "-c", "env"},
 					Env:     env,
 				},

--- a/test/e2e/expansion.go
+++ b/test/e2e/expansion.go
@@ -37,7 +37,7 @@ var _ = Describe("Variable Expansion", func() {
 				Containers: []api.Container{
 					{
 						Name:    "dapi-container",
-						Image:   "gcr.io/google_containers/busybox",
+						Image:   "gcr.io/google_containers/busybox:1.24",
 						Command: []string{"sh", "-c", "env"},
 						Env: []api.EnvVar{
 							{
@@ -77,7 +77,7 @@ var _ = Describe("Variable Expansion", func() {
 				Containers: []api.Container{
 					{
 						Name:    "dapi-container",
-						Image:   "gcr.io/google_containers/busybox",
+						Image:   "gcr.io/google_containers/busybox:1.24",
 						Command: []string{"sh", "-c", "TEST_VAR=wrong echo \"$(TEST_VAR)\""},
 						Env: []api.EnvVar{
 							{
@@ -107,7 +107,7 @@ var _ = Describe("Variable Expansion", func() {
 				Containers: []api.Container{
 					{
 						Name:    "dapi-container",
-						Image:   "gcr.io/google_containers/busybox",
+						Image:   "gcr.io/google_containers/busybox:1.24",
 						Command: []string{"sh", "-c"},
 						Args:    []string{"TEST_VAR=wrong echo \"$(TEST_VAR)\""},
 						Env: []api.EnvVar{

--- a/test/e2e/garbage_collector.go
+++ b/test/e2e/garbage_collector.go
@@ -73,7 +73,7 @@ func createTerminatingPod(f *Framework) (*api.Pod, error) {
 			Containers: []api.Container{
 				{
 					Name:  string(uuid),
-					Image: "gcr.io/google_containers/busybox",
+					Image: "gcr.io/google_containers/busybox:1.24",
 				},
 			},
 		},

--- a/test/e2e/job.go
+++ b/test/e2e/job.go
@@ -223,7 +223,7 @@ func newTestJob(behavior, name string, rPol api.RestartPolicy, parallelism, comp
 					Containers: []api.Container{
 						{
 							Name:    "c",
-							Image:   "gcr.io/google_containers/busybox",
+							Image:   "gcr.io/google_containers/busybox:1.24",
 							Command: []string{},
 							VolumeMounts: []api.VolumeMount{
 								{

--- a/test/e2e/networking.go
+++ b/test/e2e/networking.go
@@ -64,7 +64,7 @@ var _ = Describe("Networking", func() {
 				Containers: []api.Container{
 					{
 						Name:    contName,
-						Image:   "gcr.io/google_containers/busybox",
+						Image:   "gcr.io/google_containers/busybox:1.24",
 						Command: []string{"wget", "-s", "google.com"},
 					},
 				},

--- a/test/e2e/pd.go
+++ b/test/e2e/pd.go
@@ -396,7 +396,7 @@ func testPDPod(diskNames []string, targetHost string, readOnly bool, numContaine
 			containers[i].Name = fmt.Sprintf("mycontainer%v", i+1)
 		}
 
-		containers[i].Image = "gcr.io/google_containers/busybox"
+		containers[i].Image = "gcr.io/google_containers/busybox:1.24"
 
 		containers[i].Command = []string{"sleep", "6000"}
 

--- a/test/e2e/persistent_volumes.go
+++ b/test/e2e/persistent_volumes.go
@@ -162,7 +162,7 @@ func makeCheckPod(ns string, nfsserver string) *api.Pod {
 			Containers: []api.Container{
 				{
 					Name:    "scrub-checker",
-					Image:   "gcr.io/google_containers/busybox",
+					Image:   "gcr.io/google_containers/busybox:1.24",
 					Command: []string{"/bin/sh"},
 					Args:    []string{"-c", "test ! -e /mnt/index.html || exit 1"},
 					VolumeMounts: []api.VolumeMount{

--- a/test/e2e/pods.go
+++ b/test/e2e/pods.go
@@ -618,7 +618,7 @@ var _ = Describe("Pods", func() {
 				Containers: []api.Container{
 					{
 						Name:    "env3cont",
-						Image:   "gcr.io/google_containers/busybox",
+						Image:   "gcr.io/google_containers/busybox:1.24",
 						Command: []string{"sh", "-c", "env"},
 					},
 				},
@@ -647,7 +647,7 @@ var _ = Describe("Pods", func() {
 				Containers: []api.Container{
 					{
 						Name:    "liveness",
-						Image:   "gcr.io/google_containers/busybox",
+						Image:   "gcr.io/google_containers/busybox:1.24",
 						Command: []string{"/bin/sh", "-c", "echo ok >/tmp/health; sleep 10; rm -rf /tmp/health; sleep 600"},
 						LivenessProbe: &api.Probe{
 							Handler: api.Handler{
@@ -674,7 +674,7 @@ var _ = Describe("Pods", func() {
 				Containers: []api.Container{
 					{
 						Name:    "liveness",
-						Image:   "gcr.io/google_containers/busybox",
+						Image:   "gcr.io/google_containers/busybox:1.24",
 						Command: []string{"/bin/sh", "-c", "echo ok >/tmp/health; sleep 600"},
 						LivenessProbe: &api.Probe{
 							Handler: api.Handler{
@@ -799,7 +799,7 @@ var _ = Describe("Pods", func() {
 				Containers: []api.Container{
 					{
 						Name:    "main",
-						Image:   "gcr.io/google_containers/busybox",
+						Image:   "gcr.io/google_containers/busybox:1.24",
 						Command: []string{"/bin/sh", "-c", "echo container is alive; sleep 600"},
 					},
 				},
@@ -878,7 +878,7 @@ var _ = Describe("Pods", func() {
 				Containers: []api.Container{
 					{
 						Name:    "main",
-						Image:   "gcr.io/google_containers/busybox",
+						Image:   "gcr.io/google_containers/busybox:1.24",
 						Command: []string{"/bin/sh", "-c", "echo container is alive; sleep 600"},
 					},
 				},
@@ -943,7 +943,7 @@ var _ = Describe("Pods", func() {
 				Containers: []api.Container{
 					{
 						Name:    containerName,
-						Image:   "gcr.io/google_containers/busybox",
+						Image:   "gcr.io/google_containers/busybox:1.24",
 						Command: []string{"/bin/sh", "-c", "sleep 5", "/crash/missing"},
 					},
 				},
@@ -994,7 +994,7 @@ var _ = Describe("Pods", func() {
 				Containers: []api.Container{
 					{
 						Name:    containerName,
-						Image:   "gcr.io/google_containers/busybox",
+						Image:   "gcr.io/google_containers/busybox:1.24",
 						Command: []string{"/bin/sh", "-c", "echo ok >/tmp/health; sleep 5; rm -rf /tmp/health; sleep 600"},
 						LivenessProbe: &api.Probe{
 							Handler: api.Handler{
@@ -1035,7 +1035,7 @@ var _ = Describe("Pods", func() {
 				Containers: []api.Container{
 					{
 						Name:    containerName,
-						Image:   "gcr.io/google_containers/busybox",
+						Image:   "gcr.io/google_containers/busybox:1.24",
 						Command: []string{"/bin/sh", "-c", "sleep 5", "/crash/missing"},
 					},
 				},

--- a/test/e2e/pre_stop.go
+++ b/test/e2e/pre_stop.go
@@ -76,7 +76,7 @@ func testPreStop(c *client.Client, ns string) {
 			Containers: []api.Container{
 				{
 					Name:    "tester",
-					Image:   "gcr.io/google_containers/busybox",
+					Image:   "gcr.io/google_containers/busybox:1.24",
 					Command: []string{"sleep", "600"},
 					Lifecycle: &api.Lifecycle{
 						PreStop: &api.Handler{

--- a/test/e2e/secrets.go
+++ b/test/e2e/secrets.go
@@ -131,7 +131,7 @@ var _ = Describe("Secrets", func() {
 				Containers: []api.Container{
 					{
 						Name:    "secret-env-test",
-						Image:   "gcr.io/google_containers/busybox",
+						Image:   "gcr.io/google_containers/busybox:1.24",
 						Command: []string{"sh", "-c", "env"},
 						Env: []api.EnvVar{
 							{

--- a/test/e2e/security_context.go
+++ b/test/e2e/security_context.go
@@ -47,7 +47,7 @@ func scTestPod(hostIPC bool, hostPID bool) *api.Pod {
 			Containers: []api.Container{
 				{
 					Name:  "test-container",
-					Image: "gcr.io/google_containers/busybox",
+					Image: "gcr.io/google_containers/busybox:1.24",
 				},
 			},
 			RestartPolicy: api.RestartPolicyNever,

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -1031,7 +1031,7 @@ func createExecPodOrFail(c *client.Client, ns, name string) {
 			Containers: []api.Container{
 				{
 					Name:    "exec",
-					Image:   "gcr.io/google_containers/busybox",
+					Image:   "gcr.io/google_containers/busybox:1.24",
 					Command: []string{"sh", "-c", "while true; do sleep 5; done"},
 				},
 			},

--- a/test/e2e/volumes.go
+++ b/test/e2e/volumes.go
@@ -293,7 +293,7 @@ func injectHtml(client *client.Client, config VolumeTestConfig, volume api.Volum
 			Containers: []api.Container{
 				{
 					Name:    config.prefix + "-injector",
-					Image:   "gcr.io/google_containers/busybox",
+					Image:   "gcr.io/google_containers/busybox:1.24",
 					Command: []string{"/bin/sh"},
 					Args:    []string{"-c", "echo '" + content + "' > /mnt/index.html && chmod o+rX /mnt /mnt/index.html"},
 					VolumeMounts: []api.VolumeMount{


### PR DESCRIPTION
This fixes kubernetes/kubernetes#20418. 

Note that this PR only fixes tests in `e2e/pods.go`. kubernetes/kubernetes#20836 is filed to address the same issue in all e2e tests.
