### PR TITLE
fix group mapping and encoding order

### DIFF
--- a/pkg/apimachinery/registered/registered.go
+++ b/pkg/apimachinery/registered/registered.go
@@ -114,22 +114,24 @@ func IsEnabledVersion(v unversioned.GroupVersion) bool {
 	return found
 }
 
-// EnabledVersions returns all enabled versions.
-func EnabledVersions() (ret []unversioned.GroupVersion) {
-	for v := range enabledVersions {
-		ret = append(ret, v)
+// EnabledVersions returns all enabled versions.  Groups are randomly ordered, but versions within groups
+// are priority order from best to worst
+func EnabledVersions() []unversioned.GroupVersion {
+	ret := []unversioned.GroupVersion{}
+	for _, groupMeta := range groupMetaMap {
+		ret = append(ret, groupMeta.GroupVersions...)
 	}
-	return
+	return ret
 }
 
-// EnabledVersionsForGroup returns all enabled versions for a group.
-func EnabledVersionsForGroup(group string) (ret []unversioned.GroupVersion) {
-	for v := range enabledVersions {
-		if v.Group == group {
-			ret = append(ret, v)
-		}
+// EnabledVersionsForGroup returns all enabled versions for a group in order of best to worst
+func EnabledVersionsForGroup(group string) []unversioned.GroupVersion {
+	groupMeta, ok := groupMetaMap[group]
+	if !ok {
+		return []unversioned.GroupVersion{}
 	}
-	return
+
+	return append([]unversioned.GroupVersion{}, groupMeta.GroupVersions...)
 }
 
 // Group returns the metadata of a group if the gruop is registered, otherwise

--- a/pkg/runtime/serializer/versioning/versioning.go
+++ b/pkg/runtime/serializer/versioning/versioning.go
@@ -57,12 +57,20 @@ func NewCodec(
 	if encodeVersion != nil {
 		internal.encodeVersion = make(map[string]unversioned.GroupVersion)
 		for _, v := range encodeVersion {
+			// first one for a group wins.  This is consistent with best to worst order throughout the codebase
+			if _, ok := internal.encodeVersion[v.Group]; ok {
+				continue
+			}
 			internal.encodeVersion[v.Group] = v
 		}
 	}
 	if decodeVersion != nil {
 		internal.decodeVersion = make(map[string]unversioned.GroupVersion)
 		for _, v := range decodeVersion {
+			// first one for a group wins.  This is consistent with best to worst order throughout the codebase
+			if _, ok := internal.decodeVersion[v.Group]; ok {
+				continue
+			}
 			internal.decodeVersion[v.Group] = v
 		}
 	}


### PR DESCRIPTION
This makes the order of `EnabledVersions` predictable and then makes use of that order for the `JSONEncoder` method to give a stable and proper ordering.

Without this, `edit` breaks on multiple versions.
