### PR TITLE
MESOS: add replicaset controller to k8sm controller manager

### DIFF
--- a/contrib/mesos/pkg/controllermanager/controllermanager.go
+++ b/contrib/mesos/pkg/controllermanager/controllermanager.go
@@ -46,6 +46,7 @@ import (
 	persistentvolumecontroller "k8s.io/kubernetes/pkg/controller/persistentvolume"
 	"k8s.io/kubernetes/pkg/controller/podautoscaler"
 	"k8s.io/kubernetes/pkg/controller/podautoscaler/metrics"
+	replicaset "k8s.io/kubernetes/pkg/controller/replicaset"
 	replicationcontroller "k8s.io/kubernetes/pkg/controller/replication"
 	resourcequotacontroller "k8s.io/kubernetes/pkg/controller/resourcequota"
 	routecontroller "k8s.io/kubernetes/pkg/controller/route"
@@ -233,6 +234,12 @@ func (s *CMServer) Run(_ []string) error {
 			glog.Infof("Starting deployment controller")
 			go deployment.NewDeploymentController(clientset.NewForConfigOrDie(client.AddUserAgent(kubeconfig, "deployment-controller")), s.resyncPeriod).
 				Run(s.ConcurrentDeploymentSyncs, wait.NeverStop)
+		}
+
+		if containsResource(resources, "replicasets") {
+			glog.Infof("Starting ReplicaSet controller")
+			go replicaset.NewReplicaSetController(clientset.NewForConfigOrDie(client.AddUserAgent(kubeconfig, "replicaset-controller")), s.resyncPeriod, replicaset.BurstReplicas).
+				Run(s.ConcurrentRSSyncs, wait.NeverStop)
 		}
 	}
 


### PR DESCRIPTION
replicaset controller landed in #19806 but the k8sm controller manager wasn't updated -- this PR remedies that.

required for k8sm conformance: https://github.com/mesosphere/kubernetes-mesos/issues/774
