### PR TITLE
Upgrade gce cluster to docker 1.9.1

### DIFF
--- a/cluster/saltbase/salt/docker/init.sls
+++ b/cluster/saltbase/salt/docker/init.sls
@@ -203,10 +203,10 @@ net.ipv4.ip_forward:
 {% if grains.get('cloud', '') == 'gce'
    and grains.get('os_family', '') == 'Debian'
    and grains.get('oscodename', '') == 'wheezy' -%}
-{% set docker_pkg_name='' %}
-{% set override_deb='' %}
-{% set override_deb_sha1='' %}
-{% set override_docker_ver='' %}
+{% set docker_pkg_name='docker-engine' %}
+{% set override_deb='docker-engine_1.9.1-0~wheezy_amd64.deb' %}
+{% set override_deb_sha1='d682e2f0545e21f2d7309c2d87826aa566cc4af0' %}
+{% set override_docker_ver='1.9.1' %}
 # Ubuntu presents as os_family=Debian, osfullname=Ubuntu
 {% elif grains.get('cloud', '') == 'aws'
    and grains.get('os_family', '') == 'Debian'


### PR DESCRIPTION
docker 1.9.1 passed our functionality test and performance check: https://github.com/kubernetes/kubernetes/issues/16110

cc/ @andyzheng0831 to resolve your dependency issues
cc/ @roberthbailey and @alex-mohr to resolve your concerns on lagging behind too much on docker release. 
cc/ @kubernetes/goog-node
We are going to monitor the soaking test and resource overhead for this version. If all are green, we are going to bake this version into our containervm image. 

cc/ @imkin FYI. 

close #16110
