### PR TITLE
Fix two issues of master on Trusty

### DIFF
--- a/cluster/gce/trusty/master.yaml
+++ b/cluster/gce/trusty/master.yaml
@@ -204,12 +204,49 @@ script
 	. /etc/kube-configure.sh
 	. /etc/kube-env
 	start_etcd_servers
+	start_fluentd
 	compute_master_manifest_variables
 	start_kube_apiserver
 	start_kube_controller_manager
 	start_kube_scheduler
-	start_kube_addons
+	prepare_kube_addons
 end script
+
+--====================================
+MIME-Version: 1.0
+Content-Type: text/upstart-job; charset="us-ascii"
+Content-Transfer-Encoding: 7bit
+Content-Disposition: attachment; filename="kube-addons.conf"
+
+#upstart-job
+
+description "Run kubernetes addon pods"
+
+start on stopped kube-master-components
+
+respawn
+
+script
+	set -o errexit
+	set -o nounset
+
+	. /etc/kube-env
+
+	export HOME="/root"
+	if [ "${TEST_CLUSTER:-}" = "true" ]; then
+		export KUBECTL_BIN="/usr/local/bin/kubectl"
+	else
+		export KUBECTL_BIN="/usr/bin/kubectl"
+	fi
+	export TOKEN_DIR="/etc/srv/kubernetes"
+	export kubelet_kubeconfig_file="/var/lib/kubelet/kubeconfig"
+	export TRUSTY_MASTER="true"
+	# Run the script to start and monitoring addon manifest changes.
+	exec /var/lib/cloud/scripts/kubernetes/kube-addons.sh
+end script
+
+# Wait for 10s to start it again.
+post-stop exec sleep 10
 
 --====================================
 MIME-Version: 1.0


### PR DESCRIPTION
This change moves the code of running and monitoring addon pods in a daemon type upstart job, so that addon manifest monitoring can be restarted automatically upon failure. Second, it updates the usage of "kube-ui" to "dashboard" to match the change in PR #20330.
