### PR TITLE
docs: replace Rocket with rkt

### DIFF
--- a/cluster/aws/coreos/node.yaml
+++ b/cluster/aws/coreos/node.yaml
@@ -6,7 +6,7 @@ coreos:
       command: start
       content: |
         [Unit]
-        Description=Fetch Rocket
+        Description=Fetch rkt
         Documentation=http://github.com/coreos/rkt
         Requires=network-online.target
         After=network-online.target

--- a/docs/devel/mesos-style.md
+++ b/docs/devel/mesos-style.md
@@ -129,7 +129,7 @@ In contrast, in Mesos, API operations go to a particular framework. However, the
 in the API server rather than in the controller. Of course you can choose to make these operations be no-ops for
 your application-specific collection abstractions, and handle them in your controller.
 * On the node level, Mesos allows application-specific executors, whereas Kubernetes only has
-executors for Docker and Rocket containers.
+executors for Docker and rkt containers.
 
 The end-to-end flow is
 

--- a/docs/proposals/selinux.md
+++ b/docs/proposals/selinux.md
@@ -74,9 +74,9 @@ use-cases:
 We should avoid using the `:z` flag, because it relaxes the SELinux context so that any container
 (from an SELinux standpoint) can use the volume.
 
-### Rocket
+### rkt
 
-Rocket currently reads the base SELinux context to use from `/etc/selinux/*/contexts/lxc_contexts`
+rkt currently reads the base SELinux context to use from `/etc/selinux/*/contexts/lxc_contexts`
 and allocates a unique MCS label per pod.
 
 ### Kubernetes

--- a/docs/proposals/volumes.md
+++ b/docs/proposals/volumes.md
@@ -90,15 +90,15 @@ There is a [proposal](https://github.com/docker/docker/pull/14632) to add a bind
 Docker to change the ownership of a volume to the effective UID and GID of a container, but this has
 not yet been accepted.
 
-### Rocket
+### rkt
 
-Rocket
+rkt
 [image manifests](https://github.com/appc/spec/blob/master/spec/aci.md#image-manifest-schema) can
-specify users and groups, similarly to how a Docker image can.  A Rocket
+specify users and groups, similarly to how a Docker image can.  A rkt
 [pod manifest](https://github.com/appc/spec/blob/master/spec/pods.md#pod-manifest-schema) can also
 override the default user and group specified by the image manifest.
 
-Rocket does not currently support supplemental groups or changing the owning UID or
+rkt does not currently support supplemental groups or changing the owning UID or
 group of a volume, but it has been [requested](https://github.com/coreos/rkt/issues/1309).
 
 ## Use Cases

--- a/docs/user-guide/overview.md
+++ b/docs/user-guide/overview.md
@@ -38,7 +38,7 @@ Kubernetes is an open-source system for managing containerized applications acro
 
 Kubernetes provides mechanisms for application deployment, scheduling, updating, maintenance, and scaling. A key feature of Kubernetes is that it actively manages the containers to ensure that the state of the cluster continually matches the user's intentions. An operations user should be able to launch a micro-service, letting the scheduler find the right placement. We also want to improve the tools and experience for how users can roll-out applications through patterns like canary deployments.
 
-Kubernetes supports [Docker](http://www.docker.io) and [Rocket](https://coreos.com/blog/rocket/) containers, and other container image formats and container runtimes will be supported in the future.
+Kubernetes supports [Docker](http://www.docker.io) and [rkt](https://coreos.com/blog/rocket/) containers, and other container image formats and container runtimes will be supported in the future.
 
 While Kubernetes currently focuses on continuously-running stateless (e.g. web server or in-memory object cache) and "cloud native" stateful applications (e.g. NoSQL datastores), in the near future it will support all the other workload types commonly found in production cluster environments, such as batch, stream processing, and traditional databases.
 


### PR DESCRIPTION
Long ago the Rocket project was renamed to rkt. This updates the kubernetes docs to reflect that.

Note that the lower-case rkt should be used even at the beginning of sentences.
