### PR TITLE
cluster/gce/coreos: Add command in addon templates.

### DIFF
--- a/cluster/gce/coreos/kube-manifests/addons/cluster-loadbalancing/glbc/glbc-controller.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/cluster-loadbalancing/glbc/glbc-controller.yaml
@@ -63,6 +63,8 @@ spec:
           requests:
             cpu: 100m
             memory: 50Mi
+        command:
+        - /glbc
         args:
         - --default-backend-service=kube-system/default-http-backend
         - --sync-period=300s

--- a/cluster/gce/coreos/kube-manifests/addons/dns/skydns-rc.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/dns/skydns-rc.yaml
@@ -53,8 +53,9 @@ spec:
           requests:
             cpu: 100m
             memory: 50Mi
+        command:
+        - /kube2sky
         args:
-        # command = "/kube2sky"
         - -domain=${DNS_DOMAIN}
       - name: skydns
         image: gcr.io/google_containers/skydns:2015-10-13-8c72f8c
@@ -66,8 +67,9 @@ spec:
           requests:
             cpu: 100m
             memory: 50Mi
+        command:
+        - /skydns
         args:
-        # command = "/skydns"
         - -machines=http://127.0.0.1:4001
         - -addr=0.0.0.0:53
         - -ns-rotate=false
@@ -103,6 +105,8 @@ spec:
           requests:
             cpu: 10m
             memory: 20Mi
+        command:
+        - /exechealthz
         args:
         - -cmd=nslookup kubernetes.default.svc.${DNS_DOMAIN} 127.0.0.1 >/dev/null
         - -port=8080


### PR DESCRIPTION
As appc spec only has one field for executable path
(Exec v.s. ENTRYPOINT + CMD), specifying only args
will override the image's original ENTRYPOINT.

cc @jonboulle @yujuhong @sjpotter
