### PR TITLE
MESOS: fix nil panic in scheduler procurement

### DIFF
--- a/contrib/mesos/pkg/scheduler/components/scheduler.go
+++ b/contrib/mesos/pkg/scheduler/components/scheduler.go
@@ -99,6 +99,9 @@ func New(
 				// "backs off" when it can't find an offer that matches up with a pod.
 				// The backoff period for a pod can terminate sooner if an offer becomes
 				// available that matches up.
+
+				// TODO(jdef) this will never match for a pod that uses a node selector,
+				// since we're passing a nil *api.Node here.
 				return !task.Has(podtask.Launched) && ps.Fit(task, offer, nil)
 			default:
 				// no point in continuing to check for matching offers

--- a/contrib/mesos/pkg/scheduler/podtask/procurement.go
+++ b/contrib/mesos/pkg/scheduler/podtask/procurement.go
@@ -61,6 +61,8 @@ func NewDefaultProcurement(prototype *mesos.ExecutorInfo, eir executorinfo.Regis
 //
 // In contrast T.Spec is meant not to be filled by the procurement chain
 // but rather by a final scheduler instance.
+//
+// api.Node is an optional (possibly nil) param.
 type Procurement interface {
 	Procure(*T, *api.Node, *ProcureState) error
 }
@@ -129,7 +131,8 @@ func NewNodeProcurement() Procurement {
 
 		// check the NodeSelector
 		if len(t.Pod.Spec.NodeSelector) > 0 {
-			if n.Labels == nil {
+			// *api.Node is optional for procurement
+			if n == nil || n.Labels == nil {
 				return fmt.Errorf(
 					"NodeSelector %v does not match empty labels of pod %s/%s",
 					t.Pod.Spec.NodeSelector, t.Pod.Namespace, t.Pod.Name,


### PR DESCRIPTION
handle nil *api.Node in procurement and added TODO for a better long term fix

xref https://github.com/mesosphere/kubernetes-mesos/issues/768
