### PR TITLE
Revert DaemonSet update.

### DIFF
--- a/pkg/api/testing/fuzzer.go
+++ b/pkg/api/testing/fuzzer.go
@@ -397,13 +397,6 @@ func FuzzerFor(t *testing.T, version unversioned.GroupVersion, src rand.Source) 
 			s.MinReplicas = &minReplicas
 			s.CPUUtilization = &extensions.CPUTargetUtilization{TargetPercentage: int(int32(c.RandUint64()))}
 		},
-		func(s *extensions.DaemonSetUpdateStrategy, c fuzz.Continue) {
-			c.FuzzNoCustom(s)
-			s.Type = extensions.RollingUpdateDaemonSetStrategyType
-			s.RollingUpdate = &extensions.RollingUpdateDaemonSet{
-				MaxUnavailable: intstr.FromInt(10),
-			}
-		},
 		func(psp *extensions.PodSecurityPolicySpec, c fuzz.Continue) {
 			c.FuzzNoCustom(psp) // fuzz self without calling this function again
 			userTypes := []extensions.RunAsUserStrategy{extensions.RunAsUserStrategyMustRunAsNonRoot, extensions.RunAsUserStrategyMustRunAs, extensions.RunAsUserStrategyRunAsAny}

--- a/pkg/apis/extensions/types.generated.go
+++ b/pkg/apis/extensions/types.generated.go
@@ -7665,7 +7665,7 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
-func (x *DaemonSetUpdateStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
+func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
@@ -7682,13 +7682,12 @@ func (x *DaemonSetUpdateStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq643 [2]bool
 			_, _, _ = yysep643, yyq643, yy2arr643
 			const yyr643 bool = false
-			yyq643[0] = x.Type != ""
-			yyq643[1] = x.RollingUpdate != nil
+			yyq643[0] = x.Selector != nil
 			var yynn643 int
 			if yyr643 || yy2arr643 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn643 = 0
+				yynn643 = 1
 				for _, b := range yyq643 {
 					if b {
 						yynn643++
@@ -7700,496 +7699,11 @@ func (x *DaemonSetUpdateStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr643 || yy2arr643 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq643[0] {
-					x.Type.CodecEncodeSelf(e)
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq643[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("type"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					x.Type.CodecEncodeSelf(e)
-				}
-			}
-			if yyr643 || yy2arr643 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq643[1] {
-					if x.RollingUpdate == nil {
-						r.EncodeNil()
-					} else {
-						x.RollingUpdate.CodecEncodeSelf(e)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq643[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("rollingUpdate"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if x.RollingUpdate == nil {
-						r.EncodeNil()
-					} else {
-						x.RollingUpdate.CodecEncodeSelf(e)
-					}
-				}
-			}
-			if yyr643 || yy2arr643 {
-				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
-			}
-		}
-	}
-}
-
-func (x *DaemonSetUpdateStrategy) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym646 := z.DecBinary()
-	_ = yym646
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		yyct647 := r.ContainerType()
-		if yyct647 == codecSelferValueTypeMap1234 {
-			yyl647 := r.ReadMapStart()
-			if yyl647 == 0 {
-				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-			} else {
-				x.codecDecodeSelfFromMap(yyl647, d)
-			}
-		} else if yyct647 == codecSelferValueTypeArray1234 {
-			yyl647 := r.ReadArrayStart()
-			if yyl647 == 0 {
-				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				x.codecDecodeSelfFromArray(yyl647, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *DaemonSetUpdateStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys648Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys648Slc
-	var yyhl648 bool = l >= 0
-	for yyj648 := 0; ; yyj648++ {
-		if yyhl648 {
-			if yyj648 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys648Slc = r.DecodeBytes(yys648Slc, true, true)
-		yys648 := string(yys648Slc)
-		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys648 {
-		case "type":
-			if r.TryDecodeAsNil() {
-				x.Type = ""
-			} else {
-				x.Type = DaemonSetUpdateStrategyType(r.DecodeString())
-			}
-		case "rollingUpdate":
-			if r.TryDecodeAsNil() {
-				if x.RollingUpdate != nil {
-					x.RollingUpdate = nil
-				}
-			} else {
-				if x.RollingUpdate == nil {
-					x.RollingUpdate = new(RollingUpdateDaemonSet)
-				}
-				x.RollingUpdate.CodecDecodeSelf(d)
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys648)
-		} // end switch yys648
-	} // end for yyj648
-	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-}
-
-func (x *DaemonSetUpdateStrategy) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj651 int
-	var yyb651 bool
-	var yyhl651 bool = l >= 0
-	yyj651++
-	if yyhl651 {
-		yyb651 = yyj651 > l
-	} else {
-		yyb651 = r.CheckBreak()
-	}
-	if yyb651 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Type = ""
-	} else {
-		x.Type = DaemonSetUpdateStrategyType(r.DecodeString())
-	}
-	yyj651++
-	if yyhl651 {
-		yyb651 = yyj651 > l
-	} else {
-		yyb651 = r.CheckBreak()
-	}
-	if yyb651 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		if x.RollingUpdate != nil {
-			x.RollingUpdate = nil
-		}
-	} else {
-		if x.RollingUpdate == nil {
-			x.RollingUpdate = new(RollingUpdateDaemonSet)
-		}
-		x.RollingUpdate.CodecDecodeSelf(d)
-	}
-	for {
-		yyj651++
-		if yyhl651 {
-			yyb651 = yyj651 > l
-		} else {
-			yyb651 = r.CheckBreak()
-		}
-		if yyb651 {
-			break
-		}
-		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj651-1, "")
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x DaemonSetUpdateStrategyType) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	yym654 := z.EncBinary()
-	_ = yym654
-	if false {
-	} else if z.HasExtensions() && z.EncExt(x) {
-	} else {
-		r.EncodeString(codecSelferC_UTF81234, string(x))
-	}
-}
-
-func (x *DaemonSetUpdateStrategyType) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym655 := z.DecBinary()
-	_ = yym655
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		*((*string)(x)) = r.DecodeString()
-	}
-}
-
-func (x *RollingUpdateDaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym656 := z.EncBinary()
-		_ = yym656
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep657 := !z.EncBinary()
-			yy2arr657 := z.EncBasicHandle().StructToArray
-			var yyq657 [2]bool
-			_, _, _ = yysep657, yyq657, yy2arr657
-			const yyr657 bool = false
-			yyq657[0] = true
-			yyq657[1] = x.MinReadySeconds != 0
-			var yynn657 int
-			if yyr657 || yy2arr657 {
-				r.EncodeArrayStart(2)
-			} else {
-				yynn657 = 0
-				for _, b := range yyq657 {
-					if b {
-						yynn657++
-					}
-				}
-				r.EncodeMapStart(yynn657)
-				yynn657 = 0
-			}
-			if yyr657 || yy2arr657 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq657[0] {
-					yy659 := &x.MaxUnavailable
-					yym660 := z.EncBinary()
-					_ = yym660
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy659) {
-					} else if !yym660 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy659)
-					} else {
-						z.EncFallback(yy659)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq657[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("maxUnavailable"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy661 := &x.MaxUnavailable
-					yym662 := z.EncBinary()
-					_ = yym662
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy661) {
-					} else if !yym662 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy661)
-					} else {
-						z.EncFallback(yy661)
-					}
-				}
-			}
-			if yyr657 || yy2arr657 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq657[1] {
-					yym664 := z.EncBinary()
-					_ = yym664
-					if false {
-					} else {
-						r.EncodeInt(int64(x.MinReadySeconds))
-					}
-				} else {
-					r.EncodeInt(0)
-				}
-			} else {
-				if yyq657[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("minReadySeconds"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym665 := z.EncBinary()
-					_ = yym665
-					if false {
-					} else {
-						r.EncodeInt(int64(x.MinReadySeconds))
-					}
-				}
-			}
-			if yyr657 || yy2arr657 {
-				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
-			}
-		}
-	}
-}
-
-func (x *RollingUpdateDaemonSet) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym666 := z.DecBinary()
-	_ = yym666
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		yyct667 := r.ContainerType()
-		if yyct667 == codecSelferValueTypeMap1234 {
-			yyl667 := r.ReadMapStart()
-			if yyl667 == 0 {
-				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-			} else {
-				x.codecDecodeSelfFromMap(yyl667, d)
-			}
-		} else if yyct667 == codecSelferValueTypeArray1234 {
-			yyl667 := r.ReadArrayStart()
-			if yyl667 == 0 {
-				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				x.codecDecodeSelfFromArray(yyl667, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *RollingUpdateDaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys668Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys668Slc
-	var yyhl668 bool = l >= 0
-	for yyj668 := 0; ; yyj668++ {
-		if yyhl668 {
-			if yyj668 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys668Slc = r.DecodeBytes(yys668Slc, true, true)
-		yys668 := string(yys668Slc)
-		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys668 {
-		case "maxUnavailable":
-			if r.TryDecodeAsNil() {
-				x.MaxUnavailable = pkg6_intstr.IntOrString{}
-			} else {
-				yyv669 := &x.MaxUnavailable
-				yym670 := z.DecBinary()
-				_ = yym670
-				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv669) {
-				} else if !yym670 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv669)
-				} else {
-					z.DecFallback(yyv669, false)
-				}
-			}
-		case "minReadySeconds":
-			if r.TryDecodeAsNil() {
-				x.MinReadySeconds = 0
-			} else {
-				x.MinReadySeconds = int(r.DecodeInt(codecSelferBitsize1234))
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys668)
-		} // end switch yys668
-	} // end for yyj668
-	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-}
-
-func (x *RollingUpdateDaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj672 int
-	var yyb672 bool
-	var yyhl672 bool = l >= 0
-	yyj672++
-	if yyhl672 {
-		yyb672 = yyj672 > l
-	} else {
-		yyb672 = r.CheckBreak()
-	}
-	if yyb672 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.MaxUnavailable = pkg6_intstr.IntOrString{}
-	} else {
-		yyv673 := &x.MaxUnavailable
-		yym674 := z.DecBinary()
-		_ = yym674
-		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv673) {
-		} else if !yym674 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv673)
-		} else {
-			z.DecFallback(yyv673, false)
-		}
-	}
-	yyj672++
-	if yyhl672 {
-		yyb672 = yyj672 > l
-	} else {
-		yyb672 = r.CheckBreak()
-	}
-	if yyb672 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.MinReadySeconds = 0
-	} else {
-		x.MinReadySeconds = int(r.DecodeInt(codecSelferBitsize1234))
-	}
-	for {
-		yyj672++
-		if yyhl672 {
-			yyb672 = yyj672 > l
-		} else {
-			yyb672 = r.CheckBreak()
-		}
-		if yyb672 {
-			break
-		}
-		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj672-1, "")
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym676 := z.EncBinary()
-		_ = yym676
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep677 := !z.EncBinary()
-			yy2arr677 := z.EncBasicHandle().StructToArray
-			var yyq677 [4]bool
-			_, _, _ = yysep677, yyq677, yy2arr677
-			const yyr677 bool = false
-			yyq677[0] = x.Selector != nil
-			yyq677[2] = true
-			yyq677[3] = x.UniqueLabelKey != ""
-			var yynn677 int
-			if yyr677 || yy2arr677 {
-				r.EncodeArrayStart(4)
-			} else {
-				yynn677 = 1
-				for _, b := range yyq677 {
-					if b {
-						yynn677++
-					}
-				}
-				r.EncodeMapStart(yynn677)
-				yynn677 = 0
-			}
-			if yyr677 || yy2arr677 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq677[0] {
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
-						yym679 := z.EncBinary()
-						_ = yym679
+						yym645 := z.EncBinary()
+						_ = yym645
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.Selector) {
 						} else {
@@ -8200,15 +7714,15 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq677[0] {
+				if yyq643[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
-						yym680 := z.EncBinary()
-						_ = yym680
+						yym646 := z.EncBinary()
+						_ = yym646
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.Selector) {
 						} else {
@@ -8217,60 +7731,18 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr677 || yy2arr677 {
+			if yyr643 || yy2arr643 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy682 := &x.Template
-				yy682.CodecEncodeSelf(e)
+				yy648 := &x.Template
+				yy648.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("template"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy683 := &x.Template
-				yy683.CodecEncodeSelf(e)
+				yy649 := &x.Template
+				yy649.CodecEncodeSelf(e)
 			}
-			if yyr677 || yy2arr677 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq677[2] {
-					yy685 := &x.UpdateStrategy
-					yy685.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq677[2] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("updateStrategy"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy686 := &x.UpdateStrategy
-					yy686.CodecEncodeSelf(e)
-				}
-			}
-			if yyr677 || yy2arr677 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq677[3] {
-					yym688 := z.EncBinary()
-					_ = yym688
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.UniqueLabelKey))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq677[3] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("uniqueLabelKey"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym689 := z.EncBinary()
-					_ = yym689
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.UniqueLabelKey))
-					}
-				}
-			}
-			if yyr677 || yy2arr677 {
+			if yyr643 || yy2arr643 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -8283,25 +7755,25 @@ func (x *DaemonSetSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym690 := z.DecBinary()
-	_ = yym690
+	yym650 := z.DecBinary()
+	_ = yym650
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct691 := r.ContainerType()
-		if yyct691 == codecSelferValueTypeMap1234 {
-			yyl691 := r.ReadMapStart()
-			if yyl691 == 0 {
+		yyct651 := r.ContainerType()
+		if yyct651 == codecSelferValueTypeMap1234 {
+			yyl651 := r.ReadMapStart()
+			if yyl651 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl691, d)
+				x.codecDecodeSelfFromMap(yyl651, d)
 			}
-		} else if yyct691 == codecSelferValueTypeArray1234 {
-			yyl691 := r.ReadArrayStart()
-			if yyl691 == 0 {
+		} else if yyct651 == codecSelferValueTypeArray1234 {
+			yyl651 := r.ReadArrayStart()
+			if yyl651 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl691, d)
+				x.codecDecodeSelfFromArray(yyl651, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -8313,12 +7785,12 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys692Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys692Slc
-	var yyhl692 bool = l >= 0
-	for yyj692 := 0; ; yyj692++ {
-		if yyhl692 {
-			if yyj692 >= l {
+	var yys652Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys652Slc
+	var yyhl652 bool = l >= 0
+	for yyj652 := 0; ; yyj652++ {
+		if yyhl652 {
+			if yyj652 >= l {
 				break
 			}
 		} else {
@@ -8327,10 +7799,10 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys692Slc = r.DecodeBytes(yys692Slc, true, true)
-		yys692 := string(yys692Slc)
+		yys652Slc = r.DecodeBytes(yys652Slc, true, true)
+		yys652 := string(yys652Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys692 {
+		switch yys652 {
 		case "selector":
 			if r.TryDecodeAsNil() {
 				if x.Selector != nil {
@@ -8340,8 +7812,8 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Selector == nil {
 					x.Selector = new(pkg1_unversioned.LabelSelector)
 				}
-				yym694 := z.DecBinary()
-				_ = yym694
+				yym654 := z.DecBinary()
+				_ = yym654
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.Selector) {
 				} else {
@@ -8352,26 +7824,13 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Template = pkg2_api.PodTemplateSpec{}
 			} else {
-				yyv695 := &x.Template
-				yyv695.CodecDecodeSelf(d)
-			}
-		case "updateStrategy":
-			if r.TryDecodeAsNil() {
-				x.UpdateStrategy = DaemonSetUpdateStrategy{}
-			} else {
-				yyv696 := &x.UpdateStrategy
-				yyv696.CodecDecodeSelf(d)
-			}
-		case "uniqueLabelKey":
-			if r.TryDecodeAsNil() {
-				x.UniqueLabelKey = ""
-			} else {
-				x.UniqueLabelKey = string(r.DecodeString())
+				yyv655 := &x.Template
+				yyv655.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys692)
-		} // end switch yys692
-	} // end for yyj692
+			z.DecStructFieldNotFound(-1, yys652)
+		} // end switch yys652
+	} // end for yyj652
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -8379,16 +7838,16 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj698 int
-	var yyb698 bool
-	var yyhl698 bool = l >= 0
-	yyj698++
-	if yyhl698 {
-		yyb698 = yyj698 > l
+	var yyj656 int
+	var yyb656 bool
+	var yyhl656 bool = l >= 0
+	yyj656++
+	if yyhl656 {
+		yyb656 = yyj656 > l
 	} else {
-		yyb698 = r.CheckBreak()
+		yyb656 = r.CheckBreak()
 	}
-	if yyb698 {
+	if yyb656 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8401,21 +7860,21 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.Selector == nil {
 			x.Selector = new(pkg1_unversioned.LabelSelector)
 		}
-		yym700 := z.DecBinary()
-		_ = yym700
+		yym658 := z.DecBinary()
+		_ = yym658
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.Selector) {
 		} else {
 			z.DecFallback(x.Selector, false)
 		}
 	}
-	yyj698++
-	if yyhl698 {
-		yyb698 = yyj698 > l
+	yyj656++
+	if yyhl656 {
+		yyb656 = yyj656 > l
 	} else {
-		yyb698 = r.CheckBreak()
+		yyb656 = r.CheckBreak()
 	}
-	if yyb698 {
+	if yyb656 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8423,54 +7882,21 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Template = pkg2_api.PodTemplateSpec{}
 	} else {
-		yyv701 := &x.Template
-		yyv701.CodecDecodeSelf(d)
-	}
-	yyj698++
-	if yyhl698 {
-		yyb698 = yyj698 > l
-	} else {
-		yyb698 = r.CheckBreak()
-	}
-	if yyb698 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.UpdateStrategy = DaemonSetUpdateStrategy{}
-	} else {
-		yyv702 := &x.UpdateStrategy
-		yyv702.CodecDecodeSelf(d)
-	}
-	yyj698++
-	if yyhl698 {
-		yyb698 = yyj698 > l
-	} else {
-		yyb698 = r.CheckBreak()
-	}
-	if yyb698 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.UniqueLabelKey = ""
-	} else {
-		x.UniqueLabelKey = string(r.DecodeString())
+		yyv659 := &x.Template
+		yyv659.CodecDecodeSelf(d)
 	}
 	for {
-		yyj698++
-		if yyhl698 {
-			yyb698 = yyj698 > l
+		yyj656++
+		if yyhl656 {
+			yyb656 = yyj656 > l
 		} else {
-			yyb698 = r.CheckBreak()
+			yyb656 = r.CheckBreak()
 		}
-		if yyb698 {
+		if yyb656 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj698-1, "")
+		z.DecStructFieldNotFound(yyj656-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -8482,33 +7908,33 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym704 := z.EncBinary()
-		_ = yym704
+		yym660 := z.EncBinary()
+		_ = yym660
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep705 := !z.EncBinary()
-			yy2arr705 := z.EncBasicHandle().StructToArray
-			var yyq705 [3]bool
-			_, _, _ = yysep705, yyq705, yy2arr705
-			const yyr705 bool = false
-			var yynn705 int
-			if yyr705 || yy2arr705 {
+			yysep661 := !z.EncBinary()
+			yy2arr661 := z.EncBasicHandle().StructToArray
+			var yyq661 [3]bool
+			_, _, _ = yysep661, yyq661, yy2arr661
+			const yyr661 bool = false
+			var yynn661 int
+			if yyr661 || yy2arr661 {
 				r.EncodeArrayStart(3)
 			} else {
-				yynn705 = 3
-				for _, b := range yyq705 {
+				yynn661 = 3
+				for _, b := range yyq661 {
 					if b {
-						yynn705++
+						yynn661++
 					}
 				}
-				r.EncodeMapStart(yynn705)
-				yynn705 = 0
+				r.EncodeMapStart(yynn661)
+				yynn661 = 0
 			}
-			if yyr705 || yy2arr705 {
+			if yyr661 || yy2arr661 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym707 := z.EncBinary()
-				_ = yym707
+				yym663 := z.EncBinary()
+				_ = yym663
 				if false {
 				} else {
 					r.EncodeInt(int64(x.CurrentNumberScheduled))
@@ -8517,17 +7943,17 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("currentNumberScheduled"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym708 := z.EncBinary()
-				_ = yym708
+				yym664 := z.EncBinary()
+				_ = yym664
 				if false {
 				} else {
 					r.EncodeInt(int64(x.CurrentNumberScheduled))
 				}
 			}
-			if yyr705 || yy2arr705 {
+			if yyr661 || yy2arr661 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym710 := z.EncBinary()
-				_ = yym710
+				yym666 := z.EncBinary()
+				_ = yym666
 				if false {
 				} else {
 					r.EncodeInt(int64(x.NumberMisscheduled))
@@ -8536,17 +7962,17 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("numberMisscheduled"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym711 := z.EncBinary()
-				_ = yym711
+				yym667 := z.EncBinary()
+				_ = yym667
 				if false {
 				} else {
 					r.EncodeInt(int64(x.NumberMisscheduled))
 				}
 			}
-			if yyr705 || yy2arr705 {
+			if yyr661 || yy2arr661 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym713 := z.EncBinary()
-				_ = yym713
+				yym669 := z.EncBinary()
+				_ = yym669
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DesiredNumberScheduled))
@@ -8555,14 +7981,14 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("desiredNumberScheduled"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym714 := z.EncBinary()
-				_ = yym714
+				yym670 := z.EncBinary()
+				_ = yym670
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DesiredNumberScheduled))
 				}
 			}
-			if yyr705 || yy2arr705 {
+			if yyr661 || yy2arr661 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -8575,25 +8001,25 @@ func (x *DaemonSetStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym715 := z.DecBinary()
-	_ = yym715
+	yym671 := z.DecBinary()
+	_ = yym671
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct716 := r.ContainerType()
-		if yyct716 == codecSelferValueTypeMap1234 {
-			yyl716 := r.ReadMapStart()
-			if yyl716 == 0 {
+		yyct672 := r.ContainerType()
+		if yyct672 == codecSelferValueTypeMap1234 {
+			yyl672 := r.ReadMapStart()
+			if yyl672 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl716, d)
+				x.codecDecodeSelfFromMap(yyl672, d)
 			}
-		} else if yyct716 == codecSelferValueTypeArray1234 {
-			yyl716 := r.ReadArrayStart()
-			if yyl716 == 0 {
+		} else if yyct672 == codecSelferValueTypeArray1234 {
+			yyl672 := r.ReadArrayStart()
+			if yyl672 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl716, d)
+				x.codecDecodeSelfFromArray(yyl672, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -8605,12 +8031,12 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys717Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys717Slc
-	var yyhl717 bool = l >= 0
-	for yyj717 := 0; ; yyj717++ {
-		if yyhl717 {
-			if yyj717 >= l {
+	var yys673Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys673Slc
+	var yyhl673 bool = l >= 0
+	for yyj673 := 0; ; yyj673++ {
+		if yyhl673 {
+			if yyj673 >= l {
 				break
 			}
 		} else {
@@ -8619,10 +8045,10 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys717Slc = r.DecodeBytes(yys717Slc, true, true)
-		yys717 := string(yys717Slc)
+		yys673Slc = r.DecodeBytes(yys673Slc, true, true)
+		yys673 := string(yys673Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys717 {
+		switch yys673 {
 		case "currentNumberScheduled":
 			if r.TryDecodeAsNil() {
 				x.CurrentNumberScheduled = 0
@@ -8642,9 +8068,9 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.DesiredNumberScheduled = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys717)
-		} // end switch yys717
-	} // end for yyj717
+			z.DecStructFieldNotFound(-1, yys673)
+		} // end switch yys673
+	} // end for yyj673
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -8652,16 +8078,16 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj721 int
-	var yyb721 bool
-	var yyhl721 bool = l >= 0
-	yyj721++
-	if yyhl721 {
-		yyb721 = yyj721 > l
+	var yyj677 int
+	var yyb677 bool
+	var yyhl677 bool = l >= 0
+	yyj677++
+	if yyhl677 {
+		yyb677 = yyj677 > l
 	} else {
-		yyb721 = r.CheckBreak()
+		yyb677 = r.CheckBreak()
 	}
-	if yyb721 {
+	if yyb677 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8671,13 +8097,13 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.CurrentNumberScheduled = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj721++
-	if yyhl721 {
-		yyb721 = yyj721 > l
+	yyj677++
+	if yyhl677 {
+		yyb677 = yyj677 > l
 	} else {
-		yyb721 = r.CheckBreak()
+		yyb677 = r.CheckBreak()
 	}
-	if yyb721 {
+	if yyb677 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8687,13 +8113,13 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.NumberMisscheduled = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj721++
-	if yyhl721 {
-		yyb721 = yyj721 > l
+	yyj677++
+	if yyhl677 {
+		yyb677 = yyj677 > l
 	} else {
-		yyb721 = r.CheckBreak()
+		yyb677 = r.CheckBreak()
 	}
-	if yyb721 {
+	if yyb677 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8704,17 +8130,17 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.DesiredNumberScheduled = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj721++
-		if yyhl721 {
-			yyb721 = yyj721 > l
+		yyj677++
+		if yyhl677 {
+			yyb677 = yyj677 > l
 		} else {
-			yyb721 = r.CheckBreak()
+			yyb677 = r.CheckBreak()
 		}
-		if yyb721 {
+		if yyb677 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj721-1, "")
+		z.DecStructFieldNotFound(yyj677-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -8726,90 +8152,90 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym725 := z.EncBinary()
-		_ = yym725
+		yym681 := z.EncBinary()
+		_ = yym681
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep726 := !z.EncBinary()
-			yy2arr726 := z.EncBasicHandle().StructToArray
-			var yyq726 [5]bool
-			_, _, _ = yysep726, yyq726, yy2arr726
-			const yyr726 bool = false
-			yyq726[0] = true
-			yyq726[1] = true
-			yyq726[2] = true
-			yyq726[3] = x.Kind != ""
-			yyq726[4] = x.APIVersion != ""
-			var yynn726 int
-			if yyr726 || yy2arr726 {
+			yysep682 := !z.EncBinary()
+			yy2arr682 := z.EncBasicHandle().StructToArray
+			var yyq682 [5]bool
+			_, _, _ = yysep682, yyq682, yy2arr682
+			const yyr682 bool = false
+			yyq682[0] = true
+			yyq682[1] = true
+			yyq682[2] = true
+			yyq682[3] = x.Kind != ""
+			yyq682[4] = x.APIVersion != ""
+			var yynn682 int
+			if yyr682 || yy2arr682 {
 				r.EncodeArrayStart(5)
 			} else {
-				yynn726 = 0
-				for _, b := range yyq726 {
+				yynn682 = 0
+				for _, b := range yyq682 {
 					if b {
-						yynn726++
+						yynn682++
 					}
 				}
-				r.EncodeMapStart(yynn726)
-				yynn726 = 0
+				r.EncodeMapStart(yynn682)
+				yynn682 = 0
 			}
-			if yyr726 || yy2arr726 {
+			if yyr682 || yy2arr682 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq726[0] {
-					yy728 := &x.ObjectMeta
-					yy728.CodecEncodeSelf(e)
+				if yyq682[0] {
+					yy684 := &x.ObjectMeta
+					yy684.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq726[0] {
+				if yyq682[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy729 := &x.ObjectMeta
-					yy729.CodecEncodeSelf(e)
+					yy685 := &x.ObjectMeta
+					yy685.CodecEncodeSelf(e)
 				}
 			}
-			if yyr726 || yy2arr726 {
+			if yyr682 || yy2arr682 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq726[1] {
-					yy731 := &x.Spec
-					yy731.CodecEncodeSelf(e)
+				if yyq682[1] {
+					yy687 := &x.Spec
+					yy687.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq726[1] {
+				if yyq682[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy732 := &x.Spec
-					yy732.CodecEncodeSelf(e)
+					yy688 := &x.Spec
+					yy688.CodecEncodeSelf(e)
 				}
 			}
-			if yyr726 || yy2arr726 {
+			if yyr682 || yy2arr682 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq726[2] {
-					yy734 := &x.Status
-					yy734.CodecEncodeSelf(e)
+				if yyq682[2] {
+					yy690 := &x.Status
+					yy690.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq726[2] {
+				if yyq682[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy735 := &x.Status
-					yy735.CodecEncodeSelf(e)
+					yy691 := &x.Status
+					yy691.CodecEncodeSelf(e)
 				}
 			}
-			if yyr726 || yy2arr726 {
+			if yyr682 || yy2arr682 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq726[3] {
-					yym737 := z.EncBinary()
-					_ = yym737
+				if yyq682[3] {
+					yym693 := z.EncBinary()
+					_ = yym693
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -8818,23 +8244,23 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq726[3] {
+				if yyq682[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym738 := z.EncBinary()
-					_ = yym738
+					yym694 := z.EncBinary()
+					_ = yym694
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr726 || yy2arr726 {
+			if yyr682 || yy2arr682 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq726[4] {
-					yym740 := z.EncBinary()
-					_ = yym740
+				if yyq682[4] {
+					yym696 := z.EncBinary()
+					_ = yym696
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -8843,19 +8269,19 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq726[4] {
+				if yyq682[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym741 := z.EncBinary()
-					_ = yym741
+					yym697 := z.EncBinary()
+					_ = yym697
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr726 || yy2arr726 {
+			if yyr682 || yy2arr682 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -8868,25 +8294,25 @@ func (x *DaemonSet) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym742 := z.DecBinary()
-	_ = yym742
+	yym698 := z.DecBinary()
+	_ = yym698
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct743 := r.ContainerType()
-		if yyct743 == codecSelferValueTypeMap1234 {
-			yyl743 := r.ReadMapStart()
-			if yyl743 == 0 {
+		yyct699 := r.ContainerType()
+		if yyct699 == codecSelferValueTypeMap1234 {
+			yyl699 := r.ReadMapStart()
+			if yyl699 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl743, d)
+				x.codecDecodeSelfFromMap(yyl699, d)
 			}
-		} else if yyct743 == codecSelferValueTypeArray1234 {
-			yyl743 := r.ReadArrayStart()
-			if yyl743 == 0 {
+		} else if yyct699 == codecSelferValueTypeArray1234 {
+			yyl699 := r.ReadArrayStart()
+			if yyl699 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl743, d)
+				x.codecDecodeSelfFromArray(yyl699, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -8898,12 +8324,12 @@ func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys744Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys744Slc
-	var yyhl744 bool = l >= 0
-	for yyj744 := 0; ; yyj744++ {
-		if yyhl744 {
-			if yyj744 >= l {
+	var yys700Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys700Slc
+	var yyhl700 bool = l >= 0
+	for yyj700 := 0; ; yyj700++ {
+		if yyhl700 {
+			if yyj700 >= l {
 				break
 			}
 		} else {
@@ -8912,30 +8338,30 @@ func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys744Slc = r.DecodeBytes(yys744Slc, true, true)
-		yys744 := string(yys744Slc)
+		yys700Slc = r.DecodeBytes(yys700Slc, true, true)
+		yys700 := string(yys700Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys744 {
+		switch yys700 {
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv745 := &x.ObjectMeta
-				yyv745.CodecDecodeSelf(d)
+				yyv701 := &x.ObjectMeta
+				yyv701.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = DaemonSetSpec{}
 			} else {
-				yyv746 := &x.Spec
-				yyv746.CodecDecodeSelf(d)
+				yyv702 := &x.Spec
+				yyv702.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = DaemonSetStatus{}
 			} else {
-				yyv747 := &x.Status
-				yyv747.CodecDecodeSelf(d)
+				yyv703 := &x.Status
+				yyv703.CodecDecodeSelf(d)
 			}
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -8950,9 +8376,9 @@ func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys744)
-		} // end switch yys744
-	} // end for yyj744
+			z.DecStructFieldNotFound(-1, yys700)
+		} // end switch yys700
+	} // end for yyj700
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -8960,16 +8386,16 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj750 int
-	var yyb750 bool
-	var yyhl750 bool = l >= 0
-	yyj750++
-	if yyhl750 {
-		yyb750 = yyj750 > l
+	var yyj706 int
+	var yyb706 bool
+	var yyhl706 bool = l >= 0
+	yyj706++
+	if yyhl706 {
+		yyb706 = yyj706 > l
 	} else {
-		yyb750 = r.CheckBreak()
+		yyb706 = r.CheckBreak()
 	}
-	if yyb750 {
+	if yyb706 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8977,16 +8403,16 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv751 := &x.ObjectMeta
-		yyv751.CodecDecodeSelf(d)
+		yyv707 := &x.ObjectMeta
+		yyv707.CodecDecodeSelf(d)
 	}
-	yyj750++
-	if yyhl750 {
-		yyb750 = yyj750 > l
+	yyj706++
+	if yyhl706 {
+		yyb706 = yyj706 > l
 	} else {
-		yyb750 = r.CheckBreak()
+		yyb706 = r.CheckBreak()
 	}
-	if yyb750 {
+	if yyb706 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8994,16 +8420,16 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Spec = DaemonSetSpec{}
 	} else {
-		yyv752 := &x.Spec
-		yyv752.CodecDecodeSelf(d)
+		yyv708 := &x.Spec
+		yyv708.CodecDecodeSelf(d)
 	}
-	yyj750++
-	if yyhl750 {
-		yyb750 = yyj750 > l
+	yyj706++
+	if yyhl706 {
+		yyb706 = yyj706 > l
 	} else {
-		yyb750 = r.CheckBreak()
+		yyb706 = r.CheckBreak()
 	}
-	if yyb750 {
+	if yyb706 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9011,16 +8437,16 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Status = DaemonSetStatus{}
 	} else {
-		yyv753 := &x.Status
-		yyv753.CodecDecodeSelf(d)
+		yyv709 := &x.Status
+		yyv709.CodecDecodeSelf(d)
 	}
-	yyj750++
-	if yyhl750 {
-		yyb750 = yyj750 > l
+	yyj706++
+	if yyhl706 {
+		yyb706 = yyj706 > l
 	} else {
-		yyb750 = r.CheckBreak()
+		yyb706 = r.CheckBreak()
 	}
-	if yyb750 {
+	if yyb706 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9030,13 +8456,13 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj750++
-	if yyhl750 {
-		yyb750 = yyj750 > l
+	yyj706++
+	if yyhl706 {
+		yyb706 = yyj706 > l
 	} else {
-		yyb750 = r.CheckBreak()
+		yyb706 = r.CheckBreak()
 	}
-	if yyb750 {
+	if yyb706 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9047,17 +8473,17 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = string(r.DecodeString())
 	}
 	for {
-		yyj750++
-		if yyhl750 {
-			yyb750 = yyj750 > l
+		yyj706++
+		if yyhl706 {
+			yyb706 = yyj706 > l
 		} else {
-			yyb750 = r.CheckBreak()
+			yyb706 = r.CheckBreak()
 		}
-		if yyb750 {
+		if yyb706 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj750-1, "")
+		z.DecStructFieldNotFound(yyj706-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -9069,68 +8495,68 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym756 := z.EncBinary()
-		_ = yym756
+		yym712 := z.EncBinary()
+		_ = yym712
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep757 := !z.EncBinary()
-			yy2arr757 := z.EncBasicHandle().StructToArray
-			var yyq757 [4]bool
-			_, _, _ = yysep757, yyq757, yy2arr757
-			const yyr757 bool = false
-			yyq757[0] = true
-			yyq757[2] = x.Kind != ""
-			yyq757[3] = x.APIVersion != ""
-			var yynn757 int
-			if yyr757 || yy2arr757 {
+			yysep713 := !z.EncBinary()
+			yy2arr713 := z.EncBasicHandle().StructToArray
+			var yyq713 [4]bool
+			_, _, _ = yysep713, yyq713, yy2arr713
+			const yyr713 bool = false
+			yyq713[0] = true
+			yyq713[2] = x.Kind != ""
+			yyq713[3] = x.APIVersion != ""
+			var yynn713 int
+			if yyr713 || yy2arr713 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn757 = 1
-				for _, b := range yyq757 {
+				yynn713 = 1
+				for _, b := range yyq713 {
 					if b {
-						yynn757++
+						yynn713++
 					}
 				}
-				r.EncodeMapStart(yynn757)
-				yynn757 = 0
+				r.EncodeMapStart(yynn713)
+				yynn713 = 0
 			}
-			if yyr757 || yy2arr757 {
+			if yyr713 || yy2arr713 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq757[0] {
-					yy759 := &x.ListMeta
-					yym760 := z.EncBinary()
-					_ = yym760
+				if yyq713[0] {
+					yy715 := &x.ListMeta
+					yym716 := z.EncBinary()
+					_ = yym716
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy759) {
+					} else if z.HasExtensions() && z.EncExt(yy715) {
 					} else {
-						z.EncFallback(yy759)
+						z.EncFallback(yy715)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq757[0] {
+				if yyq713[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy761 := &x.ListMeta
-					yym762 := z.EncBinary()
-					_ = yym762
+					yy717 := &x.ListMeta
+					yym718 := z.EncBinary()
+					_ = yym718
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy761) {
+					} else if z.HasExtensions() && z.EncExt(yy717) {
 					} else {
-						z.EncFallback(yy761)
+						z.EncFallback(yy717)
 					}
 				}
 			}
-			if yyr757 || yy2arr757 {
+			if yyr713 || yy2arr713 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym764 := z.EncBinary()
-					_ = yym764
+					yym720 := z.EncBinary()
+					_ = yym720
 					if false {
 					} else {
 						h.encSliceDaemonSet(([]DaemonSet)(x.Items), e)
@@ -9143,19 +8569,19 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym765 := z.EncBinary()
-					_ = yym765
+					yym721 := z.EncBinary()
+					_ = yym721
 					if false {
 					} else {
 						h.encSliceDaemonSet(([]DaemonSet)(x.Items), e)
 					}
 				}
 			}
-			if yyr757 || yy2arr757 {
+			if yyr713 || yy2arr713 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq757[2] {
-					yym767 := z.EncBinary()
-					_ = yym767
+				if yyq713[2] {
+					yym723 := z.EncBinary()
+					_ = yym723
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -9164,23 +8590,23 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq757[2] {
+				if yyq713[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym768 := z.EncBinary()
-					_ = yym768
+					yym724 := z.EncBinary()
+					_ = yym724
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr757 || yy2arr757 {
+			if yyr713 || yy2arr713 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq757[3] {
-					yym770 := z.EncBinary()
-					_ = yym770
+				if yyq713[3] {
+					yym726 := z.EncBinary()
+					_ = yym726
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -9189,19 +8615,19 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq757[3] {
+				if yyq713[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym771 := z.EncBinary()
-					_ = yym771
+					yym727 := z.EncBinary()
+					_ = yym727
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr757 || yy2arr757 {
+			if yyr713 || yy2arr713 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -9214,25 +8640,25 @@ func (x *DaemonSetList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym772 := z.DecBinary()
-	_ = yym772
+	yym728 := z.DecBinary()
+	_ = yym728
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct773 := r.ContainerType()
-		if yyct773 == codecSelferValueTypeMap1234 {
-			yyl773 := r.ReadMapStart()
-			if yyl773 == 0 {
+		yyct729 := r.ContainerType()
+		if yyct729 == codecSelferValueTypeMap1234 {
+			yyl729 := r.ReadMapStart()
+			if yyl729 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl773, d)
+				x.codecDecodeSelfFromMap(yyl729, d)
 			}
-		} else if yyct773 == codecSelferValueTypeArray1234 {
-			yyl773 := r.ReadArrayStart()
-			if yyl773 == 0 {
+		} else if yyct729 == codecSelferValueTypeArray1234 {
+			yyl729 := r.ReadArrayStart()
+			if yyl729 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl773, d)
+				x.codecDecodeSelfFromArray(yyl729, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -9244,12 +8670,12 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys774Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys774Slc
-	var yyhl774 bool = l >= 0
-	for yyj774 := 0; ; yyj774++ {
-		if yyhl774 {
-			if yyj774 >= l {
+	var yys730Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys730Slc
+	var yyhl730 bool = l >= 0
+	for yyj730 := 0; ; yyj730++ {
+		if yyhl730 {
+			if yyj730 >= l {
 				break
 			}
 		} else {
@@ -9258,33 +8684,33 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys774Slc = r.DecodeBytes(yys774Slc, true, true)
-		yys774 := string(yys774Slc)
+		yys730Slc = r.DecodeBytes(yys730Slc, true, true)
+		yys730 := string(yys730Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys774 {
+		switch yys730 {
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv775 := &x.ListMeta
-				yym776 := z.DecBinary()
-				_ = yym776
+				yyv731 := &x.ListMeta
+				yym732 := z.DecBinary()
+				_ = yym732
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv775) {
+				} else if z.HasExtensions() && z.DecExt(yyv731) {
 				} else {
-					z.DecFallback(yyv775, false)
+					z.DecFallback(yyv731, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv777 := &x.Items
-				yym778 := z.DecBinary()
-				_ = yym778
+				yyv733 := &x.Items
+				yym734 := z.DecBinary()
+				_ = yym734
 				if false {
 				} else {
-					h.decSliceDaemonSet((*[]DaemonSet)(yyv777), d)
+					h.decSliceDaemonSet((*[]DaemonSet)(yyv733), d)
 				}
 			}
 		case "kind":
@@ -9300,9 +8726,9 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys774)
-		} // end switch yys774
-	} // end for yyj774
+			z.DecStructFieldNotFound(-1, yys730)
+		} // end switch yys730
+	} // end for yyj730
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -9310,16 +8736,16 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj781 int
-	var yyb781 bool
-	var yyhl781 bool = l >= 0
-	yyj781++
-	if yyhl781 {
-		yyb781 = yyj781 > l
+	var yyj737 int
+	var yyb737 bool
+	var yyhl737 bool = l >= 0
+	yyj737++
+	if yyhl737 {
+		yyb737 = yyj737 > l
 	} else {
-		yyb781 = r.CheckBreak()
+		yyb737 = r.CheckBreak()
 	}
-	if yyb781 {
+	if yyb737 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9327,22 +8753,22 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv782 := &x.ListMeta
-		yym783 := z.DecBinary()
-		_ = yym783
+		yyv738 := &x.ListMeta
+		yym739 := z.DecBinary()
+		_ = yym739
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv782) {
+		} else if z.HasExtensions() && z.DecExt(yyv738) {
 		} else {
-			z.DecFallback(yyv782, false)
+			z.DecFallback(yyv738, false)
 		}
 	}
-	yyj781++
-	if yyhl781 {
-		yyb781 = yyj781 > l
+	yyj737++
+	if yyhl737 {
+		yyb737 = yyj737 > l
 	} else {
-		yyb781 = r.CheckBreak()
+		yyb737 = r.CheckBreak()
 	}
-	if yyb781 {
+	if yyb737 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9350,21 +8776,21 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv784 := &x.Items
-		yym785 := z.DecBinary()
-		_ = yym785
+		yyv740 := &x.Items
+		yym741 := z.DecBinary()
+		_ = yym741
 		if false {
 		} else {
-			h.decSliceDaemonSet((*[]DaemonSet)(yyv784), d)
+			h.decSliceDaemonSet((*[]DaemonSet)(yyv740), d)
 		}
 	}
-	yyj781++
-	if yyhl781 {
-		yyb781 = yyj781 > l
+	yyj737++
+	if yyhl737 {
+		yyb737 = yyj737 > l
 	} else {
-		yyb781 = r.CheckBreak()
+		yyb737 = r.CheckBreak()
 	}
-	if yyb781 {
+	if yyb737 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9374,13 +8800,13 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj781++
-	if yyhl781 {
-		yyb781 = yyj781 > l
+	yyj737++
+	if yyhl737 {
+		yyb737 = yyj737 > l
 	} else {
-		yyb781 = r.CheckBreak()
+		yyb737 = r.CheckBreak()
 	}
-	if yyb781 {
+	if yyb737 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9391,17 +8817,17 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = string(r.DecodeString())
 	}
 	for {
-		yyj781++
-		if yyhl781 {
-			yyb781 = yyj781 > l
+		yyj737++
+		if yyhl737 {
+			yyb737 = yyj737 > l
 		} else {
-			yyb781 = r.CheckBreak()
+			yyb737 = r.CheckBreak()
 		}
-		if yyb781 {
+		if yyb737 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj781-1, "")
+		z.DecStructFieldNotFound(yyj737-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -9413,68 +8839,68 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym788 := z.EncBinary()
-		_ = yym788
+		yym744 := z.EncBinary()
+		_ = yym744
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep789 := !z.EncBinary()
-			yy2arr789 := z.EncBasicHandle().StructToArray
-			var yyq789 [4]bool
-			_, _, _ = yysep789, yyq789, yy2arr789
-			const yyr789 bool = false
-			yyq789[0] = true
-			yyq789[2] = x.Kind != ""
-			yyq789[3] = x.APIVersion != ""
-			var yynn789 int
-			if yyr789 || yy2arr789 {
+			yysep745 := !z.EncBinary()
+			yy2arr745 := z.EncBasicHandle().StructToArray
+			var yyq745 [4]bool
+			_, _, _ = yysep745, yyq745, yy2arr745
+			const yyr745 bool = false
+			yyq745[0] = true
+			yyq745[2] = x.Kind != ""
+			yyq745[3] = x.APIVersion != ""
+			var yynn745 int
+			if yyr745 || yy2arr745 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn789 = 1
-				for _, b := range yyq789 {
+				yynn745 = 1
+				for _, b := range yyq745 {
 					if b {
-						yynn789++
+						yynn745++
 					}
 				}
-				r.EncodeMapStart(yynn789)
-				yynn789 = 0
+				r.EncodeMapStart(yynn745)
+				yynn745 = 0
 			}
-			if yyr789 || yy2arr789 {
+			if yyr745 || yy2arr745 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq789[0] {
-					yy791 := &x.ListMeta
-					yym792 := z.EncBinary()
-					_ = yym792
+				if yyq745[0] {
+					yy747 := &x.ListMeta
+					yym748 := z.EncBinary()
+					_ = yym748
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy791) {
+					} else if z.HasExtensions() && z.EncExt(yy747) {
 					} else {
-						z.EncFallback(yy791)
+						z.EncFallback(yy747)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq789[0] {
+				if yyq745[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy793 := &x.ListMeta
-					yym794 := z.EncBinary()
-					_ = yym794
+					yy749 := &x.ListMeta
+					yym750 := z.EncBinary()
+					_ = yym750
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy793) {
+					} else if z.HasExtensions() && z.EncExt(yy749) {
 					} else {
-						z.EncFallback(yy793)
+						z.EncFallback(yy749)
 					}
 				}
 			}
-			if yyr789 || yy2arr789 {
+			if yyr745 || yy2arr745 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym796 := z.EncBinary()
-					_ = yym796
+					yym752 := z.EncBinary()
+					_ = yym752
 					if false {
 					} else {
 						h.encSliceThirdPartyResourceData(([]ThirdPartyResourceData)(x.Items), e)
@@ -9487,19 +8913,19 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym797 := z.EncBinary()
-					_ = yym797
+					yym753 := z.EncBinary()
+					_ = yym753
 					if false {
 					} else {
 						h.encSliceThirdPartyResourceData(([]ThirdPartyResourceData)(x.Items), e)
 					}
 				}
 			}
-			if yyr789 || yy2arr789 {
+			if yyr745 || yy2arr745 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq789[2] {
-					yym799 := z.EncBinary()
-					_ = yym799
+				if yyq745[2] {
+					yym755 := z.EncBinary()
+					_ = yym755
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -9508,23 +8934,23 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq789[2] {
+				if yyq745[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym800 := z.EncBinary()
-					_ = yym800
+					yym756 := z.EncBinary()
+					_ = yym756
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr789 || yy2arr789 {
+			if yyr745 || yy2arr745 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq789[3] {
-					yym802 := z.EncBinary()
-					_ = yym802
+				if yyq745[3] {
+					yym758 := z.EncBinary()
+					_ = yym758
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -9533,19 +8959,19 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq789[3] {
+				if yyq745[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym803 := z.EncBinary()
-					_ = yym803
+					yym759 := z.EncBinary()
+					_ = yym759
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr789 || yy2arr789 {
+			if yyr745 || yy2arr745 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -9558,25 +8984,25 @@ func (x *ThirdPartyResourceDataList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym804 := z.DecBinary()
-	_ = yym804
+	yym760 := z.DecBinary()
+	_ = yym760
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct805 := r.ContainerType()
-		if yyct805 == codecSelferValueTypeMap1234 {
-			yyl805 := r.ReadMapStart()
-			if yyl805 == 0 {
+		yyct761 := r.ContainerType()
+		if yyct761 == codecSelferValueTypeMap1234 {
+			yyl761 := r.ReadMapStart()
+			if yyl761 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl805, d)
+				x.codecDecodeSelfFromMap(yyl761, d)
 			}
-		} else if yyct805 == codecSelferValueTypeArray1234 {
-			yyl805 := r.ReadArrayStart()
-			if yyl805 == 0 {
+		} else if yyct761 == codecSelferValueTypeArray1234 {
+			yyl761 := r.ReadArrayStart()
+			if yyl761 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl805, d)
+				x.codecDecodeSelfFromArray(yyl761, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -9588,12 +9014,12 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys806Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys806Slc
-	var yyhl806 bool = l >= 0
-	for yyj806 := 0; ; yyj806++ {
-		if yyhl806 {
-			if yyj806 >= l {
+	var yys762Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys762Slc
+	var yyhl762 bool = l >= 0
+	for yyj762 := 0; ; yyj762++ {
+		if yyhl762 {
+			if yyj762 >= l {
 				break
 			}
 		} else {
@@ -9602,33 +9028,33 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys806Slc = r.DecodeBytes(yys806Slc, true, true)
-		yys806 := string(yys806Slc)
+		yys762Slc = r.DecodeBytes(yys762Slc, true, true)
+		yys762 := string(yys762Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys806 {
+		switch yys762 {
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv807 := &x.ListMeta
-				yym808 := z.DecBinary()
-				_ = yym808
+				yyv763 := &x.ListMeta
+				yym764 := z.DecBinary()
+				_ = yym764
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv807) {
+				} else if z.HasExtensions() && z.DecExt(yyv763) {
 				} else {
-					z.DecFallback(yyv807, false)
+					z.DecFallback(yyv763, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv809 := &x.Items
-				yym810 := z.DecBinary()
-				_ = yym810
+				yyv765 := &x.Items
+				yym766 := z.DecBinary()
+				_ = yym766
 				if false {
 				} else {
-					h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv809), d)
+					h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv765), d)
 				}
 			}
 		case "kind":
@@ -9644,9 +9070,9 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 				x.APIVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys806)
-		} // end switch yys806
-	} // end for yyj806
+			z.DecStructFieldNotFound(-1, yys762)
+		} // end switch yys762
+	} // end for yyj762
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -9654,16 +9080,16 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj813 int
-	var yyb813 bool
-	var yyhl813 bool = l >= 0
-	yyj813++
-	if yyhl813 {
-		yyb813 = yyj813 > l
+	var yyj769 int
+	var yyb769 bool
+	var yyhl769 bool = l >= 0
+	yyj769++
+	if yyhl769 {
+		yyb769 = yyj769 > l
 	} else {
-		yyb813 = r.CheckBreak()
+		yyb769 = r.CheckBreak()
 	}
-	if yyb813 {
+	if yyb769 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9671,22 +9097,22 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv814 := &x.ListMeta
-		yym815 := z.DecBinary()
-		_ = yym815
+		yyv770 := &x.ListMeta
+		yym771 := z.DecBinary()
+		_ = yym771
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv814) {
+		} else if z.HasExtensions() && z.DecExt(yyv770) {
 		} else {
-			z.DecFallback(yyv814, false)
+			z.DecFallback(yyv770, false)
 		}
 	}
-	yyj813++
-	if yyhl813 {
-		yyb813 = yyj813 > l
+	yyj769++
+	if yyhl769 {
+		yyb769 = yyj769 > l
 	} else {
-		yyb813 = r.CheckBreak()
+		yyb769 = r.CheckBreak()
 	}
-	if yyb813 {
+	if yyb769 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9694,21 +9120,21 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv816 := &x.Items
-		yym817 := z.DecBinary()
-		_ = yym817
+		yyv772 := &x.Items
+		yym773 := z.DecBinary()
+		_ = yym773
 		if false {
 		} else {
-			h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv816), d)
+			h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv772), d)
 		}
 	}
-	yyj813++
-	if yyhl813 {
-		yyb813 = yyj813 > l
+	yyj769++
+	if yyhl769 {
+		yyb769 = yyj769 > l
 	} else {
-		yyb813 = r.CheckBreak()
+		yyb769 = r.CheckBreak()
 	}
-	if yyb813 {
+	if yyb769 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9718,13 +9144,13 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj813++
-	if yyhl813 {
-		yyb813 = yyj813 > l
+	yyj769++
+	if yyhl769 {
+		yyb769 = yyj769 > l
 	} else {
-		yyb813 = r.CheckBreak()
+		yyb769 = r.CheckBreak()
 	}
-	if yyb813 {
+	if yyb769 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9735,17 +9161,17 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 		x.APIVersion = string(r.DecodeString())
 	}
 	for {
-		yyj813++
-		if yyhl813 {
-			yyb813 = yyj813 > l
+		yyj769++
+		if yyhl769 {
+			yyb769 = yyj769 > l
 		} else {
-			yyb813 = r.CheckBreak()
+			yyb769 = r.CheckBreak()
 		}
-		if yyb813 {
+		if yyb769 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj813-1, "")
+		z.DecStructFieldNotFound(yyj769-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -9757,90 +9183,90 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym820 := z.EncBinary()
-		_ = yym820
+		yym776 := z.EncBinary()
+		_ = yym776
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep821 := !z.EncBinary()
-			yy2arr821 := z.EncBasicHandle().StructToArray
-			var yyq821 [5]bool
-			_, _, _ = yysep821, yyq821, yy2arr821
-			const yyr821 bool = false
-			yyq821[0] = true
-			yyq821[1] = true
-			yyq821[2] = true
-			yyq821[3] = x.Kind != ""
-			yyq821[4] = x.APIVersion != ""
-			var yynn821 int
-			if yyr821 || yy2arr821 {
+			yysep777 := !z.EncBinary()
+			yy2arr777 := z.EncBasicHandle().StructToArray
+			var yyq777 [5]bool
+			_, _, _ = yysep777, yyq777, yy2arr777
+			const yyr777 bool = false
+			yyq777[0] = true
+			yyq777[1] = true
+			yyq777[2] = true
+			yyq777[3] = x.Kind != ""
+			yyq777[4] = x.APIVersion != ""
+			var yynn777 int
+			if yyr777 || yy2arr777 {
 				r.EncodeArrayStart(5)
 			} else {
-				yynn821 = 0
-				for _, b := range yyq821 {
+				yynn777 = 0
+				for _, b := range yyq777 {
 					if b {
-						yynn821++
+						yynn777++
 					}
 				}
-				r.EncodeMapStart(yynn821)
-				yynn821 = 0
+				r.EncodeMapStart(yynn777)
+				yynn777 = 0
 			}
-			if yyr821 || yy2arr821 {
+			if yyr777 || yy2arr777 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq821[0] {
-					yy823 := &x.ObjectMeta
-					yy823.CodecEncodeSelf(e)
+				if yyq777[0] {
+					yy779 := &x.ObjectMeta
+					yy779.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq821[0] {
+				if yyq777[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy824 := &x.ObjectMeta
-					yy824.CodecEncodeSelf(e)
+					yy780 := &x.ObjectMeta
+					yy780.CodecEncodeSelf(e)
 				}
 			}
-			if yyr821 || yy2arr821 {
+			if yyr777 || yy2arr777 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq821[1] {
-					yy826 := &x.Spec
-					yy826.CodecEncodeSelf(e)
+				if yyq777[1] {
+					yy782 := &x.Spec
+					yy782.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq821[1] {
+				if yyq777[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy827 := &x.Spec
-					yy827.CodecEncodeSelf(e)
+					yy783 := &x.Spec
+					yy783.CodecEncodeSelf(e)
 				}
 			}
-			if yyr821 || yy2arr821 {
+			if yyr777 || yy2arr777 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq821[2] {
-					yy829 := &x.Status
-					yy829.CodecEncodeSelf(e)
+				if yyq777[2] {
+					yy785 := &x.Status
+					yy785.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq821[2] {
+				if yyq777[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy830 := &x.Status
-					yy830.CodecEncodeSelf(e)
+					yy786 := &x.Status
+					yy786.CodecEncodeSelf(e)
 				}
 			}
-			if yyr821 || yy2arr821 {
+			if yyr777 || yy2arr777 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq821[3] {
-					yym832 := z.EncBinary()
-					_ = yym832
+				if yyq777[3] {
+					yym788 := z.EncBinary()
+					_ = yym788
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -9849,23 +9275,23 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq821[3] {
+				if yyq777[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym833 := z.EncBinary()
-					_ = yym833
+					yym789 := z.EncBinary()
+					_ = yym789
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr821 || yy2arr821 {
+			if yyr777 || yy2arr777 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq821[4] {
-					yym835 := z.EncBinary()
-					_ = yym835
+				if yyq777[4] {
+					yym791 := z.EncBinary()
+					_ = yym791
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -9874,19 +9300,19 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq821[4] {
+				if yyq777[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym836 := z.EncBinary()
-					_ = yym836
+					yym792 := z.EncBinary()
+					_ = yym792
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr821 || yy2arr821 {
+			if yyr777 || yy2arr777 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -9899,25 +9325,25 @@ func (x *Job) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym837 := z.DecBinary()
-	_ = yym837
+	yym793 := z.DecBinary()
+	_ = yym793
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct838 := r.ContainerType()
-		if yyct838 == codecSelferValueTypeMap1234 {
-			yyl838 := r.ReadMapStart()
-			if yyl838 == 0 {
+		yyct794 := r.ContainerType()
+		if yyct794 == codecSelferValueTypeMap1234 {
+			yyl794 := r.ReadMapStart()
+			if yyl794 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl838, d)
+				x.codecDecodeSelfFromMap(yyl794, d)
 			}
-		} else if yyct838 == codecSelferValueTypeArray1234 {
-			yyl838 := r.ReadArrayStart()
-			if yyl838 == 0 {
+		} else if yyct794 == codecSelferValueTypeArray1234 {
+			yyl794 := r.ReadArrayStart()
+			if yyl794 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl838, d)
+				x.codecDecodeSelfFromArray(yyl794, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -9929,12 +9355,12 @@ func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys839Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys839Slc
-	var yyhl839 bool = l >= 0
-	for yyj839 := 0; ; yyj839++ {
-		if yyhl839 {
-			if yyj839 >= l {
+	var yys795Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys795Slc
+	var yyhl795 bool = l >= 0
+	for yyj795 := 0; ; yyj795++ {
+		if yyhl795 {
+			if yyj795 >= l {
 				break
 			}
 		} else {
@@ -9943,30 +9369,30 @@ func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys839Slc = r.DecodeBytes(yys839Slc, true, true)
-		yys839 := string(yys839Slc)
+		yys795Slc = r.DecodeBytes(yys795Slc, true, true)
+		yys795 := string(yys795Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys839 {
+		switch yys795 {
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv840 := &x.ObjectMeta
-				yyv840.CodecDecodeSelf(d)
+				yyv796 := &x.ObjectMeta
+				yyv796.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = JobSpec{}
 			} else {
-				yyv841 := &x.Spec
-				yyv841.CodecDecodeSelf(d)
+				yyv797 := &x.Spec
+				yyv797.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = JobStatus{}
 			} else {
-				yyv842 := &x.Status
-				yyv842.CodecDecodeSelf(d)
+				yyv798 := &x.Status
+				yyv798.CodecDecodeSelf(d)
 			}
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -9981,9 +9407,9 @@ func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys839)
-		} // end switch yys839
-	} // end for yyj839
+			z.DecStructFieldNotFound(-1, yys795)
+		} // end switch yys795
+	} // end for yyj795
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -9991,16 +9417,16 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj845 int
-	var yyb845 bool
-	var yyhl845 bool = l >= 0
-	yyj845++
-	if yyhl845 {
-		yyb845 = yyj845 > l
+	var yyj801 int
+	var yyb801 bool
+	var yyhl801 bool = l >= 0
+	yyj801++
+	if yyhl801 {
+		yyb801 = yyj801 > l
 	} else {
-		yyb845 = r.CheckBreak()
+		yyb801 = r.CheckBreak()
 	}
-	if yyb845 {
+	if yyb801 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10008,16 +9434,16 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv846 := &x.ObjectMeta
-		yyv846.CodecDecodeSelf(d)
+		yyv802 := &x.ObjectMeta
+		yyv802.CodecDecodeSelf(d)
 	}
-	yyj845++
-	if yyhl845 {
-		yyb845 = yyj845 > l
+	yyj801++
+	if yyhl801 {
+		yyb801 = yyj801 > l
 	} else {
-		yyb845 = r.CheckBreak()
+		yyb801 = r.CheckBreak()
 	}
-	if yyb845 {
+	if yyb801 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10025,16 +9451,16 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Spec = JobSpec{}
 	} else {
-		yyv847 := &x.Spec
-		yyv847.CodecDecodeSelf(d)
+		yyv803 := &x.Spec
+		yyv803.CodecDecodeSelf(d)
 	}
-	yyj845++
-	if yyhl845 {
-		yyb845 = yyj845 > l
+	yyj801++
+	if yyhl801 {
+		yyb801 = yyj801 > l
 	} else {
-		yyb845 = r.CheckBreak()
+		yyb801 = r.CheckBreak()
 	}
-	if yyb845 {
+	if yyb801 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10042,16 +9468,16 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Status = JobStatus{}
 	} else {
-		yyv848 := &x.Status
-		yyv848.CodecDecodeSelf(d)
+		yyv804 := &x.Status
+		yyv804.CodecDecodeSelf(d)
 	}
-	yyj845++
-	if yyhl845 {
-		yyb845 = yyj845 > l
+	yyj801++
+	if yyhl801 {
+		yyb801 = yyj801 > l
 	} else {
-		yyb845 = r.CheckBreak()
+		yyb801 = r.CheckBreak()
 	}
-	if yyb845 {
+	if yyb801 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10061,13 +9487,13 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj845++
-	if yyhl845 {
-		yyb845 = yyj845 > l
+	yyj801++
+	if yyhl801 {
+		yyb801 = yyj801 > l
 	} else {
-		yyb845 = r.CheckBreak()
+		yyb801 = r.CheckBreak()
 	}
-	if yyb845 {
+	if yyb801 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10078,17 +9504,17 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = string(r.DecodeString())
 	}
 	for {
-		yyj845++
-		if yyhl845 {
-			yyb845 = yyj845 > l
+		yyj801++
+		if yyhl801 {
+			yyb801 = yyj801 > l
 		} else {
-			yyb845 = r.CheckBreak()
+			yyb801 = r.CheckBreak()
 		}
-		if yyb845 {
+		if yyb801 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj845-1, "")
+		z.DecStructFieldNotFound(yyj801-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -10100,68 +9526,68 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym851 := z.EncBinary()
-		_ = yym851
+		yym807 := z.EncBinary()
+		_ = yym807
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep852 := !z.EncBinary()
-			yy2arr852 := z.EncBasicHandle().StructToArray
-			var yyq852 [4]bool
-			_, _, _ = yysep852, yyq852, yy2arr852
-			const yyr852 bool = false
-			yyq852[0] = true
-			yyq852[2] = x.Kind != ""
-			yyq852[3] = x.APIVersion != ""
-			var yynn852 int
-			if yyr852 || yy2arr852 {
+			yysep808 := !z.EncBinary()
+			yy2arr808 := z.EncBasicHandle().StructToArray
+			var yyq808 [4]bool
+			_, _, _ = yysep808, yyq808, yy2arr808
+			const yyr808 bool = false
+			yyq808[0] = true
+			yyq808[2] = x.Kind != ""
+			yyq808[3] = x.APIVersion != ""
+			var yynn808 int
+			if yyr808 || yy2arr808 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn852 = 1
-				for _, b := range yyq852 {
+				yynn808 = 1
+				for _, b := range yyq808 {
 					if b {
-						yynn852++
+						yynn808++
 					}
 				}
-				r.EncodeMapStart(yynn852)
-				yynn852 = 0
+				r.EncodeMapStart(yynn808)
+				yynn808 = 0
 			}
-			if yyr852 || yy2arr852 {
+			if yyr808 || yy2arr808 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq852[0] {
-					yy854 := &x.ListMeta
-					yym855 := z.EncBinary()
-					_ = yym855
+				if yyq808[0] {
+					yy810 := &x.ListMeta
+					yym811 := z.EncBinary()
+					_ = yym811
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy854) {
+					} else if z.HasExtensions() && z.EncExt(yy810) {
 					} else {
-						z.EncFallback(yy854)
+						z.EncFallback(yy810)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq852[0] {
+				if yyq808[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy856 := &x.ListMeta
-					yym857 := z.EncBinary()
-					_ = yym857
+					yy812 := &x.ListMeta
+					yym813 := z.EncBinary()
+					_ = yym813
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy856) {
+					} else if z.HasExtensions() && z.EncExt(yy812) {
 					} else {
-						z.EncFallback(yy856)
+						z.EncFallback(yy812)
 					}
 				}
 			}
-			if yyr852 || yy2arr852 {
+			if yyr808 || yy2arr808 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym859 := z.EncBinary()
-					_ = yym859
+					yym815 := z.EncBinary()
+					_ = yym815
 					if false {
 					} else {
 						h.encSliceJob(([]Job)(x.Items), e)
@@ -10174,19 +9600,19 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym860 := z.EncBinary()
-					_ = yym860
+					yym816 := z.EncBinary()
+					_ = yym816
 					if false {
 					} else {
 						h.encSliceJob(([]Job)(x.Items), e)
 					}
 				}
 			}
-			if yyr852 || yy2arr852 {
+			if yyr808 || yy2arr808 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq852[2] {
-					yym862 := z.EncBinary()
-					_ = yym862
+				if yyq808[2] {
+					yym818 := z.EncBinary()
+					_ = yym818
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -10195,23 +9621,23 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq852[2] {
+				if yyq808[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym863 := z.EncBinary()
-					_ = yym863
+					yym819 := z.EncBinary()
+					_ = yym819
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr852 || yy2arr852 {
+			if yyr808 || yy2arr808 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq852[3] {
-					yym865 := z.EncBinary()
-					_ = yym865
+				if yyq808[3] {
+					yym821 := z.EncBinary()
+					_ = yym821
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -10220,19 +9646,19 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq852[3] {
+				if yyq808[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym866 := z.EncBinary()
-					_ = yym866
+					yym822 := z.EncBinary()
+					_ = yym822
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr852 || yy2arr852 {
+			if yyr808 || yy2arr808 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -10245,25 +9671,25 @@ func (x *JobList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym867 := z.DecBinary()
-	_ = yym867
+	yym823 := z.DecBinary()
+	_ = yym823
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct868 := r.ContainerType()
-		if yyct868 == codecSelferValueTypeMap1234 {
-			yyl868 := r.ReadMapStart()
-			if yyl868 == 0 {
+		yyct824 := r.ContainerType()
+		if yyct824 == codecSelferValueTypeMap1234 {
+			yyl824 := r.ReadMapStart()
+			if yyl824 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl868, d)
+				x.codecDecodeSelfFromMap(yyl824, d)
 			}
-		} else if yyct868 == codecSelferValueTypeArray1234 {
-			yyl868 := r.ReadArrayStart()
-			if yyl868 == 0 {
+		} else if yyct824 == codecSelferValueTypeArray1234 {
+			yyl824 := r.ReadArrayStart()
+			if yyl824 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl868, d)
+				x.codecDecodeSelfFromArray(yyl824, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10275,12 +9701,12 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys869Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys869Slc
-	var yyhl869 bool = l >= 0
-	for yyj869 := 0; ; yyj869++ {
-		if yyhl869 {
-			if yyj869 >= l {
+	var yys825Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys825Slc
+	var yyhl825 bool = l >= 0
+	for yyj825 := 0; ; yyj825++ {
+		if yyhl825 {
+			if yyj825 >= l {
 				break
 			}
 		} else {
@@ -10289,33 +9715,33 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys869Slc = r.DecodeBytes(yys869Slc, true, true)
-		yys869 := string(yys869Slc)
+		yys825Slc = r.DecodeBytes(yys825Slc, true, true)
+		yys825 := string(yys825Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys869 {
+		switch yys825 {
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv870 := &x.ListMeta
-				yym871 := z.DecBinary()
-				_ = yym871
+				yyv826 := &x.ListMeta
+				yym827 := z.DecBinary()
+				_ = yym827
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv870) {
+				} else if z.HasExtensions() && z.DecExt(yyv826) {
 				} else {
-					z.DecFallback(yyv870, false)
+					z.DecFallback(yyv826, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv872 := &x.Items
-				yym873 := z.DecBinary()
-				_ = yym873
+				yyv828 := &x.Items
+				yym829 := z.DecBinary()
+				_ = yym829
 				if false {
 				} else {
-					h.decSliceJob((*[]Job)(yyv872), d)
+					h.decSliceJob((*[]Job)(yyv828), d)
 				}
 			}
 		case "kind":
@@ -10331,9 +9757,9 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys869)
-		} // end switch yys869
-	} // end for yyj869
+			z.DecStructFieldNotFound(-1, yys825)
+		} // end switch yys825
+	} // end for yyj825
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -10341,16 +9767,16 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj876 int
-	var yyb876 bool
-	var yyhl876 bool = l >= 0
-	yyj876++
-	if yyhl876 {
-		yyb876 = yyj876 > l
+	var yyj832 int
+	var yyb832 bool
+	var yyhl832 bool = l >= 0
+	yyj832++
+	if yyhl832 {
+		yyb832 = yyj832 > l
 	} else {
-		yyb876 = r.CheckBreak()
+		yyb832 = r.CheckBreak()
 	}
-	if yyb876 {
+	if yyb832 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10358,22 +9784,22 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv877 := &x.ListMeta
-		yym878 := z.DecBinary()
-		_ = yym878
+		yyv833 := &x.ListMeta
+		yym834 := z.DecBinary()
+		_ = yym834
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv877) {
+		} else if z.HasExtensions() && z.DecExt(yyv833) {
 		} else {
-			z.DecFallback(yyv877, false)
+			z.DecFallback(yyv833, false)
 		}
 	}
-	yyj876++
-	if yyhl876 {
-		yyb876 = yyj876 > l
+	yyj832++
+	if yyhl832 {
+		yyb832 = yyj832 > l
 	} else {
-		yyb876 = r.CheckBreak()
+		yyb832 = r.CheckBreak()
 	}
-	if yyb876 {
+	if yyb832 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10381,21 +9807,21 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv879 := &x.Items
-		yym880 := z.DecBinary()
-		_ = yym880
+		yyv835 := &x.Items
+		yym836 := z.DecBinary()
+		_ = yym836
 		if false {
 		} else {
-			h.decSliceJob((*[]Job)(yyv879), d)
+			h.decSliceJob((*[]Job)(yyv835), d)
 		}
 	}
-	yyj876++
-	if yyhl876 {
-		yyb876 = yyj876 > l
+	yyj832++
+	if yyhl832 {
+		yyb832 = yyj832 > l
 	} else {
-		yyb876 = r.CheckBreak()
+		yyb832 = r.CheckBreak()
 	}
-	if yyb876 {
+	if yyb832 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10405,13 +9831,13 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj876++
-	if yyhl876 {
-		yyb876 = yyj876 > l
+	yyj832++
+	if yyhl832 {
+		yyb832 = yyj832 > l
 	} else {
-		yyb876 = r.CheckBreak()
+		yyb832 = r.CheckBreak()
 	}
-	if yyb876 {
+	if yyb832 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10422,17 +9848,17 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = string(r.DecodeString())
 	}
 	for {
-		yyj876++
-		if yyhl876 {
-			yyb876 = yyj876 > l
+		yyj832++
+		if yyhl832 {
+			yyb832 = yyj832 > l
 		} else {
-			yyb876 = r.CheckBreak()
+			yyb832 = r.CheckBreak()
 		}
-		if yyb876 {
+		if yyb832 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj876-1, "")
+		z.DecStructFieldNotFound(yyj832-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -10444,146 +9870,146 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym883 := z.EncBinary()
-		_ = yym883
+		yym839 := z.EncBinary()
+		_ = yym839
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep884 := !z.EncBinary()
-			yy2arr884 := z.EncBasicHandle().StructToArray
-			var yyq884 [5]bool
-			_, _, _ = yysep884, yyq884, yy2arr884
-			const yyr884 bool = false
-			yyq884[0] = x.Parallelism != nil
-			yyq884[1] = x.Completions != nil
-			yyq884[2] = x.ActiveDeadlineSeconds != nil
-			yyq884[3] = x.Selector != nil
-			var yynn884 int
-			if yyr884 || yy2arr884 {
+			yysep840 := !z.EncBinary()
+			yy2arr840 := z.EncBasicHandle().StructToArray
+			var yyq840 [5]bool
+			_, _, _ = yysep840, yyq840, yy2arr840
+			const yyr840 bool = false
+			yyq840[0] = x.Parallelism != nil
+			yyq840[1] = x.Completions != nil
+			yyq840[2] = x.ActiveDeadlineSeconds != nil
+			yyq840[3] = x.Selector != nil
+			var yynn840 int
+			if yyr840 || yy2arr840 {
 				r.EncodeArrayStart(5)
 			} else {
-				yynn884 = 1
-				for _, b := range yyq884 {
+				yynn840 = 1
+				for _, b := range yyq840 {
 					if b {
-						yynn884++
+						yynn840++
 					}
 				}
-				r.EncodeMapStart(yynn884)
-				yynn884 = 0
+				r.EncodeMapStart(yynn840)
+				yynn840 = 0
 			}
-			if yyr884 || yy2arr884 {
+			if yyr840 || yy2arr840 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq884[0] {
+				if yyq840[0] {
 					if x.Parallelism == nil {
 						r.EncodeNil()
 					} else {
-						yy886 := *x.Parallelism
-						yym887 := z.EncBinary()
-						_ = yym887
+						yy842 := *x.Parallelism
+						yym843 := z.EncBinary()
+						_ = yym843
 						if false {
 						} else {
-							r.EncodeInt(int64(yy886))
+							r.EncodeInt(int64(yy842))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq884[0] {
+				if yyq840[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("parallelism"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Parallelism == nil {
 						r.EncodeNil()
 					} else {
-						yy888 := *x.Parallelism
-						yym889 := z.EncBinary()
-						_ = yym889
+						yy844 := *x.Parallelism
+						yym845 := z.EncBinary()
+						_ = yym845
 						if false {
 						} else {
-							r.EncodeInt(int64(yy888))
+							r.EncodeInt(int64(yy844))
 						}
 					}
 				}
 			}
-			if yyr884 || yy2arr884 {
+			if yyr840 || yy2arr840 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq884[1] {
+				if yyq840[1] {
 					if x.Completions == nil {
 						r.EncodeNil()
 					} else {
-						yy891 := *x.Completions
-						yym892 := z.EncBinary()
-						_ = yym892
+						yy847 := *x.Completions
+						yym848 := z.EncBinary()
+						_ = yym848
 						if false {
 						} else {
-							r.EncodeInt(int64(yy891))
+							r.EncodeInt(int64(yy847))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq884[1] {
+				if yyq840[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("completions"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Completions == nil {
 						r.EncodeNil()
 					} else {
-						yy893 := *x.Completions
-						yym894 := z.EncBinary()
-						_ = yym894
+						yy849 := *x.Completions
+						yym850 := z.EncBinary()
+						_ = yym850
 						if false {
 						} else {
-							r.EncodeInt(int64(yy893))
+							r.EncodeInt(int64(yy849))
 						}
 					}
 				}
 			}
-			if yyr884 || yy2arr884 {
+			if yyr840 || yy2arr840 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq884[2] {
+				if yyq840[2] {
 					if x.ActiveDeadlineSeconds == nil {
 						r.EncodeNil()
 					} else {
-						yy896 := *x.ActiveDeadlineSeconds
-						yym897 := z.EncBinary()
-						_ = yym897
+						yy852 := *x.ActiveDeadlineSeconds
+						yym853 := z.EncBinary()
+						_ = yym853
 						if false {
 						} else {
-							r.EncodeInt(int64(yy896))
+							r.EncodeInt(int64(yy852))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq884[2] {
+				if yyq840[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("activeDeadlineSeconds"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.ActiveDeadlineSeconds == nil {
 						r.EncodeNil()
 					} else {
-						yy898 := *x.ActiveDeadlineSeconds
-						yym899 := z.EncBinary()
-						_ = yym899
+						yy854 := *x.ActiveDeadlineSeconds
+						yym855 := z.EncBinary()
+						_ = yym855
 						if false {
 						} else {
-							r.EncodeInt(int64(yy898))
+							r.EncodeInt(int64(yy854))
 						}
 					}
 				}
 			}
-			if yyr884 || yy2arr884 {
+			if yyr840 || yy2arr840 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq884[3] {
+				if yyq840[3] {
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
-						yym901 := z.EncBinary()
-						_ = yym901
+						yym857 := z.EncBinary()
+						_ = yym857
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.Selector) {
 						} else {
@@ -10594,15 +10020,15 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq884[3] {
+				if yyq840[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
-						yym902 := z.EncBinary()
-						_ = yym902
+						yym858 := z.EncBinary()
+						_ = yym858
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.Selector) {
 						} else {
@@ -10611,18 +10037,18 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr884 || yy2arr884 {
+			if yyr840 || yy2arr840 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy904 := &x.Template
-				yy904.CodecEncodeSelf(e)
+				yy860 := &x.Template
+				yy860.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("template"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy905 := &x.Template
-				yy905.CodecEncodeSelf(e)
+				yy861 := &x.Template
+				yy861.CodecEncodeSelf(e)
 			}
-			if yyr884 || yy2arr884 {
+			if yyr840 || yy2arr840 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -10635,25 +10061,25 @@ func (x *JobSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym906 := z.DecBinary()
-	_ = yym906
+	yym862 := z.DecBinary()
+	_ = yym862
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct907 := r.ContainerType()
-		if yyct907 == codecSelferValueTypeMap1234 {
-			yyl907 := r.ReadMapStart()
-			if yyl907 == 0 {
+		yyct863 := r.ContainerType()
+		if yyct863 == codecSelferValueTypeMap1234 {
+			yyl863 := r.ReadMapStart()
+			if yyl863 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl907, d)
+				x.codecDecodeSelfFromMap(yyl863, d)
 			}
-		} else if yyct907 == codecSelferValueTypeArray1234 {
-			yyl907 := r.ReadArrayStart()
-			if yyl907 == 0 {
+		} else if yyct863 == codecSelferValueTypeArray1234 {
+			yyl863 := r.ReadArrayStart()
+			if yyl863 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl907, d)
+				x.codecDecodeSelfFromArray(yyl863, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10665,12 +10091,12 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys908Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys908Slc
-	var yyhl908 bool = l >= 0
-	for yyj908 := 0; ; yyj908++ {
-		if yyhl908 {
-			if yyj908 >= l {
+	var yys864Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys864Slc
+	var yyhl864 bool = l >= 0
+	for yyj864 := 0; ; yyj864++ {
+		if yyhl864 {
+			if yyj864 >= l {
 				break
 			}
 		} else {
@@ -10679,10 +10105,10 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys908Slc = r.DecodeBytes(yys908Slc, true, true)
-		yys908 := string(yys908Slc)
+		yys864Slc = r.DecodeBytes(yys864Slc, true, true)
+		yys864 := string(yys864Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys908 {
+		switch yys864 {
 		case "parallelism":
 			if r.TryDecodeAsNil() {
 				if x.Parallelism != nil {
@@ -10692,8 +10118,8 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Parallelism == nil {
 					x.Parallelism = new(int)
 				}
-				yym910 := z.DecBinary()
-				_ = yym910
+				yym866 := z.DecBinary()
+				_ = yym866
 				if false {
 				} else {
 					*((*int)(x.Parallelism)) = int(r.DecodeInt(codecSelferBitsize1234))
@@ -10708,8 +10134,8 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Completions == nil {
 					x.Completions = new(int)
 				}
-				yym912 := z.DecBinary()
-				_ = yym912
+				yym868 := z.DecBinary()
+				_ = yym868
 				if false {
 				} else {
 					*((*int)(x.Completions)) = int(r.DecodeInt(codecSelferBitsize1234))
@@ -10724,8 +10150,8 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.ActiveDeadlineSeconds == nil {
 					x.ActiveDeadlineSeconds = new(int64)
 				}
-				yym914 := z.DecBinary()
-				_ = yym914
+				yym870 := z.DecBinary()
+				_ = yym870
 				if false {
 				} else {
 					*((*int64)(x.ActiveDeadlineSeconds)) = int64(r.DecodeInt(64))
@@ -10740,8 +10166,8 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Selector == nil {
 					x.Selector = new(pkg1_unversioned.LabelSelector)
 				}
-				yym916 := z.DecBinary()
-				_ = yym916
+				yym872 := z.DecBinary()
+				_ = yym872
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.Selector) {
 				} else {
@@ -10752,13 +10178,13 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Template = pkg2_api.PodTemplateSpec{}
 			} else {
-				yyv917 := &x.Template
-				yyv917.CodecDecodeSelf(d)
+				yyv873 := &x.Template
+				yyv873.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys908)
-		} // end switch yys908
-	} // end for yyj908
+			z.DecStructFieldNotFound(-1, yys864)
+		} // end switch yys864
+	} // end for yyj864
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -10766,16 +10192,16 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj918 int
-	var yyb918 bool
-	var yyhl918 bool = l >= 0
-	yyj918++
-	if yyhl918 {
-		yyb918 = yyj918 > l
+	var yyj874 int
+	var yyb874 bool
+	var yyhl874 bool = l >= 0
+	yyj874++
+	if yyhl874 {
+		yyb874 = yyj874 > l
 	} else {
-		yyb918 = r.CheckBreak()
+		yyb874 = r.CheckBreak()
 	}
-	if yyb918 {
+	if yyb874 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10788,20 +10214,20 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.Parallelism == nil {
 			x.Parallelism = new(int)
 		}
-		yym920 := z.DecBinary()
-		_ = yym920
+		yym876 := z.DecBinary()
+		_ = yym876
 		if false {
 		} else {
 			*((*int)(x.Parallelism)) = int(r.DecodeInt(codecSelferBitsize1234))
 		}
 	}
-	yyj918++
-	if yyhl918 {
-		yyb918 = yyj918 > l
+	yyj874++
+	if yyhl874 {
+		yyb874 = yyj874 > l
 	} else {
-		yyb918 = r.CheckBreak()
+		yyb874 = r.CheckBreak()
 	}
-	if yyb918 {
+	if yyb874 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10814,20 +10240,20 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.Completions == nil {
 			x.Completions = new(int)
 		}
-		yym922 := z.DecBinary()
-		_ = yym922
+		yym878 := z.DecBinary()
+		_ = yym878
 		if false {
 		} else {
 			*((*int)(x.Completions)) = int(r.DecodeInt(codecSelferBitsize1234))
 		}
 	}
-	yyj918++
-	if yyhl918 {
-		yyb918 = yyj918 > l
+	yyj874++
+	if yyhl874 {
+		yyb874 = yyj874 > l
 	} else {
-		yyb918 = r.CheckBreak()
+		yyb874 = r.CheckBreak()
 	}
-	if yyb918 {
+	if yyb874 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10840,20 +10266,20 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.ActiveDeadlineSeconds == nil {
 			x.ActiveDeadlineSeconds = new(int64)
 		}
-		yym924 := z.DecBinary()
-		_ = yym924
+		yym880 := z.DecBinary()
+		_ = yym880
 		if false {
 		} else {
 			*((*int64)(x.ActiveDeadlineSeconds)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj918++
-	if yyhl918 {
-		yyb918 = yyj918 > l
+	yyj874++
+	if yyhl874 {
+		yyb874 = yyj874 > l
 	} else {
-		yyb918 = r.CheckBreak()
+		yyb874 = r.CheckBreak()
 	}
-	if yyb918 {
+	if yyb874 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10866,21 +10292,21 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.Selector == nil {
 			x.Selector = new(pkg1_unversioned.LabelSelector)
 		}
-		yym926 := z.DecBinary()
-		_ = yym926
+		yym882 := z.DecBinary()
+		_ = yym882
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.Selector) {
 		} else {
 			z.DecFallback(x.Selector, false)
 		}
 	}
-	yyj918++
-	if yyhl918 {
-		yyb918 = yyj918 > l
+	yyj874++
+	if yyhl874 {
+		yyb874 = yyj874 > l
 	} else {
-		yyb918 = r.CheckBreak()
+		yyb874 = r.CheckBreak()
 	}
-	if yyb918 {
+	if yyb874 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10888,21 +10314,21 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Template = pkg2_api.PodTemplateSpec{}
 	} else {
-		yyv927 := &x.Template
-		yyv927.CodecDecodeSelf(d)
+		yyv883 := &x.Template
+		yyv883.CodecDecodeSelf(d)
 	}
 	for {
-		yyj918++
-		if yyhl918 {
-			yyb918 = yyj918 > l
+		yyj874++
+		if yyhl874 {
+			yyb874 = yyj874 > l
 		} else {
-			yyb918 = r.CheckBreak()
+			yyb874 = r.CheckBreak()
 		}
-		if yyb918 {
+		if yyb874 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj918-1, "")
+		z.DecStructFieldNotFound(yyj874-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -10914,43 +10340,43 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym928 := z.EncBinary()
-		_ = yym928
+		yym884 := z.EncBinary()
+		_ = yym884
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep929 := !z.EncBinary()
-			yy2arr929 := z.EncBasicHandle().StructToArray
-			var yyq929 [6]bool
-			_, _, _ = yysep929, yyq929, yy2arr929
-			const yyr929 bool = false
-			yyq929[0] = len(x.Conditions) != 0
-			yyq929[1] = x.StartTime != nil
-			yyq929[2] = x.CompletionTime != nil
-			yyq929[3] = x.Active != 0
-			yyq929[4] = x.Succeeded != 0
-			yyq929[5] = x.Failed != 0
-			var yynn929 int
-			if yyr929 || yy2arr929 {
+			yysep885 := !z.EncBinary()
+			yy2arr885 := z.EncBasicHandle().StructToArray
+			var yyq885 [6]bool
+			_, _, _ = yysep885, yyq885, yy2arr885
+			const yyr885 bool = false
+			yyq885[0] = len(x.Conditions) != 0
+			yyq885[1] = x.StartTime != nil
+			yyq885[2] = x.CompletionTime != nil
+			yyq885[3] = x.Active != 0
+			yyq885[4] = x.Succeeded != 0
+			yyq885[5] = x.Failed != 0
+			var yynn885 int
+			if yyr885 || yy2arr885 {
 				r.EncodeArrayStart(6)
 			} else {
-				yynn929 = 0
-				for _, b := range yyq929 {
+				yynn885 = 0
+				for _, b := range yyq885 {
 					if b {
-						yynn929++
+						yynn885++
 					}
 				}
-				r.EncodeMapStart(yynn929)
-				yynn929 = 0
+				r.EncodeMapStart(yynn885)
+				yynn885 = 0
 			}
-			if yyr929 || yy2arr929 {
+			if yyr885 || yy2arr885 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq929[0] {
+				if yyq885[0] {
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym931 := z.EncBinary()
-						_ = yym931
+						yym887 := z.EncBinary()
+						_ = yym887
 						if false {
 						} else {
 							h.encSliceJobCondition(([]JobCondition)(x.Conditions), e)
@@ -10960,15 +10386,15 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq929[0] {
+				if yyq885[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("conditions"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym932 := z.EncBinary()
-						_ = yym932
+						yym888 := z.EncBinary()
+						_ = yym888
 						if false {
 						} else {
 							h.encSliceJobCondition(([]JobCondition)(x.Conditions), e)
@@ -10976,19 +10402,19 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr929 || yy2arr929 {
+			if yyr885 || yy2arr885 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq929[1] {
+				if yyq885[1] {
 					if x.StartTime == nil {
 						r.EncodeNil()
 					} else {
-						yym934 := z.EncBinary()
-						_ = yym934
+						yym890 := z.EncBinary()
+						_ = yym890
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
-						} else if yym934 {
+						} else if yym890 {
 							z.EncBinaryMarshal(x.StartTime)
-						} else if !yym934 && z.IsJSONHandle() {
+						} else if !yym890 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.StartTime)
 						} else {
 							z.EncFallback(x.StartTime)
@@ -10998,20 +10424,20 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq929[1] {
+				if yyq885[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("startTime"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.StartTime == nil {
 						r.EncodeNil()
 					} else {
-						yym935 := z.EncBinary()
-						_ = yym935
+						yym891 := z.EncBinary()
+						_ = yym891
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
-						} else if yym935 {
+						} else if yym891 {
 							z.EncBinaryMarshal(x.StartTime)
-						} else if !yym935 && z.IsJSONHandle() {
+						} else if !yym891 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.StartTime)
 						} else {
 							z.EncFallback(x.StartTime)
@@ -11019,19 +10445,19 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr929 || yy2arr929 {
+			if yyr885 || yy2arr885 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq929[2] {
+				if yyq885[2] {
 					if x.CompletionTime == nil {
 						r.EncodeNil()
 					} else {
-						yym937 := z.EncBinary()
-						_ = yym937
+						yym893 := z.EncBinary()
+						_ = yym893
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.CompletionTime) {
-						} else if yym937 {
+						} else if yym893 {
 							z.EncBinaryMarshal(x.CompletionTime)
-						} else if !yym937 && z.IsJSONHandle() {
+						} else if !yym893 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.CompletionTime)
 						} else {
 							z.EncFallback(x.CompletionTime)
@@ -11041,20 +10467,20 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq929[2] {
+				if yyq885[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("completionTime"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.CompletionTime == nil {
 						r.EncodeNil()
 					} else {
-						yym938 := z.EncBinary()
-						_ = yym938
+						yym894 := z.EncBinary()
+						_ = yym894
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.CompletionTime) {
-						} else if yym938 {
+						} else if yym894 {
 							z.EncBinaryMarshal(x.CompletionTime)
-						} else if !yym938 && z.IsJSONHandle() {
+						} else if !yym894 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.CompletionTime)
 						} else {
 							z.EncFallback(x.CompletionTime)
@@ -11062,11 +10488,11 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr929 || yy2arr929 {
+			if yyr885 || yy2arr885 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq929[3] {
-					yym940 := z.EncBinary()
-					_ = yym940
+				if yyq885[3] {
+					yym896 := z.EncBinary()
+					_ = yym896
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Active))
@@ -11075,23 +10501,23 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq929[3] {
+				if yyq885[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("active"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym941 := z.EncBinary()
-					_ = yym941
+					yym897 := z.EncBinary()
+					_ = yym897
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Active))
 					}
 				}
 			}
-			if yyr929 || yy2arr929 {
+			if yyr885 || yy2arr885 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq929[4] {
-					yym943 := z.EncBinary()
-					_ = yym943
+				if yyq885[4] {
+					yym899 := z.EncBinary()
+					_ = yym899
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Succeeded))
@@ -11100,23 +10526,23 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq929[4] {
+				if yyq885[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("succeeded"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym944 := z.EncBinary()
-					_ = yym944
+					yym900 := z.EncBinary()
+					_ = yym900
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Succeeded))
 					}
 				}
 			}
-			if yyr929 || yy2arr929 {
+			if yyr885 || yy2arr885 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq929[5] {
-					yym946 := z.EncBinary()
-					_ = yym946
+				if yyq885[5] {
+					yym902 := z.EncBinary()
+					_ = yym902
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Failed))
@@ -11125,19 +10551,19 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq929[5] {
+				if yyq885[5] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("failed"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym947 := z.EncBinary()
-					_ = yym947
+					yym903 := z.EncBinary()
+					_ = yym903
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Failed))
 					}
 				}
 			}
-			if yyr929 || yy2arr929 {
+			if yyr885 || yy2arr885 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -11150,25 +10576,25 @@ func (x *JobStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym948 := z.DecBinary()
-	_ = yym948
+	yym904 := z.DecBinary()
+	_ = yym904
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct949 := r.ContainerType()
-		if yyct949 == codecSelferValueTypeMap1234 {
-			yyl949 := r.ReadMapStart()
-			if yyl949 == 0 {
+		yyct905 := r.ContainerType()
+		if yyct905 == codecSelferValueTypeMap1234 {
+			yyl905 := r.ReadMapStart()
+			if yyl905 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl949, d)
+				x.codecDecodeSelfFromMap(yyl905, d)
 			}
-		} else if yyct949 == codecSelferValueTypeArray1234 {
-			yyl949 := r.ReadArrayStart()
-			if yyl949 == 0 {
+		} else if yyct905 == codecSelferValueTypeArray1234 {
+			yyl905 := r.ReadArrayStart()
+			if yyl905 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl949, d)
+				x.codecDecodeSelfFromArray(yyl905, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -11180,12 +10606,12 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys950Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys950Slc
-	var yyhl950 bool = l >= 0
-	for yyj950 := 0; ; yyj950++ {
-		if yyhl950 {
-			if yyj950 >= l {
+	var yys906Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys906Slc
+	var yyhl906 bool = l >= 0
+	for yyj906 := 0; ; yyj906++ {
+		if yyhl906 {
+			if yyj906 >= l {
 				break
 			}
 		} else {
@@ -11194,20 +10620,20 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys950Slc = r.DecodeBytes(yys950Slc, true, true)
-		yys950 := string(yys950Slc)
+		yys906Slc = r.DecodeBytes(yys906Slc, true, true)
+		yys906 := string(yys906Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys950 {
+		switch yys906 {
 		case "conditions":
 			if r.TryDecodeAsNil() {
 				x.Conditions = nil
 			} else {
-				yyv951 := &x.Conditions
-				yym952 := z.DecBinary()
-				_ = yym952
+				yyv907 := &x.Conditions
+				yym908 := z.DecBinary()
+				_ = yym908
 				if false {
 				} else {
-					h.decSliceJobCondition((*[]JobCondition)(yyv951), d)
+					h.decSliceJobCondition((*[]JobCondition)(yyv907), d)
 				}
 			}
 		case "startTime":
@@ -11219,13 +10645,13 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.StartTime == nil {
 					x.StartTime = new(pkg1_unversioned.Time)
 				}
-				yym954 := z.DecBinary()
-				_ = yym954
+				yym910 := z.DecBinary()
+				_ = yym910
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.StartTime) {
-				} else if yym954 {
+				} else if yym910 {
 					z.DecBinaryUnmarshal(x.StartTime)
-				} else if !yym954 && z.IsJSONHandle() {
+				} else if !yym910 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.StartTime)
 				} else {
 					z.DecFallback(x.StartTime, false)
@@ -11240,13 +10666,13 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.CompletionTime == nil {
 					x.CompletionTime = new(pkg1_unversioned.Time)
 				}
-				yym956 := z.DecBinary()
-				_ = yym956
+				yym912 := z.DecBinary()
+				_ = yym912
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.CompletionTime) {
-				} else if yym956 {
+				} else if yym912 {
 					z.DecBinaryUnmarshal(x.CompletionTime)
-				} else if !yym956 && z.IsJSONHandle() {
+				} else if !yym912 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.CompletionTime)
 				} else {
 					z.DecFallback(x.CompletionTime, false)
@@ -11271,9 +10697,9 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Failed = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys950)
-		} // end switch yys950
-	} // end for yyj950
+			z.DecStructFieldNotFound(-1, yys906)
+		} // end switch yys906
+	} // end for yyj906
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -11281,16 +10707,16 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj960 int
-	var yyb960 bool
-	var yyhl960 bool = l >= 0
-	yyj960++
-	if yyhl960 {
-		yyb960 = yyj960 > l
+	var yyj916 int
+	var yyb916 bool
+	var yyhl916 bool = l >= 0
+	yyj916++
+	if yyhl916 {
+		yyb916 = yyj916 > l
 	} else {
-		yyb960 = r.CheckBreak()
+		yyb916 = r.CheckBreak()
 	}
-	if yyb960 {
+	if yyb916 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11298,21 +10724,21 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Conditions = nil
 	} else {
-		yyv961 := &x.Conditions
-		yym962 := z.DecBinary()
-		_ = yym962
+		yyv917 := &x.Conditions
+		yym918 := z.DecBinary()
+		_ = yym918
 		if false {
 		} else {
-			h.decSliceJobCondition((*[]JobCondition)(yyv961), d)
+			h.decSliceJobCondition((*[]JobCondition)(yyv917), d)
 		}
 	}
-	yyj960++
-	if yyhl960 {
-		yyb960 = yyj960 > l
+	yyj916++
+	if yyhl916 {
+		yyb916 = yyj916 > l
 	} else {
-		yyb960 = r.CheckBreak()
+		yyb916 = r.CheckBreak()
 	}
-	if yyb960 {
+	if yyb916 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11325,25 +10751,25 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.StartTime == nil {
 			x.StartTime = new(pkg1_unversioned.Time)
 		}
-		yym964 := z.DecBinary()
-		_ = yym964
+		yym920 := z.DecBinary()
+		_ = yym920
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.StartTime) {
-		} else if yym964 {
+		} else if yym920 {
 			z.DecBinaryUnmarshal(x.StartTime)
-		} else if !yym964 && z.IsJSONHandle() {
+		} else if !yym920 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.StartTime)
 		} else {
 			z.DecFallback(x.StartTime, false)
 		}
 	}
-	yyj960++
-	if yyhl960 {
-		yyb960 = yyj960 > l
+	yyj916++
+	if yyhl916 {
+		yyb916 = yyj916 > l
 	} else {
-		yyb960 = r.CheckBreak()
+		yyb916 = r.CheckBreak()
 	}
-	if yyb960 {
+	if yyb916 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11356,25 +10782,25 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.CompletionTime == nil {
 			x.CompletionTime = new(pkg1_unversioned.Time)
 		}
-		yym966 := z.DecBinary()
-		_ = yym966
+		yym922 := z.DecBinary()
+		_ = yym922
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.CompletionTime) {
-		} else if yym966 {
+		} else if yym922 {
 			z.DecBinaryUnmarshal(x.CompletionTime)
-		} else if !yym966 && z.IsJSONHandle() {
+		} else if !yym922 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.CompletionTime)
 		} else {
 			z.DecFallback(x.CompletionTime, false)
 		}
 	}
-	yyj960++
-	if yyhl960 {
-		yyb960 = yyj960 > l
+	yyj916++
+	if yyhl916 {
+		yyb916 = yyj916 > l
 	} else {
-		yyb960 = r.CheckBreak()
+		yyb916 = r.CheckBreak()
 	}
-	if yyb960 {
+	if yyb916 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11384,13 +10810,13 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Active = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj960++
-	if yyhl960 {
-		yyb960 = yyj960 > l
+	yyj916++
+	if yyhl916 {
+		yyb916 = yyj916 > l
 	} else {
-		yyb960 = r.CheckBreak()
+		yyb916 = r.CheckBreak()
 	}
-	if yyb960 {
+	if yyb916 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11400,13 +10826,13 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Succeeded = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj960++
-	if yyhl960 {
-		yyb960 = yyj960 > l
+	yyj916++
+	if yyhl916 {
+		yyb916 = yyj916 > l
 	} else {
-		yyb960 = r.CheckBreak()
+		yyb916 = r.CheckBreak()
 	}
-	if yyb960 {
+	if yyb916 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11417,17 +10843,17 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Failed = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj960++
-		if yyhl960 {
-			yyb960 = yyj960 > l
+		yyj916++
+		if yyhl916 {
+			yyb916 = yyj916 > l
 		} else {
-			yyb960 = r.CheckBreak()
+			yyb916 = r.CheckBreak()
 		}
-		if yyb960 {
+		if yyb916 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj960-1, "")
+		z.DecStructFieldNotFound(yyj916-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -11436,8 +10862,8 @@ func (x JobConditionType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym970 := z.EncBinary()
-	_ = yym970
+	yym926 := z.EncBinary()
+	_ = yym926
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -11449,8 +10875,8 @@ func (x *JobConditionType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym971 := z.DecBinary()
-	_ = yym971
+	yym927 := z.DecBinary()
+	_ = yym927
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -11465,34 +10891,34 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym972 := z.EncBinary()
-		_ = yym972
+		yym928 := z.EncBinary()
+		_ = yym928
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep973 := !z.EncBinary()
-			yy2arr973 := z.EncBasicHandle().StructToArray
-			var yyq973 [6]bool
-			_, _, _ = yysep973, yyq973, yy2arr973
-			const yyr973 bool = false
-			yyq973[2] = true
-			yyq973[3] = true
-			yyq973[4] = x.Reason != ""
-			yyq973[5] = x.Message != ""
-			var yynn973 int
-			if yyr973 || yy2arr973 {
+			yysep929 := !z.EncBinary()
+			yy2arr929 := z.EncBasicHandle().StructToArray
+			var yyq929 [6]bool
+			_, _, _ = yysep929, yyq929, yy2arr929
+			const yyr929 bool = false
+			yyq929[2] = true
+			yyq929[3] = true
+			yyq929[4] = x.Reason != ""
+			yyq929[5] = x.Message != ""
+			var yynn929 int
+			if yyr929 || yy2arr929 {
 				r.EncodeArrayStart(6)
 			} else {
-				yynn973 = 2
-				for _, b := range yyq973 {
+				yynn929 = 2
+				for _, b := range yyq929 {
 					if b {
-						yynn973++
+						yynn929++
 					}
 				}
-				r.EncodeMapStart(yynn973)
-				yynn973 = 0
+				r.EncodeMapStart(yynn929)
+				yynn929 = 0
 			}
-			if yyr973 || yy2arr973 {
+			if yyr929 || yy2arr929 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Type.CodecEncodeSelf(e)
 			} else {
@@ -11501,10 +10927,10 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Type.CodecEncodeSelf(e)
 			}
-			if yyr973 || yy2arr973 {
+			if yyr929 || yy2arr929 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym976 := z.EncBinary()
-				_ = yym976
+				yym932 := z.EncBinary()
+				_ = yym932
 				if false {
 				} else if z.HasExtensions() && z.EncExt(x.Status) {
 				} else {
@@ -11514,93 +10940,93 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("status"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym977 := z.EncBinary()
-				_ = yym977
+				yym933 := z.EncBinary()
+				_ = yym933
 				if false {
 				} else if z.HasExtensions() && z.EncExt(x.Status) {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Status))
 				}
 			}
-			if yyr973 || yy2arr973 {
+			if yyr929 || yy2arr929 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq973[2] {
-					yy979 := &x.LastProbeTime
-					yym980 := z.EncBinary()
-					_ = yym980
+				if yyq929[2] {
+					yy935 := &x.LastProbeTime
+					yym936 := z.EncBinary()
+					_ = yym936
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy979) {
-					} else if yym980 {
-						z.EncBinaryMarshal(yy979)
-					} else if !yym980 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy979)
+					} else if z.HasExtensions() && z.EncExt(yy935) {
+					} else if yym936 {
+						z.EncBinaryMarshal(yy935)
+					} else if !yym936 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy935)
 					} else {
-						z.EncFallback(yy979)
+						z.EncFallback(yy935)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq973[2] {
+				if yyq929[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("lastProbeTime"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy981 := &x.LastProbeTime
-					yym982 := z.EncBinary()
-					_ = yym982
+					yy937 := &x.LastProbeTime
+					yym938 := z.EncBinary()
+					_ = yym938
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy981) {
-					} else if yym982 {
-						z.EncBinaryMarshal(yy981)
-					} else if !yym982 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy981)
+					} else if z.HasExtensions() && z.EncExt(yy937) {
+					} else if yym938 {
+						z.EncBinaryMarshal(yy937)
+					} else if !yym938 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy937)
 					} else {
-						z.EncFallback(yy981)
+						z.EncFallback(yy937)
 					}
 				}
 			}
-			if yyr973 || yy2arr973 {
+			if yyr929 || yy2arr929 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq973[3] {
-					yy984 := &x.LastTransitionTime
-					yym985 := z.EncBinary()
-					_ = yym985
+				if yyq929[3] {
+					yy940 := &x.LastTransitionTime
+					yym941 := z.EncBinary()
+					_ = yym941
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy984) {
-					} else if yym985 {
-						z.EncBinaryMarshal(yy984)
-					} else if !yym985 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy984)
+					} else if z.HasExtensions() && z.EncExt(yy940) {
+					} else if yym941 {
+						z.EncBinaryMarshal(yy940)
+					} else if !yym941 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy940)
 					} else {
-						z.EncFallback(yy984)
+						z.EncFallback(yy940)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq973[3] {
+				if yyq929[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("lastTransitionTime"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy986 := &x.LastTransitionTime
-					yym987 := z.EncBinary()
-					_ = yym987
+					yy942 := &x.LastTransitionTime
+					yym943 := z.EncBinary()
+					_ = yym943
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy986) {
-					} else if yym987 {
-						z.EncBinaryMarshal(yy986)
-					} else if !yym987 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy986)
+					} else if z.HasExtensions() && z.EncExt(yy942) {
+					} else if yym943 {
+						z.EncBinaryMarshal(yy942)
+					} else if !yym943 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy942)
 					} else {
-						z.EncFallback(yy986)
+						z.EncFallback(yy942)
 					}
 				}
 			}
-			if yyr973 || yy2arr973 {
+			if yyr929 || yy2arr929 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq973[4] {
-					yym989 := z.EncBinary()
-					_ = yym989
+				if yyq929[4] {
+					yym945 := z.EncBinary()
+					_ = yym945
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
@@ -11609,23 +11035,23 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq973[4] {
+				if yyq929[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("reason"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym990 := z.EncBinary()
-					_ = yym990
+					yym946 := z.EncBinary()
+					_ = yym946
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
 					}
 				}
 			}
-			if yyr973 || yy2arr973 {
+			if yyr929 || yy2arr929 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq973[5] {
-					yym992 := z.EncBinary()
-					_ = yym992
+				if yyq929[5] {
+					yym948 := z.EncBinary()
+					_ = yym948
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
@@ -11634,19 +11060,19 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq973[5] {
+				if yyq929[5] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym993 := z.EncBinary()
-					_ = yym993
+					yym949 := z.EncBinary()
+					_ = yym949
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
 					}
 				}
 			}
-			if yyr973 || yy2arr973 {
+			if yyr929 || yy2arr929 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -11659,25 +11085,25 @@ func (x *JobCondition) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym994 := z.DecBinary()
-	_ = yym994
+	yym950 := z.DecBinary()
+	_ = yym950
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct995 := r.ContainerType()
-		if yyct995 == codecSelferValueTypeMap1234 {
-			yyl995 := r.ReadMapStart()
-			if yyl995 == 0 {
+		yyct951 := r.ContainerType()
+		if yyct951 == codecSelferValueTypeMap1234 {
+			yyl951 := r.ReadMapStart()
+			if yyl951 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl995, d)
+				x.codecDecodeSelfFromMap(yyl951, d)
 			}
-		} else if yyct995 == codecSelferValueTypeArray1234 {
-			yyl995 := r.ReadArrayStart()
-			if yyl995 == 0 {
+		} else if yyct951 == codecSelferValueTypeArray1234 {
+			yyl951 := r.ReadArrayStart()
+			if yyl951 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl995, d)
+				x.codecDecodeSelfFromArray(yyl951, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -11689,12 +11115,12 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys996Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys996Slc
-	var yyhl996 bool = l >= 0
-	for yyj996 := 0; ; yyj996++ {
-		if yyhl996 {
-			if yyj996 >= l {
+	var yys952Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys952Slc
+	var yyhl952 bool = l >= 0
+	for yyj952 := 0; ; yyj952++ {
+		if yyhl952 {
+			if yyj952 >= l {
 				break
 			}
 		} else {
@@ -11703,10 +11129,10 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys996Slc = r.DecodeBytes(yys996Slc, true, true)
-		yys996 := string(yys996Slc)
+		yys952Slc = r.DecodeBytes(yys952Slc, true, true)
+		yys952 := string(yys952Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys996 {
+		switch yys952 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -11723,34 +11149,34 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.LastProbeTime = pkg1_unversioned.Time{}
 			} else {
-				yyv999 := &x.LastProbeTime
-				yym1000 := z.DecBinary()
-				_ = yym1000
+				yyv955 := &x.LastProbeTime
+				yym956 := z.DecBinary()
+				_ = yym956
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv999) {
-				} else if yym1000 {
-					z.DecBinaryUnmarshal(yyv999)
-				} else if !yym1000 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv999)
+				} else if z.HasExtensions() && z.DecExt(yyv955) {
+				} else if yym956 {
+					z.DecBinaryUnmarshal(yyv955)
+				} else if !yym956 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv955)
 				} else {
-					z.DecFallback(yyv999, false)
+					z.DecFallback(yyv955, false)
 				}
 			}
 		case "lastTransitionTime":
 			if r.TryDecodeAsNil() {
 				x.LastTransitionTime = pkg1_unversioned.Time{}
 			} else {
-				yyv1001 := &x.LastTransitionTime
-				yym1002 := z.DecBinary()
-				_ = yym1002
+				yyv957 := &x.LastTransitionTime
+				yym958 := z.DecBinary()
+				_ = yym958
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1001) {
-				} else if yym1002 {
-					z.DecBinaryUnmarshal(yyv1001)
-				} else if !yym1002 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1001)
+				} else if z.HasExtensions() && z.DecExt(yyv957) {
+				} else if yym958 {
+					z.DecBinaryUnmarshal(yyv957)
+				} else if !yym958 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv957)
 				} else {
-					z.DecFallback(yyv1001, false)
+					z.DecFallback(yyv957, false)
 				}
 			}
 		case "reason":
@@ -11766,9 +11192,9 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Message = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys996)
-		} // end switch yys996
-	} // end for yyj996
+			z.DecStructFieldNotFound(-1, yys952)
+		} // end switch yys952
+	} // end for yyj952
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -11776,16 +11202,16 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1005 int
-	var yyb1005 bool
-	var yyhl1005 bool = l >= 0
-	yyj1005++
-	if yyhl1005 {
-		yyb1005 = yyj1005 > l
+	var yyj961 int
+	var yyb961 bool
+	var yyhl961 bool = l >= 0
+	yyj961++
+	if yyhl961 {
+		yyb961 = yyj961 > l
 	} else {
-		yyb1005 = r.CheckBreak()
+		yyb961 = r.CheckBreak()
 	}
-	if yyb1005 {
+	if yyb961 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11795,13 +11221,13 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Type = JobConditionType(r.DecodeString())
 	}
-	yyj1005++
-	if yyhl1005 {
-		yyb1005 = yyj1005 > l
+	yyj961++
+	if yyhl961 {
+		yyb961 = yyj961 > l
 	} else {
-		yyb1005 = r.CheckBreak()
+		yyb961 = r.CheckBreak()
 	}
-	if yyb1005 {
+	if yyb961 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11811,13 +11237,13 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Status = pkg2_api.ConditionStatus(r.DecodeString())
 	}
-	yyj1005++
-	if yyhl1005 {
-		yyb1005 = yyj1005 > l
+	yyj961++
+	if yyhl961 {
+		yyb961 = yyj961 > l
 	} else {
-		yyb1005 = r.CheckBreak()
+		yyb961 = r.CheckBreak()
 	}
-	if yyb1005 {
+	if yyb961 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11825,26 +11251,26 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.LastProbeTime = pkg1_unversioned.Time{}
 	} else {
-		yyv1008 := &x.LastProbeTime
-		yym1009 := z.DecBinary()
-		_ = yym1009
+		yyv964 := &x.LastProbeTime
+		yym965 := z.DecBinary()
+		_ = yym965
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1008) {
-		} else if yym1009 {
-			z.DecBinaryUnmarshal(yyv1008)
-		} else if !yym1009 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1008)
+		} else if z.HasExtensions() && z.DecExt(yyv964) {
+		} else if yym965 {
+			z.DecBinaryUnmarshal(yyv964)
+		} else if !yym965 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv964)
 		} else {
-			z.DecFallback(yyv1008, false)
+			z.DecFallback(yyv964, false)
 		}
 	}
-	yyj1005++
-	if yyhl1005 {
-		yyb1005 = yyj1005 > l
+	yyj961++
+	if yyhl961 {
+		yyb961 = yyj961 > l
 	} else {
-		yyb1005 = r.CheckBreak()
+		yyb961 = r.CheckBreak()
 	}
-	if yyb1005 {
+	if yyb961 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11852,26 +11278,26 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.LastTransitionTime = pkg1_unversioned.Time{}
 	} else {
-		yyv1010 := &x.LastTransitionTime
-		yym1011 := z.DecBinary()
-		_ = yym1011
+		yyv966 := &x.LastTransitionTime
+		yym967 := z.DecBinary()
+		_ = yym967
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1010) {
-		} else if yym1011 {
-			z.DecBinaryUnmarshal(yyv1010)
-		} else if !yym1011 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1010)
+		} else if z.HasExtensions() && z.DecExt(yyv966) {
+		} else if yym967 {
+			z.DecBinaryUnmarshal(yyv966)
+		} else if !yym967 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv966)
 		} else {
-			z.DecFallback(yyv1010, false)
+			z.DecFallback(yyv966, false)
 		}
 	}
-	yyj1005++
-	if yyhl1005 {
-		yyb1005 = yyj1005 > l
+	yyj961++
+	if yyhl961 {
+		yyb961 = yyj961 > l
 	} else {
-		yyb1005 = r.CheckBreak()
+		yyb961 = r.CheckBreak()
 	}
-	if yyb1005 {
+	if yyb961 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11881,13 +11307,13 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Reason = string(r.DecodeString())
 	}
-	yyj1005++
-	if yyhl1005 {
-		yyb1005 = yyj1005 > l
+	yyj961++
+	if yyhl961 {
+		yyb961 = yyj961 > l
 	} else {
-		yyb1005 = r.CheckBreak()
+		yyb961 = r.CheckBreak()
 	}
-	if yyb1005 {
+	if yyb961 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11898,17 +11324,17 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Message = string(r.DecodeString())
 	}
 	for {
-		yyj1005++
-		if yyhl1005 {
-			yyb1005 = yyj1005 > l
+		yyj961++
+		if yyhl961 {
+			yyb961 = yyj961 > l
 		} else {
-			yyb1005 = r.CheckBreak()
+			yyb961 = r.CheckBreak()
 		}
-		if yyb1005 {
+		if yyb961 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1005-1, "")
+		z.DecStructFieldNotFound(yyj961-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -11920,90 +11346,90 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1014 := z.EncBinary()
-		_ = yym1014
+		yym970 := z.EncBinary()
+		_ = yym970
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1015 := !z.EncBinary()
-			yy2arr1015 := z.EncBasicHandle().StructToArray
-			var yyq1015 [5]bool
-			_, _, _ = yysep1015, yyq1015, yy2arr1015
-			const yyr1015 bool = false
-			yyq1015[0] = true
-			yyq1015[1] = true
-			yyq1015[2] = true
-			yyq1015[3] = x.Kind != ""
-			yyq1015[4] = x.APIVersion != ""
-			var yynn1015 int
-			if yyr1015 || yy2arr1015 {
+			yysep971 := !z.EncBinary()
+			yy2arr971 := z.EncBasicHandle().StructToArray
+			var yyq971 [5]bool
+			_, _, _ = yysep971, yyq971, yy2arr971
+			const yyr971 bool = false
+			yyq971[0] = true
+			yyq971[1] = true
+			yyq971[2] = true
+			yyq971[3] = x.Kind != ""
+			yyq971[4] = x.APIVersion != ""
+			var yynn971 int
+			if yyr971 || yy2arr971 {
 				r.EncodeArrayStart(5)
 			} else {
-				yynn1015 = 0
-				for _, b := range yyq1015 {
+				yynn971 = 0
+				for _, b := range yyq971 {
 					if b {
-						yynn1015++
+						yynn971++
 					}
 				}
-				r.EncodeMapStart(yynn1015)
-				yynn1015 = 0
+				r.EncodeMapStart(yynn971)
+				yynn971 = 0
 			}
-			if yyr1015 || yy2arr1015 {
+			if yyr971 || yy2arr971 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1015[0] {
-					yy1017 := &x.ObjectMeta
-					yy1017.CodecEncodeSelf(e)
+				if yyq971[0] {
+					yy973 := &x.ObjectMeta
+					yy973.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1015[0] {
+				if yyq971[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1018 := &x.ObjectMeta
-					yy1018.CodecEncodeSelf(e)
+					yy974 := &x.ObjectMeta
+					yy974.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1015 || yy2arr1015 {
+			if yyr971 || yy2arr971 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1015[1] {
-					yy1020 := &x.Spec
-					yy1020.CodecEncodeSelf(e)
+				if yyq971[1] {
+					yy976 := &x.Spec
+					yy976.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1015[1] {
+				if yyq971[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1021 := &x.Spec
-					yy1021.CodecEncodeSelf(e)
+					yy977 := &x.Spec
+					yy977.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1015 || yy2arr1015 {
+			if yyr971 || yy2arr971 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1015[2] {
-					yy1023 := &x.Status
-					yy1023.CodecEncodeSelf(e)
+				if yyq971[2] {
+					yy979 := &x.Status
+					yy979.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1015[2] {
+				if yyq971[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1024 := &x.Status
-					yy1024.CodecEncodeSelf(e)
+					yy980 := &x.Status
+					yy980.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1015 || yy2arr1015 {
+			if yyr971 || yy2arr971 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1015[3] {
-					yym1026 := z.EncBinary()
-					_ = yym1026
+				if yyq971[3] {
+					yym982 := z.EncBinary()
+					_ = yym982
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -12012,23 +11438,23 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1015[3] {
+				if yyq971[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1027 := z.EncBinary()
-					_ = yym1027
+					yym983 := z.EncBinary()
+					_ = yym983
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1015 || yy2arr1015 {
+			if yyr971 || yy2arr971 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1015[4] {
-					yym1029 := z.EncBinary()
-					_ = yym1029
+				if yyq971[4] {
+					yym985 := z.EncBinary()
+					_ = yym985
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -12037,19 +11463,19 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1015[4] {
+				if yyq971[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1030 := z.EncBinary()
-					_ = yym1030
+					yym986 := z.EncBinary()
+					_ = yym986
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1015 || yy2arr1015 {
+			if yyr971 || yy2arr971 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -12062,25 +11488,25 @@ func (x *Ingress) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1031 := z.DecBinary()
-	_ = yym1031
+	yym987 := z.DecBinary()
+	_ = yym987
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1032 := r.ContainerType()
-		if yyct1032 == codecSelferValueTypeMap1234 {
-			yyl1032 := r.ReadMapStart()
-			if yyl1032 == 0 {
+		yyct988 := r.ContainerType()
+		if yyct988 == codecSelferValueTypeMap1234 {
+			yyl988 := r.ReadMapStart()
+			if yyl988 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1032, d)
+				x.codecDecodeSelfFromMap(yyl988, d)
 			}
-		} else if yyct1032 == codecSelferValueTypeArray1234 {
-			yyl1032 := r.ReadArrayStart()
-			if yyl1032 == 0 {
+		} else if yyct988 == codecSelferValueTypeArray1234 {
+			yyl988 := r.ReadArrayStart()
+			if yyl988 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1032, d)
+				x.codecDecodeSelfFromArray(yyl988, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -12092,12 +11518,12 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1033Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1033Slc
-	var yyhl1033 bool = l >= 0
-	for yyj1033 := 0; ; yyj1033++ {
-		if yyhl1033 {
-			if yyj1033 >= l {
+	var yys989Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys989Slc
+	var yyhl989 bool = l >= 0
+	for yyj989 := 0; ; yyj989++ {
+		if yyhl989 {
+			if yyj989 >= l {
 				break
 			}
 		} else {
@@ -12106,30 +11532,30 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1033Slc = r.DecodeBytes(yys1033Slc, true, true)
-		yys1033 := string(yys1033Slc)
+		yys989Slc = r.DecodeBytes(yys989Slc, true, true)
+		yys989 := string(yys989Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1033 {
+		switch yys989 {
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv1034 := &x.ObjectMeta
-				yyv1034.CodecDecodeSelf(d)
+				yyv990 := &x.ObjectMeta
+				yyv990.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = IngressSpec{}
 			} else {
-				yyv1035 := &x.Spec
-				yyv1035.CodecDecodeSelf(d)
+				yyv991 := &x.Spec
+				yyv991.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = IngressStatus{}
 			} else {
-				yyv1036 := &x.Status
-				yyv1036.CodecDecodeSelf(d)
+				yyv992 := &x.Status
+				yyv992.CodecDecodeSelf(d)
 			}
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -12144,9 +11570,9 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1033)
-		} // end switch yys1033
-	} // end for yyj1033
+			z.DecStructFieldNotFound(-1, yys989)
+		} // end switch yys989
+	} // end for yyj989
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -12154,16 +11580,16 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1039 int
-	var yyb1039 bool
-	var yyhl1039 bool = l >= 0
-	yyj1039++
-	if yyhl1039 {
-		yyb1039 = yyj1039 > l
+	var yyj995 int
+	var yyb995 bool
+	var yyhl995 bool = l >= 0
+	yyj995++
+	if yyhl995 {
+		yyb995 = yyj995 > l
 	} else {
-		yyb1039 = r.CheckBreak()
+		yyb995 = r.CheckBreak()
 	}
-	if yyb1039 {
+	if yyb995 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -12171,16 +11597,16 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv1040 := &x.ObjectMeta
-		yyv1040.CodecDecodeSelf(d)
+		yyv996 := &x.ObjectMeta
+		yyv996.CodecDecodeSelf(d)
 	}
-	yyj1039++
-	if yyhl1039 {
-		yyb1039 = yyj1039 > l
+	yyj995++
+	if yyhl995 {
+		yyb995 = yyj995 > l
 	} else {
-		yyb1039 = r.CheckBreak()
+		yyb995 = r.CheckBreak()
 	}
-	if yyb1039 {
+	if yyb995 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -12188,16 +11614,16 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Spec = IngressSpec{}
 	} else {
-		yyv1041 := &x.Spec
-		yyv1041.CodecDecodeSelf(d)
+		yyv997 := &x.Spec
+		yyv997.CodecDecodeSelf(d)
 	}
-	yyj1039++
-	if yyhl1039 {
-		yyb1039 = yyj1039 > l
+	yyj995++
+	if yyhl995 {
+		yyb995 = yyj995 > l
 	} else {
-		yyb1039 = r.CheckBreak()
+		yyb995 = r.CheckBreak()
 	}
-	if yyb1039 {
+	if yyb995 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -12205,16 +11631,16 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Status = IngressStatus{}
 	} else {
-		yyv1042 := &x.Status
-		yyv1042.CodecDecodeSelf(d)
+		yyv998 := &x.Status
+		yyv998.CodecDecodeSelf(d)
 	}
-	yyj1039++
-	if yyhl1039 {
-		yyb1039 = yyj1039 > l
+	yyj995++
+	if yyhl995 {
+		yyb995 = yyj995 > l
 	} else {
-		yyb1039 = r.CheckBreak()
+		yyb995 = r.CheckBreak()
 	}
-	if yyb1039 {
+	if yyb995 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -12224,13 +11650,13 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1039++
-	if yyhl1039 {
-		yyb1039 = yyj1039 > l
+	yyj995++
+	if yyhl995 {
+		yyb995 = yyj995 > l
 	} else {
-		yyb1039 = r.CheckBreak()
+		yyb995 = r.CheckBreak()
 	}
-	if yyb1039 {
+	if yyb995 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -12241,17 +11667,17 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = string(r.DecodeString())
 	}
 	for {
-		yyj1039++
-		if yyhl1039 {
-			yyb1039 = yyj1039 > l
+		yyj995++
+		if yyhl995 {
+			yyb995 = yyj995 > l
 		} else {
-			yyb1039 = r.CheckBreak()
+			yyb995 = r.CheckBreak()
 		}
-		if yyb1039 {
+		if yyb995 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1039-1, "")
+		z.DecStructFieldNotFound(yyj995-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -12263,68 +11689,68 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1045 := z.EncBinary()
-		_ = yym1045
+		yym1001 := z.EncBinary()
+		_ = yym1001
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1046 := !z.EncBinary()
-			yy2arr1046 := z.EncBasicHandle().StructToArray
-			var yyq1046 [4]bool
-			_, _, _ = yysep1046, yyq1046, yy2arr1046
-			const yyr1046 bool = false
-			yyq1046[0] = true
-			yyq1046[2] = x.Kind != ""
-			yyq1046[3] = x.APIVersion != ""
-			var yynn1046 int
-			if yyr1046 || yy2arr1046 {
+			yysep1002 := !z.EncBinary()
+			yy2arr1002 := z.EncBasicHandle().StructToArray
+			var yyq1002 [4]bool
+			_, _, _ = yysep1002, yyq1002, yy2arr1002
+			const yyr1002 bool = false
+			yyq1002[0] = true
+			yyq1002[2] = x.Kind != ""
+			yyq1002[3] = x.APIVersion != ""
+			var yynn1002 int
+			if yyr1002 || yy2arr1002 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn1046 = 1
-				for _, b := range yyq1046 {
+				yynn1002 = 1
+				for _, b := range yyq1002 {
 					if b {
-						yynn1046++
+						yynn1002++
 					}
 				}
-				r.EncodeMapStart(yynn1046)
-				yynn1046 = 0
+				r.EncodeMapStart(yynn1002)
+				yynn1002 = 0
 			}
-			if yyr1046 || yy2arr1046 {
+			if yyr1002 || yy2arr1002 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1046[0] {
-					yy1048 := &x.ListMeta
-					yym1049 := z.EncBinary()
-					_ = yym1049
+				if yyq1002[0] {
+					yy1004 := &x.ListMeta
+					yym1005 := z.EncBinary()
+					_ = yym1005
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1048) {
+					} else if z.HasExtensions() && z.EncExt(yy1004) {
 					} else {
-						z.EncFallback(yy1048)
+						z.EncFallback(yy1004)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1046[0] {
+				if yyq1002[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1050 := &x.ListMeta
-					yym1051 := z.EncBinary()
-					_ = yym1051
+					yy1006 := &x.ListMeta
+					yym1007 := z.EncBinary()
+					_ = yym1007
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1050) {
+					} else if z.HasExtensions() && z.EncExt(yy1006) {
 					} else {
-						z.EncFallback(yy1050)
+						z.EncFallback(yy1006)
 					}
 				}
 			}
-			if yyr1046 || yy2arr1046 {
+			if yyr1002 || yy2arr1002 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1053 := z.EncBinary()
-					_ = yym1053
+					yym1009 := z.EncBinary()
+					_ = yym1009
 					if false {
 					} else {
 						h.encSliceIngress(([]Ingress)(x.Items), e)
@@ -12337,19 +11763,19 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1054 := z.EncBinary()
-					_ = yym1054
+					yym1010 := z.EncBinary()
+					_ = yym1010
 					if false {
 					} else {
 						h.encSliceIngress(([]Ingress)(x.Items), e)
 					}
 				}
 			}
-			if yyr1046 || yy2arr1046 {
+			if yyr1002 || yy2arr1002 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1046[2] {
-					yym1056 := z.EncBinary()
-					_ = yym1056
+				if yyq1002[2] {
+					yym1012 := z.EncBinary()
+					_ = yym1012
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -12358,23 +11784,23 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1046[2] {
+				if yyq1002[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1057 := z.EncBinary()
-					_ = yym1057
+					yym1013 := z.EncBinary()
+					_ = yym1013
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1046 || yy2arr1046 {
+			if yyr1002 || yy2arr1002 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1046[3] {
-					yym1059 := z.EncBinary()
-					_ = yym1059
+				if yyq1002[3] {
+					yym1015 := z.EncBinary()
+					_ = yym1015
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -12383,19 +11809,19 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1046[3] {
+				if yyq1002[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1060 := z.EncBinary()
-					_ = yym1060
+					yym1016 := z.EncBinary()
+					_ = yym1016
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1046 || yy2arr1046 {
+			if yyr1002 || yy2arr1002 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -12408,25 +11834,25 @@ func (x *IngressList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1061 := z.DecBinary()
-	_ = yym1061
+	yym1017 := z.DecBinary()
+	_ = yym1017
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1062 := r.ContainerType()
-		if yyct1062 == codecSelferValueTypeMap1234 {
-			yyl1062 := r.ReadMapStart()
-			if yyl1062 == 0 {
+		yyct1018 := r.ContainerType()
+		if yyct1018 == codecSelferValueTypeMap1234 {
+			yyl1018 := r.ReadMapStart()
+			if yyl1018 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1062, d)
+				x.codecDecodeSelfFromMap(yyl1018, d)
 			}
-		} else if yyct1062 == codecSelferValueTypeArray1234 {
-			yyl1062 := r.ReadArrayStart()
-			if yyl1062 == 0 {
+		} else if yyct1018 == codecSelferValueTypeArray1234 {
+			yyl1018 := r.ReadArrayStart()
+			if yyl1018 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1062, d)
+				x.codecDecodeSelfFromArray(yyl1018, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -12438,12 +11864,12 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1063Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1063Slc
-	var yyhl1063 bool = l >= 0
-	for yyj1063 := 0; ; yyj1063++ {
-		if yyhl1063 {
-			if yyj1063 >= l {
+	var yys1019Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1019Slc
+	var yyhl1019 bool = l >= 0
+	for yyj1019 := 0; ; yyj1019++ {
+		if yyhl1019 {
+			if yyj1019 >= l {
 				break
 			}
 		} else {
@@ -12452,33 +11878,33 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1063Slc = r.DecodeBytes(yys1063Slc, true, true)
-		yys1063 := string(yys1063Slc)
+		yys1019Slc = r.DecodeBytes(yys1019Slc, true, true)
+		yys1019 := string(yys1019Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1063 {
+		switch yys1019 {
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv1064 := &x.ListMeta
-				yym1065 := z.DecBinary()
-				_ = yym1065
+				yyv1020 := &x.ListMeta
+				yym1021 := z.DecBinary()
+				_ = yym1021
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1064) {
+				} else if z.HasExtensions() && z.DecExt(yyv1020) {
 				} else {
-					z.DecFallback(yyv1064, false)
+					z.DecFallback(yyv1020, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv1066 := &x.Items
-				yym1067 := z.DecBinary()
-				_ = yym1067
+				yyv1022 := &x.Items
+				yym1023 := z.DecBinary()
+				_ = yym1023
 				if false {
 				} else {
-					h.decSliceIngress((*[]Ingress)(yyv1066), d)
+					h.decSliceIngress((*[]Ingress)(yyv1022), d)
 				}
 			}
 		case "kind":
@@ -12494,13 +11920,602 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1063)
-		} // end switch yys1063
-	} // end for yyj1063
+			z.DecStructFieldNotFound(-1, yys1019)
+		} // end switch yys1019
+	} // end for yyj1019
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
 func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj1026 int
+	var yyb1026 bool
+	var yyhl1026 bool = l >= 0
+	yyj1026++
+	if yyhl1026 {
+		yyb1026 = yyj1026 > l
+	} else {
+		yyb1026 = r.CheckBreak()
+	}
+	if yyb1026 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.ListMeta = pkg1_unversioned.ListMeta{}
+	} else {
+		yyv1027 := &x.ListMeta
+		yym1028 := z.DecBinary()
+		_ = yym1028
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1027) {
+		} else {
+			z.DecFallback(yyv1027, false)
+		}
+	}
+	yyj1026++
+	if yyhl1026 {
+		yyb1026 = yyj1026 > l
+	} else {
+		yyb1026 = r.CheckBreak()
+	}
+	if yyb1026 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Items = nil
+	} else {
+		yyv1029 := &x.Items
+		yym1030 := z.DecBinary()
+		_ = yym1030
+		if false {
+		} else {
+			h.decSliceIngress((*[]Ingress)(yyv1029), d)
+		}
+	}
+	yyj1026++
+	if yyhl1026 {
+		yyb1026 = yyj1026 > l
+	} else {
+		yyb1026 = r.CheckBreak()
+	}
+	if yyb1026 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj1026++
+	if yyhl1026 {
+		yyb1026 = yyj1026 > l
+	} else {
+		yyb1026 = r.CheckBreak()
+	}
+	if yyb1026 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
+	}
+	for {
+		yyj1026++
+		if yyhl1026 {
+			yyb1026 = yyj1026 > l
+		} else {
+			yyb1026 = r.CheckBreak()
+		}
+		if yyb1026 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj1026-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym1033 := z.EncBinary()
+		_ = yym1033
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep1034 := !z.EncBinary()
+			yy2arr1034 := z.EncBasicHandle().StructToArray
+			var yyq1034 [3]bool
+			_, _, _ = yysep1034, yyq1034, yy2arr1034
+			const yyr1034 bool = false
+			yyq1034[0] = x.Backend != nil
+			yyq1034[1] = len(x.TLS) != 0
+			yyq1034[2] = len(x.Rules) != 0
+			var yynn1034 int
+			if yyr1034 || yy2arr1034 {
+				r.EncodeArrayStart(3)
+			} else {
+				yynn1034 = 0
+				for _, b := range yyq1034 {
+					if b {
+						yynn1034++
+					}
+				}
+				r.EncodeMapStart(yynn1034)
+				yynn1034 = 0
+			}
+			if yyr1034 || yy2arr1034 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1034[0] {
+					if x.Backend == nil {
+						r.EncodeNil()
+					} else {
+						x.Backend.CodecEncodeSelf(e)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1034[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("backend"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if x.Backend == nil {
+						r.EncodeNil()
+					} else {
+						x.Backend.CodecEncodeSelf(e)
+					}
+				}
+			}
+			if yyr1034 || yy2arr1034 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1034[1] {
+					if x.TLS == nil {
+						r.EncodeNil()
+					} else {
+						yym1037 := z.EncBinary()
+						_ = yym1037
+						if false {
+						} else {
+							h.encSliceIngressTLS(([]IngressTLS)(x.TLS), e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1034[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("tls"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if x.TLS == nil {
+						r.EncodeNil()
+					} else {
+						yym1038 := z.EncBinary()
+						_ = yym1038
+						if false {
+						} else {
+							h.encSliceIngressTLS(([]IngressTLS)(x.TLS), e)
+						}
+					}
+				}
+			}
+			if yyr1034 || yy2arr1034 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1034[2] {
+					if x.Rules == nil {
+						r.EncodeNil()
+					} else {
+						yym1040 := z.EncBinary()
+						_ = yym1040
+						if false {
+						} else {
+							h.encSliceIngressRule(([]IngressRule)(x.Rules), e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1034[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("rules"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if x.Rules == nil {
+						r.EncodeNil()
+					} else {
+						yym1041 := z.EncBinary()
+						_ = yym1041
+						if false {
+						} else {
+							h.encSliceIngressRule(([]IngressRule)(x.Rules), e)
+						}
+					}
+				}
+			}
+			if yyr1034 || yy2arr1034 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *IngressSpec) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym1042 := z.DecBinary()
+	_ = yym1042
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct1043 := r.ContainerType()
+		if yyct1043 == codecSelferValueTypeMap1234 {
+			yyl1043 := r.ReadMapStart()
+			if yyl1043 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl1043, d)
+			}
+		} else if yyct1043 == codecSelferValueTypeArray1234 {
+			yyl1043 := r.ReadArrayStart()
+			if yyl1043 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl1043, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *IngressSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys1044Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1044Slc
+	var yyhl1044 bool = l >= 0
+	for yyj1044 := 0; ; yyj1044++ {
+		if yyhl1044 {
+			if yyj1044 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys1044Slc = r.DecodeBytes(yys1044Slc, true, true)
+		yys1044 := string(yys1044Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys1044 {
+		case "backend":
+			if r.TryDecodeAsNil() {
+				if x.Backend != nil {
+					x.Backend = nil
+				}
+			} else {
+				if x.Backend == nil {
+					x.Backend = new(IngressBackend)
+				}
+				x.Backend.CodecDecodeSelf(d)
+			}
+		case "tls":
+			if r.TryDecodeAsNil() {
+				x.TLS = nil
+			} else {
+				yyv1046 := &x.TLS
+				yym1047 := z.DecBinary()
+				_ = yym1047
+				if false {
+				} else {
+					h.decSliceIngressTLS((*[]IngressTLS)(yyv1046), d)
+				}
+			}
+		case "rules":
+			if r.TryDecodeAsNil() {
+				x.Rules = nil
+			} else {
+				yyv1048 := &x.Rules
+				yym1049 := z.DecBinary()
+				_ = yym1049
+				if false {
+				} else {
+					h.decSliceIngressRule((*[]IngressRule)(yyv1048), d)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys1044)
+		} // end switch yys1044
+	} // end for yyj1044
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *IngressSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj1050 int
+	var yyb1050 bool
+	var yyhl1050 bool = l >= 0
+	yyj1050++
+	if yyhl1050 {
+		yyb1050 = yyj1050 > l
+	} else {
+		yyb1050 = r.CheckBreak()
+	}
+	if yyb1050 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		if x.Backend != nil {
+			x.Backend = nil
+		}
+	} else {
+		if x.Backend == nil {
+			x.Backend = new(IngressBackend)
+		}
+		x.Backend.CodecDecodeSelf(d)
+	}
+	yyj1050++
+	if yyhl1050 {
+		yyb1050 = yyj1050 > l
+	} else {
+		yyb1050 = r.CheckBreak()
+	}
+	if yyb1050 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.TLS = nil
+	} else {
+		yyv1052 := &x.TLS
+		yym1053 := z.DecBinary()
+		_ = yym1053
+		if false {
+		} else {
+			h.decSliceIngressTLS((*[]IngressTLS)(yyv1052), d)
+		}
+	}
+	yyj1050++
+	if yyhl1050 {
+		yyb1050 = yyj1050 > l
+	} else {
+		yyb1050 = r.CheckBreak()
+	}
+	if yyb1050 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Rules = nil
+	} else {
+		yyv1054 := &x.Rules
+		yym1055 := z.DecBinary()
+		_ = yym1055
+		if false {
+		} else {
+			h.decSliceIngressRule((*[]IngressRule)(yyv1054), d)
+		}
+	}
+	for {
+		yyj1050++
+		if yyhl1050 {
+			yyb1050 = yyj1050 > l
+		} else {
+			yyb1050 = r.CheckBreak()
+		}
+		if yyb1050 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj1050-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x *IngressTLS) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym1056 := z.EncBinary()
+		_ = yym1056
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep1057 := !z.EncBinary()
+			yy2arr1057 := z.EncBasicHandle().StructToArray
+			var yyq1057 [2]bool
+			_, _, _ = yysep1057, yyq1057, yy2arr1057
+			const yyr1057 bool = false
+			yyq1057[0] = len(x.Hosts) != 0
+			yyq1057[1] = x.SecretName != ""
+			var yynn1057 int
+			if yyr1057 || yy2arr1057 {
+				r.EncodeArrayStart(2)
+			} else {
+				yynn1057 = 0
+				for _, b := range yyq1057 {
+					if b {
+						yynn1057++
+					}
+				}
+				r.EncodeMapStart(yynn1057)
+				yynn1057 = 0
+			}
+			if yyr1057 || yy2arr1057 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1057[0] {
+					if x.Hosts == nil {
+						r.EncodeNil()
+					} else {
+						yym1059 := z.EncBinary()
+						_ = yym1059
+						if false {
+						} else {
+							z.F.EncSliceStringV(x.Hosts, false, e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1057[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("hosts"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if x.Hosts == nil {
+						r.EncodeNil()
+					} else {
+						yym1060 := z.EncBinary()
+						_ = yym1060
+						if false {
+						} else {
+							z.F.EncSliceStringV(x.Hosts, false, e)
+						}
+					}
+				}
+			}
+			if yyr1057 || yy2arr1057 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1057[1] {
+					yym1062 := z.EncBinary()
+					_ = yym1062
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.SecretName))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1057[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("secretName"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1063 := z.EncBinary()
+					_ = yym1063
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.SecretName))
+					}
+				}
+			}
+			if yyr1057 || yy2arr1057 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *IngressTLS) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym1064 := z.DecBinary()
+	_ = yym1064
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct1065 := r.ContainerType()
+		if yyct1065 == codecSelferValueTypeMap1234 {
+			yyl1065 := r.ReadMapStart()
+			if yyl1065 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl1065, d)
+			}
+		} else if yyct1065 == codecSelferValueTypeArray1234 {
+			yyl1065 := r.ReadArrayStart()
+			if yyl1065 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl1065, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *IngressTLS) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys1066Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1066Slc
+	var yyhl1066 bool = l >= 0
+	for yyj1066 := 0; ; yyj1066++ {
+		if yyhl1066 {
+			if yyj1066 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys1066Slc = r.DecodeBytes(yys1066Slc, true, true)
+		yys1066 := string(yys1066Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys1066 {
+		case "hosts":
+			if r.TryDecodeAsNil() {
+				x.Hosts = nil
+			} else {
+				yyv1067 := &x.Hosts
+				yym1068 := z.DecBinary()
+				_ = yym1068
+				if false {
+				} else {
+					z.F.DecSliceStringX(yyv1067, false, d)
+				}
+			}
+		case "secretName":
+			if r.TryDecodeAsNil() {
+				x.SecretName = ""
+			} else {
+				x.SecretName = string(r.DecodeString())
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys1066)
+		} // end switch yys1066
+	} // end for yyj1066
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *IngressTLS) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -12519,15 +12534,14 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg1_unversioned.ListMeta{}
+		x.Hosts = nil
 	} else {
-		yyv1071 := &x.ListMeta
+		yyv1071 := &x.Hosts
 		yym1072 := z.DecBinary()
 		_ = yym1072
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1071) {
 		} else {
-			z.DecFallback(yyv1071, false)
+			z.F.DecSliceStringX(yyv1071, false, d)
 		}
 	}
 	yyj1070++
@@ -12542,47 +12556,9 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.Items = nil
+		x.SecretName = ""
 	} else {
-		yyv1073 := &x.Items
-		yym1074 := z.DecBinary()
-		_ = yym1074
-		if false {
-		} else {
-			h.decSliceIngress((*[]Ingress)(yyv1073), d)
-		}
-	}
-	yyj1070++
-	if yyhl1070 {
-		yyb1070 = yyj1070 > l
-	} else {
-		yyb1070 = r.CheckBreak()
-	}
-	if yyb1070 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Kind = ""
-	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj1070++
-	if yyhl1070 {
-		yyb1070 = yyj1070 > l
-	} else {
-		yyb1070 = r.CheckBreak()
-	}
-	if yyb1070 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
+		x.SecretName = string(r.DecodeString())
 	}
 	for {
 		yyj1070++
@@ -12600,556 +12576,6 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
-func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym1077 := z.EncBinary()
-		_ = yym1077
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep1078 := !z.EncBinary()
-			yy2arr1078 := z.EncBasicHandle().StructToArray
-			var yyq1078 [3]bool
-			_, _, _ = yysep1078, yyq1078, yy2arr1078
-			const yyr1078 bool = false
-			yyq1078[0] = x.Backend != nil
-			yyq1078[1] = len(x.TLS) != 0
-			yyq1078[2] = len(x.Rules) != 0
-			var yynn1078 int
-			if yyr1078 || yy2arr1078 {
-				r.EncodeArrayStart(3)
-			} else {
-				yynn1078 = 0
-				for _, b := range yyq1078 {
-					if b {
-						yynn1078++
-					}
-				}
-				r.EncodeMapStart(yynn1078)
-				yynn1078 = 0
-			}
-			if yyr1078 || yy2arr1078 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1078[0] {
-					if x.Backend == nil {
-						r.EncodeNil()
-					} else {
-						x.Backend.CodecEncodeSelf(e)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1078[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("backend"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if x.Backend == nil {
-						r.EncodeNil()
-					} else {
-						x.Backend.CodecEncodeSelf(e)
-					}
-				}
-			}
-			if yyr1078 || yy2arr1078 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1078[1] {
-					if x.TLS == nil {
-						r.EncodeNil()
-					} else {
-						yym1081 := z.EncBinary()
-						_ = yym1081
-						if false {
-						} else {
-							h.encSliceIngressTLS(([]IngressTLS)(x.TLS), e)
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1078[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("tls"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if x.TLS == nil {
-						r.EncodeNil()
-					} else {
-						yym1082 := z.EncBinary()
-						_ = yym1082
-						if false {
-						} else {
-							h.encSliceIngressTLS(([]IngressTLS)(x.TLS), e)
-						}
-					}
-				}
-			}
-			if yyr1078 || yy2arr1078 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1078[2] {
-					if x.Rules == nil {
-						r.EncodeNil()
-					} else {
-						yym1084 := z.EncBinary()
-						_ = yym1084
-						if false {
-						} else {
-							h.encSliceIngressRule(([]IngressRule)(x.Rules), e)
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1078[2] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("rules"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if x.Rules == nil {
-						r.EncodeNil()
-					} else {
-						yym1085 := z.EncBinary()
-						_ = yym1085
-						if false {
-						} else {
-							h.encSliceIngressRule(([]IngressRule)(x.Rules), e)
-						}
-					}
-				}
-			}
-			if yyr1078 || yy2arr1078 {
-				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
-			}
-		}
-	}
-}
-
-func (x *IngressSpec) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym1086 := z.DecBinary()
-	_ = yym1086
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		yyct1087 := r.ContainerType()
-		if yyct1087 == codecSelferValueTypeMap1234 {
-			yyl1087 := r.ReadMapStart()
-			if yyl1087 == 0 {
-				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-			} else {
-				x.codecDecodeSelfFromMap(yyl1087, d)
-			}
-		} else if yyct1087 == codecSelferValueTypeArray1234 {
-			yyl1087 := r.ReadArrayStart()
-			if yyl1087 == 0 {
-				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				x.codecDecodeSelfFromArray(yyl1087, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *IngressSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys1088Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1088Slc
-	var yyhl1088 bool = l >= 0
-	for yyj1088 := 0; ; yyj1088++ {
-		if yyhl1088 {
-			if yyj1088 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1088Slc = r.DecodeBytes(yys1088Slc, true, true)
-		yys1088 := string(yys1088Slc)
-		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1088 {
-		case "backend":
-			if r.TryDecodeAsNil() {
-				if x.Backend != nil {
-					x.Backend = nil
-				}
-			} else {
-				if x.Backend == nil {
-					x.Backend = new(IngressBackend)
-				}
-				x.Backend.CodecDecodeSelf(d)
-			}
-		case "tls":
-			if r.TryDecodeAsNil() {
-				x.TLS = nil
-			} else {
-				yyv1090 := &x.TLS
-				yym1091 := z.DecBinary()
-				_ = yym1091
-				if false {
-				} else {
-					h.decSliceIngressTLS((*[]IngressTLS)(yyv1090), d)
-				}
-			}
-		case "rules":
-			if r.TryDecodeAsNil() {
-				x.Rules = nil
-			} else {
-				yyv1092 := &x.Rules
-				yym1093 := z.DecBinary()
-				_ = yym1093
-				if false {
-				} else {
-					h.decSliceIngressRule((*[]IngressRule)(yyv1092), d)
-				}
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys1088)
-		} // end switch yys1088
-	} // end for yyj1088
-	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-}
-
-func (x *IngressSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj1094 int
-	var yyb1094 bool
-	var yyhl1094 bool = l >= 0
-	yyj1094++
-	if yyhl1094 {
-		yyb1094 = yyj1094 > l
-	} else {
-		yyb1094 = r.CheckBreak()
-	}
-	if yyb1094 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		if x.Backend != nil {
-			x.Backend = nil
-		}
-	} else {
-		if x.Backend == nil {
-			x.Backend = new(IngressBackend)
-		}
-		x.Backend.CodecDecodeSelf(d)
-	}
-	yyj1094++
-	if yyhl1094 {
-		yyb1094 = yyj1094 > l
-	} else {
-		yyb1094 = r.CheckBreak()
-	}
-	if yyb1094 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.TLS = nil
-	} else {
-		yyv1096 := &x.TLS
-		yym1097 := z.DecBinary()
-		_ = yym1097
-		if false {
-		} else {
-			h.decSliceIngressTLS((*[]IngressTLS)(yyv1096), d)
-		}
-	}
-	yyj1094++
-	if yyhl1094 {
-		yyb1094 = yyj1094 > l
-	} else {
-		yyb1094 = r.CheckBreak()
-	}
-	if yyb1094 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Rules = nil
-	} else {
-		yyv1098 := &x.Rules
-		yym1099 := z.DecBinary()
-		_ = yym1099
-		if false {
-		} else {
-			h.decSliceIngressRule((*[]IngressRule)(yyv1098), d)
-		}
-	}
-	for {
-		yyj1094++
-		if yyhl1094 {
-			yyb1094 = yyj1094 > l
-		} else {
-			yyb1094 = r.CheckBreak()
-		}
-		if yyb1094 {
-			break
-		}
-		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1094-1, "")
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x *IngressTLS) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym1100 := z.EncBinary()
-		_ = yym1100
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep1101 := !z.EncBinary()
-			yy2arr1101 := z.EncBasicHandle().StructToArray
-			var yyq1101 [2]bool
-			_, _, _ = yysep1101, yyq1101, yy2arr1101
-			const yyr1101 bool = false
-			yyq1101[0] = len(x.Hosts) != 0
-			yyq1101[1] = x.SecretName != ""
-			var yynn1101 int
-			if yyr1101 || yy2arr1101 {
-				r.EncodeArrayStart(2)
-			} else {
-				yynn1101 = 0
-				for _, b := range yyq1101 {
-					if b {
-						yynn1101++
-					}
-				}
-				r.EncodeMapStart(yynn1101)
-				yynn1101 = 0
-			}
-			if yyr1101 || yy2arr1101 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1101[0] {
-					if x.Hosts == nil {
-						r.EncodeNil()
-					} else {
-						yym1103 := z.EncBinary()
-						_ = yym1103
-						if false {
-						} else {
-							z.F.EncSliceStringV(x.Hosts, false, e)
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1101[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("hosts"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if x.Hosts == nil {
-						r.EncodeNil()
-					} else {
-						yym1104 := z.EncBinary()
-						_ = yym1104
-						if false {
-						} else {
-							z.F.EncSliceStringV(x.Hosts, false, e)
-						}
-					}
-				}
-			}
-			if yyr1101 || yy2arr1101 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1101[1] {
-					yym1106 := z.EncBinary()
-					_ = yym1106
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.SecretName))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1101[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("secretName"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1107 := z.EncBinary()
-					_ = yym1107
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.SecretName))
-					}
-				}
-			}
-			if yyr1101 || yy2arr1101 {
-				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
-			}
-		}
-	}
-}
-
-func (x *IngressTLS) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym1108 := z.DecBinary()
-	_ = yym1108
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		yyct1109 := r.ContainerType()
-		if yyct1109 == codecSelferValueTypeMap1234 {
-			yyl1109 := r.ReadMapStart()
-			if yyl1109 == 0 {
-				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-			} else {
-				x.codecDecodeSelfFromMap(yyl1109, d)
-			}
-		} else if yyct1109 == codecSelferValueTypeArray1234 {
-			yyl1109 := r.ReadArrayStart()
-			if yyl1109 == 0 {
-				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				x.codecDecodeSelfFromArray(yyl1109, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *IngressTLS) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys1110Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1110Slc
-	var yyhl1110 bool = l >= 0
-	for yyj1110 := 0; ; yyj1110++ {
-		if yyhl1110 {
-			if yyj1110 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1110Slc = r.DecodeBytes(yys1110Slc, true, true)
-		yys1110 := string(yys1110Slc)
-		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1110 {
-		case "hosts":
-			if r.TryDecodeAsNil() {
-				x.Hosts = nil
-			} else {
-				yyv1111 := &x.Hosts
-				yym1112 := z.DecBinary()
-				_ = yym1112
-				if false {
-				} else {
-					z.F.DecSliceStringX(yyv1111, false, d)
-				}
-			}
-		case "secretName":
-			if r.TryDecodeAsNil() {
-				x.SecretName = ""
-			} else {
-				x.SecretName = string(r.DecodeString())
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys1110)
-		} // end switch yys1110
-	} // end for yyj1110
-	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-}
-
-func (x *IngressTLS) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj1114 int
-	var yyb1114 bool
-	var yyhl1114 bool = l >= 0
-	yyj1114++
-	if yyhl1114 {
-		yyb1114 = yyj1114 > l
-	} else {
-		yyb1114 = r.CheckBreak()
-	}
-	if yyb1114 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Hosts = nil
-	} else {
-		yyv1115 := &x.Hosts
-		yym1116 := z.DecBinary()
-		_ = yym1116
-		if false {
-		} else {
-			z.F.DecSliceStringX(yyv1115, false, d)
-		}
-	}
-	yyj1114++
-	if yyhl1114 {
-		yyb1114 = yyj1114 > l
-	} else {
-		yyb1114 = r.CheckBreak()
-	}
-	if yyb1114 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.SecretName = ""
-	} else {
-		x.SecretName = string(r.DecodeString())
-	}
-	for {
-		yyj1114++
-		if yyhl1114 {
-			yyb1114 = yyj1114 > l
-		} else {
-			yyb1114 = r.CheckBreak()
-		}
-		if yyb1114 {
-			break
-		}
-		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1114-1, "")
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
 func (x *IngressStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
@@ -13157,48 +12583,48 @@ func (x *IngressStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1118 := z.EncBinary()
-		_ = yym1118
+		yym1074 := z.EncBinary()
+		_ = yym1074
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1119 := !z.EncBinary()
-			yy2arr1119 := z.EncBasicHandle().StructToArray
-			var yyq1119 [1]bool
-			_, _, _ = yysep1119, yyq1119, yy2arr1119
-			const yyr1119 bool = false
-			yyq1119[0] = true
-			var yynn1119 int
-			if yyr1119 || yy2arr1119 {
+			yysep1075 := !z.EncBinary()
+			yy2arr1075 := z.EncBasicHandle().StructToArray
+			var yyq1075 [1]bool
+			_, _, _ = yysep1075, yyq1075, yy2arr1075
+			const yyr1075 bool = false
+			yyq1075[0] = true
+			var yynn1075 int
+			if yyr1075 || yy2arr1075 {
 				r.EncodeArrayStart(1)
 			} else {
-				yynn1119 = 0
-				for _, b := range yyq1119 {
+				yynn1075 = 0
+				for _, b := range yyq1075 {
 					if b {
-						yynn1119++
+						yynn1075++
 					}
 				}
-				r.EncodeMapStart(yynn1119)
-				yynn1119 = 0
+				r.EncodeMapStart(yynn1075)
+				yynn1075 = 0
 			}
-			if yyr1119 || yy2arr1119 {
+			if yyr1075 || yy2arr1075 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1119[0] {
-					yy1121 := &x.LoadBalancer
-					yy1121.CodecEncodeSelf(e)
+				if yyq1075[0] {
+					yy1077 := &x.LoadBalancer
+					yy1077.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1119[0] {
+				if yyq1075[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("loadBalancer"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1122 := &x.LoadBalancer
-					yy1122.CodecEncodeSelf(e)
+					yy1078 := &x.LoadBalancer
+					yy1078.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1119 || yy2arr1119 {
+			if yyr1075 || yy2arr1075 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -13211,25 +12637,25 @@ func (x *IngressStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1123 := z.DecBinary()
-	_ = yym1123
+	yym1079 := z.DecBinary()
+	_ = yym1079
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1124 := r.ContainerType()
-		if yyct1124 == codecSelferValueTypeMap1234 {
-			yyl1124 := r.ReadMapStart()
-			if yyl1124 == 0 {
+		yyct1080 := r.ContainerType()
+		if yyct1080 == codecSelferValueTypeMap1234 {
+			yyl1080 := r.ReadMapStart()
+			if yyl1080 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1124, d)
+				x.codecDecodeSelfFromMap(yyl1080, d)
 			}
-		} else if yyct1124 == codecSelferValueTypeArray1234 {
-			yyl1124 := r.ReadArrayStart()
-			if yyl1124 == 0 {
+		} else if yyct1080 == codecSelferValueTypeArray1234 {
+			yyl1080 := r.ReadArrayStart()
+			if yyl1080 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1124, d)
+				x.codecDecodeSelfFromArray(yyl1080, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -13241,12 +12667,12 @@ func (x *IngressStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1125Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1125Slc
-	var yyhl1125 bool = l >= 0
-	for yyj1125 := 0; ; yyj1125++ {
-		if yyhl1125 {
-			if yyj1125 >= l {
+	var yys1081Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1081Slc
+	var yyhl1081 bool = l >= 0
+	for yyj1081 := 0; ; yyj1081++ {
+		if yyhl1081 {
+			if yyj1081 >= l {
 				break
 			}
 		} else {
@@ -13255,21 +12681,21 @@ func (x *IngressStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1125Slc = r.DecodeBytes(yys1125Slc, true, true)
-		yys1125 := string(yys1125Slc)
+		yys1081Slc = r.DecodeBytes(yys1081Slc, true, true)
+		yys1081 := string(yys1081Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1125 {
+		switch yys1081 {
 		case "loadBalancer":
 			if r.TryDecodeAsNil() {
 				x.LoadBalancer = pkg2_api.LoadBalancerStatus{}
 			} else {
-				yyv1126 := &x.LoadBalancer
-				yyv1126.CodecDecodeSelf(d)
+				yyv1082 := &x.LoadBalancer
+				yyv1082.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1125)
-		} // end switch yys1125
-	} // end for yyj1125
+			z.DecStructFieldNotFound(-1, yys1081)
+		} // end switch yys1081
+	} // end for yyj1081
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -13277,16 +12703,16 @@ func (x *IngressStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1127 int
-	var yyb1127 bool
-	var yyhl1127 bool = l >= 0
-	yyj1127++
-	if yyhl1127 {
-		yyb1127 = yyj1127 > l
+	var yyj1083 int
+	var yyb1083 bool
+	var yyhl1083 bool = l >= 0
+	yyj1083++
+	if yyhl1083 {
+		yyb1083 = yyj1083 > l
 	} else {
-		yyb1127 = r.CheckBreak()
+		yyb1083 = r.CheckBreak()
 	}
-	if yyb1127 {
+	if yyb1083 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -13294,21 +12720,21 @@ func (x *IngressStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.LoadBalancer = pkg2_api.LoadBalancerStatus{}
 	} else {
-		yyv1128 := &x.LoadBalancer
-		yyv1128.CodecDecodeSelf(d)
+		yyv1084 := &x.LoadBalancer
+		yyv1084.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1127++
-		if yyhl1127 {
-			yyb1127 = yyj1127 > l
+		yyj1083++
+		if yyhl1083 {
+			yyb1083 = yyj1083 > l
 		} else {
-			yyb1127 = r.CheckBreak()
+			yyb1083 = r.CheckBreak()
 		}
-		if yyb1127 {
+		if yyb1083 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1127-1, "")
+		z.DecStructFieldNotFound(yyj1083-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -13320,36 +12746,36 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1129 := z.EncBinary()
-		_ = yym1129
+		yym1085 := z.EncBinary()
+		_ = yym1085
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1130 := !z.EncBinary()
-			yy2arr1130 := z.EncBasicHandle().StructToArray
-			var yyq1130 [2]bool
-			_, _, _ = yysep1130, yyq1130, yy2arr1130
-			const yyr1130 bool = false
-			yyq1130[0] = x.Host != ""
-			yyq1130[1] = x.IngressRuleValue.HTTP != nil && x.HTTP != nil
-			var yynn1130 int
-			if yyr1130 || yy2arr1130 {
+			yysep1086 := !z.EncBinary()
+			yy2arr1086 := z.EncBasicHandle().StructToArray
+			var yyq1086 [2]bool
+			_, _, _ = yysep1086, yyq1086, yy2arr1086
+			const yyr1086 bool = false
+			yyq1086[0] = x.Host != ""
+			yyq1086[1] = x.IngressRuleValue.HTTP != nil && x.HTTP != nil
+			var yynn1086 int
+			if yyr1086 || yy2arr1086 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn1130 = 0
-				for _, b := range yyq1130 {
+				yynn1086 = 0
+				for _, b := range yyq1086 {
 					if b {
-						yynn1130++
+						yynn1086++
 					}
 				}
-				r.EncodeMapStart(yynn1130)
-				yynn1130 = 0
+				r.EncodeMapStart(yynn1086)
+				yynn1086 = 0
 			}
-			if yyr1130 || yy2arr1130 {
+			if yyr1086 || yy2arr1086 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1130[0] {
-					yym1132 := z.EncBinary()
-					_ = yym1132
+				if yyq1086[0] {
+					yym1088 := z.EncBinary()
+					_ = yym1088
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Host))
@@ -13358,30 +12784,30 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1130[0] {
+				if yyq1086[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("host"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1133 := z.EncBinary()
-					_ = yym1133
+					yym1089 := z.EncBinary()
+					_ = yym1089
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Host))
 					}
 				}
 			}
-			var yyn1134 bool
+			var yyn1090 bool
 			if x.IngressRuleValue.HTTP == nil {
-				yyn1134 = true
-				goto LABEL1134
+				yyn1090 = true
+				goto LABEL1090
 			}
-		LABEL1134:
-			if yyr1130 || yy2arr1130 {
-				if yyn1134 {
+		LABEL1090:
+			if yyr1086 || yy2arr1086 {
+				if yyn1090 {
 					r.EncodeNil()
 				} else {
 					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq1130[1] {
+					if yyq1086[1] {
 						if x.HTTP == nil {
 							r.EncodeNil()
 						} else {
@@ -13392,11 +12818,11 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
-				if yyq1130[1] {
+				if yyq1086[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("http"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn1134 {
+					if yyn1090 {
 						r.EncodeNil()
 					} else {
 						if x.HTTP == nil {
@@ -13407,7 +12833,7 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1130 || yy2arr1130 {
+			if yyr1086 || yy2arr1086 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -13420,25 +12846,25 @@ func (x *IngressRule) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1135 := z.DecBinary()
-	_ = yym1135
+	yym1091 := z.DecBinary()
+	_ = yym1091
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1136 := r.ContainerType()
-		if yyct1136 == codecSelferValueTypeMap1234 {
-			yyl1136 := r.ReadMapStart()
-			if yyl1136 == 0 {
+		yyct1092 := r.ContainerType()
+		if yyct1092 == codecSelferValueTypeMap1234 {
+			yyl1092 := r.ReadMapStart()
+			if yyl1092 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1136, d)
+				x.codecDecodeSelfFromMap(yyl1092, d)
 			}
-		} else if yyct1136 == codecSelferValueTypeArray1234 {
-			yyl1136 := r.ReadArrayStart()
-			if yyl1136 == 0 {
+		} else if yyct1092 == codecSelferValueTypeArray1234 {
+			yyl1092 := r.ReadArrayStart()
+			if yyl1092 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1136, d)
+				x.codecDecodeSelfFromArray(yyl1092, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -13450,12 +12876,12 @@ func (x *IngressRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1137Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1137Slc
-	var yyhl1137 bool = l >= 0
-	for yyj1137 := 0; ; yyj1137++ {
-		if yyhl1137 {
-			if yyj1137 >= l {
+	var yys1093Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1093Slc
+	var yyhl1093 bool = l >= 0
+	for yyj1093 := 0; ; yyj1093++ {
+		if yyhl1093 {
+			if yyj1093 >= l {
 				break
 			}
 		} else {
@@ -13464,10 +12890,10 @@ func (x *IngressRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1137Slc = r.DecodeBytes(yys1137Slc, true, true)
-		yys1137 := string(yys1137Slc)
+		yys1093Slc = r.DecodeBytes(yys1093Slc, true, true)
+		yys1093 := string(yys1093Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1137 {
+		switch yys1093 {
 		case "host":
 			if r.TryDecodeAsNil() {
 				x.Host = ""
@@ -13489,9 +12915,9 @@ func (x *IngressRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.HTTP.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1137)
-		} // end switch yys1137
-	} // end for yyj1137
+			z.DecStructFieldNotFound(-1, yys1093)
+		} // end switch yys1093
+	} // end for yyj1093
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -13499,16 +12925,16 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1140 int
-	var yyb1140 bool
-	var yyhl1140 bool = l >= 0
-	yyj1140++
-	if yyhl1140 {
-		yyb1140 = yyj1140 > l
+	var yyj1096 int
+	var yyb1096 bool
+	var yyhl1096 bool = l >= 0
+	yyj1096++
+	if yyhl1096 {
+		yyb1096 = yyj1096 > l
 	} else {
-		yyb1140 = r.CheckBreak()
+		yyb1096 = r.CheckBreak()
 	}
-	if yyb1140 {
+	if yyb1096 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -13521,13 +12947,13 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if x.IngressRuleValue.HTTP == nil {
 		x.IngressRuleValue.HTTP = new(HTTPIngressRuleValue)
 	}
-	yyj1140++
-	if yyhl1140 {
-		yyb1140 = yyj1140 > l
+	yyj1096++
+	if yyhl1096 {
+		yyb1096 = yyj1096 > l
 	} else {
-		yyb1140 = r.CheckBreak()
+		yyb1096 = r.CheckBreak()
 	}
-	if yyb1140 {
+	if yyb1096 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -13543,17 +12969,17 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.HTTP.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1140++
-		if yyhl1140 {
-			yyb1140 = yyj1140 > l
+		yyj1096++
+		if yyhl1096 {
+			yyb1096 = yyj1096 > l
 		} else {
-			yyb1140 = r.CheckBreak()
+			yyb1096 = r.CheckBreak()
 		}
-		if yyb1140 {
+		if yyb1096 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1140-1, "")
+		z.DecStructFieldNotFound(yyj1096-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -13565,33 +12991,33 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1143 := z.EncBinary()
-		_ = yym1143
+		yym1099 := z.EncBinary()
+		_ = yym1099
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1144 := !z.EncBinary()
-			yy2arr1144 := z.EncBasicHandle().StructToArray
-			var yyq1144 [1]bool
-			_, _, _ = yysep1144, yyq1144, yy2arr1144
-			const yyr1144 bool = false
-			yyq1144[0] = x.HTTP != nil
-			var yynn1144 int
-			if yyr1144 || yy2arr1144 {
+			yysep1100 := !z.EncBinary()
+			yy2arr1100 := z.EncBasicHandle().StructToArray
+			var yyq1100 [1]bool
+			_, _, _ = yysep1100, yyq1100, yy2arr1100
+			const yyr1100 bool = false
+			yyq1100[0] = x.HTTP != nil
+			var yynn1100 int
+			if yyr1100 || yy2arr1100 {
 				r.EncodeArrayStart(1)
 			} else {
-				yynn1144 = 0
-				for _, b := range yyq1144 {
+				yynn1100 = 0
+				for _, b := range yyq1100 {
 					if b {
-						yynn1144++
+						yynn1100++
 					}
 				}
-				r.EncodeMapStart(yynn1144)
-				yynn1144 = 0
+				r.EncodeMapStart(yynn1100)
+				yynn1100 = 0
 			}
-			if yyr1144 || yy2arr1144 {
+			if yyr1100 || yy2arr1100 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1144[0] {
+				if yyq1100[0] {
 					if x.HTTP == nil {
 						r.EncodeNil()
 					} else {
@@ -13601,7 +13027,7 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1144[0] {
+				if yyq1100[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("http"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
@@ -13612,7 +13038,7 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1144 || yy2arr1144 {
+			if yyr1100 || yy2arr1100 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -13625,25 +13051,25 @@ func (x *IngressRuleValue) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1146 := z.DecBinary()
-	_ = yym1146
+	yym1102 := z.DecBinary()
+	_ = yym1102
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1147 := r.ContainerType()
-		if yyct1147 == codecSelferValueTypeMap1234 {
-			yyl1147 := r.ReadMapStart()
-			if yyl1147 == 0 {
+		yyct1103 := r.ContainerType()
+		if yyct1103 == codecSelferValueTypeMap1234 {
+			yyl1103 := r.ReadMapStart()
+			if yyl1103 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1147, d)
+				x.codecDecodeSelfFromMap(yyl1103, d)
 			}
-		} else if yyct1147 == codecSelferValueTypeArray1234 {
-			yyl1147 := r.ReadArrayStart()
-			if yyl1147 == 0 {
+		} else if yyct1103 == codecSelferValueTypeArray1234 {
+			yyl1103 := r.ReadArrayStart()
+			if yyl1103 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1147, d)
+				x.codecDecodeSelfFromArray(yyl1103, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -13655,12 +13081,12 @@ func (x *IngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1148Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1148Slc
-	var yyhl1148 bool = l >= 0
-	for yyj1148 := 0; ; yyj1148++ {
-		if yyhl1148 {
-			if yyj1148 >= l {
+	var yys1104Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1104Slc
+	var yyhl1104 bool = l >= 0
+	for yyj1104 := 0; ; yyj1104++ {
+		if yyhl1104 {
+			if yyj1104 >= l {
 				break
 			}
 		} else {
@@ -13669,10 +13095,10 @@ func (x *IngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1148Slc = r.DecodeBytes(yys1148Slc, true, true)
-		yys1148 := string(yys1148Slc)
+		yys1104Slc = r.DecodeBytes(yys1104Slc, true, true)
+		yys1104 := string(yys1104Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1148 {
+		switch yys1104 {
 		case "http":
 			if r.TryDecodeAsNil() {
 				if x.HTTP != nil {
@@ -13685,9 +13111,9 @@ func (x *IngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.HTTP.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1148)
-		} // end switch yys1148
-	} // end for yyj1148
+			z.DecStructFieldNotFound(-1, yys1104)
+		} // end switch yys1104
+	} // end for yyj1104
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -13695,16 +13121,16 @@ func (x *IngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1150 int
-	var yyb1150 bool
-	var yyhl1150 bool = l >= 0
-	yyj1150++
-	if yyhl1150 {
-		yyb1150 = yyj1150 > l
+	var yyj1106 int
+	var yyb1106 bool
+	var yyhl1106 bool = l >= 0
+	yyj1106++
+	if yyhl1106 {
+		yyb1106 = yyj1106 > l
 	} else {
-		yyb1150 = r.CheckBreak()
+		yyb1106 = r.CheckBreak()
 	}
-	if yyb1150 {
+	if yyb1106 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -13720,17 +13146,17 @@ func (x *IngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		x.HTTP.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1150++
-		if yyhl1150 {
-			yyb1150 = yyj1150 > l
+		yyj1106++
+		if yyhl1106 {
+			yyb1106 = yyj1106 > l
 		} else {
-			yyb1150 = r.CheckBreak()
+			yyb1106 = r.CheckBreak()
 		}
-		if yyb1150 {
+		if yyb1106 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1150-1, "")
+		z.DecStructFieldNotFound(yyj1106-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -13742,36 +13168,36 @@ func (x *HTTPIngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1152 := z.EncBinary()
-		_ = yym1152
+		yym1108 := z.EncBinary()
+		_ = yym1108
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1153 := !z.EncBinary()
-			yy2arr1153 := z.EncBasicHandle().StructToArray
-			var yyq1153 [1]bool
-			_, _, _ = yysep1153, yyq1153, yy2arr1153
-			const yyr1153 bool = false
-			var yynn1153 int
-			if yyr1153 || yy2arr1153 {
+			yysep1109 := !z.EncBinary()
+			yy2arr1109 := z.EncBasicHandle().StructToArray
+			var yyq1109 [1]bool
+			_, _, _ = yysep1109, yyq1109, yy2arr1109
+			const yyr1109 bool = false
+			var yynn1109 int
+			if yyr1109 || yy2arr1109 {
 				r.EncodeArrayStart(1)
 			} else {
-				yynn1153 = 1
-				for _, b := range yyq1153 {
+				yynn1109 = 1
+				for _, b := range yyq1109 {
 					if b {
-						yynn1153++
+						yynn1109++
 					}
 				}
-				r.EncodeMapStart(yynn1153)
-				yynn1153 = 0
+				r.EncodeMapStart(yynn1109)
+				yynn1109 = 0
 			}
-			if yyr1153 || yy2arr1153 {
+			if yyr1109 || yy2arr1109 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Paths == nil {
 					r.EncodeNil()
 				} else {
-					yym1155 := z.EncBinary()
-					_ = yym1155
+					yym1111 := z.EncBinary()
+					_ = yym1111
 					if false {
 					} else {
 						h.encSliceHTTPIngressPath(([]HTTPIngressPath)(x.Paths), e)
@@ -13784,15 +13210,15 @@ func (x *HTTPIngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Paths == nil {
 					r.EncodeNil()
 				} else {
-					yym1156 := z.EncBinary()
-					_ = yym1156
+					yym1112 := z.EncBinary()
+					_ = yym1112
 					if false {
 					} else {
 						h.encSliceHTTPIngressPath(([]HTTPIngressPath)(x.Paths), e)
 					}
 				}
 			}
-			if yyr1153 || yy2arr1153 {
+			if yyr1109 || yy2arr1109 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -13805,25 +13231,25 @@ func (x *HTTPIngressRuleValue) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1157 := z.DecBinary()
-	_ = yym1157
+	yym1113 := z.DecBinary()
+	_ = yym1113
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1158 := r.ContainerType()
-		if yyct1158 == codecSelferValueTypeMap1234 {
-			yyl1158 := r.ReadMapStart()
-			if yyl1158 == 0 {
+		yyct1114 := r.ContainerType()
+		if yyct1114 == codecSelferValueTypeMap1234 {
+			yyl1114 := r.ReadMapStart()
+			if yyl1114 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1158, d)
+				x.codecDecodeSelfFromMap(yyl1114, d)
 			}
-		} else if yyct1158 == codecSelferValueTypeArray1234 {
-			yyl1158 := r.ReadArrayStart()
-			if yyl1158 == 0 {
+		} else if yyct1114 == codecSelferValueTypeArray1234 {
+			yyl1114 := r.ReadArrayStart()
+			if yyl1114 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1158, d)
+				x.codecDecodeSelfFromArray(yyl1114, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -13835,12 +13261,12 @@ func (x *HTTPIngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1159Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1159Slc
-	var yyhl1159 bool = l >= 0
-	for yyj1159 := 0; ; yyj1159++ {
-		if yyhl1159 {
-			if yyj1159 >= l {
+	var yys1115Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1115Slc
+	var yyhl1115 bool = l >= 0
+	for yyj1115 := 0; ; yyj1115++ {
+		if yyhl1115 {
+			if yyj1115 >= l {
 				break
 			}
 		} else {
@@ -13849,26 +13275,26 @@ func (x *HTTPIngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1159Slc = r.DecodeBytes(yys1159Slc, true, true)
-		yys1159 := string(yys1159Slc)
+		yys1115Slc = r.DecodeBytes(yys1115Slc, true, true)
+		yys1115 := string(yys1115Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1159 {
+		switch yys1115 {
 		case "paths":
 			if r.TryDecodeAsNil() {
 				x.Paths = nil
 			} else {
-				yyv1160 := &x.Paths
-				yym1161 := z.DecBinary()
-				_ = yym1161
+				yyv1116 := &x.Paths
+				yym1117 := z.DecBinary()
+				_ = yym1117
 				if false {
 				} else {
-					h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv1160), d)
+					h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv1116), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1159)
-		} // end switch yys1159
-	} // end for yyj1159
+			z.DecStructFieldNotFound(-1, yys1115)
+		} // end switch yys1115
+	} // end for yyj1115
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -13876,16 +13302,16 @@ func (x *HTTPIngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1162 int
-	var yyb1162 bool
-	var yyhl1162 bool = l >= 0
-	yyj1162++
-	if yyhl1162 {
-		yyb1162 = yyj1162 > l
+	var yyj1118 int
+	var yyb1118 bool
+	var yyhl1118 bool = l >= 0
+	yyj1118++
+	if yyhl1118 {
+		yyb1118 = yyj1118 > l
 	} else {
-		yyb1162 = r.CheckBreak()
+		yyb1118 = r.CheckBreak()
 	}
-	if yyb1162 {
+	if yyb1118 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -13893,26 +13319,26 @@ func (x *HTTPIngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.Paths = nil
 	} else {
-		yyv1163 := &x.Paths
-		yym1164 := z.DecBinary()
-		_ = yym1164
+		yyv1119 := &x.Paths
+		yym1120 := z.DecBinary()
+		_ = yym1120
 		if false {
 		} else {
-			h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv1163), d)
+			h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv1119), d)
 		}
 	}
 	for {
-		yyj1162++
-		if yyhl1162 {
-			yyb1162 = yyj1162 > l
+		yyj1118++
+		if yyhl1118 {
+			yyb1118 = yyj1118 > l
 		} else {
-			yyb1162 = r.CheckBreak()
+			yyb1118 = r.CheckBreak()
 		}
-		if yyb1162 {
+		if yyb1118 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1162-1, "")
+		z.DecStructFieldNotFound(yyj1118-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -13924,35 +13350,35 @@ func (x *HTTPIngressPath) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1165 := z.EncBinary()
-		_ = yym1165
+		yym1121 := z.EncBinary()
+		_ = yym1121
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1166 := !z.EncBinary()
-			yy2arr1166 := z.EncBasicHandle().StructToArray
-			var yyq1166 [2]bool
-			_, _, _ = yysep1166, yyq1166, yy2arr1166
-			const yyr1166 bool = false
-			yyq1166[0] = x.Path != ""
-			var yynn1166 int
-			if yyr1166 || yy2arr1166 {
+			yysep1122 := !z.EncBinary()
+			yy2arr1122 := z.EncBasicHandle().StructToArray
+			var yyq1122 [2]bool
+			_, _, _ = yysep1122, yyq1122, yy2arr1122
+			const yyr1122 bool = false
+			yyq1122[0] = x.Path != ""
+			var yynn1122 int
+			if yyr1122 || yy2arr1122 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn1166 = 1
-				for _, b := range yyq1166 {
+				yynn1122 = 1
+				for _, b := range yyq1122 {
 					if b {
-						yynn1166++
+						yynn1122++
 					}
 				}
-				r.EncodeMapStart(yynn1166)
-				yynn1166 = 0
+				r.EncodeMapStart(yynn1122)
+				yynn1122 = 0
 			}
-			if yyr1166 || yy2arr1166 {
+			if yyr1122 || yy2arr1122 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1166[0] {
-					yym1168 := z.EncBinary()
-					_ = yym1168
+				if yyq1122[0] {
+					yym1124 := z.EncBinary()
+					_ = yym1124
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Path))
@@ -13961,30 +13387,30 @@ func (x *HTTPIngressPath) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1166[0] {
+				if yyq1122[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("path"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1169 := z.EncBinary()
-					_ = yym1169
+					yym1125 := z.EncBinary()
+					_ = yym1125
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 					}
 				}
 			}
-			if yyr1166 || yy2arr1166 {
+			if yyr1122 || yy2arr1122 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy1171 := &x.Backend
-				yy1171.CodecEncodeSelf(e)
+				yy1127 := &x.Backend
+				yy1127.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("backend"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy1172 := &x.Backend
-				yy1172.CodecEncodeSelf(e)
+				yy1128 := &x.Backend
+				yy1128.CodecEncodeSelf(e)
 			}
-			if yyr1166 || yy2arr1166 {
+			if yyr1122 || yy2arr1122 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -13997,25 +13423,25 @@ func (x *HTTPIngressPath) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1173 := z.DecBinary()
-	_ = yym1173
+	yym1129 := z.DecBinary()
+	_ = yym1129
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1174 := r.ContainerType()
-		if yyct1174 == codecSelferValueTypeMap1234 {
-			yyl1174 := r.ReadMapStart()
-			if yyl1174 == 0 {
+		yyct1130 := r.ContainerType()
+		if yyct1130 == codecSelferValueTypeMap1234 {
+			yyl1130 := r.ReadMapStart()
+			if yyl1130 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1174, d)
+				x.codecDecodeSelfFromMap(yyl1130, d)
 			}
-		} else if yyct1174 == codecSelferValueTypeArray1234 {
-			yyl1174 := r.ReadArrayStart()
-			if yyl1174 == 0 {
+		} else if yyct1130 == codecSelferValueTypeArray1234 {
+			yyl1130 := r.ReadArrayStart()
+			if yyl1130 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1174, d)
+				x.codecDecodeSelfFromArray(yyl1130, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -14027,12 +13453,12 @@ func (x *HTTPIngressPath) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1175Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1175Slc
-	var yyhl1175 bool = l >= 0
-	for yyj1175 := 0; ; yyj1175++ {
-		if yyhl1175 {
-			if yyj1175 >= l {
+	var yys1131Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1131Slc
+	var yyhl1131 bool = l >= 0
+	for yyj1131 := 0; ; yyj1131++ {
+		if yyhl1131 {
+			if yyj1131 >= l {
 				break
 			}
 		} else {
@@ -14041,10 +13467,10 @@ func (x *HTTPIngressPath) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1175Slc = r.DecodeBytes(yys1175Slc, true, true)
-		yys1175 := string(yys1175Slc)
+		yys1131Slc = r.DecodeBytes(yys1131Slc, true, true)
+		yys1131 := string(yys1131Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1175 {
+		switch yys1131 {
 		case "path":
 			if r.TryDecodeAsNil() {
 				x.Path = ""
@@ -14055,13 +13481,13 @@ func (x *HTTPIngressPath) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Backend = IngressBackend{}
 			} else {
-				yyv1177 := &x.Backend
-				yyv1177.CodecDecodeSelf(d)
+				yyv1133 := &x.Backend
+				yyv1133.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1175)
-		} // end switch yys1175
-	} // end for yyj1175
+			z.DecStructFieldNotFound(-1, yys1131)
+		} // end switch yys1131
+	} // end for yyj1131
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -14069,16 +13495,16 @@ func (x *HTTPIngressPath) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1178 int
-	var yyb1178 bool
-	var yyhl1178 bool = l >= 0
-	yyj1178++
-	if yyhl1178 {
-		yyb1178 = yyj1178 > l
+	var yyj1134 int
+	var yyb1134 bool
+	var yyhl1134 bool = l >= 0
+	yyj1134++
+	if yyhl1134 {
+		yyb1134 = yyj1134 > l
 	} else {
-		yyb1178 = r.CheckBreak()
+		yyb1134 = r.CheckBreak()
 	}
-	if yyb1178 {
+	if yyb1134 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14088,13 +13514,13 @@ func (x *HTTPIngressPath) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Path = string(r.DecodeString())
 	}
-	yyj1178++
-	if yyhl1178 {
-		yyb1178 = yyj1178 > l
+	yyj1134++
+	if yyhl1134 {
+		yyb1134 = yyj1134 > l
 	} else {
-		yyb1178 = r.CheckBreak()
+		yyb1134 = r.CheckBreak()
 	}
-	if yyb1178 {
+	if yyb1134 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14102,21 +13528,21 @@ func (x *HTTPIngressPath) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	if r.TryDecodeAsNil() {
 		x.Backend = IngressBackend{}
 	} else {
-		yyv1180 := &x.Backend
-		yyv1180.CodecDecodeSelf(d)
+		yyv1136 := &x.Backend
+		yyv1136.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1178++
-		if yyhl1178 {
-			yyb1178 = yyj1178 > l
+		yyj1134++
+		if yyhl1134 {
+			yyb1134 = yyj1134 > l
 		} else {
-			yyb1178 = r.CheckBreak()
+			yyb1134 = r.CheckBreak()
 		}
-		if yyb1178 {
+		if yyb1134 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1178-1, "")
+		z.DecStructFieldNotFound(yyj1134-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -14128,33 +13554,33 @@ func (x *IngressBackend) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1181 := z.EncBinary()
-		_ = yym1181
+		yym1137 := z.EncBinary()
+		_ = yym1137
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1182 := !z.EncBinary()
-			yy2arr1182 := z.EncBasicHandle().StructToArray
-			var yyq1182 [2]bool
-			_, _, _ = yysep1182, yyq1182, yy2arr1182
-			const yyr1182 bool = false
-			var yynn1182 int
-			if yyr1182 || yy2arr1182 {
+			yysep1138 := !z.EncBinary()
+			yy2arr1138 := z.EncBasicHandle().StructToArray
+			var yyq1138 [2]bool
+			_, _, _ = yysep1138, yyq1138, yy2arr1138
+			const yyr1138 bool = false
+			var yynn1138 int
+			if yyr1138 || yy2arr1138 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn1182 = 2
-				for _, b := range yyq1182 {
+				yynn1138 = 2
+				for _, b := range yyq1138 {
 					if b {
-						yynn1182++
+						yynn1138++
 					}
 				}
-				r.EncodeMapStart(yynn1182)
-				yynn1182 = 0
+				r.EncodeMapStart(yynn1138)
+				yynn1138 = 0
 			}
-			if yyr1182 || yy2arr1182 {
+			if yyr1138 || yy2arr1138 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1184 := z.EncBinary()
-				_ = yym1184
+				yym1140 := z.EncBinary()
+				_ = yym1140
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceName))
@@ -14163,41 +13589,41 @@ func (x *IngressBackend) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("serviceName"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1185 := z.EncBinary()
-				_ = yym1185
+				yym1141 := z.EncBinary()
+				_ = yym1141
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceName))
 				}
 			}
-			if yyr1182 || yy2arr1182 {
+			if yyr1138 || yy2arr1138 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy1187 := &x.ServicePort
-				yym1188 := z.EncBinary()
-				_ = yym1188
+				yy1143 := &x.ServicePort
+				yym1144 := z.EncBinary()
+				_ = yym1144
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy1187) {
-				} else if !yym1188 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy1187)
+				} else if z.HasExtensions() && z.EncExt(yy1143) {
+				} else if !yym1144 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy1143)
 				} else {
-					z.EncFallback(yy1187)
+					z.EncFallback(yy1143)
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("servicePort"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy1189 := &x.ServicePort
-				yym1190 := z.EncBinary()
-				_ = yym1190
+				yy1145 := &x.ServicePort
+				yym1146 := z.EncBinary()
+				_ = yym1146
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy1189) {
-				} else if !yym1190 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy1189)
+				} else if z.HasExtensions() && z.EncExt(yy1145) {
+				} else if !yym1146 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy1145)
 				} else {
-					z.EncFallback(yy1189)
+					z.EncFallback(yy1145)
 				}
 			}
-			if yyr1182 || yy2arr1182 {
+			if yyr1138 || yy2arr1138 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -14210,25 +13636,25 @@ func (x *IngressBackend) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1191 := z.DecBinary()
-	_ = yym1191
+	yym1147 := z.DecBinary()
+	_ = yym1147
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1192 := r.ContainerType()
-		if yyct1192 == codecSelferValueTypeMap1234 {
-			yyl1192 := r.ReadMapStart()
-			if yyl1192 == 0 {
+		yyct1148 := r.ContainerType()
+		if yyct1148 == codecSelferValueTypeMap1234 {
+			yyl1148 := r.ReadMapStart()
+			if yyl1148 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1192, d)
+				x.codecDecodeSelfFromMap(yyl1148, d)
 			}
-		} else if yyct1192 == codecSelferValueTypeArray1234 {
-			yyl1192 := r.ReadArrayStart()
-			if yyl1192 == 0 {
+		} else if yyct1148 == codecSelferValueTypeArray1234 {
+			yyl1148 := r.ReadArrayStart()
+			if yyl1148 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1192, d)
+				x.codecDecodeSelfFromArray(yyl1148, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -14240,12 +13666,12 @@ func (x *IngressBackend) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1193Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1193Slc
-	var yyhl1193 bool = l >= 0
-	for yyj1193 := 0; ; yyj1193++ {
-		if yyhl1193 {
-			if yyj1193 >= l {
+	var yys1149Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1149Slc
+	var yyhl1149 bool = l >= 0
+	for yyj1149 := 0; ; yyj1149++ {
+		if yyhl1149 {
+			if yyj1149 >= l {
 				break
 			}
 		} else {
@@ -14254,10 +13680,10 @@ func (x *IngressBackend) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1193Slc = r.DecodeBytes(yys1193Slc, true, true)
-		yys1193 := string(yys1193Slc)
+		yys1149Slc = r.DecodeBytes(yys1149Slc, true, true)
+		yys1149 := string(yys1149Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1193 {
+		switch yys1149 {
 		case "serviceName":
 			if r.TryDecodeAsNil() {
 				x.ServiceName = ""
@@ -14268,21 +13694,21 @@ func (x *IngressBackend) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ServicePort = pkg6_intstr.IntOrString{}
 			} else {
-				yyv1195 := &x.ServicePort
-				yym1196 := z.DecBinary()
-				_ = yym1196
+				yyv1151 := &x.ServicePort
+				yym1152 := z.DecBinary()
+				_ = yym1152
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1195) {
-				} else if !yym1196 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1195)
+				} else if z.HasExtensions() && z.DecExt(yyv1151) {
+				} else if !yym1152 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1151)
 				} else {
-					z.DecFallback(yyv1195, false)
+					z.DecFallback(yyv1151, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1193)
-		} // end switch yys1193
-	} // end for yyj1193
+			z.DecStructFieldNotFound(-1, yys1149)
+		} // end switch yys1149
+	} // end for yyj1149
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -14290,16 +13716,16 @@ func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1197 int
-	var yyb1197 bool
-	var yyhl1197 bool = l >= 0
-	yyj1197++
-	if yyhl1197 {
-		yyb1197 = yyj1197 > l
+	var yyj1153 int
+	var yyb1153 bool
+	var yyhl1153 bool = l >= 0
+	yyj1153++
+	if yyhl1153 {
+		yyb1153 = yyj1153 > l
 	} else {
-		yyb1197 = r.CheckBreak()
+		yyb1153 = r.CheckBreak()
 	}
-	if yyb1197 {
+	if yyb1153 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14309,13 +13735,13 @@ func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.ServiceName = string(r.DecodeString())
 	}
-	yyj1197++
-	if yyhl1197 {
-		yyb1197 = yyj1197 > l
+	yyj1153++
+	if yyhl1153 {
+		yyb1153 = yyj1153 > l
 	} else {
-		yyb1197 = r.CheckBreak()
+		yyb1153 = r.CheckBreak()
 	}
-	if yyb1197 {
+	if yyb1153 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14323,29 +13749,29 @@ func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ServicePort = pkg6_intstr.IntOrString{}
 	} else {
-		yyv1199 := &x.ServicePort
-		yym1200 := z.DecBinary()
-		_ = yym1200
+		yyv1155 := &x.ServicePort
+		yym1156 := z.DecBinary()
+		_ = yym1156
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1199) {
-		} else if !yym1200 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1199)
+		} else if z.HasExtensions() && z.DecExt(yyv1155) {
+		} else if !yym1156 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv1155)
 		} else {
-			z.DecFallback(yyv1199, false)
+			z.DecFallback(yyv1155, false)
 		}
 	}
 	for {
-		yyj1197++
-		if yyhl1197 {
-			yyb1197 = yyj1197 > l
+		yyj1153++
+		if yyhl1153 {
+			yyb1153 = yyj1153 > l
 		} else {
-			yyb1197 = r.CheckBreak()
+			yyb1153 = r.CheckBreak()
 		}
-		if yyb1197 {
+		if yyb1153 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1197-1, "")
+		z.DecStructFieldNotFound(yyj1153-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -14354,8 +13780,8 @@ func (x NodeResource) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym1201 := z.EncBinary()
-	_ = yym1201
+	yym1157 := z.EncBinary()
+	_ = yym1157
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -14367,8 +13793,8 @@ func (x *NodeResource) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1202 := z.DecBinary()
-	_ = yym1202
+	yym1158 := z.DecBinary()
+	_ = yym1158
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -14383,30 +13809,30 @@ func (x *NodeUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1203 := z.EncBinary()
-		_ = yym1203
+		yym1159 := z.EncBinary()
+		_ = yym1159
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1204 := !z.EncBinary()
-			yy2arr1204 := z.EncBasicHandle().StructToArray
-			var yyq1204 [2]bool
-			_, _, _ = yysep1204, yyq1204, yy2arr1204
-			const yyr1204 bool = false
-			var yynn1204 int
-			if yyr1204 || yy2arr1204 {
+			yysep1160 := !z.EncBinary()
+			yy2arr1160 := z.EncBasicHandle().StructToArray
+			var yyq1160 [2]bool
+			_, _, _ = yysep1160, yyq1160, yy2arr1160
+			const yyr1160 bool = false
+			var yynn1160 int
+			if yyr1160 || yy2arr1160 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn1204 = 2
-				for _, b := range yyq1204 {
+				yynn1160 = 2
+				for _, b := range yyq1160 {
 					if b {
-						yynn1204++
+						yynn1160++
 					}
 				}
-				r.EncodeMapStart(yynn1204)
-				yynn1204 = 0
+				r.EncodeMapStart(yynn1160)
+				yynn1160 = 0
 			}
-			if yyr1204 || yy2arr1204 {
+			if yyr1160 || yy2arr1160 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Resource.CodecEncodeSelf(e)
 			} else {
@@ -14415,10 +13841,10 @@ func (x *NodeUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Resource.CodecEncodeSelf(e)
 			}
-			if yyr1204 || yy2arr1204 {
+			if yyr1160 || yy2arr1160 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1207 := z.EncBinary()
-				_ = yym1207
+				yym1163 := z.EncBinary()
+				_ = yym1163
 				if false {
 				} else {
 					r.EncodeFloat64(float64(x.Value))
@@ -14427,14 +13853,14 @@ func (x *NodeUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("value"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1208 := z.EncBinary()
-				_ = yym1208
+				yym1164 := z.EncBinary()
+				_ = yym1164
 				if false {
 				} else {
 					r.EncodeFloat64(float64(x.Value))
 				}
 			}
-			if yyr1204 || yy2arr1204 {
+			if yyr1160 || yy2arr1160 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -14447,25 +13873,25 @@ func (x *NodeUtilization) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1209 := z.DecBinary()
-	_ = yym1209
+	yym1165 := z.DecBinary()
+	_ = yym1165
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1210 := r.ContainerType()
-		if yyct1210 == codecSelferValueTypeMap1234 {
-			yyl1210 := r.ReadMapStart()
-			if yyl1210 == 0 {
+		yyct1166 := r.ContainerType()
+		if yyct1166 == codecSelferValueTypeMap1234 {
+			yyl1166 := r.ReadMapStart()
+			if yyl1166 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1210, d)
+				x.codecDecodeSelfFromMap(yyl1166, d)
 			}
-		} else if yyct1210 == codecSelferValueTypeArray1234 {
-			yyl1210 := r.ReadArrayStart()
-			if yyl1210 == 0 {
+		} else if yyct1166 == codecSelferValueTypeArray1234 {
+			yyl1166 := r.ReadArrayStart()
+			if yyl1166 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1210, d)
+				x.codecDecodeSelfFromArray(yyl1166, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -14477,12 +13903,12 @@ func (x *NodeUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1211Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1211Slc
-	var yyhl1211 bool = l >= 0
-	for yyj1211 := 0; ; yyj1211++ {
-		if yyhl1211 {
-			if yyj1211 >= l {
+	var yys1167Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1167Slc
+	var yyhl1167 bool = l >= 0
+	for yyj1167 := 0; ; yyj1167++ {
+		if yyhl1167 {
+			if yyj1167 >= l {
 				break
 			}
 		} else {
@@ -14491,10 +13917,10 @@ func (x *NodeUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1211Slc = r.DecodeBytes(yys1211Slc, true, true)
-		yys1211 := string(yys1211Slc)
+		yys1167Slc = r.DecodeBytes(yys1167Slc, true, true)
+		yys1167 := string(yys1167Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1211 {
+		switch yys1167 {
 		case "resource":
 			if r.TryDecodeAsNil() {
 				x.Resource = ""
@@ -14508,9 +13934,9 @@ func (x *NodeUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Value = float64(r.DecodeFloat(false))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1211)
-		} // end switch yys1211
-	} // end for yyj1211
+			z.DecStructFieldNotFound(-1, yys1167)
+		} // end switch yys1167
+	} // end for yyj1167
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -14518,16 +13944,16 @@ func (x *NodeUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1214 int
-	var yyb1214 bool
-	var yyhl1214 bool = l >= 0
-	yyj1214++
-	if yyhl1214 {
-		yyb1214 = yyj1214 > l
+	var yyj1170 int
+	var yyb1170 bool
+	var yyhl1170 bool = l >= 0
+	yyj1170++
+	if yyhl1170 {
+		yyb1170 = yyj1170 > l
 	} else {
-		yyb1214 = r.CheckBreak()
+		yyb1170 = r.CheckBreak()
 	}
-	if yyb1214 {
+	if yyb1170 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14537,13 +13963,13 @@ func (x *NodeUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Resource = NodeResource(r.DecodeString())
 	}
-	yyj1214++
-	if yyhl1214 {
-		yyb1214 = yyj1214 > l
+	yyj1170++
+	if yyhl1170 {
+		yyb1170 = yyj1170 > l
 	} else {
-		yyb1214 = r.CheckBreak()
+		yyb1170 = r.CheckBreak()
 	}
-	if yyb1214 {
+	if yyb1170 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14554,17 +13980,17 @@ func (x *NodeUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.Value = float64(r.DecodeFloat(false))
 	}
 	for {
-		yyj1214++
-		if yyhl1214 {
-			yyb1214 = yyj1214 > l
+		yyj1170++
+		if yyhl1170 {
+			yyb1170 = yyj1170 > l
 		} else {
-			yyb1214 = r.CheckBreak()
+			yyb1170 = r.CheckBreak()
 		}
-		if yyb1214 {
+		if yyb1170 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1214-1, "")
+		z.DecStructFieldNotFound(yyj1170-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -14576,33 +14002,33 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1217 := z.EncBinary()
-		_ = yym1217
+		yym1173 := z.EncBinary()
+		_ = yym1173
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1218 := !z.EncBinary()
-			yy2arr1218 := z.EncBasicHandle().StructToArray
-			var yyq1218 [3]bool
-			_, _, _ = yysep1218, yyq1218, yy2arr1218
-			const yyr1218 bool = false
-			var yynn1218 int
-			if yyr1218 || yy2arr1218 {
+			yysep1174 := !z.EncBinary()
+			yy2arr1174 := z.EncBasicHandle().StructToArray
+			var yyq1174 [3]bool
+			_, _, _ = yysep1174, yyq1174, yy2arr1174
+			const yyr1174 bool = false
+			var yynn1174 int
+			if yyr1174 || yy2arr1174 {
 				r.EncodeArrayStart(3)
 			} else {
-				yynn1218 = 3
-				for _, b := range yyq1218 {
+				yynn1174 = 3
+				for _, b := range yyq1174 {
 					if b {
-						yynn1218++
+						yynn1174++
 					}
 				}
-				r.EncodeMapStart(yynn1218)
-				yynn1218 = 0
+				r.EncodeMapStart(yynn1174)
+				yynn1174 = 0
 			}
-			if yyr1218 || yy2arr1218 {
+			if yyr1174 || yy2arr1174 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1220 := z.EncBinary()
-				_ = yym1220
+				yym1176 := z.EncBinary()
+				_ = yym1176
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MinNodes))
@@ -14611,17 +14037,17 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("minNodes"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1221 := z.EncBinary()
-				_ = yym1221
+				yym1177 := z.EncBinary()
+				_ = yym1177
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MinNodes))
 				}
 			}
-			if yyr1218 || yy2arr1218 {
+			if yyr1174 || yy2arr1174 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1223 := z.EncBinary()
-				_ = yym1223
+				yym1179 := z.EncBinary()
+				_ = yym1179
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MaxNodes))
@@ -14630,20 +14056,20 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("maxNodes"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1224 := z.EncBinary()
-				_ = yym1224
+				yym1180 := z.EncBinary()
+				_ = yym1180
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MaxNodes))
 				}
 			}
-			if yyr1218 || yy2arr1218 {
+			if yyr1174 || yy2arr1174 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.TargetUtilization == nil {
 					r.EncodeNil()
 				} else {
-					yym1226 := z.EncBinary()
-					_ = yym1226
+					yym1182 := z.EncBinary()
+					_ = yym1182
 					if false {
 					} else {
 						h.encSliceNodeUtilization(([]NodeUtilization)(x.TargetUtilization), e)
@@ -14656,15 +14082,15 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.TargetUtilization == nil {
 					r.EncodeNil()
 				} else {
-					yym1227 := z.EncBinary()
-					_ = yym1227
+					yym1183 := z.EncBinary()
+					_ = yym1183
 					if false {
 					} else {
 						h.encSliceNodeUtilization(([]NodeUtilization)(x.TargetUtilization), e)
 					}
 				}
 			}
-			if yyr1218 || yy2arr1218 {
+			if yyr1174 || yy2arr1174 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -14677,25 +14103,25 @@ func (x *ClusterAutoscalerSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1228 := z.DecBinary()
-	_ = yym1228
+	yym1184 := z.DecBinary()
+	_ = yym1184
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1229 := r.ContainerType()
-		if yyct1229 == codecSelferValueTypeMap1234 {
-			yyl1229 := r.ReadMapStart()
-			if yyl1229 == 0 {
+		yyct1185 := r.ContainerType()
+		if yyct1185 == codecSelferValueTypeMap1234 {
+			yyl1185 := r.ReadMapStart()
+			if yyl1185 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1229, d)
+				x.codecDecodeSelfFromMap(yyl1185, d)
 			}
-		} else if yyct1229 == codecSelferValueTypeArray1234 {
-			yyl1229 := r.ReadArrayStart()
-			if yyl1229 == 0 {
+		} else if yyct1185 == codecSelferValueTypeArray1234 {
+			yyl1185 := r.ReadArrayStart()
+			if yyl1185 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1229, d)
+				x.codecDecodeSelfFromArray(yyl1185, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -14707,12 +14133,12 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1230Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1230Slc
-	var yyhl1230 bool = l >= 0
-	for yyj1230 := 0; ; yyj1230++ {
-		if yyhl1230 {
-			if yyj1230 >= l {
+	var yys1186Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1186Slc
+	var yyhl1186 bool = l >= 0
+	for yyj1186 := 0; ; yyj1186++ {
+		if yyhl1186 {
+			if yyj1186 >= l {
 				break
 			}
 		} else {
@@ -14721,10 +14147,10 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1230Slc = r.DecodeBytes(yys1230Slc, true, true)
-		yys1230 := string(yys1230Slc)
+		yys1186Slc = r.DecodeBytes(yys1186Slc, true, true)
+		yys1186 := string(yys1186Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1230 {
+		switch yys1186 {
 		case "minNodes":
 			if r.TryDecodeAsNil() {
 				x.MinNodes = 0
@@ -14741,18 +14167,18 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			if r.TryDecodeAsNil() {
 				x.TargetUtilization = nil
 			} else {
-				yyv1233 := &x.TargetUtilization
-				yym1234 := z.DecBinary()
-				_ = yym1234
+				yyv1189 := &x.TargetUtilization
+				yym1190 := z.DecBinary()
+				_ = yym1190
 				if false {
 				} else {
-					h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1233), d)
+					h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1189), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1230)
-		} // end switch yys1230
-	} // end for yyj1230
+			z.DecStructFieldNotFound(-1, yys1186)
+		} // end switch yys1186
+	} // end for yyj1186
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -14760,16 +14186,16 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1235 int
-	var yyb1235 bool
-	var yyhl1235 bool = l >= 0
-	yyj1235++
-	if yyhl1235 {
-		yyb1235 = yyj1235 > l
+	var yyj1191 int
+	var yyb1191 bool
+	var yyhl1191 bool = l >= 0
+	yyj1191++
+	if yyhl1191 {
+		yyb1191 = yyj1191 > l
 	} else {
-		yyb1235 = r.CheckBreak()
+		yyb1191 = r.CheckBreak()
 	}
-	if yyb1235 {
+	if yyb1191 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14779,13 +14205,13 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.MinNodes = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj1235++
-	if yyhl1235 {
-		yyb1235 = yyj1235 > l
+	yyj1191++
+	if yyhl1191 {
+		yyb1191 = yyj1191 > l
 	} else {
-		yyb1235 = r.CheckBreak()
+		yyb1191 = r.CheckBreak()
 	}
-	if yyb1235 {
+	if yyb1191 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14795,13 +14221,13 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.MaxNodes = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj1235++
-	if yyhl1235 {
-		yyb1235 = yyj1235 > l
+	yyj1191++
+	if yyhl1191 {
+		yyb1191 = yyj1191 > l
 	} else {
-		yyb1235 = r.CheckBreak()
+		yyb1191 = r.CheckBreak()
 	}
-	if yyb1235 {
+	if yyb1191 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14809,26 +14235,26 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	if r.TryDecodeAsNil() {
 		x.TargetUtilization = nil
 	} else {
-		yyv1238 := &x.TargetUtilization
-		yym1239 := z.DecBinary()
-		_ = yym1239
+		yyv1194 := &x.TargetUtilization
+		yym1195 := z.DecBinary()
+		_ = yym1195
 		if false {
 		} else {
-			h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1238), d)
+			h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1194), d)
 		}
 	}
 	for {
-		yyj1235++
-		if yyhl1235 {
-			yyb1235 = yyj1235 > l
+		yyj1191++
+		if yyhl1191 {
+			yyb1191 = yyj1191 > l
 		} else {
-			yyb1235 = r.CheckBreak()
+			yyb1191 = r.CheckBreak()
 		}
-		if yyb1235 {
+		if yyb1191 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1235-1, "")
+		z.DecStructFieldNotFound(yyj1191-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -14840,72 +14266,72 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1240 := z.EncBinary()
-		_ = yym1240
+		yym1196 := z.EncBinary()
+		_ = yym1196
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1241 := !z.EncBinary()
-			yy2arr1241 := z.EncBasicHandle().StructToArray
-			var yyq1241 [4]bool
-			_, _, _ = yysep1241, yyq1241, yy2arr1241
-			const yyr1241 bool = false
-			yyq1241[0] = true
-			yyq1241[1] = true
-			yyq1241[2] = x.Kind != ""
-			yyq1241[3] = x.APIVersion != ""
-			var yynn1241 int
-			if yyr1241 || yy2arr1241 {
+			yysep1197 := !z.EncBinary()
+			yy2arr1197 := z.EncBasicHandle().StructToArray
+			var yyq1197 [4]bool
+			_, _, _ = yysep1197, yyq1197, yy2arr1197
+			const yyr1197 bool = false
+			yyq1197[0] = true
+			yyq1197[1] = true
+			yyq1197[2] = x.Kind != ""
+			yyq1197[3] = x.APIVersion != ""
+			var yynn1197 int
+			if yyr1197 || yy2arr1197 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn1241 = 0
-				for _, b := range yyq1241 {
+				yynn1197 = 0
+				for _, b := range yyq1197 {
 					if b {
-						yynn1241++
+						yynn1197++
 					}
 				}
-				r.EncodeMapStart(yynn1241)
-				yynn1241 = 0
+				r.EncodeMapStart(yynn1197)
+				yynn1197 = 0
 			}
-			if yyr1241 || yy2arr1241 {
+			if yyr1197 || yy2arr1197 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1241[0] {
-					yy1243 := &x.ObjectMeta
-					yy1243.CodecEncodeSelf(e)
+				if yyq1197[0] {
+					yy1199 := &x.ObjectMeta
+					yy1199.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1241[0] {
+				if yyq1197[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1244 := &x.ObjectMeta
-					yy1244.CodecEncodeSelf(e)
+					yy1200 := &x.ObjectMeta
+					yy1200.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1241 || yy2arr1241 {
+			if yyr1197 || yy2arr1197 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1241[1] {
-					yy1246 := &x.Spec
-					yy1246.CodecEncodeSelf(e)
+				if yyq1197[1] {
+					yy1202 := &x.Spec
+					yy1202.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1241[1] {
+				if yyq1197[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1247 := &x.Spec
-					yy1247.CodecEncodeSelf(e)
+					yy1203 := &x.Spec
+					yy1203.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1241 || yy2arr1241 {
+			if yyr1197 || yy2arr1197 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1241[2] {
-					yym1249 := z.EncBinary()
-					_ = yym1249
+				if yyq1197[2] {
+					yym1205 := z.EncBinary()
+					_ = yym1205
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -14914,23 +14340,23 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1241[2] {
+				if yyq1197[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1250 := z.EncBinary()
-					_ = yym1250
+					yym1206 := z.EncBinary()
+					_ = yym1206
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1241 || yy2arr1241 {
+			if yyr1197 || yy2arr1197 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1241[3] {
-					yym1252 := z.EncBinary()
-					_ = yym1252
+				if yyq1197[3] {
+					yym1208 := z.EncBinary()
+					_ = yym1208
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -14939,19 +14365,19 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1241[3] {
+				if yyq1197[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1253 := z.EncBinary()
-					_ = yym1253
+					yym1209 := z.EncBinary()
+					_ = yym1209
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1241 || yy2arr1241 {
+			if yyr1197 || yy2arr1197 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -14964,25 +14390,25 @@ func (x *ClusterAutoscaler) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1254 := z.DecBinary()
-	_ = yym1254
+	yym1210 := z.DecBinary()
+	_ = yym1210
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1255 := r.ContainerType()
-		if yyct1255 == codecSelferValueTypeMap1234 {
-			yyl1255 := r.ReadMapStart()
-			if yyl1255 == 0 {
+		yyct1211 := r.ContainerType()
+		if yyct1211 == codecSelferValueTypeMap1234 {
+			yyl1211 := r.ReadMapStart()
+			if yyl1211 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1255, d)
+				x.codecDecodeSelfFromMap(yyl1211, d)
 			}
-		} else if yyct1255 == codecSelferValueTypeArray1234 {
-			yyl1255 := r.ReadArrayStart()
-			if yyl1255 == 0 {
+		} else if yyct1211 == codecSelferValueTypeArray1234 {
+			yyl1211 := r.ReadArrayStart()
+			if yyl1211 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1255, d)
+				x.codecDecodeSelfFromArray(yyl1211, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -14994,12 +14420,12 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1256Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1256Slc
-	var yyhl1256 bool = l >= 0
-	for yyj1256 := 0; ; yyj1256++ {
-		if yyhl1256 {
-			if yyj1256 >= l {
+	var yys1212Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1212Slc
+	var yyhl1212 bool = l >= 0
+	for yyj1212 := 0; ; yyj1212++ {
+		if yyhl1212 {
+			if yyj1212 >= l {
 				break
 			}
 		} else {
@@ -15008,23 +14434,23 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1256Slc = r.DecodeBytes(yys1256Slc, true, true)
-		yys1256 := string(yys1256Slc)
+		yys1212Slc = r.DecodeBytes(yys1212Slc, true, true)
+		yys1212 := string(yys1212Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1256 {
+		switch yys1212 {
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv1257 := &x.ObjectMeta
-				yyv1257.CodecDecodeSelf(d)
+				yyv1213 := &x.ObjectMeta
+				yyv1213.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = ClusterAutoscalerSpec{}
 			} else {
-				yyv1258 := &x.Spec
-				yyv1258.CodecDecodeSelf(d)
+				yyv1214 := &x.Spec
+				yyv1214.CodecDecodeSelf(d)
 			}
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -15039,9 +14465,9 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				x.APIVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1256)
-		} // end switch yys1256
-	} // end for yyj1256
+			z.DecStructFieldNotFound(-1, yys1212)
+		} // end switch yys1212
+	} // end for yyj1212
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -15049,16 +14475,16 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1261 int
-	var yyb1261 bool
-	var yyhl1261 bool = l >= 0
-	yyj1261++
-	if yyhl1261 {
-		yyb1261 = yyj1261 > l
+	var yyj1217 int
+	var yyb1217 bool
+	var yyhl1217 bool = l >= 0
+	yyj1217++
+	if yyhl1217 {
+		yyb1217 = yyj1217 > l
 	} else {
-		yyb1261 = r.CheckBreak()
+		yyb1217 = r.CheckBreak()
 	}
-	if yyb1261 {
+	if yyb1217 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15066,16 +14492,16 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv1262 := &x.ObjectMeta
-		yyv1262.CodecDecodeSelf(d)
+		yyv1218 := &x.ObjectMeta
+		yyv1218.CodecDecodeSelf(d)
 	}
-	yyj1261++
-	if yyhl1261 {
-		yyb1261 = yyj1261 > l
+	yyj1217++
+	if yyhl1217 {
+		yyb1217 = yyj1217 > l
 	} else {
-		yyb1261 = r.CheckBreak()
+		yyb1217 = r.CheckBreak()
 	}
-	if yyb1261 {
+	if yyb1217 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15083,16 +14509,16 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	if r.TryDecodeAsNil() {
 		x.Spec = ClusterAutoscalerSpec{}
 	} else {
-		yyv1263 := &x.Spec
-		yyv1263.CodecDecodeSelf(d)
+		yyv1219 := &x.Spec
+		yyv1219.CodecDecodeSelf(d)
 	}
-	yyj1261++
-	if yyhl1261 {
-		yyb1261 = yyj1261 > l
+	yyj1217++
+	if yyhl1217 {
+		yyb1217 = yyj1217 > l
 	} else {
-		yyb1261 = r.CheckBreak()
+		yyb1217 = r.CheckBreak()
 	}
-	if yyb1261 {
+	if yyb1217 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15102,13 +14528,13 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1261++
-	if yyhl1261 {
-		yyb1261 = yyj1261 > l
+	yyj1217++
+	if yyhl1217 {
+		yyb1217 = yyj1217 > l
 	} else {
-		yyb1261 = r.CheckBreak()
+		yyb1217 = r.CheckBreak()
 	}
-	if yyb1261 {
+	if yyb1217 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15119,17 +14545,17 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		x.APIVersion = string(r.DecodeString())
 	}
 	for {
-		yyj1261++
-		if yyhl1261 {
-			yyb1261 = yyj1261 > l
+		yyj1217++
+		if yyhl1217 {
+			yyb1217 = yyj1217 > l
 		} else {
-			yyb1261 = r.CheckBreak()
+			yyb1217 = r.CheckBreak()
 		}
-		if yyb1261 {
+		if yyb1217 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1261-1, "")
+		z.DecStructFieldNotFound(yyj1217-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -15141,68 +14567,68 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1266 := z.EncBinary()
-		_ = yym1266
+		yym1222 := z.EncBinary()
+		_ = yym1222
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1267 := !z.EncBinary()
-			yy2arr1267 := z.EncBasicHandle().StructToArray
-			var yyq1267 [4]bool
-			_, _, _ = yysep1267, yyq1267, yy2arr1267
-			const yyr1267 bool = false
-			yyq1267[0] = true
-			yyq1267[2] = x.Kind != ""
-			yyq1267[3] = x.APIVersion != ""
-			var yynn1267 int
-			if yyr1267 || yy2arr1267 {
+			yysep1223 := !z.EncBinary()
+			yy2arr1223 := z.EncBasicHandle().StructToArray
+			var yyq1223 [4]bool
+			_, _, _ = yysep1223, yyq1223, yy2arr1223
+			const yyr1223 bool = false
+			yyq1223[0] = true
+			yyq1223[2] = x.Kind != ""
+			yyq1223[3] = x.APIVersion != ""
+			var yynn1223 int
+			if yyr1223 || yy2arr1223 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn1267 = 1
-				for _, b := range yyq1267 {
+				yynn1223 = 1
+				for _, b := range yyq1223 {
 					if b {
-						yynn1267++
+						yynn1223++
 					}
 				}
-				r.EncodeMapStart(yynn1267)
-				yynn1267 = 0
+				r.EncodeMapStart(yynn1223)
+				yynn1223 = 0
 			}
-			if yyr1267 || yy2arr1267 {
+			if yyr1223 || yy2arr1223 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1267[0] {
-					yy1269 := &x.ListMeta
-					yym1270 := z.EncBinary()
-					_ = yym1270
+				if yyq1223[0] {
+					yy1225 := &x.ListMeta
+					yym1226 := z.EncBinary()
+					_ = yym1226
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1269) {
+					} else if z.HasExtensions() && z.EncExt(yy1225) {
 					} else {
-						z.EncFallback(yy1269)
+						z.EncFallback(yy1225)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1267[0] {
+				if yyq1223[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1271 := &x.ListMeta
-					yym1272 := z.EncBinary()
-					_ = yym1272
+					yy1227 := &x.ListMeta
+					yym1228 := z.EncBinary()
+					_ = yym1228
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1271) {
+					} else if z.HasExtensions() && z.EncExt(yy1227) {
 					} else {
-						z.EncFallback(yy1271)
+						z.EncFallback(yy1227)
 					}
 				}
 			}
-			if yyr1267 || yy2arr1267 {
+			if yyr1223 || yy2arr1223 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1274 := z.EncBinary()
-					_ = yym1274
+					yym1230 := z.EncBinary()
+					_ = yym1230
 					if false {
 					} else {
 						h.encSliceClusterAutoscaler(([]ClusterAutoscaler)(x.Items), e)
@@ -15215,19 +14641,19 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1275 := z.EncBinary()
-					_ = yym1275
+					yym1231 := z.EncBinary()
+					_ = yym1231
 					if false {
 					} else {
 						h.encSliceClusterAutoscaler(([]ClusterAutoscaler)(x.Items), e)
 					}
 				}
 			}
-			if yyr1267 || yy2arr1267 {
+			if yyr1223 || yy2arr1223 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1267[2] {
-					yym1277 := z.EncBinary()
-					_ = yym1277
+				if yyq1223[2] {
+					yym1233 := z.EncBinary()
+					_ = yym1233
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -15236,23 +14662,23 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1267[2] {
+				if yyq1223[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1278 := z.EncBinary()
-					_ = yym1278
+					yym1234 := z.EncBinary()
+					_ = yym1234
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1267 || yy2arr1267 {
+			if yyr1223 || yy2arr1223 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1267[3] {
-					yym1280 := z.EncBinary()
-					_ = yym1280
+				if yyq1223[3] {
+					yym1236 := z.EncBinary()
+					_ = yym1236
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -15261,19 +14687,19 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1267[3] {
+				if yyq1223[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1281 := z.EncBinary()
-					_ = yym1281
+					yym1237 := z.EncBinary()
+					_ = yym1237
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1267 || yy2arr1267 {
+			if yyr1223 || yy2arr1223 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -15286,25 +14712,25 @@ func (x *ClusterAutoscalerList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1282 := z.DecBinary()
-	_ = yym1282
+	yym1238 := z.DecBinary()
+	_ = yym1238
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1283 := r.ContainerType()
-		if yyct1283 == codecSelferValueTypeMap1234 {
-			yyl1283 := r.ReadMapStart()
-			if yyl1283 == 0 {
+		yyct1239 := r.ContainerType()
+		if yyct1239 == codecSelferValueTypeMap1234 {
+			yyl1239 := r.ReadMapStart()
+			if yyl1239 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1283, d)
+				x.codecDecodeSelfFromMap(yyl1239, d)
 			}
-		} else if yyct1283 == codecSelferValueTypeArray1234 {
-			yyl1283 := r.ReadArrayStart()
-			if yyl1283 == 0 {
+		} else if yyct1239 == codecSelferValueTypeArray1234 {
+			yyl1239 := r.ReadArrayStart()
+			if yyl1239 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1283, d)
+				x.codecDecodeSelfFromArray(yyl1239, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -15316,12 +14742,12 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1284Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1284Slc
-	var yyhl1284 bool = l >= 0
-	for yyj1284 := 0; ; yyj1284++ {
-		if yyhl1284 {
-			if yyj1284 >= l {
+	var yys1240Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1240Slc
+	var yyhl1240 bool = l >= 0
+	for yyj1240 := 0; ; yyj1240++ {
+		if yyhl1240 {
+			if yyj1240 >= l {
 				break
 			}
 		} else {
@@ -15330,33 +14756,33 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1284Slc = r.DecodeBytes(yys1284Slc, true, true)
-		yys1284 := string(yys1284Slc)
+		yys1240Slc = r.DecodeBytes(yys1240Slc, true, true)
+		yys1240 := string(yys1240Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1284 {
+		switch yys1240 {
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv1285 := &x.ListMeta
-				yym1286 := z.DecBinary()
-				_ = yym1286
+				yyv1241 := &x.ListMeta
+				yym1242 := z.DecBinary()
+				_ = yym1242
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1285) {
+				} else if z.HasExtensions() && z.DecExt(yyv1241) {
 				} else {
-					z.DecFallback(yyv1285, false)
+					z.DecFallback(yyv1241, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv1287 := &x.Items
-				yym1288 := z.DecBinary()
-				_ = yym1288
+				yyv1243 := &x.Items
+				yym1244 := z.DecBinary()
+				_ = yym1244
 				if false {
 				} else {
-					h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1287), d)
+					h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1243), d)
 				}
 			}
 		case "kind":
@@ -15372,9 +14798,9 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				x.APIVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1284)
-		} // end switch yys1284
-	} // end for yyj1284
+			z.DecStructFieldNotFound(-1, yys1240)
+		} // end switch yys1240
+	} // end for yyj1240
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -15382,16 +14808,16 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1291 int
-	var yyb1291 bool
-	var yyhl1291 bool = l >= 0
-	yyj1291++
-	if yyhl1291 {
-		yyb1291 = yyj1291 > l
+	var yyj1247 int
+	var yyb1247 bool
+	var yyhl1247 bool = l >= 0
+	yyj1247++
+	if yyhl1247 {
+		yyb1247 = yyj1247 > l
 	} else {
-		yyb1291 = r.CheckBreak()
+		yyb1247 = r.CheckBreak()
 	}
-	if yyb1291 {
+	if yyb1247 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15399,22 +14825,22 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv1292 := &x.ListMeta
-		yym1293 := z.DecBinary()
-		_ = yym1293
+		yyv1248 := &x.ListMeta
+		yym1249 := z.DecBinary()
+		_ = yym1249
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1292) {
+		} else if z.HasExtensions() && z.DecExt(yyv1248) {
 		} else {
-			z.DecFallback(yyv1292, false)
+			z.DecFallback(yyv1248, false)
 		}
 	}
-	yyj1291++
-	if yyhl1291 {
-		yyb1291 = yyj1291 > l
+	yyj1247++
+	if yyhl1247 {
+		yyb1247 = yyj1247 > l
 	} else {
-		yyb1291 = r.CheckBreak()
+		yyb1247 = r.CheckBreak()
 	}
-	if yyb1291 {
+	if yyb1247 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15422,21 +14848,21 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv1294 := &x.Items
-		yym1295 := z.DecBinary()
-		_ = yym1295
+		yyv1250 := &x.Items
+		yym1251 := z.DecBinary()
+		_ = yym1251
 		if false {
 		} else {
-			h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1294), d)
+			h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1250), d)
 		}
 	}
-	yyj1291++
-	if yyhl1291 {
-		yyb1291 = yyj1291 > l
+	yyj1247++
+	if yyhl1247 {
+		yyb1247 = yyj1247 > l
 	} else {
-		yyb1291 = r.CheckBreak()
+		yyb1247 = r.CheckBreak()
 	}
-	if yyb1291 {
+	if yyb1247 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15446,13 +14872,13 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1291++
-	if yyhl1291 {
-		yyb1291 = yyj1291 > l
+	yyj1247++
+	if yyhl1247 {
+		yyb1247 = yyj1247 > l
 	} else {
-		yyb1291 = r.CheckBreak()
+		yyb1247 = r.CheckBreak()
 	}
-	if yyb1291 {
+	if yyb1247 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15463,17 +14889,17 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		x.APIVersion = string(r.DecodeString())
 	}
 	for {
-		yyj1291++
-		if yyhl1291 {
-			yyb1291 = yyj1291 > l
+		yyj1247++
+		if yyhl1247 {
+			yyb1247 = yyj1247 > l
 		} else {
-			yyb1291 = r.CheckBreak()
+			yyb1247 = r.CheckBreak()
 		}
-		if yyb1291 {
+		if yyb1247 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1291-1, "")
+		z.DecStructFieldNotFound(yyj1247-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -15485,90 +14911,90 @@ func (x *ReplicaSet) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1298 := z.EncBinary()
-		_ = yym1298
+		yym1254 := z.EncBinary()
+		_ = yym1254
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1299 := !z.EncBinary()
-			yy2arr1299 := z.EncBasicHandle().StructToArray
-			var yyq1299 [5]bool
-			_, _, _ = yysep1299, yyq1299, yy2arr1299
-			const yyr1299 bool = false
-			yyq1299[0] = true
-			yyq1299[1] = true
-			yyq1299[2] = true
-			yyq1299[3] = x.Kind != ""
-			yyq1299[4] = x.APIVersion != ""
-			var yynn1299 int
-			if yyr1299 || yy2arr1299 {
+			yysep1255 := !z.EncBinary()
+			yy2arr1255 := z.EncBasicHandle().StructToArray
+			var yyq1255 [5]bool
+			_, _, _ = yysep1255, yyq1255, yy2arr1255
+			const yyr1255 bool = false
+			yyq1255[0] = true
+			yyq1255[1] = true
+			yyq1255[2] = true
+			yyq1255[3] = x.Kind != ""
+			yyq1255[4] = x.APIVersion != ""
+			var yynn1255 int
+			if yyr1255 || yy2arr1255 {
 				r.EncodeArrayStart(5)
 			} else {
-				yynn1299 = 0
-				for _, b := range yyq1299 {
+				yynn1255 = 0
+				for _, b := range yyq1255 {
 					if b {
-						yynn1299++
+						yynn1255++
 					}
 				}
-				r.EncodeMapStart(yynn1299)
-				yynn1299 = 0
+				r.EncodeMapStart(yynn1255)
+				yynn1255 = 0
 			}
-			if yyr1299 || yy2arr1299 {
+			if yyr1255 || yy2arr1255 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1299[0] {
-					yy1301 := &x.ObjectMeta
-					yy1301.CodecEncodeSelf(e)
+				if yyq1255[0] {
+					yy1257 := &x.ObjectMeta
+					yy1257.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1299[0] {
+				if yyq1255[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1302 := &x.ObjectMeta
-					yy1302.CodecEncodeSelf(e)
+					yy1258 := &x.ObjectMeta
+					yy1258.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1299 || yy2arr1299 {
+			if yyr1255 || yy2arr1255 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1299[1] {
-					yy1304 := &x.Spec
-					yy1304.CodecEncodeSelf(e)
+				if yyq1255[1] {
+					yy1260 := &x.Spec
+					yy1260.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1299[1] {
+				if yyq1255[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1305 := &x.Spec
-					yy1305.CodecEncodeSelf(e)
+					yy1261 := &x.Spec
+					yy1261.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1299 || yy2arr1299 {
+			if yyr1255 || yy2arr1255 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1299[2] {
-					yy1307 := &x.Status
-					yy1307.CodecEncodeSelf(e)
+				if yyq1255[2] {
+					yy1263 := &x.Status
+					yy1263.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1299[2] {
+				if yyq1255[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1308 := &x.Status
-					yy1308.CodecEncodeSelf(e)
+					yy1264 := &x.Status
+					yy1264.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1299 || yy2arr1299 {
+			if yyr1255 || yy2arr1255 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1299[3] {
-					yym1310 := z.EncBinary()
-					_ = yym1310
+				if yyq1255[3] {
+					yym1266 := z.EncBinary()
+					_ = yym1266
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -15577,23 +15003,23 @@ func (x *ReplicaSet) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1299[3] {
+				if yyq1255[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1311 := z.EncBinary()
-					_ = yym1311
+					yym1267 := z.EncBinary()
+					_ = yym1267
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1299 || yy2arr1299 {
+			if yyr1255 || yy2arr1255 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1299[4] {
-					yym1313 := z.EncBinary()
-					_ = yym1313
+				if yyq1255[4] {
+					yym1269 := z.EncBinary()
+					_ = yym1269
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -15602,19 +15028,19 @@ func (x *ReplicaSet) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1299[4] {
+				if yyq1255[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1314 := z.EncBinary()
-					_ = yym1314
+					yym1270 := z.EncBinary()
+					_ = yym1270
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1299 || yy2arr1299 {
+			if yyr1255 || yy2arr1255 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -15627,25 +15053,25 @@ func (x *ReplicaSet) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1315 := z.DecBinary()
-	_ = yym1315
+	yym1271 := z.DecBinary()
+	_ = yym1271
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1316 := r.ContainerType()
-		if yyct1316 == codecSelferValueTypeMap1234 {
-			yyl1316 := r.ReadMapStart()
-			if yyl1316 == 0 {
+		yyct1272 := r.ContainerType()
+		if yyct1272 == codecSelferValueTypeMap1234 {
+			yyl1272 := r.ReadMapStart()
+			if yyl1272 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1316, d)
+				x.codecDecodeSelfFromMap(yyl1272, d)
 			}
-		} else if yyct1316 == codecSelferValueTypeArray1234 {
-			yyl1316 := r.ReadArrayStart()
-			if yyl1316 == 0 {
+		} else if yyct1272 == codecSelferValueTypeArray1234 {
+			yyl1272 := r.ReadArrayStart()
+			if yyl1272 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1316, d)
+				x.codecDecodeSelfFromArray(yyl1272, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -15657,12 +15083,12 @@ func (x *ReplicaSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1317Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1317Slc
-	var yyhl1317 bool = l >= 0
-	for yyj1317 := 0; ; yyj1317++ {
-		if yyhl1317 {
-			if yyj1317 >= l {
+	var yys1273Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1273Slc
+	var yyhl1273 bool = l >= 0
+	for yyj1273 := 0; ; yyj1273++ {
+		if yyhl1273 {
+			if yyj1273 >= l {
 				break
 			}
 		} else {
@@ -15671,30 +15097,30 @@ func (x *ReplicaSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1317Slc = r.DecodeBytes(yys1317Slc, true, true)
-		yys1317 := string(yys1317Slc)
+		yys1273Slc = r.DecodeBytes(yys1273Slc, true, true)
+		yys1273 := string(yys1273Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1317 {
+		switch yys1273 {
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv1318 := &x.ObjectMeta
-				yyv1318.CodecDecodeSelf(d)
+				yyv1274 := &x.ObjectMeta
+				yyv1274.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = ReplicaSetSpec{}
 			} else {
-				yyv1319 := &x.Spec
-				yyv1319.CodecDecodeSelf(d)
+				yyv1275 := &x.Spec
+				yyv1275.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = ReplicaSetStatus{}
 			} else {
-				yyv1320 := &x.Status
-				yyv1320.CodecDecodeSelf(d)
+				yyv1276 := &x.Status
+				yyv1276.CodecDecodeSelf(d)
 			}
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -15709,9 +15135,9 @@ func (x *ReplicaSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1317)
-		} // end switch yys1317
-	} // end for yyj1317
+			z.DecStructFieldNotFound(-1, yys1273)
+		} // end switch yys1273
+	} // end for yyj1273
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -15719,16 +15145,16 @@ func (x *ReplicaSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1323 int
-	var yyb1323 bool
-	var yyhl1323 bool = l >= 0
-	yyj1323++
-	if yyhl1323 {
-		yyb1323 = yyj1323 > l
+	var yyj1279 int
+	var yyb1279 bool
+	var yyhl1279 bool = l >= 0
+	yyj1279++
+	if yyhl1279 {
+		yyb1279 = yyj1279 > l
 	} else {
-		yyb1323 = r.CheckBreak()
+		yyb1279 = r.CheckBreak()
 	}
-	if yyb1323 {
+	if yyb1279 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15736,16 +15162,16 @@ func (x *ReplicaSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv1324 := &x.ObjectMeta
-		yyv1324.CodecDecodeSelf(d)
+		yyv1280 := &x.ObjectMeta
+		yyv1280.CodecDecodeSelf(d)
 	}
-	yyj1323++
-	if yyhl1323 {
-		yyb1323 = yyj1323 > l
+	yyj1279++
+	if yyhl1279 {
+		yyb1279 = yyj1279 > l
 	} else {
-		yyb1323 = r.CheckBreak()
+		yyb1279 = r.CheckBreak()
 	}
-	if yyb1323 {
+	if yyb1279 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15753,16 +15179,16 @@ func (x *ReplicaSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Spec = ReplicaSetSpec{}
 	} else {
-		yyv1325 := &x.Spec
-		yyv1325.CodecDecodeSelf(d)
+		yyv1281 := &x.Spec
+		yyv1281.CodecDecodeSelf(d)
 	}
-	yyj1323++
-	if yyhl1323 {
-		yyb1323 = yyj1323 > l
+	yyj1279++
+	if yyhl1279 {
+		yyb1279 = yyj1279 > l
 	} else {
-		yyb1323 = r.CheckBreak()
+		yyb1279 = r.CheckBreak()
 	}
-	if yyb1323 {
+	if yyb1279 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15770,16 +15196,16 @@ func (x *ReplicaSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Status = ReplicaSetStatus{}
 	} else {
-		yyv1326 := &x.Status
-		yyv1326.CodecDecodeSelf(d)
+		yyv1282 := &x.Status
+		yyv1282.CodecDecodeSelf(d)
 	}
-	yyj1323++
-	if yyhl1323 {
-		yyb1323 = yyj1323 > l
+	yyj1279++
+	if yyhl1279 {
+		yyb1279 = yyj1279 > l
 	} else {
-		yyb1323 = r.CheckBreak()
+		yyb1279 = r.CheckBreak()
 	}
-	if yyb1323 {
+	if yyb1279 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15789,13 +15215,13 @@ func (x *ReplicaSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1323++
-	if yyhl1323 {
-		yyb1323 = yyj1323 > l
+	yyj1279++
+	if yyhl1279 {
+		yyb1279 = yyj1279 > l
 	} else {
-		yyb1323 = r.CheckBreak()
+		yyb1279 = r.CheckBreak()
 	}
-	if yyb1323 {
+	if yyb1279 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15806,17 +15232,17 @@ func (x *ReplicaSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = string(r.DecodeString())
 	}
 	for {
-		yyj1323++
-		if yyhl1323 {
-			yyb1323 = yyj1323 > l
+		yyj1279++
+		if yyhl1279 {
+			yyb1279 = yyj1279 > l
 		} else {
-			yyb1323 = r.CheckBreak()
+			yyb1279 = r.CheckBreak()
 		}
-		if yyb1323 {
+		if yyb1279 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1323-1, "")
+		z.DecStructFieldNotFound(yyj1279-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -15828,68 +15254,68 @@ func (x *ReplicaSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1329 := z.EncBinary()
-		_ = yym1329
+		yym1285 := z.EncBinary()
+		_ = yym1285
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1330 := !z.EncBinary()
-			yy2arr1330 := z.EncBasicHandle().StructToArray
-			var yyq1330 [4]bool
-			_, _, _ = yysep1330, yyq1330, yy2arr1330
-			const yyr1330 bool = false
-			yyq1330[0] = true
-			yyq1330[2] = x.Kind != ""
-			yyq1330[3] = x.APIVersion != ""
-			var yynn1330 int
-			if yyr1330 || yy2arr1330 {
+			yysep1286 := !z.EncBinary()
+			yy2arr1286 := z.EncBasicHandle().StructToArray
+			var yyq1286 [4]bool
+			_, _, _ = yysep1286, yyq1286, yy2arr1286
+			const yyr1286 bool = false
+			yyq1286[0] = true
+			yyq1286[2] = x.Kind != ""
+			yyq1286[3] = x.APIVersion != ""
+			var yynn1286 int
+			if yyr1286 || yy2arr1286 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn1330 = 1
-				for _, b := range yyq1330 {
+				yynn1286 = 1
+				for _, b := range yyq1286 {
 					if b {
-						yynn1330++
+						yynn1286++
 					}
 				}
-				r.EncodeMapStart(yynn1330)
-				yynn1330 = 0
+				r.EncodeMapStart(yynn1286)
+				yynn1286 = 0
 			}
-			if yyr1330 || yy2arr1330 {
+			if yyr1286 || yy2arr1286 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1330[0] {
-					yy1332 := &x.ListMeta
-					yym1333 := z.EncBinary()
-					_ = yym1333
+				if yyq1286[0] {
+					yy1288 := &x.ListMeta
+					yym1289 := z.EncBinary()
+					_ = yym1289
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1332) {
+					} else if z.HasExtensions() && z.EncExt(yy1288) {
 					} else {
-						z.EncFallback(yy1332)
+						z.EncFallback(yy1288)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1330[0] {
+				if yyq1286[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1334 := &x.ListMeta
-					yym1335 := z.EncBinary()
-					_ = yym1335
+					yy1290 := &x.ListMeta
+					yym1291 := z.EncBinary()
+					_ = yym1291
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1334) {
+					} else if z.HasExtensions() && z.EncExt(yy1290) {
 					} else {
-						z.EncFallback(yy1334)
+						z.EncFallback(yy1290)
 					}
 				}
 			}
-			if yyr1330 || yy2arr1330 {
+			if yyr1286 || yy2arr1286 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1337 := z.EncBinary()
-					_ = yym1337
+					yym1293 := z.EncBinary()
+					_ = yym1293
 					if false {
 					} else {
 						h.encSliceReplicaSet(([]ReplicaSet)(x.Items), e)
@@ -15902,19 +15328,19 @@ func (x *ReplicaSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1338 := z.EncBinary()
-					_ = yym1338
+					yym1294 := z.EncBinary()
+					_ = yym1294
 					if false {
 					} else {
 						h.encSliceReplicaSet(([]ReplicaSet)(x.Items), e)
 					}
 				}
 			}
-			if yyr1330 || yy2arr1330 {
+			if yyr1286 || yy2arr1286 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1330[2] {
-					yym1340 := z.EncBinary()
-					_ = yym1340
+				if yyq1286[2] {
+					yym1296 := z.EncBinary()
+					_ = yym1296
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -15923,23 +15349,23 @@ func (x *ReplicaSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1330[2] {
+				if yyq1286[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1341 := z.EncBinary()
-					_ = yym1341
+					yym1297 := z.EncBinary()
+					_ = yym1297
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1330 || yy2arr1330 {
+			if yyr1286 || yy2arr1286 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1330[3] {
-					yym1343 := z.EncBinary()
-					_ = yym1343
+				if yyq1286[3] {
+					yym1299 := z.EncBinary()
+					_ = yym1299
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -15948,19 +15374,19 @@ func (x *ReplicaSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1330[3] {
+				if yyq1286[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1344 := z.EncBinary()
-					_ = yym1344
+					yym1300 := z.EncBinary()
+					_ = yym1300
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1330 || yy2arr1330 {
+			if yyr1286 || yy2arr1286 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -15973,25 +15399,25 @@ func (x *ReplicaSetList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1345 := z.DecBinary()
-	_ = yym1345
+	yym1301 := z.DecBinary()
+	_ = yym1301
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1346 := r.ContainerType()
-		if yyct1346 == codecSelferValueTypeMap1234 {
-			yyl1346 := r.ReadMapStart()
-			if yyl1346 == 0 {
+		yyct1302 := r.ContainerType()
+		if yyct1302 == codecSelferValueTypeMap1234 {
+			yyl1302 := r.ReadMapStart()
+			if yyl1302 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1346, d)
+				x.codecDecodeSelfFromMap(yyl1302, d)
 			}
-		} else if yyct1346 == codecSelferValueTypeArray1234 {
-			yyl1346 := r.ReadArrayStart()
-			if yyl1346 == 0 {
+		} else if yyct1302 == codecSelferValueTypeArray1234 {
+			yyl1302 := r.ReadArrayStart()
+			if yyl1302 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1346, d)
+				x.codecDecodeSelfFromArray(yyl1302, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -16003,12 +15429,12 @@ func (x *ReplicaSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1347Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1347Slc
-	var yyhl1347 bool = l >= 0
-	for yyj1347 := 0; ; yyj1347++ {
-		if yyhl1347 {
-			if yyj1347 >= l {
+	var yys1303Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1303Slc
+	var yyhl1303 bool = l >= 0
+	for yyj1303 := 0; ; yyj1303++ {
+		if yyhl1303 {
+			if yyj1303 >= l {
 				break
 			}
 		} else {
@@ -16017,33 +15443,33 @@ func (x *ReplicaSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1347Slc = r.DecodeBytes(yys1347Slc, true, true)
-		yys1347 := string(yys1347Slc)
+		yys1303Slc = r.DecodeBytes(yys1303Slc, true, true)
+		yys1303 := string(yys1303Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1347 {
+		switch yys1303 {
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv1348 := &x.ListMeta
-				yym1349 := z.DecBinary()
-				_ = yym1349
+				yyv1304 := &x.ListMeta
+				yym1305 := z.DecBinary()
+				_ = yym1305
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1348) {
+				} else if z.HasExtensions() && z.DecExt(yyv1304) {
 				} else {
-					z.DecFallback(yyv1348, false)
+					z.DecFallback(yyv1304, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv1350 := &x.Items
-				yym1351 := z.DecBinary()
-				_ = yym1351
+				yyv1306 := &x.Items
+				yym1307 := z.DecBinary()
+				_ = yym1307
 				if false {
 				} else {
-					h.decSliceReplicaSet((*[]ReplicaSet)(yyv1350), d)
+					h.decSliceReplicaSet((*[]ReplicaSet)(yyv1306), d)
 				}
 			}
 		case "kind":
@@ -16059,9 +15485,9 @@ func (x *ReplicaSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1347)
-		} // end switch yys1347
-	} // end for yyj1347
+			z.DecStructFieldNotFound(-1, yys1303)
+		} // end switch yys1303
+	} // end for yyj1303
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -16069,16 +15495,16 @@ func (x *ReplicaSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1354 int
-	var yyb1354 bool
-	var yyhl1354 bool = l >= 0
-	yyj1354++
-	if yyhl1354 {
-		yyb1354 = yyj1354 > l
+	var yyj1310 int
+	var yyb1310 bool
+	var yyhl1310 bool = l >= 0
+	yyj1310++
+	if yyhl1310 {
+		yyb1310 = yyj1310 > l
 	} else {
-		yyb1354 = r.CheckBreak()
+		yyb1310 = r.CheckBreak()
 	}
-	if yyb1354 {
+	if yyb1310 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -16086,22 +15512,22 @@ func (x *ReplicaSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv1355 := &x.ListMeta
-		yym1356 := z.DecBinary()
-		_ = yym1356
+		yyv1311 := &x.ListMeta
+		yym1312 := z.DecBinary()
+		_ = yym1312
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1355) {
+		} else if z.HasExtensions() && z.DecExt(yyv1311) {
 		} else {
-			z.DecFallback(yyv1355, false)
+			z.DecFallback(yyv1311, false)
 		}
 	}
-	yyj1354++
-	if yyhl1354 {
-		yyb1354 = yyj1354 > l
+	yyj1310++
+	if yyhl1310 {
+		yyb1310 = yyj1310 > l
 	} else {
-		yyb1354 = r.CheckBreak()
+		yyb1310 = r.CheckBreak()
 	}
-	if yyb1354 {
+	if yyb1310 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -16109,21 +15535,21 @@ func (x *ReplicaSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv1357 := &x.Items
-		yym1358 := z.DecBinary()
-		_ = yym1358
+		yyv1313 := &x.Items
+		yym1314 := z.DecBinary()
+		_ = yym1314
 		if false {
 		} else {
-			h.decSliceReplicaSet((*[]ReplicaSet)(yyv1357), d)
+			h.decSliceReplicaSet((*[]ReplicaSet)(yyv1313), d)
 		}
 	}
-	yyj1354++
-	if yyhl1354 {
-		yyb1354 = yyj1354 > l
+	yyj1310++
+	if yyhl1310 {
+		yyb1310 = yyj1310 > l
 	} else {
-		yyb1354 = r.CheckBreak()
+		yyb1310 = r.CheckBreak()
 	}
-	if yyb1354 {
+	if yyb1310 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -16133,13 +15559,13 @@ func (x *ReplicaSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1354++
-	if yyhl1354 {
-		yyb1354 = yyj1354 > l
+	yyj1310++
+	if yyhl1310 {
+		yyb1310 = yyj1310 > l
 	} else {
-		yyb1354 = r.CheckBreak()
+		yyb1310 = r.CheckBreak()
 	}
-	if yyb1354 {
+	if yyb1310 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -16150,17 +15576,17 @@ func (x *ReplicaSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = string(r.DecodeString())
 	}
 	for {
-		yyj1354++
-		if yyhl1354 {
-			yyb1354 = yyj1354 > l
+		yyj1310++
+		if yyhl1310 {
+			yyb1310 = yyj1310 > l
 		} else {
-			yyb1354 = r.CheckBreak()
+			yyb1310 = r.CheckBreak()
 		}
-		if yyb1354 {
+		if yyb1310 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1354-1, "")
+		z.DecStructFieldNotFound(yyj1310-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -16172,35 +15598,35 @@ func (x *ReplicaSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1361 := z.EncBinary()
-		_ = yym1361
+		yym1317 := z.EncBinary()
+		_ = yym1317
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1362 := !z.EncBinary()
-			yy2arr1362 := z.EncBasicHandle().StructToArray
-			var yyq1362 [3]bool
-			_, _, _ = yysep1362, yyq1362, yy2arr1362
-			const yyr1362 bool = false
-			yyq1362[1] = x.Selector != nil
-			yyq1362[2] = x.Template != nil
-			var yynn1362 int
-			if yyr1362 || yy2arr1362 {
+			yysep1318 := !z.EncBinary()
+			yy2arr1318 := z.EncBasicHandle().StructToArray
+			var yyq1318 [3]bool
+			_, _, _ = yysep1318, yyq1318, yy2arr1318
+			const yyr1318 bool = false
+			yyq1318[1] = x.Selector != nil
+			yyq1318[2] = x.Template != nil
+			var yynn1318 int
+			if yyr1318 || yy2arr1318 {
 				r.EncodeArrayStart(3)
 			} else {
-				yynn1362 = 1
-				for _, b := range yyq1362 {
+				yynn1318 = 1
+				for _, b := range yyq1318 {
 					if b {
-						yynn1362++
+						yynn1318++
 					}
 				}
-				r.EncodeMapStart(yynn1362)
-				yynn1362 = 0
+				r.EncodeMapStart(yynn1318)
+				yynn1318 = 0
 			}
-			if yyr1362 || yy2arr1362 {
+			if yyr1318 || yy2arr1318 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1364 := z.EncBinary()
-				_ = yym1364
+				yym1320 := z.EncBinary()
+				_ = yym1320
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Replicas))
@@ -16209,21 +15635,21 @@ func (x *ReplicaSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("replicas"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1365 := z.EncBinary()
-				_ = yym1365
+				yym1321 := z.EncBinary()
+				_ = yym1321
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Replicas))
 				}
 			}
-			if yyr1362 || yy2arr1362 {
+			if yyr1318 || yy2arr1318 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1362[1] {
+				if yyq1318[1] {
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
-						yym1367 := z.EncBinary()
-						_ = yym1367
+						yym1323 := z.EncBinary()
+						_ = yym1323
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.Selector) {
 						} else {
@@ -16234,15 +15660,15 @@ func (x *ReplicaSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1362[1] {
+				if yyq1318[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
-						yym1368 := z.EncBinary()
-						_ = yym1368
+						yym1324 := z.EncBinary()
+						_ = yym1324
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.Selector) {
 						} else {
@@ -16251,9 +15677,9 @@ func (x *ReplicaSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1362 || yy2arr1362 {
+			if yyr1318 || yy2arr1318 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1362[2] {
+				if yyq1318[2] {
 					if x.Template == nil {
 						r.EncodeNil()
 					} else {
@@ -16263,7 +15689,7 @@ func (x *ReplicaSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1362[2] {
+				if yyq1318[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("template"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
@@ -16274,7 +15700,7 @@ func (x *ReplicaSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1362 || yy2arr1362 {
+			if yyr1318 || yy2arr1318 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -16287,25 +15713,25 @@ func (x *ReplicaSetSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1370 := z.DecBinary()
-	_ = yym1370
+	yym1326 := z.DecBinary()
+	_ = yym1326
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1371 := r.ContainerType()
-		if yyct1371 == codecSelferValueTypeMap1234 {
-			yyl1371 := r.ReadMapStart()
-			if yyl1371 == 0 {
+		yyct1327 := r.ContainerType()
+		if yyct1327 == codecSelferValueTypeMap1234 {
+			yyl1327 := r.ReadMapStart()
+			if yyl1327 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1371, d)
+				x.codecDecodeSelfFromMap(yyl1327, d)
 			}
-		} else if yyct1371 == codecSelferValueTypeArray1234 {
-			yyl1371 := r.ReadArrayStart()
-			if yyl1371 == 0 {
+		} else if yyct1327 == codecSelferValueTypeArray1234 {
+			yyl1327 := r.ReadArrayStart()
+			if yyl1327 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1371, d)
+				x.codecDecodeSelfFromArray(yyl1327, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -16317,12 +15743,12 @@ func (x *ReplicaSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1372Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1372Slc
-	var yyhl1372 bool = l >= 0
-	for yyj1372 := 0; ; yyj1372++ {
-		if yyhl1372 {
-			if yyj1372 >= l {
+	var yys1328Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1328Slc
+	var yyhl1328 bool = l >= 0
+	for yyj1328 := 0; ; yyj1328++ {
+		if yyhl1328 {
+			if yyj1328 >= l {
 				break
 			}
 		} else {
@@ -16331,10 +15757,10 @@ func (x *ReplicaSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1372Slc = r.DecodeBytes(yys1372Slc, true, true)
-		yys1372 := string(yys1372Slc)
+		yys1328Slc = r.DecodeBytes(yys1328Slc, true, true)
+		yys1328 := string(yys1328Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1372 {
+		switch yys1328 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
 				x.Replicas = 0
@@ -16350,8 +15776,8 @@ func (x *ReplicaSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Selector == nil {
 					x.Selector = new(pkg1_unversioned.LabelSelector)
 				}
-				yym1375 := z.DecBinary()
-				_ = yym1375
+				yym1331 := z.DecBinary()
+				_ = yym1331
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.Selector) {
 				} else {
@@ -16370,9 +15796,9 @@ func (x *ReplicaSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Template.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1372)
-		} // end switch yys1372
-	} // end for yyj1372
+			z.DecStructFieldNotFound(-1, yys1328)
+		} // end switch yys1328
+	} // end for yyj1328
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -16380,16 +15806,16 @@ func (x *ReplicaSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1377 int
-	var yyb1377 bool
-	var yyhl1377 bool = l >= 0
-	yyj1377++
-	if yyhl1377 {
-		yyb1377 = yyj1377 > l
+	var yyj1333 int
+	var yyb1333 bool
+	var yyhl1333 bool = l >= 0
+	yyj1333++
+	if yyhl1333 {
+		yyb1333 = yyj1333 > l
 	} else {
-		yyb1377 = r.CheckBreak()
+		yyb1333 = r.CheckBreak()
 	}
-	if yyb1377 {
+	if yyb1333 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -16399,13 +15825,13 @@ func (x *ReplicaSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj1377++
-	if yyhl1377 {
-		yyb1377 = yyj1377 > l
+	yyj1333++
+	if yyhl1333 {
+		yyb1333 = yyj1333 > l
 	} else {
-		yyb1377 = r.CheckBreak()
+		yyb1333 = r.CheckBreak()
 	}
-	if yyb1377 {
+	if yyb1333 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -16418,21 +15844,21 @@ func (x *ReplicaSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.Selector == nil {
 			x.Selector = new(pkg1_unversioned.LabelSelector)
 		}
-		yym1380 := z.DecBinary()
-		_ = yym1380
+		yym1336 := z.DecBinary()
+		_ = yym1336
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.Selector) {
 		} else {
 			z.DecFallback(x.Selector, false)
 		}
 	}
-	yyj1377++
-	if yyhl1377 {
-		yyb1377 = yyj1377 > l
+	yyj1333++
+	if yyhl1333 {
+		yyb1333 = yyj1333 > l
 	} else {
-		yyb1377 = r.CheckBreak()
+		yyb1333 = r.CheckBreak()
 	}
-	if yyb1377 {
+	if yyb1333 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -16448,17 +15874,17 @@ func (x *ReplicaSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Template.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1377++
-		if yyhl1377 {
-			yyb1377 = yyj1377 > l
+		yyj1333++
+		if yyhl1333 {
+			yyb1333 = yyj1333 > l
 		} else {
-			yyb1377 = r.CheckBreak()
+			yyb1333 = r.CheckBreak()
 		}
-		if yyb1377 {
+		if yyb1333 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1377-1, "")
+		z.DecStructFieldNotFound(yyj1333-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -16470,34 +15896,34 @@ func (x *ReplicaSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1382 := z.EncBinary()
-		_ = yym1382
+		yym1338 := z.EncBinary()
+		_ = yym1338
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1383 := !z.EncBinary()
-			yy2arr1383 := z.EncBasicHandle().StructToArray
-			var yyq1383 [2]bool
-			_, _, _ = yysep1383, yyq1383, yy2arr1383
-			const yyr1383 bool = false
-			yyq1383[1] = x.ObservedGeneration != 0
-			var yynn1383 int
-			if yyr1383 || yy2arr1383 {
+			yysep1339 := !z.EncBinary()
+			yy2arr1339 := z.EncBasicHandle().StructToArray
+			var yyq1339 [2]bool
+			_, _, _ = yysep1339, yyq1339, yy2arr1339
+			const yyr1339 bool = false
+			yyq1339[1] = x.ObservedGeneration != 0
+			var yynn1339 int
+			if yyr1339 || yy2arr1339 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn1383 = 1
-				for _, b := range yyq1383 {
+				yynn1339 = 1
+				for _, b := range yyq1339 {
 					if b {
-						yynn1383++
+						yynn1339++
 					}
 				}
-				r.EncodeMapStart(yynn1383)
-				yynn1383 = 0
+				r.EncodeMapStart(yynn1339)
+				yynn1339 = 0
 			}
-			if yyr1383 || yy2arr1383 {
+			if yyr1339 || yy2arr1339 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1385 := z.EncBinary()
-				_ = yym1385
+				yym1341 := z.EncBinary()
+				_ = yym1341
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Replicas))
@@ -16506,18 +15932,18 @@ func (x *ReplicaSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("replicas"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1386 := z.EncBinary()
-				_ = yym1386
+				yym1342 := z.EncBinary()
+				_ = yym1342
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Replicas))
 				}
 			}
-			if yyr1383 || yy2arr1383 {
+			if yyr1339 || yy2arr1339 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1383[1] {
-					yym1388 := z.EncBinary()
-					_ = yym1388
+				if yyq1339[1] {
+					yym1344 := z.EncBinary()
+					_ = yym1344
 					if false {
 					} else {
 						r.EncodeInt(int64(x.ObservedGeneration))
@@ -16526,19 +15952,19 @@ func (x *ReplicaSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq1383[1] {
+				if yyq1339[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("observedGeneration"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1389 := z.EncBinary()
-					_ = yym1389
+					yym1345 := z.EncBinary()
+					_ = yym1345
 					if false {
 					} else {
 						r.EncodeInt(int64(x.ObservedGeneration))
 					}
 				}
 			}
-			if yyr1383 || yy2arr1383 {
+			if yyr1339 || yy2arr1339 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -16551,25 +15977,25 @@ func (x *ReplicaSetStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1390 := z.DecBinary()
-	_ = yym1390
+	yym1346 := z.DecBinary()
+	_ = yym1346
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1391 := r.ContainerType()
-		if yyct1391 == codecSelferValueTypeMap1234 {
-			yyl1391 := r.ReadMapStart()
-			if yyl1391 == 0 {
+		yyct1347 := r.ContainerType()
+		if yyct1347 == codecSelferValueTypeMap1234 {
+			yyl1347 := r.ReadMapStart()
+			if yyl1347 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1391, d)
+				x.codecDecodeSelfFromMap(yyl1347, d)
 			}
-		} else if yyct1391 == codecSelferValueTypeArray1234 {
-			yyl1391 := r.ReadArrayStart()
-			if yyl1391 == 0 {
+		} else if yyct1347 == codecSelferValueTypeArray1234 {
+			yyl1347 := r.ReadArrayStart()
+			if yyl1347 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1391, d)
+				x.codecDecodeSelfFromArray(yyl1347, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -16581,12 +16007,12 @@ func (x *ReplicaSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1392Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1392Slc
-	var yyhl1392 bool = l >= 0
-	for yyj1392 := 0; ; yyj1392++ {
-		if yyhl1392 {
-			if yyj1392 >= l {
+	var yys1348Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1348Slc
+	var yyhl1348 bool = l >= 0
+	for yyj1348 := 0; ; yyj1348++ {
+		if yyhl1348 {
+			if yyj1348 >= l {
 				break
 			}
 		} else {
@@ -16595,10 +16021,10 @@ func (x *ReplicaSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1392Slc = r.DecodeBytes(yys1392Slc, true, true)
-		yys1392 := string(yys1392Slc)
+		yys1348Slc = r.DecodeBytes(yys1348Slc, true, true)
+		yys1348 := string(yys1348Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1392 {
+		switch yys1348 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
 				x.Replicas = 0
@@ -16612,9 +16038,9 @@ func (x *ReplicaSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.ObservedGeneration = int64(r.DecodeInt(64))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1392)
-		} // end switch yys1392
-	} // end for yyj1392
+			z.DecStructFieldNotFound(-1, yys1348)
+		} // end switch yys1348
+	} // end for yyj1348
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -16622,16 +16048,16 @@ func (x *ReplicaSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1395 int
-	var yyb1395 bool
-	var yyhl1395 bool = l >= 0
-	yyj1395++
-	if yyhl1395 {
-		yyb1395 = yyj1395 > l
+	var yyj1351 int
+	var yyb1351 bool
+	var yyhl1351 bool = l >= 0
+	yyj1351++
+	if yyhl1351 {
+		yyb1351 = yyj1351 > l
 	} else {
-		yyb1395 = r.CheckBreak()
+		yyb1351 = r.CheckBreak()
 	}
-	if yyb1395 {
+	if yyb1351 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -16641,13 +16067,13 @@ func (x *ReplicaSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj1395++
-	if yyhl1395 {
-		yyb1395 = yyj1395 > l
+	yyj1351++
+	if yyhl1351 {
+		yyb1351 = yyj1351 > l
 	} else {
-		yyb1395 = r.CheckBreak()
+		yyb1351 = r.CheckBreak()
 	}
-	if yyb1395 {
+	if yyb1351 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -16658,17 +16084,17 @@ func (x *ReplicaSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		x.ObservedGeneration = int64(r.DecodeInt(64))
 	}
 	for {
-		yyj1395++
-		if yyhl1395 {
-			yyb1395 = yyj1395 > l
+		yyj1351++
+		if yyhl1351 {
+			yyb1351 = yyj1351 > l
 		} else {
-			yyb1395 = r.CheckBreak()
+			yyb1351 = r.CheckBreak()
 		}
-		if yyb1395 {
+		if yyb1351 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1395-1, "")
+		z.DecStructFieldNotFound(yyj1351-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -16680,72 +16106,72 @@ func (x *PodSecurityPolicy) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1398 := z.EncBinary()
-		_ = yym1398
+		yym1354 := z.EncBinary()
+		_ = yym1354
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1399 := !z.EncBinary()
-			yy2arr1399 := z.EncBasicHandle().StructToArray
-			var yyq1399 [4]bool
-			_, _, _ = yysep1399, yyq1399, yy2arr1399
-			const yyr1399 bool = false
-			yyq1399[0] = true
-			yyq1399[1] = true
-			yyq1399[2] = x.Kind != ""
-			yyq1399[3] = x.APIVersion != ""
-			var yynn1399 int
-			if yyr1399 || yy2arr1399 {
+			yysep1355 := !z.EncBinary()
+			yy2arr1355 := z.EncBasicHandle().StructToArray
+			var yyq1355 [4]bool
+			_, _, _ = yysep1355, yyq1355, yy2arr1355
+			const yyr1355 bool = false
+			yyq1355[0] = true
+			yyq1355[1] = true
+			yyq1355[2] = x.Kind != ""
+			yyq1355[3] = x.APIVersion != ""
+			var yynn1355 int
+			if yyr1355 || yy2arr1355 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn1399 = 0
-				for _, b := range yyq1399 {
+				yynn1355 = 0
+				for _, b := range yyq1355 {
 					if b {
-						yynn1399++
+						yynn1355++
 					}
 				}
-				r.EncodeMapStart(yynn1399)
-				yynn1399 = 0
+				r.EncodeMapStart(yynn1355)
+				yynn1355 = 0
 			}
-			if yyr1399 || yy2arr1399 {
+			if yyr1355 || yy2arr1355 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1399[0] {
-					yy1401 := &x.ObjectMeta
-					yy1401.CodecEncodeSelf(e)
+				if yyq1355[0] {
+					yy1357 := &x.ObjectMeta
+					yy1357.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1399[0] {
+				if yyq1355[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1402 := &x.ObjectMeta
-					yy1402.CodecEncodeSelf(e)
+					yy1358 := &x.ObjectMeta
+					yy1358.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1399 || yy2arr1399 {
+			if yyr1355 || yy2arr1355 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1399[1] {
-					yy1404 := &x.Spec
-					yy1404.CodecEncodeSelf(e)
+				if yyq1355[1] {
+					yy1360 := &x.Spec
+					yy1360.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1399[1] {
+				if yyq1355[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1405 := &x.Spec
-					yy1405.CodecEncodeSelf(e)
+					yy1361 := &x.Spec
+					yy1361.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1399 || yy2arr1399 {
+			if yyr1355 || yy2arr1355 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1399[2] {
-					yym1407 := z.EncBinary()
-					_ = yym1407
+				if yyq1355[2] {
+					yym1363 := z.EncBinary()
+					_ = yym1363
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -16754,23 +16180,23 @@ func (x *PodSecurityPolicy) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1399[2] {
+				if yyq1355[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1408 := z.EncBinary()
-					_ = yym1408
+					yym1364 := z.EncBinary()
+					_ = yym1364
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1399 || yy2arr1399 {
+			if yyr1355 || yy2arr1355 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1399[3] {
-					yym1410 := z.EncBinary()
-					_ = yym1410
+				if yyq1355[3] {
+					yym1366 := z.EncBinary()
+					_ = yym1366
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -16779,19 +16205,19 @@ func (x *PodSecurityPolicy) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1399[3] {
+				if yyq1355[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1411 := z.EncBinary()
-					_ = yym1411
+					yym1367 := z.EncBinary()
+					_ = yym1367
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1399 || yy2arr1399 {
+			if yyr1355 || yy2arr1355 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -16804,25 +16230,25 @@ func (x *PodSecurityPolicy) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1412 := z.DecBinary()
-	_ = yym1412
+	yym1368 := z.DecBinary()
+	_ = yym1368
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1413 := r.ContainerType()
-		if yyct1413 == codecSelferValueTypeMap1234 {
-			yyl1413 := r.ReadMapStart()
-			if yyl1413 == 0 {
+		yyct1369 := r.ContainerType()
+		if yyct1369 == codecSelferValueTypeMap1234 {
+			yyl1369 := r.ReadMapStart()
+			if yyl1369 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1413, d)
+				x.codecDecodeSelfFromMap(yyl1369, d)
 			}
-		} else if yyct1413 == codecSelferValueTypeArray1234 {
-			yyl1413 := r.ReadArrayStart()
-			if yyl1413 == 0 {
+		} else if yyct1369 == codecSelferValueTypeArray1234 {
+			yyl1369 := r.ReadArrayStart()
+			if yyl1369 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1413, d)
+				x.codecDecodeSelfFromArray(yyl1369, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -16834,12 +16260,12 @@ func (x *PodSecurityPolicy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1414Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1414Slc
-	var yyhl1414 bool = l >= 0
-	for yyj1414 := 0; ; yyj1414++ {
-		if yyhl1414 {
-			if yyj1414 >= l {
+	var yys1370Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1370Slc
+	var yyhl1370 bool = l >= 0
+	for yyj1370 := 0; ; yyj1370++ {
+		if yyhl1370 {
+			if yyj1370 >= l {
 				break
 			}
 		} else {
@@ -16848,23 +16274,23 @@ func (x *PodSecurityPolicy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1414Slc = r.DecodeBytes(yys1414Slc, true, true)
-		yys1414 := string(yys1414Slc)
+		yys1370Slc = r.DecodeBytes(yys1370Slc, true, true)
+		yys1370 := string(yys1370Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1414 {
+		switch yys1370 {
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv1415 := &x.ObjectMeta
-				yyv1415.CodecDecodeSelf(d)
+				yyv1371 := &x.ObjectMeta
+				yyv1371.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = PodSecurityPolicySpec{}
 			} else {
-				yyv1416 := &x.Spec
-				yyv1416.CodecDecodeSelf(d)
+				yyv1372 := &x.Spec
+				yyv1372.CodecDecodeSelf(d)
 			}
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -16879,9 +16305,9 @@ func (x *PodSecurityPolicy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				x.APIVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1414)
-		} // end switch yys1414
-	} // end for yyj1414
+			z.DecStructFieldNotFound(-1, yys1370)
+		} // end switch yys1370
+	} // end for yyj1370
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -16889,16 +16315,16 @@ func (x *PodSecurityPolicy) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1419 int
-	var yyb1419 bool
-	var yyhl1419 bool = l >= 0
-	yyj1419++
-	if yyhl1419 {
-		yyb1419 = yyj1419 > l
+	var yyj1375 int
+	var yyb1375 bool
+	var yyhl1375 bool = l >= 0
+	yyj1375++
+	if yyhl1375 {
+		yyb1375 = yyj1375 > l
 	} else {
-		yyb1419 = r.CheckBreak()
+		yyb1375 = r.CheckBreak()
 	}
-	if yyb1419 {
+	if yyb1375 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -16906,16 +16332,16 @@ func (x *PodSecurityPolicy) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv1420 := &x.ObjectMeta
-		yyv1420.CodecDecodeSelf(d)
+		yyv1376 := &x.ObjectMeta
+		yyv1376.CodecDecodeSelf(d)
 	}
-	yyj1419++
-	if yyhl1419 {
-		yyb1419 = yyj1419 > l
+	yyj1375++
+	if yyhl1375 {
+		yyb1375 = yyj1375 > l
 	} else {
-		yyb1419 = r.CheckBreak()
+		yyb1375 = r.CheckBreak()
 	}
-	if yyb1419 {
+	if yyb1375 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -16923,16 +16349,16 @@ func (x *PodSecurityPolicy) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	if r.TryDecodeAsNil() {
 		x.Spec = PodSecurityPolicySpec{}
 	} else {
-		yyv1421 := &x.Spec
-		yyv1421.CodecDecodeSelf(d)
+		yyv1377 := &x.Spec
+		yyv1377.CodecDecodeSelf(d)
 	}
-	yyj1419++
-	if yyhl1419 {
-		yyb1419 = yyj1419 > l
+	yyj1375++
+	if yyhl1375 {
+		yyb1375 = yyj1375 > l
 	} else {
-		yyb1419 = r.CheckBreak()
+		yyb1375 = r.CheckBreak()
 	}
-	if yyb1419 {
+	if yyb1375 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -16942,13 +16368,13 @@ func (x *PodSecurityPolicy) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1419++
-	if yyhl1419 {
-		yyb1419 = yyj1419 > l
+	yyj1375++
+	if yyhl1375 {
+		yyb1375 = yyj1375 > l
 	} else {
-		yyb1419 = r.CheckBreak()
+		yyb1375 = r.CheckBreak()
 	}
-	if yyb1419 {
+	if yyb1375 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -16959,17 +16385,17 @@ func (x *PodSecurityPolicy) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		x.APIVersion = string(r.DecodeString())
 	}
 	for {
-		yyj1419++
-		if yyhl1419 {
-			yyb1419 = yyj1419 > l
+		yyj1375++
+		if yyhl1375 {
+			yyb1375 = yyj1375 > l
 		} else {
-			yyb1419 = r.CheckBreak()
+			yyb1375 = r.CheckBreak()
 		}
-		if yyb1419 {
+		if yyb1375 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1419-1, "")
+		z.DecStructFieldNotFound(yyj1375-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -16981,43 +16407,43 @@ func (x *PodSecurityPolicySpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1424 := z.EncBinary()
-		_ = yym1424
+		yym1380 := z.EncBinary()
+		_ = yym1380
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1425 := !z.EncBinary()
-			yy2arr1425 := z.EncBasicHandle().StructToArray
-			var yyq1425 [9]bool
-			_, _, _ = yysep1425, yyq1425, yy2arr1425
-			const yyr1425 bool = false
-			yyq1425[0] = x.Privileged != false
-			yyq1425[1] = len(x.Capabilities) != 0
-			yyq1425[2] = len(x.Volumes) != 0
-			yyq1425[3] = x.HostNetwork != false
-			yyq1425[4] = len(x.HostPorts) != 0
-			yyq1425[5] = x.HostPID != false
-			yyq1425[6] = x.HostIPC != false
-			yyq1425[7] = true
-			yyq1425[8] = true
-			var yynn1425 int
-			if yyr1425 || yy2arr1425 {
+			yysep1381 := !z.EncBinary()
+			yy2arr1381 := z.EncBasicHandle().StructToArray
+			var yyq1381 [9]bool
+			_, _, _ = yysep1381, yyq1381, yy2arr1381
+			const yyr1381 bool = false
+			yyq1381[0] = x.Privileged != false
+			yyq1381[1] = len(x.Capabilities) != 0
+			yyq1381[2] = len(x.Volumes) != 0
+			yyq1381[3] = x.HostNetwork != false
+			yyq1381[4] = len(x.HostPorts) != 0
+			yyq1381[5] = x.HostPID != false
+			yyq1381[6] = x.HostIPC != false
+			yyq1381[7] = true
+			yyq1381[8] = true
+			var yynn1381 int
+			if yyr1381 || yy2arr1381 {
 				r.EncodeArrayStart(9)
 			} else {
-				yynn1425 = 0
-				for _, b := range yyq1425 {
+				yynn1381 = 0
+				for _, b := range yyq1381 {
 					if b {
-						yynn1425++
+						yynn1381++
 					}
 				}
-				r.EncodeMapStart(yynn1425)
-				yynn1425 = 0
+				r.EncodeMapStart(yynn1381)
+				yynn1381 = 0
 			}
-			if yyr1425 || yy2arr1425 {
+			if yyr1381 || yy2arr1381 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1425[0] {
-					yym1427 := z.EncBinary()
-					_ = yym1427
+				if yyq1381[0] {
+					yym1383 := z.EncBinary()
+					_ = yym1383
 					if false {
 					} else {
 						r.EncodeBool(bool(x.Privileged))
@@ -17026,26 +16452,26 @@ func (x *PodSecurityPolicySpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq1425[0] {
+				if yyq1381[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("privileged"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1428 := z.EncBinary()
-					_ = yym1428
+					yym1384 := z.EncBinary()
+					_ = yym1384
 					if false {
 					} else {
 						r.EncodeBool(bool(x.Privileged))
 					}
 				}
 			}
-			if yyr1425 || yy2arr1425 {
+			if yyr1381 || yy2arr1381 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1425[1] {
+				if yyq1381[1] {
 					if x.Capabilities == nil {
 						r.EncodeNil()
 					} else {
-						yym1430 := z.EncBinary()
-						_ = yym1430
+						yym1386 := z.EncBinary()
+						_ = yym1386
 						if false {
 						} else {
 							h.encSliceapi_Capability(([]pkg2_api.Capability)(x.Capabilities), e)
@@ -17055,15 +16481,15 @@ func (x *PodSecurityPolicySpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1425[1] {
+				if yyq1381[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("capabilities"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Capabilities == nil {
 						r.EncodeNil()
 					} else {
-						yym1431 := z.EncBinary()
-						_ = yym1431
+						yym1387 := z.EncBinary()
+						_ = yym1387
 						if false {
 						} else {
 							h.encSliceapi_Capability(([]pkg2_api.Capability)(x.Capabilities), e)
@@ -17071,14 +16497,14 @@ func (x *PodSecurityPolicySpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1425 || yy2arr1425 {
+			if yyr1381 || yy2arr1381 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1425[2] {
+				if yyq1381[2] {
 					if x.Volumes == nil {
 						r.EncodeNil()
 					} else {
-						yym1433 := z.EncBinary()
-						_ = yym1433
+						yym1389 := z.EncBinary()
+						_ = yym1389
 						if false {
 						} else {
 							h.encSliceFSType(([]FSType)(x.Volumes), e)
@@ -17088,15 +16514,15 @@ func (x *PodSecurityPolicySpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1425[2] {
+				if yyq1381[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("volumes"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Volumes == nil {
 						r.EncodeNil()
 					} else {
-						yym1434 := z.EncBinary()
-						_ = yym1434
+						yym1390 := z.EncBinary()
+						_ = yym1390
 						if false {
 						} else {
 							h.encSliceFSType(([]FSType)(x.Volumes), e)
@@ -17104,11 +16530,11 @@ func (x *PodSecurityPolicySpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1425 || yy2arr1425 {
+			if yyr1381 || yy2arr1381 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1425[3] {
-					yym1436 := z.EncBinary()
-					_ = yym1436
+				if yyq1381[3] {
+					yym1392 := z.EncBinary()
+					_ = yym1392
 					if false {
 					} else {
 						r.EncodeBool(bool(x.HostNetwork))
@@ -17117,26 +16543,26 @@ func (x *PodSecurityPolicySpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq1425[3] {
+				if yyq1381[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hostNetwork"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1437 := z.EncBinary()
-					_ = yym1437
+					yym1393 := z.EncBinary()
+					_ = yym1393
 					if false {
 					} else {
 						r.EncodeBool(bool(x.HostNetwork))
 					}
 				}
 			}
-			if yyr1425 || yy2arr1425 {
+			if yyr1381 || yy2arr1381 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1425[4] {
+				if yyq1381[4] {
 					if x.HostPorts == nil {
 						r.EncodeNil()
 					} else {
-						yym1439 := z.EncBinary()
-						_ = yym1439
+						yym1395 := z.EncBinary()
+						_ = yym1395
 						if false {
 						} else {
 							h.encSliceHostPortRange(([]HostPortRange)(x.HostPorts), e)
@@ -17146,15 +16572,15 @@ func (x *PodSecurityPolicySpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1425[4] {
+				if yyq1381[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hostPorts"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.HostPorts == nil {
 						r.EncodeNil()
 					} else {
-						yym1440 := z.EncBinary()
-						_ = yym1440
+						yym1396 := z.EncBinary()
+						_ = yym1396
 						if false {
 						} else {
 							h.encSliceHostPortRange(([]HostPortRange)(x.HostPorts), e)
@@ -17162,11 +16588,11 @@ func (x *PodSecurityPolicySpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1425 || yy2arr1425 {
+			if yyr1381 || yy2arr1381 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1425[5] {
-					yym1442 := z.EncBinary()
-					_ = yym1442
+				if yyq1381[5] {
+					yym1398 := z.EncBinary()
+					_ = yym1398
 					if false {
 					} else {
 						r.EncodeBool(bool(x.HostPID))
@@ -17175,23 +16601,23 @@ func (x *PodSecurityPolicySpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq1425[5] {
+				if yyq1381[5] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hostPID"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1443 := z.EncBinary()
-					_ = yym1443
+					yym1399 := z.EncBinary()
+					_ = yym1399
 					if false {
 					} else {
 						r.EncodeBool(bool(x.HostPID))
 					}
 				}
 			}
-			if yyr1425 || yy2arr1425 {
+			if yyr1381 || yy2arr1381 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1425[6] {
-					yym1445 := z.EncBinary()
-					_ = yym1445
+				if yyq1381[6] {
+					yym1401 := z.EncBinary()
+					_ = yym1401
 					if false {
 					} else {
 						r.EncodeBool(bool(x.HostIPC))
@@ -17200,53 +16626,53 @@ func (x *PodSecurityPolicySpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq1425[6] {
+				if yyq1381[6] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hostIPC"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1446 := z.EncBinary()
-					_ = yym1446
+					yym1402 := z.EncBinary()
+					_ = yym1402
 					if false {
 					} else {
 						r.EncodeBool(bool(x.HostIPC))
 					}
 				}
 			}
-			if yyr1425 || yy2arr1425 {
+			if yyr1381 || yy2arr1381 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1425[7] {
-					yy1448 := &x.SELinuxContext
-					yy1448.CodecEncodeSelf(e)
+				if yyq1381[7] {
+					yy1404 := &x.SELinuxContext
+					yy1404.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1425[7] {
+				if yyq1381[7] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("seLinuxContext"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1449 := &x.SELinuxContext
-					yy1449.CodecEncodeSelf(e)
+					yy1405 := &x.SELinuxContext
+					yy1405.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1425 || yy2arr1425 {
+			if yyr1381 || yy2arr1381 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1425[8] {
-					yy1451 := &x.RunAsUser
-					yy1451.CodecEncodeSelf(e)
+				if yyq1381[8] {
+					yy1407 := &x.RunAsUser
+					yy1407.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1425[8] {
+				if yyq1381[8] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("runAsUser"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1452 := &x.RunAsUser
-					yy1452.CodecEncodeSelf(e)
+					yy1408 := &x.RunAsUser
+					yy1408.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1425 || yy2arr1425 {
+			if yyr1381 || yy2arr1381 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -17259,25 +16685,25 @@ func (x *PodSecurityPolicySpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1453 := z.DecBinary()
-	_ = yym1453
+	yym1409 := z.DecBinary()
+	_ = yym1409
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1454 := r.ContainerType()
-		if yyct1454 == codecSelferValueTypeMap1234 {
-			yyl1454 := r.ReadMapStart()
-			if yyl1454 == 0 {
+		yyct1410 := r.ContainerType()
+		if yyct1410 == codecSelferValueTypeMap1234 {
+			yyl1410 := r.ReadMapStart()
+			if yyl1410 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1454, d)
+				x.codecDecodeSelfFromMap(yyl1410, d)
 			}
-		} else if yyct1454 == codecSelferValueTypeArray1234 {
-			yyl1454 := r.ReadArrayStart()
-			if yyl1454 == 0 {
+		} else if yyct1410 == codecSelferValueTypeArray1234 {
+			yyl1410 := r.ReadArrayStart()
+			if yyl1410 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1454, d)
+				x.codecDecodeSelfFromArray(yyl1410, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -17289,12 +16715,12 @@ func (x *PodSecurityPolicySpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1455Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1455Slc
-	var yyhl1455 bool = l >= 0
-	for yyj1455 := 0; ; yyj1455++ {
-		if yyhl1455 {
-			if yyj1455 >= l {
+	var yys1411Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1411Slc
+	var yyhl1411 bool = l >= 0
+	for yyj1411 := 0; ; yyj1411++ {
+		if yyhl1411 {
+			if yyj1411 >= l {
 				break
 			}
 		} else {
@@ -17303,10 +16729,10 @@ func (x *PodSecurityPolicySpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1455Slc = r.DecodeBytes(yys1455Slc, true, true)
-		yys1455 := string(yys1455Slc)
+		yys1411Slc = r.DecodeBytes(yys1411Slc, true, true)
+		yys1411 := string(yys1411Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1455 {
+		switch yys1411 {
 		case "privileged":
 			if r.TryDecodeAsNil() {
 				x.Privileged = false
@@ -17317,24 +16743,24 @@ func (x *PodSecurityPolicySpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			if r.TryDecodeAsNil() {
 				x.Capabilities = nil
 			} else {
-				yyv1457 := &x.Capabilities
-				yym1458 := z.DecBinary()
-				_ = yym1458
+				yyv1413 := &x.Capabilities
+				yym1414 := z.DecBinary()
+				_ = yym1414
 				if false {
 				} else {
-					h.decSliceapi_Capability((*[]pkg2_api.Capability)(yyv1457), d)
+					h.decSliceapi_Capability((*[]pkg2_api.Capability)(yyv1413), d)
 				}
 			}
 		case "volumes":
 			if r.TryDecodeAsNil() {
 				x.Volumes = nil
 			} else {
-				yyv1459 := &x.Volumes
-				yym1460 := z.DecBinary()
-				_ = yym1460
+				yyv1415 := &x.Volumes
+				yym1416 := z.DecBinary()
+				_ = yym1416
 				if false {
 				} else {
-					h.decSliceFSType((*[]FSType)(yyv1459), d)
+					h.decSliceFSType((*[]FSType)(yyv1415), d)
 				}
 			}
 		case "hostNetwork":
@@ -17347,12 +16773,12 @@ func (x *PodSecurityPolicySpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			if r.TryDecodeAsNil() {
 				x.HostPorts = nil
 			} else {
-				yyv1462 := &x.HostPorts
-				yym1463 := z.DecBinary()
-				_ = yym1463
+				yyv1418 := &x.HostPorts
+				yym1419 := z.DecBinary()
+				_ = yym1419
 				if false {
 				} else {
-					h.decSliceHostPortRange((*[]HostPortRange)(yyv1462), d)
+					h.decSliceHostPortRange((*[]HostPortRange)(yyv1418), d)
 				}
 			}
 		case "hostPID":
@@ -17371,20 +16797,20 @@ func (x *PodSecurityPolicySpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			if r.TryDecodeAsNil() {
 				x.SELinuxContext = SELinuxContextStrategyOptions{}
 			} else {
-				yyv1466 := &x.SELinuxContext
-				yyv1466.CodecDecodeSelf(d)
+				yyv1422 := &x.SELinuxContext
+				yyv1422.CodecDecodeSelf(d)
 			}
 		case "runAsUser":
 			if r.TryDecodeAsNil() {
 				x.RunAsUser = RunAsUserStrategyOptions{}
 			} else {
-				yyv1467 := &x.RunAsUser
-				yyv1467.CodecDecodeSelf(d)
+				yyv1423 := &x.RunAsUser
+				yyv1423.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1455)
-		} // end switch yys1455
-	} // end for yyj1455
+			z.DecStructFieldNotFound(-1, yys1411)
+		} // end switch yys1411
+	} // end for yyj1411
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -17392,16 +16818,16 @@ func (x *PodSecurityPolicySpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1468 int
-	var yyb1468 bool
-	var yyhl1468 bool = l >= 0
-	yyj1468++
-	if yyhl1468 {
-		yyb1468 = yyj1468 > l
+	var yyj1424 int
+	var yyb1424 bool
+	var yyhl1424 bool = l >= 0
+	yyj1424++
+	if yyhl1424 {
+		yyb1424 = yyj1424 > l
 	} else {
-		yyb1468 = r.CheckBreak()
+		yyb1424 = r.CheckBreak()
 	}
-	if yyb1468 {
+	if yyb1424 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -17411,13 +16837,13 @@ func (x *PodSecurityPolicySpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.Privileged = bool(r.DecodeBool())
 	}
-	yyj1468++
-	if yyhl1468 {
-		yyb1468 = yyj1468 > l
+	yyj1424++
+	if yyhl1424 {
+		yyb1424 = yyj1424 > l
 	} else {
-		yyb1468 = r.CheckBreak()
+		yyb1424 = r.CheckBreak()
 	}
-	if yyb1468 {
+	if yyb1424 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -17425,21 +16851,21 @@ func (x *PodSecurityPolicySpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	if r.TryDecodeAsNil() {
 		x.Capabilities = nil
 	} else {
-		yyv1470 := &x.Capabilities
-		yym1471 := z.DecBinary()
-		_ = yym1471
+		yyv1426 := &x.Capabilities
+		yym1427 := z.DecBinary()
+		_ = yym1427
 		if false {
 		} else {
-			h.decSliceapi_Capability((*[]pkg2_api.Capability)(yyv1470), d)
+			h.decSliceapi_Capability((*[]pkg2_api.Capability)(yyv1426), d)
 		}
 	}
-	yyj1468++
-	if yyhl1468 {
-		yyb1468 = yyj1468 > l
+	yyj1424++
+	if yyhl1424 {
+		yyb1424 = yyj1424 > l
 	} else {
-		yyb1468 = r.CheckBreak()
+		yyb1424 = r.CheckBreak()
 	}
-	if yyb1468 {
+	if yyb1424 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -17447,21 +16873,21 @@ func (x *PodSecurityPolicySpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	if r.TryDecodeAsNil() {
 		x.Volumes = nil
 	} else {
-		yyv1472 := &x.Volumes
-		yym1473 := z.DecBinary()
-		_ = yym1473
+		yyv1428 := &x.Volumes
+		yym1429 := z.DecBinary()
+		_ = yym1429
 		if false {
 		} else {
-			h.decSliceFSType((*[]FSType)(yyv1472), d)
+			h.decSliceFSType((*[]FSType)(yyv1428), d)
 		}
 	}
-	yyj1468++
-	if yyhl1468 {
-		yyb1468 = yyj1468 > l
+	yyj1424++
+	if yyhl1424 {
+		yyb1424 = yyj1424 > l
 	} else {
-		yyb1468 = r.CheckBreak()
+		yyb1424 = r.CheckBreak()
 	}
-	if yyb1468 {
+	if yyb1424 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -17471,13 +16897,13 @@ func (x *PodSecurityPolicySpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.HostNetwork = bool(r.DecodeBool())
 	}
-	yyj1468++
-	if yyhl1468 {
-		yyb1468 = yyj1468 > l
+	yyj1424++
+	if yyhl1424 {
+		yyb1424 = yyj1424 > l
 	} else {
-		yyb1468 = r.CheckBreak()
+		yyb1424 = r.CheckBreak()
 	}
-	if yyb1468 {
+	if yyb1424 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -17485,21 +16911,21 @@ func (x *PodSecurityPolicySpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	if r.TryDecodeAsNil() {
 		x.HostPorts = nil
 	} else {
-		yyv1475 := &x.HostPorts
-		yym1476 := z.DecBinary()
-		_ = yym1476
+		yyv1431 := &x.HostPorts
+		yym1432 := z.DecBinary()
+		_ = yym1432
 		if false {
 		} else {
-			h.decSliceHostPortRange((*[]HostPortRange)(yyv1475), d)
+			h.decSliceHostPortRange((*[]HostPortRange)(yyv1431), d)
 		}
 	}
-	yyj1468++
-	if yyhl1468 {
-		yyb1468 = yyj1468 > l
+	yyj1424++
+	if yyhl1424 {
+		yyb1424 = yyj1424 > l
 	} else {
-		yyb1468 = r.CheckBreak()
+		yyb1424 = r.CheckBreak()
 	}
-	if yyb1468 {
+	if yyb1424 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -17509,13 +16935,13 @@ func (x *PodSecurityPolicySpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.HostPID = bool(r.DecodeBool())
 	}
-	yyj1468++
-	if yyhl1468 {
-		yyb1468 = yyj1468 > l
+	yyj1424++
+	if yyhl1424 {
+		yyb1424 = yyj1424 > l
 	} else {
-		yyb1468 = r.CheckBreak()
+		yyb1424 = r.CheckBreak()
 	}
-	if yyb1468 {
+	if yyb1424 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -17525,13 +16951,13 @@ func (x *PodSecurityPolicySpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.HostIPC = bool(r.DecodeBool())
 	}
-	yyj1468++
-	if yyhl1468 {
-		yyb1468 = yyj1468 > l
+	yyj1424++
+	if yyhl1424 {
+		yyb1424 = yyj1424 > l
 	} else {
-		yyb1468 = r.CheckBreak()
+		yyb1424 = r.CheckBreak()
 	}
-	if yyb1468 {
+	if yyb1424 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -17539,16 +16965,16 @@ func (x *PodSecurityPolicySpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	if r.TryDecodeAsNil() {
 		x.SELinuxContext = SELinuxContextStrategyOptions{}
 	} else {
-		yyv1479 := &x.SELinuxContext
-		yyv1479.CodecDecodeSelf(d)
+		yyv1435 := &x.SELinuxContext
+		yyv1435.CodecDecodeSelf(d)
 	}
-	yyj1468++
-	if yyhl1468 {
-		yyb1468 = yyj1468 > l
+	yyj1424++
+	if yyhl1424 {
+		yyb1424 = yyj1424 > l
 	} else {
-		yyb1468 = r.CheckBreak()
+		yyb1424 = r.CheckBreak()
 	}
-	if yyb1468 {
+	if yyb1424 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -17556,21 +16982,21 @@ func (x *PodSecurityPolicySpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	if r.TryDecodeAsNil() {
 		x.RunAsUser = RunAsUserStrategyOptions{}
 	} else {
-		yyv1480 := &x.RunAsUser
-		yyv1480.CodecDecodeSelf(d)
+		yyv1436 := &x.RunAsUser
+		yyv1436.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1468++
-		if yyhl1468 {
-			yyb1468 = yyj1468 > l
+		yyj1424++
+		if yyhl1424 {
+			yyb1424 = yyj1424 > l
 		} else {
-			yyb1468 = r.CheckBreak()
+			yyb1424 = r.CheckBreak()
 		}
-		if yyb1468 {
+		if yyb1424 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1468-1, "")
+		z.DecStructFieldNotFound(yyj1424-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -17582,33 +17008,33 @@ func (x *HostPortRange) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1481 := z.EncBinary()
-		_ = yym1481
+		yym1437 := z.EncBinary()
+		_ = yym1437
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1482 := !z.EncBinary()
-			yy2arr1482 := z.EncBasicHandle().StructToArray
-			var yyq1482 [2]bool
-			_, _, _ = yysep1482, yyq1482, yy2arr1482
-			const yyr1482 bool = false
-			var yynn1482 int
-			if yyr1482 || yy2arr1482 {
+			yysep1438 := !z.EncBinary()
+			yy2arr1438 := z.EncBasicHandle().StructToArray
+			var yyq1438 [2]bool
+			_, _, _ = yysep1438, yyq1438, yy2arr1438
+			const yyr1438 bool = false
+			var yynn1438 int
+			if yyr1438 || yy2arr1438 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn1482 = 2
-				for _, b := range yyq1482 {
+				yynn1438 = 2
+				for _, b := range yyq1438 {
 					if b {
-						yynn1482++
+						yynn1438++
 					}
 				}
-				r.EncodeMapStart(yynn1482)
-				yynn1482 = 0
+				r.EncodeMapStart(yynn1438)
+				yynn1438 = 0
 			}
-			if yyr1482 || yy2arr1482 {
+			if yyr1438 || yy2arr1438 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1484 := z.EncBinary()
-				_ = yym1484
+				yym1440 := z.EncBinary()
+				_ = yym1440
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Min))
@@ -17617,17 +17043,17 @@ func (x *HostPortRange) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("min"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1485 := z.EncBinary()
-				_ = yym1485
+				yym1441 := z.EncBinary()
+				_ = yym1441
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Min))
 				}
 			}
-			if yyr1482 || yy2arr1482 {
+			if yyr1438 || yy2arr1438 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1487 := z.EncBinary()
-				_ = yym1487
+				yym1443 := z.EncBinary()
+				_ = yym1443
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Max))
@@ -17636,14 +17062,14 @@ func (x *HostPortRange) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("max"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1488 := z.EncBinary()
-				_ = yym1488
+				yym1444 := z.EncBinary()
+				_ = yym1444
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Max))
 				}
 			}
-			if yyr1482 || yy2arr1482 {
+			if yyr1438 || yy2arr1438 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -17656,25 +17082,25 @@ func (x *HostPortRange) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1489 := z.DecBinary()
-	_ = yym1489
+	yym1445 := z.DecBinary()
+	_ = yym1445
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1490 := r.ContainerType()
-		if yyct1490 == codecSelferValueTypeMap1234 {
-			yyl1490 := r.ReadMapStart()
-			if yyl1490 == 0 {
+		yyct1446 := r.ContainerType()
+		if yyct1446 == codecSelferValueTypeMap1234 {
+			yyl1446 := r.ReadMapStart()
+			if yyl1446 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1490, d)
+				x.codecDecodeSelfFromMap(yyl1446, d)
 			}
-		} else if yyct1490 == codecSelferValueTypeArray1234 {
-			yyl1490 := r.ReadArrayStart()
-			if yyl1490 == 0 {
+		} else if yyct1446 == codecSelferValueTypeArray1234 {
+			yyl1446 := r.ReadArrayStart()
+			if yyl1446 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1490, d)
+				x.codecDecodeSelfFromArray(yyl1446, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -17686,12 +17112,12 @@ func (x *HostPortRange) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1491Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1491Slc
-	var yyhl1491 bool = l >= 0
-	for yyj1491 := 0; ; yyj1491++ {
-		if yyhl1491 {
-			if yyj1491 >= l {
+	var yys1447Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1447Slc
+	var yyhl1447 bool = l >= 0
+	for yyj1447 := 0; ; yyj1447++ {
+		if yyhl1447 {
+			if yyj1447 >= l {
 				break
 			}
 		} else {
@@ -17700,10 +17126,10 @@ func (x *HostPortRange) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1491Slc = r.DecodeBytes(yys1491Slc, true, true)
-		yys1491 := string(yys1491Slc)
+		yys1447Slc = r.DecodeBytes(yys1447Slc, true, true)
+		yys1447 := string(yys1447Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1491 {
+		switch yys1447 {
 		case "min":
 			if r.TryDecodeAsNil() {
 				x.Min = 0
@@ -17717,9 +17143,9 @@ func (x *HostPortRange) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Max = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1491)
-		} // end switch yys1491
-	} // end for yyj1491
+			z.DecStructFieldNotFound(-1, yys1447)
+		} // end switch yys1447
+	} // end for yyj1447
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -17727,16 +17153,16 @@ func (x *HostPortRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1494 int
-	var yyb1494 bool
-	var yyhl1494 bool = l >= 0
-	yyj1494++
-	if yyhl1494 {
-		yyb1494 = yyj1494 > l
+	var yyj1450 int
+	var yyb1450 bool
+	var yyhl1450 bool = l >= 0
+	yyj1450++
+	if yyhl1450 {
+		yyb1450 = yyj1450 > l
 	} else {
-		yyb1494 = r.CheckBreak()
+		yyb1450 = r.CheckBreak()
 	}
-	if yyb1494 {
+	if yyb1450 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -17746,13 +17172,13 @@ func (x *HostPortRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Min = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj1494++
-	if yyhl1494 {
-		yyb1494 = yyj1494 > l
+	yyj1450++
+	if yyhl1450 {
+		yyb1450 = yyj1450 > l
 	} else {
-		yyb1494 = r.CheckBreak()
+		yyb1450 = r.CheckBreak()
 	}
-	if yyb1494 {
+	if yyb1450 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -17763,17 +17189,17 @@ func (x *HostPortRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Max = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj1494++
-		if yyhl1494 {
-			yyb1494 = yyj1494 > l
+		yyj1450++
+		if yyhl1450 {
+			yyb1450 = yyj1450 > l
 		} else {
-			yyb1494 = r.CheckBreak()
+			yyb1450 = r.CheckBreak()
 		}
-		if yyb1494 {
+		if yyb1450 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1494-1, "")
+		z.DecStructFieldNotFound(yyj1450-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -17782,8 +17208,8 @@ func (x FSType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym1497 := z.EncBinary()
-	_ = yym1497
+	yym1453 := z.EncBinary()
+	_ = yym1453
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -17795,8 +17221,8 @@ func (x *FSType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1498 := z.DecBinary()
-	_ = yym1498
+	yym1454 := z.DecBinary()
+	_ = yym1454
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -17811,31 +17237,31 @@ func (x *SELinuxContextStrategyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1499 := z.EncBinary()
-		_ = yym1499
+		yym1455 := z.EncBinary()
+		_ = yym1455
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1500 := !z.EncBinary()
-			yy2arr1500 := z.EncBasicHandle().StructToArray
-			var yyq1500 [2]bool
-			_, _, _ = yysep1500, yyq1500, yy2arr1500
-			const yyr1500 bool = false
-			yyq1500[1] = x.SELinuxOptions != nil
-			var yynn1500 int
-			if yyr1500 || yy2arr1500 {
+			yysep1456 := !z.EncBinary()
+			yy2arr1456 := z.EncBasicHandle().StructToArray
+			var yyq1456 [2]bool
+			_, _, _ = yysep1456, yyq1456, yy2arr1456
+			const yyr1456 bool = false
+			yyq1456[1] = x.SELinuxOptions != nil
+			var yynn1456 int
+			if yyr1456 || yy2arr1456 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn1500 = 1
-				for _, b := range yyq1500 {
+				yynn1456 = 1
+				for _, b := range yyq1456 {
 					if b {
-						yynn1500++
+						yynn1456++
 					}
 				}
-				r.EncodeMapStart(yynn1500)
-				yynn1500 = 0
+				r.EncodeMapStart(yynn1456)
+				yynn1456 = 0
 			}
-			if yyr1500 || yy2arr1500 {
+			if yyr1456 || yy2arr1456 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Type.CodecEncodeSelf(e)
 			} else {
@@ -17844,9 +17270,9 @@ func (x *SELinuxContextStrategyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Type.CodecEncodeSelf(e)
 			}
-			if yyr1500 || yy2arr1500 {
+			if yyr1456 || yy2arr1456 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1500[1] {
+				if yyq1456[1] {
 					if x.SELinuxOptions == nil {
 						r.EncodeNil()
 					} else {
@@ -17856,7 +17282,7 @@ func (x *SELinuxContextStrategyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1500[1] {
+				if yyq1456[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("seLinuxOptions"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
@@ -17867,7 +17293,7 @@ func (x *SELinuxContextStrategyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1500 || yy2arr1500 {
+			if yyr1456 || yy2arr1456 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -17880,25 +17306,25 @@ func (x *SELinuxContextStrategyOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1503 := z.DecBinary()
-	_ = yym1503
+	yym1459 := z.DecBinary()
+	_ = yym1459
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1504 := r.ContainerType()
-		if yyct1504 == codecSelferValueTypeMap1234 {
-			yyl1504 := r.ReadMapStart()
-			if yyl1504 == 0 {
+		yyct1460 := r.ContainerType()
+		if yyct1460 == codecSelferValueTypeMap1234 {
+			yyl1460 := r.ReadMapStart()
+			if yyl1460 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1504, d)
+				x.codecDecodeSelfFromMap(yyl1460, d)
 			}
-		} else if yyct1504 == codecSelferValueTypeArray1234 {
-			yyl1504 := r.ReadArrayStart()
-			if yyl1504 == 0 {
+		} else if yyct1460 == codecSelferValueTypeArray1234 {
+			yyl1460 := r.ReadArrayStart()
+			if yyl1460 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1504, d)
+				x.codecDecodeSelfFromArray(yyl1460, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -17910,12 +17336,12 @@ func (x *SELinuxContextStrategyOptions) codecDecodeSelfFromMap(l int, d *codec19
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1505Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1505Slc
-	var yyhl1505 bool = l >= 0
-	for yyj1505 := 0; ; yyj1505++ {
-		if yyhl1505 {
-			if yyj1505 >= l {
+	var yys1461Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1461Slc
+	var yyhl1461 bool = l >= 0
+	for yyj1461 := 0; ; yyj1461++ {
+		if yyhl1461 {
+			if yyj1461 >= l {
 				break
 			}
 		} else {
@@ -17924,10 +17350,10 @@ func (x *SELinuxContextStrategyOptions) codecDecodeSelfFromMap(l int, d *codec19
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1505Slc = r.DecodeBytes(yys1505Slc, true, true)
-		yys1505 := string(yys1505Slc)
+		yys1461Slc = r.DecodeBytes(yys1461Slc, true, true)
+		yys1461 := string(yys1461Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1505 {
+		switch yys1461 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -17946,9 +17372,9 @@ func (x *SELinuxContextStrategyOptions) codecDecodeSelfFromMap(l int, d *codec19
 				x.SELinuxOptions.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1505)
-		} // end switch yys1505
-	} // end for yyj1505
+			z.DecStructFieldNotFound(-1, yys1461)
+		} // end switch yys1461
+	} // end for yyj1461
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -17956,16 +17382,16 @@ func (x *SELinuxContextStrategyOptions) codecDecodeSelfFromArray(l int, d *codec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1508 int
-	var yyb1508 bool
-	var yyhl1508 bool = l >= 0
-	yyj1508++
-	if yyhl1508 {
-		yyb1508 = yyj1508 > l
+	var yyj1464 int
+	var yyb1464 bool
+	var yyhl1464 bool = l >= 0
+	yyj1464++
+	if yyhl1464 {
+		yyb1464 = yyj1464 > l
 	} else {
-		yyb1508 = r.CheckBreak()
+		yyb1464 = r.CheckBreak()
 	}
-	if yyb1508 {
+	if yyb1464 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -17975,13 +17401,13 @@ func (x *SELinuxContextStrategyOptions) codecDecodeSelfFromArray(l int, d *codec
 	} else {
 		x.Type = SELinuxContextStrategy(r.DecodeString())
 	}
-	yyj1508++
-	if yyhl1508 {
-		yyb1508 = yyj1508 > l
+	yyj1464++
+	if yyhl1464 {
+		yyb1464 = yyj1464 > l
 	} else {
-		yyb1508 = r.CheckBreak()
+		yyb1464 = r.CheckBreak()
 	}
-	if yyb1508 {
+	if yyb1464 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -17997,17 +17423,17 @@ func (x *SELinuxContextStrategyOptions) codecDecodeSelfFromArray(l int, d *codec
 		x.SELinuxOptions.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1508++
-		if yyhl1508 {
-			yyb1508 = yyj1508 > l
+		yyj1464++
+		if yyhl1464 {
+			yyb1464 = yyj1464 > l
 		} else {
-			yyb1508 = r.CheckBreak()
+			yyb1464 = r.CheckBreak()
 		}
-		if yyb1508 {
+		if yyb1464 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1508-1, "")
+		z.DecStructFieldNotFound(yyj1464-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -18016,8 +17442,8 @@ func (x SELinuxContextStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym1511 := z.EncBinary()
-	_ = yym1511
+	yym1467 := z.EncBinary()
+	_ = yym1467
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -18029,8 +17455,8 @@ func (x *SELinuxContextStrategy) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1512 := z.DecBinary()
-	_ = yym1512
+	yym1468 := z.DecBinary()
+	_ = yym1468
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -18045,31 +17471,31 @@ func (x *RunAsUserStrategyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1513 := z.EncBinary()
-		_ = yym1513
+		yym1469 := z.EncBinary()
+		_ = yym1469
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1514 := !z.EncBinary()
-			yy2arr1514 := z.EncBasicHandle().StructToArray
-			var yyq1514 [2]bool
-			_, _, _ = yysep1514, yyq1514, yy2arr1514
-			const yyr1514 bool = false
-			yyq1514[1] = len(x.Ranges) != 0
-			var yynn1514 int
-			if yyr1514 || yy2arr1514 {
+			yysep1470 := !z.EncBinary()
+			yy2arr1470 := z.EncBasicHandle().StructToArray
+			var yyq1470 [2]bool
+			_, _, _ = yysep1470, yyq1470, yy2arr1470
+			const yyr1470 bool = false
+			yyq1470[1] = len(x.Ranges) != 0
+			var yynn1470 int
+			if yyr1470 || yy2arr1470 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn1514 = 1
-				for _, b := range yyq1514 {
+				yynn1470 = 1
+				for _, b := range yyq1470 {
 					if b {
-						yynn1514++
+						yynn1470++
 					}
 				}
-				r.EncodeMapStart(yynn1514)
-				yynn1514 = 0
+				r.EncodeMapStart(yynn1470)
+				yynn1470 = 0
 			}
-			if yyr1514 || yy2arr1514 {
+			if yyr1470 || yy2arr1470 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Type.CodecEncodeSelf(e)
 			} else {
@@ -18078,14 +17504,14 @@ func (x *RunAsUserStrategyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Type.CodecEncodeSelf(e)
 			}
-			if yyr1514 || yy2arr1514 {
+			if yyr1470 || yy2arr1470 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1514[1] {
+				if yyq1470[1] {
 					if x.Ranges == nil {
 						r.EncodeNil()
 					} else {
-						yym1517 := z.EncBinary()
-						_ = yym1517
+						yym1473 := z.EncBinary()
+						_ = yym1473
 						if false {
 						} else {
 							h.encSliceIDRange(([]IDRange)(x.Ranges), e)
@@ -18095,15 +17521,15 @@ func (x *RunAsUserStrategyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1514[1] {
+				if yyq1470[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("ranges"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Ranges == nil {
 						r.EncodeNil()
 					} else {
-						yym1518 := z.EncBinary()
-						_ = yym1518
+						yym1474 := z.EncBinary()
+						_ = yym1474
 						if false {
 						} else {
 							h.encSliceIDRange(([]IDRange)(x.Ranges), e)
@@ -18111,7 +17537,7 @@ func (x *RunAsUserStrategyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1514 || yy2arr1514 {
+			if yyr1470 || yy2arr1470 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -18121,6 +17547,521 @@ func (x *RunAsUserStrategyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 }
 
 func (x *RunAsUserStrategyOptions) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym1475 := z.DecBinary()
+	_ = yym1475
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct1476 := r.ContainerType()
+		if yyct1476 == codecSelferValueTypeMap1234 {
+			yyl1476 := r.ReadMapStart()
+			if yyl1476 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl1476, d)
+			}
+		} else if yyct1476 == codecSelferValueTypeArray1234 {
+			yyl1476 := r.ReadArrayStart()
+			if yyl1476 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl1476, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *RunAsUserStrategyOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys1477Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1477Slc
+	var yyhl1477 bool = l >= 0
+	for yyj1477 := 0; ; yyj1477++ {
+		if yyhl1477 {
+			if yyj1477 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys1477Slc = r.DecodeBytes(yys1477Slc, true, true)
+		yys1477 := string(yys1477Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys1477 {
+		case "type":
+			if r.TryDecodeAsNil() {
+				x.Type = ""
+			} else {
+				x.Type = RunAsUserStrategy(r.DecodeString())
+			}
+		case "ranges":
+			if r.TryDecodeAsNil() {
+				x.Ranges = nil
+			} else {
+				yyv1479 := &x.Ranges
+				yym1480 := z.DecBinary()
+				_ = yym1480
+				if false {
+				} else {
+					h.decSliceIDRange((*[]IDRange)(yyv1479), d)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys1477)
+		} // end switch yys1477
+	} // end for yyj1477
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *RunAsUserStrategyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj1481 int
+	var yyb1481 bool
+	var yyhl1481 bool = l >= 0
+	yyj1481++
+	if yyhl1481 {
+		yyb1481 = yyj1481 > l
+	} else {
+		yyb1481 = r.CheckBreak()
+	}
+	if yyb1481 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Type = ""
+	} else {
+		x.Type = RunAsUserStrategy(r.DecodeString())
+	}
+	yyj1481++
+	if yyhl1481 {
+		yyb1481 = yyj1481 > l
+	} else {
+		yyb1481 = r.CheckBreak()
+	}
+	if yyb1481 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Ranges = nil
+	} else {
+		yyv1483 := &x.Ranges
+		yym1484 := z.DecBinary()
+		_ = yym1484
+		if false {
+		} else {
+			h.decSliceIDRange((*[]IDRange)(yyv1483), d)
+		}
+	}
+	for {
+		yyj1481++
+		if yyhl1481 {
+			yyb1481 = yyj1481 > l
+		} else {
+			yyb1481 = r.CheckBreak()
+		}
+		if yyb1481 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj1481-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x *IDRange) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym1485 := z.EncBinary()
+		_ = yym1485
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep1486 := !z.EncBinary()
+			yy2arr1486 := z.EncBasicHandle().StructToArray
+			var yyq1486 [2]bool
+			_, _, _ = yysep1486, yyq1486, yy2arr1486
+			const yyr1486 bool = false
+			var yynn1486 int
+			if yyr1486 || yy2arr1486 {
+				r.EncodeArrayStart(2)
+			} else {
+				yynn1486 = 2
+				for _, b := range yyq1486 {
+					if b {
+						yynn1486++
+					}
+				}
+				r.EncodeMapStart(yynn1486)
+				yynn1486 = 0
+			}
+			if yyr1486 || yy2arr1486 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym1488 := z.EncBinary()
+				_ = yym1488
+				if false {
+				} else {
+					r.EncodeInt(int64(x.Min))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("min"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym1489 := z.EncBinary()
+				_ = yym1489
+				if false {
+				} else {
+					r.EncodeInt(int64(x.Min))
+				}
+			}
+			if yyr1486 || yy2arr1486 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym1491 := z.EncBinary()
+				_ = yym1491
+				if false {
+				} else {
+					r.EncodeInt(int64(x.Max))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("max"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym1492 := z.EncBinary()
+				_ = yym1492
+				if false {
+				} else {
+					r.EncodeInt(int64(x.Max))
+				}
+			}
+			if yyr1486 || yy2arr1486 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *IDRange) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym1493 := z.DecBinary()
+	_ = yym1493
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct1494 := r.ContainerType()
+		if yyct1494 == codecSelferValueTypeMap1234 {
+			yyl1494 := r.ReadMapStart()
+			if yyl1494 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl1494, d)
+			}
+		} else if yyct1494 == codecSelferValueTypeArray1234 {
+			yyl1494 := r.ReadArrayStart()
+			if yyl1494 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl1494, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *IDRange) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys1495Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1495Slc
+	var yyhl1495 bool = l >= 0
+	for yyj1495 := 0; ; yyj1495++ {
+		if yyhl1495 {
+			if yyj1495 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys1495Slc = r.DecodeBytes(yys1495Slc, true, true)
+		yys1495 := string(yys1495Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys1495 {
+		case "min":
+			if r.TryDecodeAsNil() {
+				x.Min = 0
+			} else {
+				x.Min = int64(r.DecodeInt(64))
+			}
+		case "max":
+			if r.TryDecodeAsNil() {
+				x.Max = 0
+			} else {
+				x.Max = int64(r.DecodeInt(64))
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys1495)
+		} // end switch yys1495
+	} // end for yyj1495
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *IDRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj1498 int
+	var yyb1498 bool
+	var yyhl1498 bool = l >= 0
+	yyj1498++
+	if yyhl1498 {
+		yyb1498 = yyj1498 > l
+	} else {
+		yyb1498 = r.CheckBreak()
+	}
+	if yyb1498 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Min = 0
+	} else {
+		x.Min = int64(r.DecodeInt(64))
+	}
+	yyj1498++
+	if yyhl1498 {
+		yyb1498 = yyj1498 > l
+	} else {
+		yyb1498 = r.CheckBreak()
+	}
+	if yyb1498 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Max = 0
+	} else {
+		x.Max = int64(r.DecodeInt(64))
+	}
+	for {
+		yyj1498++
+		if yyhl1498 {
+			yyb1498 = yyj1498 > l
+		} else {
+			yyb1498 = r.CheckBreak()
+		}
+		if yyb1498 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj1498-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x RunAsUserStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	yym1501 := z.EncBinary()
+	_ = yym1501
+	if false {
+	} else if z.HasExtensions() && z.EncExt(x) {
+	} else {
+		r.EncodeString(codecSelferC_UTF81234, string(x))
+	}
+}
+
+func (x *RunAsUserStrategy) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym1502 := z.DecBinary()
+	_ = yym1502
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		*((*string)(x)) = r.DecodeString()
+	}
+}
+
+func (x *PodSecurityPolicyList) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym1503 := z.EncBinary()
+		_ = yym1503
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep1504 := !z.EncBinary()
+			yy2arr1504 := z.EncBasicHandle().StructToArray
+			var yyq1504 [4]bool
+			_, _, _ = yysep1504, yyq1504, yy2arr1504
+			const yyr1504 bool = false
+			yyq1504[0] = true
+			yyq1504[2] = x.Kind != ""
+			yyq1504[3] = x.APIVersion != ""
+			var yynn1504 int
+			if yyr1504 || yy2arr1504 {
+				r.EncodeArrayStart(4)
+			} else {
+				yynn1504 = 1
+				for _, b := range yyq1504 {
+					if b {
+						yynn1504++
+					}
+				}
+				r.EncodeMapStart(yynn1504)
+				yynn1504 = 0
+			}
+			if yyr1504 || yy2arr1504 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1504[0] {
+					yy1506 := &x.ListMeta
+					yym1507 := z.EncBinary()
+					_ = yym1507
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1506) {
+					} else {
+						z.EncFallback(yy1506)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1504[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy1508 := &x.ListMeta
+					yym1509 := z.EncBinary()
+					_ = yym1509
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1508) {
+					} else {
+						z.EncFallback(yy1508)
+					}
+				}
+			}
+			if yyr1504 || yy2arr1504 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if x.Items == nil {
+					r.EncodeNil()
+				} else {
+					yym1511 := z.EncBinary()
+					_ = yym1511
+					if false {
+					} else {
+						h.encSlicePodSecurityPolicy(([]PodSecurityPolicy)(x.Items), e)
+					}
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				if x.Items == nil {
+					r.EncodeNil()
+				} else {
+					yym1512 := z.EncBinary()
+					_ = yym1512
+					if false {
+					} else {
+						h.encSlicePodSecurityPolicy(([]PodSecurityPolicy)(x.Items), e)
+					}
+				}
+			}
+			if yyr1504 || yy2arr1504 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1504[2] {
+					yym1514 := z.EncBinary()
+					_ = yym1514
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1504[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1515 := z.EncBinary()
+					_ = yym1515
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr1504 || yy2arr1504 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1504[3] {
+					yym1517 := z.EncBinary()
+					_ = yym1517
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq1504[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym1518 := z.EncBinary()
+					_ = yym1518
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr1504 || yy2arr1504 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *PodSecurityPolicyList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -18150,7 +18091,7 @@ func (x *RunAsUserStrategyOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	}
 }
 
-func (x *RunAsUserStrategyOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+func (x *PodSecurityPolicyList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -18172,544 +18113,29 @@ func (x *RunAsUserStrategyOptions) codecDecodeSelfFromMap(l int, d *codec1978.De
 		yys1521 := string(yys1521Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys1521 {
-		case "type":
-			if r.TryDecodeAsNil() {
-				x.Type = ""
-			} else {
-				x.Type = RunAsUserStrategy(r.DecodeString())
-			}
-		case "ranges":
-			if r.TryDecodeAsNil() {
-				x.Ranges = nil
-			} else {
-				yyv1523 := &x.Ranges
-				yym1524 := z.DecBinary()
-				_ = yym1524
-				if false {
-				} else {
-					h.decSliceIDRange((*[]IDRange)(yyv1523), d)
-				}
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys1521)
-		} // end switch yys1521
-	} // end for yyj1521
-	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-}
-
-func (x *RunAsUserStrategyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj1525 int
-	var yyb1525 bool
-	var yyhl1525 bool = l >= 0
-	yyj1525++
-	if yyhl1525 {
-		yyb1525 = yyj1525 > l
-	} else {
-		yyb1525 = r.CheckBreak()
-	}
-	if yyb1525 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Type = ""
-	} else {
-		x.Type = RunAsUserStrategy(r.DecodeString())
-	}
-	yyj1525++
-	if yyhl1525 {
-		yyb1525 = yyj1525 > l
-	} else {
-		yyb1525 = r.CheckBreak()
-	}
-	if yyb1525 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Ranges = nil
-	} else {
-		yyv1527 := &x.Ranges
-		yym1528 := z.DecBinary()
-		_ = yym1528
-		if false {
-		} else {
-			h.decSliceIDRange((*[]IDRange)(yyv1527), d)
-		}
-	}
-	for {
-		yyj1525++
-		if yyhl1525 {
-			yyb1525 = yyj1525 > l
-		} else {
-			yyb1525 = r.CheckBreak()
-		}
-		if yyb1525 {
-			break
-		}
-		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1525-1, "")
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x *IDRange) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym1529 := z.EncBinary()
-		_ = yym1529
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep1530 := !z.EncBinary()
-			yy2arr1530 := z.EncBasicHandle().StructToArray
-			var yyq1530 [2]bool
-			_, _, _ = yysep1530, yyq1530, yy2arr1530
-			const yyr1530 bool = false
-			var yynn1530 int
-			if yyr1530 || yy2arr1530 {
-				r.EncodeArrayStart(2)
-			} else {
-				yynn1530 = 2
-				for _, b := range yyq1530 {
-					if b {
-						yynn1530++
-					}
-				}
-				r.EncodeMapStart(yynn1530)
-				yynn1530 = 0
-			}
-			if yyr1530 || yy2arr1530 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1532 := z.EncBinary()
-				_ = yym1532
-				if false {
-				} else {
-					r.EncodeInt(int64(x.Min))
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("min"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1533 := z.EncBinary()
-				_ = yym1533
-				if false {
-				} else {
-					r.EncodeInt(int64(x.Min))
-				}
-			}
-			if yyr1530 || yy2arr1530 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1535 := z.EncBinary()
-				_ = yym1535
-				if false {
-				} else {
-					r.EncodeInt(int64(x.Max))
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("max"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1536 := z.EncBinary()
-				_ = yym1536
-				if false {
-				} else {
-					r.EncodeInt(int64(x.Max))
-				}
-			}
-			if yyr1530 || yy2arr1530 {
-				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
-			}
-		}
-	}
-}
-
-func (x *IDRange) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym1537 := z.DecBinary()
-	_ = yym1537
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		yyct1538 := r.ContainerType()
-		if yyct1538 == codecSelferValueTypeMap1234 {
-			yyl1538 := r.ReadMapStart()
-			if yyl1538 == 0 {
-				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-			} else {
-				x.codecDecodeSelfFromMap(yyl1538, d)
-			}
-		} else if yyct1538 == codecSelferValueTypeArray1234 {
-			yyl1538 := r.ReadArrayStart()
-			if yyl1538 == 0 {
-				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				x.codecDecodeSelfFromArray(yyl1538, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *IDRange) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys1539Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1539Slc
-	var yyhl1539 bool = l >= 0
-	for yyj1539 := 0; ; yyj1539++ {
-		if yyhl1539 {
-			if yyj1539 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1539Slc = r.DecodeBytes(yys1539Slc, true, true)
-		yys1539 := string(yys1539Slc)
-		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1539 {
-		case "min":
-			if r.TryDecodeAsNil() {
-				x.Min = 0
-			} else {
-				x.Min = int64(r.DecodeInt(64))
-			}
-		case "max":
-			if r.TryDecodeAsNil() {
-				x.Max = 0
-			} else {
-				x.Max = int64(r.DecodeInt(64))
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys1539)
-		} // end switch yys1539
-	} // end for yyj1539
-	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-}
-
-func (x *IDRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj1542 int
-	var yyb1542 bool
-	var yyhl1542 bool = l >= 0
-	yyj1542++
-	if yyhl1542 {
-		yyb1542 = yyj1542 > l
-	} else {
-		yyb1542 = r.CheckBreak()
-	}
-	if yyb1542 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Min = 0
-	} else {
-		x.Min = int64(r.DecodeInt(64))
-	}
-	yyj1542++
-	if yyhl1542 {
-		yyb1542 = yyj1542 > l
-	} else {
-		yyb1542 = r.CheckBreak()
-	}
-	if yyb1542 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Max = 0
-	} else {
-		x.Max = int64(r.DecodeInt(64))
-	}
-	for {
-		yyj1542++
-		if yyhl1542 {
-			yyb1542 = yyj1542 > l
-		} else {
-			yyb1542 = r.CheckBreak()
-		}
-		if yyb1542 {
-			break
-		}
-		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1542-1, "")
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x RunAsUserStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	yym1545 := z.EncBinary()
-	_ = yym1545
-	if false {
-	} else if z.HasExtensions() && z.EncExt(x) {
-	} else {
-		r.EncodeString(codecSelferC_UTF81234, string(x))
-	}
-}
-
-func (x *RunAsUserStrategy) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym1546 := z.DecBinary()
-	_ = yym1546
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		*((*string)(x)) = r.DecodeString()
-	}
-}
-
-func (x *PodSecurityPolicyList) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym1547 := z.EncBinary()
-		_ = yym1547
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep1548 := !z.EncBinary()
-			yy2arr1548 := z.EncBasicHandle().StructToArray
-			var yyq1548 [4]bool
-			_, _, _ = yysep1548, yyq1548, yy2arr1548
-			const yyr1548 bool = false
-			yyq1548[0] = true
-			yyq1548[2] = x.Kind != ""
-			yyq1548[3] = x.APIVersion != ""
-			var yynn1548 int
-			if yyr1548 || yy2arr1548 {
-				r.EncodeArrayStart(4)
-			} else {
-				yynn1548 = 1
-				for _, b := range yyq1548 {
-					if b {
-						yynn1548++
-					}
-				}
-				r.EncodeMapStart(yynn1548)
-				yynn1548 = 0
-			}
-			if yyr1548 || yy2arr1548 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1548[0] {
-					yy1550 := &x.ListMeta
-					yym1551 := z.EncBinary()
-					_ = yym1551
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1550) {
-					} else {
-						z.EncFallback(yy1550)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1548[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1552 := &x.ListMeta
-					yym1553 := z.EncBinary()
-					_ = yym1553
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1552) {
-					} else {
-						z.EncFallback(yy1552)
-					}
-				}
-			}
-			if yyr1548 || yy2arr1548 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if x.Items == nil {
-					r.EncodeNil()
-				} else {
-					yym1555 := z.EncBinary()
-					_ = yym1555
-					if false {
-					} else {
-						h.encSlicePodSecurityPolicy(([]PodSecurityPolicy)(x.Items), e)
-					}
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("items"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				if x.Items == nil {
-					r.EncodeNil()
-				} else {
-					yym1556 := z.EncBinary()
-					_ = yym1556
-					if false {
-					} else {
-						h.encSlicePodSecurityPolicy(([]PodSecurityPolicy)(x.Items), e)
-					}
-				}
-			}
-			if yyr1548 || yy2arr1548 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1548[2] {
-					yym1558 := z.EncBinary()
-					_ = yym1558
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1548[2] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1559 := z.EncBinary()
-					_ = yym1559
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr1548 || yy2arr1548 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1548[3] {
-					yym1561 := z.EncBinary()
-					_ = yym1561
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq1548[3] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1562 := z.EncBinary()
-					_ = yym1562
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr1548 || yy2arr1548 {
-				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
-			}
-		}
-	}
-}
-
-func (x *PodSecurityPolicyList) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym1563 := z.DecBinary()
-	_ = yym1563
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		yyct1564 := r.ContainerType()
-		if yyct1564 == codecSelferValueTypeMap1234 {
-			yyl1564 := r.ReadMapStart()
-			if yyl1564 == 0 {
-				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-			} else {
-				x.codecDecodeSelfFromMap(yyl1564, d)
-			}
-		} else if yyct1564 == codecSelferValueTypeArray1234 {
-			yyl1564 := r.ReadArrayStart()
-			if yyl1564 == 0 {
-				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				x.codecDecodeSelfFromArray(yyl1564, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *PodSecurityPolicyList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys1565Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1565Slc
-	var yyhl1565 bool = l >= 0
-	for yyj1565 := 0; ; yyj1565++ {
-		if yyhl1565 {
-			if yyj1565 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1565Slc = r.DecodeBytes(yys1565Slc, true, true)
-		yys1565 := string(yys1565Slc)
-		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1565 {
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv1566 := &x.ListMeta
-				yym1567 := z.DecBinary()
-				_ = yym1567
+				yyv1522 := &x.ListMeta
+				yym1523 := z.DecBinary()
+				_ = yym1523
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1566) {
+				} else if z.HasExtensions() && z.DecExt(yyv1522) {
 				} else {
-					z.DecFallback(yyv1566, false)
+					z.DecFallback(yyv1522, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv1568 := &x.Items
-				yym1569 := z.DecBinary()
-				_ = yym1569
+				yyv1524 := &x.Items
+				yym1525 := z.DecBinary()
+				_ = yym1525
 				if false {
 				} else {
-					h.decSlicePodSecurityPolicy((*[]PodSecurityPolicy)(yyv1568), d)
+					h.decSlicePodSecurityPolicy((*[]PodSecurityPolicy)(yyv1524), d)
 				}
 			}
 		case "kind":
@@ -18725,9 +18151,9 @@ func (x *PodSecurityPolicyList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				x.APIVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1565)
-		} // end switch yys1565
-	} // end for yyj1565
+			z.DecStructFieldNotFound(-1, yys1521)
+		} // end switch yys1521
+	} // end for yyj1521
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -18735,16 +18161,16 @@ func (x *PodSecurityPolicyList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1572 int
-	var yyb1572 bool
-	var yyhl1572 bool = l >= 0
-	yyj1572++
-	if yyhl1572 {
-		yyb1572 = yyj1572 > l
+	var yyj1528 int
+	var yyb1528 bool
+	var yyhl1528 bool = l >= 0
+	yyj1528++
+	if yyhl1528 {
+		yyb1528 = yyj1528 > l
 	} else {
-		yyb1572 = r.CheckBreak()
+		yyb1528 = r.CheckBreak()
 	}
-	if yyb1572 {
+	if yyb1528 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -18752,22 +18178,22 @@ func (x *PodSecurityPolicyList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv1573 := &x.ListMeta
-		yym1574 := z.DecBinary()
-		_ = yym1574
+		yyv1529 := &x.ListMeta
+		yym1530 := z.DecBinary()
+		_ = yym1530
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1573) {
+		} else if z.HasExtensions() && z.DecExt(yyv1529) {
 		} else {
-			z.DecFallback(yyv1573, false)
+			z.DecFallback(yyv1529, false)
 		}
 	}
-	yyj1572++
-	if yyhl1572 {
-		yyb1572 = yyj1572 > l
+	yyj1528++
+	if yyhl1528 {
+		yyb1528 = yyj1528 > l
 	} else {
-		yyb1572 = r.CheckBreak()
+		yyb1528 = r.CheckBreak()
 	}
-	if yyb1572 {
+	if yyb1528 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -18775,21 +18201,21 @@ func (x *PodSecurityPolicyList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv1575 := &x.Items
-		yym1576 := z.DecBinary()
-		_ = yym1576
+		yyv1531 := &x.Items
+		yym1532 := z.DecBinary()
+		_ = yym1532
 		if false {
 		} else {
-			h.decSlicePodSecurityPolicy((*[]PodSecurityPolicy)(yyv1575), d)
+			h.decSlicePodSecurityPolicy((*[]PodSecurityPolicy)(yyv1531), d)
 		}
 	}
-	yyj1572++
-	if yyhl1572 {
-		yyb1572 = yyj1572 > l
+	yyj1528++
+	if yyhl1528 {
+		yyb1528 = yyj1528 > l
 	} else {
-		yyb1572 = r.CheckBreak()
+		yyb1528 = r.CheckBreak()
 	}
-	if yyb1572 {
+	if yyb1528 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -18799,13 +18225,13 @@ func (x *PodSecurityPolicyList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1572++
-	if yyhl1572 {
-		yyb1572 = yyj1572 > l
+	yyj1528++
+	if yyhl1528 {
+		yyb1528 = yyj1528 > l
 	} else {
-		yyb1572 = r.CheckBreak()
+		yyb1528 = r.CheckBreak()
 	}
-	if yyb1572 {
+	if yyb1528 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -18816,17 +18242,17 @@ func (x *PodSecurityPolicyList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		x.APIVersion = string(r.DecodeString())
 	}
 	for {
-		yyj1572++
-		if yyhl1572 {
-			yyb1572 = yyj1572 > l
+		yyj1528++
+		if yyhl1528 {
+			yyb1528 = yyj1528 > l
 		} else {
-			yyb1572 = r.CheckBreak()
+			yyb1528 = r.CheckBreak()
 		}
-		if yyb1572 {
+		if yyb1528 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1572-1, "")
+		z.DecStructFieldNotFound(yyj1528-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -18836,10 +18262,10 @@ func (x codecSelfer1234) encSliceCustomMetricTarget(v []CustomMetricTarget, e *c
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1579 := range v {
+	for _, yyv1535 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1580 := &yyv1579
-		yy1580.CodecEncodeSelf(e)
+		yy1536 := &yyv1535
+		yy1536.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -18849,83 +18275,83 @@ func (x codecSelfer1234) decSliceCustomMetricTarget(v *[]CustomMetricTarget, d *
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1581 := *v
-	yyh1581, yyl1581 := z.DecSliceHelperStart()
-	var yyc1581 bool
-	if yyl1581 == 0 {
-		if yyv1581 == nil {
-			yyv1581 = []CustomMetricTarget{}
-			yyc1581 = true
-		} else if len(yyv1581) != 0 {
-			yyv1581 = yyv1581[:0]
-			yyc1581 = true
+	yyv1537 := *v
+	yyh1537, yyl1537 := z.DecSliceHelperStart()
+	var yyc1537 bool
+	if yyl1537 == 0 {
+		if yyv1537 == nil {
+			yyv1537 = []CustomMetricTarget{}
+			yyc1537 = true
+		} else if len(yyv1537) != 0 {
+			yyv1537 = yyv1537[:0]
+			yyc1537 = true
 		}
-	} else if yyl1581 > 0 {
-		var yyrr1581, yyrl1581 int
-		var yyrt1581 bool
-		if yyl1581 > cap(yyv1581) {
+	} else if yyl1537 > 0 {
+		var yyrr1537, yyrl1537 int
+		var yyrt1537 bool
+		if yyl1537 > cap(yyv1537) {
 
-			yyrg1581 := len(yyv1581) > 0
-			yyv21581 := yyv1581
-			yyrl1581, yyrt1581 = z.DecInferLen(yyl1581, z.DecBasicHandle().MaxInitLen, 40)
-			if yyrt1581 {
-				if yyrl1581 <= cap(yyv1581) {
-					yyv1581 = yyv1581[:yyrl1581]
+			yyrg1537 := len(yyv1537) > 0
+			yyv21537 := yyv1537
+			yyrl1537, yyrt1537 = z.DecInferLen(yyl1537, z.DecBasicHandle().MaxInitLen, 40)
+			if yyrt1537 {
+				if yyrl1537 <= cap(yyv1537) {
+					yyv1537 = yyv1537[:yyrl1537]
 				} else {
-					yyv1581 = make([]CustomMetricTarget, yyrl1581)
+					yyv1537 = make([]CustomMetricTarget, yyrl1537)
 				}
 			} else {
-				yyv1581 = make([]CustomMetricTarget, yyrl1581)
+				yyv1537 = make([]CustomMetricTarget, yyrl1537)
 			}
-			yyc1581 = true
-			yyrr1581 = len(yyv1581)
-			if yyrg1581 {
-				copy(yyv1581, yyv21581)
+			yyc1537 = true
+			yyrr1537 = len(yyv1537)
+			if yyrg1537 {
+				copy(yyv1537, yyv21537)
 			}
-		} else if yyl1581 != len(yyv1581) {
-			yyv1581 = yyv1581[:yyl1581]
-			yyc1581 = true
+		} else if yyl1537 != len(yyv1537) {
+			yyv1537 = yyv1537[:yyl1537]
+			yyc1537 = true
 		}
-		yyj1581 := 0
-		for ; yyj1581 < yyrr1581; yyj1581++ {
-			yyh1581.ElemContainerState(yyj1581)
+		yyj1537 := 0
+		for ; yyj1537 < yyrr1537; yyj1537++ {
+			yyh1537.ElemContainerState(yyj1537)
 			if r.TryDecodeAsNil() {
-				yyv1581[yyj1581] = CustomMetricTarget{}
+				yyv1537[yyj1537] = CustomMetricTarget{}
 			} else {
-				yyv1582 := &yyv1581[yyj1581]
-				yyv1582.CodecDecodeSelf(d)
+				yyv1538 := &yyv1537[yyj1537]
+				yyv1538.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1581 {
-			for ; yyj1581 < yyl1581; yyj1581++ {
-				yyv1581 = append(yyv1581, CustomMetricTarget{})
-				yyh1581.ElemContainerState(yyj1581)
+		if yyrt1537 {
+			for ; yyj1537 < yyl1537; yyj1537++ {
+				yyv1537 = append(yyv1537, CustomMetricTarget{})
+				yyh1537.ElemContainerState(yyj1537)
 				if r.TryDecodeAsNil() {
-					yyv1581[yyj1581] = CustomMetricTarget{}
+					yyv1537[yyj1537] = CustomMetricTarget{}
 				} else {
-					yyv1583 := &yyv1581[yyj1581]
-					yyv1583.CodecDecodeSelf(d)
+					yyv1539 := &yyv1537[yyj1537]
+					yyv1539.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1581 := 0
-		for ; !r.CheckBreak(); yyj1581++ {
+		yyj1537 := 0
+		for ; !r.CheckBreak(); yyj1537++ {
 
-			if yyj1581 >= len(yyv1581) {
-				yyv1581 = append(yyv1581, CustomMetricTarget{}) // var yyz1581 CustomMetricTarget
-				yyc1581 = true
+			if yyj1537 >= len(yyv1537) {
+				yyv1537 = append(yyv1537, CustomMetricTarget{}) // var yyz1537 CustomMetricTarget
+				yyc1537 = true
 			}
-			yyh1581.ElemContainerState(yyj1581)
-			if yyj1581 < len(yyv1581) {
+			yyh1537.ElemContainerState(yyj1537)
+			if yyj1537 < len(yyv1537) {
 				if r.TryDecodeAsNil() {
-					yyv1581[yyj1581] = CustomMetricTarget{}
+					yyv1537[yyj1537] = CustomMetricTarget{}
 				} else {
-					yyv1584 := &yyv1581[yyj1581]
-					yyv1584.CodecDecodeSelf(d)
+					yyv1540 := &yyv1537[yyj1537]
+					yyv1540.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -18933,17 +18359,17 @@ func (x codecSelfer1234) decSliceCustomMetricTarget(v *[]CustomMetricTarget, d *
 			}
 
 		}
-		if yyj1581 < len(yyv1581) {
-			yyv1581 = yyv1581[:yyj1581]
-			yyc1581 = true
-		} else if yyj1581 == 0 && yyv1581 == nil {
-			yyv1581 = []CustomMetricTarget{}
-			yyc1581 = true
+		if yyj1537 < len(yyv1537) {
+			yyv1537 = yyv1537[:yyj1537]
+			yyc1537 = true
+		} else if yyj1537 == 0 && yyv1537 == nil {
+			yyv1537 = []CustomMetricTarget{}
+			yyc1537 = true
 		}
 	}
-	yyh1581.End()
-	if yyc1581 {
-		*v = yyv1581
+	yyh1537.End()
+	if yyc1537 {
+		*v = yyv1537
 	}
 }
 
@@ -18952,10 +18378,10 @@ func (x codecSelfer1234) encSliceCustomMetricCurrentStatus(v []CustomMetricCurre
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1585 := range v {
+	for _, yyv1541 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1586 := &yyv1585
-		yy1586.CodecEncodeSelf(e)
+		yy1542 := &yyv1541
+		yy1542.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -18965,83 +18391,83 @@ func (x codecSelfer1234) decSliceCustomMetricCurrentStatus(v *[]CustomMetricCurr
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1587 := *v
-	yyh1587, yyl1587 := z.DecSliceHelperStart()
-	var yyc1587 bool
-	if yyl1587 == 0 {
-		if yyv1587 == nil {
-			yyv1587 = []CustomMetricCurrentStatus{}
-			yyc1587 = true
-		} else if len(yyv1587) != 0 {
-			yyv1587 = yyv1587[:0]
-			yyc1587 = true
+	yyv1543 := *v
+	yyh1543, yyl1543 := z.DecSliceHelperStart()
+	var yyc1543 bool
+	if yyl1543 == 0 {
+		if yyv1543 == nil {
+			yyv1543 = []CustomMetricCurrentStatus{}
+			yyc1543 = true
+		} else if len(yyv1543) != 0 {
+			yyv1543 = yyv1543[:0]
+			yyc1543 = true
 		}
-	} else if yyl1587 > 0 {
-		var yyrr1587, yyrl1587 int
-		var yyrt1587 bool
-		if yyl1587 > cap(yyv1587) {
+	} else if yyl1543 > 0 {
+		var yyrr1543, yyrl1543 int
+		var yyrt1543 bool
+		if yyl1543 > cap(yyv1543) {
 
-			yyrg1587 := len(yyv1587) > 0
-			yyv21587 := yyv1587
-			yyrl1587, yyrt1587 = z.DecInferLen(yyl1587, z.DecBasicHandle().MaxInitLen, 40)
-			if yyrt1587 {
-				if yyrl1587 <= cap(yyv1587) {
-					yyv1587 = yyv1587[:yyrl1587]
+			yyrg1543 := len(yyv1543) > 0
+			yyv21543 := yyv1543
+			yyrl1543, yyrt1543 = z.DecInferLen(yyl1543, z.DecBasicHandle().MaxInitLen, 40)
+			if yyrt1543 {
+				if yyrl1543 <= cap(yyv1543) {
+					yyv1543 = yyv1543[:yyrl1543]
 				} else {
-					yyv1587 = make([]CustomMetricCurrentStatus, yyrl1587)
+					yyv1543 = make([]CustomMetricCurrentStatus, yyrl1543)
 				}
 			} else {
-				yyv1587 = make([]CustomMetricCurrentStatus, yyrl1587)
+				yyv1543 = make([]CustomMetricCurrentStatus, yyrl1543)
 			}
-			yyc1587 = true
-			yyrr1587 = len(yyv1587)
-			if yyrg1587 {
-				copy(yyv1587, yyv21587)
+			yyc1543 = true
+			yyrr1543 = len(yyv1543)
+			if yyrg1543 {
+				copy(yyv1543, yyv21543)
 			}
-		} else if yyl1587 != len(yyv1587) {
-			yyv1587 = yyv1587[:yyl1587]
-			yyc1587 = true
+		} else if yyl1543 != len(yyv1543) {
+			yyv1543 = yyv1543[:yyl1543]
+			yyc1543 = true
 		}
-		yyj1587 := 0
-		for ; yyj1587 < yyrr1587; yyj1587++ {
-			yyh1587.ElemContainerState(yyj1587)
+		yyj1543 := 0
+		for ; yyj1543 < yyrr1543; yyj1543++ {
+			yyh1543.ElemContainerState(yyj1543)
 			if r.TryDecodeAsNil() {
-				yyv1587[yyj1587] = CustomMetricCurrentStatus{}
+				yyv1543[yyj1543] = CustomMetricCurrentStatus{}
 			} else {
-				yyv1588 := &yyv1587[yyj1587]
-				yyv1588.CodecDecodeSelf(d)
+				yyv1544 := &yyv1543[yyj1543]
+				yyv1544.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1587 {
-			for ; yyj1587 < yyl1587; yyj1587++ {
-				yyv1587 = append(yyv1587, CustomMetricCurrentStatus{})
-				yyh1587.ElemContainerState(yyj1587)
+		if yyrt1543 {
+			for ; yyj1543 < yyl1543; yyj1543++ {
+				yyv1543 = append(yyv1543, CustomMetricCurrentStatus{})
+				yyh1543.ElemContainerState(yyj1543)
 				if r.TryDecodeAsNil() {
-					yyv1587[yyj1587] = CustomMetricCurrentStatus{}
+					yyv1543[yyj1543] = CustomMetricCurrentStatus{}
 				} else {
-					yyv1589 := &yyv1587[yyj1587]
-					yyv1589.CodecDecodeSelf(d)
+					yyv1545 := &yyv1543[yyj1543]
+					yyv1545.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1587 := 0
-		for ; !r.CheckBreak(); yyj1587++ {
+		yyj1543 := 0
+		for ; !r.CheckBreak(); yyj1543++ {
 
-			if yyj1587 >= len(yyv1587) {
-				yyv1587 = append(yyv1587, CustomMetricCurrentStatus{}) // var yyz1587 CustomMetricCurrentStatus
-				yyc1587 = true
+			if yyj1543 >= len(yyv1543) {
+				yyv1543 = append(yyv1543, CustomMetricCurrentStatus{}) // var yyz1543 CustomMetricCurrentStatus
+				yyc1543 = true
 			}
-			yyh1587.ElemContainerState(yyj1587)
-			if yyj1587 < len(yyv1587) {
+			yyh1543.ElemContainerState(yyj1543)
+			if yyj1543 < len(yyv1543) {
 				if r.TryDecodeAsNil() {
-					yyv1587[yyj1587] = CustomMetricCurrentStatus{}
+					yyv1543[yyj1543] = CustomMetricCurrentStatus{}
 				} else {
-					yyv1590 := &yyv1587[yyj1587]
-					yyv1590.CodecDecodeSelf(d)
+					yyv1546 := &yyv1543[yyj1543]
+					yyv1546.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -19049,17 +18475,17 @@ func (x codecSelfer1234) decSliceCustomMetricCurrentStatus(v *[]CustomMetricCurr
 			}
 
 		}
-		if yyj1587 < len(yyv1587) {
-			yyv1587 = yyv1587[:yyj1587]
-			yyc1587 = true
-		} else if yyj1587 == 0 && yyv1587 == nil {
-			yyv1587 = []CustomMetricCurrentStatus{}
-			yyc1587 = true
+		if yyj1543 < len(yyv1543) {
+			yyv1543 = yyv1543[:yyj1543]
+			yyc1543 = true
+		} else if yyj1543 == 0 && yyv1543 == nil {
+			yyv1543 = []CustomMetricCurrentStatus{}
+			yyc1543 = true
 		}
 	}
-	yyh1587.End()
-	if yyc1587 {
-		*v = yyv1587
+	yyh1543.End()
+	if yyc1543 {
+		*v = yyv1543
 	}
 }
 
@@ -19068,10 +18494,10 @@ func (x codecSelfer1234) encSliceHorizontalPodAutoscaler(v []HorizontalPodAutosc
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1591 := range v {
+	for _, yyv1547 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1592 := &yyv1591
-		yy1592.CodecEncodeSelf(e)
+		yy1548 := &yyv1547
+		yy1548.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -19081,83 +18507,83 @@ func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutos
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1593 := *v
-	yyh1593, yyl1593 := z.DecSliceHelperStart()
-	var yyc1593 bool
-	if yyl1593 == 0 {
-		if yyv1593 == nil {
-			yyv1593 = []HorizontalPodAutoscaler{}
-			yyc1593 = true
-		} else if len(yyv1593) != 0 {
-			yyv1593 = yyv1593[:0]
-			yyc1593 = true
+	yyv1549 := *v
+	yyh1549, yyl1549 := z.DecSliceHelperStart()
+	var yyc1549 bool
+	if yyl1549 == 0 {
+		if yyv1549 == nil {
+			yyv1549 = []HorizontalPodAutoscaler{}
+			yyc1549 = true
+		} else if len(yyv1549) != 0 {
+			yyv1549 = yyv1549[:0]
+			yyc1549 = true
 		}
-	} else if yyl1593 > 0 {
-		var yyrr1593, yyrl1593 int
-		var yyrt1593 bool
-		if yyl1593 > cap(yyv1593) {
+	} else if yyl1549 > 0 {
+		var yyrr1549, yyrl1549 int
+		var yyrt1549 bool
+		if yyl1549 > cap(yyv1549) {
 
-			yyrg1593 := len(yyv1593) > 0
-			yyv21593 := yyv1593
-			yyrl1593, yyrt1593 = z.DecInferLen(yyl1593, z.DecBasicHandle().MaxInitLen, 320)
-			if yyrt1593 {
-				if yyrl1593 <= cap(yyv1593) {
-					yyv1593 = yyv1593[:yyrl1593]
+			yyrg1549 := len(yyv1549) > 0
+			yyv21549 := yyv1549
+			yyrl1549, yyrt1549 = z.DecInferLen(yyl1549, z.DecBasicHandle().MaxInitLen, 320)
+			if yyrt1549 {
+				if yyrl1549 <= cap(yyv1549) {
+					yyv1549 = yyv1549[:yyrl1549]
 				} else {
-					yyv1593 = make([]HorizontalPodAutoscaler, yyrl1593)
+					yyv1549 = make([]HorizontalPodAutoscaler, yyrl1549)
 				}
 			} else {
-				yyv1593 = make([]HorizontalPodAutoscaler, yyrl1593)
+				yyv1549 = make([]HorizontalPodAutoscaler, yyrl1549)
 			}
-			yyc1593 = true
-			yyrr1593 = len(yyv1593)
-			if yyrg1593 {
-				copy(yyv1593, yyv21593)
+			yyc1549 = true
+			yyrr1549 = len(yyv1549)
+			if yyrg1549 {
+				copy(yyv1549, yyv21549)
 			}
-		} else if yyl1593 != len(yyv1593) {
-			yyv1593 = yyv1593[:yyl1593]
-			yyc1593 = true
+		} else if yyl1549 != len(yyv1549) {
+			yyv1549 = yyv1549[:yyl1549]
+			yyc1549 = true
 		}
-		yyj1593 := 0
-		for ; yyj1593 < yyrr1593; yyj1593++ {
-			yyh1593.ElemContainerState(yyj1593)
+		yyj1549 := 0
+		for ; yyj1549 < yyrr1549; yyj1549++ {
+			yyh1549.ElemContainerState(yyj1549)
 			if r.TryDecodeAsNil() {
-				yyv1593[yyj1593] = HorizontalPodAutoscaler{}
+				yyv1549[yyj1549] = HorizontalPodAutoscaler{}
 			} else {
-				yyv1594 := &yyv1593[yyj1593]
-				yyv1594.CodecDecodeSelf(d)
+				yyv1550 := &yyv1549[yyj1549]
+				yyv1550.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1593 {
-			for ; yyj1593 < yyl1593; yyj1593++ {
-				yyv1593 = append(yyv1593, HorizontalPodAutoscaler{})
-				yyh1593.ElemContainerState(yyj1593)
+		if yyrt1549 {
+			for ; yyj1549 < yyl1549; yyj1549++ {
+				yyv1549 = append(yyv1549, HorizontalPodAutoscaler{})
+				yyh1549.ElemContainerState(yyj1549)
 				if r.TryDecodeAsNil() {
-					yyv1593[yyj1593] = HorizontalPodAutoscaler{}
+					yyv1549[yyj1549] = HorizontalPodAutoscaler{}
 				} else {
-					yyv1595 := &yyv1593[yyj1593]
-					yyv1595.CodecDecodeSelf(d)
+					yyv1551 := &yyv1549[yyj1549]
+					yyv1551.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1593 := 0
-		for ; !r.CheckBreak(); yyj1593++ {
+		yyj1549 := 0
+		for ; !r.CheckBreak(); yyj1549++ {
 
-			if yyj1593 >= len(yyv1593) {
-				yyv1593 = append(yyv1593, HorizontalPodAutoscaler{}) // var yyz1593 HorizontalPodAutoscaler
-				yyc1593 = true
+			if yyj1549 >= len(yyv1549) {
+				yyv1549 = append(yyv1549, HorizontalPodAutoscaler{}) // var yyz1549 HorizontalPodAutoscaler
+				yyc1549 = true
 			}
-			yyh1593.ElemContainerState(yyj1593)
-			if yyj1593 < len(yyv1593) {
+			yyh1549.ElemContainerState(yyj1549)
+			if yyj1549 < len(yyv1549) {
 				if r.TryDecodeAsNil() {
-					yyv1593[yyj1593] = HorizontalPodAutoscaler{}
+					yyv1549[yyj1549] = HorizontalPodAutoscaler{}
 				} else {
-					yyv1596 := &yyv1593[yyj1593]
-					yyv1596.CodecDecodeSelf(d)
+					yyv1552 := &yyv1549[yyj1549]
+					yyv1552.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -19165,17 +18591,17 @@ func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutos
 			}
 
 		}
-		if yyj1593 < len(yyv1593) {
-			yyv1593 = yyv1593[:yyj1593]
-			yyc1593 = true
-		} else if yyj1593 == 0 && yyv1593 == nil {
-			yyv1593 = []HorizontalPodAutoscaler{}
-			yyc1593 = true
+		if yyj1549 < len(yyv1549) {
+			yyv1549 = yyv1549[:yyj1549]
+			yyc1549 = true
+		} else if yyj1549 == 0 && yyv1549 == nil {
+			yyv1549 = []HorizontalPodAutoscaler{}
+			yyc1549 = true
 		}
 	}
-	yyh1593.End()
-	if yyc1593 {
-		*v = yyv1593
+	yyh1549.End()
+	if yyc1549 {
+		*v = yyv1549
 	}
 }
 
@@ -19184,10 +18610,10 @@ func (x codecSelfer1234) encSliceAPIVersion(v []APIVersion, e *codec1978.Encoder
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1597 := range v {
+	for _, yyv1553 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1598 := &yyv1597
-		yy1598.CodecEncodeSelf(e)
+		yy1554 := &yyv1553
+		yy1554.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -19197,83 +18623,83 @@ func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decode
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1599 := *v
-	yyh1599, yyl1599 := z.DecSliceHelperStart()
-	var yyc1599 bool
-	if yyl1599 == 0 {
-		if yyv1599 == nil {
-			yyv1599 = []APIVersion{}
-			yyc1599 = true
-		} else if len(yyv1599) != 0 {
-			yyv1599 = yyv1599[:0]
-			yyc1599 = true
+	yyv1555 := *v
+	yyh1555, yyl1555 := z.DecSliceHelperStart()
+	var yyc1555 bool
+	if yyl1555 == 0 {
+		if yyv1555 == nil {
+			yyv1555 = []APIVersion{}
+			yyc1555 = true
+		} else if len(yyv1555) != 0 {
+			yyv1555 = yyv1555[:0]
+			yyc1555 = true
 		}
-	} else if yyl1599 > 0 {
-		var yyrr1599, yyrl1599 int
-		var yyrt1599 bool
-		if yyl1599 > cap(yyv1599) {
+	} else if yyl1555 > 0 {
+		var yyrr1555, yyrl1555 int
+		var yyrt1555 bool
+		if yyl1555 > cap(yyv1555) {
 
-			yyrg1599 := len(yyv1599) > 0
-			yyv21599 := yyv1599
-			yyrl1599, yyrt1599 = z.DecInferLen(yyl1599, z.DecBasicHandle().MaxInitLen, 32)
-			if yyrt1599 {
-				if yyrl1599 <= cap(yyv1599) {
-					yyv1599 = yyv1599[:yyrl1599]
+			yyrg1555 := len(yyv1555) > 0
+			yyv21555 := yyv1555
+			yyrl1555, yyrt1555 = z.DecInferLen(yyl1555, z.DecBasicHandle().MaxInitLen, 32)
+			if yyrt1555 {
+				if yyrl1555 <= cap(yyv1555) {
+					yyv1555 = yyv1555[:yyrl1555]
 				} else {
-					yyv1599 = make([]APIVersion, yyrl1599)
+					yyv1555 = make([]APIVersion, yyrl1555)
 				}
 			} else {
-				yyv1599 = make([]APIVersion, yyrl1599)
+				yyv1555 = make([]APIVersion, yyrl1555)
 			}
-			yyc1599 = true
-			yyrr1599 = len(yyv1599)
-			if yyrg1599 {
-				copy(yyv1599, yyv21599)
+			yyc1555 = true
+			yyrr1555 = len(yyv1555)
+			if yyrg1555 {
+				copy(yyv1555, yyv21555)
 			}
-		} else if yyl1599 != len(yyv1599) {
-			yyv1599 = yyv1599[:yyl1599]
-			yyc1599 = true
+		} else if yyl1555 != len(yyv1555) {
+			yyv1555 = yyv1555[:yyl1555]
+			yyc1555 = true
 		}
-		yyj1599 := 0
-		for ; yyj1599 < yyrr1599; yyj1599++ {
-			yyh1599.ElemContainerState(yyj1599)
+		yyj1555 := 0
+		for ; yyj1555 < yyrr1555; yyj1555++ {
+			yyh1555.ElemContainerState(yyj1555)
 			if r.TryDecodeAsNil() {
-				yyv1599[yyj1599] = APIVersion{}
+				yyv1555[yyj1555] = APIVersion{}
 			} else {
-				yyv1600 := &yyv1599[yyj1599]
-				yyv1600.CodecDecodeSelf(d)
+				yyv1556 := &yyv1555[yyj1555]
+				yyv1556.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1599 {
-			for ; yyj1599 < yyl1599; yyj1599++ {
-				yyv1599 = append(yyv1599, APIVersion{})
-				yyh1599.ElemContainerState(yyj1599)
+		if yyrt1555 {
+			for ; yyj1555 < yyl1555; yyj1555++ {
+				yyv1555 = append(yyv1555, APIVersion{})
+				yyh1555.ElemContainerState(yyj1555)
 				if r.TryDecodeAsNil() {
-					yyv1599[yyj1599] = APIVersion{}
+					yyv1555[yyj1555] = APIVersion{}
 				} else {
-					yyv1601 := &yyv1599[yyj1599]
-					yyv1601.CodecDecodeSelf(d)
+					yyv1557 := &yyv1555[yyj1555]
+					yyv1557.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1599 := 0
-		for ; !r.CheckBreak(); yyj1599++ {
+		yyj1555 := 0
+		for ; !r.CheckBreak(); yyj1555++ {
 
-			if yyj1599 >= len(yyv1599) {
-				yyv1599 = append(yyv1599, APIVersion{}) // var yyz1599 APIVersion
-				yyc1599 = true
+			if yyj1555 >= len(yyv1555) {
+				yyv1555 = append(yyv1555, APIVersion{}) // var yyz1555 APIVersion
+				yyc1555 = true
 			}
-			yyh1599.ElemContainerState(yyj1599)
-			if yyj1599 < len(yyv1599) {
+			yyh1555.ElemContainerState(yyj1555)
+			if yyj1555 < len(yyv1555) {
 				if r.TryDecodeAsNil() {
-					yyv1599[yyj1599] = APIVersion{}
+					yyv1555[yyj1555] = APIVersion{}
 				} else {
-					yyv1602 := &yyv1599[yyj1599]
-					yyv1602.CodecDecodeSelf(d)
+					yyv1558 := &yyv1555[yyj1555]
+					yyv1558.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -19281,17 +18707,17 @@ func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decode
 			}
 
 		}
-		if yyj1599 < len(yyv1599) {
-			yyv1599 = yyv1599[:yyj1599]
-			yyc1599 = true
-		} else if yyj1599 == 0 && yyv1599 == nil {
-			yyv1599 = []APIVersion{}
-			yyc1599 = true
+		if yyj1555 < len(yyv1555) {
+			yyv1555 = yyv1555[:yyj1555]
+			yyc1555 = true
+		} else if yyj1555 == 0 && yyv1555 == nil {
+			yyv1555 = []APIVersion{}
+			yyc1555 = true
 		}
 	}
-	yyh1599.End()
-	if yyc1599 {
-		*v = yyv1599
+	yyh1555.End()
+	if yyc1555 {
+		*v = yyv1555
 	}
 }
 
@@ -19300,10 +18726,10 @@ func (x codecSelfer1234) encSliceThirdPartyResource(v []ThirdPartyResource, e *c
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1603 := range v {
+	for _, yyv1559 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1604 := &yyv1603
-		yy1604.CodecEncodeSelf(e)
+		yy1560 := &yyv1559
+		yy1560.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -19313,83 +18739,83 @@ func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1605 := *v
-	yyh1605, yyl1605 := z.DecSliceHelperStart()
-	var yyc1605 bool
-	if yyl1605 == 0 {
-		if yyv1605 == nil {
-			yyv1605 = []ThirdPartyResource{}
-			yyc1605 = true
-		} else if len(yyv1605) != 0 {
-			yyv1605 = yyv1605[:0]
-			yyc1605 = true
+	yyv1561 := *v
+	yyh1561, yyl1561 := z.DecSliceHelperStart()
+	var yyc1561 bool
+	if yyl1561 == 0 {
+		if yyv1561 == nil {
+			yyv1561 = []ThirdPartyResource{}
+			yyc1561 = true
+		} else if len(yyv1561) != 0 {
+			yyv1561 = yyv1561[:0]
+			yyc1561 = true
 		}
-	} else if yyl1605 > 0 {
-		var yyrr1605, yyrl1605 int
-		var yyrt1605 bool
-		if yyl1605 > cap(yyv1605) {
+	} else if yyl1561 > 0 {
+		var yyrr1561, yyrl1561 int
+		var yyrt1561 bool
+		if yyl1561 > cap(yyv1561) {
 
-			yyrg1605 := len(yyv1605) > 0
-			yyv21605 := yyv1605
-			yyrl1605, yyrt1605 = z.DecInferLen(yyl1605, z.DecBasicHandle().MaxInitLen, 232)
-			if yyrt1605 {
-				if yyrl1605 <= cap(yyv1605) {
-					yyv1605 = yyv1605[:yyrl1605]
+			yyrg1561 := len(yyv1561) > 0
+			yyv21561 := yyv1561
+			yyrl1561, yyrt1561 = z.DecInferLen(yyl1561, z.DecBasicHandle().MaxInitLen, 232)
+			if yyrt1561 {
+				if yyrl1561 <= cap(yyv1561) {
+					yyv1561 = yyv1561[:yyrl1561]
 				} else {
-					yyv1605 = make([]ThirdPartyResource, yyrl1605)
+					yyv1561 = make([]ThirdPartyResource, yyrl1561)
 				}
 			} else {
-				yyv1605 = make([]ThirdPartyResource, yyrl1605)
+				yyv1561 = make([]ThirdPartyResource, yyrl1561)
 			}
-			yyc1605 = true
-			yyrr1605 = len(yyv1605)
-			if yyrg1605 {
-				copy(yyv1605, yyv21605)
+			yyc1561 = true
+			yyrr1561 = len(yyv1561)
+			if yyrg1561 {
+				copy(yyv1561, yyv21561)
 			}
-		} else if yyl1605 != len(yyv1605) {
-			yyv1605 = yyv1605[:yyl1605]
-			yyc1605 = true
+		} else if yyl1561 != len(yyv1561) {
+			yyv1561 = yyv1561[:yyl1561]
+			yyc1561 = true
 		}
-		yyj1605 := 0
-		for ; yyj1605 < yyrr1605; yyj1605++ {
-			yyh1605.ElemContainerState(yyj1605)
+		yyj1561 := 0
+		for ; yyj1561 < yyrr1561; yyj1561++ {
+			yyh1561.ElemContainerState(yyj1561)
 			if r.TryDecodeAsNil() {
-				yyv1605[yyj1605] = ThirdPartyResource{}
+				yyv1561[yyj1561] = ThirdPartyResource{}
 			} else {
-				yyv1606 := &yyv1605[yyj1605]
-				yyv1606.CodecDecodeSelf(d)
+				yyv1562 := &yyv1561[yyj1561]
+				yyv1562.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1605 {
-			for ; yyj1605 < yyl1605; yyj1605++ {
-				yyv1605 = append(yyv1605, ThirdPartyResource{})
-				yyh1605.ElemContainerState(yyj1605)
+		if yyrt1561 {
+			for ; yyj1561 < yyl1561; yyj1561++ {
+				yyv1561 = append(yyv1561, ThirdPartyResource{})
+				yyh1561.ElemContainerState(yyj1561)
 				if r.TryDecodeAsNil() {
-					yyv1605[yyj1605] = ThirdPartyResource{}
+					yyv1561[yyj1561] = ThirdPartyResource{}
 				} else {
-					yyv1607 := &yyv1605[yyj1605]
-					yyv1607.CodecDecodeSelf(d)
+					yyv1563 := &yyv1561[yyj1561]
+					yyv1563.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1605 := 0
-		for ; !r.CheckBreak(); yyj1605++ {
+		yyj1561 := 0
+		for ; !r.CheckBreak(); yyj1561++ {
 
-			if yyj1605 >= len(yyv1605) {
-				yyv1605 = append(yyv1605, ThirdPartyResource{}) // var yyz1605 ThirdPartyResource
-				yyc1605 = true
+			if yyj1561 >= len(yyv1561) {
+				yyv1561 = append(yyv1561, ThirdPartyResource{}) // var yyz1561 ThirdPartyResource
+				yyc1561 = true
 			}
-			yyh1605.ElemContainerState(yyj1605)
-			if yyj1605 < len(yyv1605) {
+			yyh1561.ElemContainerState(yyj1561)
+			if yyj1561 < len(yyv1561) {
 				if r.TryDecodeAsNil() {
-					yyv1605[yyj1605] = ThirdPartyResource{}
+					yyv1561[yyj1561] = ThirdPartyResource{}
 				} else {
-					yyv1608 := &yyv1605[yyj1605]
-					yyv1608.CodecDecodeSelf(d)
+					yyv1564 := &yyv1561[yyj1561]
+					yyv1564.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -19397,17 +18823,17 @@ func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *
 			}
 
 		}
-		if yyj1605 < len(yyv1605) {
-			yyv1605 = yyv1605[:yyj1605]
-			yyc1605 = true
-		} else if yyj1605 == 0 && yyv1605 == nil {
-			yyv1605 = []ThirdPartyResource{}
-			yyc1605 = true
+		if yyj1561 < len(yyv1561) {
+			yyv1561 = yyv1561[:yyj1561]
+			yyc1561 = true
+		} else if yyj1561 == 0 && yyv1561 == nil {
+			yyv1561 = []ThirdPartyResource{}
+			yyc1561 = true
 		}
 	}
-	yyh1605.End()
-	if yyc1605 {
-		*v = yyv1605
+	yyh1561.End()
+	if yyc1561 {
+		*v = yyv1561
 	}
 }
 
@@ -19416,10 +18842,10 @@ func (x codecSelfer1234) encSliceDeployment(v []Deployment, e *codec1978.Encoder
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1609 := range v {
+	for _, yyv1565 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1610 := &yyv1609
-		yy1610.CodecEncodeSelf(e)
+		yy1566 := &yyv1565
+		yy1566.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -19429,83 +18855,83 @@ func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decode
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1611 := *v
-	yyh1611, yyl1611 := z.DecSliceHelperStart()
-	var yyc1611 bool
-	if yyl1611 == 0 {
-		if yyv1611 == nil {
-			yyv1611 = []Deployment{}
-			yyc1611 = true
-		} else if len(yyv1611) != 0 {
-			yyv1611 = yyv1611[:0]
-			yyc1611 = true
+	yyv1567 := *v
+	yyh1567, yyl1567 := z.DecSliceHelperStart()
+	var yyc1567 bool
+	if yyl1567 == 0 {
+		if yyv1567 == nil {
+			yyv1567 = []Deployment{}
+			yyc1567 = true
+		} else if len(yyv1567) != 0 {
+			yyv1567 = yyv1567[:0]
+			yyc1567 = true
 		}
-	} else if yyl1611 > 0 {
-		var yyrr1611, yyrl1611 int
-		var yyrt1611 bool
-		if yyl1611 > cap(yyv1611) {
+	} else if yyl1567 > 0 {
+		var yyrr1567, yyrl1567 int
+		var yyrt1567 bool
+		if yyl1567 > cap(yyv1567) {
 
-			yyrg1611 := len(yyv1611) > 0
-			yyv21611 := yyv1611
-			yyrl1611, yyrt1611 = z.DecInferLen(yyl1611, z.DecBasicHandle().MaxInitLen, 624)
-			if yyrt1611 {
-				if yyrl1611 <= cap(yyv1611) {
-					yyv1611 = yyv1611[:yyrl1611]
+			yyrg1567 := len(yyv1567) > 0
+			yyv21567 := yyv1567
+			yyrl1567, yyrt1567 = z.DecInferLen(yyl1567, z.DecBasicHandle().MaxInitLen, 624)
+			if yyrt1567 {
+				if yyrl1567 <= cap(yyv1567) {
+					yyv1567 = yyv1567[:yyrl1567]
 				} else {
-					yyv1611 = make([]Deployment, yyrl1611)
+					yyv1567 = make([]Deployment, yyrl1567)
 				}
 			} else {
-				yyv1611 = make([]Deployment, yyrl1611)
+				yyv1567 = make([]Deployment, yyrl1567)
 			}
-			yyc1611 = true
-			yyrr1611 = len(yyv1611)
-			if yyrg1611 {
-				copy(yyv1611, yyv21611)
+			yyc1567 = true
+			yyrr1567 = len(yyv1567)
+			if yyrg1567 {
+				copy(yyv1567, yyv21567)
 			}
-		} else if yyl1611 != len(yyv1611) {
-			yyv1611 = yyv1611[:yyl1611]
-			yyc1611 = true
+		} else if yyl1567 != len(yyv1567) {
+			yyv1567 = yyv1567[:yyl1567]
+			yyc1567 = true
 		}
-		yyj1611 := 0
-		for ; yyj1611 < yyrr1611; yyj1611++ {
-			yyh1611.ElemContainerState(yyj1611)
+		yyj1567 := 0
+		for ; yyj1567 < yyrr1567; yyj1567++ {
+			yyh1567.ElemContainerState(yyj1567)
 			if r.TryDecodeAsNil() {
-				yyv1611[yyj1611] = Deployment{}
+				yyv1567[yyj1567] = Deployment{}
 			} else {
-				yyv1612 := &yyv1611[yyj1611]
-				yyv1612.CodecDecodeSelf(d)
+				yyv1568 := &yyv1567[yyj1567]
+				yyv1568.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1611 {
-			for ; yyj1611 < yyl1611; yyj1611++ {
-				yyv1611 = append(yyv1611, Deployment{})
-				yyh1611.ElemContainerState(yyj1611)
+		if yyrt1567 {
+			for ; yyj1567 < yyl1567; yyj1567++ {
+				yyv1567 = append(yyv1567, Deployment{})
+				yyh1567.ElemContainerState(yyj1567)
 				if r.TryDecodeAsNil() {
-					yyv1611[yyj1611] = Deployment{}
+					yyv1567[yyj1567] = Deployment{}
 				} else {
-					yyv1613 := &yyv1611[yyj1611]
-					yyv1613.CodecDecodeSelf(d)
+					yyv1569 := &yyv1567[yyj1567]
+					yyv1569.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1611 := 0
-		for ; !r.CheckBreak(); yyj1611++ {
+		yyj1567 := 0
+		for ; !r.CheckBreak(); yyj1567++ {
 
-			if yyj1611 >= len(yyv1611) {
-				yyv1611 = append(yyv1611, Deployment{}) // var yyz1611 Deployment
-				yyc1611 = true
+			if yyj1567 >= len(yyv1567) {
+				yyv1567 = append(yyv1567, Deployment{}) // var yyz1567 Deployment
+				yyc1567 = true
 			}
-			yyh1611.ElemContainerState(yyj1611)
-			if yyj1611 < len(yyv1611) {
+			yyh1567.ElemContainerState(yyj1567)
+			if yyj1567 < len(yyv1567) {
 				if r.TryDecodeAsNil() {
-					yyv1611[yyj1611] = Deployment{}
+					yyv1567[yyj1567] = Deployment{}
 				} else {
-					yyv1614 := &yyv1611[yyj1611]
-					yyv1614.CodecDecodeSelf(d)
+					yyv1570 := &yyv1567[yyj1567]
+					yyv1570.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -19513,17 +18939,17 @@ func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decode
 			}
 
 		}
-		if yyj1611 < len(yyv1611) {
-			yyv1611 = yyv1611[:yyj1611]
-			yyc1611 = true
-		} else if yyj1611 == 0 && yyv1611 == nil {
-			yyv1611 = []Deployment{}
-			yyc1611 = true
+		if yyj1567 < len(yyv1567) {
+			yyv1567 = yyv1567[:yyj1567]
+			yyc1567 = true
+		} else if yyj1567 == 0 && yyv1567 == nil {
+			yyv1567 = []Deployment{}
+			yyc1567 = true
 		}
 	}
-	yyh1611.End()
-	if yyc1611 {
-		*v = yyv1611
+	yyh1567.End()
+	if yyc1567 {
+		*v = yyv1567
 	}
 }
 
@@ -19532,10 +18958,10 @@ func (x codecSelfer1234) encSliceDaemonSet(v []DaemonSet, e *codec1978.Encoder) 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1615 := range v {
+	for _, yyv1571 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1616 := &yyv1615
-		yy1616.CodecEncodeSelf(e)
+		yy1572 := &yyv1571
+		yy1572.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -19545,83 +18971,83 @@ func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder)
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1617 := *v
-	yyh1617, yyl1617 := z.DecSliceHelperStart()
-	var yyc1617 bool
-	if yyl1617 == 0 {
-		if yyv1617 == nil {
-			yyv1617 = []DaemonSet{}
-			yyc1617 = true
-		} else if len(yyv1617) != 0 {
-			yyv1617 = yyv1617[:0]
-			yyc1617 = true
+	yyv1573 := *v
+	yyh1573, yyl1573 := z.DecSliceHelperStart()
+	var yyc1573 bool
+	if yyl1573 == 0 {
+		if yyv1573 == nil {
+			yyv1573 = []DaemonSet{}
+			yyc1573 = true
+		} else if len(yyv1573) != 0 {
+			yyv1573 = yyv1573[:0]
+			yyc1573 = true
 		}
-	} else if yyl1617 > 0 {
-		var yyrr1617, yyrl1617 int
-		var yyrt1617 bool
-		if yyl1617 > cap(yyv1617) {
+	} else if yyl1573 > 0 {
+		var yyrr1573, yyrl1573 int
+		var yyrt1573 bool
+		if yyl1573 > cap(yyv1573) {
 
-			yyrg1617 := len(yyv1617) > 0
-			yyv21617 := yyv1617
-			yyrl1617, yyrt1617 = z.DecInferLen(yyl1617, z.DecBasicHandle().MaxInitLen, 592)
-			if yyrt1617 {
-				if yyrl1617 <= cap(yyv1617) {
-					yyv1617 = yyv1617[:yyrl1617]
+			yyrg1573 := len(yyv1573) > 0
+			yyv21573 := yyv1573
+			yyrl1573, yyrt1573 = z.DecInferLen(yyl1573, z.DecBasicHandle().MaxInitLen, 552)
+			if yyrt1573 {
+				if yyrl1573 <= cap(yyv1573) {
+					yyv1573 = yyv1573[:yyrl1573]
 				} else {
-					yyv1617 = make([]DaemonSet, yyrl1617)
+					yyv1573 = make([]DaemonSet, yyrl1573)
 				}
 			} else {
-				yyv1617 = make([]DaemonSet, yyrl1617)
+				yyv1573 = make([]DaemonSet, yyrl1573)
 			}
-			yyc1617 = true
-			yyrr1617 = len(yyv1617)
-			if yyrg1617 {
-				copy(yyv1617, yyv21617)
+			yyc1573 = true
+			yyrr1573 = len(yyv1573)
+			if yyrg1573 {
+				copy(yyv1573, yyv21573)
 			}
-		} else if yyl1617 != len(yyv1617) {
-			yyv1617 = yyv1617[:yyl1617]
-			yyc1617 = true
+		} else if yyl1573 != len(yyv1573) {
+			yyv1573 = yyv1573[:yyl1573]
+			yyc1573 = true
 		}
-		yyj1617 := 0
-		for ; yyj1617 < yyrr1617; yyj1617++ {
-			yyh1617.ElemContainerState(yyj1617)
+		yyj1573 := 0
+		for ; yyj1573 < yyrr1573; yyj1573++ {
+			yyh1573.ElemContainerState(yyj1573)
 			if r.TryDecodeAsNil() {
-				yyv1617[yyj1617] = DaemonSet{}
+				yyv1573[yyj1573] = DaemonSet{}
 			} else {
-				yyv1618 := &yyv1617[yyj1617]
-				yyv1618.CodecDecodeSelf(d)
+				yyv1574 := &yyv1573[yyj1573]
+				yyv1574.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1617 {
-			for ; yyj1617 < yyl1617; yyj1617++ {
-				yyv1617 = append(yyv1617, DaemonSet{})
-				yyh1617.ElemContainerState(yyj1617)
+		if yyrt1573 {
+			for ; yyj1573 < yyl1573; yyj1573++ {
+				yyv1573 = append(yyv1573, DaemonSet{})
+				yyh1573.ElemContainerState(yyj1573)
 				if r.TryDecodeAsNil() {
-					yyv1617[yyj1617] = DaemonSet{}
+					yyv1573[yyj1573] = DaemonSet{}
 				} else {
-					yyv1619 := &yyv1617[yyj1617]
-					yyv1619.CodecDecodeSelf(d)
+					yyv1575 := &yyv1573[yyj1573]
+					yyv1575.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1617 := 0
-		for ; !r.CheckBreak(); yyj1617++ {
+		yyj1573 := 0
+		for ; !r.CheckBreak(); yyj1573++ {
 
-			if yyj1617 >= len(yyv1617) {
-				yyv1617 = append(yyv1617, DaemonSet{}) // var yyz1617 DaemonSet
-				yyc1617 = true
+			if yyj1573 >= len(yyv1573) {
+				yyv1573 = append(yyv1573, DaemonSet{}) // var yyz1573 DaemonSet
+				yyc1573 = true
 			}
-			yyh1617.ElemContainerState(yyj1617)
-			if yyj1617 < len(yyv1617) {
+			yyh1573.ElemContainerState(yyj1573)
+			if yyj1573 < len(yyv1573) {
 				if r.TryDecodeAsNil() {
-					yyv1617[yyj1617] = DaemonSet{}
+					yyv1573[yyj1573] = DaemonSet{}
 				} else {
-					yyv1620 := &yyv1617[yyj1617]
-					yyv1620.CodecDecodeSelf(d)
+					yyv1576 := &yyv1573[yyj1573]
+					yyv1576.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -19629,17 +19055,17 @@ func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder)
 			}
 
 		}
-		if yyj1617 < len(yyv1617) {
-			yyv1617 = yyv1617[:yyj1617]
-			yyc1617 = true
-		} else if yyj1617 == 0 && yyv1617 == nil {
-			yyv1617 = []DaemonSet{}
-			yyc1617 = true
+		if yyj1573 < len(yyv1573) {
+			yyv1573 = yyv1573[:yyj1573]
+			yyc1573 = true
+		} else if yyj1573 == 0 && yyv1573 == nil {
+			yyv1573 = []DaemonSet{}
+			yyc1573 = true
 		}
 	}
-	yyh1617.End()
-	if yyc1617 {
-		*v = yyv1617
+	yyh1573.End()
+	if yyc1573 {
+		*v = yyv1573
 	}
 }
 
@@ -19648,10 +19074,10 @@ func (x codecSelfer1234) encSliceThirdPartyResourceData(v []ThirdPartyResourceDa
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1621 := range v {
+	for _, yyv1577 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1622 := &yyv1621
-		yy1622.CodecEncodeSelf(e)
+		yy1578 := &yyv1577
+		yy1578.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -19661,83 +19087,83 @@ func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceD
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1623 := *v
-	yyh1623, yyl1623 := z.DecSliceHelperStart()
-	var yyc1623 bool
-	if yyl1623 == 0 {
-		if yyv1623 == nil {
-			yyv1623 = []ThirdPartyResourceData{}
-			yyc1623 = true
-		} else if len(yyv1623) != 0 {
-			yyv1623 = yyv1623[:0]
-			yyc1623 = true
+	yyv1579 := *v
+	yyh1579, yyl1579 := z.DecSliceHelperStart()
+	var yyc1579 bool
+	if yyl1579 == 0 {
+		if yyv1579 == nil {
+			yyv1579 = []ThirdPartyResourceData{}
+			yyc1579 = true
+		} else if len(yyv1579) != 0 {
+			yyv1579 = yyv1579[:0]
+			yyc1579 = true
 		}
-	} else if yyl1623 > 0 {
-		var yyrr1623, yyrl1623 int
-		var yyrt1623 bool
-		if yyl1623 > cap(yyv1623) {
+	} else if yyl1579 > 0 {
+		var yyrr1579, yyrl1579 int
+		var yyrt1579 bool
+		if yyl1579 > cap(yyv1579) {
 
-			yyrg1623 := len(yyv1623) > 0
-			yyv21623 := yyv1623
-			yyrl1623, yyrt1623 = z.DecInferLen(yyl1623, z.DecBasicHandle().MaxInitLen, 216)
-			if yyrt1623 {
-				if yyrl1623 <= cap(yyv1623) {
-					yyv1623 = yyv1623[:yyrl1623]
+			yyrg1579 := len(yyv1579) > 0
+			yyv21579 := yyv1579
+			yyrl1579, yyrt1579 = z.DecInferLen(yyl1579, z.DecBasicHandle().MaxInitLen, 216)
+			if yyrt1579 {
+				if yyrl1579 <= cap(yyv1579) {
+					yyv1579 = yyv1579[:yyrl1579]
 				} else {
-					yyv1623 = make([]ThirdPartyResourceData, yyrl1623)
+					yyv1579 = make([]ThirdPartyResourceData, yyrl1579)
 				}
 			} else {
-				yyv1623 = make([]ThirdPartyResourceData, yyrl1623)
+				yyv1579 = make([]ThirdPartyResourceData, yyrl1579)
 			}
-			yyc1623 = true
-			yyrr1623 = len(yyv1623)
-			if yyrg1623 {
-				copy(yyv1623, yyv21623)
+			yyc1579 = true
+			yyrr1579 = len(yyv1579)
+			if yyrg1579 {
+				copy(yyv1579, yyv21579)
 			}
-		} else if yyl1623 != len(yyv1623) {
-			yyv1623 = yyv1623[:yyl1623]
-			yyc1623 = true
+		} else if yyl1579 != len(yyv1579) {
+			yyv1579 = yyv1579[:yyl1579]
+			yyc1579 = true
 		}
-		yyj1623 := 0
-		for ; yyj1623 < yyrr1623; yyj1623++ {
-			yyh1623.ElemContainerState(yyj1623)
+		yyj1579 := 0
+		for ; yyj1579 < yyrr1579; yyj1579++ {
+			yyh1579.ElemContainerState(yyj1579)
 			if r.TryDecodeAsNil() {
-				yyv1623[yyj1623] = ThirdPartyResourceData{}
+				yyv1579[yyj1579] = ThirdPartyResourceData{}
 			} else {
-				yyv1624 := &yyv1623[yyj1623]
-				yyv1624.CodecDecodeSelf(d)
+				yyv1580 := &yyv1579[yyj1579]
+				yyv1580.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1623 {
-			for ; yyj1623 < yyl1623; yyj1623++ {
-				yyv1623 = append(yyv1623, ThirdPartyResourceData{})
-				yyh1623.ElemContainerState(yyj1623)
+		if yyrt1579 {
+			for ; yyj1579 < yyl1579; yyj1579++ {
+				yyv1579 = append(yyv1579, ThirdPartyResourceData{})
+				yyh1579.ElemContainerState(yyj1579)
 				if r.TryDecodeAsNil() {
-					yyv1623[yyj1623] = ThirdPartyResourceData{}
+					yyv1579[yyj1579] = ThirdPartyResourceData{}
 				} else {
-					yyv1625 := &yyv1623[yyj1623]
-					yyv1625.CodecDecodeSelf(d)
+					yyv1581 := &yyv1579[yyj1579]
+					yyv1581.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1623 := 0
-		for ; !r.CheckBreak(); yyj1623++ {
+		yyj1579 := 0
+		for ; !r.CheckBreak(); yyj1579++ {
 
-			if yyj1623 >= len(yyv1623) {
-				yyv1623 = append(yyv1623, ThirdPartyResourceData{}) // var yyz1623 ThirdPartyResourceData
-				yyc1623 = true
+			if yyj1579 >= len(yyv1579) {
+				yyv1579 = append(yyv1579, ThirdPartyResourceData{}) // var yyz1579 ThirdPartyResourceData
+				yyc1579 = true
 			}
-			yyh1623.ElemContainerState(yyj1623)
-			if yyj1623 < len(yyv1623) {
+			yyh1579.ElemContainerState(yyj1579)
+			if yyj1579 < len(yyv1579) {
 				if r.TryDecodeAsNil() {
-					yyv1623[yyj1623] = ThirdPartyResourceData{}
+					yyv1579[yyj1579] = ThirdPartyResourceData{}
 				} else {
-					yyv1626 := &yyv1623[yyj1623]
-					yyv1626.CodecDecodeSelf(d)
+					yyv1582 := &yyv1579[yyj1579]
+					yyv1582.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -19745,17 +19171,17 @@ func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceD
 			}
 
 		}
-		if yyj1623 < len(yyv1623) {
-			yyv1623 = yyv1623[:yyj1623]
-			yyc1623 = true
-		} else if yyj1623 == 0 && yyv1623 == nil {
-			yyv1623 = []ThirdPartyResourceData{}
-			yyc1623 = true
+		if yyj1579 < len(yyv1579) {
+			yyv1579 = yyv1579[:yyj1579]
+			yyc1579 = true
+		} else if yyj1579 == 0 && yyv1579 == nil {
+			yyv1579 = []ThirdPartyResourceData{}
+			yyc1579 = true
 		}
 	}
-	yyh1623.End()
-	if yyc1623 {
-		*v = yyv1623
+	yyh1579.End()
+	if yyc1579 {
+		*v = yyv1579
 	}
 }
 
@@ -19764,10 +19190,10 @@ func (x codecSelfer1234) encSliceJob(v []Job, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1627 := range v {
+	for _, yyv1583 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1628 := &yyv1627
-		yy1628.CodecEncodeSelf(e)
+		yy1584 := &yyv1583
+		yy1584.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -19777,83 +19203,83 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1629 := *v
-	yyh1629, yyl1629 := z.DecSliceHelperStart()
-	var yyc1629 bool
-	if yyl1629 == 0 {
-		if yyv1629 == nil {
-			yyv1629 = []Job{}
-			yyc1629 = true
-		} else if len(yyv1629) != 0 {
-			yyv1629 = yyv1629[:0]
-			yyc1629 = true
+	yyv1585 := *v
+	yyh1585, yyl1585 := z.DecSliceHelperStart()
+	var yyc1585 bool
+	if yyl1585 == 0 {
+		if yyv1585 == nil {
+			yyv1585 = []Job{}
+			yyc1585 = true
+		} else if len(yyv1585) != 0 {
+			yyv1585 = yyv1585[:0]
+			yyc1585 = true
 		}
-	} else if yyl1629 > 0 {
-		var yyrr1629, yyrl1629 int
-		var yyrt1629 bool
-		if yyl1629 > cap(yyv1629) {
+	} else if yyl1585 > 0 {
+		var yyrr1585, yyrl1585 int
+		var yyrt1585 bool
+		if yyl1585 > cap(yyv1585) {
 
-			yyrg1629 := len(yyv1629) > 0
-			yyv21629 := yyv1629
-			yyrl1629, yyrt1629 = z.DecInferLen(yyl1629, z.DecBasicHandle().MaxInitLen, 616)
-			if yyrt1629 {
-				if yyrl1629 <= cap(yyv1629) {
-					yyv1629 = yyv1629[:yyrl1629]
+			yyrg1585 := len(yyv1585) > 0
+			yyv21585 := yyv1585
+			yyrl1585, yyrt1585 = z.DecInferLen(yyl1585, z.DecBasicHandle().MaxInitLen, 616)
+			if yyrt1585 {
+				if yyrl1585 <= cap(yyv1585) {
+					yyv1585 = yyv1585[:yyrl1585]
 				} else {
-					yyv1629 = make([]Job, yyrl1629)
+					yyv1585 = make([]Job, yyrl1585)
 				}
 			} else {
-				yyv1629 = make([]Job, yyrl1629)
+				yyv1585 = make([]Job, yyrl1585)
 			}
-			yyc1629 = true
-			yyrr1629 = len(yyv1629)
-			if yyrg1629 {
-				copy(yyv1629, yyv21629)
+			yyc1585 = true
+			yyrr1585 = len(yyv1585)
+			if yyrg1585 {
+				copy(yyv1585, yyv21585)
 			}
-		} else if yyl1629 != len(yyv1629) {
-			yyv1629 = yyv1629[:yyl1629]
-			yyc1629 = true
+		} else if yyl1585 != len(yyv1585) {
+			yyv1585 = yyv1585[:yyl1585]
+			yyc1585 = true
 		}
-		yyj1629 := 0
-		for ; yyj1629 < yyrr1629; yyj1629++ {
-			yyh1629.ElemContainerState(yyj1629)
+		yyj1585 := 0
+		for ; yyj1585 < yyrr1585; yyj1585++ {
+			yyh1585.ElemContainerState(yyj1585)
 			if r.TryDecodeAsNil() {
-				yyv1629[yyj1629] = Job{}
+				yyv1585[yyj1585] = Job{}
 			} else {
-				yyv1630 := &yyv1629[yyj1629]
-				yyv1630.CodecDecodeSelf(d)
+				yyv1586 := &yyv1585[yyj1585]
+				yyv1586.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1629 {
-			for ; yyj1629 < yyl1629; yyj1629++ {
-				yyv1629 = append(yyv1629, Job{})
-				yyh1629.ElemContainerState(yyj1629)
+		if yyrt1585 {
+			for ; yyj1585 < yyl1585; yyj1585++ {
+				yyv1585 = append(yyv1585, Job{})
+				yyh1585.ElemContainerState(yyj1585)
 				if r.TryDecodeAsNil() {
-					yyv1629[yyj1629] = Job{}
+					yyv1585[yyj1585] = Job{}
 				} else {
-					yyv1631 := &yyv1629[yyj1629]
-					yyv1631.CodecDecodeSelf(d)
+					yyv1587 := &yyv1585[yyj1585]
+					yyv1587.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1629 := 0
-		for ; !r.CheckBreak(); yyj1629++ {
+		yyj1585 := 0
+		for ; !r.CheckBreak(); yyj1585++ {
 
-			if yyj1629 >= len(yyv1629) {
-				yyv1629 = append(yyv1629, Job{}) // var yyz1629 Job
-				yyc1629 = true
+			if yyj1585 >= len(yyv1585) {
+				yyv1585 = append(yyv1585, Job{}) // var yyz1585 Job
+				yyc1585 = true
 			}
-			yyh1629.ElemContainerState(yyj1629)
-			if yyj1629 < len(yyv1629) {
+			yyh1585.ElemContainerState(yyj1585)
+			if yyj1585 < len(yyv1585) {
 				if r.TryDecodeAsNil() {
-					yyv1629[yyj1629] = Job{}
+					yyv1585[yyj1585] = Job{}
 				} else {
-					yyv1632 := &yyv1629[yyj1629]
-					yyv1632.CodecDecodeSelf(d)
+					yyv1588 := &yyv1585[yyj1585]
+					yyv1588.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -19861,17 +19287,17 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 			}
 
 		}
-		if yyj1629 < len(yyv1629) {
-			yyv1629 = yyv1629[:yyj1629]
-			yyc1629 = true
-		} else if yyj1629 == 0 && yyv1629 == nil {
-			yyv1629 = []Job{}
-			yyc1629 = true
+		if yyj1585 < len(yyv1585) {
+			yyv1585 = yyv1585[:yyj1585]
+			yyc1585 = true
+		} else if yyj1585 == 0 && yyv1585 == nil {
+			yyv1585 = []Job{}
+			yyc1585 = true
 		}
 	}
-	yyh1629.End()
-	if yyc1629 {
-		*v = yyv1629
+	yyh1585.End()
+	if yyc1585 {
+		*v = yyv1585
 	}
 }
 
@@ -19880,10 +19306,10 @@ func (x codecSelfer1234) encSliceJobCondition(v []JobCondition, e *codec1978.Enc
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1633 := range v {
+	for _, yyv1589 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1634 := &yyv1633
-		yy1634.CodecEncodeSelf(e)
+		yy1590 := &yyv1589
+		yy1590.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -19893,83 +19319,83 @@ func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.De
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1635 := *v
-	yyh1635, yyl1635 := z.DecSliceHelperStart()
-	var yyc1635 bool
-	if yyl1635 == 0 {
-		if yyv1635 == nil {
-			yyv1635 = []JobCondition{}
-			yyc1635 = true
-		} else if len(yyv1635) != 0 {
-			yyv1635 = yyv1635[:0]
-			yyc1635 = true
+	yyv1591 := *v
+	yyh1591, yyl1591 := z.DecSliceHelperStart()
+	var yyc1591 bool
+	if yyl1591 == 0 {
+		if yyv1591 == nil {
+			yyv1591 = []JobCondition{}
+			yyc1591 = true
+		} else if len(yyv1591) != 0 {
+			yyv1591 = yyv1591[:0]
+			yyc1591 = true
 		}
-	} else if yyl1635 > 0 {
-		var yyrr1635, yyrl1635 int
-		var yyrt1635 bool
-		if yyl1635 > cap(yyv1635) {
+	} else if yyl1591 > 0 {
+		var yyrr1591, yyrl1591 int
+		var yyrt1591 bool
+		if yyl1591 > cap(yyv1591) {
 
-			yyrg1635 := len(yyv1635) > 0
-			yyv21635 := yyv1635
-			yyrl1635, yyrt1635 = z.DecInferLen(yyl1635, z.DecBasicHandle().MaxInitLen, 112)
-			if yyrt1635 {
-				if yyrl1635 <= cap(yyv1635) {
-					yyv1635 = yyv1635[:yyrl1635]
+			yyrg1591 := len(yyv1591) > 0
+			yyv21591 := yyv1591
+			yyrl1591, yyrt1591 = z.DecInferLen(yyl1591, z.DecBasicHandle().MaxInitLen, 112)
+			if yyrt1591 {
+				if yyrl1591 <= cap(yyv1591) {
+					yyv1591 = yyv1591[:yyrl1591]
 				} else {
-					yyv1635 = make([]JobCondition, yyrl1635)
+					yyv1591 = make([]JobCondition, yyrl1591)
 				}
 			} else {
-				yyv1635 = make([]JobCondition, yyrl1635)
+				yyv1591 = make([]JobCondition, yyrl1591)
 			}
-			yyc1635 = true
-			yyrr1635 = len(yyv1635)
-			if yyrg1635 {
-				copy(yyv1635, yyv21635)
+			yyc1591 = true
+			yyrr1591 = len(yyv1591)
+			if yyrg1591 {
+				copy(yyv1591, yyv21591)
 			}
-		} else if yyl1635 != len(yyv1635) {
-			yyv1635 = yyv1635[:yyl1635]
-			yyc1635 = true
+		} else if yyl1591 != len(yyv1591) {
+			yyv1591 = yyv1591[:yyl1591]
+			yyc1591 = true
 		}
-		yyj1635 := 0
-		for ; yyj1635 < yyrr1635; yyj1635++ {
-			yyh1635.ElemContainerState(yyj1635)
+		yyj1591 := 0
+		for ; yyj1591 < yyrr1591; yyj1591++ {
+			yyh1591.ElemContainerState(yyj1591)
 			if r.TryDecodeAsNil() {
-				yyv1635[yyj1635] = JobCondition{}
+				yyv1591[yyj1591] = JobCondition{}
 			} else {
-				yyv1636 := &yyv1635[yyj1635]
-				yyv1636.CodecDecodeSelf(d)
+				yyv1592 := &yyv1591[yyj1591]
+				yyv1592.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1635 {
-			for ; yyj1635 < yyl1635; yyj1635++ {
-				yyv1635 = append(yyv1635, JobCondition{})
-				yyh1635.ElemContainerState(yyj1635)
+		if yyrt1591 {
+			for ; yyj1591 < yyl1591; yyj1591++ {
+				yyv1591 = append(yyv1591, JobCondition{})
+				yyh1591.ElemContainerState(yyj1591)
 				if r.TryDecodeAsNil() {
-					yyv1635[yyj1635] = JobCondition{}
+					yyv1591[yyj1591] = JobCondition{}
 				} else {
-					yyv1637 := &yyv1635[yyj1635]
-					yyv1637.CodecDecodeSelf(d)
+					yyv1593 := &yyv1591[yyj1591]
+					yyv1593.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1635 := 0
-		for ; !r.CheckBreak(); yyj1635++ {
+		yyj1591 := 0
+		for ; !r.CheckBreak(); yyj1591++ {
 
-			if yyj1635 >= len(yyv1635) {
-				yyv1635 = append(yyv1635, JobCondition{}) // var yyz1635 JobCondition
-				yyc1635 = true
+			if yyj1591 >= len(yyv1591) {
+				yyv1591 = append(yyv1591, JobCondition{}) // var yyz1591 JobCondition
+				yyc1591 = true
 			}
-			yyh1635.ElemContainerState(yyj1635)
-			if yyj1635 < len(yyv1635) {
+			yyh1591.ElemContainerState(yyj1591)
+			if yyj1591 < len(yyv1591) {
 				if r.TryDecodeAsNil() {
-					yyv1635[yyj1635] = JobCondition{}
+					yyv1591[yyj1591] = JobCondition{}
 				} else {
-					yyv1638 := &yyv1635[yyj1635]
-					yyv1638.CodecDecodeSelf(d)
+					yyv1594 := &yyv1591[yyj1591]
+					yyv1594.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -19977,17 +19403,17 @@ func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.De
 			}
 
 		}
-		if yyj1635 < len(yyv1635) {
-			yyv1635 = yyv1635[:yyj1635]
-			yyc1635 = true
-		} else if yyj1635 == 0 && yyv1635 == nil {
-			yyv1635 = []JobCondition{}
-			yyc1635 = true
+		if yyj1591 < len(yyv1591) {
+			yyv1591 = yyv1591[:yyj1591]
+			yyc1591 = true
+		} else if yyj1591 == 0 && yyv1591 == nil {
+			yyv1591 = []JobCondition{}
+			yyc1591 = true
 		}
 	}
-	yyh1635.End()
-	if yyc1635 {
-		*v = yyv1635
+	yyh1591.End()
+	if yyc1591 {
+		*v = yyv1591
 	}
 }
 
@@ -19996,10 +19422,10 @@ func (x codecSelfer1234) encSliceIngress(v []Ingress, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1639 := range v {
+	for _, yyv1595 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1640 := &yyv1639
-		yy1640.CodecEncodeSelf(e)
+		yy1596 := &yyv1595
+		yy1596.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -20009,83 +19435,83 @@ func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1641 := *v
-	yyh1641, yyl1641 := z.DecSliceHelperStart()
-	var yyc1641 bool
-	if yyl1641 == 0 {
-		if yyv1641 == nil {
-			yyv1641 = []Ingress{}
-			yyc1641 = true
-		} else if len(yyv1641) != 0 {
-			yyv1641 = yyv1641[:0]
-			yyc1641 = true
+	yyv1597 := *v
+	yyh1597, yyl1597 := z.DecSliceHelperStart()
+	var yyc1597 bool
+	if yyl1597 == 0 {
+		if yyv1597 == nil {
+			yyv1597 = []Ingress{}
+			yyc1597 = true
+		} else if len(yyv1597) != 0 {
+			yyv1597 = yyv1597[:0]
+			yyc1597 = true
 		}
-	} else if yyl1641 > 0 {
-		var yyrr1641, yyrl1641 int
-		var yyrt1641 bool
-		if yyl1641 > cap(yyv1641) {
+	} else if yyl1597 > 0 {
+		var yyrr1597, yyrl1597 int
+		var yyrt1597 bool
+		if yyl1597 > cap(yyv1597) {
 
-			yyrg1641 := len(yyv1641) > 0
-			yyv21641 := yyv1641
-			yyrl1641, yyrt1641 = z.DecInferLen(yyl1641, z.DecBasicHandle().MaxInitLen, 272)
-			if yyrt1641 {
-				if yyrl1641 <= cap(yyv1641) {
-					yyv1641 = yyv1641[:yyrl1641]
+			yyrg1597 := len(yyv1597) > 0
+			yyv21597 := yyv1597
+			yyrl1597, yyrt1597 = z.DecInferLen(yyl1597, z.DecBasicHandle().MaxInitLen, 272)
+			if yyrt1597 {
+				if yyrl1597 <= cap(yyv1597) {
+					yyv1597 = yyv1597[:yyrl1597]
 				} else {
-					yyv1641 = make([]Ingress, yyrl1641)
+					yyv1597 = make([]Ingress, yyrl1597)
 				}
 			} else {
-				yyv1641 = make([]Ingress, yyrl1641)
+				yyv1597 = make([]Ingress, yyrl1597)
 			}
-			yyc1641 = true
-			yyrr1641 = len(yyv1641)
-			if yyrg1641 {
-				copy(yyv1641, yyv21641)
+			yyc1597 = true
+			yyrr1597 = len(yyv1597)
+			if yyrg1597 {
+				copy(yyv1597, yyv21597)
 			}
-		} else if yyl1641 != len(yyv1641) {
-			yyv1641 = yyv1641[:yyl1641]
-			yyc1641 = true
+		} else if yyl1597 != len(yyv1597) {
+			yyv1597 = yyv1597[:yyl1597]
+			yyc1597 = true
 		}
-		yyj1641 := 0
-		for ; yyj1641 < yyrr1641; yyj1641++ {
-			yyh1641.ElemContainerState(yyj1641)
+		yyj1597 := 0
+		for ; yyj1597 < yyrr1597; yyj1597++ {
+			yyh1597.ElemContainerState(yyj1597)
 			if r.TryDecodeAsNil() {
-				yyv1641[yyj1641] = Ingress{}
+				yyv1597[yyj1597] = Ingress{}
 			} else {
-				yyv1642 := &yyv1641[yyj1641]
-				yyv1642.CodecDecodeSelf(d)
+				yyv1598 := &yyv1597[yyj1597]
+				yyv1598.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1641 {
-			for ; yyj1641 < yyl1641; yyj1641++ {
-				yyv1641 = append(yyv1641, Ingress{})
-				yyh1641.ElemContainerState(yyj1641)
+		if yyrt1597 {
+			for ; yyj1597 < yyl1597; yyj1597++ {
+				yyv1597 = append(yyv1597, Ingress{})
+				yyh1597.ElemContainerState(yyj1597)
 				if r.TryDecodeAsNil() {
-					yyv1641[yyj1641] = Ingress{}
+					yyv1597[yyj1597] = Ingress{}
 				} else {
-					yyv1643 := &yyv1641[yyj1641]
-					yyv1643.CodecDecodeSelf(d)
+					yyv1599 := &yyv1597[yyj1597]
+					yyv1599.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1641 := 0
-		for ; !r.CheckBreak(); yyj1641++ {
+		yyj1597 := 0
+		for ; !r.CheckBreak(); yyj1597++ {
 
-			if yyj1641 >= len(yyv1641) {
-				yyv1641 = append(yyv1641, Ingress{}) // var yyz1641 Ingress
-				yyc1641 = true
+			if yyj1597 >= len(yyv1597) {
+				yyv1597 = append(yyv1597, Ingress{}) // var yyz1597 Ingress
+				yyc1597 = true
 			}
-			yyh1641.ElemContainerState(yyj1641)
-			if yyj1641 < len(yyv1641) {
+			yyh1597.ElemContainerState(yyj1597)
+			if yyj1597 < len(yyv1597) {
 				if r.TryDecodeAsNil() {
-					yyv1641[yyj1641] = Ingress{}
+					yyv1597[yyj1597] = Ingress{}
 				} else {
-					yyv1644 := &yyv1641[yyj1641]
-					yyv1644.CodecDecodeSelf(d)
+					yyv1600 := &yyv1597[yyj1597]
+					yyv1600.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -20093,17 +19519,17 @@ func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
 			}
 
 		}
-		if yyj1641 < len(yyv1641) {
-			yyv1641 = yyv1641[:yyj1641]
-			yyc1641 = true
-		} else if yyj1641 == 0 && yyv1641 == nil {
-			yyv1641 = []Ingress{}
-			yyc1641 = true
+		if yyj1597 < len(yyv1597) {
+			yyv1597 = yyv1597[:yyj1597]
+			yyc1597 = true
+		} else if yyj1597 == 0 && yyv1597 == nil {
+			yyv1597 = []Ingress{}
+			yyc1597 = true
 		}
 	}
-	yyh1641.End()
-	if yyc1641 {
-		*v = yyv1641
+	yyh1597.End()
+	if yyc1597 {
+		*v = yyv1597
 	}
 }
 
@@ -20112,10 +19538,10 @@ func (x codecSelfer1234) encSliceIngressTLS(v []IngressTLS, e *codec1978.Encoder
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1645 := range v {
+	for _, yyv1601 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1646 := &yyv1645
-		yy1646.CodecEncodeSelf(e)
+		yy1602 := &yyv1601
+		yy1602.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -20125,83 +19551,83 @@ func (x codecSelfer1234) decSliceIngressTLS(v *[]IngressTLS, d *codec1978.Decode
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1647 := *v
-	yyh1647, yyl1647 := z.DecSliceHelperStart()
-	var yyc1647 bool
-	if yyl1647 == 0 {
-		if yyv1647 == nil {
-			yyv1647 = []IngressTLS{}
-			yyc1647 = true
-		} else if len(yyv1647) != 0 {
-			yyv1647 = yyv1647[:0]
-			yyc1647 = true
+	yyv1603 := *v
+	yyh1603, yyl1603 := z.DecSliceHelperStart()
+	var yyc1603 bool
+	if yyl1603 == 0 {
+		if yyv1603 == nil {
+			yyv1603 = []IngressTLS{}
+			yyc1603 = true
+		} else if len(yyv1603) != 0 {
+			yyv1603 = yyv1603[:0]
+			yyc1603 = true
 		}
-	} else if yyl1647 > 0 {
-		var yyrr1647, yyrl1647 int
-		var yyrt1647 bool
-		if yyl1647 > cap(yyv1647) {
+	} else if yyl1603 > 0 {
+		var yyrr1603, yyrl1603 int
+		var yyrt1603 bool
+		if yyl1603 > cap(yyv1603) {
 
-			yyrg1647 := len(yyv1647) > 0
-			yyv21647 := yyv1647
-			yyrl1647, yyrt1647 = z.DecInferLen(yyl1647, z.DecBasicHandle().MaxInitLen, 40)
-			if yyrt1647 {
-				if yyrl1647 <= cap(yyv1647) {
-					yyv1647 = yyv1647[:yyrl1647]
+			yyrg1603 := len(yyv1603) > 0
+			yyv21603 := yyv1603
+			yyrl1603, yyrt1603 = z.DecInferLen(yyl1603, z.DecBasicHandle().MaxInitLen, 40)
+			if yyrt1603 {
+				if yyrl1603 <= cap(yyv1603) {
+					yyv1603 = yyv1603[:yyrl1603]
 				} else {
-					yyv1647 = make([]IngressTLS, yyrl1647)
+					yyv1603 = make([]IngressTLS, yyrl1603)
 				}
 			} else {
-				yyv1647 = make([]IngressTLS, yyrl1647)
+				yyv1603 = make([]IngressTLS, yyrl1603)
 			}
-			yyc1647 = true
-			yyrr1647 = len(yyv1647)
-			if yyrg1647 {
-				copy(yyv1647, yyv21647)
+			yyc1603 = true
+			yyrr1603 = len(yyv1603)
+			if yyrg1603 {
+				copy(yyv1603, yyv21603)
 			}
-		} else if yyl1647 != len(yyv1647) {
-			yyv1647 = yyv1647[:yyl1647]
-			yyc1647 = true
+		} else if yyl1603 != len(yyv1603) {
+			yyv1603 = yyv1603[:yyl1603]
+			yyc1603 = true
 		}
-		yyj1647 := 0
-		for ; yyj1647 < yyrr1647; yyj1647++ {
-			yyh1647.ElemContainerState(yyj1647)
+		yyj1603 := 0
+		for ; yyj1603 < yyrr1603; yyj1603++ {
+			yyh1603.ElemContainerState(yyj1603)
 			if r.TryDecodeAsNil() {
-				yyv1647[yyj1647] = IngressTLS{}
+				yyv1603[yyj1603] = IngressTLS{}
 			} else {
-				yyv1648 := &yyv1647[yyj1647]
-				yyv1648.CodecDecodeSelf(d)
+				yyv1604 := &yyv1603[yyj1603]
+				yyv1604.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1647 {
-			for ; yyj1647 < yyl1647; yyj1647++ {
-				yyv1647 = append(yyv1647, IngressTLS{})
-				yyh1647.ElemContainerState(yyj1647)
+		if yyrt1603 {
+			for ; yyj1603 < yyl1603; yyj1603++ {
+				yyv1603 = append(yyv1603, IngressTLS{})
+				yyh1603.ElemContainerState(yyj1603)
 				if r.TryDecodeAsNil() {
-					yyv1647[yyj1647] = IngressTLS{}
+					yyv1603[yyj1603] = IngressTLS{}
 				} else {
-					yyv1649 := &yyv1647[yyj1647]
-					yyv1649.CodecDecodeSelf(d)
+					yyv1605 := &yyv1603[yyj1603]
+					yyv1605.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1647 := 0
-		for ; !r.CheckBreak(); yyj1647++ {
+		yyj1603 := 0
+		for ; !r.CheckBreak(); yyj1603++ {
 
-			if yyj1647 >= len(yyv1647) {
-				yyv1647 = append(yyv1647, IngressTLS{}) // var yyz1647 IngressTLS
-				yyc1647 = true
+			if yyj1603 >= len(yyv1603) {
+				yyv1603 = append(yyv1603, IngressTLS{}) // var yyz1603 IngressTLS
+				yyc1603 = true
 			}
-			yyh1647.ElemContainerState(yyj1647)
-			if yyj1647 < len(yyv1647) {
+			yyh1603.ElemContainerState(yyj1603)
+			if yyj1603 < len(yyv1603) {
 				if r.TryDecodeAsNil() {
-					yyv1647[yyj1647] = IngressTLS{}
+					yyv1603[yyj1603] = IngressTLS{}
 				} else {
-					yyv1650 := &yyv1647[yyj1647]
-					yyv1650.CodecDecodeSelf(d)
+					yyv1606 := &yyv1603[yyj1603]
+					yyv1606.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -20209,17 +19635,17 @@ func (x codecSelfer1234) decSliceIngressTLS(v *[]IngressTLS, d *codec1978.Decode
 			}
 
 		}
-		if yyj1647 < len(yyv1647) {
-			yyv1647 = yyv1647[:yyj1647]
-			yyc1647 = true
-		} else if yyj1647 == 0 && yyv1647 == nil {
-			yyv1647 = []IngressTLS{}
-			yyc1647 = true
+		if yyj1603 < len(yyv1603) {
+			yyv1603 = yyv1603[:yyj1603]
+			yyc1603 = true
+		} else if yyj1603 == 0 && yyv1603 == nil {
+			yyv1603 = []IngressTLS{}
+			yyc1603 = true
 		}
 	}
-	yyh1647.End()
-	if yyc1647 {
-		*v = yyv1647
+	yyh1603.End()
+	if yyc1603 {
+		*v = yyv1603
 	}
 }
 
@@ -20228,10 +19654,10 @@ func (x codecSelfer1234) encSliceIngressRule(v []IngressRule, e *codec1978.Encod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1651 := range v {
+	for _, yyv1607 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1652 := &yyv1651
-		yy1652.CodecEncodeSelf(e)
+		yy1608 := &yyv1607
+		yy1608.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -20241,83 +19667,83 @@ func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Deco
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1653 := *v
-	yyh1653, yyl1653 := z.DecSliceHelperStart()
-	var yyc1653 bool
-	if yyl1653 == 0 {
-		if yyv1653 == nil {
-			yyv1653 = []IngressRule{}
-			yyc1653 = true
-		} else if len(yyv1653) != 0 {
-			yyv1653 = yyv1653[:0]
-			yyc1653 = true
+	yyv1609 := *v
+	yyh1609, yyl1609 := z.DecSliceHelperStart()
+	var yyc1609 bool
+	if yyl1609 == 0 {
+		if yyv1609 == nil {
+			yyv1609 = []IngressRule{}
+			yyc1609 = true
+		} else if len(yyv1609) != 0 {
+			yyv1609 = yyv1609[:0]
+			yyc1609 = true
 		}
-	} else if yyl1653 > 0 {
-		var yyrr1653, yyrl1653 int
-		var yyrt1653 bool
-		if yyl1653 > cap(yyv1653) {
+	} else if yyl1609 > 0 {
+		var yyrr1609, yyrl1609 int
+		var yyrt1609 bool
+		if yyl1609 > cap(yyv1609) {
 
-			yyrg1653 := len(yyv1653) > 0
-			yyv21653 := yyv1653
-			yyrl1653, yyrt1653 = z.DecInferLen(yyl1653, z.DecBasicHandle().MaxInitLen, 24)
-			if yyrt1653 {
-				if yyrl1653 <= cap(yyv1653) {
-					yyv1653 = yyv1653[:yyrl1653]
+			yyrg1609 := len(yyv1609) > 0
+			yyv21609 := yyv1609
+			yyrl1609, yyrt1609 = z.DecInferLen(yyl1609, z.DecBasicHandle().MaxInitLen, 24)
+			if yyrt1609 {
+				if yyrl1609 <= cap(yyv1609) {
+					yyv1609 = yyv1609[:yyrl1609]
 				} else {
-					yyv1653 = make([]IngressRule, yyrl1653)
+					yyv1609 = make([]IngressRule, yyrl1609)
 				}
 			} else {
-				yyv1653 = make([]IngressRule, yyrl1653)
+				yyv1609 = make([]IngressRule, yyrl1609)
 			}
-			yyc1653 = true
-			yyrr1653 = len(yyv1653)
-			if yyrg1653 {
-				copy(yyv1653, yyv21653)
+			yyc1609 = true
+			yyrr1609 = len(yyv1609)
+			if yyrg1609 {
+				copy(yyv1609, yyv21609)
 			}
-		} else if yyl1653 != len(yyv1653) {
-			yyv1653 = yyv1653[:yyl1653]
-			yyc1653 = true
+		} else if yyl1609 != len(yyv1609) {
+			yyv1609 = yyv1609[:yyl1609]
+			yyc1609 = true
 		}
-		yyj1653 := 0
-		for ; yyj1653 < yyrr1653; yyj1653++ {
-			yyh1653.ElemContainerState(yyj1653)
+		yyj1609 := 0
+		for ; yyj1609 < yyrr1609; yyj1609++ {
+			yyh1609.ElemContainerState(yyj1609)
 			if r.TryDecodeAsNil() {
-				yyv1653[yyj1653] = IngressRule{}
+				yyv1609[yyj1609] = IngressRule{}
 			} else {
-				yyv1654 := &yyv1653[yyj1653]
-				yyv1654.CodecDecodeSelf(d)
+				yyv1610 := &yyv1609[yyj1609]
+				yyv1610.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1653 {
-			for ; yyj1653 < yyl1653; yyj1653++ {
-				yyv1653 = append(yyv1653, IngressRule{})
-				yyh1653.ElemContainerState(yyj1653)
+		if yyrt1609 {
+			for ; yyj1609 < yyl1609; yyj1609++ {
+				yyv1609 = append(yyv1609, IngressRule{})
+				yyh1609.ElemContainerState(yyj1609)
 				if r.TryDecodeAsNil() {
-					yyv1653[yyj1653] = IngressRule{}
+					yyv1609[yyj1609] = IngressRule{}
 				} else {
-					yyv1655 := &yyv1653[yyj1653]
-					yyv1655.CodecDecodeSelf(d)
+					yyv1611 := &yyv1609[yyj1609]
+					yyv1611.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1653 := 0
-		for ; !r.CheckBreak(); yyj1653++ {
+		yyj1609 := 0
+		for ; !r.CheckBreak(); yyj1609++ {
 
-			if yyj1653 >= len(yyv1653) {
-				yyv1653 = append(yyv1653, IngressRule{}) // var yyz1653 IngressRule
-				yyc1653 = true
+			if yyj1609 >= len(yyv1609) {
+				yyv1609 = append(yyv1609, IngressRule{}) // var yyz1609 IngressRule
+				yyc1609 = true
 			}
-			yyh1653.ElemContainerState(yyj1653)
-			if yyj1653 < len(yyv1653) {
+			yyh1609.ElemContainerState(yyj1609)
+			if yyj1609 < len(yyv1609) {
 				if r.TryDecodeAsNil() {
-					yyv1653[yyj1653] = IngressRule{}
+					yyv1609[yyj1609] = IngressRule{}
 				} else {
-					yyv1656 := &yyv1653[yyj1653]
-					yyv1656.CodecDecodeSelf(d)
+					yyv1612 := &yyv1609[yyj1609]
+					yyv1612.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -20325,17 +19751,17 @@ func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Deco
 			}
 
 		}
-		if yyj1653 < len(yyv1653) {
-			yyv1653 = yyv1653[:yyj1653]
-			yyc1653 = true
-		} else if yyj1653 == 0 && yyv1653 == nil {
-			yyv1653 = []IngressRule{}
-			yyc1653 = true
+		if yyj1609 < len(yyv1609) {
+			yyv1609 = yyv1609[:yyj1609]
+			yyc1609 = true
+		} else if yyj1609 == 0 && yyv1609 == nil {
+			yyv1609 = []IngressRule{}
+			yyc1609 = true
 		}
 	}
-	yyh1653.End()
-	if yyc1653 {
-		*v = yyv1653
+	yyh1609.End()
+	if yyc1609 {
+		*v = yyv1609
 	}
 }
 
@@ -20344,10 +19770,10 @@ func (x codecSelfer1234) encSliceHTTPIngressPath(v []HTTPIngressPath, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1657 := range v {
+	for _, yyv1613 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1658 := &yyv1657
-		yy1658.CodecEncodeSelf(e)
+		yy1614 := &yyv1613
+		yy1614.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -20357,83 +19783,83 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1659 := *v
-	yyh1659, yyl1659 := z.DecSliceHelperStart()
-	var yyc1659 bool
-	if yyl1659 == 0 {
-		if yyv1659 == nil {
-			yyv1659 = []HTTPIngressPath{}
-			yyc1659 = true
-		} else if len(yyv1659) != 0 {
-			yyv1659 = yyv1659[:0]
-			yyc1659 = true
+	yyv1615 := *v
+	yyh1615, yyl1615 := z.DecSliceHelperStart()
+	var yyc1615 bool
+	if yyl1615 == 0 {
+		if yyv1615 == nil {
+			yyv1615 = []HTTPIngressPath{}
+			yyc1615 = true
+		} else if len(yyv1615) != 0 {
+			yyv1615 = yyv1615[:0]
+			yyc1615 = true
 		}
-	} else if yyl1659 > 0 {
-		var yyrr1659, yyrl1659 int
-		var yyrt1659 bool
-		if yyl1659 > cap(yyv1659) {
+	} else if yyl1615 > 0 {
+		var yyrr1615, yyrl1615 int
+		var yyrt1615 bool
+		if yyl1615 > cap(yyv1615) {
 
-			yyrg1659 := len(yyv1659) > 0
-			yyv21659 := yyv1659
-			yyrl1659, yyrt1659 = z.DecInferLen(yyl1659, z.DecBasicHandle().MaxInitLen, 64)
-			if yyrt1659 {
-				if yyrl1659 <= cap(yyv1659) {
-					yyv1659 = yyv1659[:yyrl1659]
+			yyrg1615 := len(yyv1615) > 0
+			yyv21615 := yyv1615
+			yyrl1615, yyrt1615 = z.DecInferLen(yyl1615, z.DecBasicHandle().MaxInitLen, 64)
+			if yyrt1615 {
+				if yyrl1615 <= cap(yyv1615) {
+					yyv1615 = yyv1615[:yyrl1615]
 				} else {
-					yyv1659 = make([]HTTPIngressPath, yyrl1659)
+					yyv1615 = make([]HTTPIngressPath, yyrl1615)
 				}
 			} else {
-				yyv1659 = make([]HTTPIngressPath, yyrl1659)
+				yyv1615 = make([]HTTPIngressPath, yyrl1615)
 			}
-			yyc1659 = true
-			yyrr1659 = len(yyv1659)
-			if yyrg1659 {
-				copy(yyv1659, yyv21659)
+			yyc1615 = true
+			yyrr1615 = len(yyv1615)
+			if yyrg1615 {
+				copy(yyv1615, yyv21615)
 			}
-		} else if yyl1659 != len(yyv1659) {
-			yyv1659 = yyv1659[:yyl1659]
-			yyc1659 = true
+		} else if yyl1615 != len(yyv1615) {
+			yyv1615 = yyv1615[:yyl1615]
+			yyc1615 = true
 		}
-		yyj1659 := 0
-		for ; yyj1659 < yyrr1659; yyj1659++ {
-			yyh1659.ElemContainerState(yyj1659)
+		yyj1615 := 0
+		for ; yyj1615 < yyrr1615; yyj1615++ {
+			yyh1615.ElemContainerState(yyj1615)
 			if r.TryDecodeAsNil() {
-				yyv1659[yyj1659] = HTTPIngressPath{}
+				yyv1615[yyj1615] = HTTPIngressPath{}
 			} else {
-				yyv1660 := &yyv1659[yyj1659]
-				yyv1660.CodecDecodeSelf(d)
+				yyv1616 := &yyv1615[yyj1615]
+				yyv1616.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1659 {
-			for ; yyj1659 < yyl1659; yyj1659++ {
-				yyv1659 = append(yyv1659, HTTPIngressPath{})
-				yyh1659.ElemContainerState(yyj1659)
+		if yyrt1615 {
+			for ; yyj1615 < yyl1615; yyj1615++ {
+				yyv1615 = append(yyv1615, HTTPIngressPath{})
+				yyh1615.ElemContainerState(yyj1615)
 				if r.TryDecodeAsNil() {
-					yyv1659[yyj1659] = HTTPIngressPath{}
+					yyv1615[yyj1615] = HTTPIngressPath{}
 				} else {
-					yyv1661 := &yyv1659[yyj1659]
-					yyv1661.CodecDecodeSelf(d)
+					yyv1617 := &yyv1615[yyj1615]
+					yyv1617.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1659 := 0
-		for ; !r.CheckBreak(); yyj1659++ {
+		yyj1615 := 0
+		for ; !r.CheckBreak(); yyj1615++ {
 
-			if yyj1659 >= len(yyv1659) {
-				yyv1659 = append(yyv1659, HTTPIngressPath{}) // var yyz1659 HTTPIngressPath
-				yyc1659 = true
+			if yyj1615 >= len(yyv1615) {
+				yyv1615 = append(yyv1615, HTTPIngressPath{}) // var yyz1615 HTTPIngressPath
+				yyc1615 = true
 			}
-			yyh1659.ElemContainerState(yyj1659)
-			if yyj1659 < len(yyv1659) {
+			yyh1615.ElemContainerState(yyj1615)
+			if yyj1615 < len(yyv1615) {
 				if r.TryDecodeAsNil() {
-					yyv1659[yyj1659] = HTTPIngressPath{}
+					yyv1615[yyj1615] = HTTPIngressPath{}
 				} else {
-					yyv1662 := &yyv1659[yyj1659]
-					yyv1662.CodecDecodeSelf(d)
+					yyv1618 := &yyv1615[yyj1615]
+					yyv1618.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -20441,17 +19867,17 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 			}
 
 		}
-		if yyj1659 < len(yyv1659) {
-			yyv1659 = yyv1659[:yyj1659]
-			yyc1659 = true
-		} else if yyj1659 == 0 && yyv1659 == nil {
-			yyv1659 = []HTTPIngressPath{}
-			yyc1659 = true
+		if yyj1615 < len(yyv1615) {
+			yyv1615 = yyv1615[:yyj1615]
+			yyc1615 = true
+		} else if yyj1615 == 0 && yyv1615 == nil {
+			yyv1615 = []HTTPIngressPath{}
+			yyc1615 = true
 		}
 	}
-	yyh1659.End()
-	if yyc1659 {
-		*v = yyv1659
+	yyh1615.End()
+	if yyc1615 {
+		*v = yyv1615
 	}
 }
 
@@ -20460,10 +19886,10 @@ func (x codecSelfer1234) encSliceNodeUtilization(v []NodeUtilization, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1663 := range v {
+	for _, yyv1619 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1664 := &yyv1663
-		yy1664.CodecEncodeSelf(e)
+		yy1620 := &yyv1619
+		yy1620.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -20473,83 +19899,83 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1665 := *v
-	yyh1665, yyl1665 := z.DecSliceHelperStart()
-	var yyc1665 bool
-	if yyl1665 == 0 {
-		if yyv1665 == nil {
-			yyv1665 = []NodeUtilization{}
-			yyc1665 = true
-		} else if len(yyv1665) != 0 {
-			yyv1665 = yyv1665[:0]
-			yyc1665 = true
+	yyv1621 := *v
+	yyh1621, yyl1621 := z.DecSliceHelperStart()
+	var yyc1621 bool
+	if yyl1621 == 0 {
+		if yyv1621 == nil {
+			yyv1621 = []NodeUtilization{}
+			yyc1621 = true
+		} else if len(yyv1621) != 0 {
+			yyv1621 = yyv1621[:0]
+			yyc1621 = true
 		}
-	} else if yyl1665 > 0 {
-		var yyrr1665, yyrl1665 int
-		var yyrt1665 bool
-		if yyl1665 > cap(yyv1665) {
+	} else if yyl1621 > 0 {
+		var yyrr1621, yyrl1621 int
+		var yyrt1621 bool
+		if yyl1621 > cap(yyv1621) {
 
-			yyrg1665 := len(yyv1665) > 0
-			yyv21665 := yyv1665
-			yyrl1665, yyrt1665 = z.DecInferLen(yyl1665, z.DecBasicHandle().MaxInitLen, 24)
-			if yyrt1665 {
-				if yyrl1665 <= cap(yyv1665) {
-					yyv1665 = yyv1665[:yyrl1665]
+			yyrg1621 := len(yyv1621) > 0
+			yyv21621 := yyv1621
+			yyrl1621, yyrt1621 = z.DecInferLen(yyl1621, z.DecBasicHandle().MaxInitLen, 24)
+			if yyrt1621 {
+				if yyrl1621 <= cap(yyv1621) {
+					yyv1621 = yyv1621[:yyrl1621]
 				} else {
-					yyv1665 = make([]NodeUtilization, yyrl1665)
+					yyv1621 = make([]NodeUtilization, yyrl1621)
 				}
 			} else {
-				yyv1665 = make([]NodeUtilization, yyrl1665)
+				yyv1621 = make([]NodeUtilization, yyrl1621)
 			}
-			yyc1665 = true
-			yyrr1665 = len(yyv1665)
-			if yyrg1665 {
-				copy(yyv1665, yyv21665)
+			yyc1621 = true
+			yyrr1621 = len(yyv1621)
+			if yyrg1621 {
+				copy(yyv1621, yyv21621)
 			}
-		} else if yyl1665 != len(yyv1665) {
-			yyv1665 = yyv1665[:yyl1665]
-			yyc1665 = true
+		} else if yyl1621 != len(yyv1621) {
+			yyv1621 = yyv1621[:yyl1621]
+			yyc1621 = true
 		}
-		yyj1665 := 0
-		for ; yyj1665 < yyrr1665; yyj1665++ {
-			yyh1665.ElemContainerState(yyj1665)
+		yyj1621 := 0
+		for ; yyj1621 < yyrr1621; yyj1621++ {
+			yyh1621.ElemContainerState(yyj1621)
 			if r.TryDecodeAsNil() {
-				yyv1665[yyj1665] = NodeUtilization{}
+				yyv1621[yyj1621] = NodeUtilization{}
 			} else {
-				yyv1666 := &yyv1665[yyj1665]
-				yyv1666.CodecDecodeSelf(d)
+				yyv1622 := &yyv1621[yyj1621]
+				yyv1622.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1665 {
-			for ; yyj1665 < yyl1665; yyj1665++ {
-				yyv1665 = append(yyv1665, NodeUtilization{})
-				yyh1665.ElemContainerState(yyj1665)
+		if yyrt1621 {
+			for ; yyj1621 < yyl1621; yyj1621++ {
+				yyv1621 = append(yyv1621, NodeUtilization{})
+				yyh1621.ElemContainerState(yyj1621)
 				if r.TryDecodeAsNil() {
-					yyv1665[yyj1665] = NodeUtilization{}
+					yyv1621[yyj1621] = NodeUtilization{}
 				} else {
-					yyv1667 := &yyv1665[yyj1665]
-					yyv1667.CodecDecodeSelf(d)
+					yyv1623 := &yyv1621[yyj1621]
+					yyv1623.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1665 := 0
-		for ; !r.CheckBreak(); yyj1665++ {
+		yyj1621 := 0
+		for ; !r.CheckBreak(); yyj1621++ {
 
-			if yyj1665 >= len(yyv1665) {
-				yyv1665 = append(yyv1665, NodeUtilization{}) // var yyz1665 NodeUtilization
-				yyc1665 = true
+			if yyj1621 >= len(yyv1621) {
+				yyv1621 = append(yyv1621, NodeUtilization{}) // var yyz1621 NodeUtilization
+				yyc1621 = true
 			}
-			yyh1665.ElemContainerState(yyj1665)
-			if yyj1665 < len(yyv1665) {
+			yyh1621.ElemContainerState(yyj1621)
+			if yyj1621 < len(yyv1621) {
 				if r.TryDecodeAsNil() {
-					yyv1665[yyj1665] = NodeUtilization{}
+					yyv1621[yyj1621] = NodeUtilization{}
 				} else {
-					yyv1668 := &yyv1665[yyj1665]
-					yyv1668.CodecDecodeSelf(d)
+					yyv1624 := &yyv1621[yyj1621]
+					yyv1624.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -20557,17 +19983,17 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 			}
 
 		}
-		if yyj1665 < len(yyv1665) {
-			yyv1665 = yyv1665[:yyj1665]
-			yyc1665 = true
-		} else if yyj1665 == 0 && yyv1665 == nil {
-			yyv1665 = []NodeUtilization{}
-			yyc1665 = true
+		if yyj1621 < len(yyv1621) {
+			yyv1621 = yyv1621[:yyj1621]
+			yyc1621 = true
+		} else if yyj1621 == 0 && yyv1621 == nil {
+			yyv1621 = []NodeUtilization{}
+			yyc1621 = true
 		}
 	}
-	yyh1665.End()
-	if yyc1665 {
-		*v = yyv1665
+	yyh1621.End()
+	if yyc1621 {
+		*v = yyv1621
 	}
 }
 
@@ -20576,10 +20002,10 @@ func (x codecSelfer1234) encSliceClusterAutoscaler(v []ClusterAutoscaler, e *cod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1669 := range v {
+	for _, yyv1625 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1670 := &yyv1669
-		yy1670.CodecEncodeSelf(e)
+		yy1626 := &yyv1625
+		yy1626.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -20589,83 +20015,83 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1671 := *v
-	yyh1671, yyl1671 := z.DecSliceHelperStart()
-	var yyc1671 bool
-	if yyl1671 == 0 {
-		if yyv1671 == nil {
-			yyv1671 = []ClusterAutoscaler{}
-			yyc1671 = true
-		} else if len(yyv1671) != 0 {
-			yyv1671 = yyv1671[:0]
-			yyc1671 = true
+	yyv1627 := *v
+	yyh1627, yyl1627 := z.DecSliceHelperStart()
+	var yyc1627 bool
+	if yyl1627 == 0 {
+		if yyv1627 == nil {
+			yyv1627 = []ClusterAutoscaler{}
+			yyc1627 = true
+		} else if len(yyv1627) != 0 {
+			yyv1627 = yyv1627[:0]
+			yyc1627 = true
 		}
-	} else if yyl1671 > 0 {
-		var yyrr1671, yyrl1671 int
-		var yyrt1671 bool
-		if yyl1671 > cap(yyv1671) {
+	} else if yyl1627 > 0 {
+		var yyrr1627, yyrl1627 int
+		var yyrt1627 bool
+		if yyl1627 > cap(yyv1627) {
 
-			yyrg1671 := len(yyv1671) > 0
-			yyv21671 := yyv1671
-			yyrl1671, yyrt1671 = z.DecInferLen(yyl1671, z.DecBasicHandle().MaxInitLen, 232)
-			if yyrt1671 {
-				if yyrl1671 <= cap(yyv1671) {
-					yyv1671 = yyv1671[:yyrl1671]
+			yyrg1627 := len(yyv1627) > 0
+			yyv21627 := yyv1627
+			yyrl1627, yyrt1627 = z.DecInferLen(yyl1627, z.DecBasicHandle().MaxInitLen, 232)
+			if yyrt1627 {
+				if yyrl1627 <= cap(yyv1627) {
+					yyv1627 = yyv1627[:yyrl1627]
 				} else {
-					yyv1671 = make([]ClusterAutoscaler, yyrl1671)
+					yyv1627 = make([]ClusterAutoscaler, yyrl1627)
 				}
 			} else {
-				yyv1671 = make([]ClusterAutoscaler, yyrl1671)
+				yyv1627 = make([]ClusterAutoscaler, yyrl1627)
 			}
-			yyc1671 = true
-			yyrr1671 = len(yyv1671)
-			if yyrg1671 {
-				copy(yyv1671, yyv21671)
+			yyc1627 = true
+			yyrr1627 = len(yyv1627)
+			if yyrg1627 {
+				copy(yyv1627, yyv21627)
 			}
-		} else if yyl1671 != len(yyv1671) {
-			yyv1671 = yyv1671[:yyl1671]
-			yyc1671 = true
+		} else if yyl1627 != len(yyv1627) {
+			yyv1627 = yyv1627[:yyl1627]
+			yyc1627 = true
 		}
-		yyj1671 := 0
-		for ; yyj1671 < yyrr1671; yyj1671++ {
-			yyh1671.ElemContainerState(yyj1671)
+		yyj1627 := 0
+		for ; yyj1627 < yyrr1627; yyj1627++ {
+			yyh1627.ElemContainerState(yyj1627)
 			if r.TryDecodeAsNil() {
-				yyv1671[yyj1671] = ClusterAutoscaler{}
+				yyv1627[yyj1627] = ClusterAutoscaler{}
 			} else {
-				yyv1672 := &yyv1671[yyj1671]
-				yyv1672.CodecDecodeSelf(d)
+				yyv1628 := &yyv1627[yyj1627]
+				yyv1628.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1671 {
-			for ; yyj1671 < yyl1671; yyj1671++ {
-				yyv1671 = append(yyv1671, ClusterAutoscaler{})
-				yyh1671.ElemContainerState(yyj1671)
+		if yyrt1627 {
+			for ; yyj1627 < yyl1627; yyj1627++ {
+				yyv1627 = append(yyv1627, ClusterAutoscaler{})
+				yyh1627.ElemContainerState(yyj1627)
 				if r.TryDecodeAsNil() {
-					yyv1671[yyj1671] = ClusterAutoscaler{}
+					yyv1627[yyj1627] = ClusterAutoscaler{}
 				} else {
-					yyv1673 := &yyv1671[yyj1671]
-					yyv1673.CodecDecodeSelf(d)
+					yyv1629 := &yyv1627[yyj1627]
+					yyv1629.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1671 := 0
-		for ; !r.CheckBreak(); yyj1671++ {
+		yyj1627 := 0
+		for ; !r.CheckBreak(); yyj1627++ {
 
-			if yyj1671 >= len(yyv1671) {
-				yyv1671 = append(yyv1671, ClusterAutoscaler{}) // var yyz1671 ClusterAutoscaler
-				yyc1671 = true
+			if yyj1627 >= len(yyv1627) {
+				yyv1627 = append(yyv1627, ClusterAutoscaler{}) // var yyz1627 ClusterAutoscaler
+				yyc1627 = true
 			}
-			yyh1671.ElemContainerState(yyj1671)
-			if yyj1671 < len(yyv1671) {
+			yyh1627.ElemContainerState(yyj1627)
+			if yyj1627 < len(yyv1627) {
 				if r.TryDecodeAsNil() {
-					yyv1671[yyj1671] = ClusterAutoscaler{}
+					yyv1627[yyj1627] = ClusterAutoscaler{}
 				} else {
-					yyv1674 := &yyv1671[yyj1671]
-					yyv1674.CodecDecodeSelf(d)
+					yyv1630 := &yyv1627[yyj1627]
+					yyv1630.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -20673,17 +20099,17 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 			}
 
 		}
-		if yyj1671 < len(yyv1671) {
-			yyv1671 = yyv1671[:yyj1671]
-			yyc1671 = true
-		} else if yyj1671 == 0 && yyv1671 == nil {
-			yyv1671 = []ClusterAutoscaler{}
-			yyc1671 = true
+		if yyj1627 < len(yyv1627) {
+			yyv1627 = yyv1627[:yyj1627]
+			yyc1627 = true
+		} else if yyj1627 == 0 && yyv1627 == nil {
+			yyv1627 = []ClusterAutoscaler{}
+			yyc1627 = true
 		}
 	}
-	yyh1671.End()
-	if yyc1671 {
-		*v = yyv1671
+	yyh1627.End()
+	if yyc1627 {
+		*v = yyv1627
 	}
 }
 
@@ -20692,10 +20118,10 @@ func (x codecSelfer1234) encSliceReplicaSet(v []ReplicaSet, e *codec1978.Encoder
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1675 := range v {
+	for _, yyv1631 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1676 := &yyv1675
-		yy1676.CodecEncodeSelf(e)
+		yy1632 := &yyv1631
+		yy1632.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -20705,83 +20131,83 @@ func (x codecSelfer1234) decSliceReplicaSet(v *[]ReplicaSet, d *codec1978.Decode
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1677 := *v
-	yyh1677, yyl1677 := z.DecSliceHelperStart()
-	var yyc1677 bool
-	if yyl1677 == 0 {
-		if yyv1677 == nil {
-			yyv1677 = []ReplicaSet{}
-			yyc1677 = true
-		} else if len(yyv1677) != 0 {
-			yyv1677 = yyv1677[:0]
-			yyc1677 = true
+	yyv1633 := *v
+	yyh1633, yyl1633 := z.DecSliceHelperStart()
+	var yyc1633 bool
+	if yyl1633 == 0 {
+		if yyv1633 == nil {
+			yyv1633 = []ReplicaSet{}
+			yyc1633 = true
+		} else if len(yyv1633) != 0 {
+			yyv1633 = yyv1633[:0]
+			yyc1633 = true
 		}
-	} else if yyl1677 > 0 {
-		var yyrr1677, yyrl1677 int
-		var yyrt1677 bool
-		if yyl1677 > cap(yyv1677) {
+	} else if yyl1633 > 0 {
+		var yyrr1633, yyrl1633 int
+		var yyrt1633 bool
+		if yyl1633 > cap(yyv1633) {
 
-			yyrg1677 := len(yyv1677) > 0
-			yyv21677 := yyv1677
-			yyrl1677, yyrt1677 = z.DecInferLen(yyl1677, z.DecBasicHandle().MaxInitLen, 232)
-			if yyrt1677 {
-				if yyrl1677 <= cap(yyv1677) {
-					yyv1677 = yyv1677[:yyrl1677]
+			yyrg1633 := len(yyv1633) > 0
+			yyv21633 := yyv1633
+			yyrl1633, yyrt1633 = z.DecInferLen(yyl1633, z.DecBasicHandle().MaxInitLen, 232)
+			if yyrt1633 {
+				if yyrl1633 <= cap(yyv1633) {
+					yyv1633 = yyv1633[:yyrl1633]
 				} else {
-					yyv1677 = make([]ReplicaSet, yyrl1677)
+					yyv1633 = make([]ReplicaSet, yyrl1633)
 				}
 			} else {
-				yyv1677 = make([]ReplicaSet, yyrl1677)
+				yyv1633 = make([]ReplicaSet, yyrl1633)
 			}
-			yyc1677 = true
-			yyrr1677 = len(yyv1677)
-			if yyrg1677 {
-				copy(yyv1677, yyv21677)
+			yyc1633 = true
+			yyrr1633 = len(yyv1633)
+			if yyrg1633 {
+				copy(yyv1633, yyv21633)
 			}
-		} else if yyl1677 != len(yyv1677) {
-			yyv1677 = yyv1677[:yyl1677]
-			yyc1677 = true
+		} else if yyl1633 != len(yyv1633) {
+			yyv1633 = yyv1633[:yyl1633]
+			yyc1633 = true
 		}
-		yyj1677 := 0
-		for ; yyj1677 < yyrr1677; yyj1677++ {
-			yyh1677.ElemContainerState(yyj1677)
+		yyj1633 := 0
+		for ; yyj1633 < yyrr1633; yyj1633++ {
+			yyh1633.ElemContainerState(yyj1633)
 			if r.TryDecodeAsNil() {
-				yyv1677[yyj1677] = ReplicaSet{}
+				yyv1633[yyj1633] = ReplicaSet{}
 			} else {
-				yyv1678 := &yyv1677[yyj1677]
-				yyv1678.CodecDecodeSelf(d)
+				yyv1634 := &yyv1633[yyj1633]
+				yyv1634.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1677 {
-			for ; yyj1677 < yyl1677; yyj1677++ {
-				yyv1677 = append(yyv1677, ReplicaSet{})
-				yyh1677.ElemContainerState(yyj1677)
+		if yyrt1633 {
+			for ; yyj1633 < yyl1633; yyj1633++ {
+				yyv1633 = append(yyv1633, ReplicaSet{})
+				yyh1633.ElemContainerState(yyj1633)
 				if r.TryDecodeAsNil() {
-					yyv1677[yyj1677] = ReplicaSet{}
+					yyv1633[yyj1633] = ReplicaSet{}
 				} else {
-					yyv1679 := &yyv1677[yyj1677]
-					yyv1679.CodecDecodeSelf(d)
+					yyv1635 := &yyv1633[yyj1633]
+					yyv1635.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1677 := 0
-		for ; !r.CheckBreak(); yyj1677++ {
+		yyj1633 := 0
+		for ; !r.CheckBreak(); yyj1633++ {
 
-			if yyj1677 >= len(yyv1677) {
-				yyv1677 = append(yyv1677, ReplicaSet{}) // var yyz1677 ReplicaSet
-				yyc1677 = true
+			if yyj1633 >= len(yyv1633) {
+				yyv1633 = append(yyv1633, ReplicaSet{}) // var yyz1633 ReplicaSet
+				yyc1633 = true
 			}
-			yyh1677.ElemContainerState(yyj1677)
-			if yyj1677 < len(yyv1677) {
+			yyh1633.ElemContainerState(yyj1633)
+			if yyj1633 < len(yyv1633) {
 				if r.TryDecodeAsNil() {
-					yyv1677[yyj1677] = ReplicaSet{}
+					yyv1633[yyj1633] = ReplicaSet{}
 				} else {
-					yyv1680 := &yyv1677[yyj1677]
-					yyv1680.CodecDecodeSelf(d)
+					yyv1636 := &yyv1633[yyj1633]
+					yyv1636.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -20789,17 +20215,17 @@ func (x codecSelfer1234) decSliceReplicaSet(v *[]ReplicaSet, d *codec1978.Decode
 			}
 
 		}
-		if yyj1677 < len(yyv1677) {
-			yyv1677 = yyv1677[:yyj1677]
-			yyc1677 = true
-		} else if yyj1677 == 0 && yyv1677 == nil {
-			yyv1677 = []ReplicaSet{}
-			yyc1677 = true
+		if yyj1633 < len(yyv1633) {
+			yyv1633 = yyv1633[:yyj1633]
+			yyc1633 = true
+		} else if yyj1633 == 0 && yyv1633 == nil {
+			yyv1633 = []ReplicaSet{}
+			yyc1633 = true
 		}
 	}
-	yyh1677.End()
-	if yyc1677 {
-		*v = yyv1677
+	yyh1633.End()
+	if yyc1633 {
+		*v = yyv1633
 	}
 }
 
@@ -20808,14 +20234,14 @@ func (x codecSelfer1234) encSliceapi_Capability(v []pkg2_api.Capability, e *code
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1681 := range v {
+	for _, yyv1637 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yym1682 := z.EncBinary()
-		_ = yym1682
+		yym1638 := z.EncBinary()
+		_ = yym1638
 		if false {
-		} else if z.HasExtensions() && z.EncExt(yyv1681) {
+		} else if z.HasExtensions() && z.EncExt(yyv1637) {
 		} else {
-			r.EncodeString(codecSelferC_UTF81234, string(yyv1681))
+			r.EncodeString(codecSelferC_UTF81234, string(yyv1637))
 		}
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
@@ -20826,75 +20252,75 @@ func (x codecSelfer1234) decSliceapi_Capability(v *[]pkg2_api.Capability, d *cod
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1683 := *v
-	yyh1683, yyl1683 := z.DecSliceHelperStart()
-	var yyc1683 bool
-	if yyl1683 == 0 {
-		if yyv1683 == nil {
-			yyv1683 = []pkg2_api.Capability{}
-			yyc1683 = true
-		} else if len(yyv1683) != 0 {
-			yyv1683 = yyv1683[:0]
-			yyc1683 = true
+	yyv1639 := *v
+	yyh1639, yyl1639 := z.DecSliceHelperStart()
+	var yyc1639 bool
+	if yyl1639 == 0 {
+		if yyv1639 == nil {
+			yyv1639 = []pkg2_api.Capability{}
+			yyc1639 = true
+		} else if len(yyv1639) != 0 {
+			yyv1639 = yyv1639[:0]
+			yyc1639 = true
 		}
-	} else if yyl1683 > 0 {
-		var yyrr1683, yyrl1683 int
-		var yyrt1683 bool
-		if yyl1683 > cap(yyv1683) {
+	} else if yyl1639 > 0 {
+		var yyrr1639, yyrl1639 int
+		var yyrt1639 bool
+		if yyl1639 > cap(yyv1639) {
 
-			yyrl1683, yyrt1683 = z.DecInferLen(yyl1683, z.DecBasicHandle().MaxInitLen, 16)
-			if yyrt1683 {
-				if yyrl1683 <= cap(yyv1683) {
-					yyv1683 = yyv1683[:yyrl1683]
+			yyrl1639, yyrt1639 = z.DecInferLen(yyl1639, z.DecBasicHandle().MaxInitLen, 16)
+			if yyrt1639 {
+				if yyrl1639 <= cap(yyv1639) {
+					yyv1639 = yyv1639[:yyrl1639]
 				} else {
-					yyv1683 = make([]pkg2_api.Capability, yyrl1683)
+					yyv1639 = make([]pkg2_api.Capability, yyrl1639)
 				}
 			} else {
-				yyv1683 = make([]pkg2_api.Capability, yyrl1683)
+				yyv1639 = make([]pkg2_api.Capability, yyrl1639)
 			}
-			yyc1683 = true
-			yyrr1683 = len(yyv1683)
-		} else if yyl1683 != len(yyv1683) {
-			yyv1683 = yyv1683[:yyl1683]
-			yyc1683 = true
+			yyc1639 = true
+			yyrr1639 = len(yyv1639)
+		} else if yyl1639 != len(yyv1639) {
+			yyv1639 = yyv1639[:yyl1639]
+			yyc1639 = true
 		}
-		yyj1683 := 0
-		for ; yyj1683 < yyrr1683; yyj1683++ {
-			yyh1683.ElemContainerState(yyj1683)
+		yyj1639 := 0
+		for ; yyj1639 < yyrr1639; yyj1639++ {
+			yyh1639.ElemContainerState(yyj1639)
 			if r.TryDecodeAsNil() {
-				yyv1683[yyj1683] = ""
+				yyv1639[yyj1639] = ""
 			} else {
-				yyv1683[yyj1683] = pkg2_api.Capability(r.DecodeString())
+				yyv1639[yyj1639] = pkg2_api.Capability(r.DecodeString())
 			}
 
 		}
-		if yyrt1683 {
-			for ; yyj1683 < yyl1683; yyj1683++ {
-				yyv1683 = append(yyv1683, "")
-				yyh1683.ElemContainerState(yyj1683)
+		if yyrt1639 {
+			for ; yyj1639 < yyl1639; yyj1639++ {
+				yyv1639 = append(yyv1639, "")
+				yyh1639.ElemContainerState(yyj1639)
 				if r.TryDecodeAsNil() {
-					yyv1683[yyj1683] = ""
+					yyv1639[yyj1639] = ""
 				} else {
-					yyv1683[yyj1683] = pkg2_api.Capability(r.DecodeString())
+					yyv1639[yyj1639] = pkg2_api.Capability(r.DecodeString())
 				}
 
 			}
 		}
 
 	} else {
-		yyj1683 := 0
-		for ; !r.CheckBreak(); yyj1683++ {
+		yyj1639 := 0
+		for ; !r.CheckBreak(); yyj1639++ {
 
-			if yyj1683 >= len(yyv1683) {
-				yyv1683 = append(yyv1683, "") // var yyz1683 pkg2_api.Capability
-				yyc1683 = true
+			if yyj1639 >= len(yyv1639) {
+				yyv1639 = append(yyv1639, "") // var yyz1639 pkg2_api.Capability
+				yyc1639 = true
 			}
-			yyh1683.ElemContainerState(yyj1683)
-			if yyj1683 < len(yyv1683) {
+			yyh1639.ElemContainerState(yyj1639)
+			if yyj1639 < len(yyv1639) {
 				if r.TryDecodeAsNil() {
-					yyv1683[yyj1683] = ""
+					yyv1639[yyj1639] = ""
 				} else {
-					yyv1683[yyj1683] = pkg2_api.Capability(r.DecodeString())
+					yyv1639[yyj1639] = pkg2_api.Capability(r.DecodeString())
 				}
 
 			} else {
@@ -20902,17 +20328,17 @@ func (x codecSelfer1234) decSliceapi_Capability(v *[]pkg2_api.Capability, d *cod
 			}
 
 		}
-		if yyj1683 < len(yyv1683) {
-			yyv1683 = yyv1683[:yyj1683]
-			yyc1683 = true
-		} else if yyj1683 == 0 && yyv1683 == nil {
-			yyv1683 = []pkg2_api.Capability{}
-			yyc1683 = true
+		if yyj1639 < len(yyv1639) {
+			yyv1639 = yyv1639[:yyj1639]
+			yyc1639 = true
+		} else if yyj1639 == 0 && yyv1639 == nil {
+			yyv1639 = []pkg2_api.Capability{}
+			yyc1639 = true
 		}
 	}
-	yyh1683.End()
-	if yyc1683 {
-		*v = yyv1683
+	yyh1639.End()
+	if yyc1639 {
+		*v = yyv1639
 	}
 }
 
@@ -20921,9 +20347,9 @@ func (x codecSelfer1234) encSliceFSType(v []FSType, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1687 := range v {
+	for _, yyv1643 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yyv1687.CodecEncodeSelf(e)
+		yyv1643.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -20933,75 +20359,75 @@ func (x codecSelfer1234) decSliceFSType(v *[]FSType, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1688 := *v
-	yyh1688, yyl1688 := z.DecSliceHelperStart()
-	var yyc1688 bool
-	if yyl1688 == 0 {
-		if yyv1688 == nil {
-			yyv1688 = []FSType{}
-			yyc1688 = true
-		} else if len(yyv1688) != 0 {
-			yyv1688 = yyv1688[:0]
-			yyc1688 = true
+	yyv1644 := *v
+	yyh1644, yyl1644 := z.DecSliceHelperStart()
+	var yyc1644 bool
+	if yyl1644 == 0 {
+		if yyv1644 == nil {
+			yyv1644 = []FSType{}
+			yyc1644 = true
+		} else if len(yyv1644) != 0 {
+			yyv1644 = yyv1644[:0]
+			yyc1644 = true
 		}
-	} else if yyl1688 > 0 {
-		var yyrr1688, yyrl1688 int
-		var yyrt1688 bool
-		if yyl1688 > cap(yyv1688) {
+	} else if yyl1644 > 0 {
+		var yyrr1644, yyrl1644 int
+		var yyrt1644 bool
+		if yyl1644 > cap(yyv1644) {
 
-			yyrl1688, yyrt1688 = z.DecInferLen(yyl1688, z.DecBasicHandle().MaxInitLen, 16)
-			if yyrt1688 {
-				if yyrl1688 <= cap(yyv1688) {
-					yyv1688 = yyv1688[:yyrl1688]
+			yyrl1644, yyrt1644 = z.DecInferLen(yyl1644, z.DecBasicHandle().MaxInitLen, 16)
+			if yyrt1644 {
+				if yyrl1644 <= cap(yyv1644) {
+					yyv1644 = yyv1644[:yyrl1644]
 				} else {
-					yyv1688 = make([]FSType, yyrl1688)
+					yyv1644 = make([]FSType, yyrl1644)
 				}
 			} else {
-				yyv1688 = make([]FSType, yyrl1688)
+				yyv1644 = make([]FSType, yyrl1644)
 			}
-			yyc1688 = true
-			yyrr1688 = len(yyv1688)
-		} else if yyl1688 != len(yyv1688) {
-			yyv1688 = yyv1688[:yyl1688]
-			yyc1688 = true
+			yyc1644 = true
+			yyrr1644 = len(yyv1644)
+		} else if yyl1644 != len(yyv1644) {
+			yyv1644 = yyv1644[:yyl1644]
+			yyc1644 = true
 		}
-		yyj1688 := 0
-		for ; yyj1688 < yyrr1688; yyj1688++ {
-			yyh1688.ElemContainerState(yyj1688)
+		yyj1644 := 0
+		for ; yyj1644 < yyrr1644; yyj1644++ {
+			yyh1644.ElemContainerState(yyj1644)
 			if r.TryDecodeAsNil() {
-				yyv1688[yyj1688] = ""
+				yyv1644[yyj1644] = ""
 			} else {
-				yyv1688[yyj1688] = FSType(r.DecodeString())
+				yyv1644[yyj1644] = FSType(r.DecodeString())
 			}
 
 		}
-		if yyrt1688 {
-			for ; yyj1688 < yyl1688; yyj1688++ {
-				yyv1688 = append(yyv1688, "")
-				yyh1688.ElemContainerState(yyj1688)
+		if yyrt1644 {
+			for ; yyj1644 < yyl1644; yyj1644++ {
+				yyv1644 = append(yyv1644, "")
+				yyh1644.ElemContainerState(yyj1644)
 				if r.TryDecodeAsNil() {
-					yyv1688[yyj1688] = ""
+					yyv1644[yyj1644] = ""
 				} else {
-					yyv1688[yyj1688] = FSType(r.DecodeString())
+					yyv1644[yyj1644] = FSType(r.DecodeString())
 				}
 
 			}
 		}
 
 	} else {
-		yyj1688 := 0
-		for ; !r.CheckBreak(); yyj1688++ {
+		yyj1644 := 0
+		for ; !r.CheckBreak(); yyj1644++ {
 
-			if yyj1688 >= len(yyv1688) {
-				yyv1688 = append(yyv1688, "") // var yyz1688 FSType
-				yyc1688 = true
+			if yyj1644 >= len(yyv1644) {
+				yyv1644 = append(yyv1644, "") // var yyz1644 FSType
+				yyc1644 = true
 			}
-			yyh1688.ElemContainerState(yyj1688)
-			if yyj1688 < len(yyv1688) {
+			yyh1644.ElemContainerState(yyj1644)
+			if yyj1644 < len(yyv1644) {
 				if r.TryDecodeAsNil() {
-					yyv1688[yyj1688] = ""
+					yyv1644[yyj1644] = ""
 				} else {
-					yyv1688[yyj1688] = FSType(r.DecodeString())
+					yyv1644[yyj1644] = FSType(r.DecodeString())
 				}
 
 			} else {
@@ -21009,17 +20435,17 @@ func (x codecSelfer1234) decSliceFSType(v *[]FSType, d *codec1978.Decoder) {
 			}
 
 		}
-		if yyj1688 < len(yyv1688) {
-			yyv1688 = yyv1688[:yyj1688]
-			yyc1688 = true
-		} else if yyj1688 == 0 && yyv1688 == nil {
-			yyv1688 = []FSType{}
-			yyc1688 = true
+		if yyj1644 < len(yyv1644) {
+			yyv1644 = yyv1644[:yyj1644]
+			yyc1644 = true
+		} else if yyj1644 == 0 && yyv1644 == nil {
+			yyv1644 = []FSType{}
+			yyc1644 = true
 		}
 	}
-	yyh1688.End()
-	if yyc1688 {
-		*v = yyv1688
+	yyh1644.End()
+	if yyc1644 {
+		*v = yyv1644
 	}
 }
 
@@ -21028,10 +20454,10 @@ func (x codecSelfer1234) encSliceHostPortRange(v []HostPortRange, e *codec1978.E
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1692 := range v {
+	for _, yyv1648 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1693 := &yyv1692
-		yy1693.CodecEncodeSelf(e)
+		yy1649 := &yyv1648
+		yy1649.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -21041,83 +20467,83 @@ func (x codecSelfer1234) decSliceHostPortRange(v *[]HostPortRange, d *codec1978.
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1694 := *v
-	yyh1694, yyl1694 := z.DecSliceHelperStart()
-	var yyc1694 bool
-	if yyl1694 == 0 {
-		if yyv1694 == nil {
-			yyv1694 = []HostPortRange{}
-			yyc1694 = true
-		} else if len(yyv1694) != 0 {
-			yyv1694 = yyv1694[:0]
-			yyc1694 = true
+	yyv1650 := *v
+	yyh1650, yyl1650 := z.DecSliceHelperStart()
+	var yyc1650 bool
+	if yyl1650 == 0 {
+		if yyv1650 == nil {
+			yyv1650 = []HostPortRange{}
+			yyc1650 = true
+		} else if len(yyv1650) != 0 {
+			yyv1650 = yyv1650[:0]
+			yyc1650 = true
 		}
-	} else if yyl1694 > 0 {
-		var yyrr1694, yyrl1694 int
-		var yyrt1694 bool
-		if yyl1694 > cap(yyv1694) {
+	} else if yyl1650 > 0 {
+		var yyrr1650, yyrl1650 int
+		var yyrt1650 bool
+		if yyl1650 > cap(yyv1650) {
 
-			yyrg1694 := len(yyv1694) > 0
-			yyv21694 := yyv1694
-			yyrl1694, yyrt1694 = z.DecInferLen(yyl1694, z.DecBasicHandle().MaxInitLen, 16)
-			if yyrt1694 {
-				if yyrl1694 <= cap(yyv1694) {
-					yyv1694 = yyv1694[:yyrl1694]
+			yyrg1650 := len(yyv1650) > 0
+			yyv21650 := yyv1650
+			yyrl1650, yyrt1650 = z.DecInferLen(yyl1650, z.DecBasicHandle().MaxInitLen, 16)
+			if yyrt1650 {
+				if yyrl1650 <= cap(yyv1650) {
+					yyv1650 = yyv1650[:yyrl1650]
 				} else {
-					yyv1694 = make([]HostPortRange, yyrl1694)
+					yyv1650 = make([]HostPortRange, yyrl1650)
 				}
 			} else {
-				yyv1694 = make([]HostPortRange, yyrl1694)
+				yyv1650 = make([]HostPortRange, yyrl1650)
 			}
-			yyc1694 = true
-			yyrr1694 = len(yyv1694)
-			if yyrg1694 {
-				copy(yyv1694, yyv21694)
+			yyc1650 = true
+			yyrr1650 = len(yyv1650)
+			if yyrg1650 {
+				copy(yyv1650, yyv21650)
 			}
-		} else if yyl1694 != len(yyv1694) {
-			yyv1694 = yyv1694[:yyl1694]
-			yyc1694 = true
+		} else if yyl1650 != len(yyv1650) {
+			yyv1650 = yyv1650[:yyl1650]
+			yyc1650 = true
 		}
-		yyj1694 := 0
-		for ; yyj1694 < yyrr1694; yyj1694++ {
-			yyh1694.ElemContainerState(yyj1694)
+		yyj1650 := 0
+		for ; yyj1650 < yyrr1650; yyj1650++ {
+			yyh1650.ElemContainerState(yyj1650)
 			if r.TryDecodeAsNil() {
-				yyv1694[yyj1694] = HostPortRange{}
+				yyv1650[yyj1650] = HostPortRange{}
 			} else {
-				yyv1695 := &yyv1694[yyj1694]
-				yyv1695.CodecDecodeSelf(d)
+				yyv1651 := &yyv1650[yyj1650]
+				yyv1651.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1694 {
-			for ; yyj1694 < yyl1694; yyj1694++ {
-				yyv1694 = append(yyv1694, HostPortRange{})
-				yyh1694.ElemContainerState(yyj1694)
+		if yyrt1650 {
+			for ; yyj1650 < yyl1650; yyj1650++ {
+				yyv1650 = append(yyv1650, HostPortRange{})
+				yyh1650.ElemContainerState(yyj1650)
 				if r.TryDecodeAsNil() {
-					yyv1694[yyj1694] = HostPortRange{}
+					yyv1650[yyj1650] = HostPortRange{}
 				} else {
-					yyv1696 := &yyv1694[yyj1694]
-					yyv1696.CodecDecodeSelf(d)
+					yyv1652 := &yyv1650[yyj1650]
+					yyv1652.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1694 := 0
-		for ; !r.CheckBreak(); yyj1694++ {
+		yyj1650 := 0
+		for ; !r.CheckBreak(); yyj1650++ {
 
-			if yyj1694 >= len(yyv1694) {
-				yyv1694 = append(yyv1694, HostPortRange{}) // var yyz1694 HostPortRange
-				yyc1694 = true
+			if yyj1650 >= len(yyv1650) {
+				yyv1650 = append(yyv1650, HostPortRange{}) // var yyz1650 HostPortRange
+				yyc1650 = true
 			}
-			yyh1694.ElemContainerState(yyj1694)
-			if yyj1694 < len(yyv1694) {
+			yyh1650.ElemContainerState(yyj1650)
+			if yyj1650 < len(yyv1650) {
 				if r.TryDecodeAsNil() {
-					yyv1694[yyj1694] = HostPortRange{}
+					yyv1650[yyj1650] = HostPortRange{}
 				} else {
-					yyv1697 := &yyv1694[yyj1694]
-					yyv1697.CodecDecodeSelf(d)
+					yyv1653 := &yyv1650[yyj1650]
+					yyv1653.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -21125,17 +20551,17 @@ func (x codecSelfer1234) decSliceHostPortRange(v *[]HostPortRange, d *codec1978.
 			}
 
 		}
-		if yyj1694 < len(yyv1694) {
-			yyv1694 = yyv1694[:yyj1694]
-			yyc1694 = true
-		} else if yyj1694 == 0 && yyv1694 == nil {
-			yyv1694 = []HostPortRange{}
-			yyc1694 = true
+		if yyj1650 < len(yyv1650) {
+			yyv1650 = yyv1650[:yyj1650]
+			yyc1650 = true
+		} else if yyj1650 == 0 && yyv1650 == nil {
+			yyv1650 = []HostPortRange{}
+			yyc1650 = true
 		}
 	}
-	yyh1694.End()
-	if yyc1694 {
-		*v = yyv1694
+	yyh1650.End()
+	if yyc1650 {
+		*v = yyv1650
 	}
 }
 
@@ -21144,10 +20570,10 @@ func (x codecSelfer1234) encSliceIDRange(v []IDRange, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1698 := range v {
+	for _, yyv1654 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1699 := &yyv1698
-		yy1699.CodecEncodeSelf(e)
+		yy1655 := &yyv1654
+		yy1655.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -21157,83 +20583,83 @@ func (x codecSelfer1234) decSliceIDRange(v *[]IDRange, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1700 := *v
-	yyh1700, yyl1700 := z.DecSliceHelperStart()
-	var yyc1700 bool
-	if yyl1700 == 0 {
-		if yyv1700 == nil {
-			yyv1700 = []IDRange{}
-			yyc1700 = true
-		} else if len(yyv1700) != 0 {
-			yyv1700 = yyv1700[:0]
-			yyc1700 = true
+	yyv1656 := *v
+	yyh1656, yyl1656 := z.DecSliceHelperStart()
+	var yyc1656 bool
+	if yyl1656 == 0 {
+		if yyv1656 == nil {
+			yyv1656 = []IDRange{}
+			yyc1656 = true
+		} else if len(yyv1656) != 0 {
+			yyv1656 = yyv1656[:0]
+			yyc1656 = true
 		}
-	} else if yyl1700 > 0 {
-		var yyrr1700, yyrl1700 int
-		var yyrt1700 bool
-		if yyl1700 > cap(yyv1700) {
+	} else if yyl1656 > 0 {
+		var yyrr1656, yyrl1656 int
+		var yyrt1656 bool
+		if yyl1656 > cap(yyv1656) {
 
-			yyrg1700 := len(yyv1700) > 0
-			yyv21700 := yyv1700
-			yyrl1700, yyrt1700 = z.DecInferLen(yyl1700, z.DecBasicHandle().MaxInitLen, 16)
-			if yyrt1700 {
-				if yyrl1700 <= cap(yyv1700) {
-					yyv1700 = yyv1700[:yyrl1700]
+			yyrg1656 := len(yyv1656) > 0
+			yyv21656 := yyv1656
+			yyrl1656, yyrt1656 = z.DecInferLen(yyl1656, z.DecBasicHandle().MaxInitLen, 16)
+			if yyrt1656 {
+				if yyrl1656 <= cap(yyv1656) {
+					yyv1656 = yyv1656[:yyrl1656]
 				} else {
-					yyv1700 = make([]IDRange, yyrl1700)
+					yyv1656 = make([]IDRange, yyrl1656)
 				}
 			} else {
-				yyv1700 = make([]IDRange, yyrl1700)
+				yyv1656 = make([]IDRange, yyrl1656)
 			}
-			yyc1700 = true
-			yyrr1700 = len(yyv1700)
-			if yyrg1700 {
-				copy(yyv1700, yyv21700)
+			yyc1656 = true
+			yyrr1656 = len(yyv1656)
+			if yyrg1656 {
+				copy(yyv1656, yyv21656)
 			}
-		} else if yyl1700 != len(yyv1700) {
-			yyv1700 = yyv1700[:yyl1700]
-			yyc1700 = true
+		} else if yyl1656 != len(yyv1656) {
+			yyv1656 = yyv1656[:yyl1656]
+			yyc1656 = true
 		}
-		yyj1700 := 0
-		for ; yyj1700 < yyrr1700; yyj1700++ {
-			yyh1700.ElemContainerState(yyj1700)
+		yyj1656 := 0
+		for ; yyj1656 < yyrr1656; yyj1656++ {
+			yyh1656.ElemContainerState(yyj1656)
 			if r.TryDecodeAsNil() {
-				yyv1700[yyj1700] = IDRange{}
+				yyv1656[yyj1656] = IDRange{}
 			} else {
-				yyv1701 := &yyv1700[yyj1700]
-				yyv1701.CodecDecodeSelf(d)
+				yyv1657 := &yyv1656[yyj1656]
+				yyv1657.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1700 {
-			for ; yyj1700 < yyl1700; yyj1700++ {
-				yyv1700 = append(yyv1700, IDRange{})
-				yyh1700.ElemContainerState(yyj1700)
+		if yyrt1656 {
+			for ; yyj1656 < yyl1656; yyj1656++ {
+				yyv1656 = append(yyv1656, IDRange{})
+				yyh1656.ElemContainerState(yyj1656)
 				if r.TryDecodeAsNil() {
-					yyv1700[yyj1700] = IDRange{}
+					yyv1656[yyj1656] = IDRange{}
 				} else {
-					yyv1702 := &yyv1700[yyj1700]
-					yyv1702.CodecDecodeSelf(d)
+					yyv1658 := &yyv1656[yyj1656]
+					yyv1658.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1700 := 0
-		for ; !r.CheckBreak(); yyj1700++ {
+		yyj1656 := 0
+		for ; !r.CheckBreak(); yyj1656++ {
 
-			if yyj1700 >= len(yyv1700) {
-				yyv1700 = append(yyv1700, IDRange{}) // var yyz1700 IDRange
-				yyc1700 = true
+			if yyj1656 >= len(yyv1656) {
+				yyv1656 = append(yyv1656, IDRange{}) // var yyz1656 IDRange
+				yyc1656 = true
 			}
-			yyh1700.ElemContainerState(yyj1700)
-			if yyj1700 < len(yyv1700) {
+			yyh1656.ElemContainerState(yyj1656)
+			if yyj1656 < len(yyv1656) {
 				if r.TryDecodeAsNil() {
-					yyv1700[yyj1700] = IDRange{}
+					yyv1656[yyj1656] = IDRange{}
 				} else {
-					yyv1703 := &yyv1700[yyj1700]
-					yyv1703.CodecDecodeSelf(d)
+					yyv1659 := &yyv1656[yyj1656]
+					yyv1659.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -21241,17 +20667,17 @@ func (x codecSelfer1234) decSliceIDRange(v *[]IDRange, d *codec1978.Decoder) {
 			}
 
 		}
-		if yyj1700 < len(yyv1700) {
-			yyv1700 = yyv1700[:yyj1700]
-			yyc1700 = true
-		} else if yyj1700 == 0 && yyv1700 == nil {
-			yyv1700 = []IDRange{}
-			yyc1700 = true
+		if yyj1656 < len(yyv1656) {
+			yyv1656 = yyv1656[:yyj1656]
+			yyc1656 = true
+		} else if yyj1656 == 0 && yyv1656 == nil {
+			yyv1656 = []IDRange{}
+			yyc1656 = true
 		}
 	}
-	yyh1700.End()
-	if yyc1700 {
-		*v = yyv1700
+	yyh1656.End()
+	if yyc1656 {
+		*v = yyv1656
 	}
 }
 
@@ -21260,10 +20686,10 @@ func (x codecSelfer1234) encSlicePodSecurityPolicy(v []PodSecurityPolicy, e *cod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1704 := range v {
+	for _, yyv1660 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1705 := &yyv1704
-		yy1705.CodecEncodeSelf(e)
+		yy1661 := &yyv1660
+		yy1661.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -21273,83 +20699,83 @@ func (x codecSelfer1234) decSlicePodSecurityPolicy(v *[]PodSecurityPolicy, d *co
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1706 := *v
-	yyh1706, yyl1706 := z.DecSliceHelperStart()
-	var yyc1706 bool
-	if yyl1706 == 0 {
-		if yyv1706 == nil {
-			yyv1706 = []PodSecurityPolicy{}
-			yyc1706 = true
-		} else if len(yyv1706) != 0 {
-			yyv1706 = yyv1706[:0]
-			yyc1706 = true
+	yyv1662 := *v
+	yyh1662, yyl1662 := z.DecSliceHelperStart()
+	var yyc1662 bool
+	if yyl1662 == 0 {
+		if yyv1662 == nil {
+			yyv1662 = []PodSecurityPolicy{}
+			yyc1662 = true
+		} else if len(yyv1662) != 0 {
+			yyv1662 = yyv1662[:0]
+			yyc1662 = true
 		}
-	} else if yyl1706 > 0 {
-		var yyrr1706, yyrl1706 int
-		var yyrt1706 bool
-		if yyl1706 > cap(yyv1706) {
+	} else if yyl1662 > 0 {
+		var yyrr1662, yyrl1662 int
+		var yyrt1662 bool
+		if yyl1662 > cap(yyv1662) {
 
-			yyrg1706 := len(yyv1706) > 0
-			yyv21706 := yyv1706
-			yyrl1706, yyrt1706 = z.DecInferLen(yyl1706, z.DecBasicHandle().MaxInitLen, 352)
-			if yyrt1706 {
-				if yyrl1706 <= cap(yyv1706) {
-					yyv1706 = yyv1706[:yyrl1706]
+			yyrg1662 := len(yyv1662) > 0
+			yyv21662 := yyv1662
+			yyrl1662, yyrt1662 = z.DecInferLen(yyl1662, z.DecBasicHandle().MaxInitLen, 352)
+			if yyrt1662 {
+				if yyrl1662 <= cap(yyv1662) {
+					yyv1662 = yyv1662[:yyrl1662]
 				} else {
-					yyv1706 = make([]PodSecurityPolicy, yyrl1706)
+					yyv1662 = make([]PodSecurityPolicy, yyrl1662)
 				}
 			} else {
-				yyv1706 = make([]PodSecurityPolicy, yyrl1706)
+				yyv1662 = make([]PodSecurityPolicy, yyrl1662)
 			}
-			yyc1706 = true
-			yyrr1706 = len(yyv1706)
-			if yyrg1706 {
-				copy(yyv1706, yyv21706)
+			yyc1662 = true
+			yyrr1662 = len(yyv1662)
+			if yyrg1662 {
+				copy(yyv1662, yyv21662)
 			}
-		} else if yyl1706 != len(yyv1706) {
-			yyv1706 = yyv1706[:yyl1706]
-			yyc1706 = true
+		} else if yyl1662 != len(yyv1662) {
+			yyv1662 = yyv1662[:yyl1662]
+			yyc1662 = true
 		}
-		yyj1706 := 0
-		for ; yyj1706 < yyrr1706; yyj1706++ {
-			yyh1706.ElemContainerState(yyj1706)
+		yyj1662 := 0
+		for ; yyj1662 < yyrr1662; yyj1662++ {
+			yyh1662.ElemContainerState(yyj1662)
 			if r.TryDecodeAsNil() {
-				yyv1706[yyj1706] = PodSecurityPolicy{}
+				yyv1662[yyj1662] = PodSecurityPolicy{}
 			} else {
-				yyv1707 := &yyv1706[yyj1706]
-				yyv1707.CodecDecodeSelf(d)
+				yyv1663 := &yyv1662[yyj1662]
+				yyv1663.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1706 {
-			for ; yyj1706 < yyl1706; yyj1706++ {
-				yyv1706 = append(yyv1706, PodSecurityPolicy{})
-				yyh1706.ElemContainerState(yyj1706)
+		if yyrt1662 {
+			for ; yyj1662 < yyl1662; yyj1662++ {
+				yyv1662 = append(yyv1662, PodSecurityPolicy{})
+				yyh1662.ElemContainerState(yyj1662)
 				if r.TryDecodeAsNil() {
-					yyv1706[yyj1706] = PodSecurityPolicy{}
+					yyv1662[yyj1662] = PodSecurityPolicy{}
 				} else {
-					yyv1708 := &yyv1706[yyj1706]
-					yyv1708.CodecDecodeSelf(d)
+					yyv1664 := &yyv1662[yyj1662]
+					yyv1664.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1706 := 0
-		for ; !r.CheckBreak(); yyj1706++ {
+		yyj1662 := 0
+		for ; !r.CheckBreak(); yyj1662++ {
 
-			if yyj1706 >= len(yyv1706) {
-				yyv1706 = append(yyv1706, PodSecurityPolicy{}) // var yyz1706 PodSecurityPolicy
-				yyc1706 = true
+			if yyj1662 >= len(yyv1662) {
+				yyv1662 = append(yyv1662, PodSecurityPolicy{}) // var yyz1662 PodSecurityPolicy
+				yyc1662 = true
 			}
-			yyh1706.ElemContainerState(yyj1706)
-			if yyj1706 < len(yyv1706) {
+			yyh1662.ElemContainerState(yyj1662)
+			if yyj1662 < len(yyv1662) {
 				if r.TryDecodeAsNil() {
-					yyv1706[yyj1706] = PodSecurityPolicy{}
+					yyv1662[yyj1662] = PodSecurityPolicy{}
 				} else {
-					yyv1709 := &yyv1706[yyj1706]
-					yyv1709.CodecDecodeSelf(d)
+					yyv1665 := &yyv1662[yyj1662]
+					yyv1665.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -21357,16 +20783,16 @@ func (x codecSelfer1234) decSlicePodSecurityPolicy(v *[]PodSecurityPolicy, d *co
 			}
 
 		}
-		if yyj1706 < len(yyv1706) {
-			yyv1706 = yyv1706[:yyj1706]
-			yyc1706 = true
-		} else if yyj1706 == 0 && yyv1706 == nil {
-			yyv1706 = []PodSecurityPolicy{}
-			yyc1706 = true
+		if yyj1662 < len(yyv1662) {
+			yyv1662 = yyv1662[:yyj1662]
+			yyc1662 = true
+		} else if yyj1662 == 0 && yyv1662 == nil {
+			yyv1662 = []PodSecurityPolicy{}
+			yyc1662 = true
 		}
 	}
-	yyh1706.End()
-	if yyc1706 {
-		*v = yyv1706
+	yyh1662.End()
+	if yyc1662 {
+		*v = yyv1662
 	}
 }

--- a/pkg/apis/extensions/types.go
+++ b/pkg/apis/extensions/types.go
@@ -353,6 +353,8 @@ type DeploymentList struct {
 	Items []Deployment `json:"items"`
 }
 
+// TODO(madhusudancs): Uncomment while implementing DaemonSet updates.
+/* Commenting out for v1.2. We are planning to bring these types back with a more robust DaemonSet update implementation in v1.3, hence not deleting but just commenting the types out.
 type DaemonSetUpdateStrategy struct {
 	// Type of daemon set update. Only "RollingUpdate" is supported at this time. Default is RollingUpdate.
 	Type DaemonSetUpdateStrategyType `json:"type,omitempty"`
@@ -395,6 +397,7 @@ type RollingUpdateDaemonSet struct {
 	// is ready).
 	MinReadySeconds int `json:"minReadySeconds,omitempty"`
 }
+*/
 
 // DaemonSetSpec is the specification of a daemon set.
 type DaemonSetSpec struct {
@@ -411,6 +414,8 @@ type DaemonSetSpec struct {
 	// More info: http://releases.k8s.io/HEAD/docs/user-guide/replication-controller.md#pod-template
 	Template api.PodTemplateSpec `json:"template"`
 
+	// TODO(madhusudancs): Uncomment while implementing DaemonSet updates.
+	/* Commenting out for v1.2. We are planning to bring these fields back with a more robust DaemonSet update implementation in v1.3, hence not deleting but just commenting these fields out.
 	// Update strategy to replace existing DaemonSet pods with new pods.
 	UpdateStrategy DaemonSetUpdateStrategy `json:"updateStrategy,omitempty"`
 
@@ -422,6 +427,7 @@ type DaemonSetSpec struct {
 	// Value of this key is hash of DaemonSetSpec.PodTemplateSpec.
 	// No label is added if this is set to empty string.
 	UniqueLabelKey string `json:"uniqueLabelKey,omitempty"`
+	*/
 }
 
 const (

--- a/pkg/apis/extensions/v1beta1/conversion.go
+++ b/pkg/apis/extensions/v1beta1/conversion.go
@@ -40,12 +40,6 @@ func addConversionFuncs(scheme *runtime.Scheme) {
 		Convert_v1beta1_DeploymentStrategy_To_extensions_DeploymentStrategy,
 		Convert_extensions_RollingUpdateDeployment_To_v1beta1_RollingUpdateDeployment,
 		Convert_v1beta1_RollingUpdateDeployment_To_extensions_RollingUpdateDeployment,
-		Convert_extensions_DaemonSetSpec_To_v1beta1_DaemonSetSpec,
-		Convert_v1beta1_DaemonSetSpec_To_extensions_DaemonSetSpec,
-		Convert_extensions_DaemonSetUpdateStrategy_To_v1beta1_DaemonSetUpdateStrategy,
-		Convert_v1beta1_DaemonSetUpdateStrategy_To_extensions_DaemonSetUpdateStrategy,
-		Convert_extensions_RollingUpdateDaemonSet_To_v1beta1_RollingUpdateDaemonSet,
-		Convert_v1beta1_RollingUpdateDaemonSet_To_extensions_RollingUpdateDaemonSet,
 		Convert_extensions_ReplicaSetSpec_To_v1beta1_ReplicaSetSpec,
 		Convert_v1beta1_ReplicaSetSpec_To_extensions_ReplicaSetSpec,
 	)
@@ -230,112 +224,6 @@ func Convert_v1beta1_RollingUpdateDeployment_To_extensions_RollingUpdateDeployme
 	if err := s.Convert(in.MaxSurge, &out.MaxSurge, 0); err != nil {
 		return err
 	}
-	return nil
-}
-
-func Convert_extensions_DaemonSetSpec_To_v1beta1_DaemonSetSpec(in *extensions.DaemonSetSpec, out *DaemonSetSpec, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*extensions.DaemonSetSpec))(in)
-	}
-	// unable to generate simple pointer conversion for unversioned.LabelSelector -> v1beta1.LabelSelector
-	if in.Selector != nil {
-		out.Selector = new(LabelSelector)
-		if err := Convert_unversioned_LabelSelector_To_v1beta1_LabelSelector(in.Selector, out.Selector, s); err != nil {
-			return err
-		}
-	} else {
-		out.Selector = nil
-	}
-	if err := v1.Convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
-		return err
-	}
-	if err := Convert_extensions_DaemonSetUpdateStrategy_To_v1beta1_DaemonSetUpdateStrategy(&in.UpdateStrategy, &out.UpdateStrategy, s); err != nil {
-		return err
-	}
-	out.UniqueLabelKey = new(string)
-	*out.UniqueLabelKey = in.UniqueLabelKey
-	return nil
-}
-
-func Convert_v1beta1_DaemonSetSpec_To_extensions_DaemonSetSpec(in *DaemonSetSpec, out *extensions.DaemonSetSpec, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*DaemonSetSpec))(in)
-	}
-	// unable to generate simple pointer conversion for v1beta1.LabelSelector -> unversioned.LabelSelector
-	if in.Selector != nil {
-		out.Selector = new(unversioned.LabelSelector)
-		if err := Convert_v1beta1_LabelSelector_To_unversioned_LabelSelector(in.Selector, out.Selector, s); err != nil {
-			return err
-		}
-	} else {
-		out.Selector = nil
-	}
-	if err := v1.Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
-		return err
-	}
-	if err := Convert_v1beta1_DaemonSetUpdateStrategy_To_extensions_DaemonSetUpdateStrategy(&in.UpdateStrategy, &out.UpdateStrategy, s); err != nil {
-		return err
-	}
-	if in.UniqueLabelKey != nil {
-		out.UniqueLabelKey = *in.UniqueLabelKey
-	}
-	return nil
-}
-
-func Convert_extensions_DaemonSetUpdateStrategy_To_v1beta1_DaemonSetUpdateStrategy(in *extensions.DaemonSetUpdateStrategy, out *DaemonSetUpdateStrategy, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*extensions.DaemonSetUpdateStrategy))(in)
-	}
-	out.Type = DaemonSetUpdateStrategyType(in.Type)
-	if in.RollingUpdate != nil {
-		out.RollingUpdate = new(RollingUpdateDaemonSet)
-		if err := Convert_extensions_RollingUpdateDaemonSet_To_v1beta1_RollingUpdateDaemonSet(in.RollingUpdate, out.RollingUpdate, s); err != nil {
-			return err
-		}
-	} else {
-		out.RollingUpdate = nil
-	}
-	return nil
-}
-
-func Convert_v1beta1_DaemonSetUpdateStrategy_To_extensions_DaemonSetUpdateStrategy(in *DaemonSetUpdateStrategy, out *extensions.DaemonSetUpdateStrategy, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*DaemonSetUpdateStrategy))(in)
-	}
-	out.Type = extensions.DaemonSetUpdateStrategyType(in.Type)
-	if in.RollingUpdate != nil {
-		out.RollingUpdate = new(extensions.RollingUpdateDaemonSet)
-		if err := Convert_v1beta1_RollingUpdateDaemonSet_To_extensions_RollingUpdateDaemonSet(in.RollingUpdate, out.RollingUpdate, s); err != nil {
-			return err
-		}
-	} else {
-		out.RollingUpdate = nil
-	}
-	return nil
-}
-
-func Convert_extensions_RollingUpdateDaemonSet_To_v1beta1_RollingUpdateDaemonSet(in *extensions.RollingUpdateDaemonSet, out *RollingUpdateDaemonSet, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*extensions.RollingUpdateDaemonSet))(in)
-	}
-	if out.MaxUnavailable == nil {
-		out.MaxUnavailable = &intstr.IntOrString{}
-	}
-	if err := s.Convert(&in.MaxUnavailable, out.MaxUnavailable, 0); err != nil {
-		return err
-	}
-	out.MinReadySeconds = int32(in.MinReadySeconds)
-	return nil
-}
-
-func Convert_v1beta1_RollingUpdateDaemonSet_To_extensions_RollingUpdateDaemonSet(in *RollingUpdateDaemonSet, out *extensions.RollingUpdateDaemonSet, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*RollingUpdateDaemonSet))(in)
-	}
-	if err := s.Convert(in.MaxUnavailable, &out.MaxUnavailable, 0); err != nil {
-		return err
-	}
-	out.MinReadySeconds = int(in.MinReadySeconds)
 	return nil
 }
 

--- a/pkg/apis/extensions/v1beta1/conversion_generated.go
+++ b/pkg/apis/extensions/v1beta1/conversion_generated.go
@@ -2732,13 +2732,11 @@ func autoConvert_extensions_DaemonSetSpec_To_v1beta1_DaemonSetSpec(in *extension
 	if err := Convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
-	if err := Convert_extensions_DaemonSetUpdateStrategy_To_v1beta1_DaemonSetUpdateStrategy(&in.UpdateStrategy, &out.UpdateStrategy, s); err != nil {
-		return err
-	}
-	if err := api.Convert_string_To_string_ref(&in.UniqueLabelKey, &out.UniqueLabelKey, s); err != nil {
-		return err
-	}
 	return nil
+}
+
+func Convert_extensions_DaemonSetSpec_To_v1beta1_DaemonSetSpec(in *extensions.DaemonSetSpec, out *DaemonSetSpec, s conversion.Scope) error {
+	return autoConvert_extensions_DaemonSetSpec_To_v1beta1_DaemonSetSpec(in, out, s)
 }
 
 func autoConvert_extensions_DaemonSetStatus_To_v1beta1_DaemonSetStatus(in *extensions.DaemonSetStatus, out *DaemonSetStatus, s conversion.Scope) error {
@@ -2753,23 +2751,6 @@ func autoConvert_extensions_DaemonSetStatus_To_v1beta1_DaemonSetStatus(in *exten
 
 func Convert_extensions_DaemonSetStatus_To_v1beta1_DaemonSetStatus(in *extensions.DaemonSetStatus, out *DaemonSetStatus, s conversion.Scope) error {
 	return autoConvert_extensions_DaemonSetStatus_To_v1beta1_DaemonSetStatus(in, out, s)
-}
-
-func autoConvert_extensions_DaemonSetUpdateStrategy_To_v1beta1_DaemonSetUpdateStrategy(in *extensions.DaemonSetUpdateStrategy, out *DaemonSetUpdateStrategy, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*extensions.DaemonSetUpdateStrategy))(in)
-	}
-	out.Type = DaemonSetUpdateStrategyType(in.Type)
-	// unable to generate simple pointer conversion for extensions.RollingUpdateDaemonSet -> v1beta1.RollingUpdateDaemonSet
-	if in.RollingUpdate != nil {
-		out.RollingUpdate = new(RollingUpdateDaemonSet)
-		if err := Convert_extensions_RollingUpdateDaemonSet_To_v1beta1_RollingUpdateDaemonSet(in.RollingUpdate, out.RollingUpdate, s); err != nil {
-			return err
-		}
-	} else {
-		out.RollingUpdate = nil
-	}
-	return nil
 }
 
 func autoConvert_extensions_Deployment_To_v1beta1_Deployment(in *extensions.Deployment, out *Deployment, s conversion.Scope) error {
@@ -3650,17 +3631,6 @@ func Convert_extensions_RollbackConfig_To_v1beta1_RollbackConfig(in *extensions.
 	return autoConvert_extensions_RollbackConfig_To_v1beta1_RollbackConfig(in, out, s)
 }
 
-func autoConvert_extensions_RollingUpdateDaemonSet_To_v1beta1_RollingUpdateDaemonSet(in *extensions.RollingUpdateDaemonSet, out *RollingUpdateDaemonSet, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*extensions.RollingUpdateDaemonSet))(in)
-	}
-	if err := s.Convert(&in.MaxUnavailable, &out.MaxUnavailable, 0); err != nil {
-		return err
-	}
-	out.MinReadySeconds = int32(in.MinReadySeconds)
-	return nil
-}
-
 func autoConvert_extensions_RollingUpdateDeployment_To_v1beta1_RollingUpdateDeployment(in *extensions.RollingUpdateDeployment, out *RollingUpdateDeployment, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.RollingUpdateDeployment))(in)
@@ -4050,13 +4020,11 @@ func autoConvert_v1beta1_DaemonSetSpec_To_extensions_DaemonSetSpec(in *DaemonSet
 	if err := Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
-	if err := Convert_v1beta1_DaemonSetUpdateStrategy_To_extensions_DaemonSetUpdateStrategy(&in.UpdateStrategy, &out.UpdateStrategy, s); err != nil {
-		return err
-	}
-	if err := api.Convert_string_ref_To_string(&in.UniqueLabelKey, &out.UniqueLabelKey, s); err != nil {
-		return err
-	}
 	return nil
+}
+
+func Convert_v1beta1_DaemonSetSpec_To_extensions_DaemonSetSpec(in *DaemonSetSpec, out *extensions.DaemonSetSpec, s conversion.Scope) error {
+	return autoConvert_v1beta1_DaemonSetSpec_To_extensions_DaemonSetSpec(in, out, s)
 }
 
 func autoConvert_v1beta1_DaemonSetStatus_To_extensions_DaemonSetStatus(in *DaemonSetStatus, out *extensions.DaemonSetStatus, s conversion.Scope) error {
@@ -4071,23 +4039,6 @@ func autoConvert_v1beta1_DaemonSetStatus_To_extensions_DaemonSetStatus(in *Daemo
 
 func Convert_v1beta1_DaemonSetStatus_To_extensions_DaemonSetStatus(in *DaemonSetStatus, out *extensions.DaemonSetStatus, s conversion.Scope) error {
 	return autoConvert_v1beta1_DaemonSetStatus_To_extensions_DaemonSetStatus(in, out, s)
-}
-
-func autoConvert_v1beta1_DaemonSetUpdateStrategy_To_extensions_DaemonSetUpdateStrategy(in *DaemonSetUpdateStrategy, out *extensions.DaemonSetUpdateStrategy, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*DaemonSetUpdateStrategy))(in)
-	}
-	out.Type = extensions.DaemonSetUpdateStrategyType(in.Type)
-	// unable to generate simple pointer conversion for v1beta1.RollingUpdateDaemonSet -> extensions.RollingUpdateDaemonSet
-	if in.RollingUpdate != nil {
-		out.RollingUpdate = new(extensions.RollingUpdateDaemonSet)
-		if err := Convert_v1beta1_RollingUpdateDaemonSet_To_extensions_RollingUpdateDaemonSet(in.RollingUpdate, out.RollingUpdate, s); err != nil {
-			return err
-		}
-	} else {
-		out.RollingUpdate = nil
-	}
-	return nil
 }
 
 func autoConvert_v1beta1_Deployment_To_extensions_Deployment(in *Deployment, out *extensions.Deployment, s conversion.Scope) error {
@@ -5025,15 +4976,6 @@ func Convert_v1beta1_RollbackConfig_To_extensions_RollbackConfig(in *RollbackCon
 	return autoConvert_v1beta1_RollbackConfig_To_extensions_RollbackConfig(in, out, s)
 }
 
-func autoConvert_v1beta1_RollingUpdateDaemonSet_To_extensions_RollingUpdateDaemonSet(in *RollingUpdateDaemonSet, out *extensions.RollingUpdateDaemonSet, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*RollingUpdateDaemonSet))(in)
-	}
-	// in.MaxUnavailable has no peer in out
-	out.MinReadySeconds = int(in.MinReadySeconds)
-	return nil
-}
-
 func autoConvert_v1beta1_RollingUpdateDeployment_To_extensions_RollingUpdateDeployment(in *RollingUpdateDeployment, out *extensions.RollingUpdateDeployment, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*RollingUpdateDeployment))(in)
@@ -5315,7 +5257,6 @@ func init() {
 		autoConvert_extensions_DaemonSetList_To_v1beta1_DaemonSetList,
 		autoConvert_extensions_DaemonSetSpec_To_v1beta1_DaemonSetSpec,
 		autoConvert_extensions_DaemonSetStatus_To_v1beta1_DaemonSetStatus,
-		autoConvert_extensions_DaemonSetUpdateStrategy_To_v1beta1_DaemonSetUpdateStrategy,
 		autoConvert_extensions_DaemonSet_To_v1beta1_DaemonSet,
 		autoConvert_extensions_DeploymentList_To_v1beta1_DeploymentList,
 		autoConvert_extensions_DeploymentRollback_To_v1beta1_DeploymentRollback,
@@ -5354,7 +5295,6 @@ func init() {
 		autoConvert_extensions_ReplicaSet_To_v1beta1_ReplicaSet,
 		autoConvert_extensions_ReplicationControllerDummy_To_v1beta1_ReplicationControllerDummy,
 		autoConvert_extensions_RollbackConfig_To_v1beta1_RollbackConfig,
-		autoConvert_extensions_RollingUpdateDaemonSet_To_v1beta1_RollingUpdateDaemonSet,
 		autoConvert_extensions_RollingUpdateDeployment_To_v1beta1_RollingUpdateDeployment,
 		autoConvert_extensions_RunAsUserStrategyOptions_To_v1beta1_RunAsUserStrategyOptions,
 		autoConvert_extensions_SELinuxContextStrategyOptions_To_v1beta1_SELinuxContextStrategyOptions,
@@ -5422,7 +5362,6 @@ func init() {
 		autoConvert_v1beta1_DaemonSetList_To_extensions_DaemonSetList,
 		autoConvert_v1beta1_DaemonSetSpec_To_extensions_DaemonSetSpec,
 		autoConvert_v1beta1_DaemonSetStatus_To_extensions_DaemonSetStatus,
-		autoConvert_v1beta1_DaemonSetUpdateStrategy_To_extensions_DaemonSetUpdateStrategy,
 		autoConvert_v1beta1_DaemonSet_To_extensions_DaemonSet,
 		autoConvert_v1beta1_DeploymentList_To_extensions_DeploymentList,
 		autoConvert_v1beta1_DeploymentRollback_To_extensions_DeploymentRollback,
@@ -5463,7 +5402,6 @@ func init() {
 		autoConvert_v1beta1_ReplicaSet_To_extensions_ReplicaSet,
 		autoConvert_v1beta1_ReplicationControllerDummy_To_extensions_ReplicationControllerDummy,
 		autoConvert_v1beta1_RollbackConfig_To_extensions_RollbackConfig,
-		autoConvert_v1beta1_RollingUpdateDaemonSet_To_extensions_RollingUpdateDaemonSet,
 		autoConvert_v1beta1_RollingUpdateDeployment_To_extensions_RollingUpdateDeployment,
 		autoConvert_v1beta1_RunAsUserStrategyOptions_To_extensions_RunAsUserStrategyOptions,
 		autoConvert_v1beta1_SELinuxContextStrategyOptions_To_extensions_SELinuxContextStrategyOptions,

--- a/pkg/apis/extensions/v1beta1/deep_copy_generated.go
+++ b/pkg/apis/extensions/v1beta1/deep_copy_generated.go
@@ -1090,15 +1090,6 @@ func deepCopy_v1beta1_DaemonSetSpec(in DaemonSetSpec, out *DaemonSetSpec, c *con
 	if err := deepCopy_v1_PodTemplateSpec(in.Template, &out.Template, c); err != nil {
 		return err
 	}
-	if err := deepCopy_v1beta1_DaemonSetUpdateStrategy(in.UpdateStrategy, &out.UpdateStrategy, c); err != nil {
-		return err
-	}
-	if in.UniqueLabelKey != nil {
-		out.UniqueLabelKey = new(string)
-		*out.UniqueLabelKey = *in.UniqueLabelKey
-	} else {
-		out.UniqueLabelKey = nil
-	}
 	return nil
 }
 
@@ -1106,19 +1097,6 @@ func deepCopy_v1beta1_DaemonSetStatus(in DaemonSetStatus, out *DaemonSetStatus, 
 	out.CurrentNumberScheduled = in.CurrentNumberScheduled
 	out.NumberMisscheduled = in.NumberMisscheduled
 	out.DesiredNumberScheduled = in.DesiredNumberScheduled
-	return nil
-}
-
-func deepCopy_v1beta1_DaemonSetUpdateStrategy(in DaemonSetUpdateStrategy, out *DaemonSetUpdateStrategy, c *conversion.Cloner) error {
-	out.Type = in.Type
-	if in.RollingUpdate != nil {
-		out.RollingUpdate = new(RollingUpdateDaemonSet)
-		if err := deepCopy_v1beta1_RollingUpdateDaemonSet(*in.RollingUpdate, out.RollingUpdate, c); err != nil {
-			return err
-		}
-	} else {
-		out.RollingUpdate = nil
-	}
 	return nil
 }
 
@@ -1800,19 +1778,6 @@ func deepCopy_v1beta1_RollbackConfig(in RollbackConfig, out *RollbackConfig, c *
 	return nil
 }
 
-func deepCopy_v1beta1_RollingUpdateDaemonSet(in RollingUpdateDaemonSet, out *RollingUpdateDaemonSet, c *conversion.Cloner) error {
-	if in.MaxUnavailable != nil {
-		out.MaxUnavailable = new(intstr.IntOrString)
-		if err := deepCopy_intstr_IntOrString(*in.MaxUnavailable, out.MaxUnavailable, c); err != nil {
-			return err
-		}
-	} else {
-		out.MaxUnavailable = nil
-	}
-	out.MinReadySeconds = in.MinReadySeconds
-	return nil
-}
-
 func deepCopy_v1beta1_RollingUpdateDeployment(in RollingUpdateDeployment, out *RollingUpdateDeployment, c *conversion.Cloner) error {
 	if in.MaxUnavailable != nil {
 		out.MaxUnavailable = new(intstr.IntOrString)
@@ -2051,7 +2016,6 @@ func init() {
 		deepCopy_v1beta1_DaemonSetList,
 		deepCopy_v1beta1_DaemonSetSpec,
 		deepCopy_v1beta1_DaemonSetStatus,
-		deepCopy_v1beta1_DaemonSetUpdateStrategy,
 		deepCopy_v1beta1_Deployment,
 		deepCopy_v1beta1_DeploymentList,
 		deepCopy_v1beta1_DeploymentRollback,
@@ -2092,7 +2056,6 @@ func init() {
 		deepCopy_v1beta1_ReplicaSetStatus,
 		deepCopy_v1beta1_ReplicationControllerDummy,
 		deepCopy_v1beta1_RollbackConfig,
-		deepCopy_v1beta1_RollingUpdateDaemonSet,
 		deepCopy_v1beta1_RollingUpdateDeployment,
 		deepCopy_v1beta1_RunAsUserStrategyOptions,
 		deepCopy_v1beta1_SELinuxContextStrategyOptions,

--- a/pkg/apis/extensions/v1beta1/defaults.go
+++ b/pkg/apis/extensions/v1beta1/defaults.go
@@ -42,25 +42,6 @@ func addDefaultingFuncs(scheme *runtime.Scheme) {
 					obj.Labels = labels
 				}
 			}
-			updateStrategy := &obj.Spec.UpdateStrategy
-			if updateStrategy.Type == "" {
-				updateStrategy.Type = RollingUpdateDaemonSetStrategyType
-			}
-			if updateStrategy.Type == RollingUpdateDaemonSetStrategyType {
-				if updateStrategy.RollingUpdate == nil {
-					rollingUpdate := RollingUpdateDaemonSet{}
-					updateStrategy.RollingUpdate = &rollingUpdate
-				}
-				if updateStrategy.RollingUpdate.MaxUnavailable == nil {
-					// Set default MaxUnavailable as 1 by default.
-					maxUnavailable := intstr.FromInt(1)
-					updateStrategy.RollingUpdate.MaxUnavailable = &maxUnavailable
-				}
-			}
-			if obj.Spec.UniqueLabelKey == nil {
-				obj.Spec.UniqueLabelKey = new(string)
-				*obj.Spec.UniqueLabelKey = DefaultDaemonSetUniqueLabelKey
-			}
 		},
 		func(obj *Deployment) {
 			// Default labels and selector to labels from pod template spec.

--- a/pkg/apis/extensions/v1beta1/defaults_test.go
+++ b/pkg/apis/extensions/v1beta1/defaults_test.go
@@ -31,7 +31,6 @@ import (
 )
 
 func TestSetDefaultDaemonSet(t *testing.T) {
-	defaultIntOrString := intstr.FromInt(1)
 	defaultLabels := map[string]string{"foo": "bar"}
 	period := int64(v1.DefaultTerminationGracePeriodSeconds)
 	defaultTemplate := v1.PodTemplateSpec{
@@ -72,13 +71,6 @@ func TestSetDefaultDaemonSet(t *testing.T) {
 						MatchLabels: defaultLabels,
 					},
 					Template: defaultTemplate,
-					UpdateStrategy: DaemonSetUpdateStrategy{
-						Type: RollingUpdateDaemonSetStrategyType,
-						RollingUpdate: &RollingUpdateDaemonSet{
-							MaxUnavailable: &defaultIntOrString,
-						},
-					},
-					UniqueLabelKey: newString(DefaultDaemonSetUniqueLabelKey),
 				},
 			},
 		},
@@ -91,12 +83,6 @@ func TestSetDefaultDaemonSet(t *testing.T) {
 				},
 				Spec: DaemonSetSpec{
 					Template: defaultTemplate,
-					UpdateStrategy: DaemonSetUpdateStrategy{
-						Type: RollingUpdateDaemonSetStrategyType,
-						RollingUpdate: &RollingUpdateDaemonSet{
-							MaxUnavailable: &defaultIntOrString,
-						},
-					},
 				},
 			},
 			expected: &DaemonSet{
@@ -110,13 +96,6 @@ func TestSetDefaultDaemonSet(t *testing.T) {
 						MatchLabels: defaultLabels,
 					},
 					Template: defaultTemplate,
-					UpdateStrategy: DaemonSetUpdateStrategy{
-						Type: RollingUpdateDaemonSetStrategyType,
-						RollingUpdate: &RollingUpdateDaemonSet{
-							MaxUnavailable: &defaultIntOrString,
-						},
-					},
-					UniqueLabelKey: newString(DefaultDaemonSetUniqueLabelKey),
 				},
 			},
 		},
@@ -125,56 +104,26 @@ func TestSetDefaultDaemonSet(t *testing.T) {
 			expected: &DaemonSet{
 				Spec: DaemonSetSpec{
 					Template: templateNoLabel,
-					UpdateStrategy: DaemonSetUpdateStrategy{
-						Type: RollingUpdateDaemonSetStrategyType,
-						RollingUpdate: &RollingUpdateDaemonSet{
-							MaxUnavailable: &defaultIntOrString,
-						},
-					},
-					UniqueLabelKey: newString(DefaultDaemonSetUniqueLabelKey),
 				},
 			},
 		},
 		{ // Update strategy.
 			original: &DaemonSet{
-				Spec: DaemonSetSpec{
-					UpdateStrategy: DaemonSetUpdateStrategy{
-						RollingUpdate: &RollingUpdateDaemonSet{},
-					},
-				},
+				Spec: DaemonSetSpec{},
 			},
 			expected: &DaemonSet{
 				Spec: DaemonSetSpec{
 					Template: templateNoLabel,
-					UpdateStrategy: DaemonSetUpdateStrategy{
-						Type: RollingUpdateDaemonSetStrategyType,
-						RollingUpdate: &RollingUpdateDaemonSet{
-							MaxUnavailable: &defaultIntOrString,
-						},
-					},
-					UniqueLabelKey: newString(DefaultDaemonSetUniqueLabelKey),
 				},
 			},
 		},
 		{ // Custom unique label key.
 			original: &DaemonSet{
-				Spec: DaemonSetSpec{
-					UpdateStrategy: DaemonSetUpdateStrategy{
-						RollingUpdate: &RollingUpdateDaemonSet{},
-					},
-					UniqueLabelKey: newString("customDaemonSetKey"),
-				},
+				Spec: DaemonSetSpec{},
 			},
 			expected: &DaemonSet{
 				Spec: DaemonSetSpec{
 					Template: templateNoLabel,
-					UpdateStrategy: DaemonSetUpdateStrategy{
-						Type: RollingUpdateDaemonSetStrategyType,
-						RollingUpdate: &RollingUpdateDaemonSet{
-							MaxUnavailable: &defaultIntOrString,
-						},
-					},
-					UniqueLabelKey: newString("customDaemonSetKey"),
 				},
 			},
 		},

--- a/pkg/apis/extensions/v1beta1/types.generated.go
+++ b/pkg/apis/extensions/v1beta1/types.generated.go
@@ -7699,7 +7699,7 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
-func (x *DaemonSetUpdateStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
+func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
@@ -7716,13 +7716,12 @@ func (x *DaemonSetUpdateStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq639 [2]bool
 			_, _, _ = yysep639, yyq639, yy2arr639
 			const yyr639 bool = false
-			yyq639[0] = x.Type != ""
-			yyq639[1] = x.RollingUpdate != nil
+			yyq639[0] = x.Selector != nil
 			var yynn639 int
 			if yyr639 || yy2arr639 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn639 = 0
+				yynn639 = 1
 				for _, b := range yyq639 {
 					if b {
 						yynn639++
@@ -7734,505 +7733,6 @@ func (x *DaemonSetUpdateStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr639 || yy2arr639 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq639[0] {
-					x.Type.CodecEncodeSelf(e)
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq639[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("type"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					x.Type.CodecEncodeSelf(e)
-				}
-			}
-			if yyr639 || yy2arr639 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq639[1] {
-					if x.RollingUpdate == nil {
-						r.EncodeNil()
-					} else {
-						x.RollingUpdate.CodecEncodeSelf(e)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq639[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("rollingUpdate"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if x.RollingUpdate == nil {
-						r.EncodeNil()
-					} else {
-						x.RollingUpdate.CodecEncodeSelf(e)
-					}
-				}
-			}
-			if yyr639 || yy2arr639 {
-				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
-			}
-		}
-	}
-}
-
-func (x *DaemonSetUpdateStrategy) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym642 := z.DecBinary()
-	_ = yym642
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		yyct643 := r.ContainerType()
-		if yyct643 == codecSelferValueTypeMap1234 {
-			yyl643 := r.ReadMapStart()
-			if yyl643 == 0 {
-				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-			} else {
-				x.codecDecodeSelfFromMap(yyl643, d)
-			}
-		} else if yyct643 == codecSelferValueTypeArray1234 {
-			yyl643 := r.ReadArrayStart()
-			if yyl643 == 0 {
-				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				x.codecDecodeSelfFromArray(yyl643, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *DaemonSetUpdateStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys644Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys644Slc
-	var yyhl644 bool = l >= 0
-	for yyj644 := 0; ; yyj644++ {
-		if yyhl644 {
-			if yyj644 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys644Slc = r.DecodeBytes(yys644Slc, true, true)
-		yys644 := string(yys644Slc)
-		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys644 {
-		case "type":
-			if r.TryDecodeAsNil() {
-				x.Type = ""
-			} else {
-				x.Type = DaemonSetUpdateStrategyType(r.DecodeString())
-			}
-		case "rollingUpdate":
-			if r.TryDecodeAsNil() {
-				if x.RollingUpdate != nil {
-					x.RollingUpdate = nil
-				}
-			} else {
-				if x.RollingUpdate == nil {
-					x.RollingUpdate = new(RollingUpdateDaemonSet)
-				}
-				x.RollingUpdate.CodecDecodeSelf(d)
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys644)
-		} // end switch yys644
-	} // end for yyj644
-	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-}
-
-func (x *DaemonSetUpdateStrategy) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj647 int
-	var yyb647 bool
-	var yyhl647 bool = l >= 0
-	yyj647++
-	if yyhl647 {
-		yyb647 = yyj647 > l
-	} else {
-		yyb647 = r.CheckBreak()
-	}
-	if yyb647 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Type = ""
-	} else {
-		x.Type = DaemonSetUpdateStrategyType(r.DecodeString())
-	}
-	yyj647++
-	if yyhl647 {
-		yyb647 = yyj647 > l
-	} else {
-		yyb647 = r.CheckBreak()
-	}
-	if yyb647 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		if x.RollingUpdate != nil {
-			x.RollingUpdate = nil
-		}
-	} else {
-		if x.RollingUpdate == nil {
-			x.RollingUpdate = new(RollingUpdateDaemonSet)
-		}
-		x.RollingUpdate.CodecDecodeSelf(d)
-	}
-	for {
-		yyj647++
-		if yyhl647 {
-			yyb647 = yyj647 > l
-		} else {
-			yyb647 = r.CheckBreak()
-		}
-		if yyb647 {
-			break
-		}
-		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj647-1, "")
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x DaemonSetUpdateStrategyType) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	yym650 := z.EncBinary()
-	_ = yym650
-	if false {
-	} else if z.HasExtensions() && z.EncExt(x) {
-	} else {
-		r.EncodeString(codecSelferC_UTF81234, string(x))
-	}
-}
-
-func (x *DaemonSetUpdateStrategyType) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym651 := z.DecBinary()
-	_ = yym651
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		*((*string)(x)) = r.DecodeString()
-	}
-}
-
-func (x *RollingUpdateDaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym652 := z.EncBinary()
-		_ = yym652
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep653 := !z.EncBinary()
-			yy2arr653 := z.EncBasicHandle().StructToArray
-			var yyq653 [2]bool
-			_, _, _ = yysep653, yyq653, yy2arr653
-			const yyr653 bool = false
-			yyq653[0] = x.MaxUnavailable != nil
-			yyq653[1] = x.MinReadySeconds != 0
-			var yynn653 int
-			if yyr653 || yy2arr653 {
-				r.EncodeArrayStart(2)
-			} else {
-				yynn653 = 0
-				for _, b := range yyq653 {
-					if b {
-						yynn653++
-					}
-				}
-				r.EncodeMapStart(yynn653)
-				yynn653 = 0
-			}
-			if yyr653 || yy2arr653 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq653[0] {
-					if x.MaxUnavailable == nil {
-						r.EncodeNil()
-					} else {
-						yym655 := z.EncBinary()
-						_ = yym655
-						if false {
-						} else if z.HasExtensions() && z.EncExt(x.MaxUnavailable) {
-						} else if !yym655 && z.IsJSONHandle() {
-							z.EncJSONMarshal(x.MaxUnavailable)
-						} else {
-							z.EncFallback(x.MaxUnavailable)
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq653[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("maxUnavailable"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if x.MaxUnavailable == nil {
-						r.EncodeNil()
-					} else {
-						yym656 := z.EncBinary()
-						_ = yym656
-						if false {
-						} else if z.HasExtensions() && z.EncExt(x.MaxUnavailable) {
-						} else if !yym656 && z.IsJSONHandle() {
-							z.EncJSONMarshal(x.MaxUnavailable)
-						} else {
-							z.EncFallback(x.MaxUnavailable)
-						}
-					}
-				}
-			}
-			if yyr653 || yy2arr653 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq653[1] {
-					yym658 := z.EncBinary()
-					_ = yym658
-					if false {
-					} else {
-						r.EncodeInt(int64(x.MinReadySeconds))
-					}
-				} else {
-					r.EncodeInt(0)
-				}
-			} else {
-				if yyq653[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("minReadySeconds"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym659 := z.EncBinary()
-					_ = yym659
-					if false {
-					} else {
-						r.EncodeInt(int64(x.MinReadySeconds))
-					}
-				}
-			}
-			if yyr653 || yy2arr653 {
-				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
-			}
-		}
-	}
-}
-
-func (x *RollingUpdateDaemonSet) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym660 := z.DecBinary()
-	_ = yym660
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		yyct661 := r.ContainerType()
-		if yyct661 == codecSelferValueTypeMap1234 {
-			yyl661 := r.ReadMapStart()
-			if yyl661 == 0 {
-				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-			} else {
-				x.codecDecodeSelfFromMap(yyl661, d)
-			}
-		} else if yyct661 == codecSelferValueTypeArray1234 {
-			yyl661 := r.ReadArrayStart()
-			if yyl661 == 0 {
-				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				x.codecDecodeSelfFromArray(yyl661, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *RollingUpdateDaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys662Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys662Slc
-	var yyhl662 bool = l >= 0
-	for yyj662 := 0; ; yyj662++ {
-		if yyhl662 {
-			if yyj662 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys662Slc = r.DecodeBytes(yys662Slc, true, true)
-		yys662 := string(yys662Slc)
-		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys662 {
-		case "maxUnavailable":
-			if r.TryDecodeAsNil() {
-				if x.MaxUnavailable != nil {
-					x.MaxUnavailable = nil
-				}
-			} else {
-				if x.MaxUnavailable == nil {
-					x.MaxUnavailable = new(pkg6_intstr.IntOrString)
-				}
-				yym664 := z.DecBinary()
-				_ = yym664
-				if false {
-				} else if z.HasExtensions() && z.DecExt(x.MaxUnavailable) {
-				} else if !yym664 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(x.MaxUnavailable)
-				} else {
-					z.DecFallback(x.MaxUnavailable, false)
-				}
-			}
-		case "minReadySeconds":
-			if r.TryDecodeAsNil() {
-				x.MinReadySeconds = 0
-			} else {
-				x.MinReadySeconds = int32(r.DecodeInt(32))
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys662)
-		} // end switch yys662
-	} // end for yyj662
-	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-}
-
-func (x *RollingUpdateDaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj666 int
-	var yyb666 bool
-	var yyhl666 bool = l >= 0
-	yyj666++
-	if yyhl666 {
-		yyb666 = yyj666 > l
-	} else {
-		yyb666 = r.CheckBreak()
-	}
-	if yyb666 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		if x.MaxUnavailable != nil {
-			x.MaxUnavailable = nil
-		}
-	} else {
-		if x.MaxUnavailable == nil {
-			x.MaxUnavailable = new(pkg6_intstr.IntOrString)
-		}
-		yym668 := z.DecBinary()
-		_ = yym668
-		if false {
-		} else if z.HasExtensions() && z.DecExt(x.MaxUnavailable) {
-		} else if !yym668 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(x.MaxUnavailable)
-		} else {
-			z.DecFallback(x.MaxUnavailable, false)
-		}
-	}
-	yyj666++
-	if yyhl666 {
-		yyb666 = yyj666 > l
-	} else {
-		yyb666 = r.CheckBreak()
-	}
-	if yyb666 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.MinReadySeconds = 0
-	} else {
-		x.MinReadySeconds = int32(r.DecodeInt(32))
-	}
-	for {
-		yyj666++
-		if yyhl666 {
-			yyb666 = yyj666 > l
-		} else {
-			yyb666 = r.CheckBreak()
-		}
-		if yyb666 {
-			break
-		}
-		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj666-1, "")
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym670 := z.EncBinary()
-		_ = yym670
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep671 := !z.EncBinary()
-			yy2arr671 := z.EncBasicHandle().StructToArray
-			var yyq671 [4]bool
-			_, _, _ = yysep671, yyq671, yy2arr671
-			const yyr671 bool = false
-			yyq671[0] = x.Selector != nil
-			yyq671[2] = true
-			yyq671[3] = x.UniqueLabelKey != nil
-			var yynn671 int
-			if yyr671 || yy2arr671 {
-				r.EncodeArrayStart(4)
-			} else {
-				yynn671 = 1
-				for _, b := range yyq671 {
-					if b {
-						yynn671++
-					}
-				}
-				r.EncodeMapStart(yynn671)
-				yynn671 = 0
-			}
-			if yyr671 || yy2arr671 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq671[0] {
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
@@ -8242,7 +7742,7 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq671[0] {
+				if yyq639[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
@@ -8253,70 +7753,18 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr671 || yy2arr671 {
+			if yyr639 || yy2arr639 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy674 := &x.Template
-				yy674.CodecEncodeSelf(e)
+				yy642 := &x.Template
+				yy642.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("template"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy675 := &x.Template
-				yy675.CodecEncodeSelf(e)
+				yy643 := &x.Template
+				yy643.CodecEncodeSelf(e)
 			}
-			if yyr671 || yy2arr671 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq671[2] {
-					yy677 := &x.UpdateStrategy
-					yy677.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq671[2] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("updateStrategy"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy678 := &x.UpdateStrategy
-					yy678.CodecEncodeSelf(e)
-				}
-			}
-			if yyr671 || yy2arr671 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq671[3] {
-					if x.UniqueLabelKey == nil {
-						r.EncodeNil()
-					} else {
-						yy680 := *x.UniqueLabelKey
-						yym681 := z.EncBinary()
-						_ = yym681
-						if false {
-						} else {
-							r.EncodeString(codecSelferC_UTF81234, string(yy680))
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq671[3] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("uniqueLabelKey"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if x.UniqueLabelKey == nil {
-						r.EncodeNil()
-					} else {
-						yy682 := *x.UniqueLabelKey
-						yym683 := z.EncBinary()
-						_ = yym683
-						if false {
-						} else {
-							r.EncodeString(codecSelferC_UTF81234, string(yy682))
-						}
-					}
-				}
-			}
-			if yyr671 || yy2arr671 {
+			if yyr639 || yy2arr639 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -8329,25 +7777,25 @@ func (x *DaemonSetSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym684 := z.DecBinary()
-	_ = yym684
+	yym644 := z.DecBinary()
+	_ = yym644
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct685 := r.ContainerType()
-		if yyct685 == codecSelferValueTypeMap1234 {
-			yyl685 := r.ReadMapStart()
-			if yyl685 == 0 {
+		yyct645 := r.ContainerType()
+		if yyct645 == codecSelferValueTypeMap1234 {
+			yyl645 := r.ReadMapStart()
+			if yyl645 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl685, d)
+				x.codecDecodeSelfFromMap(yyl645, d)
 			}
-		} else if yyct685 == codecSelferValueTypeArray1234 {
-			yyl685 := r.ReadArrayStart()
-			if yyl685 == 0 {
+		} else if yyct645 == codecSelferValueTypeArray1234 {
+			yyl645 := r.ReadArrayStart()
+			if yyl645 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl685, d)
+				x.codecDecodeSelfFromArray(yyl645, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -8359,12 +7807,12 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys686Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys686Slc
-	var yyhl686 bool = l >= 0
-	for yyj686 := 0; ; yyj686++ {
-		if yyhl686 {
-			if yyj686 >= l {
+	var yys646Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys646Slc
+	var yyhl646 bool = l >= 0
+	for yyj646 := 0; ; yyj646++ {
+		if yyhl646 {
+			if yyj646 >= l {
 				break
 			}
 		} else {
@@ -8373,10 +7821,10 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys686Slc = r.DecodeBytes(yys686Slc, true, true)
-		yys686 := string(yys686Slc)
+		yys646Slc = r.DecodeBytes(yys646Slc, true, true)
+		yys646 := string(yys646Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys686 {
+		switch yys646 {
 		case "selector":
 			if r.TryDecodeAsNil() {
 				if x.Selector != nil {
@@ -8392,36 +7840,13 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Template = pkg2_v1.PodTemplateSpec{}
 			} else {
-				yyv688 := &x.Template
-				yyv688.CodecDecodeSelf(d)
-			}
-		case "updateStrategy":
-			if r.TryDecodeAsNil() {
-				x.UpdateStrategy = DaemonSetUpdateStrategy{}
-			} else {
-				yyv689 := &x.UpdateStrategy
-				yyv689.CodecDecodeSelf(d)
-			}
-		case "uniqueLabelKey":
-			if r.TryDecodeAsNil() {
-				if x.UniqueLabelKey != nil {
-					x.UniqueLabelKey = nil
-				}
-			} else {
-				if x.UniqueLabelKey == nil {
-					x.UniqueLabelKey = new(string)
-				}
-				yym691 := z.DecBinary()
-				_ = yym691
-				if false {
-				} else {
-					*((*string)(x.UniqueLabelKey)) = r.DecodeString()
-				}
+				yyv648 := &x.Template
+				yyv648.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys686)
-		} // end switch yys686
-	} // end for yyj686
+			z.DecStructFieldNotFound(-1, yys646)
+		} // end switch yys646
+	} // end for yyj646
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -8429,16 +7854,16 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj692 int
-	var yyb692 bool
-	var yyhl692 bool = l >= 0
-	yyj692++
-	if yyhl692 {
-		yyb692 = yyj692 > l
+	var yyj649 int
+	var yyb649 bool
+	var yyhl649 bool = l >= 0
+	yyj649++
+	if yyhl649 {
+		yyb649 = yyj649 > l
 	} else {
-		yyb692 = r.CheckBreak()
+		yyb649 = r.CheckBreak()
 	}
-	if yyb692 {
+	if yyb649 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8453,13 +7878,13 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Selector.CodecDecodeSelf(d)
 	}
-	yyj692++
-	if yyhl692 {
-		yyb692 = yyj692 > l
+	yyj649++
+	if yyhl649 {
+		yyb649 = yyj649 > l
 	} else {
-		yyb692 = r.CheckBreak()
+		yyb649 = r.CheckBreak()
 	}
-	if yyb692 {
+	if yyb649 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8467,64 +7892,21 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Template = pkg2_v1.PodTemplateSpec{}
 	} else {
-		yyv694 := &x.Template
-		yyv694.CodecDecodeSelf(d)
-	}
-	yyj692++
-	if yyhl692 {
-		yyb692 = yyj692 > l
-	} else {
-		yyb692 = r.CheckBreak()
-	}
-	if yyb692 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.UpdateStrategy = DaemonSetUpdateStrategy{}
-	} else {
-		yyv695 := &x.UpdateStrategy
-		yyv695.CodecDecodeSelf(d)
-	}
-	yyj692++
-	if yyhl692 {
-		yyb692 = yyj692 > l
-	} else {
-		yyb692 = r.CheckBreak()
-	}
-	if yyb692 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		if x.UniqueLabelKey != nil {
-			x.UniqueLabelKey = nil
-		}
-	} else {
-		if x.UniqueLabelKey == nil {
-			x.UniqueLabelKey = new(string)
-		}
-		yym697 := z.DecBinary()
-		_ = yym697
-		if false {
-		} else {
-			*((*string)(x.UniqueLabelKey)) = r.DecodeString()
-		}
+		yyv651 := &x.Template
+		yyv651.CodecDecodeSelf(d)
 	}
 	for {
-		yyj692++
-		if yyhl692 {
-			yyb692 = yyj692 > l
+		yyj649++
+		if yyhl649 {
+			yyb649 = yyj649 > l
 		} else {
-			yyb692 = r.CheckBreak()
+			yyb649 = r.CheckBreak()
 		}
-		if yyb692 {
+		if yyb649 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj692-1, "")
+		z.DecStructFieldNotFound(yyj649-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -8536,33 +7918,33 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym698 := z.EncBinary()
-		_ = yym698
+		yym652 := z.EncBinary()
+		_ = yym652
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep699 := !z.EncBinary()
-			yy2arr699 := z.EncBasicHandle().StructToArray
-			var yyq699 [3]bool
-			_, _, _ = yysep699, yyq699, yy2arr699
-			const yyr699 bool = false
-			var yynn699 int
-			if yyr699 || yy2arr699 {
+			yysep653 := !z.EncBinary()
+			yy2arr653 := z.EncBasicHandle().StructToArray
+			var yyq653 [3]bool
+			_, _, _ = yysep653, yyq653, yy2arr653
+			const yyr653 bool = false
+			var yynn653 int
+			if yyr653 || yy2arr653 {
 				r.EncodeArrayStart(3)
 			} else {
-				yynn699 = 3
-				for _, b := range yyq699 {
+				yynn653 = 3
+				for _, b := range yyq653 {
 					if b {
-						yynn699++
+						yynn653++
 					}
 				}
-				r.EncodeMapStart(yynn699)
-				yynn699 = 0
+				r.EncodeMapStart(yynn653)
+				yynn653 = 0
 			}
-			if yyr699 || yy2arr699 {
+			if yyr653 || yy2arr653 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym701 := z.EncBinary()
-				_ = yym701
+				yym655 := z.EncBinary()
+				_ = yym655
 				if false {
 				} else {
 					r.EncodeInt(int64(x.CurrentNumberScheduled))
@@ -8571,17 +7953,17 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("currentNumberScheduled"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym702 := z.EncBinary()
-				_ = yym702
+				yym656 := z.EncBinary()
+				_ = yym656
 				if false {
 				} else {
 					r.EncodeInt(int64(x.CurrentNumberScheduled))
 				}
 			}
-			if yyr699 || yy2arr699 {
+			if yyr653 || yy2arr653 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym704 := z.EncBinary()
-				_ = yym704
+				yym658 := z.EncBinary()
+				_ = yym658
 				if false {
 				} else {
 					r.EncodeInt(int64(x.NumberMisscheduled))
@@ -8590,17 +7972,17 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("numberMisscheduled"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym705 := z.EncBinary()
-				_ = yym705
+				yym659 := z.EncBinary()
+				_ = yym659
 				if false {
 				} else {
 					r.EncodeInt(int64(x.NumberMisscheduled))
 				}
 			}
-			if yyr699 || yy2arr699 {
+			if yyr653 || yy2arr653 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym707 := z.EncBinary()
-				_ = yym707
+				yym661 := z.EncBinary()
+				_ = yym661
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DesiredNumberScheduled))
@@ -8609,14 +7991,14 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("desiredNumberScheduled"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym708 := z.EncBinary()
-				_ = yym708
+				yym662 := z.EncBinary()
+				_ = yym662
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DesiredNumberScheduled))
 				}
 			}
-			if yyr699 || yy2arr699 {
+			if yyr653 || yy2arr653 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -8629,25 +8011,25 @@ func (x *DaemonSetStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym709 := z.DecBinary()
-	_ = yym709
+	yym663 := z.DecBinary()
+	_ = yym663
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct710 := r.ContainerType()
-		if yyct710 == codecSelferValueTypeMap1234 {
-			yyl710 := r.ReadMapStart()
-			if yyl710 == 0 {
+		yyct664 := r.ContainerType()
+		if yyct664 == codecSelferValueTypeMap1234 {
+			yyl664 := r.ReadMapStart()
+			if yyl664 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl710, d)
+				x.codecDecodeSelfFromMap(yyl664, d)
 			}
-		} else if yyct710 == codecSelferValueTypeArray1234 {
-			yyl710 := r.ReadArrayStart()
-			if yyl710 == 0 {
+		} else if yyct664 == codecSelferValueTypeArray1234 {
+			yyl664 := r.ReadArrayStart()
+			if yyl664 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl710, d)
+				x.codecDecodeSelfFromArray(yyl664, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -8659,12 +8041,12 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys711Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys711Slc
-	var yyhl711 bool = l >= 0
-	for yyj711 := 0; ; yyj711++ {
-		if yyhl711 {
-			if yyj711 >= l {
+	var yys665Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys665Slc
+	var yyhl665 bool = l >= 0
+	for yyj665 := 0; ; yyj665++ {
+		if yyhl665 {
+			if yyj665 >= l {
 				break
 			}
 		} else {
@@ -8673,10 +8055,10 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys711Slc = r.DecodeBytes(yys711Slc, true, true)
-		yys711 := string(yys711Slc)
+		yys665Slc = r.DecodeBytes(yys665Slc, true, true)
+		yys665 := string(yys665Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys711 {
+		switch yys665 {
 		case "currentNumberScheduled":
 			if r.TryDecodeAsNil() {
 				x.CurrentNumberScheduled = 0
@@ -8696,9 +8078,9 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.DesiredNumberScheduled = int32(r.DecodeInt(32))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys711)
-		} // end switch yys711
-	} // end for yyj711
+			z.DecStructFieldNotFound(-1, yys665)
+		} // end switch yys665
+	} // end for yyj665
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -8706,16 +8088,16 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj715 int
-	var yyb715 bool
-	var yyhl715 bool = l >= 0
-	yyj715++
-	if yyhl715 {
-		yyb715 = yyj715 > l
+	var yyj669 int
+	var yyb669 bool
+	var yyhl669 bool = l >= 0
+	yyj669++
+	if yyhl669 {
+		yyb669 = yyj669 > l
 	} else {
-		yyb715 = r.CheckBreak()
+		yyb669 = r.CheckBreak()
 	}
-	if yyb715 {
+	if yyb669 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8725,13 +8107,13 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.CurrentNumberScheduled = int32(r.DecodeInt(32))
 	}
-	yyj715++
-	if yyhl715 {
-		yyb715 = yyj715 > l
+	yyj669++
+	if yyhl669 {
+		yyb669 = yyj669 > l
 	} else {
-		yyb715 = r.CheckBreak()
+		yyb669 = r.CheckBreak()
 	}
-	if yyb715 {
+	if yyb669 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8741,13 +8123,13 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.NumberMisscheduled = int32(r.DecodeInt(32))
 	}
-	yyj715++
-	if yyhl715 {
-		yyb715 = yyj715 > l
+	yyj669++
+	if yyhl669 {
+		yyb669 = yyj669 > l
 	} else {
-		yyb715 = r.CheckBreak()
+		yyb669 = r.CheckBreak()
 	}
-	if yyb715 {
+	if yyb669 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -8758,17 +8140,17 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.DesiredNumberScheduled = int32(r.DecodeInt(32))
 	}
 	for {
-		yyj715++
-		if yyhl715 {
-			yyb715 = yyj715 > l
+		yyj669++
+		if yyhl669 {
+			yyb669 = yyj669 > l
 		} else {
-			yyb715 = r.CheckBreak()
+			yyb669 = r.CheckBreak()
 		}
-		if yyb715 {
+		if yyb669 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj715-1, "")
+		z.DecStructFieldNotFound(yyj669-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -8780,90 +8162,90 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym719 := z.EncBinary()
-		_ = yym719
+		yym673 := z.EncBinary()
+		_ = yym673
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep720 := !z.EncBinary()
-			yy2arr720 := z.EncBasicHandle().StructToArray
-			var yyq720 [5]bool
-			_, _, _ = yysep720, yyq720, yy2arr720
-			const yyr720 bool = false
-			yyq720[0] = true
-			yyq720[1] = true
-			yyq720[2] = true
-			yyq720[3] = x.Kind != ""
-			yyq720[4] = x.APIVersion != ""
-			var yynn720 int
-			if yyr720 || yy2arr720 {
+			yysep674 := !z.EncBinary()
+			yy2arr674 := z.EncBasicHandle().StructToArray
+			var yyq674 [5]bool
+			_, _, _ = yysep674, yyq674, yy2arr674
+			const yyr674 bool = false
+			yyq674[0] = true
+			yyq674[1] = true
+			yyq674[2] = true
+			yyq674[3] = x.Kind != ""
+			yyq674[4] = x.APIVersion != ""
+			var yynn674 int
+			if yyr674 || yy2arr674 {
 				r.EncodeArrayStart(5)
 			} else {
-				yynn720 = 0
-				for _, b := range yyq720 {
+				yynn674 = 0
+				for _, b := range yyq674 {
 					if b {
-						yynn720++
+						yynn674++
 					}
 				}
-				r.EncodeMapStart(yynn720)
-				yynn720 = 0
+				r.EncodeMapStart(yynn674)
+				yynn674 = 0
 			}
-			if yyr720 || yy2arr720 {
+			if yyr674 || yy2arr674 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq720[0] {
-					yy722 := &x.ObjectMeta
-					yy722.CodecEncodeSelf(e)
+				if yyq674[0] {
+					yy676 := &x.ObjectMeta
+					yy676.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq720[0] {
+				if yyq674[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy723 := &x.ObjectMeta
-					yy723.CodecEncodeSelf(e)
+					yy677 := &x.ObjectMeta
+					yy677.CodecEncodeSelf(e)
 				}
 			}
-			if yyr720 || yy2arr720 {
+			if yyr674 || yy2arr674 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq720[1] {
-					yy725 := &x.Spec
-					yy725.CodecEncodeSelf(e)
+				if yyq674[1] {
+					yy679 := &x.Spec
+					yy679.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq720[1] {
+				if yyq674[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy726 := &x.Spec
-					yy726.CodecEncodeSelf(e)
+					yy680 := &x.Spec
+					yy680.CodecEncodeSelf(e)
 				}
 			}
-			if yyr720 || yy2arr720 {
+			if yyr674 || yy2arr674 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq720[2] {
-					yy728 := &x.Status
-					yy728.CodecEncodeSelf(e)
+				if yyq674[2] {
+					yy682 := &x.Status
+					yy682.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq720[2] {
+				if yyq674[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy729 := &x.Status
-					yy729.CodecEncodeSelf(e)
+					yy683 := &x.Status
+					yy683.CodecEncodeSelf(e)
 				}
 			}
-			if yyr720 || yy2arr720 {
+			if yyr674 || yy2arr674 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq720[3] {
-					yym731 := z.EncBinary()
-					_ = yym731
+				if yyq674[3] {
+					yym685 := z.EncBinary()
+					_ = yym685
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -8872,23 +8254,23 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq720[3] {
+				if yyq674[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym732 := z.EncBinary()
-					_ = yym732
+					yym686 := z.EncBinary()
+					_ = yym686
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr720 || yy2arr720 {
+			if yyr674 || yy2arr674 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq720[4] {
-					yym734 := z.EncBinary()
-					_ = yym734
+				if yyq674[4] {
+					yym688 := z.EncBinary()
+					_ = yym688
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -8897,19 +8279,19 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq720[4] {
+				if yyq674[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym735 := z.EncBinary()
-					_ = yym735
+					yym689 := z.EncBinary()
+					_ = yym689
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr720 || yy2arr720 {
+			if yyr674 || yy2arr674 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -8922,25 +8304,25 @@ func (x *DaemonSet) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym736 := z.DecBinary()
-	_ = yym736
+	yym690 := z.DecBinary()
+	_ = yym690
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct737 := r.ContainerType()
-		if yyct737 == codecSelferValueTypeMap1234 {
-			yyl737 := r.ReadMapStart()
-			if yyl737 == 0 {
+		yyct691 := r.ContainerType()
+		if yyct691 == codecSelferValueTypeMap1234 {
+			yyl691 := r.ReadMapStart()
+			if yyl691 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl737, d)
+				x.codecDecodeSelfFromMap(yyl691, d)
 			}
-		} else if yyct737 == codecSelferValueTypeArray1234 {
-			yyl737 := r.ReadArrayStart()
-			if yyl737 == 0 {
+		} else if yyct691 == codecSelferValueTypeArray1234 {
+			yyl691 := r.ReadArrayStart()
+			if yyl691 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl737, d)
+				x.codecDecodeSelfFromArray(yyl691, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -8952,12 +8334,12 @@ func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys738Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys738Slc
-	var yyhl738 bool = l >= 0
-	for yyj738 := 0; ; yyj738++ {
-		if yyhl738 {
-			if yyj738 >= l {
+	var yys692Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys692Slc
+	var yyhl692 bool = l >= 0
+	for yyj692 := 0; ; yyj692++ {
+		if yyhl692 {
+			if yyj692 >= l {
 				break
 			}
 		} else {
@@ -8966,30 +8348,30 @@ func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys738Slc = r.DecodeBytes(yys738Slc, true, true)
-		yys738 := string(yys738Slc)
+		yys692Slc = r.DecodeBytes(yys692Slc, true, true)
+		yys692 := string(yys692Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys738 {
+		switch yys692 {
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_v1.ObjectMeta{}
 			} else {
-				yyv739 := &x.ObjectMeta
-				yyv739.CodecDecodeSelf(d)
+				yyv693 := &x.ObjectMeta
+				yyv693.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = DaemonSetSpec{}
 			} else {
-				yyv740 := &x.Spec
-				yyv740.CodecDecodeSelf(d)
+				yyv694 := &x.Spec
+				yyv694.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = DaemonSetStatus{}
 			} else {
-				yyv741 := &x.Status
-				yyv741.CodecDecodeSelf(d)
+				yyv695 := &x.Status
+				yyv695.CodecDecodeSelf(d)
 			}
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -9004,9 +8386,9 @@ func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys738)
-		} // end switch yys738
-	} // end for yyj738
+			z.DecStructFieldNotFound(-1, yys692)
+		} // end switch yys692
+	} // end for yyj692
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -9014,16 +8396,16 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj744 int
-	var yyb744 bool
-	var yyhl744 bool = l >= 0
-	yyj744++
-	if yyhl744 {
-		yyb744 = yyj744 > l
+	var yyj698 int
+	var yyb698 bool
+	var yyhl698 bool = l >= 0
+	yyj698++
+	if yyhl698 {
+		yyb698 = yyj698 > l
 	} else {
-		yyb744 = r.CheckBreak()
+		yyb698 = r.CheckBreak()
 	}
-	if yyb744 {
+	if yyb698 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9031,16 +8413,16 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_v1.ObjectMeta{}
 	} else {
-		yyv745 := &x.ObjectMeta
-		yyv745.CodecDecodeSelf(d)
+		yyv699 := &x.ObjectMeta
+		yyv699.CodecDecodeSelf(d)
 	}
-	yyj744++
-	if yyhl744 {
-		yyb744 = yyj744 > l
+	yyj698++
+	if yyhl698 {
+		yyb698 = yyj698 > l
 	} else {
-		yyb744 = r.CheckBreak()
+		yyb698 = r.CheckBreak()
 	}
-	if yyb744 {
+	if yyb698 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9048,16 +8430,16 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Spec = DaemonSetSpec{}
 	} else {
-		yyv746 := &x.Spec
-		yyv746.CodecDecodeSelf(d)
+		yyv700 := &x.Spec
+		yyv700.CodecDecodeSelf(d)
 	}
-	yyj744++
-	if yyhl744 {
-		yyb744 = yyj744 > l
+	yyj698++
+	if yyhl698 {
+		yyb698 = yyj698 > l
 	} else {
-		yyb744 = r.CheckBreak()
+		yyb698 = r.CheckBreak()
 	}
-	if yyb744 {
+	if yyb698 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9065,16 +8447,16 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Status = DaemonSetStatus{}
 	} else {
-		yyv747 := &x.Status
-		yyv747.CodecDecodeSelf(d)
+		yyv701 := &x.Status
+		yyv701.CodecDecodeSelf(d)
 	}
-	yyj744++
-	if yyhl744 {
-		yyb744 = yyj744 > l
+	yyj698++
+	if yyhl698 {
+		yyb698 = yyj698 > l
 	} else {
-		yyb744 = r.CheckBreak()
+		yyb698 = r.CheckBreak()
 	}
-	if yyb744 {
+	if yyb698 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9084,13 +8466,13 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj744++
-	if yyhl744 {
-		yyb744 = yyj744 > l
+	yyj698++
+	if yyhl698 {
+		yyb698 = yyj698 > l
 	} else {
-		yyb744 = r.CheckBreak()
+		yyb698 = r.CheckBreak()
 	}
-	if yyb744 {
+	if yyb698 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9101,17 +8483,17 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = string(r.DecodeString())
 	}
 	for {
-		yyj744++
-		if yyhl744 {
-			yyb744 = yyj744 > l
+		yyj698++
+		if yyhl698 {
+			yyb698 = yyj698 > l
 		} else {
-			yyb744 = r.CheckBreak()
+			yyb698 = r.CheckBreak()
 		}
-		if yyb744 {
+		if yyb698 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj744-1, "")
+		z.DecStructFieldNotFound(yyj698-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -9123,68 +8505,68 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym750 := z.EncBinary()
-		_ = yym750
+		yym704 := z.EncBinary()
+		_ = yym704
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep751 := !z.EncBinary()
-			yy2arr751 := z.EncBasicHandle().StructToArray
-			var yyq751 [4]bool
-			_, _, _ = yysep751, yyq751, yy2arr751
-			const yyr751 bool = false
-			yyq751[0] = true
-			yyq751[2] = x.Kind != ""
-			yyq751[3] = x.APIVersion != ""
-			var yynn751 int
-			if yyr751 || yy2arr751 {
+			yysep705 := !z.EncBinary()
+			yy2arr705 := z.EncBasicHandle().StructToArray
+			var yyq705 [4]bool
+			_, _, _ = yysep705, yyq705, yy2arr705
+			const yyr705 bool = false
+			yyq705[0] = true
+			yyq705[2] = x.Kind != ""
+			yyq705[3] = x.APIVersion != ""
+			var yynn705 int
+			if yyr705 || yy2arr705 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn751 = 1
-				for _, b := range yyq751 {
+				yynn705 = 1
+				for _, b := range yyq705 {
 					if b {
-						yynn751++
+						yynn705++
 					}
 				}
-				r.EncodeMapStart(yynn751)
-				yynn751 = 0
+				r.EncodeMapStart(yynn705)
+				yynn705 = 0
 			}
-			if yyr751 || yy2arr751 {
+			if yyr705 || yy2arr705 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq751[0] {
-					yy753 := &x.ListMeta
-					yym754 := z.EncBinary()
-					_ = yym754
+				if yyq705[0] {
+					yy707 := &x.ListMeta
+					yym708 := z.EncBinary()
+					_ = yym708
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy753) {
+					} else if z.HasExtensions() && z.EncExt(yy707) {
 					} else {
-						z.EncFallback(yy753)
+						z.EncFallback(yy707)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq751[0] {
+				if yyq705[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy755 := &x.ListMeta
-					yym756 := z.EncBinary()
-					_ = yym756
+					yy709 := &x.ListMeta
+					yym710 := z.EncBinary()
+					_ = yym710
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy755) {
+					} else if z.HasExtensions() && z.EncExt(yy709) {
 					} else {
-						z.EncFallback(yy755)
+						z.EncFallback(yy709)
 					}
 				}
 			}
-			if yyr751 || yy2arr751 {
+			if yyr705 || yy2arr705 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym758 := z.EncBinary()
-					_ = yym758
+					yym712 := z.EncBinary()
+					_ = yym712
 					if false {
 					} else {
 						h.encSliceDaemonSet(([]DaemonSet)(x.Items), e)
@@ -9197,19 +8579,19 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym759 := z.EncBinary()
-					_ = yym759
+					yym713 := z.EncBinary()
+					_ = yym713
 					if false {
 					} else {
 						h.encSliceDaemonSet(([]DaemonSet)(x.Items), e)
 					}
 				}
 			}
-			if yyr751 || yy2arr751 {
+			if yyr705 || yy2arr705 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq751[2] {
-					yym761 := z.EncBinary()
-					_ = yym761
+				if yyq705[2] {
+					yym715 := z.EncBinary()
+					_ = yym715
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -9218,23 +8600,23 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq751[2] {
+				if yyq705[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym762 := z.EncBinary()
-					_ = yym762
+					yym716 := z.EncBinary()
+					_ = yym716
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr751 || yy2arr751 {
+			if yyr705 || yy2arr705 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq751[3] {
-					yym764 := z.EncBinary()
-					_ = yym764
+				if yyq705[3] {
+					yym718 := z.EncBinary()
+					_ = yym718
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -9243,19 +8625,19 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq751[3] {
+				if yyq705[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym765 := z.EncBinary()
-					_ = yym765
+					yym719 := z.EncBinary()
+					_ = yym719
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr751 || yy2arr751 {
+			if yyr705 || yy2arr705 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -9268,25 +8650,25 @@ func (x *DaemonSetList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym766 := z.DecBinary()
-	_ = yym766
+	yym720 := z.DecBinary()
+	_ = yym720
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct767 := r.ContainerType()
-		if yyct767 == codecSelferValueTypeMap1234 {
-			yyl767 := r.ReadMapStart()
-			if yyl767 == 0 {
+		yyct721 := r.ContainerType()
+		if yyct721 == codecSelferValueTypeMap1234 {
+			yyl721 := r.ReadMapStart()
+			if yyl721 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl767, d)
+				x.codecDecodeSelfFromMap(yyl721, d)
 			}
-		} else if yyct767 == codecSelferValueTypeArray1234 {
-			yyl767 := r.ReadArrayStart()
-			if yyl767 == 0 {
+		} else if yyct721 == codecSelferValueTypeArray1234 {
+			yyl721 := r.ReadArrayStart()
+			if yyl721 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl767, d)
+				x.codecDecodeSelfFromArray(yyl721, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -9298,12 +8680,12 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys768Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys768Slc
-	var yyhl768 bool = l >= 0
-	for yyj768 := 0; ; yyj768++ {
-		if yyhl768 {
-			if yyj768 >= l {
+	var yys722Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys722Slc
+	var yyhl722 bool = l >= 0
+	for yyj722 := 0; ; yyj722++ {
+		if yyhl722 {
+			if yyj722 >= l {
 				break
 			}
 		} else {
@@ -9312,33 +8694,33 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys768Slc = r.DecodeBytes(yys768Slc, true, true)
-		yys768 := string(yys768Slc)
+		yys722Slc = r.DecodeBytes(yys722Slc, true, true)
+		yys722 := string(yys722Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys768 {
+		switch yys722 {
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv769 := &x.ListMeta
-				yym770 := z.DecBinary()
-				_ = yym770
+				yyv723 := &x.ListMeta
+				yym724 := z.DecBinary()
+				_ = yym724
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv769) {
+				} else if z.HasExtensions() && z.DecExt(yyv723) {
 				} else {
-					z.DecFallback(yyv769, false)
+					z.DecFallback(yyv723, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv771 := &x.Items
-				yym772 := z.DecBinary()
-				_ = yym772
+				yyv725 := &x.Items
+				yym726 := z.DecBinary()
+				_ = yym726
 				if false {
 				} else {
-					h.decSliceDaemonSet((*[]DaemonSet)(yyv771), d)
+					h.decSliceDaemonSet((*[]DaemonSet)(yyv725), d)
 				}
 			}
 		case "kind":
@@ -9354,9 +8736,9 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys768)
-		} // end switch yys768
-	} // end for yyj768
+			z.DecStructFieldNotFound(-1, yys722)
+		} // end switch yys722
+	} // end for yyj722
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -9364,16 +8746,16 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj775 int
-	var yyb775 bool
-	var yyhl775 bool = l >= 0
-	yyj775++
-	if yyhl775 {
-		yyb775 = yyj775 > l
+	var yyj729 int
+	var yyb729 bool
+	var yyhl729 bool = l >= 0
+	yyj729++
+	if yyhl729 {
+		yyb729 = yyj729 > l
 	} else {
-		yyb775 = r.CheckBreak()
+		yyb729 = r.CheckBreak()
 	}
-	if yyb775 {
+	if yyb729 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9381,22 +8763,22 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv776 := &x.ListMeta
-		yym777 := z.DecBinary()
-		_ = yym777
+		yyv730 := &x.ListMeta
+		yym731 := z.DecBinary()
+		_ = yym731
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv776) {
+		} else if z.HasExtensions() && z.DecExt(yyv730) {
 		} else {
-			z.DecFallback(yyv776, false)
+			z.DecFallback(yyv730, false)
 		}
 	}
-	yyj775++
-	if yyhl775 {
-		yyb775 = yyj775 > l
+	yyj729++
+	if yyhl729 {
+		yyb729 = yyj729 > l
 	} else {
-		yyb775 = r.CheckBreak()
+		yyb729 = r.CheckBreak()
 	}
-	if yyb775 {
+	if yyb729 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9404,21 +8786,21 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv778 := &x.Items
-		yym779 := z.DecBinary()
-		_ = yym779
+		yyv732 := &x.Items
+		yym733 := z.DecBinary()
+		_ = yym733
 		if false {
 		} else {
-			h.decSliceDaemonSet((*[]DaemonSet)(yyv778), d)
+			h.decSliceDaemonSet((*[]DaemonSet)(yyv732), d)
 		}
 	}
-	yyj775++
-	if yyhl775 {
-		yyb775 = yyj775 > l
+	yyj729++
+	if yyhl729 {
+		yyb729 = yyj729 > l
 	} else {
-		yyb775 = r.CheckBreak()
+		yyb729 = r.CheckBreak()
 	}
-	if yyb775 {
+	if yyb729 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9428,13 +8810,13 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj775++
-	if yyhl775 {
-		yyb775 = yyj775 > l
+	yyj729++
+	if yyhl729 {
+		yyb729 = yyj729 > l
 	} else {
-		yyb775 = r.CheckBreak()
+		yyb729 = r.CheckBreak()
 	}
-	if yyb775 {
+	if yyb729 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9445,17 +8827,17 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = string(r.DecodeString())
 	}
 	for {
-		yyj775++
-		if yyhl775 {
-			yyb775 = yyj775 > l
+		yyj729++
+		if yyhl729 {
+			yyb729 = yyj729 > l
 		} else {
-			yyb775 = r.CheckBreak()
+			yyb729 = r.CheckBreak()
 		}
-		if yyb775 {
+		if yyb729 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj775-1, "")
+		z.DecStructFieldNotFound(yyj729-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -9467,68 +8849,68 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym782 := z.EncBinary()
-		_ = yym782
+		yym736 := z.EncBinary()
+		_ = yym736
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep783 := !z.EncBinary()
-			yy2arr783 := z.EncBasicHandle().StructToArray
-			var yyq783 [4]bool
-			_, _, _ = yysep783, yyq783, yy2arr783
-			const yyr783 bool = false
-			yyq783[0] = true
-			yyq783[2] = x.Kind != ""
-			yyq783[3] = x.APIVersion != ""
-			var yynn783 int
-			if yyr783 || yy2arr783 {
+			yysep737 := !z.EncBinary()
+			yy2arr737 := z.EncBasicHandle().StructToArray
+			var yyq737 [4]bool
+			_, _, _ = yysep737, yyq737, yy2arr737
+			const yyr737 bool = false
+			yyq737[0] = true
+			yyq737[2] = x.Kind != ""
+			yyq737[3] = x.APIVersion != ""
+			var yynn737 int
+			if yyr737 || yy2arr737 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn783 = 1
-				for _, b := range yyq783 {
+				yynn737 = 1
+				for _, b := range yyq737 {
 					if b {
-						yynn783++
+						yynn737++
 					}
 				}
-				r.EncodeMapStart(yynn783)
-				yynn783 = 0
+				r.EncodeMapStart(yynn737)
+				yynn737 = 0
 			}
-			if yyr783 || yy2arr783 {
+			if yyr737 || yy2arr737 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq783[0] {
-					yy785 := &x.ListMeta
-					yym786 := z.EncBinary()
-					_ = yym786
+				if yyq737[0] {
+					yy739 := &x.ListMeta
+					yym740 := z.EncBinary()
+					_ = yym740
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy785) {
+					} else if z.HasExtensions() && z.EncExt(yy739) {
 					} else {
-						z.EncFallback(yy785)
+						z.EncFallback(yy739)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq783[0] {
+				if yyq737[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy787 := &x.ListMeta
-					yym788 := z.EncBinary()
-					_ = yym788
+					yy741 := &x.ListMeta
+					yym742 := z.EncBinary()
+					_ = yym742
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy787) {
+					} else if z.HasExtensions() && z.EncExt(yy741) {
 					} else {
-						z.EncFallback(yy787)
+						z.EncFallback(yy741)
 					}
 				}
 			}
-			if yyr783 || yy2arr783 {
+			if yyr737 || yy2arr737 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym790 := z.EncBinary()
-					_ = yym790
+					yym744 := z.EncBinary()
+					_ = yym744
 					if false {
 					} else {
 						h.encSliceThirdPartyResourceData(([]ThirdPartyResourceData)(x.Items), e)
@@ -9541,19 +8923,19 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym791 := z.EncBinary()
-					_ = yym791
+					yym745 := z.EncBinary()
+					_ = yym745
 					if false {
 					} else {
 						h.encSliceThirdPartyResourceData(([]ThirdPartyResourceData)(x.Items), e)
 					}
 				}
 			}
-			if yyr783 || yy2arr783 {
+			if yyr737 || yy2arr737 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq783[2] {
-					yym793 := z.EncBinary()
-					_ = yym793
+				if yyq737[2] {
+					yym747 := z.EncBinary()
+					_ = yym747
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -9562,23 +8944,23 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq783[2] {
+				if yyq737[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym794 := z.EncBinary()
-					_ = yym794
+					yym748 := z.EncBinary()
+					_ = yym748
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr783 || yy2arr783 {
+			if yyr737 || yy2arr737 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq783[3] {
-					yym796 := z.EncBinary()
-					_ = yym796
+				if yyq737[3] {
+					yym750 := z.EncBinary()
+					_ = yym750
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -9587,19 +8969,19 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq783[3] {
+				if yyq737[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym797 := z.EncBinary()
-					_ = yym797
+					yym751 := z.EncBinary()
+					_ = yym751
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr783 || yy2arr783 {
+			if yyr737 || yy2arr737 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -9612,25 +8994,25 @@ func (x *ThirdPartyResourceDataList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym798 := z.DecBinary()
-	_ = yym798
+	yym752 := z.DecBinary()
+	_ = yym752
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct799 := r.ContainerType()
-		if yyct799 == codecSelferValueTypeMap1234 {
-			yyl799 := r.ReadMapStart()
-			if yyl799 == 0 {
+		yyct753 := r.ContainerType()
+		if yyct753 == codecSelferValueTypeMap1234 {
+			yyl753 := r.ReadMapStart()
+			if yyl753 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl799, d)
+				x.codecDecodeSelfFromMap(yyl753, d)
 			}
-		} else if yyct799 == codecSelferValueTypeArray1234 {
-			yyl799 := r.ReadArrayStart()
-			if yyl799 == 0 {
+		} else if yyct753 == codecSelferValueTypeArray1234 {
+			yyl753 := r.ReadArrayStart()
+			if yyl753 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl799, d)
+				x.codecDecodeSelfFromArray(yyl753, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -9642,12 +9024,12 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys800Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys800Slc
-	var yyhl800 bool = l >= 0
-	for yyj800 := 0; ; yyj800++ {
-		if yyhl800 {
-			if yyj800 >= l {
+	var yys754Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys754Slc
+	var yyhl754 bool = l >= 0
+	for yyj754 := 0; ; yyj754++ {
+		if yyhl754 {
+			if yyj754 >= l {
 				break
 			}
 		} else {
@@ -9656,33 +9038,33 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys800Slc = r.DecodeBytes(yys800Slc, true, true)
-		yys800 := string(yys800Slc)
+		yys754Slc = r.DecodeBytes(yys754Slc, true, true)
+		yys754 := string(yys754Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys800 {
+		switch yys754 {
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv801 := &x.ListMeta
-				yym802 := z.DecBinary()
-				_ = yym802
+				yyv755 := &x.ListMeta
+				yym756 := z.DecBinary()
+				_ = yym756
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv801) {
+				} else if z.HasExtensions() && z.DecExt(yyv755) {
 				} else {
-					z.DecFallback(yyv801, false)
+					z.DecFallback(yyv755, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv803 := &x.Items
-				yym804 := z.DecBinary()
-				_ = yym804
+				yyv757 := &x.Items
+				yym758 := z.DecBinary()
+				_ = yym758
 				if false {
 				} else {
-					h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv803), d)
+					h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv757), d)
 				}
 			}
 		case "kind":
@@ -9698,9 +9080,9 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 				x.APIVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys800)
-		} // end switch yys800
-	} // end for yyj800
+			z.DecStructFieldNotFound(-1, yys754)
+		} // end switch yys754
+	} // end for yyj754
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -9708,16 +9090,16 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj807 int
-	var yyb807 bool
-	var yyhl807 bool = l >= 0
-	yyj807++
-	if yyhl807 {
-		yyb807 = yyj807 > l
+	var yyj761 int
+	var yyb761 bool
+	var yyhl761 bool = l >= 0
+	yyj761++
+	if yyhl761 {
+		yyb761 = yyj761 > l
 	} else {
-		yyb807 = r.CheckBreak()
+		yyb761 = r.CheckBreak()
 	}
-	if yyb807 {
+	if yyb761 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9725,22 +9107,22 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv808 := &x.ListMeta
-		yym809 := z.DecBinary()
-		_ = yym809
+		yyv762 := &x.ListMeta
+		yym763 := z.DecBinary()
+		_ = yym763
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv808) {
+		} else if z.HasExtensions() && z.DecExt(yyv762) {
 		} else {
-			z.DecFallback(yyv808, false)
+			z.DecFallback(yyv762, false)
 		}
 	}
-	yyj807++
-	if yyhl807 {
-		yyb807 = yyj807 > l
+	yyj761++
+	if yyhl761 {
+		yyb761 = yyj761 > l
 	} else {
-		yyb807 = r.CheckBreak()
+		yyb761 = r.CheckBreak()
 	}
-	if yyb807 {
+	if yyb761 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9748,21 +9130,21 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv810 := &x.Items
-		yym811 := z.DecBinary()
-		_ = yym811
+		yyv764 := &x.Items
+		yym765 := z.DecBinary()
+		_ = yym765
 		if false {
 		} else {
-			h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv810), d)
+			h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv764), d)
 		}
 	}
-	yyj807++
-	if yyhl807 {
-		yyb807 = yyj807 > l
+	yyj761++
+	if yyhl761 {
+		yyb761 = yyj761 > l
 	} else {
-		yyb807 = r.CheckBreak()
+		yyb761 = r.CheckBreak()
 	}
-	if yyb807 {
+	if yyb761 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9772,13 +9154,13 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj807++
-	if yyhl807 {
-		yyb807 = yyj807 > l
+	yyj761++
+	if yyhl761 {
+		yyb761 = yyj761 > l
 	} else {
-		yyb807 = r.CheckBreak()
+		yyb761 = r.CheckBreak()
 	}
-	if yyb807 {
+	if yyb761 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9789,17 +9171,17 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 		x.APIVersion = string(r.DecodeString())
 	}
 	for {
-		yyj807++
-		if yyhl807 {
-			yyb807 = yyj807 > l
+		yyj761++
+		if yyhl761 {
+			yyb761 = yyj761 > l
 		} else {
-			yyb807 = r.CheckBreak()
+			yyb761 = r.CheckBreak()
 		}
-		if yyb807 {
+		if yyb761 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj807-1, "")
+		z.DecStructFieldNotFound(yyj761-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -9811,90 +9193,90 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym814 := z.EncBinary()
-		_ = yym814
+		yym768 := z.EncBinary()
+		_ = yym768
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep815 := !z.EncBinary()
-			yy2arr815 := z.EncBasicHandle().StructToArray
-			var yyq815 [5]bool
-			_, _, _ = yysep815, yyq815, yy2arr815
-			const yyr815 bool = false
-			yyq815[0] = true
-			yyq815[1] = true
-			yyq815[2] = true
-			yyq815[3] = x.Kind != ""
-			yyq815[4] = x.APIVersion != ""
-			var yynn815 int
-			if yyr815 || yy2arr815 {
+			yysep769 := !z.EncBinary()
+			yy2arr769 := z.EncBasicHandle().StructToArray
+			var yyq769 [5]bool
+			_, _, _ = yysep769, yyq769, yy2arr769
+			const yyr769 bool = false
+			yyq769[0] = true
+			yyq769[1] = true
+			yyq769[2] = true
+			yyq769[3] = x.Kind != ""
+			yyq769[4] = x.APIVersion != ""
+			var yynn769 int
+			if yyr769 || yy2arr769 {
 				r.EncodeArrayStart(5)
 			} else {
-				yynn815 = 0
-				for _, b := range yyq815 {
+				yynn769 = 0
+				for _, b := range yyq769 {
 					if b {
-						yynn815++
+						yynn769++
 					}
 				}
-				r.EncodeMapStart(yynn815)
-				yynn815 = 0
+				r.EncodeMapStart(yynn769)
+				yynn769 = 0
 			}
-			if yyr815 || yy2arr815 {
+			if yyr769 || yy2arr769 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq815[0] {
-					yy817 := &x.ObjectMeta
-					yy817.CodecEncodeSelf(e)
+				if yyq769[0] {
+					yy771 := &x.ObjectMeta
+					yy771.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq815[0] {
+				if yyq769[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy818 := &x.ObjectMeta
-					yy818.CodecEncodeSelf(e)
+					yy772 := &x.ObjectMeta
+					yy772.CodecEncodeSelf(e)
 				}
 			}
-			if yyr815 || yy2arr815 {
+			if yyr769 || yy2arr769 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq815[1] {
-					yy820 := &x.Spec
-					yy820.CodecEncodeSelf(e)
+				if yyq769[1] {
+					yy774 := &x.Spec
+					yy774.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq815[1] {
+				if yyq769[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy821 := &x.Spec
-					yy821.CodecEncodeSelf(e)
+					yy775 := &x.Spec
+					yy775.CodecEncodeSelf(e)
 				}
 			}
-			if yyr815 || yy2arr815 {
+			if yyr769 || yy2arr769 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq815[2] {
-					yy823 := &x.Status
-					yy823.CodecEncodeSelf(e)
+				if yyq769[2] {
+					yy777 := &x.Status
+					yy777.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq815[2] {
+				if yyq769[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy824 := &x.Status
-					yy824.CodecEncodeSelf(e)
+					yy778 := &x.Status
+					yy778.CodecEncodeSelf(e)
 				}
 			}
-			if yyr815 || yy2arr815 {
+			if yyr769 || yy2arr769 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq815[3] {
-					yym826 := z.EncBinary()
-					_ = yym826
+				if yyq769[3] {
+					yym780 := z.EncBinary()
+					_ = yym780
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -9903,23 +9285,23 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq815[3] {
+				if yyq769[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym827 := z.EncBinary()
-					_ = yym827
+					yym781 := z.EncBinary()
+					_ = yym781
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr815 || yy2arr815 {
+			if yyr769 || yy2arr769 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq815[4] {
-					yym829 := z.EncBinary()
-					_ = yym829
+				if yyq769[4] {
+					yym783 := z.EncBinary()
+					_ = yym783
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -9928,19 +9310,19 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq815[4] {
+				if yyq769[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym830 := z.EncBinary()
-					_ = yym830
+					yym784 := z.EncBinary()
+					_ = yym784
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr815 || yy2arr815 {
+			if yyr769 || yy2arr769 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -9953,25 +9335,25 @@ func (x *Job) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym831 := z.DecBinary()
-	_ = yym831
+	yym785 := z.DecBinary()
+	_ = yym785
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct832 := r.ContainerType()
-		if yyct832 == codecSelferValueTypeMap1234 {
-			yyl832 := r.ReadMapStart()
-			if yyl832 == 0 {
+		yyct786 := r.ContainerType()
+		if yyct786 == codecSelferValueTypeMap1234 {
+			yyl786 := r.ReadMapStart()
+			if yyl786 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl832, d)
+				x.codecDecodeSelfFromMap(yyl786, d)
 			}
-		} else if yyct832 == codecSelferValueTypeArray1234 {
-			yyl832 := r.ReadArrayStart()
-			if yyl832 == 0 {
+		} else if yyct786 == codecSelferValueTypeArray1234 {
+			yyl786 := r.ReadArrayStart()
+			if yyl786 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl832, d)
+				x.codecDecodeSelfFromArray(yyl786, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -9983,12 +9365,12 @@ func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys833Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys833Slc
-	var yyhl833 bool = l >= 0
-	for yyj833 := 0; ; yyj833++ {
-		if yyhl833 {
-			if yyj833 >= l {
+	var yys787Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys787Slc
+	var yyhl787 bool = l >= 0
+	for yyj787 := 0; ; yyj787++ {
+		if yyhl787 {
+			if yyj787 >= l {
 				break
 			}
 		} else {
@@ -9997,30 +9379,30 @@ func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys833Slc = r.DecodeBytes(yys833Slc, true, true)
-		yys833 := string(yys833Slc)
+		yys787Slc = r.DecodeBytes(yys787Slc, true, true)
+		yys787 := string(yys787Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys833 {
+		switch yys787 {
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_v1.ObjectMeta{}
 			} else {
-				yyv834 := &x.ObjectMeta
-				yyv834.CodecDecodeSelf(d)
+				yyv788 := &x.ObjectMeta
+				yyv788.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = JobSpec{}
 			} else {
-				yyv835 := &x.Spec
-				yyv835.CodecDecodeSelf(d)
+				yyv789 := &x.Spec
+				yyv789.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = JobStatus{}
 			} else {
-				yyv836 := &x.Status
-				yyv836.CodecDecodeSelf(d)
+				yyv790 := &x.Status
+				yyv790.CodecDecodeSelf(d)
 			}
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -10035,9 +9417,9 @@ func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys833)
-		} // end switch yys833
-	} // end for yyj833
+			z.DecStructFieldNotFound(-1, yys787)
+		} // end switch yys787
+	} // end for yyj787
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -10045,16 +9427,16 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj839 int
-	var yyb839 bool
-	var yyhl839 bool = l >= 0
-	yyj839++
-	if yyhl839 {
-		yyb839 = yyj839 > l
+	var yyj793 int
+	var yyb793 bool
+	var yyhl793 bool = l >= 0
+	yyj793++
+	if yyhl793 {
+		yyb793 = yyj793 > l
 	} else {
-		yyb839 = r.CheckBreak()
+		yyb793 = r.CheckBreak()
 	}
-	if yyb839 {
+	if yyb793 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10062,16 +9444,16 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_v1.ObjectMeta{}
 	} else {
-		yyv840 := &x.ObjectMeta
-		yyv840.CodecDecodeSelf(d)
+		yyv794 := &x.ObjectMeta
+		yyv794.CodecDecodeSelf(d)
 	}
-	yyj839++
-	if yyhl839 {
-		yyb839 = yyj839 > l
+	yyj793++
+	if yyhl793 {
+		yyb793 = yyj793 > l
 	} else {
-		yyb839 = r.CheckBreak()
+		yyb793 = r.CheckBreak()
 	}
-	if yyb839 {
+	if yyb793 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10079,16 +9461,16 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Spec = JobSpec{}
 	} else {
-		yyv841 := &x.Spec
-		yyv841.CodecDecodeSelf(d)
+		yyv795 := &x.Spec
+		yyv795.CodecDecodeSelf(d)
 	}
-	yyj839++
-	if yyhl839 {
-		yyb839 = yyj839 > l
+	yyj793++
+	if yyhl793 {
+		yyb793 = yyj793 > l
 	} else {
-		yyb839 = r.CheckBreak()
+		yyb793 = r.CheckBreak()
 	}
-	if yyb839 {
+	if yyb793 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10096,16 +9478,16 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Status = JobStatus{}
 	} else {
-		yyv842 := &x.Status
-		yyv842.CodecDecodeSelf(d)
+		yyv796 := &x.Status
+		yyv796.CodecDecodeSelf(d)
 	}
-	yyj839++
-	if yyhl839 {
-		yyb839 = yyj839 > l
+	yyj793++
+	if yyhl793 {
+		yyb793 = yyj793 > l
 	} else {
-		yyb839 = r.CheckBreak()
+		yyb793 = r.CheckBreak()
 	}
-	if yyb839 {
+	if yyb793 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10115,13 +9497,13 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj839++
-	if yyhl839 {
-		yyb839 = yyj839 > l
+	yyj793++
+	if yyhl793 {
+		yyb793 = yyj793 > l
 	} else {
-		yyb839 = r.CheckBreak()
+		yyb793 = r.CheckBreak()
 	}
-	if yyb839 {
+	if yyb793 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10132,17 +9514,17 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = string(r.DecodeString())
 	}
 	for {
-		yyj839++
-		if yyhl839 {
-			yyb839 = yyj839 > l
+		yyj793++
+		if yyhl793 {
+			yyb793 = yyj793 > l
 		} else {
-			yyb839 = r.CheckBreak()
+			yyb793 = r.CheckBreak()
 		}
-		if yyb839 {
+		if yyb793 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj839-1, "")
+		z.DecStructFieldNotFound(yyj793-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -10154,68 +9536,68 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym845 := z.EncBinary()
-		_ = yym845
+		yym799 := z.EncBinary()
+		_ = yym799
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep846 := !z.EncBinary()
-			yy2arr846 := z.EncBasicHandle().StructToArray
-			var yyq846 [4]bool
-			_, _, _ = yysep846, yyq846, yy2arr846
-			const yyr846 bool = false
-			yyq846[0] = true
-			yyq846[2] = x.Kind != ""
-			yyq846[3] = x.APIVersion != ""
-			var yynn846 int
-			if yyr846 || yy2arr846 {
+			yysep800 := !z.EncBinary()
+			yy2arr800 := z.EncBasicHandle().StructToArray
+			var yyq800 [4]bool
+			_, _, _ = yysep800, yyq800, yy2arr800
+			const yyr800 bool = false
+			yyq800[0] = true
+			yyq800[2] = x.Kind != ""
+			yyq800[3] = x.APIVersion != ""
+			var yynn800 int
+			if yyr800 || yy2arr800 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn846 = 1
-				for _, b := range yyq846 {
+				yynn800 = 1
+				for _, b := range yyq800 {
 					if b {
-						yynn846++
+						yynn800++
 					}
 				}
-				r.EncodeMapStart(yynn846)
-				yynn846 = 0
+				r.EncodeMapStart(yynn800)
+				yynn800 = 0
 			}
-			if yyr846 || yy2arr846 {
+			if yyr800 || yy2arr800 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq846[0] {
-					yy848 := &x.ListMeta
-					yym849 := z.EncBinary()
-					_ = yym849
+				if yyq800[0] {
+					yy802 := &x.ListMeta
+					yym803 := z.EncBinary()
+					_ = yym803
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy848) {
+					} else if z.HasExtensions() && z.EncExt(yy802) {
 					} else {
-						z.EncFallback(yy848)
+						z.EncFallback(yy802)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq846[0] {
+				if yyq800[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy850 := &x.ListMeta
-					yym851 := z.EncBinary()
-					_ = yym851
+					yy804 := &x.ListMeta
+					yym805 := z.EncBinary()
+					_ = yym805
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy850) {
+					} else if z.HasExtensions() && z.EncExt(yy804) {
 					} else {
-						z.EncFallback(yy850)
+						z.EncFallback(yy804)
 					}
 				}
 			}
-			if yyr846 || yy2arr846 {
+			if yyr800 || yy2arr800 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym853 := z.EncBinary()
-					_ = yym853
+					yym807 := z.EncBinary()
+					_ = yym807
 					if false {
 					} else {
 						h.encSliceJob(([]Job)(x.Items), e)
@@ -10228,19 +9610,19 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym854 := z.EncBinary()
-					_ = yym854
+					yym808 := z.EncBinary()
+					_ = yym808
 					if false {
 					} else {
 						h.encSliceJob(([]Job)(x.Items), e)
 					}
 				}
 			}
-			if yyr846 || yy2arr846 {
+			if yyr800 || yy2arr800 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq846[2] {
-					yym856 := z.EncBinary()
-					_ = yym856
+				if yyq800[2] {
+					yym810 := z.EncBinary()
+					_ = yym810
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -10249,23 +9631,23 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq846[2] {
+				if yyq800[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym857 := z.EncBinary()
-					_ = yym857
+					yym811 := z.EncBinary()
+					_ = yym811
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr846 || yy2arr846 {
+			if yyr800 || yy2arr800 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq846[3] {
-					yym859 := z.EncBinary()
-					_ = yym859
+				if yyq800[3] {
+					yym813 := z.EncBinary()
+					_ = yym813
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -10274,19 +9656,19 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq846[3] {
+				if yyq800[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym860 := z.EncBinary()
-					_ = yym860
+					yym814 := z.EncBinary()
+					_ = yym814
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr846 || yy2arr846 {
+			if yyr800 || yy2arr800 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -10299,25 +9681,25 @@ func (x *JobList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym861 := z.DecBinary()
-	_ = yym861
+	yym815 := z.DecBinary()
+	_ = yym815
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct862 := r.ContainerType()
-		if yyct862 == codecSelferValueTypeMap1234 {
-			yyl862 := r.ReadMapStart()
-			if yyl862 == 0 {
+		yyct816 := r.ContainerType()
+		if yyct816 == codecSelferValueTypeMap1234 {
+			yyl816 := r.ReadMapStart()
+			if yyl816 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl862, d)
+				x.codecDecodeSelfFromMap(yyl816, d)
 			}
-		} else if yyct862 == codecSelferValueTypeArray1234 {
-			yyl862 := r.ReadArrayStart()
-			if yyl862 == 0 {
+		} else if yyct816 == codecSelferValueTypeArray1234 {
+			yyl816 := r.ReadArrayStart()
+			if yyl816 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl862, d)
+				x.codecDecodeSelfFromArray(yyl816, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10329,12 +9711,12 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys863Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys863Slc
-	var yyhl863 bool = l >= 0
-	for yyj863 := 0; ; yyj863++ {
-		if yyhl863 {
-			if yyj863 >= l {
+	var yys817Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys817Slc
+	var yyhl817 bool = l >= 0
+	for yyj817 := 0; ; yyj817++ {
+		if yyhl817 {
+			if yyj817 >= l {
 				break
 			}
 		} else {
@@ -10343,33 +9725,33 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys863Slc = r.DecodeBytes(yys863Slc, true, true)
-		yys863 := string(yys863Slc)
+		yys817Slc = r.DecodeBytes(yys817Slc, true, true)
+		yys817 := string(yys817Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys863 {
+		switch yys817 {
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv864 := &x.ListMeta
-				yym865 := z.DecBinary()
-				_ = yym865
+				yyv818 := &x.ListMeta
+				yym819 := z.DecBinary()
+				_ = yym819
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv864) {
+				} else if z.HasExtensions() && z.DecExt(yyv818) {
 				} else {
-					z.DecFallback(yyv864, false)
+					z.DecFallback(yyv818, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv866 := &x.Items
-				yym867 := z.DecBinary()
-				_ = yym867
+				yyv820 := &x.Items
+				yym821 := z.DecBinary()
+				_ = yym821
 				if false {
 				} else {
-					h.decSliceJob((*[]Job)(yyv866), d)
+					h.decSliceJob((*[]Job)(yyv820), d)
 				}
 			}
 		case "kind":
@@ -10385,9 +9767,9 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys863)
-		} // end switch yys863
-	} // end for yyj863
+			z.DecStructFieldNotFound(-1, yys817)
+		} // end switch yys817
+	} // end for yyj817
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -10395,16 +9777,16 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj870 int
-	var yyb870 bool
-	var yyhl870 bool = l >= 0
-	yyj870++
-	if yyhl870 {
-		yyb870 = yyj870 > l
+	var yyj824 int
+	var yyb824 bool
+	var yyhl824 bool = l >= 0
+	yyj824++
+	if yyhl824 {
+		yyb824 = yyj824 > l
 	} else {
-		yyb870 = r.CheckBreak()
+		yyb824 = r.CheckBreak()
 	}
-	if yyb870 {
+	if yyb824 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10412,22 +9794,22 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv871 := &x.ListMeta
-		yym872 := z.DecBinary()
-		_ = yym872
+		yyv825 := &x.ListMeta
+		yym826 := z.DecBinary()
+		_ = yym826
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv871) {
+		} else if z.HasExtensions() && z.DecExt(yyv825) {
 		} else {
-			z.DecFallback(yyv871, false)
+			z.DecFallback(yyv825, false)
 		}
 	}
-	yyj870++
-	if yyhl870 {
-		yyb870 = yyj870 > l
+	yyj824++
+	if yyhl824 {
+		yyb824 = yyj824 > l
 	} else {
-		yyb870 = r.CheckBreak()
+		yyb824 = r.CheckBreak()
 	}
-	if yyb870 {
+	if yyb824 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10435,21 +9817,21 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv873 := &x.Items
-		yym874 := z.DecBinary()
-		_ = yym874
+		yyv827 := &x.Items
+		yym828 := z.DecBinary()
+		_ = yym828
 		if false {
 		} else {
-			h.decSliceJob((*[]Job)(yyv873), d)
+			h.decSliceJob((*[]Job)(yyv827), d)
 		}
 	}
-	yyj870++
-	if yyhl870 {
-		yyb870 = yyj870 > l
+	yyj824++
+	if yyhl824 {
+		yyb824 = yyj824 > l
 	} else {
-		yyb870 = r.CheckBreak()
+		yyb824 = r.CheckBreak()
 	}
-	if yyb870 {
+	if yyb824 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10459,13 +9841,13 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj870++
-	if yyhl870 {
-		yyb870 = yyj870 > l
+	yyj824++
+	if yyhl824 {
+		yyb824 = yyj824 > l
 	} else {
-		yyb870 = r.CheckBreak()
+		yyb824 = r.CheckBreak()
 	}
-	if yyb870 {
+	if yyb824 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10476,17 +9858,17 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = string(r.DecodeString())
 	}
 	for {
-		yyj870++
-		if yyhl870 {
-			yyb870 = yyj870 > l
+		yyj824++
+		if yyhl824 {
+			yyb824 = yyj824 > l
 		} else {
-			yyb870 = r.CheckBreak()
+			yyb824 = r.CheckBreak()
 		}
-		if yyb870 {
+		if yyb824 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj870-1, "")
+		z.DecStructFieldNotFound(yyj824-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -10498,141 +9880,141 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym877 := z.EncBinary()
-		_ = yym877
+		yym831 := z.EncBinary()
+		_ = yym831
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep878 := !z.EncBinary()
-			yy2arr878 := z.EncBasicHandle().StructToArray
-			var yyq878 [5]bool
-			_, _, _ = yysep878, yyq878, yy2arr878
-			const yyr878 bool = false
-			yyq878[0] = x.Parallelism != nil
-			yyq878[1] = x.Completions != nil
-			yyq878[2] = x.ActiveDeadlineSeconds != nil
-			yyq878[3] = x.Selector != nil
-			var yynn878 int
-			if yyr878 || yy2arr878 {
+			yysep832 := !z.EncBinary()
+			yy2arr832 := z.EncBasicHandle().StructToArray
+			var yyq832 [5]bool
+			_, _, _ = yysep832, yyq832, yy2arr832
+			const yyr832 bool = false
+			yyq832[0] = x.Parallelism != nil
+			yyq832[1] = x.Completions != nil
+			yyq832[2] = x.ActiveDeadlineSeconds != nil
+			yyq832[3] = x.Selector != nil
+			var yynn832 int
+			if yyr832 || yy2arr832 {
 				r.EncodeArrayStart(5)
 			} else {
-				yynn878 = 1
-				for _, b := range yyq878 {
+				yynn832 = 1
+				for _, b := range yyq832 {
 					if b {
-						yynn878++
+						yynn832++
 					}
 				}
-				r.EncodeMapStart(yynn878)
-				yynn878 = 0
+				r.EncodeMapStart(yynn832)
+				yynn832 = 0
 			}
-			if yyr878 || yy2arr878 {
+			if yyr832 || yy2arr832 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq878[0] {
+				if yyq832[0] {
 					if x.Parallelism == nil {
 						r.EncodeNil()
 					} else {
-						yy880 := *x.Parallelism
-						yym881 := z.EncBinary()
-						_ = yym881
+						yy834 := *x.Parallelism
+						yym835 := z.EncBinary()
+						_ = yym835
 						if false {
 						} else {
-							r.EncodeInt(int64(yy880))
+							r.EncodeInt(int64(yy834))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq878[0] {
+				if yyq832[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("parallelism"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Parallelism == nil {
 						r.EncodeNil()
 					} else {
-						yy882 := *x.Parallelism
-						yym883 := z.EncBinary()
-						_ = yym883
+						yy836 := *x.Parallelism
+						yym837 := z.EncBinary()
+						_ = yym837
 						if false {
 						} else {
-							r.EncodeInt(int64(yy882))
+							r.EncodeInt(int64(yy836))
 						}
 					}
 				}
 			}
-			if yyr878 || yy2arr878 {
+			if yyr832 || yy2arr832 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq878[1] {
+				if yyq832[1] {
 					if x.Completions == nil {
 						r.EncodeNil()
 					} else {
-						yy885 := *x.Completions
-						yym886 := z.EncBinary()
-						_ = yym886
+						yy839 := *x.Completions
+						yym840 := z.EncBinary()
+						_ = yym840
 						if false {
 						} else {
-							r.EncodeInt(int64(yy885))
+							r.EncodeInt(int64(yy839))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq878[1] {
+				if yyq832[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("completions"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Completions == nil {
 						r.EncodeNil()
 					} else {
-						yy887 := *x.Completions
-						yym888 := z.EncBinary()
-						_ = yym888
+						yy841 := *x.Completions
+						yym842 := z.EncBinary()
+						_ = yym842
 						if false {
 						} else {
-							r.EncodeInt(int64(yy887))
+							r.EncodeInt(int64(yy841))
 						}
 					}
 				}
 			}
-			if yyr878 || yy2arr878 {
+			if yyr832 || yy2arr832 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq878[2] {
+				if yyq832[2] {
 					if x.ActiveDeadlineSeconds == nil {
 						r.EncodeNil()
 					} else {
-						yy890 := *x.ActiveDeadlineSeconds
-						yym891 := z.EncBinary()
-						_ = yym891
+						yy844 := *x.ActiveDeadlineSeconds
+						yym845 := z.EncBinary()
+						_ = yym845
 						if false {
 						} else {
-							r.EncodeInt(int64(yy890))
+							r.EncodeInt(int64(yy844))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq878[2] {
+				if yyq832[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("activeDeadlineSeconds"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.ActiveDeadlineSeconds == nil {
 						r.EncodeNil()
 					} else {
-						yy892 := *x.ActiveDeadlineSeconds
-						yym893 := z.EncBinary()
-						_ = yym893
+						yy846 := *x.ActiveDeadlineSeconds
+						yym847 := z.EncBinary()
+						_ = yym847
 						if false {
 						} else {
-							r.EncodeInt(int64(yy892))
+							r.EncodeInt(int64(yy846))
 						}
 					}
 				}
 			}
-			if yyr878 || yy2arr878 {
+			if yyr832 || yy2arr832 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq878[3] {
+				if yyq832[3] {
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
@@ -10642,7 +10024,7 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq878[3] {
+				if yyq832[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
@@ -10653,18 +10035,18 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr878 || yy2arr878 {
+			if yyr832 || yy2arr832 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy896 := &x.Template
-				yy896.CodecEncodeSelf(e)
+				yy850 := &x.Template
+				yy850.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("template"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy897 := &x.Template
-				yy897.CodecEncodeSelf(e)
+				yy851 := &x.Template
+				yy851.CodecEncodeSelf(e)
 			}
-			if yyr878 || yy2arr878 {
+			if yyr832 || yy2arr832 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -10677,25 +10059,25 @@ func (x *JobSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym898 := z.DecBinary()
-	_ = yym898
+	yym852 := z.DecBinary()
+	_ = yym852
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct899 := r.ContainerType()
-		if yyct899 == codecSelferValueTypeMap1234 {
-			yyl899 := r.ReadMapStart()
-			if yyl899 == 0 {
+		yyct853 := r.ContainerType()
+		if yyct853 == codecSelferValueTypeMap1234 {
+			yyl853 := r.ReadMapStart()
+			if yyl853 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl899, d)
+				x.codecDecodeSelfFromMap(yyl853, d)
 			}
-		} else if yyct899 == codecSelferValueTypeArray1234 {
-			yyl899 := r.ReadArrayStart()
-			if yyl899 == 0 {
+		} else if yyct853 == codecSelferValueTypeArray1234 {
+			yyl853 := r.ReadArrayStart()
+			if yyl853 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl899, d)
+				x.codecDecodeSelfFromArray(yyl853, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10707,12 +10089,12 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys900Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys900Slc
-	var yyhl900 bool = l >= 0
-	for yyj900 := 0; ; yyj900++ {
-		if yyhl900 {
-			if yyj900 >= l {
+	var yys854Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys854Slc
+	var yyhl854 bool = l >= 0
+	for yyj854 := 0; ; yyj854++ {
+		if yyhl854 {
+			if yyj854 >= l {
 				break
 			}
 		} else {
@@ -10721,10 +10103,10 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys900Slc = r.DecodeBytes(yys900Slc, true, true)
-		yys900 := string(yys900Slc)
+		yys854Slc = r.DecodeBytes(yys854Slc, true, true)
+		yys854 := string(yys854Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys900 {
+		switch yys854 {
 		case "parallelism":
 			if r.TryDecodeAsNil() {
 				if x.Parallelism != nil {
@@ -10734,8 +10116,8 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Parallelism == nil {
 					x.Parallelism = new(int32)
 				}
-				yym902 := z.DecBinary()
-				_ = yym902
+				yym856 := z.DecBinary()
+				_ = yym856
 				if false {
 				} else {
 					*((*int32)(x.Parallelism)) = int32(r.DecodeInt(32))
@@ -10750,8 +10132,8 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Completions == nil {
 					x.Completions = new(int32)
 				}
-				yym904 := z.DecBinary()
-				_ = yym904
+				yym858 := z.DecBinary()
+				_ = yym858
 				if false {
 				} else {
 					*((*int32)(x.Completions)) = int32(r.DecodeInt(32))
@@ -10766,8 +10148,8 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.ActiveDeadlineSeconds == nil {
 					x.ActiveDeadlineSeconds = new(int64)
 				}
-				yym906 := z.DecBinary()
-				_ = yym906
+				yym860 := z.DecBinary()
+				_ = yym860
 				if false {
 				} else {
 					*((*int64)(x.ActiveDeadlineSeconds)) = int64(r.DecodeInt(64))
@@ -10788,13 +10170,13 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Template = pkg2_v1.PodTemplateSpec{}
 			} else {
-				yyv908 := &x.Template
-				yyv908.CodecDecodeSelf(d)
+				yyv862 := &x.Template
+				yyv862.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys900)
-		} // end switch yys900
-	} // end for yyj900
+			z.DecStructFieldNotFound(-1, yys854)
+		} // end switch yys854
+	} // end for yyj854
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -10802,16 +10184,16 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj909 int
-	var yyb909 bool
-	var yyhl909 bool = l >= 0
-	yyj909++
-	if yyhl909 {
-		yyb909 = yyj909 > l
+	var yyj863 int
+	var yyb863 bool
+	var yyhl863 bool = l >= 0
+	yyj863++
+	if yyhl863 {
+		yyb863 = yyj863 > l
 	} else {
-		yyb909 = r.CheckBreak()
+		yyb863 = r.CheckBreak()
 	}
-	if yyb909 {
+	if yyb863 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10824,20 +10206,20 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.Parallelism == nil {
 			x.Parallelism = new(int32)
 		}
-		yym911 := z.DecBinary()
-		_ = yym911
+		yym865 := z.DecBinary()
+		_ = yym865
 		if false {
 		} else {
 			*((*int32)(x.Parallelism)) = int32(r.DecodeInt(32))
 		}
 	}
-	yyj909++
-	if yyhl909 {
-		yyb909 = yyj909 > l
+	yyj863++
+	if yyhl863 {
+		yyb863 = yyj863 > l
 	} else {
-		yyb909 = r.CheckBreak()
+		yyb863 = r.CheckBreak()
 	}
-	if yyb909 {
+	if yyb863 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10850,20 +10232,20 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.Completions == nil {
 			x.Completions = new(int32)
 		}
-		yym913 := z.DecBinary()
-		_ = yym913
+		yym867 := z.DecBinary()
+		_ = yym867
 		if false {
 		} else {
 			*((*int32)(x.Completions)) = int32(r.DecodeInt(32))
 		}
 	}
-	yyj909++
-	if yyhl909 {
-		yyb909 = yyj909 > l
+	yyj863++
+	if yyhl863 {
+		yyb863 = yyj863 > l
 	} else {
-		yyb909 = r.CheckBreak()
+		yyb863 = r.CheckBreak()
 	}
-	if yyb909 {
+	if yyb863 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10876,20 +10258,20 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.ActiveDeadlineSeconds == nil {
 			x.ActiveDeadlineSeconds = new(int64)
 		}
-		yym915 := z.DecBinary()
-		_ = yym915
+		yym869 := z.DecBinary()
+		_ = yym869
 		if false {
 		} else {
 			*((*int64)(x.ActiveDeadlineSeconds)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj909++
-	if yyhl909 {
-		yyb909 = yyj909 > l
+	yyj863++
+	if yyhl863 {
+		yyb863 = yyj863 > l
 	} else {
-		yyb909 = r.CheckBreak()
+		yyb863 = r.CheckBreak()
 	}
-	if yyb909 {
+	if yyb863 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10904,13 +10286,13 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Selector.CodecDecodeSelf(d)
 	}
-	yyj909++
-	if yyhl909 {
-		yyb909 = yyj909 > l
+	yyj863++
+	if yyhl863 {
+		yyb863 = yyj863 > l
 	} else {
-		yyb909 = r.CheckBreak()
+		yyb863 = r.CheckBreak()
 	}
-	if yyb909 {
+	if yyb863 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -10918,21 +10300,21 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Template = pkg2_v1.PodTemplateSpec{}
 	} else {
-		yyv917 := &x.Template
-		yyv917.CodecDecodeSelf(d)
+		yyv871 := &x.Template
+		yyv871.CodecDecodeSelf(d)
 	}
 	for {
-		yyj909++
-		if yyhl909 {
-			yyb909 = yyj909 > l
+		yyj863++
+		if yyhl863 {
+			yyb863 = yyj863 > l
 		} else {
-			yyb909 = r.CheckBreak()
+			yyb863 = r.CheckBreak()
 		}
-		if yyb909 {
+		if yyb863 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj909-1, "")
+		z.DecStructFieldNotFound(yyj863-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -10944,43 +10326,43 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym918 := z.EncBinary()
-		_ = yym918
+		yym872 := z.EncBinary()
+		_ = yym872
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep919 := !z.EncBinary()
-			yy2arr919 := z.EncBasicHandle().StructToArray
-			var yyq919 [6]bool
-			_, _, _ = yysep919, yyq919, yy2arr919
-			const yyr919 bool = false
-			yyq919[0] = len(x.Conditions) != 0
-			yyq919[1] = x.StartTime != nil
-			yyq919[2] = x.CompletionTime != nil
-			yyq919[3] = x.Active != 0
-			yyq919[4] = x.Succeeded != 0
-			yyq919[5] = x.Failed != 0
-			var yynn919 int
-			if yyr919 || yy2arr919 {
+			yysep873 := !z.EncBinary()
+			yy2arr873 := z.EncBasicHandle().StructToArray
+			var yyq873 [6]bool
+			_, _, _ = yysep873, yyq873, yy2arr873
+			const yyr873 bool = false
+			yyq873[0] = len(x.Conditions) != 0
+			yyq873[1] = x.StartTime != nil
+			yyq873[2] = x.CompletionTime != nil
+			yyq873[3] = x.Active != 0
+			yyq873[4] = x.Succeeded != 0
+			yyq873[5] = x.Failed != 0
+			var yynn873 int
+			if yyr873 || yy2arr873 {
 				r.EncodeArrayStart(6)
 			} else {
-				yynn919 = 0
-				for _, b := range yyq919 {
+				yynn873 = 0
+				for _, b := range yyq873 {
 					if b {
-						yynn919++
+						yynn873++
 					}
 				}
-				r.EncodeMapStart(yynn919)
-				yynn919 = 0
+				r.EncodeMapStart(yynn873)
+				yynn873 = 0
 			}
-			if yyr919 || yy2arr919 {
+			if yyr873 || yy2arr873 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq919[0] {
+				if yyq873[0] {
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym921 := z.EncBinary()
-						_ = yym921
+						yym875 := z.EncBinary()
+						_ = yym875
 						if false {
 						} else {
 							h.encSliceJobCondition(([]JobCondition)(x.Conditions), e)
@@ -10990,15 +10372,15 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq919[0] {
+				if yyq873[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("conditions"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym922 := z.EncBinary()
-						_ = yym922
+						yym876 := z.EncBinary()
+						_ = yym876
 						if false {
 						} else {
 							h.encSliceJobCondition(([]JobCondition)(x.Conditions), e)
@@ -11006,19 +10388,19 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr919 || yy2arr919 {
+			if yyr873 || yy2arr873 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq919[1] {
+				if yyq873[1] {
 					if x.StartTime == nil {
 						r.EncodeNil()
 					} else {
-						yym924 := z.EncBinary()
-						_ = yym924
+						yym878 := z.EncBinary()
+						_ = yym878
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
-						} else if yym924 {
+						} else if yym878 {
 							z.EncBinaryMarshal(x.StartTime)
-						} else if !yym924 && z.IsJSONHandle() {
+						} else if !yym878 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.StartTime)
 						} else {
 							z.EncFallback(x.StartTime)
@@ -11028,20 +10410,20 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq919[1] {
+				if yyq873[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("startTime"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.StartTime == nil {
 						r.EncodeNil()
 					} else {
-						yym925 := z.EncBinary()
-						_ = yym925
+						yym879 := z.EncBinary()
+						_ = yym879
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
-						} else if yym925 {
+						} else if yym879 {
 							z.EncBinaryMarshal(x.StartTime)
-						} else if !yym925 && z.IsJSONHandle() {
+						} else if !yym879 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.StartTime)
 						} else {
 							z.EncFallback(x.StartTime)
@@ -11049,19 +10431,19 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr919 || yy2arr919 {
+			if yyr873 || yy2arr873 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq919[2] {
+				if yyq873[2] {
 					if x.CompletionTime == nil {
 						r.EncodeNil()
 					} else {
-						yym927 := z.EncBinary()
-						_ = yym927
+						yym881 := z.EncBinary()
+						_ = yym881
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.CompletionTime) {
-						} else if yym927 {
+						} else if yym881 {
 							z.EncBinaryMarshal(x.CompletionTime)
-						} else if !yym927 && z.IsJSONHandle() {
+						} else if !yym881 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.CompletionTime)
 						} else {
 							z.EncFallback(x.CompletionTime)
@@ -11071,20 +10453,20 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq919[2] {
+				if yyq873[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("completionTime"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.CompletionTime == nil {
 						r.EncodeNil()
 					} else {
-						yym928 := z.EncBinary()
-						_ = yym928
+						yym882 := z.EncBinary()
+						_ = yym882
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.CompletionTime) {
-						} else if yym928 {
+						} else if yym882 {
 							z.EncBinaryMarshal(x.CompletionTime)
-						} else if !yym928 && z.IsJSONHandle() {
+						} else if !yym882 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.CompletionTime)
 						} else {
 							z.EncFallback(x.CompletionTime)
@@ -11092,11 +10474,11 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr919 || yy2arr919 {
+			if yyr873 || yy2arr873 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq919[3] {
-					yym930 := z.EncBinary()
-					_ = yym930
+				if yyq873[3] {
+					yym884 := z.EncBinary()
+					_ = yym884
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Active))
@@ -11105,23 +10487,23 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq919[3] {
+				if yyq873[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("active"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym931 := z.EncBinary()
-					_ = yym931
+					yym885 := z.EncBinary()
+					_ = yym885
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Active))
 					}
 				}
 			}
-			if yyr919 || yy2arr919 {
+			if yyr873 || yy2arr873 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq919[4] {
-					yym933 := z.EncBinary()
-					_ = yym933
+				if yyq873[4] {
+					yym887 := z.EncBinary()
+					_ = yym887
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Succeeded))
@@ -11130,23 +10512,23 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq919[4] {
+				if yyq873[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("succeeded"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym934 := z.EncBinary()
-					_ = yym934
+					yym888 := z.EncBinary()
+					_ = yym888
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Succeeded))
 					}
 				}
 			}
-			if yyr919 || yy2arr919 {
+			if yyr873 || yy2arr873 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq919[5] {
-					yym936 := z.EncBinary()
-					_ = yym936
+				if yyq873[5] {
+					yym890 := z.EncBinary()
+					_ = yym890
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Failed))
@@ -11155,19 +10537,19 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq919[5] {
+				if yyq873[5] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("failed"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym937 := z.EncBinary()
-					_ = yym937
+					yym891 := z.EncBinary()
+					_ = yym891
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Failed))
 					}
 				}
 			}
-			if yyr919 || yy2arr919 {
+			if yyr873 || yy2arr873 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -11177,6 +10559,515 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 }
 
 func (x *JobStatus) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym892 := z.DecBinary()
+	_ = yym892
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct893 := r.ContainerType()
+		if yyct893 == codecSelferValueTypeMap1234 {
+			yyl893 := r.ReadMapStart()
+			if yyl893 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl893, d)
+			}
+		} else if yyct893 == codecSelferValueTypeArray1234 {
+			yyl893 := r.ReadArrayStart()
+			if yyl893 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl893, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys894Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys894Slc
+	var yyhl894 bool = l >= 0
+	for yyj894 := 0; ; yyj894++ {
+		if yyhl894 {
+			if yyj894 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys894Slc = r.DecodeBytes(yys894Slc, true, true)
+		yys894 := string(yys894Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys894 {
+		case "conditions":
+			if r.TryDecodeAsNil() {
+				x.Conditions = nil
+			} else {
+				yyv895 := &x.Conditions
+				yym896 := z.DecBinary()
+				_ = yym896
+				if false {
+				} else {
+					h.decSliceJobCondition((*[]JobCondition)(yyv895), d)
+				}
+			}
+		case "startTime":
+			if r.TryDecodeAsNil() {
+				if x.StartTime != nil {
+					x.StartTime = nil
+				}
+			} else {
+				if x.StartTime == nil {
+					x.StartTime = new(pkg1_unversioned.Time)
+				}
+				yym898 := z.DecBinary()
+				_ = yym898
+				if false {
+				} else if z.HasExtensions() && z.DecExt(x.StartTime) {
+				} else if yym898 {
+					z.DecBinaryUnmarshal(x.StartTime)
+				} else if !yym898 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(x.StartTime)
+				} else {
+					z.DecFallback(x.StartTime, false)
+				}
+			}
+		case "completionTime":
+			if r.TryDecodeAsNil() {
+				if x.CompletionTime != nil {
+					x.CompletionTime = nil
+				}
+			} else {
+				if x.CompletionTime == nil {
+					x.CompletionTime = new(pkg1_unversioned.Time)
+				}
+				yym900 := z.DecBinary()
+				_ = yym900
+				if false {
+				} else if z.HasExtensions() && z.DecExt(x.CompletionTime) {
+				} else if yym900 {
+					z.DecBinaryUnmarshal(x.CompletionTime)
+				} else if !yym900 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(x.CompletionTime)
+				} else {
+					z.DecFallback(x.CompletionTime, false)
+				}
+			}
+		case "active":
+			if r.TryDecodeAsNil() {
+				x.Active = 0
+			} else {
+				x.Active = int32(r.DecodeInt(32))
+			}
+		case "succeeded":
+			if r.TryDecodeAsNil() {
+				x.Succeeded = 0
+			} else {
+				x.Succeeded = int32(r.DecodeInt(32))
+			}
+		case "failed":
+			if r.TryDecodeAsNil() {
+				x.Failed = 0
+			} else {
+				x.Failed = int32(r.DecodeInt(32))
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys894)
+		} // end switch yys894
+	} // end for yyj894
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj904 int
+	var yyb904 bool
+	var yyhl904 bool = l >= 0
+	yyj904++
+	if yyhl904 {
+		yyb904 = yyj904 > l
+	} else {
+		yyb904 = r.CheckBreak()
+	}
+	if yyb904 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Conditions = nil
+	} else {
+		yyv905 := &x.Conditions
+		yym906 := z.DecBinary()
+		_ = yym906
+		if false {
+		} else {
+			h.decSliceJobCondition((*[]JobCondition)(yyv905), d)
+		}
+	}
+	yyj904++
+	if yyhl904 {
+		yyb904 = yyj904 > l
+	} else {
+		yyb904 = r.CheckBreak()
+	}
+	if yyb904 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		if x.StartTime != nil {
+			x.StartTime = nil
+		}
+	} else {
+		if x.StartTime == nil {
+			x.StartTime = new(pkg1_unversioned.Time)
+		}
+		yym908 := z.DecBinary()
+		_ = yym908
+		if false {
+		} else if z.HasExtensions() && z.DecExt(x.StartTime) {
+		} else if yym908 {
+			z.DecBinaryUnmarshal(x.StartTime)
+		} else if !yym908 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(x.StartTime)
+		} else {
+			z.DecFallback(x.StartTime, false)
+		}
+	}
+	yyj904++
+	if yyhl904 {
+		yyb904 = yyj904 > l
+	} else {
+		yyb904 = r.CheckBreak()
+	}
+	if yyb904 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		if x.CompletionTime != nil {
+			x.CompletionTime = nil
+		}
+	} else {
+		if x.CompletionTime == nil {
+			x.CompletionTime = new(pkg1_unversioned.Time)
+		}
+		yym910 := z.DecBinary()
+		_ = yym910
+		if false {
+		} else if z.HasExtensions() && z.DecExt(x.CompletionTime) {
+		} else if yym910 {
+			z.DecBinaryUnmarshal(x.CompletionTime)
+		} else if !yym910 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(x.CompletionTime)
+		} else {
+			z.DecFallback(x.CompletionTime, false)
+		}
+	}
+	yyj904++
+	if yyhl904 {
+		yyb904 = yyj904 > l
+	} else {
+		yyb904 = r.CheckBreak()
+	}
+	if yyb904 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Active = 0
+	} else {
+		x.Active = int32(r.DecodeInt(32))
+	}
+	yyj904++
+	if yyhl904 {
+		yyb904 = yyj904 > l
+	} else {
+		yyb904 = r.CheckBreak()
+	}
+	if yyb904 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Succeeded = 0
+	} else {
+		x.Succeeded = int32(r.DecodeInt(32))
+	}
+	yyj904++
+	if yyhl904 {
+		yyb904 = yyj904 > l
+	} else {
+		yyb904 = r.CheckBreak()
+	}
+	if yyb904 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Failed = 0
+	} else {
+		x.Failed = int32(r.DecodeInt(32))
+	}
+	for {
+		yyj904++
+		if yyhl904 {
+			yyb904 = yyj904 > l
+		} else {
+			yyb904 = r.CheckBreak()
+		}
+		if yyb904 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj904-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x JobConditionType) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	yym914 := z.EncBinary()
+	_ = yym914
+	if false {
+	} else if z.HasExtensions() && z.EncExt(x) {
+	} else {
+		r.EncodeString(codecSelferC_UTF81234, string(x))
+	}
+}
+
+func (x *JobConditionType) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym915 := z.DecBinary()
+	_ = yym915
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		*((*string)(x)) = r.DecodeString()
+	}
+}
+
+func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym916 := z.EncBinary()
+		_ = yym916
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep917 := !z.EncBinary()
+			yy2arr917 := z.EncBasicHandle().StructToArray
+			var yyq917 [6]bool
+			_, _, _ = yysep917, yyq917, yy2arr917
+			const yyr917 bool = false
+			yyq917[2] = true
+			yyq917[3] = true
+			yyq917[4] = x.Reason != ""
+			yyq917[5] = x.Message != ""
+			var yynn917 int
+			if yyr917 || yy2arr917 {
+				r.EncodeArrayStart(6)
+			} else {
+				yynn917 = 2
+				for _, b := range yyq917 {
+					if b {
+						yynn917++
+					}
+				}
+				r.EncodeMapStart(yynn917)
+				yynn917 = 0
+			}
+			if yyr917 || yy2arr917 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				x.Type.CodecEncodeSelf(e)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("type"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				x.Type.CodecEncodeSelf(e)
+			}
+			if yyr917 || yy2arr917 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym920 := z.EncBinary()
+				_ = yym920
+				if false {
+				} else if z.HasExtensions() && z.EncExt(x.Status) {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Status))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("status"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym921 := z.EncBinary()
+				_ = yym921
+				if false {
+				} else if z.HasExtensions() && z.EncExt(x.Status) {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Status))
+				}
+			}
+			if yyr917 || yy2arr917 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq917[2] {
+					yy923 := &x.LastProbeTime
+					yym924 := z.EncBinary()
+					_ = yym924
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy923) {
+					} else if yym924 {
+						z.EncBinaryMarshal(yy923)
+					} else if !yym924 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy923)
+					} else {
+						z.EncFallback(yy923)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq917[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("lastProbeTime"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy925 := &x.LastProbeTime
+					yym926 := z.EncBinary()
+					_ = yym926
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy925) {
+					} else if yym926 {
+						z.EncBinaryMarshal(yy925)
+					} else if !yym926 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy925)
+					} else {
+						z.EncFallback(yy925)
+					}
+				}
+			}
+			if yyr917 || yy2arr917 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq917[3] {
+					yy928 := &x.LastTransitionTime
+					yym929 := z.EncBinary()
+					_ = yym929
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy928) {
+					} else if yym929 {
+						z.EncBinaryMarshal(yy928)
+					} else if !yym929 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy928)
+					} else {
+						z.EncFallback(yy928)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq917[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("lastTransitionTime"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yy930 := &x.LastTransitionTime
+					yym931 := z.EncBinary()
+					_ = yym931
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy930) {
+					} else if yym931 {
+						z.EncBinaryMarshal(yy930)
+					} else if !yym931 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy930)
+					} else {
+						z.EncFallback(yy930)
+					}
+				}
+			}
+			if yyr917 || yy2arr917 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq917[4] {
+					yym933 := z.EncBinary()
+					_ = yym933
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq917[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("reason"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym934 := z.EncBinary()
+					_ = yym934
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
+					}
+				}
+			}
+			if yyr917 || yy2arr917 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq917[5] {
+					yym936 := z.EncBinary()
+					_ = yym936
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq917[5] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("message"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym937 := z.EncBinary()
+					_ = yym937
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
+					}
+				}
+			}
+			if yyr917 || yy2arr917 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *JobCondition) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -11206,7 +11097,7 @@ func (x *JobStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	}
 }
 
-func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -11228,515 +11119,6 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys940 := string(yys940Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
 		switch yys940 {
-		case "conditions":
-			if r.TryDecodeAsNil() {
-				x.Conditions = nil
-			} else {
-				yyv941 := &x.Conditions
-				yym942 := z.DecBinary()
-				_ = yym942
-				if false {
-				} else {
-					h.decSliceJobCondition((*[]JobCondition)(yyv941), d)
-				}
-			}
-		case "startTime":
-			if r.TryDecodeAsNil() {
-				if x.StartTime != nil {
-					x.StartTime = nil
-				}
-			} else {
-				if x.StartTime == nil {
-					x.StartTime = new(pkg1_unversioned.Time)
-				}
-				yym944 := z.DecBinary()
-				_ = yym944
-				if false {
-				} else if z.HasExtensions() && z.DecExt(x.StartTime) {
-				} else if yym944 {
-					z.DecBinaryUnmarshal(x.StartTime)
-				} else if !yym944 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(x.StartTime)
-				} else {
-					z.DecFallback(x.StartTime, false)
-				}
-			}
-		case "completionTime":
-			if r.TryDecodeAsNil() {
-				if x.CompletionTime != nil {
-					x.CompletionTime = nil
-				}
-			} else {
-				if x.CompletionTime == nil {
-					x.CompletionTime = new(pkg1_unversioned.Time)
-				}
-				yym946 := z.DecBinary()
-				_ = yym946
-				if false {
-				} else if z.HasExtensions() && z.DecExt(x.CompletionTime) {
-				} else if yym946 {
-					z.DecBinaryUnmarshal(x.CompletionTime)
-				} else if !yym946 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(x.CompletionTime)
-				} else {
-					z.DecFallback(x.CompletionTime, false)
-				}
-			}
-		case "active":
-			if r.TryDecodeAsNil() {
-				x.Active = 0
-			} else {
-				x.Active = int32(r.DecodeInt(32))
-			}
-		case "succeeded":
-			if r.TryDecodeAsNil() {
-				x.Succeeded = 0
-			} else {
-				x.Succeeded = int32(r.DecodeInt(32))
-			}
-		case "failed":
-			if r.TryDecodeAsNil() {
-				x.Failed = 0
-			} else {
-				x.Failed = int32(r.DecodeInt(32))
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys940)
-		} // end switch yys940
-	} // end for yyj940
-	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-}
-
-func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj950 int
-	var yyb950 bool
-	var yyhl950 bool = l >= 0
-	yyj950++
-	if yyhl950 {
-		yyb950 = yyj950 > l
-	} else {
-		yyb950 = r.CheckBreak()
-	}
-	if yyb950 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Conditions = nil
-	} else {
-		yyv951 := &x.Conditions
-		yym952 := z.DecBinary()
-		_ = yym952
-		if false {
-		} else {
-			h.decSliceJobCondition((*[]JobCondition)(yyv951), d)
-		}
-	}
-	yyj950++
-	if yyhl950 {
-		yyb950 = yyj950 > l
-	} else {
-		yyb950 = r.CheckBreak()
-	}
-	if yyb950 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		if x.StartTime != nil {
-			x.StartTime = nil
-		}
-	} else {
-		if x.StartTime == nil {
-			x.StartTime = new(pkg1_unversioned.Time)
-		}
-		yym954 := z.DecBinary()
-		_ = yym954
-		if false {
-		} else if z.HasExtensions() && z.DecExt(x.StartTime) {
-		} else if yym954 {
-			z.DecBinaryUnmarshal(x.StartTime)
-		} else if !yym954 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(x.StartTime)
-		} else {
-			z.DecFallback(x.StartTime, false)
-		}
-	}
-	yyj950++
-	if yyhl950 {
-		yyb950 = yyj950 > l
-	} else {
-		yyb950 = r.CheckBreak()
-	}
-	if yyb950 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		if x.CompletionTime != nil {
-			x.CompletionTime = nil
-		}
-	} else {
-		if x.CompletionTime == nil {
-			x.CompletionTime = new(pkg1_unversioned.Time)
-		}
-		yym956 := z.DecBinary()
-		_ = yym956
-		if false {
-		} else if z.HasExtensions() && z.DecExt(x.CompletionTime) {
-		} else if yym956 {
-			z.DecBinaryUnmarshal(x.CompletionTime)
-		} else if !yym956 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(x.CompletionTime)
-		} else {
-			z.DecFallback(x.CompletionTime, false)
-		}
-	}
-	yyj950++
-	if yyhl950 {
-		yyb950 = yyj950 > l
-	} else {
-		yyb950 = r.CheckBreak()
-	}
-	if yyb950 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Active = 0
-	} else {
-		x.Active = int32(r.DecodeInt(32))
-	}
-	yyj950++
-	if yyhl950 {
-		yyb950 = yyj950 > l
-	} else {
-		yyb950 = r.CheckBreak()
-	}
-	if yyb950 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Succeeded = 0
-	} else {
-		x.Succeeded = int32(r.DecodeInt(32))
-	}
-	yyj950++
-	if yyhl950 {
-		yyb950 = yyj950 > l
-	} else {
-		yyb950 = r.CheckBreak()
-	}
-	if yyb950 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Failed = 0
-	} else {
-		x.Failed = int32(r.DecodeInt(32))
-	}
-	for {
-		yyj950++
-		if yyhl950 {
-			yyb950 = yyj950 > l
-		} else {
-			yyb950 = r.CheckBreak()
-		}
-		if yyb950 {
-			break
-		}
-		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj950-1, "")
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x JobConditionType) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	yym960 := z.EncBinary()
-	_ = yym960
-	if false {
-	} else if z.HasExtensions() && z.EncExt(x) {
-	} else {
-		r.EncodeString(codecSelferC_UTF81234, string(x))
-	}
-}
-
-func (x *JobConditionType) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym961 := z.DecBinary()
-	_ = yym961
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		*((*string)(x)) = r.DecodeString()
-	}
-}
-
-func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym962 := z.EncBinary()
-		_ = yym962
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep963 := !z.EncBinary()
-			yy2arr963 := z.EncBasicHandle().StructToArray
-			var yyq963 [6]bool
-			_, _, _ = yysep963, yyq963, yy2arr963
-			const yyr963 bool = false
-			yyq963[2] = true
-			yyq963[3] = true
-			yyq963[4] = x.Reason != ""
-			yyq963[5] = x.Message != ""
-			var yynn963 int
-			if yyr963 || yy2arr963 {
-				r.EncodeArrayStart(6)
-			} else {
-				yynn963 = 2
-				for _, b := range yyq963 {
-					if b {
-						yynn963++
-					}
-				}
-				r.EncodeMapStart(yynn963)
-				yynn963 = 0
-			}
-			if yyr963 || yy2arr963 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				x.Type.CodecEncodeSelf(e)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("type"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				x.Type.CodecEncodeSelf(e)
-			}
-			if yyr963 || yy2arr963 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym966 := z.EncBinary()
-				_ = yym966
-				if false {
-				} else if z.HasExtensions() && z.EncExt(x.Status) {
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.Status))
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("status"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym967 := z.EncBinary()
-				_ = yym967
-				if false {
-				} else if z.HasExtensions() && z.EncExt(x.Status) {
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.Status))
-				}
-			}
-			if yyr963 || yy2arr963 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq963[2] {
-					yy969 := &x.LastProbeTime
-					yym970 := z.EncBinary()
-					_ = yym970
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy969) {
-					} else if yym970 {
-						z.EncBinaryMarshal(yy969)
-					} else if !yym970 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy969)
-					} else {
-						z.EncFallback(yy969)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq963[2] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("lastProbeTime"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy971 := &x.LastProbeTime
-					yym972 := z.EncBinary()
-					_ = yym972
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy971) {
-					} else if yym972 {
-						z.EncBinaryMarshal(yy971)
-					} else if !yym972 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy971)
-					} else {
-						z.EncFallback(yy971)
-					}
-				}
-			}
-			if yyr963 || yy2arr963 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq963[3] {
-					yy974 := &x.LastTransitionTime
-					yym975 := z.EncBinary()
-					_ = yym975
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy974) {
-					} else if yym975 {
-						z.EncBinaryMarshal(yy974)
-					} else if !yym975 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy974)
-					} else {
-						z.EncFallback(yy974)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq963[3] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("lastTransitionTime"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy976 := &x.LastTransitionTime
-					yym977 := z.EncBinary()
-					_ = yym977
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy976) {
-					} else if yym977 {
-						z.EncBinaryMarshal(yy976)
-					} else if !yym977 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy976)
-					} else {
-						z.EncFallback(yy976)
-					}
-				}
-			}
-			if yyr963 || yy2arr963 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq963[4] {
-					yym979 := z.EncBinary()
-					_ = yym979
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq963[4] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("reason"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym980 := z.EncBinary()
-					_ = yym980
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
-					}
-				}
-			}
-			if yyr963 || yy2arr963 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq963[5] {
-					yym982 := z.EncBinary()
-					_ = yym982
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq963[5] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("message"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym983 := z.EncBinary()
-					_ = yym983
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
-					}
-				}
-			}
-			if yyr963 || yy2arr963 {
-				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
-			}
-		}
-	}
-}
-
-func (x *JobCondition) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym984 := z.DecBinary()
-	_ = yym984
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		yyct985 := r.ContainerType()
-		if yyct985 == codecSelferValueTypeMap1234 {
-			yyl985 := r.ReadMapStart()
-			if yyl985 == 0 {
-				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-			} else {
-				x.codecDecodeSelfFromMap(yyl985, d)
-			}
-		} else if yyct985 == codecSelferValueTypeArray1234 {
-			yyl985 := r.ReadArrayStart()
-			if yyl985 == 0 {
-				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				x.codecDecodeSelfFromArray(yyl985, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys986Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys986Slc
-	var yyhl986 bool = l >= 0
-	for yyj986 := 0; ; yyj986++ {
-		if yyhl986 {
-			if yyj986 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys986Slc = r.DecodeBytes(yys986Slc, true, true)
-		yys986 := string(yys986Slc)
-		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys986 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -11753,34 +11135,34 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.LastProbeTime = pkg1_unversioned.Time{}
 			} else {
-				yyv989 := &x.LastProbeTime
-				yym990 := z.DecBinary()
-				_ = yym990
+				yyv943 := &x.LastProbeTime
+				yym944 := z.DecBinary()
+				_ = yym944
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv989) {
-				} else if yym990 {
-					z.DecBinaryUnmarshal(yyv989)
-				} else if !yym990 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv989)
+				} else if z.HasExtensions() && z.DecExt(yyv943) {
+				} else if yym944 {
+					z.DecBinaryUnmarshal(yyv943)
+				} else if !yym944 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv943)
 				} else {
-					z.DecFallback(yyv989, false)
+					z.DecFallback(yyv943, false)
 				}
 			}
 		case "lastTransitionTime":
 			if r.TryDecodeAsNil() {
 				x.LastTransitionTime = pkg1_unversioned.Time{}
 			} else {
-				yyv991 := &x.LastTransitionTime
-				yym992 := z.DecBinary()
-				_ = yym992
+				yyv945 := &x.LastTransitionTime
+				yym946 := z.DecBinary()
+				_ = yym946
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv991) {
-				} else if yym992 {
-					z.DecBinaryUnmarshal(yyv991)
-				} else if !yym992 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv991)
+				} else if z.HasExtensions() && z.DecExt(yyv945) {
+				} else if yym946 {
+					z.DecBinaryUnmarshal(yyv945)
+				} else if !yym946 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv945)
 				} else {
-					z.DecFallback(yyv991, false)
+					z.DecFallback(yyv945, false)
 				}
 			}
 		case "reason":
@@ -11796,9 +11178,9 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Message = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys986)
-		} // end switch yys986
-	} // end for yyj986
+			z.DecStructFieldNotFound(-1, yys940)
+		} // end switch yys940
+	} // end for yyj940
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -11806,16 +11188,16 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj995 int
-	var yyb995 bool
-	var yyhl995 bool = l >= 0
-	yyj995++
-	if yyhl995 {
-		yyb995 = yyj995 > l
+	var yyj949 int
+	var yyb949 bool
+	var yyhl949 bool = l >= 0
+	yyj949++
+	if yyhl949 {
+		yyb949 = yyj949 > l
 	} else {
-		yyb995 = r.CheckBreak()
+		yyb949 = r.CheckBreak()
 	}
-	if yyb995 {
+	if yyb949 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11825,13 +11207,13 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Type = JobConditionType(r.DecodeString())
 	}
-	yyj995++
-	if yyhl995 {
-		yyb995 = yyj995 > l
+	yyj949++
+	if yyhl949 {
+		yyb949 = yyj949 > l
 	} else {
-		yyb995 = r.CheckBreak()
+		yyb949 = r.CheckBreak()
 	}
-	if yyb995 {
+	if yyb949 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11841,13 +11223,13 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Status = pkg2_v1.ConditionStatus(r.DecodeString())
 	}
-	yyj995++
-	if yyhl995 {
-		yyb995 = yyj995 > l
+	yyj949++
+	if yyhl949 {
+		yyb949 = yyj949 > l
 	} else {
-		yyb995 = r.CheckBreak()
+		yyb949 = r.CheckBreak()
 	}
-	if yyb995 {
+	if yyb949 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11855,26 +11237,26 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.LastProbeTime = pkg1_unversioned.Time{}
 	} else {
-		yyv998 := &x.LastProbeTime
-		yym999 := z.DecBinary()
-		_ = yym999
+		yyv952 := &x.LastProbeTime
+		yym953 := z.DecBinary()
+		_ = yym953
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv998) {
-		} else if yym999 {
-			z.DecBinaryUnmarshal(yyv998)
-		} else if !yym999 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv998)
+		} else if z.HasExtensions() && z.DecExt(yyv952) {
+		} else if yym953 {
+			z.DecBinaryUnmarshal(yyv952)
+		} else if !yym953 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv952)
 		} else {
-			z.DecFallback(yyv998, false)
+			z.DecFallback(yyv952, false)
 		}
 	}
-	yyj995++
-	if yyhl995 {
-		yyb995 = yyj995 > l
+	yyj949++
+	if yyhl949 {
+		yyb949 = yyj949 > l
 	} else {
-		yyb995 = r.CheckBreak()
+		yyb949 = r.CheckBreak()
 	}
-	if yyb995 {
+	if yyb949 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11882,26 +11264,26 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.LastTransitionTime = pkg1_unversioned.Time{}
 	} else {
-		yyv1000 := &x.LastTransitionTime
-		yym1001 := z.DecBinary()
-		_ = yym1001
+		yyv954 := &x.LastTransitionTime
+		yym955 := z.DecBinary()
+		_ = yym955
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1000) {
-		} else if yym1001 {
-			z.DecBinaryUnmarshal(yyv1000)
-		} else if !yym1001 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1000)
+		} else if z.HasExtensions() && z.DecExt(yyv954) {
+		} else if yym955 {
+			z.DecBinaryUnmarshal(yyv954)
+		} else if !yym955 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv954)
 		} else {
-			z.DecFallback(yyv1000, false)
+			z.DecFallback(yyv954, false)
 		}
 	}
-	yyj995++
-	if yyhl995 {
-		yyb995 = yyj995 > l
+	yyj949++
+	if yyhl949 {
+		yyb949 = yyj949 > l
 	} else {
-		yyb995 = r.CheckBreak()
+		yyb949 = r.CheckBreak()
 	}
-	if yyb995 {
+	if yyb949 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11911,13 +11293,13 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Reason = string(r.DecodeString())
 	}
-	yyj995++
-	if yyhl995 {
-		yyb995 = yyj995 > l
+	yyj949++
+	if yyhl949 {
+		yyb949 = yyj949 > l
 	} else {
-		yyb995 = r.CheckBreak()
+		yyb949 = r.CheckBreak()
 	}
-	if yyb995 {
+	if yyb949 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -11928,17 +11310,17 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Message = string(r.DecodeString())
 	}
 	for {
-		yyj995++
-		if yyhl995 {
-			yyb995 = yyj995 > l
+		yyj949++
+		if yyhl949 {
+			yyb949 = yyj949 > l
 		} else {
-			yyb995 = r.CheckBreak()
+			yyb949 = r.CheckBreak()
 		}
-		if yyb995 {
+		if yyb949 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj995-1, "")
+		z.DecStructFieldNotFound(yyj949-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -11950,90 +11332,90 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1004 := z.EncBinary()
-		_ = yym1004
+		yym958 := z.EncBinary()
+		_ = yym958
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1005 := !z.EncBinary()
-			yy2arr1005 := z.EncBasicHandle().StructToArray
-			var yyq1005 [5]bool
-			_, _, _ = yysep1005, yyq1005, yy2arr1005
-			const yyr1005 bool = false
-			yyq1005[0] = true
-			yyq1005[1] = true
-			yyq1005[2] = true
-			yyq1005[3] = x.Kind != ""
-			yyq1005[4] = x.APIVersion != ""
-			var yynn1005 int
-			if yyr1005 || yy2arr1005 {
+			yysep959 := !z.EncBinary()
+			yy2arr959 := z.EncBasicHandle().StructToArray
+			var yyq959 [5]bool
+			_, _, _ = yysep959, yyq959, yy2arr959
+			const yyr959 bool = false
+			yyq959[0] = true
+			yyq959[1] = true
+			yyq959[2] = true
+			yyq959[3] = x.Kind != ""
+			yyq959[4] = x.APIVersion != ""
+			var yynn959 int
+			if yyr959 || yy2arr959 {
 				r.EncodeArrayStart(5)
 			} else {
-				yynn1005 = 0
-				for _, b := range yyq1005 {
+				yynn959 = 0
+				for _, b := range yyq959 {
 					if b {
-						yynn1005++
+						yynn959++
 					}
 				}
-				r.EncodeMapStart(yynn1005)
-				yynn1005 = 0
+				r.EncodeMapStart(yynn959)
+				yynn959 = 0
 			}
-			if yyr1005 || yy2arr1005 {
+			if yyr959 || yy2arr959 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1005[0] {
-					yy1007 := &x.ObjectMeta
-					yy1007.CodecEncodeSelf(e)
+				if yyq959[0] {
+					yy961 := &x.ObjectMeta
+					yy961.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1005[0] {
+				if yyq959[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1008 := &x.ObjectMeta
-					yy1008.CodecEncodeSelf(e)
+					yy962 := &x.ObjectMeta
+					yy962.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1005 || yy2arr1005 {
+			if yyr959 || yy2arr959 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1005[1] {
-					yy1010 := &x.Spec
-					yy1010.CodecEncodeSelf(e)
+				if yyq959[1] {
+					yy964 := &x.Spec
+					yy964.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1005[1] {
+				if yyq959[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1011 := &x.Spec
-					yy1011.CodecEncodeSelf(e)
+					yy965 := &x.Spec
+					yy965.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1005 || yy2arr1005 {
+			if yyr959 || yy2arr959 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1005[2] {
-					yy1013 := &x.Status
-					yy1013.CodecEncodeSelf(e)
+				if yyq959[2] {
+					yy967 := &x.Status
+					yy967.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1005[2] {
+				if yyq959[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1014 := &x.Status
-					yy1014.CodecEncodeSelf(e)
+					yy968 := &x.Status
+					yy968.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1005 || yy2arr1005 {
+			if yyr959 || yy2arr959 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1005[3] {
-					yym1016 := z.EncBinary()
-					_ = yym1016
+				if yyq959[3] {
+					yym970 := z.EncBinary()
+					_ = yym970
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -12042,23 +11424,23 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1005[3] {
+				if yyq959[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1017 := z.EncBinary()
-					_ = yym1017
+					yym971 := z.EncBinary()
+					_ = yym971
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1005 || yy2arr1005 {
+			if yyr959 || yy2arr959 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1005[4] {
-					yym1019 := z.EncBinary()
-					_ = yym1019
+				if yyq959[4] {
+					yym973 := z.EncBinary()
+					_ = yym973
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -12067,19 +11449,19 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1005[4] {
+				if yyq959[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1020 := z.EncBinary()
-					_ = yym1020
+					yym974 := z.EncBinary()
+					_ = yym974
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1005 || yy2arr1005 {
+			if yyr959 || yy2arr959 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -12092,25 +11474,25 @@ func (x *Ingress) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1021 := z.DecBinary()
-	_ = yym1021
+	yym975 := z.DecBinary()
+	_ = yym975
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1022 := r.ContainerType()
-		if yyct1022 == codecSelferValueTypeMap1234 {
-			yyl1022 := r.ReadMapStart()
-			if yyl1022 == 0 {
+		yyct976 := r.ContainerType()
+		if yyct976 == codecSelferValueTypeMap1234 {
+			yyl976 := r.ReadMapStart()
+			if yyl976 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1022, d)
+				x.codecDecodeSelfFromMap(yyl976, d)
 			}
-		} else if yyct1022 == codecSelferValueTypeArray1234 {
-			yyl1022 := r.ReadArrayStart()
-			if yyl1022 == 0 {
+		} else if yyct976 == codecSelferValueTypeArray1234 {
+			yyl976 := r.ReadArrayStart()
+			if yyl976 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1022, d)
+				x.codecDecodeSelfFromArray(yyl976, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -12122,12 +11504,12 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1023Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1023Slc
-	var yyhl1023 bool = l >= 0
-	for yyj1023 := 0; ; yyj1023++ {
-		if yyhl1023 {
-			if yyj1023 >= l {
+	var yys977Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys977Slc
+	var yyhl977 bool = l >= 0
+	for yyj977 := 0; ; yyj977++ {
+		if yyhl977 {
+			if yyj977 >= l {
 				break
 			}
 		} else {
@@ -12136,30 +11518,30 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1023Slc = r.DecodeBytes(yys1023Slc, true, true)
-		yys1023 := string(yys1023Slc)
+		yys977Slc = r.DecodeBytes(yys977Slc, true, true)
+		yys977 := string(yys977Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1023 {
+		switch yys977 {
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_v1.ObjectMeta{}
 			} else {
-				yyv1024 := &x.ObjectMeta
-				yyv1024.CodecDecodeSelf(d)
+				yyv978 := &x.ObjectMeta
+				yyv978.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = IngressSpec{}
 			} else {
-				yyv1025 := &x.Spec
-				yyv1025.CodecDecodeSelf(d)
+				yyv979 := &x.Spec
+				yyv979.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = IngressStatus{}
 			} else {
-				yyv1026 := &x.Status
-				yyv1026.CodecDecodeSelf(d)
+				yyv980 := &x.Status
+				yyv980.CodecDecodeSelf(d)
 			}
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -12174,9 +11556,9 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1023)
-		} // end switch yys1023
-	} // end for yyj1023
+			z.DecStructFieldNotFound(-1, yys977)
+		} // end switch yys977
+	} // end for yyj977
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -12184,16 +11566,16 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1029 int
-	var yyb1029 bool
-	var yyhl1029 bool = l >= 0
-	yyj1029++
-	if yyhl1029 {
-		yyb1029 = yyj1029 > l
+	var yyj983 int
+	var yyb983 bool
+	var yyhl983 bool = l >= 0
+	yyj983++
+	if yyhl983 {
+		yyb983 = yyj983 > l
 	} else {
-		yyb1029 = r.CheckBreak()
+		yyb983 = r.CheckBreak()
 	}
-	if yyb1029 {
+	if yyb983 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -12201,16 +11583,16 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_v1.ObjectMeta{}
 	} else {
-		yyv1030 := &x.ObjectMeta
-		yyv1030.CodecDecodeSelf(d)
+		yyv984 := &x.ObjectMeta
+		yyv984.CodecDecodeSelf(d)
 	}
-	yyj1029++
-	if yyhl1029 {
-		yyb1029 = yyj1029 > l
+	yyj983++
+	if yyhl983 {
+		yyb983 = yyj983 > l
 	} else {
-		yyb1029 = r.CheckBreak()
+		yyb983 = r.CheckBreak()
 	}
-	if yyb1029 {
+	if yyb983 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -12218,16 +11600,16 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Spec = IngressSpec{}
 	} else {
-		yyv1031 := &x.Spec
-		yyv1031.CodecDecodeSelf(d)
+		yyv985 := &x.Spec
+		yyv985.CodecDecodeSelf(d)
 	}
-	yyj1029++
-	if yyhl1029 {
-		yyb1029 = yyj1029 > l
+	yyj983++
+	if yyhl983 {
+		yyb983 = yyj983 > l
 	} else {
-		yyb1029 = r.CheckBreak()
+		yyb983 = r.CheckBreak()
 	}
-	if yyb1029 {
+	if yyb983 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -12235,16 +11617,16 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Status = IngressStatus{}
 	} else {
-		yyv1032 := &x.Status
-		yyv1032.CodecDecodeSelf(d)
+		yyv986 := &x.Status
+		yyv986.CodecDecodeSelf(d)
 	}
-	yyj1029++
-	if yyhl1029 {
-		yyb1029 = yyj1029 > l
+	yyj983++
+	if yyhl983 {
+		yyb983 = yyj983 > l
 	} else {
-		yyb1029 = r.CheckBreak()
+		yyb983 = r.CheckBreak()
 	}
-	if yyb1029 {
+	if yyb983 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -12254,13 +11636,13 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1029++
-	if yyhl1029 {
-		yyb1029 = yyj1029 > l
+	yyj983++
+	if yyhl983 {
+		yyb983 = yyj983 > l
 	} else {
-		yyb1029 = r.CheckBreak()
+		yyb983 = r.CheckBreak()
 	}
-	if yyb1029 {
+	if yyb983 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -12271,17 +11653,17 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = string(r.DecodeString())
 	}
 	for {
-		yyj1029++
-		if yyhl1029 {
-			yyb1029 = yyj1029 > l
+		yyj983++
+		if yyhl983 {
+			yyb983 = yyj983 > l
 		} else {
-			yyb1029 = r.CheckBreak()
+			yyb983 = r.CheckBreak()
 		}
-		if yyb1029 {
+		if yyb983 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1029-1, "")
+		z.DecStructFieldNotFound(yyj983-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -12293,68 +11675,68 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1035 := z.EncBinary()
-		_ = yym1035
+		yym989 := z.EncBinary()
+		_ = yym989
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1036 := !z.EncBinary()
-			yy2arr1036 := z.EncBasicHandle().StructToArray
-			var yyq1036 [4]bool
-			_, _, _ = yysep1036, yyq1036, yy2arr1036
-			const yyr1036 bool = false
-			yyq1036[0] = true
-			yyq1036[2] = x.Kind != ""
-			yyq1036[3] = x.APIVersion != ""
-			var yynn1036 int
-			if yyr1036 || yy2arr1036 {
+			yysep990 := !z.EncBinary()
+			yy2arr990 := z.EncBasicHandle().StructToArray
+			var yyq990 [4]bool
+			_, _, _ = yysep990, yyq990, yy2arr990
+			const yyr990 bool = false
+			yyq990[0] = true
+			yyq990[2] = x.Kind != ""
+			yyq990[3] = x.APIVersion != ""
+			var yynn990 int
+			if yyr990 || yy2arr990 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn1036 = 1
-				for _, b := range yyq1036 {
+				yynn990 = 1
+				for _, b := range yyq990 {
 					if b {
-						yynn1036++
+						yynn990++
 					}
 				}
-				r.EncodeMapStart(yynn1036)
-				yynn1036 = 0
+				r.EncodeMapStart(yynn990)
+				yynn990 = 0
 			}
-			if yyr1036 || yy2arr1036 {
+			if yyr990 || yy2arr990 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1036[0] {
-					yy1038 := &x.ListMeta
-					yym1039 := z.EncBinary()
-					_ = yym1039
+				if yyq990[0] {
+					yy992 := &x.ListMeta
+					yym993 := z.EncBinary()
+					_ = yym993
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1038) {
+					} else if z.HasExtensions() && z.EncExt(yy992) {
 					} else {
-						z.EncFallback(yy1038)
+						z.EncFallback(yy992)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1036[0] {
+				if yyq990[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1040 := &x.ListMeta
-					yym1041 := z.EncBinary()
-					_ = yym1041
+					yy994 := &x.ListMeta
+					yym995 := z.EncBinary()
+					_ = yym995
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1040) {
+					} else if z.HasExtensions() && z.EncExt(yy994) {
 					} else {
-						z.EncFallback(yy1040)
+						z.EncFallback(yy994)
 					}
 				}
 			}
-			if yyr1036 || yy2arr1036 {
+			if yyr990 || yy2arr990 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1043 := z.EncBinary()
-					_ = yym1043
+					yym997 := z.EncBinary()
+					_ = yym997
 					if false {
 					} else {
 						h.encSliceIngress(([]Ingress)(x.Items), e)
@@ -12367,19 +11749,19 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1044 := z.EncBinary()
-					_ = yym1044
+					yym998 := z.EncBinary()
+					_ = yym998
 					if false {
 					} else {
 						h.encSliceIngress(([]Ingress)(x.Items), e)
 					}
 				}
 			}
-			if yyr1036 || yy2arr1036 {
+			if yyr990 || yy2arr990 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1036[2] {
-					yym1046 := z.EncBinary()
-					_ = yym1046
+				if yyq990[2] {
+					yym1000 := z.EncBinary()
+					_ = yym1000
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -12388,23 +11770,23 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1036[2] {
+				if yyq990[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1047 := z.EncBinary()
-					_ = yym1047
+					yym1001 := z.EncBinary()
+					_ = yym1001
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1036 || yy2arr1036 {
+			if yyr990 || yy2arr990 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1036[3] {
-					yym1049 := z.EncBinary()
-					_ = yym1049
+				if yyq990[3] {
+					yym1003 := z.EncBinary()
+					_ = yym1003
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -12413,19 +11795,19 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1036[3] {
+				if yyq990[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1050 := z.EncBinary()
-					_ = yym1050
+					yym1004 := z.EncBinary()
+					_ = yym1004
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1036 || yy2arr1036 {
+			if yyr990 || yy2arr990 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -12438,25 +11820,25 @@ func (x *IngressList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1051 := z.DecBinary()
-	_ = yym1051
+	yym1005 := z.DecBinary()
+	_ = yym1005
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1052 := r.ContainerType()
-		if yyct1052 == codecSelferValueTypeMap1234 {
-			yyl1052 := r.ReadMapStart()
-			if yyl1052 == 0 {
+		yyct1006 := r.ContainerType()
+		if yyct1006 == codecSelferValueTypeMap1234 {
+			yyl1006 := r.ReadMapStart()
+			if yyl1006 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1052, d)
+				x.codecDecodeSelfFromMap(yyl1006, d)
 			}
-		} else if yyct1052 == codecSelferValueTypeArray1234 {
-			yyl1052 := r.ReadArrayStart()
-			if yyl1052 == 0 {
+		} else if yyct1006 == codecSelferValueTypeArray1234 {
+			yyl1006 := r.ReadArrayStart()
+			if yyl1006 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1052, d)
+				x.codecDecodeSelfFromArray(yyl1006, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -12468,12 +11850,12 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1053Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1053Slc
-	var yyhl1053 bool = l >= 0
-	for yyj1053 := 0; ; yyj1053++ {
-		if yyhl1053 {
-			if yyj1053 >= l {
+	var yys1007Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1007Slc
+	var yyhl1007 bool = l >= 0
+	for yyj1007 := 0; ; yyj1007++ {
+		if yyhl1007 {
+			if yyj1007 >= l {
 				break
 			}
 		} else {
@@ -12482,33 +11864,33 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1053Slc = r.DecodeBytes(yys1053Slc, true, true)
-		yys1053 := string(yys1053Slc)
+		yys1007Slc = r.DecodeBytes(yys1007Slc, true, true)
+		yys1007 := string(yys1007Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1053 {
+		switch yys1007 {
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv1054 := &x.ListMeta
-				yym1055 := z.DecBinary()
-				_ = yym1055
+				yyv1008 := &x.ListMeta
+				yym1009 := z.DecBinary()
+				_ = yym1009
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1054) {
+				} else if z.HasExtensions() && z.DecExt(yyv1008) {
 				} else {
-					z.DecFallback(yyv1054, false)
+					z.DecFallback(yyv1008, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv1056 := &x.Items
-				yym1057 := z.DecBinary()
-				_ = yym1057
+				yyv1010 := &x.Items
+				yym1011 := z.DecBinary()
+				_ = yym1011
 				if false {
 				} else {
-					h.decSliceIngress((*[]Ingress)(yyv1056), d)
+					h.decSliceIngress((*[]Ingress)(yyv1010), d)
 				}
 			}
 		case "kind":
@@ -12524,9 +11906,9 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1053)
-		} // end switch yys1053
-	} // end for yyj1053
+			z.DecStructFieldNotFound(-1, yys1007)
+		} // end switch yys1007
+	} // end for yyj1007
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -12534,16 +11916,16 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1060 int
-	var yyb1060 bool
-	var yyhl1060 bool = l >= 0
-	yyj1060++
-	if yyhl1060 {
-		yyb1060 = yyj1060 > l
+	var yyj1014 int
+	var yyb1014 bool
+	var yyhl1014 bool = l >= 0
+	yyj1014++
+	if yyhl1014 {
+		yyb1014 = yyj1014 > l
 	} else {
-		yyb1060 = r.CheckBreak()
+		yyb1014 = r.CheckBreak()
 	}
-	if yyb1060 {
+	if yyb1014 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -12551,22 +11933,22 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv1061 := &x.ListMeta
-		yym1062 := z.DecBinary()
-		_ = yym1062
+		yyv1015 := &x.ListMeta
+		yym1016 := z.DecBinary()
+		_ = yym1016
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1061) {
+		} else if z.HasExtensions() && z.DecExt(yyv1015) {
 		} else {
-			z.DecFallback(yyv1061, false)
+			z.DecFallback(yyv1015, false)
 		}
 	}
-	yyj1060++
-	if yyhl1060 {
-		yyb1060 = yyj1060 > l
+	yyj1014++
+	if yyhl1014 {
+		yyb1014 = yyj1014 > l
 	} else {
-		yyb1060 = r.CheckBreak()
+		yyb1014 = r.CheckBreak()
 	}
-	if yyb1060 {
+	if yyb1014 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -12574,21 +11956,21 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv1063 := &x.Items
-		yym1064 := z.DecBinary()
-		_ = yym1064
+		yyv1017 := &x.Items
+		yym1018 := z.DecBinary()
+		_ = yym1018
 		if false {
 		} else {
-			h.decSliceIngress((*[]Ingress)(yyv1063), d)
+			h.decSliceIngress((*[]Ingress)(yyv1017), d)
 		}
 	}
-	yyj1060++
-	if yyhl1060 {
-		yyb1060 = yyj1060 > l
+	yyj1014++
+	if yyhl1014 {
+		yyb1014 = yyj1014 > l
 	} else {
-		yyb1060 = r.CheckBreak()
+		yyb1014 = r.CheckBreak()
 	}
-	if yyb1060 {
+	if yyb1014 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -12598,13 +11980,13 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1060++
-	if yyhl1060 {
-		yyb1060 = yyj1060 > l
+	yyj1014++
+	if yyhl1014 {
+		yyb1014 = yyj1014 > l
 	} else {
-		yyb1060 = r.CheckBreak()
+		yyb1014 = r.CheckBreak()
 	}
-	if yyb1060 {
+	if yyb1014 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -12615,17 +11997,17 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = string(r.DecodeString())
 	}
 	for {
-		yyj1060++
-		if yyhl1060 {
-			yyb1060 = yyj1060 > l
+		yyj1014++
+		if yyhl1014 {
+			yyb1014 = yyj1014 > l
 		} else {
-			yyb1060 = r.CheckBreak()
+			yyb1014 = r.CheckBreak()
 		}
-		if yyb1060 {
+		if yyb1014 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1060-1, "")
+		z.DecStructFieldNotFound(yyj1014-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -12637,35 +12019,35 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1067 := z.EncBinary()
-		_ = yym1067
+		yym1021 := z.EncBinary()
+		_ = yym1021
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1068 := !z.EncBinary()
-			yy2arr1068 := z.EncBasicHandle().StructToArray
-			var yyq1068 [3]bool
-			_, _, _ = yysep1068, yyq1068, yy2arr1068
-			const yyr1068 bool = false
-			yyq1068[0] = x.Backend != nil
-			yyq1068[1] = len(x.TLS) != 0
-			yyq1068[2] = len(x.Rules) != 0
-			var yynn1068 int
-			if yyr1068 || yy2arr1068 {
+			yysep1022 := !z.EncBinary()
+			yy2arr1022 := z.EncBasicHandle().StructToArray
+			var yyq1022 [3]bool
+			_, _, _ = yysep1022, yyq1022, yy2arr1022
+			const yyr1022 bool = false
+			yyq1022[0] = x.Backend != nil
+			yyq1022[1] = len(x.TLS) != 0
+			yyq1022[2] = len(x.Rules) != 0
+			var yynn1022 int
+			if yyr1022 || yy2arr1022 {
 				r.EncodeArrayStart(3)
 			} else {
-				yynn1068 = 0
-				for _, b := range yyq1068 {
+				yynn1022 = 0
+				for _, b := range yyq1022 {
 					if b {
-						yynn1068++
+						yynn1022++
 					}
 				}
-				r.EncodeMapStart(yynn1068)
-				yynn1068 = 0
+				r.EncodeMapStart(yynn1022)
+				yynn1022 = 0
 			}
-			if yyr1068 || yy2arr1068 {
+			if yyr1022 || yy2arr1022 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1068[0] {
+				if yyq1022[0] {
 					if x.Backend == nil {
 						r.EncodeNil()
 					} else {
@@ -12675,7 +12057,7 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1068[0] {
+				if yyq1022[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("backend"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
@@ -12686,14 +12068,14 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1068 || yy2arr1068 {
+			if yyr1022 || yy2arr1022 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1068[1] {
+				if yyq1022[1] {
 					if x.TLS == nil {
 						r.EncodeNil()
 					} else {
-						yym1071 := z.EncBinary()
-						_ = yym1071
+						yym1025 := z.EncBinary()
+						_ = yym1025
 						if false {
 						} else {
 							h.encSliceIngressTLS(([]IngressTLS)(x.TLS), e)
@@ -12703,15 +12085,15 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1068[1] {
+				if yyq1022[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("tls"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.TLS == nil {
 						r.EncodeNil()
 					} else {
-						yym1072 := z.EncBinary()
-						_ = yym1072
+						yym1026 := z.EncBinary()
+						_ = yym1026
 						if false {
 						} else {
 							h.encSliceIngressTLS(([]IngressTLS)(x.TLS), e)
@@ -12719,14 +12101,14 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1068 || yy2arr1068 {
+			if yyr1022 || yy2arr1022 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1068[2] {
+				if yyq1022[2] {
 					if x.Rules == nil {
 						r.EncodeNil()
 					} else {
-						yym1074 := z.EncBinary()
-						_ = yym1074
+						yym1028 := z.EncBinary()
+						_ = yym1028
 						if false {
 						} else {
 							h.encSliceIngressRule(([]IngressRule)(x.Rules), e)
@@ -12736,15 +12118,15 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1068[2] {
+				if yyq1022[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("rules"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Rules == nil {
 						r.EncodeNil()
 					} else {
-						yym1075 := z.EncBinary()
-						_ = yym1075
+						yym1029 := z.EncBinary()
+						_ = yym1029
 						if false {
 						} else {
 							h.encSliceIngressRule(([]IngressRule)(x.Rules), e)
@@ -12752,7 +12134,7 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1068 || yy2arr1068 {
+			if yyr1022 || yy2arr1022 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -12765,25 +12147,25 @@ func (x *IngressSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1076 := z.DecBinary()
-	_ = yym1076
+	yym1030 := z.DecBinary()
+	_ = yym1030
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1077 := r.ContainerType()
-		if yyct1077 == codecSelferValueTypeMap1234 {
-			yyl1077 := r.ReadMapStart()
-			if yyl1077 == 0 {
+		yyct1031 := r.ContainerType()
+		if yyct1031 == codecSelferValueTypeMap1234 {
+			yyl1031 := r.ReadMapStart()
+			if yyl1031 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1077, d)
+				x.codecDecodeSelfFromMap(yyl1031, d)
 			}
-		} else if yyct1077 == codecSelferValueTypeArray1234 {
-			yyl1077 := r.ReadArrayStart()
-			if yyl1077 == 0 {
+		} else if yyct1031 == codecSelferValueTypeArray1234 {
+			yyl1031 := r.ReadArrayStart()
+			if yyl1031 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1077, d)
+				x.codecDecodeSelfFromArray(yyl1031, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -12795,12 +12177,12 @@ func (x *IngressSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1078Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1078Slc
-	var yyhl1078 bool = l >= 0
-	for yyj1078 := 0; ; yyj1078++ {
-		if yyhl1078 {
-			if yyj1078 >= l {
+	var yys1032Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1032Slc
+	var yyhl1032 bool = l >= 0
+	for yyj1032 := 0; ; yyj1032++ {
+		if yyhl1032 {
+			if yyj1032 >= l {
 				break
 			}
 		} else {
@@ -12809,10 +12191,10 @@ func (x *IngressSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1078Slc = r.DecodeBytes(yys1078Slc, true, true)
-		yys1078 := string(yys1078Slc)
+		yys1032Slc = r.DecodeBytes(yys1032Slc, true, true)
+		yys1032 := string(yys1032Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1078 {
+		switch yys1032 {
 		case "backend":
 			if r.TryDecodeAsNil() {
 				if x.Backend != nil {
@@ -12828,30 +12210,30 @@ func (x *IngressSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.TLS = nil
 			} else {
-				yyv1080 := &x.TLS
-				yym1081 := z.DecBinary()
-				_ = yym1081
+				yyv1034 := &x.TLS
+				yym1035 := z.DecBinary()
+				_ = yym1035
 				if false {
 				} else {
-					h.decSliceIngressTLS((*[]IngressTLS)(yyv1080), d)
+					h.decSliceIngressTLS((*[]IngressTLS)(yyv1034), d)
 				}
 			}
 		case "rules":
 			if r.TryDecodeAsNil() {
 				x.Rules = nil
 			} else {
-				yyv1082 := &x.Rules
-				yym1083 := z.DecBinary()
-				_ = yym1083
+				yyv1036 := &x.Rules
+				yym1037 := z.DecBinary()
+				_ = yym1037
 				if false {
 				} else {
-					h.decSliceIngressRule((*[]IngressRule)(yyv1082), d)
+					h.decSliceIngressRule((*[]IngressRule)(yyv1036), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1078)
-		} // end switch yys1078
-	} // end for yyj1078
+			z.DecStructFieldNotFound(-1, yys1032)
+		} // end switch yys1032
+	} // end for yyj1032
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -12859,16 +12241,16 @@ func (x *IngressSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1084 int
-	var yyb1084 bool
-	var yyhl1084 bool = l >= 0
-	yyj1084++
-	if yyhl1084 {
-		yyb1084 = yyj1084 > l
+	var yyj1038 int
+	var yyb1038 bool
+	var yyhl1038 bool = l >= 0
+	yyj1038++
+	if yyhl1038 {
+		yyb1038 = yyj1038 > l
 	} else {
-		yyb1084 = r.CheckBreak()
+		yyb1038 = r.CheckBreak()
 	}
-	if yyb1084 {
+	if yyb1038 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -12883,13 +12265,13 @@ func (x *IngressSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Backend.CodecDecodeSelf(d)
 	}
-	yyj1084++
-	if yyhl1084 {
-		yyb1084 = yyj1084 > l
+	yyj1038++
+	if yyhl1038 {
+		yyb1038 = yyj1038 > l
 	} else {
-		yyb1084 = r.CheckBreak()
+		yyb1038 = r.CheckBreak()
 	}
-	if yyb1084 {
+	if yyb1038 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -12897,21 +12279,21 @@ func (x *IngressSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.TLS = nil
 	} else {
-		yyv1086 := &x.TLS
-		yym1087 := z.DecBinary()
-		_ = yym1087
+		yyv1040 := &x.TLS
+		yym1041 := z.DecBinary()
+		_ = yym1041
 		if false {
 		} else {
-			h.decSliceIngressTLS((*[]IngressTLS)(yyv1086), d)
+			h.decSliceIngressTLS((*[]IngressTLS)(yyv1040), d)
 		}
 	}
-	yyj1084++
-	if yyhl1084 {
-		yyb1084 = yyj1084 > l
+	yyj1038++
+	if yyhl1038 {
+		yyb1038 = yyj1038 > l
 	} else {
-		yyb1084 = r.CheckBreak()
+		yyb1038 = r.CheckBreak()
 	}
-	if yyb1084 {
+	if yyb1038 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -12919,26 +12301,26 @@ func (x *IngressSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Rules = nil
 	} else {
-		yyv1088 := &x.Rules
-		yym1089 := z.DecBinary()
-		_ = yym1089
+		yyv1042 := &x.Rules
+		yym1043 := z.DecBinary()
+		_ = yym1043
 		if false {
 		} else {
-			h.decSliceIngressRule((*[]IngressRule)(yyv1088), d)
+			h.decSliceIngressRule((*[]IngressRule)(yyv1042), d)
 		}
 	}
 	for {
-		yyj1084++
-		if yyhl1084 {
-			yyb1084 = yyj1084 > l
+		yyj1038++
+		if yyhl1038 {
+			yyb1038 = yyj1038 > l
 		} else {
-			yyb1084 = r.CheckBreak()
+			yyb1038 = r.CheckBreak()
 		}
-		if yyb1084 {
+		if yyb1038 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1084-1, "")
+		z.DecStructFieldNotFound(yyj1038-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -12950,39 +12332,39 @@ func (x *IngressTLS) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1090 := z.EncBinary()
-		_ = yym1090
+		yym1044 := z.EncBinary()
+		_ = yym1044
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1091 := !z.EncBinary()
-			yy2arr1091 := z.EncBasicHandle().StructToArray
-			var yyq1091 [2]bool
-			_, _, _ = yysep1091, yyq1091, yy2arr1091
-			const yyr1091 bool = false
-			yyq1091[0] = len(x.Hosts) != 0
-			yyq1091[1] = x.SecretName != ""
-			var yynn1091 int
-			if yyr1091 || yy2arr1091 {
+			yysep1045 := !z.EncBinary()
+			yy2arr1045 := z.EncBasicHandle().StructToArray
+			var yyq1045 [2]bool
+			_, _, _ = yysep1045, yyq1045, yy2arr1045
+			const yyr1045 bool = false
+			yyq1045[0] = len(x.Hosts) != 0
+			yyq1045[1] = x.SecretName != ""
+			var yynn1045 int
+			if yyr1045 || yy2arr1045 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn1091 = 0
-				for _, b := range yyq1091 {
+				yynn1045 = 0
+				for _, b := range yyq1045 {
 					if b {
-						yynn1091++
+						yynn1045++
 					}
 				}
-				r.EncodeMapStart(yynn1091)
-				yynn1091 = 0
+				r.EncodeMapStart(yynn1045)
+				yynn1045 = 0
 			}
-			if yyr1091 || yy2arr1091 {
+			if yyr1045 || yy2arr1045 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1091[0] {
+				if yyq1045[0] {
 					if x.Hosts == nil {
 						r.EncodeNil()
 					} else {
-						yym1093 := z.EncBinary()
-						_ = yym1093
+						yym1047 := z.EncBinary()
+						_ = yym1047
 						if false {
 						} else {
 							z.F.EncSliceStringV(x.Hosts, false, e)
@@ -12992,15 +12374,15 @@ func (x *IngressTLS) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1091[0] {
+				if yyq1045[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hosts"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Hosts == nil {
 						r.EncodeNil()
 					} else {
-						yym1094 := z.EncBinary()
-						_ = yym1094
+						yym1048 := z.EncBinary()
+						_ = yym1048
 						if false {
 						} else {
 							z.F.EncSliceStringV(x.Hosts, false, e)
@@ -13008,11 +12390,11 @@ func (x *IngressTLS) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1091 || yy2arr1091 {
+			if yyr1045 || yy2arr1045 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1091[1] {
-					yym1096 := z.EncBinary()
-					_ = yym1096
+				if yyq1045[1] {
+					yym1050 := z.EncBinary()
+					_ = yym1050
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.SecretName))
@@ -13021,19 +12403,19 @@ func (x *IngressTLS) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1091[1] {
+				if yyq1045[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("secretName"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1097 := z.EncBinary()
-					_ = yym1097
+					yym1051 := z.EncBinary()
+					_ = yym1051
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.SecretName))
 					}
 				}
 			}
-			if yyr1091 || yy2arr1091 {
+			if yyr1045 || yy2arr1045 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -13046,25 +12428,25 @@ func (x *IngressTLS) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1098 := z.DecBinary()
-	_ = yym1098
+	yym1052 := z.DecBinary()
+	_ = yym1052
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1099 := r.ContainerType()
-		if yyct1099 == codecSelferValueTypeMap1234 {
-			yyl1099 := r.ReadMapStart()
-			if yyl1099 == 0 {
+		yyct1053 := r.ContainerType()
+		if yyct1053 == codecSelferValueTypeMap1234 {
+			yyl1053 := r.ReadMapStart()
+			if yyl1053 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1099, d)
+				x.codecDecodeSelfFromMap(yyl1053, d)
 			}
-		} else if yyct1099 == codecSelferValueTypeArray1234 {
-			yyl1099 := r.ReadArrayStart()
-			if yyl1099 == 0 {
+		} else if yyct1053 == codecSelferValueTypeArray1234 {
+			yyl1053 := r.ReadArrayStart()
+			if yyl1053 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1099, d)
+				x.codecDecodeSelfFromArray(yyl1053, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -13076,12 +12458,12 @@ func (x *IngressTLS) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1100Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1100Slc
-	var yyhl1100 bool = l >= 0
-	for yyj1100 := 0; ; yyj1100++ {
-		if yyhl1100 {
-			if yyj1100 >= l {
+	var yys1054Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1054Slc
+	var yyhl1054 bool = l >= 0
+	for yyj1054 := 0; ; yyj1054++ {
+		if yyhl1054 {
+			if yyj1054 >= l {
 				break
 			}
 		} else {
@@ -13090,20 +12472,20 @@ func (x *IngressTLS) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1100Slc = r.DecodeBytes(yys1100Slc, true, true)
-		yys1100 := string(yys1100Slc)
+		yys1054Slc = r.DecodeBytes(yys1054Slc, true, true)
+		yys1054 := string(yys1054Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1100 {
+		switch yys1054 {
 		case "hosts":
 			if r.TryDecodeAsNil() {
 				x.Hosts = nil
 			} else {
-				yyv1101 := &x.Hosts
-				yym1102 := z.DecBinary()
-				_ = yym1102
+				yyv1055 := &x.Hosts
+				yym1056 := z.DecBinary()
+				_ = yym1056
 				if false {
 				} else {
-					z.F.DecSliceStringX(yyv1101, false, d)
+					z.F.DecSliceStringX(yyv1055, false, d)
 				}
 			}
 		case "secretName":
@@ -13113,9 +12495,9 @@ func (x *IngressTLS) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.SecretName = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1100)
-		} // end switch yys1100
-	} // end for yyj1100
+			z.DecStructFieldNotFound(-1, yys1054)
+		} // end switch yys1054
+	} // end for yyj1054
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -13123,16 +12505,16 @@ func (x *IngressTLS) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1104 int
-	var yyb1104 bool
-	var yyhl1104 bool = l >= 0
-	yyj1104++
-	if yyhl1104 {
-		yyb1104 = yyj1104 > l
+	var yyj1058 int
+	var yyb1058 bool
+	var yyhl1058 bool = l >= 0
+	yyj1058++
+	if yyhl1058 {
+		yyb1058 = yyj1058 > l
 	} else {
-		yyb1104 = r.CheckBreak()
+		yyb1058 = r.CheckBreak()
 	}
-	if yyb1104 {
+	if yyb1058 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -13140,21 +12522,21 @@ func (x *IngressTLS) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Hosts = nil
 	} else {
-		yyv1105 := &x.Hosts
-		yym1106 := z.DecBinary()
-		_ = yym1106
+		yyv1059 := &x.Hosts
+		yym1060 := z.DecBinary()
+		_ = yym1060
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv1105, false, d)
+			z.F.DecSliceStringX(yyv1059, false, d)
 		}
 	}
-	yyj1104++
-	if yyhl1104 {
-		yyb1104 = yyj1104 > l
+	yyj1058++
+	if yyhl1058 {
+		yyb1058 = yyj1058 > l
 	} else {
-		yyb1104 = r.CheckBreak()
+		yyb1058 = r.CheckBreak()
 	}
-	if yyb1104 {
+	if yyb1058 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -13165,17 +12547,17 @@ func (x *IngressTLS) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.SecretName = string(r.DecodeString())
 	}
 	for {
-		yyj1104++
-		if yyhl1104 {
-			yyb1104 = yyj1104 > l
+		yyj1058++
+		if yyhl1058 {
+			yyb1058 = yyj1058 > l
 		} else {
-			yyb1104 = r.CheckBreak()
+			yyb1058 = r.CheckBreak()
 		}
-		if yyb1104 {
+		if yyb1058 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1104-1, "")
+		z.DecStructFieldNotFound(yyj1058-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -13187,48 +12569,48 @@ func (x *IngressStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1108 := z.EncBinary()
-		_ = yym1108
+		yym1062 := z.EncBinary()
+		_ = yym1062
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1109 := !z.EncBinary()
-			yy2arr1109 := z.EncBasicHandle().StructToArray
-			var yyq1109 [1]bool
-			_, _, _ = yysep1109, yyq1109, yy2arr1109
-			const yyr1109 bool = false
-			yyq1109[0] = true
-			var yynn1109 int
-			if yyr1109 || yy2arr1109 {
+			yysep1063 := !z.EncBinary()
+			yy2arr1063 := z.EncBasicHandle().StructToArray
+			var yyq1063 [1]bool
+			_, _, _ = yysep1063, yyq1063, yy2arr1063
+			const yyr1063 bool = false
+			yyq1063[0] = true
+			var yynn1063 int
+			if yyr1063 || yy2arr1063 {
 				r.EncodeArrayStart(1)
 			} else {
-				yynn1109 = 0
-				for _, b := range yyq1109 {
+				yynn1063 = 0
+				for _, b := range yyq1063 {
 					if b {
-						yynn1109++
+						yynn1063++
 					}
 				}
-				r.EncodeMapStart(yynn1109)
-				yynn1109 = 0
+				r.EncodeMapStart(yynn1063)
+				yynn1063 = 0
 			}
-			if yyr1109 || yy2arr1109 {
+			if yyr1063 || yy2arr1063 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1109[0] {
-					yy1111 := &x.LoadBalancer
-					yy1111.CodecEncodeSelf(e)
+				if yyq1063[0] {
+					yy1065 := &x.LoadBalancer
+					yy1065.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1109[0] {
+				if yyq1063[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("loadBalancer"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1112 := &x.LoadBalancer
-					yy1112.CodecEncodeSelf(e)
+					yy1066 := &x.LoadBalancer
+					yy1066.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1109 || yy2arr1109 {
+			if yyr1063 || yy2arr1063 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -13241,25 +12623,25 @@ func (x *IngressStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1113 := z.DecBinary()
-	_ = yym1113
+	yym1067 := z.DecBinary()
+	_ = yym1067
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1114 := r.ContainerType()
-		if yyct1114 == codecSelferValueTypeMap1234 {
-			yyl1114 := r.ReadMapStart()
-			if yyl1114 == 0 {
+		yyct1068 := r.ContainerType()
+		if yyct1068 == codecSelferValueTypeMap1234 {
+			yyl1068 := r.ReadMapStart()
+			if yyl1068 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1114, d)
+				x.codecDecodeSelfFromMap(yyl1068, d)
 			}
-		} else if yyct1114 == codecSelferValueTypeArray1234 {
-			yyl1114 := r.ReadArrayStart()
-			if yyl1114 == 0 {
+		} else if yyct1068 == codecSelferValueTypeArray1234 {
+			yyl1068 := r.ReadArrayStart()
+			if yyl1068 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1114, d)
+				x.codecDecodeSelfFromArray(yyl1068, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -13271,12 +12653,12 @@ func (x *IngressStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1115Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1115Slc
-	var yyhl1115 bool = l >= 0
-	for yyj1115 := 0; ; yyj1115++ {
-		if yyhl1115 {
-			if yyj1115 >= l {
+	var yys1069Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1069Slc
+	var yyhl1069 bool = l >= 0
+	for yyj1069 := 0; ; yyj1069++ {
+		if yyhl1069 {
+			if yyj1069 >= l {
 				break
 			}
 		} else {
@@ -13285,21 +12667,21 @@ func (x *IngressStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1115Slc = r.DecodeBytes(yys1115Slc, true, true)
-		yys1115 := string(yys1115Slc)
+		yys1069Slc = r.DecodeBytes(yys1069Slc, true, true)
+		yys1069 := string(yys1069Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1115 {
+		switch yys1069 {
 		case "loadBalancer":
 			if r.TryDecodeAsNil() {
 				x.LoadBalancer = pkg2_v1.LoadBalancerStatus{}
 			} else {
-				yyv1116 := &x.LoadBalancer
-				yyv1116.CodecDecodeSelf(d)
+				yyv1070 := &x.LoadBalancer
+				yyv1070.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1115)
-		} // end switch yys1115
-	} // end for yyj1115
+			z.DecStructFieldNotFound(-1, yys1069)
+		} // end switch yys1069
+	} // end for yyj1069
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -13307,16 +12689,16 @@ func (x *IngressStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1117 int
-	var yyb1117 bool
-	var yyhl1117 bool = l >= 0
-	yyj1117++
-	if yyhl1117 {
-		yyb1117 = yyj1117 > l
+	var yyj1071 int
+	var yyb1071 bool
+	var yyhl1071 bool = l >= 0
+	yyj1071++
+	if yyhl1071 {
+		yyb1071 = yyj1071 > l
 	} else {
-		yyb1117 = r.CheckBreak()
+		yyb1071 = r.CheckBreak()
 	}
-	if yyb1117 {
+	if yyb1071 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -13324,21 +12706,21 @@ func (x *IngressStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.LoadBalancer = pkg2_v1.LoadBalancerStatus{}
 	} else {
-		yyv1118 := &x.LoadBalancer
-		yyv1118.CodecDecodeSelf(d)
+		yyv1072 := &x.LoadBalancer
+		yyv1072.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1117++
-		if yyhl1117 {
-			yyb1117 = yyj1117 > l
+		yyj1071++
+		if yyhl1071 {
+			yyb1071 = yyj1071 > l
 		} else {
-			yyb1117 = r.CheckBreak()
+			yyb1071 = r.CheckBreak()
 		}
-		if yyb1117 {
+		if yyb1071 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1117-1, "")
+		z.DecStructFieldNotFound(yyj1071-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -13350,36 +12732,36 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1119 := z.EncBinary()
-		_ = yym1119
+		yym1073 := z.EncBinary()
+		_ = yym1073
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1120 := !z.EncBinary()
-			yy2arr1120 := z.EncBasicHandle().StructToArray
-			var yyq1120 [2]bool
-			_, _, _ = yysep1120, yyq1120, yy2arr1120
-			const yyr1120 bool = false
-			yyq1120[0] = x.Host != ""
-			yyq1120[1] = x.IngressRuleValue.HTTP != nil && x.HTTP != nil
-			var yynn1120 int
-			if yyr1120 || yy2arr1120 {
+			yysep1074 := !z.EncBinary()
+			yy2arr1074 := z.EncBasicHandle().StructToArray
+			var yyq1074 [2]bool
+			_, _, _ = yysep1074, yyq1074, yy2arr1074
+			const yyr1074 bool = false
+			yyq1074[0] = x.Host != ""
+			yyq1074[1] = x.IngressRuleValue.HTTP != nil && x.HTTP != nil
+			var yynn1074 int
+			if yyr1074 || yy2arr1074 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn1120 = 0
-				for _, b := range yyq1120 {
+				yynn1074 = 0
+				for _, b := range yyq1074 {
 					if b {
-						yynn1120++
+						yynn1074++
 					}
 				}
-				r.EncodeMapStart(yynn1120)
-				yynn1120 = 0
+				r.EncodeMapStart(yynn1074)
+				yynn1074 = 0
 			}
-			if yyr1120 || yy2arr1120 {
+			if yyr1074 || yy2arr1074 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1120[0] {
-					yym1122 := z.EncBinary()
-					_ = yym1122
+				if yyq1074[0] {
+					yym1076 := z.EncBinary()
+					_ = yym1076
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Host))
@@ -13388,30 +12770,30 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1120[0] {
+				if yyq1074[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("host"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1123 := z.EncBinary()
-					_ = yym1123
+					yym1077 := z.EncBinary()
+					_ = yym1077
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Host))
 					}
 				}
 			}
-			var yyn1124 bool
+			var yyn1078 bool
 			if x.IngressRuleValue.HTTP == nil {
-				yyn1124 = true
-				goto LABEL1124
+				yyn1078 = true
+				goto LABEL1078
 			}
-		LABEL1124:
-			if yyr1120 || yy2arr1120 {
-				if yyn1124 {
+		LABEL1078:
+			if yyr1074 || yy2arr1074 {
+				if yyn1078 {
 					r.EncodeNil()
 				} else {
 					z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-					if yyq1120[1] {
+					if yyq1074[1] {
 						if x.HTTP == nil {
 							r.EncodeNil()
 						} else {
@@ -13422,11 +12804,11 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
-				if yyq1120[1] {
+				if yyq1074[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("http"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if yyn1124 {
+					if yyn1078 {
 						r.EncodeNil()
 					} else {
 						if x.HTTP == nil {
@@ -13437,7 +12819,7 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1120 || yy2arr1120 {
+			if yyr1074 || yy2arr1074 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -13450,25 +12832,25 @@ func (x *IngressRule) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1125 := z.DecBinary()
-	_ = yym1125
+	yym1079 := z.DecBinary()
+	_ = yym1079
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1126 := r.ContainerType()
-		if yyct1126 == codecSelferValueTypeMap1234 {
-			yyl1126 := r.ReadMapStart()
-			if yyl1126 == 0 {
+		yyct1080 := r.ContainerType()
+		if yyct1080 == codecSelferValueTypeMap1234 {
+			yyl1080 := r.ReadMapStart()
+			if yyl1080 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1126, d)
+				x.codecDecodeSelfFromMap(yyl1080, d)
 			}
-		} else if yyct1126 == codecSelferValueTypeArray1234 {
-			yyl1126 := r.ReadArrayStart()
-			if yyl1126 == 0 {
+		} else if yyct1080 == codecSelferValueTypeArray1234 {
+			yyl1080 := r.ReadArrayStart()
+			if yyl1080 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1126, d)
+				x.codecDecodeSelfFromArray(yyl1080, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -13480,12 +12862,12 @@ func (x *IngressRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1127Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1127Slc
-	var yyhl1127 bool = l >= 0
-	for yyj1127 := 0; ; yyj1127++ {
-		if yyhl1127 {
-			if yyj1127 >= l {
+	var yys1081Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1081Slc
+	var yyhl1081 bool = l >= 0
+	for yyj1081 := 0; ; yyj1081++ {
+		if yyhl1081 {
+			if yyj1081 >= l {
 				break
 			}
 		} else {
@@ -13494,10 +12876,10 @@ func (x *IngressRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1127Slc = r.DecodeBytes(yys1127Slc, true, true)
-		yys1127 := string(yys1127Slc)
+		yys1081Slc = r.DecodeBytes(yys1081Slc, true, true)
+		yys1081 := string(yys1081Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1127 {
+		switch yys1081 {
 		case "host":
 			if r.TryDecodeAsNil() {
 				x.Host = ""
@@ -13519,9 +12901,9 @@ func (x *IngressRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.HTTP.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1127)
-		} // end switch yys1127
-	} // end for yyj1127
+			z.DecStructFieldNotFound(-1, yys1081)
+		} // end switch yys1081
+	} // end for yyj1081
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -13529,16 +12911,16 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1130 int
-	var yyb1130 bool
-	var yyhl1130 bool = l >= 0
-	yyj1130++
-	if yyhl1130 {
-		yyb1130 = yyj1130 > l
+	var yyj1084 int
+	var yyb1084 bool
+	var yyhl1084 bool = l >= 0
+	yyj1084++
+	if yyhl1084 {
+		yyb1084 = yyj1084 > l
 	} else {
-		yyb1130 = r.CheckBreak()
+		yyb1084 = r.CheckBreak()
 	}
-	if yyb1130 {
+	if yyb1084 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -13551,13 +12933,13 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if x.IngressRuleValue.HTTP == nil {
 		x.IngressRuleValue.HTTP = new(HTTPIngressRuleValue)
 	}
-	yyj1130++
-	if yyhl1130 {
-		yyb1130 = yyj1130 > l
+	yyj1084++
+	if yyhl1084 {
+		yyb1084 = yyj1084 > l
 	} else {
-		yyb1130 = r.CheckBreak()
+		yyb1084 = r.CheckBreak()
 	}
-	if yyb1130 {
+	if yyb1084 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -13573,17 +12955,17 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.HTTP.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1130++
-		if yyhl1130 {
-			yyb1130 = yyj1130 > l
+		yyj1084++
+		if yyhl1084 {
+			yyb1084 = yyj1084 > l
 		} else {
-			yyb1130 = r.CheckBreak()
+			yyb1084 = r.CheckBreak()
 		}
-		if yyb1130 {
+		if yyb1084 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1130-1, "")
+		z.DecStructFieldNotFound(yyj1084-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -13595,33 +12977,33 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1133 := z.EncBinary()
-		_ = yym1133
+		yym1087 := z.EncBinary()
+		_ = yym1087
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1134 := !z.EncBinary()
-			yy2arr1134 := z.EncBasicHandle().StructToArray
-			var yyq1134 [1]bool
-			_, _, _ = yysep1134, yyq1134, yy2arr1134
-			const yyr1134 bool = false
-			yyq1134[0] = x.HTTP != nil
-			var yynn1134 int
-			if yyr1134 || yy2arr1134 {
+			yysep1088 := !z.EncBinary()
+			yy2arr1088 := z.EncBasicHandle().StructToArray
+			var yyq1088 [1]bool
+			_, _, _ = yysep1088, yyq1088, yy2arr1088
+			const yyr1088 bool = false
+			yyq1088[0] = x.HTTP != nil
+			var yynn1088 int
+			if yyr1088 || yy2arr1088 {
 				r.EncodeArrayStart(1)
 			} else {
-				yynn1134 = 0
-				for _, b := range yyq1134 {
+				yynn1088 = 0
+				for _, b := range yyq1088 {
 					if b {
-						yynn1134++
+						yynn1088++
 					}
 				}
-				r.EncodeMapStart(yynn1134)
-				yynn1134 = 0
+				r.EncodeMapStart(yynn1088)
+				yynn1088 = 0
 			}
-			if yyr1134 || yy2arr1134 {
+			if yyr1088 || yy2arr1088 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1134[0] {
+				if yyq1088[0] {
 					if x.HTTP == nil {
 						r.EncodeNil()
 					} else {
@@ -13631,7 +13013,7 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1134[0] {
+				if yyq1088[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("http"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
@@ -13642,7 +13024,7 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1134 || yy2arr1134 {
+			if yyr1088 || yy2arr1088 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -13655,25 +13037,25 @@ func (x *IngressRuleValue) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1136 := z.DecBinary()
-	_ = yym1136
+	yym1090 := z.DecBinary()
+	_ = yym1090
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1137 := r.ContainerType()
-		if yyct1137 == codecSelferValueTypeMap1234 {
-			yyl1137 := r.ReadMapStart()
-			if yyl1137 == 0 {
+		yyct1091 := r.ContainerType()
+		if yyct1091 == codecSelferValueTypeMap1234 {
+			yyl1091 := r.ReadMapStart()
+			if yyl1091 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1137, d)
+				x.codecDecodeSelfFromMap(yyl1091, d)
 			}
-		} else if yyct1137 == codecSelferValueTypeArray1234 {
-			yyl1137 := r.ReadArrayStart()
-			if yyl1137 == 0 {
+		} else if yyct1091 == codecSelferValueTypeArray1234 {
+			yyl1091 := r.ReadArrayStart()
+			if yyl1091 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1137, d)
+				x.codecDecodeSelfFromArray(yyl1091, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -13685,12 +13067,12 @@ func (x *IngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1138Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1138Slc
-	var yyhl1138 bool = l >= 0
-	for yyj1138 := 0; ; yyj1138++ {
-		if yyhl1138 {
-			if yyj1138 >= l {
+	var yys1092Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1092Slc
+	var yyhl1092 bool = l >= 0
+	for yyj1092 := 0; ; yyj1092++ {
+		if yyhl1092 {
+			if yyj1092 >= l {
 				break
 			}
 		} else {
@@ -13699,10 +13081,10 @@ func (x *IngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1138Slc = r.DecodeBytes(yys1138Slc, true, true)
-		yys1138 := string(yys1138Slc)
+		yys1092Slc = r.DecodeBytes(yys1092Slc, true, true)
+		yys1092 := string(yys1092Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1138 {
+		switch yys1092 {
 		case "http":
 			if r.TryDecodeAsNil() {
 				if x.HTTP != nil {
@@ -13715,9 +13097,9 @@ func (x *IngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.HTTP.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1138)
-		} // end switch yys1138
-	} // end for yyj1138
+			z.DecStructFieldNotFound(-1, yys1092)
+		} // end switch yys1092
+	} // end for yyj1092
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -13725,16 +13107,16 @@ func (x *IngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1140 int
-	var yyb1140 bool
-	var yyhl1140 bool = l >= 0
-	yyj1140++
-	if yyhl1140 {
-		yyb1140 = yyj1140 > l
+	var yyj1094 int
+	var yyb1094 bool
+	var yyhl1094 bool = l >= 0
+	yyj1094++
+	if yyhl1094 {
+		yyb1094 = yyj1094 > l
 	} else {
-		yyb1140 = r.CheckBreak()
+		yyb1094 = r.CheckBreak()
 	}
-	if yyb1140 {
+	if yyb1094 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -13750,17 +13132,17 @@ func (x *IngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		x.HTTP.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1140++
-		if yyhl1140 {
-			yyb1140 = yyj1140 > l
+		yyj1094++
+		if yyhl1094 {
+			yyb1094 = yyj1094 > l
 		} else {
-			yyb1140 = r.CheckBreak()
+			yyb1094 = r.CheckBreak()
 		}
-		if yyb1140 {
+		if yyb1094 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1140-1, "")
+		z.DecStructFieldNotFound(yyj1094-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -13772,36 +13154,36 @@ func (x *HTTPIngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1142 := z.EncBinary()
-		_ = yym1142
+		yym1096 := z.EncBinary()
+		_ = yym1096
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1143 := !z.EncBinary()
-			yy2arr1143 := z.EncBasicHandle().StructToArray
-			var yyq1143 [1]bool
-			_, _, _ = yysep1143, yyq1143, yy2arr1143
-			const yyr1143 bool = false
-			var yynn1143 int
-			if yyr1143 || yy2arr1143 {
+			yysep1097 := !z.EncBinary()
+			yy2arr1097 := z.EncBasicHandle().StructToArray
+			var yyq1097 [1]bool
+			_, _, _ = yysep1097, yyq1097, yy2arr1097
+			const yyr1097 bool = false
+			var yynn1097 int
+			if yyr1097 || yy2arr1097 {
 				r.EncodeArrayStart(1)
 			} else {
-				yynn1143 = 1
-				for _, b := range yyq1143 {
+				yynn1097 = 1
+				for _, b := range yyq1097 {
 					if b {
-						yynn1143++
+						yynn1097++
 					}
 				}
-				r.EncodeMapStart(yynn1143)
-				yynn1143 = 0
+				r.EncodeMapStart(yynn1097)
+				yynn1097 = 0
 			}
-			if yyr1143 || yy2arr1143 {
+			if yyr1097 || yy2arr1097 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Paths == nil {
 					r.EncodeNil()
 				} else {
-					yym1145 := z.EncBinary()
-					_ = yym1145
+					yym1099 := z.EncBinary()
+					_ = yym1099
 					if false {
 					} else {
 						h.encSliceHTTPIngressPath(([]HTTPIngressPath)(x.Paths), e)
@@ -13814,15 +13196,15 @@ func (x *HTTPIngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Paths == nil {
 					r.EncodeNil()
 				} else {
-					yym1146 := z.EncBinary()
-					_ = yym1146
+					yym1100 := z.EncBinary()
+					_ = yym1100
 					if false {
 					} else {
 						h.encSliceHTTPIngressPath(([]HTTPIngressPath)(x.Paths), e)
 					}
 				}
 			}
-			if yyr1143 || yy2arr1143 {
+			if yyr1097 || yy2arr1097 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -13835,25 +13217,25 @@ func (x *HTTPIngressRuleValue) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1147 := z.DecBinary()
-	_ = yym1147
+	yym1101 := z.DecBinary()
+	_ = yym1101
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1148 := r.ContainerType()
-		if yyct1148 == codecSelferValueTypeMap1234 {
-			yyl1148 := r.ReadMapStart()
-			if yyl1148 == 0 {
+		yyct1102 := r.ContainerType()
+		if yyct1102 == codecSelferValueTypeMap1234 {
+			yyl1102 := r.ReadMapStart()
+			if yyl1102 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1148, d)
+				x.codecDecodeSelfFromMap(yyl1102, d)
 			}
-		} else if yyct1148 == codecSelferValueTypeArray1234 {
-			yyl1148 := r.ReadArrayStart()
-			if yyl1148 == 0 {
+		} else if yyct1102 == codecSelferValueTypeArray1234 {
+			yyl1102 := r.ReadArrayStart()
+			if yyl1102 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1148, d)
+				x.codecDecodeSelfFromArray(yyl1102, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -13865,12 +13247,12 @@ func (x *HTTPIngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1149Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1149Slc
-	var yyhl1149 bool = l >= 0
-	for yyj1149 := 0; ; yyj1149++ {
-		if yyhl1149 {
-			if yyj1149 >= l {
+	var yys1103Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1103Slc
+	var yyhl1103 bool = l >= 0
+	for yyj1103 := 0; ; yyj1103++ {
+		if yyhl1103 {
+			if yyj1103 >= l {
 				break
 			}
 		} else {
@@ -13879,26 +13261,26 @@ func (x *HTTPIngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1149Slc = r.DecodeBytes(yys1149Slc, true, true)
-		yys1149 := string(yys1149Slc)
+		yys1103Slc = r.DecodeBytes(yys1103Slc, true, true)
+		yys1103 := string(yys1103Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1149 {
+		switch yys1103 {
 		case "paths":
 			if r.TryDecodeAsNil() {
 				x.Paths = nil
 			} else {
-				yyv1150 := &x.Paths
-				yym1151 := z.DecBinary()
-				_ = yym1151
+				yyv1104 := &x.Paths
+				yym1105 := z.DecBinary()
+				_ = yym1105
 				if false {
 				} else {
-					h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv1150), d)
+					h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv1104), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1149)
-		} // end switch yys1149
-	} // end for yyj1149
+			z.DecStructFieldNotFound(-1, yys1103)
+		} // end switch yys1103
+	} // end for yyj1103
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -13906,16 +13288,16 @@ func (x *HTTPIngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1152 int
-	var yyb1152 bool
-	var yyhl1152 bool = l >= 0
-	yyj1152++
-	if yyhl1152 {
-		yyb1152 = yyj1152 > l
+	var yyj1106 int
+	var yyb1106 bool
+	var yyhl1106 bool = l >= 0
+	yyj1106++
+	if yyhl1106 {
+		yyb1106 = yyj1106 > l
 	} else {
-		yyb1152 = r.CheckBreak()
+		yyb1106 = r.CheckBreak()
 	}
-	if yyb1152 {
+	if yyb1106 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -13923,26 +13305,26 @@ func (x *HTTPIngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	if r.TryDecodeAsNil() {
 		x.Paths = nil
 	} else {
-		yyv1153 := &x.Paths
-		yym1154 := z.DecBinary()
-		_ = yym1154
+		yyv1107 := &x.Paths
+		yym1108 := z.DecBinary()
+		_ = yym1108
 		if false {
 		} else {
-			h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv1153), d)
+			h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv1107), d)
 		}
 	}
 	for {
-		yyj1152++
-		if yyhl1152 {
-			yyb1152 = yyj1152 > l
+		yyj1106++
+		if yyhl1106 {
+			yyb1106 = yyj1106 > l
 		} else {
-			yyb1152 = r.CheckBreak()
+			yyb1106 = r.CheckBreak()
 		}
-		if yyb1152 {
+		if yyb1106 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1152-1, "")
+		z.DecStructFieldNotFound(yyj1106-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -13954,35 +13336,35 @@ func (x *HTTPIngressPath) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1155 := z.EncBinary()
-		_ = yym1155
+		yym1109 := z.EncBinary()
+		_ = yym1109
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1156 := !z.EncBinary()
-			yy2arr1156 := z.EncBasicHandle().StructToArray
-			var yyq1156 [2]bool
-			_, _, _ = yysep1156, yyq1156, yy2arr1156
-			const yyr1156 bool = false
-			yyq1156[0] = x.Path != ""
-			var yynn1156 int
-			if yyr1156 || yy2arr1156 {
+			yysep1110 := !z.EncBinary()
+			yy2arr1110 := z.EncBasicHandle().StructToArray
+			var yyq1110 [2]bool
+			_, _, _ = yysep1110, yyq1110, yy2arr1110
+			const yyr1110 bool = false
+			yyq1110[0] = x.Path != ""
+			var yynn1110 int
+			if yyr1110 || yy2arr1110 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn1156 = 1
-				for _, b := range yyq1156 {
+				yynn1110 = 1
+				for _, b := range yyq1110 {
 					if b {
-						yynn1156++
+						yynn1110++
 					}
 				}
-				r.EncodeMapStart(yynn1156)
-				yynn1156 = 0
+				r.EncodeMapStart(yynn1110)
+				yynn1110 = 0
 			}
-			if yyr1156 || yy2arr1156 {
+			if yyr1110 || yy2arr1110 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1156[0] {
-					yym1158 := z.EncBinary()
-					_ = yym1158
+				if yyq1110[0] {
+					yym1112 := z.EncBinary()
+					_ = yym1112
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Path))
@@ -13991,30 +13373,30 @@ func (x *HTTPIngressPath) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1156[0] {
+				if yyq1110[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("path"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1159 := z.EncBinary()
-					_ = yym1159
+					yym1113 := z.EncBinary()
+					_ = yym1113
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 					}
 				}
 			}
-			if yyr1156 || yy2arr1156 {
+			if yyr1110 || yy2arr1110 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy1161 := &x.Backend
-				yy1161.CodecEncodeSelf(e)
+				yy1115 := &x.Backend
+				yy1115.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("backend"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy1162 := &x.Backend
-				yy1162.CodecEncodeSelf(e)
+				yy1116 := &x.Backend
+				yy1116.CodecEncodeSelf(e)
 			}
-			if yyr1156 || yy2arr1156 {
+			if yyr1110 || yy2arr1110 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -14027,25 +13409,25 @@ func (x *HTTPIngressPath) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1163 := z.DecBinary()
-	_ = yym1163
+	yym1117 := z.DecBinary()
+	_ = yym1117
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1164 := r.ContainerType()
-		if yyct1164 == codecSelferValueTypeMap1234 {
-			yyl1164 := r.ReadMapStart()
-			if yyl1164 == 0 {
+		yyct1118 := r.ContainerType()
+		if yyct1118 == codecSelferValueTypeMap1234 {
+			yyl1118 := r.ReadMapStart()
+			if yyl1118 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1164, d)
+				x.codecDecodeSelfFromMap(yyl1118, d)
 			}
-		} else if yyct1164 == codecSelferValueTypeArray1234 {
-			yyl1164 := r.ReadArrayStart()
-			if yyl1164 == 0 {
+		} else if yyct1118 == codecSelferValueTypeArray1234 {
+			yyl1118 := r.ReadArrayStart()
+			if yyl1118 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1164, d)
+				x.codecDecodeSelfFromArray(yyl1118, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -14057,12 +13439,12 @@ func (x *HTTPIngressPath) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1165Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1165Slc
-	var yyhl1165 bool = l >= 0
-	for yyj1165 := 0; ; yyj1165++ {
-		if yyhl1165 {
-			if yyj1165 >= l {
+	var yys1119Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1119Slc
+	var yyhl1119 bool = l >= 0
+	for yyj1119 := 0; ; yyj1119++ {
+		if yyhl1119 {
+			if yyj1119 >= l {
 				break
 			}
 		} else {
@@ -14071,10 +13453,10 @@ func (x *HTTPIngressPath) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1165Slc = r.DecodeBytes(yys1165Slc, true, true)
-		yys1165 := string(yys1165Slc)
+		yys1119Slc = r.DecodeBytes(yys1119Slc, true, true)
+		yys1119 := string(yys1119Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1165 {
+		switch yys1119 {
 		case "path":
 			if r.TryDecodeAsNil() {
 				x.Path = ""
@@ -14085,13 +13467,13 @@ func (x *HTTPIngressPath) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Backend = IngressBackend{}
 			} else {
-				yyv1167 := &x.Backend
-				yyv1167.CodecDecodeSelf(d)
+				yyv1121 := &x.Backend
+				yyv1121.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1165)
-		} // end switch yys1165
-	} // end for yyj1165
+			z.DecStructFieldNotFound(-1, yys1119)
+		} // end switch yys1119
+	} // end for yyj1119
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -14099,16 +13481,16 @@ func (x *HTTPIngressPath) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1168 int
-	var yyb1168 bool
-	var yyhl1168 bool = l >= 0
-	yyj1168++
-	if yyhl1168 {
-		yyb1168 = yyj1168 > l
+	var yyj1122 int
+	var yyb1122 bool
+	var yyhl1122 bool = l >= 0
+	yyj1122++
+	if yyhl1122 {
+		yyb1122 = yyj1122 > l
 	} else {
-		yyb1168 = r.CheckBreak()
+		yyb1122 = r.CheckBreak()
 	}
-	if yyb1168 {
+	if yyb1122 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14118,13 +13500,13 @@ func (x *HTTPIngressPath) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Path = string(r.DecodeString())
 	}
-	yyj1168++
-	if yyhl1168 {
-		yyb1168 = yyj1168 > l
+	yyj1122++
+	if yyhl1122 {
+		yyb1122 = yyj1122 > l
 	} else {
-		yyb1168 = r.CheckBreak()
+		yyb1122 = r.CheckBreak()
 	}
-	if yyb1168 {
+	if yyb1122 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14132,21 +13514,21 @@ func (x *HTTPIngressPath) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	if r.TryDecodeAsNil() {
 		x.Backend = IngressBackend{}
 	} else {
-		yyv1170 := &x.Backend
-		yyv1170.CodecDecodeSelf(d)
+		yyv1124 := &x.Backend
+		yyv1124.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1168++
-		if yyhl1168 {
-			yyb1168 = yyj1168 > l
+		yyj1122++
+		if yyhl1122 {
+			yyb1122 = yyj1122 > l
 		} else {
-			yyb1168 = r.CheckBreak()
+			yyb1122 = r.CheckBreak()
 		}
-		if yyb1168 {
+		if yyb1122 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1168-1, "")
+		z.DecStructFieldNotFound(yyj1122-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -14158,33 +13540,33 @@ func (x *IngressBackend) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1171 := z.EncBinary()
-		_ = yym1171
+		yym1125 := z.EncBinary()
+		_ = yym1125
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1172 := !z.EncBinary()
-			yy2arr1172 := z.EncBasicHandle().StructToArray
-			var yyq1172 [2]bool
-			_, _, _ = yysep1172, yyq1172, yy2arr1172
-			const yyr1172 bool = false
-			var yynn1172 int
-			if yyr1172 || yy2arr1172 {
+			yysep1126 := !z.EncBinary()
+			yy2arr1126 := z.EncBasicHandle().StructToArray
+			var yyq1126 [2]bool
+			_, _, _ = yysep1126, yyq1126, yy2arr1126
+			const yyr1126 bool = false
+			var yynn1126 int
+			if yyr1126 || yy2arr1126 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn1172 = 2
-				for _, b := range yyq1172 {
+				yynn1126 = 2
+				for _, b := range yyq1126 {
 					if b {
-						yynn1172++
+						yynn1126++
 					}
 				}
-				r.EncodeMapStart(yynn1172)
-				yynn1172 = 0
+				r.EncodeMapStart(yynn1126)
+				yynn1126 = 0
 			}
-			if yyr1172 || yy2arr1172 {
+			if yyr1126 || yy2arr1126 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1174 := z.EncBinary()
-				_ = yym1174
+				yym1128 := z.EncBinary()
+				_ = yym1128
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceName))
@@ -14193,41 +13575,41 @@ func (x *IngressBackend) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("serviceName"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1175 := z.EncBinary()
-				_ = yym1175
+				yym1129 := z.EncBinary()
+				_ = yym1129
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceName))
 				}
 			}
-			if yyr1172 || yy2arr1172 {
+			if yyr1126 || yy2arr1126 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy1177 := &x.ServicePort
-				yym1178 := z.EncBinary()
-				_ = yym1178
+				yy1131 := &x.ServicePort
+				yym1132 := z.EncBinary()
+				_ = yym1132
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy1177) {
-				} else if !yym1178 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy1177)
+				} else if z.HasExtensions() && z.EncExt(yy1131) {
+				} else if !yym1132 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy1131)
 				} else {
-					z.EncFallback(yy1177)
+					z.EncFallback(yy1131)
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("servicePort"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy1179 := &x.ServicePort
-				yym1180 := z.EncBinary()
-				_ = yym1180
+				yy1133 := &x.ServicePort
+				yym1134 := z.EncBinary()
+				_ = yym1134
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy1179) {
-				} else if !yym1180 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy1179)
+				} else if z.HasExtensions() && z.EncExt(yy1133) {
+				} else if !yym1134 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy1133)
 				} else {
-					z.EncFallback(yy1179)
+					z.EncFallback(yy1133)
 				}
 			}
-			if yyr1172 || yy2arr1172 {
+			if yyr1126 || yy2arr1126 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -14240,25 +13622,25 @@ func (x *IngressBackend) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1181 := z.DecBinary()
-	_ = yym1181
+	yym1135 := z.DecBinary()
+	_ = yym1135
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1182 := r.ContainerType()
-		if yyct1182 == codecSelferValueTypeMap1234 {
-			yyl1182 := r.ReadMapStart()
-			if yyl1182 == 0 {
+		yyct1136 := r.ContainerType()
+		if yyct1136 == codecSelferValueTypeMap1234 {
+			yyl1136 := r.ReadMapStart()
+			if yyl1136 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1182, d)
+				x.codecDecodeSelfFromMap(yyl1136, d)
 			}
-		} else if yyct1182 == codecSelferValueTypeArray1234 {
-			yyl1182 := r.ReadArrayStart()
-			if yyl1182 == 0 {
+		} else if yyct1136 == codecSelferValueTypeArray1234 {
+			yyl1136 := r.ReadArrayStart()
+			if yyl1136 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1182, d)
+				x.codecDecodeSelfFromArray(yyl1136, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -14270,12 +13652,12 @@ func (x *IngressBackend) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1183Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1183Slc
-	var yyhl1183 bool = l >= 0
-	for yyj1183 := 0; ; yyj1183++ {
-		if yyhl1183 {
-			if yyj1183 >= l {
+	var yys1137Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1137Slc
+	var yyhl1137 bool = l >= 0
+	for yyj1137 := 0; ; yyj1137++ {
+		if yyhl1137 {
+			if yyj1137 >= l {
 				break
 			}
 		} else {
@@ -14284,10 +13666,10 @@ func (x *IngressBackend) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1183Slc = r.DecodeBytes(yys1183Slc, true, true)
-		yys1183 := string(yys1183Slc)
+		yys1137Slc = r.DecodeBytes(yys1137Slc, true, true)
+		yys1137 := string(yys1137Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1183 {
+		switch yys1137 {
 		case "serviceName":
 			if r.TryDecodeAsNil() {
 				x.ServiceName = ""
@@ -14298,21 +13680,21 @@ func (x *IngressBackend) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ServicePort = pkg6_intstr.IntOrString{}
 			} else {
-				yyv1185 := &x.ServicePort
-				yym1186 := z.DecBinary()
-				_ = yym1186
+				yyv1139 := &x.ServicePort
+				yym1140 := z.DecBinary()
+				_ = yym1140
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1185) {
-				} else if !yym1186 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv1185)
+				} else if z.HasExtensions() && z.DecExt(yyv1139) {
+				} else if !yym1140 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1139)
 				} else {
-					z.DecFallback(yyv1185, false)
+					z.DecFallback(yyv1139, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1183)
-		} // end switch yys1183
-	} // end for yyj1183
+			z.DecStructFieldNotFound(-1, yys1137)
+		} // end switch yys1137
+	} // end for yyj1137
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -14320,16 +13702,16 @@ func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1187 int
-	var yyb1187 bool
-	var yyhl1187 bool = l >= 0
-	yyj1187++
-	if yyhl1187 {
-		yyb1187 = yyj1187 > l
+	var yyj1141 int
+	var yyb1141 bool
+	var yyhl1141 bool = l >= 0
+	yyj1141++
+	if yyhl1141 {
+		yyb1141 = yyj1141 > l
 	} else {
-		yyb1187 = r.CheckBreak()
+		yyb1141 = r.CheckBreak()
 	}
-	if yyb1187 {
+	if yyb1141 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14339,13 +13721,13 @@ func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.ServiceName = string(r.DecodeString())
 	}
-	yyj1187++
-	if yyhl1187 {
-		yyb1187 = yyj1187 > l
+	yyj1141++
+	if yyhl1141 {
+		yyb1141 = yyj1141 > l
 	} else {
-		yyb1187 = r.CheckBreak()
+		yyb1141 = r.CheckBreak()
 	}
-	if yyb1187 {
+	if yyb1141 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14353,29 +13735,29 @@ func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ServicePort = pkg6_intstr.IntOrString{}
 	} else {
-		yyv1189 := &x.ServicePort
-		yym1190 := z.DecBinary()
-		_ = yym1190
+		yyv1143 := &x.ServicePort
+		yym1144 := z.DecBinary()
+		_ = yym1144
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1189) {
-		} else if !yym1190 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv1189)
+		} else if z.HasExtensions() && z.DecExt(yyv1143) {
+		} else if !yym1144 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv1143)
 		} else {
-			z.DecFallback(yyv1189, false)
+			z.DecFallback(yyv1143, false)
 		}
 	}
 	for {
-		yyj1187++
-		if yyhl1187 {
-			yyb1187 = yyj1187 > l
+		yyj1141++
+		if yyhl1141 {
+			yyb1141 = yyj1141 > l
 		} else {
-			yyb1187 = r.CheckBreak()
+			yyb1141 = r.CheckBreak()
 		}
-		if yyb1187 {
+		if yyb1141 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1187-1, "")
+		z.DecStructFieldNotFound(yyj1141-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -14384,8 +13766,8 @@ func (x NodeResource) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym1191 := z.EncBinary()
-	_ = yym1191
+	yym1145 := z.EncBinary()
+	_ = yym1145
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -14397,8 +13779,8 @@ func (x *NodeResource) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1192 := z.DecBinary()
-	_ = yym1192
+	yym1146 := z.DecBinary()
+	_ = yym1146
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -14413,30 +13795,30 @@ func (x *NodeUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1193 := z.EncBinary()
-		_ = yym1193
+		yym1147 := z.EncBinary()
+		_ = yym1147
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1194 := !z.EncBinary()
-			yy2arr1194 := z.EncBasicHandle().StructToArray
-			var yyq1194 [2]bool
-			_, _, _ = yysep1194, yyq1194, yy2arr1194
-			const yyr1194 bool = false
-			var yynn1194 int
-			if yyr1194 || yy2arr1194 {
+			yysep1148 := !z.EncBinary()
+			yy2arr1148 := z.EncBasicHandle().StructToArray
+			var yyq1148 [2]bool
+			_, _, _ = yysep1148, yyq1148, yy2arr1148
+			const yyr1148 bool = false
+			var yynn1148 int
+			if yyr1148 || yy2arr1148 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn1194 = 2
-				for _, b := range yyq1194 {
+				yynn1148 = 2
+				for _, b := range yyq1148 {
 					if b {
-						yynn1194++
+						yynn1148++
 					}
 				}
-				r.EncodeMapStart(yynn1194)
-				yynn1194 = 0
+				r.EncodeMapStart(yynn1148)
+				yynn1148 = 0
 			}
-			if yyr1194 || yy2arr1194 {
+			if yyr1148 || yy2arr1148 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Resource.CodecEncodeSelf(e)
 			} else {
@@ -14445,10 +13827,10 @@ func (x *NodeUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Resource.CodecEncodeSelf(e)
 			}
-			if yyr1194 || yy2arr1194 {
+			if yyr1148 || yy2arr1148 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1197 := z.EncBinary()
-				_ = yym1197
+				yym1151 := z.EncBinary()
+				_ = yym1151
 				if false {
 				} else {
 					r.EncodeFloat64(float64(x.Value))
@@ -14457,14 +13839,14 @@ func (x *NodeUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("value"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1198 := z.EncBinary()
-				_ = yym1198
+				yym1152 := z.EncBinary()
+				_ = yym1152
 				if false {
 				} else {
 					r.EncodeFloat64(float64(x.Value))
 				}
 			}
-			if yyr1194 || yy2arr1194 {
+			if yyr1148 || yy2arr1148 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -14477,25 +13859,25 @@ func (x *NodeUtilization) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1199 := z.DecBinary()
-	_ = yym1199
+	yym1153 := z.DecBinary()
+	_ = yym1153
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1200 := r.ContainerType()
-		if yyct1200 == codecSelferValueTypeMap1234 {
-			yyl1200 := r.ReadMapStart()
-			if yyl1200 == 0 {
+		yyct1154 := r.ContainerType()
+		if yyct1154 == codecSelferValueTypeMap1234 {
+			yyl1154 := r.ReadMapStart()
+			if yyl1154 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1200, d)
+				x.codecDecodeSelfFromMap(yyl1154, d)
 			}
-		} else if yyct1200 == codecSelferValueTypeArray1234 {
-			yyl1200 := r.ReadArrayStart()
-			if yyl1200 == 0 {
+		} else if yyct1154 == codecSelferValueTypeArray1234 {
+			yyl1154 := r.ReadArrayStart()
+			if yyl1154 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1200, d)
+				x.codecDecodeSelfFromArray(yyl1154, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -14507,12 +13889,12 @@ func (x *NodeUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1201Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1201Slc
-	var yyhl1201 bool = l >= 0
-	for yyj1201 := 0; ; yyj1201++ {
-		if yyhl1201 {
-			if yyj1201 >= l {
+	var yys1155Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1155Slc
+	var yyhl1155 bool = l >= 0
+	for yyj1155 := 0; ; yyj1155++ {
+		if yyhl1155 {
+			if yyj1155 >= l {
 				break
 			}
 		} else {
@@ -14521,10 +13903,10 @@ func (x *NodeUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1201Slc = r.DecodeBytes(yys1201Slc, true, true)
-		yys1201 := string(yys1201Slc)
+		yys1155Slc = r.DecodeBytes(yys1155Slc, true, true)
+		yys1155 := string(yys1155Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1201 {
+		switch yys1155 {
 		case "resource":
 			if r.TryDecodeAsNil() {
 				x.Resource = ""
@@ -14538,9 +13920,9 @@ func (x *NodeUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Value = float64(r.DecodeFloat(false))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1201)
-		} // end switch yys1201
-	} // end for yyj1201
+			z.DecStructFieldNotFound(-1, yys1155)
+		} // end switch yys1155
+	} // end for yyj1155
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -14548,16 +13930,16 @@ func (x *NodeUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1204 int
-	var yyb1204 bool
-	var yyhl1204 bool = l >= 0
-	yyj1204++
-	if yyhl1204 {
-		yyb1204 = yyj1204 > l
+	var yyj1158 int
+	var yyb1158 bool
+	var yyhl1158 bool = l >= 0
+	yyj1158++
+	if yyhl1158 {
+		yyb1158 = yyj1158 > l
 	} else {
-		yyb1204 = r.CheckBreak()
+		yyb1158 = r.CheckBreak()
 	}
-	if yyb1204 {
+	if yyb1158 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14567,13 +13949,13 @@ func (x *NodeUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Resource = NodeResource(r.DecodeString())
 	}
-	yyj1204++
-	if yyhl1204 {
-		yyb1204 = yyj1204 > l
+	yyj1158++
+	if yyhl1158 {
+		yyb1158 = yyj1158 > l
 	} else {
-		yyb1204 = r.CheckBreak()
+		yyb1158 = r.CheckBreak()
 	}
-	if yyb1204 {
+	if yyb1158 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14584,17 +13966,17 @@ func (x *NodeUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.Value = float64(r.DecodeFloat(false))
 	}
 	for {
-		yyj1204++
-		if yyhl1204 {
-			yyb1204 = yyj1204 > l
+		yyj1158++
+		if yyhl1158 {
+			yyb1158 = yyj1158 > l
 		} else {
-			yyb1204 = r.CheckBreak()
+			yyb1158 = r.CheckBreak()
 		}
-		if yyb1204 {
+		if yyb1158 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1204-1, "")
+		z.DecStructFieldNotFound(yyj1158-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -14606,33 +13988,33 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1207 := z.EncBinary()
-		_ = yym1207
+		yym1161 := z.EncBinary()
+		_ = yym1161
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1208 := !z.EncBinary()
-			yy2arr1208 := z.EncBasicHandle().StructToArray
-			var yyq1208 [3]bool
-			_, _, _ = yysep1208, yyq1208, yy2arr1208
-			const yyr1208 bool = false
-			var yynn1208 int
-			if yyr1208 || yy2arr1208 {
+			yysep1162 := !z.EncBinary()
+			yy2arr1162 := z.EncBasicHandle().StructToArray
+			var yyq1162 [3]bool
+			_, _, _ = yysep1162, yyq1162, yy2arr1162
+			const yyr1162 bool = false
+			var yynn1162 int
+			if yyr1162 || yy2arr1162 {
 				r.EncodeArrayStart(3)
 			} else {
-				yynn1208 = 3
-				for _, b := range yyq1208 {
+				yynn1162 = 3
+				for _, b := range yyq1162 {
 					if b {
-						yynn1208++
+						yynn1162++
 					}
 				}
-				r.EncodeMapStart(yynn1208)
-				yynn1208 = 0
+				r.EncodeMapStart(yynn1162)
+				yynn1162 = 0
 			}
-			if yyr1208 || yy2arr1208 {
+			if yyr1162 || yy2arr1162 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1210 := z.EncBinary()
-				_ = yym1210
+				yym1164 := z.EncBinary()
+				_ = yym1164
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MinNodes))
@@ -14641,17 +14023,17 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("minNodes"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1211 := z.EncBinary()
-				_ = yym1211
+				yym1165 := z.EncBinary()
+				_ = yym1165
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MinNodes))
 				}
 			}
-			if yyr1208 || yy2arr1208 {
+			if yyr1162 || yy2arr1162 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1213 := z.EncBinary()
-				_ = yym1213
+				yym1167 := z.EncBinary()
+				_ = yym1167
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MaxNodes))
@@ -14660,20 +14042,20 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("maxNodes"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1214 := z.EncBinary()
-				_ = yym1214
+				yym1168 := z.EncBinary()
+				_ = yym1168
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MaxNodes))
 				}
 			}
-			if yyr1208 || yy2arr1208 {
+			if yyr1162 || yy2arr1162 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.TargetUtilization == nil {
 					r.EncodeNil()
 				} else {
-					yym1216 := z.EncBinary()
-					_ = yym1216
+					yym1170 := z.EncBinary()
+					_ = yym1170
 					if false {
 					} else {
 						h.encSliceNodeUtilization(([]NodeUtilization)(x.TargetUtilization), e)
@@ -14686,15 +14068,15 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.TargetUtilization == nil {
 					r.EncodeNil()
 				} else {
-					yym1217 := z.EncBinary()
-					_ = yym1217
+					yym1171 := z.EncBinary()
+					_ = yym1171
 					if false {
 					} else {
 						h.encSliceNodeUtilization(([]NodeUtilization)(x.TargetUtilization), e)
 					}
 				}
 			}
-			if yyr1208 || yy2arr1208 {
+			if yyr1162 || yy2arr1162 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -14707,25 +14089,25 @@ func (x *ClusterAutoscalerSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1218 := z.DecBinary()
-	_ = yym1218
+	yym1172 := z.DecBinary()
+	_ = yym1172
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1219 := r.ContainerType()
-		if yyct1219 == codecSelferValueTypeMap1234 {
-			yyl1219 := r.ReadMapStart()
-			if yyl1219 == 0 {
+		yyct1173 := r.ContainerType()
+		if yyct1173 == codecSelferValueTypeMap1234 {
+			yyl1173 := r.ReadMapStart()
+			if yyl1173 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1219, d)
+				x.codecDecodeSelfFromMap(yyl1173, d)
 			}
-		} else if yyct1219 == codecSelferValueTypeArray1234 {
-			yyl1219 := r.ReadArrayStart()
-			if yyl1219 == 0 {
+		} else if yyct1173 == codecSelferValueTypeArray1234 {
+			yyl1173 := r.ReadArrayStart()
+			if yyl1173 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1219, d)
+				x.codecDecodeSelfFromArray(yyl1173, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -14737,12 +14119,12 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1220Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1220Slc
-	var yyhl1220 bool = l >= 0
-	for yyj1220 := 0; ; yyj1220++ {
-		if yyhl1220 {
-			if yyj1220 >= l {
+	var yys1174Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1174Slc
+	var yyhl1174 bool = l >= 0
+	for yyj1174 := 0; ; yyj1174++ {
+		if yyhl1174 {
+			if yyj1174 >= l {
 				break
 			}
 		} else {
@@ -14751,10 +14133,10 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1220Slc = r.DecodeBytes(yys1220Slc, true, true)
-		yys1220 := string(yys1220Slc)
+		yys1174Slc = r.DecodeBytes(yys1174Slc, true, true)
+		yys1174 := string(yys1174Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1220 {
+		switch yys1174 {
 		case "minNodes":
 			if r.TryDecodeAsNil() {
 				x.MinNodes = 0
@@ -14771,18 +14153,18 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			if r.TryDecodeAsNil() {
 				x.TargetUtilization = nil
 			} else {
-				yyv1223 := &x.TargetUtilization
-				yym1224 := z.DecBinary()
-				_ = yym1224
+				yyv1177 := &x.TargetUtilization
+				yym1178 := z.DecBinary()
+				_ = yym1178
 				if false {
 				} else {
-					h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1223), d)
+					h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1177), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1220)
-		} // end switch yys1220
-	} // end for yyj1220
+			z.DecStructFieldNotFound(-1, yys1174)
+		} // end switch yys1174
+	} // end for yyj1174
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -14790,16 +14172,16 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1225 int
-	var yyb1225 bool
-	var yyhl1225 bool = l >= 0
-	yyj1225++
-	if yyhl1225 {
-		yyb1225 = yyj1225 > l
+	var yyj1179 int
+	var yyb1179 bool
+	var yyhl1179 bool = l >= 0
+	yyj1179++
+	if yyhl1179 {
+		yyb1179 = yyj1179 > l
 	} else {
-		yyb1225 = r.CheckBreak()
+		yyb1179 = r.CheckBreak()
 	}
-	if yyb1225 {
+	if yyb1179 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14809,13 +14191,13 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.MinNodes = int32(r.DecodeInt(32))
 	}
-	yyj1225++
-	if yyhl1225 {
-		yyb1225 = yyj1225 > l
+	yyj1179++
+	if yyhl1179 {
+		yyb1179 = yyj1179 > l
 	} else {
-		yyb1225 = r.CheckBreak()
+		yyb1179 = r.CheckBreak()
 	}
-	if yyb1225 {
+	if yyb1179 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14825,13 +14207,13 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.MaxNodes = int32(r.DecodeInt(32))
 	}
-	yyj1225++
-	if yyhl1225 {
-		yyb1225 = yyj1225 > l
+	yyj1179++
+	if yyhl1179 {
+		yyb1179 = yyj1179 > l
 	} else {
-		yyb1225 = r.CheckBreak()
+		yyb1179 = r.CheckBreak()
 	}
-	if yyb1225 {
+	if yyb1179 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -14839,26 +14221,26 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	if r.TryDecodeAsNil() {
 		x.TargetUtilization = nil
 	} else {
-		yyv1228 := &x.TargetUtilization
-		yym1229 := z.DecBinary()
-		_ = yym1229
+		yyv1182 := &x.TargetUtilization
+		yym1183 := z.DecBinary()
+		_ = yym1183
 		if false {
 		} else {
-			h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1228), d)
+			h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1182), d)
 		}
 	}
 	for {
-		yyj1225++
-		if yyhl1225 {
-			yyb1225 = yyj1225 > l
+		yyj1179++
+		if yyhl1179 {
+			yyb1179 = yyj1179 > l
 		} else {
-			yyb1225 = r.CheckBreak()
+			yyb1179 = r.CheckBreak()
 		}
-		if yyb1225 {
+		if yyb1179 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1225-1, "")
+		z.DecStructFieldNotFound(yyj1179-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -14870,72 +14252,72 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1230 := z.EncBinary()
-		_ = yym1230
+		yym1184 := z.EncBinary()
+		_ = yym1184
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1231 := !z.EncBinary()
-			yy2arr1231 := z.EncBasicHandle().StructToArray
-			var yyq1231 [4]bool
-			_, _, _ = yysep1231, yyq1231, yy2arr1231
-			const yyr1231 bool = false
-			yyq1231[0] = true
-			yyq1231[1] = true
-			yyq1231[2] = x.Kind != ""
-			yyq1231[3] = x.APIVersion != ""
-			var yynn1231 int
-			if yyr1231 || yy2arr1231 {
+			yysep1185 := !z.EncBinary()
+			yy2arr1185 := z.EncBasicHandle().StructToArray
+			var yyq1185 [4]bool
+			_, _, _ = yysep1185, yyq1185, yy2arr1185
+			const yyr1185 bool = false
+			yyq1185[0] = true
+			yyq1185[1] = true
+			yyq1185[2] = x.Kind != ""
+			yyq1185[3] = x.APIVersion != ""
+			var yynn1185 int
+			if yyr1185 || yy2arr1185 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn1231 = 0
-				for _, b := range yyq1231 {
+				yynn1185 = 0
+				for _, b := range yyq1185 {
 					if b {
-						yynn1231++
+						yynn1185++
 					}
 				}
-				r.EncodeMapStart(yynn1231)
-				yynn1231 = 0
+				r.EncodeMapStart(yynn1185)
+				yynn1185 = 0
 			}
-			if yyr1231 || yy2arr1231 {
+			if yyr1185 || yy2arr1185 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1231[0] {
-					yy1233 := &x.ObjectMeta
-					yy1233.CodecEncodeSelf(e)
+				if yyq1185[0] {
+					yy1187 := &x.ObjectMeta
+					yy1187.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1231[0] {
+				if yyq1185[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1234 := &x.ObjectMeta
-					yy1234.CodecEncodeSelf(e)
+					yy1188 := &x.ObjectMeta
+					yy1188.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1231 || yy2arr1231 {
+			if yyr1185 || yy2arr1185 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1231[1] {
-					yy1236 := &x.Spec
-					yy1236.CodecEncodeSelf(e)
+				if yyq1185[1] {
+					yy1190 := &x.Spec
+					yy1190.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1231[1] {
+				if yyq1185[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1237 := &x.Spec
-					yy1237.CodecEncodeSelf(e)
+					yy1191 := &x.Spec
+					yy1191.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1231 || yy2arr1231 {
+			if yyr1185 || yy2arr1185 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1231[2] {
-					yym1239 := z.EncBinary()
-					_ = yym1239
+				if yyq1185[2] {
+					yym1193 := z.EncBinary()
+					_ = yym1193
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -14944,23 +14326,23 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1231[2] {
+				if yyq1185[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1240 := z.EncBinary()
-					_ = yym1240
+					yym1194 := z.EncBinary()
+					_ = yym1194
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1231 || yy2arr1231 {
+			if yyr1185 || yy2arr1185 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1231[3] {
-					yym1242 := z.EncBinary()
-					_ = yym1242
+				if yyq1185[3] {
+					yym1196 := z.EncBinary()
+					_ = yym1196
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -14969,19 +14351,19 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1231[3] {
+				if yyq1185[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1243 := z.EncBinary()
-					_ = yym1243
+					yym1197 := z.EncBinary()
+					_ = yym1197
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1231 || yy2arr1231 {
+			if yyr1185 || yy2arr1185 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -14994,25 +14376,25 @@ func (x *ClusterAutoscaler) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1244 := z.DecBinary()
-	_ = yym1244
+	yym1198 := z.DecBinary()
+	_ = yym1198
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1245 := r.ContainerType()
-		if yyct1245 == codecSelferValueTypeMap1234 {
-			yyl1245 := r.ReadMapStart()
-			if yyl1245 == 0 {
+		yyct1199 := r.ContainerType()
+		if yyct1199 == codecSelferValueTypeMap1234 {
+			yyl1199 := r.ReadMapStart()
+			if yyl1199 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1245, d)
+				x.codecDecodeSelfFromMap(yyl1199, d)
 			}
-		} else if yyct1245 == codecSelferValueTypeArray1234 {
-			yyl1245 := r.ReadArrayStart()
-			if yyl1245 == 0 {
+		} else if yyct1199 == codecSelferValueTypeArray1234 {
+			yyl1199 := r.ReadArrayStart()
+			if yyl1199 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1245, d)
+				x.codecDecodeSelfFromArray(yyl1199, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -15024,12 +14406,12 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1246Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1246Slc
-	var yyhl1246 bool = l >= 0
-	for yyj1246 := 0; ; yyj1246++ {
-		if yyhl1246 {
-			if yyj1246 >= l {
+	var yys1200Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1200Slc
+	var yyhl1200 bool = l >= 0
+	for yyj1200 := 0; ; yyj1200++ {
+		if yyhl1200 {
+			if yyj1200 >= l {
 				break
 			}
 		} else {
@@ -15038,23 +14420,23 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1246Slc = r.DecodeBytes(yys1246Slc, true, true)
-		yys1246 := string(yys1246Slc)
+		yys1200Slc = r.DecodeBytes(yys1200Slc, true, true)
+		yys1200 := string(yys1200Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1246 {
+		switch yys1200 {
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_v1.ObjectMeta{}
 			} else {
-				yyv1247 := &x.ObjectMeta
-				yyv1247.CodecDecodeSelf(d)
+				yyv1201 := &x.ObjectMeta
+				yyv1201.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = ClusterAutoscalerSpec{}
 			} else {
-				yyv1248 := &x.Spec
-				yyv1248.CodecDecodeSelf(d)
+				yyv1202 := &x.Spec
+				yyv1202.CodecDecodeSelf(d)
 			}
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -15069,9 +14451,9 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				x.APIVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1246)
-		} // end switch yys1246
-	} // end for yyj1246
+			z.DecStructFieldNotFound(-1, yys1200)
+		} // end switch yys1200
+	} // end for yyj1200
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -15079,16 +14461,16 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1251 int
-	var yyb1251 bool
-	var yyhl1251 bool = l >= 0
-	yyj1251++
-	if yyhl1251 {
-		yyb1251 = yyj1251 > l
+	var yyj1205 int
+	var yyb1205 bool
+	var yyhl1205 bool = l >= 0
+	yyj1205++
+	if yyhl1205 {
+		yyb1205 = yyj1205 > l
 	} else {
-		yyb1251 = r.CheckBreak()
+		yyb1205 = r.CheckBreak()
 	}
-	if yyb1251 {
+	if yyb1205 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15096,16 +14478,16 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_v1.ObjectMeta{}
 	} else {
-		yyv1252 := &x.ObjectMeta
-		yyv1252.CodecDecodeSelf(d)
+		yyv1206 := &x.ObjectMeta
+		yyv1206.CodecDecodeSelf(d)
 	}
-	yyj1251++
-	if yyhl1251 {
-		yyb1251 = yyj1251 > l
+	yyj1205++
+	if yyhl1205 {
+		yyb1205 = yyj1205 > l
 	} else {
-		yyb1251 = r.CheckBreak()
+		yyb1205 = r.CheckBreak()
 	}
-	if yyb1251 {
+	if yyb1205 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15113,16 +14495,16 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	if r.TryDecodeAsNil() {
 		x.Spec = ClusterAutoscalerSpec{}
 	} else {
-		yyv1253 := &x.Spec
-		yyv1253.CodecDecodeSelf(d)
+		yyv1207 := &x.Spec
+		yyv1207.CodecDecodeSelf(d)
 	}
-	yyj1251++
-	if yyhl1251 {
-		yyb1251 = yyj1251 > l
+	yyj1205++
+	if yyhl1205 {
+		yyb1205 = yyj1205 > l
 	} else {
-		yyb1251 = r.CheckBreak()
+		yyb1205 = r.CheckBreak()
 	}
-	if yyb1251 {
+	if yyb1205 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15132,13 +14514,13 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1251++
-	if yyhl1251 {
-		yyb1251 = yyj1251 > l
+	yyj1205++
+	if yyhl1205 {
+		yyb1205 = yyj1205 > l
 	} else {
-		yyb1251 = r.CheckBreak()
+		yyb1205 = r.CheckBreak()
 	}
-	if yyb1251 {
+	if yyb1205 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15149,17 +14531,17 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		x.APIVersion = string(r.DecodeString())
 	}
 	for {
-		yyj1251++
-		if yyhl1251 {
-			yyb1251 = yyj1251 > l
+		yyj1205++
+		if yyhl1205 {
+			yyb1205 = yyj1205 > l
 		} else {
-			yyb1251 = r.CheckBreak()
+			yyb1205 = r.CheckBreak()
 		}
-		if yyb1251 {
+		if yyb1205 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1251-1, "")
+		z.DecStructFieldNotFound(yyj1205-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -15171,68 +14553,68 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1256 := z.EncBinary()
-		_ = yym1256
+		yym1210 := z.EncBinary()
+		_ = yym1210
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1257 := !z.EncBinary()
-			yy2arr1257 := z.EncBasicHandle().StructToArray
-			var yyq1257 [4]bool
-			_, _, _ = yysep1257, yyq1257, yy2arr1257
-			const yyr1257 bool = false
-			yyq1257[0] = true
-			yyq1257[2] = x.Kind != ""
-			yyq1257[3] = x.APIVersion != ""
-			var yynn1257 int
-			if yyr1257 || yy2arr1257 {
+			yysep1211 := !z.EncBinary()
+			yy2arr1211 := z.EncBasicHandle().StructToArray
+			var yyq1211 [4]bool
+			_, _, _ = yysep1211, yyq1211, yy2arr1211
+			const yyr1211 bool = false
+			yyq1211[0] = true
+			yyq1211[2] = x.Kind != ""
+			yyq1211[3] = x.APIVersion != ""
+			var yynn1211 int
+			if yyr1211 || yy2arr1211 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn1257 = 1
-				for _, b := range yyq1257 {
+				yynn1211 = 1
+				for _, b := range yyq1211 {
 					if b {
-						yynn1257++
+						yynn1211++
 					}
 				}
-				r.EncodeMapStart(yynn1257)
-				yynn1257 = 0
+				r.EncodeMapStart(yynn1211)
+				yynn1211 = 0
 			}
-			if yyr1257 || yy2arr1257 {
+			if yyr1211 || yy2arr1211 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1257[0] {
-					yy1259 := &x.ListMeta
-					yym1260 := z.EncBinary()
-					_ = yym1260
+				if yyq1211[0] {
+					yy1213 := &x.ListMeta
+					yym1214 := z.EncBinary()
+					_ = yym1214
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1259) {
+					} else if z.HasExtensions() && z.EncExt(yy1213) {
 					} else {
-						z.EncFallback(yy1259)
+						z.EncFallback(yy1213)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1257[0] {
+				if yyq1211[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1261 := &x.ListMeta
-					yym1262 := z.EncBinary()
-					_ = yym1262
+					yy1215 := &x.ListMeta
+					yym1216 := z.EncBinary()
+					_ = yym1216
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1261) {
+					} else if z.HasExtensions() && z.EncExt(yy1215) {
 					} else {
-						z.EncFallback(yy1261)
+						z.EncFallback(yy1215)
 					}
 				}
 			}
-			if yyr1257 || yy2arr1257 {
+			if yyr1211 || yy2arr1211 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1264 := z.EncBinary()
-					_ = yym1264
+					yym1218 := z.EncBinary()
+					_ = yym1218
 					if false {
 					} else {
 						h.encSliceClusterAutoscaler(([]ClusterAutoscaler)(x.Items), e)
@@ -15245,19 +14627,19 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1265 := z.EncBinary()
-					_ = yym1265
+					yym1219 := z.EncBinary()
+					_ = yym1219
 					if false {
 					} else {
 						h.encSliceClusterAutoscaler(([]ClusterAutoscaler)(x.Items), e)
 					}
 				}
 			}
-			if yyr1257 || yy2arr1257 {
+			if yyr1211 || yy2arr1211 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1257[2] {
-					yym1267 := z.EncBinary()
-					_ = yym1267
+				if yyq1211[2] {
+					yym1221 := z.EncBinary()
+					_ = yym1221
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -15266,23 +14648,23 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1257[2] {
+				if yyq1211[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1268 := z.EncBinary()
-					_ = yym1268
+					yym1222 := z.EncBinary()
+					_ = yym1222
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1257 || yy2arr1257 {
+			if yyr1211 || yy2arr1211 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1257[3] {
-					yym1270 := z.EncBinary()
-					_ = yym1270
+				if yyq1211[3] {
+					yym1224 := z.EncBinary()
+					_ = yym1224
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -15291,19 +14673,19 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1257[3] {
+				if yyq1211[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1271 := z.EncBinary()
-					_ = yym1271
+					yym1225 := z.EncBinary()
+					_ = yym1225
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1257 || yy2arr1257 {
+			if yyr1211 || yy2arr1211 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -15316,25 +14698,25 @@ func (x *ClusterAutoscalerList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1272 := z.DecBinary()
-	_ = yym1272
+	yym1226 := z.DecBinary()
+	_ = yym1226
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1273 := r.ContainerType()
-		if yyct1273 == codecSelferValueTypeMap1234 {
-			yyl1273 := r.ReadMapStart()
-			if yyl1273 == 0 {
+		yyct1227 := r.ContainerType()
+		if yyct1227 == codecSelferValueTypeMap1234 {
+			yyl1227 := r.ReadMapStart()
+			if yyl1227 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1273, d)
+				x.codecDecodeSelfFromMap(yyl1227, d)
 			}
-		} else if yyct1273 == codecSelferValueTypeArray1234 {
-			yyl1273 := r.ReadArrayStart()
-			if yyl1273 == 0 {
+		} else if yyct1227 == codecSelferValueTypeArray1234 {
+			yyl1227 := r.ReadArrayStart()
+			if yyl1227 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1273, d)
+				x.codecDecodeSelfFromArray(yyl1227, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -15346,12 +14728,12 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1274Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1274Slc
-	var yyhl1274 bool = l >= 0
-	for yyj1274 := 0; ; yyj1274++ {
-		if yyhl1274 {
-			if yyj1274 >= l {
+	var yys1228Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1228Slc
+	var yyhl1228 bool = l >= 0
+	for yyj1228 := 0; ; yyj1228++ {
+		if yyhl1228 {
+			if yyj1228 >= l {
 				break
 			}
 		} else {
@@ -15360,33 +14742,33 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1274Slc = r.DecodeBytes(yys1274Slc, true, true)
-		yys1274 := string(yys1274Slc)
+		yys1228Slc = r.DecodeBytes(yys1228Slc, true, true)
+		yys1228 := string(yys1228Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1274 {
+		switch yys1228 {
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv1275 := &x.ListMeta
-				yym1276 := z.DecBinary()
-				_ = yym1276
+				yyv1229 := &x.ListMeta
+				yym1230 := z.DecBinary()
+				_ = yym1230
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1275) {
+				} else if z.HasExtensions() && z.DecExt(yyv1229) {
 				} else {
-					z.DecFallback(yyv1275, false)
+					z.DecFallback(yyv1229, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv1277 := &x.Items
-				yym1278 := z.DecBinary()
-				_ = yym1278
+				yyv1231 := &x.Items
+				yym1232 := z.DecBinary()
+				_ = yym1232
 				if false {
 				} else {
-					h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1277), d)
+					h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1231), d)
 				}
 			}
 		case "kind":
@@ -15402,9 +14784,9 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				x.APIVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1274)
-		} // end switch yys1274
-	} // end for yyj1274
+			z.DecStructFieldNotFound(-1, yys1228)
+		} // end switch yys1228
+	} // end for yyj1228
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -15412,16 +14794,16 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1281 int
-	var yyb1281 bool
-	var yyhl1281 bool = l >= 0
-	yyj1281++
-	if yyhl1281 {
-		yyb1281 = yyj1281 > l
+	var yyj1235 int
+	var yyb1235 bool
+	var yyhl1235 bool = l >= 0
+	yyj1235++
+	if yyhl1235 {
+		yyb1235 = yyj1235 > l
 	} else {
-		yyb1281 = r.CheckBreak()
+		yyb1235 = r.CheckBreak()
 	}
-	if yyb1281 {
+	if yyb1235 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15429,22 +14811,22 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv1282 := &x.ListMeta
-		yym1283 := z.DecBinary()
-		_ = yym1283
+		yyv1236 := &x.ListMeta
+		yym1237 := z.DecBinary()
+		_ = yym1237
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1282) {
+		} else if z.HasExtensions() && z.DecExt(yyv1236) {
 		} else {
-			z.DecFallback(yyv1282, false)
+			z.DecFallback(yyv1236, false)
 		}
 	}
-	yyj1281++
-	if yyhl1281 {
-		yyb1281 = yyj1281 > l
+	yyj1235++
+	if yyhl1235 {
+		yyb1235 = yyj1235 > l
 	} else {
-		yyb1281 = r.CheckBreak()
+		yyb1235 = r.CheckBreak()
 	}
-	if yyb1281 {
+	if yyb1235 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15452,21 +14834,21 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv1284 := &x.Items
-		yym1285 := z.DecBinary()
-		_ = yym1285
+		yyv1238 := &x.Items
+		yym1239 := z.DecBinary()
+		_ = yym1239
 		if false {
 		} else {
-			h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1284), d)
+			h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1238), d)
 		}
 	}
-	yyj1281++
-	if yyhl1281 {
-		yyb1281 = yyj1281 > l
+	yyj1235++
+	if yyhl1235 {
+		yyb1235 = yyj1235 > l
 	} else {
-		yyb1281 = r.CheckBreak()
+		yyb1235 = r.CheckBreak()
 	}
-	if yyb1281 {
+	if yyb1235 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15476,13 +14858,13 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1281++
-	if yyhl1281 {
-		yyb1281 = yyj1281 > l
+	yyj1235++
+	if yyhl1235 {
+		yyb1235 = yyj1235 > l
 	} else {
-		yyb1281 = r.CheckBreak()
+		yyb1235 = r.CheckBreak()
 	}
-	if yyb1281 {
+	if yyb1235 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15493,17 +14875,17 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		x.APIVersion = string(r.DecodeString())
 	}
 	for {
-		yyj1281++
-		if yyhl1281 {
-			yyb1281 = yyj1281 > l
+		yyj1235++
+		if yyhl1235 {
+			yyb1235 = yyj1235 > l
 		} else {
-			yyb1281 = r.CheckBreak()
+			yyb1235 = r.CheckBreak()
 		}
-		if yyb1281 {
+		if yyb1235 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1281-1, "")
+		z.DecStructFieldNotFound(yyj1235-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -15515,35 +14897,35 @@ func (x *ExportOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1288 := z.EncBinary()
-		_ = yym1288
+		yym1242 := z.EncBinary()
+		_ = yym1242
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1289 := !z.EncBinary()
-			yy2arr1289 := z.EncBasicHandle().StructToArray
-			var yyq1289 [4]bool
-			_, _, _ = yysep1289, yyq1289, yy2arr1289
-			const yyr1289 bool = false
-			yyq1289[2] = x.Kind != ""
-			yyq1289[3] = x.APIVersion != ""
-			var yynn1289 int
-			if yyr1289 || yy2arr1289 {
+			yysep1243 := !z.EncBinary()
+			yy2arr1243 := z.EncBasicHandle().StructToArray
+			var yyq1243 [4]bool
+			_, _, _ = yysep1243, yyq1243, yy2arr1243
+			const yyr1243 bool = false
+			yyq1243[2] = x.Kind != ""
+			yyq1243[3] = x.APIVersion != ""
+			var yynn1243 int
+			if yyr1243 || yy2arr1243 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn1289 = 2
-				for _, b := range yyq1289 {
+				yynn1243 = 2
+				for _, b := range yyq1243 {
 					if b {
-						yynn1289++
+						yynn1243++
 					}
 				}
-				r.EncodeMapStart(yynn1289)
-				yynn1289 = 0
+				r.EncodeMapStart(yynn1243)
+				yynn1243 = 0
 			}
-			if yyr1289 || yy2arr1289 {
+			if yyr1243 || yy2arr1243 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1291 := z.EncBinary()
-				_ = yym1291
+				yym1245 := z.EncBinary()
+				_ = yym1245
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Export))
@@ -15552,17 +14934,17 @@ func (x *ExportOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("export"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1292 := z.EncBinary()
-				_ = yym1292
+				yym1246 := z.EncBinary()
+				_ = yym1246
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Export))
 				}
 			}
-			if yyr1289 || yy2arr1289 {
+			if yyr1243 || yy2arr1243 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1294 := z.EncBinary()
-				_ = yym1294
+				yym1248 := z.EncBinary()
+				_ = yym1248
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Exact))
@@ -15571,18 +14953,18 @@ func (x *ExportOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("exact"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1295 := z.EncBinary()
-				_ = yym1295
+				yym1249 := z.EncBinary()
+				_ = yym1249
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Exact))
 				}
 			}
-			if yyr1289 || yy2arr1289 {
+			if yyr1243 || yy2arr1243 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1289[2] {
-					yym1297 := z.EncBinary()
-					_ = yym1297
+				if yyq1243[2] {
+					yym1251 := z.EncBinary()
+					_ = yym1251
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -15591,23 +14973,23 @@ func (x *ExportOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1289[2] {
+				if yyq1243[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1298 := z.EncBinary()
-					_ = yym1298
+					yym1252 := z.EncBinary()
+					_ = yym1252
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1289 || yy2arr1289 {
+			if yyr1243 || yy2arr1243 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1289[3] {
-					yym1300 := z.EncBinary()
-					_ = yym1300
+				if yyq1243[3] {
+					yym1254 := z.EncBinary()
+					_ = yym1254
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -15616,19 +14998,19 @@ func (x *ExportOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1289[3] {
+				if yyq1243[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1301 := z.EncBinary()
-					_ = yym1301
+					yym1255 := z.EncBinary()
+					_ = yym1255
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1289 || yy2arr1289 {
+			if yyr1243 || yy2arr1243 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -15641,25 +15023,25 @@ func (x *ExportOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1302 := z.DecBinary()
-	_ = yym1302
+	yym1256 := z.DecBinary()
+	_ = yym1256
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1303 := r.ContainerType()
-		if yyct1303 == codecSelferValueTypeMap1234 {
-			yyl1303 := r.ReadMapStart()
-			if yyl1303 == 0 {
+		yyct1257 := r.ContainerType()
+		if yyct1257 == codecSelferValueTypeMap1234 {
+			yyl1257 := r.ReadMapStart()
+			if yyl1257 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1303, d)
+				x.codecDecodeSelfFromMap(yyl1257, d)
 			}
-		} else if yyct1303 == codecSelferValueTypeArray1234 {
-			yyl1303 := r.ReadArrayStart()
-			if yyl1303 == 0 {
+		} else if yyct1257 == codecSelferValueTypeArray1234 {
+			yyl1257 := r.ReadArrayStart()
+			if yyl1257 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1303, d)
+				x.codecDecodeSelfFromArray(yyl1257, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -15671,12 +15053,12 @@ func (x *ExportOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1304Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1304Slc
-	var yyhl1304 bool = l >= 0
-	for yyj1304 := 0; ; yyj1304++ {
-		if yyhl1304 {
-			if yyj1304 >= l {
+	var yys1258Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1258Slc
+	var yyhl1258 bool = l >= 0
+	for yyj1258 := 0; ; yyj1258++ {
+		if yyhl1258 {
+			if yyj1258 >= l {
 				break
 			}
 		} else {
@@ -15685,10 +15067,10 @@ func (x *ExportOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1304Slc = r.DecodeBytes(yys1304Slc, true, true)
-		yys1304 := string(yys1304Slc)
+		yys1258Slc = r.DecodeBytes(yys1258Slc, true, true)
+		yys1258 := string(yys1258Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1304 {
+		switch yys1258 {
 		case "export":
 			if r.TryDecodeAsNil() {
 				x.Export = false
@@ -15714,9 +15096,9 @@ func (x *ExportOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1304)
-		} // end switch yys1304
-	} // end for yyj1304
+			z.DecStructFieldNotFound(-1, yys1258)
+		} // end switch yys1258
+	} // end for yyj1258
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -15724,16 +15106,16 @@ func (x *ExportOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1309 int
-	var yyb1309 bool
-	var yyhl1309 bool = l >= 0
-	yyj1309++
-	if yyhl1309 {
-		yyb1309 = yyj1309 > l
+	var yyj1263 int
+	var yyb1263 bool
+	var yyhl1263 bool = l >= 0
+	yyj1263++
+	if yyhl1263 {
+		yyb1263 = yyj1263 > l
 	} else {
-		yyb1309 = r.CheckBreak()
+		yyb1263 = r.CheckBreak()
 	}
-	if yyb1309 {
+	if yyb1263 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15743,13 +15125,13 @@ func (x *ExportOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Export = bool(r.DecodeBool())
 	}
-	yyj1309++
-	if yyhl1309 {
-		yyb1309 = yyj1309 > l
+	yyj1263++
+	if yyhl1263 {
+		yyb1263 = yyj1263 > l
 	} else {
-		yyb1309 = r.CheckBreak()
+		yyb1263 = r.CheckBreak()
 	}
-	if yyb1309 {
+	if yyb1263 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15759,13 +15141,13 @@ func (x *ExportOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Exact = bool(r.DecodeBool())
 	}
-	yyj1309++
-	if yyhl1309 {
-		yyb1309 = yyj1309 > l
+	yyj1263++
+	if yyhl1263 {
+		yyb1263 = yyj1263 > l
 	} else {
-		yyb1309 = r.CheckBreak()
+		yyb1263 = r.CheckBreak()
 	}
-	if yyb1309 {
+	if yyb1263 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15775,13 +15157,13 @@ func (x *ExportOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1309++
-	if yyhl1309 {
-		yyb1309 = yyj1309 > l
+	yyj1263++
+	if yyhl1263 {
+		yyb1263 = yyj1263 > l
 	} else {
-		yyb1309 = r.CheckBreak()
+		yyb1263 = r.CheckBreak()
 	}
-	if yyb1309 {
+	if yyb1263 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -15792,17 +15174,17 @@ func (x *ExportOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = string(r.DecodeString())
 	}
 	for {
-		yyj1309++
-		if yyhl1309 {
-			yyb1309 = yyj1309 > l
+		yyj1263++
+		if yyhl1263 {
+			yyb1263 = yyj1263 > l
 		} else {
-			yyb1309 = r.CheckBreak()
+			yyb1263 = r.CheckBreak()
 		}
-		if yyb1309 {
+		if yyb1263 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1309-1, "")
+		z.DecStructFieldNotFound(yyj1263-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -15814,41 +15196,41 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1314 := z.EncBinary()
-		_ = yym1314
+		yym1268 := z.EncBinary()
+		_ = yym1268
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1315 := !z.EncBinary()
-			yy2arr1315 := z.EncBasicHandle().StructToArray
-			var yyq1315 [7]bool
-			_, _, _ = yysep1315, yyq1315, yy2arr1315
-			const yyr1315 bool = false
-			yyq1315[0] = x.LabelSelector != ""
-			yyq1315[1] = x.FieldSelector != ""
-			yyq1315[2] = x.Watch != false
-			yyq1315[3] = x.ResourceVersion != ""
-			yyq1315[4] = x.TimeoutSeconds != nil
-			yyq1315[5] = x.Kind != ""
-			yyq1315[6] = x.APIVersion != ""
-			var yynn1315 int
-			if yyr1315 || yy2arr1315 {
+			yysep1269 := !z.EncBinary()
+			yy2arr1269 := z.EncBasicHandle().StructToArray
+			var yyq1269 [7]bool
+			_, _, _ = yysep1269, yyq1269, yy2arr1269
+			const yyr1269 bool = false
+			yyq1269[0] = x.LabelSelector != ""
+			yyq1269[1] = x.FieldSelector != ""
+			yyq1269[2] = x.Watch != false
+			yyq1269[3] = x.ResourceVersion != ""
+			yyq1269[4] = x.TimeoutSeconds != nil
+			yyq1269[5] = x.Kind != ""
+			yyq1269[6] = x.APIVersion != ""
+			var yynn1269 int
+			if yyr1269 || yy2arr1269 {
 				r.EncodeArrayStart(7)
 			} else {
-				yynn1315 = 0
-				for _, b := range yyq1315 {
+				yynn1269 = 0
+				for _, b := range yyq1269 {
 					if b {
-						yynn1315++
+						yynn1269++
 					}
 				}
-				r.EncodeMapStart(yynn1315)
-				yynn1315 = 0
+				r.EncodeMapStart(yynn1269)
+				yynn1269 = 0
 			}
-			if yyr1315 || yy2arr1315 {
+			if yyr1269 || yy2arr1269 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1315[0] {
-					yym1317 := z.EncBinary()
-					_ = yym1317
+				if yyq1269[0] {
+					yym1271 := z.EncBinary()
+					_ = yym1271
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.LabelSelector))
@@ -15857,23 +15239,23 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1315[0] {
+				if yyq1269[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("labelSelector"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1318 := z.EncBinary()
-					_ = yym1318
+					yym1272 := z.EncBinary()
+					_ = yym1272
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.LabelSelector))
 					}
 				}
 			}
-			if yyr1315 || yy2arr1315 {
+			if yyr1269 || yy2arr1269 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1315[1] {
-					yym1320 := z.EncBinary()
-					_ = yym1320
+				if yyq1269[1] {
+					yym1274 := z.EncBinary()
+					_ = yym1274
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.FieldSelector))
@@ -15882,23 +15264,23 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1315[1] {
+				if yyq1269[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("fieldSelector"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1321 := z.EncBinary()
-					_ = yym1321
+					yym1275 := z.EncBinary()
+					_ = yym1275
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.FieldSelector))
 					}
 				}
 			}
-			if yyr1315 || yy2arr1315 {
+			if yyr1269 || yy2arr1269 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1315[2] {
-					yym1323 := z.EncBinary()
-					_ = yym1323
+				if yyq1269[2] {
+					yym1277 := z.EncBinary()
+					_ = yym1277
 					if false {
 					} else {
 						r.EncodeBool(bool(x.Watch))
@@ -15907,23 +15289,23 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq1315[2] {
+				if yyq1269[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("watch"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1324 := z.EncBinary()
-					_ = yym1324
+					yym1278 := z.EncBinary()
+					_ = yym1278
 					if false {
 					} else {
 						r.EncodeBool(bool(x.Watch))
 					}
 				}
 			}
-			if yyr1315 || yy2arr1315 {
+			if yyr1269 || yy2arr1269 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1315[3] {
-					yym1326 := z.EncBinary()
-					_ = yym1326
+				if yyq1269[3] {
+					yym1280 := z.EncBinary()
+					_ = yym1280
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
@@ -15932,58 +15314,58 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1315[3] {
+				if yyq1269[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("resourceVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1327 := z.EncBinary()
-					_ = yym1327
+					yym1281 := z.EncBinary()
+					_ = yym1281
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
 					}
 				}
 			}
-			if yyr1315 || yy2arr1315 {
+			if yyr1269 || yy2arr1269 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1315[4] {
+				if yyq1269[4] {
 					if x.TimeoutSeconds == nil {
 						r.EncodeNil()
 					} else {
-						yy1329 := *x.TimeoutSeconds
-						yym1330 := z.EncBinary()
-						_ = yym1330
+						yy1283 := *x.TimeoutSeconds
+						yym1284 := z.EncBinary()
+						_ = yym1284
 						if false {
 						} else {
-							r.EncodeInt(int64(yy1329))
+							r.EncodeInt(int64(yy1283))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1315[4] {
+				if yyq1269[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("timeoutSeconds"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.TimeoutSeconds == nil {
 						r.EncodeNil()
 					} else {
-						yy1331 := *x.TimeoutSeconds
-						yym1332 := z.EncBinary()
-						_ = yym1332
+						yy1285 := *x.TimeoutSeconds
+						yym1286 := z.EncBinary()
+						_ = yym1286
 						if false {
 						} else {
-							r.EncodeInt(int64(yy1331))
+							r.EncodeInt(int64(yy1285))
 						}
 					}
 				}
 			}
-			if yyr1315 || yy2arr1315 {
+			if yyr1269 || yy2arr1269 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1315[5] {
-					yym1334 := z.EncBinary()
-					_ = yym1334
+				if yyq1269[5] {
+					yym1288 := z.EncBinary()
+					_ = yym1288
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -15992,23 +15374,23 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1315[5] {
+				if yyq1269[5] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1335 := z.EncBinary()
-					_ = yym1335
+					yym1289 := z.EncBinary()
+					_ = yym1289
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1315 || yy2arr1315 {
+			if yyr1269 || yy2arr1269 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1315[6] {
-					yym1337 := z.EncBinary()
-					_ = yym1337
+				if yyq1269[6] {
+					yym1291 := z.EncBinary()
+					_ = yym1291
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -16017,19 +15399,19 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1315[6] {
+				if yyq1269[6] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1338 := z.EncBinary()
-					_ = yym1338
+					yym1292 := z.EncBinary()
+					_ = yym1292
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1315 || yy2arr1315 {
+			if yyr1269 || yy2arr1269 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -16042,25 +15424,25 @@ func (x *ListOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1339 := z.DecBinary()
-	_ = yym1339
+	yym1293 := z.DecBinary()
+	_ = yym1293
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1340 := r.ContainerType()
-		if yyct1340 == codecSelferValueTypeMap1234 {
-			yyl1340 := r.ReadMapStart()
-			if yyl1340 == 0 {
+		yyct1294 := r.ContainerType()
+		if yyct1294 == codecSelferValueTypeMap1234 {
+			yyl1294 := r.ReadMapStart()
+			if yyl1294 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1340, d)
+				x.codecDecodeSelfFromMap(yyl1294, d)
 			}
-		} else if yyct1340 == codecSelferValueTypeArray1234 {
-			yyl1340 := r.ReadArrayStart()
-			if yyl1340 == 0 {
+		} else if yyct1294 == codecSelferValueTypeArray1234 {
+			yyl1294 := r.ReadArrayStart()
+			if yyl1294 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1340, d)
+				x.codecDecodeSelfFromArray(yyl1294, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -16072,12 +15454,12 @@ func (x *ListOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1341Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1341Slc
-	var yyhl1341 bool = l >= 0
-	for yyj1341 := 0; ; yyj1341++ {
-		if yyhl1341 {
-			if yyj1341 >= l {
+	var yys1295Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1295Slc
+	var yyhl1295 bool = l >= 0
+	for yyj1295 := 0; ; yyj1295++ {
+		if yyhl1295 {
+			if yyj1295 >= l {
 				break
 			}
 		} else {
@@ -16086,10 +15468,10 @@ func (x *ListOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1341Slc = r.DecodeBytes(yys1341Slc, true, true)
-		yys1341 := string(yys1341Slc)
+		yys1295Slc = r.DecodeBytes(yys1295Slc, true, true)
+		yys1295 := string(yys1295Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1341 {
+		switch yys1295 {
 		case "labelSelector":
 			if r.TryDecodeAsNil() {
 				x.LabelSelector = ""
@@ -16123,8 +15505,8 @@ func (x *ListOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TimeoutSeconds == nil {
 					x.TimeoutSeconds = new(int64)
 				}
-				yym1347 := z.DecBinary()
-				_ = yym1347
+				yym1301 := z.DecBinary()
+				_ = yym1301
 				if false {
 				} else {
 					*((*int64)(x.TimeoutSeconds)) = int64(r.DecodeInt(64))
@@ -16143,9 +15525,9 @@ func (x *ListOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1341)
-		} // end switch yys1341
-	} // end for yyj1341
+			z.DecStructFieldNotFound(-1, yys1295)
+		} // end switch yys1295
+	} // end for yyj1295
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -16153,16 +15535,16 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1350 int
-	var yyb1350 bool
-	var yyhl1350 bool = l >= 0
-	yyj1350++
-	if yyhl1350 {
-		yyb1350 = yyj1350 > l
+	var yyj1304 int
+	var yyb1304 bool
+	var yyhl1304 bool = l >= 0
+	yyj1304++
+	if yyhl1304 {
+		yyb1304 = yyj1304 > l
 	} else {
-		yyb1350 = r.CheckBreak()
+		yyb1304 = r.CheckBreak()
 	}
-	if yyb1350 {
+	if yyb1304 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -16172,13 +15554,13 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.LabelSelector = string(r.DecodeString())
 	}
-	yyj1350++
-	if yyhl1350 {
-		yyb1350 = yyj1350 > l
+	yyj1304++
+	if yyhl1304 {
+		yyb1304 = yyj1304 > l
 	} else {
-		yyb1350 = r.CheckBreak()
+		yyb1304 = r.CheckBreak()
 	}
-	if yyb1350 {
+	if yyb1304 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -16188,13 +15570,13 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.FieldSelector = string(r.DecodeString())
 	}
-	yyj1350++
-	if yyhl1350 {
-		yyb1350 = yyj1350 > l
+	yyj1304++
+	if yyhl1304 {
+		yyb1304 = yyj1304 > l
 	} else {
-		yyb1350 = r.CheckBreak()
+		yyb1304 = r.CheckBreak()
 	}
-	if yyb1350 {
+	if yyb1304 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -16204,13 +15586,13 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Watch = bool(r.DecodeBool())
 	}
-	yyj1350++
-	if yyhl1350 {
-		yyb1350 = yyj1350 > l
+	yyj1304++
+	if yyhl1304 {
+		yyb1304 = yyj1304 > l
 	} else {
-		yyb1350 = r.CheckBreak()
+		yyb1304 = r.CheckBreak()
 	}
-	if yyb1350 {
+	if yyb1304 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -16220,13 +15602,13 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.ResourceVersion = string(r.DecodeString())
 	}
-	yyj1350++
-	if yyhl1350 {
-		yyb1350 = yyj1350 > l
+	yyj1304++
+	if yyhl1304 {
+		yyb1304 = yyj1304 > l
 	} else {
-		yyb1350 = r.CheckBreak()
+		yyb1304 = r.CheckBreak()
 	}
-	if yyb1350 {
+	if yyb1304 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -16239,20 +15621,20 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TimeoutSeconds == nil {
 			x.TimeoutSeconds = new(int64)
 		}
-		yym1356 := z.DecBinary()
-		_ = yym1356
+		yym1310 := z.DecBinary()
+		_ = yym1310
 		if false {
 		} else {
 			*((*int64)(x.TimeoutSeconds)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj1350++
-	if yyhl1350 {
-		yyb1350 = yyj1350 > l
+	yyj1304++
+	if yyhl1304 {
+		yyb1304 = yyj1304 > l
 	} else {
-		yyb1350 = r.CheckBreak()
+		yyb1304 = r.CheckBreak()
 	}
-	if yyb1350 {
+	if yyb1304 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -16262,13 +15644,13 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1350++
-	if yyhl1350 {
-		yyb1350 = yyj1350 > l
+	yyj1304++
+	if yyhl1304 {
+		yyb1304 = yyj1304 > l
 	} else {
-		yyb1350 = r.CheckBreak()
+		yyb1304 = r.CheckBreak()
 	}
-	if yyb1350 {
+	if yyb1304 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -16279,17 +15661,17 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = string(r.DecodeString())
 	}
 	for {
-		yyj1350++
-		if yyhl1350 {
-			yyb1350 = yyj1350 > l
+		yyj1304++
+		if yyhl1304 {
+			yyb1304 = yyj1304 > l
 		} else {
-			yyb1350 = r.CheckBreak()
+			yyb1304 = r.CheckBreak()
 		}
-		if yyb1350 {
+		if yyb1304 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1350-1, "")
+		z.DecStructFieldNotFound(yyj1304-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -16301,39 +15683,39 @@ func (x *LabelSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1359 := z.EncBinary()
-		_ = yym1359
+		yym1313 := z.EncBinary()
+		_ = yym1313
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1360 := !z.EncBinary()
-			yy2arr1360 := z.EncBasicHandle().StructToArray
-			var yyq1360 [2]bool
-			_, _, _ = yysep1360, yyq1360, yy2arr1360
-			const yyr1360 bool = false
-			yyq1360[0] = len(x.MatchLabels) != 0
-			yyq1360[1] = len(x.MatchExpressions) != 0
-			var yynn1360 int
-			if yyr1360 || yy2arr1360 {
+			yysep1314 := !z.EncBinary()
+			yy2arr1314 := z.EncBasicHandle().StructToArray
+			var yyq1314 [2]bool
+			_, _, _ = yysep1314, yyq1314, yy2arr1314
+			const yyr1314 bool = false
+			yyq1314[0] = len(x.MatchLabels) != 0
+			yyq1314[1] = len(x.MatchExpressions) != 0
+			var yynn1314 int
+			if yyr1314 || yy2arr1314 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn1360 = 0
-				for _, b := range yyq1360 {
+				yynn1314 = 0
+				for _, b := range yyq1314 {
 					if b {
-						yynn1360++
+						yynn1314++
 					}
 				}
-				r.EncodeMapStart(yynn1360)
-				yynn1360 = 0
+				r.EncodeMapStart(yynn1314)
+				yynn1314 = 0
 			}
-			if yyr1360 || yy2arr1360 {
+			if yyr1314 || yy2arr1314 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1360[0] {
+				if yyq1314[0] {
 					if x.MatchLabels == nil {
 						r.EncodeNil()
 					} else {
-						yym1362 := z.EncBinary()
-						_ = yym1362
+						yym1316 := z.EncBinary()
+						_ = yym1316
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.MatchLabels, false, e)
@@ -16343,15 +15725,15 @@ func (x *LabelSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1360[0] {
+				if yyq1314[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("matchLabels"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.MatchLabels == nil {
 						r.EncodeNil()
 					} else {
-						yym1363 := z.EncBinary()
-						_ = yym1363
+						yym1317 := z.EncBinary()
+						_ = yym1317
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.MatchLabels, false, e)
@@ -16359,14 +15741,14 @@ func (x *LabelSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1360 || yy2arr1360 {
+			if yyr1314 || yy2arr1314 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1360[1] {
+				if yyq1314[1] {
 					if x.MatchExpressions == nil {
 						r.EncodeNil()
 					} else {
-						yym1365 := z.EncBinary()
-						_ = yym1365
+						yym1319 := z.EncBinary()
+						_ = yym1319
 						if false {
 						} else {
 							h.encSliceLabelSelectorRequirement(([]LabelSelectorRequirement)(x.MatchExpressions), e)
@@ -16376,15 +15758,15 @@ func (x *LabelSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1360[1] {
+				if yyq1314[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("matchExpressions"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.MatchExpressions == nil {
 						r.EncodeNil()
 					} else {
-						yym1366 := z.EncBinary()
-						_ = yym1366
+						yym1320 := z.EncBinary()
+						_ = yym1320
 						if false {
 						} else {
 							h.encSliceLabelSelectorRequirement(([]LabelSelectorRequirement)(x.MatchExpressions), e)
@@ -16392,7 +15774,7 @@ func (x *LabelSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1360 || yy2arr1360 {
+			if yyr1314 || yy2arr1314 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -16405,25 +15787,25 @@ func (x *LabelSelector) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1367 := z.DecBinary()
-	_ = yym1367
+	yym1321 := z.DecBinary()
+	_ = yym1321
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1368 := r.ContainerType()
-		if yyct1368 == codecSelferValueTypeMap1234 {
-			yyl1368 := r.ReadMapStart()
-			if yyl1368 == 0 {
+		yyct1322 := r.ContainerType()
+		if yyct1322 == codecSelferValueTypeMap1234 {
+			yyl1322 := r.ReadMapStart()
+			if yyl1322 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1368, d)
+				x.codecDecodeSelfFromMap(yyl1322, d)
 			}
-		} else if yyct1368 == codecSelferValueTypeArray1234 {
-			yyl1368 := r.ReadArrayStart()
-			if yyl1368 == 0 {
+		} else if yyct1322 == codecSelferValueTypeArray1234 {
+			yyl1322 := r.ReadArrayStart()
+			if yyl1322 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1368, d)
+				x.codecDecodeSelfFromArray(yyl1322, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -16435,12 +15817,12 @@ func (x *LabelSelector) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1369Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1369Slc
-	var yyhl1369 bool = l >= 0
-	for yyj1369 := 0; ; yyj1369++ {
-		if yyhl1369 {
-			if yyj1369 >= l {
+	var yys1323Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1323Slc
+	var yyhl1323 bool = l >= 0
+	for yyj1323 := 0; ; yyj1323++ {
+		if yyhl1323 {
+			if yyj1323 >= l {
 				break
 			}
 		} else {
@@ -16449,38 +15831,38 @@ func (x *LabelSelector) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1369Slc = r.DecodeBytes(yys1369Slc, true, true)
-		yys1369 := string(yys1369Slc)
+		yys1323Slc = r.DecodeBytes(yys1323Slc, true, true)
+		yys1323 := string(yys1323Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1369 {
+		switch yys1323 {
 		case "matchLabels":
 			if r.TryDecodeAsNil() {
 				x.MatchLabels = nil
 			} else {
-				yyv1370 := &x.MatchLabels
-				yym1371 := z.DecBinary()
-				_ = yym1371
+				yyv1324 := &x.MatchLabels
+				yym1325 := z.DecBinary()
+				_ = yym1325
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv1370, false, d)
+					z.F.DecMapStringStringX(yyv1324, false, d)
 				}
 			}
 		case "matchExpressions":
 			if r.TryDecodeAsNil() {
 				x.MatchExpressions = nil
 			} else {
-				yyv1372 := &x.MatchExpressions
-				yym1373 := z.DecBinary()
-				_ = yym1373
+				yyv1326 := &x.MatchExpressions
+				yym1327 := z.DecBinary()
+				_ = yym1327
 				if false {
 				} else {
-					h.decSliceLabelSelectorRequirement((*[]LabelSelectorRequirement)(yyv1372), d)
+					h.decSliceLabelSelectorRequirement((*[]LabelSelectorRequirement)(yyv1326), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1369)
-		} // end switch yys1369
-	} // end for yyj1369
+			z.DecStructFieldNotFound(-1, yys1323)
+		} // end switch yys1323
+	} // end for yyj1323
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -16488,16 +15870,16 @@ func (x *LabelSelector) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1374 int
-	var yyb1374 bool
-	var yyhl1374 bool = l >= 0
-	yyj1374++
-	if yyhl1374 {
-		yyb1374 = yyj1374 > l
+	var yyj1328 int
+	var yyb1328 bool
+	var yyhl1328 bool = l >= 0
+	yyj1328++
+	if yyhl1328 {
+		yyb1328 = yyj1328 > l
 	} else {
-		yyb1374 = r.CheckBreak()
+		yyb1328 = r.CheckBreak()
 	}
-	if yyb1374 {
+	if yyb1328 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -16505,21 +15887,21 @@ func (x *LabelSelector) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.MatchLabels = nil
 	} else {
-		yyv1375 := &x.MatchLabels
-		yym1376 := z.DecBinary()
-		_ = yym1376
+		yyv1329 := &x.MatchLabels
+		yym1330 := z.DecBinary()
+		_ = yym1330
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv1375, false, d)
+			z.F.DecMapStringStringX(yyv1329, false, d)
 		}
 	}
-	yyj1374++
-	if yyhl1374 {
-		yyb1374 = yyj1374 > l
+	yyj1328++
+	if yyhl1328 {
+		yyb1328 = yyj1328 > l
 	} else {
-		yyb1374 = r.CheckBreak()
+		yyb1328 = r.CheckBreak()
 	}
-	if yyb1374 {
+	if yyb1328 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -16527,26 +15909,26 @@ func (x *LabelSelector) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.MatchExpressions = nil
 	} else {
-		yyv1377 := &x.MatchExpressions
-		yym1378 := z.DecBinary()
-		_ = yym1378
+		yyv1331 := &x.MatchExpressions
+		yym1332 := z.DecBinary()
+		_ = yym1332
 		if false {
 		} else {
-			h.decSliceLabelSelectorRequirement((*[]LabelSelectorRequirement)(yyv1377), d)
+			h.decSliceLabelSelectorRequirement((*[]LabelSelectorRequirement)(yyv1331), d)
 		}
 	}
 	for {
-		yyj1374++
-		if yyhl1374 {
-			yyb1374 = yyj1374 > l
+		yyj1328++
+		if yyhl1328 {
+			yyb1328 = yyj1328 > l
 		} else {
-			yyb1374 = r.CheckBreak()
+			yyb1328 = r.CheckBreak()
 		}
-		if yyb1374 {
+		if yyb1328 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1374-1, "")
+		z.DecStructFieldNotFound(yyj1328-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -16558,34 +15940,34 @@ func (x *LabelSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1379 := z.EncBinary()
-		_ = yym1379
+		yym1333 := z.EncBinary()
+		_ = yym1333
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1380 := !z.EncBinary()
-			yy2arr1380 := z.EncBasicHandle().StructToArray
-			var yyq1380 [3]bool
-			_, _, _ = yysep1380, yyq1380, yy2arr1380
-			const yyr1380 bool = false
-			yyq1380[2] = len(x.Values) != 0
-			var yynn1380 int
-			if yyr1380 || yy2arr1380 {
+			yysep1334 := !z.EncBinary()
+			yy2arr1334 := z.EncBasicHandle().StructToArray
+			var yyq1334 [3]bool
+			_, _, _ = yysep1334, yyq1334, yy2arr1334
+			const yyr1334 bool = false
+			yyq1334[2] = len(x.Values) != 0
+			var yynn1334 int
+			if yyr1334 || yy2arr1334 {
 				r.EncodeArrayStart(3)
 			} else {
-				yynn1380 = 2
-				for _, b := range yyq1380 {
+				yynn1334 = 2
+				for _, b := range yyq1334 {
 					if b {
-						yynn1380++
+						yynn1334++
 					}
 				}
-				r.EncodeMapStart(yynn1380)
-				yynn1380 = 0
+				r.EncodeMapStart(yynn1334)
+				yynn1334 = 0
 			}
-			if yyr1380 || yy2arr1380 {
+			if yyr1334 || yy2arr1334 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1382 := z.EncBinary()
-				_ = yym1382
+				yym1336 := z.EncBinary()
+				_ = yym1336
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
@@ -16594,14 +15976,14 @@ func (x *LabelSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("key"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1383 := z.EncBinary()
-				_ = yym1383
+				yym1337 := z.EncBinary()
+				_ = yym1337
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
 				}
 			}
-			if yyr1380 || yy2arr1380 {
+			if yyr1334 || yy2arr1334 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				x.Operator.CodecEncodeSelf(e)
 			} else {
@@ -16610,14 +15992,14 @@ func (x *LabelSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				x.Operator.CodecEncodeSelf(e)
 			}
-			if yyr1380 || yy2arr1380 {
+			if yyr1334 || yy2arr1334 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1380[2] {
+				if yyq1334[2] {
 					if x.Values == nil {
 						r.EncodeNil()
 					} else {
-						yym1386 := z.EncBinary()
-						_ = yym1386
+						yym1340 := z.EncBinary()
+						_ = yym1340
 						if false {
 						} else {
 							z.F.EncSliceStringV(x.Values, false, e)
@@ -16627,15 +16009,15 @@ func (x *LabelSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1380[2] {
+				if yyq1334[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("values"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Values == nil {
 						r.EncodeNil()
 					} else {
-						yym1387 := z.EncBinary()
-						_ = yym1387
+						yym1341 := z.EncBinary()
+						_ = yym1341
 						if false {
 						} else {
 							z.F.EncSliceStringV(x.Values, false, e)
@@ -16643,7 +16025,7 @@ func (x *LabelSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1380 || yy2arr1380 {
+			if yyr1334 || yy2arr1334 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -16656,25 +16038,25 @@ func (x *LabelSelectorRequirement) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1388 := z.DecBinary()
-	_ = yym1388
+	yym1342 := z.DecBinary()
+	_ = yym1342
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1389 := r.ContainerType()
-		if yyct1389 == codecSelferValueTypeMap1234 {
-			yyl1389 := r.ReadMapStart()
-			if yyl1389 == 0 {
+		yyct1343 := r.ContainerType()
+		if yyct1343 == codecSelferValueTypeMap1234 {
+			yyl1343 := r.ReadMapStart()
+			if yyl1343 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1389, d)
+				x.codecDecodeSelfFromMap(yyl1343, d)
 			}
-		} else if yyct1389 == codecSelferValueTypeArray1234 {
-			yyl1389 := r.ReadArrayStart()
-			if yyl1389 == 0 {
+		} else if yyct1343 == codecSelferValueTypeArray1234 {
+			yyl1343 := r.ReadArrayStart()
+			if yyl1343 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1389, d)
+				x.codecDecodeSelfFromArray(yyl1343, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -16686,12 +16068,12 @@ func (x *LabelSelectorRequirement) codecDecodeSelfFromMap(l int, d *codec1978.De
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1390Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1390Slc
-	var yyhl1390 bool = l >= 0
-	for yyj1390 := 0; ; yyj1390++ {
-		if yyhl1390 {
-			if yyj1390 >= l {
+	var yys1344Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1344Slc
+	var yyhl1344 bool = l >= 0
+	for yyj1344 := 0; ; yyj1344++ {
+		if yyhl1344 {
+			if yyj1344 >= l {
 				break
 			}
 		} else {
@@ -16700,10 +16082,10 @@ func (x *LabelSelectorRequirement) codecDecodeSelfFromMap(l int, d *codec1978.De
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1390Slc = r.DecodeBytes(yys1390Slc, true, true)
-		yys1390 := string(yys1390Slc)
+		yys1344Slc = r.DecodeBytes(yys1344Slc, true, true)
+		yys1344 := string(yys1344Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1390 {
+		switch yys1344 {
 		case "key":
 			if r.TryDecodeAsNil() {
 				x.Key = ""
@@ -16720,18 +16102,18 @@ func (x *LabelSelectorRequirement) codecDecodeSelfFromMap(l int, d *codec1978.De
 			if r.TryDecodeAsNil() {
 				x.Values = nil
 			} else {
-				yyv1393 := &x.Values
-				yym1394 := z.DecBinary()
-				_ = yym1394
+				yyv1347 := &x.Values
+				yym1348 := z.DecBinary()
+				_ = yym1348
 				if false {
 				} else {
-					z.F.DecSliceStringX(yyv1393, false, d)
+					z.F.DecSliceStringX(yyv1347, false, d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1390)
-		} // end switch yys1390
-	} // end for yyj1390
+			z.DecStructFieldNotFound(-1, yys1344)
+		} // end switch yys1344
+	} // end for yyj1344
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -16739,16 +16121,16 @@ func (x *LabelSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1395 int
-	var yyb1395 bool
-	var yyhl1395 bool = l >= 0
-	yyj1395++
-	if yyhl1395 {
-		yyb1395 = yyj1395 > l
+	var yyj1349 int
+	var yyb1349 bool
+	var yyhl1349 bool = l >= 0
+	yyj1349++
+	if yyhl1349 {
+		yyb1349 = yyj1349 > l
 	} else {
-		yyb1395 = r.CheckBreak()
+		yyb1349 = r.CheckBreak()
 	}
-	if yyb1395 {
+	if yyb1349 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -16758,13 +16140,13 @@ func (x *LabelSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.
 	} else {
 		x.Key = string(r.DecodeString())
 	}
-	yyj1395++
-	if yyhl1395 {
-		yyb1395 = yyj1395 > l
+	yyj1349++
+	if yyhl1349 {
+		yyb1349 = yyj1349 > l
 	} else {
-		yyb1395 = r.CheckBreak()
+		yyb1349 = r.CheckBreak()
 	}
-	if yyb1395 {
+	if yyb1349 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -16774,13 +16156,13 @@ func (x *LabelSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.
 	} else {
 		x.Operator = LabelSelectorOperator(r.DecodeString())
 	}
-	yyj1395++
-	if yyhl1395 {
-		yyb1395 = yyj1395 > l
+	yyj1349++
+	if yyhl1349 {
+		yyb1349 = yyj1349 > l
 	} else {
-		yyb1395 = r.CheckBreak()
+		yyb1349 = r.CheckBreak()
 	}
-	if yyb1395 {
+	if yyb1349 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -16788,26 +16170,26 @@ func (x *LabelSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.
 	if r.TryDecodeAsNil() {
 		x.Values = nil
 	} else {
-		yyv1398 := &x.Values
-		yym1399 := z.DecBinary()
-		_ = yym1399
+		yyv1352 := &x.Values
+		yym1353 := z.DecBinary()
+		_ = yym1353
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv1398, false, d)
+			z.F.DecSliceStringX(yyv1352, false, d)
 		}
 	}
 	for {
-		yyj1395++
-		if yyhl1395 {
-			yyb1395 = yyj1395 > l
+		yyj1349++
+		if yyhl1349 {
+			yyb1349 = yyj1349 > l
 		} else {
-			yyb1395 = r.CheckBreak()
+			yyb1349 = r.CheckBreak()
 		}
-		if yyb1395 {
+		if yyb1349 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1395-1, "")
+		z.DecStructFieldNotFound(yyj1349-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -16816,8 +16198,8 @@ func (x LabelSelectorOperator) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym1400 := z.EncBinary()
-	_ = yym1400
+	yym1354 := z.EncBinary()
+	_ = yym1354
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -16829,8 +16211,8 @@ func (x *LabelSelectorOperator) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1401 := z.DecBinary()
-	_ = yym1401
+	yym1355 := z.DecBinary()
+	_ = yym1355
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -16845,90 +16227,90 @@ func (x *ReplicaSet) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1402 := z.EncBinary()
-		_ = yym1402
+		yym1356 := z.EncBinary()
+		_ = yym1356
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1403 := !z.EncBinary()
-			yy2arr1403 := z.EncBasicHandle().StructToArray
-			var yyq1403 [5]bool
-			_, _, _ = yysep1403, yyq1403, yy2arr1403
-			const yyr1403 bool = false
-			yyq1403[0] = true
-			yyq1403[1] = true
-			yyq1403[2] = true
-			yyq1403[3] = x.Kind != ""
-			yyq1403[4] = x.APIVersion != ""
-			var yynn1403 int
-			if yyr1403 || yy2arr1403 {
+			yysep1357 := !z.EncBinary()
+			yy2arr1357 := z.EncBasicHandle().StructToArray
+			var yyq1357 [5]bool
+			_, _, _ = yysep1357, yyq1357, yy2arr1357
+			const yyr1357 bool = false
+			yyq1357[0] = true
+			yyq1357[1] = true
+			yyq1357[2] = true
+			yyq1357[3] = x.Kind != ""
+			yyq1357[4] = x.APIVersion != ""
+			var yynn1357 int
+			if yyr1357 || yy2arr1357 {
 				r.EncodeArrayStart(5)
 			} else {
-				yynn1403 = 0
-				for _, b := range yyq1403 {
+				yynn1357 = 0
+				for _, b := range yyq1357 {
 					if b {
-						yynn1403++
+						yynn1357++
 					}
 				}
-				r.EncodeMapStart(yynn1403)
-				yynn1403 = 0
+				r.EncodeMapStart(yynn1357)
+				yynn1357 = 0
 			}
-			if yyr1403 || yy2arr1403 {
+			if yyr1357 || yy2arr1357 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1403[0] {
-					yy1405 := &x.ObjectMeta
-					yy1405.CodecEncodeSelf(e)
+				if yyq1357[0] {
+					yy1359 := &x.ObjectMeta
+					yy1359.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1403[0] {
+				if yyq1357[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1406 := &x.ObjectMeta
-					yy1406.CodecEncodeSelf(e)
+					yy1360 := &x.ObjectMeta
+					yy1360.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1403 || yy2arr1403 {
+			if yyr1357 || yy2arr1357 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1403[1] {
-					yy1408 := &x.Spec
-					yy1408.CodecEncodeSelf(e)
+				if yyq1357[1] {
+					yy1362 := &x.Spec
+					yy1362.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1403[1] {
+				if yyq1357[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1409 := &x.Spec
-					yy1409.CodecEncodeSelf(e)
+					yy1363 := &x.Spec
+					yy1363.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1403 || yy2arr1403 {
+			if yyr1357 || yy2arr1357 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1403[2] {
-					yy1411 := &x.Status
-					yy1411.CodecEncodeSelf(e)
+				if yyq1357[2] {
+					yy1365 := &x.Status
+					yy1365.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1403[2] {
+				if yyq1357[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1412 := &x.Status
-					yy1412.CodecEncodeSelf(e)
+					yy1366 := &x.Status
+					yy1366.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1403 || yy2arr1403 {
+			if yyr1357 || yy2arr1357 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1403[3] {
-					yym1414 := z.EncBinary()
-					_ = yym1414
+				if yyq1357[3] {
+					yym1368 := z.EncBinary()
+					_ = yym1368
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -16937,23 +16319,23 @@ func (x *ReplicaSet) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1403[3] {
+				if yyq1357[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1415 := z.EncBinary()
-					_ = yym1415
+					yym1369 := z.EncBinary()
+					_ = yym1369
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1403 || yy2arr1403 {
+			if yyr1357 || yy2arr1357 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1403[4] {
-					yym1417 := z.EncBinary()
-					_ = yym1417
+				if yyq1357[4] {
+					yym1371 := z.EncBinary()
+					_ = yym1371
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -16962,19 +16344,19 @@ func (x *ReplicaSet) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1403[4] {
+				if yyq1357[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1418 := z.EncBinary()
-					_ = yym1418
+					yym1372 := z.EncBinary()
+					_ = yym1372
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1403 || yy2arr1403 {
+			if yyr1357 || yy2arr1357 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -16987,25 +16369,25 @@ func (x *ReplicaSet) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1419 := z.DecBinary()
-	_ = yym1419
+	yym1373 := z.DecBinary()
+	_ = yym1373
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1420 := r.ContainerType()
-		if yyct1420 == codecSelferValueTypeMap1234 {
-			yyl1420 := r.ReadMapStart()
-			if yyl1420 == 0 {
+		yyct1374 := r.ContainerType()
+		if yyct1374 == codecSelferValueTypeMap1234 {
+			yyl1374 := r.ReadMapStart()
+			if yyl1374 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1420, d)
+				x.codecDecodeSelfFromMap(yyl1374, d)
 			}
-		} else if yyct1420 == codecSelferValueTypeArray1234 {
-			yyl1420 := r.ReadArrayStart()
-			if yyl1420 == 0 {
+		} else if yyct1374 == codecSelferValueTypeArray1234 {
+			yyl1374 := r.ReadArrayStart()
+			if yyl1374 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1420, d)
+				x.codecDecodeSelfFromArray(yyl1374, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -17017,12 +16399,12 @@ func (x *ReplicaSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1421Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1421Slc
-	var yyhl1421 bool = l >= 0
-	for yyj1421 := 0; ; yyj1421++ {
-		if yyhl1421 {
-			if yyj1421 >= l {
+	var yys1375Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1375Slc
+	var yyhl1375 bool = l >= 0
+	for yyj1375 := 0; ; yyj1375++ {
+		if yyhl1375 {
+			if yyj1375 >= l {
 				break
 			}
 		} else {
@@ -17031,30 +16413,30 @@ func (x *ReplicaSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1421Slc = r.DecodeBytes(yys1421Slc, true, true)
-		yys1421 := string(yys1421Slc)
+		yys1375Slc = r.DecodeBytes(yys1375Slc, true, true)
+		yys1375 := string(yys1375Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1421 {
+		switch yys1375 {
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_v1.ObjectMeta{}
 			} else {
-				yyv1422 := &x.ObjectMeta
-				yyv1422.CodecDecodeSelf(d)
+				yyv1376 := &x.ObjectMeta
+				yyv1376.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = ReplicaSetSpec{}
 			} else {
-				yyv1423 := &x.Spec
-				yyv1423.CodecDecodeSelf(d)
+				yyv1377 := &x.Spec
+				yyv1377.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = ReplicaSetStatus{}
 			} else {
-				yyv1424 := &x.Status
-				yyv1424.CodecDecodeSelf(d)
+				yyv1378 := &x.Status
+				yyv1378.CodecDecodeSelf(d)
 			}
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -17069,9 +16451,9 @@ func (x *ReplicaSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1421)
-		} // end switch yys1421
-	} // end for yyj1421
+			z.DecStructFieldNotFound(-1, yys1375)
+		} // end switch yys1375
+	} // end for yyj1375
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -17079,16 +16461,16 @@ func (x *ReplicaSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1427 int
-	var yyb1427 bool
-	var yyhl1427 bool = l >= 0
-	yyj1427++
-	if yyhl1427 {
-		yyb1427 = yyj1427 > l
+	var yyj1381 int
+	var yyb1381 bool
+	var yyhl1381 bool = l >= 0
+	yyj1381++
+	if yyhl1381 {
+		yyb1381 = yyj1381 > l
 	} else {
-		yyb1427 = r.CheckBreak()
+		yyb1381 = r.CheckBreak()
 	}
-	if yyb1427 {
+	if yyb1381 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -17096,16 +16478,16 @@ func (x *ReplicaSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_v1.ObjectMeta{}
 	} else {
-		yyv1428 := &x.ObjectMeta
-		yyv1428.CodecDecodeSelf(d)
+		yyv1382 := &x.ObjectMeta
+		yyv1382.CodecDecodeSelf(d)
 	}
-	yyj1427++
-	if yyhl1427 {
-		yyb1427 = yyj1427 > l
+	yyj1381++
+	if yyhl1381 {
+		yyb1381 = yyj1381 > l
 	} else {
-		yyb1427 = r.CheckBreak()
+		yyb1381 = r.CheckBreak()
 	}
-	if yyb1427 {
+	if yyb1381 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -17113,16 +16495,16 @@ func (x *ReplicaSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Spec = ReplicaSetSpec{}
 	} else {
-		yyv1429 := &x.Spec
-		yyv1429.CodecDecodeSelf(d)
+		yyv1383 := &x.Spec
+		yyv1383.CodecDecodeSelf(d)
 	}
-	yyj1427++
-	if yyhl1427 {
-		yyb1427 = yyj1427 > l
+	yyj1381++
+	if yyhl1381 {
+		yyb1381 = yyj1381 > l
 	} else {
-		yyb1427 = r.CheckBreak()
+		yyb1381 = r.CheckBreak()
 	}
-	if yyb1427 {
+	if yyb1381 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -17130,16 +16512,16 @@ func (x *ReplicaSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Status = ReplicaSetStatus{}
 	} else {
-		yyv1430 := &x.Status
-		yyv1430.CodecDecodeSelf(d)
+		yyv1384 := &x.Status
+		yyv1384.CodecDecodeSelf(d)
 	}
-	yyj1427++
-	if yyhl1427 {
-		yyb1427 = yyj1427 > l
+	yyj1381++
+	if yyhl1381 {
+		yyb1381 = yyj1381 > l
 	} else {
-		yyb1427 = r.CheckBreak()
+		yyb1381 = r.CheckBreak()
 	}
-	if yyb1427 {
+	if yyb1381 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -17149,13 +16531,13 @@ func (x *ReplicaSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1427++
-	if yyhl1427 {
-		yyb1427 = yyj1427 > l
+	yyj1381++
+	if yyhl1381 {
+		yyb1381 = yyj1381 > l
 	} else {
-		yyb1427 = r.CheckBreak()
+		yyb1381 = r.CheckBreak()
 	}
-	if yyb1427 {
+	if yyb1381 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -17166,17 +16548,17 @@ func (x *ReplicaSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = string(r.DecodeString())
 	}
 	for {
-		yyj1427++
-		if yyhl1427 {
-			yyb1427 = yyj1427 > l
+		yyj1381++
+		if yyhl1381 {
+			yyb1381 = yyj1381 > l
 		} else {
-			yyb1427 = r.CheckBreak()
+			yyb1381 = r.CheckBreak()
 		}
-		if yyb1427 {
+		if yyb1381 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1427-1, "")
+		z.DecStructFieldNotFound(yyj1381-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -17188,68 +16570,68 @@ func (x *ReplicaSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1433 := z.EncBinary()
-		_ = yym1433
+		yym1387 := z.EncBinary()
+		_ = yym1387
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1434 := !z.EncBinary()
-			yy2arr1434 := z.EncBasicHandle().StructToArray
-			var yyq1434 [4]bool
-			_, _, _ = yysep1434, yyq1434, yy2arr1434
-			const yyr1434 bool = false
-			yyq1434[0] = true
-			yyq1434[2] = x.Kind != ""
-			yyq1434[3] = x.APIVersion != ""
-			var yynn1434 int
-			if yyr1434 || yy2arr1434 {
+			yysep1388 := !z.EncBinary()
+			yy2arr1388 := z.EncBasicHandle().StructToArray
+			var yyq1388 [4]bool
+			_, _, _ = yysep1388, yyq1388, yy2arr1388
+			const yyr1388 bool = false
+			yyq1388[0] = true
+			yyq1388[2] = x.Kind != ""
+			yyq1388[3] = x.APIVersion != ""
+			var yynn1388 int
+			if yyr1388 || yy2arr1388 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn1434 = 1
-				for _, b := range yyq1434 {
+				yynn1388 = 1
+				for _, b := range yyq1388 {
 					if b {
-						yynn1434++
+						yynn1388++
 					}
 				}
-				r.EncodeMapStart(yynn1434)
-				yynn1434 = 0
+				r.EncodeMapStart(yynn1388)
+				yynn1388 = 0
 			}
-			if yyr1434 || yy2arr1434 {
+			if yyr1388 || yy2arr1388 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1434[0] {
-					yy1436 := &x.ListMeta
-					yym1437 := z.EncBinary()
-					_ = yym1437
+				if yyq1388[0] {
+					yy1390 := &x.ListMeta
+					yym1391 := z.EncBinary()
+					_ = yym1391
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1436) {
+					} else if z.HasExtensions() && z.EncExt(yy1390) {
 					} else {
-						z.EncFallback(yy1436)
+						z.EncFallback(yy1390)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1434[0] {
+				if yyq1388[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1438 := &x.ListMeta
-					yym1439 := z.EncBinary()
-					_ = yym1439
+					yy1392 := &x.ListMeta
+					yym1393 := z.EncBinary()
+					_ = yym1393
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1438) {
+					} else if z.HasExtensions() && z.EncExt(yy1392) {
 					} else {
-						z.EncFallback(yy1438)
+						z.EncFallback(yy1392)
 					}
 				}
 			}
-			if yyr1434 || yy2arr1434 {
+			if yyr1388 || yy2arr1388 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1441 := z.EncBinary()
-					_ = yym1441
+					yym1395 := z.EncBinary()
+					_ = yym1395
 					if false {
 					} else {
 						h.encSliceReplicaSet(([]ReplicaSet)(x.Items), e)
@@ -17262,19 +16644,19 @@ func (x *ReplicaSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1442 := z.EncBinary()
-					_ = yym1442
+					yym1396 := z.EncBinary()
+					_ = yym1396
 					if false {
 					} else {
 						h.encSliceReplicaSet(([]ReplicaSet)(x.Items), e)
 					}
 				}
 			}
-			if yyr1434 || yy2arr1434 {
+			if yyr1388 || yy2arr1388 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1434[2] {
-					yym1444 := z.EncBinary()
-					_ = yym1444
+				if yyq1388[2] {
+					yym1398 := z.EncBinary()
+					_ = yym1398
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -17283,23 +16665,23 @@ func (x *ReplicaSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1434[2] {
+				if yyq1388[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1445 := z.EncBinary()
-					_ = yym1445
+					yym1399 := z.EncBinary()
+					_ = yym1399
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1434 || yy2arr1434 {
+			if yyr1388 || yy2arr1388 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1434[3] {
-					yym1447 := z.EncBinary()
-					_ = yym1447
+				if yyq1388[3] {
+					yym1401 := z.EncBinary()
+					_ = yym1401
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -17308,19 +16690,19 @@ func (x *ReplicaSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1434[3] {
+				if yyq1388[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1448 := z.EncBinary()
-					_ = yym1448
+					yym1402 := z.EncBinary()
+					_ = yym1402
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1434 || yy2arr1434 {
+			if yyr1388 || yy2arr1388 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -17333,25 +16715,25 @@ func (x *ReplicaSetList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1449 := z.DecBinary()
-	_ = yym1449
+	yym1403 := z.DecBinary()
+	_ = yym1403
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1450 := r.ContainerType()
-		if yyct1450 == codecSelferValueTypeMap1234 {
-			yyl1450 := r.ReadMapStart()
-			if yyl1450 == 0 {
+		yyct1404 := r.ContainerType()
+		if yyct1404 == codecSelferValueTypeMap1234 {
+			yyl1404 := r.ReadMapStart()
+			if yyl1404 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1450, d)
+				x.codecDecodeSelfFromMap(yyl1404, d)
 			}
-		} else if yyct1450 == codecSelferValueTypeArray1234 {
-			yyl1450 := r.ReadArrayStart()
-			if yyl1450 == 0 {
+		} else if yyct1404 == codecSelferValueTypeArray1234 {
+			yyl1404 := r.ReadArrayStart()
+			if yyl1404 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1450, d)
+				x.codecDecodeSelfFromArray(yyl1404, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -17363,12 +16745,12 @@ func (x *ReplicaSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1451Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1451Slc
-	var yyhl1451 bool = l >= 0
-	for yyj1451 := 0; ; yyj1451++ {
-		if yyhl1451 {
-			if yyj1451 >= l {
+	var yys1405Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1405Slc
+	var yyhl1405 bool = l >= 0
+	for yyj1405 := 0; ; yyj1405++ {
+		if yyhl1405 {
+			if yyj1405 >= l {
 				break
 			}
 		} else {
@@ -17377,33 +16759,33 @@ func (x *ReplicaSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1451Slc = r.DecodeBytes(yys1451Slc, true, true)
-		yys1451 := string(yys1451Slc)
+		yys1405Slc = r.DecodeBytes(yys1405Slc, true, true)
+		yys1405 := string(yys1405Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1451 {
+		switch yys1405 {
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv1452 := &x.ListMeta
-				yym1453 := z.DecBinary()
-				_ = yym1453
+				yyv1406 := &x.ListMeta
+				yym1407 := z.DecBinary()
+				_ = yym1407
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1452) {
+				} else if z.HasExtensions() && z.DecExt(yyv1406) {
 				} else {
-					z.DecFallback(yyv1452, false)
+					z.DecFallback(yyv1406, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv1454 := &x.Items
-				yym1455 := z.DecBinary()
-				_ = yym1455
+				yyv1408 := &x.Items
+				yym1409 := z.DecBinary()
+				_ = yym1409
 				if false {
 				} else {
-					h.decSliceReplicaSet((*[]ReplicaSet)(yyv1454), d)
+					h.decSliceReplicaSet((*[]ReplicaSet)(yyv1408), d)
 				}
 			}
 		case "kind":
@@ -17419,9 +16801,9 @@ func (x *ReplicaSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1451)
-		} // end switch yys1451
-	} // end for yyj1451
+			z.DecStructFieldNotFound(-1, yys1405)
+		} // end switch yys1405
+	} // end for yyj1405
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -17429,16 +16811,16 @@ func (x *ReplicaSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1458 int
-	var yyb1458 bool
-	var yyhl1458 bool = l >= 0
-	yyj1458++
-	if yyhl1458 {
-		yyb1458 = yyj1458 > l
+	var yyj1412 int
+	var yyb1412 bool
+	var yyhl1412 bool = l >= 0
+	yyj1412++
+	if yyhl1412 {
+		yyb1412 = yyj1412 > l
 	} else {
-		yyb1458 = r.CheckBreak()
+		yyb1412 = r.CheckBreak()
 	}
-	if yyb1458 {
+	if yyb1412 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -17446,22 +16828,22 @@ func (x *ReplicaSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv1459 := &x.ListMeta
-		yym1460 := z.DecBinary()
-		_ = yym1460
+		yyv1413 := &x.ListMeta
+		yym1414 := z.DecBinary()
+		_ = yym1414
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1459) {
+		} else if z.HasExtensions() && z.DecExt(yyv1413) {
 		} else {
-			z.DecFallback(yyv1459, false)
+			z.DecFallback(yyv1413, false)
 		}
 	}
-	yyj1458++
-	if yyhl1458 {
-		yyb1458 = yyj1458 > l
+	yyj1412++
+	if yyhl1412 {
+		yyb1412 = yyj1412 > l
 	} else {
-		yyb1458 = r.CheckBreak()
+		yyb1412 = r.CheckBreak()
 	}
-	if yyb1458 {
+	if yyb1412 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -17469,21 +16851,21 @@ func (x *ReplicaSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv1461 := &x.Items
-		yym1462 := z.DecBinary()
-		_ = yym1462
+		yyv1415 := &x.Items
+		yym1416 := z.DecBinary()
+		_ = yym1416
 		if false {
 		} else {
-			h.decSliceReplicaSet((*[]ReplicaSet)(yyv1461), d)
+			h.decSliceReplicaSet((*[]ReplicaSet)(yyv1415), d)
 		}
 	}
-	yyj1458++
-	if yyhl1458 {
-		yyb1458 = yyj1458 > l
+	yyj1412++
+	if yyhl1412 {
+		yyb1412 = yyj1412 > l
 	} else {
-		yyb1458 = r.CheckBreak()
+		yyb1412 = r.CheckBreak()
 	}
-	if yyb1458 {
+	if yyb1412 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -17493,13 +16875,13 @@ func (x *ReplicaSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1458++
-	if yyhl1458 {
-		yyb1458 = yyj1458 > l
+	yyj1412++
+	if yyhl1412 {
+		yyb1412 = yyj1412 > l
 	} else {
-		yyb1458 = r.CheckBreak()
+		yyb1412 = r.CheckBreak()
 	}
-	if yyb1458 {
+	if yyb1412 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -17510,17 +16892,17 @@ func (x *ReplicaSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIVersion = string(r.DecodeString())
 	}
 	for {
-		yyj1458++
-		if yyhl1458 {
-			yyb1458 = yyj1458 > l
+		yyj1412++
+		if yyhl1412 {
+			yyb1412 = yyj1412 > l
 		} else {
-			yyb1458 = r.CheckBreak()
+			yyb1412 = r.CheckBreak()
 		}
-		if yyb1458 {
+		if yyb1412 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1458-1, "")
+		z.DecStructFieldNotFound(yyj1412-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -17532,70 +16914,70 @@ func (x *ReplicaSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1465 := z.EncBinary()
-		_ = yym1465
+		yym1419 := z.EncBinary()
+		_ = yym1419
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1466 := !z.EncBinary()
-			yy2arr1466 := z.EncBasicHandle().StructToArray
-			var yyq1466 [3]bool
-			_, _, _ = yysep1466, yyq1466, yy2arr1466
-			const yyr1466 bool = false
-			yyq1466[0] = x.Replicas != nil
-			yyq1466[1] = x.Selector != nil
-			yyq1466[2] = x.Template != nil
-			var yynn1466 int
-			if yyr1466 || yy2arr1466 {
+			yysep1420 := !z.EncBinary()
+			yy2arr1420 := z.EncBasicHandle().StructToArray
+			var yyq1420 [3]bool
+			_, _, _ = yysep1420, yyq1420, yy2arr1420
+			const yyr1420 bool = false
+			yyq1420[0] = x.Replicas != nil
+			yyq1420[1] = x.Selector != nil
+			yyq1420[2] = x.Template != nil
+			var yynn1420 int
+			if yyr1420 || yy2arr1420 {
 				r.EncodeArrayStart(3)
 			} else {
-				yynn1466 = 0
-				for _, b := range yyq1466 {
+				yynn1420 = 0
+				for _, b := range yyq1420 {
 					if b {
-						yynn1466++
+						yynn1420++
 					}
 				}
-				r.EncodeMapStart(yynn1466)
-				yynn1466 = 0
+				r.EncodeMapStart(yynn1420)
+				yynn1420 = 0
 			}
-			if yyr1466 || yy2arr1466 {
+			if yyr1420 || yy2arr1420 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1466[0] {
+				if yyq1420[0] {
 					if x.Replicas == nil {
 						r.EncodeNil()
 					} else {
-						yy1468 := *x.Replicas
-						yym1469 := z.EncBinary()
-						_ = yym1469
+						yy1422 := *x.Replicas
+						yym1423 := z.EncBinary()
+						_ = yym1423
 						if false {
 						} else {
-							r.EncodeInt(int64(yy1468))
+							r.EncodeInt(int64(yy1422))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1466[0] {
+				if yyq1420[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("replicas"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Replicas == nil {
 						r.EncodeNil()
 					} else {
-						yy1470 := *x.Replicas
-						yym1471 := z.EncBinary()
-						_ = yym1471
+						yy1424 := *x.Replicas
+						yym1425 := z.EncBinary()
+						_ = yym1425
 						if false {
 						} else {
-							r.EncodeInt(int64(yy1470))
+							r.EncodeInt(int64(yy1424))
 						}
 					}
 				}
 			}
-			if yyr1466 || yy2arr1466 {
+			if yyr1420 || yy2arr1420 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1466[1] {
+				if yyq1420[1] {
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
@@ -17605,7 +16987,7 @@ func (x *ReplicaSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1466[1] {
+				if yyq1420[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
@@ -17616,9 +16998,9 @@ func (x *ReplicaSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1466 || yy2arr1466 {
+			if yyr1420 || yy2arr1420 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1466[2] {
+				if yyq1420[2] {
 					if x.Template == nil {
 						r.EncodeNil()
 					} else {
@@ -17628,7 +17010,7 @@ func (x *ReplicaSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1466[2] {
+				if yyq1420[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("template"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
@@ -17639,7 +17021,7 @@ func (x *ReplicaSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1466 || yy2arr1466 {
+			if yyr1420 || yy2arr1420 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -17652,25 +17034,25 @@ func (x *ReplicaSetSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1474 := z.DecBinary()
-	_ = yym1474
+	yym1428 := z.DecBinary()
+	_ = yym1428
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1475 := r.ContainerType()
-		if yyct1475 == codecSelferValueTypeMap1234 {
-			yyl1475 := r.ReadMapStart()
-			if yyl1475 == 0 {
+		yyct1429 := r.ContainerType()
+		if yyct1429 == codecSelferValueTypeMap1234 {
+			yyl1429 := r.ReadMapStart()
+			if yyl1429 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1475, d)
+				x.codecDecodeSelfFromMap(yyl1429, d)
 			}
-		} else if yyct1475 == codecSelferValueTypeArray1234 {
-			yyl1475 := r.ReadArrayStart()
-			if yyl1475 == 0 {
+		} else if yyct1429 == codecSelferValueTypeArray1234 {
+			yyl1429 := r.ReadArrayStart()
+			if yyl1429 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1475, d)
+				x.codecDecodeSelfFromArray(yyl1429, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -17682,12 +17064,12 @@ func (x *ReplicaSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1476Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1476Slc
-	var yyhl1476 bool = l >= 0
-	for yyj1476 := 0; ; yyj1476++ {
-		if yyhl1476 {
-			if yyj1476 >= l {
+	var yys1430Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1430Slc
+	var yyhl1430 bool = l >= 0
+	for yyj1430 := 0; ; yyj1430++ {
+		if yyhl1430 {
+			if yyj1430 >= l {
 				break
 			}
 		} else {
@@ -17696,10 +17078,10 @@ func (x *ReplicaSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1476Slc = r.DecodeBytes(yys1476Slc, true, true)
-		yys1476 := string(yys1476Slc)
+		yys1430Slc = r.DecodeBytes(yys1430Slc, true, true)
+		yys1430 := string(yys1430Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1476 {
+		switch yys1430 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
 				if x.Replicas != nil {
@@ -17709,8 +17091,8 @@ func (x *ReplicaSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Replicas == nil {
 					x.Replicas = new(int32)
 				}
-				yym1478 := z.DecBinary()
-				_ = yym1478
+				yym1432 := z.DecBinary()
+				_ = yym1432
 				if false {
 				} else {
 					*((*int32)(x.Replicas)) = int32(r.DecodeInt(32))
@@ -17739,9 +17121,9 @@ func (x *ReplicaSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Template.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1476)
-		} // end switch yys1476
-	} // end for yyj1476
+			z.DecStructFieldNotFound(-1, yys1430)
+		} // end switch yys1430
+	} // end for yyj1430
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -17749,16 +17131,16 @@ func (x *ReplicaSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1481 int
-	var yyb1481 bool
-	var yyhl1481 bool = l >= 0
-	yyj1481++
-	if yyhl1481 {
-		yyb1481 = yyj1481 > l
+	var yyj1435 int
+	var yyb1435 bool
+	var yyhl1435 bool = l >= 0
+	yyj1435++
+	if yyhl1435 {
+		yyb1435 = yyj1435 > l
 	} else {
-		yyb1481 = r.CheckBreak()
+		yyb1435 = r.CheckBreak()
 	}
-	if yyb1481 {
+	if yyb1435 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -17771,20 +17153,20 @@ func (x *ReplicaSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.Replicas == nil {
 			x.Replicas = new(int32)
 		}
-		yym1483 := z.DecBinary()
-		_ = yym1483
+		yym1437 := z.DecBinary()
+		_ = yym1437
 		if false {
 		} else {
 			*((*int32)(x.Replicas)) = int32(r.DecodeInt(32))
 		}
 	}
-	yyj1481++
-	if yyhl1481 {
-		yyb1481 = yyj1481 > l
+	yyj1435++
+	if yyhl1435 {
+		yyb1435 = yyj1435 > l
 	} else {
-		yyb1481 = r.CheckBreak()
+		yyb1435 = r.CheckBreak()
 	}
-	if yyb1481 {
+	if yyb1435 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -17799,13 +17181,13 @@ func (x *ReplicaSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Selector.CodecDecodeSelf(d)
 	}
-	yyj1481++
-	if yyhl1481 {
-		yyb1481 = yyj1481 > l
+	yyj1435++
+	if yyhl1435 {
+		yyb1435 = yyj1435 > l
 	} else {
-		yyb1481 = r.CheckBreak()
+		yyb1435 = r.CheckBreak()
 	}
-	if yyb1481 {
+	if yyb1435 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -17821,17 +17203,17 @@ func (x *ReplicaSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Template.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1481++
-		if yyhl1481 {
-			yyb1481 = yyj1481 > l
+		yyj1435++
+		if yyhl1435 {
+			yyb1435 = yyj1435 > l
 		} else {
-			yyb1481 = r.CheckBreak()
+			yyb1435 = r.CheckBreak()
 		}
-		if yyb1481 {
+		if yyb1435 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1481-1, "")
+		z.DecStructFieldNotFound(yyj1435-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -17843,34 +17225,34 @@ func (x *ReplicaSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1486 := z.EncBinary()
-		_ = yym1486
+		yym1440 := z.EncBinary()
+		_ = yym1440
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1487 := !z.EncBinary()
-			yy2arr1487 := z.EncBasicHandle().StructToArray
-			var yyq1487 [2]bool
-			_, _, _ = yysep1487, yyq1487, yy2arr1487
-			const yyr1487 bool = false
-			yyq1487[1] = x.ObservedGeneration != 0
-			var yynn1487 int
-			if yyr1487 || yy2arr1487 {
+			yysep1441 := !z.EncBinary()
+			yy2arr1441 := z.EncBasicHandle().StructToArray
+			var yyq1441 [2]bool
+			_, _, _ = yysep1441, yyq1441, yy2arr1441
+			const yyr1441 bool = false
+			yyq1441[1] = x.ObservedGeneration != 0
+			var yynn1441 int
+			if yyr1441 || yy2arr1441 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn1487 = 1
-				for _, b := range yyq1487 {
+				yynn1441 = 1
+				for _, b := range yyq1441 {
 					if b {
-						yynn1487++
+						yynn1441++
 					}
 				}
-				r.EncodeMapStart(yynn1487)
-				yynn1487 = 0
+				r.EncodeMapStart(yynn1441)
+				yynn1441 = 0
 			}
-			if yyr1487 || yy2arr1487 {
+			if yyr1441 || yy2arr1441 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1489 := z.EncBinary()
-				_ = yym1489
+				yym1443 := z.EncBinary()
+				_ = yym1443
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Replicas))
@@ -17879,18 +17261,18 @@ func (x *ReplicaSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("replicas"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1490 := z.EncBinary()
-				_ = yym1490
+				yym1444 := z.EncBinary()
+				_ = yym1444
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Replicas))
 				}
 			}
-			if yyr1487 || yy2arr1487 {
+			if yyr1441 || yy2arr1441 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1487[1] {
-					yym1492 := z.EncBinary()
-					_ = yym1492
+				if yyq1441[1] {
+					yym1446 := z.EncBinary()
+					_ = yym1446
 					if false {
 					} else {
 						r.EncodeInt(int64(x.ObservedGeneration))
@@ -17899,19 +17281,19 @@ func (x *ReplicaSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq1487[1] {
+				if yyq1441[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("observedGeneration"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1493 := z.EncBinary()
-					_ = yym1493
+					yym1447 := z.EncBinary()
+					_ = yym1447
 					if false {
 					} else {
 						r.EncodeInt(int64(x.ObservedGeneration))
 					}
 				}
 			}
-			if yyr1487 || yy2arr1487 {
+			if yyr1441 || yy2arr1441 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -17924,25 +17306,25 @@ func (x *ReplicaSetStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1494 := z.DecBinary()
-	_ = yym1494
+	yym1448 := z.DecBinary()
+	_ = yym1448
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1495 := r.ContainerType()
-		if yyct1495 == codecSelferValueTypeMap1234 {
-			yyl1495 := r.ReadMapStart()
-			if yyl1495 == 0 {
+		yyct1449 := r.ContainerType()
+		if yyct1449 == codecSelferValueTypeMap1234 {
+			yyl1449 := r.ReadMapStart()
+			if yyl1449 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1495, d)
+				x.codecDecodeSelfFromMap(yyl1449, d)
 			}
-		} else if yyct1495 == codecSelferValueTypeArray1234 {
-			yyl1495 := r.ReadArrayStart()
-			if yyl1495 == 0 {
+		} else if yyct1449 == codecSelferValueTypeArray1234 {
+			yyl1449 := r.ReadArrayStart()
+			if yyl1449 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1495, d)
+				x.codecDecodeSelfFromArray(yyl1449, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -17954,12 +17336,12 @@ func (x *ReplicaSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1496Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1496Slc
-	var yyhl1496 bool = l >= 0
-	for yyj1496 := 0; ; yyj1496++ {
-		if yyhl1496 {
-			if yyj1496 >= l {
+	var yys1450Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1450Slc
+	var yyhl1450 bool = l >= 0
+	for yyj1450 := 0; ; yyj1450++ {
+		if yyhl1450 {
+			if yyj1450 >= l {
 				break
 			}
 		} else {
@@ -17968,10 +17350,10 @@ func (x *ReplicaSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1496Slc = r.DecodeBytes(yys1496Slc, true, true)
-		yys1496 := string(yys1496Slc)
+		yys1450Slc = r.DecodeBytes(yys1450Slc, true, true)
+		yys1450 := string(yys1450Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1496 {
+		switch yys1450 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
 				x.Replicas = 0
@@ -17985,9 +17367,9 @@ func (x *ReplicaSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.ObservedGeneration = int64(r.DecodeInt(64))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1496)
-		} // end switch yys1496
-	} // end for yyj1496
+			z.DecStructFieldNotFound(-1, yys1450)
+		} // end switch yys1450
+	} // end for yyj1450
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -17995,16 +17377,16 @@ func (x *ReplicaSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1499 int
-	var yyb1499 bool
-	var yyhl1499 bool = l >= 0
-	yyj1499++
-	if yyhl1499 {
-		yyb1499 = yyj1499 > l
+	var yyj1453 int
+	var yyb1453 bool
+	var yyhl1453 bool = l >= 0
+	yyj1453++
+	if yyhl1453 {
+		yyb1453 = yyj1453 > l
 	} else {
-		yyb1499 = r.CheckBreak()
+		yyb1453 = r.CheckBreak()
 	}
-	if yyb1499 {
+	if yyb1453 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -18014,13 +17396,13 @@ func (x *ReplicaSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Replicas = int32(r.DecodeInt(32))
 	}
-	yyj1499++
-	if yyhl1499 {
-		yyb1499 = yyj1499 > l
+	yyj1453++
+	if yyhl1453 {
+		yyb1453 = yyj1453 > l
 	} else {
-		yyb1499 = r.CheckBreak()
+		yyb1453 = r.CheckBreak()
 	}
-	if yyb1499 {
+	if yyb1453 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -18031,17 +17413,17 @@ func (x *ReplicaSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		x.ObservedGeneration = int64(r.DecodeInt(64))
 	}
 	for {
-		yyj1499++
-		if yyhl1499 {
-			yyb1499 = yyj1499 > l
+		yyj1453++
+		if yyhl1453 {
+			yyb1453 = yyj1453 > l
 		} else {
-			yyb1499 = r.CheckBreak()
+			yyb1453 = r.CheckBreak()
 		}
-		if yyb1499 {
+		if yyb1453 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1499-1, "")
+		z.DecStructFieldNotFound(yyj1453-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -18053,72 +17435,72 @@ func (x *PodSecurityPolicy) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1502 := z.EncBinary()
-		_ = yym1502
+		yym1456 := z.EncBinary()
+		_ = yym1456
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1503 := !z.EncBinary()
-			yy2arr1503 := z.EncBasicHandle().StructToArray
-			var yyq1503 [4]bool
-			_, _, _ = yysep1503, yyq1503, yy2arr1503
-			const yyr1503 bool = false
-			yyq1503[0] = true
-			yyq1503[1] = true
-			yyq1503[2] = x.Kind != ""
-			yyq1503[3] = x.APIVersion != ""
-			var yynn1503 int
-			if yyr1503 || yy2arr1503 {
+			yysep1457 := !z.EncBinary()
+			yy2arr1457 := z.EncBasicHandle().StructToArray
+			var yyq1457 [4]bool
+			_, _, _ = yysep1457, yyq1457, yy2arr1457
+			const yyr1457 bool = false
+			yyq1457[0] = true
+			yyq1457[1] = true
+			yyq1457[2] = x.Kind != ""
+			yyq1457[3] = x.APIVersion != ""
+			var yynn1457 int
+			if yyr1457 || yy2arr1457 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn1503 = 0
-				for _, b := range yyq1503 {
+				yynn1457 = 0
+				for _, b := range yyq1457 {
 					if b {
-						yynn1503++
+						yynn1457++
 					}
 				}
-				r.EncodeMapStart(yynn1503)
-				yynn1503 = 0
+				r.EncodeMapStart(yynn1457)
+				yynn1457 = 0
 			}
-			if yyr1503 || yy2arr1503 {
+			if yyr1457 || yy2arr1457 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1503[0] {
-					yy1505 := &x.ObjectMeta
-					yy1505.CodecEncodeSelf(e)
+				if yyq1457[0] {
+					yy1459 := &x.ObjectMeta
+					yy1459.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1503[0] {
+				if yyq1457[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1506 := &x.ObjectMeta
-					yy1506.CodecEncodeSelf(e)
+					yy1460 := &x.ObjectMeta
+					yy1460.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1503 || yy2arr1503 {
+			if yyr1457 || yy2arr1457 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1503[1] {
-					yy1508 := &x.Spec
-					yy1508.CodecEncodeSelf(e)
+				if yyq1457[1] {
+					yy1462 := &x.Spec
+					yy1462.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1503[1] {
+				if yyq1457[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1509 := &x.Spec
-					yy1509.CodecEncodeSelf(e)
+					yy1463 := &x.Spec
+					yy1463.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1503 || yy2arr1503 {
+			if yyr1457 || yy2arr1457 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1503[2] {
-					yym1511 := z.EncBinary()
-					_ = yym1511
+				if yyq1457[2] {
+					yym1465 := z.EncBinary()
+					_ = yym1465
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -18127,23 +17509,23 @@ func (x *PodSecurityPolicy) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1503[2] {
+				if yyq1457[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1512 := z.EncBinary()
-					_ = yym1512
+					yym1466 := z.EncBinary()
+					_ = yym1466
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1503 || yy2arr1503 {
+			if yyr1457 || yy2arr1457 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1503[3] {
-					yym1514 := z.EncBinary()
-					_ = yym1514
+				if yyq1457[3] {
+					yym1468 := z.EncBinary()
+					_ = yym1468
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -18152,19 +17534,19 @@ func (x *PodSecurityPolicy) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1503[3] {
+				if yyq1457[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1515 := z.EncBinary()
-					_ = yym1515
+					yym1469 := z.EncBinary()
+					_ = yym1469
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1503 || yy2arr1503 {
+			if yyr1457 || yy2arr1457 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -18177,25 +17559,25 @@ func (x *PodSecurityPolicy) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1516 := z.DecBinary()
-	_ = yym1516
+	yym1470 := z.DecBinary()
+	_ = yym1470
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1517 := r.ContainerType()
-		if yyct1517 == codecSelferValueTypeMap1234 {
-			yyl1517 := r.ReadMapStart()
-			if yyl1517 == 0 {
+		yyct1471 := r.ContainerType()
+		if yyct1471 == codecSelferValueTypeMap1234 {
+			yyl1471 := r.ReadMapStart()
+			if yyl1471 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1517, d)
+				x.codecDecodeSelfFromMap(yyl1471, d)
 			}
-		} else if yyct1517 == codecSelferValueTypeArray1234 {
-			yyl1517 := r.ReadArrayStart()
-			if yyl1517 == 0 {
+		} else if yyct1471 == codecSelferValueTypeArray1234 {
+			yyl1471 := r.ReadArrayStart()
+			if yyl1471 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1517, d)
+				x.codecDecodeSelfFromArray(yyl1471, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -18207,12 +17589,12 @@ func (x *PodSecurityPolicy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1518Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1518Slc
-	var yyhl1518 bool = l >= 0
-	for yyj1518 := 0; ; yyj1518++ {
-		if yyhl1518 {
-			if yyj1518 >= l {
+	var yys1472Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1472Slc
+	var yyhl1472 bool = l >= 0
+	for yyj1472 := 0; ; yyj1472++ {
+		if yyhl1472 {
+			if yyj1472 >= l {
 				break
 			}
 		} else {
@@ -18221,23 +17603,23 @@ func (x *PodSecurityPolicy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1518Slc = r.DecodeBytes(yys1518Slc, true, true)
-		yys1518 := string(yys1518Slc)
+		yys1472Slc = r.DecodeBytes(yys1472Slc, true, true)
+		yys1472 := string(yys1472Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1518 {
+		switch yys1472 {
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_v1.ObjectMeta{}
 			} else {
-				yyv1519 := &x.ObjectMeta
-				yyv1519.CodecDecodeSelf(d)
+				yyv1473 := &x.ObjectMeta
+				yyv1473.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = PodSecurityPolicySpec{}
 			} else {
-				yyv1520 := &x.Spec
-				yyv1520.CodecDecodeSelf(d)
+				yyv1474 := &x.Spec
+				yyv1474.CodecDecodeSelf(d)
 			}
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -18252,9 +17634,9 @@ func (x *PodSecurityPolicy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				x.APIVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1518)
-		} // end switch yys1518
-	} // end for yyj1518
+			z.DecStructFieldNotFound(-1, yys1472)
+		} // end switch yys1472
+	} // end for yyj1472
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -18262,16 +17644,16 @@ func (x *PodSecurityPolicy) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1523 int
-	var yyb1523 bool
-	var yyhl1523 bool = l >= 0
-	yyj1523++
-	if yyhl1523 {
-		yyb1523 = yyj1523 > l
+	var yyj1477 int
+	var yyb1477 bool
+	var yyhl1477 bool = l >= 0
+	yyj1477++
+	if yyhl1477 {
+		yyb1477 = yyj1477 > l
 	} else {
-		yyb1523 = r.CheckBreak()
+		yyb1477 = r.CheckBreak()
 	}
-	if yyb1523 {
+	if yyb1477 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -18279,16 +17661,16 @@ func (x *PodSecurityPolicy) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_v1.ObjectMeta{}
 	} else {
-		yyv1524 := &x.ObjectMeta
-		yyv1524.CodecDecodeSelf(d)
+		yyv1478 := &x.ObjectMeta
+		yyv1478.CodecDecodeSelf(d)
 	}
-	yyj1523++
-	if yyhl1523 {
-		yyb1523 = yyj1523 > l
+	yyj1477++
+	if yyhl1477 {
+		yyb1477 = yyj1477 > l
 	} else {
-		yyb1523 = r.CheckBreak()
+		yyb1477 = r.CheckBreak()
 	}
-	if yyb1523 {
+	if yyb1477 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -18296,16 +17678,16 @@ func (x *PodSecurityPolicy) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	if r.TryDecodeAsNil() {
 		x.Spec = PodSecurityPolicySpec{}
 	} else {
-		yyv1525 := &x.Spec
-		yyv1525.CodecDecodeSelf(d)
+		yyv1479 := &x.Spec
+		yyv1479.CodecDecodeSelf(d)
 	}
-	yyj1523++
-	if yyhl1523 {
-		yyb1523 = yyj1523 > l
+	yyj1477++
+	if yyhl1477 {
+		yyb1477 = yyj1477 > l
 	} else {
-		yyb1523 = r.CheckBreak()
+		yyb1477 = r.CheckBreak()
 	}
-	if yyb1523 {
+	if yyb1477 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -18315,13 +17697,13 @@ func (x *PodSecurityPolicy) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1523++
-	if yyhl1523 {
-		yyb1523 = yyj1523 > l
+	yyj1477++
+	if yyhl1477 {
+		yyb1477 = yyj1477 > l
 	} else {
-		yyb1523 = r.CheckBreak()
+		yyb1477 = r.CheckBreak()
 	}
-	if yyb1523 {
+	if yyb1477 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -18332,17 +17714,17 @@ func (x *PodSecurityPolicy) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 		x.APIVersion = string(r.DecodeString())
 	}
 	for {
-		yyj1523++
-		if yyhl1523 {
-			yyb1523 = yyj1523 > l
+		yyj1477++
+		if yyhl1477 {
+			yyb1477 = yyj1477 > l
 		} else {
-			yyb1523 = r.CheckBreak()
+			yyb1477 = r.CheckBreak()
 		}
-		if yyb1523 {
+		if yyb1477 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1523-1, "")
+		z.DecStructFieldNotFound(yyj1477-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -18354,43 +17736,43 @@ func (x *PodSecurityPolicySpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1528 := z.EncBinary()
-		_ = yym1528
+		yym1482 := z.EncBinary()
+		_ = yym1482
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1529 := !z.EncBinary()
-			yy2arr1529 := z.EncBasicHandle().StructToArray
-			var yyq1529 [9]bool
-			_, _, _ = yysep1529, yyq1529, yy2arr1529
-			const yyr1529 bool = false
-			yyq1529[0] = x.Privileged != false
-			yyq1529[1] = len(x.Capabilities) != 0
-			yyq1529[2] = len(x.Volumes) != 0
-			yyq1529[3] = x.HostNetwork != false
-			yyq1529[4] = len(x.HostPorts) != 0
-			yyq1529[5] = x.HostPID != false
-			yyq1529[6] = x.HostIPC != false
-			yyq1529[7] = true
-			yyq1529[8] = true
-			var yynn1529 int
-			if yyr1529 || yy2arr1529 {
+			yysep1483 := !z.EncBinary()
+			yy2arr1483 := z.EncBasicHandle().StructToArray
+			var yyq1483 [9]bool
+			_, _, _ = yysep1483, yyq1483, yy2arr1483
+			const yyr1483 bool = false
+			yyq1483[0] = x.Privileged != false
+			yyq1483[1] = len(x.Capabilities) != 0
+			yyq1483[2] = len(x.Volumes) != 0
+			yyq1483[3] = x.HostNetwork != false
+			yyq1483[4] = len(x.HostPorts) != 0
+			yyq1483[5] = x.HostPID != false
+			yyq1483[6] = x.HostIPC != false
+			yyq1483[7] = true
+			yyq1483[8] = true
+			var yynn1483 int
+			if yyr1483 || yy2arr1483 {
 				r.EncodeArrayStart(9)
 			} else {
-				yynn1529 = 0
-				for _, b := range yyq1529 {
+				yynn1483 = 0
+				for _, b := range yyq1483 {
 					if b {
-						yynn1529++
+						yynn1483++
 					}
 				}
-				r.EncodeMapStart(yynn1529)
-				yynn1529 = 0
+				r.EncodeMapStart(yynn1483)
+				yynn1483 = 0
 			}
-			if yyr1529 || yy2arr1529 {
+			if yyr1483 || yy2arr1483 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1529[0] {
-					yym1531 := z.EncBinary()
-					_ = yym1531
+				if yyq1483[0] {
+					yym1485 := z.EncBinary()
+					_ = yym1485
 					if false {
 					} else {
 						r.EncodeBool(bool(x.Privileged))
@@ -18399,26 +17781,26 @@ func (x *PodSecurityPolicySpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq1529[0] {
+				if yyq1483[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("privileged"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1532 := z.EncBinary()
-					_ = yym1532
+					yym1486 := z.EncBinary()
+					_ = yym1486
 					if false {
 					} else {
 						r.EncodeBool(bool(x.Privileged))
 					}
 				}
 			}
-			if yyr1529 || yy2arr1529 {
+			if yyr1483 || yy2arr1483 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1529[1] {
+				if yyq1483[1] {
 					if x.Capabilities == nil {
 						r.EncodeNil()
 					} else {
-						yym1534 := z.EncBinary()
-						_ = yym1534
+						yym1488 := z.EncBinary()
+						_ = yym1488
 						if false {
 						} else {
 							h.encSlicev1_Capability(([]pkg2_v1.Capability)(x.Capabilities), e)
@@ -18428,15 +17810,15 @@ func (x *PodSecurityPolicySpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1529[1] {
+				if yyq1483[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("capabilities"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Capabilities == nil {
 						r.EncodeNil()
 					} else {
-						yym1535 := z.EncBinary()
-						_ = yym1535
+						yym1489 := z.EncBinary()
+						_ = yym1489
 						if false {
 						} else {
 							h.encSlicev1_Capability(([]pkg2_v1.Capability)(x.Capabilities), e)
@@ -18444,14 +17826,14 @@ func (x *PodSecurityPolicySpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1529 || yy2arr1529 {
+			if yyr1483 || yy2arr1483 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1529[2] {
+				if yyq1483[2] {
 					if x.Volumes == nil {
 						r.EncodeNil()
 					} else {
-						yym1537 := z.EncBinary()
-						_ = yym1537
+						yym1491 := z.EncBinary()
+						_ = yym1491
 						if false {
 						} else {
 							h.encSliceFSType(([]FSType)(x.Volumes), e)
@@ -18461,15 +17843,15 @@ func (x *PodSecurityPolicySpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1529[2] {
+				if yyq1483[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("volumes"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.Volumes == nil {
 						r.EncodeNil()
 					} else {
-						yym1538 := z.EncBinary()
-						_ = yym1538
+						yym1492 := z.EncBinary()
+						_ = yym1492
 						if false {
 						} else {
 							h.encSliceFSType(([]FSType)(x.Volumes), e)
@@ -18477,11 +17859,11 @@ func (x *PodSecurityPolicySpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1529 || yy2arr1529 {
+			if yyr1483 || yy2arr1483 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1529[3] {
-					yym1540 := z.EncBinary()
-					_ = yym1540
+				if yyq1483[3] {
+					yym1494 := z.EncBinary()
+					_ = yym1494
 					if false {
 					} else {
 						r.EncodeBool(bool(x.HostNetwork))
@@ -18490,26 +17872,26 @@ func (x *PodSecurityPolicySpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq1529[3] {
+				if yyq1483[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hostNetwork"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1541 := z.EncBinary()
-					_ = yym1541
+					yym1495 := z.EncBinary()
+					_ = yym1495
 					if false {
 					} else {
 						r.EncodeBool(bool(x.HostNetwork))
 					}
 				}
 			}
-			if yyr1529 || yy2arr1529 {
+			if yyr1483 || yy2arr1483 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1529[4] {
+				if yyq1483[4] {
 					if x.HostPorts == nil {
 						r.EncodeNil()
 					} else {
-						yym1543 := z.EncBinary()
-						_ = yym1543
+						yym1497 := z.EncBinary()
+						_ = yym1497
 						if false {
 						} else {
 							h.encSliceHostPortRange(([]HostPortRange)(x.HostPorts), e)
@@ -18519,15 +17901,15 @@ func (x *PodSecurityPolicySpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1529[4] {
+				if yyq1483[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hostPorts"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.HostPorts == nil {
 						r.EncodeNil()
 					} else {
-						yym1544 := z.EncBinary()
-						_ = yym1544
+						yym1498 := z.EncBinary()
+						_ = yym1498
 						if false {
 						} else {
 							h.encSliceHostPortRange(([]HostPortRange)(x.HostPorts), e)
@@ -18535,11 +17917,11 @@ func (x *PodSecurityPolicySpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1529 || yy2arr1529 {
+			if yyr1483 || yy2arr1483 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1529[5] {
-					yym1546 := z.EncBinary()
-					_ = yym1546
+				if yyq1483[5] {
+					yym1500 := z.EncBinary()
+					_ = yym1500
 					if false {
 					} else {
 						r.EncodeBool(bool(x.HostPID))
@@ -18548,23 +17930,23 @@ func (x *PodSecurityPolicySpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq1529[5] {
+				if yyq1483[5] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hostPID"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1547 := z.EncBinary()
-					_ = yym1547
+					yym1501 := z.EncBinary()
+					_ = yym1501
 					if false {
 					} else {
 						r.EncodeBool(bool(x.HostPID))
 					}
 				}
 			}
-			if yyr1529 || yy2arr1529 {
+			if yyr1483 || yy2arr1483 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1529[6] {
-					yym1549 := z.EncBinary()
-					_ = yym1549
+				if yyq1483[6] {
+					yym1503 := z.EncBinary()
+					_ = yym1503
 					if false {
 					} else {
 						r.EncodeBool(bool(x.HostIPC))
@@ -18573,53 +17955,53 @@ func (x *PodSecurityPolicySpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq1529[6] {
+				if yyq1483[6] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("hostIPC"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1550 := z.EncBinary()
-					_ = yym1550
+					yym1504 := z.EncBinary()
+					_ = yym1504
 					if false {
 					} else {
 						r.EncodeBool(bool(x.HostIPC))
 					}
 				}
 			}
-			if yyr1529 || yy2arr1529 {
+			if yyr1483 || yy2arr1483 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1529[7] {
-					yy1552 := &x.SELinuxContext
-					yy1552.CodecEncodeSelf(e)
+				if yyq1483[7] {
+					yy1506 := &x.SELinuxContext
+					yy1506.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1529[7] {
+				if yyq1483[7] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("seLinuxContext"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1553 := &x.SELinuxContext
-					yy1553.CodecEncodeSelf(e)
+					yy1507 := &x.SELinuxContext
+					yy1507.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1529 || yy2arr1529 {
+			if yyr1483 || yy2arr1483 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1529[8] {
-					yy1555 := &x.RunAsUser
-					yy1555.CodecEncodeSelf(e)
+				if yyq1483[8] {
+					yy1509 := &x.RunAsUser
+					yy1509.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1529[8] {
+				if yyq1483[8] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("runAsUser"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1556 := &x.RunAsUser
-					yy1556.CodecEncodeSelf(e)
+					yy1510 := &x.RunAsUser
+					yy1510.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1529 || yy2arr1529 {
+			if yyr1483 || yy2arr1483 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -18632,25 +18014,25 @@ func (x *PodSecurityPolicySpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1557 := z.DecBinary()
-	_ = yym1557
+	yym1511 := z.DecBinary()
+	_ = yym1511
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1558 := r.ContainerType()
-		if yyct1558 == codecSelferValueTypeMap1234 {
-			yyl1558 := r.ReadMapStart()
-			if yyl1558 == 0 {
+		yyct1512 := r.ContainerType()
+		if yyct1512 == codecSelferValueTypeMap1234 {
+			yyl1512 := r.ReadMapStart()
+			if yyl1512 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1558, d)
+				x.codecDecodeSelfFromMap(yyl1512, d)
 			}
-		} else if yyct1558 == codecSelferValueTypeArray1234 {
-			yyl1558 := r.ReadArrayStart()
-			if yyl1558 == 0 {
+		} else if yyct1512 == codecSelferValueTypeArray1234 {
+			yyl1512 := r.ReadArrayStart()
+			if yyl1512 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1558, d)
+				x.codecDecodeSelfFromArray(yyl1512, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -18662,12 +18044,12 @@ func (x *PodSecurityPolicySpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1559Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1559Slc
-	var yyhl1559 bool = l >= 0
-	for yyj1559 := 0; ; yyj1559++ {
-		if yyhl1559 {
-			if yyj1559 >= l {
+	var yys1513Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1513Slc
+	var yyhl1513 bool = l >= 0
+	for yyj1513 := 0; ; yyj1513++ {
+		if yyhl1513 {
+			if yyj1513 >= l {
 				break
 			}
 		} else {
@@ -18676,10 +18058,10 @@ func (x *PodSecurityPolicySpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1559Slc = r.DecodeBytes(yys1559Slc, true, true)
-		yys1559 := string(yys1559Slc)
+		yys1513Slc = r.DecodeBytes(yys1513Slc, true, true)
+		yys1513 := string(yys1513Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1559 {
+		switch yys1513 {
 		case "privileged":
 			if r.TryDecodeAsNil() {
 				x.Privileged = false
@@ -18690,24 +18072,24 @@ func (x *PodSecurityPolicySpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			if r.TryDecodeAsNil() {
 				x.Capabilities = nil
 			} else {
-				yyv1561 := &x.Capabilities
-				yym1562 := z.DecBinary()
-				_ = yym1562
+				yyv1515 := &x.Capabilities
+				yym1516 := z.DecBinary()
+				_ = yym1516
 				if false {
 				} else {
-					h.decSlicev1_Capability((*[]pkg2_v1.Capability)(yyv1561), d)
+					h.decSlicev1_Capability((*[]pkg2_v1.Capability)(yyv1515), d)
 				}
 			}
 		case "volumes":
 			if r.TryDecodeAsNil() {
 				x.Volumes = nil
 			} else {
-				yyv1563 := &x.Volumes
-				yym1564 := z.DecBinary()
-				_ = yym1564
+				yyv1517 := &x.Volumes
+				yym1518 := z.DecBinary()
+				_ = yym1518
 				if false {
 				} else {
-					h.decSliceFSType((*[]FSType)(yyv1563), d)
+					h.decSliceFSType((*[]FSType)(yyv1517), d)
 				}
 			}
 		case "hostNetwork":
@@ -18720,12 +18102,12 @@ func (x *PodSecurityPolicySpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			if r.TryDecodeAsNil() {
 				x.HostPorts = nil
 			} else {
-				yyv1566 := &x.HostPorts
-				yym1567 := z.DecBinary()
-				_ = yym1567
+				yyv1520 := &x.HostPorts
+				yym1521 := z.DecBinary()
+				_ = yym1521
 				if false {
 				} else {
-					h.decSliceHostPortRange((*[]HostPortRange)(yyv1566), d)
+					h.decSliceHostPortRange((*[]HostPortRange)(yyv1520), d)
 				}
 			}
 		case "hostPID":
@@ -18744,20 +18126,20 @@ func (x *PodSecurityPolicySpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			if r.TryDecodeAsNil() {
 				x.SELinuxContext = SELinuxContextStrategyOptions{}
 			} else {
-				yyv1570 := &x.SELinuxContext
-				yyv1570.CodecDecodeSelf(d)
+				yyv1524 := &x.SELinuxContext
+				yyv1524.CodecDecodeSelf(d)
 			}
 		case "runAsUser":
 			if r.TryDecodeAsNil() {
 				x.RunAsUser = RunAsUserStrategyOptions{}
 			} else {
-				yyv1571 := &x.RunAsUser
-				yyv1571.CodecDecodeSelf(d)
+				yyv1525 := &x.RunAsUser
+				yyv1525.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1559)
-		} // end switch yys1559
-	} // end for yyj1559
+			z.DecStructFieldNotFound(-1, yys1513)
+		} // end switch yys1513
+	} // end for yyj1513
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -18765,16 +18147,16 @@ func (x *PodSecurityPolicySpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1572 int
-	var yyb1572 bool
-	var yyhl1572 bool = l >= 0
-	yyj1572++
-	if yyhl1572 {
-		yyb1572 = yyj1572 > l
+	var yyj1526 int
+	var yyb1526 bool
+	var yyhl1526 bool = l >= 0
+	yyj1526++
+	if yyhl1526 {
+		yyb1526 = yyj1526 > l
 	} else {
-		yyb1572 = r.CheckBreak()
+		yyb1526 = r.CheckBreak()
 	}
-	if yyb1572 {
+	if yyb1526 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -18784,13 +18166,13 @@ func (x *PodSecurityPolicySpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.Privileged = bool(r.DecodeBool())
 	}
-	yyj1572++
-	if yyhl1572 {
-		yyb1572 = yyj1572 > l
+	yyj1526++
+	if yyhl1526 {
+		yyb1526 = yyj1526 > l
 	} else {
-		yyb1572 = r.CheckBreak()
+		yyb1526 = r.CheckBreak()
 	}
-	if yyb1572 {
+	if yyb1526 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -18798,21 +18180,21 @@ func (x *PodSecurityPolicySpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	if r.TryDecodeAsNil() {
 		x.Capabilities = nil
 	} else {
-		yyv1574 := &x.Capabilities
-		yym1575 := z.DecBinary()
-		_ = yym1575
+		yyv1528 := &x.Capabilities
+		yym1529 := z.DecBinary()
+		_ = yym1529
 		if false {
 		} else {
-			h.decSlicev1_Capability((*[]pkg2_v1.Capability)(yyv1574), d)
+			h.decSlicev1_Capability((*[]pkg2_v1.Capability)(yyv1528), d)
 		}
 	}
-	yyj1572++
-	if yyhl1572 {
-		yyb1572 = yyj1572 > l
+	yyj1526++
+	if yyhl1526 {
+		yyb1526 = yyj1526 > l
 	} else {
-		yyb1572 = r.CheckBreak()
+		yyb1526 = r.CheckBreak()
 	}
-	if yyb1572 {
+	if yyb1526 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -18820,21 +18202,21 @@ func (x *PodSecurityPolicySpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	if r.TryDecodeAsNil() {
 		x.Volumes = nil
 	} else {
-		yyv1576 := &x.Volumes
-		yym1577 := z.DecBinary()
-		_ = yym1577
+		yyv1530 := &x.Volumes
+		yym1531 := z.DecBinary()
+		_ = yym1531
 		if false {
 		} else {
-			h.decSliceFSType((*[]FSType)(yyv1576), d)
+			h.decSliceFSType((*[]FSType)(yyv1530), d)
 		}
 	}
-	yyj1572++
-	if yyhl1572 {
-		yyb1572 = yyj1572 > l
+	yyj1526++
+	if yyhl1526 {
+		yyb1526 = yyj1526 > l
 	} else {
-		yyb1572 = r.CheckBreak()
+		yyb1526 = r.CheckBreak()
 	}
-	if yyb1572 {
+	if yyb1526 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -18844,13 +18226,13 @@ func (x *PodSecurityPolicySpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.HostNetwork = bool(r.DecodeBool())
 	}
-	yyj1572++
-	if yyhl1572 {
-		yyb1572 = yyj1572 > l
+	yyj1526++
+	if yyhl1526 {
+		yyb1526 = yyj1526 > l
 	} else {
-		yyb1572 = r.CheckBreak()
+		yyb1526 = r.CheckBreak()
 	}
-	if yyb1572 {
+	if yyb1526 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -18858,21 +18240,21 @@ func (x *PodSecurityPolicySpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	if r.TryDecodeAsNil() {
 		x.HostPorts = nil
 	} else {
-		yyv1579 := &x.HostPorts
-		yym1580 := z.DecBinary()
-		_ = yym1580
+		yyv1533 := &x.HostPorts
+		yym1534 := z.DecBinary()
+		_ = yym1534
 		if false {
 		} else {
-			h.decSliceHostPortRange((*[]HostPortRange)(yyv1579), d)
+			h.decSliceHostPortRange((*[]HostPortRange)(yyv1533), d)
 		}
 	}
-	yyj1572++
-	if yyhl1572 {
-		yyb1572 = yyj1572 > l
+	yyj1526++
+	if yyhl1526 {
+		yyb1526 = yyj1526 > l
 	} else {
-		yyb1572 = r.CheckBreak()
+		yyb1526 = r.CheckBreak()
 	}
-	if yyb1572 {
+	if yyb1526 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -18882,13 +18264,13 @@ func (x *PodSecurityPolicySpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.HostPID = bool(r.DecodeBool())
 	}
-	yyj1572++
-	if yyhl1572 {
-		yyb1572 = yyj1572 > l
+	yyj1526++
+	if yyhl1526 {
+		yyb1526 = yyj1526 > l
 	} else {
-		yyb1572 = r.CheckBreak()
+		yyb1526 = r.CheckBreak()
 	}
-	if yyb1572 {
+	if yyb1526 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -18898,13 +18280,13 @@ func (x *PodSecurityPolicySpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.HostIPC = bool(r.DecodeBool())
 	}
-	yyj1572++
-	if yyhl1572 {
-		yyb1572 = yyj1572 > l
+	yyj1526++
+	if yyhl1526 {
+		yyb1526 = yyj1526 > l
 	} else {
-		yyb1572 = r.CheckBreak()
+		yyb1526 = r.CheckBreak()
 	}
-	if yyb1572 {
+	if yyb1526 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -18912,16 +18294,16 @@ func (x *PodSecurityPolicySpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	if r.TryDecodeAsNil() {
 		x.SELinuxContext = SELinuxContextStrategyOptions{}
 	} else {
-		yyv1583 := &x.SELinuxContext
-		yyv1583.CodecDecodeSelf(d)
+		yyv1537 := &x.SELinuxContext
+		yyv1537.CodecDecodeSelf(d)
 	}
-	yyj1572++
-	if yyhl1572 {
-		yyb1572 = yyj1572 > l
+	yyj1526++
+	if yyhl1526 {
+		yyb1526 = yyj1526 > l
 	} else {
-		yyb1572 = r.CheckBreak()
+		yyb1526 = r.CheckBreak()
 	}
-	if yyb1572 {
+	if yyb1526 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -18929,21 +18311,21 @@ func (x *PodSecurityPolicySpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	if r.TryDecodeAsNil() {
 		x.RunAsUser = RunAsUserStrategyOptions{}
 	} else {
-		yyv1584 := &x.RunAsUser
-		yyv1584.CodecDecodeSelf(d)
+		yyv1538 := &x.RunAsUser
+		yyv1538.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1572++
-		if yyhl1572 {
-			yyb1572 = yyj1572 > l
+		yyj1526++
+		if yyhl1526 {
+			yyb1526 = yyj1526 > l
 		} else {
-			yyb1572 = r.CheckBreak()
+			yyb1526 = r.CheckBreak()
 		}
-		if yyb1572 {
+		if yyb1526 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1572-1, "")
+		z.DecStructFieldNotFound(yyj1526-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -18952,8 +18334,8 @@ func (x FSType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym1585 := z.EncBinary()
-	_ = yym1585
+	yym1539 := z.EncBinary()
+	_ = yym1539
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -18965,8 +18347,8 @@ func (x *FSType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1586 := z.DecBinary()
-	_ = yym1586
+	yym1540 := z.DecBinary()
+	_ = yym1540
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -18975,6 +18357,663 @@ func (x *FSType) CodecDecodeSelf(d *codec1978.Decoder) {
 }
 
 func (x *HostPortRange) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym1541 := z.EncBinary()
+		_ = yym1541
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep1542 := !z.EncBinary()
+			yy2arr1542 := z.EncBasicHandle().StructToArray
+			var yyq1542 [2]bool
+			_, _, _ = yysep1542, yyq1542, yy2arr1542
+			const yyr1542 bool = false
+			var yynn1542 int
+			if yyr1542 || yy2arr1542 {
+				r.EncodeArrayStart(2)
+			} else {
+				yynn1542 = 2
+				for _, b := range yyq1542 {
+					if b {
+						yynn1542++
+					}
+				}
+				r.EncodeMapStart(yynn1542)
+				yynn1542 = 0
+			}
+			if yyr1542 || yy2arr1542 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym1544 := z.EncBinary()
+				_ = yym1544
+				if false {
+				} else {
+					r.EncodeInt(int64(x.Min))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("min"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym1545 := z.EncBinary()
+				_ = yym1545
+				if false {
+				} else {
+					r.EncodeInt(int64(x.Min))
+				}
+			}
+			if yyr1542 || yy2arr1542 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym1547 := z.EncBinary()
+				_ = yym1547
+				if false {
+				} else {
+					r.EncodeInt(int64(x.Max))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("max"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym1548 := z.EncBinary()
+				_ = yym1548
+				if false {
+				} else {
+					r.EncodeInt(int64(x.Max))
+				}
+			}
+			if yyr1542 || yy2arr1542 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *HostPortRange) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym1549 := z.DecBinary()
+	_ = yym1549
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct1550 := r.ContainerType()
+		if yyct1550 == codecSelferValueTypeMap1234 {
+			yyl1550 := r.ReadMapStart()
+			if yyl1550 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl1550, d)
+			}
+		} else if yyct1550 == codecSelferValueTypeArray1234 {
+			yyl1550 := r.ReadArrayStart()
+			if yyl1550 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl1550, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *HostPortRange) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys1551Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1551Slc
+	var yyhl1551 bool = l >= 0
+	for yyj1551 := 0; ; yyj1551++ {
+		if yyhl1551 {
+			if yyj1551 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys1551Slc = r.DecodeBytes(yys1551Slc, true, true)
+		yys1551 := string(yys1551Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys1551 {
+		case "min":
+			if r.TryDecodeAsNil() {
+				x.Min = 0
+			} else {
+				x.Min = int32(r.DecodeInt(32))
+			}
+		case "max":
+			if r.TryDecodeAsNil() {
+				x.Max = 0
+			} else {
+				x.Max = int32(r.DecodeInt(32))
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys1551)
+		} // end switch yys1551
+	} // end for yyj1551
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *HostPortRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj1554 int
+	var yyb1554 bool
+	var yyhl1554 bool = l >= 0
+	yyj1554++
+	if yyhl1554 {
+		yyb1554 = yyj1554 > l
+	} else {
+		yyb1554 = r.CheckBreak()
+	}
+	if yyb1554 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Min = 0
+	} else {
+		x.Min = int32(r.DecodeInt(32))
+	}
+	yyj1554++
+	if yyhl1554 {
+		yyb1554 = yyj1554 > l
+	} else {
+		yyb1554 = r.CheckBreak()
+	}
+	if yyb1554 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Max = 0
+	} else {
+		x.Max = int32(r.DecodeInt(32))
+	}
+	for {
+		yyj1554++
+		if yyhl1554 {
+			yyb1554 = yyj1554 > l
+		} else {
+			yyb1554 = r.CheckBreak()
+		}
+		if yyb1554 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj1554-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x *SELinuxContextStrategyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym1557 := z.EncBinary()
+		_ = yym1557
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep1558 := !z.EncBinary()
+			yy2arr1558 := z.EncBasicHandle().StructToArray
+			var yyq1558 [2]bool
+			_, _, _ = yysep1558, yyq1558, yy2arr1558
+			const yyr1558 bool = false
+			yyq1558[1] = x.SELinuxOptions != nil
+			var yynn1558 int
+			if yyr1558 || yy2arr1558 {
+				r.EncodeArrayStart(2)
+			} else {
+				yynn1558 = 1
+				for _, b := range yyq1558 {
+					if b {
+						yynn1558++
+					}
+				}
+				r.EncodeMapStart(yynn1558)
+				yynn1558 = 0
+			}
+			if yyr1558 || yy2arr1558 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				x.Type.CodecEncodeSelf(e)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("type"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				x.Type.CodecEncodeSelf(e)
+			}
+			if yyr1558 || yy2arr1558 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1558[1] {
+					if x.SELinuxOptions == nil {
+						r.EncodeNil()
+					} else {
+						x.SELinuxOptions.CodecEncodeSelf(e)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1558[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("seLinuxOptions"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if x.SELinuxOptions == nil {
+						r.EncodeNil()
+					} else {
+						x.SELinuxOptions.CodecEncodeSelf(e)
+					}
+				}
+			}
+			if yyr1558 || yy2arr1558 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *SELinuxContextStrategyOptions) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym1561 := z.DecBinary()
+	_ = yym1561
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct1562 := r.ContainerType()
+		if yyct1562 == codecSelferValueTypeMap1234 {
+			yyl1562 := r.ReadMapStart()
+			if yyl1562 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl1562, d)
+			}
+		} else if yyct1562 == codecSelferValueTypeArray1234 {
+			yyl1562 := r.ReadArrayStart()
+			if yyl1562 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl1562, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *SELinuxContextStrategyOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys1563Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1563Slc
+	var yyhl1563 bool = l >= 0
+	for yyj1563 := 0; ; yyj1563++ {
+		if yyhl1563 {
+			if yyj1563 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys1563Slc = r.DecodeBytes(yys1563Slc, true, true)
+		yys1563 := string(yys1563Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys1563 {
+		case "type":
+			if r.TryDecodeAsNil() {
+				x.Type = ""
+			} else {
+				x.Type = SELinuxContextStrategy(r.DecodeString())
+			}
+		case "seLinuxOptions":
+			if r.TryDecodeAsNil() {
+				if x.SELinuxOptions != nil {
+					x.SELinuxOptions = nil
+				}
+			} else {
+				if x.SELinuxOptions == nil {
+					x.SELinuxOptions = new(pkg2_v1.SELinuxOptions)
+				}
+				x.SELinuxOptions.CodecDecodeSelf(d)
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys1563)
+		} // end switch yys1563
+	} // end for yyj1563
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *SELinuxContextStrategyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj1566 int
+	var yyb1566 bool
+	var yyhl1566 bool = l >= 0
+	yyj1566++
+	if yyhl1566 {
+		yyb1566 = yyj1566 > l
+	} else {
+		yyb1566 = r.CheckBreak()
+	}
+	if yyb1566 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Type = ""
+	} else {
+		x.Type = SELinuxContextStrategy(r.DecodeString())
+	}
+	yyj1566++
+	if yyhl1566 {
+		yyb1566 = yyj1566 > l
+	} else {
+		yyb1566 = r.CheckBreak()
+	}
+	if yyb1566 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		if x.SELinuxOptions != nil {
+			x.SELinuxOptions = nil
+		}
+	} else {
+		if x.SELinuxOptions == nil {
+			x.SELinuxOptions = new(pkg2_v1.SELinuxOptions)
+		}
+		x.SELinuxOptions.CodecDecodeSelf(d)
+	}
+	for {
+		yyj1566++
+		if yyhl1566 {
+			yyb1566 = yyj1566 > l
+		} else {
+			yyb1566 = r.CheckBreak()
+		}
+		if yyb1566 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj1566-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x SELinuxContextStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	yym1569 := z.EncBinary()
+	_ = yym1569
+	if false {
+	} else if z.HasExtensions() && z.EncExt(x) {
+	} else {
+		r.EncodeString(codecSelferC_UTF81234, string(x))
+	}
+}
+
+func (x *SELinuxContextStrategy) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym1570 := z.DecBinary()
+	_ = yym1570
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		*((*string)(x)) = r.DecodeString()
+	}
+}
+
+func (x *RunAsUserStrategyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym1571 := z.EncBinary()
+		_ = yym1571
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep1572 := !z.EncBinary()
+			yy2arr1572 := z.EncBasicHandle().StructToArray
+			var yyq1572 [2]bool
+			_, _, _ = yysep1572, yyq1572, yy2arr1572
+			const yyr1572 bool = false
+			yyq1572[1] = len(x.Ranges) != 0
+			var yynn1572 int
+			if yyr1572 || yy2arr1572 {
+				r.EncodeArrayStart(2)
+			} else {
+				yynn1572 = 1
+				for _, b := range yyq1572 {
+					if b {
+						yynn1572++
+					}
+				}
+				r.EncodeMapStart(yynn1572)
+				yynn1572 = 0
+			}
+			if yyr1572 || yy2arr1572 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				x.Type.CodecEncodeSelf(e)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("type"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				x.Type.CodecEncodeSelf(e)
+			}
+			if yyr1572 || yy2arr1572 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq1572[1] {
+					if x.Ranges == nil {
+						r.EncodeNil()
+					} else {
+						yym1575 := z.EncBinary()
+						_ = yym1575
+						if false {
+						} else {
+							h.encSliceIDRange(([]IDRange)(x.Ranges), e)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1572[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("ranges"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if x.Ranges == nil {
+						r.EncodeNil()
+					} else {
+						yym1576 := z.EncBinary()
+						_ = yym1576
+						if false {
+						} else {
+							h.encSliceIDRange(([]IDRange)(x.Ranges), e)
+						}
+					}
+				}
+			}
+			if yyr1572 || yy2arr1572 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *RunAsUserStrategyOptions) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym1577 := z.DecBinary()
+	_ = yym1577
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct1578 := r.ContainerType()
+		if yyct1578 == codecSelferValueTypeMap1234 {
+			yyl1578 := r.ReadMapStart()
+			if yyl1578 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl1578, d)
+			}
+		} else if yyct1578 == codecSelferValueTypeArray1234 {
+			yyl1578 := r.ReadArrayStart()
+			if yyl1578 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl1578, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *RunAsUserStrategyOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys1579Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1579Slc
+	var yyhl1579 bool = l >= 0
+	for yyj1579 := 0; ; yyj1579++ {
+		if yyhl1579 {
+			if yyj1579 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys1579Slc = r.DecodeBytes(yys1579Slc, true, true)
+		yys1579 := string(yys1579Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys1579 {
+		case "type":
+			if r.TryDecodeAsNil() {
+				x.Type = ""
+			} else {
+				x.Type = RunAsUserStrategy(r.DecodeString())
+			}
+		case "ranges":
+			if r.TryDecodeAsNil() {
+				x.Ranges = nil
+			} else {
+				yyv1581 := &x.Ranges
+				yym1582 := z.DecBinary()
+				_ = yym1582
+				if false {
+				} else {
+					h.decSliceIDRange((*[]IDRange)(yyv1581), d)
+				}
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys1579)
+		} // end switch yys1579
+	} // end for yyj1579
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *RunAsUserStrategyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj1583 int
+	var yyb1583 bool
+	var yyhl1583 bool = l >= 0
+	yyj1583++
+	if yyhl1583 {
+		yyb1583 = yyj1583 > l
+	} else {
+		yyb1583 = r.CheckBreak()
+	}
+	if yyb1583 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Type = ""
+	} else {
+		x.Type = RunAsUserStrategy(r.DecodeString())
+	}
+	yyj1583++
+	if yyhl1583 {
+		yyb1583 = yyj1583 > l
+	} else {
+		yyb1583 = r.CheckBreak()
+	}
+	if yyb1583 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.Ranges = nil
+	} else {
+		yyv1585 := &x.Ranges
+		yym1586 := z.DecBinary()
+		_ = yym1586
+		if false {
+		} else {
+			h.decSliceIDRange((*[]IDRange)(yyv1585), d)
+		}
+	}
+	for {
+		yyj1583++
+		if yyhl1583 {
+			yyb1583 = yyj1583 > l
+		} else {
+			yyb1583 = r.CheckBreak()
+		}
+		if yyb1583 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj1583-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x *IDRange) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
@@ -19051,7 +19090,7 @@ func (x *HostPortRange) CodecEncodeSelf(e *codec1978.Encoder) {
 	}
 }
 
-func (x *HostPortRange) CodecDecodeSelf(d *codec1978.Decoder) {
+func (x *IDRange) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -19081,7 +19120,7 @@ func (x *HostPortRange) CodecDecodeSelf(d *codec1978.Decoder) {
 	}
 }
 
-func (x *HostPortRange) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+func (x *IDRange) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -19107,13 +19146,13 @@ func (x *HostPortRange) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Min = 0
 			} else {
-				x.Min = int32(r.DecodeInt(32))
+				x.Min = int64(r.DecodeInt(64))
 			}
 		case "max":
 			if r.TryDecodeAsNil() {
 				x.Max = 0
 			} else {
-				x.Max = int32(r.DecodeInt(32))
+				x.Max = int64(r.DecodeInt(64))
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys1597)
@@ -19122,7 +19161,7 @@ func (x *HostPortRange) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
-func (x *HostPortRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+func (x *IDRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -19143,7 +19182,7 @@ func (x *HostPortRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Min = 0
 	} else {
-		x.Min = int32(r.DecodeInt(32))
+		x.Min = int64(r.DecodeInt(64))
 	}
 	yyj1600++
 	if yyhl1600 {
@@ -19159,7 +19198,7 @@ func (x *HostPortRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Max = 0
 	} else {
-		x.Max = int32(r.DecodeInt(32))
+		x.Max = int64(r.DecodeInt(64))
 	}
 	for {
 		yyj1600++
@@ -19177,669 +19216,12 @@ func (x *HostPortRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
-func (x *SELinuxContextStrategyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym1603 := z.EncBinary()
-		_ = yym1603
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep1604 := !z.EncBinary()
-			yy2arr1604 := z.EncBasicHandle().StructToArray
-			var yyq1604 [2]bool
-			_, _, _ = yysep1604, yyq1604, yy2arr1604
-			const yyr1604 bool = false
-			yyq1604[1] = x.SELinuxOptions != nil
-			var yynn1604 int
-			if yyr1604 || yy2arr1604 {
-				r.EncodeArrayStart(2)
-			} else {
-				yynn1604 = 1
-				for _, b := range yyq1604 {
-					if b {
-						yynn1604++
-					}
-				}
-				r.EncodeMapStart(yynn1604)
-				yynn1604 = 0
-			}
-			if yyr1604 || yy2arr1604 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				x.Type.CodecEncodeSelf(e)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("type"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				x.Type.CodecEncodeSelf(e)
-			}
-			if yyr1604 || yy2arr1604 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1604[1] {
-					if x.SELinuxOptions == nil {
-						r.EncodeNil()
-					} else {
-						x.SELinuxOptions.CodecEncodeSelf(e)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1604[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("seLinuxOptions"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if x.SELinuxOptions == nil {
-						r.EncodeNil()
-					} else {
-						x.SELinuxOptions.CodecEncodeSelf(e)
-					}
-				}
-			}
-			if yyr1604 || yy2arr1604 {
-				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
-			}
-		}
-	}
-}
-
-func (x *SELinuxContextStrategyOptions) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym1607 := z.DecBinary()
-	_ = yym1607
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		yyct1608 := r.ContainerType()
-		if yyct1608 == codecSelferValueTypeMap1234 {
-			yyl1608 := r.ReadMapStart()
-			if yyl1608 == 0 {
-				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-			} else {
-				x.codecDecodeSelfFromMap(yyl1608, d)
-			}
-		} else if yyct1608 == codecSelferValueTypeArray1234 {
-			yyl1608 := r.ReadArrayStart()
-			if yyl1608 == 0 {
-				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				x.codecDecodeSelfFromArray(yyl1608, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *SELinuxContextStrategyOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys1609Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1609Slc
-	var yyhl1609 bool = l >= 0
-	for yyj1609 := 0; ; yyj1609++ {
-		if yyhl1609 {
-			if yyj1609 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1609Slc = r.DecodeBytes(yys1609Slc, true, true)
-		yys1609 := string(yys1609Slc)
-		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1609 {
-		case "type":
-			if r.TryDecodeAsNil() {
-				x.Type = ""
-			} else {
-				x.Type = SELinuxContextStrategy(r.DecodeString())
-			}
-		case "seLinuxOptions":
-			if r.TryDecodeAsNil() {
-				if x.SELinuxOptions != nil {
-					x.SELinuxOptions = nil
-				}
-			} else {
-				if x.SELinuxOptions == nil {
-					x.SELinuxOptions = new(pkg2_v1.SELinuxOptions)
-				}
-				x.SELinuxOptions.CodecDecodeSelf(d)
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys1609)
-		} // end switch yys1609
-	} // end for yyj1609
-	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-}
-
-func (x *SELinuxContextStrategyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj1612 int
-	var yyb1612 bool
-	var yyhl1612 bool = l >= 0
-	yyj1612++
-	if yyhl1612 {
-		yyb1612 = yyj1612 > l
-	} else {
-		yyb1612 = r.CheckBreak()
-	}
-	if yyb1612 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Type = ""
-	} else {
-		x.Type = SELinuxContextStrategy(r.DecodeString())
-	}
-	yyj1612++
-	if yyhl1612 {
-		yyb1612 = yyj1612 > l
-	} else {
-		yyb1612 = r.CheckBreak()
-	}
-	if yyb1612 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		if x.SELinuxOptions != nil {
-			x.SELinuxOptions = nil
-		}
-	} else {
-		if x.SELinuxOptions == nil {
-			x.SELinuxOptions = new(pkg2_v1.SELinuxOptions)
-		}
-		x.SELinuxOptions.CodecDecodeSelf(d)
-	}
-	for {
-		yyj1612++
-		if yyhl1612 {
-			yyb1612 = yyj1612 > l
-		} else {
-			yyb1612 = r.CheckBreak()
-		}
-		if yyb1612 {
-			break
-		}
-		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1612-1, "")
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x SELinuxContextStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	yym1615 := z.EncBinary()
-	_ = yym1615
-	if false {
-	} else if z.HasExtensions() && z.EncExt(x) {
-	} else {
-		r.EncodeString(codecSelferC_UTF81234, string(x))
-	}
-}
-
-func (x *SELinuxContextStrategy) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym1616 := z.DecBinary()
-	_ = yym1616
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		*((*string)(x)) = r.DecodeString()
-	}
-}
-
-func (x *RunAsUserStrategyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym1617 := z.EncBinary()
-		_ = yym1617
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep1618 := !z.EncBinary()
-			yy2arr1618 := z.EncBasicHandle().StructToArray
-			var yyq1618 [2]bool
-			_, _, _ = yysep1618, yyq1618, yy2arr1618
-			const yyr1618 bool = false
-			yyq1618[1] = len(x.Ranges) != 0
-			var yynn1618 int
-			if yyr1618 || yy2arr1618 {
-				r.EncodeArrayStart(2)
-			} else {
-				yynn1618 = 1
-				for _, b := range yyq1618 {
-					if b {
-						yynn1618++
-					}
-				}
-				r.EncodeMapStart(yynn1618)
-				yynn1618 = 0
-			}
-			if yyr1618 || yy2arr1618 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				x.Type.CodecEncodeSelf(e)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("type"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				x.Type.CodecEncodeSelf(e)
-			}
-			if yyr1618 || yy2arr1618 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1618[1] {
-					if x.Ranges == nil {
-						r.EncodeNil()
-					} else {
-						yym1621 := z.EncBinary()
-						_ = yym1621
-						if false {
-						} else {
-							h.encSliceIDRange(([]IDRange)(x.Ranges), e)
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1618[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("ranges"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if x.Ranges == nil {
-						r.EncodeNil()
-					} else {
-						yym1622 := z.EncBinary()
-						_ = yym1622
-						if false {
-						} else {
-							h.encSliceIDRange(([]IDRange)(x.Ranges), e)
-						}
-					}
-				}
-			}
-			if yyr1618 || yy2arr1618 {
-				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
-			}
-		}
-	}
-}
-
-func (x *RunAsUserStrategyOptions) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym1623 := z.DecBinary()
-	_ = yym1623
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		yyct1624 := r.ContainerType()
-		if yyct1624 == codecSelferValueTypeMap1234 {
-			yyl1624 := r.ReadMapStart()
-			if yyl1624 == 0 {
-				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-			} else {
-				x.codecDecodeSelfFromMap(yyl1624, d)
-			}
-		} else if yyct1624 == codecSelferValueTypeArray1234 {
-			yyl1624 := r.ReadArrayStart()
-			if yyl1624 == 0 {
-				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				x.codecDecodeSelfFromArray(yyl1624, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *RunAsUserStrategyOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys1625Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1625Slc
-	var yyhl1625 bool = l >= 0
-	for yyj1625 := 0; ; yyj1625++ {
-		if yyhl1625 {
-			if yyj1625 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1625Slc = r.DecodeBytes(yys1625Slc, true, true)
-		yys1625 := string(yys1625Slc)
-		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1625 {
-		case "type":
-			if r.TryDecodeAsNil() {
-				x.Type = ""
-			} else {
-				x.Type = RunAsUserStrategy(r.DecodeString())
-			}
-		case "ranges":
-			if r.TryDecodeAsNil() {
-				x.Ranges = nil
-			} else {
-				yyv1627 := &x.Ranges
-				yym1628 := z.DecBinary()
-				_ = yym1628
-				if false {
-				} else {
-					h.decSliceIDRange((*[]IDRange)(yyv1627), d)
-				}
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys1625)
-		} // end switch yys1625
-	} // end for yyj1625
-	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-}
-
-func (x *RunAsUserStrategyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj1629 int
-	var yyb1629 bool
-	var yyhl1629 bool = l >= 0
-	yyj1629++
-	if yyhl1629 {
-		yyb1629 = yyj1629 > l
-	} else {
-		yyb1629 = r.CheckBreak()
-	}
-	if yyb1629 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Type = ""
-	} else {
-		x.Type = RunAsUserStrategy(r.DecodeString())
-	}
-	yyj1629++
-	if yyhl1629 {
-		yyb1629 = yyj1629 > l
-	} else {
-		yyb1629 = r.CheckBreak()
-	}
-	if yyb1629 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Ranges = nil
-	} else {
-		yyv1631 := &x.Ranges
-		yym1632 := z.DecBinary()
-		_ = yym1632
-		if false {
-		} else {
-			h.decSliceIDRange((*[]IDRange)(yyv1631), d)
-		}
-	}
-	for {
-		yyj1629++
-		if yyhl1629 {
-			yyb1629 = yyj1629 > l
-		} else {
-			yyb1629 = r.CheckBreak()
-		}
-		if yyb1629 {
-			break
-		}
-		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1629-1, "")
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
-func (x *IDRange) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym1633 := z.EncBinary()
-		_ = yym1633
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep1634 := !z.EncBinary()
-			yy2arr1634 := z.EncBasicHandle().StructToArray
-			var yyq1634 [2]bool
-			_, _, _ = yysep1634, yyq1634, yy2arr1634
-			const yyr1634 bool = false
-			var yynn1634 int
-			if yyr1634 || yy2arr1634 {
-				r.EncodeArrayStart(2)
-			} else {
-				yynn1634 = 2
-				for _, b := range yyq1634 {
-					if b {
-						yynn1634++
-					}
-				}
-				r.EncodeMapStart(yynn1634)
-				yynn1634 = 0
-			}
-			if yyr1634 || yy2arr1634 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1636 := z.EncBinary()
-				_ = yym1636
-				if false {
-				} else {
-					r.EncodeInt(int64(x.Min))
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("min"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1637 := z.EncBinary()
-				_ = yym1637
-				if false {
-				} else {
-					r.EncodeInt(int64(x.Min))
-				}
-			}
-			if yyr1634 || yy2arr1634 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym1639 := z.EncBinary()
-				_ = yym1639
-				if false {
-				} else {
-					r.EncodeInt(int64(x.Max))
-				}
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("max"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym1640 := z.EncBinary()
-				_ = yym1640
-				if false {
-				} else {
-					r.EncodeInt(int64(x.Max))
-				}
-			}
-			if yyr1634 || yy2arr1634 {
-				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
-			}
-		}
-	}
-}
-
-func (x *IDRange) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym1641 := z.DecBinary()
-	_ = yym1641
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		yyct1642 := r.ContainerType()
-		if yyct1642 == codecSelferValueTypeMap1234 {
-			yyl1642 := r.ReadMapStart()
-			if yyl1642 == 0 {
-				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-			} else {
-				x.codecDecodeSelfFromMap(yyl1642, d)
-			}
-		} else if yyct1642 == codecSelferValueTypeArray1234 {
-			yyl1642 := r.ReadArrayStart()
-			if yyl1642 == 0 {
-				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-			} else {
-				x.codecDecodeSelfFromArray(yyl1642, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *IDRange) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys1643Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1643Slc
-	var yyhl1643 bool = l >= 0
-	for yyj1643 := 0; ; yyj1643++ {
-		if yyhl1643 {
-			if yyj1643 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1643Slc = r.DecodeBytes(yys1643Slc, true, true)
-		yys1643 := string(yys1643Slc)
-		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1643 {
-		case "min":
-			if r.TryDecodeAsNil() {
-				x.Min = 0
-			} else {
-				x.Min = int64(r.DecodeInt(64))
-			}
-		case "max":
-			if r.TryDecodeAsNil() {
-				x.Max = 0
-			} else {
-				x.Max = int64(r.DecodeInt(64))
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys1643)
-		} // end switch yys1643
-	} // end for yyj1643
-	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
-}
-
-func (x *IDRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj1646 int
-	var yyb1646 bool
-	var yyhl1646 bool = l >= 0
-	yyj1646++
-	if yyhl1646 {
-		yyb1646 = yyj1646 > l
-	} else {
-		yyb1646 = r.CheckBreak()
-	}
-	if yyb1646 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Min = 0
-	} else {
-		x.Min = int64(r.DecodeInt(64))
-	}
-	yyj1646++
-	if yyhl1646 {
-		yyb1646 = yyj1646 > l
-	} else {
-		yyb1646 = r.CheckBreak()
-	}
-	if yyb1646 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-	if r.TryDecodeAsNil() {
-		x.Max = 0
-	} else {
-		x.Max = int64(r.DecodeInt(64))
-	}
-	for {
-		yyj1646++
-		if yyhl1646 {
-			yyb1646 = yyj1646 > l
-		} else {
-			yyb1646 = r.CheckBreak()
-		}
-		if yyb1646 {
-			break
-		}
-		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1646-1, "")
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
-}
-
 func (x RunAsUserStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym1649 := z.EncBinary()
-	_ = yym1649
+	yym1603 := z.EncBinary()
+	_ = yym1603
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -19851,8 +19233,8 @@ func (x *RunAsUserStrategy) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1650 := z.DecBinary()
-	_ = yym1650
+	yym1604 := z.DecBinary()
+	_ = yym1604
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -19867,68 +19249,68 @@ func (x *PodSecurityPolicyList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1651 := z.EncBinary()
-		_ = yym1651
+		yym1605 := z.EncBinary()
+		_ = yym1605
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1652 := !z.EncBinary()
-			yy2arr1652 := z.EncBasicHandle().StructToArray
-			var yyq1652 [4]bool
-			_, _, _ = yysep1652, yyq1652, yy2arr1652
-			const yyr1652 bool = false
-			yyq1652[0] = true
-			yyq1652[2] = x.Kind != ""
-			yyq1652[3] = x.APIVersion != ""
-			var yynn1652 int
-			if yyr1652 || yy2arr1652 {
+			yysep1606 := !z.EncBinary()
+			yy2arr1606 := z.EncBasicHandle().StructToArray
+			var yyq1606 [4]bool
+			_, _, _ = yysep1606, yyq1606, yy2arr1606
+			const yyr1606 bool = false
+			yyq1606[0] = true
+			yyq1606[2] = x.Kind != ""
+			yyq1606[3] = x.APIVersion != ""
+			var yynn1606 int
+			if yyr1606 || yy2arr1606 {
 				r.EncodeArrayStart(4)
 			} else {
-				yynn1652 = 1
-				for _, b := range yyq1652 {
+				yynn1606 = 1
+				for _, b := range yyq1606 {
 					if b {
-						yynn1652++
+						yynn1606++
 					}
 				}
-				r.EncodeMapStart(yynn1652)
-				yynn1652 = 0
+				r.EncodeMapStart(yynn1606)
+				yynn1606 = 0
 			}
-			if yyr1652 || yy2arr1652 {
+			if yyr1606 || yy2arr1606 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1652[0] {
-					yy1654 := &x.ListMeta
-					yym1655 := z.EncBinary()
-					_ = yym1655
+				if yyq1606[0] {
+					yy1608 := &x.ListMeta
+					yym1609 := z.EncBinary()
+					_ = yym1609
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1654) {
+					} else if z.HasExtensions() && z.EncExt(yy1608) {
 					} else {
-						z.EncFallback(yy1654)
+						z.EncFallback(yy1608)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1652[0] {
+				if yyq1606[0] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yy1656 := &x.ListMeta
-					yym1657 := z.EncBinary()
-					_ = yym1657
+					yy1610 := &x.ListMeta
+					yym1611 := z.EncBinary()
+					_ = yym1611
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1656) {
+					} else if z.HasExtensions() && z.EncExt(yy1610) {
 					} else {
-						z.EncFallback(yy1656)
+						z.EncFallback(yy1610)
 					}
 				}
 			}
-			if yyr1652 || yy2arr1652 {
+			if yyr1606 || yy2arr1606 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1659 := z.EncBinary()
-					_ = yym1659
+					yym1613 := z.EncBinary()
+					_ = yym1613
 					if false {
 					} else {
 						h.encSlicePodSecurityPolicy(([]PodSecurityPolicy)(x.Items), e)
@@ -19941,19 +19323,19 @@ func (x *PodSecurityPolicyList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1660 := z.EncBinary()
-					_ = yym1660
+					yym1614 := z.EncBinary()
+					_ = yym1614
 					if false {
 					} else {
 						h.encSlicePodSecurityPolicy(([]PodSecurityPolicy)(x.Items), e)
 					}
 				}
 			}
-			if yyr1652 || yy2arr1652 {
+			if yyr1606 || yy2arr1606 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1652[2] {
-					yym1662 := z.EncBinary()
-					_ = yym1662
+				if yyq1606[2] {
+					yym1616 := z.EncBinary()
+					_ = yym1616
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -19962,23 +19344,23 @@ func (x *PodSecurityPolicyList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1652[2] {
+				if yyq1606[2] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1663 := z.EncBinary()
-					_ = yym1663
+					yym1617 := z.EncBinary()
+					_ = yym1617
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1652 || yy2arr1652 {
+			if yyr1606 || yy2arr1606 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq1652[3] {
-					yym1665 := z.EncBinary()
-					_ = yym1665
+				if yyq1606[3] {
+					yym1619 := z.EncBinary()
+					_ = yym1619
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -19987,19 +19369,19 @@ func (x *PodSecurityPolicyList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1652[3] {
+				if yyq1606[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym1666 := z.EncBinary()
-					_ = yym1666
+					yym1620 := z.EncBinary()
+					_ = yym1620
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1652 || yy2arr1652 {
+			if yyr1606 || yy2arr1606 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
@@ -20012,25 +19394,25 @@ func (x *PodSecurityPolicyList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1667 := z.DecBinary()
-	_ = yym1667
+	yym1621 := z.DecBinary()
+	_ = yym1621
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		yyct1668 := r.ContainerType()
-		if yyct1668 == codecSelferValueTypeMap1234 {
-			yyl1668 := r.ReadMapStart()
-			if yyl1668 == 0 {
+		yyct1622 := r.ContainerType()
+		if yyct1622 == codecSelferValueTypeMap1234 {
+			yyl1622 := r.ReadMapStart()
+			if yyl1622 == 0 {
 				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 			} else {
-				x.codecDecodeSelfFromMap(yyl1668, d)
+				x.codecDecodeSelfFromMap(yyl1622, d)
 			}
-		} else if yyct1668 == codecSelferValueTypeArray1234 {
-			yyl1668 := r.ReadArrayStart()
-			if yyl1668 == 0 {
+		} else if yyct1622 == codecSelferValueTypeArray1234 {
+			yyl1622 := r.ReadArrayStart()
+			if yyl1622 == 0 {
 				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 			} else {
-				x.codecDecodeSelfFromArray(yyl1668, d)
+				x.codecDecodeSelfFromArray(yyl1622, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -20042,12 +19424,12 @@ func (x *PodSecurityPolicyList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1669Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1669Slc
-	var yyhl1669 bool = l >= 0
-	for yyj1669 := 0; ; yyj1669++ {
-		if yyhl1669 {
-			if yyj1669 >= l {
+	var yys1623Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1623Slc
+	var yyhl1623 bool = l >= 0
+	for yyj1623 := 0; ; yyj1623++ {
+		if yyhl1623 {
+			if yyj1623 >= l {
 				break
 			}
 		} else {
@@ -20056,33 +19438,33 @@ func (x *PodSecurityPolicyList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1234)
-		yys1669Slc = r.DecodeBytes(yys1669Slc, true, true)
-		yys1669 := string(yys1669Slc)
+		yys1623Slc = r.DecodeBytes(yys1623Slc, true, true)
+		yys1623 := string(yys1623Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1234)
-		switch yys1669 {
+		switch yys1623 {
 		case "metadata":
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv1670 := &x.ListMeta
-				yym1671 := z.DecBinary()
-				_ = yym1671
+				yyv1624 := &x.ListMeta
+				yym1625 := z.DecBinary()
+				_ = yym1625
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1670) {
+				} else if z.HasExtensions() && z.DecExt(yyv1624) {
 				} else {
-					z.DecFallback(yyv1670, false)
+					z.DecFallback(yyv1624, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv1672 := &x.Items
-				yym1673 := z.DecBinary()
-				_ = yym1673
+				yyv1626 := &x.Items
+				yym1627 := z.DecBinary()
+				_ = yym1627
 				if false {
 				} else {
-					h.decSlicePodSecurityPolicy((*[]PodSecurityPolicy)(yyv1672), d)
+					h.decSlicePodSecurityPolicy((*[]PodSecurityPolicy)(yyv1626), d)
 				}
 			}
 		case "kind":
@@ -20098,9 +19480,9 @@ func (x *PodSecurityPolicyList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				x.APIVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1669)
-		} // end switch yys1669
-	} // end for yyj1669
+			z.DecStructFieldNotFound(-1, yys1623)
+		} // end switch yys1623
+	} // end for yyj1623
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
@@ -20108,16 +19490,16 @@ func (x *PodSecurityPolicyList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1676 int
-	var yyb1676 bool
-	var yyhl1676 bool = l >= 0
-	yyj1676++
-	if yyhl1676 {
-		yyb1676 = yyj1676 > l
+	var yyj1630 int
+	var yyb1630 bool
+	var yyhl1630 bool = l >= 0
+	yyj1630++
+	if yyhl1630 {
+		yyb1630 = yyj1630 > l
 	} else {
-		yyb1676 = r.CheckBreak()
+		yyb1630 = r.CheckBreak()
 	}
-	if yyb1676 {
+	if yyb1630 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -20125,22 +19507,22 @@ func (x *PodSecurityPolicyList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv1677 := &x.ListMeta
-		yym1678 := z.DecBinary()
-		_ = yym1678
+		yyv1631 := &x.ListMeta
+		yym1632 := z.DecBinary()
+		_ = yym1632
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1677) {
+		} else if z.HasExtensions() && z.DecExt(yyv1631) {
 		} else {
-			z.DecFallback(yyv1677, false)
+			z.DecFallback(yyv1631, false)
 		}
 	}
-	yyj1676++
-	if yyhl1676 {
-		yyb1676 = yyj1676 > l
+	yyj1630++
+	if yyhl1630 {
+		yyb1630 = yyj1630 > l
 	} else {
-		yyb1676 = r.CheckBreak()
+		yyb1630 = r.CheckBreak()
 	}
-	if yyb1676 {
+	if yyb1630 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -20148,21 +19530,21 @@ func (x *PodSecurityPolicyList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv1679 := &x.Items
-		yym1680 := z.DecBinary()
-		_ = yym1680
+		yyv1633 := &x.Items
+		yym1634 := z.DecBinary()
+		_ = yym1634
 		if false {
 		} else {
-			h.decSlicePodSecurityPolicy((*[]PodSecurityPolicy)(yyv1679), d)
+			h.decSlicePodSecurityPolicy((*[]PodSecurityPolicy)(yyv1633), d)
 		}
 	}
-	yyj1676++
-	if yyhl1676 {
-		yyb1676 = yyj1676 > l
+	yyj1630++
+	if yyhl1630 {
+		yyb1630 = yyj1630 > l
 	} else {
-		yyb1676 = r.CheckBreak()
+		yyb1630 = r.CheckBreak()
 	}
-	if yyb1676 {
+	if yyb1630 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -20172,13 +19554,13 @@ func (x *PodSecurityPolicyList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1676++
-	if yyhl1676 {
-		yyb1676 = yyj1676 > l
+	yyj1630++
+	if yyhl1630 {
+		yyb1630 = yyj1630 > l
 	} else {
-		yyb1676 = r.CheckBreak()
+		yyb1630 = r.CheckBreak()
 	}
-	if yyb1676 {
+	if yyb1630 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -20189,17 +19571,17 @@ func (x *PodSecurityPolicyList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		x.APIVersion = string(r.DecodeString())
 	}
 	for {
-		yyj1676++
-		if yyhl1676 {
-			yyb1676 = yyj1676 > l
+		yyj1630++
+		if yyhl1630 {
+			yyb1630 = yyj1630 > l
 		} else {
-			yyb1676 = r.CheckBreak()
+			yyb1630 = r.CheckBreak()
 		}
-		if yyb1676 {
+		if yyb1630 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj1676-1, "")
+		z.DecStructFieldNotFound(yyj1630-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -20209,10 +19591,10 @@ func (x codecSelfer1234) encSliceCustomMetricTarget(v []CustomMetricTarget, e *c
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1683 := range v {
+	for _, yyv1637 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1684 := &yyv1683
-		yy1684.CodecEncodeSelf(e)
+		yy1638 := &yyv1637
+		yy1638.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -20222,83 +19604,83 @@ func (x codecSelfer1234) decSliceCustomMetricTarget(v *[]CustomMetricTarget, d *
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1685 := *v
-	yyh1685, yyl1685 := z.DecSliceHelperStart()
-	var yyc1685 bool
-	if yyl1685 == 0 {
-		if yyv1685 == nil {
-			yyv1685 = []CustomMetricTarget{}
-			yyc1685 = true
-		} else if len(yyv1685) != 0 {
-			yyv1685 = yyv1685[:0]
-			yyc1685 = true
+	yyv1639 := *v
+	yyh1639, yyl1639 := z.DecSliceHelperStart()
+	var yyc1639 bool
+	if yyl1639 == 0 {
+		if yyv1639 == nil {
+			yyv1639 = []CustomMetricTarget{}
+			yyc1639 = true
+		} else if len(yyv1639) != 0 {
+			yyv1639 = yyv1639[:0]
+			yyc1639 = true
 		}
-	} else if yyl1685 > 0 {
-		var yyrr1685, yyrl1685 int
-		var yyrt1685 bool
-		if yyl1685 > cap(yyv1685) {
+	} else if yyl1639 > 0 {
+		var yyrr1639, yyrl1639 int
+		var yyrt1639 bool
+		if yyl1639 > cap(yyv1639) {
 
-			yyrg1685 := len(yyv1685) > 0
-			yyv21685 := yyv1685
-			yyrl1685, yyrt1685 = z.DecInferLen(yyl1685, z.DecBasicHandle().MaxInitLen, 40)
-			if yyrt1685 {
-				if yyrl1685 <= cap(yyv1685) {
-					yyv1685 = yyv1685[:yyrl1685]
+			yyrg1639 := len(yyv1639) > 0
+			yyv21639 := yyv1639
+			yyrl1639, yyrt1639 = z.DecInferLen(yyl1639, z.DecBasicHandle().MaxInitLen, 40)
+			if yyrt1639 {
+				if yyrl1639 <= cap(yyv1639) {
+					yyv1639 = yyv1639[:yyrl1639]
 				} else {
-					yyv1685 = make([]CustomMetricTarget, yyrl1685)
+					yyv1639 = make([]CustomMetricTarget, yyrl1639)
 				}
 			} else {
-				yyv1685 = make([]CustomMetricTarget, yyrl1685)
+				yyv1639 = make([]CustomMetricTarget, yyrl1639)
 			}
-			yyc1685 = true
-			yyrr1685 = len(yyv1685)
-			if yyrg1685 {
-				copy(yyv1685, yyv21685)
+			yyc1639 = true
+			yyrr1639 = len(yyv1639)
+			if yyrg1639 {
+				copy(yyv1639, yyv21639)
 			}
-		} else if yyl1685 != len(yyv1685) {
-			yyv1685 = yyv1685[:yyl1685]
-			yyc1685 = true
+		} else if yyl1639 != len(yyv1639) {
+			yyv1639 = yyv1639[:yyl1639]
+			yyc1639 = true
 		}
-		yyj1685 := 0
-		for ; yyj1685 < yyrr1685; yyj1685++ {
-			yyh1685.ElemContainerState(yyj1685)
+		yyj1639 := 0
+		for ; yyj1639 < yyrr1639; yyj1639++ {
+			yyh1639.ElemContainerState(yyj1639)
 			if r.TryDecodeAsNil() {
-				yyv1685[yyj1685] = CustomMetricTarget{}
+				yyv1639[yyj1639] = CustomMetricTarget{}
 			} else {
-				yyv1686 := &yyv1685[yyj1685]
-				yyv1686.CodecDecodeSelf(d)
+				yyv1640 := &yyv1639[yyj1639]
+				yyv1640.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1685 {
-			for ; yyj1685 < yyl1685; yyj1685++ {
-				yyv1685 = append(yyv1685, CustomMetricTarget{})
-				yyh1685.ElemContainerState(yyj1685)
+		if yyrt1639 {
+			for ; yyj1639 < yyl1639; yyj1639++ {
+				yyv1639 = append(yyv1639, CustomMetricTarget{})
+				yyh1639.ElemContainerState(yyj1639)
 				if r.TryDecodeAsNil() {
-					yyv1685[yyj1685] = CustomMetricTarget{}
+					yyv1639[yyj1639] = CustomMetricTarget{}
 				} else {
-					yyv1687 := &yyv1685[yyj1685]
-					yyv1687.CodecDecodeSelf(d)
+					yyv1641 := &yyv1639[yyj1639]
+					yyv1641.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1685 := 0
-		for ; !r.CheckBreak(); yyj1685++ {
+		yyj1639 := 0
+		for ; !r.CheckBreak(); yyj1639++ {
 
-			if yyj1685 >= len(yyv1685) {
-				yyv1685 = append(yyv1685, CustomMetricTarget{}) // var yyz1685 CustomMetricTarget
-				yyc1685 = true
+			if yyj1639 >= len(yyv1639) {
+				yyv1639 = append(yyv1639, CustomMetricTarget{}) // var yyz1639 CustomMetricTarget
+				yyc1639 = true
 			}
-			yyh1685.ElemContainerState(yyj1685)
-			if yyj1685 < len(yyv1685) {
+			yyh1639.ElemContainerState(yyj1639)
+			if yyj1639 < len(yyv1639) {
 				if r.TryDecodeAsNil() {
-					yyv1685[yyj1685] = CustomMetricTarget{}
+					yyv1639[yyj1639] = CustomMetricTarget{}
 				} else {
-					yyv1688 := &yyv1685[yyj1685]
-					yyv1688.CodecDecodeSelf(d)
+					yyv1642 := &yyv1639[yyj1639]
+					yyv1642.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -20306,17 +19688,17 @@ func (x codecSelfer1234) decSliceCustomMetricTarget(v *[]CustomMetricTarget, d *
 			}
 
 		}
-		if yyj1685 < len(yyv1685) {
-			yyv1685 = yyv1685[:yyj1685]
-			yyc1685 = true
-		} else if yyj1685 == 0 && yyv1685 == nil {
-			yyv1685 = []CustomMetricTarget{}
-			yyc1685 = true
+		if yyj1639 < len(yyv1639) {
+			yyv1639 = yyv1639[:yyj1639]
+			yyc1639 = true
+		} else if yyj1639 == 0 && yyv1639 == nil {
+			yyv1639 = []CustomMetricTarget{}
+			yyc1639 = true
 		}
 	}
-	yyh1685.End()
-	if yyc1685 {
-		*v = yyv1685
+	yyh1639.End()
+	if yyc1639 {
+		*v = yyv1639
 	}
 }
 
@@ -20325,10 +19707,10 @@ func (x codecSelfer1234) encSliceCustomMetricCurrentStatus(v []CustomMetricCurre
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1689 := range v {
+	for _, yyv1643 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1690 := &yyv1689
-		yy1690.CodecEncodeSelf(e)
+		yy1644 := &yyv1643
+		yy1644.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -20338,83 +19720,83 @@ func (x codecSelfer1234) decSliceCustomMetricCurrentStatus(v *[]CustomMetricCurr
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1691 := *v
-	yyh1691, yyl1691 := z.DecSliceHelperStart()
-	var yyc1691 bool
-	if yyl1691 == 0 {
-		if yyv1691 == nil {
-			yyv1691 = []CustomMetricCurrentStatus{}
-			yyc1691 = true
-		} else if len(yyv1691) != 0 {
-			yyv1691 = yyv1691[:0]
-			yyc1691 = true
+	yyv1645 := *v
+	yyh1645, yyl1645 := z.DecSliceHelperStart()
+	var yyc1645 bool
+	if yyl1645 == 0 {
+		if yyv1645 == nil {
+			yyv1645 = []CustomMetricCurrentStatus{}
+			yyc1645 = true
+		} else if len(yyv1645) != 0 {
+			yyv1645 = yyv1645[:0]
+			yyc1645 = true
 		}
-	} else if yyl1691 > 0 {
-		var yyrr1691, yyrl1691 int
-		var yyrt1691 bool
-		if yyl1691 > cap(yyv1691) {
+	} else if yyl1645 > 0 {
+		var yyrr1645, yyrl1645 int
+		var yyrt1645 bool
+		if yyl1645 > cap(yyv1645) {
 
-			yyrg1691 := len(yyv1691) > 0
-			yyv21691 := yyv1691
-			yyrl1691, yyrt1691 = z.DecInferLen(yyl1691, z.DecBasicHandle().MaxInitLen, 40)
-			if yyrt1691 {
-				if yyrl1691 <= cap(yyv1691) {
-					yyv1691 = yyv1691[:yyrl1691]
+			yyrg1645 := len(yyv1645) > 0
+			yyv21645 := yyv1645
+			yyrl1645, yyrt1645 = z.DecInferLen(yyl1645, z.DecBasicHandle().MaxInitLen, 40)
+			if yyrt1645 {
+				if yyrl1645 <= cap(yyv1645) {
+					yyv1645 = yyv1645[:yyrl1645]
 				} else {
-					yyv1691 = make([]CustomMetricCurrentStatus, yyrl1691)
+					yyv1645 = make([]CustomMetricCurrentStatus, yyrl1645)
 				}
 			} else {
-				yyv1691 = make([]CustomMetricCurrentStatus, yyrl1691)
+				yyv1645 = make([]CustomMetricCurrentStatus, yyrl1645)
 			}
-			yyc1691 = true
-			yyrr1691 = len(yyv1691)
-			if yyrg1691 {
-				copy(yyv1691, yyv21691)
+			yyc1645 = true
+			yyrr1645 = len(yyv1645)
+			if yyrg1645 {
+				copy(yyv1645, yyv21645)
 			}
-		} else if yyl1691 != len(yyv1691) {
-			yyv1691 = yyv1691[:yyl1691]
-			yyc1691 = true
+		} else if yyl1645 != len(yyv1645) {
+			yyv1645 = yyv1645[:yyl1645]
+			yyc1645 = true
 		}
-		yyj1691 := 0
-		for ; yyj1691 < yyrr1691; yyj1691++ {
-			yyh1691.ElemContainerState(yyj1691)
+		yyj1645 := 0
+		for ; yyj1645 < yyrr1645; yyj1645++ {
+			yyh1645.ElemContainerState(yyj1645)
 			if r.TryDecodeAsNil() {
-				yyv1691[yyj1691] = CustomMetricCurrentStatus{}
+				yyv1645[yyj1645] = CustomMetricCurrentStatus{}
 			} else {
-				yyv1692 := &yyv1691[yyj1691]
-				yyv1692.CodecDecodeSelf(d)
+				yyv1646 := &yyv1645[yyj1645]
+				yyv1646.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1691 {
-			for ; yyj1691 < yyl1691; yyj1691++ {
-				yyv1691 = append(yyv1691, CustomMetricCurrentStatus{})
-				yyh1691.ElemContainerState(yyj1691)
+		if yyrt1645 {
+			for ; yyj1645 < yyl1645; yyj1645++ {
+				yyv1645 = append(yyv1645, CustomMetricCurrentStatus{})
+				yyh1645.ElemContainerState(yyj1645)
 				if r.TryDecodeAsNil() {
-					yyv1691[yyj1691] = CustomMetricCurrentStatus{}
+					yyv1645[yyj1645] = CustomMetricCurrentStatus{}
 				} else {
-					yyv1693 := &yyv1691[yyj1691]
-					yyv1693.CodecDecodeSelf(d)
+					yyv1647 := &yyv1645[yyj1645]
+					yyv1647.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1691 := 0
-		for ; !r.CheckBreak(); yyj1691++ {
+		yyj1645 := 0
+		for ; !r.CheckBreak(); yyj1645++ {
 
-			if yyj1691 >= len(yyv1691) {
-				yyv1691 = append(yyv1691, CustomMetricCurrentStatus{}) // var yyz1691 CustomMetricCurrentStatus
-				yyc1691 = true
+			if yyj1645 >= len(yyv1645) {
+				yyv1645 = append(yyv1645, CustomMetricCurrentStatus{}) // var yyz1645 CustomMetricCurrentStatus
+				yyc1645 = true
 			}
-			yyh1691.ElemContainerState(yyj1691)
-			if yyj1691 < len(yyv1691) {
+			yyh1645.ElemContainerState(yyj1645)
+			if yyj1645 < len(yyv1645) {
 				if r.TryDecodeAsNil() {
-					yyv1691[yyj1691] = CustomMetricCurrentStatus{}
+					yyv1645[yyj1645] = CustomMetricCurrentStatus{}
 				} else {
-					yyv1694 := &yyv1691[yyj1691]
-					yyv1694.CodecDecodeSelf(d)
+					yyv1648 := &yyv1645[yyj1645]
+					yyv1648.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -20422,17 +19804,17 @@ func (x codecSelfer1234) decSliceCustomMetricCurrentStatus(v *[]CustomMetricCurr
 			}
 
 		}
-		if yyj1691 < len(yyv1691) {
-			yyv1691 = yyv1691[:yyj1691]
-			yyc1691 = true
-		} else if yyj1691 == 0 && yyv1691 == nil {
-			yyv1691 = []CustomMetricCurrentStatus{}
-			yyc1691 = true
+		if yyj1645 < len(yyv1645) {
+			yyv1645 = yyv1645[:yyj1645]
+			yyc1645 = true
+		} else if yyj1645 == 0 && yyv1645 == nil {
+			yyv1645 = []CustomMetricCurrentStatus{}
+			yyc1645 = true
 		}
 	}
-	yyh1691.End()
-	if yyc1691 {
-		*v = yyv1691
+	yyh1645.End()
+	if yyc1645 {
+		*v = yyv1645
 	}
 }
 
@@ -20441,10 +19823,10 @@ func (x codecSelfer1234) encSliceHorizontalPodAutoscaler(v []HorizontalPodAutosc
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1695 := range v {
+	for _, yyv1649 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1696 := &yyv1695
-		yy1696.CodecEncodeSelf(e)
+		yy1650 := &yyv1649
+		yy1650.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -20454,83 +19836,83 @@ func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutos
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1697 := *v
-	yyh1697, yyl1697 := z.DecSliceHelperStart()
-	var yyc1697 bool
-	if yyl1697 == 0 {
-		if yyv1697 == nil {
-			yyv1697 = []HorizontalPodAutoscaler{}
-			yyc1697 = true
-		} else if len(yyv1697) != 0 {
-			yyv1697 = yyv1697[:0]
-			yyc1697 = true
+	yyv1651 := *v
+	yyh1651, yyl1651 := z.DecSliceHelperStart()
+	var yyc1651 bool
+	if yyl1651 == 0 {
+		if yyv1651 == nil {
+			yyv1651 = []HorizontalPodAutoscaler{}
+			yyc1651 = true
+		} else if len(yyv1651) != 0 {
+			yyv1651 = yyv1651[:0]
+			yyc1651 = true
 		}
-	} else if yyl1697 > 0 {
-		var yyrr1697, yyrl1697 int
-		var yyrt1697 bool
-		if yyl1697 > cap(yyv1697) {
+	} else if yyl1651 > 0 {
+		var yyrr1651, yyrl1651 int
+		var yyrt1651 bool
+		if yyl1651 > cap(yyv1651) {
 
-			yyrg1697 := len(yyv1697) > 0
-			yyv21697 := yyv1697
-			yyrl1697, yyrt1697 = z.DecInferLen(yyl1697, z.DecBasicHandle().MaxInitLen, 312)
-			if yyrt1697 {
-				if yyrl1697 <= cap(yyv1697) {
-					yyv1697 = yyv1697[:yyrl1697]
+			yyrg1651 := len(yyv1651) > 0
+			yyv21651 := yyv1651
+			yyrl1651, yyrt1651 = z.DecInferLen(yyl1651, z.DecBasicHandle().MaxInitLen, 312)
+			if yyrt1651 {
+				if yyrl1651 <= cap(yyv1651) {
+					yyv1651 = yyv1651[:yyrl1651]
 				} else {
-					yyv1697 = make([]HorizontalPodAutoscaler, yyrl1697)
+					yyv1651 = make([]HorizontalPodAutoscaler, yyrl1651)
 				}
 			} else {
-				yyv1697 = make([]HorizontalPodAutoscaler, yyrl1697)
+				yyv1651 = make([]HorizontalPodAutoscaler, yyrl1651)
 			}
-			yyc1697 = true
-			yyrr1697 = len(yyv1697)
-			if yyrg1697 {
-				copy(yyv1697, yyv21697)
+			yyc1651 = true
+			yyrr1651 = len(yyv1651)
+			if yyrg1651 {
+				copy(yyv1651, yyv21651)
 			}
-		} else if yyl1697 != len(yyv1697) {
-			yyv1697 = yyv1697[:yyl1697]
-			yyc1697 = true
+		} else if yyl1651 != len(yyv1651) {
+			yyv1651 = yyv1651[:yyl1651]
+			yyc1651 = true
 		}
-		yyj1697 := 0
-		for ; yyj1697 < yyrr1697; yyj1697++ {
-			yyh1697.ElemContainerState(yyj1697)
+		yyj1651 := 0
+		for ; yyj1651 < yyrr1651; yyj1651++ {
+			yyh1651.ElemContainerState(yyj1651)
 			if r.TryDecodeAsNil() {
-				yyv1697[yyj1697] = HorizontalPodAutoscaler{}
+				yyv1651[yyj1651] = HorizontalPodAutoscaler{}
 			} else {
-				yyv1698 := &yyv1697[yyj1697]
-				yyv1698.CodecDecodeSelf(d)
+				yyv1652 := &yyv1651[yyj1651]
+				yyv1652.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1697 {
-			for ; yyj1697 < yyl1697; yyj1697++ {
-				yyv1697 = append(yyv1697, HorizontalPodAutoscaler{})
-				yyh1697.ElemContainerState(yyj1697)
+		if yyrt1651 {
+			for ; yyj1651 < yyl1651; yyj1651++ {
+				yyv1651 = append(yyv1651, HorizontalPodAutoscaler{})
+				yyh1651.ElemContainerState(yyj1651)
 				if r.TryDecodeAsNil() {
-					yyv1697[yyj1697] = HorizontalPodAutoscaler{}
+					yyv1651[yyj1651] = HorizontalPodAutoscaler{}
 				} else {
-					yyv1699 := &yyv1697[yyj1697]
-					yyv1699.CodecDecodeSelf(d)
+					yyv1653 := &yyv1651[yyj1651]
+					yyv1653.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1697 := 0
-		for ; !r.CheckBreak(); yyj1697++ {
+		yyj1651 := 0
+		for ; !r.CheckBreak(); yyj1651++ {
 
-			if yyj1697 >= len(yyv1697) {
-				yyv1697 = append(yyv1697, HorizontalPodAutoscaler{}) // var yyz1697 HorizontalPodAutoscaler
-				yyc1697 = true
+			if yyj1651 >= len(yyv1651) {
+				yyv1651 = append(yyv1651, HorizontalPodAutoscaler{}) // var yyz1651 HorizontalPodAutoscaler
+				yyc1651 = true
 			}
-			yyh1697.ElemContainerState(yyj1697)
-			if yyj1697 < len(yyv1697) {
+			yyh1651.ElemContainerState(yyj1651)
+			if yyj1651 < len(yyv1651) {
 				if r.TryDecodeAsNil() {
-					yyv1697[yyj1697] = HorizontalPodAutoscaler{}
+					yyv1651[yyj1651] = HorizontalPodAutoscaler{}
 				} else {
-					yyv1700 := &yyv1697[yyj1697]
-					yyv1700.CodecDecodeSelf(d)
+					yyv1654 := &yyv1651[yyj1651]
+					yyv1654.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -20538,17 +19920,17 @@ func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutos
 			}
 
 		}
-		if yyj1697 < len(yyv1697) {
-			yyv1697 = yyv1697[:yyj1697]
-			yyc1697 = true
-		} else if yyj1697 == 0 && yyv1697 == nil {
-			yyv1697 = []HorizontalPodAutoscaler{}
-			yyc1697 = true
+		if yyj1651 < len(yyv1651) {
+			yyv1651 = yyv1651[:yyj1651]
+			yyc1651 = true
+		} else if yyj1651 == 0 && yyv1651 == nil {
+			yyv1651 = []HorizontalPodAutoscaler{}
+			yyc1651 = true
 		}
 	}
-	yyh1697.End()
-	if yyc1697 {
-		*v = yyv1697
+	yyh1651.End()
+	if yyc1651 {
+		*v = yyv1651
 	}
 }
 
@@ -20557,10 +19939,10 @@ func (x codecSelfer1234) encSliceAPIVersion(v []APIVersion, e *codec1978.Encoder
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1701 := range v {
+	for _, yyv1655 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1702 := &yyv1701
-		yy1702.CodecEncodeSelf(e)
+		yy1656 := &yyv1655
+		yy1656.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -20570,83 +19952,83 @@ func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decode
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1703 := *v
-	yyh1703, yyl1703 := z.DecSliceHelperStart()
-	var yyc1703 bool
-	if yyl1703 == 0 {
-		if yyv1703 == nil {
-			yyv1703 = []APIVersion{}
-			yyc1703 = true
-		} else if len(yyv1703) != 0 {
-			yyv1703 = yyv1703[:0]
-			yyc1703 = true
+	yyv1657 := *v
+	yyh1657, yyl1657 := z.DecSliceHelperStart()
+	var yyc1657 bool
+	if yyl1657 == 0 {
+		if yyv1657 == nil {
+			yyv1657 = []APIVersion{}
+			yyc1657 = true
+		} else if len(yyv1657) != 0 {
+			yyv1657 = yyv1657[:0]
+			yyc1657 = true
 		}
-	} else if yyl1703 > 0 {
-		var yyrr1703, yyrl1703 int
-		var yyrt1703 bool
-		if yyl1703 > cap(yyv1703) {
+	} else if yyl1657 > 0 {
+		var yyrr1657, yyrl1657 int
+		var yyrt1657 bool
+		if yyl1657 > cap(yyv1657) {
 
-			yyrg1703 := len(yyv1703) > 0
-			yyv21703 := yyv1703
-			yyrl1703, yyrt1703 = z.DecInferLen(yyl1703, z.DecBasicHandle().MaxInitLen, 32)
-			if yyrt1703 {
-				if yyrl1703 <= cap(yyv1703) {
-					yyv1703 = yyv1703[:yyrl1703]
+			yyrg1657 := len(yyv1657) > 0
+			yyv21657 := yyv1657
+			yyrl1657, yyrt1657 = z.DecInferLen(yyl1657, z.DecBasicHandle().MaxInitLen, 32)
+			if yyrt1657 {
+				if yyrl1657 <= cap(yyv1657) {
+					yyv1657 = yyv1657[:yyrl1657]
 				} else {
-					yyv1703 = make([]APIVersion, yyrl1703)
+					yyv1657 = make([]APIVersion, yyrl1657)
 				}
 			} else {
-				yyv1703 = make([]APIVersion, yyrl1703)
+				yyv1657 = make([]APIVersion, yyrl1657)
 			}
-			yyc1703 = true
-			yyrr1703 = len(yyv1703)
-			if yyrg1703 {
-				copy(yyv1703, yyv21703)
+			yyc1657 = true
+			yyrr1657 = len(yyv1657)
+			if yyrg1657 {
+				copy(yyv1657, yyv21657)
 			}
-		} else if yyl1703 != len(yyv1703) {
-			yyv1703 = yyv1703[:yyl1703]
-			yyc1703 = true
+		} else if yyl1657 != len(yyv1657) {
+			yyv1657 = yyv1657[:yyl1657]
+			yyc1657 = true
 		}
-		yyj1703 := 0
-		for ; yyj1703 < yyrr1703; yyj1703++ {
-			yyh1703.ElemContainerState(yyj1703)
+		yyj1657 := 0
+		for ; yyj1657 < yyrr1657; yyj1657++ {
+			yyh1657.ElemContainerState(yyj1657)
 			if r.TryDecodeAsNil() {
-				yyv1703[yyj1703] = APIVersion{}
+				yyv1657[yyj1657] = APIVersion{}
 			} else {
-				yyv1704 := &yyv1703[yyj1703]
-				yyv1704.CodecDecodeSelf(d)
+				yyv1658 := &yyv1657[yyj1657]
+				yyv1658.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1703 {
-			for ; yyj1703 < yyl1703; yyj1703++ {
-				yyv1703 = append(yyv1703, APIVersion{})
-				yyh1703.ElemContainerState(yyj1703)
+		if yyrt1657 {
+			for ; yyj1657 < yyl1657; yyj1657++ {
+				yyv1657 = append(yyv1657, APIVersion{})
+				yyh1657.ElemContainerState(yyj1657)
 				if r.TryDecodeAsNil() {
-					yyv1703[yyj1703] = APIVersion{}
+					yyv1657[yyj1657] = APIVersion{}
 				} else {
-					yyv1705 := &yyv1703[yyj1703]
-					yyv1705.CodecDecodeSelf(d)
+					yyv1659 := &yyv1657[yyj1657]
+					yyv1659.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1703 := 0
-		for ; !r.CheckBreak(); yyj1703++ {
+		yyj1657 := 0
+		for ; !r.CheckBreak(); yyj1657++ {
 
-			if yyj1703 >= len(yyv1703) {
-				yyv1703 = append(yyv1703, APIVersion{}) // var yyz1703 APIVersion
-				yyc1703 = true
+			if yyj1657 >= len(yyv1657) {
+				yyv1657 = append(yyv1657, APIVersion{}) // var yyz1657 APIVersion
+				yyc1657 = true
 			}
-			yyh1703.ElemContainerState(yyj1703)
-			if yyj1703 < len(yyv1703) {
+			yyh1657.ElemContainerState(yyj1657)
+			if yyj1657 < len(yyv1657) {
 				if r.TryDecodeAsNil() {
-					yyv1703[yyj1703] = APIVersion{}
+					yyv1657[yyj1657] = APIVersion{}
 				} else {
-					yyv1706 := &yyv1703[yyj1703]
-					yyv1706.CodecDecodeSelf(d)
+					yyv1660 := &yyv1657[yyj1657]
+					yyv1660.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -20654,17 +20036,17 @@ func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decode
 			}
 
 		}
-		if yyj1703 < len(yyv1703) {
-			yyv1703 = yyv1703[:yyj1703]
-			yyc1703 = true
-		} else if yyj1703 == 0 && yyv1703 == nil {
-			yyv1703 = []APIVersion{}
-			yyc1703 = true
+		if yyj1657 < len(yyv1657) {
+			yyv1657 = yyv1657[:yyj1657]
+			yyc1657 = true
+		} else if yyj1657 == 0 && yyv1657 == nil {
+			yyv1657 = []APIVersion{}
+			yyc1657 = true
 		}
 	}
-	yyh1703.End()
-	if yyc1703 {
-		*v = yyv1703
+	yyh1657.End()
+	if yyc1657 {
+		*v = yyv1657
 	}
 }
 
@@ -20673,10 +20055,10 @@ func (x codecSelfer1234) encSliceThirdPartyResource(v []ThirdPartyResource, e *c
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1707 := range v {
+	for _, yyv1661 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1708 := &yyv1707
-		yy1708.CodecEncodeSelf(e)
+		yy1662 := &yyv1661
+		yy1662.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -20686,83 +20068,83 @@ func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1709 := *v
-	yyh1709, yyl1709 := z.DecSliceHelperStart()
-	var yyc1709 bool
-	if yyl1709 == 0 {
-		if yyv1709 == nil {
-			yyv1709 = []ThirdPartyResource{}
-			yyc1709 = true
-		} else if len(yyv1709) != 0 {
-			yyv1709 = yyv1709[:0]
-			yyc1709 = true
+	yyv1663 := *v
+	yyh1663, yyl1663 := z.DecSliceHelperStart()
+	var yyc1663 bool
+	if yyl1663 == 0 {
+		if yyv1663 == nil {
+			yyv1663 = []ThirdPartyResource{}
+			yyc1663 = true
+		} else if len(yyv1663) != 0 {
+			yyv1663 = yyv1663[:0]
+			yyc1663 = true
 		}
-	} else if yyl1709 > 0 {
-		var yyrr1709, yyrl1709 int
-		var yyrt1709 bool
-		if yyl1709 > cap(yyv1709) {
+	} else if yyl1663 > 0 {
+		var yyrr1663, yyrl1663 int
+		var yyrt1663 bool
+		if yyl1663 > cap(yyv1663) {
 
-			yyrg1709 := len(yyv1709) > 0
-			yyv21709 := yyv1709
-			yyrl1709, yyrt1709 = z.DecInferLen(yyl1709, z.DecBasicHandle().MaxInitLen, 232)
-			if yyrt1709 {
-				if yyrl1709 <= cap(yyv1709) {
-					yyv1709 = yyv1709[:yyrl1709]
+			yyrg1663 := len(yyv1663) > 0
+			yyv21663 := yyv1663
+			yyrl1663, yyrt1663 = z.DecInferLen(yyl1663, z.DecBasicHandle().MaxInitLen, 232)
+			if yyrt1663 {
+				if yyrl1663 <= cap(yyv1663) {
+					yyv1663 = yyv1663[:yyrl1663]
 				} else {
-					yyv1709 = make([]ThirdPartyResource, yyrl1709)
+					yyv1663 = make([]ThirdPartyResource, yyrl1663)
 				}
 			} else {
-				yyv1709 = make([]ThirdPartyResource, yyrl1709)
+				yyv1663 = make([]ThirdPartyResource, yyrl1663)
 			}
-			yyc1709 = true
-			yyrr1709 = len(yyv1709)
-			if yyrg1709 {
-				copy(yyv1709, yyv21709)
+			yyc1663 = true
+			yyrr1663 = len(yyv1663)
+			if yyrg1663 {
+				copy(yyv1663, yyv21663)
 			}
-		} else if yyl1709 != len(yyv1709) {
-			yyv1709 = yyv1709[:yyl1709]
-			yyc1709 = true
+		} else if yyl1663 != len(yyv1663) {
+			yyv1663 = yyv1663[:yyl1663]
+			yyc1663 = true
 		}
-		yyj1709 := 0
-		for ; yyj1709 < yyrr1709; yyj1709++ {
-			yyh1709.ElemContainerState(yyj1709)
+		yyj1663 := 0
+		for ; yyj1663 < yyrr1663; yyj1663++ {
+			yyh1663.ElemContainerState(yyj1663)
 			if r.TryDecodeAsNil() {
-				yyv1709[yyj1709] = ThirdPartyResource{}
+				yyv1663[yyj1663] = ThirdPartyResource{}
 			} else {
-				yyv1710 := &yyv1709[yyj1709]
-				yyv1710.CodecDecodeSelf(d)
+				yyv1664 := &yyv1663[yyj1663]
+				yyv1664.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1709 {
-			for ; yyj1709 < yyl1709; yyj1709++ {
-				yyv1709 = append(yyv1709, ThirdPartyResource{})
-				yyh1709.ElemContainerState(yyj1709)
+		if yyrt1663 {
+			for ; yyj1663 < yyl1663; yyj1663++ {
+				yyv1663 = append(yyv1663, ThirdPartyResource{})
+				yyh1663.ElemContainerState(yyj1663)
 				if r.TryDecodeAsNil() {
-					yyv1709[yyj1709] = ThirdPartyResource{}
+					yyv1663[yyj1663] = ThirdPartyResource{}
 				} else {
-					yyv1711 := &yyv1709[yyj1709]
-					yyv1711.CodecDecodeSelf(d)
+					yyv1665 := &yyv1663[yyj1663]
+					yyv1665.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1709 := 0
-		for ; !r.CheckBreak(); yyj1709++ {
+		yyj1663 := 0
+		for ; !r.CheckBreak(); yyj1663++ {
 
-			if yyj1709 >= len(yyv1709) {
-				yyv1709 = append(yyv1709, ThirdPartyResource{}) // var yyz1709 ThirdPartyResource
-				yyc1709 = true
+			if yyj1663 >= len(yyv1663) {
+				yyv1663 = append(yyv1663, ThirdPartyResource{}) // var yyz1663 ThirdPartyResource
+				yyc1663 = true
 			}
-			yyh1709.ElemContainerState(yyj1709)
-			if yyj1709 < len(yyv1709) {
+			yyh1663.ElemContainerState(yyj1663)
+			if yyj1663 < len(yyv1663) {
 				if r.TryDecodeAsNil() {
-					yyv1709[yyj1709] = ThirdPartyResource{}
+					yyv1663[yyj1663] = ThirdPartyResource{}
 				} else {
-					yyv1712 := &yyv1709[yyj1709]
-					yyv1712.CodecDecodeSelf(d)
+					yyv1666 := &yyv1663[yyj1663]
+					yyv1666.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -20770,17 +20152,17 @@ func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *
 			}
 
 		}
-		if yyj1709 < len(yyv1709) {
-			yyv1709 = yyv1709[:yyj1709]
-			yyc1709 = true
-		} else if yyj1709 == 0 && yyv1709 == nil {
-			yyv1709 = []ThirdPartyResource{}
-			yyc1709 = true
+		if yyj1663 < len(yyv1663) {
+			yyv1663 = yyv1663[:yyj1663]
+			yyc1663 = true
+		} else if yyj1663 == 0 && yyv1663 == nil {
+			yyv1663 = []ThirdPartyResource{}
+			yyc1663 = true
 		}
 	}
-	yyh1709.End()
-	if yyc1709 {
-		*v = yyv1709
+	yyh1663.End()
+	if yyc1663 {
+		*v = yyv1663
 	}
 }
 
@@ -20789,10 +20171,10 @@ func (x codecSelfer1234) encSliceDeployment(v []Deployment, e *codec1978.Encoder
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1713 := range v {
+	for _, yyv1667 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1714 := &yyv1713
-		yy1714.CodecEncodeSelf(e)
+		yy1668 := &yyv1667
+		yy1668.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -20802,83 +20184,83 @@ func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decode
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1715 := *v
-	yyh1715, yyl1715 := z.DecSliceHelperStart()
-	var yyc1715 bool
-	if yyl1715 == 0 {
-		if yyv1715 == nil {
-			yyv1715 = []Deployment{}
-			yyc1715 = true
-		} else if len(yyv1715) != 0 {
-			yyv1715 = yyv1715[:0]
-			yyc1715 = true
+	yyv1669 := *v
+	yyh1669, yyl1669 := z.DecSliceHelperStart()
+	var yyc1669 bool
+	if yyl1669 == 0 {
+		if yyv1669 == nil {
+			yyv1669 = []Deployment{}
+			yyc1669 = true
+		} else if len(yyv1669) != 0 {
+			yyv1669 = yyv1669[:0]
+			yyc1669 = true
 		}
-	} else if yyl1715 > 0 {
-		var yyrr1715, yyrl1715 int
-		var yyrt1715 bool
-		if yyl1715 > cap(yyv1715) {
+	} else if yyl1669 > 0 {
+		var yyrr1669, yyrl1669 int
+		var yyrt1669 bool
+		if yyl1669 > cap(yyv1669) {
 
-			yyrg1715 := len(yyv1715) > 0
-			yyv21715 := yyv1715
-			yyrl1715, yyrt1715 = z.DecInferLen(yyl1715, z.DecBasicHandle().MaxInitLen, 632)
-			if yyrt1715 {
-				if yyrl1715 <= cap(yyv1715) {
-					yyv1715 = yyv1715[:yyrl1715]
+			yyrg1669 := len(yyv1669) > 0
+			yyv21669 := yyv1669
+			yyrl1669, yyrt1669 = z.DecInferLen(yyl1669, z.DecBasicHandle().MaxInitLen, 632)
+			if yyrt1669 {
+				if yyrl1669 <= cap(yyv1669) {
+					yyv1669 = yyv1669[:yyrl1669]
 				} else {
-					yyv1715 = make([]Deployment, yyrl1715)
+					yyv1669 = make([]Deployment, yyrl1669)
 				}
 			} else {
-				yyv1715 = make([]Deployment, yyrl1715)
+				yyv1669 = make([]Deployment, yyrl1669)
 			}
-			yyc1715 = true
-			yyrr1715 = len(yyv1715)
-			if yyrg1715 {
-				copy(yyv1715, yyv21715)
+			yyc1669 = true
+			yyrr1669 = len(yyv1669)
+			if yyrg1669 {
+				copy(yyv1669, yyv21669)
 			}
-		} else if yyl1715 != len(yyv1715) {
-			yyv1715 = yyv1715[:yyl1715]
-			yyc1715 = true
+		} else if yyl1669 != len(yyv1669) {
+			yyv1669 = yyv1669[:yyl1669]
+			yyc1669 = true
 		}
-		yyj1715 := 0
-		for ; yyj1715 < yyrr1715; yyj1715++ {
-			yyh1715.ElemContainerState(yyj1715)
+		yyj1669 := 0
+		for ; yyj1669 < yyrr1669; yyj1669++ {
+			yyh1669.ElemContainerState(yyj1669)
 			if r.TryDecodeAsNil() {
-				yyv1715[yyj1715] = Deployment{}
+				yyv1669[yyj1669] = Deployment{}
 			} else {
-				yyv1716 := &yyv1715[yyj1715]
-				yyv1716.CodecDecodeSelf(d)
+				yyv1670 := &yyv1669[yyj1669]
+				yyv1670.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1715 {
-			for ; yyj1715 < yyl1715; yyj1715++ {
-				yyv1715 = append(yyv1715, Deployment{})
-				yyh1715.ElemContainerState(yyj1715)
+		if yyrt1669 {
+			for ; yyj1669 < yyl1669; yyj1669++ {
+				yyv1669 = append(yyv1669, Deployment{})
+				yyh1669.ElemContainerState(yyj1669)
 				if r.TryDecodeAsNil() {
-					yyv1715[yyj1715] = Deployment{}
+					yyv1669[yyj1669] = Deployment{}
 				} else {
-					yyv1717 := &yyv1715[yyj1715]
-					yyv1717.CodecDecodeSelf(d)
+					yyv1671 := &yyv1669[yyj1669]
+					yyv1671.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1715 := 0
-		for ; !r.CheckBreak(); yyj1715++ {
+		yyj1669 := 0
+		for ; !r.CheckBreak(); yyj1669++ {
 
-			if yyj1715 >= len(yyv1715) {
-				yyv1715 = append(yyv1715, Deployment{}) // var yyz1715 Deployment
-				yyc1715 = true
+			if yyj1669 >= len(yyv1669) {
+				yyv1669 = append(yyv1669, Deployment{}) // var yyz1669 Deployment
+				yyc1669 = true
 			}
-			yyh1715.ElemContainerState(yyj1715)
-			if yyj1715 < len(yyv1715) {
+			yyh1669.ElemContainerState(yyj1669)
+			if yyj1669 < len(yyv1669) {
 				if r.TryDecodeAsNil() {
-					yyv1715[yyj1715] = Deployment{}
+					yyv1669[yyj1669] = Deployment{}
 				} else {
-					yyv1718 := &yyv1715[yyj1715]
-					yyv1718.CodecDecodeSelf(d)
+					yyv1672 := &yyv1669[yyj1669]
+					yyv1672.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -20886,17 +20268,17 @@ func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decode
 			}
 
 		}
-		if yyj1715 < len(yyv1715) {
-			yyv1715 = yyv1715[:yyj1715]
-			yyc1715 = true
-		} else if yyj1715 == 0 && yyv1715 == nil {
-			yyv1715 = []Deployment{}
-			yyc1715 = true
+		if yyj1669 < len(yyv1669) {
+			yyv1669 = yyv1669[:yyj1669]
+			yyc1669 = true
+		} else if yyj1669 == 0 && yyv1669 == nil {
+			yyv1669 = []Deployment{}
+			yyc1669 = true
 		}
 	}
-	yyh1715.End()
-	if yyc1715 {
-		*v = yyv1715
+	yyh1669.End()
+	if yyc1669 {
+		*v = yyv1669
 	}
 }
 
@@ -20905,10 +20287,10 @@ func (x codecSelfer1234) encSliceDaemonSet(v []DaemonSet, e *codec1978.Encoder) 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1719 := range v {
+	for _, yyv1673 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1720 := &yyv1719
-		yy1720.CodecEncodeSelf(e)
+		yy1674 := &yyv1673
+		yy1674.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -20918,83 +20300,83 @@ func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder)
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1721 := *v
-	yyh1721, yyl1721 := z.DecSliceHelperStart()
-	var yyc1721 bool
-	if yyl1721 == 0 {
-		if yyv1721 == nil {
-			yyv1721 = []DaemonSet{}
-			yyc1721 = true
-		} else if len(yyv1721) != 0 {
-			yyv1721 = yyv1721[:0]
-			yyc1721 = true
+	yyv1675 := *v
+	yyh1675, yyl1675 := z.DecSliceHelperStart()
+	var yyc1675 bool
+	if yyl1675 == 0 {
+		if yyv1675 == nil {
+			yyv1675 = []DaemonSet{}
+			yyc1675 = true
+		} else if len(yyv1675) != 0 {
+			yyv1675 = yyv1675[:0]
+			yyc1675 = true
 		}
-	} else if yyl1721 > 0 {
-		var yyrr1721, yyrl1721 int
-		var yyrt1721 bool
-		if yyl1721 > cap(yyv1721) {
+	} else if yyl1675 > 0 {
+		var yyrr1675, yyrl1675 int
+		var yyrt1675 bool
+		if yyl1675 > cap(yyv1675) {
 
-			yyrg1721 := len(yyv1721) > 0
-			yyv21721 := yyv1721
-			yyrl1721, yyrt1721 = z.DecInferLen(yyl1721, z.DecBasicHandle().MaxInitLen, 600)
-			if yyrt1721 {
-				if yyrl1721 <= cap(yyv1721) {
-					yyv1721 = yyv1721[:yyrl1721]
+			yyrg1675 := len(yyv1675) > 0
+			yyv21675 := yyv1675
+			yyrl1675, yyrt1675 = z.DecInferLen(yyl1675, z.DecBasicHandle().MaxInitLen, 568)
+			if yyrt1675 {
+				if yyrl1675 <= cap(yyv1675) {
+					yyv1675 = yyv1675[:yyrl1675]
 				} else {
-					yyv1721 = make([]DaemonSet, yyrl1721)
+					yyv1675 = make([]DaemonSet, yyrl1675)
 				}
 			} else {
-				yyv1721 = make([]DaemonSet, yyrl1721)
+				yyv1675 = make([]DaemonSet, yyrl1675)
 			}
-			yyc1721 = true
-			yyrr1721 = len(yyv1721)
-			if yyrg1721 {
-				copy(yyv1721, yyv21721)
+			yyc1675 = true
+			yyrr1675 = len(yyv1675)
+			if yyrg1675 {
+				copy(yyv1675, yyv21675)
 			}
-		} else if yyl1721 != len(yyv1721) {
-			yyv1721 = yyv1721[:yyl1721]
-			yyc1721 = true
+		} else if yyl1675 != len(yyv1675) {
+			yyv1675 = yyv1675[:yyl1675]
+			yyc1675 = true
 		}
-		yyj1721 := 0
-		for ; yyj1721 < yyrr1721; yyj1721++ {
-			yyh1721.ElemContainerState(yyj1721)
+		yyj1675 := 0
+		for ; yyj1675 < yyrr1675; yyj1675++ {
+			yyh1675.ElemContainerState(yyj1675)
 			if r.TryDecodeAsNil() {
-				yyv1721[yyj1721] = DaemonSet{}
+				yyv1675[yyj1675] = DaemonSet{}
 			} else {
-				yyv1722 := &yyv1721[yyj1721]
-				yyv1722.CodecDecodeSelf(d)
+				yyv1676 := &yyv1675[yyj1675]
+				yyv1676.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1721 {
-			for ; yyj1721 < yyl1721; yyj1721++ {
-				yyv1721 = append(yyv1721, DaemonSet{})
-				yyh1721.ElemContainerState(yyj1721)
+		if yyrt1675 {
+			for ; yyj1675 < yyl1675; yyj1675++ {
+				yyv1675 = append(yyv1675, DaemonSet{})
+				yyh1675.ElemContainerState(yyj1675)
 				if r.TryDecodeAsNil() {
-					yyv1721[yyj1721] = DaemonSet{}
+					yyv1675[yyj1675] = DaemonSet{}
 				} else {
-					yyv1723 := &yyv1721[yyj1721]
-					yyv1723.CodecDecodeSelf(d)
+					yyv1677 := &yyv1675[yyj1675]
+					yyv1677.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1721 := 0
-		for ; !r.CheckBreak(); yyj1721++ {
+		yyj1675 := 0
+		for ; !r.CheckBreak(); yyj1675++ {
 
-			if yyj1721 >= len(yyv1721) {
-				yyv1721 = append(yyv1721, DaemonSet{}) // var yyz1721 DaemonSet
-				yyc1721 = true
+			if yyj1675 >= len(yyv1675) {
+				yyv1675 = append(yyv1675, DaemonSet{}) // var yyz1675 DaemonSet
+				yyc1675 = true
 			}
-			yyh1721.ElemContainerState(yyj1721)
-			if yyj1721 < len(yyv1721) {
+			yyh1675.ElemContainerState(yyj1675)
+			if yyj1675 < len(yyv1675) {
 				if r.TryDecodeAsNil() {
-					yyv1721[yyj1721] = DaemonSet{}
+					yyv1675[yyj1675] = DaemonSet{}
 				} else {
-					yyv1724 := &yyv1721[yyj1721]
-					yyv1724.CodecDecodeSelf(d)
+					yyv1678 := &yyv1675[yyj1675]
+					yyv1678.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -21002,17 +20384,17 @@ func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder)
 			}
 
 		}
-		if yyj1721 < len(yyv1721) {
-			yyv1721 = yyv1721[:yyj1721]
-			yyc1721 = true
-		} else if yyj1721 == 0 && yyv1721 == nil {
-			yyv1721 = []DaemonSet{}
-			yyc1721 = true
+		if yyj1675 < len(yyv1675) {
+			yyv1675 = yyv1675[:yyj1675]
+			yyc1675 = true
+		} else if yyj1675 == 0 && yyv1675 == nil {
+			yyv1675 = []DaemonSet{}
+			yyc1675 = true
 		}
 	}
-	yyh1721.End()
-	if yyc1721 {
-		*v = yyv1721
+	yyh1675.End()
+	if yyc1675 {
+		*v = yyv1675
 	}
 }
 
@@ -21021,10 +20403,10 @@ func (x codecSelfer1234) encSliceThirdPartyResourceData(v []ThirdPartyResourceDa
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1725 := range v {
+	for _, yyv1679 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1726 := &yyv1725
-		yy1726.CodecEncodeSelf(e)
+		yy1680 := &yyv1679
+		yy1680.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -21034,83 +20416,83 @@ func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceD
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1727 := *v
-	yyh1727, yyl1727 := z.DecSliceHelperStart()
-	var yyc1727 bool
-	if yyl1727 == 0 {
-		if yyv1727 == nil {
-			yyv1727 = []ThirdPartyResourceData{}
-			yyc1727 = true
-		} else if len(yyv1727) != 0 {
-			yyv1727 = yyv1727[:0]
-			yyc1727 = true
+	yyv1681 := *v
+	yyh1681, yyl1681 := z.DecSliceHelperStart()
+	var yyc1681 bool
+	if yyl1681 == 0 {
+		if yyv1681 == nil {
+			yyv1681 = []ThirdPartyResourceData{}
+			yyc1681 = true
+		} else if len(yyv1681) != 0 {
+			yyv1681 = yyv1681[:0]
+			yyc1681 = true
 		}
-	} else if yyl1727 > 0 {
-		var yyrr1727, yyrl1727 int
-		var yyrt1727 bool
-		if yyl1727 > cap(yyv1727) {
+	} else if yyl1681 > 0 {
+		var yyrr1681, yyrl1681 int
+		var yyrt1681 bool
+		if yyl1681 > cap(yyv1681) {
 
-			yyrg1727 := len(yyv1727) > 0
-			yyv21727 := yyv1727
-			yyrl1727, yyrt1727 = z.DecInferLen(yyl1727, z.DecBasicHandle().MaxInitLen, 216)
-			if yyrt1727 {
-				if yyrl1727 <= cap(yyv1727) {
-					yyv1727 = yyv1727[:yyrl1727]
+			yyrg1681 := len(yyv1681) > 0
+			yyv21681 := yyv1681
+			yyrl1681, yyrt1681 = z.DecInferLen(yyl1681, z.DecBasicHandle().MaxInitLen, 216)
+			if yyrt1681 {
+				if yyrl1681 <= cap(yyv1681) {
+					yyv1681 = yyv1681[:yyrl1681]
 				} else {
-					yyv1727 = make([]ThirdPartyResourceData, yyrl1727)
+					yyv1681 = make([]ThirdPartyResourceData, yyrl1681)
 				}
 			} else {
-				yyv1727 = make([]ThirdPartyResourceData, yyrl1727)
+				yyv1681 = make([]ThirdPartyResourceData, yyrl1681)
 			}
-			yyc1727 = true
-			yyrr1727 = len(yyv1727)
-			if yyrg1727 {
-				copy(yyv1727, yyv21727)
+			yyc1681 = true
+			yyrr1681 = len(yyv1681)
+			if yyrg1681 {
+				copy(yyv1681, yyv21681)
 			}
-		} else if yyl1727 != len(yyv1727) {
-			yyv1727 = yyv1727[:yyl1727]
-			yyc1727 = true
+		} else if yyl1681 != len(yyv1681) {
+			yyv1681 = yyv1681[:yyl1681]
+			yyc1681 = true
 		}
-		yyj1727 := 0
-		for ; yyj1727 < yyrr1727; yyj1727++ {
-			yyh1727.ElemContainerState(yyj1727)
+		yyj1681 := 0
+		for ; yyj1681 < yyrr1681; yyj1681++ {
+			yyh1681.ElemContainerState(yyj1681)
 			if r.TryDecodeAsNil() {
-				yyv1727[yyj1727] = ThirdPartyResourceData{}
+				yyv1681[yyj1681] = ThirdPartyResourceData{}
 			} else {
-				yyv1728 := &yyv1727[yyj1727]
-				yyv1728.CodecDecodeSelf(d)
+				yyv1682 := &yyv1681[yyj1681]
+				yyv1682.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1727 {
-			for ; yyj1727 < yyl1727; yyj1727++ {
-				yyv1727 = append(yyv1727, ThirdPartyResourceData{})
-				yyh1727.ElemContainerState(yyj1727)
+		if yyrt1681 {
+			for ; yyj1681 < yyl1681; yyj1681++ {
+				yyv1681 = append(yyv1681, ThirdPartyResourceData{})
+				yyh1681.ElemContainerState(yyj1681)
 				if r.TryDecodeAsNil() {
-					yyv1727[yyj1727] = ThirdPartyResourceData{}
+					yyv1681[yyj1681] = ThirdPartyResourceData{}
 				} else {
-					yyv1729 := &yyv1727[yyj1727]
-					yyv1729.CodecDecodeSelf(d)
+					yyv1683 := &yyv1681[yyj1681]
+					yyv1683.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1727 := 0
-		for ; !r.CheckBreak(); yyj1727++ {
+		yyj1681 := 0
+		for ; !r.CheckBreak(); yyj1681++ {
 
-			if yyj1727 >= len(yyv1727) {
-				yyv1727 = append(yyv1727, ThirdPartyResourceData{}) // var yyz1727 ThirdPartyResourceData
-				yyc1727 = true
+			if yyj1681 >= len(yyv1681) {
+				yyv1681 = append(yyv1681, ThirdPartyResourceData{}) // var yyz1681 ThirdPartyResourceData
+				yyc1681 = true
 			}
-			yyh1727.ElemContainerState(yyj1727)
-			if yyj1727 < len(yyv1727) {
+			yyh1681.ElemContainerState(yyj1681)
+			if yyj1681 < len(yyv1681) {
 				if r.TryDecodeAsNil() {
-					yyv1727[yyj1727] = ThirdPartyResourceData{}
+					yyv1681[yyj1681] = ThirdPartyResourceData{}
 				} else {
-					yyv1730 := &yyv1727[yyj1727]
-					yyv1730.CodecDecodeSelf(d)
+					yyv1684 := &yyv1681[yyj1681]
+					yyv1684.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -21118,17 +20500,17 @@ func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceD
 			}
 
 		}
-		if yyj1727 < len(yyv1727) {
-			yyv1727 = yyv1727[:yyj1727]
-			yyc1727 = true
-		} else if yyj1727 == 0 && yyv1727 == nil {
-			yyv1727 = []ThirdPartyResourceData{}
-			yyc1727 = true
+		if yyj1681 < len(yyv1681) {
+			yyv1681 = yyv1681[:yyj1681]
+			yyc1681 = true
+		} else if yyj1681 == 0 && yyv1681 == nil {
+			yyv1681 = []ThirdPartyResourceData{}
+			yyc1681 = true
 		}
 	}
-	yyh1727.End()
-	if yyc1727 {
-		*v = yyv1727
+	yyh1681.End()
+	if yyc1681 {
+		*v = yyv1681
 	}
 }
 
@@ -21137,10 +20519,10 @@ func (x codecSelfer1234) encSliceJob(v []Job, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1731 := range v {
+	for _, yyv1685 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1732 := &yyv1731
-		yy1732.CodecEncodeSelf(e)
+		yy1686 := &yyv1685
+		yy1686.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -21150,83 +20532,83 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1733 := *v
-	yyh1733, yyl1733 := z.DecSliceHelperStart()
-	var yyc1733 bool
-	if yyl1733 == 0 {
-		if yyv1733 == nil {
-			yyv1733 = []Job{}
-			yyc1733 = true
-		} else if len(yyv1733) != 0 {
-			yyv1733 = yyv1733[:0]
-			yyc1733 = true
+	yyv1687 := *v
+	yyh1687, yyl1687 := z.DecSliceHelperStart()
+	var yyc1687 bool
+	if yyl1687 == 0 {
+		if yyv1687 == nil {
+			yyv1687 = []Job{}
+			yyc1687 = true
+		} else if len(yyv1687) != 0 {
+			yyv1687 = yyv1687[:0]
+			yyc1687 = true
 		}
-	} else if yyl1733 > 0 {
-		var yyrr1733, yyrl1733 int
-		var yyrt1733 bool
-		if yyl1733 > cap(yyv1733) {
+	} else if yyl1687 > 0 {
+		var yyrr1687, yyrl1687 int
+		var yyrt1687 bool
+		if yyl1687 > cap(yyv1687) {
 
-			yyrg1733 := len(yyv1733) > 0
-			yyv21733 := yyv1733
-			yyrl1733, yyrt1733 = z.DecInferLen(yyl1733, z.DecBasicHandle().MaxInitLen, 632)
-			if yyrt1733 {
-				if yyrl1733 <= cap(yyv1733) {
-					yyv1733 = yyv1733[:yyrl1733]
+			yyrg1687 := len(yyv1687) > 0
+			yyv21687 := yyv1687
+			yyrl1687, yyrt1687 = z.DecInferLen(yyl1687, z.DecBasicHandle().MaxInitLen, 632)
+			if yyrt1687 {
+				if yyrl1687 <= cap(yyv1687) {
+					yyv1687 = yyv1687[:yyrl1687]
 				} else {
-					yyv1733 = make([]Job, yyrl1733)
+					yyv1687 = make([]Job, yyrl1687)
 				}
 			} else {
-				yyv1733 = make([]Job, yyrl1733)
+				yyv1687 = make([]Job, yyrl1687)
 			}
-			yyc1733 = true
-			yyrr1733 = len(yyv1733)
-			if yyrg1733 {
-				copy(yyv1733, yyv21733)
+			yyc1687 = true
+			yyrr1687 = len(yyv1687)
+			if yyrg1687 {
+				copy(yyv1687, yyv21687)
 			}
-		} else if yyl1733 != len(yyv1733) {
-			yyv1733 = yyv1733[:yyl1733]
-			yyc1733 = true
+		} else if yyl1687 != len(yyv1687) {
+			yyv1687 = yyv1687[:yyl1687]
+			yyc1687 = true
 		}
-		yyj1733 := 0
-		for ; yyj1733 < yyrr1733; yyj1733++ {
-			yyh1733.ElemContainerState(yyj1733)
+		yyj1687 := 0
+		for ; yyj1687 < yyrr1687; yyj1687++ {
+			yyh1687.ElemContainerState(yyj1687)
 			if r.TryDecodeAsNil() {
-				yyv1733[yyj1733] = Job{}
+				yyv1687[yyj1687] = Job{}
 			} else {
-				yyv1734 := &yyv1733[yyj1733]
-				yyv1734.CodecDecodeSelf(d)
+				yyv1688 := &yyv1687[yyj1687]
+				yyv1688.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1733 {
-			for ; yyj1733 < yyl1733; yyj1733++ {
-				yyv1733 = append(yyv1733, Job{})
-				yyh1733.ElemContainerState(yyj1733)
+		if yyrt1687 {
+			for ; yyj1687 < yyl1687; yyj1687++ {
+				yyv1687 = append(yyv1687, Job{})
+				yyh1687.ElemContainerState(yyj1687)
 				if r.TryDecodeAsNil() {
-					yyv1733[yyj1733] = Job{}
+					yyv1687[yyj1687] = Job{}
 				} else {
-					yyv1735 := &yyv1733[yyj1733]
-					yyv1735.CodecDecodeSelf(d)
+					yyv1689 := &yyv1687[yyj1687]
+					yyv1689.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1733 := 0
-		for ; !r.CheckBreak(); yyj1733++ {
+		yyj1687 := 0
+		for ; !r.CheckBreak(); yyj1687++ {
 
-			if yyj1733 >= len(yyv1733) {
-				yyv1733 = append(yyv1733, Job{}) // var yyz1733 Job
-				yyc1733 = true
+			if yyj1687 >= len(yyv1687) {
+				yyv1687 = append(yyv1687, Job{}) // var yyz1687 Job
+				yyc1687 = true
 			}
-			yyh1733.ElemContainerState(yyj1733)
-			if yyj1733 < len(yyv1733) {
+			yyh1687.ElemContainerState(yyj1687)
+			if yyj1687 < len(yyv1687) {
 				if r.TryDecodeAsNil() {
-					yyv1733[yyj1733] = Job{}
+					yyv1687[yyj1687] = Job{}
 				} else {
-					yyv1736 := &yyv1733[yyj1733]
-					yyv1736.CodecDecodeSelf(d)
+					yyv1690 := &yyv1687[yyj1687]
+					yyv1690.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -21234,17 +20616,17 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 			}
 
 		}
-		if yyj1733 < len(yyv1733) {
-			yyv1733 = yyv1733[:yyj1733]
-			yyc1733 = true
-		} else if yyj1733 == 0 && yyv1733 == nil {
-			yyv1733 = []Job{}
-			yyc1733 = true
+		if yyj1687 < len(yyv1687) {
+			yyv1687 = yyv1687[:yyj1687]
+			yyc1687 = true
+		} else if yyj1687 == 0 && yyv1687 == nil {
+			yyv1687 = []Job{}
+			yyc1687 = true
 		}
 	}
-	yyh1733.End()
-	if yyc1733 {
-		*v = yyv1733
+	yyh1687.End()
+	if yyc1687 {
+		*v = yyv1687
 	}
 }
 
@@ -21253,10 +20635,10 @@ func (x codecSelfer1234) encSliceJobCondition(v []JobCondition, e *codec1978.Enc
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1737 := range v {
+	for _, yyv1691 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1738 := &yyv1737
-		yy1738.CodecEncodeSelf(e)
+		yy1692 := &yyv1691
+		yy1692.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -21266,83 +20648,83 @@ func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.De
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1739 := *v
-	yyh1739, yyl1739 := z.DecSliceHelperStart()
-	var yyc1739 bool
-	if yyl1739 == 0 {
-		if yyv1739 == nil {
-			yyv1739 = []JobCondition{}
-			yyc1739 = true
-		} else if len(yyv1739) != 0 {
-			yyv1739 = yyv1739[:0]
-			yyc1739 = true
+	yyv1693 := *v
+	yyh1693, yyl1693 := z.DecSliceHelperStart()
+	var yyc1693 bool
+	if yyl1693 == 0 {
+		if yyv1693 == nil {
+			yyv1693 = []JobCondition{}
+			yyc1693 = true
+		} else if len(yyv1693) != 0 {
+			yyv1693 = yyv1693[:0]
+			yyc1693 = true
 		}
-	} else if yyl1739 > 0 {
-		var yyrr1739, yyrl1739 int
-		var yyrt1739 bool
-		if yyl1739 > cap(yyv1739) {
+	} else if yyl1693 > 0 {
+		var yyrr1693, yyrl1693 int
+		var yyrt1693 bool
+		if yyl1693 > cap(yyv1693) {
 
-			yyrg1739 := len(yyv1739) > 0
-			yyv21739 := yyv1739
-			yyrl1739, yyrt1739 = z.DecInferLen(yyl1739, z.DecBasicHandle().MaxInitLen, 112)
-			if yyrt1739 {
-				if yyrl1739 <= cap(yyv1739) {
-					yyv1739 = yyv1739[:yyrl1739]
+			yyrg1693 := len(yyv1693) > 0
+			yyv21693 := yyv1693
+			yyrl1693, yyrt1693 = z.DecInferLen(yyl1693, z.DecBasicHandle().MaxInitLen, 112)
+			if yyrt1693 {
+				if yyrl1693 <= cap(yyv1693) {
+					yyv1693 = yyv1693[:yyrl1693]
 				} else {
-					yyv1739 = make([]JobCondition, yyrl1739)
+					yyv1693 = make([]JobCondition, yyrl1693)
 				}
 			} else {
-				yyv1739 = make([]JobCondition, yyrl1739)
+				yyv1693 = make([]JobCondition, yyrl1693)
 			}
-			yyc1739 = true
-			yyrr1739 = len(yyv1739)
-			if yyrg1739 {
-				copy(yyv1739, yyv21739)
+			yyc1693 = true
+			yyrr1693 = len(yyv1693)
+			if yyrg1693 {
+				copy(yyv1693, yyv21693)
 			}
-		} else if yyl1739 != len(yyv1739) {
-			yyv1739 = yyv1739[:yyl1739]
-			yyc1739 = true
+		} else if yyl1693 != len(yyv1693) {
+			yyv1693 = yyv1693[:yyl1693]
+			yyc1693 = true
 		}
-		yyj1739 := 0
-		for ; yyj1739 < yyrr1739; yyj1739++ {
-			yyh1739.ElemContainerState(yyj1739)
+		yyj1693 := 0
+		for ; yyj1693 < yyrr1693; yyj1693++ {
+			yyh1693.ElemContainerState(yyj1693)
 			if r.TryDecodeAsNil() {
-				yyv1739[yyj1739] = JobCondition{}
+				yyv1693[yyj1693] = JobCondition{}
 			} else {
-				yyv1740 := &yyv1739[yyj1739]
-				yyv1740.CodecDecodeSelf(d)
+				yyv1694 := &yyv1693[yyj1693]
+				yyv1694.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1739 {
-			for ; yyj1739 < yyl1739; yyj1739++ {
-				yyv1739 = append(yyv1739, JobCondition{})
-				yyh1739.ElemContainerState(yyj1739)
+		if yyrt1693 {
+			for ; yyj1693 < yyl1693; yyj1693++ {
+				yyv1693 = append(yyv1693, JobCondition{})
+				yyh1693.ElemContainerState(yyj1693)
 				if r.TryDecodeAsNil() {
-					yyv1739[yyj1739] = JobCondition{}
+					yyv1693[yyj1693] = JobCondition{}
 				} else {
-					yyv1741 := &yyv1739[yyj1739]
-					yyv1741.CodecDecodeSelf(d)
+					yyv1695 := &yyv1693[yyj1693]
+					yyv1695.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1739 := 0
-		for ; !r.CheckBreak(); yyj1739++ {
+		yyj1693 := 0
+		for ; !r.CheckBreak(); yyj1693++ {
 
-			if yyj1739 >= len(yyv1739) {
-				yyv1739 = append(yyv1739, JobCondition{}) // var yyz1739 JobCondition
-				yyc1739 = true
+			if yyj1693 >= len(yyv1693) {
+				yyv1693 = append(yyv1693, JobCondition{}) // var yyz1693 JobCondition
+				yyc1693 = true
 			}
-			yyh1739.ElemContainerState(yyj1739)
-			if yyj1739 < len(yyv1739) {
+			yyh1693.ElemContainerState(yyj1693)
+			if yyj1693 < len(yyv1693) {
 				if r.TryDecodeAsNil() {
-					yyv1739[yyj1739] = JobCondition{}
+					yyv1693[yyj1693] = JobCondition{}
 				} else {
-					yyv1742 := &yyv1739[yyj1739]
-					yyv1742.CodecDecodeSelf(d)
+					yyv1696 := &yyv1693[yyj1693]
+					yyv1696.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -21350,17 +20732,17 @@ func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.De
 			}
 
 		}
-		if yyj1739 < len(yyv1739) {
-			yyv1739 = yyv1739[:yyj1739]
-			yyc1739 = true
-		} else if yyj1739 == 0 && yyv1739 == nil {
-			yyv1739 = []JobCondition{}
-			yyc1739 = true
+		if yyj1693 < len(yyv1693) {
+			yyv1693 = yyv1693[:yyj1693]
+			yyc1693 = true
+		} else if yyj1693 == 0 && yyv1693 == nil {
+			yyv1693 = []JobCondition{}
+			yyc1693 = true
 		}
 	}
-	yyh1739.End()
-	if yyc1739 {
-		*v = yyv1739
+	yyh1693.End()
+	if yyc1693 {
+		*v = yyv1693
 	}
 }
 
@@ -21369,10 +20751,10 @@ func (x codecSelfer1234) encSliceIngress(v []Ingress, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1743 := range v {
+	for _, yyv1697 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1744 := &yyv1743
-		yy1744.CodecEncodeSelf(e)
+		yy1698 := &yyv1697
+		yy1698.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -21382,83 +20764,83 @@ func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1745 := *v
-	yyh1745, yyl1745 := z.DecSliceHelperStart()
-	var yyc1745 bool
-	if yyl1745 == 0 {
-		if yyv1745 == nil {
-			yyv1745 = []Ingress{}
-			yyc1745 = true
-		} else if len(yyv1745) != 0 {
-			yyv1745 = yyv1745[:0]
-			yyc1745 = true
+	yyv1699 := *v
+	yyh1699, yyl1699 := z.DecSliceHelperStart()
+	var yyc1699 bool
+	if yyl1699 == 0 {
+		if yyv1699 == nil {
+			yyv1699 = []Ingress{}
+			yyc1699 = true
+		} else if len(yyv1699) != 0 {
+			yyv1699 = yyv1699[:0]
+			yyc1699 = true
 		}
-	} else if yyl1745 > 0 {
-		var yyrr1745, yyrl1745 int
-		var yyrt1745 bool
-		if yyl1745 > cap(yyv1745) {
+	} else if yyl1699 > 0 {
+		var yyrr1699, yyrl1699 int
+		var yyrt1699 bool
+		if yyl1699 > cap(yyv1699) {
 
-			yyrg1745 := len(yyv1745) > 0
-			yyv21745 := yyv1745
-			yyrl1745, yyrt1745 = z.DecInferLen(yyl1745, z.DecBasicHandle().MaxInitLen, 272)
-			if yyrt1745 {
-				if yyrl1745 <= cap(yyv1745) {
-					yyv1745 = yyv1745[:yyrl1745]
+			yyrg1699 := len(yyv1699) > 0
+			yyv21699 := yyv1699
+			yyrl1699, yyrt1699 = z.DecInferLen(yyl1699, z.DecBasicHandle().MaxInitLen, 272)
+			if yyrt1699 {
+				if yyrl1699 <= cap(yyv1699) {
+					yyv1699 = yyv1699[:yyrl1699]
 				} else {
-					yyv1745 = make([]Ingress, yyrl1745)
+					yyv1699 = make([]Ingress, yyrl1699)
 				}
 			} else {
-				yyv1745 = make([]Ingress, yyrl1745)
+				yyv1699 = make([]Ingress, yyrl1699)
 			}
-			yyc1745 = true
-			yyrr1745 = len(yyv1745)
-			if yyrg1745 {
-				copy(yyv1745, yyv21745)
+			yyc1699 = true
+			yyrr1699 = len(yyv1699)
+			if yyrg1699 {
+				copy(yyv1699, yyv21699)
 			}
-		} else if yyl1745 != len(yyv1745) {
-			yyv1745 = yyv1745[:yyl1745]
-			yyc1745 = true
+		} else if yyl1699 != len(yyv1699) {
+			yyv1699 = yyv1699[:yyl1699]
+			yyc1699 = true
 		}
-		yyj1745 := 0
-		for ; yyj1745 < yyrr1745; yyj1745++ {
-			yyh1745.ElemContainerState(yyj1745)
+		yyj1699 := 0
+		for ; yyj1699 < yyrr1699; yyj1699++ {
+			yyh1699.ElemContainerState(yyj1699)
 			if r.TryDecodeAsNil() {
-				yyv1745[yyj1745] = Ingress{}
+				yyv1699[yyj1699] = Ingress{}
 			} else {
-				yyv1746 := &yyv1745[yyj1745]
-				yyv1746.CodecDecodeSelf(d)
+				yyv1700 := &yyv1699[yyj1699]
+				yyv1700.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1745 {
-			for ; yyj1745 < yyl1745; yyj1745++ {
-				yyv1745 = append(yyv1745, Ingress{})
-				yyh1745.ElemContainerState(yyj1745)
+		if yyrt1699 {
+			for ; yyj1699 < yyl1699; yyj1699++ {
+				yyv1699 = append(yyv1699, Ingress{})
+				yyh1699.ElemContainerState(yyj1699)
 				if r.TryDecodeAsNil() {
-					yyv1745[yyj1745] = Ingress{}
+					yyv1699[yyj1699] = Ingress{}
 				} else {
-					yyv1747 := &yyv1745[yyj1745]
-					yyv1747.CodecDecodeSelf(d)
+					yyv1701 := &yyv1699[yyj1699]
+					yyv1701.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1745 := 0
-		for ; !r.CheckBreak(); yyj1745++ {
+		yyj1699 := 0
+		for ; !r.CheckBreak(); yyj1699++ {
 
-			if yyj1745 >= len(yyv1745) {
-				yyv1745 = append(yyv1745, Ingress{}) // var yyz1745 Ingress
-				yyc1745 = true
+			if yyj1699 >= len(yyv1699) {
+				yyv1699 = append(yyv1699, Ingress{}) // var yyz1699 Ingress
+				yyc1699 = true
 			}
-			yyh1745.ElemContainerState(yyj1745)
-			if yyj1745 < len(yyv1745) {
+			yyh1699.ElemContainerState(yyj1699)
+			if yyj1699 < len(yyv1699) {
 				if r.TryDecodeAsNil() {
-					yyv1745[yyj1745] = Ingress{}
+					yyv1699[yyj1699] = Ingress{}
 				} else {
-					yyv1748 := &yyv1745[yyj1745]
-					yyv1748.CodecDecodeSelf(d)
+					yyv1702 := &yyv1699[yyj1699]
+					yyv1702.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -21466,17 +20848,17 @@ func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
 			}
 
 		}
-		if yyj1745 < len(yyv1745) {
-			yyv1745 = yyv1745[:yyj1745]
-			yyc1745 = true
-		} else if yyj1745 == 0 && yyv1745 == nil {
-			yyv1745 = []Ingress{}
-			yyc1745 = true
+		if yyj1699 < len(yyv1699) {
+			yyv1699 = yyv1699[:yyj1699]
+			yyc1699 = true
+		} else if yyj1699 == 0 && yyv1699 == nil {
+			yyv1699 = []Ingress{}
+			yyc1699 = true
 		}
 	}
-	yyh1745.End()
-	if yyc1745 {
-		*v = yyv1745
+	yyh1699.End()
+	if yyc1699 {
+		*v = yyv1699
 	}
 }
 
@@ -21485,10 +20867,10 @@ func (x codecSelfer1234) encSliceIngressTLS(v []IngressTLS, e *codec1978.Encoder
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1749 := range v {
+	for _, yyv1703 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1750 := &yyv1749
-		yy1750.CodecEncodeSelf(e)
+		yy1704 := &yyv1703
+		yy1704.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -21498,83 +20880,83 @@ func (x codecSelfer1234) decSliceIngressTLS(v *[]IngressTLS, d *codec1978.Decode
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1751 := *v
-	yyh1751, yyl1751 := z.DecSliceHelperStart()
-	var yyc1751 bool
-	if yyl1751 == 0 {
-		if yyv1751 == nil {
-			yyv1751 = []IngressTLS{}
-			yyc1751 = true
-		} else if len(yyv1751) != 0 {
-			yyv1751 = yyv1751[:0]
-			yyc1751 = true
+	yyv1705 := *v
+	yyh1705, yyl1705 := z.DecSliceHelperStart()
+	var yyc1705 bool
+	if yyl1705 == 0 {
+		if yyv1705 == nil {
+			yyv1705 = []IngressTLS{}
+			yyc1705 = true
+		} else if len(yyv1705) != 0 {
+			yyv1705 = yyv1705[:0]
+			yyc1705 = true
 		}
-	} else if yyl1751 > 0 {
-		var yyrr1751, yyrl1751 int
-		var yyrt1751 bool
-		if yyl1751 > cap(yyv1751) {
+	} else if yyl1705 > 0 {
+		var yyrr1705, yyrl1705 int
+		var yyrt1705 bool
+		if yyl1705 > cap(yyv1705) {
 
-			yyrg1751 := len(yyv1751) > 0
-			yyv21751 := yyv1751
-			yyrl1751, yyrt1751 = z.DecInferLen(yyl1751, z.DecBasicHandle().MaxInitLen, 40)
-			if yyrt1751 {
-				if yyrl1751 <= cap(yyv1751) {
-					yyv1751 = yyv1751[:yyrl1751]
+			yyrg1705 := len(yyv1705) > 0
+			yyv21705 := yyv1705
+			yyrl1705, yyrt1705 = z.DecInferLen(yyl1705, z.DecBasicHandle().MaxInitLen, 40)
+			if yyrt1705 {
+				if yyrl1705 <= cap(yyv1705) {
+					yyv1705 = yyv1705[:yyrl1705]
 				} else {
-					yyv1751 = make([]IngressTLS, yyrl1751)
+					yyv1705 = make([]IngressTLS, yyrl1705)
 				}
 			} else {
-				yyv1751 = make([]IngressTLS, yyrl1751)
+				yyv1705 = make([]IngressTLS, yyrl1705)
 			}
-			yyc1751 = true
-			yyrr1751 = len(yyv1751)
-			if yyrg1751 {
-				copy(yyv1751, yyv21751)
+			yyc1705 = true
+			yyrr1705 = len(yyv1705)
+			if yyrg1705 {
+				copy(yyv1705, yyv21705)
 			}
-		} else if yyl1751 != len(yyv1751) {
-			yyv1751 = yyv1751[:yyl1751]
-			yyc1751 = true
+		} else if yyl1705 != len(yyv1705) {
+			yyv1705 = yyv1705[:yyl1705]
+			yyc1705 = true
 		}
-		yyj1751 := 0
-		for ; yyj1751 < yyrr1751; yyj1751++ {
-			yyh1751.ElemContainerState(yyj1751)
+		yyj1705 := 0
+		for ; yyj1705 < yyrr1705; yyj1705++ {
+			yyh1705.ElemContainerState(yyj1705)
 			if r.TryDecodeAsNil() {
-				yyv1751[yyj1751] = IngressTLS{}
+				yyv1705[yyj1705] = IngressTLS{}
 			} else {
-				yyv1752 := &yyv1751[yyj1751]
-				yyv1752.CodecDecodeSelf(d)
+				yyv1706 := &yyv1705[yyj1705]
+				yyv1706.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1751 {
-			for ; yyj1751 < yyl1751; yyj1751++ {
-				yyv1751 = append(yyv1751, IngressTLS{})
-				yyh1751.ElemContainerState(yyj1751)
+		if yyrt1705 {
+			for ; yyj1705 < yyl1705; yyj1705++ {
+				yyv1705 = append(yyv1705, IngressTLS{})
+				yyh1705.ElemContainerState(yyj1705)
 				if r.TryDecodeAsNil() {
-					yyv1751[yyj1751] = IngressTLS{}
+					yyv1705[yyj1705] = IngressTLS{}
 				} else {
-					yyv1753 := &yyv1751[yyj1751]
-					yyv1753.CodecDecodeSelf(d)
+					yyv1707 := &yyv1705[yyj1705]
+					yyv1707.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1751 := 0
-		for ; !r.CheckBreak(); yyj1751++ {
+		yyj1705 := 0
+		for ; !r.CheckBreak(); yyj1705++ {
 
-			if yyj1751 >= len(yyv1751) {
-				yyv1751 = append(yyv1751, IngressTLS{}) // var yyz1751 IngressTLS
-				yyc1751 = true
+			if yyj1705 >= len(yyv1705) {
+				yyv1705 = append(yyv1705, IngressTLS{}) // var yyz1705 IngressTLS
+				yyc1705 = true
 			}
-			yyh1751.ElemContainerState(yyj1751)
-			if yyj1751 < len(yyv1751) {
+			yyh1705.ElemContainerState(yyj1705)
+			if yyj1705 < len(yyv1705) {
 				if r.TryDecodeAsNil() {
-					yyv1751[yyj1751] = IngressTLS{}
+					yyv1705[yyj1705] = IngressTLS{}
 				} else {
-					yyv1754 := &yyv1751[yyj1751]
-					yyv1754.CodecDecodeSelf(d)
+					yyv1708 := &yyv1705[yyj1705]
+					yyv1708.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -21582,17 +20964,17 @@ func (x codecSelfer1234) decSliceIngressTLS(v *[]IngressTLS, d *codec1978.Decode
 			}
 
 		}
-		if yyj1751 < len(yyv1751) {
-			yyv1751 = yyv1751[:yyj1751]
-			yyc1751 = true
-		} else if yyj1751 == 0 && yyv1751 == nil {
-			yyv1751 = []IngressTLS{}
-			yyc1751 = true
+		if yyj1705 < len(yyv1705) {
+			yyv1705 = yyv1705[:yyj1705]
+			yyc1705 = true
+		} else if yyj1705 == 0 && yyv1705 == nil {
+			yyv1705 = []IngressTLS{}
+			yyc1705 = true
 		}
 	}
-	yyh1751.End()
-	if yyc1751 {
-		*v = yyv1751
+	yyh1705.End()
+	if yyc1705 {
+		*v = yyv1705
 	}
 }
 
@@ -21601,10 +20983,10 @@ func (x codecSelfer1234) encSliceIngressRule(v []IngressRule, e *codec1978.Encod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1755 := range v {
+	for _, yyv1709 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1756 := &yyv1755
-		yy1756.CodecEncodeSelf(e)
+		yy1710 := &yyv1709
+		yy1710.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -21614,83 +20996,83 @@ func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Deco
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1757 := *v
-	yyh1757, yyl1757 := z.DecSliceHelperStart()
-	var yyc1757 bool
-	if yyl1757 == 0 {
-		if yyv1757 == nil {
-			yyv1757 = []IngressRule{}
-			yyc1757 = true
-		} else if len(yyv1757) != 0 {
-			yyv1757 = yyv1757[:0]
-			yyc1757 = true
+	yyv1711 := *v
+	yyh1711, yyl1711 := z.DecSliceHelperStart()
+	var yyc1711 bool
+	if yyl1711 == 0 {
+		if yyv1711 == nil {
+			yyv1711 = []IngressRule{}
+			yyc1711 = true
+		} else if len(yyv1711) != 0 {
+			yyv1711 = yyv1711[:0]
+			yyc1711 = true
 		}
-	} else if yyl1757 > 0 {
-		var yyrr1757, yyrl1757 int
-		var yyrt1757 bool
-		if yyl1757 > cap(yyv1757) {
+	} else if yyl1711 > 0 {
+		var yyrr1711, yyrl1711 int
+		var yyrt1711 bool
+		if yyl1711 > cap(yyv1711) {
 
-			yyrg1757 := len(yyv1757) > 0
-			yyv21757 := yyv1757
-			yyrl1757, yyrt1757 = z.DecInferLen(yyl1757, z.DecBasicHandle().MaxInitLen, 24)
-			if yyrt1757 {
-				if yyrl1757 <= cap(yyv1757) {
-					yyv1757 = yyv1757[:yyrl1757]
+			yyrg1711 := len(yyv1711) > 0
+			yyv21711 := yyv1711
+			yyrl1711, yyrt1711 = z.DecInferLen(yyl1711, z.DecBasicHandle().MaxInitLen, 24)
+			if yyrt1711 {
+				if yyrl1711 <= cap(yyv1711) {
+					yyv1711 = yyv1711[:yyrl1711]
 				} else {
-					yyv1757 = make([]IngressRule, yyrl1757)
+					yyv1711 = make([]IngressRule, yyrl1711)
 				}
 			} else {
-				yyv1757 = make([]IngressRule, yyrl1757)
+				yyv1711 = make([]IngressRule, yyrl1711)
 			}
-			yyc1757 = true
-			yyrr1757 = len(yyv1757)
-			if yyrg1757 {
-				copy(yyv1757, yyv21757)
+			yyc1711 = true
+			yyrr1711 = len(yyv1711)
+			if yyrg1711 {
+				copy(yyv1711, yyv21711)
 			}
-		} else if yyl1757 != len(yyv1757) {
-			yyv1757 = yyv1757[:yyl1757]
-			yyc1757 = true
+		} else if yyl1711 != len(yyv1711) {
+			yyv1711 = yyv1711[:yyl1711]
+			yyc1711 = true
 		}
-		yyj1757 := 0
-		for ; yyj1757 < yyrr1757; yyj1757++ {
-			yyh1757.ElemContainerState(yyj1757)
+		yyj1711 := 0
+		for ; yyj1711 < yyrr1711; yyj1711++ {
+			yyh1711.ElemContainerState(yyj1711)
 			if r.TryDecodeAsNil() {
-				yyv1757[yyj1757] = IngressRule{}
+				yyv1711[yyj1711] = IngressRule{}
 			} else {
-				yyv1758 := &yyv1757[yyj1757]
-				yyv1758.CodecDecodeSelf(d)
+				yyv1712 := &yyv1711[yyj1711]
+				yyv1712.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1757 {
-			for ; yyj1757 < yyl1757; yyj1757++ {
-				yyv1757 = append(yyv1757, IngressRule{})
-				yyh1757.ElemContainerState(yyj1757)
+		if yyrt1711 {
+			for ; yyj1711 < yyl1711; yyj1711++ {
+				yyv1711 = append(yyv1711, IngressRule{})
+				yyh1711.ElemContainerState(yyj1711)
 				if r.TryDecodeAsNil() {
-					yyv1757[yyj1757] = IngressRule{}
+					yyv1711[yyj1711] = IngressRule{}
 				} else {
-					yyv1759 := &yyv1757[yyj1757]
-					yyv1759.CodecDecodeSelf(d)
+					yyv1713 := &yyv1711[yyj1711]
+					yyv1713.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1757 := 0
-		for ; !r.CheckBreak(); yyj1757++ {
+		yyj1711 := 0
+		for ; !r.CheckBreak(); yyj1711++ {
 
-			if yyj1757 >= len(yyv1757) {
-				yyv1757 = append(yyv1757, IngressRule{}) // var yyz1757 IngressRule
-				yyc1757 = true
+			if yyj1711 >= len(yyv1711) {
+				yyv1711 = append(yyv1711, IngressRule{}) // var yyz1711 IngressRule
+				yyc1711 = true
 			}
-			yyh1757.ElemContainerState(yyj1757)
-			if yyj1757 < len(yyv1757) {
+			yyh1711.ElemContainerState(yyj1711)
+			if yyj1711 < len(yyv1711) {
 				if r.TryDecodeAsNil() {
-					yyv1757[yyj1757] = IngressRule{}
+					yyv1711[yyj1711] = IngressRule{}
 				} else {
-					yyv1760 := &yyv1757[yyj1757]
-					yyv1760.CodecDecodeSelf(d)
+					yyv1714 := &yyv1711[yyj1711]
+					yyv1714.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -21698,17 +21080,17 @@ func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Deco
 			}
 
 		}
-		if yyj1757 < len(yyv1757) {
-			yyv1757 = yyv1757[:yyj1757]
-			yyc1757 = true
-		} else if yyj1757 == 0 && yyv1757 == nil {
-			yyv1757 = []IngressRule{}
-			yyc1757 = true
+		if yyj1711 < len(yyv1711) {
+			yyv1711 = yyv1711[:yyj1711]
+			yyc1711 = true
+		} else if yyj1711 == 0 && yyv1711 == nil {
+			yyv1711 = []IngressRule{}
+			yyc1711 = true
 		}
 	}
-	yyh1757.End()
-	if yyc1757 {
-		*v = yyv1757
+	yyh1711.End()
+	if yyc1711 {
+		*v = yyv1711
 	}
 }
 
@@ -21717,10 +21099,10 @@ func (x codecSelfer1234) encSliceHTTPIngressPath(v []HTTPIngressPath, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1761 := range v {
+	for _, yyv1715 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1762 := &yyv1761
-		yy1762.CodecEncodeSelf(e)
+		yy1716 := &yyv1715
+		yy1716.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -21730,83 +21112,83 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1763 := *v
-	yyh1763, yyl1763 := z.DecSliceHelperStart()
-	var yyc1763 bool
-	if yyl1763 == 0 {
-		if yyv1763 == nil {
-			yyv1763 = []HTTPIngressPath{}
-			yyc1763 = true
-		} else if len(yyv1763) != 0 {
-			yyv1763 = yyv1763[:0]
-			yyc1763 = true
+	yyv1717 := *v
+	yyh1717, yyl1717 := z.DecSliceHelperStart()
+	var yyc1717 bool
+	if yyl1717 == 0 {
+		if yyv1717 == nil {
+			yyv1717 = []HTTPIngressPath{}
+			yyc1717 = true
+		} else if len(yyv1717) != 0 {
+			yyv1717 = yyv1717[:0]
+			yyc1717 = true
 		}
-	} else if yyl1763 > 0 {
-		var yyrr1763, yyrl1763 int
-		var yyrt1763 bool
-		if yyl1763 > cap(yyv1763) {
+	} else if yyl1717 > 0 {
+		var yyrr1717, yyrl1717 int
+		var yyrt1717 bool
+		if yyl1717 > cap(yyv1717) {
 
-			yyrg1763 := len(yyv1763) > 0
-			yyv21763 := yyv1763
-			yyrl1763, yyrt1763 = z.DecInferLen(yyl1763, z.DecBasicHandle().MaxInitLen, 64)
-			if yyrt1763 {
-				if yyrl1763 <= cap(yyv1763) {
-					yyv1763 = yyv1763[:yyrl1763]
+			yyrg1717 := len(yyv1717) > 0
+			yyv21717 := yyv1717
+			yyrl1717, yyrt1717 = z.DecInferLen(yyl1717, z.DecBasicHandle().MaxInitLen, 64)
+			if yyrt1717 {
+				if yyrl1717 <= cap(yyv1717) {
+					yyv1717 = yyv1717[:yyrl1717]
 				} else {
-					yyv1763 = make([]HTTPIngressPath, yyrl1763)
+					yyv1717 = make([]HTTPIngressPath, yyrl1717)
 				}
 			} else {
-				yyv1763 = make([]HTTPIngressPath, yyrl1763)
+				yyv1717 = make([]HTTPIngressPath, yyrl1717)
 			}
-			yyc1763 = true
-			yyrr1763 = len(yyv1763)
-			if yyrg1763 {
-				copy(yyv1763, yyv21763)
+			yyc1717 = true
+			yyrr1717 = len(yyv1717)
+			if yyrg1717 {
+				copy(yyv1717, yyv21717)
 			}
-		} else if yyl1763 != len(yyv1763) {
-			yyv1763 = yyv1763[:yyl1763]
-			yyc1763 = true
+		} else if yyl1717 != len(yyv1717) {
+			yyv1717 = yyv1717[:yyl1717]
+			yyc1717 = true
 		}
-		yyj1763 := 0
-		for ; yyj1763 < yyrr1763; yyj1763++ {
-			yyh1763.ElemContainerState(yyj1763)
+		yyj1717 := 0
+		for ; yyj1717 < yyrr1717; yyj1717++ {
+			yyh1717.ElemContainerState(yyj1717)
 			if r.TryDecodeAsNil() {
-				yyv1763[yyj1763] = HTTPIngressPath{}
+				yyv1717[yyj1717] = HTTPIngressPath{}
 			} else {
-				yyv1764 := &yyv1763[yyj1763]
-				yyv1764.CodecDecodeSelf(d)
+				yyv1718 := &yyv1717[yyj1717]
+				yyv1718.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1763 {
-			for ; yyj1763 < yyl1763; yyj1763++ {
-				yyv1763 = append(yyv1763, HTTPIngressPath{})
-				yyh1763.ElemContainerState(yyj1763)
+		if yyrt1717 {
+			for ; yyj1717 < yyl1717; yyj1717++ {
+				yyv1717 = append(yyv1717, HTTPIngressPath{})
+				yyh1717.ElemContainerState(yyj1717)
 				if r.TryDecodeAsNil() {
-					yyv1763[yyj1763] = HTTPIngressPath{}
+					yyv1717[yyj1717] = HTTPIngressPath{}
 				} else {
-					yyv1765 := &yyv1763[yyj1763]
-					yyv1765.CodecDecodeSelf(d)
+					yyv1719 := &yyv1717[yyj1717]
+					yyv1719.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1763 := 0
-		for ; !r.CheckBreak(); yyj1763++ {
+		yyj1717 := 0
+		for ; !r.CheckBreak(); yyj1717++ {
 
-			if yyj1763 >= len(yyv1763) {
-				yyv1763 = append(yyv1763, HTTPIngressPath{}) // var yyz1763 HTTPIngressPath
-				yyc1763 = true
+			if yyj1717 >= len(yyv1717) {
+				yyv1717 = append(yyv1717, HTTPIngressPath{}) // var yyz1717 HTTPIngressPath
+				yyc1717 = true
 			}
-			yyh1763.ElemContainerState(yyj1763)
-			if yyj1763 < len(yyv1763) {
+			yyh1717.ElemContainerState(yyj1717)
+			if yyj1717 < len(yyv1717) {
 				if r.TryDecodeAsNil() {
-					yyv1763[yyj1763] = HTTPIngressPath{}
+					yyv1717[yyj1717] = HTTPIngressPath{}
 				} else {
-					yyv1766 := &yyv1763[yyj1763]
-					yyv1766.CodecDecodeSelf(d)
+					yyv1720 := &yyv1717[yyj1717]
+					yyv1720.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -21814,17 +21196,17 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 			}
 
 		}
-		if yyj1763 < len(yyv1763) {
-			yyv1763 = yyv1763[:yyj1763]
-			yyc1763 = true
-		} else if yyj1763 == 0 && yyv1763 == nil {
-			yyv1763 = []HTTPIngressPath{}
-			yyc1763 = true
+		if yyj1717 < len(yyv1717) {
+			yyv1717 = yyv1717[:yyj1717]
+			yyc1717 = true
+		} else if yyj1717 == 0 && yyv1717 == nil {
+			yyv1717 = []HTTPIngressPath{}
+			yyc1717 = true
 		}
 	}
-	yyh1763.End()
-	if yyc1763 {
-		*v = yyv1763
+	yyh1717.End()
+	if yyc1717 {
+		*v = yyv1717
 	}
 }
 
@@ -21833,10 +21215,10 @@ func (x codecSelfer1234) encSliceNodeUtilization(v []NodeUtilization, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1767 := range v {
+	for _, yyv1721 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1768 := &yyv1767
-		yy1768.CodecEncodeSelf(e)
+		yy1722 := &yyv1721
+		yy1722.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -21846,83 +21228,83 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1769 := *v
-	yyh1769, yyl1769 := z.DecSliceHelperStart()
-	var yyc1769 bool
-	if yyl1769 == 0 {
-		if yyv1769 == nil {
-			yyv1769 = []NodeUtilization{}
-			yyc1769 = true
-		} else if len(yyv1769) != 0 {
-			yyv1769 = yyv1769[:0]
-			yyc1769 = true
+	yyv1723 := *v
+	yyh1723, yyl1723 := z.DecSliceHelperStart()
+	var yyc1723 bool
+	if yyl1723 == 0 {
+		if yyv1723 == nil {
+			yyv1723 = []NodeUtilization{}
+			yyc1723 = true
+		} else if len(yyv1723) != 0 {
+			yyv1723 = yyv1723[:0]
+			yyc1723 = true
 		}
-	} else if yyl1769 > 0 {
-		var yyrr1769, yyrl1769 int
-		var yyrt1769 bool
-		if yyl1769 > cap(yyv1769) {
+	} else if yyl1723 > 0 {
+		var yyrr1723, yyrl1723 int
+		var yyrt1723 bool
+		if yyl1723 > cap(yyv1723) {
 
-			yyrg1769 := len(yyv1769) > 0
-			yyv21769 := yyv1769
-			yyrl1769, yyrt1769 = z.DecInferLen(yyl1769, z.DecBasicHandle().MaxInitLen, 24)
-			if yyrt1769 {
-				if yyrl1769 <= cap(yyv1769) {
-					yyv1769 = yyv1769[:yyrl1769]
+			yyrg1723 := len(yyv1723) > 0
+			yyv21723 := yyv1723
+			yyrl1723, yyrt1723 = z.DecInferLen(yyl1723, z.DecBasicHandle().MaxInitLen, 24)
+			if yyrt1723 {
+				if yyrl1723 <= cap(yyv1723) {
+					yyv1723 = yyv1723[:yyrl1723]
 				} else {
-					yyv1769 = make([]NodeUtilization, yyrl1769)
+					yyv1723 = make([]NodeUtilization, yyrl1723)
 				}
 			} else {
-				yyv1769 = make([]NodeUtilization, yyrl1769)
+				yyv1723 = make([]NodeUtilization, yyrl1723)
 			}
-			yyc1769 = true
-			yyrr1769 = len(yyv1769)
-			if yyrg1769 {
-				copy(yyv1769, yyv21769)
+			yyc1723 = true
+			yyrr1723 = len(yyv1723)
+			if yyrg1723 {
+				copy(yyv1723, yyv21723)
 			}
-		} else if yyl1769 != len(yyv1769) {
-			yyv1769 = yyv1769[:yyl1769]
-			yyc1769 = true
+		} else if yyl1723 != len(yyv1723) {
+			yyv1723 = yyv1723[:yyl1723]
+			yyc1723 = true
 		}
-		yyj1769 := 0
-		for ; yyj1769 < yyrr1769; yyj1769++ {
-			yyh1769.ElemContainerState(yyj1769)
+		yyj1723 := 0
+		for ; yyj1723 < yyrr1723; yyj1723++ {
+			yyh1723.ElemContainerState(yyj1723)
 			if r.TryDecodeAsNil() {
-				yyv1769[yyj1769] = NodeUtilization{}
+				yyv1723[yyj1723] = NodeUtilization{}
 			} else {
-				yyv1770 := &yyv1769[yyj1769]
-				yyv1770.CodecDecodeSelf(d)
+				yyv1724 := &yyv1723[yyj1723]
+				yyv1724.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1769 {
-			for ; yyj1769 < yyl1769; yyj1769++ {
-				yyv1769 = append(yyv1769, NodeUtilization{})
-				yyh1769.ElemContainerState(yyj1769)
+		if yyrt1723 {
+			for ; yyj1723 < yyl1723; yyj1723++ {
+				yyv1723 = append(yyv1723, NodeUtilization{})
+				yyh1723.ElemContainerState(yyj1723)
 				if r.TryDecodeAsNil() {
-					yyv1769[yyj1769] = NodeUtilization{}
+					yyv1723[yyj1723] = NodeUtilization{}
 				} else {
-					yyv1771 := &yyv1769[yyj1769]
-					yyv1771.CodecDecodeSelf(d)
+					yyv1725 := &yyv1723[yyj1723]
+					yyv1725.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1769 := 0
-		for ; !r.CheckBreak(); yyj1769++ {
+		yyj1723 := 0
+		for ; !r.CheckBreak(); yyj1723++ {
 
-			if yyj1769 >= len(yyv1769) {
-				yyv1769 = append(yyv1769, NodeUtilization{}) // var yyz1769 NodeUtilization
-				yyc1769 = true
+			if yyj1723 >= len(yyv1723) {
+				yyv1723 = append(yyv1723, NodeUtilization{}) // var yyz1723 NodeUtilization
+				yyc1723 = true
 			}
-			yyh1769.ElemContainerState(yyj1769)
-			if yyj1769 < len(yyv1769) {
+			yyh1723.ElemContainerState(yyj1723)
+			if yyj1723 < len(yyv1723) {
 				if r.TryDecodeAsNil() {
-					yyv1769[yyj1769] = NodeUtilization{}
+					yyv1723[yyj1723] = NodeUtilization{}
 				} else {
-					yyv1772 := &yyv1769[yyj1769]
-					yyv1772.CodecDecodeSelf(d)
+					yyv1726 := &yyv1723[yyj1723]
+					yyv1726.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -21930,17 +21312,17 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 			}
 
 		}
-		if yyj1769 < len(yyv1769) {
-			yyv1769 = yyv1769[:yyj1769]
-			yyc1769 = true
-		} else if yyj1769 == 0 && yyv1769 == nil {
-			yyv1769 = []NodeUtilization{}
-			yyc1769 = true
+		if yyj1723 < len(yyv1723) {
+			yyv1723 = yyv1723[:yyj1723]
+			yyc1723 = true
+		} else if yyj1723 == 0 && yyv1723 == nil {
+			yyv1723 = []NodeUtilization{}
+			yyc1723 = true
 		}
 	}
-	yyh1769.End()
-	if yyc1769 {
-		*v = yyv1769
+	yyh1723.End()
+	if yyc1723 {
+		*v = yyv1723
 	}
 }
 
@@ -21949,10 +21331,10 @@ func (x codecSelfer1234) encSliceClusterAutoscaler(v []ClusterAutoscaler, e *cod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1773 := range v {
+	for _, yyv1727 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1774 := &yyv1773
-		yy1774.CodecEncodeSelf(e)
+		yy1728 := &yyv1727
+		yy1728.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -21962,83 +21344,83 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1775 := *v
-	yyh1775, yyl1775 := z.DecSliceHelperStart()
-	var yyc1775 bool
-	if yyl1775 == 0 {
-		if yyv1775 == nil {
-			yyv1775 = []ClusterAutoscaler{}
-			yyc1775 = true
-		} else if len(yyv1775) != 0 {
-			yyv1775 = yyv1775[:0]
-			yyc1775 = true
+	yyv1729 := *v
+	yyh1729, yyl1729 := z.DecSliceHelperStart()
+	var yyc1729 bool
+	if yyl1729 == 0 {
+		if yyv1729 == nil {
+			yyv1729 = []ClusterAutoscaler{}
+			yyc1729 = true
+		} else if len(yyv1729) != 0 {
+			yyv1729 = yyv1729[:0]
+			yyc1729 = true
 		}
-	} else if yyl1775 > 0 {
-		var yyrr1775, yyrl1775 int
-		var yyrt1775 bool
-		if yyl1775 > cap(yyv1775) {
+	} else if yyl1729 > 0 {
+		var yyrr1729, yyrl1729 int
+		var yyrt1729 bool
+		if yyl1729 > cap(yyv1729) {
 
-			yyrg1775 := len(yyv1775) > 0
-			yyv21775 := yyv1775
-			yyrl1775, yyrt1775 = z.DecInferLen(yyl1775, z.DecBasicHandle().MaxInitLen, 224)
-			if yyrt1775 {
-				if yyrl1775 <= cap(yyv1775) {
-					yyv1775 = yyv1775[:yyrl1775]
+			yyrg1729 := len(yyv1729) > 0
+			yyv21729 := yyv1729
+			yyrl1729, yyrt1729 = z.DecInferLen(yyl1729, z.DecBasicHandle().MaxInitLen, 224)
+			if yyrt1729 {
+				if yyrl1729 <= cap(yyv1729) {
+					yyv1729 = yyv1729[:yyrl1729]
 				} else {
-					yyv1775 = make([]ClusterAutoscaler, yyrl1775)
+					yyv1729 = make([]ClusterAutoscaler, yyrl1729)
 				}
 			} else {
-				yyv1775 = make([]ClusterAutoscaler, yyrl1775)
+				yyv1729 = make([]ClusterAutoscaler, yyrl1729)
 			}
-			yyc1775 = true
-			yyrr1775 = len(yyv1775)
-			if yyrg1775 {
-				copy(yyv1775, yyv21775)
+			yyc1729 = true
+			yyrr1729 = len(yyv1729)
+			if yyrg1729 {
+				copy(yyv1729, yyv21729)
 			}
-		} else if yyl1775 != len(yyv1775) {
-			yyv1775 = yyv1775[:yyl1775]
-			yyc1775 = true
+		} else if yyl1729 != len(yyv1729) {
+			yyv1729 = yyv1729[:yyl1729]
+			yyc1729 = true
 		}
-		yyj1775 := 0
-		for ; yyj1775 < yyrr1775; yyj1775++ {
-			yyh1775.ElemContainerState(yyj1775)
+		yyj1729 := 0
+		for ; yyj1729 < yyrr1729; yyj1729++ {
+			yyh1729.ElemContainerState(yyj1729)
 			if r.TryDecodeAsNil() {
-				yyv1775[yyj1775] = ClusterAutoscaler{}
+				yyv1729[yyj1729] = ClusterAutoscaler{}
 			} else {
-				yyv1776 := &yyv1775[yyj1775]
-				yyv1776.CodecDecodeSelf(d)
+				yyv1730 := &yyv1729[yyj1729]
+				yyv1730.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1775 {
-			for ; yyj1775 < yyl1775; yyj1775++ {
-				yyv1775 = append(yyv1775, ClusterAutoscaler{})
-				yyh1775.ElemContainerState(yyj1775)
+		if yyrt1729 {
+			for ; yyj1729 < yyl1729; yyj1729++ {
+				yyv1729 = append(yyv1729, ClusterAutoscaler{})
+				yyh1729.ElemContainerState(yyj1729)
 				if r.TryDecodeAsNil() {
-					yyv1775[yyj1775] = ClusterAutoscaler{}
+					yyv1729[yyj1729] = ClusterAutoscaler{}
 				} else {
-					yyv1777 := &yyv1775[yyj1775]
-					yyv1777.CodecDecodeSelf(d)
+					yyv1731 := &yyv1729[yyj1729]
+					yyv1731.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1775 := 0
-		for ; !r.CheckBreak(); yyj1775++ {
+		yyj1729 := 0
+		for ; !r.CheckBreak(); yyj1729++ {
 
-			if yyj1775 >= len(yyv1775) {
-				yyv1775 = append(yyv1775, ClusterAutoscaler{}) // var yyz1775 ClusterAutoscaler
-				yyc1775 = true
+			if yyj1729 >= len(yyv1729) {
+				yyv1729 = append(yyv1729, ClusterAutoscaler{}) // var yyz1729 ClusterAutoscaler
+				yyc1729 = true
 			}
-			yyh1775.ElemContainerState(yyj1775)
-			if yyj1775 < len(yyv1775) {
+			yyh1729.ElemContainerState(yyj1729)
+			if yyj1729 < len(yyv1729) {
 				if r.TryDecodeAsNil() {
-					yyv1775[yyj1775] = ClusterAutoscaler{}
+					yyv1729[yyj1729] = ClusterAutoscaler{}
 				} else {
-					yyv1778 := &yyv1775[yyj1775]
-					yyv1778.CodecDecodeSelf(d)
+					yyv1732 := &yyv1729[yyj1729]
+					yyv1732.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -22046,17 +21428,17 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 			}
 
 		}
-		if yyj1775 < len(yyv1775) {
-			yyv1775 = yyv1775[:yyj1775]
-			yyc1775 = true
-		} else if yyj1775 == 0 && yyv1775 == nil {
-			yyv1775 = []ClusterAutoscaler{}
-			yyc1775 = true
+		if yyj1729 < len(yyv1729) {
+			yyv1729 = yyv1729[:yyj1729]
+			yyc1729 = true
+		} else if yyj1729 == 0 && yyv1729 == nil {
+			yyv1729 = []ClusterAutoscaler{}
+			yyc1729 = true
 		}
 	}
-	yyh1775.End()
-	if yyc1775 {
-		*v = yyv1775
+	yyh1729.End()
+	if yyc1729 {
+		*v = yyv1729
 	}
 }
 
@@ -22065,10 +21447,10 @@ func (x codecSelfer1234) encSliceLabelSelectorRequirement(v []LabelSelectorRequi
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1779 := range v {
+	for _, yyv1733 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1780 := &yyv1779
-		yy1780.CodecEncodeSelf(e)
+		yy1734 := &yyv1733
+		yy1734.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -22078,83 +21460,83 @@ func (x codecSelfer1234) decSliceLabelSelectorRequirement(v *[]LabelSelectorRequ
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1781 := *v
-	yyh1781, yyl1781 := z.DecSliceHelperStart()
-	var yyc1781 bool
-	if yyl1781 == 0 {
-		if yyv1781 == nil {
-			yyv1781 = []LabelSelectorRequirement{}
-			yyc1781 = true
-		} else if len(yyv1781) != 0 {
-			yyv1781 = yyv1781[:0]
-			yyc1781 = true
+	yyv1735 := *v
+	yyh1735, yyl1735 := z.DecSliceHelperStart()
+	var yyc1735 bool
+	if yyl1735 == 0 {
+		if yyv1735 == nil {
+			yyv1735 = []LabelSelectorRequirement{}
+			yyc1735 = true
+		} else if len(yyv1735) != 0 {
+			yyv1735 = yyv1735[:0]
+			yyc1735 = true
 		}
-	} else if yyl1781 > 0 {
-		var yyrr1781, yyrl1781 int
-		var yyrt1781 bool
-		if yyl1781 > cap(yyv1781) {
+	} else if yyl1735 > 0 {
+		var yyrr1735, yyrl1735 int
+		var yyrt1735 bool
+		if yyl1735 > cap(yyv1735) {
 
-			yyrg1781 := len(yyv1781) > 0
-			yyv21781 := yyv1781
-			yyrl1781, yyrt1781 = z.DecInferLen(yyl1781, z.DecBasicHandle().MaxInitLen, 56)
-			if yyrt1781 {
-				if yyrl1781 <= cap(yyv1781) {
-					yyv1781 = yyv1781[:yyrl1781]
+			yyrg1735 := len(yyv1735) > 0
+			yyv21735 := yyv1735
+			yyrl1735, yyrt1735 = z.DecInferLen(yyl1735, z.DecBasicHandle().MaxInitLen, 56)
+			if yyrt1735 {
+				if yyrl1735 <= cap(yyv1735) {
+					yyv1735 = yyv1735[:yyrl1735]
 				} else {
-					yyv1781 = make([]LabelSelectorRequirement, yyrl1781)
+					yyv1735 = make([]LabelSelectorRequirement, yyrl1735)
 				}
 			} else {
-				yyv1781 = make([]LabelSelectorRequirement, yyrl1781)
+				yyv1735 = make([]LabelSelectorRequirement, yyrl1735)
 			}
-			yyc1781 = true
-			yyrr1781 = len(yyv1781)
-			if yyrg1781 {
-				copy(yyv1781, yyv21781)
+			yyc1735 = true
+			yyrr1735 = len(yyv1735)
+			if yyrg1735 {
+				copy(yyv1735, yyv21735)
 			}
-		} else if yyl1781 != len(yyv1781) {
-			yyv1781 = yyv1781[:yyl1781]
-			yyc1781 = true
+		} else if yyl1735 != len(yyv1735) {
+			yyv1735 = yyv1735[:yyl1735]
+			yyc1735 = true
 		}
-		yyj1781 := 0
-		for ; yyj1781 < yyrr1781; yyj1781++ {
-			yyh1781.ElemContainerState(yyj1781)
+		yyj1735 := 0
+		for ; yyj1735 < yyrr1735; yyj1735++ {
+			yyh1735.ElemContainerState(yyj1735)
 			if r.TryDecodeAsNil() {
-				yyv1781[yyj1781] = LabelSelectorRequirement{}
+				yyv1735[yyj1735] = LabelSelectorRequirement{}
 			} else {
-				yyv1782 := &yyv1781[yyj1781]
-				yyv1782.CodecDecodeSelf(d)
+				yyv1736 := &yyv1735[yyj1735]
+				yyv1736.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1781 {
-			for ; yyj1781 < yyl1781; yyj1781++ {
-				yyv1781 = append(yyv1781, LabelSelectorRequirement{})
-				yyh1781.ElemContainerState(yyj1781)
+		if yyrt1735 {
+			for ; yyj1735 < yyl1735; yyj1735++ {
+				yyv1735 = append(yyv1735, LabelSelectorRequirement{})
+				yyh1735.ElemContainerState(yyj1735)
 				if r.TryDecodeAsNil() {
-					yyv1781[yyj1781] = LabelSelectorRequirement{}
+					yyv1735[yyj1735] = LabelSelectorRequirement{}
 				} else {
-					yyv1783 := &yyv1781[yyj1781]
-					yyv1783.CodecDecodeSelf(d)
+					yyv1737 := &yyv1735[yyj1735]
+					yyv1737.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1781 := 0
-		for ; !r.CheckBreak(); yyj1781++ {
+		yyj1735 := 0
+		for ; !r.CheckBreak(); yyj1735++ {
 
-			if yyj1781 >= len(yyv1781) {
-				yyv1781 = append(yyv1781, LabelSelectorRequirement{}) // var yyz1781 LabelSelectorRequirement
-				yyc1781 = true
+			if yyj1735 >= len(yyv1735) {
+				yyv1735 = append(yyv1735, LabelSelectorRequirement{}) // var yyz1735 LabelSelectorRequirement
+				yyc1735 = true
 			}
-			yyh1781.ElemContainerState(yyj1781)
-			if yyj1781 < len(yyv1781) {
+			yyh1735.ElemContainerState(yyj1735)
+			if yyj1735 < len(yyv1735) {
 				if r.TryDecodeAsNil() {
-					yyv1781[yyj1781] = LabelSelectorRequirement{}
+					yyv1735[yyj1735] = LabelSelectorRequirement{}
 				} else {
-					yyv1784 := &yyv1781[yyj1781]
-					yyv1784.CodecDecodeSelf(d)
+					yyv1738 := &yyv1735[yyj1735]
+					yyv1738.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -22162,17 +21544,17 @@ func (x codecSelfer1234) decSliceLabelSelectorRequirement(v *[]LabelSelectorRequ
 			}
 
 		}
-		if yyj1781 < len(yyv1781) {
-			yyv1781 = yyv1781[:yyj1781]
-			yyc1781 = true
-		} else if yyj1781 == 0 && yyv1781 == nil {
-			yyv1781 = []LabelSelectorRequirement{}
-			yyc1781 = true
+		if yyj1735 < len(yyv1735) {
+			yyv1735 = yyv1735[:yyj1735]
+			yyc1735 = true
+		} else if yyj1735 == 0 && yyv1735 == nil {
+			yyv1735 = []LabelSelectorRequirement{}
+			yyc1735 = true
 		}
 	}
-	yyh1781.End()
-	if yyc1781 {
-		*v = yyv1781
+	yyh1735.End()
+	if yyc1735 {
+		*v = yyv1735
 	}
 }
 
@@ -22181,10 +21563,10 @@ func (x codecSelfer1234) encSliceReplicaSet(v []ReplicaSet, e *codec1978.Encoder
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1785 := range v {
+	for _, yyv1739 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1786 := &yyv1785
-		yy1786.CodecEncodeSelf(e)
+		yy1740 := &yyv1739
+		yy1740.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -22194,83 +21576,83 @@ func (x codecSelfer1234) decSliceReplicaSet(v *[]ReplicaSet, d *codec1978.Decode
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1787 := *v
-	yyh1787, yyl1787 := z.DecSliceHelperStart()
-	var yyc1787 bool
-	if yyl1787 == 0 {
-		if yyv1787 == nil {
-			yyv1787 = []ReplicaSet{}
-			yyc1787 = true
-		} else if len(yyv1787) != 0 {
-			yyv1787 = yyv1787[:0]
-			yyc1787 = true
+	yyv1741 := *v
+	yyh1741, yyl1741 := z.DecSliceHelperStart()
+	var yyc1741 bool
+	if yyl1741 == 0 {
+		if yyv1741 == nil {
+			yyv1741 = []ReplicaSet{}
+			yyc1741 = true
+		} else if len(yyv1741) != 0 {
+			yyv1741 = yyv1741[:0]
+			yyc1741 = true
 		}
-	} else if yyl1787 > 0 {
-		var yyrr1787, yyrl1787 int
-		var yyrt1787 bool
-		if yyl1787 > cap(yyv1787) {
+	} else if yyl1741 > 0 {
+		var yyrr1741, yyrl1741 int
+		var yyrt1741 bool
+		if yyl1741 > cap(yyv1741) {
 
-			yyrg1787 := len(yyv1787) > 0
-			yyv21787 := yyv1787
-			yyrl1787, yyrt1787 = z.DecInferLen(yyl1787, z.DecBasicHandle().MaxInitLen, 232)
-			if yyrt1787 {
-				if yyrl1787 <= cap(yyv1787) {
-					yyv1787 = yyv1787[:yyrl1787]
+			yyrg1741 := len(yyv1741) > 0
+			yyv21741 := yyv1741
+			yyrl1741, yyrt1741 = z.DecInferLen(yyl1741, z.DecBasicHandle().MaxInitLen, 232)
+			if yyrt1741 {
+				if yyrl1741 <= cap(yyv1741) {
+					yyv1741 = yyv1741[:yyrl1741]
 				} else {
-					yyv1787 = make([]ReplicaSet, yyrl1787)
+					yyv1741 = make([]ReplicaSet, yyrl1741)
 				}
 			} else {
-				yyv1787 = make([]ReplicaSet, yyrl1787)
+				yyv1741 = make([]ReplicaSet, yyrl1741)
 			}
-			yyc1787 = true
-			yyrr1787 = len(yyv1787)
-			if yyrg1787 {
-				copy(yyv1787, yyv21787)
+			yyc1741 = true
+			yyrr1741 = len(yyv1741)
+			if yyrg1741 {
+				copy(yyv1741, yyv21741)
 			}
-		} else if yyl1787 != len(yyv1787) {
-			yyv1787 = yyv1787[:yyl1787]
-			yyc1787 = true
+		} else if yyl1741 != len(yyv1741) {
+			yyv1741 = yyv1741[:yyl1741]
+			yyc1741 = true
 		}
-		yyj1787 := 0
-		for ; yyj1787 < yyrr1787; yyj1787++ {
-			yyh1787.ElemContainerState(yyj1787)
+		yyj1741 := 0
+		for ; yyj1741 < yyrr1741; yyj1741++ {
+			yyh1741.ElemContainerState(yyj1741)
 			if r.TryDecodeAsNil() {
-				yyv1787[yyj1787] = ReplicaSet{}
+				yyv1741[yyj1741] = ReplicaSet{}
 			} else {
-				yyv1788 := &yyv1787[yyj1787]
-				yyv1788.CodecDecodeSelf(d)
+				yyv1742 := &yyv1741[yyj1741]
+				yyv1742.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1787 {
-			for ; yyj1787 < yyl1787; yyj1787++ {
-				yyv1787 = append(yyv1787, ReplicaSet{})
-				yyh1787.ElemContainerState(yyj1787)
+		if yyrt1741 {
+			for ; yyj1741 < yyl1741; yyj1741++ {
+				yyv1741 = append(yyv1741, ReplicaSet{})
+				yyh1741.ElemContainerState(yyj1741)
 				if r.TryDecodeAsNil() {
-					yyv1787[yyj1787] = ReplicaSet{}
+					yyv1741[yyj1741] = ReplicaSet{}
 				} else {
-					yyv1789 := &yyv1787[yyj1787]
-					yyv1789.CodecDecodeSelf(d)
+					yyv1743 := &yyv1741[yyj1741]
+					yyv1743.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1787 := 0
-		for ; !r.CheckBreak(); yyj1787++ {
+		yyj1741 := 0
+		for ; !r.CheckBreak(); yyj1741++ {
 
-			if yyj1787 >= len(yyv1787) {
-				yyv1787 = append(yyv1787, ReplicaSet{}) // var yyz1787 ReplicaSet
-				yyc1787 = true
+			if yyj1741 >= len(yyv1741) {
+				yyv1741 = append(yyv1741, ReplicaSet{}) // var yyz1741 ReplicaSet
+				yyc1741 = true
 			}
-			yyh1787.ElemContainerState(yyj1787)
-			if yyj1787 < len(yyv1787) {
+			yyh1741.ElemContainerState(yyj1741)
+			if yyj1741 < len(yyv1741) {
 				if r.TryDecodeAsNil() {
-					yyv1787[yyj1787] = ReplicaSet{}
+					yyv1741[yyj1741] = ReplicaSet{}
 				} else {
-					yyv1790 := &yyv1787[yyj1787]
-					yyv1790.CodecDecodeSelf(d)
+					yyv1744 := &yyv1741[yyj1741]
+					yyv1744.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -22278,17 +21660,17 @@ func (x codecSelfer1234) decSliceReplicaSet(v *[]ReplicaSet, d *codec1978.Decode
 			}
 
 		}
-		if yyj1787 < len(yyv1787) {
-			yyv1787 = yyv1787[:yyj1787]
-			yyc1787 = true
-		} else if yyj1787 == 0 && yyv1787 == nil {
-			yyv1787 = []ReplicaSet{}
-			yyc1787 = true
+		if yyj1741 < len(yyv1741) {
+			yyv1741 = yyv1741[:yyj1741]
+			yyc1741 = true
+		} else if yyj1741 == 0 && yyv1741 == nil {
+			yyv1741 = []ReplicaSet{}
+			yyc1741 = true
 		}
 	}
-	yyh1787.End()
-	if yyc1787 {
-		*v = yyv1787
+	yyh1741.End()
+	if yyc1741 {
+		*v = yyv1741
 	}
 }
 
@@ -22297,14 +21679,14 @@ func (x codecSelfer1234) encSlicev1_Capability(v []pkg2_v1.Capability, e *codec1
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1791 := range v {
+	for _, yyv1745 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yym1792 := z.EncBinary()
-		_ = yym1792
+		yym1746 := z.EncBinary()
+		_ = yym1746
 		if false {
-		} else if z.HasExtensions() && z.EncExt(yyv1791) {
+		} else if z.HasExtensions() && z.EncExt(yyv1745) {
 		} else {
-			r.EncodeString(codecSelferC_UTF81234, string(yyv1791))
+			r.EncodeString(codecSelferC_UTF81234, string(yyv1745))
 		}
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
@@ -22315,75 +21697,75 @@ func (x codecSelfer1234) decSlicev1_Capability(v *[]pkg2_v1.Capability, d *codec
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1793 := *v
-	yyh1793, yyl1793 := z.DecSliceHelperStart()
-	var yyc1793 bool
-	if yyl1793 == 0 {
-		if yyv1793 == nil {
-			yyv1793 = []pkg2_v1.Capability{}
-			yyc1793 = true
-		} else if len(yyv1793) != 0 {
-			yyv1793 = yyv1793[:0]
-			yyc1793 = true
+	yyv1747 := *v
+	yyh1747, yyl1747 := z.DecSliceHelperStart()
+	var yyc1747 bool
+	if yyl1747 == 0 {
+		if yyv1747 == nil {
+			yyv1747 = []pkg2_v1.Capability{}
+			yyc1747 = true
+		} else if len(yyv1747) != 0 {
+			yyv1747 = yyv1747[:0]
+			yyc1747 = true
 		}
-	} else if yyl1793 > 0 {
-		var yyrr1793, yyrl1793 int
-		var yyrt1793 bool
-		if yyl1793 > cap(yyv1793) {
+	} else if yyl1747 > 0 {
+		var yyrr1747, yyrl1747 int
+		var yyrt1747 bool
+		if yyl1747 > cap(yyv1747) {
 
-			yyrl1793, yyrt1793 = z.DecInferLen(yyl1793, z.DecBasicHandle().MaxInitLen, 16)
-			if yyrt1793 {
-				if yyrl1793 <= cap(yyv1793) {
-					yyv1793 = yyv1793[:yyrl1793]
+			yyrl1747, yyrt1747 = z.DecInferLen(yyl1747, z.DecBasicHandle().MaxInitLen, 16)
+			if yyrt1747 {
+				if yyrl1747 <= cap(yyv1747) {
+					yyv1747 = yyv1747[:yyrl1747]
 				} else {
-					yyv1793 = make([]pkg2_v1.Capability, yyrl1793)
+					yyv1747 = make([]pkg2_v1.Capability, yyrl1747)
 				}
 			} else {
-				yyv1793 = make([]pkg2_v1.Capability, yyrl1793)
+				yyv1747 = make([]pkg2_v1.Capability, yyrl1747)
 			}
-			yyc1793 = true
-			yyrr1793 = len(yyv1793)
-		} else if yyl1793 != len(yyv1793) {
-			yyv1793 = yyv1793[:yyl1793]
-			yyc1793 = true
+			yyc1747 = true
+			yyrr1747 = len(yyv1747)
+		} else if yyl1747 != len(yyv1747) {
+			yyv1747 = yyv1747[:yyl1747]
+			yyc1747 = true
 		}
-		yyj1793 := 0
-		for ; yyj1793 < yyrr1793; yyj1793++ {
-			yyh1793.ElemContainerState(yyj1793)
+		yyj1747 := 0
+		for ; yyj1747 < yyrr1747; yyj1747++ {
+			yyh1747.ElemContainerState(yyj1747)
 			if r.TryDecodeAsNil() {
-				yyv1793[yyj1793] = ""
+				yyv1747[yyj1747] = ""
 			} else {
-				yyv1793[yyj1793] = pkg2_v1.Capability(r.DecodeString())
+				yyv1747[yyj1747] = pkg2_v1.Capability(r.DecodeString())
 			}
 
 		}
-		if yyrt1793 {
-			for ; yyj1793 < yyl1793; yyj1793++ {
-				yyv1793 = append(yyv1793, "")
-				yyh1793.ElemContainerState(yyj1793)
+		if yyrt1747 {
+			for ; yyj1747 < yyl1747; yyj1747++ {
+				yyv1747 = append(yyv1747, "")
+				yyh1747.ElemContainerState(yyj1747)
 				if r.TryDecodeAsNil() {
-					yyv1793[yyj1793] = ""
+					yyv1747[yyj1747] = ""
 				} else {
-					yyv1793[yyj1793] = pkg2_v1.Capability(r.DecodeString())
+					yyv1747[yyj1747] = pkg2_v1.Capability(r.DecodeString())
 				}
 
 			}
 		}
 
 	} else {
-		yyj1793 := 0
-		for ; !r.CheckBreak(); yyj1793++ {
+		yyj1747 := 0
+		for ; !r.CheckBreak(); yyj1747++ {
 
-			if yyj1793 >= len(yyv1793) {
-				yyv1793 = append(yyv1793, "") // var yyz1793 pkg2_v1.Capability
-				yyc1793 = true
+			if yyj1747 >= len(yyv1747) {
+				yyv1747 = append(yyv1747, "") // var yyz1747 pkg2_v1.Capability
+				yyc1747 = true
 			}
-			yyh1793.ElemContainerState(yyj1793)
-			if yyj1793 < len(yyv1793) {
+			yyh1747.ElemContainerState(yyj1747)
+			if yyj1747 < len(yyv1747) {
 				if r.TryDecodeAsNil() {
-					yyv1793[yyj1793] = ""
+					yyv1747[yyj1747] = ""
 				} else {
-					yyv1793[yyj1793] = pkg2_v1.Capability(r.DecodeString())
+					yyv1747[yyj1747] = pkg2_v1.Capability(r.DecodeString())
 				}
 
 			} else {
@@ -22391,17 +21773,17 @@ func (x codecSelfer1234) decSlicev1_Capability(v *[]pkg2_v1.Capability, d *codec
 			}
 
 		}
-		if yyj1793 < len(yyv1793) {
-			yyv1793 = yyv1793[:yyj1793]
-			yyc1793 = true
-		} else if yyj1793 == 0 && yyv1793 == nil {
-			yyv1793 = []pkg2_v1.Capability{}
-			yyc1793 = true
+		if yyj1747 < len(yyv1747) {
+			yyv1747 = yyv1747[:yyj1747]
+			yyc1747 = true
+		} else if yyj1747 == 0 && yyv1747 == nil {
+			yyv1747 = []pkg2_v1.Capability{}
+			yyc1747 = true
 		}
 	}
-	yyh1793.End()
-	if yyc1793 {
-		*v = yyv1793
+	yyh1747.End()
+	if yyc1747 {
+		*v = yyv1747
 	}
 }
 
@@ -22410,9 +21792,9 @@ func (x codecSelfer1234) encSliceFSType(v []FSType, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1797 := range v {
+	for _, yyv1751 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yyv1797.CodecEncodeSelf(e)
+		yyv1751.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -22422,75 +21804,75 @@ func (x codecSelfer1234) decSliceFSType(v *[]FSType, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1798 := *v
-	yyh1798, yyl1798 := z.DecSliceHelperStart()
-	var yyc1798 bool
-	if yyl1798 == 0 {
-		if yyv1798 == nil {
-			yyv1798 = []FSType{}
-			yyc1798 = true
-		} else if len(yyv1798) != 0 {
-			yyv1798 = yyv1798[:0]
-			yyc1798 = true
+	yyv1752 := *v
+	yyh1752, yyl1752 := z.DecSliceHelperStart()
+	var yyc1752 bool
+	if yyl1752 == 0 {
+		if yyv1752 == nil {
+			yyv1752 = []FSType{}
+			yyc1752 = true
+		} else if len(yyv1752) != 0 {
+			yyv1752 = yyv1752[:0]
+			yyc1752 = true
 		}
-	} else if yyl1798 > 0 {
-		var yyrr1798, yyrl1798 int
-		var yyrt1798 bool
-		if yyl1798 > cap(yyv1798) {
+	} else if yyl1752 > 0 {
+		var yyrr1752, yyrl1752 int
+		var yyrt1752 bool
+		if yyl1752 > cap(yyv1752) {
 
-			yyrl1798, yyrt1798 = z.DecInferLen(yyl1798, z.DecBasicHandle().MaxInitLen, 16)
-			if yyrt1798 {
-				if yyrl1798 <= cap(yyv1798) {
-					yyv1798 = yyv1798[:yyrl1798]
+			yyrl1752, yyrt1752 = z.DecInferLen(yyl1752, z.DecBasicHandle().MaxInitLen, 16)
+			if yyrt1752 {
+				if yyrl1752 <= cap(yyv1752) {
+					yyv1752 = yyv1752[:yyrl1752]
 				} else {
-					yyv1798 = make([]FSType, yyrl1798)
+					yyv1752 = make([]FSType, yyrl1752)
 				}
 			} else {
-				yyv1798 = make([]FSType, yyrl1798)
+				yyv1752 = make([]FSType, yyrl1752)
 			}
-			yyc1798 = true
-			yyrr1798 = len(yyv1798)
-		} else if yyl1798 != len(yyv1798) {
-			yyv1798 = yyv1798[:yyl1798]
-			yyc1798 = true
+			yyc1752 = true
+			yyrr1752 = len(yyv1752)
+		} else if yyl1752 != len(yyv1752) {
+			yyv1752 = yyv1752[:yyl1752]
+			yyc1752 = true
 		}
-		yyj1798 := 0
-		for ; yyj1798 < yyrr1798; yyj1798++ {
-			yyh1798.ElemContainerState(yyj1798)
+		yyj1752 := 0
+		for ; yyj1752 < yyrr1752; yyj1752++ {
+			yyh1752.ElemContainerState(yyj1752)
 			if r.TryDecodeAsNil() {
-				yyv1798[yyj1798] = ""
+				yyv1752[yyj1752] = ""
 			} else {
-				yyv1798[yyj1798] = FSType(r.DecodeString())
+				yyv1752[yyj1752] = FSType(r.DecodeString())
 			}
 
 		}
-		if yyrt1798 {
-			for ; yyj1798 < yyl1798; yyj1798++ {
-				yyv1798 = append(yyv1798, "")
-				yyh1798.ElemContainerState(yyj1798)
+		if yyrt1752 {
+			for ; yyj1752 < yyl1752; yyj1752++ {
+				yyv1752 = append(yyv1752, "")
+				yyh1752.ElemContainerState(yyj1752)
 				if r.TryDecodeAsNil() {
-					yyv1798[yyj1798] = ""
+					yyv1752[yyj1752] = ""
 				} else {
-					yyv1798[yyj1798] = FSType(r.DecodeString())
+					yyv1752[yyj1752] = FSType(r.DecodeString())
 				}
 
 			}
 		}
 
 	} else {
-		yyj1798 := 0
-		for ; !r.CheckBreak(); yyj1798++ {
+		yyj1752 := 0
+		for ; !r.CheckBreak(); yyj1752++ {
 
-			if yyj1798 >= len(yyv1798) {
-				yyv1798 = append(yyv1798, "") // var yyz1798 FSType
-				yyc1798 = true
+			if yyj1752 >= len(yyv1752) {
+				yyv1752 = append(yyv1752, "") // var yyz1752 FSType
+				yyc1752 = true
 			}
-			yyh1798.ElemContainerState(yyj1798)
-			if yyj1798 < len(yyv1798) {
+			yyh1752.ElemContainerState(yyj1752)
+			if yyj1752 < len(yyv1752) {
 				if r.TryDecodeAsNil() {
-					yyv1798[yyj1798] = ""
+					yyv1752[yyj1752] = ""
 				} else {
-					yyv1798[yyj1798] = FSType(r.DecodeString())
+					yyv1752[yyj1752] = FSType(r.DecodeString())
 				}
 
 			} else {
@@ -22498,17 +21880,17 @@ func (x codecSelfer1234) decSliceFSType(v *[]FSType, d *codec1978.Decoder) {
 			}
 
 		}
-		if yyj1798 < len(yyv1798) {
-			yyv1798 = yyv1798[:yyj1798]
-			yyc1798 = true
-		} else if yyj1798 == 0 && yyv1798 == nil {
-			yyv1798 = []FSType{}
-			yyc1798 = true
+		if yyj1752 < len(yyv1752) {
+			yyv1752 = yyv1752[:yyj1752]
+			yyc1752 = true
+		} else if yyj1752 == 0 && yyv1752 == nil {
+			yyv1752 = []FSType{}
+			yyc1752 = true
 		}
 	}
-	yyh1798.End()
-	if yyc1798 {
-		*v = yyv1798
+	yyh1752.End()
+	if yyc1752 {
+		*v = yyv1752
 	}
 }
 
@@ -22517,10 +21899,10 @@ func (x codecSelfer1234) encSliceHostPortRange(v []HostPortRange, e *codec1978.E
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1802 := range v {
+	for _, yyv1756 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1803 := &yyv1802
-		yy1803.CodecEncodeSelf(e)
+		yy1757 := &yyv1756
+		yy1757.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -22530,83 +21912,83 @@ func (x codecSelfer1234) decSliceHostPortRange(v *[]HostPortRange, d *codec1978.
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1804 := *v
-	yyh1804, yyl1804 := z.DecSliceHelperStart()
-	var yyc1804 bool
-	if yyl1804 == 0 {
-		if yyv1804 == nil {
-			yyv1804 = []HostPortRange{}
-			yyc1804 = true
-		} else if len(yyv1804) != 0 {
-			yyv1804 = yyv1804[:0]
-			yyc1804 = true
+	yyv1758 := *v
+	yyh1758, yyl1758 := z.DecSliceHelperStart()
+	var yyc1758 bool
+	if yyl1758 == 0 {
+		if yyv1758 == nil {
+			yyv1758 = []HostPortRange{}
+			yyc1758 = true
+		} else if len(yyv1758) != 0 {
+			yyv1758 = yyv1758[:0]
+			yyc1758 = true
 		}
-	} else if yyl1804 > 0 {
-		var yyrr1804, yyrl1804 int
-		var yyrt1804 bool
-		if yyl1804 > cap(yyv1804) {
+	} else if yyl1758 > 0 {
+		var yyrr1758, yyrl1758 int
+		var yyrt1758 bool
+		if yyl1758 > cap(yyv1758) {
 
-			yyrg1804 := len(yyv1804) > 0
-			yyv21804 := yyv1804
-			yyrl1804, yyrt1804 = z.DecInferLen(yyl1804, z.DecBasicHandle().MaxInitLen, 8)
-			if yyrt1804 {
-				if yyrl1804 <= cap(yyv1804) {
-					yyv1804 = yyv1804[:yyrl1804]
+			yyrg1758 := len(yyv1758) > 0
+			yyv21758 := yyv1758
+			yyrl1758, yyrt1758 = z.DecInferLen(yyl1758, z.DecBasicHandle().MaxInitLen, 8)
+			if yyrt1758 {
+				if yyrl1758 <= cap(yyv1758) {
+					yyv1758 = yyv1758[:yyrl1758]
 				} else {
-					yyv1804 = make([]HostPortRange, yyrl1804)
+					yyv1758 = make([]HostPortRange, yyrl1758)
 				}
 			} else {
-				yyv1804 = make([]HostPortRange, yyrl1804)
+				yyv1758 = make([]HostPortRange, yyrl1758)
 			}
-			yyc1804 = true
-			yyrr1804 = len(yyv1804)
-			if yyrg1804 {
-				copy(yyv1804, yyv21804)
+			yyc1758 = true
+			yyrr1758 = len(yyv1758)
+			if yyrg1758 {
+				copy(yyv1758, yyv21758)
 			}
-		} else if yyl1804 != len(yyv1804) {
-			yyv1804 = yyv1804[:yyl1804]
-			yyc1804 = true
+		} else if yyl1758 != len(yyv1758) {
+			yyv1758 = yyv1758[:yyl1758]
+			yyc1758 = true
 		}
-		yyj1804 := 0
-		for ; yyj1804 < yyrr1804; yyj1804++ {
-			yyh1804.ElemContainerState(yyj1804)
+		yyj1758 := 0
+		for ; yyj1758 < yyrr1758; yyj1758++ {
+			yyh1758.ElemContainerState(yyj1758)
 			if r.TryDecodeAsNil() {
-				yyv1804[yyj1804] = HostPortRange{}
+				yyv1758[yyj1758] = HostPortRange{}
 			} else {
-				yyv1805 := &yyv1804[yyj1804]
-				yyv1805.CodecDecodeSelf(d)
+				yyv1759 := &yyv1758[yyj1758]
+				yyv1759.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1804 {
-			for ; yyj1804 < yyl1804; yyj1804++ {
-				yyv1804 = append(yyv1804, HostPortRange{})
-				yyh1804.ElemContainerState(yyj1804)
+		if yyrt1758 {
+			for ; yyj1758 < yyl1758; yyj1758++ {
+				yyv1758 = append(yyv1758, HostPortRange{})
+				yyh1758.ElemContainerState(yyj1758)
 				if r.TryDecodeAsNil() {
-					yyv1804[yyj1804] = HostPortRange{}
+					yyv1758[yyj1758] = HostPortRange{}
 				} else {
-					yyv1806 := &yyv1804[yyj1804]
-					yyv1806.CodecDecodeSelf(d)
+					yyv1760 := &yyv1758[yyj1758]
+					yyv1760.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1804 := 0
-		for ; !r.CheckBreak(); yyj1804++ {
+		yyj1758 := 0
+		for ; !r.CheckBreak(); yyj1758++ {
 
-			if yyj1804 >= len(yyv1804) {
-				yyv1804 = append(yyv1804, HostPortRange{}) // var yyz1804 HostPortRange
-				yyc1804 = true
+			if yyj1758 >= len(yyv1758) {
+				yyv1758 = append(yyv1758, HostPortRange{}) // var yyz1758 HostPortRange
+				yyc1758 = true
 			}
-			yyh1804.ElemContainerState(yyj1804)
-			if yyj1804 < len(yyv1804) {
+			yyh1758.ElemContainerState(yyj1758)
+			if yyj1758 < len(yyv1758) {
 				if r.TryDecodeAsNil() {
-					yyv1804[yyj1804] = HostPortRange{}
+					yyv1758[yyj1758] = HostPortRange{}
 				} else {
-					yyv1807 := &yyv1804[yyj1804]
-					yyv1807.CodecDecodeSelf(d)
+					yyv1761 := &yyv1758[yyj1758]
+					yyv1761.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -22614,17 +21996,17 @@ func (x codecSelfer1234) decSliceHostPortRange(v *[]HostPortRange, d *codec1978.
 			}
 
 		}
-		if yyj1804 < len(yyv1804) {
-			yyv1804 = yyv1804[:yyj1804]
-			yyc1804 = true
-		} else if yyj1804 == 0 && yyv1804 == nil {
-			yyv1804 = []HostPortRange{}
-			yyc1804 = true
+		if yyj1758 < len(yyv1758) {
+			yyv1758 = yyv1758[:yyj1758]
+			yyc1758 = true
+		} else if yyj1758 == 0 && yyv1758 == nil {
+			yyv1758 = []HostPortRange{}
+			yyc1758 = true
 		}
 	}
-	yyh1804.End()
-	if yyc1804 {
-		*v = yyv1804
+	yyh1758.End()
+	if yyc1758 {
+		*v = yyv1758
 	}
 }
 
@@ -22633,10 +22015,10 @@ func (x codecSelfer1234) encSliceIDRange(v []IDRange, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1808 := range v {
+	for _, yyv1762 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1809 := &yyv1808
-		yy1809.CodecEncodeSelf(e)
+		yy1763 := &yyv1762
+		yy1763.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -22646,83 +22028,83 @@ func (x codecSelfer1234) decSliceIDRange(v *[]IDRange, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1810 := *v
-	yyh1810, yyl1810 := z.DecSliceHelperStart()
-	var yyc1810 bool
-	if yyl1810 == 0 {
-		if yyv1810 == nil {
-			yyv1810 = []IDRange{}
-			yyc1810 = true
-		} else if len(yyv1810) != 0 {
-			yyv1810 = yyv1810[:0]
-			yyc1810 = true
+	yyv1764 := *v
+	yyh1764, yyl1764 := z.DecSliceHelperStart()
+	var yyc1764 bool
+	if yyl1764 == 0 {
+		if yyv1764 == nil {
+			yyv1764 = []IDRange{}
+			yyc1764 = true
+		} else if len(yyv1764) != 0 {
+			yyv1764 = yyv1764[:0]
+			yyc1764 = true
 		}
-	} else if yyl1810 > 0 {
-		var yyrr1810, yyrl1810 int
-		var yyrt1810 bool
-		if yyl1810 > cap(yyv1810) {
+	} else if yyl1764 > 0 {
+		var yyrr1764, yyrl1764 int
+		var yyrt1764 bool
+		if yyl1764 > cap(yyv1764) {
 
-			yyrg1810 := len(yyv1810) > 0
-			yyv21810 := yyv1810
-			yyrl1810, yyrt1810 = z.DecInferLen(yyl1810, z.DecBasicHandle().MaxInitLen, 16)
-			if yyrt1810 {
-				if yyrl1810 <= cap(yyv1810) {
-					yyv1810 = yyv1810[:yyrl1810]
+			yyrg1764 := len(yyv1764) > 0
+			yyv21764 := yyv1764
+			yyrl1764, yyrt1764 = z.DecInferLen(yyl1764, z.DecBasicHandle().MaxInitLen, 16)
+			if yyrt1764 {
+				if yyrl1764 <= cap(yyv1764) {
+					yyv1764 = yyv1764[:yyrl1764]
 				} else {
-					yyv1810 = make([]IDRange, yyrl1810)
+					yyv1764 = make([]IDRange, yyrl1764)
 				}
 			} else {
-				yyv1810 = make([]IDRange, yyrl1810)
+				yyv1764 = make([]IDRange, yyrl1764)
 			}
-			yyc1810 = true
-			yyrr1810 = len(yyv1810)
-			if yyrg1810 {
-				copy(yyv1810, yyv21810)
+			yyc1764 = true
+			yyrr1764 = len(yyv1764)
+			if yyrg1764 {
+				copy(yyv1764, yyv21764)
 			}
-		} else if yyl1810 != len(yyv1810) {
-			yyv1810 = yyv1810[:yyl1810]
-			yyc1810 = true
+		} else if yyl1764 != len(yyv1764) {
+			yyv1764 = yyv1764[:yyl1764]
+			yyc1764 = true
 		}
-		yyj1810 := 0
-		for ; yyj1810 < yyrr1810; yyj1810++ {
-			yyh1810.ElemContainerState(yyj1810)
+		yyj1764 := 0
+		for ; yyj1764 < yyrr1764; yyj1764++ {
+			yyh1764.ElemContainerState(yyj1764)
 			if r.TryDecodeAsNil() {
-				yyv1810[yyj1810] = IDRange{}
+				yyv1764[yyj1764] = IDRange{}
 			} else {
-				yyv1811 := &yyv1810[yyj1810]
-				yyv1811.CodecDecodeSelf(d)
+				yyv1765 := &yyv1764[yyj1764]
+				yyv1765.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1810 {
-			for ; yyj1810 < yyl1810; yyj1810++ {
-				yyv1810 = append(yyv1810, IDRange{})
-				yyh1810.ElemContainerState(yyj1810)
+		if yyrt1764 {
+			for ; yyj1764 < yyl1764; yyj1764++ {
+				yyv1764 = append(yyv1764, IDRange{})
+				yyh1764.ElemContainerState(yyj1764)
 				if r.TryDecodeAsNil() {
-					yyv1810[yyj1810] = IDRange{}
+					yyv1764[yyj1764] = IDRange{}
 				} else {
-					yyv1812 := &yyv1810[yyj1810]
-					yyv1812.CodecDecodeSelf(d)
+					yyv1766 := &yyv1764[yyj1764]
+					yyv1766.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1810 := 0
-		for ; !r.CheckBreak(); yyj1810++ {
+		yyj1764 := 0
+		for ; !r.CheckBreak(); yyj1764++ {
 
-			if yyj1810 >= len(yyv1810) {
-				yyv1810 = append(yyv1810, IDRange{}) // var yyz1810 IDRange
-				yyc1810 = true
+			if yyj1764 >= len(yyv1764) {
+				yyv1764 = append(yyv1764, IDRange{}) // var yyz1764 IDRange
+				yyc1764 = true
 			}
-			yyh1810.ElemContainerState(yyj1810)
-			if yyj1810 < len(yyv1810) {
+			yyh1764.ElemContainerState(yyj1764)
+			if yyj1764 < len(yyv1764) {
 				if r.TryDecodeAsNil() {
-					yyv1810[yyj1810] = IDRange{}
+					yyv1764[yyj1764] = IDRange{}
 				} else {
-					yyv1813 := &yyv1810[yyj1810]
-					yyv1813.CodecDecodeSelf(d)
+					yyv1767 := &yyv1764[yyj1764]
+					yyv1767.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -22730,17 +22112,17 @@ func (x codecSelfer1234) decSliceIDRange(v *[]IDRange, d *codec1978.Decoder) {
 			}
 
 		}
-		if yyj1810 < len(yyv1810) {
-			yyv1810 = yyv1810[:yyj1810]
-			yyc1810 = true
-		} else if yyj1810 == 0 && yyv1810 == nil {
-			yyv1810 = []IDRange{}
-			yyc1810 = true
+		if yyj1764 < len(yyv1764) {
+			yyv1764 = yyv1764[:yyj1764]
+			yyc1764 = true
+		} else if yyj1764 == 0 && yyv1764 == nil {
+			yyv1764 = []IDRange{}
+			yyc1764 = true
 		}
 	}
-	yyh1810.End()
-	if yyc1810 {
-		*v = yyv1810
+	yyh1764.End()
+	if yyc1764 {
+		*v = yyv1764
 	}
 }
 
@@ -22749,10 +22131,10 @@ func (x codecSelfer1234) encSlicePodSecurityPolicy(v []PodSecurityPolicy, e *cod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1814 := range v {
+	for _, yyv1768 := range v {
 		z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-		yy1815 := &yyv1814
-		yy1815.CodecEncodeSelf(e)
+		yy1769 := &yyv1768
+		yy1769.CodecEncodeSelf(e)
 	}
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -22762,83 +22144,83 @@ func (x codecSelfer1234) decSlicePodSecurityPolicy(v *[]PodSecurityPolicy, d *co
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1816 := *v
-	yyh1816, yyl1816 := z.DecSliceHelperStart()
-	var yyc1816 bool
-	if yyl1816 == 0 {
-		if yyv1816 == nil {
-			yyv1816 = []PodSecurityPolicy{}
-			yyc1816 = true
-		} else if len(yyv1816) != 0 {
-			yyv1816 = yyv1816[:0]
-			yyc1816 = true
+	yyv1770 := *v
+	yyh1770, yyl1770 := z.DecSliceHelperStart()
+	var yyc1770 bool
+	if yyl1770 == 0 {
+		if yyv1770 == nil {
+			yyv1770 = []PodSecurityPolicy{}
+			yyc1770 = true
+		} else if len(yyv1770) != 0 {
+			yyv1770 = yyv1770[:0]
+			yyc1770 = true
 		}
-	} else if yyl1816 > 0 {
-		var yyrr1816, yyrl1816 int
-		var yyrt1816 bool
-		if yyl1816 > cap(yyv1816) {
+	} else if yyl1770 > 0 {
+		var yyrr1770, yyrl1770 int
+		var yyrt1770 bool
+		if yyl1770 > cap(yyv1770) {
 
-			yyrg1816 := len(yyv1816) > 0
-			yyv21816 := yyv1816
-			yyrl1816, yyrt1816 = z.DecInferLen(yyl1816, z.DecBasicHandle().MaxInitLen, 352)
-			if yyrt1816 {
-				if yyrl1816 <= cap(yyv1816) {
-					yyv1816 = yyv1816[:yyrl1816]
+			yyrg1770 := len(yyv1770) > 0
+			yyv21770 := yyv1770
+			yyrl1770, yyrt1770 = z.DecInferLen(yyl1770, z.DecBasicHandle().MaxInitLen, 352)
+			if yyrt1770 {
+				if yyrl1770 <= cap(yyv1770) {
+					yyv1770 = yyv1770[:yyrl1770]
 				} else {
-					yyv1816 = make([]PodSecurityPolicy, yyrl1816)
+					yyv1770 = make([]PodSecurityPolicy, yyrl1770)
 				}
 			} else {
-				yyv1816 = make([]PodSecurityPolicy, yyrl1816)
+				yyv1770 = make([]PodSecurityPolicy, yyrl1770)
 			}
-			yyc1816 = true
-			yyrr1816 = len(yyv1816)
-			if yyrg1816 {
-				copy(yyv1816, yyv21816)
+			yyc1770 = true
+			yyrr1770 = len(yyv1770)
+			if yyrg1770 {
+				copy(yyv1770, yyv21770)
 			}
-		} else if yyl1816 != len(yyv1816) {
-			yyv1816 = yyv1816[:yyl1816]
-			yyc1816 = true
+		} else if yyl1770 != len(yyv1770) {
+			yyv1770 = yyv1770[:yyl1770]
+			yyc1770 = true
 		}
-		yyj1816 := 0
-		for ; yyj1816 < yyrr1816; yyj1816++ {
-			yyh1816.ElemContainerState(yyj1816)
+		yyj1770 := 0
+		for ; yyj1770 < yyrr1770; yyj1770++ {
+			yyh1770.ElemContainerState(yyj1770)
 			if r.TryDecodeAsNil() {
-				yyv1816[yyj1816] = PodSecurityPolicy{}
+				yyv1770[yyj1770] = PodSecurityPolicy{}
 			} else {
-				yyv1817 := &yyv1816[yyj1816]
-				yyv1817.CodecDecodeSelf(d)
+				yyv1771 := &yyv1770[yyj1770]
+				yyv1771.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1816 {
-			for ; yyj1816 < yyl1816; yyj1816++ {
-				yyv1816 = append(yyv1816, PodSecurityPolicy{})
-				yyh1816.ElemContainerState(yyj1816)
+		if yyrt1770 {
+			for ; yyj1770 < yyl1770; yyj1770++ {
+				yyv1770 = append(yyv1770, PodSecurityPolicy{})
+				yyh1770.ElemContainerState(yyj1770)
 				if r.TryDecodeAsNil() {
-					yyv1816[yyj1816] = PodSecurityPolicy{}
+					yyv1770[yyj1770] = PodSecurityPolicy{}
 				} else {
-					yyv1818 := &yyv1816[yyj1816]
-					yyv1818.CodecDecodeSelf(d)
+					yyv1772 := &yyv1770[yyj1770]
+					yyv1772.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		yyj1816 := 0
-		for ; !r.CheckBreak(); yyj1816++ {
+		yyj1770 := 0
+		for ; !r.CheckBreak(); yyj1770++ {
 
-			if yyj1816 >= len(yyv1816) {
-				yyv1816 = append(yyv1816, PodSecurityPolicy{}) // var yyz1816 PodSecurityPolicy
-				yyc1816 = true
+			if yyj1770 >= len(yyv1770) {
+				yyv1770 = append(yyv1770, PodSecurityPolicy{}) // var yyz1770 PodSecurityPolicy
+				yyc1770 = true
 			}
-			yyh1816.ElemContainerState(yyj1816)
-			if yyj1816 < len(yyv1816) {
+			yyh1770.ElemContainerState(yyj1770)
+			if yyj1770 < len(yyv1770) {
 				if r.TryDecodeAsNil() {
-					yyv1816[yyj1816] = PodSecurityPolicy{}
+					yyv1770[yyj1770] = PodSecurityPolicy{}
 				} else {
-					yyv1819 := &yyv1816[yyj1816]
-					yyv1819.CodecDecodeSelf(d)
+					yyv1773 := &yyv1770[yyj1770]
+					yyv1773.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -22846,16 +22228,16 @@ func (x codecSelfer1234) decSlicePodSecurityPolicy(v *[]PodSecurityPolicy, d *co
 			}
 
 		}
-		if yyj1816 < len(yyv1816) {
-			yyv1816 = yyv1816[:yyj1816]
-			yyc1816 = true
-		} else if yyj1816 == 0 && yyv1816 == nil {
-			yyv1816 = []PodSecurityPolicy{}
-			yyc1816 = true
+		if yyj1770 < len(yyv1770) {
+			yyv1770 = yyv1770[:yyj1770]
+			yyc1770 = true
+		} else if yyj1770 == 0 && yyv1770 == nil {
+			yyv1770 = []PodSecurityPolicy{}
+			yyc1770 = true
 		}
 	}
-	yyh1816.End()
-	if yyc1816 {
-		*v = yyv1816
+	yyh1770.End()
+	if yyc1770 {
+		*v = yyv1770
 	}
 }

--- a/pkg/apis/extensions/v1beta1/types.go
+++ b/pkg/apis/extensions/v1beta1/types.go
@@ -343,6 +343,8 @@ type DeploymentList struct {
 	Items []Deployment `json:"items"`
 }
 
+// TODO(madhusudancs): Uncomment while implementing DaemonSet updates.
+/* Commenting out for v1.2. We are planning to bring these types back with a more robust DaemonSet update implementation in v1.3, hence not deleting but just commenting the types out.
 type DaemonSetUpdateStrategy struct {
 	// Type of daemon set update. Only "RollingUpdate" is supported at this time. Default is RollingUpdate.
 	Type DaemonSetUpdateStrategyType `json:"type,omitempty"`
@@ -385,6 +387,7 @@ type RollingUpdateDaemonSet struct {
 	// is ready).
 	MinReadySeconds int32 `json:"minReadySeconds,omitempty"`
 }
+*/
 
 // DaemonSetSpec is the specification of a daemon set.
 type DaemonSetSpec struct {
@@ -401,6 +404,8 @@ type DaemonSetSpec struct {
 	// More info: http://releases.k8s.io/HEAD/docs/user-guide/replication-controller.md#pod-template
 	Template v1.PodTemplateSpec `json:"template"`
 
+	// TODO(madhusudancs): Uncomment while implementing DaemonSet updates.
+	/* Commenting out for v1.2. We are planning to bring these fields back with a more robust DaemonSet update implementation in v1.3, hence not deleting but just commenting these fields out.
 	// Update strategy to replace existing DaemonSet pods with new pods.
 	UpdateStrategy DaemonSetUpdateStrategy `json:"updateStrategy,omitempty"`
 
@@ -412,6 +417,7 @@ type DaemonSetSpec struct {
 	// Value of this key is hash of DaemonSetSpec.PodTemplateSpec.
 	// No label is added if this is set to empty string.
 	UniqueLabelKey *string `json:"uniqueLabelKey,omitempty"`
+	*/
 }
 
 const (

--- a/pkg/apis/extensions/v1beta1/types_swagger_doc_generated.go
+++ b/pkg/apis/extensions/v1beta1/types_swagger_doc_generated.go
@@ -115,11 +115,9 @@ func (DaemonSetList) SwaggerDoc() map[string]string {
 }
 
 var map_DaemonSetSpec = map[string]string{
-	"":               "DaemonSetSpec is the specification of a daemon set.",
-	"selector":       "Selector is a label query over pods that are managed by the daemon set. Must match in order to be controlled. If empty, defaulted to labels on Pod template. More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md#label-selectors",
-	"template":       "Template is the object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: http://releases.k8s.io/HEAD/docs/user-guide/replication-controller.md#pod-template",
-	"updateStrategy": "Update strategy to replace existing DaemonSet pods with new pods.",
-	"uniqueLabelKey": "Label key that is added to DaemonSet pods to distinguish between old and new pod templates during DaemonSet update. Users can set this to an empty string to indicate that the system should not add any label. If unspecified, system uses DefaultDaemonSetUniqueLabelKey(\"daemonset.kubernetes.io/podTemplateHash\"). Value of this key is hash of DaemonSetSpec.PodTemplateSpec. No label is added if this is set to empty string.",
+	"":         "DaemonSetSpec is the specification of a daemon set.",
+	"selector": "Selector is a label query over pods that are managed by the daemon set. Must match in order to be controlled. If empty, defaulted to labels on Pod template. More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md#label-selectors",
+	"template": "Template is the object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: http://releases.k8s.io/HEAD/docs/user-guide/replication-controller.md#pod-template",
 }
 
 func (DaemonSetSpec) SwaggerDoc() map[string]string {
@@ -135,15 +133,6 @@ var map_DaemonSetStatus = map[string]string{
 
 func (DaemonSetStatus) SwaggerDoc() map[string]string {
 	return map_DaemonSetStatus
-}
-
-var map_DaemonSetUpdateStrategy = map[string]string{
-	"type":          "Type of daemon set update. Only \"RollingUpdate\" is supported at this time. Default is RollingUpdate.",
-	"rollingUpdate": "Rolling update config params. Present only if DaemonSetUpdateStrategy = RollingUpdate.",
-}
-
-func (DaemonSetUpdateStrategy) SwaggerDoc() map[string]string {
-	return map_DaemonSetUpdateStrategy
 }
 
 var map_Deployment = map[string]string{
@@ -587,16 +576,6 @@ var map_RollbackConfig = map[string]string{
 
 func (RollbackConfig) SwaggerDoc() map[string]string {
 	return map_RollbackConfig
-}
-
-var map_RollingUpdateDaemonSet = map[string]string{
-	"":                "Spec to control the desired behavior of daemon set rolling update.",
-	"maxUnavailable":  "The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0. Default value is 1. Example: when this is set to 30%, 30% of the currently running DaemonSet pods can be stopped for an update at any given time. The update starts by stopping at most 30% of the currently running DaemonSet pods and then brings up new DaemonSet pods in their place. Once the new pods are ready, it then proceeds onto other DaemonSet pods, thus ensuring that at least 70% of original number of DaemonSet pods are available at all times during the update.",
-	"minReadySeconds": "Minimum number of seconds for which a newly created DaemonSet pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready).",
-}
-
-func (RollingUpdateDaemonSet) SwaggerDoc() map[string]string {
-	return map_RollingUpdateDaemonSet
 }
 
 var map_RollingUpdateDeployment = map[string]string{

--- a/pkg/apis/extensions/validation/validation_test.go
+++ b/pkg/apis/extensions/validation/validation_test.go
@@ -387,13 +387,6 @@ func TestValidateDaemonSetUpdate(t *testing.T) {
 	validSelector2 := map[string]string{"c": "d"}
 	invalidSelector := map[string]string{"NoUppercaseOrSpecialCharsLike=Equals": "b"}
 
-	validUpdateStrategy := extensions.DaemonSetUpdateStrategy{
-		Type: extensions.RollingUpdateDaemonSetStrategyType,
-		RollingUpdate: &extensions.RollingUpdateDaemonSet{
-			MaxUnavailable: intstr.FromInt(1),
-		},
-	}
-
 	validPodSpecAbc := api.PodSpec{
 		RestartPolicy: api.RestartPolicyAlways,
 		DNSPolicy:     api.DNSClusterFirst,
@@ -479,17 +472,15 @@ func TestValidateDaemonSetUpdate(t *testing.T) {
 			old: extensions.DaemonSet{
 				ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: api.NamespaceDefault},
 				Spec: extensions.DaemonSetSpec{
-					Selector:       &unversioned.LabelSelector{MatchLabels: validSelector},
-					Template:       validPodTemplateAbc.Template,
-					UpdateStrategy: validUpdateStrategy,
+					Selector: &unversioned.LabelSelector{MatchLabels: validSelector},
+					Template: validPodTemplateAbc.Template,
 				},
 			},
 			update: extensions.DaemonSet{
 				ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: api.NamespaceDefault},
 				Spec: extensions.DaemonSetSpec{
-					Selector:       &unversioned.LabelSelector{MatchLabels: validSelector},
-					Template:       validPodTemplateAbc.Template,
-					UpdateStrategy: validUpdateStrategy,
+					Selector: &unversioned.LabelSelector{MatchLabels: validSelector},
+					Template: validPodTemplateAbc.Template,
 				},
 			},
 		},
@@ -497,17 +488,15 @@ func TestValidateDaemonSetUpdate(t *testing.T) {
 			old: extensions.DaemonSet{
 				ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: api.NamespaceDefault},
 				Spec: extensions.DaemonSetSpec{
-					Selector:       &unversioned.LabelSelector{MatchLabels: validSelector},
-					Template:       validPodTemplateAbc.Template,
-					UpdateStrategy: validUpdateStrategy,
+					Selector: &unversioned.LabelSelector{MatchLabels: validSelector},
+					Template: validPodTemplateAbc.Template,
 				},
 			},
 			update: extensions.DaemonSet{
 				ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: api.NamespaceDefault},
 				Spec: extensions.DaemonSetSpec{
-					Selector:       &unversioned.LabelSelector{MatchLabels: validSelector2},
-					Template:       validPodTemplateAbc2.Template,
-					UpdateStrategy: validUpdateStrategy,
+					Selector: &unversioned.LabelSelector{MatchLabels: validSelector2},
+					Template: validPodTemplateAbc2.Template,
 				},
 			},
 		},
@@ -515,17 +504,15 @@ func TestValidateDaemonSetUpdate(t *testing.T) {
 			old: extensions.DaemonSet{
 				ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: api.NamespaceDefault},
 				Spec: extensions.DaemonSetSpec{
-					Selector:       &unversioned.LabelSelector{MatchLabels: validSelector},
-					Template:       validPodTemplateAbc.Template,
-					UpdateStrategy: validUpdateStrategy,
+					Selector: &unversioned.LabelSelector{MatchLabels: validSelector},
+					Template: validPodTemplateAbc.Template,
 				},
 			},
 			update: extensions.DaemonSet{
 				ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: api.NamespaceDefault},
 				Spec: extensions.DaemonSetSpec{
-					Selector:       &unversioned.LabelSelector{MatchLabels: validSelector},
-					Template:       validPodTemplateNodeSelector.Template,
-					UpdateStrategy: validUpdateStrategy,
+					Selector: &unversioned.LabelSelector{MatchLabels: validSelector},
+					Template: validPodTemplateNodeSelector.Template,
 				},
 			},
 		},
@@ -542,17 +529,15 @@ func TestValidateDaemonSetUpdate(t *testing.T) {
 			old: extensions.DaemonSet{
 				ObjectMeta: api.ObjectMeta{Name: "", Namespace: api.NamespaceDefault},
 				Spec: extensions.DaemonSetSpec{
-					Selector:       &unversioned.LabelSelector{MatchLabels: validSelector},
-					Template:       validPodTemplateAbc.Template,
-					UpdateStrategy: validUpdateStrategy,
+					Selector: &unversioned.LabelSelector{MatchLabels: validSelector},
+					Template: validPodTemplateAbc.Template,
 				},
 			},
 			update: extensions.DaemonSet{
 				ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: api.NamespaceDefault},
 				Spec: extensions.DaemonSetSpec{
-					Selector:       &unversioned.LabelSelector{MatchLabels: validSelector},
-					Template:       validPodTemplateAbc.Template,
-					UpdateStrategy: validUpdateStrategy,
+					Selector: &unversioned.LabelSelector{MatchLabels: validSelector},
+					Template: validPodTemplateAbc.Template,
 				},
 			},
 		},
@@ -560,81 +545,8 @@ func TestValidateDaemonSetUpdate(t *testing.T) {
 			old: extensions.DaemonSet{
 				ObjectMeta: api.ObjectMeta{Name: "", Namespace: api.NamespaceDefault},
 				Spec: extensions.DaemonSetSpec{
-					Selector:       &unversioned.LabelSelector{MatchLabels: validSelector},
-					Template:       validPodTemplateAbc.Template,
-					UpdateStrategy: validUpdateStrategy,
-				},
-			},
-			update: extensions.DaemonSet{
-				ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: api.NamespaceDefault},
-				Spec: extensions.DaemonSetSpec{
-					Selector:       &unversioned.LabelSelector{MatchLabels: invalidSelector},
-					Template:       validPodTemplateAbc.Template,
-					UpdateStrategy: validUpdateStrategy,
-				},
-			},
-		},
-		"invalid pod": {
-			old: extensions.DaemonSet{
-				ObjectMeta: api.ObjectMeta{Name: "", Namespace: api.NamespaceDefault},
-				Spec: extensions.DaemonSetSpec{
-					Selector:       &unversioned.LabelSelector{MatchLabels: validSelector},
-					Template:       validPodTemplateAbc.Template,
-					UpdateStrategy: validUpdateStrategy,
-				},
-			},
-			update: extensions.DaemonSet{
-				ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: api.NamespaceDefault},
-				Spec: extensions.DaemonSetSpec{
-					Selector:       &unversioned.LabelSelector{MatchLabels: validSelector},
-					Template:       invalidPodTemplate.Template,
-					UpdateStrategy: validUpdateStrategy,
-				},
-			},
-		},
-		"change container image": {
-			old: extensions.DaemonSet{
-				ObjectMeta: api.ObjectMeta{Name: "", Namespace: api.NamespaceDefault},
-				Spec: extensions.DaemonSetSpec{
-					Selector:       &unversioned.LabelSelector{MatchLabels: validSelector},
-					Template:       validPodTemplateAbc.Template,
-					UpdateStrategy: validUpdateStrategy,
-				},
-			},
-			update: extensions.DaemonSet{
-				ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: api.NamespaceDefault},
-				Spec: extensions.DaemonSetSpec{
-					Selector:       &unversioned.LabelSelector{MatchLabels: validSelector},
-					Template:       validPodTemplateDef.Template,
-					UpdateStrategy: validUpdateStrategy,
-				},
-			},
-		},
-		"read-write volume": {
-			old: extensions.DaemonSet{
-				ObjectMeta: api.ObjectMeta{Name: "", Namespace: api.NamespaceDefault},
-				Spec: extensions.DaemonSetSpec{
-					Selector:       &unversioned.LabelSelector{MatchLabels: validSelector},
-					Template:       validPodTemplateAbc.Template,
-					UpdateStrategy: validUpdateStrategy,
-				},
-			},
-			update: extensions.DaemonSet{
-				ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: api.NamespaceDefault},
-				Spec: extensions.DaemonSetSpec{
-					Selector:       &unversioned.LabelSelector{MatchLabels: validSelector},
-					Template:       readWriteVolumePodTemplate.Template,
-					UpdateStrategy: validUpdateStrategy,
-				},
-			},
-		},
-		"invalid update strategy": {
-			old: extensions.DaemonSet{
-				ObjectMeta: api.ObjectMeta{Name: "", Namespace: api.NamespaceDefault},
-				Spec: extensions.DaemonSetSpec{
-					Selector:       &unversioned.LabelSelector{MatchLabels: validSelector},
-					Template:       validPodTemplateAbc.Template,
-					UpdateStrategy: validUpdateStrategy,
+					Selector: &unversioned.LabelSelector{MatchLabels: validSelector},
+					Template: validPodTemplateAbc.Template,
 				},
 			},
 			update: extensions.DaemonSet{
@@ -642,10 +554,70 @@ func TestValidateDaemonSetUpdate(t *testing.T) {
 				Spec: extensions.DaemonSetSpec{
 					Selector: &unversioned.LabelSelector{MatchLabels: invalidSelector},
 					Template: validPodTemplateAbc.Template,
-					UpdateStrategy: extensions.DaemonSetUpdateStrategy{
-						Type:          extensions.RollingUpdateDaemonSetStrategyType,
-						RollingUpdate: nil,
-					},
+				},
+			},
+		},
+		"invalid pod": {
+			old: extensions.DaemonSet{
+				ObjectMeta: api.ObjectMeta{Name: "", Namespace: api.NamespaceDefault},
+				Spec: extensions.DaemonSetSpec{
+					Selector: &unversioned.LabelSelector{MatchLabels: validSelector},
+					Template: validPodTemplateAbc.Template,
+				},
+			},
+			update: extensions.DaemonSet{
+				ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: api.NamespaceDefault},
+				Spec: extensions.DaemonSetSpec{
+					Selector: &unversioned.LabelSelector{MatchLabels: validSelector},
+					Template: invalidPodTemplate.Template,
+				},
+			},
+		},
+		"change container image": {
+			old: extensions.DaemonSet{
+				ObjectMeta: api.ObjectMeta{Name: "", Namespace: api.NamespaceDefault},
+				Spec: extensions.DaemonSetSpec{
+					Selector: &unversioned.LabelSelector{MatchLabels: validSelector},
+					Template: validPodTemplateAbc.Template,
+				},
+			},
+			update: extensions.DaemonSet{
+				ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: api.NamespaceDefault},
+				Spec: extensions.DaemonSetSpec{
+					Selector: &unversioned.LabelSelector{MatchLabels: validSelector},
+					Template: validPodTemplateDef.Template,
+				},
+			},
+		},
+		"read-write volume": {
+			old: extensions.DaemonSet{
+				ObjectMeta: api.ObjectMeta{Name: "", Namespace: api.NamespaceDefault},
+				Spec: extensions.DaemonSetSpec{
+					Selector: &unversioned.LabelSelector{MatchLabels: validSelector},
+					Template: validPodTemplateAbc.Template,
+				},
+			},
+			update: extensions.DaemonSet{
+				ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: api.NamespaceDefault},
+				Spec: extensions.DaemonSetSpec{
+					Selector: &unversioned.LabelSelector{MatchLabels: validSelector},
+					Template: readWriteVolumePodTemplate.Template,
+				},
+			},
+		},
+		"invalid update strategy": {
+			old: extensions.DaemonSet{
+				ObjectMeta: api.ObjectMeta{Name: "", Namespace: api.NamespaceDefault},
+				Spec: extensions.DaemonSetSpec{
+					Selector: &unversioned.LabelSelector{MatchLabels: validSelector},
+					Template: validPodTemplateAbc.Template,
+				},
+			},
+			update: extensions.DaemonSet{
+				ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: api.NamespaceDefault},
+				Spec: extensions.DaemonSetSpec{
+					Selector: &unversioned.LabelSelector{MatchLabels: invalidSelector},
+					Template: validPodTemplateAbc.Template,
 				},
 			},
 		},
@@ -659,12 +631,6 @@ func TestValidateDaemonSetUpdate(t *testing.T) {
 
 func TestValidateDaemonSet(t *testing.T) {
 	validSelector := map[string]string{"a": "b"}
-	validUpdateStrategy := extensions.DaemonSetUpdateStrategy{
-		Type: extensions.RollingUpdateDaemonSetStrategyType,
-		RollingUpdate: &extensions.RollingUpdateDaemonSet{
-			MaxUnavailable: intstr.FromInt(1),
-		},
-	}
 	validPodTemplate := api.PodTemplate{
 		Template: api.PodTemplateSpec{
 			ObjectMeta: api.ObjectMeta{
@@ -693,17 +659,15 @@ func TestValidateDaemonSet(t *testing.T) {
 		{
 			ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: api.NamespaceDefault},
 			Spec: extensions.DaemonSetSpec{
-				Selector:       &unversioned.LabelSelector{MatchLabels: validSelector},
-				Template:       validPodTemplate.Template,
-				UpdateStrategy: validUpdateStrategy,
+				Selector: &unversioned.LabelSelector{MatchLabels: validSelector},
+				Template: validPodTemplate.Template,
 			},
 		},
 		{
 			ObjectMeta: api.ObjectMeta{Name: "abc-123", Namespace: api.NamespaceDefault},
 			Spec: extensions.DaemonSetSpec{
-				Selector:       &unversioned.LabelSelector{MatchLabels: validSelector},
-				Template:       validPodTemplate.Template,
-				UpdateStrategy: validUpdateStrategy,
+				Selector: &unversioned.LabelSelector{MatchLabels: validSelector},
+				Template: validPodTemplate.Template,
 			},
 		},
 	}
@@ -819,104 +783,6 @@ func TestValidateDaemonSet(t *testing.T) {
 					},
 					ObjectMeta: api.ObjectMeta{
 						Labels: validSelector,
-					},
-				},
-			},
-		},
-		"invalid update strategy - Type is not RollingUpdate": {
-			ObjectMeta: api.ObjectMeta{
-				Name:      "abc-123",
-				Namespace: api.NamespaceDefault,
-			},
-			Spec: extensions.DaemonSetSpec{
-				Selector: &unversioned.LabelSelector{MatchLabels: validSelector},
-				Template: validPodTemplate.Template,
-				UpdateStrategy: extensions.DaemonSetUpdateStrategy{
-					Type: "",
-					RollingUpdate: &extensions.RollingUpdateDaemonSet{
-						MaxUnavailable: intstr.FromInt(1),
-					},
-				},
-			},
-		},
-		"invalid update strategy - RollingUpdate field is nil": {
-			ObjectMeta: api.ObjectMeta{
-				Name:      "abc-123",
-				Namespace: api.NamespaceDefault,
-			},
-			Spec: extensions.DaemonSetSpec{
-				Selector: &unversioned.LabelSelector{MatchLabels: validSelector},
-				Template: validPodTemplate.Template,
-				UpdateStrategy: extensions.DaemonSetUpdateStrategy{
-					Type:          extensions.RollingUpdateDaemonSetStrategyType,
-					RollingUpdate: nil,
-				},
-			},
-		},
-		"invalid update strategy - MaxUnavailable is 0": {
-			ObjectMeta: api.ObjectMeta{
-				Name:      "abc-123",
-				Namespace: api.NamespaceDefault,
-			},
-			Spec: extensions.DaemonSetSpec{
-				Selector: &unversioned.LabelSelector{MatchLabels: validSelector},
-				Template: validPodTemplate.Template,
-				UpdateStrategy: extensions.DaemonSetUpdateStrategy{
-					Type: extensions.RollingUpdateDaemonSetStrategyType,
-					RollingUpdate: &extensions.RollingUpdateDaemonSet{
-						MaxUnavailable:  intstr.FromInt(0),
-						MinReadySeconds: 1,
-					},
-				},
-			},
-		},
-		"invalid update strategy - MaxUnavailable is greater than 100%": {
-			ObjectMeta: api.ObjectMeta{
-				Name:      "abc-123",
-				Namespace: api.NamespaceDefault,
-			},
-			Spec: extensions.DaemonSetSpec{
-				Selector: &unversioned.LabelSelector{MatchLabels: validSelector},
-				Template: validPodTemplate.Template,
-				UpdateStrategy: extensions.DaemonSetUpdateStrategy{
-					Type: extensions.RollingUpdateDaemonSetStrategyType,
-					RollingUpdate: &extensions.RollingUpdateDaemonSet{
-						MaxUnavailable:  intstr.FromString("150%"),
-						MinReadySeconds: 1,
-					},
-				},
-			},
-		},
-		"invalid update strategy - MaxUnavailable is negative": {
-			ObjectMeta: api.ObjectMeta{
-				Name:      "abc-123",
-				Namespace: api.NamespaceDefault,
-			},
-			Spec: extensions.DaemonSetSpec{
-				Selector: &unversioned.LabelSelector{MatchLabels: validSelector},
-				Template: validPodTemplate.Template,
-				UpdateStrategy: extensions.DaemonSetUpdateStrategy{
-					Type: extensions.RollingUpdateDaemonSetStrategyType,
-					RollingUpdate: &extensions.RollingUpdateDaemonSet{
-						MaxUnavailable:  intstr.FromInt(-1),
-						MinReadySeconds: 0,
-					},
-				},
-			},
-		},
-		"invalid update strategy - MinReadySeconds is negative": {
-			ObjectMeta: api.ObjectMeta{
-				Name:      "abc-123",
-				Namespace: api.NamespaceDefault,
-			},
-			Spec: extensions.DaemonSetSpec{
-				Selector: &unversioned.LabelSelector{MatchLabels: validSelector},
-				Template: validPodTemplate.Template,
-				UpdateStrategy: extensions.DaemonSetUpdateStrategy{
-					Type: extensions.RollingUpdateDaemonSetStrategyType,
-					RollingUpdate: &extensions.RollingUpdateDaemonSet{
-						MaxUnavailable:  intstr.FromInt(-1),
-						MinReadySeconds: -1,
 					},
 				},
 			},

--- a/pkg/registry/daemonset/etcd/etcd_test.go
+++ b/pkg/registry/daemonset/etcd/etcd_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 	"k8s.io/kubernetes/pkg/runtime"
 	etcdtesting "k8s.io/kubernetes/pkg/storage/etcd/testing"
-	"k8s.io/kubernetes/pkg/util/intstr"
 )
 
 func newStorage(t *testing.T) (*REST, *StatusREST, *etcdtesting.EtcdTestServer) {
@@ -61,13 +60,6 @@ func newValidDaemonSet() *extensions.DaemonSet {
 					DNSPolicy:     api.DNSClusterFirst,
 				},
 			},
-			UpdateStrategy: extensions.DaemonSetUpdateStrategy{
-				Type: extensions.RollingUpdateDaemonSetStrategyType,
-				RollingUpdate: &extensions.RollingUpdateDaemonSet{
-					MaxUnavailable: intstr.FromInt(1),
-				},
-			},
-			UniqueLabelKey: "foo-label",
 		},
 	}
 }
@@ -93,9 +85,8 @@ func TestCreate(t *testing.T) {
 		// invalid update strategy
 		&extensions.DaemonSet{
 			Spec: extensions.DaemonSetSpec{
-				Selector:       validDaemonSet.Spec.Selector,
-				Template:       validDaemonSet.Spec.Template,
-				UniqueLabelKey: validDaemonSet.Spec.UniqueLabelKey,
+				Selector: validDaemonSet.Spec.Selector,
+				Template: validDaemonSet.Spec.Template,
 			},
 		},
 	)
@@ -133,11 +124,6 @@ func TestUpdate(t *testing.T) {
 		func(obj runtime.Object) runtime.Object {
 			object := obj.(*extensions.DaemonSet)
 			object.Spec.Selector = &unversioned.LabelSelector{MatchLabels: map[string]string{}}
-			return object
-		},
-		func(obj runtime.Object) runtime.Object {
-			object := obj.(*extensions.DaemonSet)
-			object.Spec.UpdateStrategy = extensions.DaemonSetUpdateStrategy{}
 			return object
 		},
 	)


### PR DESCRIPTION
Comment out the type fields and remove the code that uses these fields.

This is part of the DaemonSet beta graduation plan as described in https://github.com/kubernetes/kubernetes/issues/15310#issuecomment-177062027.
