### PR TITLE
Make all e2e tests use Framework

### DIFF
--- a/test/e2e/cadvisor.go
+++ b/test/e2e/cadvisor.go
@@ -32,16 +32,11 @@ const (
 )
 
 var _ = Describe("Cadvisor", func() {
-	var c *client.Client
 
-	BeforeEach(func() {
-		var err error
-		c, err = loadClient()
-		expectNoError(err)
-	})
+	f := NewFramework("cadvisor")
 
 	It("should be healthy on every node.", func() {
-		CheckCadvisorHealthOnAllNodes(c, 5*time.Minute)
+		CheckCadvisorHealthOnAllNodes(f.Client, 5*time.Minute)
 	})
 })
 

--- a/test/e2e/monitoring.go
+++ b/test/e2e/monitoring.go
@@ -33,18 +33,14 @@ import (
 
 // TODO: quinton: debug issue #6541 and then remove Pending flag here.
 var _ = Describe("[Flaky] Monitoring", func() {
-	var c *client.Client
+	f := NewFramework("monitoring")
 
 	BeforeEach(func() {
-		var err error
-		c, err = loadClient()
-		expectNoError(err)
-
 		SkipUnlessProviderIs("gce")
 	})
 
 	It("should verify monitoring pods and all cluster nodes are available on influxdb using heapster.", func() {
-		testMonitoringUsingHeapsterInfluxdb(c)
+		testMonitoringUsingHeapsterInfluxdb(f.Client)
 	})
 })
 

--- a/test/e2e/namespace.go
+++ b/test/e2e/namespace.go
@@ -105,22 +105,12 @@ func extinguish(c *client.Client, totalNS int, maxAllowedAfterDel int, maxSecond
 // rate of approximately 1 per second.
 var _ = Describe("Namespaces [Serial]", func() {
 
-	//This namespace is modified throughout the course of the test.
-	var c *client.Client
-	var err error = nil
-	BeforeEach(func() {
-		By("Creating a kubernetes client")
-		c, err = loadClient()
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	AfterEach(func() {
-	})
+	f := NewFramework("namespaces")
 
 	It("should delete fast enough (90 percent of 100 namespaces in 150 seconds)",
-		func() { extinguish(c, 100, 10, 150) })
+		func() { extinguish(f.Client, 100, 10, 150) })
 
 	// On hold until etcd3; see #7372
 	It("should always delete fast (ALL of 100 namespaces in 150 seconds) [Feature:ComprehensiveNamespaceDraining]",
-		func() { extinguish(c, 100, 0, 150) })
+		func() { extinguish(f.Client, 100, 0, 150) })
 })

--- a/test/e2e/ssh.go
+++ b/test/e2e/ssh.go
@@ -20,20 +20,14 @@ import (
 	"fmt"
 	"strings"
 
-	client "k8s.io/kubernetes/pkg/client/unversioned"
-
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("SSH", func() {
-	var c *client.Client
+
+	f := NewFramework("ssh")
 
 	BeforeEach(func() {
-		var err error
-		c, err = loadClient()
-		Expect(err).NotTo(HaveOccurred())
-
 		// When adding more providers here, also implement their functionality in util.go's getSigner(...).
 		SkipUnlessProviderIs(providersWithSSH...)
 	})
@@ -41,7 +35,7 @@ var _ = Describe("SSH", func() {
 	It("should SSH to all nodes and run commands", func() {
 		// Get all nodes' external IPs.
 		By("Getting all nodes' SSH-able IP addresses")
-		hosts, err := NodeSSHHosts(c)
+		hosts, err := NodeSSHHosts(f.Client)
 		if err != nil {
 			Failf("Error getting node hostnames: %v", err)
 		}


### PR DESCRIPTION
A few e2e tests were not using `Framework` (as noticed in https://github.com/kubernetes/kubernetes/pull/20771/files#r52256471), probably because the tests predated it and were never updated. This gets everything up to spec with best practices.

@kubernetes/sig-testing 
