### PR TITLE
Fix reference to versioned object in kubectl apply

### DIFF
--- a/pkg/kubectl/cmd/apply_test.go
+++ b/pkg/kubectl/cmd/apply_test.go
@@ -52,8 +52,9 @@ func validateApplyArgs(cmd *cobra.Command, args []string) error {
 }
 
 const (
-	filenameRC  = "../../../examples/guestbook/redis-master-controller.yaml"
-	filenameSVC = "../../../examples/guestbook/frontend-service.yaml"
+	filenameRC    = "../../../test/fixtures/pkg/kubectl/cmd/apply/rc.yaml"
+	filenameSVC   = "../../../test/fixtures/pkg/kubectl/cmd/apply/service.yaml"
+	filenameRCSVC = "../../../test/fixtures/pkg/kubectl/cmd/apply/rc-service.yaml"
 )
 
 func readBytesFromFile(t *testing.T, filename string) []byte {
@@ -245,7 +246,15 @@ func TestApplyNonExistObject(t *testing.T) {
 	}
 }
 
-func TestApplyMultipleObject(t *testing.T) {
+func TestApplyMultipleObjectsAsList(t *testing.T) {
+	testApplyMultipleObjects(t, true)
+}
+
+func TestApplyMultipleObjectsAsFiles(t *testing.T) {
+	testApplyMultipleObjects(t, false)
+}
+
+func testApplyMultipleObjects(t *testing.T, asList bool) {
 	nameRC, currentRC := readAndAnnotateReplicationController(t, filenameRC)
 	pathRC := "/namespaces/test/replicationcontrollers/" + nameRC
 
@@ -282,8 +291,12 @@ func TestApplyMultipleObject(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 
 	cmd := NewCmdApply(f, buf)
-	cmd.Flags().Set("filename", filenameRC)
-	cmd.Flags().Set("filename", filenameSVC)
+	if asList {
+		cmd.Flags().Set("filename", filenameRCSVC)
+	} else {
+		cmd.Flags().Set("filename", filenameRC)
+		cmd.Flags().Set("filename", filenameSVC)
+	}
 	cmd.Flags().Set("output", "name")
 
 	cmd.Run(cmd, []string{})
@@ -291,8 +304,10 @@ func TestApplyMultipleObject(t *testing.T) {
 	// Names should come from the REST response, NOT the files
 	expectRC := "replicationcontroller/" + nameRC + "\n"
 	expectSVC := "service/" + nameSVC + "\n"
-	expect := expectRC + expectSVC
-	if buf.String() != expect {
-		t.Fatalf("unexpected output: %s\nexpected: %s", buf.String(), expect)
+	// Test both possible orders since output is non-deterministic.
+	expectOne := expectRC + expectSVC
+	expectTwo := expectSVC + expectRC
+	if buf.String() != expectOne && buf.String() != expectTwo {
+		t.Fatalf("unexpected output: %s\nexpected: %s OR %s", buf.String(), expectOne, expectTwo)
 	}
 }

--- a/test/fixtures/pkg/kubectl/cmd/apply/rc-service.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/apply/rc-service.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service
+      labels:
+        name: test-service
+    spec:
+      ports:
+      - port: 80
+      selector:
+        name: test-rc
+  - apiVersion: v1
+    kind: ReplicationController
+    metadata:
+      name: test-rc
+      labels:
+        name: test-rc
+    spec:
+      replicas: 1
+      template:
+        metadata:
+          labels:
+            name: test-rc
+        spec:
+          containers:
+            - name: test-rc
+              image: nginx
+              ports:
+              - containerPort: 80

--- a/test/fixtures/pkg/kubectl/cmd/apply/rc.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/apply/rc.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: test-rc
+  labels:
+    name: test-rc
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: test-rc
+    spec:
+      containers:
+        - name: test-rc
+          image: nginx
+          ports:
+          - containerPort: 80

--- a/test/fixtures/pkg/kubectl/cmd/apply/service.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/apply/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-service
+  labels:
+    name: test-service
+spec:
+  ports:
+  - port: 80
+  selector:
+    name: test-rc


### PR DESCRIPTION
Fixes #19639.
#19639 occurs because info.VersionedObject is not filled in when Visit'ing elements of a builder when the input is a List (as opposed to a single object). VersionedObject is the struct used to create the strategic merge patch that is sent to the server. One option is to try and fix builder so that VersionedObject is filled in for List items, but it would require really bending builder over backwards because builder isn't really designed to provide VersionedObjects alongside Objects (VersionedObjects are [considered optional](https://github.com/kubernetes/kubernetes/blob/2fd38a7dc022c28f05403355061d521d8f124da3/pkg/kubectl/resource/visitor.go#L77-L80) and there's even a [TODO to eliminate them](https://github.com/kubernetes/kubernetes/blob/2fd38a7/pkg/kubectl/resource/mapper.go#L65-L67)). Instead @smarterclayton has recommended creating a RawResult method on builder, which provides the raw result from the server instead of one that has been converted to a potentially internal object or gone through any other mutations.

That would be a pretty major refactoring, while this is fairly broken behavior (List works for all other kubectl actions e.g. create, delete, etc.), and it would be great to get this fix into 1.2. As a result, I've just switched from using info.VersionedObject to using the server-side versioned serialized object (which will always exist by this point in the code) to create a versioned struct.

This is a little hacky but the whole thing will be much simpler when we create and move to RawResult, and looking even further ahead it's possible this code will be refactored to move server-side. As is, this fix doesn't change the status quo in any fundamental way and fixes a major bug.
