### PR TITLE
Add missing PodSyncResult in KillPod

### DIFF
--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -1202,7 +1202,9 @@ func (dm *DockerManager) killPodWithSyncResult(pod *api.Pod, runningPod kubecont
 	if networkContainer != nil {
 		ins, err := dm.client.InspectContainer(networkContainer.ID.ID)
 		if err != nil {
-			glog.Errorf("Error inspecting container %v: %v", networkContainer.ID.ID, err)
+			err = fmt.Errorf("Error inspecting container %v: %v", networkContainer.ID.ID, err)
+			glog.Error(err)
+			result.Fail(err)
 			return
 		}
 		if ins.HostConfig != nil && ins.HostConfig.NetworkMode != namespaceModeHost {


### PR DESCRIPTION
A small fix to add the missing `PodSyncResult` error in #20019.

/cc @yujuhong 
