### PR TITLE
e2e: Don't try to create a UDP LoadBalancer on AWS

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws_loadbalancer.go
+++ b/pkg/cloudprovider/providers/aws/aws_loadbalancer.go
@@ -200,7 +200,7 @@ func (s *AWSCloud) ensureLoadBalancerHealthCheck(loadBalancer *elb.LoadBalancerD
 	expectedTimeout := int64(5)
 	expectedInterval := int64(10)
 
-	// We only a TCP health-check on the first port
+	// We only configure a TCP health-check on the first port
 	expectedTarget := ""
 	for _, listener := range listeners {
 		if listener.InstancePort == nil {

--- a/test/e2e/cluster_upgrade.go
+++ b/test/e2e/cluster_upgrade.go
@@ -611,6 +611,10 @@ func migRollingUpdatePoll(id string, nt time.Duration) error {
 }
 
 func testLoadBalancerReachable(ingress api.LoadBalancerIngress, port int) bool {
+	loadBalancerLagTimeout := loadBalancerLagTimeoutDefault
+	if providerIs("aws") {
+		loadBalancerLagTimeout = loadBalancerLagTimeoutAWS
+	}
 	return testLoadBalancerReachableInTime(ingress, port, loadBalancerLagTimeout)
 }
 

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -48,7 +48,11 @@ import (
 const kubeProxyLagTimeout = 5 * time.Minute
 
 // Maximum time a load balancer is allowed to not respond after creation.
-const loadBalancerLagTimeout = 2 * time.Minute
+const loadBalancerLagTimeoutDefault = 2 * time.Minute
+
+// On AWS there is a delay between ELB creation and serving traffic;
+// a few minutes is typical, so use 10m.
+const loadBalancerLagTimeoutAWS = 10 * time.Minute
 
 // How long to wait for a load balancer to be created/modified.
 //TODO: once support ticket 21807001 is resolved, reduce this timeout back to something reasonable
@@ -419,6 +423,11 @@ var _ = Describe("Services", func() {
 		SkipUnlessProviderIs("gce", "gke", "aws")
 
 		loadBalancerSupportsUDP := !providerIs("aws")
+
+		loadBalancerLagTimeout := loadBalancerLagTimeoutDefault
+		if providerIs("aws") {
+			loadBalancerLagTimeout = loadBalancerLagTimeoutAWS
+		}
 
 		// This test is more monolithic than we'd like because LB turnup can be
 		// very slow, so we lumped all the tests into one LB lifecycle.


### PR DESCRIPTION
AWS doesn't support type=LoadBalancer with UDP services.  For now, we
simply skip over the test with type=LoadBalancer on AWS for the UDP
service.

Fix #20911
