### PR TITLE
Add bearer token authentication to Vagrant clusters

### DIFF
--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -75,7 +75,8 @@ if [[ ! -f "${known_tokens_file}" ]]; then
   known_tokens_file="/srv/salt-overlay/salt/kube-apiserver/known_tokens.csv"
   (umask u=rw,go= ;
    echo "$KUBELET_TOKEN,kubelet,kubelet" > $known_tokens_file;
-   echo "$KUBE_PROXY_TOKEN,kube_proxy,kube_proxy" >> $known_tokens_file)
+   echo "$KUBE_PROXY_TOKEN,kube_proxy,kube_proxy" >> $known_tokens_file;
+   echo "$KUBE_BEARER_TOKEN,admin,admin" >> $known_tokens_file)
 
   mkdir -p /srv/salt-overlay/salt/kubelet
   kubelet_auth_file="/srv/salt-overlay/salt/kubelet/kubernetes_auth"

--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -162,6 +162,7 @@ function echo-kube-env() {
   echo "MASTER_PASSWD='${MASTER_PASSWD}'"
   echo "KUBE_USER='${KUBE_USER}'"
   echo "KUBE_PASSWORD='${KUBE_PASSWORD}'"
+  echo "KUBE_BEARER_TOKEN='${KUBE_BEARER_TOKEN}'"
   echo "ENABLE_CLUSTER_MONITORING='${ENABLE_CLUSTER_MONITORING}'"
   echo "ENABLE_CLUSTER_LOGGING='${ENABLE_CLUSTER_LOGGING:-false}'"
   echo "ELASTICSEARCH_LOGGING_REPLICAS='${ELASTICSEARCH_LOGGING_REPLICAS:-1}'"
@@ -275,6 +276,7 @@ function verify-cluster {
 # Instantiate a kubernetes cluster
 function kube-up {
   load-or-gen-kube-basicauth
+  load-or-gen-kube-bearertoken
   get-tokens
   create-provision-scripts
 


### PR DESCRIPTION
This does not remove basic authentication in Vagrant clusters.
Users will still be able to authenticate with username=vagrant, password=vagrant
