### PR TITLE
make partial resource detection work for singular matches

### DIFF
--- a/pkg/api/meta/restmapper.go
+++ b/pkg/api/meta/restmapper.go
@@ -206,23 +206,32 @@ func (m *DefaultRESTMapper) ResourcesFor(resource unversioned.GroupVersionResour
 
 	case hasGroup:
 		requestedGroupResource := resource.GroupResource()
-		for currResource := range m.pluralToSingular {
-			if currResource.GroupResource() == requestedGroupResource {
-				ret = append(ret, currResource)
+		for plural, singular := range m.pluralToSingular {
+			if singular.GroupResource() == requestedGroupResource {
+				ret = append(ret, plural)
+			}
+			if plural.GroupResource() == requestedGroupResource {
+				ret = append(ret, plural)
 			}
 		}
 
 	case hasVersion:
-		for currResource := range m.pluralToSingular {
-			if currResource.Version == resource.Version && currResource.Resource == resource.Resource {
-				ret = append(ret, currResource)
+		for plural, singular := range m.pluralToSingular {
+			if singular.Version == resource.Version && singular.Resource == resource.Resource {
+				ret = append(ret, plural)
+			}
+			if plural.Version == resource.Version && plural.Resource == resource.Resource {
+				ret = append(ret, plural)
 			}
 		}
 
 	default:
-		for currResource := range m.pluralToSingular {
-			if currResource.Resource == resource.Resource {
-				ret = append(ret, currResource)
+		for plural, singular := range m.pluralToSingular {
+			if singular.Resource == resource.Resource {
+				ret = append(ret, plural)
+			}
+			if plural.Resource == resource.Resource {
+				ret = append(ret, plural)
 			}
 		}
 	}

--- a/pkg/api/meta/restmapper_test.go
+++ b/pkg/api/meta/restmapper_test.go
@@ -234,10 +234,11 @@ func TestRESTMapperKindsFor(t *testing.T) {
 
 func TestRESTMapperResourcesFor(t *testing.T) {
 	testCases := []struct {
-		Name                     string
-		PreferredOrder           []unversioned.GroupVersion
-		KindsToRegister          []unversioned.GroupVersionKind
-		PartialResourceToRequest unversioned.GroupVersionResource
+		Name                             string
+		PreferredOrder                   []unversioned.GroupVersion
+		KindsToRegister                  []unversioned.GroupVersionKind
+		PluralPartialResourceToRequest   unversioned.GroupVersionResource
+		SingularPartialResourceToRequest unversioned.GroupVersionResource
 
 		ExpectedResources   []unversioned.GroupVersionResource
 		ExpectedResourceErr string
@@ -254,7 +255,8 @@ func TestRESTMapperResourcesFor(t *testing.T) {
 				{Group: "second-group", Version: "first-version", Kind: "my-kind"},
 				{Group: "second-group", Version: "first-version", Kind: "your-kind"},
 			},
-			PartialResourceToRequest: unversioned.GroupVersionResource{Resource: "my-kinds"},
+			PluralPartialResourceToRequest:   unversioned.GroupVersionResource{Resource: "my-kinds"},
+			SingularPartialResourceToRequest: unversioned.GroupVersionResource{Resource: "my-kind"},
 
 			ExpectedResources: []unversioned.GroupVersionResource{
 				{Group: "second-group", Version: "first-version", Resource: "my-kinds"},
@@ -275,7 +277,8 @@ func TestRESTMapperResourcesFor(t *testing.T) {
 				{Group: "second-group", Version: "first-version", Kind: "my-kind"},
 				{Group: "second-group", Version: "first-version", Kind: "your-kind"},
 			},
-			PartialResourceToRequest: unversioned.GroupVersionResource{Group: "first-group", Resource: "my-kinds"},
+			PluralPartialResourceToRequest:   unversioned.GroupVersionResource{Group: "first-group", Resource: "my-kinds"},
+			SingularPartialResourceToRequest: unversioned.GroupVersionResource{Group: "first-group", Resource: "my-kind"},
 
 			ExpectedResources: []unversioned.GroupVersionResource{
 				{Group: "first-group", Version: "first-version", Resource: "my-kinds"},
@@ -294,7 +297,8 @@ func TestRESTMapperResourcesFor(t *testing.T) {
 				{Group: "second-group", Version: "first-version", Kind: "my-kind"},
 				{Group: "second-group", Version: "first-version", Kind: "your-kind"},
 			},
-			PartialResourceToRequest: unversioned.GroupVersionResource{Version: "first-version", Resource: "my-kinds"},
+			PluralPartialResourceToRequest:   unversioned.GroupVersionResource{Version: "first-version", Resource: "my-kinds"},
+			SingularPartialResourceToRequest: unversioned.GroupVersionResource{Version: "first-version", Resource: "my-kind"},
 
 			ExpectedResources: []unversioned.GroupVersionResource{
 				{Group: "first-group", Version: "first-version", Resource: "my-kinds"},
@@ -305,41 +309,44 @@ func TestRESTMapperResourcesFor(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		tcName := testCase.Name
-		mapper := NewDefaultRESTMapper(testCase.PreferredOrder, fakeInterfaces)
-		for _, kind := range testCase.KindsToRegister {
-			mapper.Add(kind, RESTScopeNamespace)
-		}
 
-		actualResources, err := mapper.ResourcesFor(testCase.PartialResourceToRequest)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", tcName, err)
-			continue
-		}
-		if !reflect.DeepEqual(testCase.ExpectedResources, actualResources) {
-			t.Errorf("%s: expected %v, got %v", tcName, testCase.ExpectedResources, actualResources)
-		}
+		for _, partialResource := range []unversioned.GroupVersionResource{testCase.PluralPartialResourceToRequest, testCase.SingularPartialResourceToRequest} {
+			mapper := NewDefaultRESTMapper(testCase.PreferredOrder, fakeInterfaces)
+			for _, kind := range testCase.KindsToRegister {
+				mapper.Add(kind, RESTScopeNamespace)
+			}
 
-		singleResource, err := mapper.ResourceFor(testCase.PartialResourceToRequest)
-		if err == nil && len(testCase.ExpectedResourceErr) != 0 {
-			t.Errorf("%s: expected error: %v", tcName, testCase.ExpectedResourceErr)
-			continue
-		}
-		if err != nil {
-			if len(testCase.ExpectedResourceErr) == 0 {
+			actualResources, err := mapper.ResourcesFor(partialResource)
+			if err != nil {
 				t.Errorf("%s: unexpected error: %v", tcName, err)
 				continue
-			} else {
-				if !strings.Contains(err.Error(), testCase.ExpectedResourceErr) {
-					t.Errorf("%s: expected %v, got %v", tcName, testCase.ExpectedResourceErr, err)
+			}
+			if !reflect.DeepEqual(testCase.ExpectedResources, actualResources) {
+				t.Errorf("%s: expected %v, got %v", tcName, testCase.ExpectedResources, actualResources)
+			}
+
+			singleResource, err := mapper.ResourceFor(partialResource)
+			if err == nil && len(testCase.ExpectedResourceErr) != 0 {
+				t.Errorf("%s: expected error: %v", tcName, testCase.ExpectedResourceErr)
+				continue
+			}
+			if err != nil {
+				if len(testCase.ExpectedResourceErr) == 0 {
+					t.Errorf("%s: unexpected error: %v", tcName, err)
 					continue
+				} else {
+					if !strings.Contains(err.Error(), testCase.ExpectedResourceErr) {
+						t.Errorf("%s: expected %v, got %v", tcName, testCase.ExpectedResourceErr, err)
+						continue
+					}
 				}
-			}
 
-		} else {
-			if testCase.ExpectedResources[0] != singleResource {
-				t.Errorf("%s: expected %v, got %v", tcName, testCase.ExpectedResources[0], singleResource)
-			}
+			} else {
+				if testCase.ExpectedResources[0] != singleResource {
+					t.Errorf("%s: expected %v, got %v", tcName, testCase.ExpectedResources[0], singleResource)
+				}
 
+			}
 		}
 	}
 }


### PR DESCRIPTION
Singular partial resource matches were only respected for fully qualified matches.  If you expand the diff up, you'll see this worked for fully qualified case and other three were just oversights.

The plural version is always returned for the consistency of the match since that's considered "canonical" (see the other pre-existing maps).
