### PR TITLE
e2e runner: make build start/finished upload configurable

### DIFF
--- a/hack/jenkins/upload-finished.sh
+++ b/hack/jenkins/upload-finished.sh
@@ -29,9 +29,17 @@ if [[ $# -ne 1 ]]; then
     exit 1
 fi
 
+# TODO: DRY. Refactor into upload-to-gcs.sh ?
+: ${JENKINS_GCS_LOGS_PATH:="gs://kubernetes-jenkins/logs"}
+: ${JENKINS_UPLOAD_TO_GCS:="y"}
+
+if [[ ! ${JENKINS_UPLOAD_TO_GCS:-} =~ ^[yY]$ ]]; then
+  exit 0
+fi
+
 readonly result="$1"
 readonly timestamp=$(date +%s)
-readonly location="gs://kubernetes-jenkins/logs/${JOB_NAME}/${BUILD_NUMBER}/finished.json"
+readonly location="${JENKINS_GCS_LOGS_PATH}/${JOB_NAME}/${BUILD_NUMBER}/finished.json"
 
 echo "Uploading build result to: ${location}"
 gsutil -q cp -a "public-read" <(

--- a/hack/jenkins/upload-started.sh
+++ b/hack/jenkins/upload-started.sh
@@ -24,9 +24,17 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# TODO: DRY. Refactor into upload-to-gcs.sh ?
+: ${JENKINS_GCS_LOGS_PATH:="gs://kubernetes-jenkins/logs"}
+: ${JENKINS_UPLOAD_TO_GCS:="y"}
+
+if [[ ! ${JENKINS_UPLOAD_TO_GCS:-} =~ ^[yY]$ ]]; then
+  exit 0
+fi
+
 version=""
 readonly timestamp=$(date +%s)
-readonly location="gs://kubernetes-jenkins/logs/${JOB_NAME}/${BUILD_NUMBER}/started.json"
+readonly location="${JENKINS_GCS_LOGS_PATH}/${JOB_NAME}/${BUILD_NUMBER}/started.json"
 
 # Try to discover the kubernetes version.
 if [[ -e "version" ]]; then


### PR DESCRIPTION
Allow the target GCS bucket to be changed, and allow upload to GCS to be
suppressed altogether, with the same env vars that upload-to-gcs.sh
uses.
