### PR TITLE
Fix the label selector to selector conversion error string.

### DIFF
--- a/pkg/apis/extensions/helpers.go
+++ b/pkg/apis/extensions/helpers.go
@@ -28,7 +28,7 @@ package extensions
 // func ScaleFromDeployment(deployment *Deployment) (*Scale, error) {
 // 	selector, err := unversioned.LabelSelectorAsSelector(deployment.Spec.Selector)
 // 	if err != nil {
-// 		return nil, fmt.Errorf("failed to convert label selector to selector: %v", err)
+// 		return nil, fmt.Errorf("invalid label selector: %v", err)
 // 	}
 // 	return &Scale{
 // 		ObjectMeta: api.ObjectMeta{

--- a/pkg/apis/extensions/validation/validation.go
+++ b/pkg/apis/extensions/validation/validation.go
@@ -359,7 +359,7 @@ func ValidateDeploymentSpec(spec *extensions.DeploymentSpec, fldPath *field.Path
 
 	selector, err := unversioned.LabelSelectorAsSelector(spec.Selector)
 	if err != nil {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("selector"), spec.Selector, "failed to convert LabelSelector to Selector."))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("selector"), spec.Selector, "invalid label selector."))
 	} else {
 		allErrs = append(allErrs, ValidatePodTemplateSpecForReplicaSet(&spec.Template, selector, spec.Replicas, fldPath.Child("template"))...)
 	}
@@ -721,7 +721,7 @@ func ValidateReplicaSetSpec(spec *extensions.ReplicaSetSpec, fldPath *field.Path
 
 	selector, err := unversioned.LabelSelectorAsSelector(spec.Selector)
 	if err != nil {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("selector"), spec.Selector, "failed to convert LabelSelector to Selector."))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("selector"), spec.Selector, "invalid label selector."))
 	} else {
 		allErrs = append(allErrs, ValidatePodTemplateSpecForReplicaSet(spec.Template, selector, spec.Replicas, fldPath.Child("template"))...)
 	}

--- a/pkg/client/cache/listers.go
+++ b/pkg/client/cache/listers.go
@@ -254,7 +254,7 @@ func (s *StoreToDeploymentLister) GetDeploymentsForReplicaSet(rs *extensions.Rep
 
 		selector, err := unversioned.LabelSelectorAsSelector(rs.Spec.Selector)
 		if err != nil {
-			return nil, fmt.Errorf("failed to convert LabelSelector to Selector: %v", err)
+			return nil, fmt.Errorf("invalid label selector: %v", err)
 		}
 		// If a deployment with a nil or empty selector creeps in, it should match nothing, not everything.
 		if selector.Empty() || !selector.Matches(labels.Set(rs.Labels)) {
@@ -329,7 +329,7 @@ func (s *StoreToReplicaSetLister) GetPodReplicaSets(pod *api.Pod) (rss []extensi
 		}
 		selector, err = unversioned.LabelSelectorAsSelector(rs.Spec.Selector)
 		if err != nil {
-			err = fmt.Errorf("failed to convert pod selector to selector: %v", err)
+			err = fmt.Errorf("invalid selector: %v", err)
 			return
 		}
 

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -263,7 +263,7 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 			case *extensions.Deployment:
 				selector, err := unversioned.LabelSelectorAsSelector(t.Spec.Selector)
 				if err != nil {
-					return "", fmt.Errorf("failed to convert label selector to selector: %v", err)
+					return "", fmt.Errorf("invalid label selector: %v", err)
 				}
 				return selector.String(), nil
 			default:
@@ -490,13 +490,13 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 			case *extensions.Deployment:
 				selector, err := unversioned.LabelSelectorAsSelector(t.Spec.Selector)
 				if err != nil {
-					return nil, fmt.Errorf("failed to convert label selector to selector: %v", err)
+					return nil, fmt.Errorf("invalid label selector: %v", err)
 				}
 				return GetFirstPod(client, t.Namespace, selector)
 			case *extensions.Job:
 				selector, err := unversioned.LabelSelectorAsSelector(t.Spec.Selector)
 				if err != nil {
-					return nil, fmt.Errorf("failed to convert label selector to selector: %v", err)
+					return nil, fmt.Errorf("invalid label selector: %v", err)
 				}
 				return GetFirstPod(client, t.Namespace, selector)
 			case *api.Pod:

--- a/pkg/util/deployment/deployment.go
+++ b/pkg/util/deployment/deployment.go
@@ -59,7 +59,7 @@ func GetOldReplicaSetsFromLists(deployment extensions.Deployment, c clientset.In
 	namespace := deployment.ObjectMeta.Namespace
 	selector, err := unversioned.LabelSelectorAsSelector(deployment.Spec.Selector)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to convert LabelSelector to Selector: %v", err)
+		return nil, nil, fmt.Errorf("invalid label selector: %v", err)
 	}
 
 	// 1. Find all pods whose labels match deployment.Spec.Selector
@@ -82,7 +82,7 @@ func GetOldReplicaSetsFromLists(deployment extensions.Deployment, c clientset.In
 		for _, rs := range rsList {
 			rsLabelsSelector, err := unversioned.LabelSelectorAsSelector(rs.Spec.Selector)
 			if err != nil {
-				return nil, nil, fmt.Errorf("failed to convert LabelSelector to Selector: %v", err)
+				return nil, nil, fmt.Errorf("invalid label selector: %v", err)
 			}
 			// Filter out replica set that has the same pod template spec as the deployment - that is the new replica set.
 			if api.Semantic.DeepEqual(rs.Spec.Template, &newRSTemplate) {
@@ -123,7 +123,7 @@ func GetNewReplicaSetFromList(deployment extensions.Deployment, c clientset.Inte
 	namespace := deployment.ObjectMeta.Namespace
 	selector, err := unversioned.LabelSelectorAsSelector(deployment.Spec.Selector)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert LabelSelector to Selector: %v", err)
+		return nil, fmt.Errorf("invalid label selector: %v", err)
 	}
 
 	rsList, err := getRSList(namespace, api.ListOptions{LabelSelector: selector})
@@ -213,7 +213,7 @@ func getPodsForReplicaSets(c clientset.Interface, replicaSets []*extensions.Repl
 	for _, rs := range replicaSets {
 		selector, err := unversioned.LabelSelectorAsSelector(rs.Spec.Selector)
 		if err != nil {
-			return nil, fmt.Errorf("failed to convert LabelSelector to Selector: %v", err)
+			return nil, fmt.Errorf("invalid label selector: %v", err)
 		}
 		options := api.ListOptions{LabelSelector: selector}
 		podList, err := c.Core().Pods(rs.ObjectMeta.Namespace).List(options)


### PR DESCRIPTION
The message as it is framed right now does not make any sense for the
end users of our system. It might even lead to confusion. So this is
attempt to make the error message less confusing.
