### PR TITLE
Fix selector output when get/describe replicasets

### DIFF
--- a/pkg/api/unversioned/helpers.go
+++ b/pkg/api/unversioned/helpers.go
@@ -81,13 +81,13 @@ func SetAsLabelSelector(ls labels.Set) *LabelSelector {
 
 // FormatLabelSelector convert labelSelector into plain string
 func FormatLabelSelector(labelSelector *LabelSelector) string {
-	var l string
-	if selector, err := LabelSelectorAsSelector(labelSelector); err != nil {
-		l = selector.String()
-	} else {
-		l = "<error>"
+	selector, err := LabelSelectorAsSelector(labelSelector)
+	if err != nil {
+		return "<error>"
 	}
-	if l == "" {
+
+	l := selector.String()
+	if len(l) == 0 {
 		l = "<none>"
 	}
 	return l


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/20886#discussion-diff-52506673

``` console
# BEFORE:
$ kubectl get rs 
CONTROLLER               CONTAINER(S)   IMAGE(S)   SELECTOR   REPLICAS   AGE
nginx-deployment-awla1   nginx          nginx      <error>    3          59s

# AFTER:
$ kubectl get rs 
CONTROLLER               CONTAINER(S)   IMAGE(S)   SELECTOR                                           REPLICAS   AGE
nginx-deployment-ydomw   nginx          nginx      name in (nginx),pod-template-hash in (811039852)   3          3s
```

@kubernetes/kubectl @mqliang 
