### PR TITLE
Use a different verb for delete collection

### DIFF
--- a/docs/admin/authorization.md
+++ b/docs/admin/authorization.md
@@ -65,8 +65,8 @@ A request has the following attributes that can be considered for authorization:
   - the request path.
     - allows authorizing access to miscellaneous endpoints like `/api` or `/healthz` (see [kubectl](#kubectl)).
   - the request verb.
-    - API verbs like `get`, `list`, `create`, `update`, and `watch` are used for API requests
-    - HTTP verbs like `get`, `post`, and `put` are used for non-API requests
+    - API verbs like `get`, `list`, `create`, `update`, `watch`, `delete`, and `deletecollection` are used for API requests
+    - HTTP verbs like `get`, `post`, `put`, and `delete` are used for non-API requests
   - what resource is being accessed (for API requests only)
   - the namespace of the object being accessed (for namespaced API requests only)
   - the API group being accessed (for API requests only)

--- a/pkg/apiserver/handlers.go
+++ b/pkg/apiserver/handlers.go
@@ -554,6 +554,10 @@ func (r *RequestInfoResolver) GetRequestInfo(req *http.Request) (RequestInfo, er
 	if len(requestInfo.Name) == 0 && requestInfo.Verb == "get" {
 		requestInfo.Verb = "list"
 	}
+	// if there's no name on the request and we thought it was a delete before, then the actual verb is deletecollection
+	if len(requestInfo.Name) == 0 && requestInfo.Verb == "delete" {
+		requestInfo.Verb = "deletecollection"
+	}
 
 	return requestInfo, nil
 }

--- a/pkg/apiserver/handlers_test.go
+++ b/pkg/apiserver/handlers_test.go
@@ -364,6 +364,12 @@ func TestGetAPIRequestInfo(t *testing.T) {
 		{"DELETE", "/api/v1/namespaces/other/pods/foo", "delete", "api", "", "v1", "other", "pods", "", "foo", []string{"pods", "foo"}},
 		{"POST", "/api/v1/namespaces/other/pods", "create", "api", "", "v1", "other", "pods", "", "", []string{"pods"}},
 
+		// deletecollection verb identification
+		{"DELETE", "/api/v1/nodes", "deletecollection", "api", "", "v1", "", "nodes", "", "", []string{"nodes"}},
+		{"DELETE", "/api/v1/namespaces", "deletecollection", "api", "", "v1", "", "namespaces", "", "", []string{"namespaces"}},
+		{"DELETE", "/api/v1/namespaces/other/pods", "deletecollection", "api", "", "v1", "other", "pods", "", "", []string{"pods"}},
+		{"DELETE", "/apis/extensions/v1/namespaces/other/pods", "deletecollection", "api", "extensions", "v1", "other", "pods", "", "", []string{"pods"}},
+
 		// api group identification
 		{"POST", "/apis/extensions/v1/namespaces/other/pods", "create", "api", "extensions", "v1", "other", "pods", "", "", []string{"pods"}},
 


### PR DESCRIPTION
Congruent with `list` having a separate verb from `get`, deleting an entire collection of objects should have a different verb than `delete`.

Added in https://github.com/kubernetes/kubernetes/pull/18290.
