### PR TITLE
Ensure Deployment labels adopted ReplicaSets and pods

### DIFF
--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -665,6 +665,10 @@ func (dc *DeploymentController) getNewReplicaSet(deployment extensions.Deploymen
 	newRevision := strconv.FormatInt(maxOldRevision+1, 10)
 
 	existingNewRS, err := deploymentutil.GetNewReplicaSetFromList(deployment, dc.client,
+		func(namespace string, options api.ListOptions) (*api.PodList, error) {
+			podList, err := dc.podStore.Pods(namespace).List(options.LabelSelector)
+			return &podList, err
+		},
 		func(namespace string, options api.ListOptions) ([]extensions.ReplicaSet, error) {
 			return dc.rsStore.ReplicaSets(namespace).List(options.LabelSelector)
 		})

--- a/pkg/util/deployment/deployment.go
+++ b/pkg/util/deployment/deployment.go
@@ -191,7 +191,7 @@ func addHashKeyToRSAndPods(deployment extensions.Deployment, c clientset.Interfa
 		}
 	}
 	// Make sure rs pod template is updated so that it won't create pods without the new label (orphaned pods).
-	if updatedRS.Generation != updatedRS.Status.ObservedGeneration {
+	if updatedRS.Generation > updatedRS.Status.ObservedGeneration {
 		if err = waitForReplicaSetUpdated(c, updatedRS.Generation, namespace, rs.Name); err != nil {
 			return nil, err
 		}

--- a/pkg/util/labels/labels.go
+++ b/pkg/util/labels/labels.go
@@ -55,7 +55,7 @@ func CloneAndRemoveLabel(labels map[string]string, labelKey string) map[string]s
 }
 
 // AddLabel returns a map with the given key and value added to the given map.
-func AddLabel(labels map[string]string, labelKey string, labelValue uint32) map[string]string {
+func AddLabel(labels map[string]string, labelKey string, labelValue string) map[string]string {
 	if labelKey == "" {
 		// Dont need to add a label.
 		return labels
@@ -63,7 +63,7 @@ func AddLabel(labels map[string]string, labelKey string, labelValue uint32) map[
 	if labels == nil {
 		labels = make(map[string]string)
 	}
-	labels[labelKey] = fmt.Sprintf("%d", labelValue)
+	labels[labelKey] = labelValue
 	return labels
 }
 
@@ -108,7 +108,7 @@ func CloneSelectorAndAddLabel(selector *unversioned.LabelSelector, labelKey stri
 }
 
 // AddLabelToSelector returns a selector with the given key and value added to the given selector's MatchLabels.
-func AddLabelToSelector(selector *unversioned.LabelSelector, labelKey string, labelValue uint32) *unversioned.LabelSelector {
+func AddLabelToSelector(selector *unversioned.LabelSelector, labelKey string, labelValue string) *unversioned.LabelSelector {
 	if labelKey == "" {
 		// Dont need to add a label.
 		return selector
@@ -116,7 +116,7 @@ func AddLabelToSelector(selector *unversioned.LabelSelector, labelKey string, la
 	if selector.MatchLabels == nil {
 		selector.MatchLabels = make(map[string]string)
 	}
-	selector.MatchLabels[labelKey] = fmt.Sprintf("%d", labelValue)
+	selector.MatchLabels[labelKey] = labelValue
 	return selector
 }
 

--- a/pkg/util/labels/labels.go
+++ b/pkg/util/labels/labels.go
@@ -54,6 +54,19 @@ func CloneAndRemoveLabel(labels map[string]string, labelKey string) map[string]s
 	return newLabels
 }
 
+// AddLabel returns a map with the given key and value added to the given map.
+func AddLabel(labels map[string]string, labelKey string, labelValue uint32) map[string]string {
+	if labelKey == "" {
+		// Dont need to add a label.
+		return labels
+	}
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[labelKey] = fmt.Sprintf("%d", labelValue)
+	return labels
+}
+
 // Clones the given selector and returns a new selector with the given key and value added.
 // Returns the given selector, if labelKey is empty.
 func CloneSelectorAndAddLabel(selector *unversioned.LabelSelector, labelKey string, labelValue uint32) *unversioned.LabelSelector {
@@ -92,4 +105,31 @@ func CloneSelectorAndAddLabel(selector *unversioned.LabelSelector, labelKey stri
 	}
 
 	return newSelector
+}
+
+// AddLabelToSelector returns a selector with the given key and value added to the given selector's MatchLabels.
+func AddLabelToSelector(selector *unversioned.LabelSelector, labelKey string, labelValue uint32) *unversioned.LabelSelector {
+	if labelKey == "" {
+		// Dont need to add a label.
+		return selector
+	}
+	if selector.MatchLabels == nil {
+		selector.MatchLabels = make(map[string]string)
+	}
+	selector.MatchLabels[labelKey] = fmt.Sprintf("%d", labelValue)
+	return selector
+}
+
+// SelectorHasLabel checks if the given selector contains the given label key in its MatchLabels or MatchExpressions
+func SelectorHasLabel(selector *unversioned.LabelSelector, labelKey string) bool {
+	_, found := selector.MatchLabels[labelKey]
+	if found {
+		return true
+	}
+	for _, exp := range selector.MatchExpressions {
+		if exp.Key == labelKey && exp.Operator != unversioned.LabelSelectorOpDoesNotExist {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/util/labels/labels.go
+++ b/pkg/util/labels/labels.go
@@ -120,16 +120,7 @@ func AddLabelToSelector(selector *unversioned.LabelSelector, labelKey string, la
 	return selector
 }
 
-// SelectorHasLabel checks if the given selector contains the given label key in its MatchLabels or MatchExpressions
+// SelectorHasLabel checks if the given selector contains the given label key in its MatchLabels
 func SelectorHasLabel(selector *unversioned.LabelSelector, labelKey string) bool {
-	_, found := selector.MatchLabels[labelKey]
-	if found {
-		return true
-	}
-	for _, exp := range selector.MatchExpressions {
-		if exp.Key == labelKey && exp.Operator != unversioned.LabelSelectorOpDoesNotExist {
-			return true
-		}
-	}
-	return false
+	return len(selector.MatchLabels[labelKey]) > 0
 }

--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -849,6 +849,7 @@ func testDeploymentLabelAdopted(f *Framework) {
 		Expect(c.Extensions().ReplicaSets(ns).Delete(newRS.Name, nil)).NotTo(HaveOccurred())
 	}()
 
+	// The RS and pods should be relabeled before the status is updated by syncRollingUpdateDeployment
 	err = waitForDeploymentStatus(c, ns, deploymentName, replicas, replicas-1, replicas+1, 0)
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
Ensure Deployment labels adopted ReplicaSets and pods. Otherwise, new RCs produced by Deployment will overlap we pre-existing ones that aren't constrained by the pod-template-hash.

Fixes #20755

Ignore the first commit (from #20994)
cc @bgrant0607 @nikhiljindal @ironcladlou @kargakis @kubernetes/sig-config @madhusudancs @mqliang 
