### PR TITLE
move helper funcs to util/deployment.go from util.go

### DIFF
--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/kubernetes/pkg/controller/framework"
 	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util"
 	deploymentutil "k8s.io/kubernetes/pkg/util/deployment"
 	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/integer"
@@ -768,12 +767,12 @@ func (dc *DeploymentController) reconcileNewReplicaSet(allRSs []*extensions.Repl
 		return true, err
 	}
 	// Check if we can scale up.
-	maxSurge, isPercent, err := util.GetIntOrPercentValue(&deployment.Spec.Strategy.RollingUpdate.MaxSurge)
+	maxSurge, isPercent, err := intstrutil.GetIntOrPercentValue(&deployment.Spec.Strategy.RollingUpdate.MaxSurge)
 	if err != nil {
 		return false, fmt.Errorf("invalid value for MaxSurge: %v", err)
 	}
 	if isPercent {
-		maxSurge = util.GetValueFromPercent(maxSurge, deployment.Spec.Replicas)
+		maxSurge = intstrutil.GetValueFromPercent(maxSurge, deployment.Spec.Replicas)
 	}
 	// Find the total number of pods
 	currentPodCount := deploymentutil.GetReplicaCountForReplicaSets(allRSs)
@@ -816,12 +815,12 @@ func (dc *DeploymentController) reconcileOldReplicaSets(allRSs []*extensions.Rep
 		return false, fmt.Errorf("could not find available pods: %v", err)
 	}
 
-	maxUnavailable, isPercent, err := util.GetIntOrPercentValue(&deployment.Spec.Strategy.RollingUpdate.MaxUnavailable)
+	maxUnavailable, isPercent, err := intstrutil.GetIntOrPercentValue(&deployment.Spec.Strategy.RollingUpdate.MaxUnavailable)
 	if err != nil {
 		return false, fmt.Errorf("invalid value for MaxUnavailable: %v", err)
 	}
 	if isPercent {
-		maxUnavailable = util.GetValueFromPercent(maxUnavailable, deployment.Spec.Replicas)
+		maxUnavailable = intstrutil.GetValueFromPercent(maxUnavailable, deployment.Spec.Replicas)
 	}
 
 	// Check if we can scale down. We can scale down in the following 2 cases:
@@ -920,12 +919,12 @@ func (dc *DeploymentController) cleanupUnhealthyReplicas(oldRSs []*extensions.Re
 // scaleDownOldReplicaSetsForRollingUpdate scales down old replica sets when deployment strategy is "RollingUpdate".
 // Need check maxUnavailable to ensure availability
 func (dc *DeploymentController) scaleDownOldReplicaSetsForRollingUpdate(allRSs []*extensions.ReplicaSet, oldRSs []*extensions.ReplicaSet, deployment extensions.Deployment) (int, error) {
-	maxUnavailable, isPercent, err := util.GetIntOrPercentValue(&deployment.Spec.Strategy.RollingUpdate.MaxUnavailable)
+	maxUnavailable, isPercent, err := intstrutil.GetIntOrPercentValue(&deployment.Spec.Strategy.RollingUpdate.MaxUnavailable)
 	if err != nil {
 		return 0, fmt.Errorf("invalid value for MaxUnavailable: %v", err)
 	}
 	if isPercent {
-		maxUnavailable = util.GetValueFromPercent(maxUnavailable, deployment.Spec.Replicas)
+		maxUnavailable = intstrutil.GetValueFromPercent(maxUnavailable, deployment.Spec.Replicas)
 	}
 	// Check if we can scale down.
 	minAvailable := deployment.Spec.Replicas - maxUnavailable

--- a/pkg/util/intstr/intstr.go
+++ b/pkg/util/intstr/intstr.go
@@ -19,7 +19,9 @@ package intstr
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"strconv"
+	"strings"
 
 	"github.com/google/gofuzz"
 )
@@ -112,4 +114,23 @@ func (intstr *IntOrString) Fuzz(c fuzz.Continue) {
 		intstr.IntVal = 0
 		c.Fuzz(&intstr.StrVal)
 	}
+}
+
+func GetIntOrPercentValue(intOrStr *IntOrString) (int, bool, error) {
+	switch intOrStr.Type {
+	case Int:
+		return intOrStr.IntValue(), false, nil
+	case String:
+		s := strings.Replace(intOrStr.StrVal, "%", "", -1)
+		v, err := strconv.Atoi(s)
+		if err != nil {
+			return 0, false, fmt.Errorf("invalid value %q: %v", intOrStr.StrVal, err)
+		}
+		return int(v), true, nil
+	}
+	return 0, false, fmt.Errorf("invalid value: neither int nor percentage")
+}
+
+func GetValueFromPercent(percent int, value int) int {
+	return int(math.Ceil(float64(percent) * (float64(value)) / 100))
 }

--- a/pkg/util/intstr/intstr.go
+++ b/pkg/util/intstr/intstr.go
@@ -116,7 +116,18 @@ func (intstr *IntOrString) Fuzz(c fuzz.Continue) {
 	}
 }
 
-func GetIntOrPercentValue(intOrStr *IntOrString) (int, bool, error) {
+func GetValueFromIntOrPercent(intOrPercent *IntOrString, total int) (int, error) {
+	value, isPercent, err := getIntOrPercentValue(intOrPercent)
+	if err != nil {
+		return 0, fmt.Errorf("invalid value for IntOrString: %v", err)
+	}
+	if isPercent {
+		value = int(math.Ceil(float64(value) * (float64(total)) / 100))
+	}
+	return value, nil
+}
+
+func getIntOrPercentValue(intOrStr *IntOrString) (int, bool, error) {
 	switch intOrStr.Type {
 	case Int:
 		return intOrStr.IntValue(), false, nil
@@ -129,8 +140,4 @@ func GetIntOrPercentValue(intOrStr *IntOrString) (int, bool, error) {
 		return int(v), true, nil
 	}
 	return 0, false, fmt.Errorf("invalid value: neither int nor percentage")
-}
-
-func GetValueFromPercent(percent int, value int) int {
-	return int(math.Ceil(float64(percent) * (float64(value)) / 100))
 }

--- a/pkg/util/intstr/intstr_test.go
+++ b/pkg/util/intstr/intstr_test.go
@@ -109,3 +109,52 @@ func TestIntOrStringMarshalJSONUnmarshalYAML(t *testing.T) {
 		}
 	}
 }
+
+func TestGetValueFromIntOrPercent(t *testing.T) {
+	tests := []struct {
+		input     IntOrString
+		total     int
+		expectErr bool
+		expectVal int
+	}{
+		{
+			input:     FromInt(123),
+			expectErr: false,
+			expectVal: 123,
+		},
+		{
+			input:     FromString("90%"),
+			total:     100,
+			expectErr: false,
+			expectVal: 90,
+		},
+		{
+			input:     FromString("%"),
+			expectErr: true,
+		},
+		{
+			input:     FromString("90#"),
+			expectErr: true,
+		},
+		{
+			input:     FromString("#%"),
+			expectErr: true,
+		},
+	}
+
+	for i, test := range tests {
+		t.Logf("test case %d", i)
+		value, err := GetValueFromIntOrPercent(&test.input, test.total)
+		if test.expectErr && err == nil {
+			t.Errorf("expected error, but got none")
+			continue
+		}
+		if !test.expectErr && err != nil {
+			t.Errorf("unexpected err: %v", err)
+			continue
+		}
+		if test.expectVal != value {
+			t.Errorf("expected %v, but got %v", test.expectErr, value)
+		}
+	}
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -18,34 +18,10 @@ package util
 
 import (
 	"fmt"
-	"math"
 	"os"
 	"reflect"
 	"regexp"
-	"strconv"
-	"strings"
-
-	"k8s.io/kubernetes/pkg/util/intstr"
 )
-
-func GetIntOrPercentValue(intOrStr *intstr.IntOrString) (int, bool, error) {
-	switch intOrStr.Type {
-	case intstr.Int:
-		return intOrStr.IntValue(), false, nil
-	case intstr.String:
-		s := strings.Replace(intOrStr.StrVal, "%", "", -1)
-		v, err := strconv.Atoi(s)
-		if err != nil {
-			return 0, false, fmt.Errorf("invalid value %q: %v", intOrStr.StrVal, err)
-		}
-		return int(v), true, nil
-	}
-	return 0, false, fmt.Errorf("invalid value: neither int nor percentage")
-}
-
-func GetValueFromPercent(percent int, value int) int {
-	return int(math.Ceil(float64(percent) * (float64(value)) / 100))
-}
 
 // Takes a list of strings and compiles them into a list of regular expressions
 func CompileRegexps(regexpStrings []string) ([]*regexp.Regexp, error) {


### PR DESCRIPTION
clean up:

helper funcs `GetIntOrPercentValue()` and `GetValueFromPercent()` should be in util/deployment.go instead of  util.go

@bgrant0607 @janetkuo 
