### PR TITLE
Deploy dashboard instead of extiinct kube-ui

### DIFF
--- a/cluster/ubuntu/deployAddons.sh
+++ b/cluster/ubuntu/deployAddons.sh
@@ -59,22 +59,20 @@ function deploy_dns {
   echo
 }
 
-function deploy_ui {
-  echo "Deploying Kubernetes UI..."
+function deploy_dashboard {
+    if ${KUBECTL} get rc -l k8s-app=kubernetes-dashboard --namespace=kube-system | grep kubernetes-dashboard-v &> /dev/null; then
+        echo "Kubernetes Dashboard replicationController already exists"
+    else
+        echo "Creating Kubernetes Dashboard replicationController"
+        ${KUBECTL} create -f ${KUBE_ROOT}/cluster/addons/dashboard/dashboard-controller.yaml
+    fi
 
-  KUBEUI=`eval "${KUBECTL} get services --namespace=kube-system | grep kube-ui | cat"`
-
-  if [ ! "$KUBEUI" ]; then
-    # use kubectl to create kube-ui rc and service
-    ${KUBECTL} --namespace=kube-system create \
-        -f ${KUBE_ROOT}/cluster/addons/kube-ui/kube-ui-rc.yaml
-    ${KUBECTL} --namespace=kube-system create \
-        -f ${KUBE_ROOT}/cluster/addons/kube-ui/kube-ui-svc.yaml
-
-    echo "Kube-ui rc and service is successfully deployed."
-  else
-    echo "Kube-ui rc and service is already deployed. Skipping."
-  fi
+    if ${KUBECTL} get service/kubernetes-dashboard --namespace=kube-system &> /dev/null; then
+        echo "Kubernetes Dashboard service already exists"
+    else
+        echo "Creating Kubernetes Dashboard service"
+        ${KUBECTL} create -f ${KUBE_ROOT}/cluster/addons/dashboard/dashboard-service.yaml
+    fi
 
   echo
 }
@@ -86,6 +84,6 @@ if [ "${ENABLE_CLUSTER_DNS}" == true ]; then
 fi
 
 if [ "${ENABLE_CLUSTER_UI}" == true ]; then
-  deploy_ui
+  deploy_dashboard
 fi
 


### PR DESCRIPTION
Updated cluster/ubuntu/deployAddons.sh to deploy the UI that exists
rather than the old one that no longer exists.

Resolves #20992
