### PR TITLE
kubelet/rkt: Add kubenet support for rkt.

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -3555,9 +3555,18 @@ func (kl *Kubelet) updatePodCIDR(cidr string) {
 	if kl.networkPlugin != nil {
 		details := make(map[string]interface{})
 		details[network.NET_PLUGIN_EVENT_POD_CIDR_CHANGE_DETAIL_CIDR] = cidr
+
+		// If the container runtime is rkt,
+		// save the CNI config into the rkt config directory.
+		runtime, ok := kl.GetRuntime().(*rkt.Runtime)
+		if ok {
+			configFilePath := path.Join(runtime.GetConfig().LocalConfigDir, rkt.DefaultK8sNetConfigFile)
+			details[network.NET_PLUGIN_EVENT_POD_CIDR_CHANGE_DETAIL_PATH] = configFilePath
+		}
 		kl.networkPlugin.Event(network.NET_PLUGIN_EVENT_POD_CIDR_CHANGE, details)
 	}
 }
+
 func (kl *Kubelet) GetNodeConfig() cm.NodeConfig {
 	return kl.containerManager.GetNodeConfig()
 }

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -31,8 +31,11 @@ import (
 	"testing"
 	"time"
 
+	goruntime "runtime"
+
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
+	"github.com/stretchr/testify/assert"
 	"k8s.io/kubernetes/pkg/api"
 	apierrors "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/resource"
@@ -48,10 +51,12 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/container"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/network"
+	"k8s.io/kubernetes/pkg/kubelet/network/kubenet"
 	"k8s.io/kubernetes/pkg/kubelet/pleg"
 	kubepod "k8s.io/kubernetes/pkg/kubelet/pod"
 	"k8s.io/kubernetes/pkg/kubelet/prober"
 	proberesults "k8s.io/kubernetes/pkg/kubelet/prober/results"
+	"k8s.io/kubernetes/pkg/kubelet/rkt"
 	"k8s.io/kubernetes/pkg/kubelet/status"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/kubelet/util/queue"
@@ -4458,6 +4463,41 @@ func TestGetPodsToSync(t *testing.T) {
 	} else {
 		t.Errorf("expected %d pods to sync, got %d", 3, len(podsToSync))
 	}
+}
+
+func TestKubenetWithRkt(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("only run kubenet test on linux")
+	}
+
+	testKubelet := newTestKubelet(t)
+	kubelet := testKubelet.kubelet
+	tmpdir, err := ioutil.TempDir("", "kubelet-test-rkt")
+	assert.NoError(t, err)
+
+	defer os.RemoveAll(tmpdir)
+
+	conf, err := rkt.NewConfig("/bin/rkt", "", fmt.Sprintf("--local-config=%s", tmpdir))
+	assert.NoError(t, err)
+
+	kubelet.containerRuntime = rkt.NewFakeRuntime(conf)
+	kubenetPlugin := kubenet.NewPlugin()
+	plug, err := network.InitNetworkPlugin([]network.NetworkPlugin{kubenetPlugin}, "kubenet", &networkHost{kubelet})
+	assert.NoError(t, err)
+
+	kubelet.networkPlugin = plug
+	kubelet.updatePodCIDR("10.244.0.0/16")
+
+	// Check the result.
+	bytes, err := ioutil.ReadFile(path.Join(tmpdir, rkt.DefaultK8sNetConfigFile))
+	assert.NoError(t, err)
+
+	intf, err := kubenet.FindMinMTU()
+	assert.NoError(t, err)
+
+	expected := fmt.Sprintf(kubenet.NET_CONFIG_TEMPLATE, kubenet.BridgeName, intf.MTU, kubenet.DefaultInterfaceName, "10.244.0.0/16", "10.244.0.1")
+
+	assert.Equal(t, expected, string(bytes))
 }
 
 // TODO(random-liu): Add unit test for convertStatusToAPIStatus (issue #20478)

--- a/pkg/kubelet/network/plugins.go
+++ b/pkg/kubelet/network/plugins.go
@@ -37,8 +37,11 @@ const DefaultPluginName = "kubernetes.io/no-op"
 
 // Called when the node's Pod CIDR is known when using the
 // controller manager's --allocate-node-cidrs=true option
-const NET_PLUGIN_EVENT_POD_CIDR_CHANGE = "pod-cidr-change"
-const NET_PLUGIN_EVENT_POD_CIDR_CHANGE_DETAIL_CIDR = "pod-cidr"
+const (
+	NET_PLUGIN_EVENT_POD_CIDR_CHANGE             = "pod-cidr-change"
+	NET_PLUGIN_EVENT_POD_CIDR_CHANGE_DETAIL_CIDR = "pod-cidr"
+	NET_PLUGIN_EVENT_POD_CIDR_CHANGE_DETAIL_PATH = "pod-cidr-config-path"
+)
 
 // Plugin is an interface to network plugins for the kubelet
 type NetworkPlugin interface {

--- a/pkg/kubelet/rkt/fake_rkt_interface.go
+++ b/pkg/kubelet/rkt/fake_rkt_interface.go
@@ -160,3 +160,7 @@ func (f *fakeRuntimeHelper) GenerateRunContainerOptions(pod *api.Pod, container 
 func (f *fakeRuntimeHelper) GetClusterDNS(pod *api.Pod) ([]string, []string, error) {
 	return f.dnsServers, f.dnsSearches, f.err
 }
+
+func NewFakeRuntime(config *Config) *Runtime {
+	return &Runtime{apisvc: newFakeRktInterface(), systemd: newFakeSystemd(), config: config}
+}

--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/kubernetes/pkg/client/record"
 	"k8s.io/kubernetes/pkg/credentialprovider"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/kubelet/network/kubenet"
 	proberesults "k8s.io/kubernetes/pkg/kubelet/prober/results"
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
 	"k8s.io/kubernetes/pkg/securitycontext"
@@ -87,13 +88,14 @@ const (
 
 	defaultImageTag          = "latest"
 	defaultRktAPIServiceAddr = "localhost:15441"
-	defaultNetworkName       = "rkt.kubernetes.io"
 
 	// ndots specifies the minimum number of dots that a domain name must contain for the resolver to consider it as FQDN (fully-qualified)
 	// we want to able to consider SRV lookup names like _dns._udp.kube-dns.default.svc to be considered relative.
 	// hence, setting ndots to be 5.
 	// TODO(yifan): Move this and dockertools.ndotsDNSOption to a common package.
 	defaultDNSOption = "ndots:5"
+
+	DefaultK8sNetConfigFile = "net.d/k8s-cni.conf"
 )
 
 // Runtime implements the Containerruntime for rkt. The implementation
@@ -714,7 +716,7 @@ func (r *Runtime) generateRunCommand(pod *api.Pod, uuid string) (string, error) 
 	if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.HostNetwork {
 		runPrepared = append(runPrepared, "--net=host")
 	} else {
-		runPrepared = append(runPrepared, fmt.Sprintf("--net=%s", defaultNetworkName))
+		runPrepared = append(runPrepared, fmt.Sprintf("--net=%s", kubenet.KubenetPluginName))
 	}
 
 	// Setup DNS.
@@ -1474,7 +1476,7 @@ func (r *Runtime) GetPodStatus(uid types.UID, name, namespace string) (*kubecont
 	if latestPod != nil {
 		// Try to fill the IP info.
 		for _, n := range latestPod.Networks {
-			if n.Name == defaultNetworkName {
+			if n.Name == kubenet.KubenetPluginName {
 				podStatus.IP = n.Ipv4
 			}
 		}
@@ -1488,3 +1490,8 @@ type sortByRestartCount []*kubecontainer.ContainerStatus
 func (s sortByRestartCount) Len() int           { return len(s) }
 func (s sortByRestartCount) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 func (s sortByRestartCount) Less(i, j int) bool { return s[i].RestartCount < s[j].RestartCount }
+
+// GetConfig returns the config for the rkt runtime.
+func (r *Runtime) GetConfig() *Config {
+	return r.config
+}


### PR DESCRIPTION
If the container runtime is rkt, save the CNI config
file under the rkt config directory.
- [x] Save kubenet config under rkt config directory
- [x] Add tests
- [ ] Bandwidth shaper support?

cc @jonboulle @sjpotter @steveej  @kubernetes/sig-node @kubernetes/sig-network 
