### PR TITLE
Fix clientset e2e test flake

### DIFF
--- a/test/e2e/generated_clientset.go
+++ b/test/e2e/generated_clientset.go
@@ -89,12 +89,17 @@ var _ = Describe("Generated release_1_2 clientset", func() {
 		// the test so we can ensure that we clean up after
 		// ourselves
 		defer podClient.Delete(pod.Name, api.NewDeleteOptions(0))
-		_, err = podClient.Create(pod)
+		pod, err = podClient.Create(pod)
 		if err != nil {
 			Failf("Failed to create pod: %v", err)
 		}
 
 		By("verifying the pod is in kubernetes")
+		selector = labels.SelectorFromSet(labels.Set(map[string]string{"time": value}))
+		options = api.ListOptions{
+			LabelSelector:   selector,
+			ResourceVersion: pod.ResourceVersion,
+		}
 		pods, err = podClient.List(options)
 		if err != nil {
 			Failf("Failed to query for pods: %v", err)


### PR DESCRIPTION
Fix #21045.

Add a sleep before List() to give enough time for the server-side watch cache to receive the pod creation watch notification.

I cannot reproduce the flake locally (250 runs without failure) #so I cannot be sure if this actually fixes the test on Jenkins. I'll run the tests locally overnight to see if I can reproduce.
