### PR TITLE
use the IntPtr() funcs in util to create pointer to an int

### DIFF
--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -27,6 +27,7 @@ import (
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/kubectl"
+	"k8s.io/kubernetes/pkg/util"
 	deploymentutil "k8s.io/kubernetes/pkg/util/deployment"
 	"k8s.io/kubernetes/pkg/util/intstr"
 	"k8s.io/kubernetes/pkg/util/wait"
@@ -406,8 +407,7 @@ func testDeploymentCleanUpPolicy(f *Framework) {
 	}
 	rsName := "nginx-controller"
 	replicas := 1
-	revisionHistoryLimit := new(int)
-	*revisionHistoryLimit = 0
+	revisionHistoryLimit := util.IntPtr(0)
 	_, err := c.Extensions().ReplicaSets(ns).Create(newRS(rsName, replicas, rsPodLabels, "nginx", "nginx"))
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
@kargakis 
Small clean up for the e2e test of deployment, which was added in https://github.com/kubernetes/kubernetes/pull/19590. I just notice that there is a `IntPtr()` funcs in util. 
