### PR TITLE
Comment out calls to httptest.Server.Close() 

### DIFF
--- a/plugin/pkg/auth/authenticator/token/oidc/oidc_test.go
+++ b/plugin/pkg/auth/authenticator/token/oidc/oidc_test.go
@@ -218,7 +218,8 @@ func TestOIDCDiscoveryNoKeyEndpoint(t *testing.T) {
 		t.Fatalf("Cannot load cert/key pair: %v", err)
 	}
 	srv.StartTLS()
-	defer srv.Close()
+	// TODO: Uncomment when fix #19254
+	// defer srv.Close()
 
 	op.pcfg = oidc.ProviderConfig{
 		Issuer: srv.URL,
@@ -274,7 +275,8 @@ func TestOIDCDiscoverySecureConnection(t *testing.T) {
 		t.Fatalf("Cannot load cert/key pair: %v", err)
 	}
 	tlsSrv.StartTLS()
-	defer tlsSrv.Close()
+	// TODO: Uncomment when fix #19254
+	// defer tlsSrv.Close()
 
 	op.pcfg = oidc.ProviderConfig{
 		Issuer:       tlsSrv.URL,
@@ -309,7 +311,8 @@ func TestOIDCAuthentication(t *testing.T) {
 		t.Fatalf("Cannot load cert/key pair: %v", err)
 	}
 	srv.StartTLS()
-	defer srv.Close()
+	// TODO: Uncomment when fix #19254
+	// defer srv.Close()
 
 	op.pcfg = oidc.ProviderConfig{
 		Issuer:       srv.URL,


### PR DESCRIPTION
This is a followup to #19458, I'm constantly hitting failures in `plugin/pkg/auth/authenticator/token/oidc/`.

@davidopp ptal
