### PR TITLE
fix test-cmd when running and unprivileged user

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -146,6 +146,7 @@ kube::log::status "Running kubectl with no options"
 kube::log::status "Starting kubelet in masterless mode"
 "${KUBE_OUTPUT_HOSTBIN}/kubelet" \
   --really-crash-for-testing=true \
+  --lock-file="$(mktemp /tmp/kubelet.XXXX.lock)" \
   --root-dir=/tmp/kubelet.$$ \
   --cert-dir="${TMPDIR:-/tmp/}" \
   --docker-endpoint="fake://" \


### PR DESCRIPTION
Bad assumption that /var/run/lock is writable on all distros.
#21078
