### PR TITLE
Make default format right for nil values

### DIFF
--- a/pkg/api/resource_helpers.go
+++ b/pkg/api/resource_helpers.go
@@ -30,7 +30,7 @@ func (self *ResourceList) Cpu() *resource.Quantity {
 	if val, ok := (*self)[ResourceCPU]; ok {
 		return &val
 	}
-	return &resource.Quantity{}
+	return &resource.Quantity{Format: resource.DecimalSI}
 }
 
 // Returns the Memory limit if specified.
@@ -38,7 +38,7 @@ func (self *ResourceList) Memory() *resource.Quantity {
 	if val, ok := (*self)[ResourceMemory]; ok {
 		return &val
 	}
-	return &resource.Quantity{}
+	return &resource.Quantity{Format: resource.BinarySI}
 }
 
 func (self *ResourceList) Pods() *resource.Quantity {

--- a/pkg/api/resource_helpers_test.go
+++ b/pkg/api/resource_helpers_test.go
@@ -51,3 +51,13 @@ func TestResourceHelpers(t *testing.T) {
 		t.Errorf("expected memorylimit %v, got %v", memoryLimit, res)
 	}
 }
+
+func TestDefaultResourceHelpers(t *testing.T) {
+	resourceList := ResourceList{}
+	if resourceList.Cpu().Format != resource.DecimalSI {
+		t.Errorf("expected %v, actual %v", resource.DecimalSI, resourceList.Cpu().Format)
+	}
+	if resourceList.Memory().Format != resource.BinarySI {
+		t.Errorf("expected %v, actual %v", resource.BinarySI, resourceList.Memory().Format)
+	}
+}

--- a/plugin/pkg/scheduler/algorithm/priorities/util/non_zero.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/util/non_zero.go
@@ -16,10 +16,7 @@ limitations under the License.
 
 package util
 
-import (
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/resource"
-)
+import "k8s.io/kubernetes/pkg/api"
 
 // For each of these resources, a pod that doesn't request the resource explicitly
 // will be treated as having requested the amount indicated below, for the purpose
@@ -32,21 +29,22 @@ import (
 const DefaultMilliCpuRequest int64 = 100             // 0.1 core
 const DefaultMemoryRequest int64 = 200 * 1024 * 1024 // 200 MB
 
+// GetNonzeroRequests returns the default resource request if none is found or what is provided on the request
 // TODO: Consider setting default as a fixed fraction of machine capacity (take "capacity api.ResourceList"
 // as an additional argument here) rather than using constants
 func GetNonzeroRequests(requests *api.ResourceList) (int64, int64) {
-	var out_millicpu, out_memory int64
+	var outMilliCPU, outMemory int64
 	// Override if un-set, but not if explicitly set to zero
-	if (*requests.Cpu() == resource.Quantity{}) {
-		out_millicpu = DefaultMilliCpuRequest
+	if _, found := (*requests)[api.ResourceCPU]; !found {
+		outMilliCPU = DefaultMilliCpuRequest
 	} else {
-		out_millicpu = requests.Cpu().MilliValue()
+		outMilliCPU = requests.Cpu().MilliValue()
 	}
 	// Override if un-set, but not if explicitly set to zero
-	if (*requests.Memory() == resource.Quantity{}) {
-		out_memory = DefaultMemoryRequest
+	if _, found := (*requests)[api.ResourceMemory]; !found {
+		outMemory = DefaultMemoryRequest
 	} else {
-		out_memory = requests.Memory().Value()
+		outMemory = requests.Memory().Value()
 	}
-	return out_millicpu, out_memory
+	return outMilliCPU, outMemory
 }


### PR DESCRIPTION
There have been problems where people expect the right format for nil values.
