### PR TITLE
Quarantine reboot tests (again)

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -403,6 +403,24 @@ case ${JOB_NAME} in
 
   # Feature jobs
 
+  # Runs only the reboot tests on GCE.
+  kubernetes-e2e-gce-reboot)
+    : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-reboot"}
+    : ${E2E_NETWORK:="e2e-reboot"}
+    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Feature:Reboot\]"}
+    : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-reboot"}
+    : ${PROJECT:="kubernetes-jenkins"}
+  ;;
+
+  kubernetes-e2e-gke-reboot)
+    : ${E2E_CLUSTER_NAME:="jkns-gke-e2e-ci-reboot"}
+    : ${E2E_NETWORK:="e2e-gke-ci-reboot"}
+    : ${E2E_SET_CLUSTER_API_VERSION:=y}
+    : ${PROJECT:="k8s-jkns-e2e-gke-ci-reboot"}
+    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
+    : ${GINKGO_TEST_ARGS:="--ginkgo.focus=\[Feature:Reboot\]"}
+  ;;
+
   # Runs only the examples tests on GCE.
   kubernetes-e2e-gce-examples)
     : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-examples"}

--- a/hack/jenkins/job-configs/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-e2e.yaml
@@ -42,6 +42,12 @@
         - 'gce-slow':
             description: 'Run slow E2E tests on GCE using the latest successful build.'
             timeout: 60
+        - 'gce-serial':
+            description: 'Run [Serial], [Disruptive], and [Feature:Restart] tests on GCE using the latest successful build.'
+            timeout: 300
+        - 'gce-reboot':
+            description: 'Run [Feature:Reboot] tests on GCE using the latest successful build.'
+            timeout: 180
         - 'gce-autoscaling':
             description: 'Run autoscaling E2E tests on GCE using the latest successful build.'
             timeout: 210
@@ -76,6 +82,12 @@
         - 'gke-slow':
             description: 'Run slow E2E tests on GKE using the latest successful build.'
             timeout: 60
+        - 'gke-serial':
+            description: 'Run [Serial], [Disruptive], and [Feature:Restart] tests on GKE using the latest successful build.'
+            timeout: 300
+        - 'gke-reboot':
+            description: 'Run [Feature:Reboot] tests on GKE using the latest successful build.'
+            timeout: 180
         - 'gke-flaky':
             description: |
                 Run flaky e2e tests using the following config:<br>
@@ -179,16 +191,6 @@
     trigger-job: 'kubernetes-build'
     branch: 'master'
     suffix:
-        - 'gce-serial':
-            description: 'Run [Serial], [Disruptive], and [Feature:Restart] tests on GCE using the latest successful build.'
-            timeout: 300
-            emails: '$DEFAULT_RECIPIENTS, ihmccreery@google.com'
-            test-owner: 'ihmccreery'
-        - 'gke-serial':
-            description: 'Run [Serial], [Disruptive], and [Feature:Restart] tests on GKE using the latest successful build.'
-            timeout: 300
-            emails: '$DEFAULT_RECIPIENTS, ihmccreery@google.com'
-            test-owner: 'ihmccreery'
         - 'gke-ingress':
             description: 'Run [Feature:Ingress] tests on GKE using the latest successful build.'
             timeout: 90

--- a/test/e2e/reboot.go
+++ b/test/e2e/reboot.go
@@ -45,7 +45,7 @@ const (
 	rebootPodReadyAgainTimeout = 5 * time.Minute
 )
 
-var _ = Describe("Reboot [Disruptive]", func() {
+var _ = Describe("Reboot [Disruptive] [Feature:Reboot]", func() {
 	var f *Framework
 
 	BeforeEach(func() {


### PR DESCRIPTION
@dchen1107 and I talked, and we feel we must quarantine these tests because they muck up the signal we get on others.

This is just #20651 again.

cc @kubernetes/goog-testing 
