### PR TITLE
Echo start and finish times to build log

### DIFF
--- a/hack/jenkins/upload-finished.sh
+++ b/hack/jenkins/upload-finished.sh
@@ -33,6 +33,8 @@ readonly result="$1"
 readonly timestamp=$(date +%s)
 readonly location="gs://kubernetes-jenkins/logs/${JOB_NAME}/${BUILD_NUMBER}/finished.json"
 
+echo -n 'Run finished at '; date -d "@${timestamp}"
+
 echo "Uploading build result to: ${location}"
 gsutil -q cp -a "public-read" <(
     echo "{"

--- a/hack/jenkins/upload-started.sh
+++ b/hack/jenkins/upload-started.sh
@@ -28,6 +28,8 @@ version=""
 readonly timestamp=$(date +%s)
 readonly location="gs://kubernetes-jenkins/logs/${JOB_NAME}/${BUILD_NUMBER}/started.json"
 
+echo -n 'Run starting at '; date -d "@${timestamp}"
+
 # Try to discover the kubernetes version.
 if [[ -e "version" ]]; then
     version=$(cat "version")


### PR DESCRIPTION
Minor enhancement to make reading build logs a little easier. This makes it clear when a build or test run starts/finishes (since this always isn't evident in logs); it also spells out what time zone we're using.

It'd be nice to have this on PR Jenkins, too. I'm guessing that we'll eventually port `upload-started.sh` and `upload-finished.sh` there?
