### PR TITLE
Use a more standard numeric tag for gcr.io/google_containers/porter

### DIFF
--- a/test/e2e/proxy.go
+++ b/test/e2e/proxy.go
@@ -102,7 +102,7 @@ func proxyContext(version string) {
 		pods := []*api.Pod{}
 		cfg := RCConfig{
 			Client:       f.Client,
-			Image:        "gcr.io/google_containers/porter:cd5cb5791ebaa8641955f0e8c2a9bed669b1eaab",
+			Image:        "gcr.io/google_containers/porter:0.4",
 			Name:         service.Name,
 			Namespace:    f.Namespace.Name,
 			Replicas:     1,

--- a/test/images/porter/Makefile
+++ b/test/images/porter/Makefile
@@ -22,25 +22,17 @@
 # This image does not tag in the normal way
 # TAG =
 PREFIX = gcr.io/google_containers
-SUGGESTED_TAG = $(shell git rev-parse --verify HEAD)
+TAG = 0.4
 
 porter: porter.go
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' ./porter.go
 
-tag:
-	@echo "If all relevant changes are committed, suggest using TAG=$(SUGGESTED_TAG)"
-	@echo "$$ make container TAG=$(SUGGESTED_TAG)"
-	@echo "or"
-	@echo "$$ make push TAG=$(SUGGESTED_TAG)"
-
 container: image
 
 image:
-	$(if $(TAG),,$(error TAG is not defined. Use 'make tag' after committing changes to see a suggestion))
 	docker build -t $(PREFIX)/porter:$(TAG) .
 
 push:
-	$(if $(TAG),,$(error TAG is not defined. Use 'make tag' after committing changes to see a suggestion))
 	gcloud docker push $(PREFIX)/porter:$(TAG)
 
 clean:

--- a/test/images/porter/pod.json
+++ b/test/images/porter/pod.json
@@ -8,7 +8,7 @@
     "containers": [
       {
         "name": "porter",
-        "image": "gcr.io/google_containers/porter:cd5cb5791ebaa8641955f0e8c2a9bed669b1eaab",
+        "image": "gcr.io/google_containers/porter:0.4",
         "env": [
           {
             "name": "SERVE_PORT_80",


### PR DESCRIPTION
I chose `0.4` since there are already 3 tagged versions of this image.

I haven't pushed yet, so I expect the e2e test to fail.
