### PR TITLE
Fetch hacked easyrsa in kube-up instead of command run on master

### DIFF
--- a/cluster/saltbase/salt/generate-cert/make-ca-cert.sh
+++ b/cluster/saltbase/salt/generate-cert/make-ca-cert.sh
@@ -18,6 +18,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+if [ "${DEBUG}" == "true" ]; then
+	set -x
+fi
+
 cert_ip=$1
 extra_sans=${2:-}
 cert_dir=${CERT_DIR:-/srv/kubernetes}
@@ -57,7 +61,14 @@ cd "${tmpdir}"
 #
 # Due to GCS caching of public objects, it may take time for this to be widely
 # distributed.
-curl -L -O https://storage.googleapis.com/kubernetes-release/easy-rsa/easy-rsa.tar.gz > /dev/null 2>&1
+#
+# Use ~/kube/easy-rsa.tar.gz if it exists, so that it can be
+# pre-pushed in cases where an outgoing connection is not allowed.
+if [ -f ~/kube/easy-rsa.tar.gz ]; then
+	ln -s ~/kube/easy-rsa.tar.gz .
+else
+	curl -L -O https://storage.googleapis.com/kubernetes-release/easy-rsa/easy-rsa.tar.gz > /dev/null 2>&1
+fi
 tar xzf easy-rsa.tar.gz > /dev/null 2>&1
 
 cd easy-rsa-master/easyrsa3

--- a/cluster/ubuntu/util.sh
+++ b/cluster/ubuntu/util.sh
@@ -312,6 +312,9 @@ function kube-up() {
   # downloading tarball release
   "${KUBE_ROOT}/cluster/ubuntu/download-release.sh"
 
+  # Fetch the hacked easyrsa that make-ca-cert.sh will use
+  curl -L -O https://storage.googleapis.com/kubernetes-release/easy-rsa/easy-rsa.tar.gz > /dev/null 2>&1
+
   setClusterInfo
   local ii=0
 
@@ -357,6 +360,7 @@ function provision-master() {
   # copy the binaries and scripts to the ~/kube directory on the master
   scp -r $SSH_OPTS \
     saltbase/salt/generate-cert/make-ca-cert.sh \
+    easy-rsa.tar.gz \
     ubuntu/reconfDocker.sh \
     "${KUBE_CONFIG_FILE}" \
     ubuntu/util.sh \
@@ -404,7 +408,7 @@ function provision-master() {
       cp ~/kube/init_scripts/* /etc/init.d/
 
       groupadd -f -r kube-cert
-      ${PROXY_SETTING} ~/kube/make-ca-cert.sh \"${MASTER_IP}\" \"${EXTRA_SANS}\"
+      ${PROXY_SETTING} DEBUG='${DEBUG}' ~/kube/make-ca-cert.sh \"${MASTER_IP}\" \"${EXTRA_SANS}\"
       mkdir -p /opt/bin/
       cp ~/kube/master/* /opt/bin/
       service etcd start
@@ -478,6 +482,7 @@ function provision-masterandnode() {
   # scp order matters
   scp -r $SSH_OPTS \
     saltbase/salt/generate-cert/make-ca-cert.sh \
+    easy-rsa.tar.gz \
     "${KUBE_CONFIG_FILE}" \
     ubuntu/util.sh \
     ubuntu/minion/* \
@@ -536,7 +541,7 @@ function provision-masterandnode() {
       cp ~/kube/init_scripts/* /etc/init.d/
 
       groupadd -f -r kube-cert
-      ${PROXY_SETTING} ~/kube/make-ca-cert.sh \"${MASTER_IP}\" \"${EXTRA_SANS}\"
+      ${PROXY_SETTING} DEBUG='${DEBUG}' ~/kube/make-ca-cert.sh \"${MASTER_IP}\" \"${EXTRA_SANS}\"
       mkdir -p /opt/bin/
       cp ~/kube/master/* /opt/bin/
       cp ~/kube/minion/* /opt/bin/


### PR DESCRIPTION
This is good because it removes an obstacle to using the
cluster/ubuntu scripting to install Kubernetes into a restricted
environment where the machines can not open connections to arbitrary
external locations.

Also add debuggability to make-ca-cert.sh

Resolves #21037
Resolves #21092
