### PR TITLE
Fix deadlock in nettest webserver

### DIFF
--- a/test/e2e/networking.go
+++ b/test/e2e/networking.go
@@ -157,7 +157,7 @@ var _ = Describe("Networking", func() {
 				"Rerun it with at least two nodes to get complete coverage.")
 		}
 
-		podNames := LaunchNetTestPodPerNode(f, nodes, svcname, "1.6")
+		podNames := LaunchNetTestPodPerNode(f, nodes, svcname, "1.7")
 
 		// Clean up the pods
 		defer func() {

--- a/test/e2e/pods.go
+++ b/test/e2e/pods.go
@@ -758,7 +758,7 @@ var _ = Describe("Pods", func() {
 				Containers: []api.Container{
 					{
 						Name:  "liveness",
-						Image: "gcr.io/google_containers/nettest:1.6",
+						Image: "gcr.io/google_containers/nettest:1.7",
 						// These args are garbage but the image will exit if they're not there
 						// we just care about /read serving a 200, which it always does.
 						Args: []string{

--- a/test/e2e/pre_stop.go
+++ b/test/e2e/pre_stop.go
@@ -43,7 +43,7 @@ func testPreStop(c *client.Client, ns string) {
 			Containers: []api.Container{
 				{
 					Name:  "server",
-					Image: "gcr.io/google_containers/nettest:1.6",
+					Image: "gcr.io/google_containers/nettest:1.7",
 					Ports: []api.ContainerPort{{ContainerPort: 8080}},
 				},
 			},

--- a/test/images/network-tester/Makefile
+++ b/test/images/network-tester/Makefile
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG = 1.6
+TAG = 1.7
 PREFIX = gcr.io/google_containers
 
 all: push
 
 webserver: webserver.go
-	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' ./webserver.go
+	CGO_ENABLED=0 GOOS=linux godep go build -a -installsuffix cgo -ldflags '-w' ./webserver.go
 
 container: image
 

--- a/test/images/network-tester/rc.json
+++ b/test/images/network-tester/rc.json
@@ -22,7 +22,7 @@
         "containers": [
           {
             "name": "webserver",
-            "image": "gcr.io/google_containers/nettest:1.6",
+            "image": "gcr.io/google_containers/nettest:1.7",
             "imagePullPolicy": "Always",
             "args": [
               "-service=nettest",

--- a/test/images/network-tester/slow-pod.json
+++ b/test/images/network-tester/slow-pod.json
@@ -11,7 +11,7 @@
     "containers": [
       {
         "name": "webserver",
-        "image": "gcr.io/google_containers/nettest:1.5",
+        "image": "gcr.io/google_containers/nettest:1.7",
         "args": [
           "-service=nettest",
           "-delay-shutdown=10"

--- a/test/images/network-tester/slow-rc.json
+++ b/test/images/network-tester/slow-rc.json
@@ -23,7 +23,7 @@
         "containers": [
           {
             "name": "webserver",
-            "image": "gcr.io/google_containers/nettest:1.5",
+            "image": "gcr.io/google_containers/nettest:1.7",
             "args": [
               "-service=nettest",
               "-delay-shutdown=10"

--- a/test/images/network-tester/webserver.go
+++ b/test/images/network-tester/webserver.go
@@ -90,7 +90,8 @@ func (s *State) serveStatus(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "running")
 		return
 	}
-	s.Logf("Declaring failure for %s/%s with %d sent and %d received and %d peers", *namespace, *service, len(s.Sent), len(s.Received), *peerCount)
+	// Logf can't be called while holding the lock, so defer using a goroutine
+	go s.Logf("Declaring failure for %s/%s with %d sent and %d received and %d peers", *namespace, *service, len(s.Sent), len(s.Received), *peerCount)
 	fmt.Fprintf(w, "fail")
 }
 


### PR DESCRIPTION
Fix a potential deadlock in the `nettest` webserver as discussed in #20778.

I haven't pushed 1.7 yet, so I expect all of the affected tests to fail until that's done.
