### PR TITLE
Change pod in probe update to pod uid.

### DIFF
--- a/pkg/kubelet/dockertools/manager_test.go
+++ b/pkg/kubelet/dockertools/manager_test.go
@@ -867,7 +867,7 @@ func TestSyncPodsUnhealthy(t *testing.T) {
 			ID:   infraContainerID,
 			Name: "/k8s_POD." + strconv.FormatUint(generatePodInfraContainerHash(pod), 16) + "_foo_new_12345678_42",
 		}})
-	dm.livenessManager.Set(kubecontainer.DockerID(unhealthyContainerID).ContainerID(), proberesults.Failure, nil)
+	dm.livenessManager.Set(kubecontainer.DockerID(unhealthyContainerID).ContainerID(), proberesults.Failure, pod)
 
 	runSyncPod(t, dm, fakeDocker, pod, nil, false)
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2371,11 +2371,7 @@ func (kl *Kubelet) syncLoopIteration(updates <-chan kubetypes.PodUpdate, handler
 		if update.Result == proberesults.Failure {
 			// We should not use the pod from livenessManager, because it is never updated after
 			// initialization.
-			// TODO(random-liu): This is just a quick fix. We should:
-			//  * Just pass pod UID in probe updates to make this less confusing.
-			//  * Maybe probe manager should rely on pod manager, or at least the pod in probe manager
-			//  should be updated.
-			pod, ok := kl.podManager.GetPodByUID(update.Pod.UID)
+			pod, ok := kl.podManager.GetPodByUID(update.PodUID)
 			if !ok {
 				// If the pod no longer exists, ignore the update.
 				glog.V(4).Infof("SyncLoop (container unhealthy): ignore irrelevant update: %#v", update)

--- a/pkg/kubelet/prober/manager.go
+++ b/pkg/kubelet/prober/manager.go
@@ -33,7 +33,7 @@ import (
 
 // Manager manages pod probing. It creates a probe "worker" for every container that specifies a
 // probe (AddPod). The worker periodically probes its assigned container and caches the results. The
-// manager usse the cached probe results to set the appropriate Ready state in the PodStatus when
+// manager use the cached probe results to set the appropriate Ready state in the PodStatus when
 // requested (UpdatePodStatus). Updating probe parameters is not currently supported.
 // TODO: Move liveness probing out of the runtime, to here.
 type Manager interface {
@@ -234,5 +234,5 @@ func (m *manager) updateReadiness() {
 	update := <-m.readinessManager.Updates()
 
 	ready := update.Result == results.Success
-	m.statusManager.SetContainerReadiness(update.Pod, update.ContainerID, ready)
+	m.statusManager.SetContainerReadiness(update.PodUID, update.ContainerID, ready)
 }

--- a/pkg/kubelet/prober/manager_test.go
+++ b/pkg/kubelet/prober/manager_test.go
@@ -280,7 +280,8 @@ func TestUpdatePodStatus(t *testing.T) {
 }
 
 func TestUpdateReadiness(t *testing.T) {
-	testPod := getTestPod(readiness, api.Probe{})
+	testPod := getTestPod()
+	setTestProbe(testPod, readiness, api.Probe{})
 	m := newTestManager()
 	defer cleanup(t, m)
 
@@ -297,9 +298,9 @@ func TestUpdateReadiness(t *testing.T) {
 	exec.set(probe.Success, nil)
 	m.prober.exec = &exec
 
-	m.statusManager.SetPodStatus(&testPod, getTestRunningStatus())
+	m.statusManager.SetPodStatus(testPod, getTestRunningStatus())
 
-	m.AddPod(&testPod)
+	m.AddPod(testPod)
 	probePaths := []probeKey{{testPodUID, testContainerName, readiness}}
 	if err := expectProbes(m, probePaths); err != nil {
 		t.Error(err)

--- a/pkg/kubelet/prober/results/results_manager.go
+++ b/pkg/kubelet/prober/results/results_manager.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/types"
 )
 
 // Manager provides a probe results cache and channel of updates.
@@ -61,7 +62,7 @@ func (r Result) String() string {
 type Update struct {
 	ContainerID kubecontainer.ContainerID
 	Result      Result
-	Pod         *api.Pod
+	PodUID      types.UID
 }
 
 // Manager implementation.
@@ -93,7 +94,7 @@ func (m *manager) Get(id kubecontainer.ContainerID) (Result, bool) {
 
 func (m *manager) Set(id kubecontainer.ContainerID, result Result, pod *api.Pod) {
 	if m.setInternal(id, result) {
-		m.updates <- Update{id, result, pod}
+		m.updates <- Update{id, result, pod.UID}
 	}
 }
 

--- a/pkg/kubelet/prober/results/results_manager_test.go
+++ b/pkg/kubelet/prober/results/results_manager_test.go
@@ -35,7 +35,7 @@ func TestCacheOperations(t *testing.T) {
 	_, found := m.Get(unsetID)
 	assert.False(t, found, "unset result found")
 
-	m.Set(setID, Success, nil)
+	m.Set(setID, Success, &api.Pod{})
 	result, found := m.Get(setID)
 	assert.True(t, result == Success, "set result")
 	assert.True(t, found, "set result found")
@@ -77,10 +77,10 @@ func TestUpdates(t *testing.T) {
 
 	// New result should always push an update.
 	m.Set(fooID, Success, pod)
-	expectUpdate(Update{fooID, Success, pod}, "new success")
+	expectUpdate(Update{fooID, Success, pod.UID}, "new success")
 
 	m.Set(barID, Failure, pod)
-	expectUpdate(Update{barID, Failure, pod}, "new failure")
+	expectUpdate(Update{barID, Failure, pod.UID}, "new failure")
 
 	// Unchanged results should not send an update.
 	m.Set(fooID, Success, pod)
@@ -91,8 +91,8 @@ func TestUpdates(t *testing.T) {
 
 	// Changed results should send an update.
 	m.Set(fooID, Failure, pod)
-	expectUpdate(Update{fooID, Failure, pod}, "changed foo")
+	expectUpdate(Update{fooID, Failure, pod.UID}, "changed foo")
 
 	m.Set(barID, Success, pod)
-	expectUpdate(Update{barID, Success, pod}, "changed bar")
+	expectUpdate(Update{barID, Success, pod.UID}, "changed bar")
 }


### PR DESCRIPTION
Change `api.Pod` in probe update to pod UID.  (See [TODO](https://github.com/kubernetes/kubernetes/pull/20942/files#diff-bf28da68f62a8df6e99e447c4351122dR2362) here)

/cc @yujuhong @timstclair 
