### PR TITLE
Replica set is enabled by default now, so it is not necessary to explicitly enable it in the test config script.

### DIFF
--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -50,9 +50,7 @@ NODE_SCOPES="${NODE_SCOPES:-compute-rw,monitoring,logging-write,storage-ro}"
 RUNTIME_CONFIG="${KUBE_RUNTIME_CONFIG:-}"
 TERMINATED_POD_GC_THRESHOLD=${TERMINATED_POD_GC_THRESHOLD:-100}
 
-# Optional: enable v1beta1 related features
 ENABLE_DAEMONSETS="${KUBE_ENABLE_DAEMONSETS:-true}"
-ENABLE_REPLICASETS="${KUBE_ENABLE_REPLICASETS:-true}"
 
 # Increase the sleep interval value if concerned about API rate limits. 3, in seconds, is the default.
 POLL_SLEEP_INTERVAL=3


### PR DESCRIPTION
This PR is based on #21130. Only last commit needs review here.

cc @bgrant0607 @janetkuo @kargakis 
