### PR TITLE
exit if unable to query status from apiserver

### DIFF
--- a/cluster/saltbase/salt/kube-addons/kube-addon-update.sh
+++ b/cluster/saltbase/salt/kube-addons/kube-addon-update.sh
@@ -349,6 +349,12 @@ function match-objects() {
     new_files=""
 
     addon_nsnames_on_server=$(get-addon-nsnames-from-server "${obj_type}")
+    # if the api server is unavailable then abandon the update for this cycle 
+    if [[ $? -ne 0 ]]; then
+        log ERR "unable to query ${obj_type} - exiting"
+        exit 1
+    fi
+
     addon_paths_in_files=$(get-addon-paths-from-disk "${addon_dir}" "${obj_type}")
 
     log DB2 "addon_nsnames_on_server=${addon_nsnames_on_server}"


### PR DESCRIPTION
small patch for #20219 that checks the return code for kubectl get and exits if unavailable

there doesn't seem to be any tests for this, so to verify i just used the TEST_KUBECTL override to mock the kubectl call to simulate failing 'get' ([mock script is here](https://gist.github.com/petermd/1f1d8d5c7bd87a2a1a8d))

eg

`KC_MOCK_FAIL=get TEST_KUBECTL=/etc/kubernetes/test/mock-kubectl.sh /etc/kubernetes/kube-addon-update.sh /etc/kubernetes/addons 600`

without the patch the script will loop trying to recreate missing services, but the patch just exits straight away (the process will be retried in the next interval when hopefully kube api server has stabilized)
