### PR TITLE
Salt: Make sure git is installed, for gitRepo volumes

### DIFF
--- a/cluster/saltbase/salt/base.sls
+++ b/cluster/saltbase/salt/base.sls
@@ -17,3 +17,7 @@ pkg-core:
 {% if grains['os'] == 'Ubuntu' %}
       - netcat-traditional
 {% endif %}
+# Make sure git is installed for mounting git volumes
+{% if grains['os'] == 'Ubuntu' %}
+      - git
+{% endif %}


### PR DESCRIPTION
Seems to be included in the GCE base image, but not on the images we use
on AWS (Ubuntu images).

Fix #20957
