### PR TITLE
AWS: Fix kube-up generation of kubeconfig

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -1155,7 +1155,7 @@ function build-config() {
   export KUBE_CERT="${CERT_DIR}/pki/issued/kubecfg.crt"
   export KUBE_KEY="${CERT_DIR}/pki/private/kubecfg.key"
   export CA_CERT="${CERT_DIR}/pki/ca.crt"
-  export CONTEXT="${PROJECT}_${INSTANCE_PREFIX}"
+  export CONTEXT="aws_${INSTANCE_PREFIX}"
   (
    umask 077
    create-kubeconfig


### PR DESCRIPTION
We were assuming the PROJECT env var was set, which the e2e tests do.
But PROJECT is normally not set on AWS (it is set on GCE); this broke as
part of the harmonization.

Revert to the pre-existing behaviour here, where we use "aws_" as the
prefix.

Fix #21141
