### PR TITLE
Add docs for AWS LoadBalancers: use kubectl describe

### DIFF
--- a/docs/user-guide/connecting-applications.md
+++ b/docs/user-guide/connecting-applications.md
@@ -425,6 +425,18 @@ $ curl https://162.22.184.144 -k
 The IP address in the `EXTERNAL_IP` column is the one that is available on the public internet.  The `CLUSTER_IP` is only available inside your
 cluster/private cloud network.
 
+Note that on AWS, type `LoadBalancer` creates an ELB, which uses a (long)
+hostname, not an IP.  It's too long to fit in the standard `kubectl get svc`
+output, in fact, so you'll need to do `kubectl describe service nginxsvc` to
+see it.  You'll see something like this:
+
+```
+> kubectl describe service nginxsvc
+...
+LoadBalancer Ingress:   a320587ffd19711e5a37606cf4a74574-1142138393.us-east-1.elb.amazonaws.com
+...
+```
+
 ## What's next?
 
 [Learn about more Kubernetes features that will help you run containers reliably in production.](production-pods.md)

--- a/docs/user-guide/quick-start.md
+++ b/docs/user-guide/quick-start.md
@@ -92,6 +92,11 @@ You may need to wait for a minute or two for the external ip address to be provi
 
 In order to access your nginx landing page, you also have to make sure that traffic from external IPs is allowed. Do this by opening a [firewall to allow traffic on port 80](services-firewalls.md).
 
+If you're running on AWS, Kubernetes creates an ELB for you.  ELBs use host
+names, not IPs, so you will have to do `kubectl describe svc my-nginx` and look
+for the `LoadBalancer Ingress` host name.  Traffic from external IPs is allowed
+automatically.
+
 ## Killing the application
 
 To kill the application and delete its containers and public IP address, do:


### PR DESCRIPTION
On AWS, we create ELBs for services with Type=LoadBalancer.

ELBs use hostnames, and the hostname is too long to fit in the output of
`kubectl get`.  So instead the user must do `kubectl describe service
<id>`.

Fix #13827
