### PR TITLE
controller: fix cleanup policy for deployments

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -432,6 +432,17 @@ func FilterActivePods(pods []api.Pod) []*api.Pod {
 	return result
 }
 
+// FilterActiveReplicaSets returns replica sets that have (or at least ought to have) pods.
+func FilterActiveReplicaSets(replicaSets []*extensions.ReplicaSet) []*extensions.ReplicaSet {
+	active := []*extensions.ReplicaSet{}
+	for i := range replicaSets {
+		if replicaSets[i].Spec.Replicas > 0 {
+			active = append(active, replicaSets[i])
+		}
+	}
+	return active
+}
+
 // ControllersByCreationTimestamp sorts a list of ReplicationControllers by creation timestamp, using their names as a tie breaker.
 type ControllersByCreationTimestamp []*api.ReplicationController
 

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -2117,7 +2117,7 @@ func waitForDeploymentOldRSsNum(c *clientset.Clientset, ns, deploymentName strin
 		if err != nil {
 			return false, err
 		}
-		oldRSs, _, err := deploymentutil.GetOldReplicaSets(*deployment, c)
+		_, oldRSs, err := deploymentutil.GetOldReplicaSets(*deployment, c)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
Cleanup policy should run on all replica sets and not only on those that
have pods (we will not cleanup those anyway).

@mqliang @janetkuo PTAL

cc: @bgrant0607 
