### PR TITLE
Jenkins: add jobs for GKE+Trusty

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -49,15 +49,15 @@ function get_trusty_image_project() {
 
 # Get the latest Trusty image for a Jenkins job.
 function get_latest_trusty_image() {
-    local job_name="${1:-${JOB_NAME}}"
+    local image_type="$1"
     local image_index=""
-    if [[ "${job_name}" =~ trusty-head ]]; then
+    if [[ "${image_type}" == head ]]; then
       image_index="trusty-head"
-    elif [[ "${job_name}" =~ trusty-dev ]]; then
+    elif [[ "${image_type}" == dev ]]; then
       image_index="trusty-dev"
-    elif [[ "${job_name}" =~ trusty-beta ]]; then
+    elif [[ "${image_type}" == beta ]]; then
       image_index="trusty-beta"
-    elif [[ "${job_name}" =~ trusty-stable ]]; then
+    elif [[ "${image_type}" == stable ]]; then
       image_index="trusty-stable"
     fi
     gsutil cat "gs://${TRUSTY_IMAGE_PROJECT}/image-indices/latest-test-image-${image_index}"
@@ -529,7 +529,7 @@ case ${JOB_NAME} in
     : ${KUBE_GCE_INSTANCE_PREFIX="e2e-gce"}
     : ${PROJECT:="kubekins-e2e-gce-trusty-rls"}
     : ${KUBE_GCE_MINION_PROJECT:="${TRUSTY_IMAGE_PROJECT}"}
-    : ${KUBE_GCE_MINION_IMAGE:="$(get_latest_trusty_image ${JOB_NAME})"}
+    : ${KUBE_GCE_MINION_IMAGE:="$(get_latest_trusty_image "head")"}
     : ${KUBE_OS_DISTRIBUTION:="trusty"}
     : ${ENABLE_CLUSTER_REGISTRY:=false}
     : ${JENKINS_PUBLISHED_VERSION:="release/stable-1.1"}
@@ -547,7 +547,7 @@ case ${JOB_NAME} in
     : ${KUBE_GCE_INSTANCE_PREFIX="e2e-trusty-slow"}
     : ${PROJECT:="k8s-e2e-gce-trusty-slow"}
     : ${KUBE_GCE_MINION_PROJECT:="${TRUSTY_IMAGE_PROJECT}"}
-    : ${KUBE_GCE_MINION_IMAGE:="$(get_latest_trusty_image ${JOB_NAME})"}
+    : ${KUBE_GCE_MINION_IMAGE:="$(get_latest_trusty_image "head")"}
     : ${KUBE_OS_DISTRIBUTION:="trusty"}
     : ${ENABLE_CLUSTER_REGISTRY:=false}
     : ${JENKINS_PUBLISHED_VERSION:="release/stable-1.1"}
@@ -570,7 +570,7 @@ case ${JOB_NAME} in
    : ${KUBE_GCE_INSTANCE_PREFIX="e2e-gce"}
    : ${PROJECT:="k8s-e2e-gce-trusty-dev"}
    : ${KUBE_GCE_MINION_PROJECT:="${TRUSTY_IMAGE_PROJECT}"}
-   : ${KUBE_GCE_MINION_IMAGE:="$(get_latest_trusty_image ${JOB_NAME})"}
+   : ${KUBE_GCE_MINION_IMAGE:="$(get_latest_trusty_image "dev")"}
    : ${KUBE_OS_DISTRIBUTION:="trusty"}
    : ${ENABLE_CLUSTER_REGISTRY:=false}
    : ${JENKINS_PUBLISHED_VERSION:="release/stable-1.1"}
@@ -589,7 +589,7 @@ case ${JOB_NAME} in
    : ${KUBE_GCE_INSTANCE_PREFIX="e2e-trusty-dev-slow"}
    : ${PROJECT:="k8s-e2e-gce-trusty-dev-slow"}
    : ${KUBE_GCE_MINION_PROJECT:="${TRUSTY_IMAGE_PROJECT}"}
-   : ${KUBE_GCE_MINION_IMAGE:="$(get_latest_trusty_image ${JOB_NAME})"}
+   : ${KUBE_GCE_MINION_IMAGE:="$(get_latest_trusty_image "dev")"}
    : ${KUBE_OS_DISTRIBUTION:="trusty"}
    : ${ENABLE_CLUSTER_REGISTRY:=false}
    : ${JENKINS_PUBLISHED_VERSION:="release/stable-1.1"}
@@ -612,7 +612,7 @@ case ${JOB_NAME} in
     : ${KUBE_GCE_INSTANCE_PREFIX="e2e-gce"}
     : ${PROJECT:="k8s-e2e-gce-trusty-beta"}
     : ${KUBE_GCE_MINION_PROJECT:="${TRUSTY_IMAGE_PROJECT}"}
-    : ${KUBE_GCE_MINION_IMAGE:="$(get_latest_trusty_image ${JOB_NAME})"}
+    : ${KUBE_GCE_MINION_IMAGE:="$(get_latest_trusty_image "beta")"}
     : ${KUBE_OS_DISTRIBUTION:="trusty"}
     : ${ENABLE_CLUSTER_REGISTRY:=false}
     : ${JENKINS_PUBLISHED_VERSION:="release/stable-1.1"}
@@ -631,7 +631,7 @@ case ${JOB_NAME} in
     : ${KUBE_GCE_INSTANCE_PREFIX="e2e-trusty-beta-slow"}
     : ${PROJECT:="k8s-e2e-gce-trusty-beta-slow"}
     : ${KUBE_GCE_MINION_PROJECT:="${TRUSTY_IMAGE_PROJECT}"}
-    : ${KUBE_GCE_MINION_IMAGE:="$(get_latest_trusty_image ${JOB_NAME})"}
+    : ${KUBE_GCE_MINION_IMAGE:="$(get_latest_trusty_image "beta")"}
     : ${KUBE_OS_DISTRIBUTION:="trusty"}
     : ${ENABLE_CLUSTER_REGISTRY:=false}
     : ${JENKINS_PUBLISHED_VERSION:="release/stable-1.1"}
@@ -654,7 +654,7 @@ case ${JOB_NAME} in
     : ${KUBE_GCE_INSTANCE_PREFIX="e2e-gce"}
     : ${PROJECT:="k8s-e2e-gce-trusty-stable"}
     : ${KUBE_GCE_MINION_PROJECT:="${TRUSTY_IMAGE_PROJECT}"}
-    : ${KUBE_GCE_MINION_IMAGE:="$(get_latest_trusty_image ${JOB_NAME})"}
+    : ${KUBE_GCE_MINION_IMAGE:="$(get_latest_trusty_image "stable")"}
     : ${KUBE_OS_DISTRIBUTION:="trusty"}
     : ${ENABLE_CLUSTER_REGISTRY:=false}
     : ${JENKINS_PUBLISHED_VERSION:="release/stable-1.1"}
@@ -673,7 +673,7 @@ case ${JOB_NAME} in
     : ${KUBE_GCE_INSTANCE_PREFIX="e2e-trusty-stable-slow"}
     : ${PROJECT:="k8s-e2e-gce-trusty-stable-slow"}
     : ${KUBE_GCE_MINION_PROJECT:="${TRUSTY_IMAGE_PROJECT}"}
-    : ${KUBE_GCE_MINION_IMAGE:="$(get_latest_trusty_image ${JOB_NAME})"}
+    : ${KUBE_GCE_MINION_IMAGE:="$(get_latest_trusty_image "stable")"}
     : ${KUBE_OS_DISTRIBUTION:="trusty"}
     : ${ENABLE_CLUSTER_REGISTRY:=false}
     : ${JENKINS_PUBLISHED_VERSION:="release/stable-1.1"}
@@ -758,7 +758,7 @@ case ${JOB_NAME} in
     ;;
 
   kubernetes-e2e-gke-staging)
-    # Override GKE default to use rc Cloud SDK and prod endpoint
+    # Override GKE default to use rc Cloud SDK and staging endpoint
     CLOUDSDK_BUCKET="gs://cloud-sdk-build/testing/rc"
     GKE_API_ENDPOINT="https://staging-container.sandbox.googleapis.com/"
     : ${E2E_CLUSTER_NAME:="jkns-gke-e2e-staging"}
@@ -803,6 +803,59 @@ case ${JOB_NAME} in
           ${GKE_DEFAULT_SKIP_TESTS[@]:+${GKE_DEFAULT_SKIP_TESTS[@]}} \
           ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
           ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
+          )"}
+    ;;
+
+  kubernetes-e2e-gke-trusty-prod)
+    # Override GKE default to use prod Cloud SDK and prod endpoint
+    CLOUDSDK_BUCKET=""
+    GKE_API_ENDPOINT="https://container.googleapis.com/"
+    : ${E2E_CLUSTER_NAME:="jkns-gke-e2e-prod-trusty"}
+    : ${E2E_NETWORK:="e2e-gke-trusty-prod"}
+    : ${E2E_SET_CLUSTER_API_VERSION:=y}
+    : ${JENKINS_USE_SERVER_VERSION:=y}
+    : ${PROJECT:="kubekins-e2e-gke-trusty-prod"}
+    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
+    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
+          ${GKE_DEFAULT_SKIP_TESTS[@]:+${GKE_DEFAULT_SKIP_TESTS[@]}} \
+          ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
+          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
+          ${TRUSTY_STABLE_SKIP_TESTS[@]:+${TRUSTY_STABLE_SKIP_TESTS}} \
+          )"}
+    ;;
+
+  kubernetes-e2e-gke-trusty-staging)
+    # Override GKE default to use rc Cloud SDK and staging endpoint
+    CLOUDSDK_BUCKET="gs://cloud-sdk-build/testing/rc"
+    GKE_API_ENDPOINT="https://staging-container.sandbox.googleapis.com/"
+    : ${E2E_CLUSTER_NAME:="jkns-gke-e2e-staging-trusty"}
+    : ${E2E_NETWORK:="e2e-gke-trusty-staging"}
+    : ${E2E_SET_CLUSTER_API_VERSION:=y}
+    : ${JENKINS_USE_SERVER_VERSION:=y}
+    : ${PROJECT:="e2e-gke-trusty-staging"}
+    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
+    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
+          ${GKE_DEFAULT_SKIP_TESTS[@]:+${GKE_DEFAULT_SKIP_TESTS[@]}} \
+          ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
+          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
+          ${TRUSTY_STABLE_SKIP_TESTS[@]:+${TRUSTY_STABLE_SKIP_TESTS}} \
+          )"}
+    ;;
+
+  kubernetes-e2e-gke-trusty-test)
+    # Override GKE default to use rc Cloud SDK
+    CLOUDSDK_BUCKET="gs://cloud-sdk-build/testing/rc"
+    : ${E2E_CLUSTER_NAME:="jkns-gke-e2e-test-trusty"}
+    : ${E2E_NETWORK:="e2e-gke-trusty-test"}
+    : ${E2E_SET_CLUSTER_API_VERSION:=y}
+    : ${JENKINS_USE_SERVER_VERSION:=y}
+    : ${PROJECT:="kubekins-e2e-gke-trusty-test"}
+    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
+    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
+          ${GKE_DEFAULT_SKIP_TESTS[@]:+${GKE_DEFAULT_SKIP_TESTS[@]}} \
+          ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
+          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
+          ${TRUSTY_STABLE_SKIP_TESTS[@]:+${TRUSTY_STABLE_SKIP_TESTS}} \
           )"}
     ;;
 


### PR DESCRIPTION
Add three jobs to run e2e tests against GKE prod/staging/test API endpoints with
Trusty as node image.

@roberthbailey @spxtr 

cc/ @andyzheng0831 
