### PR TITLE
AWS kube-up: make the bootstrap script run every boot

### DIFF
--- a/cluster/aws/templates/configure-vm-aws.sh
+++ b/cluster/aws/templates/configure-vm-aws.sh
@@ -34,7 +34,7 @@ ensure-packages() {
 }
 
 set-kube-env() {
-  local kube_env_yaml="${INSTALL_DIR}/kube_env.yaml"
+  local kube_env_yaml="/etc/kubernetes/kube_env.yaml"
 
   # kube-env has all the environment variables we care about, in a flat yaml format
   eval "$(python -c '

--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -982,7 +982,16 @@ function start-master() {
     echo ""
     echo "wget -O bootstrap ${BOOTSTRAP_SCRIPT_URL}"
     echo "chmod +x bootstrap"
-    echo "./bootstrap"
+    echo "mkdir -p /etc/kubernetes"
+    echo "mv kube_env.yaml /etc/kubernetes"
+    echo "mv bootstrap /etc/kubernetes/"
+    echo "cat > /etc/rc.local << EOF_RC_LOCAL"
+    echo "#!/bin/sh -e"
+    # We want to be sure that we don't pass an argument to bootstrap
+    echo "/etc/kubernetes/bootstrap"
+    echo "exit 0"
+    echo "EOF_RC_LOCAL"
+    echo "/etc/kubernetes/bootstrap"
   ) > "${KUBE_TEMP}/master-user-data"
 
   # Compress the data to fit under the 16KB limit (cloud-init accepts compressed data)
@@ -1067,7 +1076,16 @@ function start-minions() {
     echo ""
     echo "wget -O bootstrap ${BOOTSTRAP_SCRIPT_URL}"
     echo "chmod +x bootstrap"
-    echo "./bootstrap"
+    echo "mkdir -p /etc/kubernetes"
+    echo "mv kube_env.yaml /etc/kubernetes"
+    echo "mv bootstrap /etc/kubernetes/"
+    echo "cat > /etc/rc.local << EOF_RC_LOCAL"
+    echo "#!/bin/sh -e"
+    # We want to be sure that we don't pass an argument to bootstrap
+    echo "/etc/kubernetes/bootstrap"
+    echo "exit 0"
+    echo "EOF_RC_LOCAL"
+    echo "/etc/kubernetes/bootstrap"
   ) > "${KUBE_TEMP}/node-user-data"
 
   # Compress the data to fit under the 16KB limit (cloud-init accepts compressed data)


### PR DESCRIPTION
This is so we have the same behaviour as on GCE.

This also lets us change the bootstrap script or the config, which is
nice.  Instance data is immutable on AWS once it is booted.

Fix #21150
