### PR TITLE
Make downward API volume test run faster

### DIFF
--- a/hack/verify-flags/exceptions.txt
+++ b/hack/verify-flags/exceptions.txt
@@ -5,6 +5,7 @@ cluster/aws/templates/configure-vm-aws.sh:  # We set the hostname_override to th
 cluster/aws/templates/configure-vm-aws.sh:  api_servers: '${API_SERVERS}'
 cluster/aws/templates/configure-vm-aws.sh:  env-to-grains "hostname_override"
 cluster/aws/templates/configure-vm-aws.sh:  env-to-grains "runtime_config"
+cluster/aws/templates/salt-minion.sh:# We set the hostname_override to the full EC2 private dns name
 cluster/centos/util.sh:  local node_ip=${node#*@}
 cluster/gce/configure-vm.sh:  advertise_address: '${EXTERNAL_IP}'
 cluster/gce/configure-vm.sh:  api_servers: '${KUBERNETES_MASTER_NAME}'
@@ -94,12 +95,14 @@ hack/local-up-cluster.sh:    runtime_config=""
 pkg/kubelet/qos/memory_policy_test.go:			t.Errorf("oom_score_adj should be between %d and %d, but was %d", test.lowOOMScoreAdj, test.highOOMScoreAdj, oomScoreAdj)
 pkg/kubelet/qos/memory_policy_test.go:	highOOMScoreAdj int // The min oom_score_adj score the container should be assigned.
 pkg/kubelet/qos/memory_policy_test.go:	lowOOMScoreAdj  int // The max oom_score_adj score the container should be assigned.
+pkg/util/oom/oom_linux.go:			err = fmt.Errorf("failed to read oom_score_adj: %v", readErr)
+pkg/util/oom/oom_linux.go:			err = fmt.Errorf("failed to set oom_score_adj to %d: %v", oomScoreAdj, writeErr)
 pkg/util/oom/oom_linux.go:		return fmt.Errorf("invalid PID %d specified for oom_score_adj", pid)
 pkg/util/oom/oom_linux.go:	oomScoreAdjPath := path.Join("/proc", pidStr, "oom_score_adj")
 pkg/util/oom/oom_linux.go:// Writes 'value' to /proc/<pid>/oom_score_adj for all processes in cgroup cgroupName.
 pkg/util/oom/oom_linux.go:// Writes 'value' to /proc/<pid>/oom_score_adj. PID = 0 means self
 test/e2e/configmap.go:						Command: []string{"/mt", "--break_on_expected_content=false", "--retry_time=120", "--file_content_in_loop=/etc/configmap-volume/data-1"},
-test/e2e/downwardapi_volume.go:					Command: []string{"/mt", "--break_on_expected_content=false", "--retry_time=120", "--file_content_in_loop=" + filePath},
+test/e2e/downwardapi_volume.go:			Command: []string{"/mt", "--break_on_expected_content=false", "--retry_time=120", "--file_content_in_loop=" + filePath},
 test/e2e/es_cluster_logging.go:		Failf("No cluster_name field in Elasticsearch response: %v", esResponse)
 test/e2e/es_cluster_logging.go:	// Check to see if have a cluster_name field.
 test/e2e/es_cluster_logging.go:	clusterName, ok := esResponse["cluster_name"]

--- a/test/e2e/downwardapi_volume.go
+++ b/test/e2e/downwardapi_volume.go
@@ -34,7 +34,7 @@ var _ = Describe("Downward API volume", func() {
 	f := NewFramework("downward-api")
 	It("should provide podname only [Conformance]", func() {
 		podName := "downwardapi-volume-" + string(util.NewUUID())
-		pod := downwardAPIVolumePod(podName, map[string]string{}, map[string]string{}, "/etc/podname")
+		pod := downwardAPIVolumePodForSimpleTest(podName, "/etc/podname")
 
 		testContainerOutput("downward API volume plugin", f.Client, pod, 0, []string{
 			fmt.Sprintf("%s\n", podName),
@@ -45,7 +45,7 @@ var _ = Describe("Downward API volume", func() {
 		podName := "metadata-volume-" + string(util.NewUUID())
 		uid := int64(1001)
 		gid := int64(1234)
-		pod := downwardAPIVolumePod(podName, map[string]string{}, map[string]string{}, "/etc/podname")
+		pod := downwardAPIVolumePodForSimpleTest(podName, "/etc/podname")
 		pod.Spec.SecurityContext = &api.PodSecurityContext{
 			RunAsUser: &uid,
 			FSGroup:   &gid,
@@ -61,7 +61,7 @@ var _ = Describe("Downward API volume", func() {
 		labels["key2"] = "value2"
 
 		podName := "labelsupdate" + string(util.NewUUID())
-		pod := downwardAPIVolumePod(podName, labels, map[string]string{}, "/etc/labels")
+		pod := downwardAPIVolumePodForUpdateTest(podName, labels, map[string]string{}, "/etc/labels")
 		containerName := "client-container"
 		defer func() {
 			By("Deleting the pod")
@@ -98,7 +98,7 @@ var _ = Describe("Downward API volume", func() {
 		annotations := map[string]string{}
 		annotations["builder"] = "bar"
 		podName := "annotationupdate" + string(util.NewUUID())
-		pod := downwardAPIVolumePod(podName, map[string]string{}, annotations, "/etc/annotations")
+		pod := downwardAPIVolumePodForUpdateTest(podName, map[string]string{}, annotations, "/etc/annotations")
 
 		containerName := "client-container"
 		defer func() {
@@ -132,7 +132,50 @@ var _ = Describe("Downward API volume", func() {
 	})
 })
 
-func downwardAPIVolumePod(name string, labels, annotations map[string]string, filePath string) *api.Pod {
+func downwardAPIVolumePodForSimpleTest(name string, filePath string) *api.Pod {
+	pod := downwardAPIVolumeBasePod(name, nil, nil)
+
+	pod.Spec.Containers = []api.Container{
+		{
+			Name:    "client-container",
+			Image:   "gcr.io/google_containers/mounttest:0.6",
+			Command: []string{"/mt", "--file_content=" + filePath},
+			VolumeMounts: []api.VolumeMount{
+				{
+					Name:      "podinfo",
+					MountPath: "/etc",
+					ReadOnly:  false,
+				},
+			},
+		},
+	}
+
+	return pod
+}
+
+func downwardAPIVolumePodForUpdateTest(name string, labels, annotations map[string]string, filePath string) *api.Pod {
+	pod := downwardAPIVolumeBasePod(name, labels, annotations)
+
+	pod.Spec.Containers = []api.Container{
+		{
+			Name:    "client-container",
+			Image:   "gcr.io/google_containers/mounttest:0.6",
+			Command: []string{"/mt", "--break_on_expected_content=false", "--retry_time=120", "--file_content_in_loop=" + filePath},
+			VolumeMounts: []api.VolumeMount{
+				{
+					Name:      "podinfo",
+					MountPath: "/etc",
+					ReadOnly:  false,
+				},
+			},
+		},
+	}
+
+	applyLabelsAndAnnotationsToDownwardAPIPod(labels, annotations, pod)
+	return pod
+}
+
+func downwardAPIVolumeBasePod(name string, labels, annotations map[string]string) *api.Pod {
 	pod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Name:        name,
@@ -140,20 +183,6 @@ func downwardAPIVolumePod(name string, labels, annotations map[string]string, fi
 			Annotations: annotations,
 		},
 		Spec: api.PodSpec{
-			Containers: []api.Container{
-				{
-					Name:    "client-container",
-					Image:   "gcr.io/google_containers/mounttest:0.6",
-					Command: []string{"/mt", "--break_on_expected_content=false", "--retry_time=120", "--file_content_in_loop=" + filePath},
-					VolumeMounts: []api.VolumeMount{
-						{
-							Name:      "podinfo",
-							MountPath: "/etc",
-							ReadOnly:  false,
-						},
-					},
-				},
-			},
 			Volumes: []api.Volume{
 				{
 					Name: "podinfo",
@@ -176,6 +205,10 @@ func downwardAPIVolumePod(name string, labels, annotations map[string]string, fi
 		},
 	}
 
+	return pod
+}
+
+func applyLabelsAndAnnotationsToDownwardAPIPod(labels, annotations map[string]string, pod *api.Pod) {
 	if len(labels) > 0 {
 		pod.Spec.Volumes[0].DownwardAPI.Items = append(pod.Spec.Volumes[0].DownwardAPI.Items, api.DownwardAPIVolumeFile{
 			Path: "labels",
@@ -195,7 +228,6 @@ func downwardAPIVolumePod(name string, labels, annotations map[string]string, fi
 			},
 		})
 	}
-	return pod
 }
 
 // TODO: add test-webserver example as pointed out in https://github.com/kubernetes/kubernetes/pull/5093#discussion-diff-37606771


### PR DESCRIPTION
TL;DR: two test cases in this e2e were written to poll the fs for updates for an extended period of time unnecessarily.  Replaced this with the normal method we use to do the simpler tests of projections into volumes

cc @sdminonne @smarterclayton @thockin 
