### PR TITLE
Revert 20202. Use other measures to prevent race in test-cmd.sh

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -209,6 +209,20 @@ PATH="${KUBE_OUTPUT_HOSTBIN}":$PATH
 kube::log::status "Checking kubectl version"
 kubectl version
 
+# TODO: we need to note down the current default namespace and set back to this
+# namespace after the tests are done.
+kubectl config view
+CONTEXT="test"
+kubectl config set-context "${CONTEXT}"
+kubectl config use-context "${CONTEXT}"
+
+i=0
+create_and_use_new_namespace() {
+  i=$(($i+1))
+  kubectl create namespace "namespace${i}"
+  kubectl config set-context "${CONTEXT}" --namespace="namespace${i}"
+}
+
 runTests() {
   version="$1"
   echo "Testing api version: $1"
@@ -310,6 +324,7 @@ runTests() {
 
   ### Create POD valid-pod from JSON
   # Pre-condition: no POD exists
+  create_and_use_new_namespace
   kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
   # Command
   kubectl create "${kube_flags[@]}" -f docs/admin/limitrange/valid-pod.yaml
@@ -345,9 +360,10 @@ runTests() {
 
   ### Create POD valid-pod from dumped YAML
   # Pre-condition: no POD exists
+  create_and_use_new_namespace
   kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
   # Command
-  echo "${output_pod}" | kubectl create -f - "${kube_flags[@]}"
+  echo "${output_pod}" | sed '/namespace:/d' | kubectl create -f - "${kube_flags[@]}"
   # Post-condition: valid-pod POD is created
   kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" 'valid-pod:'
 
@@ -359,8 +375,9 @@ runTests() {
   # Post-condition: valid-pod POD doesn't exist
   kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
 
-  ### Create POD redis-master from JSON
+  ### Create POD valid-pod from JSON
   # Pre-condition: no POD exists
+  create_and_use_new_namespace
   kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
   # Command
   kubectl create -f docs/admin/limitrange/valid-pod.yaml "${kube_flags[@]}"
@@ -375,8 +392,9 @@ runTests() {
   # Post-condition: valid-pod POD doesn't exist
   kube::test::get_object_assert "pods -l'name in (valid-pod)'" '{{range.items}}{{$id_field}}:{{end}}' ''
 
-  ### Create POD valid-pod from JSON
+  ### Create POD valid-pod from YAML
   # Pre-condition: no POD exists
+  create_and_use_new_namespace
   kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
   # Command
   kubectl create -f docs/admin/limitrange/valid-pod.yaml "${kube_flags[@]}"
@@ -409,6 +427,7 @@ runTests() {
 
   ### Create two PODs
   # Pre-condition: no POD exists
+  create_and_use_new_namespace
   kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
   # Command
   kubectl create -f docs/admin/limitrange/valid-pod.yaml "${kube_flags[@]}"
@@ -426,6 +445,7 @@ runTests() {
 
   ### Create valid-pod POD
   # Pre-condition: no POD exists
+  create_and_use_new_namespace
   kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
   # Command
   kubectl create -f docs/admin/limitrange/valid-pod.yaml "${kube_flags[@]}"
@@ -450,6 +470,7 @@ runTests() {
 
   ### Create valid-pod POD
   # Pre-condition: no POD exists
+  create_and_use_new_namespace
   kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
   # Command
   kubectl create -f docs/admin/limitrange/valid-pod.yaml "${kube_flags[@]}"
@@ -586,6 +607,7 @@ __EOF__
 
   ### Create two PODs from 1 yaml file
   # Pre-condition: no POD exists
+  create_and_use_new_namespace
   kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
   # Command
   kubectl create -f docs/user-guide/multi-pod.yaml "${kube_flags[@]}"
@@ -603,6 +625,7 @@ __EOF__
   ## kubectl apply should update configuration annotations only if apply is already called
   ## 1. kubectl create doesn't set the annotation
   # Pre-Condition: no POD exists
+  create_and_use_new_namespace
   kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
   # Command: create a pod "test-pod"
   kubectl create -f hack/testdata/pod.yaml "${kube_flags[@]}"
@@ -643,6 +666,7 @@ __EOF__
   ## Configuration annotations should be set when --save-config is enabled
   ## 1. kubectl create --save-config should generate configuration annotation
   # Pre-Condition: no POD exists
+  create_and_use_new_namespace
   kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
   # Command: create a pod "test-pod"
   kubectl create -f hack/testdata/pod.yaml --save-config "${kube_flags[@]}"
@@ -652,6 +676,7 @@ __EOF__
   kubectl delete -f hack/testdata/pod.yaml "${kube_flags[@]}"
   ## 2. kubectl edit --save-config should generate configuration annotation
   # Pre-Condition: no POD exists, then create pod "test-pod", which shouldn't have configuration annotation
+  create_and_use_new_namespace
   kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
   kubectl create -f hack/testdata/pod.yaml "${kube_flags[@]}"
   ! [[ "$(kubectl get pods test-pod -o yaml "${kube_flags[@]}" | grep kubectl.kubernetes.io/last-applied-configuration)" ]]
@@ -666,6 +691,7 @@ __EOF__
   kubectl delete -f hack/testdata/pod.yaml "${kube_flags[@]}"
   ## 3. kubectl replace --save-config should generate configuration annotation
   # Pre-Condition: no POD exists, then create pod "test-pod", which shouldn't have configuration annotation
+  create_and_use_new_namespace
   kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
   kubectl create -f hack/testdata/pod.yaml "${kube_flags[@]}"
   ! [[ "$(kubectl get pods test-pod -o yaml "${kube_flags[@]}" | grep kubectl.kubernetes.io/last-applied-configuration)" ]]
@@ -684,7 +710,7 @@ __EOF__
   [[ "$(kubectl get rc nginx -o yaml "${kube_flags[@]}" | grep kubectl.kubernetes.io/last-applied-configuration)" ]]
   ## 5. kubectl expose --save-config should generate configuration annotation
   # Pre-Condition: no service exists
-  kube::test::get_object_assert svc "{{range.items}}{{$id_field}}:{{end}}" 'kubernetes:'
+  kube::test::get_object_assert svc "{{range.items}}{{$id_field}}:{{end}}" ''
   # Command: expose the rc "nginx"
   kubectl expose rc nginx --save-config --port=80 --target-port=8000 "${kube_flags[@]}"
   # Post-Condition: service "nginx" has configuration annotation
@@ -739,7 +765,8 @@ __EOF__
 
   ### Create a new namespace
   # Pre-condition: only the "default" namespace exists
-  kube::test::get_object_assert namespaces "{{range.items}}{{$id_field}}:{{end}}" 'default:'
+  # The Pre-condition doesn't hold anymore after we create and switch namespaces before creating pods with same name in the test.
+  # kube::test::get_object_assert namespaces "{{range.items}}{{$id_field}}:{{end}}" 'default:'
   # Command
   kubectl create namespace my-namespace
   # Post-condition: namespace 'my-namespace' is created.
@@ -879,7 +906,8 @@ __EOF__
   ############
   # Services #
   ############
-
+  # switch back to the default namespace
+  kubectl config set-context "${CONTEXT}" --namespace=""
   kube::log::status "Testing kubectl(${version}:services)"
 
   ### Create redis-master service from JSON
@@ -1571,7 +1599,7 @@ __EOF__
   ############################
 
   # Pre-condition: the "default" namespace exists
-  kube::test::get_object_assert namespaces "{{range.items}}{{$id_field}}:{{end}}" 'default:'
+  kube::test::get_object_assert namespaces "{{range.items}}{{if eq $id_field \\\"default\\\"}}{{$id_field}}:{{end}}{{end}}" 'default:'
 
   ### Create POD
   # Pre-condition: no POD exists

--- a/pkg/api/rest/resttest/resttest.go
+++ b/pkg/api/rest/resttest/resttest.go
@@ -674,7 +674,7 @@ func (t *Tester) testDeleteGracefulImmediate(obj runtime.Object, setFn SetFunc, 
 	}
 	objectMeta = t.getObjectMetaOrFail(out)
 	// the second delete shouldn't update the object, so the objectMeta.DeletionGracePeriodSeconds should eqaul to the value set in the first delete.
-	if objectMeta.DeletionTimestamp == nil || objectMeta.DeletionGracePeriodSeconds == nil || *objectMeta.DeletionGracePeriodSeconds != expectedGrace {
+	if objectMeta.DeletionTimestamp == nil || objectMeta.DeletionGracePeriodSeconds == nil || *objectMeta.DeletionGracePeriodSeconds != 0 {
 		t.Errorf("unexpected deleted meta: %#v", objectMeta)
 	}
 }

--- a/pkg/registry/generic/etcd/etcd.go
+++ b/pkg/registry/generic/etcd/etcd.go
@@ -396,7 +396,7 @@ func (e *Etcd) Delete(ctx api.Context, name string, options *api.DeleteOptions) 
 	if pendingGraceful {
 		return e.finalizeDelete(obj, false)
 	}
-	if graceful && *options.GracePeriodSeconds > 0 {
+	if graceful {
 		out := e.NewFunc()
 		lastGraceful := int64(0)
 		err := e.Storage.GuaranteedUpdate(


### PR DESCRIPTION
#20202 skips the update when a pod is deleted with grace period = 0. That breaks the non-graceful deletion, pods will get a default deletion grace period even if the grace period is set to 0. This PR adds back the update. So the race between API server and nodecontroller/kubelet in a non-graceful deletion comes back. I haven't taken any measure to fix this race in this PR, because this race only occurs if API server is context-switched after it has done the "update" but before it does the "delete", i.e. [here](https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/generic/etcd/etcd.go#L428), which is unlikely to happen.

Reverting #20202 also lets another kind of race come back: kubelet and nodecontroller might send a deletion request that ends up deleting a deleted and then recreated pod. Kubelet has taken measures to prevent such a race, ~~I made the node controller to do the same in the second commit.~~ [Update] this is too risky for 1.2, I removed this commit.

cc @mikedanese.

I also revised hack/test-cmd.sh to switch namespace before recreating a deleted pod to completely avoid the latter race condition when running that script.

@smarterclayton @yujuhong @lavalamp 
