### PR TITLE
Can't replace a generic resource that is cluster scoped

### DIFF
--- a/pkg/kubectl/resource/helper.go
+++ b/pkg/kubectl/resource/helper.go
@@ -144,7 +144,7 @@ func (m *Helper) Replace(namespace, name string, overwrite bool, obj runtime.Obj
 	}
 	if version == "" && overwrite {
 		// Retrieve the current version of the object to overwrite the server object
-		serverObj, err := c.Get().Namespace(namespace).Resource(m.Resource).Name(name).Do().Get()
+		serverObj, err := c.Get().NamespaceIfScoped(namespace, m.NamespaceScoped).Resource(m.Resource).Name(name).Do().Get()
 		if err != nil {
 			// The object does not exist, but we want it to be created
 			return m.replaceResource(c, m.Resource, namespace, name, obj)


### PR DESCRIPTION
It should be allowed to invoke kubectl replace with a JSON file that has
no resource version set.  Namespaced resources were working correctly,
but cluster resources were silently failing to lookup the current state
of the object to get the resource version because we weren't using
NamespaceIfScoped(). Added a failing test.

```
kubectl replace -f file.json #where file.json is a Node with an empty resource version
```

@deads2k @krousey
