### PR TITLE
allow disambiguation of resources

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -666,7 +666,7 @@ runTests() {
   # Command: autoscale rc "frontend"
   kubectl autoscale -f examples/guestbook/frontend-controller.yaml --save-config "${kube_flags[@]}" --max=2
   # Post-Condition: hpa "frontend" has configuration annotation
-  [[ "$(kubectl get hpa frontend -o yaml "${kube_flags[@]}" | grep kubectl.kubernetes.io/last-applied-configuration)" ]]
+  [[ "$(kubectl get hpa.extensions frontend -o yaml "${kube_flags[@]}" | grep kubectl.kubernetes.io/last-applied-configuration)" ]]
   # Clean up
   kubectl delete rc,hpa frontend "${kube_flags[@]}"
 
@@ -1125,10 +1125,10 @@ __EOF__
   kube::test::get_object_assert deployment "{{range.items}}{{$id_field}}:{{end}}" 'nginx-deployment:'
   # autoscale 2~3 pods, default CPU utilization (80%)
   kubectl-with-retry autoscale deployment nginx-deployment "${kube_flags[@]}" --min=2 --max=3
-  kube::test::get_object_assert 'hpa nginx-deployment' "{{$hpa_min_field}} {{$hpa_max_field}} {{$hpa_cpu_field}}" '2 3 80'
+  kube::test::get_object_assert 'hpa.extensions nginx-deployment' "{{$hpa_min_field}} {{$hpa_max_field}} {{$hpa_cpu_field}}" '2 3 80'
   # Clean up
   kubectl delete hpa nginx-deployment "${kube_flags[@]}"
-  kubectl delete deployment nginx-deployment "${kube_flags[@]}"
+  kubectl delete deployment.extensions nginx-deployment "${kube_flags[@]}"
 
   ### Rollback a deployment
   # Pre-condition: no deployment exists
@@ -1143,7 +1143,7 @@ __EOF__
   kube::test::get_object_assert deployment "{{range.items}}{{$deployment_image_field}}:{{end}}" 'nginx:'
   # Update the deployment (revision 2)
   kubectl apply -f hack/testdata/deployment-revision2.yaml "${kube_flags[@]}"
-  kube::test::get_object_assert deployment "{{range.items}}{{$deployment_image_field}}:{{end}}" 'nginx:latest:'
+  kube::test::get_object_assert deployment.extensions "{{range.items}}{{$deployment_image_field}}:{{end}}" 'nginx:latest:'
   # Rollback to revision 1
   kubectl rollout undo deployment nginx-deployment --to-revision=1 "${kube_flags[@]}"
   sleep 1

--- a/pkg/api/unversioned/group_version.go
+++ b/pkg/api/unversioned/group_version.go
@@ -46,6 +46,17 @@ func (gr *GroupResource) String() string {
 	return gr.Resource + "." + gr.Group
 }
 
+// ParseGroupResource turns "resource.group" string into a GroupResource struct.  Empty strings are allowed
+// for each field.
+func ParseGroupResource(gr string) GroupResource {
+	s := strings.SplitN(gr, ".", 2)
+	if len(s) == 1 {
+		return GroupResource{Resource: s[0]}
+	}
+
+	return GroupResource{Group: s[1], Resource: s[0]}
+}
+
 // GroupVersionResource unambiguously identifies a resource.  It doesn't anonymously include GroupVersion
 // to avoid automatic coersion.  It doesn't use a GroupVersion to avoid custom marshalling
 //

--- a/pkg/kubectl/cmd/explain.go
+++ b/pkg/kubectl/cmd/explain.go
@@ -79,7 +79,7 @@ func RunExplain(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []st
 	}
 
 	// TODO: We should deduce the group for a resource by discovering the supported resources at server.
-	gvk, err := mapper.KindFor(unversioned.GroupVersionResource{Resource: inModel})
+	gvk, err := mapper.KindFor(unversioned.ParseGroupResource(inModel).WithVersion(""))
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/unversioned"
-	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
 const kubectlAnnotationPrefix = "kubectl.kubernetes.io/"
@@ -97,32 +96,36 @@ func (e ShortcutExpander) ResourceSingularizer(resource string) (string, error) 
 	return e.RESTMapper.ResourceSingularizer(expandResourceShortcut(unversioned.GroupVersionResource{Resource: resource}).Resource)
 }
 
+// shortForms is the list of short names to their expanded names
+var shortForms = map[string]string{
+	// Please keep this alphabetized
+	"cs":     "componentstatuses",
+	"ds":     "daemonsets",
+	"ep":     "endpoints",
+	"ev":     "events",
+	"hpa":    "horizontalpodautoscalers",
+	"ing":    "ingresses",
+	"limits": "limitranges",
+	"no":     "nodes",
+	"ns":     "namespaces",
+	"po":     "pods",
+	"psp":    "podSecurityPolicies",
+	"pvc":    "persistentvolumeclaims",
+	"pv":     "persistentvolumes",
+	"quota":  "resourcequotas",
+	"rc":     "replicationcontrollers",
+	"rs":     "replicasets",
+	"svc":    "services",
+}
+
 // expandResourceShortcut will return the expanded version of resource
 // (something that a pkg/api/meta.RESTMapper can understand), if it is
 // indeed a shortcut. Otherwise, will return resource unmodified.
 func expandResourceShortcut(resource unversioned.GroupVersionResource) unversioned.GroupVersionResource {
-	shortForms := map[string]unversioned.GroupVersionResource{
-		// Please keep this alphabetized
-		"cs":     api.SchemeGroupVersion.WithResource("componentstatuses"),
-		"ds":     extensions.SchemeGroupVersion.WithResource("daemonsets"),
-		"ep":     api.SchemeGroupVersion.WithResource("endpoints"),
-		"ev":     api.SchemeGroupVersion.WithResource("events"),
-		"hpa":    extensions.SchemeGroupVersion.WithResource("horizontalpodautoscalers"),
-		"ing":    extensions.SchemeGroupVersion.WithResource("ingresses"),
-		"limits": api.SchemeGroupVersion.WithResource("limitranges"),
-		"no":     api.SchemeGroupVersion.WithResource("nodes"),
-		"ns":     api.SchemeGroupVersion.WithResource("namespaces"),
-		"po":     api.SchemeGroupVersion.WithResource("pods"),
-		"psp":    api.SchemeGroupVersion.WithResource("podSecurityPolicies"),
-		"pvc":    api.SchemeGroupVersion.WithResource("persistentvolumeclaims"),
-		"pv":     api.SchemeGroupVersion.WithResource("persistentvolumes"),
-		"quota":  api.SchemeGroupVersion.WithResource("resourcequotas"),
-		"rc":     api.SchemeGroupVersion.WithResource("replicationcontrollers"),
-		"rs":     extensions.SchemeGroupVersion.WithResource("replicasets"),
-		"svc":    api.SchemeGroupVersion.WithResource("services"),
-	}
 	if expanded, ok := shortForms[resource.Resource]; ok {
-		return expanded
+		// don't change the group or version that's already been specified
+		resource.Resource = expanded
+		return resource
 	}
 	return resource
 }

--- a/pkg/kubectl/resource/builder.go
+++ b/pkg/kubectl/resource/builder.go
@@ -440,7 +440,7 @@ func (b *Builder) resourceMappings() ([]*meta.RESTMapping, error) {
 	}
 	mappings := []*meta.RESTMapping{}
 	for _, r := range b.resources {
-		gvk, err := b.mapper.KindFor(unversioned.GroupVersionResource{Resource: r})
+		gvk, err := b.mapper.KindFor(unversioned.ParseGroupResource(r).WithVersion(""))
 		if err != nil {
 			return nil, err
 		}
@@ -460,7 +460,7 @@ func (b *Builder) resourceTupleMappings() (map[string]*meta.RESTMapping, error) 
 		if _, ok := mappings[r.Resource]; ok {
 			continue
 		}
-		gvk, err := b.mapper.KindFor(unversioned.GroupVersionResource{Resource: r.Resource})
+		gvk, err := b.mapper.KindFor(unversioned.ParseGroupResource(r.Resource).WithVersion(""))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This allows users to disambiguate resources by adding a group.  For instance `kubectl get hpa.extensions`.

Without the ability to move the legacy kube resources into a group, I'm running into a specification snag.  Inside of a RESTMapper, how can I tell the difference between legacy kube and unspecified.  @smarterclayton which pulls do we need in order to default groups during conversion?  If its pretty far out, I can pursue a workaround that would work for a RESTMapper using a synthetic group.

Regardless of how we handle empty/legacy disambiguation, I expect this pull to necessary.

@kubernetes/kubectl @liggitt @lavalamp @caesarxuchao @bgrant0607 
