### PR TITLE
SPDY roundtripper must respect InsecureSkipVerify

### DIFF
--- a/pkg/util/httpstream/spdy/roundtripper.go
+++ b/pkg/util/httpstream/spdy/roundtripper.go
@@ -53,6 +53,10 @@ type SpdyRoundTripper struct {
 
 	// Dialer is the dialer used to connect.  Used if non-nil.
 	Dialer *net.Dialer
+
+	// proxier knows which proxy to use given a request, defaults to http.ProxyFromEnvironment
+	// Used primarily for mocking the proxy discovery in tests.
+	proxier func(req *http.Request) (*url.URL, error)
 }
 
 // NewRoundTripper creates a new SpdyRoundTripper that will use
@@ -70,7 +74,11 @@ func NewSpdyRoundTripper(tlsConfig *tls.Config) *SpdyRoundTripper {
 // dial dials the host specified by req, using TLS if appropriate, optionally
 // using a proxy server if one is configured via environment variables.
 func (s *SpdyRoundTripper) dial(req *http.Request) (net.Conn, error) {
-	proxyURL, err := http.ProxyFromEnvironment(req)
+	proxier := s.proxier
+	if proxier == nil {
+		proxier = http.ProxyFromEnvironment
+	}
+	proxyURL, err := proxier(req)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +114,7 @@ func (s *SpdyRoundTripper) dial(req *http.Request) (net.Conn, error) {
 		return rwc, nil
 	}
 
-	host, _, err := net.SplitHostPort(req.URL.Host)
+	host, _, err := net.SplitHostPort(targetHost)
 	if err != nil {
 		return nil, err
 	}
@@ -120,6 +128,11 @@ func (s *SpdyRoundTripper) dial(req *http.Request) (net.Conn, error) {
 	// need to manually call Handshake() so we can call VerifyHostname() below
 	if err := tlsConn.Handshake(); err != nil {
 		return nil, err
+	}
+
+	// Return if we were configured to skip validation
+	if s.tlsConfig != nil && s.tlsConfig.InsecureSkipVerify {
+		return tlsConn, nil
 	}
 
 	if err := tlsConn.VerifyHostname(host); err != nil {


### PR DESCRIPTION
~~Starting in Go 1.5, VerifyHostname in crypto/tls changed to reject the call if certificates weren't verified against the hostname beforehand.~~

~~So we now get the TLS connection state and call VerifyHostname on certificates directly. Also, we need to skip the check in case InsecureSkipVerify.~~

~~@ncdc can you please take a look? This is related to errors like "handshake did not verify certificate chain" in exec and related commands when compiled with Go 1.5+.~~

The investigation of the issue above ended up exposing that we were skipping the hostname verify when TLSSkipVerify was true. This PR fixes it.
