### PR TITLE
Adding a jenkins job config for linkchecker

### DIFF
--- a/hack/jenkins/job-configs/test-linkchecker.yaml
+++ b/hack/jenkins/job-configs/test-linkchecker.yaml
@@ -1,0 +1,33 @@
+- job:
+    name: 'kubernetes-test-linkchecker'
+    description: |
+        Grab the latest from GitHub, then run hack/verify-linkcheck.sh.<br>
+        Test Owner: Build Cop
+    logrotate:
+        numToKeep: 200
+    builders:
+        - shell: './hack/verify-linkcheck.sh'
+    publishers:
+        - claim-build
+        - gcs-uploader
+        - email-ext:
+            recipients: 'xuchao@google.com'
+    scm:
+        - git:
+            url: https://github.com/kubernetes/kubernetes
+            branches:
+                - 'master'
+            browser: githubweb
+            browser-url: https://github.com/kubernetes/kubernetes
+            wipe-workspace: false
+            skip-tag: true
+    triggers:
+        - timed: '@daily'
+    wrappers:
+        - ansicolor:
+            colormap: xterm
+        - timeout:
+            timeout: 60
+            fail: true
+        - timestamps
+        - workspace-cleanup


### PR DESCRIPTION
This PR creates a Jenkins job config to run linkchecker daily, which checks if the links in our docs are effective. This is the final step toward fixing #16233.
