### PR TITLE
WIP: Allow patch to use the input object as the patch

### DIFF
--- a/pkg/kubectl/resource/mapper.go
+++ b/pkg/kubectl/resource/mapper.go
@@ -76,6 +76,7 @@ func (m *Mapper) InfoForData(data []byte, source string) (*Info, error) {
 		Namespace:       namespace,
 		Name:            name,
 		Source:          source,
+		Raw:             data,
 		VersionedObject: versioned,
 		Object:          obj,
 		ResourceVersion: resourceVersion,


### PR DESCRIPTION
A number of commands can easily generate API objects that are sufficient
for create, but none of our update/replace/patch/apply commands make it
easy to add a list of them.

Upgrade patch to support multiple objects, and allow the input bytes
from patch to come from the objects on disk:

```
kubectl run ... --dry-run -o yaml | kubectl patch -f - -p -
```

Each object coming out of the chain will be patched on top of the
existing object.  This is much more useful than update, which fails for
most operations.

Has no tests and is not for 1.2, but allows a lot of useful CLI interactions that are otherwise extremely tedious.

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/21196)

<!-- Reviewable:end -->
