### PR TITLE
AWS: Create jessie image

### DIFF
--- a/cluster/cloudimages/README.md
+++ b/cluster/cloudimages/README.md
@@ -1,0 +1,40 @@
+## Kubernetes-optimized images
+
+This directory contains manifests for building Kubernetes-optimized images for
+various clouds (currently just AWS).  It is currently highly experimental, and
+these images are not used by default (though you can pass `AWS_IMAGE` to the
+AWS kube-up script if you're feeling brave).
+
+Advantages of an optimized image:
+
+* We can preinstall packages that would otherwise require a download.  Great
+  for speed, and also for reliability (in case the source repository is down)
+* We can make kernel configuration changes that might otherwise require a
+  reboot, or even apply kernel patches if we really want to.  For example,
+  Debian requires a kernel boot parameter to enable the cgroup memory
+  controller, which we require.
+* The more configuration we can do in advance, the easier it is for people that
+  don't want to use kube-up to get a cluster up and running.
+
+Advantages of a harmonized image:
+
+* All the platforms can test with the same versions of software, rather than
+  relying on whatever image happens to be optimal on that cloud.
+
+## bootstrap-vz
+
+Currently images are built using
+(bootstrap-vz)[https://github.com/andsens/bootstrap-vz], because this is
+default builder for the official Debian images, and because it supports
+multiple clouds including AWS, Azure & GCE.  It also supports KVM, which should
+support OpenStack.
+
+## Building an image
+
+A go program/script to build images in (in
+progress)[https://github.com/kubernetes/contrib/pull/486], in the contrib
+project.
+
+
+
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/cluster/cloudimages/README.md?pixel)]()

--- a/cluster/cloudimages/k8s-ebs-jessie-amd64-hvm.yml
+++ b/cluster/cloudimages/k8s-ebs-jessie-amd64-hvm.yml
@@ -1,0 +1,90 @@
+---
+name: k8s-1.2-debian-{system.release}-{system.architecture}-{provider.virtualization}-{%Y}-{%m}-{%d}-ebs
+provider:
+  name: ec2
+  virtualization: hvm
+  enhanced_networking: simple
+  description: Kubernetes 1.2 Base Image - Debian {system.release} {system.architecture}
+bootstrapper:
+  workspace: /target
+  # tarball speeds up development, but for prod builds we want to be 100% sure...
+  # tarball: true
+system:
+  release: jessie
+  architecture: amd64
+  # We use grub, not extlinux.
+  # See https://github.com/andsens/bootstrap-vz/issues/182
+  # extlinux makes it harder to modify boot args, and may have reboot problems
+  # bootloader: extlinux
+  bootloader: grub
+  charmap: UTF-8
+  locale: en_US
+  timezone: UTC
+volume:
+  backing: ebs
+  partitions:
+    type: msdos
+    root:
+      filesystem: ext4
+      size: 8GiB
+packages:
+  mirror: http://cloudfront.debian.net/debian
+  install:
+    # these packages are included in the official image
+    - python-boto
+    - python3-boto
+    - apt-transport-https
+    - lvm2
+    - ncurses-term
+    - parted
+    - bootlogd
+    - cloud-init
+    - cloud-utils
+    - gdisk
+    - sysvinit
+    - systemd
+    - systemd-sysv
+
+    # these packages are included in the official image, but we remove them
+    # awscli : we install from pip instead
+
+    # cloud-initramfs-growroot will resize the master partition on boot
+    - cloud-initramfs-growroot
+    # These packages would otherwise be installed during first boot
+    - aufs-tools
+    - curl
+    - python-yaml
+    - git
+    - nfs-common
+    - bridge-utils
+    - logrotate
+    - socat
+    - python-apt
+    - apt-transport-https
+    - unattended-upgrades
+    - lvm2
+    - btrfs-tools
+
+    # So we can install the latest awscli
+    - python-pip
+plugins:
+  cloud_init:
+    metadata_sources: Ec2
+    username: admin
+  ntp: {}
+  commands:
+    commands:
+       # Install python-pip
+       - [ 'chroot', '{root}', 'pip', 'install', 'awscli' ]
+
+       # We perform a full replacement of some grub conf variables:
+       #   GRUB_CMDLINE_LINUX_DEFAULT (add memory cgroup)
+       #   GRUB_TIMEOUT (remove boot delay)
+       # (but leave the old versions commented out for people to see)
+       - [ 'chroot', '{root}', 'touch', '/etc/default/grub' ]
+       - [ 'chroot', '{root}', 'sed', '-i', 's/^GRUB_CMDLINE_LINUX_DEFAULT=/#GRUB_CMDLINE_LINUX_DEFAULT=/g', '/etc/default/grub' ]
+       - [ 'chroot', '{root}', 'sed', '-i', 's/^GRUB_TIMEOUT=/#GRUB_TIMEOUT=/g', '/etc/default/grub' ]
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "# kubernetes image changes" >> /etc/default/grub' ]
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX_DEFAULT=\"cgroup_enable=memory oops=panic panic=10 console=ttyS0\"" >> /etc/default/grub' ]
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_TIMEOUT=0" >> /etc/default/grub' ]
+       - [ 'chroot', '{root}', 'update-grub2' ]


### PR DESCRIPTION
Based on the official debian image, with the following changes:
- Switched extlinux -> grub, because we need to change kernel options
  to enable the memory cgroup controller, and extlinux is harder and has
  reboot problems
- Added packages that would otherwise be installed as part of the boot
  (just an optimization)

Big problem still TODO is that the boot volume doesn't resize.  This is
a known problem upstream, supposedly fixed in bootstrap-vz, but not
working for me.
