### PR TITLE
AWS kube-up: Add support for wily

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -57,7 +57,7 @@ fi
 OS_DISTRIBUTION=${KUBE_OS_DISTRIBUTION}
 
 case "${KUBE_OS_DISTRIBUTION}" in
-  trusty|wheezy|jessie|vivid|coreos)
+  trusty|wheezy|jessie|vivid|wily|coreos)
     source "${KUBE_ROOT}/cluster/aws/${KUBE_OS_DISTRIBUTION}/util.sh"
     ;;
   *)
@@ -271,6 +271,9 @@ case "${KUBE_OS_DISTRIBUTION}" in
     ;;
   vivid)
     detect-vivid-image
+    ;;
+  wily)
+    detect-wily-image
     ;;
   wheezy)
     detect-wheezy-image

--- a/cluster/aws/wily/util.sh
+++ b/cluster/aws/wily/util.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+source "${KUBE_ROOT}/cluster/aws/trusty/common.sh"
+
+SSH_USER=ubuntu
+
+# Detects the AMI to use for ubuntu (considering the region)
+#
+# Vars set:
+#   AWS_IMAGE
+function detect-wily-image () {
+  # This is the ubuntu 15.10 image for <region>, amd64, hvm:ebs-ssd
+  # See here: http://cloud-images.ubuntu.com/locator/ec2/ for other images
+  # This will need to be updated from time to time as amis are deprecated
+  if [[ -z "${AWS_IMAGE-}" ]]; then
+    case "${AWS_REGION}" in
+      ap-northeast-1)
+        AWS_IMAGE=ami-3355505d
+        ;;
+
+      ap-southeast-1)
+        AWS_IMAGE=ami-60975903
+        ;;
+
+      eu-central-1)
+        AWS_IMAGE=ami-6da2ba01
+        ;;
+
+      eu-west-1)
+        AWS_IMAGE=ami-36a71645
+        ;;
+
+      sa-east-1)
+        AWS_IMAGE=ami-fd36b691
+        ;;
+
+      us-east-1)
+        AWS_IMAGE=ami-6610390c
+        ;;
+
+      us-west-1)
+        AWS_IMAGE=ami-6e64120e
+        ;;
+
+      cn-north-1)
+        AWS_IMAGE=ami-17a76f7a
+        ;;
+
+      us-gov-west-1)
+        AWS_IMAGE=ami-b0bad893
+        ;;
+
+      ap-southeast-2)
+        AWS_IMAGE=ami-3895b15b
+        ;;
+
+      us-west-2)
+        AWS_IMAGE=ami-d95abcb9
+        ;;
+
+      *)
+        echo "Please specify AWS_IMAGE directly (region ${AWS_REGION} not recognized)"
+        exit 1
+    esac
+  fi
+}
+

--- a/cluster/saltbase/pillar/systemd.sls
+++ b/cluster/saltbase/pillar/systemd.sls
@@ -1,4 +1,4 @@
-{% if grains['oscodename'] in [ 'vivid', 'jessie' ] %}
+{% if grains['oscodename'] in [ 'vivid', 'wily', 'jessie' ] %}
 is_systemd: True
 systemd_system_path: /lib/systemd/system
 {% elif grains['os_family'] == 'RedHat' %}

--- a/cluster/saltbase/salt/docker/init.sls
+++ b/cluster/saltbase/salt/docker/init.sls
@@ -217,6 +217,15 @@ net.ipv4.ip_forward:
 {% set override_deb='docker-engine_1.8.3-0~vivid_amd64.deb' %}
 {% set override_deb_url='http://apt.dockerproject.org/repo/pool/main/d/docker-engine/docker-engine_1.8.3-0~vivid_amd64.deb' %}
 {% set override_deb_sha1='f0259b1f04635977325c0cfa7c0006e1e5de1341' %}
+{% elif grains.get('cloud', '') == 'aws'
+   and grains.get('os_family', '') == 'Debian'
+   and grains.get('oscodename', '') == 'wily' -%}
+# TODO: Get from google storage?
+{% set docker_pkg_name='docker-engine' %}
+{% set override_docker_ver='1.8.3-0~wily' %}
+{% set override_deb='docker-engine_1.8.3-0~wily_amd64.deb' %}
+{% set override_deb_url='http://apt.dockerproject.org/repo/pool/main/d/docker-engine/docker-engine_1.8.3-0~wily_amd64.deb' %}
+{% set override_deb_sha1='aa00313498e0e8e73d9eedb39cbdff33b1474c16' %}
 {% else %}
 {% set docker_pkg_name='lxc-docker-1.7.1' %}
 {% set override_docker_ver='1.7.1' %}

--- a/cluster/saltbase/salt/kubelet/default
+++ b/cluster/saltbase/salt/kubelet/default
@@ -117,7 +117,7 @@
     {% set  kubelet_container= "--kubelet-cgroups=/kubelet" -%}
   {% endif %}
 {% endif -%}
-{% if grains['oscodename'] == 'vivid' -%}
+{% if grains['oscodename'] in ['vivid','wily'] -%}
   {% set cgroup_root = "--cgroup-root=docker" -%}
 {% endif -%}
 


### PR DESCRIPTION
vivid is technically no longer supported now, so we should support
wily.
