### PR TITLE
AWS Debian Jessie Support

### DIFF
--- a/cluster/aws/jessie/util.sh
+++ b/cluster/aws/jessie/util.sh
@@ -22,60 +22,19 @@ source "${KUBE_ROOT}/cluster/aws/trusty/common.sh"
 SSH_USER=admin
 
 # Detects the AMI to use for jessie (considering the region)
-# Source: https://wiki.debian.org/Cloud/AmazonEC2Image/Jessie
 #
 # Vars set:
 #   AWS_IMAGE
 function detect-jessie-image () {
   if [[ -z "${AWS_IMAGE-}" ]]; then
-    case "${AWS_REGION}" in
-      ap-northeast-1)
-        AWS_IMAGE=ami-e624fbe6
-        ;;
-
-      ap-southeast-1)
-        AWS_IMAGE=ami-ac360cfe
-        ;;
-
-      ap-southeast-2)
-        AWS_IMAGE=ami-bbc5bd81
-        ;;
-
-      eu-central-1)
-        AWS_IMAGE=ami-02b78e1f
-        ;;
-
-      eu-west-1)
-        AWS_IMAGE=ami-e31a6594
-        ;;
-
-      sa-east-1)
-        AWS_IMAGE=ami-0972f214
-        ;;
-
-      us-east-1)
-        AWS_IMAGE=ami-116d857a
-        ;;
-
-      us-west-1)
-        AWS_IMAGE=ami-05cf2541
-        ;;
-
-      us-west-2)
-        AWS_IMAGE=ami-818eb7b1
-        ;;
-
-      cn-north-1)
-        AWS_IMAGE=ami-888815b1
-        ;;
-
-      us-gov-west-1)
-        AWS_IMAGE=ami-35b5d516
-        ;;
-
-      *)
-        echo "Please specify AWS_IMAGE directly (region ${AWS_REGION} not recognized)"
-        exit 1
-    esac
+    # TODO: publish on a k8s AWS account
+    aws_account="721322707521"
+    # TODO: we could use tags for the image
+    image_name="k8s-1.2-debian-jessie-amd64-hvm-2016-02-23-ebs"
+    AWS_IMAGE=`aws ec2 describe-images --owner ${aws_account} --filters Name=name,Values=${image_name}  --query Images[].ImageId --output text`
+    if [[ -z "${AWS_IMAGE:-}" ]]; then
+      echo "Please specify AWS_IMAGE directly (image ${image_name} not found in region ${AWS_REGION})"
+      exit 1
+    fi
   fi
 }

--- a/cluster/aws/jessie/util.sh
+++ b/cluster/aws/jessie/util.sh
@@ -30,10 +30,12 @@ function detect-jessie-image () {
     # TODO: publish on a k8s AWS account
     aws_account="721322707521"
     # TODO: we could use tags for the image
-    image_name="k8s-1.2-debian-jessie-amd64-hvm-2016-02-23-ebs"
-    AWS_IMAGE=`aws ec2 describe-images --owner ${aws_account} --filters Name=name,Values=${image_name}  --query Images[].ImageId --output text`
-    if [[ -z "${AWS_IMAGE:-}" ]]; then
-      echo "Please specify AWS_IMAGE directly (image ${image_name} not found in region ${AWS_REGION})"
+    if [[ -z "${AWS_IMAGE_NAME:-}" ]]; then
+      AWS_IMAGE_NAME="k8s-1.2-debian-jessie-amd64-hvm-2016-02-24-ebs"
+    fi
+    AWS_IMAGE=`aws ec2 describe-images --owner ${aws_account} --filters Name=name,Values=${AWS_IMAGE_NAME} --query Images[].ImageId --output text`
+    if [[ -z "${AWS_IMAGE-}" ]]; then
+      echo "Please specify AWS_IMAGE directly (image ${AWS_IMAGE_NAME} not found in region ${AWS_REGION})"
       exit 1
     fi
   fi

--- a/cluster/aws/templates/format-disks.sh
+++ b/cluster/aws/templates/format-disks.sh
@@ -175,7 +175,9 @@ if [[ ${docker_storage} == "btrfs" ]]; then
 elif [[ ${docker_storage} == "aufs-nolvm" || ${docker_storage} == "aufs" ]]; then
   # Install aufs kernel module
   # Fix issue #14162 with extra-virtual
-  apt-get-install linux-image-extra-$(uname -r) linux-image-extra-virtual
+  if [[ `lsb_release -i -s` == 'Ubuntu' ]]; then
+    apt-get-install linux-image-extra-$(uname -r) linux-image-extra-virtual
+  fi
 
   # Install aufs tools
   apt-get-install aufs-tools

--- a/cluster/aws/templates/format-disks.sh
+++ b/cluster/aws/templates/format-disks.sh
@@ -190,6 +190,9 @@ else
 fi
 
 if [[ -n "${move_docker}" ]]; then
+  # Stop docker if it is running, so we can move its files
+  systemctl stop docker || true
+
   # Move docker to e.g. /mnt
   # but only if it is a directory, not a symlink left over from a previous run
   if [[ -d /var/lib/docker ]]; then

--- a/cluster/cloudimages/k8s-ebs-jessie-amd64-hvm.yml
+++ b/cluster/cloudimages/k8s-ebs-jessie-amd64-hvm.yml
@@ -77,6 +77,13 @@ plugins:
        # Install python-pip
        - [ 'chroot', '{root}', 'pip', 'install', 'awscli' ]
 
+       # Install docker 1.9.1
+       - [ 'wget', 'http://apt.dockerproject.org/repo/pool/main/d/docker-engine/docker-engine_1.9.1-0~jessie_amd64.deb', '-O', '{root}/tmp/docker.deb' ]
+       - [ '/bin/sh', '-c', 'cd {root}/tmp; echo "c58c39008fd6399177f6b2491222e4438f518d78  docker.deb" | shasum -c -' ]
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --assume-yes libapparmor1' ]
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'DEBIAN_FRONTEND=noninteractive dpkg --install /tmp/docker.deb' ]
+       - [ 'rm', '{root}/tmp/docker.deb' ]
+
        # We perform a full replacement of some grub conf variables:
        #   GRUB_CMDLINE_LINUX_DEFAULT (add memory cgroup)
        #   GRUB_TIMEOUT (remove boot delay)

--- a/cluster/saltbase/salt/docker/init.sls
+++ b/cluster/saltbase/salt/docker/init.sls
@@ -208,6 +208,16 @@ net.ipv4.ip_forward:
 {% set override_deb_sha1='' %}
 {% set override_docker_ver='' %}
 
+{% elif grains.get('cloud', '') == 'aws'
+   and grains.get('os_family', '') == 'Debian'
+   and grains.get('oscodename', '') == 'jessie' -%}
+# TODO: Get from google storage?
+{% set docker_pkg_name='docker-engine' %}
+{% set override_docker_ver='1.9.1-0~jessie' %}
+{% set override_deb='docker-engine_1.9.1-0~jessie_amd64.deb' %}
+{% set override_deb_url='http://apt.dockerproject.org/repo/pool/main/d/docker-engine/docker-engine_1.9.1-0~jessie_amd64.deb' %}
+{% set override_deb_sha1='c58c39008fd6399177f6b2491222e4438f518d78' %}
+
 # Ubuntu presents as os_family=Debian, osfullname=Ubuntu
 {% elif grains.get('cloud', '') == 'aws'
    and grains.get('os_family', '') == 'Debian'


### PR DESCRIPTION
Fixes the bootstrap script & Salt scripts to add support for Debian Jessie:
- Don't try to install the linux-image-extra package, not available on Debian, and only needed as a workaround for an Ubuntu problem with aufs
- Add a block to the Salt script for installation of Docker, to recognize Debian Jessie and install the correct package (they are packaged per-distro)
