### PR TITLE
Validation: Make validation func return error strings

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -65,11 +65,13 @@ func ValidateHasLabel(meta api.ObjectMeta, fldPath *field.Path, key, expectedVal
 	allErrs := field.ErrorList{}
 	actualValue, found := meta.Labels[key]
 	if !found {
-		allErrs = append(allErrs, field.Required(fldPath.Child("labels"), key+"="+expectedValue))
+		allErrs = append(allErrs, field.Required(fldPath.Child("labels").Key(key),
+			fmt.Sprintf("must be '%s'", expectedValue)))
 		return allErrs
 	}
 	if actualValue != expectedValue {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("labels"), meta.Labels, "expected "+key+"="+expectedValue))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("labels").Key(key), meta.Labels,
+			fmt.Sprintf("must be '%s'", expectedValue)))
 	}
 	return allErrs
 }

--- a/pkg/kubectl/configmap.go
+++ b/pkg/kubectl/configmap.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/validation"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/validation"
 )
 
 // ConfigMapGeneratorV1 supports stable generation of a configMap.
@@ -199,10 +199,9 @@ func addKeyFromFileToConfigMap(configMap *api.ConfigMap, keyName, filePath strin
 // addKeyFromLiteralToConfigMap adds the given key and data to the given config map,
 // returning an error if the key is not valid or if the key already exists.
 func addKeyFromLiteralToConfigMap(configMap *api.ConfigMap, keyName, data string) error {
-	// Note, the rules for ConfigMap keys are the exact same as the ones for SecretKeys
-	// to be consistent; validation.IsSecretKey is used here intentionally.
-	if !validation.IsSecretKey(keyName) {
-		return fmt.Errorf("%v is not a valid key name for a configMap", keyName)
+	// Note, the rules for ConfigMap keys are the exact same as the ones for SecretKeys.
+	if errs := validation.IsConfigMapKey(keyName); len(errs) != 0 {
+		return fmt.Errorf("%q is not a valid key name for a ConfigMap: %s", keyName, strings.Join(errs, ";"))
 	}
 	if _, entryExists := configMap.Data[keyName]; entryExists {
 		return fmt.Errorf("cannot add key %s, another key by that name already exists: %v.", keyName, configMap.Data)

--- a/pkg/kubectl/secret.go
+++ b/pkg/kubectl/secret.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/validation"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/validation"
 )
 
 // SecretGeneratorV1 supports stable generation of an opaque secret
@@ -196,9 +196,10 @@ func addKeyFromFileToSecret(secret *api.Secret, keyName, filePath string) error 
 }
 
 func addKeyFromLiteralToSecret(secret *api.Secret, keyName string, data []byte) error {
-	if !validation.IsSecretKey(keyName) {
-		return fmt.Errorf("%v is not a valid key name for a secret", keyName)
+	if errs := validation.IsConfigMapKey(keyName); len(errs) != 0 {
+		return fmt.Errorf("%q is not a valid key name for a Secret: %s", keyName, strings.Join(errs, ";"))
 	}
+
 	if _, entryExists := secret.Data[keyName]; entryExists {
 		return fmt.Errorf("cannot add key %s, another key by that name already exists: %v.", keyName, secret.Data)
 	}

--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -247,6 +247,23 @@ func IsHTTPHeaderName(value string) []string {
 	return nil
 }
 
+const configMapKeyFmt = "\\.?" + DNS1123SubdomainFmt
+
+var configMapKeyRegexp = regexp.MustCompile("^" + configMapKeyFmt + "$")
+
+// IsConfigMapKey tests for a string that conforms to the definition of a
+// subdomain in DNS (RFC 1123), except that a leading dot is allowed
+func IsConfigMapKey(value string) []string {
+	var errs []string
+	if len(value) > DNS1123SubdomainMaxLength {
+		errs = append(errs, MaxLenError(DNS1123SubdomainMaxLength))
+	}
+	if !configMapKeyRegexp.MatchString(value) {
+		errs = append(errs, RegexError(configMapKeyFmt, "key.name"))
+	}
+	return errs
+}
+
 // MaxLenError returns a string explanation of a "string too long" validation
 // failure.
 func MaxLenError(length int) string {

--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -85,10 +85,10 @@ func IsValidLabelValue(value string) []string {
 	return errs
 }
 
-const DNS1123LabelFmt string = "[a-z0-9]([-a-z0-9]*[a-z0-9])?"
+const dns1123LabelFmt string = "[a-z0-9]([-a-z0-9]*[a-z0-9])?"
 const DNS1123LabelMaxLength int = 63
 
-var dns1123LabelRegexp = regexp.MustCompile("^" + DNS1123LabelFmt + "$")
+var dns1123LabelRegexp = regexp.MustCompile("^" + dns1123LabelFmt + "$")
 
 // IsDNS1123Label tests for a string that conforms to the definition of a label in
 // DNS (RFC 1123).
@@ -98,15 +98,15 @@ func IsDNS1123Label(value string) []string {
 		errs = append(errs, MaxLenError(DNS1123LabelMaxLength))
 	}
 	if !dns1123LabelRegexp.MatchString(value) {
-		errs = append(errs, RegexError(DNS1123LabelFmt, "my-name", "123-abc"))
+		errs = append(errs, RegexError(dns1123LabelFmt, "my-name", "123-abc"))
 	}
 	return errs
 }
 
-const DNS1123SubdomainFmt string = DNS1123LabelFmt + "(\\." + DNS1123LabelFmt + ")*"
+const dns1123SubdomainFmt string = dns1123LabelFmt + "(\\." + dns1123LabelFmt + ")*"
 const DNS1123SubdomainMaxLength int = 253
 
-var dns1123SubdomainRegexp = regexp.MustCompile("^" + DNS1123SubdomainFmt + "$")
+var dns1123SubdomainRegexp = regexp.MustCompile("^" + dns1123SubdomainFmt + "$")
 
 // IsDNS1123Subdomain tests for a string that conforms to the definition of a
 // subdomain in DNS (RFC 1123).
@@ -116,15 +116,15 @@ func IsDNS1123Subdomain(value string) []string {
 		errs = append(errs, MaxLenError(DNS1123SubdomainMaxLength))
 	}
 	if !dns1123SubdomainRegexp.MatchString(value) {
-		errs = append(errs, RegexError(DNS1123SubdomainFmt, "example.com"))
+		errs = append(errs, RegexError(dns1123SubdomainFmt, "example.com"))
 	}
 	return errs
 }
 
-const DNS952LabelFmt string = "[a-z]([-a-z0-9]*[a-z0-9])?"
+const dns952LabelFmt string = "[a-z]([-a-z0-9]*[a-z0-9])?"
 const DNS952LabelMaxLength int = 24
 
-var dns952LabelRegexp = regexp.MustCompile("^" + DNS952LabelFmt + "$")
+var dns952LabelRegexp = regexp.MustCompile("^" + dns952LabelFmt + "$")
 
 // IsDNS952Label tests for a string that conforms to the definition of a label in
 // DNS (RFC 952).
@@ -134,20 +134,20 @@ func IsDNS952Label(value string) []string {
 		errs = append(errs, MaxLenError(DNS952LabelMaxLength))
 	}
 	if !dns952LabelRegexp.MatchString(value) {
-		errs = append(errs, RegexError(DNS952LabelFmt, "my-name", "abc-123"))
+		errs = append(errs, RegexError(dns952LabelFmt, "my-name", "abc-123"))
 	}
 	return errs
 }
 
-const CIdentifierFmt string = "[A-Za-z_][A-Za-z0-9_]*"
+const cIdentifierFmt string = "[A-Za-z_][A-Za-z0-9_]*"
 
-var cIdentifierRegexp = regexp.MustCompile("^" + CIdentifierFmt + "$")
+var cIdentifierRegexp = regexp.MustCompile("^" + cIdentifierFmt + "$")
 
 // IsCIdentifier tests for a string that conforms the definition of an identifier
 // in C. This checks the format, but not the length.
 func IsCIdentifier(value string) []string {
 	if !cIdentifierRegexp.MatchString(value) {
-		return []string{RegexError(CIdentifierFmt, "my_name", "MY_NAME", "MyName")}
+		return []string{RegexError(cIdentifierFmt, "my_name", "MY_NAME", "MyName")}
 	}
 	return nil
 }
@@ -247,7 +247,7 @@ func IsHTTPHeaderName(value string) []string {
 	return nil
 }
 
-const configMapKeyFmt = "\\.?" + DNS1123SubdomainFmt
+const configMapKeyFmt = "\\.?" + dns1123SubdomainFmt
 
 var configMapKeyRegexp = regexp.MustCompile("^" + configMapKeyFmt + "$")
 

--- a/pkg/util/validation/validation_test.go
+++ b/pkg/util/validation/validation_test.go
@@ -374,3 +374,31 @@ func TestIsValidPercent(t *testing.T) {
 		}
 	}
 }
+
+func TestIsConfigMapKey(t *testing.T) {
+	successCases := []string{
+		"good",
+		"good-good",
+		"still.good",
+		"this.is.also.good",
+		".so.is.this",
+	}
+
+	for i := range successCases {
+		if errs := IsConfigMapKey(successCases[i]); len(errs) != 0 {
+			t.Errorf("[%d] expected success: %v", i, errs)
+		}
+	}
+
+	failureCases := []string{
+		"bad_bad",
+		"..bad",
+		"bad.",
+	}
+
+	for i := range failureCases {
+		if errs := IsConfigMapKey(failureCases[i]); len(errs) == 0 {
+			t.Errorf("[%d] expected success", i)
+		}
+	}
+}


### PR DESCRIPTION
Part of an ongoing series of validation cleanups.

This centralizes the error strings next to the code that checks the error conditions.  Future commits will refine the messages further and provide more utility validators.

I'm OK if this doesn't go into 1.2, but I am tired of rebasing :)  I suggest commit-by-commit review, which should go pretty quickly.  This was largely mechanical.

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/21240)

<!-- Reviewable:end -->
