### PR TITLE
Increase cpu limits for Kibana in scalability tests

### DIFF
--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -86,7 +86,7 @@ func density30AddonResourceVerifier() map[string]resourceConstraint {
 		memoryConstraint: 1800 * (1024 * 1024),
 	}
 	constraints["kibana-logging"] = resourceConstraint{
-		cpuConstraint:    0.05,
+		cpuConstraint:    0.1,
 		memoryConstraint: 100 * (1024 * 1024),
 	}
 	constraints["kube-proxy"] = resourceConstraint{


### PR DESCRIPTION
Will fix problem observed in:
http://kubekins.dls.corp.google.com/view/Critical%20Builds/job/kubernetes-e2e-gce-scalability/4560/
