### PR TITLE
iscis multipath support [WIP]

### DIFF
--- a/pkg/volume/fc/disk_manager.go
+++ b/pkg/volume/fc/disk_manager.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/util/mount"
-	"k8s.io/kubernetes/pkg/volume"
 )
 
 // Abstract interface to disk operations.
@@ -34,7 +33,7 @@ type diskManager interface {
 }
 
 // utility to mount a disk based filesystem
-func diskSetUp(manager diskManager, b fcDiskBuilder, volPath string, mounter mount.Interface, fsGroup *int64) error {
+func diskSetUp(manager diskManager, b fcDiskBuilder, volPath string, mounter mount.Interface) error {
 	globalPDPath := manager.MakeGlobalPDName(*b.fcDisk)
 	// TODO: handle failed mounts here.
 	noMnt, err := mounter.IsLikelyNotMountPoint(volPath)
@@ -65,11 +64,6 @@ func diskSetUp(manager diskManager, b fcDiskBuilder, volPath string, mounter mou
 		glog.Errorf("failed to bind mount:%s", globalPDPath)
 		return err
 	}
-
-	if !b.readOnly {
-		volume.SetVolumeOwnership(&b, fsGroup)
-	}
-
 	return nil
 }
 

--- a/pkg/volume/fc/fc.go
+++ b/pkg/volume/fc/fc.go
@@ -23,9 +23,9 @@ import (
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/types"
+	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/exec"
 	"k8s.io/kubernetes/pkg/util/mount"
-	"k8s.io/kubernetes/pkg/util/strings"
 	"k8s.io/kubernetes/pkg/volume"
 )
 
@@ -46,9 +46,8 @@ const (
 	fcPluginName = "kubernetes.io/fc"
 )
 
-func (plugin *fcPlugin) Init(host volume.VolumeHost) error {
+func (plugin *fcPlugin) Init(host volume.VolumeHost) {
 	plugin.host = host
-	return nil
 }
 
 func (plugin *fcPlugin) Name() string {
@@ -108,11 +107,11 @@ func (plugin *fcPlugin) newBuilderInternal(spec *volume.Spec, podUID types.UID, 
 			wwns:    fc.TargetWWNs,
 			lun:     lun,
 			manager: manager,
+			mounter: &mount.SafeFormatAndMount{mounter, exec.New()},
 			io:      &osIOHandler{},
 			plugin:  plugin},
 		fsType:   fc.FSType,
 		readOnly: readOnly,
-		mounter:  &mount.SafeFormatAndMount{mounter, exec.New()},
 	}, nil
 }
 
@@ -122,16 +121,14 @@ func (plugin *fcPlugin) NewCleaner(volName string, podUID types.UID) (volume.Cle
 }
 
 func (plugin *fcPlugin) newCleanerInternal(volName string, podUID types.UID, manager diskManager, mounter mount.Interface) (volume.Cleaner, error) {
-	return &fcDiskCleaner{
-		fcDisk: &fcDisk{
-			podUID:  podUID,
-			volName: volName,
-			manager: manager,
-			plugin:  plugin,
-			io:      &osIOHandler{},
-		},
+	return &fcDiskCleaner{&fcDisk{
+		podUID:  podUID,
+		volName: volName,
+		manager: manager,
 		mounter: mounter,
-	}, nil
+		plugin:  plugin,
+		io:      &osIOHandler{},
+	}}, nil
 }
 
 func (plugin *fcPlugin) execCommand(command string, args []string) ([]byte, error) {
@@ -146,42 +143,34 @@ type fcDisk struct {
 	wwns    []string
 	lun     string
 	plugin  *fcPlugin
+	mounter mount.Interface
 	// Utility interface that provides API calls to the provider to attach/detach disks.
 	manager diskManager
 	// io handler interface
 	io ioHandler
-	volume.MetricsNil
 }
 
 func (fc *fcDisk) GetPath() string {
 	name := fcPluginName
 	// safe to use PodVolumeDir now: volume teardown occurs before pod is cleaned up
-	return fc.plugin.host.GetPodVolumeDir(fc.podUID, strings.EscapeQualifiedNameForDisk(name), fc.volName)
+	return fc.plugin.host.GetPodVolumeDir(fc.podUID, util.EscapeQualifiedNameForDisk(name), fc.volName)
 }
 
 type fcDiskBuilder struct {
 	*fcDisk
 	readOnly bool
 	fsType   string
-	mounter  *mount.SafeFormatAndMount
 }
 
 var _ volume.Builder = &fcDiskBuilder{}
 
-func (b *fcDiskBuilder) GetAttributes() volume.Attributes {
-	return volume.Attributes{
-		ReadOnly:        b.readOnly,
-		Managed:         !b.readOnly,
-		SupportsSELinux: true,
-	}
-}
-func (b *fcDiskBuilder) SetUp(fsGroup *int64) error {
-	return b.SetUpAt(b.GetPath(), fsGroup)
+func (b *fcDiskBuilder) SetUp() error {
+	return b.SetUpAt(b.GetPath())
 }
 
-func (b *fcDiskBuilder) SetUpAt(dir string, fsGroup *int64) error {
+func (b *fcDiskBuilder) SetUpAt(dir string) error {
 	// diskSetUp checks mountpoints and prevent repeated calls
-	err := diskSetUp(b.manager, *b, dir, b.mounter, fsGroup)
+	err := diskSetUp(b.manager, *b, dir, b.mounter)
 	if err != nil {
 		glog.Errorf("fc: failed to setup")
 	}
@@ -190,10 +179,13 @@ func (b *fcDiskBuilder) SetUpAt(dir string, fsGroup *int64) error {
 
 type fcDiskCleaner struct {
 	*fcDisk
-	mounter mount.Interface
 }
 
 var _ volume.Cleaner = &fcDiskCleaner{}
+
+func (b *fcDiskBuilder) IsReadOnly() bool {
+	return b.readOnly
+}
 
 // Unmounts the bind mount, and detaches the disk only if the disk
 // resource was the last reference to that disk on the kubelet.

--- a/pkg/volume/iscsi/iscsi.go
+++ b/pkg/volume/iscsi/iscsi.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/mount"
 	utilstrings "k8s.io/kubernetes/pkg/util/strings"
 	"k8s.io/kubernetes/pkg/volume"
+	ioutil "k8s.io/kubernetes/pkg/volume/util"
 )
 
 // This is the primary entrypoint for volume plugins.
@@ -113,6 +114,7 @@ func (plugin *iscsiPlugin) newBuilderInternal(spec *volume.Spec, podUID types.UI
 		fsType:   iscsi.FSType,
 		readOnly: readOnly,
 		mounter:  &mount.SafeFormatAndMount{mounter, exec.New()},
+		io:       ioutil.NewIOHandler(),
 	}, nil
 }
 
@@ -130,6 +132,7 @@ func (plugin *iscsiPlugin) newCleanerInternal(volName string, podUID types.UID, 
 			plugin:  plugin,
 		},
 		mounter: mounter,
+		io:      ioutil.NewIOHandler(),
 	}, nil
 }
 
@@ -162,6 +165,7 @@ type iscsiDiskBuilder struct {
 	readOnly bool
 	fsType   string
 	mounter  *mount.SafeFormatAndMount
+	io       ioutil.IoUtil
 }
 
 var _ volume.Builder = &iscsiDiskBuilder{}
@@ -190,6 +194,7 @@ func (b *iscsiDiskBuilder) SetUpAt(dir string, fsGroup *int64) error {
 type iscsiDiskCleaner struct {
 	*iscsiDisk
 	mounter mount.Interface
+	io      ioutil.IoUtil
 }
 
 var _ volume.Cleaner = &iscsiDiskCleaner{}

--- a/pkg/volume/util/io_util.go
+++ b/pkg/volume/util/io_util.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+//IoUtil is a util for common IO operations
+//it also backports certain operations from golang 1.5
+type IoUtil interface {
+	ReadDir(dirname string) ([]os.FileInfo, error)
+	Lstat(name string) (os.FileInfo, error)
+	EvalSymlinks(path string) (string, error)
+	WriteFile(filename string, data []byte, perm os.FileMode) error
+	FindMultipathDeviceForDevice(disk string) string
+	FindDevicesForMultipathDevice(disk string) []string
+}
+
+type osIOHandler struct{}
+
+//NewIOHandler Create a new IoHandler implementation
+func NewIOHandler() IoUtil {
+	return &osIOHandler{}
+}
+
+func (handler *osIOHandler) ReadDir(dirname string) ([]os.FileInfo, error) {
+	return ioutil.ReadDir(dirname)
+}
+func (handler *osIOHandler) Lstat(name string) (os.FileInfo, error) {
+	return os.Lstat(name)
+}
+func (handler *osIOHandler) EvalSymlinks(path string) (string, error) {
+	return filepath.EvalSymlinks(path)
+}
+func (handler *osIOHandler) WriteFile(filename string, data []byte, perm os.FileMode) error {
+	return ioutil.WriteFile(filename, data, perm)
+}
+
+//FindMultipathDeviceForDevice given a device name like /dev/sdx, find the devicemapper parent
+func (handler *osIOHandler) FindMultipathDeviceForDevice(device string) string {
+	disk, err := handler.FindDeviceForPath(device)
+	if err != nil {
+		return ""
+	}
+	sysPath := "/sys/block/"
+	if dirs, err := handler.ReadDir(sysPath); err == nil {
+		for _, f := range dirs {
+			name := f.Name()
+			if strings.HasPrefix(name, "dm-") {
+				if _, err1 := handler.Lstat(sysPath + name + "/slaves/" + disk); err1 == nil {
+					return "/dev/" + name
+				}
+			}
+		}
+	}
+	return ""
+}
+
+//FindDevicesForMultipathDevice given a disk name of /dev/dm-XX return a
+//slice including all the mapped devices
+//if the device isn't a mapped device return an empty slice
+func (handler *osIOHandler) FindDevicesForMultipathDevice(device string) []string {
+	disk, err := handler.FindDeviceForPath(device)
+	if err != nil {
+		return make([]string, 0, 0)
+	}
+	sysPath := "/sys/block/" + disk + "/slaves/"
+	if dirs, err := handler.ReadDir(sysPath); err == nil {
+		devs := make([]string, len(dirs), len(dirs))
+		for i, f := range dirs {
+			devs[i] = f.Name()
+		}
+		return devs
+	}
+	return make([]string, 0, 0)
+}
+
+//FindDeviceForVirtual Find the underlaying disk for a linked path such as /dev/disk/by-path/XXXX or /dev/mapper/XXXX
+// will return sdX or hdX etc, if /dev/sdX is passed in then sdX will be returned
+func (handler *osIOHandler) FindDeviceForPath(path string) (string, error) {
+	parts := strings.Split(path, "/")
+	//if path /dev/hdX splits into "", "dev", "hdX" then we will
+	//return just the last part
+	if len(parts) == 3 && strings.HasPrefix(parts[1], "dev") {
+		return parts[2], nil
+	}
+	devicePath, err := handler.EvalSymlinks(path)
+	if err != nil {
+		return "", err
+	}
+	parts = strings.Split(devicePath, "/")
+	if len(parts) == 3 && strings.HasPrefix(parts[1], "dev") {
+		return parts[2], nil
+	}
+	return "", errors.New("Illegal path for device " + devicePath)
+}


### PR DESCRIPTION
This is an initial pull request for adding multipath io support to iscsi.
It is based on the FC support already present.
This has been tested on Centos 7.2 and a Nimble device with and without multipath enabled and all works well. More testing on real devices would be great.

Comments
1. This is my first time developing in go lang so please any thing that isn't idiomatic please point out and I will rectify.
2. There is a need for more unit testing, I'm happy to add once I know I'm on the right track.
3. This does not support multiple discovery ip's yet. I would need to discuss how the API should be updated. As an example add a optional portals property to the iscsi json settings
4. I have fixed for the FC code to use the new generic methods but would prefer to submit after we have managed to get this patch in to shape.
