### PR TITLE
Fix Sprintf formatting in log message

### DIFF
--- a/pkg/genericapiserver/genericapiserver.go
+++ b/pkg/genericapiserver/genericapiserver.go
@@ -646,7 +646,7 @@ func (s *GenericAPIServer) Run(options *ServerRunOptions) {
 			if err := util.GenerateSelfSignedCert(s.ClusterIP.String(), options.TLSCertFile, options.TLSPrivateKeyFile, alternateIPs, alternateDNS); err != nil {
 				glog.Errorf("Unable to generate self signed cert: %v", err)
 			} else {
-				glog.Infof("Using self-signed cert (%options, %options)", options.TLSCertFile, options.TLSPrivateKeyFile)
+				glog.Infof("Using self-signed cert (%v, %v)", options.TLSCertFile, options.TLSPrivateKeyFile)
 			}
 		}
 


### PR DESCRIPTION
Let's restore my log files' feng shui.
