### PR TITLE
Unqualified host:port pairs are valid Docker auth fields

### DIFF
--- a/pkg/credentialprovider/keyring_test.go
+++ b/pkg/credentialprovider/keyring_test.go
@@ -125,65 +125,77 @@ func TestDockerKeyringForGlob(t *testing.T) {
 		targetUrl string
 	}{
 		{
-			globUrl:   "hello.kubernetes.io",
+			globUrl:   "https://hello.kubernetes.io",
 			targetUrl: "hello.kubernetes.io",
 		},
 		{
-			globUrl:   "*.docker.io",
+			globUrl:   "https://*.docker.io",
 			targetUrl: "prefix.docker.io",
 		},
 		{
-			globUrl:   "prefix.*.io",
+			globUrl:   "https://prefix.*.io",
 			targetUrl: "prefix.docker.io",
 		},
 		{
-			globUrl:   "prefix.docker.*",
+			globUrl:   "https://prefix.docker.*",
 			targetUrl: "prefix.docker.io",
 		},
 		{
-			globUrl:   "*.docker.io/path",
+			globUrl:   "https://*.docker.io/path",
 			targetUrl: "prefix.docker.io/path",
 		},
 		{
-			globUrl:   "prefix.*.io/path",
+			globUrl:   "https://prefix.*.io/path",
 			targetUrl: "prefix.docker.io/path/subpath",
 		},
 		{
-			globUrl:   "prefix.docker.*/path",
+			globUrl:   "https://prefix.docker.*/path",
 			targetUrl: "prefix.docker.io/path",
 		},
 		{
-			globUrl:   "*.docker.io:8888",
+			globUrl:   "https://*.docker.io:8888",
 			targetUrl: "prefix.docker.io:8888",
 		},
 		{
-			globUrl:   "prefix.*.io:8888",
+			globUrl:   "https://prefix.*.io:8888",
 			targetUrl: "prefix.docker.io:8888",
 		},
 		{
-			globUrl:   "prefix.docker.*:8888",
+			globUrl:   "https://prefix.docker.*:8888",
 			targetUrl: "prefix.docker.io:8888",
 		},
 		{
-			globUrl:   "*.docker.io/path:1111",
+			globUrl:   "https://*.docker.io/path:1111",
 			targetUrl: "prefix.docker.io/path:1111",
 		},
 		{
-			globUrl:   "prefix.*.io/path:1111",
-			targetUrl: "prefix.docker.io/path/subpath:1111",
+			globUrl:   "https://*.docker.io/v1/",
+			targetUrl: "prefix.docker.io/path:1111",
 		},
 		{
-			globUrl:   "prefix.docker.*/path:1111",
+			globUrl:   "https://*.docker.io/v2/",
 			targetUrl: "prefix.docker.io/path:1111",
+		},
+		{
+			globUrl:   "https://prefix.docker.*/path:1111",
+			targetUrl: "prefix.docker.io/path:1111",
+		},
+		{
+			globUrl:   "prefix.docker.io:1111",
+			targetUrl: "prefix.docker.io:1111/path",
+		},
+		{
+			globUrl:   "*.docker.io:1111",
+			targetUrl: "prefix.docker.io:1111/path",
 		},
 	}
-	for _, test := range tests {
+	for i, test := range tests {
 		email := "foo@bar.baz"
 		username := "foo"
 		password := "bar"
 		auth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
 		sampleDockerConfig := fmt.Sprintf(`{
-   "https://%s": {
+   "%s": {
      "email": %q,
      "auth": %q
    }
@@ -198,8 +210,8 @@ func TestDockerKeyringForGlob(t *testing.T) {
 
 		creds, ok := keyring.Lookup(test.targetUrl + "/foo/bar")
 		if !ok {
-			t.Errorf("Didn't find expected URL: %s", test.targetUrl)
-			return
+			t.Errorf("%d: Didn't find expected URL: %s", i, test.targetUrl)
+			continue
 		}
 		val := creds[0]
 
@@ -221,19 +233,27 @@ func TestKeyringMiss(t *testing.T) {
 		lookupUrl string
 	}{
 		{
-			globUrl:   "hello.kubernetes.io",
+			globUrl:   "https://hello.kubernetes.io",
 			lookupUrl: "world.mesos.org/foo/bar",
 		},
 		{
-			globUrl:   "*.docker.com",
+			globUrl:   "https://*.docker.com",
 			lookupUrl: "prefix.docker.io",
+		},
+		{
+			globUrl:   "https://suffix.*.io",
+			lookupUrl: "prefix.docker.io",
+		},
+		{
+			globUrl:   "https://prefix.docker.c*",
+			lookupUrl: "prefix.docker.io",
+		},
+		{
+			globUrl:   "https://prefix.*.io/path:1111",
+			lookupUrl: "prefix.docker.io/path/subpath:1111",
 		},
 		{
 			globUrl:   "suffix.*.io",
-			lookupUrl: "prefix.docker.io",
-		},
-		{
-			globUrl:   "prefix.docker.c*",
 			lookupUrl: "prefix.docker.io",
 		},
 	}
@@ -243,7 +263,7 @@ func TestKeyringMiss(t *testing.T) {
 		password := "bar"
 		auth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
 		sampleDockerConfig := fmt.Sprintf(`{
-   "https://%s": {
+   "%s": {
      "email": %q,
      "auth": %q
    }
@@ -265,7 +285,7 @@ func TestKeyringMiss(t *testing.T) {
 }
 
 func TestKeyringMissWithDockerHubCredentials(t *testing.T) {
-	url := defaultRegistryHost
+	url := defaultRegistryKey
 	email := "foo@bar.baz"
 	username := "foo"
 	password := "bar"
@@ -291,7 +311,7 @@ func TestKeyringMissWithDockerHubCredentials(t *testing.T) {
 }
 
 func TestKeyringHitWithUnqualifiedDockerHub(t *testing.T) {
-	url := defaultRegistryHost
+	url := defaultRegistryKey
 	email := "foo@bar.baz"
 	username := "foo"
 	password := "bar"
@@ -332,7 +352,7 @@ func TestKeyringHitWithUnqualifiedDockerHub(t *testing.T) {
 }
 
 func TestKeyringHitWithUnqualifiedLibraryDockerHub(t *testing.T) {
-	url := defaultRegistryHost
+	url := defaultRegistryKey
 	email := "foo@bar.baz"
 	username := "foo"
 	password := "bar"
@@ -373,7 +393,7 @@ func TestKeyringHitWithUnqualifiedLibraryDockerHub(t *testing.T) {
 }
 
 func TestKeyringHitWithQualifiedDockerHub(t *testing.T) {
-	url := defaultRegistryHost
+	url := defaultRegistryKey
 	email := "foo@bar.baz"
 	username := "foo"
 	password := "bar"

--- a/pkg/kubelet/dockertools/docker_test.go
+++ b/pkg/kubelet/dockertools/docker_test.go
@@ -354,7 +354,7 @@ func TestPullWithSecrets(t *testing.T) {
 			[]string{`ubuntu:latest using {"username":"passed-user","password":"passed-password","email":"passed-email"}`},
 		},
 	}
-	for _, test := range tests {
+	for i, test := range tests {
 		builtInKeyRing := &credentialprovider.BasicDockerKeyring{}
 		builtInKeyRing.Add(test.builtInDockerConfig)
 
@@ -367,17 +367,17 @@ func TestPullWithSecrets(t *testing.T) {
 
 		err := dp.Pull(test.imageName, test.passedSecrets)
 		if err != nil {
-			t.Errorf("unexpected non-nil err: %s", err)
+			t.Errorf("%s: unexpected non-nil err: %s", i, err)
 			continue
 		}
 
 		if e, a := 1, len(fakeClient.pulled); e != a {
-			t.Errorf("%s: expected 1 pulled image, got %d: %v", test.imageName, a, fakeClient.pulled)
+			t.Errorf("%s: expected 1 pulled image, got %d: %v", i, a, fakeClient.pulled)
 			continue
 		}
 
 		if e, a := test.expectedPulls, fakeClient.pulled; !reflect.DeepEqual(e, a) {
-			t.Errorf("%s: expected pull of %v, but got %v", test.imageName, e, a)
+			t.Errorf("%s: expected pull of %v, but got %v", i, e, a)
 		}
 	}
 }


### PR DESCRIPTION
The dockercfg and .docker/config.json files can contain host:path
combos, which are not correctly parsed by the keyring.

Fixes #20667
