### PR TITLE
Add test targets for ARM

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -113,6 +113,7 @@ readonly KUBE_TEST_PLATFORMS=(
   linux/amd64
   darwin/amd64
   windows/amd64
+  linux/arm
 )
 
 # Gigabytes desired for parallel platform builds. 11 is fairly


### PR DESCRIPTION
Now when I started running some `e2e` tests on ARM, the `e2e.test` binary would be useful.
So, can you merge this fast before `v1.2.0-alpha.8`, please? It's a nano-sized change
Related to: #19769 

@zmerlynn @ixdy @mikedanese @thockin @fgrzadkowski  @brendandburns 
