### PR TITLE
cluster/gce/coreos: Replace kube-ui with dashboard in configure-node.sh

### DIFF
--- a/cluster/gce/coreos/configure-node.sh
+++ b/cluster/gce/coreos/configure-node.sh
@@ -133,7 +133,7 @@ function configure-master-addons() {
   fi
 
   if [[ "${ENABLE_CLUSTER_UI}" == "true" ]]; then
-    evaluate-manifests-dir ${MANIFESTS_DIR}/addons/kube-ui ${addon_dir}/kube-ui
+    evaluate-manifests-dir ${MANIFESTS_DIR}/addons/dashboard ${addon_dir}/dashboard
   fi
 
   if [[ "${ENABLE_CLUSTER_MONITORING}" == "influxdb" ]]; then


### PR DESCRIPTION
cc @kubernetes/sig-node @jonboulle @sjpotter

The script is broken after https://github.com/kubernetes/kubernetes/commit/46f51d74bbaf695b2effae74d62d44ded3e7d2a9 as the kube-ui dir is missing.

This fixed the problem.
