### PR TITLE
Unify running tests in Kubemark

### DIFF
--- a/test/kubemark/run-e2e-tests.sh
+++ b/test/kubemark/run-e2e-tests.sh
@@ -39,4 +39,4 @@ else
 	ARGS=$@
 fi
 
-${KUBE_ROOT}/hack/ginkgo-e2e.sh "--e2e-verify-service-account=false" $ARGS
+go run ./hack/e2e.go -v --test --test_args="--e2e-verify-service-account=false ${ARGS}"


### PR DESCRIPTION
Ref #21254

This should cause logs from master components to be stored in GCS.
