### PR TITLE
update query encode/decode to support custom marshalled types

### DIFF
--- a/pkg/api/unversioned/time.go
+++ b/pkg/api/unversioned/time.go
@@ -88,6 +88,11 @@ func (t *Time) UnmarshalJSON(b []byte) error {
 	var str string
 	json.Unmarshal(b, &str)
 
+	// we were probably called with *only* the time part (no tag) from query deserialization
+	if len(b) > 0 && len(str) == 0 {
+		str = string(b)
+	}
+
 	pt, err := time.Parse(time.RFC3339, str)
 	if err != nil {
 		return err

--- a/test/e2e_node/kubelet_test.go
+++ b/test/e2e_node/kubelet_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/kubelet/server/stats"
 
@@ -43,7 +44,7 @@ var _ = Describe("Kubelet", func() {
 
 	Describe("pod scheduling", func() {
 		Context("when scheduling a busybox command in a pod", func() {
-			It("it should return succes", func() {
+			It("it should return success", func() {
 				pod := &api.Pod{
 					ObjectMeta: api.ObjectMeta{
 						Name:      "busybox",
@@ -69,7 +70,7 @@ var _ = Describe("Kubelet", func() {
 
 			It("it should print the output to logs", func() {
 				Eventually(func() string {
-					rc, err := cl.Pods(api.NamespaceDefault).GetLogs("busybox", &api.PodLogOptions{}).Stream()
+					rc, err := cl.Pods(api.NamespaceDefault).GetLogs("busybox", &api.PodLogOptions{SinceTime: unversioned.NewTime(time.Now().Sub(time.Duration(1 * time.Hour)))}).Stream()
 					if err != nil {
 						return ""
 					}


### PR DESCRIPTION
Fixes #17561

Parameter encoding and decoding lost the ability to handle `unversioned.Time`, which broke `kubect logs`.

@smarterclayton @liggitt 
