### PR TITLE
make kubectl logs work for replication controllers

### DIFF
--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -380,6 +380,42 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 					return nil, errors.New("provided options object is not a PodLogOptions")
 				}
 				return c.Pods(t.Namespace).GetLogs(t.Name, opts), nil
+
+			case *api.ReplicationController:
+				opts, ok := options.(*api.PodLogOptions)
+				if !ok {
+					return nil, errors.New("provided options object is not a PodLogOptions")
+				}
+				selector := labels.SelectorFromSet(t.Spec.Selector)
+				pod, numPods, err := GetFirstPod(c, t.Namespace, selector)
+				if err != nil {
+					return nil, err
+				}
+				if numPods > 1 {
+					fmt.Fprintf(os.Stderr, "Found %v pods, using pod/%v\n", numPods, pod.Name)
+				}
+
+				return c.Pods(pod.Namespace).GetLogs(pod.Name, opts), nil
+
+			case *extensions.ReplicaSet:
+				opts, ok := options.(*api.PodLogOptions)
+				if !ok {
+					return nil, errors.New("provided options object is not a PodLogOptions")
+				}
+				selector, err := unversioned.LabelSelectorAsSelector(t.Spec.Selector)
+				if err != nil {
+					return nil, fmt.Errorf("invalid label selector: %v", err)
+				}
+				pod, numPods, err := GetFirstPod(c, t.Namespace, selector)
+				if err != nil {
+					return nil, err
+				}
+				if numPods > 1 {
+					fmt.Fprintf(os.Stderr, "Found %v pods, using pod/%v\n", numPods, pod.Name)
+				}
+
+				return c.Pods(pod.Namespace).GetLogs(pod.Name, opts), nil
+
 			default:
 				gvk, err := api.Scheme.ObjectKind(object)
 				if err != nil {
@@ -527,19 +563,22 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 			switch t := object.(type) {
 			case *api.ReplicationController:
 				selector := labels.SelectorFromSet(t.Spec.Selector)
-				return GetFirstPod(client, t.Namespace, selector)
+				pod, _, err := GetFirstPod(client, t.Namespace, selector)
+				return pod, err
 			case *extensions.Deployment:
 				selector, err := unversioned.LabelSelectorAsSelector(t.Spec.Selector)
 				if err != nil {
 					return nil, fmt.Errorf("invalid label selector: %v", err)
 				}
-				return GetFirstPod(client, t.Namespace, selector)
+				pod, _, err := GetFirstPod(client, t.Namespace, selector)
+				return pod, err
 			case *extensions.Job:
 				selector, err := unversioned.LabelSelectorAsSelector(t.Spec.Selector)
 				if err != nil {
 					return nil, fmt.Errorf("invalid label selector: %v", err)
 				}
-				return GetFirstPod(client, t.Namespace, selector)
+				pod, _, err := GetFirstPod(client, t.Namespace, selector)
+				return pod, err
 			case *api.Pod:
 				return t, nil
 			default:
@@ -556,21 +595,21 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 	}
 }
 
-// GetFirstPod returns the first pod of an object from its namespace and selector
-func GetFirstPod(client *client.Client, namespace string, selector labels.Selector) (*api.Pod, error) {
+// GetFirstPod returns the first pod of an object from its namespace and selector and the number of matching pods
+func GetFirstPod(client *client.Client, namespace string, selector labels.Selector) (*api.Pod, int, error) {
 	var pods *api.PodList
 	for pods == nil || len(pods.Items) == 0 {
 		var err error
 		options := api.ListOptions{LabelSelector: selector}
 		if pods, err = client.Pods(namespace).List(options); err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 		if len(pods.Items) == 0 {
 			time.Sleep(2 * time.Second)
 		}
 	}
 	pod := &pods.Items[0]
-	return pod, nil
+	return pod, len(pods.Items), nil
 }
 
 // Command will stringify and return all environment arguments ie. a command run by a client

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -464,7 +464,7 @@ var _ = Describe("Kubectl client", func() {
 				withStdinData("abcd1234\n").
 				execOrDie()
 			Expect(runOutput).ToNot(ContainSubstring("stdin closed"))
-			runTestPod, err := util.GetFirstPod(c, ns, labels.SelectorFromSet(map[string]string{"run": "run-test-3"}))
+			runTestPod, _, err := util.GetFirstPod(c, ns, labels.SelectorFromSet(map[string]string{"run": "run-test-3"}))
 			if err != nil {
 				os.Exit(1)
 			}
@@ -897,6 +897,13 @@ var _ = Describe("Kubectl client", func() {
 			if pods == nil || len(pods) != 1 || len(pods[0].Spec.Containers) != 1 || pods[0].Spec.Containers[0].Image != nginxImage {
 				runKubectlOrDie("get", "pods", "-L", "run", nsFlag)
 				Failf("Failed creating 1 pod with expected image %s. Number of pods = %v", nginxImage, len(pods))
+			}
+
+			By("confirm that you can get logs from an rc")
+			_, err = runKubectl("logs", "rc/"+rcName, nsFlag)
+			// a non-nil error is fine as long as we actually found a pod.
+			if err != nil && !strings.Contains(err.Error(), " in pod ") {
+				Failf("Failed getting logs by rc %s: %v", rcName, err)
 			}
 		})
 


### PR DESCRIPTION
Adds the ability to do `kubectl logs rc/foo` and get back the logs for the first pod.

@kubernetes/kubectl 
@smarterclayton per request
