### PR TITLE
Tolerate individual NotFound errors in DeleteCollection

### DIFF
--- a/pkg/registry/generic/etcd/etcd.go
+++ b/pkg/registry/generic/etcd/etcd.go
@@ -464,7 +464,7 @@ func (e *Etcd) DeleteCollection(ctx api.Context, options *api.DeleteOptions, lis
 		if err != nil {
 			return nil, err
 		}
-		if _, err := e.Delete(ctx, accessor.GetName(), options); err != nil {
+		if _, err := e.Delete(ctx, accessor.GetName(), options); err != nil && !kubeerr.IsNotFound(err) {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Related to #21406

On namespace deletion, multiple controllers might try to clean up resources. DeleteCollection should not fail if one of the items present during the initial list does not exist by the time the iterating delete gets around to deleting it.
