### PR TITLE
Add a liveness and readiness describer to pods

### DIFF
--- a/pkg/kubectl/describe_test.go
+++ b/pkg/kubectl/describe_test.go
@@ -268,7 +268,7 @@ func TestDescribeContainers(t *testing.T) {
 				ContainerStatuses: []api.ContainerStatus{testCase.status},
 			},
 		}
-		describeContainers(&pod, out)
+		DescribeContainers(pod.Spec.Containers, pod.Status.ContainerStatuses, EnvValueRetriever(&pod), out)
 		output := out.String()
 		for _, expected := range testCase.expectedElements {
 			if !strings.Contains(output, expected) {


### PR DESCRIPTION
Also shorten the Last Termination State label so the page is denser. I think that makes that whole page easier to read, even if it does omit this is the termination state.
