### PR TITLE
Fixing mysql-galena example's config files

### DIFF
--- a/examples/mysql-galera/pxc-cluster-service.yaml
+++ b/examples/mysql-galera/pxc-cluster-service.yaml
@@ -1,13 +1,12 @@
 apiVersion: v1
 kind: Service
-id: pxc-cluster
 metadata:
   name: pxc-cluster
+  labels:
+    unit: pxc-cluster
 spec:
   ports:
     - port: 3306
       name: mysql
   selector:
     unit: pxc-cluster
-labels: 
-  unit: pxc-cluster

--- a/examples/mysql-galera/pxc-node1.yaml
+++ b/examples/mysql-galera/pxc-node1.yaml
@@ -1,8 +1,9 @@
 apiVersion: v1
 kind: Service
-id: pxc-node1
 metadata:
   name: pxc-node1
+  labels:
+    node: pxc-node1
 spec:
   ports:
     - port: 3306
@@ -15,8 +16,6 @@ spec:
       name: incremental-state-transfer 
   selector:
     node: pxc-node1 
-labels: 
-  node: pxc-node1
 ---
 apiVersion: v1
 kind: ReplicationController

--- a/examples/mysql-galera/pxc-node2.yaml
+++ b/examples/mysql-galera/pxc-node2.yaml
@@ -1,8 +1,9 @@
 apiVersion: v1
 kind: Service
-id: pxc-node2
 metadata:
   name: pxc-node2
+  labels: 
+    node: pxc-node2
 spec:
   ports:
     - port: 3306
@@ -15,8 +16,7 @@ spec:
       name: incremental-state-transfer 
   selector:
     node: pxc-node2 
-labels: 
-  node: pxc-node2
+
 ---
 apiVersion: v1
 kind: ReplicationController

--- a/examples/mysql-galera/pxc-node3.yaml
+++ b/examples/mysql-galera/pxc-node3.yaml
@@ -1,8 +1,9 @@
 apiVersion: v1
 kind: Service
-id: pxc-node3
 metadata:
   name: pxc-node3
+  labels: 
+    node: pxc-node3
 spec:
   ports:
     - port: 3306
@@ -15,8 +16,7 @@ spec:
       name: incremental-state-transfer 
   selector:
     node: pxc-node3 
-labels: 
-  node: pxc-node3
+
 ---
 apiVersion: v1
 kind: ReplicationController


### PR DESCRIPTION
I recently ran the mysql-galena example on a newly minted v1.1.7 kubernetes cluster and there seems to be errors in the configuration that prevent the example from working. Perhaps these configuration examples were created on an older kubernetes version and now they no longer work?

Anyhow, I've made some minor changes which allow the example to launch and function correctly. 
