### PR TITLE
Switch to using `docker version` as health check

### DIFF
--- a/cluster/gce/trusty/configure.sh
+++ b/cluster/gce/trusty/configure.sh
@@ -261,7 +261,7 @@ health_monitoring() {
   # We simply kill the process when there is a failure. Another upstart job will automatically
   # restart the process.
   while [ 1 ]; do
-    if ! timeout 20 docker ps > /dev/null; then
+    if ! timeout 10 docker version > /dev/null; then
       echo "Docker daemon failed!"
       pkill docker
     fi

--- a/cluster/saltbase/salt/supervisor/docker-checker.sh
+++ b/cluster/saltbase/salt/supervisor/docker-checker.sh
@@ -25,7 +25,7 @@ echo "waiting a minute for startup"
 sleep 60
 
 while true; do
-  if ! sudo timeout 20 docker ps > /dev/null; then
+  if ! sudo timeout 10 docker version > /dev/null; then
     echo "Docker failed!"
     exit 2
   fi


### PR DESCRIPTION
`docker ps` can sometimes take a long time to finish, and restarting
docker in this case doesn't help.
