### PR TITLE
Don't print reason or message if they are empty on pods

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -325,9 +325,9 @@ runTests() {
   kube::test::get_object_jsonpath_assert 'pod/valid-pod' "{$id_field}" 'valid-pod'
   kube::test::get_object_jsonpath_assert 'pods/valid-pod' "{$id_field}" 'valid-pod'
   # Describe command should print detailed information
-  kube::test::describe_object_assert pods 'valid-pod' "Name:" "Image(s):" "Node:" "Labels:" "Status:" "Controllers"
+  kube::test::describe_object_assert pods 'valid-pod' "Name:" "Image:" "Node:" "Labels:" "Status:" "Controllers"
   # Describe command (resource only) should print detailed information
-  kube::test::describe_resource_assert pods "Name:" "Image(s):" "Node:" "Labels:" "Status:" "Controllers"
+  kube::test::describe_resource_assert pods "Name:" "Image:" "Node:" "Labels:" "Status:" "Controllers"
 
   ### Validate Export ###
   kube::test::get_object_assert 'pods/valid-pod' "{{.metadata.namespace}} {{.metadata.name}}" '<no value> valid-pod' "--export=true"

--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -453,7 +453,6 @@ func describePod(pod *api.Pod, events *api.EventList) (string, error) {
 	return tabbedString(func(out io.Writer) error {
 		fmt.Fprintf(out, "Name:\t%s\n", pod.Name)
 		fmt.Fprintf(out, "Namespace:\t%s\n", pod.Namespace)
-		fmt.Fprintf(out, "Image(s):\t%s\n", makeImageList(&pod.Spec))
 		fmt.Fprintf(out, "Node:\t%s\n", pod.Spec.NodeName+"/"+pod.Status.HostIP)
 		if pod.Status.StartTime != nil {
 			fmt.Fprintf(out, "Start Time:\t%s\n", pod.Status.StartTime.Time.Format(time.RFC1123Z))
@@ -465,8 +464,12 @@ func describePod(pod *api.Pod, events *api.EventList) (string, error) {
 		} else {
 			fmt.Fprintf(out, "Status:\t%s\n", string(pod.Status.Phase))
 		}
-		fmt.Fprintf(out, "Reason:\t%s\n", pod.Status.Reason)
-		fmt.Fprintf(out, "Message:\t%s\n", pod.Status.Message)
+		if len(pod.Status.Reason) > 0 {
+			fmt.Fprintf(out, "Reason:\t%s\n", pod.Status.Reason)
+		}
+		if len(pod.Status.Message) > 0 {
+			fmt.Fprintf(out, "Message:\t%s\n", pod.Status.Message)
+		}
 		fmt.Fprintf(out, "IP:\t%s\n", pod.Status.PodIP)
 		fmt.Fprintf(out, "Controllers:\t%s\n", printControllers(pod.Annotations))
 		fmt.Fprintf(out, "Containers:\n")

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -567,14 +567,15 @@ var _ = Describe("Kubectl client", func() {
 				requiredStrings := [][]string{
 					{"Name:", "redis-master-"},
 					{"Namespace:", ns},
-					{"Image(s):", "redis"},
 					{"Node:"},
 					{"Labels:", "app=redis", "role=master"},
 					{"Status:", "Running"},
-					{"Reason:"},
-					{"Message:"},
 					{"IP:"},
-					{"Controllers:", "ReplicationController/redis-master"}}
+					{"Controllers:", "ReplicationController/redis-master"},
+					{"Image:", "redis"},
+					{"cpu:", "BestEffort"},
+					{"State:", "Running"},
+				}
 				checkOutput(output, requiredStrings)
 			})
 


### PR DESCRIPTION
For running pods they are typically empty and convey no value
