### PR TITLE
Fluentd on GCE master should not use ClusterFirst

### DIFF
--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     k8s-app: fluentd-logging
 spec:
+  dnsPolicy: Default
   containers:
   - name: fluentd-cloud-logging
     image: gcr.io/google_containers/fluentd-gcp:1.16

--- a/docs/getting-started-guides/logging.md
+++ b/docs/getting-started-guides/logging.md
@@ -170,6 +170,7 @@ metadata:
   labels:
     k8s-app: fluentd-logging
 spec:
+  dnsPolicy: Default
   containers:
   - name: fluentd-cloud-logging
     image: gcr.io/google_containers/fluentd-gcp:1.16


### PR DESCRIPTION
Master does not have kube-proxy...
