### PR TITLE
Fix DNS add-on on hyperkube-based setups

### DIFF
--- a/cluster/images/hyperkube/master-multi.json
+++ b/cluster/images/hyperkube/master-multi.json
@@ -64,7 +64,8 @@
       "name": "setup",
       "image": "gcr.io/google_containers/hyperkube-ARCH:VERSION",
       "command": [
-              "/setup-files.sh"
+              "/setup-files.sh",
+              "IP:10.0.0.1"
       ],
       "volumeMounts": [
         {

--- a/cluster/images/hyperkube/master.json
+++ b/cluster/images/hyperkube/master.json
@@ -64,7 +64,8 @@
       "name": "setup",
       "image": "gcr.io/google_containers/hyperkube-ARCH:VERSION",
       "command": [
-              "/setup-files.sh"
+              "/setup-files.sh",
+              "IP:10.0.0.1"
       ],
       "volumeMounts": [
         {

--- a/cluster/images/hyperkube/setup-files.sh
+++ b/cluster/images/hyperkube/setup-files.sh
@@ -23,6 +23,11 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# Additional address of the API server to be added to the
+# list of Subject Alternative Names of the server TLS certificate
+# Should contain internal IP, i.e. IP:10.0.0.1 for 10.0.0.0/24 cluster IP range
+EXTRA_SANS=$1
+
 create_token() {
   echo $(cat /dev/urandom | base64 | tr -d "=+/" | dd bs=32 count=1 2> /dev/null)
 }
@@ -32,7 +37,7 @@ echo "admin,admin,admin" > /data/basic_auth.csv
 
 # Create HTTPS certificates
 groupadd -f -r kube-cert-test
-CERT_DIR=/data CERT_GROUP=kube-cert-test /make-ca-cert.sh $(hostname -i)
+CERT_DIR=/data CERT_GROUP=kube-cert-test /make-ca-cert.sh $(hostname -i) ${EXTRA_SANS}
 
 # Create known tokens for service accounts
 echo "$(create_token),admin,admin" >> /data/known_tokens.csv


### PR DESCRIPTION
When dockered hyperkube-based setup is used, kube2sky tries to access API server via `10.0.0.1` IP.
However API server TLS certificate doesn't contain this IP in the list of Subject Alternative Names.

kube2sky rejects the certificate and fails to get cluster information. DNS add-on pod keeps been restarted.

This patch adds API server IP to the list of SANS. Now KubeDNS works for me.
The idea was borrowed from Ubuntu scripts.

Fixes #19864
