### PR TITLE
Fix namespace test

### DIFF
--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -146,7 +146,11 @@ func (f *Framework) afterEach() {
 					timeout = f.NamespaceDeletionTimeout
 				}
 				if err := deleteNS(f.Client, ns.Name, timeout); err != nil {
-					Failf("Couldn't delete ns %q: %s", ns.Name, err)
+					if !strings.Contains(err.Error(), "not found") {
+						Failf("Couldn't delete ns %q: %s", ns.Name, err)
+					} else {
+						Logf("Namespace %v was already deleted", ns.Name)
+					}
 				}
 			}
 			f.namespacesToDelete = nil

--- a/test/e2e/namespace.go
+++ b/test/e2e/namespace.go
@@ -34,8 +34,8 @@ func extinguish(f *Framework, totalNS int, maxAllowedAfterDel int, maxSeconds in
 
 	By("Creating testing namespaces")
 	wg := &sync.WaitGroup{}
+	wg.Add(totalNS)
 	for n := 0; n < totalNS; n += 1 {
-		wg.Add(1)
 		go func(n int) {
 			defer wg.Done()
 			defer GinkgoRecover()


### PR DESCRIPTION
Fix. #21321

The problem was with the test itself. Test:
- created a number of namespaces, adding them to `framework.namespacesToDelete` slice,
- deleted all of them - some of them finish termination phase before the end of the test, some of them don't,
- framework, during AfterEach tried to delete all namespaces from `framework.namespacesToDelete`, which includes already deleted namespaces and failed (obviously).

I think the way to solve this is to allow Framework to ignore deletion 'not found' errors. I'm not quite sure what's the suggested way to check the error type, so I'm just checking the message.

cc. @wojtek-t @thockin 
