### PR TITLE
Refactor PersistentVolume admission controller plugin to use volume plugins

### DIFF
--- a/cmd/kubelet/app/plugins.go
+++ b/cmd/kubelet/app/plugins.go
@@ -26,64 +26,10 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/network/cni"
 	"k8s.io/kubernetes/pkg/kubelet/network/exec"
 	"k8s.io/kubernetes/pkg/kubelet/network/kubenet"
-	// Volume plugins
-	"k8s.io/kubernetes/pkg/volume"
-	"k8s.io/kubernetes/pkg/volume/aws_ebs"
-	"k8s.io/kubernetes/pkg/volume/azure_file"
-	"k8s.io/kubernetes/pkg/volume/cephfs"
-	"k8s.io/kubernetes/pkg/volume/cinder"
-	"k8s.io/kubernetes/pkg/volume/configmap"
-	"k8s.io/kubernetes/pkg/volume/downwardapi"
-	"k8s.io/kubernetes/pkg/volume/empty_dir"
-	"k8s.io/kubernetes/pkg/volume/fc"
-	"k8s.io/kubernetes/pkg/volume/flexvolume"
-	"k8s.io/kubernetes/pkg/volume/flocker"
-	"k8s.io/kubernetes/pkg/volume/gce_pd"
-	"k8s.io/kubernetes/pkg/volume/git_repo"
-	"k8s.io/kubernetes/pkg/volume/glusterfs"
-	"k8s.io/kubernetes/pkg/volume/host_path"
-	"k8s.io/kubernetes/pkg/volume/iscsi"
-	"k8s.io/kubernetes/pkg/volume/nfs"
-	"k8s.io/kubernetes/pkg/volume/persistent_claim"
-	"k8s.io/kubernetes/pkg/volume/rbd"
-	"k8s.io/kubernetes/pkg/volume/secret"
+
 	// Cloud providers
 	_ "k8s.io/kubernetes/pkg/cloudprovider/providers"
 )
-
-// ProbeVolumePlugins collects all volume plugins into an easy to use list.
-// PluginDir specifies the directory to search for additional third party
-// volume plugins.
-func ProbeVolumePlugins(pluginDir string) []volume.VolumePlugin {
-	allPlugins := []volume.VolumePlugin{}
-
-	// The list of plugins to probe is decided by the kubelet binary, not
-	// by dynamic linking or other "magic".  Plugins will be analyzed and
-	// initialized later.
-	//
-	// Kubelet does not currently need to configure volume plugins.
-	// If/when it does, see kube-controller-manager/app/plugins.go for example of using volume.VolumeConfig
-	allPlugins = append(allPlugins, aws_ebs.ProbeVolumePlugins()...)
-	allPlugins = append(allPlugins, empty_dir.ProbeVolumePlugins()...)
-	allPlugins = append(allPlugins, gce_pd.ProbeVolumePlugins()...)
-	allPlugins = append(allPlugins, git_repo.ProbeVolumePlugins()...)
-	allPlugins = append(allPlugins, host_path.ProbeVolumePlugins(volume.VolumeConfig{})...)
-	allPlugins = append(allPlugins, nfs.ProbeVolumePlugins(volume.VolumeConfig{})...)
-	allPlugins = append(allPlugins, secret.ProbeVolumePlugins()...)
-	allPlugins = append(allPlugins, iscsi.ProbeVolumePlugins()...)
-	allPlugins = append(allPlugins, glusterfs.ProbeVolumePlugins()...)
-	allPlugins = append(allPlugins, persistent_claim.ProbeVolumePlugins()...)
-	allPlugins = append(allPlugins, rbd.ProbeVolumePlugins()...)
-	allPlugins = append(allPlugins, cinder.ProbeVolumePlugins()...)
-	allPlugins = append(allPlugins, cephfs.ProbeVolumePlugins()...)
-	allPlugins = append(allPlugins, downwardapi.ProbeVolumePlugins()...)
-	allPlugins = append(allPlugins, fc.ProbeVolumePlugins()...)
-	allPlugins = append(allPlugins, flocker.ProbeVolumePlugins()...)
-	allPlugins = append(allPlugins, flexvolume.ProbeVolumePlugins(pluginDir)...)
-	allPlugins = append(allPlugins, azure_file.ProbeVolumePlugins()...)
-	allPlugins = append(allPlugins, configmap.ProbeVolumePlugins()...)
-	return allPlugins
-}
 
 // ProbeNetworkPlugins collects all compiled-in plugins
 func ProbeNetworkPlugins(pluginDir string) []network.NetworkPlugin {

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -71,6 +71,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/version"
 	"k8s.io/kubernetes/pkg/volume"
+	volumeplugins "k8s.io/kubernetes/pkg/volume/util/plugins"
 )
 
 // bootstrapping interface for kubelet, targets the initialization protocol
@@ -255,7 +256,7 @@ func UnsecuredKubeletConfig(s *options.KubeletServer) (*KubeletConfig, error) {
 		SystemCgroups:                  s.SystemCgroups,
 		TLSOptions:                     tlsOptions,
 		Writer:                         writer,
-		VolumePlugins:                  ProbeVolumePlugins(s.VolumePluginDir),
+		VolumePlugins:                  volumeplugins.ProbeAllVolumePlugins(s.VolumePluginDir),
 		OutOfDiskTransitionFrequency:   s.OutOfDiskTransitionFrequency.Duration,
 		HairpinMode:                    s.HairpinMode,
 		BabysitDaemons:                 s.BabysitDaemons,

--- a/pkg/admission/chain.go
+++ b/pkg/admission/chain.go
@@ -23,10 +23,10 @@ type chainAdmissionHandler []Interface
 
 // NewFromPlugins returns an admission.Interface that will enforce admission control decisions of all
 // the given plugins.
-func NewFromPlugins(client clientset.Interface, pluginNames []string, configFilePath string) Interface {
+func NewFromPlugins(client clientset.Interface, pluginNames []string, configFilePath string, host AdmissionPluginHost) Interface {
 	plugins := []Interface{}
 	for _, pluginName := range pluginNames {
-		plugin := InitPlugin(pluginName, client, configFilePath)
+		plugin := InitPlugin(pluginName, client, configFilePath, host)
 		if plugin != nil {
 			plugins = append(plugins, plugin)
 		}

--- a/pkg/admission/host.go
+++ b/pkg/admission/host.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/cloudprovider"
+	"k8s.io/kubernetes/pkg/types"
+	"k8s.io/kubernetes/pkg/util/io"
+	"k8s.io/kubernetes/pkg/util/mount"
+	"k8s.io/kubernetes/pkg/volume"
+)
+
+// RealAdmissionPluginHost is implementation of AdmissionPluginHost.
+// To save users from implementing / providing a VolumeHost interface to
+// instantiate VolumePluginMgr, it implements the interface and initializes
+// VolumePluginMgr internally.
+type realAdmissionPluginHost struct {
+	// For VolumeHost, only functions that are relevant to APIServer were implemented.
+	cloudProvider   cloudprovider.Interface
+	volumePluginMgr *volume.VolumePluginMgr
+}
+
+var _ AdmissionPluginHost = &realAdmissionPluginHost{}
+var _ volume.VolumeHost = &realAdmissionPluginHost{}
+
+func NewAdmissionPluginHost(cloudProvider cloudprovider.Interface, volumePlugins []volume.VolumePlugin) AdmissionPluginHost {
+	host := &realAdmissionPluginHost{
+		cloudProvider:   cloudProvider,
+		volumePluginMgr: &volume.VolumePluginMgr{},
+	}
+	host.volumePluginMgr.InitPlugins(volumePlugins, host)
+	return host
+}
+
+func (host *realAdmissionPluginHost) GetCloudProvider() cloudprovider.Interface {
+	return host.cloudProvider
+}
+
+func (host *realAdmissionPluginHost) GetVolumePluginMgr() *volume.VolumePluginMgr {
+	return host.volumePluginMgr
+}
+
+// VolumeHost
+
+func (host *realAdmissionPluginHost) GetPluginDir(pluginName string) string {
+	// used only in kubelet
+	return ""
+}
+
+func (host *realAdmissionPluginHost) GetPodVolumeDir(podUID types.UID, pluginName string, volumeName string) string {
+	// used only in kubelet
+	return ""
+}
+
+func (host *realAdmissionPluginHost) GetPodPluginDir(podUID types.UID, pluginName string) string {
+	// used only in kubelet
+	return ""
+}
+
+func (host *realAdmissionPluginHost) GetKubeClient() clientset.Interface {
+	// used only in kubelet
+	return nil
+}
+
+func (host *realAdmissionPluginHost) NewWrapperMounter(volName string, spec volume.Spec, pod *api.Pod, opts volume.VolumeOptions) (volume.Mounter, error) {
+	// used only in kubelet
+	return nil, nil
+}
+
+func (host *realAdmissionPluginHost) NewWrapperUnmounter(volName string, spec volume.Spec, podUID types.UID) (volume.Unmounter, error) {
+	// used only in kubelet
+	return nil, nil
+}
+
+func (host *realAdmissionPluginHost) GetMounter() mount.Interface {
+	// used only in kubelet
+	return nil
+}
+
+func (host *realAdmissionPluginHost) GetWriter() io.Writer {
+	// used only in kubelet
+	return nil
+}
+
+func (host *realAdmissionPluginHost) GetHostName() string {
+	// used only in kubelet
+	return ""
+}

--- a/pkg/admission/interfaces.go
+++ b/pkg/admission/interfaces.go
@@ -19,7 +19,9 @@ package admission
 import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/auth/user"
+	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/volume"
 )
 
 // Attributes is an interface used by AdmissionController to get information about a request
@@ -55,6 +57,16 @@ type Interface interface {
 	// Handles returns true if this admission controller can handle the given operation
 	// where operation can be one of CREATE, UPDATE, DELETE, or CONNECT
 	Handles(operation Operation) bool
+}
+
+// AdmissionPluginHost is interface between admission plugins and rest of
+// kube-apiserver.
+type AdmissionPluginHost interface {
+	// GetCloudProvider returns current Kubernetes cloud provider, usable by the
+	// admission controller to check stuff with external cloud APIs.
+	GetCloudProvider() cloudprovider.Interface
+	// GetVolumePlugins returns list of registered volume plugins.
+	GetVolumePluginMgr() *volume.VolumePluginMgr
 }
 
 // Operation is the type of resource operation being checked for admission control

--- a/pkg/admission/plugins.go
+++ b/pkg/admission/plugins.go
@@ -30,7 +30,7 @@ import (
 // The config parameter provides an io.Reader handler to the factory in
 // order to load specific configurations. If no configuration is provided
 // the parameter is nil.
-type Factory func(client clientset.Interface, config io.Reader) (Interface, error)
+type Factory func(client clientset.Interface, config io.Reader, host AdmissionPluginHost) (Interface, error)
 
 // All registered admission options.
 var (
@@ -67,19 +67,19 @@ func RegisterPlugin(name string, plugin Factory) {
 // the name is not known. The error is returned only when the named provider was
 // known but failed to initialize.  The config parameter specifies the io.Reader
 // handler of the configuration file for the cloud provider, or nil for no configuration.
-func getPlugin(name string, client clientset.Interface, config io.Reader) (Interface, bool, error) {
+func getPlugin(name string, client clientset.Interface, config io.Reader, host AdmissionPluginHost) (Interface, bool, error) {
 	pluginsMutex.Lock()
 	defer pluginsMutex.Unlock()
 	f, found := plugins[name]
 	if !found {
 		return nil, false, nil
 	}
-	ret, err := f(client, config)
+	ret, err := f(client, config, host)
 	return ret, true, err
 }
 
 // InitPlugin creates an instance of the named interface.
-func InitPlugin(name string, client clientset.Interface, configFilePath string) Interface {
+func InitPlugin(name string, client clientset.Interface, configFilePath string, host AdmissionPluginHost) Interface {
 	var (
 		config *os.File
 		err    error
@@ -100,7 +100,7 @@ func InitPlugin(name string, client clientset.Interface, configFilePath string) 
 		defer config.Close()
 	}
 
-	plugin, found, err := getPlugin(name, client, config)
+	plugin, found, err := getPlugin(name, client, config, host)
 	if err != nil {
 		glog.Fatalf("Couldn't init admission plugin %q: %v", name, err)
 	}

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/service"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 )
 
@@ -1122,4 +1123,17 @@ func (os *OpenStack) DeleteVolume(volumeName string) error {
 		glog.Errorf("Cannot delete volume %s: %v", volumeName, err)
 	}
 	return err
+}
+
+func (os *OpenStack) GetVolumeLabels(volumeName string) (map[string]string, error) {
+	vol, err := os.getVolume(volumeName)
+	if err != nil {
+		return nil, err
+	}
+
+	labels := make(map[string]string)
+	labels[unversioned.LabelZoneFailureDomain] = vol.AvailabilityZone
+	labels[unversioned.LabelZoneRegion] = os.region
+
+	return labels, nil
 }

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -135,6 +135,13 @@ type AttachableVolumePlugin interface {
 	NewDetacher(name string, podUID types.UID) (Detacher, error)
 }
 
+// VolumeLabelerPlugin is an extended interface of VolumePlugin and is used to get default labels for
+// PersistentVolumes from external cloud.
+type VolumeLabelerPlugin interface {
+	VolumePlugin
+	NewVolumeLabeler(spec *Spec) (VolumeLabeler, error)
+}
+
 // VolumeHost is an interface that plugins can use to access the kubelet.
 type VolumeHost interface {
 	// GetPluginDir returns the absolute path to a directory under which

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -216,6 +216,10 @@ func (plugin *FakeVolumePlugin) GetAccessModes() []api.PersistentVolumeAccessMod
 	return []api.PersistentVolumeAccessMode{}
 }
 
+func (plugin *FakeVolumePlugin) NewLabeler() (VolumeLabeler, error) {
+	return &FakeLabeler{plugin.Host}, nil
+}
+
 type FakeVolume struct {
 	PodUID  types.UID
 	VolName string
@@ -385,4 +389,12 @@ func FindEmptyDirectoryUsageOnTmpfs() (*resource.Quantity, error) {
 	}
 	used.Format = resource.BinarySI
 	return used, nil
+}
+
+type FakeLabeler struct {
+	Host VolumeHost
+}
+
+func (fc *FakeLabeler) GetLabels() (map[string]string, error) {
+	return map[string]string{}, nil
 }

--- a/pkg/volume/util/plugins/probe.go
+++ b/pkg/volume/util/plugins/probe.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"k8s.io/kubernetes/pkg/volume"
+	"k8s.io/kubernetes/pkg/volume/aws_ebs"
+	"k8s.io/kubernetes/pkg/volume/azure_file"
+	"k8s.io/kubernetes/pkg/volume/cephfs"
+	"k8s.io/kubernetes/pkg/volume/cinder"
+	"k8s.io/kubernetes/pkg/volume/configmap"
+	"k8s.io/kubernetes/pkg/volume/downwardapi"
+	"k8s.io/kubernetes/pkg/volume/empty_dir"
+	"k8s.io/kubernetes/pkg/volume/fc"
+	"k8s.io/kubernetes/pkg/volume/flexvolume"
+	"k8s.io/kubernetes/pkg/volume/flocker"
+	"k8s.io/kubernetes/pkg/volume/gce_pd"
+	"k8s.io/kubernetes/pkg/volume/git_repo"
+	"k8s.io/kubernetes/pkg/volume/glusterfs"
+	"k8s.io/kubernetes/pkg/volume/host_path"
+	"k8s.io/kubernetes/pkg/volume/iscsi"
+	"k8s.io/kubernetes/pkg/volume/nfs"
+	"k8s.io/kubernetes/pkg/volume/persistent_claim"
+	"k8s.io/kubernetes/pkg/volume/rbd"
+	"k8s.io/kubernetes/pkg/volume/secret"
+)
+
+// The following function needs to be in standalone package as it imports
+// most of volume packages and placing it somewhere else would produce import
+// loop.
+
+// ProbeAllVolumePlugins returns list of all known volume plugins.
+// PluginDir specifies the directory to search for additional third party
+// volume plugins.
+func ProbeAllVolumePlugins(pluginDir string) []volume.VolumePlugin {
+	allPlugins := []volume.VolumePlugin{}
+
+	// The list of plugins to probe is decided by the kubelet binary, not
+	// by dynamic linking or other "magic".  Plugins will be analyzed and
+	// initialized later.
+	//
+	// Kubelet does not currently need to configure volume plugins.
+	// If/when it does, see kube-controller-manager/app/plugins.go for example of using volume.VolumeConfig
+	allPlugins = append(allPlugins, aws_ebs.ProbeVolumePlugins()...)
+	allPlugins = append(allPlugins, empty_dir.ProbeVolumePlugins()...)
+	allPlugins = append(allPlugins, gce_pd.ProbeVolumePlugins()...)
+	allPlugins = append(allPlugins, git_repo.ProbeVolumePlugins()...)
+	allPlugins = append(allPlugins, host_path.ProbeVolumePlugins(volume.VolumeConfig{})...)
+	allPlugins = append(allPlugins, nfs.ProbeVolumePlugins(volume.VolumeConfig{})...)
+	allPlugins = append(allPlugins, secret.ProbeVolumePlugins()...)
+	allPlugins = append(allPlugins, iscsi.ProbeVolumePlugins()...)
+	allPlugins = append(allPlugins, glusterfs.ProbeVolumePlugins()...)
+	allPlugins = append(allPlugins, persistent_claim.ProbeVolumePlugins()...)
+	allPlugins = append(allPlugins, rbd.ProbeVolumePlugins()...)
+	allPlugins = append(allPlugins, cinder.ProbeVolumePlugins()...)
+	allPlugins = append(allPlugins, cephfs.ProbeVolumePlugins()...)
+	allPlugins = append(allPlugins, downwardapi.ProbeVolumePlugins()...)
+	allPlugins = append(allPlugins, fc.ProbeVolumePlugins()...)
+	allPlugins = append(allPlugins, flocker.ProbeVolumePlugins()...)
+	if pluginDir != "" {
+		allPlugins = append(allPlugins, flexvolume.ProbeVolumePlugins(pluginDir)...)
+	}
+	allPlugins = append(allPlugins, azure_file.ProbeVolumePlugins()...)
+	allPlugins = append(allPlugins, configmap.ProbeVolumePlugins()...)
+	return allPlugins
+}

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -169,6 +169,13 @@ type Detacher interface {
 	UnmountDevice(globalMountPath string, mounter mount.Interface) error
 }
 
+// VolumeLabeler interface provides methods to get volume labels from external cloud
+type VolumeLabeler interface {
+	// GetLabels returns labels of the volume. This function SHOULD return error
+	// when the volume does not exist.
+	GetLabels() (map[string]string, error)
+}
+
 func RenameDirectory(oldPath, newName string) (string, error) {
 	newPath, err := ioutil.TempDir(path.Dir(oldPath), newName)
 	if err != nil {

--- a/plugin/pkg/admission/admit/admission.go
+++ b/plugin/pkg/admission/admit/admission.go
@@ -25,7 +25,7 @@ import (
 )
 
 func init() {
-	admission.RegisterPlugin("AlwaysAdmit", func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
+	admission.RegisterPlugin("AlwaysAdmit", func(client clientset.Interface, config io.Reader, host admission.AdmissionPluginHost) (admission.Interface, error) {
 		return NewAlwaysAdmit(), nil
 	})
 }

--- a/plugin/pkg/admission/alwayspullimages/admission.go
+++ b/plugin/pkg/admission/alwayspullimages/admission.go
@@ -35,7 +35,7 @@ import (
 )
 
 func init() {
-	admission.RegisterPlugin("AlwaysPullImages", func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
+	admission.RegisterPlugin("AlwaysPullImages", func(client clientset.Interface, config io.Reader, host admission.AdmissionPluginHost) (admission.Interface, error) {
 		return NewAlwaysPullImages(), nil
 	})
 }

--- a/plugin/pkg/admission/deny/admission.go
+++ b/plugin/pkg/admission/deny/admission.go
@@ -26,7 +26,7 @@ import (
 )
 
 func init() {
-	admission.RegisterPlugin("AlwaysDeny", func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
+	admission.RegisterPlugin("AlwaysDeny", func(client clientset.Interface, config io.Reader, host admission.AdmissionPluginHost) (admission.Interface, error) {
 		return NewAlwaysDeny(), nil
 	})
 }

--- a/plugin/pkg/admission/exec/admission.go
+++ b/plugin/pkg/admission/exec/admission.go
@@ -29,13 +29,13 @@ import (
 )
 
 func init() {
-	admission.RegisterPlugin("DenyEscalatingExec", func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
+	admission.RegisterPlugin("DenyEscalatingExec", func(client clientset.Interface, config io.Reader, host admission.AdmissionPluginHost) (admission.Interface, error) {
 		return NewDenyEscalatingExec(client), nil
 	})
 
 	// This is for legacy support of the DenyExecOnPrivileged admission controller.  Most
 	// of the time DenyEscalatingExec should be preferred.
-	admission.RegisterPlugin("DenyExecOnPrivileged", func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
+	admission.RegisterPlugin("DenyExecOnPrivileged", func(client clientset.Interface, config io.Reader, host admission.AdmissionPluginHost) (admission.Interface, error) {
 		return NewDenyExecOnPrivileged(client), nil
 	})
 }

--- a/plugin/pkg/admission/initialresources/admission.go
+++ b/plugin/pkg/admission/initialresources/admission.go
@@ -47,7 +47,7 @@ const (
 
 // WARNING: this feature is experimental and will definitely change.
 func init() {
-	admission.RegisterPlugin("InitialResources", func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
+	admission.RegisterPlugin("InitialResources", func(client clientset.Interface, config io.Reader, host admission.AdmissionPluginHost) (admission.Interface, error) {
 		s, err := newDataSource(*source)
 		if err != nil {
 			return nil, err

--- a/plugin/pkg/admission/limitranger/admission.go
+++ b/plugin/pkg/admission/limitranger/admission.go
@@ -42,7 +42,7 @@ const (
 )
 
 func init() {
-	admission.RegisterPlugin("LimitRanger", func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
+	admission.RegisterPlugin("LimitRanger", func(client clientset.Interface, config io.Reader, host admission.AdmissionPluginHost) (admission.Interface, error) {
 		return NewLimitRanger(client, &DefaultLimitRangerActions{})
 	})
 }

--- a/plugin/pkg/admission/namespace/autoprovision/admission.go
+++ b/plugin/pkg/admission/namespace/autoprovision/admission.go
@@ -30,7 +30,7 @@ import (
 )
 
 func init() {
-	admission.RegisterPlugin("NamespaceAutoProvision", func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
+	admission.RegisterPlugin("NamespaceAutoProvision", func(client clientset.Interface, config io.Reader, host admission.AdmissionPluginHost) (admission.Interface, error) {
 		return NewProvision(client), nil
 	})
 }

--- a/plugin/pkg/admission/namespace/exists/admission.go
+++ b/plugin/pkg/admission/namespace/exists/admission.go
@@ -31,7 +31,7 @@ import (
 )
 
 func init() {
-	admission.RegisterPlugin("NamespaceExists", func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
+	admission.RegisterPlugin("NamespaceExists", func(client clientset.Interface, config io.Reader, host admission.AdmissionPluginHost) (admission.Interface, error) {
 		return NewExists(client), nil
 	})
 }

--- a/plugin/pkg/admission/namespace/lifecycle/admission.go
+++ b/plugin/pkg/admission/namespace/lifecycle/admission.go
@@ -35,7 +35,7 @@ import (
 const PluginName = "NamespaceLifecycle"
 
 func init() {
-	admission.RegisterPlugin(PluginName, func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
+	admission.RegisterPlugin(PluginName, func(client clientset.Interface, config io.Reader, host admission.AdmissionPluginHost) (admission.Interface, error) {
 		return NewLifecycle(client, sets.NewString(api.NamespaceDefault)), nil
 	})
 }

--- a/plugin/pkg/admission/resourcequota/admission.go
+++ b/plugin/pkg/admission/resourcequota/admission.go
@@ -31,7 +31,7 @@ import (
 
 func init() {
 	admission.RegisterPlugin("ResourceQuota",
-		func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
+		func(client clientset.Interface, config io.Reader, host admission.AdmissionPluginHost) (admission.Interface, error) {
 			registry := install.NewRegistry(client)
 			return NewResourceQuota(client, registry, 5)
 		})

--- a/plugin/pkg/admission/securitycontext/scdeny/admission.go
+++ b/plugin/pkg/admission/securitycontext/scdeny/admission.go
@@ -28,7 +28,7 @@ import (
 )
 
 func init() {
-	admission.RegisterPlugin("SecurityContextDeny", func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
+	admission.RegisterPlugin("SecurityContextDeny", func(client clientset.Interface, config io.Reader, host admission.AdmissionPluginHost) (admission.Interface, error) {
 		return NewSecurityContextDeny(client), nil
 	})
 }

--- a/plugin/pkg/admission/serviceaccount/admission.go
+++ b/plugin/pkg/admission/serviceaccount/admission.go
@@ -52,7 +52,7 @@ const DefaultAPITokenMountPath = "/var/run/secrets/kubernetes.io/serviceaccount"
 const PluginName = "ServiceAccount"
 
 func init() {
-	admission.RegisterPlugin(PluginName, func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
+	admission.RegisterPlugin(PluginName, func(client clientset.Interface, config io.Reader, host admission.AdmissionPluginHost) (admission.Interface, error) {
 		serviceAccountAdmission := NewServiceAccount(client)
 		serviceAccountAdmission.Run()
 		return serviceAccountAdmission, nil


### PR DESCRIPTION
- AdmissionController plugins now get VolumePluginMgr and CloudProvider interface at their disposal
- PersistentVolume admission controller plugin uses it to query volume plugins  for labels to apply on created PersistentVolumes.
- VolumePlugins can optionally implement VolumeLabellerPlugin interface to     read the labels from external cloud.

Fixes https://github.com/kubernetes/kubernetes/issues/20955, https://github.com/kubernetes/kubernetes/issues/21041 and https://github.com/kubernetes/kubernetes/issues/21056

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/21386)

<!-- Reviewable:end -->
