### PR TITLE
Indicate that OpenSSL is required to run Kubernetes

### DIFF
--- a/docs/devel/running-locally.md
+++ b/docs/devel/running-locally.md
@@ -36,6 +36,7 @@ Getting started locally
     - [Docker](#docker)
     - [etcd](#etcd)
     - [go](#go)
+    - [OpenSSL](#openssl)
 - [Clone the repository](#clone-the-repository)
 - [Starting the cluster](#starting-the-cluster)
 - [Running a container](#running-a-container)
@@ -67,6 +68,14 @@ You need an [etcd](https://github.com/coreos/etcd/releases) in your path, please
 #### go
 
 You need [go](https://golang.org/doc/install) in your path (see [here](development.md#go-versions) for supported versions), please make sure it is installed and in your ``$PATH``.
+
+#### OpenSSL
+
+You need [OpenSSL](https://www.openssl.org/) installed.  If you do not have the `openssl` command available, you may see the following error in `/tmp/kube-apiserver.log`:
+
+```
+server.go:333] Invalid Authentication Config: open /tmp/kube-serviceaccount.key: no such file or directory
+```
 
 ### Clone the repository
 


### PR DESCRIPTION
The Kubernetes API server failed to start using these instructions on Fedora Cloud 23. Installing the "openssl" package resolves the problem.

This is just a simple documentation change to indicate that openssl is required. Thanks to @liggitt for helping me figure this out.  I should be covered under Red Hat's CLA.

Ping @mikedanese since you were in the commit log for this file :)
