### PR TITLE
Add label for configuring AWS ELB scheme to be internal

### DIFF
--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -19,11 +19,9 @@ package cloudprovider
 import (
 	"errors"
 	"fmt"
-	"net"
 	"strings"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/types"
 )
 
 // Interface is an abstract, pluggable interface for cloud providers.
@@ -82,18 +80,22 @@ type LoadBalancer interface {
 	// TODO: Break this up into different interfaces (LB, etc) when we have more than one type of service
 	// GetLoadBalancer returns whether the specified load balancer exists, and
 	// if so, what its status is.
-	GetLoadBalancer(name, region string) (status *api.LoadBalancerStatus, exists bool, err error)
+	// Implementations must treat the *api.Service parameter as read-only and not modify it.
+	GetLoadBalancer(service *api.Service) (status *api.LoadBalancerStatus, exists bool, err error)
 	// EnsureLoadBalancer creates a new load balancer 'name', or updates the existing one. Returns the status of the balancer
-	EnsureLoadBalancer(name, region string, loadBalancerIP net.IP, ports []*api.ServicePort, hosts []string, serviceName types.NamespacedName, affinityType api.ServiceAffinity, annotations ServiceAnnotation) (*api.LoadBalancerStatus, error)
+	// Implementations must treat the *api.Service parameter as read-only and not modify it.
+	EnsureLoadBalancer(service *api.Service, hosts []string) (*api.LoadBalancerStatus, error)
 	// UpdateLoadBalancer updates hosts under the specified load balancer.
-	UpdateLoadBalancer(name, region string, hosts []string) error
+	// Implementations must treat the *api.Service parameter as read-only and not modify it.
+	UpdateLoadBalancer(service *api.Service, hosts []string) error
 	// EnsureLoadBalancerDeleted deletes the specified load balancer if it
 	// exists, returning nil if the load balancer specified either didn't exist or
 	// was successfully deleted.
 	// This construction is useful because many cloud providers' load balancers
 	// have multiple underlying components, meaning a Get could say that the LB
 	// doesn't exist even if some part of it is still laying around.
-	EnsureLoadBalancerDeleted(name, region string) error
+	// Implementations must treat the *api.Service parameter as read-only and not modify it.
+	EnsureLoadBalancerDeleted(service *api.Service) error
 }
 
 // Instances is an abstract, pluggable interface for sets of instances.

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -58,6 +58,9 @@ const TagNameKubernetesCluster = "KubernetesCluster"
 // The tag name we use to differentiate multiple services. Used currently for ELBs only.
 const TagNameKubernetesService = "kubernetes.io/service-name"
 
+// The label we use to decide if the load balancer is internal
+const LabelLoadBalancerIsInternal = "kubernetes.io/aws-lb-internal"
+
 // We sometimes read to see if something exists; then try to create it if we didn't find it
 // This can fail once in a consistent system if done in parallel
 // In an eventually consistent system, it could fail unboundedly
@@ -1997,8 +2000,11 @@ func (s *AWSCloud) EnsureLoadBalancer(service *api.Service, hosts []string) (*ap
 		listeners = append(listeners, listener)
 	}
 
+	// Determine whether to build an internal or internet-facing load balancer
+	isInternal := service.Labels[LabelLoadBalancerIsInternal] == "true"
+
 	// Build the load balancer itself
-	loadBalancer, err := s.ensureLoadBalancer(serviceName, name, listeners, subnetIDs, securityGroupIDs)
+	loadBalancer, err := s.ensureLoadBalancer(serviceName, name, listeners, subnetIDs, securityGroupIDs, isInternal)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloudprovider/providers/aws/aws_loadbalancer.go
+++ b/pkg/cloudprovider/providers/aws/aws_loadbalancer.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/sets"
 )
 
-func (s *AWSCloud) ensureLoadBalancer(namespacedName types.NamespacedName, name string, listeners []*elb.Listener, subnetIDs []string, securityGroupIDs []string) (*elb.LoadBalancerDescription, error) {
+func (s *AWSCloud) ensureLoadBalancer(namespacedName types.NamespacedName, name string, listeners []*elb.Listener, subnetIDs []string, securityGroupIDs []string, internal bool) (*elb.LoadBalancerDescription, error) {
 	loadBalancer, err := s.describeLoadBalancer(name)
 	if err != nil {
 		return nil, err
@@ -41,6 +41,10 @@ func (s *AWSCloud) ensureLoadBalancer(namespacedName types.NamespacedName, name 
 		createRequest.LoadBalancerName = aws.String(name)
 
 		createRequest.Listeners = listeners
+
+		if internal {
+			createRequest.Scheme = aws.String("internal")
+		}
 
 		// We are supposed to specify one subnet per AZ.
 		// TODO: What happens if we have more than one subnet per AZ?

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package aws
 
 import (
-	"fmt"
 	"io"
 	"reflect"
 	"strings"
@@ -30,7 +29,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/types"
 )
 
 const TestClusterId = "clusterid.test"
@@ -694,40 +692,6 @@ func TestFindVPCID(t *testing.T) {
 	}
 	if vpcID != "vpc-mac0" {
 		t.Errorf("Unexpected vpcID: %s", vpcID)
-	}
-}
-
-func TestLoadBalancerMatchesClusterRegion(t *testing.T) {
-	awsServices := NewFakeAWSServices()
-	c, err := newAWSCloud(strings.NewReader("[global]"), awsServices)
-	if err != nil {
-		t.Errorf("Error building aws cloud: %v", err)
-		return
-	}
-
-	badELBRegion := "bad-elb-region"
-	errorMessage := fmt.Sprintf("requested load balancer region '%s' does not match cluster region '%s'", badELBRegion, c.region)
-
-	_, _, err = c.GetLoadBalancer("elb-name", badELBRegion)
-	if err == nil || err.Error() != errorMessage {
-		t.Errorf("Expected GetLoadBalancer region mismatch error.")
-	}
-
-	serviceName := types.NamespacedName{Namespace: "foo", Name: "bar"}
-
-	_, err = c.EnsureLoadBalancer("elb-name", badELBRegion, nil, nil, nil, serviceName, api.ServiceAffinityNone, nil)
-	if err == nil || err.Error() != errorMessage {
-		t.Errorf("Expected EnsureLoadBalancer region mismatch error.")
-	}
-
-	err = c.EnsureLoadBalancerDeleted("elb-name", badELBRegion)
-	if err == nil || err.Error() != errorMessage {
-		t.Errorf("Expected EnsureLoadBalancerDeleted region mismatch error.")
-	}
-
-	err = c.UpdateLoadBalancer("elb-name", badELBRegion, nil)
-	if err == nil || err.Error() != errorMessage {
-		t.Errorf("Expected UpdateLoadBalancer region mismatch error.")
 	}
 }
 

--- a/pkg/cloudprovider/providers/fake/fake.go
+++ b/pkg/cloudprovider/providers/fake/fake.go
@@ -25,24 +25,22 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/cloudprovider"
-	"k8s.io/kubernetes/pkg/types"
 )
 
 const ProviderName = "fake"
 
 // FakeBalancer is a fake storage of balancer information
 type FakeBalancer struct {
-	Name       string
-	Region     string
-	ExternalIP net.IP
-	Ports      []*api.ServicePort
-	Hosts      []string
+	Name           string
+	Region         string
+	LoadBalancerIP string
+	Ports          []api.ServicePort
+	Hosts          []string
 }
 
 type FakeUpdateBalancerCall struct {
-	Name   string
-	Region string
-	Hosts  []string
+	Service *api.Service
+	Hosts   []string
 }
 
 // FakeCloud is a test-double implementation of Interface, LoadBalancer, Instances, and Routes. It is useful for testing.
@@ -123,7 +121,7 @@ func (f *FakeCloud) Routes() (cloudprovider.Routes, bool) {
 }
 
 // GetLoadBalancer is a stub implementation of LoadBalancer.GetLoadBalancer.
-func (f *FakeCloud) GetLoadBalancer(name, region string) (*api.LoadBalancerStatus, bool, error) {
+func (f *FakeCloud) GetLoadBalancer(service *api.Service) (*api.LoadBalancerStatus, bool, error) {
 	status := &api.LoadBalancerStatus{}
 	status.Ingress = []api.LoadBalancerIngress{{IP: f.ExternalIP.String()}}
 
@@ -132,12 +130,22 @@ func (f *FakeCloud) GetLoadBalancer(name, region string) (*api.LoadBalancerStatu
 
 // EnsureLoadBalancer is a test-spy implementation of LoadBalancer.EnsureLoadBalancer.
 // It adds an entry "create" into the internal method call record.
-func (f *FakeCloud) EnsureLoadBalancer(name, region string, externalIP net.IP, ports []*api.ServicePort, hosts []string, serviceName types.NamespacedName, affinityType api.ServiceAffinity, annotations cloudprovider.ServiceAnnotation) (*api.LoadBalancerStatus, error) {
+func (f *FakeCloud) EnsureLoadBalancer(service *api.Service, hosts []string) (*api.LoadBalancerStatus, error) {
 	f.addCall("create")
 	if f.Balancers == nil {
 		f.Balancers = make(map[string]FakeBalancer)
 	}
-	f.Balancers[name] = FakeBalancer{name, region, externalIP, ports, hosts}
+
+	name := cloudprovider.GetLoadBalancerName(service)
+	spec := service.Spec
+
+	zone, err := f.GetZone()
+	if err != nil {
+		return nil, err
+	}
+	region := zone.Region
+
+	f.Balancers[name] = FakeBalancer{name, region, spec.LoadBalancerIP, spec.Ports, hosts}
 
 	status := &api.LoadBalancerStatus{}
 	status.Ingress = []api.LoadBalancerIngress{{IP: f.ExternalIP.String()}}
@@ -147,15 +155,15 @@ func (f *FakeCloud) EnsureLoadBalancer(name, region string, externalIP net.IP, p
 
 // UpdateLoadBalancer is a test-spy implementation of LoadBalancer.UpdateLoadBalancer.
 // It adds an entry "update" into the internal method call record.
-func (f *FakeCloud) UpdateLoadBalancer(name, region string, hosts []string) error {
+func (f *FakeCloud) UpdateLoadBalancer(service *api.Service, hosts []string) error {
 	f.addCall("update")
-	f.UpdateCalls = append(f.UpdateCalls, FakeUpdateBalancerCall{name, region, hosts})
+	f.UpdateCalls = append(f.UpdateCalls, FakeUpdateBalancerCall{service, hosts})
 	return f.Err
 }
 
 // EnsureLoadBalancerDeleted is a test-spy implementation of LoadBalancer.EnsureLoadBalancerDeleted.
 // It adds an entry "delete" into the internal method call record.
-func (f *FakeCloud) EnsureLoadBalancerDeleted(name, region string) error {
+func (f *FakeCloud) EnsureLoadBalancerDeleted(service *api.Service) error {
 	f.addCall("delete")
 	return f.Err
 }

--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -428,8 +428,8 @@ func (gce *GCECloud) waitForZoneOp(op *compute.Operation, zone string) error {
 }
 
 // GetLoadBalancer is an implementation of LoadBalancer.GetLoadBalancer
-func (gce *GCECloud) GetLoadBalancer(name, region string) (*api.LoadBalancerStatus, bool, error) {
-	fwd, err := gce.service.ForwardingRules.Get(gce.projectID, region, name).Do()
+func (gce *GCECloud) GetLoadBalancer(service *api.Service) (*api.LoadBalancerStatus, bool, error) {
+	fwd, err := gce.service.ForwardingRules.Get(gce.projectID, gce.region, service.Name).Do()
 	if err == nil {
 		status := &api.LoadBalancerStatus{}
 		status.Ingress = []api.LoadBalancerIngress{{IP: fwd.IPAddress}}
@@ -454,13 +454,7 @@ func isHTTPErrorCode(err error, code int) bool {
 // Due to an interesting series of design decisions, this handles both creating
 // new load balancers and updating existing load balancers, recognizing when
 // each is needed.
-func (gce *GCECloud) EnsureLoadBalancer(name, region string, requestedIP net.IP, ports []*api.ServicePort, hostNames []string, serviceName types.NamespacedName, affinityType api.ServiceAffinity, annotations cloudprovider.ServiceAnnotation) (*api.LoadBalancerStatus, error) {
-	portStr := []string{}
-	for _, p := range ports {
-		portStr = append(portStr, fmt.Sprintf("%s/%d", p.Protocol, p.Port))
-	}
-	glog.V(2).Infof("EnsureLoadBalancer(%v, %v, %v, %v, %v, %v, %v)", name, region, requestedIP, portStr, hostNames, serviceName, annotations)
-
+func (gce *GCECloud) EnsureLoadBalancer(service *api.Service, hostNames []string) (*api.LoadBalancerStatus, error) {
 	if len(hostNames) == 0 {
 		return nil, fmt.Errorf("Cannot EnsureLoadBalancer() with no hosts")
 	}
@@ -470,8 +464,23 @@ func (gce *GCECloud) EnsureLoadBalancer(name, region string, requestedIP net.IP,
 		return nil, err
 	}
 
+	name := cloudprovider.GetLoadBalancerName(service)
+	loadBalancerIP := service.Spec.LoadBalancerIP
+	ports := service.Spec.Ports
+	portStr := []string{}
+	for _, p := range service.Spec.Ports {
+		portStr = append(portStr, fmt.Sprintf("%s/%d", p.Protocol, p.Port))
+	}
+
+	affinityType := service.Spec.SessionAffinity
+	var annotations cloudprovider.ServiceAnnotation
+	annotations = service.Annotations
+
+	serviceName := types.NamespacedName{Namespace: service.Namespace, Name: service.Name}
+	glog.V(2).Infof("EnsureLoadBalancer(%v, %v, %v, %v, %v, %v, %v)", name, gce.region, loadBalancerIP, portStr, hosts, serviceName, annotations)
+
 	// Check if the forwarding rule exists, and if so, what its IP is.
-	fwdRuleExists, fwdRuleNeedsUpdate, fwdRuleIP, err := gce.forwardingRuleNeedsUpdate(name, region, requestedIP, ports)
+	fwdRuleExists, fwdRuleNeedsUpdate, fwdRuleIP, err := gce.forwardingRuleNeedsUpdate(name, gce.region, loadBalancerIP, ports)
 	if err != nil {
 		return nil, err
 	}
@@ -505,35 +514,35 @@ func (gce *GCECloud) EnsureLoadBalancer(name, region string, requestedIP net.IP,
 			return
 		}
 		if isSafeToReleaseIP {
-			if err := gce.deleteStaticIP(name, region); err != nil {
-				glog.Errorf("failed to release static IP %s for load balancer (%v(%v), %v): %v", ipAddress, name, serviceName, region, err)
+			if err := gce.deleteStaticIP(name, gce.region); err != nil {
+				glog.Errorf("failed to release static IP %s for load balancer (%v(%v), %v): %v", ipAddress, name, serviceName, gce.region, err)
 			}
 			glog.V(2).Infof("EnsureLoadBalancer(%v(%v)): released static IP %s", name, serviceName, ipAddress)
 		} else {
-			glog.Warningf("orphaning static IP %s during update of load balancer (%v(%v), %v): %v", ipAddress, name, serviceName, region, err)
+			glog.Warningf("orphaning static IP %s during update of load balancer (%v(%v), %v): %v", ipAddress, name, serviceName, gce.region, err)
 		}
 	}()
 
-	if requestedIP != nil {
+	if loadBalancerIP != "" {
 		// If a specific IP address has been requested, we have to respect the
 		// user's request and use that IP. If the forwarding rule was already using
 		// a different IP, it will be harmlessly abandoned because it was only an
 		// ephemeral IP (or it was a different static IP owned by the user, in which
 		// case we shouldn't delete it anyway).
-		if isStatic, err := gce.projectOwnsStaticIP(name, region, requestedIP.String()); err != nil {
-			return nil, fmt.Errorf("failed to test if this GCE project owns the static IP %s: %v", requestedIP.String(), err)
+		if isStatic, err := gce.projectOwnsStaticIP(name, gce.region, loadBalancerIP); err != nil {
+			return nil, fmt.Errorf("failed to test if this GCE project owns the static IP %s: %v", loadBalancerIP, err)
 		} else if isStatic {
 			// The requested IP is a static IP, owned and managed by the user.
 			isUserOwnedIP = true
 			isSafeToReleaseIP = false
-			ipAddress = requestedIP.String()
+			ipAddress = loadBalancerIP
 			glog.V(4).Infof("EnsureLoadBalancer(%v(%v)): using user-provided static IP %s", name, serviceName, ipAddress)
-		} else if requestedIP.String() == fwdRuleIP {
+		} else if loadBalancerIP == fwdRuleIP {
 			// The requested IP is not a static IP, but is currently assigned
 			// to this forwarding rule, so we can keep it.
 			isUserOwnedIP = false
 			isSafeToReleaseIP = true
-			ipAddress, _, err = gce.ensureStaticIP(name, region, fwdRuleIP)
+			ipAddress, _, err = gce.ensureStaticIP(name, gce.region, fwdRuleIP)
 			if err != nil {
 				return nil, fmt.Errorf("failed to ensure static IP %s: %v", fwdRuleIP, err)
 			}
@@ -543,7 +552,7 @@ func (gce *GCECloud) EnsureLoadBalancer(name, region string, requestedIP net.IP,
 			// current forwarding rule.  It might be attached to a different
 			// rule or it might not be part of this project at all.  Either
 			// way, we can't use it.
-			return nil, fmt.Errorf("requested ip %s is neither static nor assigned to LB %s(%v): %v", requestedIP.String(), name, serviceName, err)
+			return nil, fmt.Errorf("requested ip %s is neither static nor assigned to LB %s(%v): %v", loadBalancerIP, name, serviceName, err)
 		}
 	} else {
 		// The user did not request a specific IP.
@@ -554,7 +563,7 @@ func (gce *GCECloud) EnsureLoadBalancer(name, region string, requestedIP net.IP,
 		// IP from ephemeral to static, or it will just get the IP if it is
 		// already static.
 		existed := false
-		ipAddress, existed, err = gce.ensureStaticIP(name, region, fwdRuleIP)
+		ipAddress, existed, err = gce.ensureStaticIP(name, gce.region, fwdRuleIP)
 		if err != nil {
 			return nil, fmt.Errorf("failed to ensure static IP %s: %v", fwdRuleIP, err)
 		}
@@ -587,7 +596,7 @@ func (gce *GCECloud) EnsureLoadBalancer(name, region string, requestedIP net.IP,
 		sourceRanges = strings.Split(val, ",")
 	}
 
-	firewallExists, firewallNeedsUpdate, err := gce.firewallNeedsUpdate(name, region, ipAddress, ports, sourceRanges)
+	firewallExists, firewallNeedsUpdate, err := gce.firewallNeedsUpdate(name, gce.region, ipAddress, ports, sourceRanges)
 	if err != nil {
 		return nil, err
 	}
@@ -597,19 +606,19 @@ func (gce *GCECloud) EnsureLoadBalancer(name, region string, requestedIP net.IP,
 		// Unlike forwarding rules and target pools, firewalls can be updated
 		// without needing to be deleted and recreated.
 		if firewallExists {
-			if err := gce.updateFirewall(name, region, desc, sourceRanges, ports, hosts); err != nil {
+			if err := gce.updateFirewall(name, gce.region, desc, sourceRanges, ports, hosts); err != nil {
 				return nil, err
 			}
 			glog.V(4).Infof("EnsureLoadBalancer(%v(%v)): updated firewall", name, serviceName)
 		} else {
-			if err := gce.createFirewall(name, region, desc, sourceRanges, ports, hosts); err != nil {
+			if err := gce.createFirewall(name, gce.region, desc, sourceRanges, ports, hosts); err != nil {
 				return nil, err
 			}
 			glog.V(4).Infof("EnsureLoadBalancer(%v(%v)): created firewall", name, serviceName)
 		}
 	}
 
-	tpExists, tpNeedsUpdate, err := gce.targetPoolNeedsUpdate(name, region, affinityType)
+	tpExists, tpNeedsUpdate, err := gce.targetPoolNeedsUpdate(name, gce.region, affinityType)
 	if err != nil {
 		return nil, err
 	}
@@ -626,13 +635,13 @@ func (gce *GCECloud) EnsureLoadBalancer(name, region string, requestedIP net.IP,
 		// and something should fail before we recreate it, don't release the
 		// IP.  That way we can come back to it later.
 		isSafeToReleaseIP = false
-		if err := gce.deleteForwardingRule(name, region); err != nil {
+		if err := gce.deleteForwardingRule(name, gce.region); err != nil {
 			return nil, fmt.Errorf("failed to delete existing forwarding rule %s for load balancer update: %v", name, err)
 		}
 		glog.V(4).Infof("EnsureLoadBalancer(%v(%v)): deleted forwarding rule", name, serviceName)
 	}
 	if tpExists && tpNeedsUpdate {
-		if err := gce.deleteTargetPool(name, region); err != nil {
+		if err := gce.deleteTargetPool(name, gce.region); err != nil {
 			return nil, fmt.Errorf("failed to delete existing target pool %s for load balancer update: %v", name, err)
 		}
 		glog.V(4).Infof("EnsureLoadBalancer(%v(%v)): deleted target pool", name, serviceName)
@@ -641,13 +650,13 @@ func (gce *GCECloud) EnsureLoadBalancer(name, region string, requestedIP net.IP,
 	// Once we've deleted the resources (if necessary), build them back up (or for
 	// the first time if they're new).
 	if tpNeedsUpdate {
-		if err := gce.createTargetPool(name, region, hosts, affinityType); err != nil {
+		if err := gce.createTargetPool(name, gce.region, hosts, affinityType); err != nil {
 			return nil, fmt.Errorf("failed to create target pool %s: %v", name, err)
 		}
 		glog.V(4).Infof("EnsureLoadBalancer(%v(%v)): created target pool", name, serviceName)
 	}
 	if tpNeedsUpdate || fwdRuleNeedsUpdate {
-		if err := gce.createForwardingRule(name, region, ipAddress, ports); err != nil {
+		if err := gce.createForwardingRule(name, gce.region, ipAddress, ports); err != nil {
 			return nil, fmt.Errorf("failed to create forwarding rule %s: %v", name, err)
 		}
 		// End critical section.  It is safe to release the static IP (which
@@ -667,7 +676,7 @@ func (gce *GCECloud) EnsureLoadBalancer(name, region string, requestedIP net.IP,
 // IP is being requested.
 // Returns whether the forwarding rule exists, whether it needs to be updated,
 // what its IP address is (if it exists), and any error we encountered.
-func (gce *GCECloud) forwardingRuleNeedsUpdate(name, region string, requestedIP net.IP, ports []*api.ServicePort) (exists bool, needsUpdate bool, ipAddress string, err error) {
+func (gce *GCECloud) forwardingRuleNeedsUpdate(name, region string, loadBalancerIP string, ports []api.ServicePort) (exists bool, needsUpdate bool, ipAddress string, err error) {
 	fwd, err := gce.service.ForwardingRules.Get(gce.projectID, region, name).Do()
 	if err != nil {
 		if isHTTPErrorCode(err, http.StatusNotFound) {
@@ -675,7 +684,7 @@ func (gce *GCECloud) forwardingRuleNeedsUpdate(name, region string, requestedIP 
 		}
 		return false, false, "", fmt.Errorf("error getting load balancer's forwarding rule: %v", err)
 	}
-	if requestedIP != nil && requestedIP.String() != fwd.IPAddress {
+	if loadBalancerIP != fwd.IPAddress {
 		return true, true, fwd.IPAddress, nil
 	}
 	portRange, err := loadBalancerPortRange(ports)
@@ -693,7 +702,7 @@ func (gce *GCECloud) forwardingRuleNeedsUpdate(name, region string, requestedIP 
 	return true, false, fwd.IPAddress, nil
 }
 
-func loadBalancerPortRange(ports []*api.ServicePort) (string, error) {
+func loadBalancerPortRange(ports []api.ServicePort) (string, error) {
 	if len(ports) == 0 {
 		return "", fmt.Errorf("no ports specified for GCE load balancer")
 	}
@@ -745,7 +754,7 @@ func translateAffinityType(affinityType api.ServiceAffinity) string {
 	}
 }
 
-func (gce *GCECloud) firewallNeedsUpdate(name, region, ipAddress string, ports []*api.ServicePort, sourceRanges []string) (exists bool, needsUpdate bool, err error) {
+func (gce *GCECloud) firewallNeedsUpdate(name, region, ipAddress string, ports []api.ServicePort, sourceRanges []string) (exists bool, needsUpdate bool, err error) {
 	fw, err := gce.service.Firewalls.Get(gce.projectID, makeFirewallName(name)).Do()
 	if err != nil {
 		if isHTTPErrorCode(err, http.StatusNotFound) {
@@ -797,7 +806,7 @@ func slicesEqual(x, y []string) bool {
 	return true
 }
 
-func (gce *GCECloud) createForwardingRule(name, region, ipAddress string, ports []*api.ServicePort) error {
+func (gce *GCECloud) createForwardingRule(name, region, ipAddress string, ports []api.ServicePort) error {
 	portRange, err := loadBalancerPortRange(ports)
 	if err != nil {
 		return err
@@ -845,7 +854,7 @@ func (gce *GCECloud) createTargetPool(name, region string, hosts []*gceInstance,
 	return nil
 }
 
-func (gce *GCECloud) createFirewall(name, region, desc string, sourceRanges []string, ports []*api.ServicePort, hosts []*gceInstance) error {
+func (gce *GCECloud) createFirewall(name, region, desc string, sourceRanges []string, ports []api.ServicePort, hosts []*gceInstance) error {
 	firewall, err := gce.firewallObject(name, region, desc, sourceRanges, ports, hosts)
 	if err != nil {
 		return err
@@ -863,7 +872,7 @@ func (gce *GCECloud) createFirewall(name, region, desc string, sourceRanges []st
 	return nil
 }
 
-func (gce *GCECloud) updateFirewall(name, region, desc string, sourceRanges []string, ports []*api.ServicePort, hosts []*gceInstance) error {
+func (gce *GCECloud) updateFirewall(name, region, desc string, sourceRanges []string, ports []api.ServicePort, hosts []*gceInstance) error {
 	firewall, err := gce.firewallObject(name, region, desc, sourceRanges, ports, hosts)
 	if err != nil {
 		return err
@@ -881,7 +890,7 @@ func (gce *GCECloud) updateFirewall(name, region, desc string, sourceRanges []st
 	return nil
 }
 
-func (gce *GCECloud) firewallObject(name, region, desc string, sourceRanges []string, ports []*api.ServicePort, hosts []*gceInstance) (*compute.Firewall, error) {
+func (gce *GCECloud) firewallObject(name, region, desc string, sourceRanges []string, ports []api.ServicePort, hosts []*gceInstance) (*compute.Firewall, error) {
 	allowedPorts := make([]string, len(ports))
 	for ix := range ports {
 		allowedPorts[ix] = strconv.Itoa(ports[ix].Port)
@@ -1007,13 +1016,13 @@ func (gce *GCECloud) ensureStaticIP(name, region, existingIP string) (ipAddress 
 }
 
 // UpdateLoadBalancer is an implementation of LoadBalancer.UpdateLoadBalancer.
-func (gce *GCECloud) UpdateLoadBalancer(name, region string, hostNames []string) error {
+func (gce *GCECloud) UpdateLoadBalancer(service *api.Service, hostNames []string) error {
 	hosts, err := gce.getInstancesByNames(hostNames)
 	if err != nil {
 		return err
 	}
 
-	pool, err := gce.service.TargetPools.Get(gce.projectID, region, name).Do()
+	pool, err := gce.service.TargetPools.Get(gce.projectID, gce.region, service.Name).Do()
 	if err != nil {
 		return err
 	}
@@ -1037,22 +1046,22 @@ func (gce *GCECloud) UpdateLoadBalancer(name, region string, hostNames []string)
 
 	if len(toAdd) > 0 {
 		add := &compute.TargetPoolsAddInstanceRequest{Instances: toAdd}
-		op, err := gce.service.TargetPools.AddInstance(gce.projectID, region, name, add).Do()
+		op, err := gce.service.TargetPools.AddInstance(gce.projectID, gce.region, service.Name, add).Do()
 		if err != nil {
 			return err
 		}
-		if err := gce.waitForRegionOp(op, region); err != nil {
+		if err := gce.waitForRegionOp(op, gce.region); err != nil {
 			return err
 		}
 	}
 
 	if len(toRemove) > 0 {
 		rm := &compute.TargetPoolsRemoveInstanceRequest{Instances: toRemove}
-		op, err := gce.service.TargetPools.RemoveInstance(gce.projectID, region, name, rm).Do()
+		op, err := gce.service.TargetPools.RemoveInstance(gce.projectID, gce.region, service.Name, rm).Do()
 		if err != nil {
 			return err
 		}
-		if err := gce.waitForRegionOp(op, region); err != nil {
+		if err := gce.waitForRegionOp(op, gce.region); err != nil {
 			return err
 		}
 	}
@@ -1060,41 +1069,41 @@ func (gce *GCECloud) UpdateLoadBalancer(name, region string, hostNames []string)
 	// Try to verify that the correct number of nodes are now in the target pool.
 	// We've been bitten by a bug here before (#11327) where all nodes were
 	// accidentally removed and want to make similar problems easier to notice.
-	updatedPool, err := gce.service.TargetPools.Get(gce.projectID, region, name).Do()
+	updatedPool, err := gce.service.TargetPools.Get(gce.projectID, gce.region, service.Name).Do()
 	if err != nil {
 		return err
 	}
 	if len(updatedPool.Instances) != len(hosts) {
 		glog.Errorf("Unexpected number of instances (%d) in target pool %s after updating (expected %d). Instances in updated pool: %s",
-			len(updatedPool.Instances), name, len(hosts), strings.Join(updatedPool.Instances, ","))
-		return fmt.Errorf("Unexpected number of instances (%d) in target pool %s after update (expected %d)", len(updatedPool.Instances), name, len(hosts))
+			len(updatedPool.Instances), service.Name, len(hosts), strings.Join(updatedPool.Instances, ","))
+		return fmt.Errorf("Unexpected number of instances (%d) in target pool %s after update (expected %d)", len(updatedPool.Instances), service.Name, len(hosts))
 	}
 	return nil
 }
 
 // EnsureLoadBalancerDeleted is an implementation of LoadBalancer.EnsureLoadBalancerDeleted.
-func (gce *GCECloud) EnsureLoadBalancerDeleted(name, region string) error {
-	glog.V(2).Infof("EnsureLoadBalancerDeleted(%v, %v", name, region)
-	err := utilerrors.AggregateGoroutines(
-		func() error { return gce.deleteFirewall(name, region) },
+func (gce *GCECloud) EnsureLoadBalancerDeleted(service *api.Service) error {
+	glog.V(2).Infof("EnsureLoadBalancerDeleted(%v, %v, %v)", service.Namespace, service.Name, gce.region)
+	errs := utilerrors.AggregateGoroutines(
+		func() error { return gce.deleteFirewall(service.Name, gce.region) },
 		// Even though we don't hold on to static IPs for load balancers, it's
 		// possible that EnsureLoadBalancer left one around in a failed
 		// creation/update attempt, so make sure we clean it up here just in case.
-		func() error { return gce.deleteStaticIP(name, region) },
+		func() error { return gce.deleteStaticIP(service.Name, gce.region) },
 		func() error {
 			// The forwarding rule must be deleted before either the target pool can,
 			// unfortunately, so we have to do these two serially.
-			if err := gce.deleteForwardingRule(name, region); err != nil {
+			if err := gce.deleteForwardingRule(service.Name, gce.region); err != nil {
 				return err
 			}
-			if err := gce.deleteTargetPool(name, region); err != nil {
+			if err := gce.deleteTargetPool(service.Name, gce.region); err != nil {
 				return err
 			}
 			return nil
 		},
 	)
-	if err != nil {
-		return utilerrors.Flatten(err)
+	if errs != nil {
+		return utilerrors.Flatten(errs)
 	}
 	return nil
 }
@@ -1180,9 +1189,9 @@ func (gce *GCECloud) CreateFirewall(name, desc string, sourceRanges []string, po
 	}
 	// TODO: This completely breaks modularity in the cloudprovider but the methods
 	// shared with the TCPLoadBalancer take api.ServicePorts.
-	svcPorts := []*api.ServicePort{}
+	svcPorts := []api.ServicePort{}
 	for _, p := range ports {
-		svcPorts = append(svcPorts, &api.ServicePort{Port: int(p)})
+		svcPorts = append(svcPorts, api.ServicePort{Port: int(p)})
 	}
 	hosts, err := gce.getInstancesByNames(hostNames)
 	if err != nil {
@@ -1209,9 +1218,9 @@ func (gce *GCECloud) UpdateFirewall(name, desc string, sourceRanges []string, po
 	}
 	// TODO: This completely breaks modularity in the cloudprovider but the methods
 	// shared with the TCPLoadBalancer take api.ServicePorts.
-	svcPorts := []*api.ServicePort{}
+	svcPorts := []api.ServicePort{}
 	for _, p := range ports {
-		svcPorts = append(svcPorts, &api.ServicePort{Port: int(p)})
+		svcPorts = append(svcPorts, api.ServicePort{Port: int(p)})
 	}
 	hosts, err := gce.getInstancesByNames(hostNames)
 	if err != nil {

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"regexp"
 	"strings"
@@ -46,7 +45,6 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/cloudprovider"
-	"k8s.io/kubernetes/pkg/types"
 )
 
 const ProviderName = "openstack"
@@ -640,8 +638,8 @@ func getFloatingIPByPortID(client *gophercloud.ServiceClient, portID string) (*f
 	return &floatingIPList[0], nil
 }
 
-func (lb *LoadBalancer) GetLoadBalancer(name, region string) (*api.LoadBalancerStatus, bool, error) {
-	vip, err := getVipByName(lb.network, name)
+func (lb *LoadBalancer) GetLoadBalancer(service *api.Service) (*api.LoadBalancerStatus, bool, error) {
+	vip, err := getVipByName(lb.network, service.Name)
 	if err == ErrNotFound {
 		return nil, false, nil
 	}
@@ -660,9 +658,10 @@ func (lb *LoadBalancer) GetLoadBalancer(name, region string) (*api.LoadBalancerS
 // a list of regions (from config) and query/create loadbalancers in
 // each region.
 
-func (lb *LoadBalancer) EnsureLoadBalancer(name, region string, loadBalancerIP net.IP, ports []*api.ServicePort, hosts []string, serviceName types.NamespacedName, affinity api.ServiceAffinity, annotations cloudprovider.ServiceAnnotation) (*api.LoadBalancerStatus, error) {
-	glog.V(4).Infof("EnsureLoadBalancer(%v, %v, %v, %v, %v, %v, %v)", name, region, loadBalancerIP, ports, hosts, serviceName, annotations)
+func (lb *LoadBalancer) EnsureLoadBalancer(service *api.Service, hosts []string) (*api.LoadBalancerStatus, error) {
+	glog.V(4).Infof("EnsureLoadBalancer(%v, %v, %v, %v, %v)", service.Namespace, service.Name, service.Spec.LoadBalancerIP, service.Spec.Ports, hosts)
 
+	ports := service.Spec.Ports
 	if len(ports) > 1 {
 		return nil, fmt.Errorf("multiple ports are not yet supported in openstack load balancers")
 	} else if len(ports) == 0 {
@@ -675,6 +674,7 @@ func (lb *LoadBalancer) EnsureLoadBalancer(name, region string, loadBalancerIP n
 		return nil, fmt.Errorf("Only TCP LoadBalancer is supported for openstack load balancers")
 	}
 
+	affinity := service.Spec.SessionAffinity
 	var persistence *vips.SessionPersistence
 	switch affinity {
 	case api.ServiceAffinityNone:
@@ -685,8 +685,8 @@ func (lb *LoadBalancer) EnsureLoadBalancer(name, region string, loadBalancerIP n
 		return nil, fmt.Errorf("unsupported load balancer affinity: %v", affinity)
 	}
 
-	glog.V(2).Infof("Checking if openstack load balancer already exists: %s", name)
-	_, exists, err := lb.GetLoadBalancer(name, region)
+	glog.V(2).Infof("Checking if openstack load balancer already exists: %s", service.Name)
+	_, exists, err := lb.GetLoadBalancer(service)
 	if err != nil {
 		return nil, fmt.Errorf("error checking if openstack load balancer already exists: %v", err)
 	}
@@ -694,7 +694,7 @@ func (lb *LoadBalancer) EnsureLoadBalancer(name, region string, loadBalancerIP n
 	// TODO: Implement a more efficient update strategy for common changes than delete & create
 	// In particular, if we implement hosts update, we can get rid of UpdateHosts
 	if exists {
-		err := lb.EnsureLoadBalancerDeleted(name, region)
+		err := lb.EnsureLoadBalancerDeleted(service)
 		if err != nil {
 			return nil, fmt.Errorf("error deleting existing openstack load balancer: %v", err)
 		}
@@ -704,6 +704,7 @@ func (lb *LoadBalancer) EnsureLoadBalancer(name, region string, loadBalancerIP n
 	if lbmethod == "" {
 		lbmethod = pools.LBMethodRoundRobin
 	}
+	name := cloudprovider.GetLoadBalancerName(service)
 	pool, err := pools.Create(lb.network, pools.CreateOpts{
 		Name:     name,
 		Protocol: pools.ProtocolTCP,
@@ -761,8 +762,10 @@ func (lb *LoadBalancer) EnsureLoadBalancer(name, region string, loadBalancerIP n
 		SubnetID:     lb.opts.SubnetId,
 		Persistence:  persistence,
 	}
-	if loadBalancerIP != nil {
-		createOpts.Address = loadBalancerIP.String()
+
+	loadBalancerIP := service.Spec.LoadBalancerIP
+	if loadBalancerIP != "" {
+		createOpts.Address = loadBalancerIP
 	}
 
 	vip, err := vips.Create(lb.network, createOpts).Extract()
@@ -795,10 +798,10 @@ func (lb *LoadBalancer) EnsureLoadBalancer(name, region string, loadBalancerIP n
 
 }
 
-func (lb *LoadBalancer) UpdateLoadBalancer(name, region string, hosts []string) error {
-	glog.V(4).Infof("UpdateLoadBalancer(%v, %v, %v)", name, region, hosts)
+func (lb *LoadBalancer) UpdateLoadBalancer(service *api.Service, hosts []string) error {
+	glog.V(4).Infof("UpdateLoadBalancer(%v, %v)", *service, hosts)
 
-	vip, err := getVipByName(lb.network, name)
+	vip, err := getVipByName(lb.network, service.Name)
 	if err != nil {
 		return err
 	}
@@ -856,10 +859,10 @@ func (lb *LoadBalancer) UpdateLoadBalancer(name, region string, hosts []string) 
 	return nil
 }
 
-func (lb *LoadBalancer) EnsureLoadBalancerDeleted(name, region string) error {
-	glog.V(4).Infof("EnsureLoadBalancerDeleted(%v, %v)", name, region)
+func (lb *LoadBalancer) EnsureLoadBalancerDeleted(service *api.Service) error {
+	glog.V(4).Infof("EnsureLoadBalancerDeleted(%v)", *service)
 
-	vip, err := getVipByName(lb.network, name)
+	vip, err := getVipByName(lb.network, service.Name)
 	if err != nil && err != ErrNotFound {
 		return err
 	}
@@ -897,7 +900,7 @@ func (lb *LoadBalancer) EnsureLoadBalancerDeleted(name, region string) error {
 		// still exists that we failed to delete on some
 		// previous occasion.  Make a best effort attempt to
 		// cleanup any pools with the same name as the VIP.
-		pool, err = getPoolByName(lb.network, name)
+		pool, err = getPoolByName(lb.network, service.Name)
 		if err != nil && err != ErrNotFound {
 			return err
 		}

--- a/pkg/cloudprovider/providers/openstack/openstack_test.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/rand"
 
 	"github.com/rackspace/gophercloud"
+	"k8s.io/kubernetes/pkg/api"
 )
 
 func TestReadConfig(t *testing.T) {
@@ -169,7 +170,7 @@ func TestLoadBalancer(t *testing.T) {
 		t.Fatalf("LoadBalancer() returned false - perhaps your stack doesn't support Neutron?")
 	}
 
-	_, exists, err := lb.GetLoadBalancer("noexist", "region")
+	_, exists, err := lb.GetLoadBalancer(&api.Service{ObjectMeta: api.ObjectMeta{Name: "noexist"}})
 	if err != nil {
 		t.Fatalf("GetLoadBalancer(\"noexist\") returned error: %s", err)
 	}

--- a/pkg/controller/service/servicecontroller.go
+++ b/pkg/controller/service/servicecontroller.go
@@ -18,7 +18,6 @@ package service
 
 import (
 	"fmt"
-	"net"
 	"sort"
 	"sync"
 	"time"
@@ -29,7 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/client/cache"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/client/record"
-	unversionedcore "k8s.io/kubernetes/pkg/client/typed/generated/core/unversioned"
+	unversioned_core "k8s.io/kubernetes/pkg/client/typed/generated/core/unversioned"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/types"
@@ -83,7 +82,7 @@ type ServiceController struct {
 // (like load balancers) in sync with the registry.
 func New(cloud cloudprovider.Interface, kubeClient clientset.Interface, clusterName string) *ServiceController {
 	broadcaster := record.NewBroadcaster()
-	broadcaster.StartRecordingToSink(&unversionedcore.EventSinkImpl{kubeClient.Core().Events("")})
+	broadcaster.StartRecordingToSink(&unversioned_core.EventSinkImpl{kubeClient.Core().Events("")})
 	recorder := broadcaster.NewRecorder(api.EventSource{Component: "service-controller"})
 
 	return &ServiceController{
@@ -259,7 +258,7 @@ func (s *ServiceController) processDelta(delta *cache.Delta) (error, bool) {
 		s.cache.set(namespacedName.String(), cachedService)
 	case cache.Deleted:
 		s.eventRecorder.Event(service, api.EventTypeNormal, "DeletingLoadBalancer", "Deleting load balancer")
-		err := s.balancer.EnsureLoadBalancerDeleted(s.loadBalancerName(service), s.zone.Region)
+		err := s.balancer.EnsureLoadBalancerDeleted(service)
 		if err != nil {
 			message := "Error deleting load balancer (will retry): " + err.Error()
 			s.eventRecorder.Event(service, api.EventTypeWarning, "DeletingLoadBalancerFailed", message)
@@ -297,7 +296,7 @@ func (s *ServiceController) createLoadBalancerIfNeeded(namespacedName types.Name
 			// If we don't have any cached memory of the load balancer, we have to ask
 			// the cloud provider for what it knows about it.
 			// Technically EnsureLoadBalancerDeleted can cope, but we want to post meaningful events
-			_, exists, err := s.balancer.GetLoadBalancer(s.loadBalancerName(service), s.zone.Region)
+			_, exists, err := s.balancer.GetLoadBalancer(service)
 			if err != nil {
 				return fmt.Errorf("Error getting LB for service %s: %v", namespacedName, err), retryable
 			}
@@ -309,7 +308,7 @@ func (s *ServiceController) createLoadBalancerIfNeeded(namespacedName types.Name
 		if needDelete {
 			glog.Infof("Deleting existing load balancer for service %s that no longer needs a load balancer.", namespacedName)
 			s.eventRecorder.Event(service, api.EventTypeNormal, "DeletingLoadBalancer", "Deleting load balancer")
-			if err := s.balancer.EnsureLoadBalancerDeleted(s.loadBalancerName(service), s.zone.Region); err != nil {
+			if err := s.balancer.EnsureLoadBalancerDeleted(service); err != nil {
 				return err, retryable
 			}
 			s.eventRecorder.Event(service, api.EventTypeNormal, "DeletedLoadBalancer", "Deleted load balancer")
@@ -323,8 +322,7 @@ func (s *ServiceController) createLoadBalancerIfNeeded(namespacedName types.Name
 
 		// The load balancer doesn't exist yet, so create it.
 		s.eventRecorder.Event(service, api.EventTypeNormal, "CreatingLoadBalancer", "Creating load balancer")
-
-		err := s.createLoadBalancer(service, namespacedName)
+		err := s.createLoadBalancer(service)
 		if err != nil {
 			return fmt.Errorf("Failed to create load balancer for service %s: %v", namespacedName, err), retryable
 		}
@@ -374,21 +372,16 @@ func (s *ServiceController) persistUpdate(service *api.Service) error {
 	return err
 }
 
-func (s *ServiceController) createLoadBalancer(service *api.Service, serviceName types.NamespacedName) error {
-	ports, err := getPortsForLB(service)
-	if err != nil {
-		return err
-	}
+func (s *ServiceController) createLoadBalancer(service *api.Service) error {
 	nodes, err := s.nodeLister.List()
 	if err != nil {
 		return err
 	}
-	name := s.loadBalancerName(service)
+
 	// - Only one protocol supported per service
 	// - Not all cloud providers support all protocols and the next step is expected to return
 	//   an error for unsupported protocols
-	status, err := s.balancer.EnsureLoadBalancer(name, s.zone.Region, net.ParseIP(service.Spec.LoadBalancerIP),
-		ports, hostsFromNodeList(&nodes), serviceName, service.Spec.SessionAffinity, service.ObjectMeta.Annotations)
+	status, err := s.balancer.EnsureLoadBalancer(service, hostsFromNodeList(&nodes))
 	if err != nil {
 		return err
 	} else {
@@ -704,16 +697,15 @@ func (s *ServiceController) lockedUpdateLoadBalancerHosts(service *api.Service, 
 	}
 
 	// This operation doesn't normally take very long (and happens pretty often), so we only record the final event
-	name := cloudprovider.GetLoadBalancerName(service)
-	err := s.balancer.UpdateLoadBalancer(name, s.zone.Region, hosts)
+	err := s.balancer.UpdateLoadBalancer(service, hosts)
 	if err == nil {
 		s.eventRecorder.Event(service, api.EventTypeNormal, "UpdatedLoadBalancer", "Updated load balancer with new hosts")
 		return nil
 	}
 
 	// It's only an actual error if the load balancer still exists.
-	if _, exists, err := s.balancer.GetLoadBalancer(name, s.zone.Region); err != nil {
-		glog.Errorf("External error while checking if load balancer %q exists: name, %v", name, err)
+	if _, exists, err := s.balancer.GetLoadBalancer(service); err != nil {
+		glog.Errorf("External error while checking if load balancer %q exists: name, %v", cloudprovider.GetLoadBalancerName(service), err)
 	} else if !exists {
 		return nil
 	}

--- a/pkg/controller/service/servicecontroller.go
+++ b/pkg/controller/service/servicecontroller.go
@@ -477,6 +477,9 @@ func (s *ServiceController) needsUpdate(oldService *api.Service, newService *api
 			len(oldService.Spec.ExternalIPs), len(newService.Spec.ExternalIPs))
 		return true
 	}
+	if len(oldService.Labels) != len(newService.Labels) {
+		return true
+	}
 	for i := range oldService.Spec.ExternalIPs {
 		if oldService.Spec.ExternalIPs[i] != newService.Spec.ExternalIPs[i] {
 			s.eventRecorder.Eventf(newService, api.EventTypeNormal, "ExternalIP", "Added: %v",

--- a/pkg/controller/service/servicecontroller_test.go
+++ b/pkg/controller/service/servicecontroller_test.go
@@ -166,7 +166,7 @@ func TestUpdateNodesInExternalLoadBalancer(t *testing.T) {
 				newService("s0", "333", api.ServiceTypeLoadBalancer),
 			},
 			expectedUpdateCalls: []fakecloud.FakeUpdateBalancerCall{
-				{Name: "a333", Region: region, Hosts: []string{"node0", "node1", "node73"}},
+				{newService("s0", "333", api.ServiceTypeLoadBalancer), hosts},
 			},
 		},
 		{
@@ -177,9 +177,9 @@ func TestUpdateNodesInExternalLoadBalancer(t *testing.T) {
 				newService("s2", "666", api.ServiceTypeLoadBalancer),
 			},
 			expectedUpdateCalls: []fakecloud.FakeUpdateBalancerCall{
-				{Name: "a444", Region: region, Hosts: []string{"node0", "node1", "node73"}},
-				{Name: "a555", Region: region, Hosts: []string{"node0", "node1", "node73"}},
-				{Name: "a666", Region: region, Hosts: []string{"node0", "node1", "node73"}},
+				{newService("s0", "444", api.ServiceTypeLoadBalancer), hosts},
+				{newService("s1", "555", api.ServiceTypeLoadBalancer), hosts},
+				{newService("s2", "666", api.ServiceTypeLoadBalancer), hosts},
 			},
 		},
 		{
@@ -191,8 +191,8 @@ func TestUpdateNodesInExternalLoadBalancer(t *testing.T) {
 				newService("s4", "123", api.ServiceTypeClusterIP),
 			},
 			expectedUpdateCalls: []fakecloud.FakeUpdateBalancerCall{
-				{Name: "a888", Region: region, Hosts: []string{"node0", "node1", "node73"}},
-				{Name: "a999", Region: region, Hosts: []string{"node0", "node1", "node73"}},
+				{newService("s1", "888", api.ServiceTypeLoadBalancer), hosts},
+				{newService("s3", "999", api.ServiceTypeLoadBalancer), hosts},
 			},
 		},
 		{
@@ -202,7 +202,7 @@ func TestUpdateNodesInExternalLoadBalancer(t *testing.T) {
 				nil,
 			},
 			expectedUpdateCalls: []fakecloud.FakeUpdateBalancerCall{
-				{Name: "a234", Region: region, Hosts: []string{"node0", "node1", "node73"}},
+				{newService("s0", "234", api.ServiceTypeLoadBalancer), hosts},
 			},
 		},
 	}


### PR DESCRIPTION
If the label `kubernetes.io/aws-lb-internal` is set to "true" on the service, it will create the load balancer using the `internal` scheme, making it private.

This relies on https://github.com/kubernetes/kubernetes/pull/21378 and is branched from it.
