### PR TITLE
e2e: log events, pod/node info when kube-system pods fail to start

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -39,6 +39,8 @@ import (
 	gcecloud "k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/runtime"
+
+	. "github.com/onsi/gomega"
 )
 
 const (
@@ -180,6 +182,9 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	// test pods from running, and tests that ensure all pods are running and
 	// ready will fail).
 	if err := waitForPodsRunningReady(api.NamespaceSystem, testContext.MinStartupPods, podStartupTimeout); err != nil {
+		c, err := loadClient()
+		Expect(err).NotTo(HaveOccurred())
+		dumpAllNamespaceInfo(c, api.NamespaceSystem)
 		Failf("Error waiting for all pods to be running and ready: %v", err)
 	}
 

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -161,20 +161,7 @@ func (f *Framework) afterEach() {
 
 	// Print events if the test failed.
 	if CurrentGinkgoTestDescription().Failed {
-		By(fmt.Sprintf("Collecting events from namespace %q.", f.Namespace.Name))
-		events, err := f.Client.Events(f.Namespace.Name).List(api.ListOptions{})
-		Expect(err).NotTo(HaveOccurred())
-
-		for _, e := range events.Items {
-			Logf("event for %v: %v %v: %v", e.InvolvedObject.Name, e.Source, e.Reason, e.Message)
-		}
-		// Note that we don't wait for any cleanup to propagate, which means
-		// that if you delete a bunch of pods right before ending your test,
-		// you may or may not see the killing/deletion/cleanup events.
-
-		dumpAllPodInfo(f.Client)
-
-		dumpAllNodeInfo(f.Client)
+		dumpAllNamespaceInfo(f.Client, f.Namespace.Name)
 	}
 
 	summaries := make([]TestDataSummary, 0)

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1806,6 +1806,23 @@ func dumpPodDebugInfo(c *client.Client, pods []*api.Pod) {
 	dumpNodeDebugInfo(c, badNodes.List())
 }
 
+func dumpAllNamespaceInfo(c *client.Client, namespace string) {
+	By(fmt.Sprintf("Collecting events from namespace %q.", namespace))
+	events, err := c.Events(namespace).List(api.ListOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	for _, e := range events.Items {
+		Logf("event for %v: %v %v: %v", e.InvolvedObject.Name, e.Source, e.Reason, e.Message)
+	}
+	// Note that we don't wait for any cleanup to propagate, which means
+	// that if you delete a bunch of pods right before ending your test,
+	// you may or may not see the killing/deletion/cleanup events.
+
+	dumpAllPodInfo(c)
+
+	dumpAllNodeInfo(c)
+}
+
 func dumpAllPodInfo(c *client.Client) {
 	pods, err := c.Pods("").List(api.ListOptions{})
 	if err != nil {


### PR DESCRIPTION
Ref #21322
