### PR TITLE
Fixing broken persistent volume wordpress and mysql example and documentation

### DIFF
--- a/examples/mysql-wordpress-pd/README.md
+++ b/examples/mysql-wordpress-pd/README.md
@@ -226,6 +226,8 @@ spec:
         - name: WORDPRESS_DB_PASSWORD
           # change this - must match mysql.yaml password
           value: yourpassword
+        - name: WORDPRESS_DB_HOST
+          value: yourmysql_svc_password
       ports: 
         - containerPort: 80
           name: wordpress

--- a/examples/mysql-wordpress-pd/README.md
+++ b/examples/mysql-wordpress-pd/README.md
@@ -227,7 +227,7 @@ spec:
           # change this - must match mysql.yaml password
           value: yourpassword
         - name: WORDPRESS_DB_HOST
-          value: yourmysql_svc_password
+          value: yourmysql_svc_ip:port
       ports: 
         - containerPort: 80
           name: wordpress

--- a/examples/mysql-wordpress-pd/README.md
+++ b/examples/mysql-wordpress-pd/README.md
@@ -227,6 +227,7 @@ spec:
           # change this - must match mysql.yaml password
           value: yourpassword
         - name: WORDPRESS_DB_HOST
+          # change this - must match the ip address and port of your mysql service
           value: yourmysql_svc_ip:port
       ports: 
         - containerPort: 80

--- a/examples/mysql-wordpress-pd/wordpress.yaml
+++ b/examples/mysql-wordpress-pd/wordpress.yaml
@@ -12,6 +12,9 @@ spec:
         - name: WORDPRESS_DB_PASSWORD
           # change this - must match mysql.yaml password
           value: yourpassword
+        - name: WORDPRESS_DB_HOST
+          # change this - must match the ip address of your mysql service
+          value: yourmysql_svc_password
       ports: 
         - containerPort: 80
           name: wordpress

--- a/examples/mysql-wordpress-pd/wordpress.yaml
+++ b/examples/mysql-wordpress-pd/wordpress.yaml
@@ -13,8 +13,8 @@ spec:
           # change this - must match mysql.yaml password
           value: yourpassword
         - name: WORDPRESS_DB_HOST
-          # change this - must match the ip address of your mysql service
-          value: yourmysql_svc_password
+          # change this - must match the ip address and port of your mysql service
+          value: yourmysql_svc_ip:port
       ports: 
         - containerPort: 80
           name: wordpress


### PR DESCRIPTION
When working through this example today, I found that the wordpress container will not start properly if you do not include the WORDPRESS_DB_HOST environment variable.  I've added this in the example README.md and the example's yaml.

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/21422)

<!-- Reviewable:end -->
