### PR TITLE
Update redis example to use alpine:3.4 as image

### DIFF
--- a/examples/redis/README.md
+++ b/examples/redis/README.md
@@ -133,6 +133,9 @@ Now let's take a close look at what happens after this pod is deleted.  There ar
 
 At this point we now have a reliable, scalable Redis installation.  By scaling the replication controller for redis servers, we can increase or decrease the number of read-slaves in our cluster.  Likewise, if failures occur, the redis-sentinels will perform master election and select a new master.
 
+**NOTE:** since redis 3.2 some security measures (bind to 127.0.0.1 and `--protected-mode`) are enabled by default. Please read about this in http://antirez.com/news/96
+
+
 ### tl; dr
 
 For those of you who are impatient, here is the summary of commands we ran in this tutorial:

--- a/examples/redis/image/Dockerfile
+++ b/examples/redis/image/Dockerfile
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM redis:2.8
-RUN apt-get update
-RUN apt-get install -yy -q python
+FROM alpine:3.4
+
+RUN apk add -U redis sed bash && rm -rf /var/cache/apk/*
 
 COPY redis-master.conf /redis-master/redis.conf
 COPY redis-slave.conf /redis-slave/redis.conf
 COPY run.sh /run.sh
 
 CMD [ "/run.sh" ]
-ENTRYPOINT [ "sh", "-c" ]
+
+ENTRYPOINT [ "bash", "-c" ]

--- a/examples/redis/image/redis-master.conf
+++ b/examples/redis/image/redis-master.conf
@@ -61,7 +61,8 @@ tcp-backlog 511
 # Examples:
 #
 # bind 192.168.1.100 10.0.0.1
-# bind 127.0.0.1
+
+bind 0.0.0.0
 
 # Specify the path for the Unix socket that will be used to listen for
 # incoming connections. There is no default, so Redis will not listen

--- a/examples/redis/image/redis-slave.conf
+++ b/examples/redis/image/redis-slave.conf
@@ -61,7 +61,8 @@ tcp-backlog 511
 # Examples:
 #
 # bind 192.168.1.100 10.0.0.1
-# bind 127.0.0.1
+
+bind 0.0.0.0
 
 # Specify the path for the Unix socket that will be used to listen for
 # incoming connections. There is no default, so Redis will not listen

--- a/examples/redis/image/run.sh
+++ b/examples/redis/image/run.sh
@@ -19,7 +19,7 @@ function launchmaster() {
     echo "Redis master data doesn't exist, data won't be persistent!"
     mkdir /redis-master-data
   fi
-  redis-server /redis-master/redis.conf
+  redis-server /redis-master/redis.conf --protected-mode no
 }
 
 function launchsentinel() {
@@ -45,8 +45,9 @@ function launchsentinel() {
   echo "sentinel down-after-milliseconds mymaster 60000" >> ${sentinel_conf}
   echo "sentinel failover-timeout mymaster 180000" >> ${sentinel_conf}
   echo "sentinel parallel-syncs mymaster 1" >> ${sentinel_conf}
+  echo "bind 0.0.0.0"
 
-  redis-sentinel ${sentinel_conf}
+  redis-sentinel ${sentinel_conf} --protected-mode no
 }
 
 function launchslave() {
@@ -66,9 +67,9 @@ function launchslave() {
     echo "Connecting to master failed.  Waiting..."
     sleep 10
   done
-  perl -pi -e "s/%master-ip%/${master}/" /redis-slave/redis.conf
-  perl -pi -e "s/%master-port%/6379/" /redis-slave/redis.conf
-  redis-server /redis-slave/redis.conf
+  sed -i "s/%master-ip%/${master}/" /redis-slave/redis.conf
+  sed -i "s/%master-port%/6379/" /redis-slave/redis.conf
+  redis-server /redis-slave/redis.conf --protected-mode no
 }
 
 if [[ "${MASTER}" == "true" ]]; then

--- a/examples/redis/redis-controller.yaml
+++ b/examples/redis/redis-controller.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: redis
-        image: kubernetes/redis:v1
+        image: kubernetes/redis:v2
         ports:
         - containerPort: 6379
         resources:

--- a/examples/redis/redis-master.yaml
+++ b/examples/redis/redis-master.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   containers:
     - name: master
-      image: kubernetes/redis:v1
+      image: kubernetes/redis:v2
       env:
         - name: MASTER
           value: "true"
@@ -22,7 +22,7 @@ spec:
         - mountPath: /redis-master-data
           name: data
     - name: sentinel
-      image: kubernetes/redis:v1
+      image: kubernetes/redis:v2
       env:
         - name: SENTINEL
           value: "true"

--- a/examples/redis/redis-proxy.yaml
+++ b/examples/redis/redis-proxy.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
   - name: proxy
-    image: kubernetes/redis-proxy:v1
+    image: kubernetes/redis-proxy:v2
     ports:
     - containerPort: 6379
       name: api

--- a/examples/redis/redis-sentinel-controller.yaml
+++ b/examples/redis/redis-sentinel-controller.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: sentinel
-        image: kubernetes/redis:v1
+        image: kubernetes/redis:v2
         env:
           - name: SENTINEL
             value: "true"


### PR DESCRIPTION
```
kubernetes/redis    v2                  40e584663e63        5 minutes ago       58.25 MB
kubernetes/redis    v1                  de309495e6c7        13 months ago       146 MB
```

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/21424)

<!-- Reviewable:end -->
