### PR TITLE
E2E cleanup

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -1443,11 +1443,13 @@ function test-build-release {
 }
 
 # Execute prior to running tests to initialize required structure. This is
-# called from hack/e2e.go only when running -up (it is run after kube-up).
+# called from hack/e2e.go only when running -up.
 #
 # Assumed vars:
 #   Variables from config.sh
 function test-setup {
+  "${KUBE_ROOT}/cluster/kube-up.sh"
+
   VPC_ID=$(get_vpc_id)
   detect-security-groups
 

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -1192,13 +1192,23 @@ function test-build-release {
 }
 
 # Execute prior to running tests to initialize required structure. This is
-# called from hack/e2e.go only when running -up (it is run after kube-up).
+# called from hack/e2e.go only when running -up.
 #
 # Assumed vars:
 #   Variables from config.sh
 function test-setup {
   # Detect the project into $PROJECT if it isn't set
   detect-project
+
+  if [[ ${MULTIZONE:-} == "true" ]]; then
+    for KUBE_GCE_ZONE in ${E2E_ZONES}
+    do
+      KUBE_GCE_ZONE="${KUBE_GCE_ZONE}" KUBE_USE_EXISTING_MASTER="${KUBE_USE_EXISTING_MASTER:-}" "${KUBE_ROOT}/cluster/kube-up.sh"
+      KUBE_USE_EXISTING_MASTER="true" # For subsequent zones we use the existing master
+    done
+  else
+    "${KUBE_ROOT}/cluster/kube-up.sh"
+  fi
 
   # Open up port 80 & 8080 so common containers on minions can be reached
   # TODO(roberthbailey): Remove this once we are no longer relying on hostPorts.

--- a/cluster/gke/util.sh
+++ b/cluster/gke/util.sh
@@ -167,8 +167,11 @@ function test-setup() {
   echo "... in gke:test-setup()" >&2
   # Detect the project into $PROJECT if it isn't set
   detect-project >&2
-  detect-nodes >&2
 
+  "${KUBE_ROOT}/cluster/kube-up.sh"
+
+  detect-nodes >&2
+ 
   # At this point, CLUSTER_NAME should have been used, so its value is final.
   NODE_TAG=$($GCLOUD compute instances describe ${NODE_NAMES[0]} --project="${PROJECT}" --zone="${ZONE}" | grep -o "gke-${CLUSTER_NAME}-.\{8\}-node" | head -1)
   OLD_NODE_TAG="k8s-${CLUSTER_NAME}-node"

--- a/cluster/juju/util.sh
+++ b/cluster/juju/util.sh
@@ -165,9 +165,9 @@ function test-build-release {
 }
 
 # Execute prior to running tests to initialize required structure. This is
-# called from hack/e2e.go only when running -up (it is run after kube-up).
+# called from hack/e2e.go only when running -up.
 function test-setup {
-    echo "test-setup() " 1>&2
+  "${KUBE_ROOT}/cluster/kube-up.sh"
 }
 
 # Execute after running tests to perform any required clean-up. This is called

--- a/cluster/libvirt-coreos/util.sh
+++ b/cluster/libvirt-coreos/util.sh
@@ -316,7 +316,7 @@ function test-build-release {
 
 # Execute prior to running tests to initialize required structure
 function test-setup {
-  echo "TODO"
+  "${KUBE_ROOT}/cluster/kube-up.sh"
 }
 
 # Execute after running tests to perform any required clean-up

--- a/cluster/mesos/docker/util.sh
+++ b/cluster/mesos/docker/util.sh
@@ -317,7 +317,8 @@ function kube-down {
 }
 
 function test-setup {
-  echo "TODO: test-setup" 1>&2
+  echo "test-setup" 1>&2
+  "${KUBE_ROOT}/cluster/kube-up.sh"
 }
 
 # Execute after running tests to perform any required clean-up

--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -317,6 +317,7 @@ function test-build-release {
 
 # Execute prior to running tests to initialize required structure
 function test-setup {
+  "${KUBE_ROOT}/cluster/kube-up.sh"
   echo "Vagrant test setup complete" 1>&2
 }
 

--- a/hack/e2e-internal/e2e-up.sh
+++ b/hack/e2e-internal/e2e-up.sh
@@ -31,14 +31,4 @@ source "${KUBE_VERSION_ROOT}/cluster/${KUBERNETES_PROVIDER}/util.sh"
 
 prepare-e2e
 
-if [[ ${MULTIZONE:-} == "true" ]]; then
-    for KUBE_GCE_ZONE in ${E2E_ZONES}
-    do
-	KUBE_GCE_ZONE="${KUBE_GCE_ZONE}" KUBE_USE_EXISTING_MASTER="${KUBE_USE_EXISTING_MASTER:-}" KUBE_TEST_DEBUG=y "${KUBE_VERSION_ROOT}/cluster/kube-up.sh"
-	KUBE_USE_EXISTING_MASTER="true" # For subsequent zones we use the existing master
-    done
-else
-    KUBE_TEST_DEBUG=y "${KUBE_VERSION_ROOT}/cluster/kube-up.sh"
-fi
-
 test-setup

--- a/hack/e2e.go
+++ b/hack/e2e.go
@@ -18,12 +18,10 @@ limitations under the License.
 package main
 
 import (
-	"bytes"
 	"flag"
 	"fmt"
 	"io"
 	"log"
-	"math/rand"
 	"net/http"
 	"os"
 	"os/exec"
@@ -256,14 +254,6 @@ func PrepareVersion(version string) (string, error) {
 	return localReleaseDir, nil
 }
 
-// Fisher-Yates shuffle using the given RNG r
-func shuffleStrings(strings []string, r *rand.Rand) {
-	for i := len(strings) - 1; i > 0; i-- {
-		j := r.Intn(i + 1)
-		strings[i], strings[j] = strings[j], strings[i]
-	}
-}
-
 func Test() bool {
 	if !IsUp() {
 		log.Fatal("Testing requested, but e2e cluster not up!")
@@ -272,25 +262,6 @@ func Test() bool {
 	ValidateClusterSize()
 
 	return finishRunning("Ginkgo tests", exec.Command(filepath.Join(*root, "hack/ginkgo-e2e.sh"), strings.Fields(*testArgs)...))
-}
-
-// All nonsense below is temporary until we have go versions of these things.
-
-// call the returned anonymous function to stop.
-func runBashUntil(stepName string, cmd *exec.Cmd) func() {
-	log.Printf("Running in background: %v", stepName)
-	output := bytes.NewBuffer(nil)
-	cmd.Stdout, cmd.Stderr = output, output
-	if err := cmd.Start(); err != nil {
-		log.Printf("Unable to start '%v': '%v'", stepName, err)
-		return func() {}
-	}
-	return func() {
-		cmd.Process.Signal(os.Interrupt)
-		headerprefix := stepName + " "
-		lineprefix := "  "
-		printBashOutputs(headerprefix, lineprefix, string(output.Bytes()), false)
-	}
 }
 
 func finishRunning(stepName string, cmd *exec.Cmd) bool {
@@ -308,19 +279,6 @@ func finishRunning(stepName string, cmd *exec.Cmd) bool {
 		return false
 	}
 	return true
-}
-
-func printBashOutputs(headerprefix, lineprefix, output string, escape bool) {
-	if output != "" {
-		fmt.Printf("%voutput: |\n", headerprefix)
-		printPrefixedLines(lineprefix, output)
-	}
-}
-
-func printPrefixedLines(prefix, s string) {
-	for _, line := range strings.Split(s, "\n") {
-		fmt.Printf("%v%v\n", prefix, line)
-	}
 }
 
 // returns either "", or a list of args intended for appending with the

--- a/hack/e2e.go
+++ b/hack/e2e.go
@@ -122,6 +122,7 @@ func main() {
 	}
 
 	os.Setenv("KUBECTL", versionRoot+`/cluster/kubectl.sh`+kubectlArgs())
+	os.Setenv("KUBE_TEST_DEBUG", "y")
 
 	if *pushup {
 		if IsUp() {
@@ -175,7 +176,6 @@ func Up() bool {
 			return false
 		}
 	}
-
 	return finishRunning("up", exec.Command(path.Join(*root, "hack/e2e-internal/e2e-up.sh")))
 }
 


### PR DESCRIPTION
That stuff in `hack/e2e.go` was from back when it functioned as a test runner for bash e2e tests. We don't have those anymore, so lets get rid of the code.

I moved the `MULTIZONE` check out of `hack/e2e-internal/e2e-up.sh` and into `cluster/gce/util.sh`. It had previously been using `KUBE_VERSION_ROOT`. I switched it to use `KUBE_ROOT` instead, to match what it uses to tear down the cluster. This may be incorrect. @quinton-hoole might know?

For now I'd like to disallow changes to individual scripts in `e2e-internal`, and I will probably remove them entirely soon.
