### PR TITLE
Fix namespace test

### DIFF
--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
+	apierrs "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/release_1_2"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
@@ -146,7 +147,11 @@ func (f *Framework) afterEach() {
 					timeout = f.NamespaceDeletionTimeout
 				}
 				if err := deleteNS(f.Client, ns.Name, timeout); err != nil {
-					Failf("Couldn't delete ns %q: %s", ns.Name, err)
+					if !apierrs.IsNotFound(err) {
+						Failf("Couldn't delete ns %q: %s", ns.Name, err)
+					} else {
+						Logf("Namespace %v was already deleted", ns.Name)
+					}
 				}
 			}
 			f.namespacesToDelete = nil

--- a/test/e2e/namespace.go
+++ b/test/e2e/namespace.go
@@ -34,8 +34,8 @@ func extinguish(f *Framework, totalNS int, maxAllowedAfterDel int, maxSeconds in
 
 	By("Creating testing namespaces")
 	wg := &sync.WaitGroup{}
+	wg.Add(totalNS)
 	for n := 0; n < totalNS; n += 1 {
-		wg.Add(1)
 		go func(n int) {
 			defer wg.Done()
 			defer GinkgoRecover()


### PR DESCRIPTION
Fixes #21321. This is a copy of #21383 modified to use errors.IsNotFound. Hoping to get this in asap to unbreak e2e. Manual run of namespace test passing with this change.

@k8s-oncall ptal
