### PR TITLE
Log daemons' failure reasons to supervisord log files

### DIFF
--- a/cluster/saltbase/salt/supervisor/kubelet-checker.sh
+++ b/cluster/saltbase/salt/supervisor/kubelet-checker.sh
@@ -34,6 +34,7 @@ max_seconds=10
 while true; do
   if ! curl --insecure -m ${max_seconds} -f -s https://127.0.0.1:{{kubelet_port}}/healthz > /dev/null; then
     echo "kubelet failed!"
+    curl --insecure -s http://127.0.0.1:{{kubelet_port}}/healthz
     exit 2
   fi
   sleep 10

--- a/test/e2e/core.go
+++ b/test/e2e/core.go
@@ -55,6 +55,7 @@ func CoreDump(dir string) {
 		{"cat /var/log/kube-apiserver.log", "kube-apiserver"},
 		{"cat /var/log/kube-scheduler.log", "kube-scheduler"},
 		{"cat /var/log/kube-controller-manager.log", "kube-controller-manager"},
+		{"cat /var/log/etcd.log", "kube-etcd"},
 	}
 	if isUsingSystemdKubelet(provider, master) {
 		cmds = append(cmds, command{"sudo journalctl --output=cat -u kubelet.service", "kubelet"})
@@ -62,6 +63,8 @@ func CoreDump(dir string) {
 		cmds = append(cmds, []command{
 			{"cat /var/log/kubelet.log", "kubelet"},
 			{"cat /var/log/supervisor/supervisord.log", "supervisord"},
+			{"cat /var/log/supervisor/kubelet-stdout.log", "supervisord-kubelet-stdout"},
+			{"cat /var/log/supervisor/kubelet-stderr.log", "supervisord-kubelet-stderr"},
 			{"cat /var/log/kern.log", "kern.log"},
 		}...)
 	}
@@ -88,6 +91,8 @@ func CoreDump(dir string) {
 		cmds = append(cmds, []command{
 			{"cat /var/log/kubelet.log", "kubelet"},
 			{"cat /var/log/supervisor/supervisord.log", "supervisord"},
+			{"cat /var/log/supervisor/kubelet-stdout.log", "supervisord-kubelet-stdout"},
+			{"cat /var/log/supervisor/kubelet-stderr.log", "supervisord-kubelet-stderr"},
 			{"cat /var/log/kern.log", "kern.log"},
 		}...)
 	}

--- a/test/e2e/core.go
+++ b/test/e2e/core.go
@@ -66,6 +66,7 @@ func CoreDump(dir string) {
 			{"cat /var/log/supervisor/kubelet-stdout.log", "supervisord-kubelet-stdout"},
 			{"cat /var/log/supervisor/kubelet-stderr.log", "supervisord-kubelet-stderr"},
 			{"cat /var/log/kern.log", "kern.log"},
+			{"cat /var/log/docker.log", "docker.log"},
 		}...)
 	}
 
@@ -94,6 +95,7 @@ func CoreDump(dir string) {
 			{"cat /var/log/supervisor/kubelet-stdout.log", "supervisord-kubelet-stdout"},
 			{"cat /var/log/supervisor/kubelet-stderr.log", "supervisord-kubelet-stderr"},
 			{"cat /var/log/kern.log", "kern.log"},
+			{"cat /var/log/docker.log", "docker.log"},
 		}...)
 	}
 


### PR DESCRIPTION
Fixed #21433 

Also collect etcd log for diagnose ##21206, and supervisord/kubelet\* logs for diagnose #21261

cc/ @yujuhong 
