### PR TITLE
kube-up: install updates & reboot automatically on boot

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -996,6 +996,7 @@ function start-master() {
 
     echo "cat > kube_env.yaml << __EOF_MASTER_KUBE_ENV_YAML"
     cat ${KUBE_TEMP}/master-kube-env.yaml
+    echo "AUTO_UPGRADE: 'true'"
     # TODO: get rid of these exceptions / harmonize with common or GCE
     echo "DOCKER_STORAGE: $(yaml-quote ${DOCKER_STORAGE:-})"
     echo "API_SERVERS: $(yaml-quote ${MASTER_INTERNAL_IP:-})"
@@ -1090,6 +1091,7 @@ function start-minions() {
     echo "cd /var/cache/kubernetes-install"
     echo "cat > kube_env.yaml << __EOF_KUBE_ENV_YAML"
     cat ${KUBE_TEMP}/node-kube-env.yaml
+    echo "AUTO_UPGRADE: 'true'"
     # TODO: get rid of these exceptions / harmonize with common or GCE
     echo "DOCKER_STORAGE: $(yaml-quote ${DOCKER_STORAGE:-})"
     echo "API_SERVERS: $(yaml-quote ${MASTER_INTERNAL_IP:-})"


### PR DESCRIPTION
We run unattened-upgrades manually, and then reboot automatically if we
find /var/run/reboot-required; then we check if any services need
restarting and restart them automatically using the needrestart tool.

This should mean we don't _have_ to build new images on every security
update, though we can do so to avoid a reboot.

Issue #21382
