### PR TITLE
Limit number of keys in Secret and ConfigMap

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -2233,6 +2233,10 @@ type Secret struct {
 }
 
 const MaxSecretSize = 1 * 1024 * 1024
+const MaxSecretKeys = 1024
+
+// reserve 1k from the MaxSecretSize for serialization
+const MaxUnserializedSecretSize = MaxSecretSize - 1024
 
 type SecretType string
 

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package validation
 
 import (
+	"fmt"
 	"math/rand"
 	"reflect"
 	"strings"
@@ -4409,6 +4410,7 @@ func TestValidateSecret(t *testing.T) {
 		leadingDotKey = validSecret()
 		dotKey        = validSecret()
 		doubleDotKey  = validSecret()
+		tooManyKeys   = validSecret()
 	)
 
 	emptyName.Name = ""
@@ -4416,12 +4418,15 @@ func TestValidateSecret(t *testing.T) {
 	emptyNs.Namespace = ""
 	invalidNs.Namespace = "NoUppercaseOrSpecialCharsLike=Equals"
 	overMaxSize.Data = map[string][]byte{
-		"over": make([]byte, api.MaxSecretSize+1),
+		"over": make([]byte, api.MaxUnserializedSecretSize+1),
 	}
 	invalidKey.Data["a..b"] = []byte("whoops")
 	leadingDotKey.Data[".key"] = []byte("bar")
 	dotKey.Data["."] = []byte("bar")
 	doubleDotKey.Data[".."] = []byte("bar")
+	for i := 0; i < api.MaxSecretKeys+1; i++ {
+		tooManyKeys.Data[fmt.Sprintf("suchkeys-%d", i)] = []byte("bar")
+	}
 
 	// kubernetes.io/service-account-token secret validation
 	validServiceAccountTokenSecret := func() api.Secret {
@@ -4467,6 +4472,7 @@ func TestValidateSecret(t *testing.T) {
 		"leading dot key":                           {leadingDotKey, true},
 		"dot key":                                   {dotKey, false},
 		"double dot key":                            {doubleDotKey, false},
+		"too many keys":                             {tooManyKeys, false},
 	}
 
 	for name, tc := range tests {
@@ -5028,8 +5034,13 @@ func TestValidateConfigMap(t *testing.T) {
 		dotKey           = newConfigMap("validname", "validns", map[string]string{".": "value"})
 		doubleDotKey     = newConfigMap("validname", "validns", map[string]string{"..": "value"})
 		overMaxKeyLength = newConfigMap("validname", "validns", map[string]string{strings.Repeat("a", 254): "value"})
-		overMaxSize      = newConfigMap("validname", "validns", map[string]string{"key": strings.Repeat("a", api.MaxSecretSize+1)})
+		overMaxSize      = newConfigMap("validname", "validns", map[string]string{"key": strings.Repeat("a", api.MaxUnserializedSecretSize+1)})
+		tooManyKeys      = newConfigMap("validname", "validns", map[string]string{})
 	)
+
+	for i := 0; i < api.MaxSecretKeys+1; i++ {
+		tooManyKeys.Data[fmt.Sprintf("suchkeys-%d", i)] = "value"
+	}
 
 	tests := map[string]struct {
 		cfg     api.ConfigMap
@@ -5047,6 +5058,7 @@ func TestValidateConfigMap(t *testing.T) {
 		"double dot key":      {doubleDotKey, false},
 		"over max key length": {overMaxKeyLength, false},
 		"over max size":       {overMaxSize, false},
+		"too many keys":       {tooManyKeys, false},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
Puts a 1k limit on the number of keys and includes the key length, in addition to the value length, in the total size limit check

Fixes #19969
