### PR TITLE
Enable fluentd to parse the sub-second portion of timestamps coming from docker logs

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/td-agent.conf
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/td-agent.conf
@@ -105,11 +105,13 @@
   type null
 </match>
 
+# Example:
+# {"log":"[info:2016-02-16T16:04:05.930-08:00] Some log text here\n","stream":"stdout","time":"2016-02-17T00:04:05.931087621Z"}
 <source>
   type tail
   path /var/log/containers/*.log
   pos_file /var/log/es-containers.log.pos
-  time_format %Y-%m-%dT%H:%M:%S
+  time_format %Y-%m-%dT%H:%M:%S.%NZ
   tag kubernetes.*
   format json
   read_from_head true
@@ -142,7 +144,7 @@
 <source>
   type tail
   format /^time="(?<time>[^)]*)" level=(?<severity>[^ ]*) msg="(?<message>[^"]*)"( err="(?<error>[^"]*)")?( statusCode=($<status_code>\d+))?/
-  time_format %Y-%m-%dT%H:%M:%S.%N%z
+  time_format %Y-%m-%dT%H:%M:%S.%NZ
   path /var/log/docker.log
   pos_file /var/log/es-docker.log.pos
   tag docker

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/google-fluentd.conf
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/google-fluentd.conf
@@ -47,13 +47,15 @@
   type null
 </match>
 
+# Example:
+# {"log":"[info:2016-02-16T16:04:05.930-08:00] Some log text here\n","stream":"stdout","time":"2016-02-17T00:04:05.931087621Z"}
 <source>
   type tail
   format json
   time_key time
   path /var/log/containers/*.log
   pos_file /var/log/gcp-containers.log.pos
-  time_format %Y-%m-%dT%H:%M:%S
+  time_format %Y-%m-%dT%H:%M:%S.%NZ
   tag reform.*
   read_from_head true
 </source>
@@ -91,7 +93,7 @@
 <source>
   type tail
   format /^time="(?<time>[^)]*)" level=(?<severity>[^ ]*) msg="(?<message>[^"]*)"( err="(?<error>[^"]*)")?( statusCode=($<status_code>\d+))?/
-  time_format %Y-%m-%dT%H:%M:%S.%N%z
+  time_format %Y-%m-%dT%H:%M:%S.%NZ
   path /var/log/docker.log
   pos_file /var/log/gcp-docker.log.pos
   tag docker


### PR DESCRIPTION
Fix for issue #21480

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/kubernetes/kubernetes/21482)

<!-- Reviewable:end -->
