### PR TITLE
Move remaining two PD tests slow test suite

### DIFF
--- a/test/e2e/pd.go
+++ b/test/e2e/pd.go
@@ -63,7 +63,7 @@ var _ = Describe("Pod Disks", func() {
 		mathrand.Seed(time.Now().UTC().UnixNano())
 	})
 
-	It("should schedule a pod w/ a RW PD, remove it, then schedule it on another host", func() {
+	It("should schedule a pod w/ a RW PD, remove it, then schedule it on another host [Slow]", func() {
 		SkipUnlessProviderIs("gce", "gke", "aws")
 
 		By("creating PD")
@@ -116,7 +116,7 @@ var _ = Describe("Pod Disks", func() {
 		return
 	})
 
-	It("should schedule a pod w/ a readonly PD on two hosts, then remove both.", func() {
+	It("should schedule a pod w/ a readonly PD on two hosts, then remove both. [Slow]", func() {
 		SkipUnlessProviderIs("gce", "gke")
 
 		By("creating PD")


### PR DESCRIPTION
The two PD tests in this PR take an average of 2-3 minutes to complete, but occasionally take as long as 10 minutes to complete. This, in turn, causes the [GCE test suite](http://kubekins.dls.corp.google.com/view/Critical%20Builds/job/kubernetes-e2e-gce/) to timeout: https://github.com/kubernetes/kubernetes/issues/21138

We will move these tests to the [slow suite](http://kubekins.dls.corp.google.com/view/Critical%20Builds/job/kubernetes-e2e-gce-slow/).

The slow suite is a critical build that the build cop is responsible for monitoring and keeping green, but does not automatically block the merge queue when it fails.

CC @spxtr @fejta @ixdy 
