### PR TITLE
Don't impose a memory limit on flannel etcd.

### DIFF
--- a/cluster/saltbase/salt/flannel-server/flannel-server.manifest
+++ b/cluster/saltbase/salt/flannel-server/flannel-server.manifest
@@ -60,8 +60,8 @@
                     }
                 ],
                 "resources": {
-                    "limits": {
-                        "cpu": "100m"
+                    "requests": {
+                        "cpu": {{ cpulimit }}
                     }
                 },
                 "volumeMounts": [
@@ -89,9 +89,8 @@
                     "timeoutSeconds": 15
                 },
                 "resources": {
-                    "limits": {
-                        "cpu": {{ cpulimit }},
-                        "memory": {{ memlimit }}
+                    "requests": {
+                        "cpu": {{ cpulimit }}
                     }
                 },
                 "volumeMounts": [

--- a/cluster/saltbase/salt/flannel-server/init.sls
+++ b/cluster/saltbase/salt/flannel-server/init.sls
@@ -27,5 +27,3 @@ touch /var/log/etcd_flannel.log:
         etcd_port: 4003
         etcd_peer_port: 2382
         cpulimit: '"100m"'
-        memlimit: '"50Mi"'
-


### PR DESCRIPTION
Previous limits were not based on 1000 node cluster, and in general limiting memory will either be too little or too large for some cluster size.

https://github.com/kubernetes/kubernetes/issues/21500
@kubernetes/goog-cluster 
