### PR TITLE
Add DaemonSets and Deployments to valid resources list in kubectl.

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -110,8 +110,13 @@ __custom_func() {
     esac
 }
 `
+
+	// If you add a resource to this list, please also take a look at pkg/kubectl/kubectl.go
+	// and add a short forms entry in expandResourceShortcut() when appropriate.
 	valid_resources = `Valid resource types include:
    * componentstatuses (aka 'cs')
+   * daemonsets (aka 'ds')
+   * deployments
    * events (aka 'ev')
    * endpoints (aka 'ep')
    * horizontalpodautoscalers (aka 'hpa')

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -100,6 +100,8 @@ func (e ShortcutExpander) ResourceSingularizer(resource string) (string, error) 
 func expandResourceShortcut(resource unversioned.GroupVersionResource) unversioned.GroupVersionResource {
 	shortForms := map[string]unversioned.GroupVersionResource{
 		// Please keep this alphabetized
+		// If you add an entry here, please also take a look at pkg/kubectl/cmd/cmd.go
+		// and add an entry to valid_resources when appropriate.
 		"cs":     api.SchemeGroupVersion.WithResource("componentstatuses"),
 		"ds":     extensions.SchemeGroupVersion.WithResource("daemonsets"),
 		"ep":     api.SchemeGroupVersion.WithResource("endpoints"),


### PR DESCRIPTION
@bgrant0607 Should there be a short form for Deployments? I thought about 'dep', but that sounds more like dependencies. 
