### PR TITLE
add fastbuild option to ./build/release.sh and use it in make quick-release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,6 @@ release:
 # Example:
 #   make release-skip-tests
 release-skip-tests quick-release:
-	KUBE_RELEASE_RUN_TESTS=n build/release.sh
+	KUBE_RELEASE_RUN_TESTS=n KUBE_FASTBUILD=true build/release.sh
 .PHONY: release-skip-tests quick-release
 

--- a/build/common.sh
+++ b/build/common.sh
@@ -580,6 +580,11 @@ function kube::build::run_build_command() {
     docker_run_opts+=(-e "KUBERNETES_CONTRIB=${KUBERNETES_CONTRIB}")
   fi
 
+  docker_run_opts+=(
+    --env "KUBE_FASTBUILD=${KUBE_FASTBUILD:-false}"
+    --env "KUBE_BUILDER_OS=${OSTYPE:-notdetected}"
+  )
+
   # If we have stdin we can run interactive.  This allows things like 'shell.sh'
   # to work.  However, if we run this way and don't have stdin, then it ends up
   # running in a daemon-ish mode.  So if we don't have a stdin, we explicitly

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -47,11 +47,45 @@ kube::golang::server_targets() {
 readonly KUBE_SERVER_TARGETS=($(kube::golang::server_targets))
 readonly KUBE_SERVER_BINARIES=("${KUBE_SERVER_TARGETS[@]##*/}")
 
-# The server platform we are building on.
-readonly KUBE_SERVER_PLATFORMS=(
-  linux/amd64
-  linux/arm
-)
+if [[ "${KUBE_FASTBUILD:-}" == "true" ]]; then
+  readonly KUBE_SERVER_PLATFORMS=(linux/amd64)
+  readonly KUBE_TEST_PLATFORMS=(linux/amd64)
+  if [[ "${KUBE_BUILDER_OS:-}" == "darwin"* ]]; then
+    readonly KUBE_CLIENT_PLATFORMS=(
+      darwin/amd64
+      linux/amd64
+    )
+  else
+    readonly KUBE_CLIENT_PLATFORMS=(linux/amd64)
+  fi
+else
+
+  # The server platform we are building on.
+  readonly KUBE_SERVER_PLATFORMS=(
+    linux/amd64
+    linux/arm
+  )
+
+  # If we update this we should also update the set of golang compilers we build
+  # in 'build/build-image/cross/Dockerfile'. However, it's only a bit faster since go 1.5, not mandatory
+  readonly KUBE_CLIENT_PLATFORMS=(
+    linux/amd64
+    linux/386
+    linux/arm
+    darwin/amd64
+    darwin/386
+    windows/amd64
+    windows/386
+  )
+
+  # Which platforms we should compile test targets for. Not all client platforms need these tests
+  readonly KUBE_TEST_PLATFORMS=(
+    linux/amd64
+    darwin/amd64
+    windows/amd64
+    linux/arm
+  )
+fi
 
 # The set of client targets that we are building for all platforms
 readonly KUBE_CLIENT_TARGETS=(
@@ -59,18 +93,6 @@ readonly KUBE_CLIENT_TARGETS=(
 )
 readonly KUBE_CLIENT_BINARIES=("${KUBE_CLIENT_TARGETS[@]##*/}")
 readonly KUBE_CLIENT_BINARIES_WIN=("${KUBE_CLIENT_BINARIES[@]/%/.exe}")
-
-# If we update this we should also update the set of golang compilers we build
-# in 'build/build-image/cross/Dockerfile'. However, it's only a bit faster since go 1.5, not mandatory 
-readonly KUBE_CLIENT_PLATFORMS=(
-  linux/amd64
-  linux/386
-  linux/arm
-  darwin/amd64
-  darwin/386
-  windows/amd64
-  windows/386
-)
 
 # The set of test targets that we are building for all platforms
 kube::golang::test_targets() {
@@ -106,14 +128,6 @@ readonly KUBE_TEST_PORTABLE=(
   hack/get-build.sh
   hack/ginkgo-e2e.sh
   hack/lib
-)
-
-# Which platforms we should compile test targets for. Not all client platforms need these tests
-readonly KUBE_TEST_PLATFORMS=(
-  linux/amd64
-  darwin/amd64
-  windows/amd64
-  linux/arm
 )
 
 # Gigabytes desired for parallel platform builds. 11 is fairly


### PR DESCRIPTION
Don't build lot's of architectures.

timing done on my 32gb/12core workstation:

With:

```
make quick-release  73.37s user 6.64s system 71% cpu 1:51.14 total
```

Without:

```
make quick-release  132.21s user 10.77s system 53% cpu 4:26.45 total
```

cc @david-mcmahon @thockin @smarterclayton

TODO: test kube-up on osx

I declare war on slow builds.
