### PR TITLE
set default value for variable DEBUG

### DIFF
--- a/cluster/saltbase/salt/generate-cert/make-ca-cert.sh
+++ b/cluster/saltbase/salt/generate-cert/make-ca-cert.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [ "${DEBUG}" == "true" ]; then
+if [ "${DEBUG:-}" == "true" ]; then
 	set -x
 fi
 


### PR DESCRIPTION
DEBUG is only define in cluster/ubuntu/configure-default.sh, variable DEBUG is undefined in other platforms. This will make other platforms than ubuntu kube-up fails with error ==> master: [ERROR   ] {'pid': 5871, 'retcode': 1, 'stderr': '/tmppR9bNG.sh: line 21: DEBUG: unbound variable', 'stdout': ''}, so set the default value to avoid this.
issue #21529 was opened for approach discussion, using this PR to fix the kube-up failure to unblock others.
