### PR TITLE
Fix for "./make-ca-cert.sh: line 21: DEBUG: unbound variable"

### DIFF
--- a/cluster/saltbase/salt/generate-cert/make-ca-cert.sh
+++ b/cluster/saltbase/salt/generate-cert/make-ca-cert.sh
@@ -14,13 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -o errexit
-set -o nounset
-set -o pipefail
-
 if [ "${DEBUG}" == "true" ]; then
 	set -x
 fi
+
+set -o errexit
+set -o nounset
+set -o pipefail
 
 cert_ip=$1
 extra_sans=${2:-}


### PR DESCRIPTION
The attached fix was needed to start the script without erroring out.
