### PR TITLE
Remove a diff option not in BSD diff

### DIFF
--- a/hack/verify-api-reference-docs.sh
+++ b/hack/verify-api-reference-docs.sh
@@ -35,7 +35,7 @@ TMP_ROOT="${KUBE_ROOT}/_tmp"
 
 echo "diffing ${API_REFERENCE_DOCS_ROOT} against freshly generated docs"
 ret=0
-diff -NauprBZ -I 'Last update' --exclude=*.md "${API_REFERENCE_DOCS_ROOT}" "${OUTPUT_DIR}" || ret=$?
+diff -NauprB -I 'Last update' --exclude=*.md "${API_REFERENCE_DOCS_ROOT}" "${OUTPUT_DIR}" || ret=$?
 rm -rf "${TMP_ROOT}"
 if [[ $ret -eq 0 ]]
 then


### PR DESCRIPTION
Allows autogeneration on mac.
