### PR TITLE
WIP: Multiple provisioners in clouds

### DIFF
--- a/cmd/kube-controller-manager/app/plugins.go
+++ b/cmd/kube-controller-manager/app/plugins.go
@@ -92,7 +92,7 @@ func NewVolumeProvisioner(cloud cloudprovider.Interface, config componentconfig.
 	case cloud == nil && config.EnableHostPathProvisioning:
 		return getProvisionablePluginFromVolumePlugins(host_path.ProbeVolumePlugins(volume.VolumeConfig{}))
 	case cloud != nil && aws.ProviderName == cloud.ProviderName():
-		return getProvisionablePluginFromVolumePlugins(aws_ebs.ProbeVolumePlugins())
+		return getProvisionablePluginFromVolumePlugins(aws_ebs.ProbeProvisionableVolumePlugins())
 	case cloud != nil && gce.ProviderName == cloud.ProviderName():
 		return getProvisionablePluginFromVolumePlugins(gce_pd.ProbeProvisionableVolumePlugins())
 	case cloud != nil && openstack.ProviderName == cloud.ProviderName():

--- a/cmd/kube-controller-manager/app/plugins.go
+++ b/cmd/kube-controller-manager/app/plugins.go
@@ -96,7 +96,7 @@ func NewVolumeProvisioner(cloud cloudprovider.Interface, config componentconfig.
 	case cloud != nil && gce.ProviderName == cloud.ProviderName():
 		return getProvisionablePluginFromVolumePlugins(gce_pd.ProbeProvisionableVolumePlugins())
 	case cloud != nil && openstack.ProviderName == cloud.ProviderName():
-		return getProvisionablePluginFromVolumePlugins(cinder.ProbeVolumePlugins())
+		return getProvisionablePluginFromVolumePlugins(cinder.ProbeProvisionableVolumePlugins())
 	}
 	return nil, nil
 }

--- a/cmd/kube-controller-manager/app/plugins.go
+++ b/cmd/kube-controller-manager/app/plugins.go
@@ -94,7 +94,7 @@ func NewVolumeProvisioner(cloud cloudprovider.Interface, config componentconfig.
 	case cloud != nil && aws.ProviderName == cloud.ProviderName():
 		return getProvisionablePluginFromVolumePlugins(aws_ebs.ProbeVolumePlugins())
 	case cloud != nil && gce.ProviderName == cloud.ProviderName():
-		return getProvisionablePluginFromVolumePlugins(gce_pd.ProbeVolumePlugins())
+		return getProvisionablePluginFromVolumePlugins(gce_pd.ProbeProvisionableVolumePlugins())
 	case cloud != nil && openstack.ProviderName == cloud.ProviderName():
 		return getProvisionablePluginFromVolumePlugins(cinder.ProbeVolumePlugins())
 	}

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -151,6 +151,7 @@ type EC2Metadata interface {
 type VolumeOptions struct {
 	CapacityGB int
 	Tags       *map[string]string
+	VolumeType string
 }
 
 // Volumes is an interface for managing cloud-provisioned volumes
@@ -1398,7 +1399,11 @@ func (s *AWSCloud) CreateDisk(volumeOptions *VolumeOptions) (string, error) {
 	request.AvailabilityZone = &s.availabilityZone
 	volSize := int64(volumeOptions.CapacityGB)
 	request.Size = &volSize
-	request.VolumeType = aws.String(DefaultVolumeType)
+	if volumeOptions.VolumeType != "" {
+		request.VolumeType = aws.String(volumeOptions.VolumeType)
+	} else {
+		request.VolumeType = aws.String(DefaultVolumeType)
+	}
 	response, err := s.ec2.CreateVolume(request)
 	if err != nil {
 		return "", err

--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -64,6 +64,8 @@ const (
 
 	defaultLBSourceRange = "0.0.0.0/0"
 
+	diskTypeTemplate = "https://www.googleapis.com/compute/v1/projects/%s/zones/%s/diskTypes/%s"
+
 	//Expected annotations for GCE
 	gceLBAllowSourceRange = "net.beta.kubernetes.io/gce-source-ranges"
 )
@@ -1965,7 +1967,7 @@ func (gce *GCECloud) encodeDiskTags(tags map[string]string) (string, error) {
 // CreateDisk creates a new Persistent Disk, with the specified name & size, in
 // the specified zone. It stores specified tags endoced in JSON in Description
 // field.
-func (gce *GCECloud) CreateDisk(name string, zone string, sizeGb int64, tags map[string]string) error {
+func (gce *GCECloud) CreateDisk(name string, zone string, sizeGb int64, diskType string, tags map[string]string) error {
 	tagsStr, err := gce.encodeDiskTags(tags)
 	if err != nil {
 		return err
@@ -1975,6 +1977,7 @@ func (gce *GCECloud) CreateDisk(name string, zone string, sizeGb int64, tags map
 		Name:        name,
 		SizeGb:      sizeGb,
 		Description: tagsStr,
+		Type:        fmt.Sprintf(diskTypeTemplate, gce.projectID, zone, diskType),
 	}
 
 	createOp, err := gce.service.Disks.Insert(gce.projectID, zone, diskToCreate).Do()

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -1043,7 +1043,7 @@ func (os *OpenStack) getVolume(diskName string) (volumes.Volume, error) {
 }
 
 // Create a volume of given size (in GiB)
-func (os *OpenStack) CreateVolume(name string, size int, tags *map[string]string) (volumeName string, err error) {
+func (os *OpenStack) CreateVolume(name string, size int, volumeType string, tags *map[string]string) (volumeName string, err error) {
 
 	sClient, err := openstack.NewBlockStorageV1(os.provider, gophercloud.EndpointOpts{
 		Region: os.region,
@@ -1055,8 +1055,9 @@ func (os *OpenStack) CreateVolume(name string, size int, tags *map[string]string
 	}
 
 	opts := volumes.CreateOpts{
-		Name: name,
-		Size: size,
+		Name:       name,
+		Size:       size,
+		VolumeType: volumeType,
 	}
 	if tags != nil {
 		opts.Metadata = *tags

--- a/pkg/cloudprovider/providers/openstack/openstack_test.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_test.go
@@ -215,7 +215,7 @@ func TestVolumes(t *testing.T) {
 	tags := map[string]string{
 		"test": "value",
 	}
-	vol, err := os.CreateVolume("kubernetes-test-volume-"+rand.String(10), 1, &tags)
+	vol, err := os.CreateVolume("kubernetes-test-volume-"+rand.String(10), 1, "", &tags)
 	if err != nil {
 		t.Fatalf("Cannot create a new Cinder volume: %v", err)
 	}

--- a/pkg/kubelet/volumes.go
+++ b/pkg/kubelet/volumes.go
@@ -79,7 +79,7 @@ func (vh *volumeHost) NewWrapperCleaner(volName string, spec volume.Spec, podUID
 		spec.Volume.Name = wrapperVolumeName
 	}
 
-	plugin, err := vh.kubelet.volumePluginMgr.FindPluginBySpec(&spec)
+	plugin, err := vh.kubelet.volumePluginMgr.FindMountablePluginBySpec(&spec)
 	if err != nil {
 		return nil, err
 	}
@@ -264,7 +264,7 @@ func (kl *Kubelet) getPodVolumesFromDisk() map[string]cleanerTuple {
 }
 
 func (kl *Kubelet) newVolumeBuilderFromPlugins(spec *volume.Spec, pod *api.Pod, opts volume.VolumeOptions) (volume.Builder, error) {
-	plugin, err := kl.volumePluginMgr.FindPluginBySpec(spec)
+	plugin, err := kl.volumePluginMgr.FindMountablePluginBySpec(spec)
 	if err != nil {
 		return nil, fmt.Errorf("can't use volume plugins for %s: %v", spec.Name(), err)
 	}
@@ -300,7 +300,7 @@ func (kl *Kubelet) newVolumeAttacherFromPlugins(spec *volume.Spec, pod *api.Pod,
 
 func (kl *Kubelet) newVolumeCleanerFromPlugins(kind string, name string, podUID types.UID) (volume.Cleaner, error) {
 	plugName := strings.UnescapeQualifiedNameForDisk(kind)
-	plugin, err := kl.volumePluginMgr.FindPluginByName(plugName)
+	plugin, err := kl.volumePluginMgr.FindMountablePluginByName(plugName)
 	if err != nil {
 		// TODO: Maybe we should launch a cleanup of this dir?
 		return nil, fmt.Errorf("can't use volume plugins for %s/%s: %v", podUID, kind, err)

--- a/pkg/volume/aws_ebs/aws_ebs.go
+++ b/pkg/volume/aws_ebs/aws_ebs.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/exec"
 	"k8s.io/kubernetes/pkg/util/mount"
@@ -47,11 +46,14 @@ var _ volume.VolumePlugin = &awsElasticBlockStorePlugin{}
 var _ volume.MountableVolumePlugin = &awsElasticBlockStorePlugin{}
 var _ volume.PersistentVolumePlugin = &awsElasticBlockStorePlugin{}
 var _ volume.DeletableVolumePlugin = &awsElasticBlockStorePlugin{}
-var _ volume.ProvisionableVolumePlugin = &awsElasticBlockStorePlugin{}
 
 const (
 	awsElasticBlockStorePluginName = "kubernetes.io/aws-ebs"
 )
+
+var accessModes []api.PersistentVolumeAccessMode = []api.PersistentVolumeAccessMode{
+	api.ReadWriteOnce,
+}
 
 func (plugin *awsElasticBlockStorePlugin) Init(host volume.VolumeHost) error {
 	plugin.host = host
@@ -68,9 +70,7 @@ func (plugin *awsElasticBlockStorePlugin) CanSupport(spec *volume.Spec) bool {
 }
 
 func (plugin *awsElasticBlockStorePlugin) GetAccessModes() []api.PersistentVolumeAccessMode {
-	return []api.PersistentVolumeAccessMode{
-		api.ReadWriteOnce,
-	}
+	return accessModes
 }
 
 func (plugin *awsElasticBlockStorePlugin) NewBuilder(spec *volume.Spec, pod *api.Pod, _ volume.VolumeOptions) (volume.Builder, error) {
@@ -143,23 +143,6 @@ func (plugin *awsElasticBlockStorePlugin) newDeleterInternal(spec *volume.Spec, 
 			manager:  manager,
 			plugin:   plugin,
 		}}, nil
-}
-
-func (plugin *awsElasticBlockStorePlugin) NewProvisioner(options volume.VolumeOptions) (volume.Provisioner, error) {
-	if len(options.AccessModes) == 0 {
-		options.AccessModes = plugin.GetAccessModes()
-	}
-	return plugin.newProvisionerInternal(options, &AWSDiskUtil{})
-}
-
-func (plugin *awsElasticBlockStorePlugin) newProvisionerInternal(options volume.VolumeOptions, manager ebsManager) (volume.Provisioner, error) {
-	return &awsElasticBlockStoreProvisioner{
-		awsElasticBlockStore: &awsElasticBlockStore{
-			manager: manager,
-			plugin:  plugin,
-		},
-		options: options,
-	}, nil
 }
 
 // Abstract interface to PD operations.
@@ -399,53 +382,4 @@ func (d *awsElasticBlockStoreDeleter) GetPath() string {
 
 func (d *awsElasticBlockStoreDeleter) Delete() error {
 	return d.manager.DeleteVolume(d)
-}
-
-type awsElasticBlockStoreProvisioner struct {
-	*awsElasticBlockStore
-	options   volume.VolumeOptions
-	namespace string
-}
-
-var _ volume.Provisioner = &awsElasticBlockStoreProvisioner{}
-
-func (c *awsElasticBlockStoreProvisioner) Provision(pv *api.PersistentVolume) error {
-	volumeID, sizeGB, err := c.manager.CreateVolume(c)
-	if err != nil {
-		return err
-	}
-	pv.Spec.PersistentVolumeSource.AWSElasticBlockStore.VolumeID = volumeID
-	pv.Spec.Capacity = api.ResourceList{
-		api.ResourceName(api.ResourceStorage): resource.MustParse(fmt.Sprintf("%dGi", sizeGB)),
-	}
-	return nil
-}
-
-func (c *awsElasticBlockStoreProvisioner) NewPersistentVolumeTemplate() (*api.PersistentVolume, error) {
-	// Provide dummy api.PersistentVolume.Spec, it will be filled in
-	// awsElasticBlockStoreProvisioner.Provision()
-	return &api.PersistentVolume{
-		ObjectMeta: api.ObjectMeta{
-			GenerateName: "pv-aws-",
-			Labels:       map[string]string{},
-			Annotations: map[string]string{
-				"kubernetes.io/createdby": "aws-ebs-dynamic-provisioner",
-			},
-		},
-		Spec: api.PersistentVolumeSpec{
-			PersistentVolumeReclaimPolicy: c.options.PersistentVolumeReclaimPolicy,
-			AccessModes:                   c.options.AccessModes,
-			Capacity: api.ResourceList{
-				api.ResourceName(api.ResourceStorage): c.options.Capacity,
-			},
-			PersistentVolumeSource: api.PersistentVolumeSource{
-				AWSElasticBlockStore: &api.AWSElasticBlockStoreVolumeSource{
-					VolumeID:  "dummy",
-					FSType:    "ext4",
-					Partition: 0,
-					ReadOnly:  false,
-				},
-			},
-		},
-	}, nil
 }

--- a/pkg/volume/aws_ebs/aws_ebs.go
+++ b/pkg/volume/aws_ebs/aws_ebs.go
@@ -44,6 +44,7 @@ type awsElasticBlockStorePlugin struct {
 }
 
 var _ volume.VolumePlugin = &awsElasticBlockStorePlugin{}
+var _ volume.MountableVolumePlugin = &awsElasticBlockStorePlugin{}
 var _ volume.PersistentVolumePlugin = &awsElasticBlockStorePlugin{}
 var _ volume.DeletableVolumePlugin = &awsElasticBlockStorePlugin{}
 var _ volume.ProvisionableVolumePlugin = &awsElasticBlockStorePlugin{}

--- a/pkg/volume/aws_ebs/aws_ebs_test.go
+++ b/pkg/volume/aws_ebs/aws_ebs_test.go
@@ -286,7 +286,7 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, clientset, nil))
-	plug, _ := plugMgr.FindPluginByName(awsElasticBlockStorePluginName)
+	plug, _ := plugMgr.FindMountablePluginByName(awsElasticBlockStorePluginName)
 
 	// readOnly bool is supplied by persistent-claim volume source when its builder creates other volumes
 	spec := volume.NewSpecFromPersistentVolume(pv, true)

--- a/pkg/volume/aws_ebs/aws_ebs_test.go
+++ b/pkg/volume/aws_ebs/aws_ebs_test.go
@@ -135,6 +135,7 @@ func TestPlugin(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, nil, nil))
+	plugMgr.InitPlugins(ProbeProvisionableVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, nil, nil))
 
 	plug, err := plugMgr.FindPluginByName("kubernetes.io/aws-ebs")
 	if err != nil {
@@ -208,6 +209,8 @@ func TestPlugin(t *testing.T) {
 	}
 
 	// Test Provisioner
+	provisionerPlug, err := plugMgr.FindCreatablePluginByName("kubernetes.io/aws-ebs-ssd")
+
 	cap := resource.MustParse("100Mi")
 	options := volume.VolumeOptions{
 		Capacity: cap,
@@ -216,14 +219,14 @@ func TestPlugin(t *testing.T) {
 		},
 		PersistentVolumeReclaimPolicy: api.PersistentVolumeReclaimDelete,
 	}
-	provisioner, err := plug.(*awsElasticBlockStorePlugin).newProvisionerInternal(options, &fakePDManager{})
+	provisioner, err := provisionerPlug.(*provisionableAwsPersistentDiskPlugin).newProvisionerInternal(options, &fakePDManager{})
 	persistentSpec, err := provisioner.NewPersistentVolumeTemplate()
 	if err != nil {
 		t.Errorf("NewPersistentVolumeTemplate() failed: %v", err)
 	}
 
 	// get 2nd Provisioner - persistent volume controller will do the same
-	provisioner, err = plug.(*awsElasticBlockStorePlugin).newProvisionerInternal(options, &fakePDManager{})
+	provisioner, err = provisionerPlug.(*provisionableAwsPersistentDiskPlugin).newProvisionerInternal(options, &fakePDManager{})
 	err = provisioner.Provision(persistentSpec)
 	if err != nil {
 		t.Errorf("Provision() failed: %v", err)

--- a/pkg/volume/aws_ebs/aws_provision.go
+++ b/pkg/volume/aws_ebs/aws_provision.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws_ebs
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/volume"
+)
+
+func ProbeProvisionableVolumePlugins() []volume.VolumePlugin {
+	return []volume.VolumePlugin{
+		// SSD is first = default on AWS
+		&provisionableAwsPersistentDiskPlugin{
+			host:       nil,
+			name:       "kubernetes.io/aws-ebs-ssd",
+			volumeType: "gp2",
+		},
+		&provisionableAwsPersistentDiskPlugin{
+			host:       nil,
+			name:       "kubernetes.io/aws-ebs-standard",
+			volumeType: "standard",
+		},
+		// TODO: add IOPS provisioners based on configMap
+	}
+}
+
+type provisionableAwsPersistentDiskPlugin struct {
+	host volume.VolumeHost
+	// Name of the provisioner
+	name string
+	// AWS EBS volume type
+	volumeType string
+}
+
+var _ volume.VolumePlugin = &provisionableAwsPersistentDiskPlugin{}
+var _ volume.ProvisionableVolumePlugin = &provisionableAwsPersistentDiskPlugin{}
+
+func (plugin *provisionableAwsPersistentDiskPlugin) Init(host volume.VolumeHost) error {
+	plugin.host = host
+	return nil
+}
+
+func (plugin *provisionableAwsPersistentDiskPlugin) Name() string {
+	return plugin.name
+}
+
+func (plugin *provisionableAwsPersistentDiskPlugin) CanSupport(spec *volume.Spec) bool {
+	return (spec.PersistentVolume != nil && spec.PersistentVolume.Spec.AWSElasticBlockStore != nil) ||
+		(spec.Volume != nil && spec.Volume.AWSElasticBlockStore != nil)
+}
+
+func (plugin *provisionableAwsPersistentDiskPlugin) NewProvisioner(options volume.VolumeOptions) (volume.Provisioner, error) {
+	if len(options.AccessModes) == 0 {
+		options.AccessModes = accessModes
+	}
+	return plugin.newProvisionerInternal(options, &AWSDiskUtil{})
+}
+
+func (plugin *provisionableAwsPersistentDiskPlugin) newProvisionerInternal(options volume.VolumeOptions, manager ebsManager) (volume.Provisioner, error) {
+	return &awsElasticBlockStoreProvisioner{
+		manager: manager,
+		plugin:  plugin,
+		options: options,
+	}, nil
+}
+
+type awsElasticBlockStoreProvisioner struct {
+	manager ebsManager
+	plugin  *provisionableAwsPersistentDiskPlugin
+	options volume.VolumeOptions
+}
+
+var _ volume.Provisioner = &awsElasticBlockStoreProvisioner{}
+
+func (c *awsElasticBlockStoreProvisioner) Provision(pv *api.PersistentVolume) error {
+	volumeID, sizeGB, err := c.manager.CreateVolume(c)
+	if err != nil {
+		return err
+	}
+	pv.Spec.PersistentVolumeSource.AWSElasticBlockStore.VolumeID = volumeID
+	pv.Spec.Capacity = api.ResourceList{
+		api.ResourceName(api.ResourceStorage): resource.MustParse(fmt.Sprintf("%dGi", sizeGB)),
+	}
+	return nil
+}
+
+func (c *awsElasticBlockStoreProvisioner) NewPersistentVolumeTemplate() (*api.PersistentVolume, error) {
+	// Provide dummy api.PersistentVolume.Spec, it will be filled in
+	// awsElasticBlockStoreProvisioner.Provision()
+	return &api.PersistentVolume{
+		ObjectMeta: api.ObjectMeta{
+			GenerateName: "pv-aws-",
+			Labels:       map[string]string{},
+			Annotations: map[string]string{
+				"kubernetes.io/createdby": "aws-ebs-dynamic-provisioner",
+			},
+		},
+		Spec: api.PersistentVolumeSpec{
+			PersistentVolumeReclaimPolicy: c.options.PersistentVolumeReclaimPolicy,
+			AccessModes:                   c.options.AccessModes,
+			Capacity: api.ResourceList{
+				api.ResourceName(api.ResourceStorage): c.options.Capacity,
+			},
+			PersistentVolumeSource: api.PersistentVolumeSource{
+				AWSElasticBlockStore: &api.AWSElasticBlockStoreVolumeSource{
+					VolumeID:  "dummy",
+					FSType:    "ext4",
+					Partition: 0,
+					ReadOnly:  false,
+				},
+			},
+		},
+	}, nil
+}

--- a/pkg/volume/aws_ebs/aws_util.go
+++ b/pkg/volume/aws_ebs/aws_util.go
@@ -147,6 +147,7 @@ func (util *AWSDiskUtil) CreateVolume(c *awsElasticBlockStoreProvisioner) (volum
 	volumeOptions := &aws.VolumeOptions{
 		CapacityGB: requestGB,
 		Tags:       &tags,
+		VolumeType: c.plugin.volumeType,
 	}
 
 	name, err := cloud.CreateDisk(volumeOptions)

--- a/pkg/volume/azure_file/azure_file.go
+++ b/pkg/volume/azure_file/azure_file.go
@@ -39,6 +39,7 @@ type azureFilePlugin struct {
 }
 
 var _ volume.VolumePlugin = &azureFilePlugin{}
+var _ volume.MountableVolumePlugin = &azureFilePlugin{}
 var _ volume.PersistentVolumePlugin = &azureFilePlugin{}
 
 const (

--- a/pkg/volume/azure_file/azure_file_test.go
+++ b/pkg/volume/azure_file/azure_file_test.go
@@ -89,7 +89,7 @@ func TestPlugin(t *testing.T) {
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, nil, nil))
 
-	plug, err := plugMgr.FindPluginByName("kubernetes.io/azure-file")
+	plug, err := plugMgr.FindMountablePluginByName("kubernetes.io/azure-file")
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}
@@ -185,7 +185,7 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", client, nil))
-	plug, _ := plugMgr.FindPluginByName(azureFilePluginName)
+	plug, _ := plugMgr.FindMountablePluginByName(azureFilePluginName)
 
 	// readOnly bool is supplied by persistent-claim volume source when its builder creates other volumes
 	spec := volume.NewSpecFromPersistentVolume(pv, true)
@@ -212,7 +212,7 @@ func TestBuilderAndCleanerTypeAssert(t *testing.T) {
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, nil, nil))
 
-	plug, err := plugMgr.FindPluginByName("kubernetes.io/azure-file")
+	plug, err := plugMgr.FindMountablePluginByName("kubernetes.io/azure-file")
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}

--- a/pkg/volume/cephfs/cephfs.go
+++ b/pkg/volume/cephfs/cephfs.go
@@ -39,6 +39,7 @@ type cephfsPlugin struct {
 }
 
 var _ volume.VolumePlugin = &cephfsPlugin{}
+var _ volume.MountableVolumePlugin = &cephfsPlugin{}
 
 const (
 	cephfsPluginName = "kubernetes.io/cephfs"

--- a/pkg/volume/cephfs/cephfs_test.go
+++ b/pkg/volume/cephfs/cephfs_test.go
@@ -59,7 +59,7 @@ func TestPlugin(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, nil, nil))
-	plug, err := plugMgr.FindPluginByName("kubernetes.io/cephfs")
+	plug, err := plugMgr.FindMountablePluginByName("kubernetes.io/cephfs")
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}

--- a/pkg/volume/cinder/cinder.go
+++ b/pkg/volume/cinder/cinder.go
@@ -46,6 +46,7 @@ type cinderPlugin struct {
 }
 
 var _ volume.VolumePlugin = &cinderPlugin{}
+var _ volume.MountableVolumePlugin = &cinderPlugin{}
 var _ volume.PersistentVolumePlugin = &cinderPlugin{}
 var _ volume.DeletableVolumePlugin = &cinderPlugin{}
 var _ volume.ProvisionableVolumePlugin = &cinderPlugin{}

--- a/pkg/volume/cinder/cinder.go
+++ b/pkg/volume/cinder/cinder.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/openstack"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/exec"
@@ -49,11 +48,14 @@ var _ volume.VolumePlugin = &cinderPlugin{}
 var _ volume.MountableVolumePlugin = &cinderPlugin{}
 var _ volume.PersistentVolumePlugin = &cinderPlugin{}
 var _ volume.DeletableVolumePlugin = &cinderPlugin{}
-var _ volume.ProvisionableVolumePlugin = &cinderPlugin{}
 
 const (
 	cinderVolumePluginName = "kubernetes.io/cinder"
 )
+
+var accessModes []api.PersistentVolumeAccessMode = []api.PersistentVolumeAccessMode{
+	api.ReadWriteOnce,
+}
 
 func (plugin *cinderPlugin) Init(host volume.VolumeHost) error {
 	plugin.host = host
@@ -70,9 +72,7 @@ func (plugin *cinderPlugin) CanSupport(spec *volume.Spec) bool {
 }
 
 func (plugin *cinderPlugin) GetAccessModes() []api.PersistentVolumeAccessMode {
-	return []api.PersistentVolumeAccessMode{
-		api.ReadWriteOnce,
-	}
+	return accessModes
 }
 
 func (plugin *cinderPlugin) NewBuilder(spec *volume.Spec, pod *api.Pod, _ volume.VolumeOptions) (volume.Builder, error) {
@@ -135,23 +135,6 @@ func (plugin *cinderPlugin) newDeleterInternal(spec *volume.Spec, manager cdMana
 			manager: manager,
 			plugin:  plugin,
 		}}, nil
-}
-
-func (plugin *cinderPlugin) NewProvisioner(options volume.VolumeOptions) (volume.Provisioner, error) {
-	if len(options.AccessModes) == 0 {
-		options.AccessModes = plugin.GetAccessModes()
-	}
-	return plugin.newProvisionerInternal(options, &CinderDiskUtil{})
-}
-
-func (plugin *cinderPlugin) newProvisionerInternal(options volume.VolumeOptions, manager cdManager) (volume.Provisioner, error) {
-	return &cinderVolumeProvisioner{
-		cinderVolume: &cinderVolume{
-			manager: manager,
-			plugin:  plugin,
-		},
-		options: options,
-	}, nil
 }
 
 func (plugin *cinderPlugin) getCloudProvider() (*openstack.OpenStack, error) {
@@ -406,52 +389,4 @@ func (r *cinderVolumeDeleter) GetPath() string {
 
 func (r *cinderVolumeDeleter) Delete() error {
 	return r.manager.DeleteVolume(r)
-}
-
-type cinderVolumeProvisioner struct {
-	*cinderVolume
-	options volume.VolumeOptions
-}
-
-var _ volume.Provisioner = &cinderVolumeProvisioner{}
-
-func (c *cinderVolumeProvisioner) Provision(pv *api.PersistentVolume) error {
-	volumeID, sizeGB, err := c.manager.CreateVolume(c)
-	if err != nil {
-		return err
-	}
-	pv.Spec.PersistentVolumeSource.Cinder.VolumeID = volumeID
-	pv.Spec.Capacity = api.ResourceList{
-		api.ResourceName(api.ResourceStorage): resource.MustParse(fmt.Sprintf("%dGi", sizeGB)),
-	}
-	return nil
-}
-
-func (c *cinderVolumeProvisioner) NewPersistentVolumeTemplate() (*api.PersistentVolume, error) {
-	// Provide dummy api.PersistentVolume.Spec, it will be filled in
-	// cinderVolumeProvisioner.Provision()
-	return &api.PersistentVolume{
-		ObjectMeta: api.ObjectMeta{
-			GenerateName: "pv-cinder-",
-			Labels:       map[string]string{},
-			Annotations: map[string]string{
-				"kubernetes.io/createdby": "cinder-dynamic-provisioner",
-			},
-		},
-		Spec: api.PersistentVolumeSpec{
-			PersistentVolumeReclaimPolicy: c.options.PersistentVolumeReclaimPolicy,
-			AccessModes:                   c.options.AccessModes,
-			Capacity: api.ResourceList{
-				api.ResourceName(api.ResourceStorage): c.options.Capacity,
-			},
-			PersistentVolumeSource: api.PersistentVolumeSource{
-				Cinder: &api.CinderVolumeSource{
-					VolumeID: "dummy",
-					FSType:   "ext4",
-					ReadOnly: false,
-				},
-			},
-		},
-	}, nil
-
 }

--- a/pkg/volume/cinder/cinder_provision.go
+++ b/pkg/volume/cinder/cinder_provision.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cinder
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/golang/glog"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/openstack"
+	"k8s.io/kubernetes/pkg/volume"
+)
+
+func ProbeProvisionableVolumePlugins() []volume.VolumePlugin {
+	return []volume.VolumePlugin{
+		&provisionableCinderPlugin{
+			host:       nil,
+			name:       "kubernetes.io/cinder-provisioning-default",
+			volumeType: "",
+		},
+		// TODO: add more provisioners based on configMap
+	}
+}
+
+type provisionableCinderPlugin struct {
+	host volume.VolumeHost
+	// Name of the provisioner
+	name string
+	// Cinder volume type
+	volumeType string
+}
+
+var _ volume.VolumePlugin = &provisionableCinderPlugin{}
+var _ volume.ProvisionableVolumePlugin = &provisionableCinderPlugin{}
+
+func (plugin *provisionableCinderPlugin) Init(host volume.VolumeHost) error {
+	plugin.host = host
+	return nil
+}
+
+func (plugin *provisionableCinderPlugin) Name() string {
+	return plugin.name
+}
+
+func (plugin *provisionableCinderPlugin) CanSupport(spec *volume.Spec) bool {
+	return (spec.PersistentVolume != nil && spec.PersistentVolume.Spec.Cinder != nil) ||
+		(spec.Volume != nil && spec.Volume.Cinder != nil)
+}
+
+func (plugin *provisionableCinderPlugin) NewProvisioner(options volume.VolumeOptions) (volume.Provisioner, error) {
+	if len(options.AccessModes) == 0 {
+		options.AccessModes = accessModes
+	}
+	return plugin.newProvisionerInternal(options, &CinderDiskUtil{})
+}
+
+func (plugin *provisionableCinderPlugin) newProvisionerInternal(options volume.VolumeOptions, manager cdManager) (volume.Provisioner, error) {
+	return &cinderVolumeProvisioner{
+		manager: manager,
+		plugin:  plugin,
+		options: options,
+	}, nil
+}
+
+func (plugin *provisionableCinderPlugin) getCloudProvider() (*openstack.OpenStack, error) {
+	cloud := plugin.host.GetCloudProvider()
+	if cloud == nil {
+		glog.Errorf("Cloud provider not initialized properly")
+		return nil, errors.New("Cloud provider not initialized properly")
+	}
+
+	os := cloud.(*openstack.OpenStack)
+	if os == nil {
+		return nil, errors.New("Invalid cloud provider: expected OpenStack")
+	}
+	return os, nil
+}
+
+type cinderVolumeProvisioner struct {
+	manager cdManager
+	plugin  *provisionableCinderPlugin
+	options volume.VolumeOptions
+}
+
+var _ volume.Provisioner = &cinderVolumeProvisioner{}
+
+func (c *cinderVolumeProvisioner) Provision(pv *api.PersistentVolume) error {
+	volumeID, sizeGB, err := c.manager.CreateVolume(c)
+	if err != nil {
+		return err
+	}
+	pv.Spec.PersistentVolumeSource.Cinder.VolumeID = volumeID
+	pv.Spec.Capacity = api.ResourceList{
+		api.ResourceName(api.ResourceStorage): resource.MustParse(fmt.Sprintf("%dGi", sizeGB)),
+	}
+	return nil
+}
+
+func (c *cinderVolumeProvisioner) NewPersistentVolumeTemplate() (*api.PersistentVolume, error) {
+	// Provide dummy api.PersistentVolume.Spec, it will be filled in
+	// cinderVolumeProvisioner.Provision()
+	return &api.PersistentVolume{
+		ObjectMeta: api.ObjectMeta{
+			GenerateName: "pv-cinder-",
+			Labels:       map[string]string{},
+			Annotations: map[string]string{
+				"kubernetes.io/createdby": "cinder-dynamic-provisioner",
+			},
+		},
+		Spec: api.PersistentVolumeSpec{
+			PersistentVolumeReclaimPolicy: c.options.PersistentVolumeReclaimPolicy,
+			AccessModes:                   c.options.AccessModes,
+			Capacity: api.ResourceList{
+				api.ResourceName(api.ResourceStorage): c.options.Capacity,
+			},
+			PersistentVolumeSource: api.PersistentVolumeSource{
+				Cinder: &api.CinderVolumeSource{
+					VolumeID: "dummy",
+					FSType:   "ext4",
+					ReadOnly: false,
+				},
+			},
+		},
+	}, nil
+
+}

--- a/pkg/volume/cinder/cinder_test.go
+++ b/pkg/volume/cinder/cinder_test.go
@@ -140,7 +140,7 @@ func TestPlugin(t *testing.T) {
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, nil, nil))
 
-	plug, err := plugMgr.FindPluginByName("kubernetes.io/cinder")
+	plug, err := plugMgr.FindMountablePluginByName("kubernetes.io/cinder")
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}
@@ -254,7 +254,7 @@ func TestAttachDetachRace(t *testing.T) {
 	host := volume.NewFakeVolumeHost(tmpDir, nil, nil)
 	plugMgr.InitPlugins(ProbeVolumePlugins(), host)
 
-	plug, err := plugMgr.FindPluginByName("kubernetes.io/cinder")
+	plug, err := plugMgr.FindMountablePluginByName("kubernetes.io/cinder")
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}

--- a/pkg/volume/cinder/cinder_util.go
+++ b/pkg/volume/cinder/cinder_util.go
@@ -151,7 +151,7 @@ func (util *CinderDiskUtil) CreateVolume(c *cinderVolumeProvisioner) (volumeID s
 	// Cinder works with gigabytes, convert to GiB with rounding up
 	volSizeGB := int(volume.RoundUpSize(volSizeBytes, 1024*1024*1024))
 	name := volume.GenerateVolumeName(c.options.ClusterName, c.options.PVName, 255) // Cinder volume name can have up to 255 characters
-	name, err = cloud.CreateVolume(name, volSizeGB, c.options.CloudTags)
+	name, err = cloud.CreateVolume(name, volSizeGB, c.plugin.volumeType, c.options.CloudTags)
 	if err != nil {
 		glog.V(2).Infof("Error creating cinder volume: %v", err)
 		return "", 0, err

--- a/pkg/volume/configmap/configmap.go
+++ b/pkg/volume/configmap/configmap.go
@@ -45,6 +45,7 @@ type configMapPlugin struct {
 }
 
 var _ volume.VolumePlugin = &configMapPlugin{}
+var _ volume.MountableVolumePlugin = &configMapPlugin{}
 
 func (plugin *configMapPlugin) Init(host volume.VolumeHost) error {
 	plugin.host = host

--- a/pkg/volume/configmap/configmap_test.go
+++ b/pkg/volume/configmap/configmap_test.go
@@ -222,7 +222,7 @@ func TestPlugin(t *testing.T) {
 
 	pluginMgr.InitPlugins(ProbeVolumePlugins(), host)
 
-	plugin, err := pluginMgr.FindPluginByName(configMapPluginName)
+	plugin, err := pluginMgr.FindMountablePluginByName(configMapPluginName)
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}
@@ -277,7 +277,7 @@ func TestPluginReboot(t *testing.T) {
 
 	pluginMgr.InitPlugins(ProbeVolumePlugins(), host)
 
-	plugin, err := pluginMgr.FindPluginByName(configMapPluginName)
+	plugin, err := pluginMgr.FindMountablePluginByName(configMapPluginName)
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}
@@ -360,7 +360,7 @@ func doTestConfigMapDataInVolume(volumePath string, configMap api.ConfigMap, t *
 	}
 }
 
-func doTestCleanAndTeardown(plugin volume.VolumePlugin, podUID types.UID, testVolumeName, volumePath string, t *testing.T) {
+func doTestCleanAndTeardown(plugin volume.MountableVolumePlugin, podUID types.UID, testVolumeName, volumePath string, t *testing.T) {
 	cleaner, err := plugin.NewCleaner(testVolumeName, podUID)
 	if err != nil {
 		t.Errorf("Failed to make a new Cleaner: %v", err)

--- a/pkg/volume/downwardapi/downwardapi.go
+++ b/pkg/volume/downwardapi/downwardapi.go
@@ -50,6 +50,7 @@ type downwardAPIPlugin struct {
 }
 
 var _ volume.VolumePlugin = &downwardAPIPlugin{}
+var _ volume.MountableVolumePlugin = &downwardAPIPlugin{}
 
 var wrappedVolumeSpec = volume.Spec{
 	Volume: &api.Volume{VolumeSource: api.VolumeSource{EmptyDir: &api.EmptyDirVolumeSource{Medium: api.StorageMediumMemory}}},

--- a/pkg/volume/downwardapi/downwardapi_test.go
+++ b/pkg/volume/downwardapi/downwardapi_test.go
@@ -63,7 +63,7 @@ func TestCanSupport(t *testing.T) {
 	}
 }
 
-func CleanEverything(plugin volume.VolumePlugin, testVolumeName, volumePath string, testPodUID types.UID, t *testing.T) {
+func CleanEverything(plugin volume.MountableVolumePlugin, testVolumeName, volumePath string, testPodUID types.UID, t *testing.T) {
 	cleaner, err := plugin.NewCleaner(testVolumeName, testPodUID)
 	if err != nil {
 		t.Errorf("Failed to make a new Cleaner: %v", err)
@@ -106,7 +106,7 @@ func TestLabels(t *testing.T) {
 	rootDir, host := newTestHost(t, clientset)
 	defer os.RemoveAll(rootDir)
 	pluginMgr.InitPlugins(ProbeVolumePlugins(), host)
-	plugin, err := pluginMgr.FindPluginByName(downwardAPIPluginName)
+	plugin, err := pluginMgr.FindMountablePluginByName(downwardAPIPluginName)
 	volumeSpec := &api.Volume{
 		Name: testVolumeName,
 		VolumeSource: api.VolumeSource{
@@ -193,7 +193,7 @@ func TestAnnotations(t *testing.T) {
 	tmpDir, host := newTestHost(t, clientset)
 	defer os.RemoveAll(tmpDir)
 	pluginMgr.InitPlugins(ProbeVolumePlugins(), host)
-	plugin, err := pluginMgr.FindPluginByName(downwardAPIPluginName)
+	plugin, err := pluginMgr.FindMountablePluginByName(downwardAPIPluginName)
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}
@@ -255,7 +255,7 @@ func TestName(t *testing.T) {
 	tmpDir, host := newTestHost(t, clientset)
 	defer os.RemoveAll(tmpDir)
 	pluginMgr.InitPlugins(ProbeVolumePlugins(), host)
-	plugin, err := pluginMgr.FindPluginByName(downwardAPIPluginName)
+	plugin, err := pluginMgr.FindMountablePluginByName(downwardAPIPluginName)
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}
@@ -318,7 +318,7 @@ func TestNamespace(t *testing.T) {
 	tmpDir, host := newTestHost(t, clientset)
 	defer os.RemoveAll(tmpDir)
 	pluginMgr.InitPlugins(ProbeVolumePlugins(), host)
-	plugin, err := pluginMgr.FindPluginByName(downwardAPIPluginName)
+	plugin, err := pluginMgr.FindMountablePluginByName(downwardAPIPluginName)
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}
@@ -374,7 +374,7 @@ func TestWriteTwiceNoUpdate(t *testing.T) {
 	tmpDir, host := newTestHost(t, clientset)
 	defer os.RemoveAll(tmpDir)
 	pluginMgr.InitPlugins(ProbeVolumePlugins(), host)
-	plugin, err := pluginMgr.FindPluginByName(downwardAPIPluginName)
+	plugin, err := pluginMgr.FindMountablePluginByName(downwardAPIPluginName)
 	volumeSpec := &api.Volume{
 		Name: testVolumeName,
 		VolumeSource: api.VolumeSource{
@@ -460,7 +460,7 @@ func TestWriteTwiceWithUpdate(t *testing.T) {
 	tmpDir, host := newTestHost(t, clientset)
 	defer os.RemoveAll(tmpDir)
 	pluginMgr.InitPlugins(ProbeVolumePlugins(), host)
-	plugin, err := pluginMgr.FindPluginByName(downwardAPIPluginName)
+	plugin, err := pluginMgr.FindMountablePluginByName(downwardAPIPluginName)
 	volumeSpec := &api.Volume{
 		Name: testVolumeName,
 		VolumeSource: api.VolumeSource{
@@ -566,7 +566,7 @@ func TestWriteWithUnixPath(t *testing.T) {
 	tmpDir, host := newTestHost(t, clientset)
 	defer os.RemoveAll(tmpDir)
 	pluginMgr.InitPlugins(ProbeVolumePlugins(), host)
-	plugin, err := pluginMgr.FindPluginByName(downwardAPIPluginName)
+	plugin, err := pluginMgr.FindMountablePluginByName(downwardAPIPluginName)
 	volumeSpec := &api.Volume{
 		Name: testVolumeName,
 		VolumeSource: api.VolumeSource{
@@ -642,7 +642,7 @@ func TestWriteWithUnixPathBadPath(t *testing.T) {
 	tmpDir, host := newTestHost(t, clientset)
 	defer os.RemoveAll(tmpDir)
 	pluginMgr.InitPlugins(ProbeVolumePlugins(), host)
-	plugin, err := pluginMgr.FindPluginByName(downwardAPIPluginName)
+	plugin, err := pluginMgr.FindMountablePluginByName(downwardAPIPluginName)
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}

--- a/pkg/volume/empty_dir/empty_dir.go
+++ b/pkg/volume/empty_dir/empty_dir.go
@@ -49,6 +49,7 @@ type emptyDirPlugin struct {
 }
 
 var _ volume.VolumePlugin = &emptyDirPlugin{}
+var _ volume.MountableVolumePlugin = &emptyDirPlugin{}
 
 const (
 	emptyDirPluginName = "kubernetes.io/empty-dir"

--- a/pkg/volume/empty_dir/empty_dir_test.go
+++ b/pkg/volume/empty_dir/empty_dir_test.go
@@ -32,11 +32,11 @@ import (
 )
 
 // Construct an instance of a plugin, by name.
-func makePluginUnderTest(t *testing.T, plugName, basePath string) volume.VolumePlugin {
+func makePluginUnderTest(t *testing.T, plugName, basePath string) volume.MountableVolumePlugin {
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(basePath, nil, nil))
 
-	plug, err := plugMgr.FindPluginByName(plugName)
+	plug, err := plugMgr.FindMountablePluginByName(plugName)
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}

--- a/pkg/volume/fc/fc.go
+++ b/pkg/volume/fc/fc.go
@@ -40,6 +40,7 @@ type fcPlugin struct {
 }
 
 var _ volume.VolumePlugin = &fcPlugin{}
+var _ volume.MountableVolumePlugin = &fcPlugin{}
 var _ volume.PersistentVolumePlugin = &fcPlugin{}
 
 const (

--- a/pkg/volume/fc/fc_test.go
+++ b/pkg/volume/fc/fc_test.go
@@ -132,7 +132,7 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, nil, nil))
 
-	plug, err := plugMgr.FindPluginByName("kubernetes.io/fc")
+	plug, err := plugMgr.FindMountablePluginByName("kubernetes.io/fc")
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}
@@ -274,7 +274,7 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, client, nil))
-	plug, _ := plugMgr.FindPluginByName(fcPluginName)
+	plug, _ := plugMgr.FindMountablePluginByName(fcPluginName)
 
 	// readOnly bool is supplied by persistent-claim volume source when its builder creates other volumes
 	spec := volume.NewSpecFromPersistentVolume(pv, true)

--- a/pkg/volume/flexvolume/flexvolume_test.go
+++ b/pkg/volume/flexvolume/flexvolume_test.go
@@ -232,7 +232,7 @@ func doTestPluginAttachDetach(t *testing.T, spec *volume.Spec, tmpDir string) {
 	plugMgr := volume.VolumePluginMgr{}
 	installPluginUnderTest(t, "kubernetes.io", "fakeAttacher", tmpDir, execScriptTempl1, nil)
 	plugMgr.InitPlugins(ProbeVolumePlugins(tmpDir), volume.NewFakeVolumeHost(tmpDir, nil, nil))
-	plugin, err := plugMgr.FindPluginByName("kubernetes.io/fakeAttacher")
+	plugin, err := plugMgr.FindMountablePluginByName("kubernetes.io/fakeAttacher")
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}
@@ -311,7 +311,7 @@ func doTestPluginMountUnmount(t *testing.T, spec *volume.Spec, tmpDir string) {
 	plugMgr := volume.VolumePluginMgr{}
 	installPluginUnderTest(t, "kubernetes.io", "fakeMounter", tmpDir, execScriptTempl2, nil)
 	plugMgr.InitPlugins(ProbeVolumePlugins(tmpDir), volume.NewFakeVolumeHost(tmpDir, nil, nil))
-	plugin, err := plugMgr.FindPluginByName("kubernetes.io/fakeMounter")
+	plugin, err := plugMgr.FindMountablePluginByName("kubernetes.io/fakeMounter")
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}

--- a/pkg/volume/flocker/plugin_test.go
+++ b/pkg/volume/flocker/plugin_test.go
@@ -118,7 +118,7 @@ func TestNewBuilder(t *testing.T) {
 	assert := assert.New(t)
 
 	plugMgr, _ := newInitializedVolumePlugMgr(t)
-	plug, err := plugMgr.FindPluginByName(pluginName)
+	plug, err := plugMgr.FindMountablePluginByName(pluginName)
 	assert.NoError(err)
 
 	spec := &volume.Spec{
@@ -204,7 +204,7 @@ func TestSetUpAtInternal(t *testing.T) {
 	if rootDir != "" {
 		defer os.RemoveAll(rootDir)
 	}
-	plug, err := plugMgr.FindPluginByName(flockerPluginName)
+	plug, err := plugMgr.FindMountablePluginByName(flockerPluginName)
 	assert.NoError(err)
 
 	pod := &api.Pod{ObjectMeta: api.ObjectMeta{UID: types.UID("poduid")}}

--- a/pkg/volume/gce_pd/gce_pd.go
+++ b/pkg/volume/gce_pd/gce_pd.go
@@ -42,6 +42,7 @@ type gcePersistentDiskPlugin struct {
 }
 
 var _ volume.VolumePlugin = &gcePersistentDiskPlugin{}
+var _ volume.MountableVolumePlugin = &gcePersistentDiskPlugin{}
 var _ volume.PersistentVolumePlugin = &gcePersistentDiskPlugin{}
 var _ volume.DeletableVolumePlugin = &gcePersistentDiskPlugin{}
 var _ volume.ProvisionableVolumePlugin = &gcePersistentDiskPlugin{}

--- a/pkg/volume/gce_pd/gce_pd_provision.go
+++ b/pkg/volume/gce_pd/gce_pd_provision.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce_pd
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/volume"
+)
+
+func ProbeProvisionableVolumePlugins() []volume.VolumePlugin {
+	return []volume.VolumePlugin{
+		// SSD is first = default on GCE
+		&provisionableGcePersistentDiskPlugin{
+			host:     nil,
+			name:     "kubernetes.io/gce-pd-ssd",
+			diskType: "pd-ssd",
+		},
+		&provisionableGcePersistentDiskPlugin{
+			host:     nil,
+			name:     "kubernetes.io/gce-pd-standard",
+			diskType: "pd-standard",
+		},
+	}
+}
+
+type provisionableGcePersistentDiskPlugin struct {
+	host volume.VolumeHost
+	// Name of the provisioner
+	name string
+	// GCE PD disk type
+	diskType string
+}
+
+var _ volume.VolumePlugin = &provisionableGcePersistentDiskPlugin{}
+var _ volume.ProvisionableVolumePlugin = &provisionableGcePersistentDiskPlugin{}
+
+func (plugin *provisionableGcePersistentDiskPlugin) Init(host volume.VolumeHost) error {
+	plugin.host = host
+	return nil
+}
+
+func (plugin *provisionableGcePersistentDiskPlugin) Name() string {
+	return plugin.name
+}
+
+func (plugin *provisionableGcePersistentDiskPlugin) CanSupport(spec *volume.Spec) bool {
+	return (spec.PersistentVolume != nil && spec.PersistentVolume.Spec.GCEPersistentDisk != nil) ||
+		(spec.Volume != nil && spec.Volume.GCEPersistentDisk != nil)
+}
+
+func (plugin *provisionableGcePersistentDiskPlugin) NewProvisioner(options volume.VolumeOptions) (volume.Provisioner, error) {
+	if len(options.AccessModes) == 0 {
+		options.AccessModes = accessModes
+	}
+	return plugin.newProvisionerInternal(options, &GCEDiskUtil{})
+}
+
+func (plugin *provisionableGcePersistentDiskPlugin) newProvisionerInternal(options volume.VolumeOptions, manager pdManager) (volume.Provisioner, error) {
+	return &gcePersistentDiskProvisioner{
+		manager: manager,
+		plugin:  plugin,
+		options: options,
+	}, nil
+}
+
+type gcePersistentDiskProvisioner struct {
+	manager pdManager
+	plugin  *provisionableGcePersistentDiskPlugin
+	options volume.VolumeOptions
+}
+
+var _ volume.Provisioner = &gcePersistentDiskProvisioner{}
+
+func (c *gcePersistentDiskProvisioner) Provision(pv *api.PersistentVolume) error {
+	volumeID, sizeGB, err := c.manager.CreateVolume(c)
+	if err != nil {
+		return err
+	}
+	pv.Spec.PersistentVolumeSource.GCEPersistentDisk.PDName = volumeID
+	pv.Spec.Capacity = api.ResourceList{
+		api.ResourceName(api.ResourceStorage): resource.MustParse(fmt.Sprintf("%dGi", sizeGB)),
+	}
+	return nil
+}
+
+func (c *gcePersistentDiskProvisioner) NewPersistentVolumeTemplate() (*api.PersistentVolume, error) {
+	// Provide dummy api.PersistentVolume.Spec, it will be filled in
+	// gcePersistentDiskProvisioner.Provision()
+	return &api.PersistentVolume{
+		ObjectMeta: api.ObjectMeta{
+			GenerateName: "pv-gce-",
+			Labels:       map[string]string{},
+			Annotations: map[string]string{
+				"kubernetes.io/createdby": "gce-pd-dynamic-provisioner",
+			},
+		},
+		Spec: api.PersistentVolumeSpec{
+			PersistentVolumeReclaimPolicy: c.options.PersistentVolumeReclaimPolicy,
+			AccessModes:                   c.options.AccessModes,
+			Capacity: api.ResourceList{
+				api.ResourceName(api.ResourceStorage): c.options.Capacity,
+			},
+			PersistentVolumeSource: api.PersistentVolumeSource{
+				GCEPersistentDisk: &api.GCEPersistentDiskVolumeSource{
+					PDName:    "dummy",
+					FSType:    "ext4",
+					Partition: 0,
+					ReadOnly:  false,
+				},
+			},
+		},
+	}, nil
+}

--- a/pkg/volume/gce_pd/gce_pd_test.go
+++ b/pkg/volume/gce_pd/gce_pd_test.go
@@ -131,6 +131,7 @@ func TestPlugin(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, nil, nil))
+	plugMgr.InitPlugins(ProbeProvisionableVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, nil, nil))
 
 	plug, err := plugMgr.FindMountablePluginByName("kubernetes.io/gce-pd")
 	if err != nil {
@@ -204,6 +205,8 @@ func TestPlugin(t *testing.T) {
 	}
 
 	// Test Provisioner
+	provisionerPlug, err := plugMgr.FindCreatablePluginByName("kubernetes.io/gce-pd-ssd")
+
 	cap := resource.MustParse("100Mi")
 	options := volume.VolumeOptions{
 		Capacity: cap,
@@ -212,14 +215,14 @@ func TestPlugin(t *testing.T) {
 		},
 		PersistentVolumeReclaimPolicy: api.PersistentVolumeReclaimDelete,
 	}
-	provisioner, err := plug.(*gcePersistentDiskPlugin).newProvisionerInternal(options, &fakePDManager{})
+	provisioner, err := provisionerPlug.(*provisionableGcePersistentDiskPlugin).newProvisionerInternal(options, &fakePDManager{})
 	persistentSpec, err := provisioner.NewPersistentVolumeTemplate()
 	if err != nil {
 		t.Errorf("NewPersistentVolumeTemplate() failed: %v", err)
 	}
 
 	// get 2nd Provisioner - persistent volume controller will do the same
-	provisioner, err = plug.(*gcePersistentDiskPlugin).newProvisionerInternal(options, &fakePDManager{})
+	provisioner, err = provisionerPlug.(*provisionableGcePersistentDiskPlugin).newProvisionerInternal(options, &fakePDManager{})
 	err = provisioner.Provision(persistentSpec)
 	if err != nil {
 		t.Errorf("Provision() failed: %v", err)

--- a/pkg/volume/gce_pd/gce_pd_test.go
+++ b/pkg/volume/gce_pd/gce_pd_test.go
@@ -132,7 +132,7 @@ func TestPlugin(t *testing.T) {
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, nil, nil))
 
-	plug, err := plugMgr.FindPluginByName("kubernetes.io/gce-pd")
+	plug, err := plugMgr.FindMountablePluginByName("kubernetes.io/gce-pd")
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}
@@ -282,7 +282,7 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, client, nil))
-	plug, _ := plugMgr.FindPluginByName(gcePersistentDiskPluginName)
+	plug, _ := plugMgr.FindMountablePluginByName(gcePersistentDiskPluginName)
 
 	// readOnly bool is supplied by persistent-claim volume source when its builder creates other volumes
 	spec := volume.NewSpecFromPersistentVolume(pv, true)

--- a/pkg/volume/gce_pd/gce_util.go
+++ b/pkg/volume/gce_pd/gce_util.go
@@ -146,7 +146,7 @@ func (gceutil *GCEDiskUtil) CreateVolume(c *gcePersistentDiskProvisioner) (volum
 		return "", 0, err
 	}
 
-	err = cloud.CreateDisk(name, zone.FailureDomain, int64(requestGB), *c.options.CloudTags)
+	err = cloud.CreateDisk(name, zone.FailureDomain, int64(requestGB), c.plugin.diskType, *c.options.CloudTags)
 	if err != nil {
 		glog.V(2).Infof("Error creating GCE PD volume: %v", err)
 		return "", 0, err

--- a/pkg/volume/git_repo/git_repo.go
+++ b/pkg/volume/git_repo/git_repo.go
@@ -40,6 +40,7 @@ type gitRepoPlugin struct {
 }
 
 var _ volume.VolumePlugin = &gitRepoPlugin{}
+var _ volume.MountableVolumePlugin = &gitRepoPlugin{}
 
 var wrappedVolumeSpec = volume.Spec{
 	Volume: &api.Volume{VolumeSource: api.VolumeSource{EmptyDir: &api.EmptyDirVolumeSource{}}},

--- a/pkg/volume/git_repo/git_repo_test.go
+++ b/pkg/volume/git_repo/git_repo_test.go
@@ -222,7 +222,7 @@ func doTestPlugin(scenario struct {
 	rootDir, host := newTestHost(t)
 	plugMgr.InitPlugins(ProbeVolumePlugins(), host)
 
-	plug, err := plugMgr.FindPluginByName("kubernetes.io/git-repo")
+	plug, err := plugMgr.FindMountablePluginByName("kubernetes.io/git-repo")
 	if err != nil {
 		allErrs = append(allErrs,
 			fmt.Errorf("Can't find the plugin by name"))

--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -41,6 +41,7 @@ type glusterfsPlugin struct {
 }
 
 var _ volume.VolumePlugin = &glusterfsPlugin{}
+var _ volume.MountableVolumePlugin = &glusterfsPlugin{}
 var _ volume.PersistentVolumePlugin = &glusterfsPlugin{}
 
 const (

--- a/pkg/volume/glusterfs/glusterfs_test.go
+++ b/pkg/volume/glusterfs/glusterfs_test.go
@@ -91,7 +91,7 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, nil, nil))
-	plug, err := plugMgr.FindPluginByName("kubernetes.io/glusterfs")
+	plug, err := plugMgr.FindMountablePluginByName("kubernetes.io/glusterfs")
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}
@@ -223,7 +223,7 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, client, nil))
-	plug, _ := plugMgr.FindPluginByName(glusterfsPluginName)
+	plug, _ := plugMgr.FindMountablePluginByName(glusterfsPluginName)
 
 	// readOnly bool is supplied by persistent-claim volume source when its builder creates other volumes
 	spec := volume.NewSpecFromPersistentVolume(pv, true)

--- a/pkg/volume/host_path/host_path.go
+++ b/pkg/volume/host_path/host_path.go
@@ -64,6 +64,7 @@ type hostPathPlugin struct {
 }
 
 var _ volume.VolumePlugin = &hostPathPlugin{}
+var _ volume.MountableVolumePlugin = &hostPathPlugin{}
 var _ volume.PersistentVolumePlugin = &hostPathPlugin{}
 var _ volume.RecyclableVolumePlugin = &hostPathPlugin{}
 var _ volume.DeletableVolumePlugin = &hostPathPlugin{}

--- a/pkg/volume/host_path/host_path_test.go
+++ b/pkg/volume/host_path/host_path_test.go
@@ -189,7 +189,7 @@ func TestPlugin(t *testing.T) {
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(volume.VolumeConfig{}), volume.NewFakeVolumeHost("fake", nil, nil))
 
-	plug, err := plugMgr.FindPluginByName("kubernetes.io/host-path")
+	plug, err := plugMgr.FindMountablePluginByName("kubernetes.io/host-path")
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}
@@ -260,7 +260,7 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(volume.VolumeConfig{}), volume.NewFakeVolumeHost("/tmp/fake", client, nil))
-	plug, _ := plugMgr.FindPluginByName(hostPathPluginName)
+	plug, _ := plugMgr.FindMountablePluginByName(hostPathPluginName)
 
 	// readOnly bool is supplied by persistent-claim volume source when its builder creates other volumes
 	spec := volume.NewSpecFromPersistentVolume(pv, true)
@@ -284,7 +284,7 @@ func TestMetrics(t *testing.T) {
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(volume.VolumeConfig{}), volume.NewFakeVolumeHost(tmpDir, nil, nil))
 
-	plug, err := plugMgr.FindPluginByName("kubernetes.io/host-path")
+	plug, err := plugMgr.FindMountablePluginByName("kubernetes.io/host-path")
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}

--- a/pkg/volume/iscsi/iscsi.go
+++ b/pkg/volume/iscsi/iscsi.go
@@ -40,6 +40,7 @@ type iscsiPlugin struct {
 }
 
 var _ volume.VolumePlugin = &iscsiPlugin{}
+var _ volume.MountableVolumePlugin = &iscsiPlugin{}
 var _ volume.PersistentVolumePlugin = &iscsiPlugin{}
 
 const (

--- a/pkg/volume/iscsi/iscsi_test.go
+++ b/pkg/volume/iscsi/iscsi_test.go
@@ -132,7 +132,7 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, nil, nil))
 
-	plug, err := plugMgr.FindPluginByName("kubernetes.io/iscsi")
+	plug, err := plugMgr.FindMountablePluginByName("kubernetes.io/iscsi")
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}
@@ -274,7 +274,7 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, client, nil))
-	plug, _ := plugMgr.FindPluginByName(iscsiPluginName)
+	plug, _ := plugMgr.FindMountablePluginByName(iscsiPluginName)
 
 	// readOnly bool is supplied by persistent-claim volume source when its builder creates other volumes
 	spec := volume.NewSpecFromPersistentVolume(pv, true)

--- a/pkg/volume/nfs/nfs.go
+++ b/pkg/volume/nfs/nfs.go
@@ -51,6 +51,7 @@ type nfsPlugin struct {
 }
 
 var _ volume.VolumePlugin = &nfsPlugin{}
+var _ volume.MountableVolumePlugin = &nfsPlugin{}
 var _ volume.PersistentVolumePlugin = &nfsPlugin{}
 var _ volume.RecyclableVolumePlugin = &nfsPlugin{}
 

--- a/pkg/volume/nfs/nfs_test.go
+++ b/pkg/volume/nfs/nfs_test.go
@@ -141,7 +141,7 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(volume.VolumeConfig{}), volume.NewFakeVolumeHost(tmpDir, nil, nil))
-	plug, err := plugMgr.FindPluginByName("kubernetes.io/nfs")
+	plug, err := plugMgr.FindMountablePluginByName("kubernetes.io/nfs")
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}
@@ -269,7 +269,7 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(volume.VolumeConfig{}), volume.NewFakeVolumeHost(tmpDir, client, nil))
-	plug, _ := plugMgr.FindPluginByName(nfsPluginName)
+	plug, _ := plugMgr.FindMountablePluginByName(nfsPluginName)
 
 	// readOnly bool is supplied by persistent-claim volume source when its builder creates other volumes
 	spec := volume.NewSpecFromPersistentVolume(pv, true)

--- a/pkg/volume/persistent_claim/persistent_claim.go
+++ b/pkg/volume/persistent_claim/persistent_claim.go
@@ -35,6 +35,7 @@ type persistentClaimPlugin struct {
 }
 
 var _ volume.VolumePlugin = &persistentClaimPlugin{}
+var _ volume.MountableVolumePlugin = &persistentClaimPlugin{}
 
 const (
 	persistentClaimPluginName = "kubernetes.io/persistent-claim"

--- a/pkg/volume/persistent_claim/persistent_claim_test.go
+++ b/pkg/volume/persistent_claim/persistent_claim_test.go
@@ -244,7 +244,7 @@ func TestNewBuilder(t *testing.T) {
 		defer os.RemoveAll(tempDir)
 		plugMgr.InitPlugins(testProbeVolumePlugins(), vh)
 
-		plug, err := plugMgr.FindPluginByName("kubernetes.io/persistent-claim")
+		plug, err := plugMgr.FindMountablePluginByName("kubernetes.io/persistent-claim")
 		if err != nil {
 			t.Errorf("Can't find the plugin by name")
 		}
@@ -297,7 +297,7 @@ func TestNewBuilderClaimNotBound(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 	plugMgr.InitPlugins(testProbeVolumePlugins(), vh)
 
-	plug, err := plugMgr.FindPluginByName("kubernetes.io/persistent-claim")
+	plug, err := plugMgr.FindMountablePluginByName("kubernetes.io/persistent-claim")
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}

--- a/pkg/volume/pluginmgr.go
+++ b/pkg/volume/pluginmgr.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/golang/glog"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
+	"k8s.io/kubernetes/pkg/util/validation"
+)
+
+// VolumePluginMgr tracks registered plugins.
+type VolumePluginMgr struct {
+	mutex   sync.Mutex
+	plugins map[string]VolumePlugin
+}
+
+// InitPlugins initializes each plugin.  All plugins must have unique names.
+// This must be called exactly once before any New* methods are called on any
+// plugins.
+func (pm *VolumePluginMgr) InitPlugins(plugins []VolumePlugin, host VolumeHost) error {
+	pm.mutex.Lock()
+	defer pm.mutex.Unlock()
+
+	if pm.plugins == nil {
+		pm.plugins = map[string]VolumePlugin{}
+	}
+
+	allErrs := []error{}
+	for _, plugin := range plugins {
+		name := plugin.Name()
+		if !validation.IsQualifiedName(name) {
+			allErrs = append(allErrs, fmt.Errorf("volume plugin has invalid name: %#v", plugin))
+			continue
+		}
+
+		if _, found := pm.plugins[name]; found {
+			allErrs = append(allErrs, fmt.Errorf("volume plugin %q was registered more than once", name))
+			continue
+		}
+		err := plugin.Init(host)
+		if err != nil {
+			glog.Errorf("Failed to load volume plugin %s, error: %s", plugin, err.Error())
+			allErrs = append(allErrs, err)
+			continue
+		}
+		pm.plugins[name] = plugin
+		glog.V(1).Infof("Loaded volume plugin %q", name)
+	}
+	return utilerrors.NewAggregate(allErrs)
+}
+
+// FindPluginBySpec looks for a plugin that can support a given volume
+// specification.  If no plugins can support or more than one plugin can
+// support it, return error.
+func (pm *VolumePluginMgr) FindPluginBySpec(spec *Spec) (VolumePlugin, error) {
+	pm.mutex.Lock()
+	defer pm.mutex.Unlock()
+
+	matches := []string{}
+	for k, v := range pm.plugins {
+		if v.CanSupport(spec) {
+			matches = append(matches, k)
+		}
+	}
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("no volume plugin matched")
+	}
+	if len(matches) > 1 {
+		return nil, fmt.Errorf("multiple volume plugins matched: %s", strings.Join(matches, ","))
+	}
+	return pm.plugins[matches[0]], nil
+}
+
+// FindPluginByName fetches a plugin by name or by legacy name.  If no plugin
+// is found, returns error.
+func (pm *VolumePluginMgr) FindPluginByName(name string) (VolumePlugin, error) {
+	pm.mutex.Lock()
+	defer pm.mutex.Unlock()
+
+	// Once we can get rid of legacy names we can reduce this to a map lookup.
+	matches := []string{}
+	for k, v := range pm.plugins {
+		if v.Name() == name {
+			matches = append(matches, k)
+		}
+	}
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("no volume plugin matched")
+	}
+	if len(matches) > 1 {
+		return nil, fmt.Errorf("multiple volume plugins matched: %s", strings.Join(matches, ","))
+	}
+	return pm.plugins[matches[0]], nil
+}
+
+// FindPersistentPluginBySpec looks for a persistent volume plugin that can support a given volume
+// specification.  If no plugin is found, return an error
+func (pm *VolumePluginMgr) FindPersistentPluginBySpec(spec *Spec) (PersistentVolumePlugin, error) {
+	volumePlugin, err := pm.FindPluginBySpec(spec)
+	if err != nil {
+		return nil, fmt.Errorf("Could not find volume plugin for spec: %+v", spec)
+	}
+	if persistentVolumePlugin, ok := volumePlugin.(PersistentVolumePlugin); ok {
+		return persistentVolumePlugin, nil
+	}
+	return nil, fmt.Errorf("no persistent volume plugin matched")
+}
+
+// FindPersistentPluginByName fetches a persistent volume plugin by name.  If no plugin
+// is found, returns error.
+func (pm *VolumePluginMgr) FindPersistentPluginByName(name string) (PersistentVolumePlugin, error) {
+	volumePlugin, err := pm.FindPluginByName(name)
+	if err != nil {
+		return nil, err
+	}
+	if persistentVolumePlugin, ok := volumePlugin.(PersistentVolumePlugin); ok {
+		return persistentVolumePlugin, nil
+	}
+	return nil, fmt.Errorf("no persistent volume plugin matched")
+}
+
+// FindRecyclablePluginByName fetches a persistent volume plugin by name.  If no plugin
+// is found, returns error.
+func (pm *VolumePluginMgr) FindRecyclablePluginBySpec(spec *Spec) (RecyclableVolumePlugin, error) {
+	volumePlugin, err := pm.FindPluginBySpec(spec)
+	if err != nil {
+		return nil, err
+	}
+	if recyclableVolumePlugin, ok := volumePlugin.(RecyclableVolumePlugin); ok {
+		return recyclableVolumePlugin, nil
+	}
+	return nil, fmt.Errorf("no recyclable volume plugin matched")
+}
+
+// FindDeletablePluginByName fetches a persistent volume plugin by name.  If no plugin
+// is found, returns error.
+func (pm *VolumePluginMgr) FindDeletablePluginBySpec(spec *Spec) (DeletableVolumePlugin, error) {
+	volumePlugin, err := pm.FindPluginBySpec(spec)
+	if err != nil {
+		return nil, err
+	}
+	if deletableVolumePlugin, ok := volumePlugin.(DeletableVolumePlugin); ok {
+		return deletableVolumePlugin, nil
+	}
+	return nil, fmt.Errorf("no deletable volume plugin matched")
+}
+
+// FindCreatablePluginBySpec fetches a persistent volume plugin by name.  If no plugin
+// is found, returns error.
+func (pm *VolumePluginMgr) FindCreatablePluginBySpec(spec *Spec) (ProvisionableVolumePlugin, error) {
+	volumePlugin, err := pm.FindPluginBySpec(spec)
+	if err != nil {
+		return nil, err
+	}
+	if provisionableVolumePlugin, ok := volumePlugin.(ProvisionableVolumePlugin); ok {
+		return provisionableVolumePlugin, nil
+	}
+	return nil, fmt.Errorf("no creatable volume plugin matched")
+}
+
+// FindCreatablePluginByName fetches a persistent volume plugin by name.  If no plugin
+// is found, returns error.
+func (pm *VolumePluginMgr) FindCreatablePluginByName(name string) (ProvisionableVolumePlugin, error) {
+	volumePlugin, err := pm.FindPluginByName(name)
+	if err != nil {
+		return nil, err
+	}
+	if provisionableVolumePlugin, ok := volumePlugin.(ProvisionableVolumePlugin); ok {
+		return provisionableVolumePlugin, nil
+	}
+	return nil, fmt.Errorf("no provisionable volume plugin matched")
+}
+
+// FindAttachablePluginBySpec fetches a persistent volume plugin by name.  Unlike the other "FindPlugin" methods, this
+// does not return error if no plugin is found.  All volumes require a builder and cleaner, but not every volume will
+// have an attacher/detacher.
+func (pm *VolumePluginMgr) FindAttachablePluginBySpec(spec *Spec) (AttachableVolumePlugin, error) {
+	volumePlugin, err := pm.FindPluginBySpec(spec)
+	if err != nil {
+		return nil, err
+	}
+	if attachableVolumePlugin, ok := volumePlugin.(AttachableVolumePlugin); ok {
+		return attachableVolumePlugin, nil
+	}
+	return nil, nil
+}
+
+// FindAttachablePluginByName fetches an attachable volume plugin by name. Unlike the other "FindPlugin" methods, this
+// does not return error if no plugin is found.  All volumes require a builder and cleaner, but not every volume will
+// have an attacher/detacher.
+func (pm *VolumePluginMgr) FindAttachablePluginByName(name string) (AttachableVolumePlugin, error) {
+	volumePlugin, err := pm.FindPluginByName(name)
+	if err != nil {
+		return nil, err
+	}
+	if attachablePlugin, ok := volumePlugin.(AttachableVolumePlugin); ok {
+		return attachablePlugin, nil
+	}
+	return nil, nil
+}

--- a/pkg/volume/pluginmgr.go
+++ b/pkg/volume/pluginmgr.go
@@ -111,6 +111,32 @@ func (pm *VolumePluginMgr) FindPluginByName(name string) (VolumePlugin, error) {
 	return pm.plugins[matches[0]], nil
 }
 
+// FindMountablePluginBySpec looks for a persistent volume plugin that can support a given volume
+// specification.  If no plugin is found, return an error
+func (pm *VolumePluginMgr) FindMountablePluginBySpec(spec *Spec) (MountableVolumePlugin, error) {
+	volumePlugin, err := pm.FindPluginBySpec(spec)
+	if err != nil {
+		return nil, fmt.Errorf("Could not find volume plugin for spec: %+v", spec)
+	}
+	if mountableVolumePlugin, ok := volumePlugin.(MountableVolumePlugin); ok {
+		return mountableVolumePlugin, nil
+	}
+	return nil, fmt.Errorf("no mountable volume plugin matched")
+}
+
+// FindMountablePluginByName fetches a persistent volume plugin by name.  If no plugin
+// is found, returns error.
+func (pm *VolumePluginMgr) FindMountablePluginByName(name string) (MountableVolumePlugin, error) {
+	volumePlugin, err := pm.FindPluginByName(name)
+	if err != nil {
+		return nil, err
+	}
+	if mountableVolumePlugin, ok := volumePlugin.(MountableVolumePlugin); ok {
+		return mountableVolumePlugin, nil
+	}
+	return nil, fmt.Errorf("no mountable volume plugin matched")
+}
+
 // FindPersistentPluginBySpec looks for a persistent volume plugin that can support a given volume
 // specification.  If no plugin is found, return an error
 func (pm *VolumePluginMgr) FindPersistentPluginBySpec(spec *Spec) (PersistentVolumePlugin, error) {

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -17,20 +17,13 @@ limitations under the License.
 package volume
 
 import (
-	"fmt"
-	"strings"
-	"sync"
-
-	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/types"
-	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/io"
 	"k8s.io/kubernetes/pkg/util/mount"
-	"k8s.io/kubernetes/pkg/util/validation"
 )
 
 // VolumeOptions contains option information about a volume.
@@ -176,12 +169,6 @@ type VolumeHost interface {
 	GetHostName() string
 }
 
-// VolumePluginMgr tracks registered plugins.
-type VolumePluginMgr struct {
-	mutex   sync.Mutex
-	plugins map[string]VolumePlugin
-}
-
 // Spec is an internal representation of a volume.  All API volume types translate to Spec.
 type Spec struct {
 	Volume           *api.Volume
@@ -250,178 +237,6 @@ func NewSpecFromPersistentVolume(pv *api.PersistentVolume, readOnly bool) *Spec 
 		PersistentVolume: pv,
 		ReadOnly:         readOnly,
 	}
-}
-
-// InitPlugins initializes each plugin.  All plugins must have unique names.
-// This must be called exactly once before any New* methods are called on any
-// plugins.
-func (pm *VolumePluginMgr) InitPlugins(plugins []VolumePlugin, host VolumeHost) error {
-	pm.mutex.Lock()
-	defer pm.mutex.Unlock()
-
-	if pm.plugins == nil {
-		pm.plugins = map[string]VolumePlugin{}
-	}
-
-	allErrs := []error{}
-	for _, plugin := range plugins {
-		name := plugin.Name()
-		if !validation.IsQualifiedName(name) {
-			allErrs = append(allErrs, fmt.Errorf("volume plugin has invalid name: %#v", plugin))
-			continue
-		}
-
-		if _, found := pm.plugins[name]; found {
-			allErrs = append(allErrs, fmt.Errorf("volume plugin %q was registered more than once", name))
-			continue
-		}
-		err := plugin.Init(host)
-		if err != nil {
-			glog.Errorf("Failed to load volume plugin %s, error: %s", plugin, err.Error())
-			allErrs = append(allErrs, err)
-			continue
-		}
-		pm.plugins[name] = plugin
-		glog.V(1).Infof("Loaded volume plugin %q", name)
-	}
-	return utilerrors.NewAggregate(allErrs)
-}
-
-// FindPluginBySpec looks for a plugin that can support a given volume
-// specification.  If no plugins can support or more than one plugin can
-// support it, return error.
-func (pm *VolumePluginMgr) FindPluginBySpec(spec *Spec) (VolumePlugin, error) {
-	pm.mutex.Lock()
-	defer pm.mutex.Unlock()
-
-	matches := []string{}
-	for k, v := range pm.plugins {
-		if v.CanSupport(spec) {
-			matches = append(matches, k)
-		}
-	}
-	if len(matches) == 0 {
-		return nil, fmt.Errorf("no volume plugin matched")
-	}
-	if len(matches) > 1 {
-		return nil, fmt.Errorf("multiple volume plugins matched: %s", strings.Join(matches, ","))
-	}
-	return pm.plugins[matches[0]], nil
-}
-
-// FindPluginByName fetches a plugin by name or by legacy name.  If no plugin
-// is found, returns error.
-func (pm *VolumePluginMgr) FindPluginByName(name string) (VolumePlugin, error) {
-	pm.mutex.Lock()
-	defer pm.mutex.Unlock()
-
-	// Once we can get rid of legacy names we can reduce this to a map lookup.
-	matches := []string{}
-	for k, v := range pm.plugins {
-		if v.Name() == name {
-			matches = append(matches, k)
-		}
-	}
-	if len(matches) == 0 {
-		return nil, fmt.Errorf("no volume plugin matched")
-	}
-	if len(matches) > 1 {
-		return nil, fmt.Errorf("multiple volume plugins matched: %s", strings.Join(matches, ","))
-	}
-	return pm.plugins[matches[0]], nil
-}
-
-// FindPersistentPluginBySpec looks for a persistent volume plugin that can support a given volume
-// specification.  If no plugin is found, return an error
-func (pm *VolumePluginMgr) FindPersistentPluginBySpec(spec *Spec) (PersistentVolumePlugin, error) {
-	volumePlugin, err := pm.FindPluginBySpec(spec)
-	if err != nil {
-		return nil, fmt.Errorf("Could not find volume plugin for spec: %+v", spec)
-	}
-	if persistentVolumePlugin, ok := volumePlugin.(PersistentVolumePlugin); ok {
-		return persistentVolumePlugin, nil
-	}
-	return nil, fmt.Errorf("no persistent volume plugin matched")
-}
-
-// FindPersistentPluginByName fetches a persistent volume plugin by name.  If no plugin
-// is found, returns error.
-func (pm *VolumePluginMgr) FindPersistentPluginByName(name string) (PersistentVolumePlugin, error) {
-	volumePlugin, err := pm.FindPluginByName(name)
-	if err != nil {
-		return nil, err
-	}
-	if persistentVolumePlugin, ok := volumePlugin.(PersistentVolumePlugin); ok {
-		return persistentVolumePlugin, nil
-	}
-	return nil, fmt.Errorf("no persistent volume plugin matched")
-}
-
-// FindRecyclablePluginByName fetches a persistent volume plugin by name.  If no plugin
-// is found, returns error.
-func (pm *VolumePluginMgr) FindRecyclablePluginBySpec(spec *Spec) (RecyclableVolumePlugin, error) {
-	volumePlugin, err := pm.FindPluginBySpec(spec)
-	if err != nil {
-		return nil, err
-	}
-	if recyclableVolumePlugin, ok := volumePlugin.(RecyclableVolumePlugin); ok {
-		return recyclableVolumePlugin, nil
-	}
-	return nil, fmt.Errorf("no recyclable volume plugin matched")
-}
-
-// FindDeletablePluginByName fetches a persistent volume plugin by name.  If no plugin
-// is found, returns error.
-func (pm *VolumePluginMgr) FindDeletablePluginBySpec(spec *Spec) (DeletableVolumePlugin, error) {
-	volumePlugin, err := pm.FindPluginBySpec(spec)
-	if err != nil {
-		return nil, err
-	}
-	if deletableVolumePlugin, ok := volumePlugin.(DeletableVolumePlugin); ok {
-		return deletableVolumePlugin, nil
-	}
-	return nil, fmt.Errorf("no deletable volume plugin matched")
-}
-
-// FindCreatablePluginBySpec fetches a persistent volume plugin by name.  If no plugin
-// is found, returns error.
-func (pm *VolumePluginMgr) FindCreatablePluginBySpec(spec *Spec) (ProvisionableVolumePlugin, error) {
-	volumePlugin, err := pm.FindPluginBySpec(spec)
-	if err != nil {
-		return nil, err
-	}
-	if provisionableVolumePlugin, ok := volumePlugin.(ProvisionableVolumePlugin); ok {
-		return provisionableVolumePlugin, nil
-	}
-	return nil, fmt.Errorf("no creatable volume plugin matched")
-}
-
-// FindAttachablePluginBySpec fetches a persistent volume plugin by name.  Unlike the other "FindPlugin" methods, this
-// does not return error if no plugin is found.  All volumes require a builder and cleaner, but not every volume will
-// have an attacher/detacher.
-func (pm *VolumePluginMgr) FindAttachablePluginBySpec(spec *Spec) (AttachableVolumePlugin, error) {
-	volumePlugin, err := pm.FindPluginBySpec(spec)
-	if err != nil {
-		return nil, err
-	}
-	if attachableVolumePlugin, ok := volumePlugin.(AttachableVolumePlugin); ok {
-		return attachableVolumePlugin, nil
-	}
-	return nil, nil
-}
-
-// FindAttachablePluginByName fetches an attachable volume plugin by name. Unlike the other "FindPlugin" methods, this
-// does not return error if no plugin is found.  All volumes require a builder and cleaner, but not every volume will
-// have an attacher/detacher.
-func (pm *VolumePluginMgr) FindAttachablePluginByName(name string) (AttachableVolumePlugin, error) {
-	volumePlugin, err := pm.FindPluginByName(name)
-	if err != nil {
-		return nil, err
-	}
-	if attachablePlugin, ok := volumePlugin.(AttachableVolumePlugin); ok {
-		return attachablePlugin, nil
-	}
-	return nil, nil
 }
 
 // NewPersistentVolumeRecyclerPodTemplate creates a template for a recycler pod.  By default, a recycler pod simply runs

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -67,7 +67,12 @@ type VolumePlugin interface {
 	// specification from the API.  The spec pointer should be considered
 	// const.
 	CanSupport(spec *Spec) bool
+}
 
+// PersistentVolumePlugin is an extended interface of VolumePlugin and is used
+// by volumes that can be mounted to a node.
+type MountableVolumePlugin interface {
+	VolumePlugin
 	// NewBuilder creates a new volume.Builder from an API specification.
 	// Ownership of the spec pointer in *not* transferred.
 	// - spec: The api.Volume spec

--- a/pkg/volume/rbd/rbd.go
+++ b/pkg/volume/rbd/rbd.go
@@ -39,6 +39,7 @@ type rbdPlugin struct {
 }
 
 var _ volume.VolumePlugin = &rbdPlugin{}
+var _ volume.MountableVolumePlugin = &rbdPlugin{}
 var _ volume.PersistentVolumePlugin = &rbdPlugin{}
 
 const (

--- a/pkg/volume/rbd/rbd_test.go
+++ b/pkg/volume/rbd/rbd_test.go
@@ -96,7 +96,7 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, nil, nil))
 
-	plug, err := plugMgr.FindPluginByName("kubernetes.io/rbd")
+	plug, err := plugMgr.FindMountablePluginByName("kubernetes.io/rbd")
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}
@@ -226,7 +226,7 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost(tmpDir, client, nil))
-	plug, _ := plugMgr.FindPluginByName(rbdPluginName)
+	plug, _ := plugMgr.FindMountablePluginByName(rbdPluginName)
 
 	// readOnly bool is supplied by persistent-claim volume source when its builder creates other volumes
 	spec := volume.NewSpecFromPersistentVolume(pv, true)

--- a/pkg/volume/secret/secret.go
+++ b/pkg/volume/secret/secret.go
@@ -46,6 +46,7 @@ type secretPlugin struct {
 }
 
 var _ volume.VolumePlugin = &secretPlugin{}
+var _ volume.MountableVolumePlugin = &secretPlugin{}
 
 var wrappedVolumeSpec = volume.Spec{
 	Volume: &api.Volume{VolumeSource: api.VolumeSource{EmptyDir: &api.EmptyDirVolumeSource{Medium: api.StorageMediumMemory}}},

--- a/pkg/volume/secret/secret_test.go
+++ b/pkg/volume/secret/secret_test.go
@@ -82,7 +82,7 @@ func TestPlugin(t *testing.T) {
 
 	pluginMgr.InitPlugins(ProbeVolumePlugins(), host)
 
-	plugin, err := pluginMgr.FindPluginByName(secretPluginName)
+	plugin, err := pluginMgr.FindMountablePluginByName(secretPluginName)
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}
@@ -154,7 +154,7 @@ func TestPluginIdempotent(t *testing.T) {
 
 	pluginMgr.InitPlugins(ProbeVolumePlugins(), host)
 
-	plugin, err := pluginMgr.FindPluginByName(secretPluginName)
+	plugin, err := pluginMgr.FindMountablePluginByName(secretPluginName)
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}
@@ -215,7 +215,7 @@ func TestPluginReboot(t *testing.T) {
 
 	pluginMgr.InitPlugins(ProbeVolumePlugins(), host)
 
-	plugin, err := pluginMgr.FindPluginByName(secretPluginName)
+	plugin, err := pluginMgr.FindMountablePluginByName(secretPluginName)
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}
@@ -296,7 +296,7 @@ func doTestSecretDataInVolume(volumePath string, secret api.Secret, t *testing.T
 	}
 }
 
-func doTestCleanAndTeardown(plugin volume.VolumePlugin, podUID types.UID, testVolumeName, volumePath string, t *testing.T) {
+func doTestCleanAndTeardown(plugin volume.MountableVolumePlugin, podUID types.UID, testVolumeName, volumePath string, t *testing.T) {
 	cleaner, err := plugin.NewCleaner(testVolumeName, podUID)
 	if err != nil {
 		t.Errorf("Failed to make a new Cleaner: %v", err)

--- a/pkg/volume/testing.go
+++ b/pkg/volume/testing.go
@@ -87,7 +87,7 @@ func (f *fakeVolumeHost) NewWrapperBuilder(volName string, spec Spec, pod *api.P
 	if spec.Volume != nil {
 		spec.Volume.Name = wrapperVolumeName
 	}
-	plug, err := f.pluginMgr.FindPluginBySpec(&spec)
+	plug, err := f.pluginMgr.FindMountablePluginBySpec(&spec)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +100,7 @@ func (f *fakeVolumeHost) NewWrapperCleaner(volName string, spec Spec, podUID typ
 	if spec.Volume != nil {
 		spec.Volume.Name = wrapperVolumeName
 	}
-	plug, err := f.pluginMgr.FindPluginBySpec(&spec)
+	plug, err := f.pluginMgr.FindMountablePluginBySpec(&spec)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/pd.go
+++ b/test/e2e/pd.go
@@ -315,7 +315,7 @@ func createPD() (string, error) {
 		}
 
 		tags := map[string]string{}
-		err = gceCloud.CreateDisk(pdName, testContext.CloudConfig.Zone, 10 /* sizeGb */, tags)
+		err = gceCloud.CreateDisk(pdName, testContext.CloudConfig.Zone, 10 /* sizeGb */, "pd-standard", tags)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
Result of this PR is to have several provisioners for GCE/AWS/OSP, each for one storage class.

Currently implemented:
- GCE SSD, GCE "standard" disk
- AWS gp2 (SSD), AWS standard
- Cinder default (empty) VolumeType

TODO:
- AWS: configurable IOPS "classes" (as separate PR)
- OSP / Cinder: configure list of VolumeTypes (as separate PR)

Out of scope (for now):
- how to actually use several provisioners in provisioning controller - separate PR will follow
