### PR TITLE
Upload build log after running custom GCS scripts

### DIFF
--- a/hack/jenkins/job-configs/global.yaml
+++ b/hack/jenkins/job-configs/global.yaml
@@ -11,15 +11,6 @@
 - publisher:
     name: gcs-uploader
     publishers:
-        # Use the plugin for the build log, since it isn't available on Jenkins slaves.
-        - google-cloud-storage:
-            credentials-id: kubernetes-jenkins
-            uploads:
-                - build-log:
-                    log-name: build-log.txt
-                    storage-location: gs://kubernetes-jenkins/logs/$JOB_NAME/$BUILD_NUMBER
-                    share-publicly: true
-                    upload-for-failed-jobs: true
         # Use our script for build artifacts, since it's more flexible.
         - postbuildscript:
             builders:
@@ -58,6 +49,15 @@
                         - shell: './upload-finished.sh ABORTED'
             script-only-if-succeeded: False
             script-only-if-failed: False
+        # Use the plugin for the build log, since it isn't available on Jenkins slaves.
+        - google-cloud-storage:
+            credentials-id: kubernetes-jenkins
+            uploads:
+                - build-log:
+                    log-name: build-log.txt
+                    storage-location: gs://kubernetes-jenkins/logs/$JOB_NAME/$BUILD_NUMBER
+                    share-publicly: true
+                    upload-for-failed-jobs: true
 
 # Default log parser rules.
 - publisher:


### PR DESCRIPTION
Motivated by a chat I had with @lavalamp earlier today - it'd be nice to run the `upload-to-gcs.sh` script before we upload the build log, since that script prints out the GCS browser URL as the last thing it does. Then it is easier to find the test artifacts, since you won't need to know which magical URL to use.

I already made this change on PR Jenkins.

@kubernetes/goog-testing 
