### PR TITLE
Log pods of RS when deployment e2e test fails

### DIFF
--- a/pkg/util/deployment/deployment.go
+++ b/pkg/util/deployment/deployment.go
@@ -197,14 +197,11 @@ func getReadyPodsCount(pods []api.Pod, minReadySeconds int) int {
 }
 
 func IsPodAvailable(pod *api.Pod, minReadySeconds int) bool {
-	if !api.IsPodReady(pod) {
-		return false
-	}
 	// Check if we've passed minReadySeconds since LastTransitionTime
 	// If so, this pod is ready
 	for _, c := range pod.Status.Conditions {
 		// we only care about pod ready conditions
-		if c.Type == api.PodReady {
+		if c.Type == api.PodReady && c.Status == api.ConditionTrue {
 			// 2 cases that this ready condition is valid (passed minReadySeconds, i.e. the pod is ready):
 			// 1. minReadySeconds <= 0
 			// 2. LastTransitionTime (is set) + minReadySeconds (>0) < current time

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -2124,6 +2124,7 @@ func waitForDeploymentStatus(c clientset.Interface, ns, deploymentName string, d
 		}
 		if totalCreated > maxCreated {
 			logReplicaSetsOfDeployment(deploymentName, oldRSs, newRS)
+			logPodsOfReplicaSets(c, allRSs, minReadySeconds)
 			return false, fmt.Errorf("total pods created: %d, more than the max allowed: %d", totalCreated, maxCreated)
 		}
 		if totalAvailable < minAvailable {
@@ -2137,10 +2138,12 @@ func waitForDeploymentStatus(c clientset.Interface, ns, deploymentName string, d
 			// Verify replica sets.
 			if deploymentutil.GetReplicaCountForReplicaSets(oldRSs) != 0 {
 				logReplicaSetsOfDeployment(deploymentName, oldRSs, newRS)
+				logPodsOfReplicaSets(c, allRSs, minReadySeconds)
 				return false, fmt.Errorf("old replica sets are not fully scaled down")
 			}
 			if deploymentutil.GetReplicaCountForReplicaSets([]*extensions.ReplicaSet{newRS}) != desiredUpdatedReplicas {
 				logReplicaSetsOfDeployment(deploymentName, oldRSs, newRS)
+				logPodsOfReplicaSets(c, allRSs, minReadySeconds)
 				return false, fmt.Errorf("new replica sets is not fully scaled up")
 			}
 			return true, nil


### PR DESCRIPTION
Help debug #19299 failure mode 

```
Deployment
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/deployment.go:68
  deployment should support rollover [It]
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/deployment.go:58

  Expected error:
      <*errors.errorString | 0xc208330980>: {
          s: "total pods available: 2, less than the min required: 3",
      }
      total pods available: 2, less than the min required: 3
  not to have occurred
```

@kubernetes/sig-config @bgrant0607 
