### PR TITLE
Add autoscaling group to clientset generator tool's default list.

### DIFF
--- a/cmd/libs/go2idl/client-gen/main.go
+++ b/cmd/libs/go2idl/client-gen/main.go
@@ -32,7 +32,7 @@ import (
 
 var (
 	test          = flag.BoolP("test", "t", false, "set this flag to generate the client code for the testdata")
-	inputVersions = flag.StringSlice("input", []string{"api/", "extensions/"}, "group/versions that client-gen will generate clients for. At most one version per group is allowed. Specified in the format \"group1/version1,group2/version2...\". Default to \"api/,extensions\"")
+	inputVersions = flag.StringSlice("input", []string{"api/", "extensions/", "autoscaling/"}, "group/versions that client-gen will generate clients for. At most one version per group is allowed. Specified in the format \"group1/version1,group2/version2...\". Default to \"api/,extensions/,autoscaling/\"")
 	clientsetName = flag.StringP("clientset-name", "n", "internalclientset", "the name of the generated clientset package.")
 	clientsetPath = flag.String("clientset-path", "k8s.io/kubernetes/pkg/client/clientset_generated/", "the generated clientset will be output to <clientset-path>/<clientset-name>. Default to \"k8s.io/kubernetes/pkg/client/clientset_generated/\"")
 	clientsetOnly = flag.Bool("clientset-only", false, "when set, client-gen only generates the clientset shell, without generating the individual typed clients")


### PR DESCRIPTION
Autoscaling group is here to stay. So we should add it to the default
list so that others adding new types to autoscaling group won't
spend time debugging why their types aren't generating clientset.

cc @lavalamp 
