### PR TITLE
e2e: use e2e tag for unversioned images to avoid unnecessary pulling

### DIFF
--- a/test/e2e/container_probe.go
+++ b/test/e2e/container_probe.go
@@ -148,7 +148,7 @@ func makePodSpec(readinessProbe, livenessProbe *api.Probe) *api.Pod {
 			Containers: []api.Container{
 				{
 					Name:           probTestContainerName,
-					Image:          "gcr.io/google_containers/test-webserver",
+					Image:          "gcr.io/google_containers/test-webserver:e2e",
 					LivenessProbe:  livenessProbe,
 					ReadinessProbe: readinessProbe,
 				},

--- a/test/e2e/dns.go
+++ b/test/e2e/dns.go
@@ -61,7 +61,7 @@ func createDNSPod(namespace, wheezyProbeCmd, jessieProbeCmd string) *api.Pod {
 				// TODO: Consider scraping logs instead of running a webserver.
 				{
 					Name:  "webserver",
-					Image: "gcr.io/google_containers/test-webserver",
+					Image: "gcr.io/google_containers/test-webserver:e2e",
 					Ports: []api.ContainerPort{
 						{
 							Name:          "http",
@@ -77,7 +77,7 @@ func createDNSPod(namespace, wheezyProbeCmd, jessieProbeCmd string) *api.Pod {
 				},
 				{
 					Name:    "querier",
-					Image:   "gcr.io/google_containers/dnsutils",
+					Image:   "gcr.io/google_containers/dnsutils:e2e",
 					Command: []string{"sh", "-c", wheezyProbeCmd},
 					VolumeMounts: []api.VolumeMount{
 						{
@@ -88,7 +88,7 @@ func createDNSPod(namespace, wheezyProbeCmd, jessieProbeCmd string) *api.Pod {
 				},
 				{
 					Name:    "jessie-querier",
-					Image:   "gcr.io/google_containers/jessie-dnsutils",
+					Image:   "gcr.io/google_containers/jessie-dnsutils:e2e",
 					Command: []string{"sh", "-c", jessieProbeCmd},
 					VolumeMounts: []api.VolumeMount{
 						{

--- a/test/e2e/empty_dir_wrapper.go
+++ b/test/e2e/empty_dir_wrapper.go
@@ -134,7 +134,7 @@ var _ = Describe("EmptyDir wrapper volumes", func() {
 				Containers: []api.Container{
 					{
 						Name:  "secret-test",
-						Image: "gcr.io/google_containers/test-webserver",
+						Image: "gcr.io/google_containers/test-webserver:e2e",
 						VolumeMounts: []api.VolumeMount{
 							{
 								Name:      volumeName,

--- a/test/e2e/pods.go
+++ b/test/e2e/pods.go
@@ -701,7 +701,7 @@ var _ = Describe("Pods", func() {
 				Containers: []api.Container{
 					{
 						Name:    "liveness",
-						Image:   "gcr.io/google_containers/liveness",
+						Image:   "gcr.io/google_containers/liveness:e2e",
 						Command: []string{"/server"},
 						LivenessProbe: &api.Probe{
 							Handler: api.Handler{
@@ -730,7 +730,7 @@ var _ = Describe("Pods", func() {
 				Containers: []api.Container{
 					{
 						Name:    "liveness",
-						Image:   "gcr.io/google_containers/liveness",
+						Image:   "gcr.io/google_containers/liveness:e2e",
 						Command: []string{"/server"},
 						LivenessProbe: &api.Probe{
 							Handler: api.Handler{

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -1776,7 +1776,7 @@ func NewServerTest(client *client.Client, namespace string, serviceName string) 
 	t.services = make(map[string]bool)
 
 	t.name = "webserver"
-	t.image = "gcr.io/google_containers/test-webserver"
+	t.image = "gcr.io/google_containers/test-webserver:e2e"
 
 	return t
 }


### PR DESCRIPTION
This is to address https://github.com/kubernetes/kubernetes/issues/21608 and https://github.com/kubernetes/kubernetes/issues/20836

Instead of using the latest version of the image, request the e2e tagged version of the image, which allows us to use the cached version of this image and mitigate pulling flakes.

These versions are visible at https://console.developers.google.com/kubernetes/images/list?project=google-containers
