### PR TITLE
Cross-build hyperkube and debian-iptables for ARM. Also add a flannel image

### DIFF
--- a/build/debian-iptables/Makefile
+++ b/build/debian-iptables/Makefile
@@ -14,13 +14,47 @@
 
 .PHONY:	build push
 
-IMAGE = debian-iptables
-TAG = v1
+REGISTRY?="gcr.io/google_containers"
+IMAGE=debian-iptables
+TAG=v2
+ARCH?=amd64
+TEMP_DIR:=$(shell mktemp -d)
+
+ifeq ($(ARCH),amd64)
+	BASEIMAGE?=debian:jessie
+endif
+ifeq ($(ARCH),arm)
+	BASEIMAGE?=armel/debian:jessie
+	QEMUARCH=arm
+endif
+ifeq ($(ARCH),arm64)
+	BASEIMAGE?=aarch64/debian:jessie
+	QEMUARCH=aarch64
+endif
+ifeq ($(ARCH),ppc64le)
+	BASEIMAGE?=ppc64le/debian:jessie
+	QEMUARCH=ppc64le
+endif
 
 build:
-	docker build -t gcr.io/google_containers/$(IMAGE):$(TAG) .
+	cp ./* $(TEMP_DIR)
+	cd $(TEMP_DIR) && sed -i "s|BASEIMAGE|$(BASEIMAGE)|g" Dockerfile
+	cd $(TEMP_DIR) && sed -i "s|ARCH|$(QEMUARCH)|g" Dockerfile
 
-push:	build
-	gcloud docker --server=gcr.io push gcr.io/google_containers/$(IMAGE):$(TAG)
+ifeq ($(ARCH),amd64)
+	# When building "normally" for amd64, remove the whole line, it has no part in the amd64 image
+	cd $(TEMP_DIR) && sed -i "/CROSS_BUILD_/d" Dockerfile
+else
+	# When cross-building, only the placeholder "CROSS_BUILD_" should be removed
+	# Register /usr/bin/qemu-ARCH-static as the handler for ARM binaries in the kernel
+	docker run --rm --privileged multiarch/qemu-user-static:register --reset
+	curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/v2.5.0/x86_64_qemu-$(QEMUARCH)-static.tar.xz | tar -xJ -C $(TEMP_DIR)
+	cd $(TEMP_DIR) && sed -i "s/CROSS_BUILD_//g" Dockerfile
+endif
 
-all:	push
+	docker build -t $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)
+
+push: build
+	gcloud docker push $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG)
+
+all: push

--- a/build/debian-iptables/README.md
+++ b/build/debian-iptables/README.md
@@ -1,0 +1,29 @@
+### debian-iptables
+
+Serves as the base image for `gcr.io/google_containers/kube-proxy-${ARCH}` and multiarch (not `amd64`) `gcr.io/google_containers/flannel-${ARCH}` images.
+
+This image is compiled for multiple architectures.
+
+#### How to release
+
+If you're editing the Dockerfile or some other thing, please bump the `TAG` in the Makefile.
+
+```console
+# Build for linux/amd64 (default)
+$ make push ARCH=amd64
+# ---> gcr.io/google_containers/debian-iptables-amd64:TAG
+
+$ make push ARCH=arm
+# ---> gcr.io/google_containers/debian-iptables-arm:TAG
+
+$ make push ARCH=arm64
+# ---> gcr.io/google_containers/debian-iptables-arm64:TAG
+
+$ make push ARCH=ppc64le
+# ---> gcr.io/google_containers/debian-iptables-ppc64le:TAG
+```
+
+If you don't want to push the images, run `make` or `make build` instead
+
+
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/build/debian-iptables/README.md?pixel)]()

--- a/cluster/images/flannel/Dockerfile
+++ b/cluster/images/flannel/Dockerfile
@@ -14,12 +14,7 @@
 
 FROM BASEIMAGE
 
-# If we're building for another architecture than amd64, the CROSS_BUILD_ placeholder is removed so e.g. CROSS_BUILD_COPY turns into COPY
-# If we're building normally, for amd64, CROSS_BUILD lines are removed
-CROSS_BUILD_COPY qemu-ARCH-static /usr/bin/
+COPY flanneld /opt/bin/
+COPY mk-docker-opts.sh /opt/bin/
 
-# All apt-get's must be in one run command or the
-# cleanup has no effect.
-RUN DEBIAN_FRONTEND=noninteractive apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y iptables \
-    && rm -rf /var/lib/apt/lists/*
+CMD ["/opt/bin/flanneld"]

--- a/cluster/images/flannel/Makefile
+++ b/cluster/images/flannel/Makefile
@@ -1,0 +1,60 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build the flannel image
+#
+# Usage:
+# 	[TAG=0.5.5] [REGISTRY=gcr.io/google_containers] [ARCH=amd64] make build
+
+TAG?=0.5.5
+ARCH?=amd64
+REGISTRY?=gcr.io/google_containers
+KUBE_CROSS_TAG=v1.4.2-1
+GOARM=6
+TEMP_DIR:=$(shell mktemp -d)
+BASEIMAGE?=gcr.io/google_containers/debian-iptables-${ARCH}:v2
+
+ifeq ($(ARCH),arm)
+	CC=arm-linux-gnueabi-gcc
+endif
+
+build:
+ifeq ($(ARCH),amd64)
+	# If we should build an amd64 flannel, go with the official one
+	docker pull quay.io/coreos/flannel:$(TAG)
+
+	docker tag -f quay.io/coreos/flannel:$(TAG) $(REGISTRY)/flannel-$(ARCH):$(TAG)
+else
+	# Copy the content in this dir to the temp dir
+	cp ./* $(TEMP_DIR)
+
+	docker run -it -v $(TEMP_DIR):/flannel/bin gcr.io/google_containers/kube-cross:$(KUBE_CROSS_TAG) /bin/bash -c \
+    	"curl -sSL https://github.com/coreos/flannel/archive/v${TAG}.tar.gz | tar -C /flannel -xz --strip-components=1 \
+    	&& cd /flannel && GOARM=$(GOARM) GOARCH=$(ARCH) CC=$(CC) CGO_ENABLED=1 ./build"
+
+	# Replace BASEIMAGE with the real base image
+	cd $(TEMP_DIR) && sed -i "s|BASEIMAGE|$(BASEIMAGE)|g" Dockerfile
+
+	# Download mk-docker-opts.sh
+	curl -sSL https://raw.githubusercontent.com/coreos/flannel/v$(TAG)/dist/mk-docker-opts.sh > $(TEMP_DIR)/mk-docker-opts.sh
+
+	# And build the image
+	docker build -t $(REGISTRY)/flannel-$(ARCH):$(TAG) $(TEMP_DIR)
+endif
+
+push: build
+	gcloud docker push $(REGISTRY)/flannel-$(ARCH):$(TAG)
+
+all: build
+.PHONY: build push

--- a/cluster/images/flannel/README.md
+++ b/cluster/images/flannel/README.md
@@ -1,0 +1,22 @@
+### flannel
+
+This is used mostly for the `docker-multinode` config, but also in other places where flannel runs in a container.
+
+For `amd64`, this image equals to `quay.io/coreos/flannel` to maintain official support.
+For other architectures, `flannel` is cross-compiled. The `debian-iptables` image serves as base image.
+
+#### How to release
+
+```console
+# Build for linux/amd64 (default)
+$ make push ARCH=amd64
+# ---> gcr.io/google_containers/flannel-amd64:TAG
+
+$ make push ARCH=arm
+# ---> gcr.io/google_containers/flannel-arm:TAG
+```
+
+If you don't want to push the images, run `make` or `make build` instead
+
+
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/cluster/images/flannel/README.md?pixel)]()

--- a/cluster/images/hyperkube/Dockerfile
+++ b/cluster/images/hyperkube/Dockerfile
@@ -14,6 +14,10 @@
 
 FROM BASEIMAGE
 
+# If we're building for another architecture than amd64, the CROSS_BUILD_ placeholder is removed so e.g. CROSS_BUILD_COPY turns into COPY
+# If we're building normally, for amd64, CROSS_BUILD lines are removed
+CROSS_BUILD_COPY qemu-ARCH-static /usr/bin/
+
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y \
     && DEBIAN_FRONTEND=noninteractive apt-get -yy -q \
     install \

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -15,17 +15,19 @@
 # Build the hyperkube image.
 #
 # Usage:
-#   VERSION=v1.1.2 [REGISTRY="gcr.io/google_containers"] make build
+#   VERSION=v1.2.0 [ARCH=amd64] [REGISTRY="gcr.io/google_containers"] make build
 
 REGISTRY?="gcr.io/google_containers"
-ARCH=amd64
-BASEIMAGE=debian:jessie
+ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
 
-## Comment in for arm builds, must be run on an arm machine
-# ARCH=arm
-# need to escape '/' for the regexp below
-# BASEIMAGE=armbuild\\/debian:jessie
+
+ifeq ($(ARCH),amd64)
+	BASEIMAGE?=debian:jessie
+endif
+ifeq ($(ARCH),arm)
+	BASEIMAGE?=armel/debian:jessie
+endif
 
 all: build
 
@@ -38,18 +40,27 @@ endif
 	cp ../../saltbase/salt/generate-cert/make-ca-cert.sh ${TEMP_DIR}
 	cp ../../../_output/dockerized/bin/linux/${ARCH}/hyperkube ${TEMP_DIR}
 	cd ${TEMP_DIR} && sed -i.back "s|VERSION|${VERSION}|g" master-multi.json master.json kube-proxy.json
-	cd ${TEMP_DIR} && sed -i.back "s|ARCH|${ARCH}|g" master-multi.json master.json kube-proxy.json
+	cd ${TEMP_DIR} && sed -i.back "s|ARCH|${ARCH}|g" master-multi.json master.json kube-proxy.json etcd.json Dockerfile
 	cd ${TEMP_DIR} && sed -i.back "s|BASEIMAGE|${BASEIMAGE}|g" Dockerfile
 	rm ${TEMP_DIR}/*.back
-	docker build -t ${REGISTRY}/hyperkube-${ARCH}:${VERSION} ${TEMP_DIR}
-	# Backward compatibility.  TODO: deprecate this image tag
+
 ifeq ($(ARCH),amd64)
-	docker tag -f ${REGISTRY}/hyperkube-${ARCH}:${VERSION} ${REGISTRY}/hyperkube:${VERSION}
+	# When building "normally" for amd64, remove the whole line, it has no part in the amd64 image
+	cd ${TEMP_DIR} && sed -i "/CROSS_BUILD_/d" Dockerfile
+else
+	# When cross-building, only the placeholder "CROSS_BUILD_" should be removed
+	# Register /usr/bin/qemu-ARCH-static as the handler for ARM binaries in the kernel
+	docker run --rm --privileged multiarch/qemu-user-static:register --reset
+	curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/v2.5.0/x86_64_qemu-${ARCH}-static.tar.xz | tar -xJ -C ${TEMP_DIR}
+	cd ${TEMP_DIR} && sed -i "s/CROSS_BUILD_//g" Dockerfile
 endif
+
+	docker build -t ${REGISTRY}/hyperkube-${ARCH}:${VERSION} ${TEMP_DIR}
 
 push: build
 	gcloud docker push ${REGISTRY}/hyperkube-${ARCH}:${VERSION}
 ifeq ($(ARCH),amd64)
+	docker tag -f ${REGISTRY}/hyperkube-${ARCH}:${VERSION} ${REGISTRY}/hyperkube:${VERSION}
 	gcloud docker push ${REGISTRY}/hyperkube:${VERSION}
 endif
 

--- a/cluster/images/hyperkube/README.md
+++ b/cluster/images/hyperkube/README.md
@@ -1,0 +1,27 @@
+### hyperkube
+
+`hyperkube` is an all-in-one binary for the Kubernetes server components
+Also, it's very easy to run this `hyperkube` setup dockerized.
+See http://kubernetes.io/docs/getting-started-guides/docker/ for up-to-date commands.
+
+`hyperkube` is built for multiple architectures and pushed on every release.
+
+#### How to release by hand
+
+```console
+# First, build the 
+$ build/run.sh hack/build-cross.sh
+
+# Build for linux/amd64 (default)
+$ make push VERSION={target_version} ARCH=amd64
+# ---> gcr.io/google_containers/hyperkube-amd64:VERSION
+# ---> gcr.io/google_containers/hyperkube:VERSION (image with backwards-compatible naming)
+
+$ make push VERSION={target_version} ARCH=arm
+# ---> gcr.io/google_containers/hyperkube-arm:VERSION
+```
+
+If you don't want to push the images, run `make` or `make build` instead
+
+
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/cluster/images/hyperkube/README.md?pixel)]()

--- a/cluster/images/hyperkube/etcd.json
+++ b/cluster/images/hyperkube/etcd.json
@@ -7,7 +7,7 @@
     "containers": [
       {
         "name": "etcd",
-        "image": "gcr.io/google_containers/etcd:2.2.1",
+        "image": "gcr.io/google_containers/etcd-ARCH:2.2.1",
         "command": [
                 "/usr/local/bin/etcd",
                 "--listen-client-urls=http://127.0.0.1:4001",


### PR DESCRIPTION
We have to be able to build complex docker images too on `amd64` hosts.
Right now we can't build Dockerfiles with `RUN` commands when building for other architectures e.g. ARM.

Resin has a tutorial about this here: https://resin.io/blog/building-arm-containers-on-any-x86-machine-even-dockerhub/
But it's a bit clumsy syntax.

The other alternative would be running this command in a Makefile:

```
# This registers in the kernel that ARM binaries should be run by /usr/bin/qemu-{ARCH}-static
docker run --rm --privileged multiarch/qemu-user-static:register --reset
```

and 

```
ADD https://github.com/multiarch/qemu-user-static/releases/download/v2.5.0/x86_64_qemu-arm-static.tar.xz /usr/bin
```

Then the kernel will be able to differ ARM binaries from amd64. When it finds a ARM binary, it will invoke `/usr/bin/qemu-arm-static` first and lets `qemu` translate the ARM syscalls to amd64 ones.
Some code here: https://github.com/multiarch

WDYT is the best approach? If registering `binfmt_misc` in the kernels of the machines is OK, then I think we should go with that.
Otherwise, we'll have to wait for resin's patch to be merged into mainline qemu before we may use the code I have here now.

@fgrzadkowski @david-mcmahon @brendandburns @zmerlynn @ixdy @ihmccreery @thockin 
