### PR TITLE
Fix broken spark tests to use yaml files, 1 worker, declare DNS depe…

### DIFF
--- a/examples/spark/spark-worker-controller.yaml
+++ b/examples/spark/spark-worker-controller.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 metadata:
   name: spark-worker-controller
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     component: spark-worker
   template:
@@ -20,3 +20,4 @@ spec:
           resources:
             requests:
               cpu: 100m
+


### PR DESCRIPTION
Ok, Another set of fixes for the broken examples #20999 , this time spark yamls.
Also updates docs to declare the explicit dependency on DNS.
