### PR TITLE
Enabling DNS support in local-up-cluster.sh

### DIFF
--- a/docs/devel/running-locally.md
+++ b/docs/devel/running-locally.md
@@ -175,7 +175,16 @@ One or more of the Kubernetes daemons might've crashed. Tail the logs of each in
 
 #### The pods fail to connect to the services by host names
 
-The local-up-cluster.sh script doesn't start a DNS service. Similar situation can be found [here](http://issue.k8s.io/6667). You can start a manually. Related documents can be found [here](../../cluster/addons/dns/#how-do-i-configure-it)
+To start the DNS service, you need to set the following variables:
+
+```sh
+KUBE_ENABLE_CLUSTER_DNS=true
+KUBE_DNS_SERVER_IP="10.0.0.10"
+KUBE_DNS_DOMAIN="cluster.local"
+KUBE_DNS_REPLICAS=1
+```
+
+To know more on DNS service you can look [here](http://issue.k8s.io/6667). Related documents can be found [here](../../cluster/addons/dns/#how-do-i-configure-it)
 
 
 

--- a/docs/devel/running-locally.md
+++ b/docs/devel/running-locally.md
@@ -166,7 +166,16 @@ One or more of the Kubernetes daemons might've crashed. Tail the logs of each in
 
 #### The pods fail to connect to the services by host names
 
-The local-up-cluster.sh script doesn't start a DNS service. Similar situation can be found [here](http://issue.k8s.io/6667). You can start a manually. Related documents can be found [here](../../cluster/addons/dns/#how-do-i-configure-it)
+To start the DNS service, you need to set the following variables:
+
+```sh
+KUBE_ENABLE_CLUSTER_DNS=true
+KUBE_DNS_SERVER_IP="10.0.0.10"
+KUBE_DNS_DOMAIN="cluster.local"
+KUBE_DNS_REPLICAS=1
+```
+
+To know more on DNS service you can look [here](http://issue.k8s.io/6667). Related documents can be found [here](../../cluster/addons/dns/#how-do-i-configure-it)
 
 
 

--- a/docs/getting-started-guides/locally.md
+++ b/docs/getting-started-guides/locally.md
@@ -171,7 +171,16 @@ One or more of the Kubernetes daemons might've crashed. Tail the logs of each in
 
 #### The pods fail to connect to the services by host names
 
-The local-up-cluster.sh script doesn't start a DNS service. Similar situation can be found [here](http://issue.k8s.io/6667). You can start a manually. Related documents can be found [here](../../cluster/addons/dns/#how-do-i-configure-it)
+To start the DNS service, you need to set the following variables:
+
+```sh
+KUBE_ENABLE_CLUSTER_DNS=true
+KUBE_DNS_SERVER_IP="10.0.0.10"
+KUBE_DNS_DOMAIN="cluster.local"
+KUBE_DNS_REPLICAS=1
+```
+
+To know more on DNS service you can look [here](http://issue.k8s.io/6667). Related documents can be found [here](../../cluster/addons/dns/#how-do-i-configure-it)
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -311,7 +311,6 @@ function start_kubelet {
       else
          dns_args="--cluster-dns=127.0.0.1"
       fi
-echo dns_args=$dns_args
 
       net_plugin_args=""
       if [[ -n "${NET_PLUGIN}" ]]; then

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -25,6 +25,14 @@ ALLOW_PRIVILEGED=${ALLOW_PRIVILEGED:-""}
 ALLOW_SECURITY_CONTEXT=${ALLOW_SECURITY_CONTEXT:-""}
 RUNTIME_CONFIG=${RUNTIME_CONFIG:-""}
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+ENABLE_CLUSTER_DNS=${KUBE_ENABLE_CLUSTER_DNS:-true}
+DNS_SERVER_IP=${KUBE_DNS_SERVER_IP:-10.0.0.10}
+DNS_DOMAIN=${KUBE_DNS_NAME:-"cluster.local"}
+DNS_REPLICAS=${KUBE_DNS_REPLICAS:-1}
+KUBECTL=${KUBECTL:-cluster/kubectl.sh}
+WAIT_FOR_URL_API_SERVER=${WAIT_FOR_URL_API_SERVER:-10}
+ENABLE_DAEMON=${ENABLE_DAEMON:-false}
+
 cd "${KUBE_ROOT}"
 
 if [ "$(id -u)" != "0" ]; then
@@ -168,6 +176,14 @@ cleanup_dockerized_kubelet()
 cleanup()
 {
   echo "Cleaning up..."
+  # delete running images
+  # if [[ "${ENABLE_CLUSTER_DNS}" = true ]]; then
+  # Still need to figure why this commands throw an error: Error from server: client: etcd cluster is unavailable or misconfigured
+  #     ${KUBECTL} --namespace=kube-system delete service kube-dns
+  # And this one hang forever:
+  #     ${KUBECTL} --namespace=kube-system delete rc kube-dns-v10
+  # fi
+
   # Check if the API server is still running
   [[ -n "${APISERVER_PID-}" ]] && APISERVER_PIDS=$(pgrep -P ${APISERVER_PID} ; ps -o pid= -p ${APISERVER_PID})
   [[ -n "${APISERVER_PIDS-}" ]] && sudo kill ${APISERVER_PIDS}
@@ -251,7 +267,7 @@ function start_apiserver {
 
     # Wait for kube-apiserver to come up before launching the rest of the components.
     echo "Waiting for apiserver to come up"
-    kube::util::wait_for_url "http://${API_HOST}:${API_PORT}/api/v1/pods" "apiserver: " 1 10 || exit 1
+    kube::util::wait_for_url "http://${API_HOST}:${API_PORT}/api/v1/pods" "apiserver: " 1 ${WAIT_FOR_URL_API_SERVER} || exit 1
 }
 
 function start_controller_manager {
@@ -282,6 +298,13 @@ function start_kubelet {
             fi
 	 fi
       fi
+      # Enable dns
+      if [[ "${ENABLE_CLUSTER_DNS}" = true ]]; then
+         dns_args="--cluster-dns=${DNS_SERVER_IP} --cluster-domain=${DNS_DOMAIN}"
+      else
+         dns_args="--cluster-dns=127.0.0.1"
+      fi
+echo dns_args=$dns_args
 
       sudo -E "${GO_OUT}/kubelet" ${priv_arg}\
         --v=${LOG_LEVEL} \
@@ -293,7 +316,7 @@ function start_kubelet {
         --address="127.0.0.1" \
         --api-servers="${API_HOST}:${API_PORT}" \
         --cpu-cfs-quota=${CPU_CFS_QUOTA} \
-        --cluster-dns="127.0.0.1" \
+	${dns_args} \
         --port="$KUBELET_PORT" >"${KUBELET_LOG}" 2>&1 &
       KUBELET_PID=$!
     else
@@ -332,6 +355,31 @@ function start_kubeproxy {
     SCHEDULER_PID=$!
 }
 
+function start_kubedns {
+
+    if [[ "${ENABLE_CLUSTER_DNS}" = true ]]; then
+        echo "Creating kube-system namespace"
+        sed -e "s/{{ pillar\['dns_replicas'\] }}/${DNS_REPLICAS}/g;s/{{ pillar\['dns_domain'\] }}/${DNS_DOMAIN}/g;" "${KUBE_ROOT}/cluster/addons/dns/skydns-rc.yaml.in" >| skydns-rc.yaml
+        sed -e "s/{{ pillar\['dns_server'\] }}/${DNS_SERVER_IP}/g" "${KUBE_ROOT}/cluster/addons/dns/skydns-svc.yaml.in" >| skydns-svc.yaml
+        cat <<EOF >namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kube-system
+EOF
+        ${KUBECTL} config set-cluster local --server=http://127.0.0.1:8080 --insecure-skip-tls-verify=true
+        ${KUBECTL} config set-context local --cluster=local
+        ${KUBECTL} config use-context local
+
+        ${KUBECTL} create -f namespace.yaml
+        # use kubectl to create skydns rc and service
+        ${KUBECTL} --namespace=kube-system create -f skydns-rc.yaml 
+        ${KUBECTL} --namespace=kube-system create -f skydns-svc.yaml
+        echo "Kube-dns rc and service successfully deployed."
+    fi
+
+}
+
 function print_success {
 cat <<EOF
 Local Kubernetes cluster is running. Press Ctrl-C to shut it down.
@@ -362,7 +410,9 @@ fi
 echo "Detected host and ready to start services.  Doing some housekeeping first..."
 echo "Using GO_OUT $GO_OUT"
 KUBELET_CIDFILE=/tmp/kubelet.cid
+if [[ "${ENABLE_DAEMON}" = false ]]; then
 trap cleanup EXIT
+fi
 echo "Starting services now!"
 startETCD
 set_service_accounts
@@ -370,6 +420,9 @@ start_apiserver
 start_controller_manager
 start_kubelet
 start_kubeproxy
+start_kubedns
 print_success
 
-while true; do sleep 1; done
+if [[ "${ENABLE_DAEMON}" = false ]]; then
+   while true; do sleep 1; done
+fi


### PR DESCRIPTION
This is the same PR as #19207 with proper rebase.

Could you please merge it?

This modification should enable the support for DNS when setting up the local cluster.
It is enabled by default (I don't see when we wouldn't want to have DNS resolution).
Variables to control the setup (inspired from doc and cluster/ubuntu/deployAddons.sh):
ENABLE_CLUSTER_DNS=${KUBE_ENABLE_CLUSTER_DNS:-true}
DNS_SERVER_IP=${KUBE_DNS_SERVER_IP:-10.0.0.10}
DNS_DOMAIN=${KUBE_DNS_NAME:-"cluster.local"}
DNS_REPLICAS=${KUBE_DNS_REPLICAS:-1}
KUBECTL=${KUBECTL:-cluster/kubectl.sh}

There are two small issue remaining with this:
- Not sure whether we need to run those commands before creating the kube-dns: (it seems to work without....)

```
   ${KUBECTL} config set-cluster local --server=http://127.0.0.1:8080 --insecure-skip-tls-verify=true
   ${KUBECTL} config set-context local --cluster=local
   ${KUBECTL} config use-context local
```
- Cleanup of the cluster:
  - `${KUBECTL} --namespace=kube-system delete service kube-dns` throw this error: `Error from server: client: etcd cluster is unavailable or misconfigured`
  - `${KUBECTL} --namespace=kube-system delete rc kube-dns-v10` just hang The drawback of not doing the cleanup is that you need to manually kill the etcd process if you want to restart local-up-cluster.sh

On top of this the PR includes:
- Possibility to increase the timer to wait for the api_server. It's controlled via    `WAIT_FOR_URL_API_SERVER`. default=10 (I've encountered cases where 10sec is not enough)
- Possibility to not run the `while true loop` at the end if you want to start the cluster via a cron for example. It's controlled via `ENABLE_DAEMON`. default: false
  Both options with their default are behaving as today

Thanks
Thibault
