### PR TITLE
WIP: Refactor docker-multinode and add a turndown script

### DIFF
--- a/docs/getting-started-guides/docker-multinode/common.sh
+++ b/docs/getting-started-guides/docker-multinode/common.sh
@@ -1,0 +1,437 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Utility functions for Kubernetes in docker setup
+# Authors @luxas @wizard_cxy @resouer @loopingz 
+
+# Variables
+K8S_VERSION=${K8S_VERSION:-"1.2.0-alpha.8"}
+ETCD_VERSION=${ETCD_VERSION:-"2.2.1"}
+FLANNEL_VERSION=${FLANNEL_VERSION:-"0.5.5"}
+FLANNEL_IFACE=${FLANNEL_IFACE:-"eth0"}
+FLANNEL_IPMASQ=${FLANNEL_IPMASQ:-"true"}
+FLANNEL_BACKEND=${FLANNEL_BACKEND:-"vxlan"}
+FLANNEL_NETWORK=${FLANNEL_NETWORK:-"10.1.0.0/16"}
+DNS_DOMAIN=${DNS_DOMAIN:-"cluster.local"}
+DNS_SERVER_IP=${DNS_SERVER_IP:-"10.0.0.10"}
+RESTART_POLICY=${RESTART_POLICY:-"on-failure"}
+ARCH=${ARCH:-"amd64"}
+
+# Constants
+TIMEOUT_FOR_SERVICES=20
+BOOTSTRAP_DOCKER_SOCK="unix:///var/run/docker-bootstrap.sock"
+KUBELET_MOUNTS="\
+  -v /sys:/sys:ro \
+  -v /var/run:/var/run:rw \
+  -v /:/rootfs:ro \
+  -v /var/lib/docker/:/var/lib/docker:rw \
+  -v /var/lib/kubelet/:/var/lib/kubelet:rw"
+
+# Paths
+FLANNEL_SUBNET_TMPDIR=$(mktemp -d)
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../../..
+
+# Source useful scripts
+source "${KUBE_ROOT}/hack/lib/util.sh"
+source "${KUBE_ROOT}/cluster/lib/logging.sh"
+
+# Trap errors
+kube::log::install_errexit
+
+# Ensure everything is OK, docker is running and we're root
+kube::multinode::check_params() {
+
+  # Make sure docker daemon is running
+  if [[ $(docker ps 2>&1 1>/dev/null; echo $?) != 0 ]]; then
+    kube::log::error "Docker is not running on this machine!"
+    exit 1
+  fi
+
+  # Require root
+  if [[ "$(id -u)" != "0" ]]; then
+    kube::log::error >&2 "Please run as root"
+    exit 1
+  fi
+
+  # Output the value of the variables
+  kube::log::status "K8S_VERSION is set to: ${K8S_VERSION}"
+  kube::log::status "ETCD_VERSION is set to: ${ETCD_VERSION}"
+  kube::log::status "FLANNEL_VERSION is set to: ${FLANNEL_VERSION}"
+  kube::log::status "FLANNEL_IFACE is set to: ${FLANNEL_IFACE}"
+  kube::log::status "FLANNEL_IPMASQ is set to: ${FLANNEL_IPMASQ}"
+  kube::log::status "FLANNEL_NETWORK is set to: ${FLANNEL_NETWORK}"
+  kube::log::status "FLANNEL_BACKEND is set to: ${FLANNEL_BACKEND}"
+  kube::log::status "DNS_DOMAIN is set to: ${DNS_DOMAIN}"
+  kube::log::status "DNS_SERVER_IP is set to: ${DNS_SERVER_IP}"
+  kube::log::status "RESTART_POLICY is set to: ${RESTART_POLICY}"
+  kube::log::status "MASTER_IP is set to: ${MASTER_IP}"
+  kube::log::status "ARCH is set to: ${ARCH}"
+  kube::log::status "--------------------------------------------"
+}
+
+# Detect the OS distro, we support ubuntu, debian, mint, centos, fedora and systemd dist
+kube::multinode::detect_lsb() {
+
+  # TODO(luxas): add support for arm, arm64 and ppc64le
+  case "$(kube::util::host_platform)" in
+    linux/amd64)
+      ;;
+    *)
+      kube::log::error "Error: We currently only support the linux/amd64 platform."
+      exit 1
+      ;;
+  esac
+
+  if kube::helpers::command_exists lsb_release; then
+    lsb_dist="$(lsb_release -si)"
+  elif [[ -r /etc/lsb-release ]]; then
+    lsb_dist="$(. /etc/lsb-release && echo "$DISTRIB_ID")"
+  elif [[ -r /etc/debian_version ]]; then
+    lsb_dist='debian'
+  elif [[ -r /etc/fedora-release ]]; then
+    lsb_dist='fedora'
+  elif [[ -r /etc/os-release ]]; then
+    lsb_dist="$(. /etc/os-release && echo "$ID")"
+  elif kube::helpers::command_exists systemctl; then
+    lsb_dist='systemd'
+  fi
+
+  lsb_dist="$(echo ${lsb_dist} | tr '[:upper:]' '[:lower:]')"
+
+  case "${lsb_dist}" in
+      amzn|centos|debian|ubuntu|systemd)
+          ;;
+      *)
+          kube::log::error "Error: We currently only support ubuntu|debian|amzn|centos|systemd."
+          exit 1
+          ;;
+  esac
+
+  kube::log::status "Detected OS: ${lsb_dist}"
+}
+
+# Start a docker bootstrap for running etcd and flannel
+kube::multinode::bootstrap_daemon() {
+
+  kube::log::status "Launching docker bootstrap..."
+
+  docker daemon \
+    -H ${BOOTSTRAP_DOCKER_SOCK} \
+    -p /var/run/docker-bootstrap.pid \
+    --iptables=false \
+    --ip-masq=false \
+    --bridge=none \
+    --graph=/var/lib/docker-bootstrap \
+      2> /var/log/docker-bootstrap.log \
+      1> /dev/null &
+
+  # Wait for docker bootstrap to start by "docker ps"-ing every second
+  local BOOTSTRAP_SECONDS=0
+  while [[ $(docker -H ${BOOTSTRAP_DOCKER_SOCK} ps 2>&1 1>/dev/null; echo $?) != 0 ]]; do
+    ((BOOTSTRAP_SECONDS++))
+    if [[ ${BOOTSTRAP_SECONDS} == ${TIMEOUT_FOR_SERVICES} ]]; then
+      kube::log::error "docker bootstrap failed to start. Exiting..."
+      exit
+    fi
+    sleep 1
+  done
+}
+
+# Start etcd on the master node
+kube::multinode::start_etcd() {
+
+  kube::log::status "Launching etcd..."
+  
+  docker -H ${BOOTSTRAP_DOCKER_SOCK} run -d \
+    --restart=${RESTART_POLICY} \
+    --net=host \
+    gcr.io/google_containers/etcd-${ARCH}:${ETCD_VERSION} \
+    /usr/local/bin/etcd \
+      --listen-client-urls=http://127.0.0.1:4001,http://${MASTER_IP}:4001 \
+      --advertise-client-urls=http://${MASTER_IP}:4001 \
+      --data-dir=/var/etcd/data
+
+  # Wait for etcd to come up
+  kube::util::wait_for_url "http://localhost:4001/v2/machines" "etcd" 0.25 80
+
+  # Set flannel net config
+  docker -H ${BOOTSTRAP_DOCKER_SOCK} run \
+      --net=host \
+      gcr.io/google_containers/etcd-${ARCH}:${ETCD_VERSION} \
+      etcdctl \
+      set /coreos.com/network/config \
+          "{ \"Network\": \"${FLANNEL_NETWORK}\", \"Backend\": {\"Type\": \"${FLANNEL_BACKEND}\"}}"
+
+  sleep 2
+}
+
+# Start flannel in docker bootstrap, both for master and worker
+kube::multinode::start_flannel() {
+
+  kube::log::status "Launching flannel..."
+
+  docker -H ${BOOTSTRAP_DOCKER_SOCK} run \
+    --restart=${RESTART_POLICY} \
+    -d \
+    --net=host \
+    --privileged \
+    -v /dev/net:/dev/net \
+    -v ${FLANNEL_SUBNET_TMPDIR}:/run/flannel \
+    quay.io/coreos/flannel:${FLANNEL_VERSION} \
+    /opt/bin/flanneld \
+      --etcd-endpoints=http://${MASTER_IP}:4001 \
+      --ip-masq="${FLANNEL_IPMASQ}" \
+      --iface="${FLANNEL_IFACE}"
+
+  # Wait for the flannel subnet.env file to be created instead of a timeout. This is faster and more reliable
+  local FLANNEL_SECONDS=0
+  while [[ ! -f ${FLANNEL_SUBNET_TMPDIR}/subnet.env ]]; do
+    ((FLANNEL_SECONDS++))
+    if [[ ${FLANNEL_SECONDS} == 20 ]]; then
+      kube::log::error "flannel failed to start. Exiting..."
+      exit
+    fi
+    sleep 1
+  done
+
+  source ${FLANNEL_SUBNET_TMPDIR}/subnet.env
+
+  kube::log::status "FLANNEL_SUBNET is set to: ${FLANNEL_SUBNET}"
+  kube::log::status "FLANNEL_MTU is set to: ${FLANNEL_MTU}"
+}
+
+# Configure docker net settings, then restart it
+kube::multinode::restart_docker(){
+
+  case "${lsb_dist}" in
+    amzn)
+      DOCKER_CONF="/etc/sysconfig/docker"
+
+      kube::helpers::file_replace_line ${DOCKER_CONF} \ # Replace content in this file
+        "--bip" \ # Find a line with this content...
+        "OPTIONS=\"\$OPTIONS --mtu=${FLANNEL_MTU} --bip=${FLANNEL_SUBNET}\"" # ...and replace the found line with this line
+
+      ifconfig docker0 down
+      yum -y -q install bridge-utils 
+      brctl delbr docker0 
+      service docker restart
+      ;;
+    centos)
+      DOCKER_CONF="/etc/sysconfig/docker"
+
+      kube::helpers::file_replace_line ${DOCKER_CONF} \ # Replace content in this file
+        "--bip" \ # Find a line with this content...
+        "OPTIONS=\"\$OPTIONS --mtu=${FLANNEL_MTU} --bip=${FLANNEL_SUBNET}\"" # ...and replace the found line with this line
+      
+      if ! kube::helpers::command_exists ifconfig; then
+          yum -y -q install net-tools
+      fi
+
+      yum -y -q install bridge-utils
+      ifconfig docker0 down
+      brctl delbr docker0 
+      systemctl restart docker
+      ;;
+    ubuntu|debian)
+      # Newer ubuntu and debian releases uses systemd. Handle that
+      if kube::helpers::command_exists systemctl; then
+        kube::multinode::restart_docker_systemd
+      else
+        DOCKER_CONF="/etc/default/docker"
+        
+        kube::helpers::file_replace_line ${DOCKER_CONF} \ # Replace content in this file
+          "--bip" \ # Find a line with this content...
+          "OPTIONS=\"\$OPTIONS --mtu=${FLANNEL_MTU} --bip=${FLANNEL_SUBNET}\"" # ...and replace the found line with this line
+
+        apt-get install -y bridge-utils 
+        brctl delbr docker0 
+        service docker stop
+        while [ $(ps aux | grep /usr/bin/docker | grep -v grep | wc -l) -gt 0 ]; do
+            kube::log::status "Waiting for docker to terminate"
+            sleep 1
+        done
+        service docker start
+      fi
+      ;;
+    systemd)
+      kube::multinode::restart_docker_systemd
+      ;;
+    *)
+        kube::log::error "Unsupported operations system ${lsb_dist}"
+        exit 1
+        ;;
+  esac
+
+  kube::log::status "Restarted docker with the new flannel settings"
+}
+
+# Replace --mtu and --bip in systemd's docker.service file and restart
+kube::multinode::restart_docker_systemd(){
+
+  DOCKER_CONF="/lib/systemd/system/docker.service"
+
+  # This expression checks if the "--mtu" and "--bip" options are there
+  # If they aren't, they are inserted at the end of the docker command
+  if [[ -z $(grep -- "--mtu=" $DOCKER_CONF) ]]; then
+    sed -e "s@$(grep "/usr/bin/docker" $DOCKER_CONF)@$(grep "/usr/bin/docker" $DOCKER_CONF) --mtu=${FLANNEL_MTU}@g" -i $DOCKER_CONF
+  fi
+  if [[ -z $(grep -- "--bip=" $DOCKER_CONF) ]]; then
+    sed -e "s@$(grep "/usr/bin/docker" $DOCKER_CONF)@$(grep "/usr/bin/docker" $DOCKER_CONF) --bip=${FLANNEL_SUBNET}@g" -i $DOCKER_CONF
+  fi
+
+  # Finds "--mtu=????" and replaces with "--mtu=${FLANNEL_MTU}"
+  # Also finds "--bip=??.??.??.??" and replaces with "--bip=${FLANNEL_SUBNET}"
+  sed -e "s@$(grep -o -- "--mtu=[[:graph:]]*" $DOCKER_CONF)@--mtu=${FLANNEL_MTU}@g;s@$(grep -o -- "--bip=[[:graph:]]*" $DOCKER_CONF)@--bip=${FLANNEL_SUBNET}@g" -i $DOCKER_CONF
+
+  systemctl daemon-reload
+  systemctl restart docker
+}
+
+# Start kubelet first and then the master components as pods
+kube::multinode::start_k8s_master() {
+  
+  kube::log::status "Launching Kubernetes master components..."
+
+  docker run -d \
+    --net=host \
+    --pid=host \
+    --privileged \
+    --restart=${RESTART_POLICY} \
+    ${KUBELET_MOUNTS} \
+    gcr.io/google_containers/hyperkube-${ARCH}:v${K8S_VERSION} \
+    /hyperkube kubelet \
+      --allow-privileged=true \
+      --api-servers=http://localhost:8080 \
+      --config=/etc/kubernetes/manifests-multi \
+      --cluster-dns=${DNS_SERVER_IP} \
+      --cluster-domain=${DNS_DOMAIN} \
+      --containerized \
+      --v=2
+}
+
+# Start kubelet in a container, for a worker node
+kube::multinode::start_k8s_worker() {
+  
+  kube::log::status "Launching Kubernetes worker components..."
+
+  # TODO: Use secure port for communication
+  docker run -d \
+    --net=host \
+    --pid=host \
+    --privileged \
+    --restart=${RESTART_POLICY} \
+    ${KUBELET_MOUNTS} \
+    gcr.io/google_containers/hyperkube-${ARCH}:v${K8S_VERSION} \
+    /hyperkube kubelet \
+      --allow-privileged=true \
+      --api-servers=http://${MASTER_IP}:8080 \
+      --cluster-dns=${DNS_SERVER_IP} \
+      --cluster-domain=${DNS_DOMAIN} \
+      --containerized \
+      --v=2
+}
+
+# Start kube-proxy in a container, for a worker node
+kube::multinode::start_k8s_worker_proxy() {
+
+  kube::log::status "Launching kube-proxy..."
+  docker run -d \
+    --net=host \
+    --privileged \
+    --restart=${RESTART_POLICY} \
+    gcr.io/google_containers/hyperkube-${ARCH}:v${K8S_VERSION} \
+    /hyperkube proxy \
+        --master=http://${MASTER_IP}:8080 \
+        --v=2
+}
+
+# Turndown the local cluster
+kube::multinode::turndown(){
+
+  # Check if docker bootstrap is running
+  if [[ $(kube::helpers::is_running ${BOOTSTRAP_DOCKER_SOCK}) == "true" ]]; then
+
+    kube::log::status "Killing docker bootstrap..."
+
+    # Kill all docker bootstrap's containers
+    if [[ $(docker -H ${BOOTSTRAP_DOCKER_SOCK} ps -q | wc -l) != 0 ]]; then
+      docker -H ${BOOTSTRAP_DOCKER_SOCK} rm -f $(docker -H ${BOOTSTRAP_DOCKER_SOCK} ps -q)
+    fi
+
+    # Kill bootstrap docker
+    kill $(ps aux | grep ${BOOTSTRAP_DOCKER_SOCK} | grep -v grep | awk '{print $2}')
+
+  fi
+
+  if [[ $(kube::helpers::is_running /hyperkube) == "true" ]]; then
+    
+    kube::log::status "Killing hyperkube containers..."
+
+    # Kill all hyperkube docker images
+    docker rm -f $(docker ps | grep gcr.io/google_containers/hyperkube | awk '{print $1}')
+  fi
+
+  if [[ $(kube::helpers::is_running /pause) == "true" ]]; then
+    
+    kube::log::status "Killing pause containers..."
+
+    # Kill all pause docker images
+    docker rm -f $(docker ps | grep gcr.io/google_containers/pause | awk '{print $1}')
+  fi
+
+  if [[ -d /var/lib/kubelet ]]; then
+    read -p "Do you want to clean /var/lib/kubelet? [Y/n] " clean_kubelet_dir
+
+    case $clean_kubelet_dir in
+      [n|N]*)
+        ;; # Do nothing
+      *)
+        # umount if there's mounts bound in /var/lib/kubelet
+        if [[ ! -z $(mount | grep /var/lib/kubelet | awk '{print $3}') ]]; then
+          umount $(mount | grep /var/lib/kubelet | awk '{print $3}')
+        fi
+
+        # Delete the directory
+        rm -rf /var/lib/kubelet
+    esac
+  fi
+}
+
+## Helpers
+
+# Check if a command is valid
+kube::helpers::command_exists() {
+    command -v "$@" > /dev/null 2>&1
+}
+
+# Usage: kube::helpers::file_replace_line {path_to_file} {value_to_search_for} {replace_that_line_with_this_content}
+# Finds a line in a file and replaces the line with the third argument
+kube::helpers::file_replace_line(){
+  if [[ -z $(grep "$2" $1) ]]; then
+    echo "$3" >> $1
+  else
+    sed -i "/$2/c\\$3" $1
+  fi
+}
+
+# Check if a process is running
+kube::helpers::is_running(){
+  if [[ ! -z $(ps aux | grep ${1} | grep -v grep) ]]; then
+    echo "true"
+  else
+    echo "false"
+  fi
+}

--- a/docs/getting-started-guides/docker-multinode/master.sh
+++ b/docs/getting-started-guides/docker-multinode/master.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2015 The Kubernetes Authors All rights reserved.
+# Copyright 2016 The Kubernetes Authors All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,222 +14,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# A script to setup the k8s master in docker containers.
-# Authors @wizard_cxy @resouer
+# Source common.sh
+source $(dirname "${BASH_SOURCE}")/common.sh
 
-set -e
-
-# Make sure docker daemon is running
-if ( ! ps -ef | grep "/usr/bin/docker" | grep -v 'grep' &> /dev/null ); then
-    echo "Docker is not running on this machine!"
-    exit 1
+# Let MASTER_IP default to the current IP when starting a master
+if [[ -z ${MASTER_IP} ]]; then
+  MASTER_IP=$(hostname -I | awk '{print $1}')
 fi
 
-# Make sure k8s version env is properly set
-K8S_VERSION=${K8S_VERSION:-"1.2.0-alpha.7"}
-ETCD_VERSION=${ETCD_VERSION:-"2.2.1"}
-FLANNEL_VERSION=${FLANNEL_VERSION:-"0.5.5"}
-FLANNEL_IPMASQ=${FLANNEL_IPMASQ:-"true"}
-FLANNEL_IFACE=${FLANNEL_IFACE:-"eth0"}
-ARCH=${ARCH:-"amd64"}
+kube::multinode::check_params
 
-# Run as root
-if [ "$(id -u)" != "0" ]; then
-    echo >&2 "Please run as root"
-    exit 1
-fi
+kube::multinode::detect_lsb
 
-# Make sure master ip is properly set
-if [ -z ${MASTER_IP} ]; then
-    MASTER_IP=$(hostname -I | awk '{print $1}')
-fi
+kube::multinode::turndown
 
-echo "K8S_VERSION is set to: ${K8S_VERSION}"
-echo "ETCD_VERSION is set to: ${ETCD_VERSION}"
-echo "FLANNEL_VERSION is set to: ${FLANNEL_VERSION}"
-echo "FLANNEL_IFACE is set to: ${FLANNEL_IFACE}"
-echo "FLANNEL_IPMASQ is set to: ${FLANNEL_IPMASQ}"
-echo "MASTER_IP is set to: ${MASTER_IP}"
-echo "ARCH is set to: ${ARCH}"
+kube::multinode::bootstrap_daemon
 
-# Check if a command is valid
-command_exists() {
-    command -v "$@" > /dev/null 2>&1
-}
+kube::multinode::start_etcd
 
-lsb_dist=""
+kube::multinode::start_flannel
 
-# Detect the OS distro, we support ubuntu, debian, mint, centos, fedora dist
-detect_lsb() {
-    # TODO: remove this when ARM support is fully merged
-    case "$(uname -m)" in
-        *64)
-            ;;
-         *)
-            echo "Error: We currently only support 64-bit platforms."       
-            exit 1
-            ;;
-    esac
+kube::multinode::restart_docker
 
-    if command_exists lsb_release; then
-        lsb_dist="$(lsb_release -si)"
-    fi
-    if [ -z ${lsb_dist} ] && [ -r /etc/lsb-release ]; then
-        lsb_dist="$(. /etc/lsb-release && echo "$DISTRIB_ID")"
-    fi
-    if [ -z ${lsb_dist} ] && [ -r /etc/debian_version ]; then
-        lsb_dist='debian'
-    fi
-    if [ -z ${lsb_dist} ] && [ -r /etc/fedora-release ]; then
-        lsb_dist='fedora'
-    fi
-    if [ -z ${lsb_dist} ] && [ -r /etc/os-release ]; then
-        lsb_dist="$(. /etc/os-release && echo "$ID")"
-    fi
+kube::multinode::start_k8s_master
 
-    lsb_dist="$(echo ${lsb_dist} | tr '[:upper:]' '[:lower:]')"
-
-    case "${lsb_dist}" in
-        amzn|centos|debian|ubuntu)
-            ;;
-        *)
-            echo "Error: We currently only support ubuntu|debian|amzn|centos."
-            exit 1
-            ;;
-    esac
-}
-
-
-# Start the bootstrap daemon
-# TODO: do not start docker-bootstrap if it's already running
-bootstrap_daemon() {
-    docker -d \
-        -H unix:///var/run/docker-bootstrap.sock \
-        -p /var/run/docker-bootstrap.pid \
-        --iptables=false \
-        --ip-masq=false \
-        --bridge=none \
-        --graph=/var/lib/docker-bootstrap \
-            2> /var/log/docker-bootstrap.log \
-            1> /dev/null &
-    
-    sleep 5
-}
-
-# Start k8s components in containers
-DOCKER_CONF=""
-
-start_k8s(){
-    # Start etcd 
-    docker -H unix:///var/run/docker-bootstrap.sock run \
-        --restart=on-failure \
-        --net=host \
-        -d \
-        gcr.io/google_containers/etcd-${ARCH}:${ETCD_VERSION} \
-        /usr/local/bin/etcd \
-            --listen-client-urls=http://127.0.0.1:4001,http://${MASTER_IP}:4001 \
-            --advertise-client-urls=http://${MASTER_IP}:4001 \
-            --data-dir=/var/etcd/data
-
-    sleep 5
-    # Set flannel net config
-    docker -H unix:///var/run/docker-bootstrap.sock run \
-        --net=host gcr.io/google_containers/etcd:${ETCD_VERSION} \
-        etcdctl \
-        set /coreos.com/network/config \
-            '{ "Network": "10.1.0.0/16", "Backend": {"Type": "vxlan"}}'
-
-    # iface may change to a private network interface, eth0 is for default
-    flannelCID=$(docker -H unix:///var/run/docker-bootstrap.sock run \
-        --restart=on-failure \
-        -d \
-        --net=host \
-        --privileged \
-        -v /dev/net:/dev/net \
-        quay.io/coreos/flannel:${FLANNEL_VERSION} \
-        /opt/bin/flanneld \
-            --ip-masq="${FLANNEL_IPMASQ}" \
-            --iface="${FLANNEL_IFACE}")
-
-    sleep 8
-
-    # Copy flannel env out and source it on the host
-    docker -H unix:///var/run/docker-bootstrap.sock \
-        cp ${flannelCID}:/run/flannel/subnet.env .
-    source subnet.env
-
-    # Configure docker net settings, then restart it
-    case "${lsb_dist}" in
-        amzn)
-            DOCKER_CONF="/etc/sysconfig/docker"
-            echo "OPTIONS=\"\$OPTIONS --mtu=${FLANNEL_MTU} --bip=${FLANNEL_SUBNET}\"" | tee -a ${DOCKER_CONF}
-            ifconfig docker0 down
-            yum -y -q install bridge-utils && brctl delbr docker0 && service docker restart
-            ;;
-        centos)
-            DOCKER_CONF="/etc/sysconfig/docker"
-            echo "OPTIONS=\"\$OPTIONS --mtu=${FLANNEL_MTU} --bip=${FLANNEL_SUBNET}\"" | tee -a ${DOCKER_CONF}
-            if ! command_exists ifconfig; then
-                yum -y -q install net-tools
-            fi
-            ifconfig docker0 down
-            yum -y -q install bridge-utils && brctl delbr docker0 && systemctl restart docker
-            ;;
-        ubuntu|debian)
-            DOCKER_CONF="/etc/default/docker"
-            echo "DOCKER_OPTS=\"\$DOCKER_OPTS --mtu=${FLANNEL_MTU} --bip=${FLANNEL_SUBNET}\"" | tee -a ${DOCKER_CONF}
-            ifconfig docker0 down
-            apt-get install bridge-utils
-            brctl delbr docker0
-            service docker stop
-            while [ `ps aux | grep /usr/bin/docker | grep -v grep | wc -l` -gt 0 ]; do
-                echo "Waiting for docker to terminate"
-                sleep 1
-            done
-            service docker start
-            ;;
-        *)
-            echo "Unsupported operations system ${lsb_dist}"
-            exit 1
-            ;;
-    esac
-
-    # sleep a little bit
-    sleep 5
-
-    # Start kubelet and then start master components as pods
-    docker run \
-        --net=host \
-        --pid=host \
-        --privileged \
-        --restart=on-failure \
-        -d \
-        -v /sys:/sys:ro \
-        -v /var/run:/var/run:rw \
-        -v /:/rootfs:ro \
-        -v /var/lib/docker/:/var/lib/docker:rw \
-        -v /var/lib/kubelet/:/var/lib/kubelet:rw \
-        gcr.io/google_containers/hyperkube-${ARCH}:v${K8S_VERSION} \
-        /hyperkube kubelet \
-            --address=0.0.0.0 \
-            --allow-privileged=true \
-            --enable-server \
-            --api-servers=http://localhost:8080 \
-            --config=/etc/kubernetes/manifests-multi \
-            --cluster-dns=10.0.0.10 \
-            --cluster-domain=cluster.local \
-            --containerized \
-            --v=2
-
-}
-
-echo "Detecting your OS distro ..."
-detect_lsb
-
-echo "Starting bootstrap docker ..."
-bootstrap_daemon
-
-echo "Starting k8s ..."
-start_k8s
-
-echo "Master done!"
+kube::log::status "Done. It will take some minutes before apiserver is up though"

--- a/docs/getting-started-guides/docker-multinode/testing.md
+++ b/docs/getting-started-guides/docker-multinode/testing.md
@@ -36,50 +36,50 @@ Documentation for other releases can be found at
 
 To validate that your node(s) have been added, run:
 
-```sh
-kubectl get nodes
+```console
+$ kubectl get nodes
 ```
 
 That should show something like:
 
 ```console
-NAME           LABELS                                 STATUS
-10.240.99.26   kubernetes.io/hostname=10.240.99.26    Ready
-127.0.0.1      kubernetes.io/hostname=127.0.0.1       Ready
+NAME        LABELS                             STATUS    AGE
+127.0.0.1   kubernetes.io/hostname=127.0.0.1   Ready     2h
 ```
 
 If the status of any node is `Unknown` or `NotReady` your cluster is broken, double check that all containers are running properly, and if all else fails, contact us on [Slack](../../troubleshooting.md#slack).
+You may also check if for `docker` [troubleshooting](../docker.md#troubleshooting)
 
 ### Run an application
 
-```sh
-kubectl -s http://localhost:8080 run nginx --image=nginx --port=80
+```console
+$ kubectl run nginx --image=nginx --port=80
 ```
 
-now run `docker ps` you should see nginx running.  You may need to wait a few minutes for the image to get pulled.
+Now run `docker ps` you should see nginx running.  You may need to wait a few minutes for the image to get pulled.
 
 ### Expose it as a service
 
-```sh
-kubectl expose rc nginx --port=80
+```console
+$ kubectl expose rc nginx --port=80
 ```
 
-Run the following command to obtain the IP of this service we just created. There are two IPs, the first one is internal (CLUSTER_IP), and the second one is the external load-balanced IP.
+Run the following command to obtain the IP of this service we just created. There are two IPs, the first one is internal (CLUSTER_IP), and the second one is the external load-balanced IP (if a LoadBalancer is configured)
 
-```sh
-kubectl get svc nginx
+```console
+$ kubectl get svc nginx
 ```
 
 Alternatively, you can obtain only the first IP (CLUSTER_IP) by running:
 
-```sh
-kubectl get svc nginx --template={{.spec.clusterIP}}
+```console
+$ kubectl get svc nginx --template={{.spec.clusterIP}}
 ```
 
 Hit the webserver with the first IP (CLUSTER_IP):
 
-```sh
-curl <insert-cluster-ip-here>
+```console
+$ curl <insert-cluster-ip-here>
 ```
 
 Note that you will need run this curl command on your boot2docker VM if you are running on OS X.
@@ -88,18 +88,17 @@ Note that you will need run this curl command on your boot2docker VM if you are 
 
 Now try to scale up the nginx you created before:
 
-```sh
-kubectl scale rc nginx --replicas=3
+```console
+$ kubectl scale rc nginx --replicas=3
 ```
 
 And list the pods
 
-```sh
-kubectl get pods
+```console
+$ kubectl get pods
 ```
 
 You should see pods landing on the newly added machine.
-
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/getting-started-guides/docker-multinode/testing.md?pixel)]()

--- a/docs/getting-started-guides/docker-multinode/turndown.sh
+++ b/docs/getting-started-guides/docker-multinode/turndown.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2016 The Kubernetes Authors All rights reserved.
+# Copyright 2015 The Kubernetes Authors All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,26 +17,7 @@
 # Source common.sh
 source $(dirname "${BASH_SOURCE}")/common.sh
 
-# Make sure MASTER_IP is properly set
-if [[ -z ${MASTER_IP} ]]; then
-    echo "Please export MASTER_IP in your env"
-    exit 1
-fi
-
-kube::multinode::check_params
-
-kube::multinode::detect_lsb
-
+# Turndown kubernetes in docker
 kube::multinode::turndown
 
-kube::multinode::bootstrap_daemon
-
-kube::multinode::start_flannel
-
-kube::multinode::restart_docker
-
-kube::multinode::start_k8s_worker
-
-kube::multinode::start_k8s_worker_proxy
-
-kube::log::status "Done. After about a minute the node should be ready."
+kube::log::status "Done. It will take some minutes before apiserver is up though"

--- a/docs/getting-started-guides/docker.md
+++ b/docs/getting-started-guides/docker.md
@@ -119,24 +119,14 @@ $ chmod 755 kubectl
 $ PATH=$PATH:`pwd`
 ```
 
-Create configuration:
-
-```
-$ kubectl config set-cluster test-doc --server=http://localhost:8080
-$ kubectl config set-context test-doc --cluster=test-doc
-$ kubectl config use-context test-doc
-```
-
-For Max OS X users instead of `localhost` you will have to use IP address of your docker machine,
-which you can find by running `docker-machine env <machinename>` (see [documentation](https://docs.docker.com/machine/reference/env/)
-for details).
+Max OS X users might have to `export KUBERNETES_SERVER=http://${K8S_MASTER_IP}:8080` and replace `${K8S_MASTER_IP}` with the IP of the `docker-machine`. Find out by running: `docker-machine env <machinename>` (see the [documentation](https://docs.docker.com/machine/reference/env/) for more details).
 
 ### Test it out
 
 List the nodes in your cluster by running:
 
-```sh
-kubectl get nodes
+```console
+$ kubectl get nodes
 ```
 
 This should print:
@@ -148,43 +138,43 @@ NAME        LABELS                             STATUS
 
 ### Run an application
 
-```sh
-kubectl run nginx --image=nginx --port=80
+```console
+$ kubectl run nginx --image=nginx --port=80
 ```
 
 Now run `docker ps` you should see nginx running.  You may need to wait a few minutes for the image to get pulled.
 
 ### Expose it as a service
 
-```sh
-kubectl expose rc nginx --port=80
+```console
+$ kubectl expose rc nginx --port=80
 ```
 
 Run the following command to obtain the IP of this service we just created. There are two IPs, the first one is internal (CLUSTER_IP), and the second one is the external load-balanced IP (if a LoadBalancer is configured)
 
-```sh
-kubectl get svc nginx
+```console
+$ kubectl get svc nginx
 ```
 
 Alternatively, you can obtain only the first IP (CLUSTER_IP) by running:
 
-```sh
-kubectl get svc nginx --template={{.spec.clusterIP}}
+```console
+$ kubectl get svc nginx --template={{.spec.clusterIP}}
 ```
 
 Hit the webserver with the first IP (CLUSTER_IP):
 
-```sh
-curl <insert-cluster-ip-here>
+```console
+$ curl <insert-cluster-ip-here>
 ```
 
 Note that you will need run this curl command on your boot2docker VM if you are running on OS X.
 
-## Deploy a DNS
+### Deploy a DNS
 
 See [here](docker-multinode/deployDNS.md) for instructions.
 
-### A note on turning down your cluster
+## A note on turning down your cluster
 
 Many of these containers run under the management of the `kubelet` binary, which attempts to keep containers running, even if they fail.  So, in order to turn down
 the cluster, you need to first kill the kubelet container, and then any other containers.

--- a/docs/getting-started-guides/scratch.md
+++ b/docs/getting-started-guides/scratch.md
@@ -224,7 +224,7 @@ we recommend that you run these as containers, so you need an image to be built.
 
 You have several choices for Kubernetes images:
 - Use images hosted on Google Container Registry (GCR):
-  - e.g `gcr.io/google_containers/hyperkube:$TAG`, where `TAG` is the latest
+  - e.g `gcr.io/google_containers/hyperkube-amd64:$TAG`, where `TAG` is the latest
     release tag, which can be found on the [latest releases page](https://github.com/kubernetes/kubernetes/releases/latest).
   - Ensure $TAG is the same tag as the release tag you are using for kubelet and kube-proxy.
   - The [hyperkube](../../cmd/hyperkube/) binary is an all in one binary
@@ -238,19 +238,18 @@ You have several choices for Kubernetes images:
     command like `docker images`
 
 For etcd, you can:
-- Use images hosted on Google Container Registry (GCR), such as `gcr.io/google_containers/etcd:2.2.1`
+- Use images hosted on Google Container Registry (GCR), such as `gcr.io/google_containers/etcd-amd64:2.2.1`
 - Use images hosted on [Docker Hub](https://hub.docker.com/search/?q=etcd) or [Quay.io](https://quay.io/repository/coreos/etcd), such as `quay.io/coreos/etcd:v2.2.1`
 - Use etcd binary included in your OS distro.
 - Build your own image
   - You can do: `cd kubernetes/cluster/images/etcd; make`
 
-We recommend that you use the etcd version which is provided in the Kubernetes binary distribution.   The Kubernetes binaries in the release
-were tested extensively with this version of etcd and not with any other version.
+We recommend that you use the etcd version which is provided in the Kubernetes binary distribution. The Kubernetes binaries in the release were tested extensively with this version of etcd and not with any other version.
 The recommended version number can also be found as the value of `ETCD_VERSION` in `kubernetes/cluster/images/etcd/Makefile`.
 
 The remainder of the document assumes that the image identifiers have been chosen and stored in corresponding env vars.  Examples (replace with latest tags and appropriate registry):
-  - `HYPERKUBE_IMAGE==gcr.io/google_containers/hyperkube:$TAG`
-  - `ETCD_IMAGE=gcr.io/google_containers/etcd:$ETCD_VERSION`
+  - `HYPERKUBE_IMAGE==gcr.io/google_containers/hyperkube-amd64:$TAG`
+  - `ETCD_IMAGE=gcr.io/google_containers/etcd-amd64:$ETCD_VERSION`
 
 ### Security Models
 


### PR DESCRIPTION
**Work in progress**

Feel free to comment on it. Tested on Ubuntu 15.04
Refactor the `docker-multinode` into a `common.sh` script. Format the output nicely. Uses a `while` loop instead of a `sleep` timeout while waiting for `docker-bootstrap`, `flannel` and `etcd`, which makes it much faster and reliable. Kills running services before starting again and adds a `turndown` script. Replaces `--bip` and `--mtu` docker args instead of appending which makes it possible to run the same script multiple times without editing files by hand. Many variables are now easily editable by `export`ing.

``` console
$ sudo ./master.sh
+++ [0221 22:41:03] K8S_VERSION is set to: 1.2.0-alpha.8
+++ [0221 22:41:03] ETCD_VERSION is set to: 2.2.1
+++ [0221 22:41:03] FLANNEL_VERSION is set to: 0.5.5
+++ [0221 22:41:03] FLANNEL_IFACE is set to: eth0
+++ [0221 22:41:03] FLANNEL_IPMASQ is set to: true
+++ [0221 22:41:03] FLANNEL_NETWORK is set to: 10.1.0.0/16
+++ [0221 22:41:03] FLANNEL_BACKEND is set to: vxlan
+++ [0221 22:41:03] DNS_DOMAIN is set to: cluster.local
+++ [0221 22:41:03] DNS_SERVER_IP is set to: 10.0.0.10
+++ [0221 22:41:03] RESTART_POLICY is set to: on-failure
+++ [0221 22:41:03] MASTER_IP is set to: 192.168.1.130
+++ [0221 22:41:03] ARCH is set to: amd64
+++ [0221 22:41:03] --------------------------------------------
+++ [0221 22:41:03] Detected OS: ubuntu
+++ [0221 22:41:03] Killing docker bootstrap...
a02ada8c0dcb
db252891ed57
+++ [0221 22:41:04] Killing hyperkube containers...
0edf63a11b84
54a5a889762b
fed2f5261272
e5e064c9fe28
97adbc8a0b50
d74d2daa3810
+++ [0221 22:41:34] Killing pause containers...
f2d59059d2d3
5429b04089e8
Do you want to clean /var/lib/kubelet? [Y/n] y
+++ [0221 22:43:22] Launching docker bootstrap...
+++ [0221 22:43:23] Launching etcd...
b5228fb3ccc5a90e7b10d43173003859a44ea2e21155433d024f2e204ff84964
+++ [0221 22:43:24] On try 1, etcd: 
{ "Network": "10.1.0.0/16", "Backend": {"Type": "vxlan"}}
+++ [0221 22:43:26] Launching flannel...
eed14d245a86182ed1c87150a36cab11a9e1731e8415ac5cf7d46d3581c4ea1f
+++ [0221 22:43:28] FLANNEL_SUBNET is set to: 10.1.90.1/24
+++ [0221 22:43:28] FLANNEL_MTU is set to: 1450
+++ [0221 22:43:29] Restarted docker with the new flannel settings
+++ [0221 22:43:29] Launching Kubernetes master components...
fa7c7594e5d41f216852f55aa96a8b296bd2be123a87ff37fb7ccc8663f60f54
+++ [0221 22:43:30] Done. It will take some minutes before apiserver is up though

```

Also replaced `etcd` and `hyperkube` with `etcd-amd64` and `hyperkube-amd64`. Updated some testing docs.
Do you think this should target `v1.2` or `v1.3`?
@fgrzadkowski @dalanlan @brendandburns @resouer @thockin @loopingz

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/21646)

<!-- Reviewable:end -->
