### PR TITLE
AWS kube-up: Build kubeconfig asap

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -937,15 +937,15 @@ function kube-up {
     # Create the master
     start-master
 
+    # Build ~/.kube/config
+    build-config
+
     # Start minions
     start-minions
     wait-minions
 
     # Wait for the master to be ready
     wait-master
-
-    # Build ~/.kube/config
-    build-config
   fi
 
   # Check the cluster is OK


### PR DESCRIPTION
Once we've built the master, we can build kubeconfig.  By doing so, if
we time out waiting for the nodes, the system is still configured
correctly.

In particular, spot instances can be slow to launch.

Related to issue #21200
