### PR TITLE
Ensure created service account tokens are available to the token controller

### DIFF
--- a/pkg/controller/serviceaccount/tokens_controller.go
+++ b/pkg/controller/serviceaccount/tokens_controller.go
@@ -331,8 +331,12 @@ func (e *TokensController) createSecret(serviceAccount *api.ServiceAccount) erro
 	}
 
 	// Save the secret
-	if _, err := e.client.Core().Secrets(serviceAccount.Namespace).Create(secret); err != nil {
+	if createdToken, err := e.client.Core().Secrets(serviceAccount.Namespace).Create(secret); err != nil {
 		return err
+	} else {
+		// Manually add the new token to the cache store.
+		// This prevents the service account update (below) triggering another token creation, if the referenced token couldn't be found in the store
+		e.secrets.Add(createdToken)
 	}
 
 	liveServiceAccount.Secrets = append(liveServiceAccount.Secrets, api.ObjectReference{Name: secret.Name})


### PR DESCRIPTION
Fixes #20787

A race condition exists when a new service account shows up, in which the tokens controller can create multiple tokens:
1. Service account is created, tokens controller gets "add" event
2. Tokens controller sees no secret references in the SA, so it:
   A. creates a token (queuing a token add event)
   B. updates the service account with a reference to the token (queuing a SA update event)

Whenever the token controller sees a service account update, it ensures a reference to a valid token exists in the service account. It does so by checking the token references in the service account against a token cache store.

If the SA update from 2B is observed before the token cache store is updated with the token add in 2A, the token controller will think there are no valid tokens referenced and create a second token.

The simplest solution to this is for the token controller to add a newly created token to its cache store itself after a successful create. The controller will tolerate receiving an add event for a token already in its store, and if the token happens to have been immediately deleted, that will be recognized on the next full resync.

Added an e2e test to exercise this case.
