### PR TITLE
Report actual replicas in deployment status

### DIFF
--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -1042,8 +1042,8 @@ func (dc *DeploymentController) updateDeploymentStatus(allRSs []*extensions.Repl
 }
 
 func (dc *DeploymentController) calculateStatus(allRSs []*extensions.ReplicaSet, newRS *extensions.ReplicaSet, deployment extensions.Deployment) (totalReplicas, updatedReplicas, availableReplicas, unavailableReplicas int, err error) {
-	totalReplicas = deploymentutil.GetReplicaCountForReplicaSets(allRSs)
-	updatedReplicas = deploymentutil.GetReplicaCountForReplicaSets([]*extensions.ReplicaSet{newRS})
+	totalReplicas = deploymentutil.GetActualReplicaCountForReplicaSets(allRSs)
+	updatedReplicas = deploymentutil.GetActualReplicaCountForReplicaSets([]*extensions.ReplicaSet{newRS})
 	minReadySeconds := deployment.Spec.MinReadySeconds
 	availableReplicas, err = deploymentutil.GetAvailablePodsForReplicaSets(dc.client, allRSs, minReadySeconds)
 	if err != nil {

--- a/pkg/util/deployment/deployment.go
+++ b/pkg/util/deployment/deployment.go
@@ -177,6 +177,15 @@ func GetReplicaCountForReplicaSets(replicaSets []*extensions.ReplicaSet) int {
 	return totalReplicaCount
 }
 
+// GetActualReplicaCountForReplicaSets returns the sum of actual replicas of the given replica sets.
+func GetActualReplicaCountForReplicaSets(replicaSets []*extensions.ReplicaSet) int {
+	totalReplicaCount := 0
+	for _, rs := range replicaSets {
+		totalReplicaCount += rs.Status.Replicas
+	}
+	return totalReplicaCount
+}
+
 // Returns the number of available pods corresponding to the given replica sets.
 func GetAvailablePodsForReplicaSets(c clientset.Interface, rss []*extensions.ReplicaSet, minReadySeconds int) (int, error) {
 	allPods, err := GetPodsForReplicaSets(c, rss)


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/issues/21463#issuecomment-186688279:

> these values are computed from desired replicas of underlying RSes:
> 
> ```
>     totalReplicas = deploymentutil.GetReplicaCountForReplicaSets(allRSs)
>     updatedReplicas = deploymentutil.GetReplicaCountForReplicaSets([]*extensions.ReplicaSet{newRS})
> ```
> 
> Which kind of makes sense, but may be surprising to users, since they won't necessarily reflect the actual number of pods.

Use actual replicas (rs.status.replicas) instead. 

cc @bgrant0607 @nikhiljindal @ironcladlou @kargakis @kubernetes/sig-config @madhusudancs @mqliang
