### PR TITLE
Remove redundant call of kube::release::gcs::release.

### DIFF
--- a/build/release.sh
+++ b/build/release.sh
@@ -15,8 +15,9 @@
 # limitations under the License.
 
 # Build a Kubernetes release.  This will build the binaries, create the Docker
-# images and other build artifacts.  All intermediate artifacts will be hosted
-# publicly on Google Cloud Storage currently.
+# images and other build artifacts.
+# For pushing these artifacts publicly on Google Cloud Storage, see the 
+# associated build/push-* scripts.
 
 set -o errexit
 set -o nounset
@@ -38,4 +39,3 @@ fi
 
 kube::build::copy_output
 kube::release::package_tarballs
-kube::release::gcs::release


### PR DESCRIPTION
This is called by build/push-official-release.sh.
