### PR TITLE
Remove potential corrupted docker network checkpoint file before star…

### DIFF
--- a/cluster/saltbase/salt/supervisor/docker-checker.sh
+++ b/cluster/saltbase/salt/supervisor/docker-checker.sh
@@ -25,6 +25,10 @@ while pidof docker > /dev/null; do
     sleep 10
 done
 
+# cleanup docker network checkpoint to avoid running into known issue
+# of docker (https://github.com/docker/docker/issues/18283)
+rm -rf /var/lib/docker/network
+
 /etc/init.d/docker start
 
 echo "waiting 30s for startup"


### PR DESCRIPTION
…t docker again.

After both of prs merge:

1) https://github.com/kubernetes/kubernetes/pull/21641: mitigate the issue caused by hairpin mode
2) https://github.com/kubernetes/kubernetes/pull/21703: gracefully shutdown docker daemon

I managed to get one node out of a couple of hundreds nodes failed with:

```
time="2016-02-23T00:55:39.537622453Z" level=fatal msg="Error starting daemon: Error initializing network controller: Error creating default \"br
idge\" network: failed to allocate gateway (10.245.2.1): No available addresses on this pool" 
```

Manually removing corrupted network file, docker startup properly:

```
root@e2e-scalability-minion-9qtj:/var/log# rm -rf /var/lib/docker/network/*
root@e2e-scalability-minion-9qtj:/var/log# docker ps 
CONTAINER ID        IMAGE                                                                  COMMAND                  CREATED              STATUS 
             PORTS               NAMES
4f36a063df33        gcr.io/google_containers/fluentd-elasticsearch:1.14                    "td-agent"               About a minute ago   Up Abou
t a minute                       k8s_fluentd-elasticsearch.33dc92f6_fluentd-elasticsearch-e2e-scalability-minion-9qtj_kube-system_ca513b83a860f1
1327241aa95a352f58_4a1d0157
f2e5469b5ddc        gcr.io/google_containers/kube-proxy:2496bafa4c888dd8e1e0d8be8214a702   "/bin/sh -c 'kube-pro"   About a minute ago   Up Abou
t a minute                       k8s_kube-proxy.d6cacae1_kube-proxy-e2e-scalability-minion-9qtj_kube-system_630ffae3655bcbe9c949d5eec21cc51d_e84
b11e2
a44c24b3c53f        gcr.io/google_containers/pause:2.0                                     "/pause"                 2 minutes ago        Up 2 mi
nutes                            k8s_POD.6059dfa2_fluentd-elasticsearch-e2e-scalability-minion-9qtj_kube-system_ca513b83a860f11327241aa95a352f58
_367b43c0
97bb15e5b17f        gcr.io/google_containers/pause:2.0                                     "/pause"                 2 minutes ago        Up 2 mi
nutes                            k8s_POD.6059dfa2_kube-proxy-e2e-scalability-minion-9qtj_kube-system_630ffae3655bcbe9c949d5eec21cc51d_d1e9d1da
```

cc/ @bprashanth 
