### PR TITLE
rkt: fix KillPod() to return the correct error message.

### DIFF
--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -1045,7 +1045,8 @@ func (r *Runtime) KillPod(pod *api.Pod, runningPod kubecontainer.Pod) error {
 
 	res := <-reschan
 	if res != "done" {
-		glog.Errorf("rkt: Failed to stop unit %q: %s", serviceName, res)
+		err := fmt.Errorf("invalid result: %s", res)
+		glog.Errorf("rkt: Failed to stop unit %q: %v", serviceName, err)
 		return err
 	}
 


### PR DESCRIPTION
cc @kubernetes/sig-node @aaronlevy
