### PR TITLE
Wait for pods to become available before rolling over in deployment e2e test

### DIFF
--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -454,12 +454,14 @@ func testRolloverDeployment(f *Framework) {
 		Logf("error in waiting for pods to come up: %s", err)
 		Expect(err).NotTo(HaveOccurred())
 	}
+	deploymentMinReadySeconds := 5
+	err = waitForPodsReady(c, ns, podName, deploymentMinReadySeconds)
+	Expect(err).NotTo(HaveOccurred())
 
 	// Create a deployment to delete nginx pods and instead bring up redis-slave pods.
 	deploymentName, deploymentImageName := "redis-deployment", "redis-slave"
 	deploymentReplicas := 4
 	deploymentImage := "gcr.io/google_samples/gb-redisslave:v1"
-	deploymentMinReadySeconds := 5
 	deploymentStrategyType := extensions.RollingUpdateDeploymentStrategyType
 	Logf("Creating deployment %s", deploymentName)
 	newDeployment := newDeployment(deploymentName, deploymentReplicas, deploymentPodLabels, deploymentImageName, deploymentImage, deploymentStrategyType, nil)


### PR DESCRIPTION
#19299

In the e2e test, we created an rs, waited for its pods to be running, and then created and updated a deployment to rollover. 

However, since the `minReadySeconds` is set to 5 in the deployment, we should wait for the rs's pods to become available before creating/updating the deployment. 

cc @bgrant0607 @nikhiljindal @ironcladlou @kargakis @kubernetes/sig-config @madhusudancs @mqliang
