### PR TITLE
Hot-fix admission of volumes that are being provisioned.

### DIFF
--- a/pkg/volume/aws_ebs/aws_ebs.go
+++ b/pkg/volume/aws_ebs/aws_ebs.go
@@ -439,7 +439,7 @@ func (c *awsElasticBlockStoreProvisioner) NewPersistentVolumeTemplate() (*api.Pe
 			},
 			PersistentVolumeSource: api.PersistentVolumeSource{
 				AWSElasticBlockStore: &api.AWSElasticBlockStoreVolumeSource{
-					VolumeID:  "dummy",
+					VolumeID:  volume.ProvisionedVolumeName,
 					FSType:    "ext4",
 					Partition: 0,
 					ReadOnly:  false,

--- a/pkg/volume/cinder/cinder.go
+++ b/pkg/volume/cinder/cinder.go
@@ -445,7 +445,7 @@ func (c *cinderVolumeProvisioner) NewPersistentVolumeTemplate() (*api.Persistent
 			},
 			PersistentVolumeSource: api.PersistentVolumeSource{
 				Cinder: &api.CinderVolumeSource{
-					VolumeID: "dummy",
+					VolumeID: volume.ProvisionedVolumeName,
 					FSType:   "ext4",
 					ReadOnly: false,
 				},

--- a/pkg/volume/gce_pd/gce_pd.go
+++ b/pkg/volume/gce_pd/gce_pd.go
@@ -401,7 +401,7 @@ func (c *gcePersistentDiskProvisioner) NewPersistentVolumeTemplate() (*api.Persi
 			},
 			PersistentVolumeSource: api.PersistentVolumeSource{
 				GCEPersistentDisk: &api.GCEPersistentDiskVolumeSource{
-					PDName:    "dummy",
+					PDName:    volume.ProvisionedVolumeName,
 					FSType:    "ext4",
 					Partition: 0,
 					ReadOnly:  false,

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -113,6 +113,12 @@ type DeletableVolumePlugin interface {
 	NewDeleter(spec *Spec) (Deleter, error)
 }
 
+const (
+	// Name of a volume in external cloud that is being provisioned and thus
+	// should be ignored by rest of Kubernetes.
+	ProvisionedVolumeName = "placeholder-for-provisioning"
+)
+
 // ProvisionableVolumePlugin is an extended interface of VolumePlugin and is used to create volumes for the cluster.
 type ProvisionableVolumePlugin interface {
 	VolumePlugin

--- a/plugin/pkg/admission/persistentvolume/label/admission.go
+++ b/plugin/pkg/admission/persistentvolume/label/admission.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/aws"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
+	vol "k8s.io/kubernetes/pkg/volume"
 )
 
 func init() {
@@ -102,6 +103,10 @@ func (l *persistentVolumeLabel) Admit(a admission.Attributes) (err error) {
 }
 
 func (l *persistentVolumeLabel) findAWSEBSLabels(volume *api.PersistentVolume) (map[string]string, error) {
+	// Ignore any volumes that are being provisioned
+	if volume.Spec.AWSElasticBlockStore.VolumeID == vol.ProvisionedVolumeName {
+		return nil, nil
+	}
 	ebsVolumes, err := l.getEBSVolumes()
 	if err != nil {
 		return nil, err
@@ -141,6 +146,11 @@ func (l *persistentVolumeLabel) getEBSVolumes() (aws.Volumes, error) {
 }
 
 func (l *persistentVolumeLabel) findGCEPDLabels(volume *api.PersistentVolume) (map[string]string, error) {
+	// Ignore any volumes that are being provisioned
+	if volume.Spec.GCEPersistentDisk.PDName == vol.ProvisionedVolumeName {
+		return nil, nil
+	}
+
 	provider, err := l.getGCECloudProvider()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This is a first-aid bandage to let admission controller ignore persistent
volumes that are being provisioned right now and thus may not exist in
external cloud infrastructure yet.

Proper fix is at #21386, but it involves larger changes in volume plugins.
