### PR TITLE
Fix error logic and leaking goroutine in docker unit test.

### DIFF
--- a/pkg/kubelet/dockertools/fake_manager.go
+++ b/pkg/kubelet/dockertools/fake_manager.go
@@ -47,7 +47,7 @@ func NewFakeDockerManager(
 	fakeProcFs := procfs.NewFakeProcFS()
 	dm := NewDockerManager(client, recorder, livenessManager, containerRefManager, machineInfo, podInfraContainerImage, qps,
 		burst, containerLogsDir, osInterface, networkPlugin, runtimeHelper, httpClient, &NativeExecHandler{},
-		fakeOOMAdjuster, fakeProcFs, false, imageBackOff, true, false, true)
+		fakeOOMAdjuster, fakeProcFs, false, imageBackOff, false, false, true)
 	dm.dockerPuller = &FakeDockerPuller{}
 	return dm
 }


### PR DESCRIPTION
This PR did 2 things:
- Let fake docker manager use default image puller instead of serialized image puller to avoid leaking goroutines during unit test running.
- Fix error in `TestSyncPodWithFailure`. Different test cases should not share the same fake docker client.

/cc @yujuhong @vishh 
