### PR TITLE
Enable /healthz for kube-proxy in Hyperkube

### DIFF
--- a/cmd/hyperkube/kube-proxy.go
+++ b/cmd/hyperkube/kube-proxy.go
@@ -21,7 +21,12 @@ package main
 import (
 	"k8s.io/kubernetes/cmd/kube-proxy/app"
 	"k8s.io/kubernetes/cmd/kube-proxy/app/options"
+	"k8s.io/kubernetes/pkg/healthz"
 )
+
+func init() {
+	healthz.DefaultHealthz()
+}
 
 // NewKubeProxy creates a new hyperkube Server object that includes the
 // description and flags.


### PR DESCRIPTION
This patch enables the health check for kube-proxy when it is being run through hyperkube.

For example. This now works:

```
apiVersion: v1
kind: Pod
metadata: 
  name: kubernetes
  namespace: kube-system
spec: 
  hostNetwork: true
    - name: proxy 
      image: gcr.io/google_containers/hyperkube-amd64:1.2.0-alpha.8
      args: 
        - /hyperkube
        - proxy 
      livenessProbe:
        httpGet:
          host: 127.0.0.1
          path: /healthz
          port: 10249
      securityContext:
        privileged: true
```
