### PR TITLE
Remove gluster check for /sbin/mount.glusterfs which fails for containerized kube

### DIFF
--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -61,7 +61,7 @@ func (plugin *glusterfsPlugin) CanSupport(spec *volume.Spec) bool {
 		(spec.Volume != nil && spec.Volume.Glusterfs == nil) {
 		return false
 	}
-	
+
 	return true
 
 }

--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -61,15 +61,8 @@ func (plugin *glusterfsPlugin) CanSupport(spec *volume.Spec) bool {
 		(spec.Volume != nil && spec.Volume.Glusterfs == nil) {
 		return false
 	}
-	// see if glusterfs mount helper is there
-	// this needs a ls because the plugin container may be on a filesystem
-	// that is not visible to the volume plugin process.
-	_, err := plugin.execCommand("ls", []string{"/sbin/mount.glusterfs"})
-	if err == nil {
-		return true
-	}
-
-	return false
+	
+	return true
 
 }
 


### PR DESCRIPTION
This change removes /sbin/mount.glusterfs from the glusterfs.CanSupport volume plugin.  This check fails in containerized kube in error.

In addition, the error message resulting from this failed check is confusing.  It would be easier if the volume just failed vs the "unsupported volume type" message.

This bug is blocking Openshift 3.2 https://bugzilla.redhat.com/show_bug.cgi?id=1289921
