### PR TITLE
Pin Godep to version v53

### DIFF
--- a/hack/verify-godeps.sh
+++ b/hack/verify-godeps.sh
@@ -56,8 +56,11 @@ trap cleanup EXIT
 # build the godep tool
 export GOPATH="${_tmpdir}"
 go get -u github.com/tools/godep 2>/dev/null
-go install github.com/tools/godep 2>/dev/null
 GODEP="${_tmpdir}/bin/godep"
+pushd "${GOPATH}/src/github.com/tools/godep" > /dev/null
+  git checkout v53
+  "${GODEP}" go install
+popd > /dev/null
 
 # fill out that nice clean place with the kube godeps
 echo "Starting to download all kubernetes godeps. This takes a while"


### PR DESCRIPTION
Godep version v54+ started adding lots of new entries in Godep. It also removed needed dependency files! This pins the version we verify to v53. I'll work with godep to get them working.
