### PR TITLE
Make sure etcd2 actually gets started

### DIFF
--- a/docs/getting-started-guides/coreos/cloud-configs/master.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/master.yaml
@@ -31,6 +31,8 @@ coreos:
   fleet:
     metadata: "role=master"
   units:
+    - name: etcd2.service
+      command: start
     - name: generate-serviceaccount-key.service
       command: start
       content: |


### PR DESCRIPTION
This configures etcd2, but doesn't actually start it up.  At least using the CoreOS Openstack image, nothing else was doing this.
