### PR TITLE
Make sure etcd2 actually gets started

### DIFF
--- a/docs/getting-started-guides/coreos/cloud-configs/node.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/node.yaml
@@ -18,6 +18,8 @@ coreos:
   fleet:
     metadata: "role=node"
   units:
+    - name: etcd2.service
+      command: start
     - name: fleet.service
       command: start
     - name: flanneld.service


### PR DESCRIPTION
Need to actually start etcd2.  Right now it is just being configured and using the CoreOS Openstack image, nothing else is starting etcd2.
