### PR TITLE
Remove one check of ingress length in e2e test

### DIFF
--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -556,9 +556,6 @@ var _ = Describe("Services", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		if len(service.Status.LoadBalancer.Ingress) != 0 {
-			Failf("got unexpected len(Status.LoadBalancer.Ingress) for NodePort service: %v", service)
-		}
 		if service.Spec.Type != api.ServiceTypeClusterIP {
 			Failf("got unexpected Spec.Type for back-to-ClusterIP service: %v", service)
 		}


### PR DESCRIPTION
Fix #21693.

The removed line is wrong and is updated in #19541. Removing it so that the tests pass when running v1.1 test against v1.2 master.

cc @ihmccreery 
