### PR TITLE
Skip probe if container ID not yet set

### DIFF
--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -152,9 +152,9 @@ func (w *worker) doProbe() (keepGoing bool) {
 	}
 
 	c, ok := api.GetContainerStatus(status.ContainerStatuses, w.container.Name)
-	if !ok {
+	if !ok || len(c.ContainerID) == 0 {
 		// Either the container has not been created yet, or it was deleted.
-		glog.V(3).Infof("Non-existant container probed: %v - %v",
+		glog.V(3).Infof("Probe target container not found: %v - %v",
 			format.Pod(w.pod), w.container.Name)
 		return true // Wait for more information.
 	}


### PR DESCRIPTION
If the container status exists but the container hasn't been created yet, it won't have an ID.
Have the probe wait for a valid status if the container ID is not yet set; otherwise, you'll see the
following cryptic log message from runtime.go: invalid container ID: "".

cc @kubernetes/sig-node @kubernetes/rh-cluster-infra 
