### PR TITLE
MESOS: Adding more info to error msgs

### DIFF
--- a/contrib/mesos/pkg/scheduler/components/framework/framework.go
+++ b/contrib/mesos/pkg/scheduler/components/framework/framework.go
@@ -122,6 +122,12 @@ func New(config Config) Framework {
 				// the node must be registered and have up-to-date labels
 				n := config.LookupNode(o.GetHostname())
 				if n == nil || !node.IsUpToDate(n, node.SlaveAttributesToLabels(o.GetAttributes())) {
+					if n == nil {
+						log.V(1).Infof("cannot find node %v", o.GetHostname())
+					} else {
+						log.V(1).Infof("node %v's attributes do not match: %v != %v",
+							o.GetHostname(), n.Labels, o.GetAttributes())
+					}
 					return false
 				}
 
@@ -130,12 +136,14 @@ func New(config Config) Framework {
 				case eids > 1:
 					// at most one executor id expected. More than one means that
 					// the given node is seriously in trouble.
+					log.V(1).Infof("at most one executor id is expected, but got %v (%v)", eids, o.GetExecutorIds())
 					return false
 
 				case eids == 1:
 					// the executor id must match, otherwise the running executor
 					// is incompatible with the current scheduler configuration.
 					if eid := o.GetExecutorIds()[0]; eid.GetValue() != config.ExecutorId.GetValue() {
+						log.V(1).Infof("executor ids do not match: %v != %v", eid.GetValue(), config.ExecutorId.GetValue())
 						return false
 					}
 				}

--- a/contrib/mesos/pkg/scheduler/service/service.go
+++ b/contrib/mesos/pkg/scheduler/service/service.go
@@ -495,6 +495,7 @@ func (s *SchedulerServer) prepareExecutorInfo(hks hyperkube.Interface) (*mesos.E
 	// running executors in a cluster.
 	execInfo.ExecutorId = executorinfo.NewID(execInfo)
 	execInfo.Data = data
+	log.V(1).Infof("started with executor id %v", execInfo.ExecutorId.GetValue())
 
 	return execInfo, nil
 }


### PR DESCRIPTION
Adding more information into error messages to ease debugging. One of the difficulties in enabling HA mode in K8sm is executorID mismatch between different schedulers, resulting in "Declining incompatible offer..." error message. However, this error message can also be caused by other reasons. This PR prints out more information in error message to differentiate different situations.

This is to partly address problems described in #21761. 
