### PR TITLE
Fix flake in LimitRange e2e

### DIFF
--- a/plugin/pkg/admission/limitranger/admission.go
+++ b/plugin/pkg/admission/limitranger/admission.go
@@ -74,6 +74,11 @@ func (l *limitRanger) Admit(a admission.Attributes) (err error) {
 		return nil
 	}
 
+	// ignore all calls that do not deal with pod resources since that is all this supports now.
+	if a.GetKind() != api.Kind("Pod") {
+		return nil
+	}
+
 	obj := a.GetObject()
 	name := "Unknown"
 	if obj != nil {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/21234

The `LimitRange` TTL cache was being populated when the `LimitRange` itself was being created which meant the cache was getting set to empty by default.

The fix is that `LimitRange` should ignore things that are not pods prior to building its live look-up cache.
