### PR TITLE
Disable seccomp policy by default on docker versions >= v1.10

### DIFF
--- a/pkg/kubelet/dockertools/fake_docker_client.go
+++ b/pkg/kubelet/dockertools/fake_docker_client.go
@@ -56,8 +56,12 @@ type FakeDockerClient struct {
 }
 
 func NewFakeDockerClient() *FakeDockerClient {
+	return NewFakeDockerClientWithVersion("1.8.1", "1.20")
+}
+
+func NewFakeDockerClientWithVersion(version, apiVersion string) *FakeDockerClient {
 	return &FakeDockerClient{
-		VersionInfo:   docker.Env{"Version=1.8.1", "ApiVersion=1.20"},
+		VersionInfo:   docker.Env{fmt.Sprintf("Version=%s", version), fmt.Sprintf("ApiVersion=%s", apiVersion)},
 		Errors:        make(map[string]error),
 		RemovedImages: sets.String{},
 		ContainerMap:  make(map[string]*docker.Container),


### PR DESCRIPTION
For #20870

@dchen1107: This PR might have to be included in v1.2 if we want to be docker v1.10 compatible. Kindly add a tracking label if you agree.
