### PR TITLE
Remove host command sniffing from CanSupport(..)

### DIFF
--- a/pkg/volume/fc/fc.go
+++ b/pkg/volume/fc/fc.go
@@ -59,15 +59,8 @@ func (plugin *fcPlugin) CanSupport(spec *volume.Spec) bool {
 	if (spec.Volume != nil && spec.Volume.FC == nil) || (spec.PersistentVolume != nil && spec.PersistentVolume.Spec.FC == nil) {
 		return false
 	}
-	// TODO:  turn this into a func so CanSupport can be unit tested without
-	// having to make system calls
-	// see if /sys/class/fc_transport is there, which indicates fc is connected
-	_, err := plugin.execCommand("ls", []string{"/sys/class/fc_transport"})
-	if err == nil {
-		return true
-	}
 
-	return false
+	return true
 }
 
 func (plugin *fcPlugin) GetAccessModes() []api.PersistentVolumeAccessMode {

--- a/pkg/volume/iscsi/iscsi.go
+++ b/pkg/volume/iscsi/iscsi.go
@@ -59,15 +59,8 @@ func (plugin *iscsiPlugin) CanSupport(spec *volume.Spec) bool {
 	if (spec.Volume != nil && spec.Volume.ISCSI == nil) || (spec.PersistentVolume != nil && spec.PersistentVolume.Spec.ISCSI == nil) {
 		return false
 	}
-	// TODO:  turn this into a func so CanSupport can be unit tested without
-	// having to make system calls
-	// see if iscsiadm is there
-	_, err := plugin.execCommand("iscsiadm", []string{"-h"})
-	if err == nil {
-		return true
-	}
 
-	return false
+	return true
 }
 
 func (plugin *iscsiPlugin) GetAccessModes() []api.PersistentVolumeAccessMode {

--- a/pkg/volume/rbd/rbd.go
+++ b/pkg/volume/rbd/rbd.go
@@ -58,13 +58,8 @@ func (plugin *rbdPlugin) CanSupport(spec *volume.Spec) bool {
 	if (spec.Volume != nil && spec.Volume.RBD == nil) || (spec.PersistentVolume != nil && spec.PersistentVolume.Spec.RBD == nil) {
 		return false
 	}
-	// see if rbd is there
-	_, err := plugin.execCommand("rbd", []string{"-h"})
-	if err == nil {
-		return true
-	}
 
-	return false
+	return true
 }
 
 func (plugin *rbdPlugin) GetAccessModes() []api.PersistentVolumeAccessMode {


### PR DESCRIPTION
We've tried sniffing binaries on host to determine if it supports a particular volume plugin or not.  This has been problematic for a few reasons:
1. doesn't work well for containerized kube
2. The resulting error message is miss leading ("No volume plugin found..")
3. Binary location may differ between host operating systems.

After speaking with @markturansky and inspecting the other plugins we determined that the pattern of host binary sniffing has fallen out of use.  There is reported bugs for containerized kube with Gluster, and its expected that the same bugs exist in the other plugins which try to host-sniff binaries.

This change removes all of the host sniffing.  Now if the packages aren't installed on the host, a more accurate "mount failure" will appear in the logs.  CanSupport(..) is still required to indicate if a plugin supports a given volume spec file or not.

This fix is considered a hotfix for OpenShift 3.2.
