### PR TITLE
verify-linkchecker.sh now exits with a non-zero return code if found invalid links

### DIFF
--- a/hack/after-build/verify-linkcheck.sh
+++ b/hack/after-build/verify-linkcheck.sh
@@ -52,8 +52,7 @@ done
 if [ ${found_invalid} = true ]; then
   echo "Summary of invalid links:"
   cat ${OUTPUT}/error
+  exit 1
 fi
-
-trap "cleanup" EXIT SIGINT
 
 # ex: ts=2 sw=2 et filetype=sh


### PR DESCRIPTION
With this fix Jenkins will send email to me if linkchecker finds invalid links.
