### PR TITLE
Sort events by their first timestamp when dumping them

### DIFF
--- a/pkg/util/deployment/deployment.go
+++ b/pkg/util/deployment/deployment.go
@@ -187,13 +187,13 @@ func addHashKeyToRSAndPods(deployment extensions.Deployment, c clientset.Interfa
 			updated.Spec.Template.Labels = labelsutil.AddLabel(updated.Spec.Template.Labels, extensions.DefaultDeploymentUniqueLabelKey, hash)
 		})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error updating rs %s pod template label with template hash: %v", updatedRS.Name, err)
 		}
 	}
 	// Make sure rs pod template is updated so that it won't create pods without the new label (orphaned pods).
 	if updatedRS.Generation > updatedRS.Status.ObservedGeneration {
 		if err = waitForReplicaSetUpdated(c, updatedRS.Generation, namespace, rs.Name); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error waiting for rs %s generation %d observed by controller: %v", updatedRS.Name, updatedRS.Generation, err)
 		}
 	}
 
@@ -217,7 +217,7 @@ func addHashKeyToRSAndPods(deployment extensions.Deployment, c clientset.Interfa
 		updated.Labels = labelsutil.AddLabel(updated.Labels, extensions.DefaultDeploymentUniqueLabelKey, hash)
 		updated.Spec.Selector = labelsutil.AddLabelToSelector(updated.Spec.Selector, extensions.DefaultDeploymentUniqueLabelKey, hash)
 	}); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error updating rs %s label and selector with template hash: %v", updatedRS.Name, err)
 	}
 
 	// TODO: look for orphaned pods and label them in the background somewhere else periodically

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -2117,7 +2117,7 @@ func waitForReplicaSetPodsGone(c *client.Client, rs *extensions.ReplicaSet) erro
 // Waits for the deployment to reach desired state.
 // Returns an error if minAvailable or maxCreated is broken at any times.
 func waitForDeploymentStatus(c clientset.Interface, ns, deploymentName string, desiredUpdatedReplicas, minAvailable, maxCreated, minReadySeconds int) error {
-	var oldRSs, allRSs []*extensions.ReplicaSet
+	var oldRSs, allOldRSs, allRSs []*extensions.ReplicaSet
 	var newRS *extensions.ReplicaSet
 	var deployment *extensions.Deployment
 	err := wait.Poll(poll, 5*time.Minute, func() (bool, error) {
@@ -2127,7 +2127,7 @@ func waitForDeploymentStatus(c clientset.Interface, ns, deploymentName string, d
 		if err != nil {
 			return false, err
 		}
-		oldRSs, _, err = deploymentutil.GetOldReplicaSets(*deployment, c)
+		oldRSs, allOldRSs, err = deploymentutil.GetOldReplicaSets(*deployment, c)
 		if err != nil {
 			return false, err
 		}
@@ -2146,12 +2146,12 @@ func waitForDeploymentStatus(c clientset.Interface, ns, deploymentName string, d
 			return false, err
 		}
 		if totalCreated > maxCreated {
-			logReplicaSetsOfDeployment(deployment, oldRSs, newRS)
+			logReplicaSetsOfDeployment(deployment, allOldRSs, newRS)
 			logPodsOfReplicaSets(c, allRSs, minReadySeconds)
 			return false, fmt.Errorf("total pods created: %d, more than the max allowed: %d", totalCreated, maxCreated)
 		}
 		if totalAvailable < minAvailable {
-			logReplicaSetsOfDeployment(deployment, oldRSs, newRS)
+			logReplicaSetsOfDeployment(deployment, allOldRSs, newRS)
 			logPodsOfReplicaSets(c, allRSs, minReadySeconds)
 			return false, fmt.Errorf("total pods available: %d, less than the min required: %d", totalAvailable, minAvailable)
 		}
@@ -2167,7 +2167,7 @@ func waitForDeploymentStatus(c clientset.Interface, ns, deploymentName string, d
 	})
 
 	if err == wait.ErrWaitTimeout {
-		logReplicaSetsOfDeployment(deployment, oldRSs, newRS)
+		logReplicaSetsOfDeployment(deployment, allOldRSs, newRS)
 		logPodsOfReplicaSets(c, allRSs, minReadySeconds)
 	}
 	return err
@@ -2215,10 +2215,10 @@ func waitForObservedDeployment(c *clientset.Clientset, ns, deploymentName string
 	})
 }
 
-func logReplicaSetsOfDeployment(deployment *extensions.Deployment, oldRSs []*extensions.ReplicaSet, newRS *extensions.ReplicaSet) {
+func logReplicaSetsOfDeployment(deployment *extensions.Deployment, allOldRSs []*extensions.ReplicaSet, newRS *extensions.ReplicaSet) {
 	Logf("Deployment = %+v", deployment)
-	for i := range oldRSs {
-		Logf("Old ReplicaSets (%d/%d) of deployment %s: %+v", i+1, len(oldRSs), deployment.Name, oldRSs[i])
+	for i := range allOldRSs {
+		Logf("All old ReplicaSets (%d/%d) of deployment %s: %+v", i+1, len(allOldRSs), deployment.Name, allOldRSs[i])
 	}
 	Logf("New ReplicaSet of deployment %s: %+v", deployment.Name, newRS)
 }


### PR DESCRIPTION
#19299 #21809 #21810

Sort events by first timestamp and print those timestamps when logging events. Helps debugging.

@nikhiljindal @bgrant0607 
