### PR TITLE
Lock across item expiration in the ttl store.

### DIFF
--- a/pkg/client/cache/expiration_cache_fakes.go
+++ b/pkg/client/cache/expiration_cache_fakes.go
@@ -28,6 +28,7 @@ type fakeThreadSafeMap struct {
 
 func (c *fakeThreadSafeMap) Delete(key string) {
 	if c.deletedKeys != nil {
+		c.ThreadSafeStore.Delete(key)
 		c.deletedKeys <- key
 	}
 }

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -35,21 +35,7 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
-const (
-	CreatedByAnnotation = "kubernetes.io/created-by"
-
-	// If a watch drops a delete event for a pod, it'll take this long
-	// before a dormant controller waiting for those packets is woken up anyway. It is
-	// specifically targeted at the case where some problem prevents an update
-	// of expectations, without it the controller could stay asleep forever. This should
-	// be set based on the expected latency of watch events.
-	//
-	// Currently a controller can service (create *and* observe the watch events for said
-	// creation) about 10-20 pods a second, so it takes about 1 min to service
-	// 500 pods. Just creation is limited to 20qps, and watching happens with ~10-30s
-	// latency/pod at the scale of 3000 pods over 100 nodes.
-	ExpectationsTimeout = 3 * time.Minute
-)
+const CreatedByAnnotation = "kubernetes.io/created-by"
 
 var (
 	KeyFunc = framework.DeletionHandlingMetaNamespaceKeyFunc
@@ -221,7 +207,7 @@ func (e *ControlleeExpectations) GetExpectations() (int64, int64) {
 
 // NewControllerExpectations returns a store for ControlleeExpectations.
 func NewControllerExpectations() *ControllerExpectations {
-	return &ControllerExpectations{cache.NewTTLStore(ExpKeyFunc, ExpectationsTimeout)}
+	return &ControllerExpectations{cache.NewStore(ExpKeyFunc)}
 }
 
 // PodControlInterface is an interface that knows how to add or delete pods

--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -334,12 +334,12 @@ func (dc *DeploymentController) deletePod(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			glog.Errorf("Couldn't get object from tombstone %+v, could take up to %v before a ReplicaSet recreates a replica", obj, controller.ExpectationsTimeout)
+			glog.Errorf("Couldn't get object from tombstone %+v", obj)
 			return
 		}
 		pod, ok = tombstone.Obj.(*api.Pod)
 		if !ok {
-			glog.Errorf("Tombstone contained object that is not a pod %+v, could take up to %v before ReplicaSet recreates a replica", obj, controller.ExpectationsTimeout)
+			glog.Errorf("Tombstone contained object that is not a pod %+v", obj)
 			return
 		}
 	}

--- a/pkg/controller/job/controller.go
+++ b/pkg/controller/job/controller.go
@@ -224,12 +224,12 @@ func (jm *JobController) deletePod(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			glog.Errorf("Couldn't get object from tombstone %+v, could take up to %v before a job recreates a pod", obj, controller.ExpectationsTimeout)
+			glog.Errorf("Couldn't get object from tombstone %+v", obj)
 			return
 		}
 		pod, ok = tombstone.Obj.(*api.Pod)
 		if !ok {
-			glog.Errorf("Tombstone contained object that is not a pod %+v, could take up to %v before job recreates a pod", obj, controller.ExpectationsTimeout)
+			glog.Errorf("Tombstone contained object that is not a pod %+v", obj)
 			return
 		}
 	}

--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -283,12 +283,12 @@ func (rsc *ReplicaSetController) deletePod(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			glog.Errorf("Couldn't get object from tombstone %+v, could take up to %v before a replica set recreates a replica", obj, controller.ExpectationsTimeout)
+			glog.Errorf("Couldn't get object from tombstone %+v", obj)
 			return
 		}
 		pod, ok = tombstone.Obj.(*api.Pod)
 		if !ok {
-			glog.Errorf("Tombstone contained object that is not a pod %+v, could take up to %v before replica set recreates a replica", obj, controller.ExpectationsTimeout)
+			glog.Errorf("Tombstone contained object that is not a pod %+v", obj)
 			return
 		}
 	}

--- a/pkg/controller/replication/replication_controller.go
+++ b/pkg/controller/replication/replication_controller.go
@@ -285,12 +285,12 @@ func (rm *ReplicationManager) deletePod(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			glog.Errorf("Couldn't get object from tombstone %+v, could take up to %v before a controller recreates a replica", obj, controller.ExpectationsTimeout)
+			glog.Errorf("Couldn't get object from tombstone %+v", obj)
 			return
 		}
 		pod, ok = tombstone.Obj.(*api.Pod)
 		if !ok {
-			glog.Errorf("Tombstone contained object that is not a pod %+v, could take up to %v before controller recreates a replica", obj, controller.ExpectationsTimeout)
+			glog.Errorf("Tombstone contained object that is not a pod %+v", obj)
 			return
 		}
 	}


### PR DESCRIPTION
Some context: 
- We have an expiration cache timeout ( https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/controller_utils.go#L41) to safeguard against dropped watches, so an RC doesn't get wedged (i.e we do an add, the watch notification for the add is dropped, someone deletes the pod, the watch notification for the delete is _also_ dropped. In this case even the informer's relist won't give us the right notification).
- The cache expires items on list/Get (every time we get the item, we compare timestamp to expiration, and return none if expired).
- If there are no expectations for an RC, or the expectations are fulfilled, it assumes that either the local store is consistent with etcd, or that something went wrong (like dropped watch) and it needs to take action. It creates/deletes pods comparing Spec.Replicas with a count of the pods in the store, and Adds() a new expectation value.
- On every Add() the timestamp of the entry under the given key (rc ns/name) is updated.

We had a race where we'd compare the timestamp during a List/Get operation and decide to delete the expectation, an Add would sneak in with the new timestamp, and we'd go ahead and expire this new item based off the stale expiration computation. 

Surfaced in deployment test: https://github.com/kubernetes/kubernetes/issues/19299
Assigning to Daniel because he has context about the cache and controller. Feel free to re-assign. 

@bgrant0607 @janetkuo 'pologies for the trouble. 
