### PR TITLE
fix deployment e2e flake: Update DeploymentReaper.Stop to use ObservedGeneration

### DIFF
--- a/pkg/kubectl/stop_test.go
+++ b/pkg/kubectl/stop_test.go
@@ -538,8 +538,7 @@ func TestDeploymentStop(t *testing.T) {
 			},
 			StopError: nil,
 			ExpectedActions: []string{"get:deployments", "update:deployments",
-				"get:deployments", "get:deployments", "update:deployments",
-				"list:replicasets", "delete:deployments"},
+				"get:deployments", "delete:deployments", "list:replicasets"},
 		},
 		{
 			Name: "Deployment with single replicaset",
@@ -561,10 +560,9 @@ func TestDeploymentStop(t *testing.T) {
 			},
 			StopError: nil,
 			ExpectedActions: []string{"get:deployments", "update:deployments",
-				"get:deployments", "get:deployments", "update:deployments",
-				"list:replicasets", "get:replicasets", "get:replicasets",
-				"update:replicasets", "get:replicasets", "get:replicasets",
-				"delete:replicasets", "delete:deployments"},
+				"get:deployments", "delete:deployments", "list:replicasets",
+				"get:replicasets", "get:replicasets", "update:replicasets",
+				"get:replicasets", "get:replicasets", "delete:replicasets"},
 		},
 	}
 

--- a/pkg/kubectl/stop_test.go
+++ b/pkg/kubectl/stop_test.go
@@ -538,7 +538,7 @@ func TestDeploymentStop(t *testing.T) {
 			},
 			StopError: nil,
 			ExpectedActions: []string{"get:deployments", "update:deployments",
-				"get:deployments", "delete:deployments", "list:replicasets"},
+				"get:deployments", "list:replicasets", "delete:deployments"},
 		},
 		{
 			Name: "Deployment with single replicaset",
@@ -560,9 +560,9 @@ func TestDeploymentStop(t *testing.T) {
 			},
 			StopError: nil,
 			ExpectedActions: []string{"get:deployments", "update:deployments",
-				"get:deployments", "delete:deployments", "list:replicasets",
-				"get:replicasets", "get:replicasets", "update:replicasets",
-				"get:replicasets", "get:replicasets", "delete:replicasets"},
+				"get:deployments", "list:replicasets", "get:replicasets",
+				"get:replicasets", "update:replicasets", "get:replicasets",
+				"get:replicasets", "delete:replicasets", "delete:deployments"},
 		},
 	}
 

--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -543,7 +543,7 @@ func testPausedDeployment(f *Framework) {
 	Expect(err).NotTo(HaveOccurred())
 
 	// Use observedGeneration to determine if the controller noticed the resume.
-	err = waitForObservedDeployment(c, ns, deploymentName)
+	err = waitForObservedDeployment(c, ns, deploymentName, deployment.Generation)
 	Expect(err).NotTo(HaveOccurred())
 
 	selector, err := unversioned.LabelSelectorAsSelector(deployment.Spec.Selector)
@@ -570,7 +570,7 @@ func testPausedDeployment(f *Framework) {
 	Expect(err).NotTo(HaveOccurred())
 
 	// Use observedGeneration to determine if the controller noticed the pause.
-	err = waitForObservedDeployment(c, ns, deploymentName)
+	err = waitForObservedDeployment(c, ns, deploymentName, deployment.Generation)
 	Expect(err).NotTo(HaveOccurred())
 
 	newRS, err := deploymentutil.GetNewReplicaSet(*deployment, c)

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -2224,22 +2224,16 @@ func waitForDeploymentOldRSsNum(c *clientset.Clientset, ns, deploymentName strin
 	})
 }
 
-func waitForObservedDeployment(c *clientset.Clientset, ns, deploymentName string) error {
-	return wait.Poll(poll, 1*time.Minute, func() (bool, error) {
-		deployment, err := c.Extensions().Deployments(ns).Get(deploymentName)
-		if err != nil {
-			return false, err
-		}
-		return deployment.Generation == deployment.Status.ObservedGeneration, nil
-	})
-}
-
 func logReplicaSetsOfDeployment(deployment *extensions.Deployment, allOldRSs []*extensions.ReplicaSet, newRS *extensions.ReplicaSet) {
 	Logf("Deployment = %+v", deployment)
 	for i := range allOldRSs {
 		Logf("All old ReplicaSets (%d/%d) of deployment %s: %+v", i+1, len(allOldRSs), deployment.Name, allOldRSs[i])
 	}
 	Logf("New ReplicaSet of deployment %s: %+v", deployment.Name, newRS)
+}
+
+func waitForObservedDeployment(c *clientset.Clientset, ns, deploymentName string, desiredGeneration int64) error {
+	return deploymentutil.WaitForObservedDeployment(func() (*extensions.Deployment, error) { return c.Extensions().Deployments(ns).Get(deploymentName) }, desiredGeneration, poll, 1*time.Minute)
 }
 
 func logPodsOfReplicaSets(c clientset.Interface, rss []*extensions.ReplicaSet, minReadySeconds int) {


### PR DESCRIPTION
Removing race condition in DeploymentReaper.Stop() by waiting for the ObservedGeneration to be updated.
Support for ObservedGeneration for deployments was added in https://github.com/kubernetes/kubernetes/pull/21754

Fixes https://github.com/kubernetes/kubernetes/issues/21753 and https://github.com/kubernetes/kubernetes/issues/21798

cc @bgrant0607 @janetkuo @kargakis @mqliang @ironcladlou @soltysh 
