### PR TITLE
Add etcd basic authentication support

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -207,6 +207,8 @@ func (s *APIServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.EtcdConfig.KeyFile, "etcd-keyfile", s.EtcdConfig.KeyFile, "SSL key file used to secure etcd communication")
 	fs.StringVar(&s.EtcdConfig.CertFile, "etcd-certfile", s.EtcdConfig.CertFile, "SSL certification file used to secure etcd communication")
 	fs.StringVar(&s.EtcdConfig.CAFile, "etcd-cafile", s.EtcdConfig.CAFile, "SSL Certificate Authority file used to secure etcd communication")
+	fs.StringVar(&s.EtcdConfig.Username, "etcd-username", s.EtcdConfig.Username, "The user credential to add as an authorization header to etcd.")
+	fs.StringVar(&s.EtcdConfig.Password, "etcd-password", s.EtcdConfig.Password, "The password for the specified user to add as an authorization header.")
 	fs.BoolVar(&s.EtcdConfig.Quorum, "etcd-quorum-read", s.EtcdConfig.Quorum, "If true, enable quorum read")
 	fs.IntVar(&s.EtcdConfig.DeserializationCacheSize, "deserialization-cache-size", s.EtcdConfig.DeserializationCacheSize, "Number of deserialized json objects to cache in memory.")
 	fs.StringSliceVar(&s.CorsAllowedOriginList, "cors-allowed-origins", s.CorsAllowedOriginList, "List of allowed origins for CORS, comma separated.  An allowed origin can be a regular expression to support subdomain matching.  If this list is empty CORS will not be enabled.")

--- a/docs/admin/kube-apiserver.md
+++ b/docs/admin/kube-apiserver.md
@@ -72,10 +72,12 @@ kube-apiserver
       --etcd-cafile="": SSL Certificate Authority file used to secure etcd communication
       --etcd-certfile="": SSL certification file used to secure etcd communication
       --etcd-keyfile="": SSL key file used to secure etcd communication
+      --etcd-password="": The password for the specified user to add as an authorization header.
       --etcd-prefix="/registry": The prefix for all resource paths in etcd.
       --etcd-quorum-read[=false]: If true, enable quorum read
       --etcd-servers=[]: List of etcd servers to watch (http://ip:port), comma separated.
       --etcd-servers-overrides=[]: Per-resource etcd servers overrides, comma separated. The individual override format: group/resource#servers, where servers are http://ip:port, semicolon separated.
+      --etcd-username="": The user credential to add as an authorization header to etcd.
       --event-ttl=1h0m0s: Amount of time to retain events. Default 1 hour.
       --experimental-keystone-url="": If passed, activates the keystone authentication plugin
       --external-hostname="": The hostname to use when generating externalized URLs for this master (e.g. Swagger API Docs.)

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -109,10 +109,12 @@ etcd-config
 etcd-keyfile
 etcd-mutation-timeout
 etcd-prefix
+etcd-password
 etcd-quorum-read
 etcd-server
 etcd-servers
 etcd-servers-overrides
+etcd-username
 event-burst
 event-qps
 event-ttl

--- a/pkg/storage/etcd/etcd_helper.go
+++ b/pkg/storage/etcd/etcd_helper.go
@@ -71,6 +71,8 @@ type EtcdConfig struct {
 	KeyFile                  string
 	CertFile                 string
 	CAFile                   string
+	Username                 string
+	Password                 string
 	Quorum                   bool
 	DeserializationCacheSize int
 }
@@ -84,6 +86,8 @@ func (c *EtcdConfig) newEtcdClient() (etcd.Client, error) {
 	cli, err := etcd.New(etcd.Config{
 		Endpoints: c.ServerList,
 		Transport: t,
+		Username:  c.Username,
+		Password:  c.Password,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Add flags `etcd-username` and `etcd-password` to support etcd's authentication feature:
https://github.com/coreos/etcd/blob/master/Documentation/authentication.md
