### PR TITLE
Implement AWS provisioner with QoS

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -187,6 +187,9 @@ type Volumes interface {
 
 	// Get labels to apply to volume on creation
 	GetVolumeLabels(volumeName string) (map[string]string, error)
+
+	// Get volume properties, used only for testing of CreateDisk
+	GetDiskProperties(diskName string) (VolumeOptions, error)
 }
 
 // InstanceGroups is an interface for managing cloud-managed instance groups / autoscaling instance groups
@@ -1442,6 +1445,31 @@ func (s *AWSCloud) CreateDisk(volumeOptions *VolumeOptions) (string, error) {
 		}
 	}
 	return volumeName, nil
+}
+
+// Implements Volumes.GetDiskProperties
+func (aws *AWSCloud) GetDiskProperties(volumeName string) (VolumeOptions, error) {
+	opts := VolumeOptions{}
+
+	awsDisk, err := newAWSDisk(aws, volumeName)
+	if err != nil {
+		return opts, err
+	}
+
+	info, err := awsDisk.getInfo()
+	if err != nil {
+		return opts, err
+	}
+	if info.Size != nil {
+		opts.CapacityGB = int(*info.Size)
+	}
+	if info.Iops != nil {
+		opts.IOPS = *info.Iops
+	}
+	if info.VolumeType != nil {
+		opts.VolumeType = *info.VolumeType
+	}
+	return opts, nil
 }
 
 // Implements Volumes.DeleteDisk

--- a/pkg/volume/aws_ebs/aws_util.go
+++ b/pkg/volume/aws_ebs/aws_util.go
@@ -149,6 +149,14 @@ func (util *AWSDiskUtil) CreateVolume(c *awsElasticBlockStoreProvisioner) (volum
 		Tags:       &tags,
 	}
 
+	// Apply c.provisioningOptions
+	if c.provisioningOptions.VolumeType != "" {
+		volumeOptions.VolumeType = c.provisioningOptions.VolumeType
+		if c.provisioningOptions.VolumeType == aws.EBSVolumeTypeIO1 {
+			volumeOptions.IOPS = c.provisioningOptions.IOPS
+		}
+	}
+
 	name, err := cloud.CreateDisk(volumeOptions)
 	if err != nil {
 		glog.V(2).Infof("Error creating EBS Disk volume: %v", err)

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -55,6 +55,10 @@ type VolumeOptions struct {
 	ClusterName string
 	// Tags to attach to the real volume in the cloud provider - e.g. AWS EBS
 	CloudTags *map[string]string
+	// ProvisioningOptions are additional options for the provisioner, e.g.
+	// to create a volume of certain QoS characteristics. These options are
+	// opaque to anything but appropriate provisioner plugin.
+	ProvisioningOptions string
 }
 
 // VolumePlugin is an interface to volume plugins that can be used on a

--- a/plugin/pkg/admission/persistentvolume/label/admission_test.go
+++ b/plugin/pkg/admission/persistentvolume/label/admission_test.go
@@ -45,6 +45,10 @@ func (v *mockVolumes) CreateDisk(volumeOptions *aws.VolumeOptions) (volumeName s
 	return "", fmt.Errorf("not implemented")
 }
 
+func (v *mockVolumes) GetDiskProperties(diskName string) (aws.VolumeOptions, error) {
+	return aws.VolumeOptions{}, fmt.Errorf("not implemented")
+}
+
 func (v *mockVolumes) DeleteDisk(volumeName string) (bool, error) {
 	return false, fmt.Errorf("not implemented")
 }

--- a/test/e2e/cloud_provisioning.go
+++ b/test/e2e/cloud_provisioning.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	. "github.com/onsi/ginkgo"
+	//. "github.com/onsi/gomega"
+	awscloud "k8s.io/kubernetes/pkg/cloudprovider/providers/aws"
+)
+
+// These tests check functionality of AWS cloud provider w.r.t. disk
+// provisioning.
+
+func createAWSVolume(volumeType string, iops int64) error {
+
+	volumes, ok := testContext.CloudConfig.Provider.(awscloud.Volumes)
+	if !ok {
+		return fmt.Errorf("Provider does not support volumes")
+	}
+
+	opts := awscloud.VolumeOptions{
+		CapacityGB: 10,
+		VolumeType: volumeType,
+		IOPS:       iops,
+	}
+
+	volName, err := volumes.CreateDisk(&opts)
+	if err != nil {
+		return fmt.Errorf("Failed to create AWS volume: %v", err)
+	}
+	glog.Infof("Created disk %s", volName)
+	defer func() {
+		volumes.DeleteDisk(volName)
+		glog.Infof("Deleted disk %s", volName)
+	}()
+
+	opts, err = volumes.GetDiskProperties(volName)
+	if err != nil {
+		return fmt.Errorf("Failed to get disk properties: %v", err)
+	}
+	if opts.CapacityGB != 10 {
+		return fmt.Errorf("Expected disk size 10 GiB, got %d", opts.CapacityGB)
+	}
+	if opts.VolumeType != volumeType {
+		return fmt.Errorf("Expected disk type %s, got %s", volumeType, opts.VolumeType)
+	}
+	if iops != 0 && opts.IOPS != iops {
+		return fmt.Errorf("Expected IOPS %d, got %d", iops, opts.IOPS)
+	}
+
+	return nil
+}
+
+var _ = Describe("AWS cloud provider", func() {
+	It("should provison SSD disk", func() {
+		SkipUnlessProviderIs("aws")
+		err := createAWSVolume(awscloud.EBSVolumeTypeGP2, 0)
+		expectNoError(err, "Error creating AWS SSD disk")
+	})
+
+	It("should provison standard disk", func() {
+		SkipUnlessProviderIs("aws")
+		err := createAWSVolume(awscloud.EBSVolumeTypeStandard, 0)
+		expectNoError(err, "Error creating AWS standard disk")
+	})
+	It("should provison IOPS disk", func() {
+		SkipUnlessProviderIs("aws")
+		err := createAWSVolume(awscloud.EBSVolumeTypeIO1, 300)
+		expectNoError(err, "Error creating AWS IOPS disk")
+	})
+})


### PR DESCRIPTION
The provisioner can prepare "gp2" (SSD), "standard" (HDD) and "io1"
(configurable IOPS) EBS.

@kubernetes/rh-storage

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/21879)

<!-- Reviewable:end -->
