### PR TITLE
fake backoff implementation for speeding up flakey test

### DIFF
--- a/pkg/client/unversioned/request.go
+++ b/pkg/client/unversioned/request.go
@@ -645,7 +645,7 @@ func (r *Request) Watch() (watch.Interface, error) {
 	if client == nil {
 		client = http.DefaultClient
 	}
-	time.Sleep(r.backoffMgr.CalculateBackoff(r.URL()))
+	r.backoffMgr.Sleep(r.backoffMgr.CalculateBackoff(r.URL()))
 	resp, err := client.Do(req)
 	updateURLMetrics(r, resp, err)
 	if r.baseURL != nil {
@@ -710,7 +710,7 @@ func (r *Request) Stream() (io.ReadCloser, error) {
 	if client == nil {
 		client = http.DefaultClient
 	}
-	time.Sleep(r.backoffMgr.CalculateBackoff(r.URL()))
+	r.backoffMgr.Sleep(r.backoffMgr.CalculateBackoff(r.URL()))
 	resp, err := client.Do(req)
 	updateURLMetrics(r, resp, err)
 	if r.baseURL != nil {
@@ -792,7 +792,7 @@ func (r *Request) request(fn func(*http.Request, *http.Response)) error {
 		}
 		req.Header = r.headers
 
-		time.Sleep(r.backoffMgr.CalculateBackoff(r.URL()))
+		r.backoffMgr.Sleep(r.backoffMgr.CalculateBackoff(r.URL()))
 		resp, err := client.Do(req)
 		updateURLMetrics(r, resp, err)
 		if err != nil {
@@ -812,7 +812,7 @@ func (r *Request) request(fn func(*http.Request, *http.Response)) error {
 			retries++
 			if seconds, wait := checkWait(resp); wait && retries < maxRetries {
 				glog.V(4).Infof("Got a Retry-After %s response for attempt %d to %v", seconds, retries, url)
-				time.Sleep(time.Duration(seconds) * time.Second)
+				r.backoffMgr.Sleep(time.Duration(seconds) * time.Second)
 				return false
 			}
 			fn(req, resp)

--- a/pkg/util/backoff.go
+++ b/pkg/util/backoff.go
@@ -36,6 +36,15 @@ type Backoff struct {
 	perItemBackoff  map[string]*backoffEntry
 }
 
+func NewFakeBackOff(initial, max time.Duration, tc *FakeClock) *Backoff {
+	return &Backoff{
+		perItemBackoff:  map[string]*backoffEntry{},
+		Clock:           tc,
+		defaultDuration: initial,
+		maxDuration:     max,
+	}
+}
+
 func NewBackOff(initial, max time.Duration) *Backoff {
 	return &Backoff{
 		perItemBackoff:  map[string]*backoffEntry{},

--- a/pkg/util/backoff_test.go
+++ b/pkg/util/backoff_test.go
@@ -21,15 +21,6 @@ import (
 	"time"
 )
 
-func NewFakeBackOff(initial, max time.Duration, tc *FakeClock) *Backoff {
-	return &Backoff{
-		perItemBackoff:  map[string]*backoffEntry{},
-		Clock:           tc,
-		defaultDuration: initial,
-		maxDuration:     max,
-	}
-}
-
 func TestSlowBackoff(t *testing.T) {
 	id := "_idSlow"
 	tc := NewFakeClock(time.Now())

--- a/pkg/util/clock.go
+++ b/pkg/util/clock.go
@@ -27,6 +27,7 @@ type Clock interface {
 	Now() time.Time
 	Since(time.Time) time.Duration
 	After(d time.Duration) <-chan time.Time
+	Sleep(d time.Duration)
 }
 
 var (
@@ -51,6 +52,10 @@ func (RealClock) Since(ts time.Time) time.Duration {
 // Same as time.After(d).
 func (RealClock) After(d time.Duration) <-chan time.Time {
 	return time.After(d)
+}
+
+func (RealClock) Sleep(d time.Duration) {
+	time.Sleep(d)
 }
 
 // FakeClock implements Clock, but returns an arbitrary time.
@@ -137,6 +142,10 @@ func (f *FakeClock) HasWaiters() bool {
 	return len(f.waiters) > 0
 }
 
+func (f *FakeClock) Sleep(d time.Duration) {
+	f.Step(d)
+}
+
 // IntervalClock implements Clock, but each invocation of Now steps the clock forward the specified duration
 type IntervalClock struct {
 	Time     time.Time
@@ -158,4 +167,8 @@ func (i *IntervalClock) Since(ts time.Time) time.Duration {
 // TODO: make interval clock use FakeClock so this can be implemented.
 func (*IntervalClock) After(d time.Duration) <-chan time.Time {
 	panic("IntervalClock doesn't implement After")
+}
+
+func (*IntervalClock) Sleep(d time.Duration) {
+	panic("IntervalClock doesn't implement Sleep")
 }

--- a/pkg/util/clock_test.go
+++ b/pkg/util/clock_test.go
@@ -37,6 +37,16 @@ func TestFakeClock(t *testing.T) {
 	}
 }
 
+func TestFakeClockSleep(t *testing.T) {
+	startTime := time.Now()
+	tc := NewFakeClock(startTime)
+	tc.Sleep(time.Duration(1) * time.Hour)
+	now := tc.Now()
+	if now.Sub(startTime) != time.Hour {
+		t.Errorf("Fake sleep failed, expected time to advance by one hour, instead, its %v", now.Sub(startTime))
+	}
+}
+
 func TestFakeAfter(t *testing.T) {
 	tc := NewFakeClock(time.Now())
 	if tc.HasWaiters() {


### PR DESCRIPTION
I  put a quick patch together which Fixes #21739 .

This backoff adds a `Sleep` implementation to the clock, so that we can implement the same abstraction of sleeping during the requests `time.Sleep` using `clock.Sleep`.
