### PR TITLE
Bump Spark / Zeppelin to 1.5.2 / 0.5.6 tags

### DIFF
--- a/examples/spark/spark-gluster/spark-master-controller.yaml
+++ b/examples/spark/spark-gluster/spark-master-controller.yaml
@@ -15,7 +15,8 @@ spec:
     spec:
       containers:
         - name: spark-master
-          image: gcr.io/google_containers/spark-master:1.5.1_v2
+          image: gcr.io/google_containers/spark:1.5.2_v1
+          command: ["/start-master"]
           ports:
             - containerPort: 7077
           volumeMounts:

--- a/examples/spark/spark-gluster/spark-worker-controller.yaml
+++ b/examples/spark/spark-gluster/spark-worker-controller.yaml
@@ -16,7 +16,8 @@ spec:
     spec:
       containers:
         - name: spark-worker
-          image: gcr.io/google_containers/spark-worker:1.5.1_v2
+          image: gcr.io/google_containers/spark:1.5.2_v1
+          command: ["/start-worker"]
           ports:
             - containerPort: 8888
           volumeMounts:

--- a/examples/spark/spark-master-controller.yaml
+++ b/examples/spark/spark-master-controller.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: spark-master
-          image: gcr.io/google_containers/spark:1.5.1_v3
+          image: gcr.io/google_containers/spark:1.5.2_v1
           command: ["/start-master"]
           ports:
             - containerPort: 7077

--- a/examples/spark/spark-worker-controller.yaml
+++ b/examples/spark/spark-worker-controller.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: spark-worker
-          image: gcr.io/google_containers/spark:1.5.1_v3
+          image: gcr.io/google_containers/spark:1.5.2_v1
           command: ["/start-worker"]
           ports:
             - containerPort: 8081

--- a/examples/spark/zeppelin-controller.yaml
+++ b/examples/spark/zeppelin-controller.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: zeppelin
-          image: gcr.io/google_containers/zeppelin:v0.5.5_v2
+          image: gcr.io/google_containers/zeppelin:v0.5.6_v1
           ports:
             - containerPort: 8080
           resources:


### PR DESCRIPTION
From https://github.com/kubernetes/application-images/pull/5
