### PR TITLE
Salt: bypass Salt when installing docker package on debian

### DIFF
--- a/cluster/saltbase/salt/docker/init.sls
+++ b/cluster/saltbase/salt/docker/init.sls
@@ -276,9 +276,8 @@ purge-old-docker-package:
     - makedirs: true
 
 docker-upgrade:
-  pkg.installed:
-    - sources:
-      - {{ docker_pkg_name }}: /var/cache/docker-install/{{ override_deb }}
+  cmd.run:
+    - name: /opt/kubernetes/helpers/pkg install-no-start {{ docker_pkg_name }} {{ override_docker_ver }} /var/cache/docker-install/{{ override_deb }}
     - require:
       - file: /var/cache/docker-install/{{ override_deb }}
 {% endif %} # end override_docker_ver != ''
@@ -308,7 +307,7 @@ fix-service-docker:
       - file: {{ environment_file }}
 {% if override_docker_ver != '' %}
     - require:
-      - pkg: docker-upgrade
+      - cmd: docker-upgrade
 {% endif %}
 
 {% endif %}
@@ -327,14 +326,14 @@ docker:
     - watch:
       - file: {{ environment_file }}
 {% if override_docker_ver != '' %}
-      - pkg: docker-upgrade
+      - cmd: docker-upgrade
 {% endif %}
 {% if pillar.get('is_systemd') %}
       - file: {{ pillar.get('systemd_system_path') }}/docker.service
 {% endif %}
 {% if override_docker_ver != '' %}
     - require:
-      - pkg: docker-upgrade
+      - cmd: docker-upgrade
 {% endif %}
 {% endif %} # end grains.os_family != 'RedHat'
 

--- a/cluster/saltbase/salt/salt-helpers/init.sls
+++ b/cluster/saltbase/salt/salt-helpers/init.sls
@@ -1,4 +1,3 @@
-{% if pillar.get('is_systemd') %}
 /opt/kubernetes/helpers:
   file.directory:
     - user: root
@@ -6,9 +5,19 @@
     - makedirs: True
     - dir_mode: 755
 
+{% if pillar.get('is_systemd') %}
 /opt/kubernetes/helpers/services:
   file.managed:
     - source: salt://salt-helpers/services
+    - user: root
+    - group: root
+    - mode: 755
+{% endif %}
+
+{% if grains.get('os_family', '') == 'Debian' -%}
+/opt/kubernetes/helpers/pkg:
+  file.managed:
+    - source: salt://salt-helpers/pkg-apt
     - user: root
     - group: root
     - mode: 755

--- a/cluster/saltbase/salt/salt-helpers/pkg-apt
+++ b/cluster/saltbase/salt/salt-helpers/pkg-apt
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Helper script that installs a package, wrapping it with a policy that
+# means we won't try to start services.
+set -o errexit
+set -o nounset
+set -o pipefail
+
+ACTION=${1}
+NAME=${2}
+VERSION=${3}
+SRC=${4}
+
+if [[ -z "${ACTION}" || -z "${NAME}" || -z "${VERSION}" || -z "${SRC}" ]]; then
+  echo "Syntax: ${0} <action> <name> <version> <src>"
+  exit 1
+fi
+
+old_policy=""
+
+function install_no_start {
+  # Query the existing installed version, assuming that an error means package not found
+  existing=`dpkg-query -W -f='${Version}' ${NAME} 2>/dev/null || echo ""`
+  if [[ -n "${existing}" ]]; then
+    if [[ "${existing}" == "${VERSION}" ]]; then
+      return
+    fi
+    echo "Different version of package ${NAME} installed: ${VERSION} vs ${existing}"
+  fi
+
+  if [[ -e "/usr/sbin/policy-rc.d" ]]; then
+    tmpfile=`mktemp`
+    mv /usr/sbin/policy-rc.d ${tmpfile}
+    old_policy=${tmpfile}
+  fi
+  trap cleanup EXIT
+  echo -e '#!/bin/sh\nexit 101' > /usr/sbin/policy-rc.d
+  chmod 755 /usr/sbin/policy-rc.d
+
+  echo "Installing package ${NAME} from ${SRC}"
+  dpkg --install ${SRC}
+}
+
+function cleanup {
+  rm -f /usr/sbin/policy-rc.d
+  if [[ -n "${old_policy}" ]]; then
+    mv ${old_policy} /usr/sbin/policy-rc.d
+  fi
+}
+
+if [[ "${ACTION}" == "install-no-start" ]]; then
+  install_no_start
+else
+  echo "Unknown action: ${ACTION}"
+  exit 1
+fi


### PR DESCRIPTION
The Docker 1.9.1 package on Debian is broken, and the service fails to
install when run unattended.  This is treated as an installation failure
and causes everything to fail.

However, the service can be started by Salt once we're not installing
the package, and indeed we restart docker anyway.

So, on Debian, use a helper script to install the docker package.  The
script sets up a policy-rc.d file to prevent the service starting, and
then cleanly removes it afterwards (this would be difficult to do in
Salt, I believe).
