### PR TITLE
AWS kube-up: Increase timeout for spot instances

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -1154,7 +1154,12 @@ function start-minions() {
 function wait-minions {
   # Wait for the minions to be running
   # TODO(justinsb): This is really not needed any more
-  attempt=0
+  local attempt=0
+  local max_attempts=30
+  # Spot instances are slower to launch
+  if [[ -n "${NODE_SPOT_PRICE:-}" ]]; then
+    max_attempts=90
+  fi
   while true; do
     find-running-minions > $LOG
     if [[ ${#NODE_IDS[@]} == ${NUM_NODES} ]]; then
@@ -1162,7 +1167,7 @@ function wait-minions {
       break
     fi
 
-    if (( attempt > 30 )); then
+    if (( attempt > max_attempts )); then
       echo
       echo "Expected number of minions did not start in time"
       echo


### PR DESCRIPTION
Spot instances take a lot longer to run; wait up to 15 minutes for the
nodes to launch when we're using spot instances.  (Previously we were
waiting 5 minutes).
