### PR TITLE
Use MINION_SIZE instead of MACHINE_TYPE for upgrade configs

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -890,7 +890,7 @@ case ${JOB_NAME} in
     # Starting in v1.2, NUM_MINIONS/NUM_NODES defaults to 3, so we have to deploy 3 here.
     NUM_MINIONS=3
     # Starting in v1.2, GKE defaults to deploying to n1-standard-2, and some tests require that.
-    MACHINE_TYPE='n1-standard-2'
+    MINION_SIZE='n1-standard-2'
     ;;
 
   kubernetes-upgrade-gke-1.1-master-step4-e2e-old)
@@ -898,7 +898,7 @@ case ${JOB_NAME} in
     # Starting in v1.2, NUM_MINIONS/NUM_NODES defaults to 3, so we have to deploy 3 here.
     NUM_MINIONS=3
     # Starting in v1.2, GKE defaults to deploying to n1-standard-2, and some tests require that.
-    MACHINE_TYPE='n1-standard-2'
+    MINION_SIZE='n1-standard-2'
     ;;
 
   kubernetes-upgrade-gke-1.1-master-step6-e2e-old)
@@ -906,7 +906,7 @@ case ${JOB_NAME} in
     # Starting in v1.2, NUM_MINIONS/NUM_NODES defaults to 3, so we have to deploy 3 here.
     NUM_MINIONS=3
     # Starting in v1.2, GKE defaults to deploying to n1-standard-2, and some tests require that.
-    MACHINE_TYPE='n1-standard-2'
+    MINION_SIZE='n1-standard-2'
     ;;
 
   # kubernetes-upgrade-gce-1.1-master


### PR DESCRIPTION
`MACHINE_TYPE` doesn't get exported; it reads from `MINION_TYPE` and exports that... doh!

Fixes #20925?
