### PR TITLE
[wip] build hyperkube docker tar in release build

### DIFF
--- a/build/dockerfiles/hyperkube/Dockerfile
+++ b/build/dockerfiles/hyperkube/Dockerfile
@@ -1,0 +1,49 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM BASEIMAGE
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get -yy -q \
+    install \
+    iptables \
+    ethtool \
+    ca-certificates \
+    file \
+    util-linux \
+    socat \
+    curl \
+    && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN cp /usr/bin/nsenter /nsenter
+
+COPY hyperkube /hyperkube
+RUN chmod a+rx /hyperkube
+
+COPY master-multi.json /etc/kubernetes/manifests-multi/master.json
+COPY kube-proxy.json /etc/kubernetes/manifests-multi/kube-proxy.json
+
+COPY master.json /etc/kubernetes/manifests/master.json
+COPY etcd.json /etc/kubernetes/manifests/etcd.json
+COPY kube-proxy.json /etc/kubernetes/manifests/kube-proxy.json
+
+COPY safe_format_and_mount /usr/share/google/safe_format_and_mount
+RUN chmod a+rx /usr/share/google/safe_format_and_mount
+
+COPY setup-files.sh /setup-files.sh
+RUN chmod a+rx /setup-files.sh
+
+COPY make-ca-cert.sh /make-ca-cert.sh
+RUN chmod a+x /make-ca-cert.sh

--- a/build/dockerfiles/hyperkube/Makefile
+++ b/build/dockerfiles/hyperkube/Makefile
@@ -1,0 +1,55 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build the hyperkube image.
+#
+# Usage:
+#   VERSION=v1.1.2 [REGISTRY="gcr.io/google_containers"] make build
+
+REGISTRY?="gcr.io/google_containers"
+ARCH=amd64
+BASEIMAGE=debian:jessie
+TEMP_DIR:=$(shell mktemp -d)
+
+## Comment in for arm builds, must be run on an arm machine
+# ARCH=arm
+# need to escape '/' for the regexp below
+# BASEIMAGE=armbuild\\/debian:jessie
+
+all: build
+
+build:
+ifndef VERSION
+    $(error VERSION is undefined)
+endif
+	cp ./* ${TEMP_DIR}
+	cp ../../saltbase/salt/helpers/safe_format_and_mount ${TEMP_DIR}
+	cp ../../saltbase/salt/generate-cert/make-ca-cert.sh ${TEMP_DIR}
+	cp ../../../_output/dockerized/bin/linux/${ARCH}/hyperkube ${TEMP_DIR}
+	cd ${TEMP_DIR} && sed -i "s/VERSION/${VERSION}/g" master-multi.json master.json kube-proxy.json
+	cd ${TEMP_DIR} && sed -i "s/ARCH/${ARCH}/g" master-multi.json master.json kube-proxy.json
+	cd ${TEMP_DIR} && sed -i "s/BASEIMAGE/${BASEIMAGE}/g" Dockerfile
+	docker build -t ${REGISTRY}/hyperkube-${ARCH}:${VERSION} ${TEMP_DIR}
+	# Backward compatibility.  TODO: deprecate this image tag
+ifeq ($(ARCH),amd64)
+	docker tag -f ${REGISTRY}/hyperkube-${ARCH}:${VERSION} ${REGISTRY}/hyperkube:${VERSION}
+endif
+
+push: build
+	gcloud docker push ${REGISTRY}/hyperkube-${ARCH}:${VERSION}
+ifeq ($(ARCH),amd64)
+	gcloud docker push ${REGISTRY}/hyperkube:${VERSION}
+endif
+
+.PHONY: all

--- a/build/dockerfiles/hyperkube/etcd.json
+++ b/build/dockerfiles/hyperkube/etcd.json
@@ -1,0 +1,33 @@
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {"name":"k8s-etcd"},
+  "spec": {
+    "hostNetwork": true,
+    "containers": [
+      {
+        "name": "etcd",
+        "image": "gcr.io/google_containers/etcd:2.2.1",
+        "command": [
+                "/usr/local/bin/etcd",
+                "--listen-client-urls=http://127.0.0.1:4001",
+                "--advertise-client-urls=http://127.0.0.1:4001",
+                "--data-dir=/var/etcd/data"
+        ],
+        "volumeMounts": [
+          {
+            "name": "varetcd",
+            "mountPath": "/var/etcd",
+            "readOnly": false
+          }
+        ]
+      }
+    ],
+    "volumes":[
+      {
+        "name": "varetcd",
+        "emptyDir": {}
+      }
+    ]
+  }
+}

--- a/build/dockerfiles/hyperkube/kube-proxy.json
+++ b/build/dockerfiles/hyperkube/kube-proxy.json
@@ -1,0 +1,24 @@
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {"name":"k8s-proxy"},
+  "spec": {
+    "hostNetwork": true,
+    "containers": [
+      {
+        "name": "kube-proxy",
+        "image": "gcr.io/google_containers/hyperkube-ARCH:VERSION",
+        "command": [
+                "/hyperkube",
+                "proxy",
+                "--master=http://127.0.0.1:8080",
+                "--v=2",
+                "--resource-container=\"\""
+        ],
+        "securityContext": {
+          "privileged": true
+        }
+      }
+    ]
+  }
+}

--- a/build/dockerfiles/hyperkube/master-multi.json
+++ b/build/dockerfiles/hyperkube/master-multi.json
@@ -1,0 +1,84 @@
+{
+"apiVersion": "v1",
+"kind": "Pod",
+"metadata": {"name":"k8s-master"},
+"spec":{
+  "hostNetwork": true,
+  "containers":[
+    {
+      "name": "controller-manager",
+      "image": "gcr.io/google_containers/hyperkube-ARCH:VERSION",
+      "command": [
+              "/hyperkube",
+              "controller-manager",
+              "--master=127.0.0.1:8080",
+              "--service-account-private-key-file=/srv/kubernetes/server.key",
+              "--root-ca-file=/srv/kubernetes/ca.crt",
+              "--min-resync-period=3m",
+              "--v=2"
+      ],
+      "volumeMounts": [
+        {
+          "name": "data",
+          "mountPath": "/srv/kubernetes"
+        }
+      ]
+    },
+    {
+      "name": "apiserver",
+      "image": "gcr.io/google_containers/hyperkube-ARCH:VERSION",
+      "command": [
+              "/hyperkube",
+              "apiserver",
+              "--service-cluster-ip-range=10.0.0.1/24",
+              "--insecure-bind-address=0.0.0.0",
+              "--etcd-servers=http://127.0.0.1:4001",
+              "--admission-control=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota",
+              "--client-ca-file=/srv/kubernetes/ca.crt",
+              "--basic-auth-file=/srv/kubernetes/basic_auth.csv",
+              "--min-request-timeout=300",
+              "--tls-cert-file=/srv/kubernetes/server.cert",
+              "--tls-private-key-file=/srv/kubernetes/server.key",
+              "--token-auth-file=/srv/kubernetes/known_tokens.csv",
+              "--allow-privileged=true",
+              "--v=4"
+      ],
+      "volumeMounts": [
+        {
+          "name": "data",
+          "mountPath": "/srv/kubernetes"
+        }
+      ]
+    },
+    {
+      "name": "scheduler",
+      "image": "gcr.io/google_containers/hyperkube-ARCH:VERSION",
+      "command": [
+              "/hyperkube",
+              "scheduler",
+              "--master=127.0.0.1:8080",
+              "--v=2"
+        ]
+    },
+    {
+      "name": "setup",
+      "image": "gcr.io/google_containers/hyperkube-ARCH:VERSION",
+      "command": [
+              "/setup-files.sh"
+      ],
+      "volumeMounts": [
+        {
+          "name": "data",
+          "mountPath": "/data"
+        }
+      ]
+    }
+  ],
+  "volumes": [
+    {
+      "name": "data",
+      "emptyDir": {}
+    }
+  ]
+ }
+}

--- a/build/dockerfiles/hyperkube/master.json
+++ b/build/dockerfiles/hyperkube/master.json
@@ -1,0 +1,84 @@
+{
+"apiVersion": "v1",
+"kind": "Pod",
+"metadata": {"name":"k8s-master"},
+"spec":{
+  "hostNetwork": true,
+  "containers":[
+    {
+      "name": "controller-manager",
+      "image": "gcr.io/google_containers/hyperkube-ARCH:VERSION",
+      "command": [
+              "/hyperkube",
+              "controller-manager",
+              "--master=127.0.0.1:8080",
+              "--service-account-private-key-file=/srv/kubernetes/server.key",
+              "--root-ca-file=/srv/kubernetes/ca.crt",
+              "--min-resync-period=3m",
+              "--v=2"
+      ],
+      "volumeMounts": [
+        {
+          "name": "data",
+          "mountPath": "/srv/kubernetes"
+        }
+      ]
+    },
+    {
+      "name": "apiserver",
+      "image": "gcr.io/google_containers/hyperkube-ARCH:VERSION",
+      "command": [
+              "/hyperkube",
+              "apiserver",
+              "--service-cluster-ip-range=10.0.0.1/24",
+              "--insecure-bind-address=127.0.0.1",
+              "--etcd-servers=http://127.0.0.1:4001",
+              "--admission-control=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota",
+              "--client-ca-file=/srv/kubernetes/ca.crt",
+              "--basic-auth-file=/srv/kubernetes/basic_auth.csv",
+              "--min-request-timeout=300",
+              "--tls-cert-file=/srv/kubernetes/server.cert",
+              "--tls-private-key-file=/srv/kubernetes/server.key",
+              "--token-auth-file=/srv/kubernetes/known_tokens.csv",
+              "--allow-privileged=true",
+              "--v=4"
+      ],
+      "volumeMounts": [
+        {
+          "name": "data",
+          "mountPath": "/srv/kubernetes"
+        }
+      ]
+    },
+    {
+      "name": "scheduler",
+      "image": "gcr.io/google_containers/hyperkube-ARCH:VERSION",
+      "command": [
+              "/hyperkube",
+              "scheduler",
+              "--master=127.0.0.1:8080",
+              "--v=2"
+        ]
+    },
+    {
+      "name": "setup",
+      "image": "gcr.io/google_containers/hyperkube-ARCH:VERSION",
+      "command": [
+              "/setup-files.sh"
+      ],
+      "volumeMounts": [
+        {
+          "name": "data",
+          "mountPath": "/data"
+        }
+      ]
+    }
+  ],
+  "volumes": [
+    {
+      "name": "data",
+      "emptyDir": {}
+    }
+  ]
+ }
+}

--- a/build/dockerfiles/hyperkube/setup-files.sh
+++ b/build/dockerfiles/hyperkube/setup-files.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is intended to set up the files necessary to run a master.
+# It currently creates:
+#  * The basic auth file for access to the kubernetes api server
+#  * Service tokens for accessing the kubernetes api server
+#  * The CA cert and keys for HTTPS access to the kubernetes api server
+set -o errexit
+set -o nounset
+set -o pipefail
+
+create_token() {
+  echo $(cat /dev/urandom | base64 | tr -d "=+/" | dd bs=32 count=1 2> /dev/null)
+}
+
+# Create basic token authorization
+echo "admin,admin,admin" > /data/basic_auth.csv
+
+# Create HTTPS certificates
+groupadd -f -r kube-cert-test
+CERT_DIR=/data CERT_GROUP=kube-cert-test /make-ca-cert.sh $(hostname -i)
+
+# Create known tokens for service accounts
+echo "$(create_token),admin,admin" >> /data/known_tokens.csv
+echo "$(create_token),kubelet,kubelet" >> /data/known_tokens.csv
+echo "$(create_token),kube_proxy,kube_proxy" >> /data/known_tokens.csv
+
+while true; do
+  sleep 3600
+done

--- a/build/dockerfiles/hyperkube/teardown.sh
+++ b/build/dockerfiles/hyperkube/teardown.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Tears down an existing cluster.  Warning destroys _all_ docker containers on the machine
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo "Warning, this will delete all Docker containers on this machine."
+echo "Proceed? [Y/n]"
+
+read resp
+if [[ $resp == "n" || $resp == "N" ]]; then
+  exit 0
+fi
+
+docker ps -aq | xargs docker rm -f

--- a/build/dockerfiles/hyperkube/turnup.sh
+++ b/build/dockerfiles/hyperkube/turnup.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Useful for testing images and changes, turns up a fresh single node cluster
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+K8S_VERSION=${K8S_VERSION:-"1.2.0-alpha.7"}
+
+docker run \
+  --volume=/:/rootfs:ro \
+  --volume=/sys:/sys:ro \
+  --volume=/var/lib/docker/:/var/lib/docker:rw \
+  --volume=/var/lib/kubelet/:/var/lib/kubelet:rw \
+  --volume=/var/run:/var/run:rw \
+  --net=host \
+  --pid=host \
+  --privileged=true \
+  -d gcr.io/google_containers/hyperkube-amd64:v${K8S_VERSION} \
+  /hyperkube kubelet \
+    --containerized \
+    --hostname-override="127.0.0.1" \
+    --address="0.0.0.0" \
+    --api-servers=http://localhost:8080 \
+    --config=/etc/kubernetes/manifests \
+    --cluster-dns=10.0.0.10 \
+    --cluster-domain=cluster.local \
+    --allow-privileged=true --v=2


### PR DESCRIPTION
Inferring from #21918 that the hyperkube docker tar is still built manually outside of the release process.

This is for discussion, and currently only works for amd64. Had this sitting around for a while, thought I'd put it out for thoughts.
