### PR TITLE
Quiet cloudsdk download and untar.

### DIFF
--- a/hack/jenkins/e2e-runner.sh
+++ b/hack/jenkins/e2e-runner.sh
@@ -140,11 +140,11 @@ fi
 # Install gcloud from a custom path if provided. Used to test GKE with gcloud
 # at HEAD, release candidate.
 if [[ ! -z "${CLOUDSDK_BUCKET:-}" ]]; then
-    gsutil -m cp -r "${CLOUDSDK_BUCKET}" ~
+    gsutil -mq cp -r "${CLOUDSDK_BUCKET}" ~
     rm -rf ~/repo ~/cloudsdk
     mv ~/$(basename "${CLOUDSDK_BUCKET}") ~/repo
     mkdir ~/cloudsdk
-    tar zvxf ~/repo/google-cloud-sdk.tar.gz -C ~/cloudsdk
+    tar zxf ~/repo/google-cloud-sdk.tar.gz -C ~/cloudsdk
     export CLOUDSDK_CORE_DISABLE_PROMPTS=1
     export CLOUDSDK_COMPONENT_MANAGER_SNAPSHOT_URL=file://${HOME}/repo/components-2.json
     ~/cloudsdk/google-cloud-sdk/install.sh --disable-installation-options --bash-completion=false --path-update=false --usage-reporting=false


### PR DESCRIPTION
There's 1300 lines from the download and 2200 lines from the untar. I don't think we need all of that in our logs.

I might be wrong.
