### PR TITLE
kubelet: fix duplicated status updates at pod cleanup

### DIFF
--- a/pkg/kubelet/dockertools/fake_docker_client.go
+++ b/pkg/kubelet/dockertools/fake_docker_client.go
@@ -297,6 +297,8 @@ func (f *FakeDockerClient) StopContainer(id string, timeout uint) error {
 		return err
 	}
 	f.Stopped = append(f.Stopped, id)
+	// Container status should be Updated before container moved to ExitedContainerList
+	f.updateContainerStatus(id, statusExitedPrefix)
 	var newList []docker.APIContainers
 	for _, container := range f.ContainerList {
 		if container.ID == id {
@@ -323,7 +325,6 @@ func (f *FakeDockerClient) StopContainer(id string, timeout uint) error {
 		container.State.Running = false
 	}
 	f.ContainerMap[id] = container
-	f.updateContainerStatus(id, statusExitedPrefix)
 	f.normalSleep(200, 50, 50)
 	return nil
 }
@@ -333,11 +334,20 @@ func (f *FakeDockerClient) RemoveContainer(opts docker.RemoveContainerOptions) e
 	defer f.Unlock()
 	f.called = append(f.called, "remove")
 	err := f.popError("remove")
-	if err == nil {
-		f.Removed = append(f.Removed, opts.ID)
+	if err != nil {
+		return err
 	}
-	delete(f.ContainerMap, opts.ID)
-	return err
+	for i := range f.ExitedContainerList {
+		if f.ExitedContainerList[i].ID == opts.ID {
+			delete(f.ContainerMap, opts.ID)
+			f.ExitedContainerList = append(f.ExitedContainerList[:i], f.ExitedContainerList[i+1:]...)
+			f.Removed = append(f.Removed, opts.ID)
+			return nil
+		}
+
+	}
+	// To be a good fake, report error if container is not stopped.
+	return fmt.Errorf("container not stopped")
 }
 
 // Logs is a test-spy implementation of DockerInterface.Logs.

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1932,31 +1932,6 @@ func (kl *Kubelet) cleanupOrphanedVolumes(pods []*api.Pod, runningPods []*kubeco
 	return nil
 }
 
-// Delete any pods that are no longer running and are marked for deletion.
-func (kl *Kubelet) cleanupTerminatedPods(pods []*api.Pod, runningPods []*kubecontainer.Pod) error {
-	var terminating []*api.Pod
-	for _, pod := range pods {
-		if pod.DeletionTimestamp != nil {
-			found := false
-			for _, runningPod := range runningPods {
-				if runningPod.ID == pod.UID {
-					found = true
-					break
-				}
-			}
-			if found {
-				glog.V(5).Infof("Keeping terminated pod %q, still running", format.Pod(pod))
-				continue
-			}
-			terminating = append(terminating, pod)
-		}
-	}
-	if !kl.statusManager.TerminatePods(terminating) {
-		return errors.New("not all pods were successfully terminated")
-	}
-	return nil
-}
-
 // pastActiveDeadline returns true if the pod has been active for more than
 // ActiveDeadlineSeconds.
 func (kl *Kubelet) pastActiveDeadline(pod *api.Pod) bool {
@@ -2147,10 +2122,6 @@ func (kl *Kubelet) HandlePodCleanups() error {
 
 	// Remove any orphaned mirror pods.
 	kl.podManager.DeleteOrphanedMirrorPods()
-
-	if err := kl.cleanupTerminatedPods(allPods, runningPods); err != nil {
-		glog.Errorf("Failed to cleanup terminated pods: %v", err)
-	}
 
 	// Clear out any old bandwidth rules
 	if err = kl.cleanupBandwidthLimits(allPods); err != nil {
@@ -2412,6 +2383,13 @@ func (kl *Kubelet) syncLoopIteration(updates <-chan kubetypes.PodUpdate, handler
 
 func (kl *Kubelet) dispatchWork(pod *api.Pod, syncType kubetypes.SyncPodType, mirrorPod *api.Pod, start time.Time) {
 	if kl.podIsTerminated(pod) {
+		if pod.DeletionTimestamp != nil {
+			// If the pod is in a termianted state, there is no pod worker to
+			// handle the work item. Check if the DeletionTimestamp has been
+			// set, and force a status update to trigger a pod deletion request
+			// to the apiserver.
+			kl.statusManager.TerminatePod(pod)
+		}
 		return
 	}
 	// Run the sync in an async worker.


### PR DESCRIPTION
This is a third try of #21438.
#21732 should have fixed the original issue https://github.com/kubernetes/kubernetes/pull/21438#issuecomment-187466627 already. However, there is another bug in fake docker client that will make kubemark flaky.

I reproduced the issue in 40 nodes kubemark cluster when running the test for the 2nd time. In kubelet.log, I find that kubelet keeps panicking, sometimes even for several minutes. That's why sometimes kubelet deletes pods very slowly:

```
  E0225 00:18:44.766343       7 runtime.go:58] Recovered from panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/util/runtime/runtime.go:52
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/util/runtime/runtime.go:40
  /usr/src/go/src/runtime/asm_amd64.s:402
  /usr/src/go/src/runtime/panic.go:387
  /usr/src/go/src/runtime/panic.go:42
  /usr/src/go/src/runtime/sigpanic_unix.go:26
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubelet/dockertools/container_gc.go:141
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubelet/dockertools/container_gc.go:179
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubelet/dockertools/manager.go:2007
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubelet/container/container_gc.go:67
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubelet/kubelet.go:917
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/util/wait/wait.go:66
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/util/wait/wait.go:67
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/util/wait/wait.go:47
```

From the log, we can see that inspect result in [container_gc.go #L141](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/dockertools/container_gc.go#L141) may be _nil_.

In fake docker client, inspect result comes from [`ContainerMap`](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/dockertools/fake_docker_client.go#L207). `ContainerMap` will only be deleted in `RemoveContainer()`, but from [here](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/dockertools/fake_docker_client.go#L337) we can see that only `ContainerMap` item is deleted, but item in `ContainerList` and `ExitedContainerList` is not. So after container is removed, `ListContainer` will still return container which has no `ContainerMap` item, an inspect on such container will get _nil_.

I fixed this in the first commit of this PR and tested it in 40 nodes kubemark cluster for 4 times, each time it passed. I checked the log, there was no panic anymore. Hope this PR can finally make it.

However I have to say that **initially `fake_docker_client.go` is just aimed at `dockertools` unit test, it is really not a good fake**. The issues I fixed in this PR were there from long long ago. They were just masked by kubelet periodically cleanup. To avoid similar issue happening again, we may want to:
- Treat fake docker client seriously. Make it a good fake, add enough unit test for it or even make it a separate module or project.
- Add at least one hollow kubelet log in jenkins kubemark project. Sometimes it's really hard to reproduce issues in our own cluster.

@yujuhong @wojtek-t @gmarek 
