### PR TITLE
Fixing up local-up-cluster.sh and kubectl.sh

### DIFF
--- a/cluster/kubectl.sh
+++ b/cluster/kubectl.sh
@@ -87,7 +87,7 @@ esac
 if [[ -z "${KUBECTL_PATH:-}" ]]; then
   locations=(
     "${KUBE_ROOT}/_output/dockerized/bin/${host_os}/${host_arch}/kubectl"
-    "${KUBE_ROOT}/_output/local/bin/${host_os}/${host_arch}/kubectl"
+    "${KUBE_ROOT}/_output/local/go/bin/kubectl"
     "${KUBE_ROOT}/platforms/${host_os}/${host_arch}/kubectl"
   )
   kubectl=$( (ls -t "${locations[@]}" 2>/dev/null || true) | head -1 )

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -163,7 +163,7 @@ function detect_binary {
         ;;
     esac
 
-   GO_OUT="${KUBE_ROOT}/_output/local/bin/${host_os}/${host_arch}"
+   GO_OUT="${KUBE_ROOT}/_output/local/go/bin/"
 }
 
 cleanup_dockerized_kubelet()


### PR DESCRIPTION
FIxes #21961. Putting the right location for binaries to bring up the local cluster.
