### PR TITLE
Fix thirdparty parameter

### DIFF
--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -639,7 +639,7 @@ func (m *Master) thirdpartyapi(group, kind, version string) *apiserver.APIGroupV
 		OptionsExternalVersion: &optionsExternalVersion,
 
 		Serializer:     thirdpartyresourcedata.NewNegotiatedSerializer(api.Codecs, kind, externalVersion, internalVersion),
-		ParameterCodec: api.ParameterCodec,
+		ParameterCodec: thirdpartyresourcedata.NewThirdPartyParameterCodec(api.ParameterCodec),
 
 		Context: m.RequestContextMapper,
 

--- a/pkg/registry/thirdpartyresourcedata/codec.go
+++ b/pkg/registry/thirdpartyresourcedata/codec.go
@@ -21,12 +21,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/url"
 	"strings"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	apiutil "k8s.io/kubernetes/pkg/api/util"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/runtime"
@@ -363,4 +365,20 @@ func (t *thirdPartyResourceDataCreator) New(kind unversioned.GroupVersionKind) (
 	default:
 		return t.delegate.New(kind)
 	}
+}
+
+func NewThirdPartyParameterCodec(p runtime.ParameterCodec) runtime.ParameterCodec {
+	return &thirdPartyParameterCodec{p}
+}
+
+type thirdPartyParameterCodec struct {
+	delegate runtime.ParameterCodec
+}
+
+func (t *thirdPartyParameterCodec) DecodeParameters(parameters url.Values, from unversioned.GroupVersion, into runtime.Object) error {
+	return t.delegate.DecodeParameters(parameters, v1.SchemeGroupVersion, into)
+}
+
+func (t *thirdPartyParameterCodec) EncodeParameters(obj runtime.Object, to unversioned.GroupVersion) (url.Values, error) {
+	return t.delegate.EncodeParameters(obj, v1.SchemeGroupVersion)
 }


### PR DESCRIPTION
Partially fix #21919.
#21919 reports query parameter (e.g., ListOptions) is not properly decoded by a resthandler of thirdparty resource. The error occurs because schema cannot create a thirdparty option object. Because we don't yet have a way to register a thirdparty option to the schema, I just add a wrapper to the codec, so that the wrapped codec always assumes the query parameter is converted from a v1 option.

This PR has a simple unit test. I prefer adding e2e tests for thirdparty resources in another PR.

cc @brendandburns @smarterclayton @lavalamp 
