### PR TITLE
Implement OpenStack provisioner with volume types.

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -1043,7 +1043,7 @@ func (os *OpenStack) getVolume(diskName string) (volumes.Volume, error) {
 }
 
 // Create a volume of given size (in GiB)
-func (os *OpenStack) CreateVolume(name string, size int, tags *map[string]string) (volumeName string, err error) {
+func (os *OpenStack) CreateVolume(name string, size int, volumeType string, tags *map[string]string) (volumeName string, err error) {
 
 	sClient, err := openstack.NewBlockStorageV1(os.provider, gophercloud.EndpointOpts{
 		Region: os.region,
@@ -1055,8 +1055,9 @@ func (os *OpenStack) CreateVolume(name string, size int, tags *map[string]string
 	}
 
 	opts := volumes.CreateOpts{
-		Name: name,
-		Size: size,
+		Name:       name,
+		Size:       size,
+		VolumeType: volumeType,
 	}
 	if tags != nil {
 		opts.Metadata = *tags

--- a/pkg/cloudprovider/providers/openstack/openstack_test.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_test.go
@@ -215,7 +215,7 @@ func TestVolumes(t *testing.T) {
 	tags := map[string]string{
 		"test": "value",
 	}
-	vol, err := os.CreateVolume("kubernetes-test-volume-"+rand.String(10), 1, &tags)
+	vol, err := os.CreateVolume("kubernetes-test-volume-"+rand.String(10), 1, "", &tags)
 	if err != nil {
 		t.Fatalf("Cannot create a new Cinder volume: %v", err)
 	}

--- a/pkg/volume/cinder/cinder_util.go
+++ b/pkg/volume/cinder/cinder_util.go
@@ -151,7 +151,7 @@ func (util *CinderDiskUtil) CreateVolume(c *cinderVolumeProvisioner) (volumeID s
 	// Cinder works with gigabytes, convert to GiB with rounding up
 	volSizeGB := int(volume.RoundUpSize(volSizeBytes, 1024*1024*1024))
 	name := volume.GenerateVolumeName(c.options.ClusterName, c.options.PVName, 255) // Cinder volume name can have up to 255 characters
-	name, err = cloud.CreateVolume(name, volSizeGB, c.options.CloudTags)
+	name, err = cloud.CreateVolume(name, volSizeGB, c.provisioningOptions.VolumeType, c.options.CloudTags)
 	if err != nil {
 		glog.V(2).Infof("Error creating cinder volume: %v", err)
 		return "", 0, err

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -55,6 +55,10 @@ type VolumeOptions struct {
 	ClusterName string
 	// Tags to attach to the real volume in the cloud provider - e.g. AWS EBS
 	CloudTags *map[string]string
+	// ProvisioningOptions are additional options for the provisioner, e.g.
+	// to create a volume of certain QoS characteristics. These options are
+	// opaque to anything but appropriate provisioner plugin.
+	ProvisioningOptions string
 }
 
 // VolumePlugin is an interface to volume plugins that can be used on a


### PR DESCRIPTION
OpenStack Cinder volume types represent generic "type of storage". Cinder
volumes from different Cinder backends (e.g. NetApp or EMC) will get different
volume type.

This volume  type can represent also QoS (e.g. "slow" vs. "fast" volumes from
NetApp).

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/21979)

<!-- Reviewable:end -->
