### PR TITLE
Fix EBS when hostname is not the node name

### DIFF
--- a/pkg/volume/aws_ebs/aws_util.go
+++ b/pkg/volume/aws_ebs/aws_util.go
@@ -177,7 +177,7 @@ func attachDiskAndVerify(b *awsElasticBlockStoreBuilder, xvdBeforeSet sets.Strin
 			glog.Warningf("Retrying attach for EBS Disk %q (retry count=%v).", b.volumeID, numRetries)
 		}
 
-		devicePath, err := awsCloud.AttachDisk(b.volumeID, b.plugin.host.GetHostName(), b.readOnly)
+		devicePath, err := awsCloud.AttachDisk(b.volumeID, "", b.readOnly)
 		if err != nil {
 			glog.Errorf("Error attaching PD %q: %v", b.volumeID, err)
 			time.Sleep(errorSleepDuration)
@@ -248,7 +248,7 @@ func detachDiskAndVerify(c *awsElasticBlockStoreCleaner) {
 			glog.Warningf("Retrying detach for EBS Disk %q (retry count=%v).", c.volumeID, numRetries)
 		}
 
-		devicePath, err := awsCloud.DetachDisk(c.volumeID, c.plugin.host.GetHostName())
+		devicePath, err := awsCloud.DetachDisk(c.volumeID, "")
 		if err != nil {
 			glog.Errorf("Error detaching PD %q: %v", c.volumeID, err)
 			time.Sleep(errorSleepDuration)


### PR DESCRIPTION
Similar to #11543, the local hostname is not guaranteed to be the node
name, as the AWS cloud provider looks up node name using
`private-dns-name`. This value can be different such as when using a
private hosted zone.

The previous code uses GetHostName(), which fails in this case. Instead,
pass in an empty string so the aws cloud provider will use the cached
self instance to find the instance id.

Authors: @balooo, @dogan-sky, @jsravn
