### PR TITLE
Give new PVs deterministic names during provisioning

### DIFF
--- a/pkg/controller/persistentvolume/persistentvolume_provisioner_controller.go
+++ b/pkg/controller/persistentvolume/persistentvolume_provisioner_controller.go
@@ -370,6 +370,7 @@ func (controller *PersistentVolumeProvisionerController) newProvisioner(plugin v
 		PersistentVolumeReclaimPolicy: api.PersistentVolumeReclaimDelete,
 		CloudTags:                     &tags,
 		ClusterName:                   controller.clusterName,
+		ClaimUID:                      claim.UID,
 	}
 
 	if pv != nil {

--- a/pkg/volume/aws_ebs/aws_ebs.go
+++ b/pkg/volume/aws_ebs/aws_ebs.go
@@ -425,8 +425,8 @@ func (c *awsElasticBlockStoreProvisioner) NewPersistentVolumeTemplate() (*api.Pe
 	// awsElasticBlockStoreProvisioner.Provision()
 	return &api.PersistentVolume{
 		ObjectMeta: api.ObjectMeta{
-			GenerateName: "pv-aws-",
-			Labels:       map[string]string{},
+			Name:   fmt.Sprintf("pv-aws-%s", c.options.ClaimUID),
+			Labels: map[string]string{},
 			Annotations: map[string]string{
 				"kubernetes.io/createdby": "aws-ebs-dynamic-provisioner",
 			},

--- a/pkg/volume/cinder/cinder.go
+++ b/pkg/volume/cinder/cinder.go
@@ -431,8 +431,8 @@ func (c *cinderVolumeProvisioner) NewPersistentVolumeTemplate() (*api.Persistent
 	// cinderVolumeProvisioner.Provision()
 	return &api.PersistentVolume{
 		ObjectMeta: api.ObjectMeta{
-			GenerateName: "pv-cinder-",
-			Labels:       map[string]string{},
+			Name:   fmt.Sprintf("pv-cinder-%s", c.options.ClaimUID),
+			Labels: map[string]string{},
 			Annotations: map[string]string{
 				"kubernetes.io/createdby": "cinder-dynamic-provisioner",
 			},

--- a/pkg/volume/gce_pd/gce_pd.go
+++ b/pkg/volume/gce_pd/gce_pd.go
@@ -387,8 +387,8 @@ func (c *gcePersistentDiskProvisioner) NewPersistentVolumeTemplate() (*api.Persi
 	// gcePersistentDiskProvisioner.Provision()
 	return &api.PersistentVolume{
 		ObjectMeta: api.ObjectMeta{
-			GenerateName: "pv-gce-",
-			Labels:       map[string]string{},
+			Name:   fmt.Sprintf("pv-gce-%s", c.options.ClaimUID),
+			Labels: map[string]string{},
 			Annotations: map[string]string{
 				"kubernetes.io/createdby": "gce-pd-dynamic-provisioner",
 			},

--- a/pkg/volume/host_path/host_path.go
+++ b/pkg/volume/host_path/host_path.go
@@ -265,7 +265,7 @@ func (r *hostPathProvisioner) NewPersistentVolumeTemplate() (*api.PersistentVolu
 	fullpath := fmt.Sprintf("/tmp/hostpath_pv/%s", util.NewUUID())
 	return &api.PersistentVolume{
 		ObjectMeta: api.ObjectMeta{
-			GenerateName: "pv-hostpath-",
+			Name: fmt.Sprintf("pv-hostpath-%s", r.options.ClaimUID),
 			Annotations: map[string]string{
 				"kubernetes.io/createdby": "hostpath-dynamic-provisioner",
 			},

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -55,6 +55,8 @@ type VolumeOptions struct {
 	ClusterName string
 	// Tags to attach to the real volume in the cloud provider - e.g. AWS EBS
 	CloudTags *map[string]string
+	// The claim's UID is used to deterministically name a PV created for provisioning, allowing many concurrent provisioners
+	ClaimUID types.UID
 }
 
 // VolumePlugin is an interface to volume plugins that can be used on a


### PR DESCRIPTION
We can have active/active HA provisioners if we change the placeholder PV from using `pv.GenerateName` to `pv.Name` w/ the claim's UID as the name (with a prefix to identify the provisioner).

Many provisioners can concurrently process the same claim, but only 1 would succeed in creating the new PV w/ claim.UID as the name.  All others fail gracefully with a naming conflict.

@kubernetes/rh-storage 
