### PR TITLE
Decouple node upgrade from master upgrade

### DIFF
--- a/test/e2e/cluster_upgrade.go
+++ b/test/e2e/cluster_upgrade.go
@@ -196,10 +196,6 @@ var _ = Describe("Upgrade [Feature:Upgrade]", func() {
 	})
 
 	Describe("kube-push", func() {
-		BeforeEach(func() {
-			SkipUnlessProviderIs("gce")
-		})
-
 		It("of master should maintain responsive services", func() {
 			By("Validating cluster before master upgrade")
 			expectNoError(validate(f, svcName, rcName, ingress, replicas))
@@ -261,8 +257,6 @@ var _ = Describe("Upgrade [Feature:Upgrade]", func() {
 		})
 
 		It("should maintain a functioning cluster", func() {
-			SkipUnlessProviderIs("gce", "gke")
-
 			By("Validating cluster before node upgrade")
 			expectNoError(validate(f, svcName, rcName, ingress, replicas))
 			By("Performing a node upgrade")

--- a/test/e2e/cluster_upgrade.go
+++ b/test/e2e/cluster_upgrade.go
@@ -211,10 +211,6 @@ var _ = Describe("Upgrade [Feature:Upgrade]", func() {
 	})
 
 	Describe("upgrade-master", func() {
-		BeforeEach(func() {
-			SkipUnlessProviderIs("gce", "gke")
-		})
-
 		It("should maintain responsive services", func() {
 			By("Validating cluster before master upgrade")
 			expectNoError(validate(f, svcName, rcName, ingress, replicas))
@@ -267,13 +263,7 @@ var _ = Describe("Upgrade [Feature:Upgrade]", func() {
 		It("should maintain a functioning cluster", func() {
 			SkipUnlessProviderIs("gce", "gke")
 
-			By("Validating cluster before master upgrade")
-			expectNoError(validate(f, svcName, rcName, ingress, replicas))
-			By("Performing a master upgrade")
-			testMasterUpgrade(ip, v, masterUpgrade)
-			By("Checking master version")
-			expectNoError(checkMasterVersion(f.Client, v))
-			By("Validating cluster after master upgrade")
+			By("Validating cluster before node upgrade")
 			expectNoError(validate(f, svcName, rcName, ingress, replicas))
 			By("Performing a node upgrade")
 			testNodeUpgrade(f, nodeUpgrade, replicas, v)


### PR DESCRIPTION
Decouple node upgrades from master upgrades, so that we don't duplicate upgrading the master when running tests.  This more directly reflects reality of how upgrades happen.

@spxtr At this point, I'd really like to change `[Feature:ClusterUpgrade]` to `[Feature:NodeUpgrade]`.  Like I was saying yesterday, unlikely that things won't drift. :wink: 
