### PR TITLE
Explicitly set custom workspace for soak jobs.

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-soak.yaml
+++ b/hack/jenkins/job-configs/kubernetes-soak.yaml
@@ -32,6 +32,7 @@
 - job-template:
     name: 'kubernetes-soak-continuous-e2e-{suffix}'
     description: '{e2e-description} Test Owner: {test-owner}'
+    workspace: 'kubernetes-soak-weekly-deploy-{suffix}'
     logrotate:
         daysToKeep: 7
     builders:


### PR DESCRIPTION
@fabioy noticed the second soak cluster has been broken for a while. Turns out that all the other soak jobs have this living in their config. When you post a new XML config to Jenkins, it merges the old config with the new, rather than starting from scratch.

We previously saw this when I accidentally disabled all the jobs. Rolling back the offending commit didn't reenable them, since the commit had introduced the disabled setting and after rollback Jenkins just kept using the old one.

This is a real bother. It may be worth flashing Jenkins every now and then, since it doesn't look like there's a way to disable this behavior.
