### PR TITLE
Fix thirdparty discovery and add unit tests

### DIFF
--- a/pkg/registry/thirdpartyresourcedata/codec.go
+++ b/pkg/registry/thirdpartyresourcedata/codec.go
@@ -324,7 +324,7 @@ func (t *thirdPartyResourceDataCodec) EncodeToStream(obj runtime.Object, stream 
 		}
 		fmt.Fprintf(stream, template, t.kind+"List", strings.Join(dataStrings, ","))
 		return nil
-	case *unversioned.Status:
+	case *unversioned.Status, *unversioned.APIResourceList:
 		return t.delegate.EncodeToStream(obj, stream, overrides...)
 	default:
 		return fmt.Errorf("unexpected object to encode: %#v", obj)


### PR DESCRIPTION
Fix #21955, which reports server return 500 at http://127.0.0.1:8080/apis/example.com/v1x.

cc @brendandburns 
