### PR TITLE
Bump timeout for kubernetes-test-go to 45m

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-test-go.yaml
+++ b/hack/jenkins/job-configs/kubernetes-test-go.yaml
@@ -47,7 +47,7 @@
         - ansicolor:
             colormap: xterm
         - timeout:
-            timeout: 30
+            timeout: '{timeout}'
             fail: true
         - timestamps
         - raw:
@@ -69,7 +69,9 @@
     suffix:
         - 'go':
             branch: 'master'
+            timeout: 45
         - 'go-release-1.1':
             branch: 'release-1.1'
+            timeout: 30
     jobs:
         - 'kubernetes-test-{suffix}'


### PR DESCRIPTION
The `kubernetes-test-go` job is regularly taking around 29-30m now, so a 30m timeout is insufficient. The release-1.1 job is still taking less than 15m.

I'm not sure what made it slower, and we should probably figure out if it's expected, but we should stop flaking the build to start. Fixes #21937.

@kubernetes/goog-testing 
