### PR TITLE
Kube-proxy requests 2x cpu shares of addons.

### DIFF
--- a/cluster/saltbase/salt/kube-proxy/init.sls
+++ b/cluster/saltbase/salt/kube-proxy/init.sls
@@ -16,6 +16,8 @@
     - mode: 644
     - makedirs: true
     - dir_mode: 755
+    - context:
+        cpurequest: '200m'
     - require:
       - service: docker
       - service: kubelet
@@ -26,7 +28,7 @@
     - group: root
     - mode: 644
 
-#stop legacy kube-proxy service 
+#stop legacy kube-proxy service
 stop_kube-proxy:
   service.dead:
     - name: kube-proxy

--- a/cluster/saltbase/salt/kube-proxy/kube-proxy.manifest
+++ b/cluster/saltbase/salt/kube-proxy/kube-proxy.manifest
@@ -31,6 +31,9 @@ spec:
   containers:
   - name: kube-proxy
     image: {{pillar['kube_docker_registry']}}/kube-proxy:{{pillar['kube-proxy_docker_tag']}}
+    resources:
+      requests:
+        cpu: {{ cpurequest }}
     command:
     - /bin/sh
     - -c


### PR DESCRIPTION
see https://github.com/kubernetes/kubernetes/issues/21820#issuecomment-188546116
@kubernetes/goog-node 200m should be fine right?
