### PR TITLE
Fixing paused deployment e2e flake: Delete replica set and its pods as well rather than just deleting the replica set

### DIFF
--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -575,7 +575,7 @@ func testPausedDeployment(f *Framework) {
 
 	newRS, err := deploymentutil.GetNewReplicaSet(*deployment, c)
 	Expect(err).NotTo(HaveOccurred())
-	Expect(c.Extensions().ReplicaSets(ns).Delete(newRS.Name, nil)).NotTo(HaveOccurred())
+	Expect(DeleteReplicaSet(unversionedClient, ns, newRS.Name)).NotTo(HaveOccurred())
 
 	deployment, err = c.Extensions().Deployments(ns).Get(deploymentName)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/21491 and https://github.com/kubernetes/kubernetes/issues/21753

We were deleting just the replica set and hence, there were orphaned pods at the end of the test which were failing the test.
Fixed the code to delete pods along with the replica set
