### PR TITLE
Make hack/install-etcd.sh use hack/lib/etcd.sh

### DIFF
--- a/hack/install-etcd.sh
+++ b/hack/install-etcd.sh
@@ -14,15 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Convenience script to download and install etcd in third_party.
+# Mostly just used by CI.
+
 set -o errexit
 set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${KUBE_ROOT}/hack/lib/init.sh"
 
-ETCD_VERSION=${ETCD_VERSION:-v2.2.1}
-
-cd "${KUBE_ROOT}/third_party"
-curl -fsSL https://github.com/coreos/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz \
-  | tar xzf -
-ln -fns etcd-${ETCD_VERSION}-linux-amd64 etcd
+kube::etcd::install


### PR DESCRIPTION
Reduce the number of places we specify an etcd version in the repo by 1, and update the check in `hack/lib/etcd.sh` to the version we use nowadays.

cc @kubernetes/sig-testing @lavalamp @caesarxuchao 
