### PR TITLE
Increase memory limit for influxdb in Density test

### DIFF
--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -99,7 +99,7 @@ func density30AddonResourceVerifier() map[string]resourceConstraint {
 	}
 	constraints["influxdb"] = resourceConstraint{
 		cpuConstraint:    2,
-		memoryConstraint: 300 * (1024 * 1024),
+		memoryConstraint: 500 * (1024 * 1024),
 	}
 	return constraints
 }


### PR DESCRIPTION
This would fix the failure from here:
http://kubekins.dls.corp.google.com/view/Critical%20Builds/job/kubernetes-e2e-gce-scalability/4858/
