### PR TITLE
Allow specifying secret values as strings

### DIFF
--- a/pkg/api/conversion.go
+++ b/pkg/api/conversion.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/kubernetes/pkg/conversion"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/util/bytestr"
 	"k8s.io/kubernetes/pkg/util/intstr"
 )
 
@@ -40,6 +41,8 @@ func init() {
 		Convert_unversioned_TypeMeta_To_unversioned_TypeMeta,
 		Convert_unversioned_ListMeta_To_unversioned_ListMeta,
 		Convert_intstr_IntOrString_To_intstr_IntOrString,
+		Convert_bytestr_StringOrByteSlice_To_Slice_byte,
+		Convert_Slice_byte_To_bytestr_StringOrByteSlice,
 		Convert_unversioned_Time_To_unversioned_Time,
 		Convert_Slice_string_To_unversioned_Time,
 		Convert_string_To_labels_Selector,
@@ -110,6 +113,13 @@ func Convert_intstr_IntOrString_To_intstr_IntOrString(in, out *intstr.IntOrStrin
 	out.IntVal = in.IntVal
 	out.StrVal = in.StrVal
 	return nil
+}
+
+func Convert_bytestr_StringOrByteSlice_To_Slice_byte(in *bytestr.StringOrByteSlice, out *[]byte, s conversion.Scope) error {
+	return conversion.Convert_Slice_byte_To_Slice_byte((*[]byte)(in), out, s)
+}
+func Convert_Slice_byte_To_bytestr_StringOrByteSlice(in *[]byte, out *bytestr.StringOrByteSlice, s conversion.Scope) error {
+	return conversion.Convert_Slice_byte_To_Slice_byte(in, (*[]byte)(out), s)
 }
 
 func Convert_unversioned_Time_To_unversioned_Time(in *unversioned.Time, out *unversioned.Time, s conversion.Scope) error {

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -27,6 +27,7 @@ import (
 	conversion "k8s.io/kubernetes/pkg/conversion"
 	runtime "k8s.io/kubernetes/pkg/runtime"
 	types "k8s.io/kubernetes/pkg/types"
+	bytestr "k8s.io/kubernetes/pkg/util/bytestr"
 )
 
 func init() {
@@ -5899,7 +5900,7 @@ func autoConvert_v1_Secret_To_api_Secret(in *Secret, out *api.Secret, s conversi
 		*out = make(map[string][]byte, len(*in))
 		for key, val := range *in {
 			newVal := new([]byte)
-			if err := conversion.Convert_Slice_byte_To_Slice_byte(&val, newVal, s); err != nil {
+			if err := api.Convert_bytestr_StringOrByteSlice_To_Slice_byte(&val, newVal, s); err != nil {
 				return err
 			}
 			(*out)[key] = *newVal
@@ -5924,10 +5925,10 @@ func autoConvert_api_Secret_To_v1_Secret(in *api.Secret, out *Secret, s conversi
 	}
 	if in.Data != nil {
 		in, out := &in.Data, &out.Data
-		*out = make(map[string][]byte, len(*in))
+		*out = make(map[string]bytestr.StringOrByteSlice, len(*in))
 		for key, val := range *in {
-			newVal := new([]byte)
-			if err := conversion.Convert_Slice_byte_To_Slice_byte(&val, newVal, s); err != nil {
+			newVal := new(bytestr.StringOrByteSlice)
+			if err := api.Convert_Slice_byte_To_bytestr_StringOrByteSlice(&val, newVal, s); err != nil {
 				return err
 			}
 			(*out)[key] = *newVal

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -27,6 +27,7 @@ import (
 	conversion "k8s.io/kubernetes/pkg/conversion"
 	runtime "k8s.io/kubernetes/pkg/runtime"
 	types "k8s.io/kubernetes/pkg/types"
+	bytestr "k8s.io/kubernetes/pkg/util/bytestr"
 	intstr "k8s.io/kubernetes/pkg/util/intstr"
 )
 
@@ -2656,12 +2657,12 @@ func DeepCopy_v1_Secret(in Secret, out *Secret, c *conversion.Cloner) error {
 	}
 	if in.Data != nil {
 		in, out := in.Data, &out.Data
-		*out = make(map[string][]byte)
+		*out = make(map[string]bytestr.StringOrByteSlice)
 		for key, val := range in {
 			if newVal, err := c.DeepCopy(val); err != nil {
 				return err
 			} else {
-				(*out)[key] = newVal.([]byte)
+				(*out)[key] = newVal.(bytestr.StringOrByteSlice)
 			}
 		}
 	} else {

--- a/pkg/api/v1/generated.pb.go
+++ b/pkg/api/v1/generated.pb.go
@@ -183,6 +183,7 @@ import k8s_io_kubernetes_pkg_api_unversioned "k8s.io/kubernetes/pkg/api/unversio
 import k8s_io_kubernetes_pkg_runtime "k8s.io/kubernetes/pkg/runtime"
 
 import k8s_io_kubernetes_pkg_types "k8s.io/kubernetes/pkg/types"
+import k8s_io_kubernetes_pkg_util_bytestr "k8s.io/kubernetes/pkg/util/bytestr"
 
 import io "io"
 
@@ -30327,9 +30328,9 @@ func (m *Secret) Unmarshal(data []byte) error {
 			copy(mapvalue, data[iNdEx:postbytesIndex])
 			iNdEx = postbytesIndex
 			if m.Data == nil {
-				m.Data = make(map[string][]byte)
+				m.Data = make(map[string]k8s_io_kubernetes_pkg_util_bytestr.StringOrByteSlice)
 			}
-			m.Data[mapkey] = mapvalue
+			m.Data[mapkey] = ((k8s_io_kubernetes_pkg_util_bytestr.StringOrByteSlice)(mapvalue))
 			iNdEx = postIndex
 		case 3:
 			if wireType != 2 {

--- a/pkg/api/v1/types.generated.go
+++ b/pkg/api/v1/types.generated.go
@@ -29,6 +29,7 @@ import (
 	pkg2_unversioned "k8s.io/kubernetes/pkg/api/unversioned"
 	pkg5_runtime "k8s.io/kubernetes/pkg/runtime"
 	pkg1_types "k8s.io/kubernetes/pkg/types"
+	pkg6_bytestr "k8s.io/kubernetes/pkg/util/bytestr"
 	pkg4_intstr "k8s.io/kubernetes/pkg/util/intstr"
 	"reflect"
 	"runtime"
@@ -69,9 +70,10 @@ func init() {
 		var v1 pkg2_unversioned.Time
 		var v2 pkg5_runtime.RawExtension
 		var v3 pkg1_types.UID
-		var v4 pkg4_intstr.IntOrString
-		var v5 time.Time
-		_, _, _, _, _, _ = v0, v1, v2, v3, v4, v5
+		var v4 pkg6_bytestr.StringOrByteSlice
+		var v5 pkg4_intstr.IntOrString
+		var v6 time.Time
+		_, _, _, _, _, _, _ = v0, v1, v2, v3, v4, v5, v6
 	}
 }
 
@@ -48041,7 +48043,7 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 						_ = yym9
 						if false {
 						} else {
-							h.encMapstringSliceuint8((map[string][]uint8)(x.Data), e)
+							h.encMapstringbytestr_StringOrByteSlice((map[string]pkg6_bytestr.StringOrByteSlice)(x.Data), e)
 						}
 					}
 				} else {
@@ -48059,7 +48061,7 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 						_ = yym10
 						if false {
 						} else {
-							h.encMapstringSliceuint8((map[string][]uint8)(x.Data), e)
+							h.encMapstringbytestr_StringOrByteSlice((map[string]pkg6_bytestr.StringOrByteSlice)(x.Data), e)
 						}
 					}
 				}
@@ -48206,7 +48208,7 @@ func (x *Secret) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				_ = yym6
 				if false {
 				} else {
-					h.decMapstringSliceuint8((*map[string][]uint8)(yyv5), d)
+					h.decMapstringbytestr_StringOrByteSlice((*map[string]pkg6_bytestr.StringOrByteSlice)(yyv5), d)
 				}
 			}
 		case "type":
@@ -48277,7 +48279,7 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		_ = yym13
 		if false {
 		} else {
-			h.decMapstringSliceuint8((*map[string][]uint8)(yyv12), d)
+			h.decMapstringbytestr_StringOrByteSlice((*map[string]pkg6_bytestr.StringOrByteSlice)(yyv12), d)
 		}
 	}
 	yyj10++
@@ -57312,7 +57314,7 @@ func (x codecSelfer1234) decSliceResourceQuota(v *[]ResourceQuota, d *codec1978.
 	}
 }
 
-func (x codecSelfer1234) encMapstringSliceuint8(v map[string][]uint8, e *codec1978.Encoder) {
+func (x codecSelfer1234) encMapstringbytestr_StringOrByteSlice(v map[string]pkg6_bytestr.StringOrByteSlice, e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
@@ -57332,15 +57334,18 @@ func (x codecSelfer1234) encMapstringSliceuint8(v map[string][]uint8, e *codec19
 			yym3 := z.EncBinary()
 			_ = yym3
 			if false {
+			} else if z.HasExtensions() && z.EncExt(yyv1) {
+			} else if !yym3 && z.IsJSONHandle() {
+				z.EncJSONMarshal(yyv1)
 			} else {
-				r.EncodeStringBytes(codecSelferC_RAW1234, []byte(yyv1))
+				h.encbytestr_StringOrByteSlice((pkg6_bytestr.StringOrByteSlice)(yyv1), e)
 			}
 		}
 	}
 	z.EncSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
-func (x codecSelfer1234) decMapstringSliceuint8(v *map[string][]uint8, d *codec1978.Decoder) {
+func (x codecSelfer1234) decMapstringbytestr_StringOrByteSlice(v *map[string]pkg6_bytestr.StringOrByteSlice, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -57350,11 +57355,11 @@ func (x codecSelfer1234) decMapstringSliceuint8(v *map[string][]uint8, d *codec1
 	yybh1 := z.DecBasicHandle()
 	if yyv1 == nil {
 		yyrl1, _ := z.DecInferLen(yyl1, yybh1.MaxInitLen, 40)
-		yyv1 = make(map[string][]uint8, yyrl1)
+		yyv1 = make(map[string]pkg6_bytestr.StringOrByteSlice, yyrl1)
 		*v = yyv1
 	}
 	var yymk1 string
-	var yymv1 []uint8
+	var yymv1 pkg6_bytestr.StringOrByteSlice
 	var yymg1 bool
 	if yybh1.MapValueReset {
 		yymg1 = true
@@ -57381,8 +57386,11 @@ func (x codecSelfer1234) decMapstringSliceuint8(v *map[string][]uint8, d *codec1
 				yym4 := z.DecBinary()
 				_ = yym4
 				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv3) {
+				} else if !yym4 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv3)
 				} else {
-					*yyv3 = r.DecodeBytes(*(*[]byte)(yyv3), false, false)
+					h.decbytestr_StringOrByteSlice((*pkg6_bytestr.StringOrByteSlice)(yyv3), d)
 				}
 			}
 
@@ -57412,8 +57420,11 @@ func (x codecSelfer1234) decMapstringSliceuint8(v *map[string][]uint8, d *codec1
 				yym7 := z.DecBinary()
 				_ = yym7
 				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv6) {
+				} else if !yym7 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv6)
 				} else {
-					*yyv6 = r.DecodeBytes(*(*[]byte)(yyv6), false, false)
+					h.decbytestr_StringOrByteSlice((*pkg6_bytestr.StringOrByteSlice)(yyv6), d)
 				}
 			}
 
@@ -57425,7 +57436,7 @@ func (x codecSelfer1234) decMapstringSliceuint8(v *map[string][]uint8, d *codec1
 	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
 }
 
-func (x codecSelfer1234) encSliceuint8(v []uint8, e *codec1978.Encoder) {
+func (x codecSelfer1234) encbytestr_StringOrByteSlice(v pkg6_bytestr.StringOrByteSlice, e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
@@ -57442,7 +57453,7 @@ func (x codecSelfer1234) encSliceuint8(v []uint8, e *codec1978.Encoder) {
 	z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
 }
 
-func (x codecSelfer1234) decSliceuint8(v *[]uint8, d *codec1978.Decoder) {
+func (x codecSelfer1234) decbytestr_StringOrByteSlice(v *pkg6_bytestr.StringOrByteSlice, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/types"
+	"k8s.io/kubernetes/pkg/util/bytestr"
 	"k8s.io/kubernetes/pkg/util/intstr"
 )
 
@@ -3023,7 +3024,7 @@ type Secret struct {
 	// The serialized form of the secret data is a base64 encoded string,
 	// representing the arbitrary (possibly non-string) data value here.
 	// Described in https://tools.ietf.org/html/rfc4648#section-4
-	Data map[string][]byte `json:"data,omitempty" protobuf:"bytes,2,rep,name=data"`
+	Data map[string]bytestr.StringOrByteSlice `json:"data,omitempty" protobuf:"bytes,2,rep,name=data,castvalue=\"k8s.io/kubernetes/pkg/util/bytestr.StringOrByteSlice\""`
 
 	// Used to facilitate programmatic handling of secret data.
 	Type SecretType `json:"type,omitempty" protobuf:"bytes,3,opt,name=type,casttype=SecretType"`

--- a/pkg/util/bytestr/bytestr.go
+++ b/pkg/util/bytestr/bytestr.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bytestr
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// literalStringPrefix is checked for
+const literalStringPrefix = "string:"
+
+// StringOrByteSlice is an alias for []byte.
+// When used in JSON unmarshalling, it can consume a literal string prefixed with "string:" in addition to base64-encoded bytes.
+// This allows providing string data in JSON fields without base64-encoding it (e.g. the value foo could be provided as "string:foo" or "Zm9v")
+type StringOrByteSlice []byte
+
+func (s StringOrByteSlice) MarshalJSON() ([]byte, error) {
+	return json.Marshal([]byte(s))
+}
+func (s *StringOrByteSlice) UnmarshalJSON(data []byte) error {
+	// Attempt normal base64 decoding first
+	originalErr := json.Unmarshal(data, (*[]byte)(s))
+	if originalErr == nil {
+		return nil
+	}
+
+	// If there's an error base64-decoding, and the value unmarshals to a string starting with 'string:',
+	// strip the prefix and use the remaining bytes as the value
+	var str string
+	if strErr := json.Unmarshal(data, &str); strErr == nil && strings.HasPrefix(str, literalStringPrefix) {
+		*s = []byte(str[len(literalStringPrefix):])
+		return nil
+	}
+
+	return originalErr
+}

--- a/pkg/util/bytestr/bytestr_test.go
+++ b/pkg/util/bytestr/bytestr_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bytestr
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/ghodss/yaml"
+)
+
+type StringOrByteSliceHolder struct {
+	SorB StringOrByteSlice `json:"val"`
+}
+
+func TestStringOrByteSliceUnmarshalJSON(t *testing.T) {
+	cases := []struct {
+		input  string
+		result StringOrByteSlice
+	}{
+		{
+			input:  `{"val":null}`,
+			result: StringOrByteSlice([]byte(nil)),
+		},
+		{
+			input:  `{"val":""}`,
+			result: StringOrByteSlice([]byte(``)),
+		},
+		{
+			input:  `{"val":"string:"}`,
+			result: StringOrByteSlice([]byte(``)),
+		},
+		{
+			input:  `{"val":"QUJD"}`,
+			result: StringOrByteSlice([]byte(`ABC`)),
+		},
+		{
+			input:  `{"val":"string:ABC"}`,
+			result: StringOrByteSlice([]byte(`ABC`)),
+		},
+		{
+			input:  `{"val":"ScOxdMOrcm7DonRpw7Ruw6BsaXrDpnRpw7hu"}`,
+			result: StringOrByteSlice([]byte(`Iñtërnâtiônàlizætiøn`)),
+		},
+		{
+			input:  `{"val":"string:Iñtërnâtiônàlizætiøn"}`,
+			result: StringOrByteSlice([]byte(`Iñtërnâtiônàlizætiøn`)),
+		},
+		{
+			input:  `{"val":"5Lit5paH"}`,
+			result: StringOrByteSlice([]byte(`中文`)),
+		},
+		{
+			input:  `{"val":"string:中文"}`,
+			result: StringOrByteSlice([]byte(`中文`)),
+		},
+	}
+
+	for i, c := range cases {
+		var result StringOrByteSliceHolder
+		if err := json.Unmarshal([]byte(c.input), &result); err != nil {
+			t.Errorf("%d: Failed to unmarshal input '%v': %v", i, c.input, err)
+		}
+		if !reflect.DeepEqual(result.SorB, c.result) {
+			t.Errorf("%d: Failed to unmarshal input '%v': expected %+v, got %+v", i, c.input, c.result, result)
+		}
+	}
+}
+
+func TestStringOrByteSliceMarshalJSON(t *testing.T) {
+	cases := []struct {
+		input  StringOrByteSlice
+		result string
+	}{
+		{
+			input:  StringOrByteSlice([]byte(nil)),
+			result: `{"val":null}`,
+		},
+		{
+			input:  StringOrByteSlice([]byte(``)),
+			result: `{"val":""}`,
+		},
+		{
+			input:  StringOrByteSlice([]byte(`ABC`)),
+			result: `{"val":"QUJD"}`,
+		},
+		{
+			input:  StringOrByteSlice([]byte(`Iñtërnâtiônàlizætiøn`)),
+			result: `{"val":"ScOxdMOrcm7DonRpw7Ruw6BsaXrDpnRpw7hu"}`,
+		},
+		{
+			input:  StringOrByteSlice([]byte(`中文`)),
+			result: `{"val":"5Lit5paH"}`,
+		},
+	}
+
+	for _, c := range cases {
+		input := StringOrByteSliceHolder{c.input}
+		result, err := json.Marshal(&input)
+		if err != nil {
+			t.Errorf("Failed to marshal input '%v': %v", input, err)
+		}
+		if string(result) != c.result {
+			t.Errorf("Failed to marshal input '%v': expected: %s, got %s", input, c.result, string(result))
+		}
+	}
+}
+
+func TestStringOrByteSliceMarshalJSONUnmarshalYAML(t *testing.T) {
+	cases := []struct {
+		input StringOrByteSlice
+	}{
+		{StringOrByteSlice([]byte(nil))},
+		{StringOrByteSlice([]byte(``))},
+		{StringOrByteSlice([]byte(`ABC`))},
+		{StringOrByteSlice([]byte(`Iñtërnâtiônàlizætiøn`))},
+		{StringOrByteSlice([]byte(`中文`))},
+	}
+
+	for _, c := range cases {
+		input := StringOrByteSliceHolder{c.input}
+		jsonMarshalled, err := json.Marshal(&input)
+		if err != nil {
+			t.Errorf("1: Failed to marshal input: '%v': %v", input, err)
+		}
+
+		var result StringOrByteSliceHolder
+		err = yaml.Unmarshal(jsonMarshalled, &result)
+		if err != nil {
+			t.Errorf("2: Failed to unmarshal '%+v': %v", string(jsonMarshalled), err)
+		}
+
+		if !reflect.DeepEqual(input, result) {
+			t.Errorf("3: Failed to round-trip '%+v', got '%v' -> '%+v'", input, string(jsonMarshalled), result)
+		}
+	}
+}


### PR DESCRIPTION
Proof of concept for https://github.com/kubernetes/kubernetes/issues/19575#issuecomment-189323573, intended to make it possible to produce `Secret` definitions from templates.

Allows specifying secret values to the API in v1.Secrets as `"string:literal string value"`, in addition to the existing base64 []byte serialization (`"bGl0ZXJhbCBzdHJpbmcgdmFsdWU="`). The conversion is one-way, output is always base64 for backwards compatibility. No additional escaping/unescaping or manipulation of the content is done. The conversion process is:
1. Attempt to decode content as base64
2. If decode fails, and the content starts with `string:`, remove the `string:` prefix and use the remaining bytes as the content.

With this change, a Secret could be created like this:

```
{
  "kind":"Secret",
  "apiVersion":"v1",
  "metadata":{"name":"mysecret"},
  "data":{
    "username": "string:myuser",
    "password": "string:mypassword"
  }
}
```

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/22059)

<!-- Reviewable:end -->
