### PR TITLE
e2e flake fix: Namespace controller error handling improvements

### DIFF
--- a/pkg/controller/namespace/namespace_controller_utils.go
+++ b/pkg/controller/namespace/namespace_controller_utils.go
@@ -244,6 +244,12 @@ func syncNamespace(kubeClient clientset.Interface, versions *unversioned.APIVers
 	// we have removed content, so mark it finalized by us
 	result, err := retryOnConflictError(kubeClient, namespace, finalizeNamespaceFunc)
 	if err != nil {
+		// in normal practice, this should not be possible, but if a deployment is running
+		// two controllers to do namespace deletion that share a common finalizer token it's
+		// possible that a not found could occur since the other controller would have finished the delete.
+		if errors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
If an unexpected error is encountered during namespace deletion, automatically add the namespace back to the processing queue rather than wait for a full resync and log it.  If the error is a content remaining error, we continue to wait for the time estimate, but we now have a proper crash handler.

fixes #21406 
