### PR TITLE
Protect against race conditions in the service controller

### DIFF
--- a/pkg/controller/service/servicecontroller.go
+++ b/pkg/controller/service/servicecontroller.go
@@ -498,6 +498,11 @@ func (s *ServiceController) needsUpdate(oldService *api.Service, newService *api
 	if !reflect.DeepEqual(oldService.Annotations, newService.Annotations) {
 		return true
 	}
+	if oldService.UID != newService.UID {
+		s.eventRecorder.Eventf(newService, api.EventTypeNormal, "UID", "%v -> %v",
+			oldService.UID, newService.UID)
+		return true
+	}
 
 	return false
 }


### PR DESCRIPTION
Re-GET the service object when we process it rather than trusting the
delta. This will make for a lot more service get requests given that we
resync all the services every 5 minutes, but will avoid re-ordering of
updates and continually retrying stale updates, as has been described in
a few other issues and PRs.

Also, a load balancer should be updated if a service's UID has changed.
The load balancer's name is determined by the service's UID. If the
service's UID has changed (presumably due to a delete and recreate),
then we need to recreate the load balancer as well to avoid eventually
leaking the old one.

A simplification of #19879, as discussed on #19879, #21982, and #21952, among other places.

cc @bprashanth @justinsb @cjcullen 
