### PR TITLE
Prep for upgrade job infra fixups

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-soak.yaml
+++ b/hack/jenkins/job-configs/kubernetes-soak.yaml
@@ -71,6 +71,7 @@
         export E2E_TEST="false"
         export E2E_DOWN="false"
     soak-continuous: |
+        export JENKINS_USE_EXISTING_BINARIES="y"
         export FAIL_ON_GCP_RESOURCE_LEAK="false"
         export E2E_UP="false"
         export E2E_DOWN="false"

--- a/hack/jenkins/job-configs/kubernetes-upgrades.yaml
+++ b/hack/jenkins/job-configs/kubernetes-upgrades.yaml
@@ -192,7 +192,7 @@
     name: 'upgrade-gke'
     provider-env: |
         {gke-provider-env}
-        export JENKINS_FORCE_GET_TARS="y"
+        export JENKINS_TOLERATE_DIRTY_WORKSPACE="y"
         export FAIL_ON_GCP_RESOURCE_LEAK="false"
     jobs:
         - '{provider}-{version-old}-{version-new}-upgrades':
@@ -233,7 +233,7 @@
     provider-env: |
         {gce-provider-env}
         export NUM_NODES=5
-        export JENKINS_FORCE_GET_TARS="y"
+        export JENKINS_TOLERATE_DIRTY_WORKSPACE="y"
         export FAIL_ON_GCP_RESOURCE_LEAK="false"
     jobs:
         - '{provider}-{version-old}-{version-new}-upgrades':


### PR DESCRIPTION
Right now, this is just work in preparation for making upgrade jobs easier to run in isolation, instead of having the 7-step mess.

I don't love how I structured `JENKINS_USE_EXISTING_BINARIES` and `JENKINS_TOLERATE_DIRTY_WORKSPACE`, but I couldn't figure out anything better.  Feedback encouraged.

Plan:

For each `X`-`Y` version skew, run 4 suites:
- Deploy at `X` and run Kubectl tests at `Y`
- Deploy at `X`, upgrade master to `Y`, and run tests at `X`
- Deploy at `X`, upgrade master and nodes to `Y`, and run tests at `X`
- Deploy at `X`, upgrade master and nodes to `Y`, and run tests at `Y`

This should give us the same coverage as we have now, but without chaining runs together.  I need this refactoring because I'll have to fetch and unpack different tests between cluster-up and test.
