### PR TITLE
Fix hpa-php-apache.yaml.

### DIFF
--- a/docs/user-guide/horizontal-pod-autoscaling/hpa-php-apache.yaml
+++ b/docs/user-guide/horizontal-pod-autoscaling/hpa-php-apache.yaml
@@ -7,7 +7,6 @@ spec:
   scaleRef:
     kind: ReplicationController
     name: php-apache
-    namespace: default
     subresource: scale
   minReplicas: 1
   maxReplicas: 10


### PR DESCRIPTION
Fix docs/user-guide/horizontal-pod-autoscaling/hpa-php-apache.yaml. The issue is that there is no field "namespace" in "type SubresourceReference struct" in ./pkg/apis/extensions/types.go and thats why its failing validation.

Fixes #21938
