### PR TITLE
Add Network Security Warning to getting started

### DIFF
--- a/docs/getting-started-guides/docker.md
+++ b/docs/getting-started-guides/docker.md
@@ -91,6 +91,8 @@ docker run \
 
 This actually runs the kubelet, which in turn runs a [pod](../user-guide/pods.md) that contains the other master components.
 
+** **SECURITY WARNING** ** services exposed via Kubernetes using Hypercube are available on the host node's public network interface / IP address.  Because of this, this guide is not suitable for any host node/server that is directly internet accessible.  Refer to [#21735](https://github.com/kubernetes/kubernetes/issues/21735) for addtional info.
+
 ### Download `kubectl`
 
 At this point you should have a running Kubernetes cluster.  You can test this

--- a/docs/getting-started-guides/docker.md
+++ b/docs/getting-started-guides/docker.md
@@ -91,7 +91,7 @@ docker run \
 
 This actually runs the kubelet, which in turn runs a [pod](../user-guide/pods.md) that contains the other master components.
 
-** **SECURITY WARNING** ** services exposed via Kubernetes using Hypercube are available on the host node's public network interface / IP address.  Because of this, this guide is not suitable for any host node/server that is directly internet accessible.  Refer to [#21735](https://github.com/kubernetes/kubernetes/issues/21735) for addtional info.
+** **SECURITY WARNING** ** services exposed via Kubernetes using Hyperkube are available on the host node's public network interface / IP address.  Because of this, this guide is not suitable for any host node/server that is directly internet accessible.  Refer to [#21735](https://github.com/kubernetes/kubernetes/issues/21735) for addtional info.
 
 ### Download `kubectl`
 


### PR DESCRIPTION
Add a security warning, that hypercube & kube-proxy expose network services on public IP addresses, making this configuration guide unsuitable for servers that are not firewalled off from the Internet. Referr to issue #21735
