### PR TITLE
Fix parsing of kube logs to handle logs split across lines.

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/td-agent.conf
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/td-agent.conf
@@ -162,11 +162,17 @@
   tag etcd
 </source>
 
+# Multi-line parsing is required for all the kube logs because very large log
+# statements, such as those that include entire object bodies, get split into
+# multiple lines by glog.
+
 # Example:
 # I0204 07:32:30.020537    3368 server.go:1048] POST /stats/container/: (13.972191ms) 200 [[Go-http-client/1.1] 10.244.1.3:40537]
 <source>
   type tail
-  format /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)$/
+  format multiline
+  format_firstline /^\w\d{4}/
+  format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
   time_format %m%d %H:%M:%S.%N
   path /var/log/kubelet.log
   pos_file /var/log/es-kubelet.log.pos
@@ -177,7 +183,9 @@
 # I0204 07:00:19.604280       5 handlers.go:131] GET /api/v1/nodes: (1.624207ms) 200 [[kube-controller-manager/v1.1.3 (linux/amd64) kubernetes/6a81b50] 127.0.0.1:38266]
 <source>
   type tail
-  format /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)$/
+  format multiline
+  format_firstline /^\w\d{4}/
+  format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
   time_format %m%d %H:%M:%S.%N
   path /var/log/kube-apiserver.log
   pos_file /var/log/es-kube-apiserver.log.pos
@@ -188,7 +196,9 @@
 # I0204 06:55:31.872680       5 servicecontroller.go:277] LB already exists and doesn't need update for service kube-system/kube-ui
 <source>
   type tail
-  format /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)$/
+  format multiline
+  format_firstline /^\w\d{4}/
+  format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
   time_format %m%d %H:%M:%S.%N
   path /var/log/kube-controller-manager.log
   pos_file /var/log/es-kube-controller-manager.log.pos
@@ -199,7 +209,9 @@
 # W0204 06:49:18.239674       7 reflector.go:245] pkg/scheduler/factory/factory.go:193: watch of *api.Service ended with: 401: The event in requested index is outdated and cleared (the requested history has been cleared [2578313/2577886]) [2579312]
 <source>
   type tail
-  format /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)$/
+  format multiline
+  format_firstline /^\w\d{4}/
+  format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
   time_format %m%d %H:%M:%S.%N
   path /var/log/kube-scheduler.log
   pos_file /var/log/es-kube-scheduler.log.pos

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/google-fluentd.conf
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/google-fluentd.conf
@@ -111,11 +111,17 @@
   tag etcd
 </source>
 
+# Multi-line parsing is required for all the kube logs because very large log
+# statements, such as those that include entire object bodies, get split into
+# multiple lines by glog.
+
 # Example:
 # I0204 07:32:30.020537    3368 server.go:1048] POST /stats/container/: (13.972191ms) 200 [[Go-http-client/1.1] 10.244.1.3:40537]
 <source>
   type tail
-  format /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)$/
+  format multiline
+  format_firstline /^\w\d{4}/
+  format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
   time_format %m%d %H:%M:%S.%N
   path /var/log/kubelet.log
   pos_file /var/log/gcp-kubelet.log.pos
@@ -126,7 +132,9 @@
 # I0204 07:00:19.604280       5 handlers.go:131] GET /api/v1/nodes: (1.624207ms) 200 [[kube-controller-manager/v1.1.3 (linux/amd64) kubernetes/6a81b50] 127.0.0.1:38266]
 <source>
   type tail
-  format /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)$/
+  format multiline
+  format_firstline /^\w\d{4}/
+  format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
   time_format %m%d %H:%M:%S.%N
   path /var/log/kube-apiserver.log
   pos_file /var/log/gcp-kube-apiserver.log.pos
@@ -137,7 +145,9 @@
 # I0204 06:55:31.872680       5 servicecontroller.go:277] LB already exists and doesn't need update for service kube-system/kube-ui
 <source>
   type tail
-  format /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)$/
+  format multiline
+  format_firstline /^\w\d{4}/
+  format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
   time_format %m%d %H:%M:%S.%N
   path /var/log/kube-controller-manager.log
   pos_file /var/log/gcp-kube-controller-manager.log.pos
@@ -148,7 +158,9 @@
 # W0204 06:49:18.239674       7 reflector.go:245] pkg/scheduler/factory/factory.go:193: watch of *api.Service ended with: 401: The event in requested index is outdated and cleared (the requested history has been cleared [2578313/2577886]) [2579312]
 <source>
   type tail
-  format /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)$/
+  format multiline
+  format_firstline /^\w\d{4}/
+  format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
   time_format %m%d %H:%M:%S.%N
   path /var/log/kube-scheduler.log
   pos_file /var/log/gcp-kube-scheduler.log.pos


### PR DESCRIPTION
I didn't expect glog to split single log statements onto multiple lines,
but apparently it does if they're long enough. This groups them back
together appropriately.

Fixes #21811

cc @jimmidyson for review
cc @lavalamp as someone I think is more familiar with glog than me - are line breaks expected in the middle of log statements? I don't see any configuration options in glog to disable them.

For example, this is a kube-controller-log message split across lines:

```
I0226 23:06:32.361973       6 nodecontroller.go:648] Nodes ReadyCondition updated. Updating timestamp: {Capacity:map[cpu:{Amount:2.000 Format:DecimalSI} memory:{Amount:7864139776.000 Format:BinarySI} pods:{Amount:110.000 Format:DecimalSI}] Allocatable:map[cpu:{Amount:2.000 Format:DecimalSI} memory:{Amount:7864139776.000 Format:BinarySI} pods:{Amount:110.000 Format:DecimalSI}] Phase: Conditions:[{Type:OutOfDisk Status:False LastHeartbeatTime:2016-02-26 23:06:17 +0000 UTC LastTransitionTime:2016-02-26 19:24:20 +0000 UTC Reason:KubeletHasSufficientDisk Message:kubelet has sufficient disk space available} {Type:Ready Status:True LastHeartbeatTime:2016-02-26 23:06:17 +0000 UTC LastTransitionTime:2016-02-26 19:25:07 +0000 UTC Reason:KubeletReady Message:kubelet is posting ready status}] Addresses:[{Type:InternalIP Address:10.240.0.5} {Type:ExternalIP Address:130.211.190.115}] DaemonEndpoints:{KubeletEndpoint:{Port:10250}} NodeInfo:{MachineID: SystemUUID:85588BDF-02F1-CDD5-3523-25C117F6EAFF BootID:caf38161-0c29-4f0c-a944-946ff026518c KernelVersion:3.16.0-4-amd64 OSImage:Debian GNU/Linux 7 (wheezy) ContainerRuntimeVersion:docker://1.9.1 KubeletVersion:v1.2.0-alpha.8.404+df234d83cdae2b-dirty KubeProxyVersion:v1.2.0-alpha.8.404+df234d83cdae2b-dirty} Images:[{Names:[gcr.io/google_containers/kube-proxy:da8581a41a7f682f32d0b36b747c8d4d] SizeBytes:165654333} {Names:[gcr.io/google_samples/gb-frontend:v4] SizeBytes:510252254} {Names:[gcr.io/google_containers/fluentd-elasticsearch:1.14] SizeBytes:562034622} {Names:[gcr.io/google_containers/kube2sky:1.12] SizeBytes:24482187} {Names:[gcr.io/google_containers/elasticsearch:1.8] SizeBytes:410989305} {Names:[gcr.io/google_containers/skydns:2015-10-13-8c72f8c] SizeBytes:40551394} {Names:[gcr.io/google_containers/pause:2.0] SizeBytes:350164} {Names:[gcr.io/google_samples/gb-redisslave:v1] SizeBytes:109508753} {Names:[gcr.io/google_containers/exechealthz:1.0] SizeBytes:7099444} {Names:[gcr.io/google_containers/kibana:1.3] SizeBytes:396897764} {Names:[gcr.io/google_containers/etcd:2.0.9] SizeBytes:12819040} {Names:[gcr.io/google_containers/pause:0.8.0] SizeBytes:241656}]}
 vs {Capacity:map[memory:{Amount:7864139776.000 Format:BinarySI} pods:{Amount:110.000 Format:DecimalSI} cpu:{Amount:2.000 Format:DecimalSI}] Allocatable:map[cpu:{Amount:2.000 Format:DecimalSI} memory:{Amount:7864139776.000 Format:BinarySI} pods:{Amount:110.000 Format:DecimalSI}] Phase: Conditions:[{Type:OutOfDisk Status:False LastHeartbeatTime:2016-02-26 23:06:27 +0000 UTC LastTransitionTime:2016-02-26 19:24:20 +0000 UTC Reason:KubeletHasSufficientDisk Message:kubelet has sufficient disk space available} {Type:Ready Status:True LastHeartbeatTime:2016-02-26 23:06:27 +0000 UTC LastTransitionTime:2016-02-26 19:25:07 +0000 UTC Reason:KubeletReady Message:kubelet is posting ready status}] Addresses:[{Type:InternalIP Address:10.240.0.5} {Type:ExternalIP Address:130.211.190.115}] DaemonEndpoints:{KubeletEndpoint:{Port:10250}} NodeInfo:{MachineID: SystemUUID:85588BDF-02F1-CDD5-3523-25C117F6EAFF BootID:caf38161-0c29-4f0c-a944-946ff026518c KernelVersion:3.16.0-4-amd64 OSImage:Debian GNU/Linux 7 (wheezy) ContainerRuntimeVersion:docker://1.9.1 KubeletVersion:v1.2.0-alpha.8.404+df234d83cdae2b-dirty KubeProxyVersion:v1.2.0-alpha.8.404+df234d83cdae2b-dirty} Images:[{Names:[gcr.io/google_containers/kube-proxy:da8581a41a7f682f32d0b36b747c8d4d] SizeBytes:165654333} {Names:[gcr.io/google_samples/gb-frontend:v4] SizeBytes:510252254} {Names:[gcr.io/google_containers/fluentd-elasticsearch:1.14] SizeBytes:562034622} {Names:[gcr.io/google_containers/kube2sky:1.12] SizeBytes:24482187} {Names:[gcr.io/google_containers/elasticsearch:1.8] SizeBytes:410989305} {Names:[gcr.io/google_containers/skydns:2015-10-13-8c72f8c] SizeBytes:40551394} {Names:[gcr.io/google_containers/pause:2.0] SizeBytes:350164} {Names:[gcr.io/google_samples/gb-redisslave:v1] SizeBytes:109508753} {Names:[gcr.io/google_containers/exechealthz:1.0] SizeBytes:7099444} {Names:[gcr.io/google_containers/kibana:1.3] SizeBytes:396897764} {Names:[gcr.io/google_containers/etcd:2.0.9] SizeBytes:12819040} {Names:[gcr.io/google_containers/pause:0.8.0] SizeBytes:241656}]}.
```
