### PR TITLE
Fix hack/local-up-cluster.sh to use API_HOST in kubectl commands

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -386,17 +386,21 @@ kind: Namespace
 metadata:
   name: kube-system
 EOF
-        ${KUBECTL} config set-cluster local --server=http://127.0.0.1:8080 --insecure-skip-tls-verify=true
+        ${KUBECTL} config set-cluster local --server=http://${API_HOST}:${API_PORT} --insecure-skip-tls-verify=true
         ${KUBECTL} config set-context local --cluster=local
         ${KUBECTL} config use-context local
 
         ${KUBECTL} create -f namespace.yaml
         # use kubectl to create skydns rc and service
-        ${KUBECTL} --namespace=kube-system create -f skydns-rc.yaml 
-        ${KUBECTL} --namespace=kube-system create -f skydns-svc.yaml
-        echo "Kube-dns rc and service successfully deployed."
+        echo "Starting kube DNS RC and service..."
+        ${KUBECTL} --namespace=kube-system create -f skydns-rc.yaml && \
+            ${KUBECTL} --namespace=kube-system create -f skydns-svc.yaml
+        if [ $? -eq 0 ]; then
+            echo "SUCCESS"
+        else
+            echo "FAILURE"
+        fi
     fi
-
 }
 
 function print_success {


### PR DESCRIPTION
If you customized $API_HOST or $API_PORT before running hack/local_up_cluster.sh, the kubectl commands would fail (but still say they succeeded) because they would be trying to access 127.0.0.1:8080 instead of $API_HOST:$API_PORT. Update the commands to use API_HOST and API_PORT along with an error message if the skydns RC and service creates fail.
