### PR TITLE
Add link in deployments doc to container probes

### DIFF
--- a/docs/user-guide/deployments.md
+++ b/docs/user-guide/deployments.md
@@ -375,6 +375,7 @@ at any time during the update is at most 130% of desired pods.
 minimum number of seconds for which a newly created pod should be ready
 without any of its containers crashing, for it to be considered available.
 This defaults to 0 (the pod will be considered available as soon as it is ready).
+To learn more about when a pod is considered ready, see [Container Probes](pod-states.md#container-probes).
 
 ## Alternative to Deployments
 


### PR DESCRIPTION
Learning about MinReadySeconds made me wonder how Readiness was actually calculated. Add a link to the Container Probes section of "The life of a pod" to make it easier to discover this information.
