### PR TITLE
Revert "Revert 20202. Use other measures to prevent race in test-cmd.sh"

### DIFF
--- a/pkg/api/rest/resttest/resttest.go
+++ b/pkg/api/rest/resttest/resttest.go
@@ -674,7 +674,7 @@ func (t *Tester) testDeleteGracefulImmediate(obj runtime.Object, setFn SetFunc, 
 	}
 	objectMeta = t.getObjectMetaOrFail(out)
 	// the second delete shouldn't update the object, so the objectMeta.DeletionGracePeriodSeconds should eqaul to the value set in the first delete.
-	if objectMeta.DeletionTimestamp == nil || objectMeta.DeletionGracePeriodSeconds == nil || *objectMeta.DeletionGracePeriodSeconds != 0 {
+	if objectMeta.DeletionTimestamp == nil || objectMeta.DeletionGracePeriodSeconds == nil || *objectMeta.DeletionGracePeriodSeconds != expectedGrace {
 		t.Errorf("unexpected deleted meta: %#v", objectMeta)
 	}
 }

--- a/pkg/registry/generic/etcd/etcd.go
+++ b/pkg/registry/generic/etcd/etcd.go
@@ -396,7 +396,7 @@ func (e *Etcd) Delete(ctx api.Context, name string, options *api.DeleteOptions) 
 	if pendingGraceful {
 		return e.finalizeDelete(obj, false)
 	}
-	if graceful {
+	if graceful && *options.GracePeriodSeconds > 0 {
 		out := e.NewFunc()
 		lastGraceful := int64(0)
 		err := e.Storage.GuaranteedUpdate(


### PR DESCRIPTION
Reverts kubernetes/kubernetes#21175.

This PR broke kubernetes-test-go.

19:23:25 (B+++ [0226 19:23:25] Testing resource aliasing
19:23:25 replicationcontroller "cassandra" created
19:23:25 I0226 19:23:25.736468    7531 event.go:211] Event(api.ObjectReference{Kind:"ReplicationController", Namespace:"default", Name:"cassandra", UID:"767d73df-dd01-11e5-befa-0242ac110003", APIVersion:"v1", ResourceVersion:"1034", FieldPath:""}): type: 'Normal' reason: 'SuccessfulCreate' Created pod: cassandra-2wxmq
19:23:25 I0226 19:23:25.736613    7531 event.go:211] Event(api.ObjectReference{Kind:"ReplicationController", Namespace:"default", Name:"cassandra", UID:"767d73df-dd01-11e5-befa-0242ac110003", APIVersion:"v1", ResourceVersion:"1034", FieldPath:""}): type: 'Normal' reason: 'SuccessfulCreate' Created pod: cassandra-hsdrt
19:23:26 replicationcontroller "cassandra" scaled
19:23:26 service "cassandra" created
19:23:26 
19:23:26 FAIL!
19:23:26 Get all -l'app=cassandra' {{range.items}}{{range .metadata.labels}}{{.}}:{{end}}{{end}}
19:23:26   Expected: cassandra:cassandra:cassandra:
19:23:26   Got:      cassandra:cassandra:cassandra:cassandra:
19:23:26 (B
19:23:26 1563 ./hack/test-cmd.sh
19:23:26 (B
19:23:26 !!! Error in ./hack/test-cmd.sh:51
19:23:26   'return 1' exited with status 1
19:23:26 Call stack:
19:23:26   1: ./hack/test-cmd.sh:51 runTests(...)
19:23:26   2: ./hack/test-cmd.sh:1636 main(...)
19:23:26 Exiting with status 1
