### PR TITLE
Eliminate racy scale command from resource-alias test.

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -1529,10 +1529,9 @@ __EOF__
   #####################
 
   kube::log::status "Testing resource aliasing"
-  kubectl create -f examples/cassandra/cassandra-controller.yaml "${kube_flags[@]}"
-  kubectl scale rc cassandra --replicas=1 "${kube_flags[@]}"
+  kubectl create -f examples/cassandra/cassandra.yaml "${kube_flags[@]}"
   kubectl create -f examples/cassandra/cassandra-service.yaml "${kube_flags[@]}"
-  kube::test::get_object_assert "all -l'app=cassandra'" "{{range.items}}{{range .metadata.labels}}{{.}}:{{end}}{{end}}" 'cassandra:cassandra:cassandra:'
+  kube::test::get_object_assert "all -l'app=cassandra'" "{{range.items}}{{range .metadata.labels}}{{.}}:{{end}}{{end}}" 'cassandra:cassandra:'
   kubectl delete all -l app=cassandra "${kube_flags[@]}"
 
 


### PR DESCRIPTION
Fixes #22128.

cc @mqliang @janetkuo @kargakis @bprashanth 
