### PR TITLE
Tests: Print results of kubectl get cassandra before asserting

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -1532,6 +1532,7 @@ __EOF__
   kubectl create -f examples/cassandra/cassandra-controller.yaml "${kube_flags[@]}"
   kubectl scale rc cassandra --replicas=1 "${kube_flags[@]}"
   kubectl create -f examples/cassandra/cassandra-service.yaml "${kube_flags[@]}"
+  kubectl get all -l'app=cassandra' "${kube_flags[@]}"
   kube::test::get_object_assert "all -l'app=cassandra'" "{{range.items}}{{range .metadata.labels}}{{.}}:{{end}}{{end}}" 'cassandra:cassandra:cassandra:'
   kubectl delete all -l app=cassandra "${kube_flags[@]}"
 


### PR DESCRIPTION
This should make it easier to diagnose what is going on when we see a
failed assertion like:

```
replicationcontroller "cassandra" scaled
service "cassandra" created

FAIL!
Get all -l'app=cassandra' {{range.items}}{{range
.metadata.labels}}{{.}}:{{end}}{{end}}
  Expected: cassandra:cassandra:cassandra:
  Got:      cassandra:cassandra:cassandra:cassandra:
```
