### PR TITLE
kubelet: fix duplicated status updates at pod cleanup

### DIFF
--- a/pkg/kubelet/dockertools/fake_docker_client.go
+++ b/pkg/kubelet/dockertools/fake_docker_client.go
@@ -297,6 +297,8 @@ func (f *FakeDockerClient) StopContainer(id string, timeout uint) error {
 		return err
 	}
 	f.Stopped = append(f.Stopped, id)
+	// Container status should be Updated before container moved to ExitedContainerList
+	f.updateContainerStatus(id, statusExitedPrefix)
 	var newList []docker.APIContainers
 	for _, container := range f.ContainerList {
 		if container.ID == id {
@@ -323,7 +325,6 @@ func (f *FakeDockerClient) StopContainer(id string, timeout uint) error {
 		container.State.Running = false
 	}
 	f.ContainerMap[id] = container
-	f.updateContainerStatus(id, statusExitedPrefix)
 	f.normalSleep(200, 50, 50)
 	return nil
 }
@@ -333,11 +334,20 @@ func (f *FakeDockerClient) RemoveContainer(opts docker.RemoveContainerOptions) e
 	defer f.Unlock()
 	f.called = append(f.called, "remove")
 	err := f.popError("remove")
-	if err == nil {
-		f.Removed = append(f.Removed, opts.ID)
+	if err != nil {
+		return err
 	}
-	delete(f.ContainerMap, opts.ID)
-	return err
+	for i := range f.ExitedContainerList {
+		if f.ExitedContainerList[i].ID == opts.ID {
+			delete(f.ContainerMap, opts.ID)
+			f.ExitedContainerList = append(f.ExitedContainerList[:i], f.ExitedContainerList[i+1:]...)
+			f.Removed = append(f.Removed, opts.ID)
+			return nil
+		}
+
+	}
+	// To be a good fake, report error if container is not stopped.
+	return fmt.Errorf("container not stopped")
 }
 
 // Logs is a test-spy implementation of DockerInterface.Logs.

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1950,31 +1950,6 @@ func (kl *Kubelet) cleanupOrphanedVolumes(pods []*api.Pod, runningPods []*kubeco
 	return nil
 }
 
-// Delete any pods that are no longer running and are marked for deletion.
-func (kl *Kubelet) cleanupTerminatedPods(pods []*api.Pod, runningPods []*kubecontainer.Pod) error {
-	var terminating []*api.Pod
-	for _, pod := range pods {
-		if pod.DeletionTimestamp != nil {
-			found := false
-			for _, runningPod := range runningPods {
-				if runningPod.ID == pod.UID {
-					found = true
-					break
-				}
-			}
-			if found {
-				glog.V(5).Infof("Keeping terminated pod %q, still running", format.Pod(pod))
-				continue
-			}
-			terminating = append(terminating, pod)
-		}
-	}
-	if !kl.statusManager.TerminatePods(terminating) {
-		return errors.New("not all pods were successfully terminated")
-	}
-	return nil
-}
-
 // pastActiveDeadline returns true if the pod has been active for more than
 // ActiveDeadlineSeconds.
 func (kl *Kubelet) pastActiveDeadline(pod *api.Pod) bool {
@@ -2165,10 +2140,6 @@ func (kl *Kubelet) HandlePodCleanups() error {
 
 	// Remove any orphaned mirror pods.
 	kl.podManager.DeleteOrphanedMirrorPods()
-
-	if err := kl.cleanupTerminatedPods(allPods, runningPods); err != nil {
-		glog.Errorf("Failed to cleanup terminated pods: %v", err)
-	}
 
 	// Clear out any old bandwidth rules
 	if err = kl.cleanupBandwidthLimits(allPods); err != nil {
@@ -2430,6 +2401,13 @@ func (kl *Kubelet) syncLoopIteration(updates <-chan kubetypes.PodUpdate, handler
 
 func (kl *Kubelet) dispatchWork(pod *api.Pod, syncType kubetypes.SyncPodType, mirrorPod *api.Pod, start time.Time) {
 	if kl.podIsTerminated(pod) {
+		if pod.DeletionTimestamp != nil {
+			// If the pod is in a termianted state, there is no pod worker to
+			// handle the work item. Check if the DeletionTimestamp has been
+			// set, and force a status update to trigger a pod deletion request
+			// to the apiserver.
+			kl.statusManager.TerminatePod(pod)
+		}
 		return
 	}
 	// Run the sync in an async worker.

--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -165,9 +165,7 @@ func (g *GenericPLEG) relist() {
 		return
 	}
 	pods := kubecontainer.Pods(podList)
-	for _, pod := range pods {
-		g.podRecords.setCurrent(pod)
-	}
+	g.podRecords.setCurrent(pods)
 
 	// Compare the old and the current pods, and generate events.
 	eventsByPodID := map[types.UID][]*PodLifecycleEvent{}
@@ -308,12 +306,17 @@ func (pr podRecords) getCurrent(id types.UID) *kubecontainer.Pod {
 	return r.current
 }
 
-func (pr podRecords) setCurrent(pod *kubecontainer.Pod) {
-	if r, ok := pr[pod.ID]; ok {
-		r.current = pod
-		return
+func (pr podRecords) setCurrent(pods []*kubecontainer.Pod) {
+	for i := range pr {
+		pr[i].current = nil
 	}
-	pr[pod.ID] = &podRecord{current: pod}
+	for _, pod := range pods {
+		if r, ok := pr[pod.ID]; ok {
+			r.current = pod
+		} else {
+			pr[pod.ID] = &podRecord{current: pod}
+		}
+	}
 }
 
 func (pr podRecords) update(id types.UID) {

--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -124,17 +124,17 @@ func generateEvent(podID types.UID, cid string, oldState, newState plegContainer
 	case plegContainerExited:
 		return &PodLifecycleEvent{ID: podID, Type: ContainerDied, Data: cid}
 	case plegContainerUnknown:
-		// Don't generate any event if the status is unknown.
-		return nil
+		return &PodLifecycleEvent{ID: podID, Type: ContainerChanged, Data: cid}
 	case plegContainerNonExistent:
 		// We report "ContainerDied" when container was stopped OR removed. We
 		// may want to distinguish the two cases in the future.
 		switch oldState {
 		case plegContainerExited:
-			// We already reported that the container died before. There is no
-			// need to do it again.
-			return nil
+			// We already reported that the container died before.
+			return &PodLifecycleEvent{ID: podID, Type: ContainerRemoved, Data: cid}
 		default:
+			// TODO: We may want to generate a ContainerRemoved event as well.
+			// It's ok now because no one relies on the ContainerRemoved event.
 			return &PodLifecycleEvent{ID: podID, Type: ContainerDied, Data: cid}
 		}
 	default:
@@ -204,6 +204,10 @@ func (g *GenericPLEG) relist() {
 		// Update the internal storage and send out the events.
 		g.podRecords.update(pid)
 		for i := range events {
+			// Filter out events that are not reliable and no other components use yet.
+			if events[i].Type == ContainerChanged || events[i].Type == ContainerRemoved {
+				continue
+			}
 			g.eventChannel <- events[i]
 		}
 	}

--- a/pkg/kubelet/pleg/pleg.go
+++ b/pkg/kubelet/pleg/pleg.go
@@ -23,13 +23,14 @@ import (
 type PodLifeCycleEventType string
 
 const (
-	ContainerStarted      PodLifeCycleEventType = "ContainerStarted"
-	ContainerDied         PodLifeCycleEventType = "ContainerDied"
-	NetworkSetupCompleted PodLifeCycleEventType = "NetworkSetupCompleted"
-	NetworkFailed         PodLifeCycleEventType = "NetworkFailed"
+	ContainerStarted PodLifeCycleEventType = "ContainerStarted"
+	ContainerDied    PodLifeCycleEventType = "ContainerDied"
 	// PodSync is used to trigger syncing of a pod when the observed change of
 	// the state of the pod cannot be captured by any single event above.
 	PodSync PodLifeCycleEventType = "PodSync"
+	// Do not use the events below because they are disabled in GenericPLEG.
+	ContainerRemoved PodLifeCycleEventType = "ContainerRemoved"
+	ContainerChanged PodLifeCycleEventType = "ContainerChanged"
 )
 
 // PodLifecycleEvent is an event that reflects the change of the pod state.


### PR DESCRIPTION
4th try of #21438. Based on #22117.

I finally found the root reason of the last bug. I reproduced the issue https://github.com/kubernetes/kubernetes/pull/21959#issuecomment-189383262 for several times. I find that each time a pod failed to be deleted whose containers were `exited` and `removed` before next pleg `relist`. After that, pleg didn't report any event, thus pod cache was never updated.

After some debugging, I find that:
- After each `relist`, the current pod record will be updated no matter the container state changed or not ([here](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/pleg/generic.go#L169));
- However, only pod record of which container state is changed will be updated ([here](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/pleg/generic.go#L205)).
- For those pods whose containers are not changed, their `old` and `current` pod record will be left in the same state.
- If now all containers of a pod are removed before `relist`, because there is no corresponding pod returned by [`GetPods`](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/pleg/generic.go#L162), the current pod record will not be updated, it is still the same with old pod record.
- Then `generateEvent` will not generate any event because the old and current states are equal ([here](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/pleg/generic.go#L118)).

In the 2nd commit of this PR. I changed the `setCurrent` function to let it update all current pod records at once. Before updating, it will clear all current pod records because we'll never use them any more.

This time I have run 40 nodes kubemark test overnight (about 10 hours) without any failure. (Without this fix, it usually failed after 20 or 30 minutes)

In summary:
- The 1st commit is fetched from #22117, it ensures that all pods with container state changed whose pod records will be updated.
- The 2nd commit ensures that `pleg` can detect container being removed.
- The 3rd commit fix the bug in fake docker client which leads to error `ListContainer` result.
- The 4th commit is the original PR #21438.

This time, I think this PR will not fail kubemark anymore......:)
@yujuhong 
