### PR TITLE
Remove short-circuit of token reference cleanup

### DIFF
--- a/pkg/controller/serviceaccount/tokens_controller.go
+++ b/pkg/controller/serviceaccount/tokens_controller.go
@@ -415,11 +415,6 @@ func (e *TokensController) deleteSecret(secret *api.Secret) error {
 // removeSecretReferenceIfNeeded updates the given ServiceAccount to remove a reference to the given secretName if needed.
 // Returns whether an update was performed, and any error that occurred
 func (e *TokensController) removeSecretReferenceIfNeeded(serviceAccount *api.ServiceAccount, secretName string) error {
-	// See if the account even referenced the secret
-	if !getSecretReferences(serviceAccount).Has(secretName) {
-		return nil
-	}
-
 	// We don't want to update the cache's copy of the service account
 	// so remove the secret from a freshly retrieved copy of the service account
 	serviceAccounts := e.client.Core().ServiceAccounts(serviceAccount.Namespace)

--- a/pkg/controller/serviceaccount/tokens_controller_test.go
+++ b/pkg/controller/serviceaccount/tokens_controller_test.go
@@ -492,8 +492,10 @@ func TestTokenCreation(t *testing.T) {
 		"deleted secret with serviceaccount without reference": {
 			ExistingServiceAccount: serviceAccount(emptySecretReferences()),
 
-			DeletedSecret:   serviceAccountTokenSecret(),
-			ExpectedActions: []core.Action{},
+			DeletedSecret: serviceAccountTokenSecret(),
+			ExpectedActions: []core.Action{
+				core.NewGetAction("serviceaccounts", api.NamespaceDefault, "default"),
+			},
 		},
 	}
 


### PR DESCRIPTION
Fixes #21995

When a token deletion is observed, any corresponding reference from the service account is also removed by the token controller.

If the token was deleted immediately after being created (as is done in the "ensure single token" e2e test), AND the controller's cached copy of the service account was stale (it didn't see the service account as having a reference to the token), the reference removal was being short-circuited incorrectly.

That leads to a service account with a stale reference, as is seen in the e2e failures:

```
Feb 25 08:47:08.019: INFO: default service account still has the deleted secret reference
```
