### PR TITLE
Revert "Move scalability suite to a separate project"

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-e2e.yaml
@@ -122,13 +122,14 @@
             description: 'Run the performance/scalability tests on GCE. A larger cluster is used.'
             timeout: 120
             job-env: |
+                # XXX Not a unique project
                 export E2E_NAME="e2e-scalability"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Performance\] \
                                          --gather-resource-usage=true \
                                          --gather-metrics-at-teardown=true \
                                          --gather-logs-sizes=true \
                                          --output-print-type=json"
-                export PROJECT="google.com:k8s-jenkins-scalability"
+                export PROJECT="kubernetes-jenkins"
                 export FAIL_ON_GCP_RESOURCE_LEAK="false"
                 # Override GCE defaults.
                 export MASTER_SIZE="n1-standard-4"
@@ -137,6 +138,8 @@
                 export NUM_NODES="100"
                 # Reduce logs verbosity
                 export TEST_CLUSTER_LOG_LEVEL="--v=2"
+                # TODO: Remove when we figure out the reason for occasional failures #19048
+                export KUBELET_TEST_LOG_LEVEL="--v=4"
                 # Increase resync period to simulate production
                 export TEST_CLUSTER_RESYNC_PERIOD="--min-resync-period=12h"
                 # Increase delete collection parallelism


### PR DESCRIPTION
Reverts kubernetes/kubernetes#21749

This broke scalability suite.
