### PR TITLE
Enable parallel namespace deletion in kubemarks and enormous cluster

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-e2e.yaml
@@ -509,6 +509,8 @@
         export TEST_CLUSTER_LOG_LEVEL="--v=1"
         # Increase resync period to simulate production
         export TEST_CLUSTER_RESYNC_PERIOD="--min-resync-period=12h"
+        # Increase delete collection parallelism
+        export TEST_CLUSTER_DELETE_COLLECTION_WORKERS="--delete-collection-workers=16"
     jobs:
         - 'kubernetes-e2e-{suffix}'
 

--- a/test/kubemark/start-kubemark-master.sh
+++ b/test/kubemark/start-kubemark-master.sh
@@ -50,7 +50,8 @@ kubernetes/server/bin/kube-apiserver \
 	--client-ca-file=/srv/kubernetes/ca.crt \
 	--token-auth-file=/srv/kubernetes/known_tokens.csv \
 	--secure-port=443 \
-	--basic-auth-file=/srv/kubernetes/basic_auth.csv &> /var/log/kube-apiserver.log &
+	--basic-auth-file=/srv/kubernetes/basic_auth.csv \
+	--delete-collection-workers=16 &> /var/log/kube-apiserver.log &
 
 # kube-contoller-manager now needs running kube-api server to actually start
 until [ "$(curl 127.0.0.1:8080/healthz 2> /dev/null)" == "ok" ]; do


### PR DESCRIPTION
This should speed-up namespace deletion by ~10x (which would be tens of minutes in 1000-node clusters).
