### PR TITLE
hyperkube: kubectl: don't shift os.Args

### DIFF
--- a/cmd/hyperkube/kubectl.go
+++ b/cmd/hyperkube/kubectl.go
@@ -28,7 +28,6 @@ func NewKubectlServer() *Server {
 		SimpleUsage: "Kubernetes command line client",
 		Long:        "Kubernetes command line client",
 		Run: func(s *Server, args []string) error {
-			os.Args = os.Args[1:]
 			if err := app.Run(); err != nil {
 				os.Exit(1)
 			}


### PR DESCRIPTION
When kubectl is hardlink/symlink to hyperkube,
shifting os.Args causes kubectl to loose first argument.
When running 'kubectl get node' the command is actually transformed
into 'kubectl node' which is invalid.
In a case of empty 'kubectl' command, kubectl fails with
panic as it is trying to access empty array.
