### PR TITLE
Incorrect type passed into quota reflector for secrets

### DIFF
--- a/pkg/controller/resourcequota/replenishment_controller.go
+++ b/pkg/controller/resourcequota/replenishment_controller.go
@@ -181,7 +181,7 @@ func (r *replenishmentControllerFactory) NewController(options *ReplenishmentCon
 					return r.kubeClient.Core().Secrets(api.NamespaceAll).Watch(options)
 				},
 			},
-			&api.PersistentVolumeClaim{},
+			&api.Secret{},
 			options.ResyncPeriod(),
 			framework.ResourceEventHandlerFuncs{
 				DeleteFunc: ObjectReplenishmentDeleteFunc(options),


### PR DESCRIPTION
Possibly related to: 
https://github.com/kubernetes/kubernetes/issues/22199

While investigating source of recent flakes, it was observed that quota was passing the wrong type into a reflector.  This could have resulted in unnecessary logging activity for each secret change.

/cc @liggitt @saad-ali 
