### PR TITLE
deployment e2e flake: Fix updatePodWithRetries to get and then immediately try update

### DIFF
--- a/pkg/client/restclient/request.go
+++ b/pkg/client/restclient/request.go
@@ -624,7 +624,7 @@ func (r *Request) tryThrottle() {
 		r.throttle.Accept()
 	}
 	if latency := time.Since(now); latency > longThrottleLatency {
-		glog.Warningf("Throttling request took %v, request: %s", latency, r.URL().String())
+		glog.Warningf("Throttling request took %v, request: %s:%s", latency, r.verb, r.URL().String())
 	}
 }
 


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/21753

Updating updatePodWithRetries to fetch the latest pod first and then try update immediately.
Before this change, we were fetching the pod first, then waiting for poll interval and then trying the update, which has a higher likelihood of failing due to conflict.

cc @janetkuo @bgrant0607 
