### PR TITLE
fix setting node roles error in deployment on ubuntu

### DIFF
--- a/cluster/ubuntu/config-default.sh
+++ b/cluster/ubuntu/config-default.sh
@@ -21,7 +21,7 @@
 export nodes=${nodes:-"vcap@10.10.103.250 vcap@10.10.103.162 vcap@10.10.103.223"}
 
 # Define all your nodes role: a(master) or i(minion) or ai(both master and minion), must be the order same 
-role=${role:-"ai i i"}
+role=${roles:-"ai i i"}
 # If it practically impossible to set an array as an environment variable
 # from a script, so assume variable is a string then convert it to an array
 export roles=($role)


### PR DESCRIPTION
Configurations in config-default.sh should take default values if they
are set outside of the script. `roles` option is an exception. This
patch fix it to maintain consistency behavior with other options.

Steps to reproduce:

```
root@rgw1:~/kubernetes/cluster#export nodes="root@172.31.0.19 root@172.31.0.17 root@172.31.0.16 root@172.31.0.18"
root@rgw1:~/kubernetes/cluster#export roles="a i i i"
root@rgw1:~/kubernetes/cluster#export NUM_MINIONS=${NUM_MINIONS:-4}
root@rgw1:~/kubernetes/cluster# KUBERNETES_PROVIDER=ubuntu ./kube-up.sh
    ... Starting cluster using provider: ubuntu
    ... calling verify-prereqs
    Identity added: /root/.ssh/id_rsa (/root/.ssh/id_rsa)
    ... calling kube-up
    ./../cluster/../cluster/ubuntu/util.sh: line 48: roles[${ii}]: unbound variable

```
