### PR TITLE
add proxy settings for kube up with vagrant as provider

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -108,6 +108,16 @@ $vm_master_mem = (ENV['KUBERNETES_MASTER_MEMORY'] || ENV['KUBERNETES_MEMORY'] ||
 $vm_node_mem = (ENV['KUBERNETES_NODE_MEMORY'] || ENV['KUBERNETES_MEMORY'] || 1024).to_i
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  if Vagrant.has_plugin?("vagrant-proxyconf")
+    $http_proxy = ENV['KUBERNETES_HTTP_PROXY'] || ""
+    $https_proxy = ENV['KUBERNETES_HTTPS_PROXY'] || ""
+    $no_proxy = ENV['KUBERNETES_NO_PROXY'] || "127.0.0.1"
+    config.proxy.http     = $http_proxy
+    config.proxy.https    = $https_proxy
+    config.proxy.no_proxy = $no_proxy
+  end
+
   def setvmboxandurl(config, provider)
     if ENV['KUBERNETES_BOX_NAME'] then
       config.vm.box = ENV['KUBERNETES_BOX_NAME']

--- a/build/README.md
+++ b/build/README.md
@@ -76,15 +76,16 @@ When building final release tars, they are first staged into `_output/release-st
 If you are behind a proxy, you need to export proxy settings for kubernetes build, the following environment variables should be defined.
 
 ```
-export KUBE_BUILD_HTTP_PROXY=http://username:password@proxyaddr:proxyport
-export KUBE_BUILD_HTTPS_PROXY=http://username:password@proxyaddr:proxyport
+export KUBERNETES_HTTP_PROXY=http://username:password@proxyaddr:proxyport
+export KUBERNETES_HTTPS_PROXY=https://username:password@proxyaddr:proxyport
 ```
 
 Optionally, you can specify addresses of no proxy for kubernetes build, for example
 
 ```
-export KUBE_BUILD_NO_PROXY=127.0.0.1
+export KUBERNETES_NO_PROXY=127.0.0.1
 ```
+
 If you are using sudo to make kubernetes build for example make quick-release, you need run `sudo -E make quick-release` to pass the environment variables.
 
 ## TODOs

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -15,10 +15,6 @@
 # This file creates a standard build environment for building Kubernetes
 FROM gcr.io/google_containers/kube-cross:KUBE_BUILD_IMAGE_CROSS_TAG
 
-ENV http_proxy=KUBE_BUILD_HTTP_PROXY \
-  https_proxy=KUBE_BUILD_HTTPS_PROXY \
-  no_proxy=KUBE_BUILD_NO_PROXY
-
 # Mark this as a kube-build container
 RUN touch /kube-build-image
 

--- a/build/common.sh
+++ b/build/common.sh
@@ -193,9 +193,9 @@ function kube::build::prepare_docker_machine() {
   docker-machine inspect "${DOCKER_MACHINE_NAME}" >/dev/null || {
     kube::log::status "Creating a machine to build Kubernetes"
     docker-machine create --driver "${DOCKER_MACHINE_DRIVER}" \
-      --engine-env HTTP_PROXY="${KUBE_BUILD_HTTP_PROXY:-}" \
-      --engine-env HTTPS_PROXY="${KUBE_BUILD_HTTPS_PROXY:-}" \
-      --engine-env NO_PROXY="${KUBE_BUILD_NO_PROXY:-127.0.0.1}" \
+      --engine-env HTTP_PROXY="${KUBERNETES_HTTP_PROXY:-}" \
+      --engine-env HTTPS_PROXY="${KUBERNETES_HTTPS_PROXY:-}" \
+      --engine-env NO_PROXY="${KUBERNETES_NO_PROXY:-127.0.0.1}" \
       "${DOCKER_MACHINE_NAME}" > /dev/null || {
       kube::log::error "Something went wrong creating a machine."
       kube::log::error "Try the following: "
@@ -242,14 +242,11 @@ function kube::build::is_osx() {
 
 function kube::build::update_dockerfile() {
   if kube::build::is_osx; then
-    sed_opts=("-i ''")
+    sed_opts=(-i '')
   else
     sed_opts=(-i)
   fi
-  sed ${sed_opts[@]} "s/KUBE_BUILD_IMAGE_CROSS_TAG/${KUBE_BUILD_IMAGE_CROSS_TAG}/" "${LOCAL_OUTPUT_BUILD_CONTEXT}/Dockerfile"
-  sed ${sed_opts[@]} "s#KUBE_BUILD_HTTP_PROXY#${KUBE_BUILD_HTTP_PROXY:-\"\"}#" "${LOCAL_OUTPUT_BUILD_CONTEXT}/Dockerfile"
-  sed ${sed_opts[@]} "s#KUBE_BUILD_HTTPS_PROXY#${KUBE_BUILD_HTTPS_PROXY:-\"\"}#" "${LOCAL_OUTPUT_BUILD_CONTEXT}/Dockerfile"
-  sed ${sed_opts[@]} "s#KUBE_BUILD_NO_PROXY#${KUBE_BUILD_NO_PROXY:-127.0.0.1}#" "${LOCAL_OUTPUT_BUILD_CONTEXT}/Dockerfile"
+  sed "${sed_opts[@]}" "s/KUBE_BUILD_IMAGE_CROSS_TAG/${KUBE_BUILD_IMAGE_CROSS_TAG}/" "${LOCAL_OUTPUT_BUILD_CONTEXT}/Dockerfile"
 }
 
 function kube::build::ensure_docker_in_path() {

--- a/docs/getting-started-guides/vagrant.md
+++ b/docs/getting-started-guides/vagrant.md
@@ -412,6 +412,24 @@ export KUBERNETES_MASTER_MEMORY=1536
 export KUBERNETES_NODE_MEMORY=2048
 ```
 
+#### I want to set proxy settings for my Kubernetes cluster boot strapping!
+
+If you are behind a proxy, you need to install vagrant proxy plugin and set the proxy settings by 
+
+```sh
+vagrant plugin install vagrant-proxyconf
+export KUBERNETES_HTTP_PROXY=http://username:password@proxyaddr:proxyport
+export KUBERNETES_HTTPS_PROXY=https://username:password@proxyaddr:proxyport
+```
+
+Optionally you can specify addresses to not proxy, for example
+
+```sh
+export KUBERNETES_NO_PROXY=127.0.0.1
+```
+
+If you are using sudo to make kubernetes build for example make quick-release, you need run `sudo -E make quick-release` to pass the environment variables.
+
 #### I ran vagrant suspend and nothing works!
 
 `vagrant suspend` seems to mess up the network.  This is not supported at this time.

--- a/pkg/credentialprovider/keyring_test.go
+++ b/pkg/credentialprovider/keyring_test.go
@@ -125,65 +125,77 @@ func TestDockerKeyringForGlob(t *testing.T) {
 		targetUrl string
 	}{
 		{
-			globUrl:   "hello.kubernetes.io",
+			globUrl:   "https://hello.kubernetes.io",
 			targetUrl: "hello.kubernetes.io",
 		},
 		{
-			globUrl:   "*.docker.io",
+			globUrl:   "https://*.docker.io",
 			targetUrl: "prefix.docker.io",
 		},
 		{
-			globUrl:   "prefix.*.io",
+			globUrl:   "https://prefix.*.io",
 			targetUrl: "prefix.docker.io",
 		},
 		{
-			globUrl:   "prefix.docker.*",
+			globUrl:   "https://prefix.docker.*",
 			targetUrl: "prefix.docker.io",
 		},
 		{
-			globUrl:   "*.docker.io/path",
+			globUrl:   "https://*.docker.io/path",
 			targetUrl: "prefix.docker.io/path",
 		},
 		{
-			globUrl:   "prefix.*.io/path",
+			globUrl:   "https://prefix.*.io/path",
 			targetUrl: "prefix.docker.io/path/subpath",
 		},
 		{
-			globUrl:   "prefix.docker.*/path",
+			globUrl:   "https://prefix.docker.*/path",
 			targetUrl: "prefix.docker.io/path",
 		},
 		{
-			globUrl:   "*.docker.io:8888",
+			globUrl:   "https://*.docker.io:8888",
 			targetUrl: "prefix.docker.io:8888",
 		},
 		{
-			globUrl:   "prefix.*.io:8888",
+			globUrl:   "https://prefix.*.io:8888",
 			targetUrl: "prefix.docker.io:8888",
 		},
 		{
-			globUrl:   "prefix.docker.*:8888",
+			globUrl:   "https://prefix.docker.*:8888",
 			targetUrl: "prefix.docker.io:8888",
 		},
 		{
-			globUrl:   "*.docker.io/path:1111",
+			globUrl:   "https://*.docker.io/path:1111",
 			targetUrl: "prefix.docker.io/path:1111",
 		},
 		{
-			globUrl:   "prefix.*.io/path:1111",
-			targetUrl: "prefix.docker.io/path/subpath:1111",
+			globUrl:   "https://*.docker.io/v1/",
+			targetUrl: "prefix.docker.io/path:1111",
 		},
 		{
-			globUrl:   "prefix.docker.*/path:1111",
+			globUrl:   "https://*.docker.io/v2/",
 			targetUrl: "prefix.docker.io/path:1111",
+		},
+		{
+			globUrl:   "https://prefix.docker.*/path:1111",
+			targetUrl: "prefix.docker.io/path:1111",
+		},
+		{
+			globUrl:   "prefix.docker.io:1111",
+			targetUrl: "prefix.docker.io:1111/path",
+		},
+		{
+			globUrl:   "*.docker.io:1111",
+			targetUrl: "prefix.docker.io:1111/path",
 		},
 	}
-	for _, test := range tests {
+	for i, test := range tests {
 		email := "foo@bar.baz"
 		username := "foo"
 		password := "bar"
 		auth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
 		sampleDockerConfig := fmt.Sprintf(`{
-   "https://%s": {
+   "%s": {
      "email": %q,
      "auth": %q
    }
@@ -198,8 +210,8 @@ func TestDockerKeyringForGlob(t *testing.T) {
 
 		creds, ok := keyring.Lookup(test.targetUrl + "/foo/bar")
 		if !ok {
-			t.Errorf("Didn't find expected URL: %s", test.targetUrl)
-			return
+			t.Errorf("%d: Didn't find expected URL: %s", i, test.targetUrl)
+			continue
 		}
 		val := creds[0]
 
@@ -221,19 +233,27 @@ func TestKeyringMiss(t *testing.T) {
 		lookupUrl string
 	}{
 		{
-			globUrl:   "hello.kubernetes.io",
+			globUrl:   "https://hello.kubernetes.io",
 			lookupUrl: "world.mesos.org/foo/bar",
 		},
 		{
-			globUrl:   "*.docker.com",
+			globUrl:   "https://*.docker.com",
 			lookupUrl: "prefix.docker.io",
+		},
+		{
+			globUrl:   "https://suffix.*.io",
+			lookupUrl: "prefix.docker.io",
+		},
+		{
+			globUrl:   "https://prefix.docker.c*",
+			lookupUrl: "prefix.docker.io",
+		},
+		{
+			globUrl:   "https://prefix.*.io/path:1111",
+			lookupUrl: "prefix.docker.io/path/subpath:1111",
 		},
 		{
 			globUrl:   "suffix.*.io",
-			lookupUrl: "prefix.docker.io",
-		},
-		{
-			globUrl:   "prefix.docker.c*",
 			lookupUrl: "prefix.docker.io",
 		},
 	}
@@ -243,7 +263,7 @@ func TestKeyringMiss(t *testing.T) {
 		password := "bar"
 		auth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
 		sampleDockerConfig := fmt.Sprintf(`{
-   "https://%s": {
+   "%s": {
      "email": %q,
      "auth": %q
    }
@@ -265,7 +285,7 @@ func TestKeyringMiss(t *testing.T) {
 }
 
 func TestKeyringMissWithDockerHubCredentials(t *testing.T) {
-	url := defaultRegistryHost
+	url := defaultRegistryKey
 	email := "foo@bar.baz"
 	username := "foo"
 	password := "bar"
@@ -291,7 +311,7 @@ func TestKeyringMissWithDockerHubCredentials(t *testing.T) {
 }
 
 func TestKeyringHitWithUnqualifiedDockerHub(t *testing.T) {
-	url := defaultRegistryHost
+	url := defaultRegistryKey
 	email := "foo@bar.baz"
 	username := "foo"
 	password := "bar"
@@ -332,7 +352,7 @@ func TestKeyringHitWithUnqualifiedDockerHub(t *testing.T) {
 }
 
 func TestKeyringHitWithUnqualifiedLibraryDockerHub(t *testing.T) {
-	url := defaultRegistryHost
+	url := defaultRegistryKey
 	email := "foo@bar.baz"
 	username := "foo"
 	password := "bar"
@@ -373,7 +393,7 @@ func TestKeyringHitWithUnqualifiedLibraryDockerHub(t *testing.T) {
 }
 
 func TestKeyringHitWithQualifiedDockerHub(t *testing.T) {
-	url := defaultRegistryHost
+	url := defaultRegistryKey
 	email := "foo@bar.baz"
 	username := "foo"
 	password := "bar"

--- a/pkg/kubelet/dockertools/docker_test.go
+++ b/pkg/kubelet/dockertools/docker_test.go
@@ -354,7 +354,7 @@ func TestPullWithSecrets(t *testing.T) {
 			[]string{`ubuntu:latest using {"username":"passed-user","password":"passed-password","email":"passed-email"}`},
 		},
 	}
-	for _, test := range tests {
+	for i, test := range tests {
 		builtInKeyRing := &credentialprovider.BasicDockerKeyring{}
 		builtInKeyRing.Add(test.builtInDockerConfig)
 
@@ -367,17 +367,17 @@ func TestPullWithSecrets(t *testing.T) {
 
 		err := dp.Pull(test.imageName, test.passedSecrets)
 		if err != nil {
-			t.Errorf("unexpected non-nil err: %s", err)
+			t.Errorf("%s: unexpected non-nil err: %s", i, err)
 			continue
 		}
 
 		if e, a := 1, len(fakeClient.pulled); e != a {
-			t.Errorf("%s: expected 1 pulled image, got %d: %v", test.imageName, a, fakeClient.pulled)
+			t.Errorf("%s: expected 1 pulled image, got %d: %v", i, a, fakeClient.pulled)
 			continue
 		}
 
 		if e, a := test.expectedPulls, fakeClient.pulled; !reflect.DeepEqual(e, a) {
-			t.Errorf("%s: expected pull of %v, but got %v", test.imageName, e, a)
+			t.Errorf("%s: expected pull of %v, but got %v", i, e, a)
 		}
 	}
 }


### PR DESCRIPTION
new changes for #21665 with squash commit log and synced code.
The PR contains two changes:
1). enable proxy settings for kube-up.sh when KUBERNETES_PROVIDER=vagrant, also updates getings start docs
This would require users to install vagrant proxy config plugin and export environment variables for proxy settings.

2). update proxy settings environment variables name for Kubernetes build to align with others with format e.g. KUBERNETES_HTTP_PROXY(originally was KUBE_BUILD_HTTP_PROXY). so that users only need to set the proxy for build and cluster up with same environment variables.
