### PR TITLE
kube-up for GCE chooses master size based on number of nodes

### DIFF
--- a/cluster/gce/config-common.sh
+++ b/cluster/gce/config-common.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Vars assumed:
+#   NUM_NODES
+function get-master-size {
+  local suggested_master_size=1
+  if [[ "${NUM_NODES}" -gt "5" ]]; then
+    suggested_master_size=2
+  fi
+  if [[ "${NUM_NODES}" -gt "10" ]]; then
+    suggested_master_size=4
+  fi
+  if [[ "${NUM_NODES}" -gt "100" ]]; then
+    suggested_master_size=8
+  fi
+  if [[ "${NUM_NODES}" -gt "250" ]]; then
+    suggested_master_size=16
+  fi
+  if [[ "${NUM_NODES}" -gt "500" ]]; then
+    suggested_master_size=32
+  fi
+  echo "${suggested_master_size}"
+}

--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -16,12 +16,15 @@
 
 # TODO(jbeda): Provide a way to override project
 # gcloud multiplexing for shared GCE/GKE tests.
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${KUBE_ROOT}/cluster/gce/config-common.sh"
+
 GCLOUD=gcloud
 ZONE=${KUBE_GCE_ZONE:-us-central1-b}
 RELEASE_REGION_FALLBACK=${RELEASE_REGION_FALLBACK:-false}
-MASTER_SIZE=${MASTER_SIZE:-n1-standard-2}
 NODE_SIZE=${NODE_SIZE:-n1-standard-2}
 NUM_NODES=${NUM_NODES:-3}
+MASTER_SIZE=${MASTER_SIZE:-n1-standard-$(get-master-size)}
 MASTER_DISK_TYPE=pd-ssd
 MASTER_DISK_SIZE=${MASTER_DISK_SIZE:-20GB}
 NODE_DISK_TYPE=${NODE_DISK_TYPE:-pd-standard}

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -16,12 +16,15 @@
 
 # TODO(jbeda): Provide a way to override project
 # gcloud multiplexing for shared GCE/GKE tests.
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${KUBE_ROOT}/cluster/gce/config-common.sh"
+
 GCLOUD=gcloud
 ZONE=${KUBE_GCE_ZONE:-us-central1-b}
 RELEASE_REGION_FALLBACK=${RELEASE_REGION_FALLBACK:-false}
-MASTER_SIZE=${MASTER_SIZE:-n1-standard-2}
 NODE_SIZE=${NODE_SIZE:-n1-standard-2}
 NUM_NODES=${NUM_NODES:-3}
+MASTER_SIZE=${MASTER_SIZE:-n1-standard-$(get-master-size)}
 MASTER_DISK_TYPE=pd-ssd
 MASTER_DISK_SIZE=${MASTER_DISK_SIZE:-20GB}
 NODE_DISK_TYPE=${NODE_DISK_TYPE:-pd-standard}


### PR DESCRIPTION
Fixes #22239

cc @alex-mohr @zmerlynn 
