### PR TITLE
Revert "switch heapster addon to summary metrics api"

### DIFF
--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -38,7 +38,7 @@ spec:
               memory: {{ heapster_memory }}
           command:
             - /heapster
-            - --source=kubernetes.summary_api:''
+            - --source=kubernetes:''
             - --sink=influxdb:http://monitoring-influxdb:8086
             - --metric_resolution=60s
         - image: gcr.io/google_containers/heapster:v0.20.0-alpha8


### PR DESCRIPTION
Reverts kubernetes/kubernetes#22101

It seems that summary API is not yet tested. We need to first test if it works and only then enable it by default in kubernetes. Details to be discussed offline with @timstclair .
