### PR TITLE
Wait for namespace deletion in SchedulerPredicates

### DIFF
--- a/test/e2e/scheduler_predicates.go
+++ b/test/e2e/scheduler_predicates.go
@@ -157,6 +157,9 @@ var _ = Describe("SchedulerPredicates [Serial]", func() {
 		ns = framework.Namespace.Name
 		nodeList = ListSchedulableNodesOrDie(c)
 
+		err := checkTestingNSDeletedExcept(c, ns)
+		expectNoError(err)
+
 		// Every test case in this suite assumes that cluster add-on pods stay stable and
 		// cannot be run in parallel with any other test that touches Nodes or Pods.
 		// It is so because we need to have precise control on what's running in the cluster.


### PR DESCRIPTION
Ref. #22189

This test is not run in per-PR test, so there's no point in blocking it on it. Moreover this test is often failing, so even if it'd break something we won't be in any worse position.
