### PR TITLE
Allow additional daemonset conditions

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -290,7 +290,7 @@ func StartControllers(s *options.CMServer, kubeClient *client.Client, kubeconfig
 
 		if containsResource(resources, "daemonsets") {
 			glog.Infof("Starting daemon set controller")
-			go daemon.NewDaemonSetsController(clientset.NewForConfigOrDie(restclient.AddUserAgent(kubeconfig, "daemon-set-controller")), ResyncPeriod(s)).
+			go daemon.NewDaemonSetsController(clientset.NewForConfigOrDie(restclient.AddUserAgent(kubeconfig, "daemon-set-controller")), ResyncPeriod(s), nil).
 				Run(s.ConcurrentDaemonSetSyncs, wait.NeverStop)
 		}
 

--- a/contrib/mesos/pkg/controllermanager/controllermanager.go
+++ b/contrib/mesos/pkg/controllermanager/controllermanager.go
@@ -238,7 +238,7 @@ func (s *CMServer) Run(_ []string) error {
 
 		if containsResource(resources, "daemonsets") {
 			glog.Infof("Starting daemon set controller")
-			go daemon.NewDaemonSetsController(clientset.NewForConfigOrDie(restclient.AddUserAgent(kubeconfig, "daemon-set-controller")), s.resyncPeriod).
+			go daemon.NewDaemonSetsController(clientset.NewForConfigOrDie(restclient.AddUserAgent(kubeconfig, "daemon-set-controller")), s.resyncPeriod, nil).
 				Run(s.ConcurrentDaemonSetSyncs, wait.NeverStop)
 		}
 


### PR DESCRIPTION
In systems with additional constraints on pod creation, it is helpful to be able to inform the DaemonSet controller of those restrictions to avoid it attempting to create pods that will be rejected.

In OpenShift, we have a namespace-level restriction on what nodeSelectors are allowed on a pod, enforced at admission time. This PR would allow the daemonset controller to include that information in its decision to run on a given node or not.
