### PR TITLE
Fix a breakage of kube-proxy in Trusty

### DIFF
--- a/cluster/gce/trusty/node.yaml
+++ b/cluster/gce/trusty/node.yaml
@@ -223,6 +223,7 @@ script
 	sed -i -e "s/{{pillar\['kube_docker_registry'\]}}/${kube_docker_registry}/g" ${tmp_file}
 	sed -i -e "s/{{pillar\['kube-proxy_docker_tag'\]}}/${kube_proxy_docker_tag}/g" ${tmp_file}
 	sed -i -e "s/{{test_args}}/${test_args}/g" ${tmp_file}
+	sed -i -e "s/{{ cpurequest }}/200m/g" ${tmp_file}
 	sed -i -e "s/{{log_level}}/${log_level}/g" ${tmp_file}
 	sed -i -e "s/{{api_servers_with_port}}/${api_servers}/g" ${tmp_file}
 


### PR DESCRIPTION
PR #22022 added a new variable "cpurequest" in kube-proxy.manifest. This makes kubelet in Trusty fail to start the kube-proxy pod as the variable value is not set in nodes on Trusty.
