### PR TITLE
Remove unused import package from pkg/client/unversioned/daemon_sets_…

### DIFF
--- a/pkg/client/unversioned/daemon_sets_test.go
+++ b/pkg/client/unversioned/daemon_sets_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package unversioned_test
 
 import (
-	. "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient/simple"
 )
 


### PR DESCRIPTION
…test.go

To make it pass the unit test, following is previous failing log for unit test

_output/dockerized/go/src/k8s.io/kubernetes/pkg/client/unversioned/daemon_sets_test.go:20: imported and not used: "k8s.io/kubernetes/pkg/client/unversioned"
ok      k8s.io/kubernetes/pkg/client/restclient 0.056s
ok      k8s.io/kubernetes/pkg/client/transport  0.368s
ok      k8s.io/kubernetes/pkg/client/typed/dynamic  0.039s
FAIL    k8s.io/kubernetes/pkg/client/unversioned [build failed]
