### PR TITLE
Resetting maxUnavailable for kubectl rolling update to 0

### DIFF
--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -332,7 +332,7 @@ func RunRollingUpdate(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, arg
 		Interval:       interval,
 		Timeout:        timeout,
 		CleanupPolicy:  updateCleanupPolicy,
-		MaxUnavailable: intstr.FromInt(1),
+		MaxUnavailable: intstr.FromInt(0),
 		MaxSurge:       intstr.FromInt(1),
 	}
 	if rollback {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/18463

Reverts https://github.com/kubernetes/kubernetes/pull/18616
