### PR TITLE
Move gke ingress tests into a different project.

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-e2e.yaml
@@ -358,13 +358,8 @@
             test-owner: 'beeps'
             provider-env: '{gke-provider-env}'
             job-env: |
-                # XXX Not a unique project
-                export E2E_NAME="e2e-gke-ingress"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
-                # TODO: Move this into a different project. Currently, since this test
-                # shares resources with various other networking tests, it's easier to
-                # zero in on the source of a leak if it's run in isolation.
-                export PROJECT="kubernetes-ingress"
+                export PROJECT="kubernetes-gke-ingress"
         - 'gce-ingress':
             description: 'Run [Feature:Ingress] tests on GCE.'
             timeout: 90
@@ -372,12 +367,7 @@
             test-owner: 'beeps'
             provider-env: '{gce-provider-env}'
             job-env: |
-                # XXX Not a unique project
-                export E2E_NAME="e2e-ingress"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
-                # TODO: Move this into a different project. Currently, since this test
-                # shares resources with various other networking tests, so it's easier
-                # to zero in on the source of a leak if it's run in isolation.
                 export PROJECT="kubernetes-ingress"
         - 'gce-flannel':
             description: 'Run E2E tests on GCE using Flannel and the latest successful build. This suite is quarantined in a dedicated project because Flannel integration is experimental.'


### PR DESCRIPTION
Finally separating out these 2 to avail FAIL_ON_GCP_RESOURCE_LEAK, and remove 4 TODOS.
