### PR TITLE
AWS: Add sha to download-or-bust

### DIFF
--- a/cluster/aws/templates/configure-vm-aws.sh
+++ b/cluster/aws/templates/configure-vm-aws.sh
@@ -29,7 +29,7 @@ ensure-packages() {
   # TODO: Where to get safe_format_and_mount?
   mkdir -p /usr/share/google
   cd /usr/share/google
-  download-or-bust https://raw.githubusercontent.com/GoogleCloudPlatform/compute-image-packages/82b75f314528b90485d5239ab5d5495cc22d775f/google-startup-scripts/usr/share/google/safe_format_and_mount
+  download-or-bust "dc96f40fdc9a0815f099a51738587ef5a976f1da" https://raw.githubusercontent.com/GoogleCloudPlatform/compute-image-packages/82b75f314528b90485d5239ab5d5495cc22d775f/google-startup-scripts/usr/share/google/safe_format_and_mount
   chmod +x safe_format_and_mount
 }
 

--- a/cluster/gce/configure-vm.sh
+++ b/cluster/gce/configure-vm.sh
@@ -240,7 +240,7 @@ install-salt() {
 
   for deb in "${DEBS[@]}"; do
     if [ ! -e "${deb}" ]; then
-      download-or-bust "${URL_BASE}/${deb}"
+      download-or-bust "" "${URL_BASE}/${deb}"
     fi
   done
 


### PR DESCRIPTION
download-or-bust was changed on the GCE side to verify a hash if passed,
so we need to pass a hash in the AWS scripts that reuse this function.
