### PR TITLE
log the succussful forceful deletion

### DIFF
--- a/pkg/controller/node/nodecontroller.go
+++ b/pkg/controller/node/nodecontroller.go
@@ -368,7 +368,11 @@ func (nc *NodeController) maybeDeleteTerminatingPod(obj interface{}) {
 
 func forcefullyDeletePod(c clientset.Interface, pod *api.Pod) error {
 	var zero int64
-	return c.Core().Pods(pod.Namespace).Delete(pod.Name, &api.DeleteOptions{GracePeriodSeconds: &zero})
+	err := c.Core().Pods(pod.Namespace).Delete(pod.Name, &api.DeleteOptions{GracePeriodSeconds: &zero})
+	if err == nil {
+		glog.V(2).Infof("forceful deletion of %s succeeded", pod.Name)
+	}
+	return err
 }
 
 // monitorNodeStatus verifies node status are constantly updated by kubelet, and if not,


### PR DESCRIPTION
When debugging a flake (https://github.com/kubernetes/kubernetes/issues/19403#issuecomment-191355299) in test-cmd.sh, we'd like to see which pod is deleted by nodecontroller.
