### PR TITLE
kubelet: ensure that container runtime health check runs reliabily

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2653,7 +2653,9 @@ func (kl *Kubelet) updateRuntimeUp() {
 		glog.Errorf("Container runtime sanity check failed: %v", err)
 		return
 	}
-	kl.oneTimeInitializer.Do(kl.initializeRuntimeDependentModules)
+	// Spawn a separate goroutine to initialize the modules, so that it
+	// doesn't block/interfere the periodic runtime health check.
+	kl.oneTimeInitializer.Do(func() { go kl.initializeRuntimeDependentModules() })
 	kl.runtimeState.setRuntimeSync(kl.clock.Now())
 }
 


### PR DESCRIPTION
The runtime health check can be blocked on initialization of other modules.
This PR creates a new goroutine to run initialization, independent of the health check routine.
ref: https://github.com/kubernetes/kubernetes/issues/22259#issuecomment-191454263
