### PR TITLE
Show LICENSES in /etc/motd

### DIFF
--- a/cluster/gce/configure-vm.sh
+++ b/cluster/gce/configure-vm.sh
@@ -104,6 +104,8 @@ You can download the build image for this release at:
 It is based on the Kubernetes source at:
   https://github.com/kubernetes/kubernetes/tree/${gitref}
 ${devel}
+For Kubernetes copyright and licensing information, see:
+  /usr/local/share/doc/kubernetes/LICENSES
 EOF
 }
 

--- a/cluster/saltbase/install.sh
+++ b/cluster/saltbase/install.sh
@@ -66,8 +66,10 @@ echo "+++ Install binaries from tar: $1"
 tar -xz -C "${KUBE_TEMP}" -f "$1"
 mkdir -p /srv/salt-new/salt/kube-bins
 mkdir -p /srv/salt-new/salt/kube-addons-images
+mkdir -p /srv/salt-new/salt/kube-docs
 cp -v "${KUBE_TEMP}/kubernetes/server/bin/"* /srv/salt-new/salt/kube-bins/
 cp -v "${KUBE_TEMP}/kubernetes/addons/"* /srv/salt-new/salt/kube-addons-images/
+cp -v "${KUBE_TEMP}/kubernetes/LICENSES" /srv/salt-new/salt/kube-docs/
 
 kube_bin_dir="/srv/salt-new/salt/kube-bins";
 docker_images_sls_file="/srv/salt-new/pillar/docker-images.sls";

--- a/cluster/saltbase/salt/base.sls
+++ b/cluster/saltbase/salt/base.sls
@@ -21,3 +21,17 @@ pkg-core:
 {% if grains['os'] == 'Ubuntu' %}
       - git
 {% endif %}
+
+/usr/local/share/doc/kubernetes:
+  file.directory:
+    - user: root
+    - group: root
+    - mode: 755
+    - makedirs: True
+
+/usr/local/share/doc/kubernetes/LICENSES:
+  file.managed:
+    - source: salt://kube-docs/LICENSES
+    - user: root
+    - group: root
+    - mode: 644


### PR DESCRIPTION
Plumb through from the server tarball to
/usr/local/share/docs/kubernetes/LICENSES, then display in the motd.
