### PR TITLE
Add a simple clusterapi-tester, improve e2e logging.

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -187,6 +187,7 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 			dumpAllNamespaceInfo(c, api.NamespaceSystem)
 		}
 		logFailedContainers(api.NamespaceSystem)
+		runKubernetesServiceTestContainer(testContext.RepoRoot, api.NamespaceDefault)
 		Failf("Error waiting for all pods to be running and ready: %v", err)
 	}
 

--- a/test/images/clusterapi-tester/Dockerfile
+++ b/test/images/clusterapi-tester/Dockerfile
@@ -1,0 +1,18 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM busybox
+MAINTAINER Prashanth B <beeps@google.com>
+ADD main main
+ENTRYPOINT ["/main"]

--- a/test/images/clusterapi-tester/Makefile
+++ b/test/images/clusterapi-tester/Makefile
@@ -1,0 +1,31 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+all: push
+
+# 0.0 shouldn't clobber any released builds
+TAG = 1.0
+PREFIX = gcr.io/google_containers/clusterapi-tester
+
+main: main.go
+	CGO_ENABLED=0 GOOS=linux godep go build -a -installsuffix cgo -ldflags '-w' -o main ./main.go
+
+container: main
+	docker build -t $(PREFIX):$(TAG) .
+
+push: container
+	gcloud docker push $(PREFIX):$(TAG)
+
+clean:
+	rm -f main

--- a/test/images/clusterapi-tester/main.go
+++ b/test/images/clusterapi-tester/main.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// A simple pod that first lists all nodes/services through the Kubernetes
+// api, then serves a 200 on /healthz.
+package main
+
+import (
+	"log"
+
+	"fmt"
+	"k8s.io/kubernetes/pkg/api"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"net/http"
+)
+
+func main() {
+	kubeClient, err := client.NewInCluster()
+	if err != nil {
+		log.Fatalf("Failed to create client: %v", err)
+	}
+	listAll := api.ListOptions{LabelSelector: labels.Everything(), FieldSelector: fields.Everything()}
+	nodes, err := kubeClient.Nodes().List(listAll)
+	if err != nil {
+		log.Fatalf("Failed to list nodes: %v", err)
+	}
+	log.Printf("Nodes:")
+	for _, node := range nodes.Items {
+		log.Printf("\t%v", node.Name)
+	}
+	services, err := kubeClient.Services(api.NamespaceDefault).List(listAll)
+	if err != nil {
+		log.Fatalf("Failed to list services: %v", err)
+	}
+	log.Printf("Services:")
+	for _, svc := range services.Items {
+		log.Printf("\t%v", svc.Name)
+	}
+	log.Printf("Success")
+	http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Ok")
+	})
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/test/images/clusterapi-tester/pod.yaml
+++ b/test/images/clusterapi-tester/pod.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: clusterapi-tester
+spec:
+  containers:
+  - image: gcr.io/google_containers/clusterapi-tester:1.0
+    name: clusterapi-tester
+    readinessProbe:
+      httpGet:
+        path: /healthz
+        port: 8080
+        scheme: HTTP
+      initialDelaySeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
+      periodSeconds: 10
+      successThreshold: 1
+  restartPolicy: OnFailure


### PR DESCRIPTION
The first commit from https://github.com/kubernetes/kubernetes/pull/22253, so we can get the debug output ASAP without blocking on kubedns
