### PR TITLE
[idea] [e2e] Self-documenting/testable tags which can be called by individual e2es

### DIFF
--- a/docs/devel/e2e-tests.md
+++ b/docs/devel/e2e-tests.md
@@ -514,6 +514,16 @@ breaking changes, it does *not* block the merge-queue, and thus should run in
 some separate test suites owned by the feature owner(s)
 (see [Continuous Integration](#continuous-integration) below).
 
+### Programmatic labels for tests
+
+See [The kubernetes ginkgo tag declarations](https://github.com/test/e2e/tags.go) for the set of ginkgo labels which we apply to tests, which serve as targets for filters.  We are working on implementing clearer partitioning of our e2e tests to make running a known set of tests easier (#10548).
+
+If a test has no labels, it is expected to run fast (under five minutes), be able to be run in parallel, and be consistent.
+
+### A note on Feature test tags and CI
+
+If a feature is experimental or alpha and is not enabled by default due to being incomplete or potentially subject to breaking changes, it does *not* block the merge-queue, and thus should run in some separate test suites owned by the feature owner(s) (see #continuous_integration below).
+
 ### Conformance tests
 
 Finally, `[Conformance]` tests represent a subset of the e2e-tests we expect to

--- a/test/e2e/tags.go
+++ b/test/e2e/tags.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"strings"
+)
+
+// The use of ginkgo tags is encouraged for describing tests.
+// This file defines test tags and annotations.
+// Each annotation should have a corresponding description.
+// Tags can possibly have different metadata over time.
+type Tag struct {
+	Name string
+}
+
+// Conformance tests are tests we expect to pass on **any** Kubernetes cluster.
+// Does not supersede any other labels.
+// Test policies are a work-in-progress; see #18162.
+var TagConformanceTest = Tag{"[Conformance]"}
+
+// If a test takes more than five minutes to run (by itself or in parallel with many other tests), it is labeled `[Slow]`.
+// This partition allows us to run almost all of our tests quickly in parallel, without waiting for the stragglers to finish.
+var TagSlowTest = Tag{"[Slow]"}
+
+// If a test cannot be run in parallel with other tests (e.g. it takes too many resources or restarts nodes),
+// it is labeled `[Serial]`, and should be run in serial as part of a separate suite.
+var TagSerialTest = Tag{"[Serial]"}
+
+// If a test restarts components that might cause other tests to fail or break the cluster completely, it is labeled
+// `[Disruptive]`. Any `[Disruptive]` test is also assumed to qualify for the `[Serial]` label, but need not be labeled
+// as both.  These tests are not run against soak clusters to avoid restarting components.
+var TagDisruptive = Tag{"[Disruptive]"}
+
+// If a test is found to be flaky and we have decided that it's too hard to fix in the short term
+// (e.g. it's going to take a full engineer-week), it receives the [Flaky] label until it is fixed.
+// The [Flaky] label should be used very sparingly, and should be accompanied with a reference to the issue for
+// de-flaking the test, because while a test remains labeled since otherwise these aren't monitored closely in CI.
+// These are by default not run, unless a `focus` or `skip` argument is explicitly given.
+var TagFlakey = Tag{"[Flaky]"}
+
+// TagFeature is for things that can be turned on/off at deployment time (eg: Volumes, Ingress)
+func TagFeature(f string) string {
+	return "[Feature:" + f + "]"
+}
+
+// TagMeasurement is for things that measure things like performance, scale, etc.
+func TagMeasurement(f string) string {
+	return "[Measurement:" + f + "]"
+}
+
+// TagExperimental is for Catch-all for tests which are off the critical path, but not necessarily slow/flaky.
+func TagQuirk(f string) string {
+	return "[Quirk:" + f + "]"
+}
+
+// Function for detecting bad tags.  We can post-process Its with this, and report them.
+func getBadTags(description string) []string {
+	badTags := []string{}
+	validTags := []string{
+		"Feature",
+		"Measurement",
+		"Quirk",
+		TagConformanceTest.Name,
+		TagDisruptive.Name,
+		TagFlakey.Name,
+		TagSerialTest.Name,
+		TagSlowTest.Name,
+	}
+	for _, proposedTag := range splitBetweenChars(description, '[', ']') {
+		valid := false
+		for _, aValidTag := range validTags {
+			// If this tag has one of the validTokens, its ok.
+			if strings.Contains(proposedTag, aValidTag) {
+				valid = true
+			}
+		}
+		if !valid {
+			badTags = append(badTags, proposedTag)
+		}
+	}
+	return badTags
+}
+
+// splitBetweenChars used to split out tags i.e. "It [Feature:blah] [Flaky]"->string[]{"Feature:blah","Flaky"}
+func splitBetweenChars(s string, start byte, end byte) []string {
+	entries := []string{}
+
+	indices := func(tmpStr string, border byte) []int {
+		ints := []int{}
+		for index, i := range tmpStr {
+			if byte(i) == border {
+				ints = append(ints, index)
+			}
+		}
+		return ints
+	}
+
+	starts := indices(s, '[')
+	ends := indices(s, ']')
+
+	for i, startLoc := range starts {
+		tag := s[startLoc+1 : ends[i]]
+		entries = append(entries, tag)
+	}
+	return entries
+}


### PR DESCRIPTION
We would all benefit from less reliance on static strings that need to map to docs for defining E2Es, and it would make it easier to have lots of annotations for tests.  

Problem:

There are lots of minor issues that can be annoying w/ all the manual tags we use...
- _docs_ the docs have a need to describe the test annotations in the code, which leads to manual upkeep of the mapping of tags to their semantics.
- _indexing_ no clear namespaces for tags:  You have to grep the code to find all the tags. 
- _collisions_ other testing libraries may collide with the tag namespaces of kube.  - it would be nice if we could verify new tag or namespace collisions in downstream tests (one that comes to mind is `networking` vs `Networking`.
- _appending_ its clumsy to add tags to tests currently.  of course this increses with # of tags.
  Concretely, I Realized the need for this with
- the most useful tag of all, a `k8s.io` tag, would be super useful to add in a wrapper such as discussed in #22206, and didn't really have a good home, so i had to do it in a string constant in `framework`. And also
- with the #22380 PR, where I really couldn't think of a good tag name for SELinux.  If there was a constants impl, then the tag name could be evolved over time and maybe regression tested or tested as part of a build (i.e. once you consolidate the strings, enumerating them can allow you to make sure that every `--focus` `--skip` that is relied on actually matches at least one tag in the list of known tags.

So this is mostly an Idea, but I wanted to put it up for folks to help me flesh out.  I think it can be useful as is, but I think others may have feedback.

Either way: I think cleaner, more programmatic definition of tests and the testing namespaces is very valuable for downstream consumers, and also for upstream kube as well from a testing maint. perspective.  

... This is a step in that direction, which can be leveraged by wrappers or even tests that dont have wrappers.

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/22401)

<!-- Reviewable:end -->
