### PR TITLE
check for existing daemonset pod

### DIFF
--- a/pkg/controller/daemon/controller.go
+++ b/pkg/controller/daemon/controller.go
@@ -601,6 +601,9 @@ func (dsc *DaemonSetsController) nodeShouldRunDaemonPod(node *api.Node, ds *exte
 		if pod.Spec.NodeName != node.Name {
 			continue
 		}
+		if ds.Name == dsc.getPodDaemonSet(pod).Name {
+			continue
+		}
 		pods = append(pods, pod)
 	}
 	_, notFittingCPU, notFittingMemory := predicates.CheckPodsExceedingFreeResources(pods, node.Status.Allocatable)


### PR DESCRIPTION
This adds a check to make sure we aren't colliding with a pod of the same daemonset that is already deployed.

Fixes #22309 

Not sure if this is the best fix here, but it is _a_ fix.
