### PR TITLE
add proxy settings for vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -108,6 +108,14 @@ $vm_master_mem = (ENV['KUBERNETES_MASTER_MEMORY'] || ENV['KUBERNETES_MEMORY'] ||
 $vm_node_mem = (ENV['KUBERNETES_NODE_MEMORY'] || ENV['KUBERNETES_MEMORY'] || 1024).to_i
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  if Vagrant.has_plugin?("vagrant-proxyconf")
+    $http_proxy = ENV['KUBERNETES_HTTP_PROXY'] || ""
+    $https_proxy = ENV['KUBERNETES_HTTPS_PROXY'] || ""
+    $no_proxy = ENV['KUBERNETES_NO_PROXY'] || "127.0.0.1"
+    config.proxy.http     = $http_proxy
+    config.proxy.https    = $https_proxy
+    config.proxy.no_proxy = $no_proxy
+  end
   def setvmboxandurl(config, provider)
     if ENV['KUBERNETES_BOX_NAME'] then
       config.vm.box = ENV['KUBERNETES_BOX_NAME']

--- a/build/README.md
+++ b/build/README.md
@@ -76,15 +76,16 @@ When building final release tars, they are first staged into `_output/release-st
 If you are behind a proxy, you need to export proxy settings for kubernetes build, the following environment variables should be defined.
 
 ```
-export KUBE_BUILD_HTTP_PROXY=http://username:password@proxyaddr:proxyport
-export KUBE_BUILD_HTTPS_PROXY=http://username:password@proxyaddr:proxyport
+export KUBERNETES_HTTP_PROXY=http://username:password@proxyaddr:proxyport
+export KUBERNETES_HTTPS_PROXY=https://username:password@proxyaddr:proxyport
 ```
 
 Optionally, you can specify addresses of no proxy for kubernetes build, for example
 
 ```
-export KUBE_BUILD_NO_PROXY=127.0.0.1
+export KUBERNETES_NO_PROXY=127.0.0.1
 ```
+
 If you are using sudo to make kubernetes build for example make quick-release, you need run `sudo -E make quick-release` to pass the environment variables.
 
 ## TODOs

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -15,10 +15,6 @@
 # This file creates a standard build environment for building Kubernetes
 FROM gcr.io/google_containers/kube-cross:KUBE_BUILD_IMAGE_CROSS_TAG
 
-ENV http_proxy=KUBE_BUILD_HTTP_PROXY \
-  https_proxy=KUBE_BUILD_HTTPS_PROXY \
-  no_proxy=KUBE_BUILD_NO_PROXY
-
 # Mark this as a kube-build container
 RUN touch /kube-build-image
 

--- a/build/common.sh
+++ b/build/common.sh
@@ -193,9 +193,9 @@ function kube::build::prepare_docker_machine() {
   docker-machine inspect "${DOCKER_MACHINE_NAME}" >/dev/null || {
     kube::log::status "Creating a machine to build Kubernetes"
     docker-machine create --driver "${DOCKER_MACHINE_DRIVER}" \
-      --engine-env HTTP_PROXY="${KUBE_BUILD_HTTP_PROXY:-}" \
-      --engine-env HTTPS_PROXY="${KUBE_BUILD_HTTPS_PROXY:-}" \
-      --engine-env NO_PROXY="${KUBE_BUILD_NO_PROXY:-127.0.0.1}" \
+      --engine-env HTTP_PROXY="${KUBERNETES_HTTP_PROXY:-}" \
+      --engine-env HTTPS_PROXY="${KUBERNETES_HTTPS_PROXY:-}" \
+      --engine-env NO_PROXY="${KUBERNETES_NO_PROXY:-127.0.0.1}" \
       "${DOCKER_MACHINE_NAME}" > /dev/null || {
       kube::log::error "Something went wrong creating a machine."
       kube::log::error "Try the following: "
@@ -242,14 +242,11 @@ function kube::build::is_osx() {
 
 function kube::build::update_dockerfile() {
   if kube::build::is_osx; then
-    sed_opts=("-i ''")
+    sed_opts=(-i '')
   else
     sed_opts=(-i)
   fi
-  sed ${sed_opts[@]} "s/KUBE_BUILD_IMAGE_CROSS_TAG/${KUBE_BUILD_IMAGE_CROSS_TAG}/" "${LOCAL_OUTPUT_BUILD_CONTEXT}/Dockerfile"
-  sed ${sed_opts[@]} "s#KUBE_BUILD_HTTP_PROXY#${KUBE_BUILD_HTTP_PROXY:-\"\"}#" "${LOCAL_OUTPUT_BUILD_CONTEXT}/Dockerfile"
-  sed ${sed_opts[@]} "s#KUBE_BUILD_HTTPS_PROXY#${KUBE_BUILD_HTTPS_PROXY:-\"\"}#" "${LOCAL_OUTPUT_BUILD_CONTEXT}/Dockerfile"
-  sed ${sed_opts[@]} "s#KUBE_BUILD_NO_PROXY#${KUBE_BUILD_NO_PROXY:-127.0.0.1}#" "${LOCAL_OUTPUT_BUILD_CONTEXT}/Dockerfile"
+  sed "${sed_opts[@]}" "s/KUBE_BUILD_IMAGE_CROSS_TAG/${KUBE_BUILD_IMAGE_CROSS_TAG}/" "${LOCAL_OUTPUT_BUILD_CONTEXT}/Dockerfile"
 }
 
 function kube::build::ensure_docker_in_path() {


### PR DESCRIPTION
The PR contains two changes:
1). enable proxy settings for kube-up.sh when KUBERNETES_PROVIDER=vagrant, also updates getings start docs
This would require users to install vagrant proxy config plugin and export environment variables for proxy settings.

2). update proxy settings environment variables name for Kubernetes build to align with others with format e.g. KUBERNETES_HTTP_PROXY(originally was KUBE_BUILD_HTTP_PROXY). so that users only need to set the proxy for build and cluster up with same environment variables.
@ixdy could you please review this PR, thanks!
