### PR TITLE
AWS/Salt/Systemd support for Docker Babysitter

### DIFF
--- a/cluster/saltbase/salt/docker/docker-healthcheck
+++ b/cluster/saltbase/salt/docker/docker-healthcheck
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is intended to be run periodically, to check the health
+# of docker.  If it detects a failure, it will restart docker using systemctl.
+
+if timeout 10 docker version > /dev/null; then
+  exit 0
+fi
+
+echo "docker failed"
+echo "Giving docker 30 seconds grace before restarting"
+sleep 30
+
+if timeout 10 docker version > /dev/null; then
+  echo "docker recovered"
+  exit 0
+fi
+
+echo "docker still down; triggering docker restart"
+systemctl restart docker
+
+echo "Waiting 60 seconds to give docker time to start"
+sleep 60
+
+if timeout 10 docker version > /dev/null; then
+  echo "docker recovered"
+  exit 0
+fi
+
+echo "docker still failing"

--- a/cluster/saltbase/salt/docker/docker-healthcheck.service
+++ b/cluster/saltbase/salt/docker/docker-healthcheck.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run docker-healthcheck once
+
+[Service]
+Type=oneshot
+ExecStart=/opt/kubernetes/helpers/docker-healthcheck
+
+[Install]
+WantedBy=multi-user.target

--- a/cluster/saltbase/salt/docker/docker-healthcheck.timer
+++ b/cluster/saltbase/salt/docker/docker-healthcheck.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Trigger docker-healthcheck periodically
+
+[Timer]
+OnUnitInactiveSec=10s
+Unit=docker-healthcheck.service
+
+[Install]
+WantedBy=multi-user.target

--- a/cluster/saltbase/salt/docker/docker-prestart
+++ b/cluster/saltbase/salt/docker/docker-prestart
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is intended to be run before we start Docker.
+
+# cleanup docker network checkpoint to avoid running into known issue
+# of docker (https://github.com/docker/docker/issues/18283)
+rm -rf /var/lib/docker/network
+

--- a/cluster/saltbase/salt/docker/docker.service
+++ b/cluster/saltbase/salt/docker/docker.service
@@ -1,10 +1,11 @@
 [Unit]
 Description=Docker Application Container Engine
-Documentation=http://docs.docker.com
+Documentation=https://docs.docker.com
 After=network.target docker.socket
 Requires=docker.socket
 
 [Service]
+Type=notify
 EnvironmentFile={{ environment_file }}
 ExecStart=/usr/bin/docker daemon -H fd:// "$DOCKER_OPTS"
 MountFlags=slave
@@ -17,4 +18,3 @@ StartLimitInterval=0
 
 [Install]
 WantedBy=multi-user.target
-

--- a/cluster/saltbase/salt/docker/docker.service
+++ b/cluster/saltbase/salt/docker/docker.service
@@ -15,6 +15,7 @@ LimitCORE=infinity
 Restart=always
 RestartSec=2s
 StartLimitInterval=0
+ExecStartPre=/opt/kubernetes/helpers/docker-prestart
 
 [Install]
 WantedBy=multi-user.target

--- a/cluster/saltbase/salt/docker/init.sls
+++ b/cluster/saltbase/salt/docker/init.sls
@@ -51,6 +51,13 @@ docker:
 
 {% if pillar.get('is_systemd') %}
 
+/opt/kubernetes/helpers/docker-prestart:
+  file.managed:
+    - source: salt://docker/docker-prestart
+    - user: root
+    - group: root
+    - mode: 755
+
 {{ pillar.get('systemd_system_path') }}/docker.service:
   file.managed:
     - source: salt://docker/docker.service
@@ -60,6 +67,8 @@ docker:
     - mode: 644
     - defaults:
         environment_file: {{ environment_file }}
+    - require:
+      - file: /opt/kubernetes/helpers/docker-prestart
 
 # The docker service.running block below doesn't work reliably
 # Instead we run our script which e.g. does a systemd daemon-reload
@@ -292,9 +301,16 @@ docker-upgrade:
       - file: /var/cache/docker-install/{{ override_deb }}
 {% endif %} # end override_docker_ver != ''
 
-# Default docker systemd unit file doesn't use an EnvironmentFile; replace it with one that does.
 {% if pillar.get('is_systemd') %}
 
+/opt/kubernetes/helpers/docker-prestart:
+  file.managed:
+    - source: salt://docker/docker-prestart
+    - user: root
+    - group: root
+    - mode: 755
+
+# Default docker systemd unit file doesn't use an EnvironmentFile; replace it with one that does.
 {{ pillar.get('systemd_system_path') }}/docker.service:
   file.managed:
     - source: salt://docker/docker.service
@@ -304,6 +320,8 @@ docker-upgrade:
     - mode: 644
     - defaults:
         environment_file: {{ environment_file }}
+    - require:
+      - file: /opt/kubernetes/helpers/docker-prestart
 
 # The docker service.running block below doesn't work reliably
 # Instead we run our script which e.g. does a systemd daemon-reload

--- a/cluster/saltbase/salt/salt-helpers/services
+++ b/cluster/saltbase/salt/salt-helpers/services
@@ -63,6 +63,9 @@ elif [[ "${ACTION}" == "down" ]]; then
   reload_state
   disable_service
   stop_service
+elif [[ "${ACTION}" == "enable" ]]; then
+  reload_state
+  enable_service
 else
   echo "Unknown action: ${ACTION}"
   exit 1


### PR DESCRIPTION
This PR should be the equivalent of the GCE docker babysitter scripts, but for AWS/systemd.

Four commits, probably best described individually:
1. \- First we update the docker systemd manifest to be closer to the 1.9.1 version.  They've added Type=Notify and bought themselves an SSL certificate.
2. \- Next, we add a prestart file to the systemd manifest.  The prestart file is a script that runs before the service starts, and just does `rm -rf /var/lib/docker/network`
3. \- Then we add a healthcheck script.  I had to take some liberties here - it isn't an exact match for the semantics because we don't own the docker process.  It is run as a systemd cron job, 10 seconds in between runs, and checks for `docker version` timing out.  If it fails, it waits 30 seconds and gives it another chance.  If it is still failing, it restarts the docker service.  Then it waits, and tests the service again.  We want to wait to give docker time to restart, because 10 seconds after we exit we will be started again.
4. \- Finally, we add a fix that is not strictly related, but otherwise I just couldn't get this to work, so... We no longer use Salt to start Docker at all.  Docker will fail to start because of bridge problems.  If we let Salt try to start it, Salt will fail out all dependent tasks.  But we still need a node in the Salt DAG.  So we create a `service.enabled` node (not a `service.running` node).  Both are still named `service: docker` so the DAG continues to work.  We also have to remove the watcher block from service.enabled because otherwise Salt tries to start the service (another Salt bug).

cc @dchen1107 @bprashanth 

Fix #21731
