### PR TITLE
Kubelet: Add Status() in runtime interface and integrate it with kubelet runtime health check

### DIFF
--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -57,7 +57,10 @@ type Runtime interface {
 	Version() (Version, error)
 	// APIVersion returns the API version information of the container
 	// runtime. This may be different from the runtime engine's version.
+	// TODO(random-liu): We should fold this into Version()
 	APIVersion() (Version, error)
+	// Status returns error if the runtime is unhealthy; nil otherwise.
+	Status() error
 	// GetPods returns a list containers group by pods. The boolean parameter
 	// specifies whether the runtime returns all containers including those already
 	// exited and dead containers (used for garbage collection).

--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -48,6 +48,7 @@ type FakeRuntime struct {
 	RuntimeType       string
 	Err               error
 	InspectErr        error
+	StatusErr         error
 }
 
 // FakeRuntime should implement Runtime.
@@ -108,6 +109,7 @@ func (f *FakeRuntime) ClearCalls() {
 	f.RuntimeType = ""
 	f.Err = nil
 	f.InspectErr = nil
+	f.StatusErr = nil
 }
 
 func (f *FakeRuntime) assertList(expect []string, test []string) error {
@@ -166,6 +168,14 @@ func (f *FakeRuntime) APIVersion() (Version, error) {
 
 	f.CalledFunctions = append(f.CalledFunctions, "APIVersion")
 	return &FakeVersion{Version: f.APIVersionInfo}, f.Err
+}
+
+func (f *FakeRuntime) Status() error {
+	f.Lock()
+	defer f.Unlock()
+
+	f.CalledFunctions = append(f.CalledFunctions, "Status")
+	return f.StatusErr
 }
 
 func (f *FakeRuntime) GetPods(all bool) ([]*Pod, error) {

--- a/pkg/kubelet/container/testing/runtime_mock.go
+++ b/pkg/kubelet/container/testing/runtime_mock.go
@@ -53,6 +53,11 @@ func (r *Mock) APIVersion() (Version, error) {
 	return args.Get(0).(Version), args.Error(1)
 }
 
+func (r *Mock) Status() error {
+	args := r.Called()
+	return args.Error(0)
+}
+
 func (r *Mock) GetPods(all bool) ([]*Pod, error) {
 	args := r.Called(all)
 	return args.Get(0).([]*Pod), args.Error(1)

--- a/pkg/kubelet/dockertools/fake_docker_client.go
+++ b/pkg/kubelet/dockertools/fake_docker_client.go
@@ -68,6 +68,26 @@ func NewFakeDockerClientWithVersion(version, apiVersion string) *FakeDockerClien
 	}
 }
 
+func (f *FakeDockerClient) InjectError(fn string, err error) {
+	f.Lock()
+	defer f.Unlock()
+	f.Errors[fn] = err
+}
+
+func (f *FakeDockerClient) InjectErrors(errs map[string]error) {
+	f.Lock()
+	defer f.Unlock()
+	for fn, err := range errs {
+		f.Errors[fn] = err
+	}
+}
+
+func (f *FakeDockerClient) ClearErrors() {
+	f.Lock()
+	defer f.Unlock()
+	f.Errors = map[string]error{}
+}
+
 func (f *FakeDockerClient) ClearCalls() {
 	f.Lock()
 	defer f.Unlock()
@@ -382,7 +402,7 @@ func (f *FakeDockerClient) PullImage(opts docker.PullImageOptions, auth docker.A
 }
 
 func (f *FakeDockerClient) Version() (*docker.Env, error) {
-	return &f.VersionInfo, nil
+	return &f.VersionInfo, f.popError("version")
 }
 
 func (f *FakeDockerClient) Info() (*docker.Env, error) {

--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -60,7 +60,7 @@ import (
 const (
 	DockerType = "docker"
 
-	MinimumDockerAPIVersion = "1.18"
+	minimumDockerAPIVersion = "1.18"
 
 	// ndots specifies the minimum number of dots that a domain name must contain for the resolver to consider it as FQDN (fully-qualified)
 	// we want to able to consider SRV lookup names like _dns._udp.kube-dns.default.svc to be considered relative.
@@ -939,6 +939,30 @@ func (dm *DockerManager) APIVersion() (kubecontainer.Version, error) {
 		return nil, fmt.Errorf("docker: failed to parse docker api version %q: %v", apiVersion, err)
 	}
 	return dockerAPIVersion(version), nil
+}
+
+// Status returns error if docker daemon is unhealthy, nil otherwise.
+// Now we do this by checking whether:
+// 1) `docker version` works
+// 2) docker version is compatible with minimum requirement
+func (dm *DockerManager) Status() error {
+	return dm.checkVersionCompatibility()
+}
+
+func (dm *DockerManager) checkVersionCompatibility() error {
+	version, err := dm.APIVersion()
+	if err != nil {
+		return err
+	}
+	// Verify the docker version.
+	result, err := version.Compare(minimumDockerAPIVersion)
+	if err != nil {
+		return fmt.Errorf("failed to compare current docker version %v with minimum support Docker version %q - %v", version, minimumDockerAPIVersion, err)
+	}
+	if result < 0 {
+		return fmt.Errorf("container runtime version is older than %s", minimumDockerAPIVersion)
+	}
+	return nil
 }
 
 // The first version of docker that supports exec natively is 1.3.0 == API 1.15

--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -184,13 +184,6 @@ func New(config *Config,
 		rkt.imagePuller = kubecontainer.NewImagePuller(recorder, rkt, imageBackOff)
 	}
 
-	if err := rkt.checkVersion(minimumRktBinVersion, recommendedRktBinVersion, minimumAppcVersion, minimumRktApiVersion, minimumSystemdVersion); err != nil {
-		// TODO(yifan): Latest go-systemd version have the ability to close the
-		// dbus connection. However the 'docker/libcontainer' package is using
-		// the older go-systemd version, so we can't update the go-systemd version.
-		rkt.apisvcConn.Close()
-		return nil, err
-	}
 	return rkt, nil
 }
 
@@ -1062,7 +1055,12 @@ func (r *Runtime) Version() (kubecontainer.Version, error) {
 }
 
 func (r *Runtime) APIVersion() (kubecontainer.Version, error) {
-	return r.binVersion, nil
+	return r.apiVersion, nil
+}
+
+// Status returns error if rkt is unhealthy, nil otherwise.
+func (r *Runtime) Status() error {
+	return r.checkVersion(minimumRktBinVersion, recommendedRktBinVersion, minimumAppcVersion, minimumRktApiVersion, minimumSystemdVersion)
 }
 
 // SyncPod syncs the running pod to match the specified desired pod.

--- a/pkg/kubelet/runtime.go
+++ b/pkg/kubelet/runtime.go
@@ -30,7 +30,6 @@ type runtimeState struct {
 	internalError            error
 	cidr                     string
 	initError                error
-	runtimeCompatibility     func() error
 }
 
 func (s *runtimeState) setRuntimeSync(t time.Time) {
@@ -85,16 +84,12 @@ func (s *runtimeState) errors() []string {
 	if s.internalError != nil {
 		ret = append(ret, s.internalError.Error())
 	}
-	if err := s.runtimeCompatibility(); err != nil {
-		ret = append(ret, err.Error())
-	}
 	return ret
 }
 
 func newRuntimeState(
 	runtimeSyncThreshold time.Duration,
 	configureNetwork bool,
-	runtimeCompatibility func() error,
 ) *runtimeState {
 	var networkError error = nil
 	if configureNetwork {
@@ -105,6 +100,5 @@ func newRuntimeState(
 		baseRuntimeSyncThreshold: runtimeSyncThreshold,
 		networkError:             networkError,
 		internalError:            nil,
-		runtimeCompatibility:     runtimeCompatibility,
 	}
 }


### PR DESCRIPTION
This PR
1) Add a new function CheckStatus in runtime interface.
2) Use CheckStatus in `updateRuntimeUp()`.
3) Fix and cleanup related unit test.

RFC:
1) Is it OK to integrate version check and runtime health check like this?
2) Should we combine `Version()`, `APIVersion()` and `CheckVersionCompatibility` in runtime interface to one function?

@yujuhong @vishh @yifan-gu 

Also Ref https://github.com/kubernetes/kubernetes/pull/22377#discussion_r54791011
