### PR TITLE
Record the forceful deletion by default

### DIFF
--- a/pkg/controller/node/nodecontroller.go
+++ b/pkg/controller/node/nodecontroller.go
@@ -370,7 +370,7 @@ func forcefullyDeletePod(c clientset.Interface, pod *api.Pod) error {
 	var zero int64
 	err := c.Core().Pods(pod.Namespace).Delete(pod.Name, &api.DeleteOptions{GracePeriodSeconds: &zero})
 	if err == nil {
-		glog.V(2).Infof("forceful deletion of %s succeeded", pod.Name)
+		glog.Infof("forceful deletion of %s succeeded", pod.Name)
 	}
 	return err
 }


### PR DESCRIPTION
Make this message to be printed by default. Scripts like test-cmd.sh doesn't set the --v so the output is not recorded in tests.
