### PR TITLE
Remove log collection code in cluster/gce/util.sh.

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -792,27 +792,6 @@ function check-cluster() {
       local elapsed=$(($(date +%s) - ${start_time}))
       if [[ ${elapsed} -gt ${KUBE_CLUSTER_INITIALIZATION_TIMEOUT} ]]; then
           echo -e "${color_red}Cluster failed to initialize within ${KUBE_CLUSTER_INITIALIZATION_TIMEOUT} seconds.${color_norm}" >&2
-          if [[ ${KUBE_TEST_DEBUG-} =~ ^[yY]$ ]]; then
-            local savedir="${E2E_REPORT_DIR-}"
-            if [[ -z "${savedir}" ]]; then
-              savedir="$(mktemp -t -d k8s-e2e.XXX)"
-            fi
-            echo "Preserving master logs in ${savedir}"
-            local logdir=/var/log
-            local basename
-            for basename in startupscript docker kubelet kube-apiserver; do
-              # TODO(mml): Perhaps revisit how we name logs for preservation and
-              # centralize an implementation.  Options include putting basename
-              # before hostname and including a timestamp.
-              local src="${logdir}/${basename}.log"
-              local dst="${savedir}/${MASTER_NAME}-${basename}.log"
-              echo "Copying ${MASTER_NAME}:${src}"
-              gcloud compute copy-files \
-                --project "${PROJECT}" --zone "${ZONE}" \
-                "${MASTER_NAME}:${src}" "${dst}" \
-                || true
-            done
-          fi
           exit 2
       fi
       printf "."

--- a/docs/devel/e2e-tests.md
+++ b/docs/devel/e2e-tests.md
@@ -148,6 +148,26 @@ As mentioned earlier there are a host of other options that are available, but t
 - `rm -rf /var/run/kubernetes`, clear kube generated credentials, sometimes stale permissions can cause problems.
 - `sudo iptables -F`, clear ip tables rules left by the kube-proxy.
 
+### Debugging clusters
+
+If a cluster fails to initialize, or you'd like to better understand cluster
+state to debug a failed e2e test, you can use the `cluster/log-dump.sh` script
+to gather logs.
+
+This script requires that the cluster provider supports ssh. Assuming it does,
+running
+
+```
+cluster/log-dump.sh <directory>
+````
+
+will ssh to the master and all nodes
+and download a variety of useful logs to the provided directory (which should
+already exist).
+
+The Google-run Jenkins builds automatically collected these logs for every
+build, saving them in the `artifacts` directory uploaded to GCS.
+
 ### Local clusters
 
 It can be much faster to iterate on a local cluster instead of a cloud-based one.  To start a local cluster, you can run:

--- a/hack/e2e.go
+++ b/hack/e2e.go
@@ -93,7 +93,6 @@ func main() {
 	}
 
 	os.Setenv("KUBECTL", *root+`/cluster/kubectl.sh`+kubectlArgs())
-	os.Setenv("KUBE_TEST_DEBUG", "y")
 
 	if *pushup {
 		if IsUp() {


### PR DESCRIPTION
Also update some docs to mention cluster/log-dump.sh.

Last bit of cleanup/consistency with cluster log collection after #22230 et al.

cc @mml @kubernetes/sig-testing 

Might be nice to get this in before 1.2 splits, but not strictly necessary.
