### PR TITLE
MESOS: removing timing constants

### DIFF
--- a/contrib/mesos/pkg/executor/executor.go
+++ b/contrib/mesos/pkg/executor/executor.go
@@ -48,12 +48,6 @@ import (
 	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
 )
 
-const (
-	containerPollTime = 1 * time.Second
-	lostPodPollTime   = 1 * time.Minute
-	podRelistPeriod   = 5 * time.Minute
-)
-
 type stateType int32
 
 const (


### PR DESCRIPTION
No longer using poll-based mechanism, these constants are no longer used.
