### PR TITLE
Restrict update-jenkins-jobs to run on the master node only.

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-update-jenkins-jobs.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-update-jenkins-jobs.yaml
@@ -1,6 +1,7 @@
 - job:
     name: kubernetes-update-jenkins-jobs
     description: 'Update Jenkins jobs based on configs in https://github.com/kubernetes/kubernetes/tree/master/hack/jenkins/job-configs. Test owner: spxtr.'
+    node: master
     triggers:
         - timed: 'H/15 * * * *'
     builders:


### PR DESCRIPTION
We want this to only run on one node since it likes to keep a cache in the container.
