### PR TITLE
Update to the latest version of google-fluentd.

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Dockerfile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Dockerfile
@@ -31,7 +31,7 @@ ENV DO_NOT_INSTALL_CATCH_ALL_CONFIG true
 RUN apt-get -q update && \
     apt-get install -y curl && \
     apt-get clean && \
-    curl -s https://storage.googleapis.com/signals-agents/logging/google-fluentd-install.sh | sudo bash
+    curl -s https://dl.google.com/cloudagents/install-logging-agent.sh | bash
 
 # Install the record reformer plugin.
 RUN /usr/sbin/google-fluentd-gem install fluent-plugin-record-reformer

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
@@ -28,7 +28,7 @@
 
 .PHONY:	kbuild kpush
 
-TAG = 1.17
+TAG = 1.18
 
 # Rules for building the test image for deployment to Dockerhub with user kubernetes.
 

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/google-fluentd.conf
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/google-fluentd.conf
@@ -120,6 +120,7 @@
 <source>
   type tail
   format multiline
+  multiline_flush_interval 5s
   format_firstline /^\w\d{4}/
   format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
   time_format %m%d %H:%M:%S.%N
@@ -133,6 +134,7 @@
 <source>
   type tail
   format multiline
+  multiline_flush_interval 5s
   format_firstline /^\w\d{4}/
   format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
   time_format %m%d %H:%M:%S.%N
@@ -146,6 +148,7 @@
 <source>
   type tail
   format multiline
+  multiline_flush_interval 5s
   format_firstline /^\w\d{4}/
   format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
   time_format %m%d %H:%M:%S.%N
@@ -159,6 +162,7 @@
 <source>
   type tail
   format multiline
+  multiline_flush_interval 5s
   format_firstline /^\w\d{4}/
   format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
   time_format %m%d %H:%M:%S.%N

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -9,7 +9,7 @@ spec:
   dnsPolicy: Default
   containers:
   - name: fluentd-cloud-logging
-    image: gcr.io/google_containers/fluentd-gcp:1.17
+    image: gcr.io/google_containers/fluentd-gcp:1.18
     resources:
       limits:
         cpu: 100m


### PR DESCRIPTION
It includes some performance improvements for parsing JSON (which is
very important for us, since all Docker logs are JSON) as well as a
couple new settings, like forcing of a flush of multiline logs after a
time period rather than having to wait until a new log is seen before
feeling confident flushing the previous one.

It also adds the `buffer_queue_full_action` option, but I'm not as confident about how stable that is, so I've opened #22537 to track it.

cc @jimmidyson in case we're able to similarly get an updated version of fluentd for fluentd-es. I unfortunately am pretty swamped with other things at the moment.

Fixes #19405
