### PR TITLE
Use the summary_api with heapster by default

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -38,7 +38,7 @@ spec:
               memory: {{ heapster_memory }}
           command:
             - /heapster
-            - --source=kubernetes:''
+            - --source=kubernetes.summary_api:''
             - --sink=gcm
             - --metric_resolution=60s
           volumeMounts:

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -38,7 +38,7 @@ spec:
               memory: {{ heapster_memory }}
           command:
             - /heapster
-            - --source=kubernetes:''
+            - --source=kubernetes.summary_api:''
             - --sink=influxdb:http://monitoring-influxdb:8086
             - --sink=gcm:?metrics=autoscaling
             - --metric_resolution=60s

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -38,7 +38,7 @@ spec:
               memory: {{ heapster_memory }}
           command:
             - /heapster
-            - --source=kubernetes:''
+            - --source=kubernetes.summary_api:''
             - --sink=influxdb:http://monitoring-influxdb:8086
             - --metric_resolution=60s
         - image: gcr.io/google_containers/heapster:v0.20.0-alpha11

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -38,5 +38,5 @@ spec:
               memory: {{ heapster_memory }}
           command:
             - /heapster
-            - --source=kubernetes:''
+            - --source=kubernetes.summary_api:''
             - --metric_resolution=60s

--- a/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -28,7 +28,7 @@ spec:
               memory: 300Mi
           command:
             - /heapster
-            - --source=kubernetes:''
+            - --source=kubernetes.summary_api:''
             - --sink=gcm
             - --sink=gcmautoscaling
             - --sink=gcl

--- a/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -28,7 +28,7 @@ spec:
               memory: 300Mi
           command:
             - /heapster
-            - --source=kubernetes:''
+            - --source=kubernetes.summary_api:''
             - --sink=gcl
             - --sink=gcmautoscaling
             - --sink=influxdb:http://monitoring-influxdb:8086

--- a/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -28,7 +28,7 @@ spec:
               memory: 300Mi
           command:
             - /heapster
-            - --source=kubernetes:''
+            - --source=kubernetes.summary_api:''
             - --sink=influxdb:http://monitoring-influxdb:8086
             - --stats_resolution=30s
             - --sink_frequency=1m

--- a/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -28,4 +28,4 @@ spec:
               memory: 300Mi
           command:
             - /heapster
-            - --source=kubernetes:''
+            - --source=kubernetes.summary_api:''


### PR DESCRIPTION
Use the new [summary api](https://github.com/kubernetes/kubernetes/blob/a20258efaecfc5b46f24111f17bc18168713a124/pkg/kubelet/api/v1alpha1/stats/types.go) by default with heapster.

We have conducted correctness and performance testing on the new API, and found it to be sound. There are two changes in the metrics heapster gathers from the new API:
1. Pod infrastructure container stats are not included on pod MetricSets. CPU usage for the infra container is zero after an initial small burst (~50 milli-core-seconds), and memory RSS is around 1.3 MiB.
2. Filesystem stats are handled differently. The new API reports rootfs (resource ID = '/') and log (resource ID = 'logs') FS stats on containers, and volume stats (resource ID = volume name) on pods.

Performance of the heapster source with the summary API is improved over the cAdvisor API. A heapster instance with the old source and one with the new source were run side-by-side on the same cluster and measured while running the [density 30-pod e2e test](https://github.com/kubernetes/kubernetes/pull/22320). Results were gathered on a real 3-node and 50-node cluster, as well as on a simulated 30, 60, and 300 node cluster. The simulated results were gathered by running multiple heapster sources (metric scraper workers) per node (i.e. metrics were scraped & aggregated from each node multiple times). The 99th percentile usage was:

```
container                                                                  cpu(cores) memory(MB)
TEST: 30 pods x 3 nodes, 1 source per node, 13m42.809402175s
"heapster-perf-kubelet-j30bg/heapster-test"                                0.006      27.46
"heapster-perf-summary-vcvl6/heapster-test"                                0.005      25.25

TEST: 30 pods x 50 nodes, 1 source per node, 32m22.336210862s
"heapster-perf-kubelet-7jnaj/heapster"                                           0.067      240.07
"heapster-perf-summary-jlylm/heapster"                                           0.045      215.76

TEST: 30 pods x 3 nodes, 10 sources per node, 13m52.850112505s
"heapster-perf-kubelet-ip0os/heapster-test"                                0.019      42.32
"heapster-perf-summary-ihmnv/heapster-test"                                0.008      26.67

TEST: 30 pods x 3 nodes, 20 sources per node, 13m34.660766648s
"heapster-perf-kubelet-vgzz0/heapster-test"                                0.035      51.28
"heapster-perf-summary-3g24j/heapster-test"                                0.011      27.62

TEST: 30 pods x 3 nodes, 100 sources per node, 13m50.085140262s
"heapster-perf-kubelet-1ln3r/heapster-test"                                0.229      152.20
"heapster-perf-summary-57xg4/heapster-test"                                0.047      31.00
```

Full results [here](https://github.com/timstclair/heapster/blob/6a4372f737c968147c4f08a2b1be9ffc837eca73/results.txt)

/cc @dchen1107 @mwielgus @piosz @vishh @pwittrock 
