### PR TITLE
Move the discovery client to its own package

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -493,7 +493,7 @@ func runAPIVersionsTest(c *client.Client) {
 	if err != nil {
 		glog.Fatalf("Failed to get api versions: %v", err)
 	}
-	versions := client.ExtractGroupVersions(g)
+	versions := unversioned.ExtractGroupVersions(g)
 
 	// Verify that the server supports the API version used by the client.
 	for _, version := range versions {

--- a/cmd/libs/go2idl/client-gen/generators/fake/generator_fake_for_clientset.go
+++ b/cmd/libs/go2idl/client-gen/generators/fake/generator_fake_for_clientset.go
@@ -71,7 +71,7 @@ func (g *genClientset) Imports(c *generator.Context) (imports []string) {
 	imports = append(imports,
 		"k8s.io/kubernetes/pkg/api",
 		"k8s.io/kubernetes/pkg/client/testing/core",
-		"k8s.io/kubernetes/pkg/client/unversioned",
+		"k8s.io/kubernetes/pkg/client/typed/discovery",
 		"k8s.io/kubernetes/pkg/runtime",
 		"k8s.io/kubernetes/pkg/watch",
 	)
@@ -132,7 +132,7 @@ type Clientset struct {
 	core.Fake
 }
 
-func (c *Clientset) Discovery() unversioned.DiscoveryInterface {
+func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 	return &FakeDiscovery{&c.Fake}
 }
 `

--- a/cmd/libs/go2idl/client-gen/generators/generator_for_clientset.go
+++ b/cmd/libs/go2idl/client-gen/generators/generator_for_clientset.go
@@ -69,7 +69,7 @@ func (g *genClientset) GenerateType(c *generator.Context, t *types.Type, w io.Wr
 	// TODO: We actually don't need any type information to generate the clientset,
 	// perhaps we can adapt the go2ild framework to this kind of usage.
 	sw := generator.NewSnippetWriter(w, c, "$", "$")
-	const pkgUnversioned = "k8s.io/kubernetes/pkg/client/unversioned"
+	const pkgDiscovery = "k8s.io/kubernetes/pkg/client/typed/discovery"
 	const pkgRESTClient = "k8s.io/kubernetes/pkg/client/restclient"
 
 	type arg struct {
@@ -89,11 +89,11 @@ func (g *genClientset) GenerateType(c *generator.Context, t *types.Type, w io.Wr
 		"Config":                           c.Universe.Type(types.Name{Package: pkgRESTClient, Name: "Config"}),
 		"DefaultKubernetesUserAgent":       c.Universe.Function(types.Name{Package: pkgRESTClient, Name: "DefaultKubernetesUserAgent"}),
 		"RESTClient":                       c.Universe.Type(types.Name{Package: pkgRESTClient, Name: "RESTClient"}),
-		"DiscoveryInterface":               c.Universe.Type(types.Name{Package: pkgUnversioned, Name: "DiscoveryInterface"}),
-		"DiscoveryClient":                  c.Universe.Type(types.Name{Package: pkgUnversioned, Name: "DiscoveryClient"}),
-		"NewDiscoveryClientForConfig":      c.Universe.Function(types.Name{Package: pkgUnversioned, Name: "NewDiscoveryClientForConfig"}),
-		"NewDiscoveryClientForConfigOrDie": c.Universe.Function(types.Name{Package: pkgUnversioned, Name: "NewDiscoveryClientForConfigOrDie"}),
-		"NewDiscoveryClient":               c.Universe.Function(types.Name{Package: pkgUnversioned, Name: "NewDiscoveryClient"}),
+		"DiscoveryInterface":               c.Universe.Type(types.Name{Package: pkgDiscovery, Name: "DiscoveryInterface"}),
+		"DiscoveryClient":                  c.Universe.Type(types.Name{Package: pkgDiscovery, Name: "DiscoveryClient"}),
+		"NewDiscoveryClientForConfig":      c.Universe.Function(types.Name{Package: pkgDiscovery, Name: "NewDiscoveryClientForConfig"}),
+		"NewDiscoveryClientForConfigOrDie": c.Universe.Function(types.Name{Package: pkgDiscovery, Name: "NewDiscoveryClientForConfigOrDie"}),
+		"NewDiscoveryClient":               c.Universe.Function(types.Name{Package: pkgDiscovery, Name: "NewDiscoveryClient"}),
 	}
 	sw.Do(clientsetInterfaceTemplate, m)
 	sw.Do(clientsetTemplate, m)

--- a/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/clientset.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/clientset.go
@@ -20,18 +20,18 @@ import (
 	"github.com/golang/glog"
 	unversionedtestgroup "k8s.io/kubernetes/cmd/libs/go2idl/client-gen/testoutput/testgroup/unversioned"
 	restclient "k8s.io/kubernetes/pkg/client/restclient"
-	unversioned "k8s.io/kubernetes/pkg/client/unversioned"
+	discovery "k8s.io/kubernetes/pkg/client/typed/discovery"
 )
 
 type Interface interface {
-	Discovery() unversioned.DiscoveryInterface
+	Discovery() discovery.DiscoveryInterface
 	Testgroup() unversionedtestgroup.TestgroupInterface
 }
 
 // Clientset contains the clients for groups. Each group has exactly one
 // version included in a Clientset.
 type Clientset struct {
-	*unversioned.DiscoveryClient
+	*discovery.DiscoveryClient
 	*unversionedtestgroup.TestgroupClient
 }
 
@@ -41,7 +41,7 @@ func (c *Clientset) Testgroup() unversionedtestgroup.TestgroupInterface {
 }
 
 // Discovery retrieves the DiscoveryClient
-func (c *Clientset) Discovery() unversioned.DiscoveryInterface {
+func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 	return c.DiscoveryClient
 }
 
@@ -54,7 +54,7 @@ func NewForConfig(c *restclient.Config) (*Clientset, error) {
 		return &clientset, err
 	}
 
-	clientset.DiscoveryClient, err = unversioned.NewDiscoveryClientForConfig(c)
+	clientset.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(c)
 	if err != nil {
 		glog.Errorf("failed to create the DiscoveryClient: %v", err)
 	}
@@ -67,7 +67,7 @@ func NewForConfigOrDie(c *restclient.Config) *Clientset {
 	var clientset Clientset
 	clientset.TestgroupClient = unversionedtestgroup.NewForConfigOrDie(c)
 
-	clientset.DiscoveryClient = unversioned.NewDiscoveryClientForConfigOrDie(c)
+	clientset.DiscoveryClient = discovery.NewDiscoveryClientForConfigOrDie(c)
 	return &clientset
 }
 
@@ -76,6 +76,6 @@ func New(c *restclient.RESTClient) *Clientset {
 	var clientset Clientset
 	clientset.TestgroupClient = unversionedtestgroup.New(c)
 
-	clientset.DiscoveryClient = unversioned.NewDiscoveryClient(c)
+	clientset.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &clientset
 }

--- a/pkg/api/unversioned/helpers.go
+++ b/pkg/api/unversioned/helpers.go
@@ -92,3 +92,13 @@ func FormatLabelSelector(labelSelector *LabelSelector) string {
 	}
 	return l
 }
+
+func ExtractGroupVersions(l *APIGroupList) []string {
+	var groupVersions []string
+	for _, g := range l.Groups {
+		for _, gv := range g.Versions {
+			groupVersions = append(groupVersions, gv.GroupVersion)
+		}
+	}
+	return groupVersions
+}

--- a/pkg/client/clientset_generated/internalclientset/clientset.go
+++ b/pkg/client/clientset_generated/internalclientset/clientset.go
@@ -19,13 +19,13 @@ package internalclientset
 import (
 	"github.com/golang/glog"
 	restclient "k8s.io/kubernetes/pkg/client/restclient"
+	discovery "k8s.io/kubernetes/pkg/client/typed/discovery"
 	unversionedcore "k8s.io/kubernetes/pkg/client/typed/generated/core/unversioned"
 	unversionedextensions "k8s.io/kubernetes/pkg/client/typed/generated/extensions/unversioned"
-	unversioned "k8s.io/kubernetes/pkg/client/unversioned"
 )
 
 type Interface interface {
-	Discovery() unversioned.DiscoveryInterface
+	Discovery() discovery.DiscoveryInterface
 	Core() unversionedcore.CoreInterface
 	Extensions() unversionedextensions.ExtensionsInterface
 }
@@ -33,7 +33,7 @@ type Interface interface {
 // Clientset contains the clients for groups. Each group has exactly one
 // version included in a Clientset.
 type Clientset struct {
-	*unversioned.DiscoveryClient
+	*discovery.DiscoveryClient
 	*unversionedcore.CoreClient
 	*unversionedextensions.ExtensionsClient
 }
@@ -49,7 +49,7 @@ func (c *Clientset) Extensions() unversionedextensions.ExtensionsInterface {
 }
 
 // Discovery retrieves the DiscoveryClient
-func (c *Clientset) Discovery() unversioned.DiscoveryInterface {
+func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 	return c.DiscoveryClient
 }
 
@@ -66,7 +66,7 @@ func NewForConfig(c *restclient.Config) (*Clientset, error) {
 		return &clientset, err
 	}
 
-	clientset.DiscoveryClient, err = unversioned.NewDiscoveryClientForConfig(c)
+	clientset.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(c)
 	if err != nil {
 		glog.Errorf("failed to create the DiscoveryClient: %v", err)
 	}
@@ -80,7 +80,7 @@ func NewForConfigOrDie(c *restclient.Config) *Clientset {
 	clientset.CoreClient = unversionedcore.NewForConfigOrDie(c)
 	clientset.ExtensionsClient = unversionedextensions.NewForConfigOrDie(c)
 
-	clientset.DiscoveryClient = unversioned.NewDiscoveryClientForConfigOrDie(c)
+	clientset.DiscoveryClient = discovery.NewDiscoveryClientForConfigOrDie(c)
 	return &clientset
 }
 
@@ -90,6 +90,6 @@ func New(c *restclient.RESTClient) *Clientset {
 	clientset.CoreClient = unversionedcore.New(c)
 	clientset.ExtensionsClient = unversionedextensions.New(c)
 
-	clientset.DiscoveryClient = unversioned.NewDiscoveryClient(c)
+	clientset.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &clientset
 }

--- a/pkg/client/clientset_generated/internalclientset/clientset_adaption.go
+++ b/pkg/client/clientset_generated/internalclientset/clientset_adaption.go
@@ -17,6 +17,7 @@ limitations under the License.
 package internalclientset
 
 import (
+	"k8s.io/kubernetes/pkg/client/typed/discovery"
 	unversionedcore "k8s.io/kubernetes/pkg/client/typed/generated/core/unversioned"
 	unversionedextensions "k8s.io/kubernetes/pkg/client/typed/generated/extensions/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned"
@@ -39,9 +40,9 @@ func FromUnversionedClient(c *unversioned.Client) *Clientset {
 	}
 
 	if c != nil && c.DiscoveryClient != nil {
-		clientset.DiscoveryClient = unversioned.NewDiscoveryClient(c.DiscoveryClient.RESTClient)
+		clientset.DiscoveryClient = discovery.NewDiscoveryClient(c.DiscoveryClient.RESTClient)
 	} else {
-		clientset.DiscoveryClient = unversioned.NewDiscoveryClient(nil)
+		clientset.DiscoveryClient = discovery.NewDiscoveryClient(nil)
 	}
 
 	return &clientset

--- a/pkg/client/clientset_generated/internalclientset/fake/clientset_generated.go
+++ b/pkg/client/clientset_generated/internalclientset/fake/clientset_generated.go
@@ -20,11 +20,11 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/client/testing/core"
+	"k8s.io/kubernetes/pkg/client/typed/discovery"
 	unversionedcore "k8s.io/kubernetes/pkg/client/typed/generated/core/unversioned"
 	fakeunversionedcore "k8s.io/kubernetes/pkg/client/typed/generated/core/unversioned/fake"
 	unversionedextensions "k8s.io/kubernetes/pkg/client/typed/generated/extensions/unversioned"
 	fakeunversionedextensions "k8s.io/kubernetes/pkg/client/typed/generated/extensions/unversioned/fake"
-	"k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch"
 )
@@ -53,7 +53,7 @@ type Clientset struct {
 	core.Fake
 }
 
-func (c *Clientset) Discovery() unversioned.DiscoveryInterface {
+func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 	return &FakeDiscovery{&c.Fake}
 }
 

--- a/pkg/client/clientset_generated/release_1_2/clientset.go
+++ b/pkg/client/clientset_generated/release_1_2/clientset.go
@@ -19,13 +19,13 @@ package release_1_2
 import (
 	"github.com/golang/glog"
 	restclient "k8s.io/kubernetes/pkg/client/restclient"
+	discovery "k8s.io/kubernetes/pkg/client/typed/discovery"
 	v1core "k8s.io/kubernetes/pkg/client/typed/generated/core/v1"
 	v1beta1extensions "k8s.io/kubernetes/pkg/client/typed/generated/extensions/v1beta1"
-	unversioned "k8s.io/kubernetes/pkg/client/unversioned"
 )
 
 type Interface interface {
-	Discovery() unversioned.DiscoveryInterface
+	Discovery() discovery.DiscoveryInterface
 	Core() v1core.CoreInterface
 	Extensions() v1beta1extensions.ExtensionsInterface
 }
@@ -33,7 +33,7 @@ type Interface interface {
 // Clientset contains the clients for groups. Each group has exactly one
 // version included in a Clientset.
 type Clientset struct {
-	*unversioned.DiscoveryClient
+	*discovery.DiscoveryClient
 	*v1core.CoreClient
 	*v1beta1extensions.ExtensionsClient
 }
@@ -49,7 +49,7 @@ func (c *Clientset) Extensions() v1beta1extensions.ExtensionsInterface {
 }
 
 // Discovery retrieves the DiscoveryClient
-func (c *Clientset) Discovery() unversioned.DiscoveryInterface {
+func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 	return c.DiscoveryClient
 }
 
@@ -66,7 +66,7 @@ func NewForConfig(c *restclient.Config) (*Clientset, error) {
 		return &clientset, err
 	}
 
-	clientset.DiscoveryClient, err = unversioned.NewDiscoveryClientForConfig(c)
+	clientset.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(c)
 	if err != nil {
 		glog.Errorf("failed to create the DiscoveryClient: %v", err)
 	}
@@ -80,7 +80,7 @@ func NewForConfigOrDie(c *restclient.Config) *Clientset {
 	clientset.CoreClient = v1core.NewForConfigOrDie(c)
 	clientset.ExtensionsClient = v1beta1extensions.NewForConfigOrDie(c)
 
-	clientset.DiscoveryClient = unversioned.NewDiscoveryClientForConfigOrDie(c)
+	clientset.DiscoveryClient = discovery.NewDiscoveryClientForConfigOrDie(c)
 	return &clientset
 }
 
@@ -90,6 +90,6 @@ func New(c *restclient.RESTClient) *Clientset {
 	clientset.CoreClient = v1core.New(c)
 	clientset.ExtensionsClient = v1beta1extensions.New(c)
 
-	clientset.DiscoveryClient = unversioned.NewDiscoveryClient(c)
+	clientset.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &clientset
 }

--- a/pkg/client/clientset_generated/release_1_2/clientset_adaption.go
+++ b/pkg/client/clientset_generated/release_1_2/clientset_adaption.go
@@ -17,6 +17,7 @@ limitations under the License.
 package release_1_2
 
 import (
+	"k8s.io/kubernetes/pkg/client/typed/discovery"
 	v1core "k8s.io/kubernetes/pkg/client/typed/generated/core/v1"
 	v1beta1extensions "k8s.io/kubernetes/pkg/client/typed/generated/extensions/v1beta1"
 	"k8s.io/kubernetes/pkg/client/unversioned"
@@ -39,9 +40,9 @@ func FromUnversionedClient(c *unversioned.Client) *Clientset {
 	}
 
 	if c != nil && c.DiscoveryClient != nil {
-		clientset.DiscoveryClient = unversioned.NewDiscoveryClient(c.DiscoveryClient.RESTClient)
+		clientset.DiscoveryClient = discovery.NewDiscoveryClient(c.DiscoveryClient.RESTClient)
 	} else {
-		clientset.DiscoveryClient = unversioned.NewDiscoveryClient(nil)
+		clientset.DiscoveryClient = discovery.NewDiscoveryClient(nil)
 	}
 
 	return &clientset

--- a/pkg/client/clientset_generated/release_1_2/fake/clientset_generated.go
+++ b/pkg/client/clientset_generated/release_1_2/fake/clientset_generated.go
@@ -20,11 +20,11 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_2"
 	"k8s.io/kubernetes/pkg/client/testing/core"
+	"k8s.io/kubernetes/pkg/client/typed/discovery"
 	v1core "k8s.io/kubernetes/pkg/client/typed/generated/core/v1"
 	fakev1core "k8s.io/kubernetes/pkg/client/typed/generated/core/v1/fake"
 	v1beta1extensions "k8s.io/kubernetes/pkg/client/typed/generated/extensions/v1beta1"
 	fakev1beta1extensions "k8s.io/kubernetes/pkg/client/typed/generated/extensions/v1beta1/fake"
-	"k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch"
 )
@@ -53,7 +53,7 @@ type Clientset struct {
 	core.Fake
 }
 
-func (c *Clientset) Discovery() unversioned.DiscoveryInterface {
+func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 	return &FakeDiscovery{&c.Fake}
 }
 

--- a/pkg/client/typed/discovery/client_test.go
+++ b/pkg/client/typed/discovery/client_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package discovery
 
 import (
 	"encoding/json"
@@ -49,9 +49,9 @@ func TestGetServerVersion(t *testing.T) {
 	}))
 	// TODO: Uncomment when fix #19254
 	// defer server.Close()
-	client := NewOrDie(&restclient.Config{Host: server.URL})
+	client := NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
 
-	got, err := client.Discovery().ServerVersion()
+	got, err := client.ServerVersion()
 	if err != nil {
 		t.Fatalf("unexpected encoding error: %v", err)
 	}
@@ -85,13 +85,13 @@ func TestGetServerGroupsWithV1Server(t *testing.T) {
 	}))
 	// TODO: Uncomment when fix #19254
 	// defer server.Close()
-	client := NewOrDie(&restclient.Config{Host: server.URL})
+	client := NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
 	// ServerGroups should not return an error even if server returns error at /api and /apis
-	apiGroupList, err := client.Discovery().ServerGroups()
+	apiGroupList, err := client.ServerGroups()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	groupVersions := ExtractGroupVersions(apiGroupList)
+	groupVersions := unversioned.ExtractGroupVersions(apiGroupList)
 	if !reflect.DeepEqual(groupVersions, []string{"v1"}) {
 		t.Errorf("expected: %q, got: %q", []string{"v1"}, groupVersions)
 	}
@@ -122,9 +122,9 @@ func TestGetServerResourcesWithV1Server(t *testing.T) {
 	}))
 	// TODO: Uncomment when fix #19254
 	// defer server.Close()
-	client := NewOrDie(&restclient.Config{Host: server.URL})
+	client := NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
 	// ServerResources should not return an error even if server returns error at /api/v1.
-	resourceMap, err := client.Discovery().ServerResources()
+	resourceMap, err := client.ServerResources()
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -215,9 +215,9 @@ func TestGetServerResources(t *testing.T) {
 	}))
 	// TODO: Uncomment when fix #19254
 	// defer server.Close()
-	client := NewOrDie(&restclient.Config{Host: server.URL})
+	client := NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
 	for _, test := range tests {
-		got, err := client.Discovery().ServerResourcesForGroupVersion(test.request)
+		got, err := client.ServerResourcesForGroupVersion(test.request)
 		if test.expectErr {
 			if err == nil {
 				t.Error("unexpected non-error")
@@ -233,7 +233,7 @@ func TestGetServerResources(t *testing.T) {
 		}
 	}
 
-	resourceMap, err := client.Discovery().ServerResources()
+	resourceMap, err := client.ServerResources()
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -278,8 +278,8 @@ func TestGetSwaggerSchema(t *testing.T) {
 	// TODO: Uncomment when fix #19254
 	// defer server.Close()
 
-	client := NewOrDie(&restclient.Config{Host: server.URL})
-	got, err := client.Discovery().SwaggerSchema(v1.SchemeGroupVersion)
+	client := NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
+	got, err := client.SwaggerSchema(v1.SchemeGroupVersion)
 	if err != nil {
 		t.Fatalf("unexpected encoding error: %v", err)
 	}
@@ -298,8 +298,8 @@ func TestGetSwaggerSchemaFail(t *testing.T) {
 	// TODO: Uncomment when fix #19254
 	// defer server.Close()
 
-	client := NewOrDie(&restclient.Config{Host: server.URL})
-	got, err := client.Discovery().SwaggerSchema(unversioned.GroupVersion{Group: "api.group", Version: "v4"})
+	client := NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
+	got, err := client.SwaggerSchema(unversioned.GroupVersion{Group: "api.group", Version: "v4"})
 	if got != nil {
 		t.Fatalf("unexpected response: %v", got)
 	}

--- a/pkg/client/typed/discovery/discovery_client.go
+++ b/pkg/client/typed/discovery/discovery_client.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package discovery
 
 import (
 	"encoding/json"
@@ -148,7 +148,7 @@ func (d *DiscoveryClient) ServerResources() (map[string]*unversioned.APIResource
 	if err != nil {
 		return nil, err
 	}
-	groupVersions := ExtractGroupVersions(apiGroups)
+	groupVersions := unversioned.ExtractGroupVersions(apiGroups)
 	result := map[string]*unversioned.APIResourceList{}
 	for _, groupVersion := range groupVersions {
 		resources, err := d.ServerResourcesForGroupVersion(groupVersion)
@@ -184,7 +184,7 @@ func (d *DiscoveryClient) SwaggerSchema(version unversioned.GroupVersion) (*swag
 	if err != nil {
 		return nil, err
 	}
-	groupVersions := ExtractGroupVersions(groupList)
+	groupVersions := unversioned.ExtractGroupVersions(groupList)
 	// This check also takes care the case that kubectl is newer than the running endpoint
 	if stringDoesntExistIn(version.String(), groupVersions) {
 		return nil, fmt.Errorf("API version: %v is not supported by the server. Use one of: %v", version, groupVersions)
@@ -240,4 +240,13 @@ func NewDiscoveryClientForConfigOrDie(c *restclient.Config) *DiscoveryClient {
 // New creates a new DiscoveryClient for the given RESTClient.
 func NewDiscoveryClient(c *restclient.RESTClient) *DiscoveryClient {
 	return &DiscoveryClient{c}
+}
+
+func stringDoesntExistIn(str string, slice []string) bool {
+	for _, s := range slice {
+		if s == str {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/client/unversioned/client.go
+++ b/pkg/client/unversioned/client.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/kubernetes/pkg/client/typed/discovery"
 )
 
 // Interface holds the methods for clients of Kubernetes,
@@ -46,7 +47,7 @@ type Interface interface {
 	Autoscaling() AutoscalingInterface
 	Batch() BatchInterface
 	Extensions() ExtensionsInterface
-	Discovery() DiscoveryInterface
+	Discovery() discovery.DiscoveryInterface
 }
 
 func (c *Client) ReplicationControllers(namespace string) ReplicationControllerInterface {
@@ -118,16 +119,7 @@ type Client struct {
 	*AutoscalingClient
 	*BatchClient
 	*ExtensionsClient
-	*DiscoveryClient
-}
-
-func stringDoesntExistIn(str string, slice []string) bool {
-	for _, s := range slice {
-		if s == str {
-			return false
-		}
-	}
-	return true
+	*discovery.DiscoveryClient
 }
 
 // IsTimeout tests if this is a timeout error in the underlying transport.
@@ -164,6 +156,6 @@ func (c *Client) Extensions() ExtensionsInterface {
 	return c.ExtensionsClient
 }
 
-func (c *Client) Discovery() DiscoveryInterface {
+func (c *Client) Discovery() discovery.DiscoveryInterface {
 	return c.DiscoveryClient
 }

--- a/pkg/client/unversioned/helper.go
+++ b/pkg/client/unversioned/helper.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/batch"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/kubernetes/pkg/client/typed/discovery"
 	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/version"
 )
@@ -51,7 +52,7 @@ func New(c *restclient.Config) (*Client, error) {
 	}
 
 	discoveryConfig := *c
-	discoveryClient, err := NewDiscoveryClientForConfig(&discoveryConfig)
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(&discoveryConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -109,16 +110,6 @@ func MatchesServerVersion(client *Client, c *restclient.Config) error {
 	return nil
 }
 
-func ExtractGroupVersions(l *unversioned.APIGroupList) []string {
-	var groupVersions []string
-	for _, g := range l.Groups {
-		for _, gv := range g.Versions {
-			groupVersions = append(groupVersions, gv.GroupVersion)
-		}
-	}
-	return groupVersions
-}
-
 // NegotiateVersion queries the server's supported api versions to find
 // a version that both client and server support.
 // - If no version is provided, try registered client versions in order of
@@ -146,7 +137,7 @@ func NegotiateVersion(client *Client, c *restclient.Config, requestedGV *unversi
 		// not a negotiation specific error.
 		return nil, err
 	}
-	versions := ExtractGroupVersions(groups)
+	versions := unversioned.ExtractGroupVersions(groups)
 	serverVersions := sets.String{}
 	for _, v := range versions {
 		serverVersions.Insert(v)

--- a/pkg/client/unversioned/testclient/testclient.go
+++ b/pkg/client/unversioned/testclient/testclient.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/kubernetes/pkg/client/typed/discovery"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/version"
@@ -288,7 +289,7 @@ func (c *Fake) Extensions() client.ExtensionsInterface {
 	return &FakeExperimental{c}
 }
 
-func (c *Fake) Discovery() client.DiscoveryInterface {
+func (c *Fake) Discovery() discovery.DiscoveryInterface {
 	return &FakeDiscovery{c}
 }
 

--- a/pkg/controller/namespace/namespace_controller_utils.go
+++ b/pkg/controller/namespace/namespace_controller_utils.go
@@ -26,8 +26,8 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/api/v1"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/client/typed/discovery"
 	"k8s.io/kubernetes/pkg/client/typed/dynamic"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/sets"
 
@@ -453,7 +453,7 @@ func estimateGracefulTerminationForPods(kubeClient clientset.Interface, ns strin
 }
 
 // ServerPreferredNamespacedGroupVersionResources uses the specified client to discover the set of preferred groupVersionResources that are namespaced
-func ServerPreferredNamespacedGroupVersionResources(discoveryClient client.DiscoveryInterface) ([]unversioned.GroupVersionResource, error) {
+func ServerPreferredNamespacedGroupVersionResources(discoveryClient discovery.DiscoveryInterface) ([]unversioned.GroupVersionResource, error) {
 	results := []unversioned.GroupVersionResource{}
 	serverGroupList, err := discoveryClient.ServerGroups()
 	if err != nil {

--- a/pkg/kubectl/cmd/apiversions.go
+++ b/pkg/kubectl/cmd/apiversions.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	unversioned_client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 )
 
@@ -56,7 +56,7 @@ func RunApiVersions(f *cmdutil.Factory, w io.Writer) error {
 	if err != nil {
 		return fmt.Errorf("Couldn't get available api versions from server: %v\n", err)
 	}
-	apiVersions := unversioned_client.ExtractGroupVersions(groupList)
+	apiVersions := unversioned.ExtractGroupVersions(groupList)
 	sort.Strings(apiVersions)
 	for _, v := range apiVersions {
 		fmt.Fprintln(w, v)

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/kubernetes/pkg/client/cache"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/kubernetes/pkg/client/typed/discovery"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
@@ -341,7 +342,7 @@ func providerIs(providers ...string) bool {
 	return false
 }
 
-func SkipUnlessServerVersionGTE(v semver.Version, c client.ServerVersionInterface) {
+func SkipUnlessServerVersionGTE(v semver.Version, c discovery.ServerVersionInterface) {
 	gte, err := serverVersionGTE(v, c)
 	if err != nil {
 		Failf("Failed to get server version: %v", err)
@@ -1141,7 +1142,7 @@ func (r podProxyResponseChecker) checkAllResponses() (done bool, err error) {
 // version.
 //
 // TODO(18726): This should be incorporated into client.VersionInterface.
-func serverVersionGTE(v semver.Version, c client.ServerVersionInterface) (bool, error) {
+func serverVersionGTE(v semver.Version, c discovery.ServerVersionInterface) (bool, error) {
 	serverVersion, err := c.ServerVersion()
 	if err != nil {
 		return false, fmt.Errorf("Unable to get server version: %v", err)


### PR DESCRIPTION
This moves the discovery client out of the unversioned client for cleaner reuse by all the generated clients.

Take 2 after it was reverted due to clashing with a change in the namespace controller.
