### PR TITLE
Fix typo in developer guide README.md

### DIFF
--- a/docs/devel/README.md
+++ b/docs/devel/README.md
@@ -64,7 +64,7 @@ Guide](../admin/README.md).
 * **Hunting flaky tests** ([flaky-tests.md](flaky-tests.md)): We have a goal of 99.9% flake free tests.
   Here's how to run your tests many times.
 
-* **Logging Conventions** ([logging.md](logging.md)]: Glog levels.
+* **Logging Conventions** ([logging.md](logging.md)): Glog levels.
 
 * **Profiling Kubernetes** ([profiling.md](profiling.md)): How to plug in go pprof profiler to Kubernetes.
 


### PR DESCRIPTION
While looking at the Kubernetes Developer Guide I found a small typo.
