### PR TITLE
Considering all nodes for the scheduler cache to allow lookups

### DIFF
--- a/test/integration/scheduler_test.go
+++ b/test/integration/scheduler_test.go
@@ -170,8 +170,11 @@ func DoTestUnschedulableNodes(t *testing.T, restClient *client.Client, nodeStore
 					t.Fatalf("Failed to update node with unschedulable=true: %v", err)
 				}
 				err = waitForReflection(t, s, nodeKey, func(node interface{}) bool {
-					// An unschedulable node should get deleted from the store
-					return node == nil
+					// An unschedulable node should still be present in the store
+					// Nodes that are unschedulable or that are not ready or
+					// have their disk full (Node.Spec.Conditions) are exluded
+					// based on NodeConditionPredicate, a separate check
+					return node != nil && node.(*api.Node).Spec.Unschedulable == true
 				})
 				if err != nil {
 					t.Fatalf("Failed to observe reflected update for setting unschedulable=true: %v", err)


### PR DESCRIPTION
Fixes the actual issue that led me to create https://github.com/kubernetes/kubernetes/issues/22554

Currently the nodes in the cache provided to the predicates excludes the unschedulable nodes using field level filtering for the watch results. This results in the above issue as the `ServiceAffinity` predicate uses the cached node list to look up the node metadata for a peer pod (another pod belonging to the same service). Since this peer pod could be currently hosted on a node that is currently unschedulable, the lookup could potentially fail, resulting in the pod failing to be scheduled.

As part of the fix, we are now including all nodes in the watch results and excluding the unschedulable nodes using `NodeCondition`

@derekwaynecarr PTAL
