### PR TITLE
Filter out inactive pods first when determining if it's available

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -490,9 +490,7 @@ func FilterActivePods(pods []api.Pod) []*api.Pod {
 	var result []*api.Pod
 	for i := range pods {
 		p := pods[i]
-		if api.PodSucceeded != p.Status.Phase &&
-			api.PodFailed != p.Status.Phase &&
-			p.DeletionTimestamp == nil {
+		if IsPodActive(p) {
 			result = append(result, &p)
 		} else {
 			glog.V(4).Infof("Ignoring inactive pod %v/%v in state %v, deletion time %v",
@@ -500,6 +498,12 @@ func FilterActivePods(pods []api.Pod) []*api.Pod {
 		}
 	}
 	return result
+}
+
+func IsPodActive(p api.Pod) bool {
+	return api.PodSucceeded != p.Status.Phase &&
+		api.PodFailed != p.Status.Phase &&
+		p.DeletionTimestamp == nil
 }
 
 // FilterActiveReplicaSets returns replica sets that have (or at least ought to have) pods.

--- a/pkg/util/deployment/deployment.go
+++ b/pkg/util/deployment/deployment.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/util/integer"
 	intstrutil "k8s.io/kubernetes/pkg/util/intstr"
@@ -346,6 +347,9 @@ func getReadyPodsCount(pods []api.Pod, minReadySeconds int) int {
 }
 
 func IsPodAvailable(pod *api.Pod, minReadySeconds int) bool {
+	if !controller.IsPodActive(*pod) {
+		return false
+	}
 	// Check if we've passed minReadySeconds since LastTransitionTime
 	// If so, this pod is ready
 	for _, c := range pod.Status.Conditions {


### PR DESCRIPTION
Addresses #22512

When a pod is in the middle of being deleted, its deletion timestamp is set but its condition is still ready. It should be seen as not available, otherwise other components referencing it, such as updating deployment status or cleaning up unhealthy replicas will do weird things. 

@bgrant0607 @kubernetes/sig-config @mqliang @caesarxuchao 
