### PR TITLE
Improve go report card by fixing typos in comments

### DIFF
--- a/pkg/client/cache/expiration_cache.go
+++ b/pkg/client/cache/expiration_cache.go
@@ -33,7 +33,7 @@ import (
 //		   *any* item in the cache.
 //	3. Time-stamps are stripped off unexpired entries before return
 // Note that the ExpirationCache is inherently slower than a normal
-// threadSafeStore because it takes a write lock everytime it checks if
+// threadSafeStore because it takes a write lock every time it checks if
 // an item has expired.
 type ExpirationCache struct {
 	cacheStorage     ThreadSafeStore

--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -428,7 +428,7 @@ func (dc *DeploymentController) syncDeployment(key string) error {
 
 	if d.Spec.Paused {
 		// TODO: Implement scaling for paused deployments.
-		// Dont take any action for paused deployment.
+		// Don't take any action for paused deployment.
 		// But keep the status up-to-date.
 		// Ignore paused deployments
 		glog.V(4).Infof("Updating status only for paused deployment %s/%s", d.Namespace, d.Name)

--- a/pkg/kubelet/container_bridge.go
+++ b/pkg/kubelet/container_bridge.go
@@ -98,7 +98,7 @@ func ensureCbr0(wantCIDR *net.IPNet, promiscuous, babysitDaemons bool) error {
 	// TODO: Remove this once the kernel bug (#20096) is fixed.
 	if promiscuous {
 		// Checking if the bridge is in promiscuous mode is as expensive and more brittle than
-		// simply setting the flag everytime.
+		// simply setting the flag every time.
 		if err := exec.Command("ip", "link", "set", "cbr0", "promisc", "on").Run(); err != nil {
 			glog.Error(err)
 			return err

--- a/pkg/util/labels/labels.go
+++ b/pkg/util/labels/labels.go
@@ -57,7 +57,7 @@ func CloneAndRemoveLabel(labels map[string]string, labelKey string) map[string]s
 // AddLabel returns a map with the given key and value added to the given map.
 func AddLabel(labels map[string]string, labelKey string, labelValue string) map[string]string {
 	if labelKey == "" {
-		// Dont need to add a label.
+		// Don't need to add a label.
 		return labels
 	}
 	if labels == nil {
@@ -110,7 +110,7 @@ func CloneSelectorAndAddLabel(selector *unversioned.LabelSelector, labelKey stri
 // AddLabelToSelector returns a selector with the given key and value added to the given selector's MatchLabels.
 func AddLabelToSelector(selector *unversioned.LabelSelector, labelKey string, labelValue string) *unversioned.LabelSelector {
 	if labelKey == "" {
-		// Dont need to add a label.
+		// Don't need to add a label.
 		return selector
 	}
 	if selector.MatchLabels == nil {

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -2619,7 +2619,7 @@ func NodeAddresses(nodelist *api.NodeList, addrType api.NodeAddressType) []strin
 	return hosts
 }
 
-// NodeSSHHosts returns SSH-able host names for all schedulable nodes - this exludes master node.
+// NodeSSHHosts returns SSH-able host names for all schedulable nodes - this excludes master node.
 // It returns an error if it can't find an external IP for every node, though it still returns all
 // hosts that it found in that case.
 func NodeSSHHosts(c *client.Client) ([]string, error) {


### PR DESCRIPTION
https://goreportcard.com/report/k8s.io/kubernetes#misspell

Fixed all but 2 of the typos found by misspell. I didn't change `enqueueing` to `enqueuing` since the former spelling seems to be the favored spelling in the repo and on the web. Also ignored the suggestion to rename `ObjectConvertor` to `ObjectConverter`.
