### PR TITLE
Automated cherry pick of #22367 upstream release 1.2

### DIFF
--- a/cluster/saltbase/salt/fluentd-es/fluentd-es.yaml
+++ b/cluster/saltbase/salt/fluentd-es/fluentd-es.yaml
@@ -11,7 +11,10 @@ spec:
     image: gcr.io/google_containers/fluentd-elasticsearch:1.15
     resources:
       limits:
+        memory: 200Mi
+      requests:
         cpu: 100m
+        memory: 200Mi
     volumeMounts:
     - name: varlog
       mountPath: /var/log

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -12,6 +12,8 @@ spec:
     image: gcr.io/google_containers/fluentd-gcp:1.17
     resources:
       limits:
+        memory: 200Mi
+      requests:
         cpu: 100m
         memory: 200Mi
     env:

--- a/docs/getting-started-guides/logging.md
+++ b/docs/getting-started-guides/logging.md
@@ -147,6 +147,8 @@ spec:
     image: gcr.io/google_containers/fluentd-gcp:1.17
     resources:
       limits:
+        memory: 200Mi
+      requests:
         cpu: 100m
         memory: 200Mi
     env:


### PR DESCRIPTION
Removes CPU limit on fluentd, sets memory limit on fluentd-es to match fluentd-gcp. Cross-reference #22367
