### PR TITLE
AWS: Update jessie image, to fix reboot issue

### DIFF
--- a/cluster/aws/jessie/util.sh
+++ b/cluster/aws/jessie/util.sh
@@ -31,7 +31,7 @@ function detect-jessie-image () {
     aws_account="721322707521"
     # TODO: we could use tags for the image
     if [[ -z "${AWS_IMAGE_NAME:-}" ]]; then
-      AWS_IMAGE_NAME="k8s-1.2-debian-jessie-amd64-hvm-2016-02-24-ebs"
+      AWS_IMAGE_NAME="k8s-1.2-debian-jessie-amd64-hvm-2016-03-05-ebs"
     fi
     AWS_IMAGE=`aws ec2 describe-images --owner ${aws_account} --filters Name=name,Values=${AWS_IMAGE_NAME} --query Images[].ImageId --output text`
     if [[ -z "${AWS_IMAGE-}" ]]; then

--- a/cluster/cloudimages/k8s-ebs-jessie-amd64-hvm.yml
+++ b/cluster/cloudimages/k8s-ebs-jessie-amd64-hvm.yml
@@ -84,6 +84,10 @@ plugins:
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'DEBIAN_FRONTEND=noninteractive dpkg --install /tmp/docker.deb' ]
        - [ 'rm', '{root}/tmp/docker.deb' ]
 
+       # Fix a cloud-init bug where it uses nobootwait
+       # see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=789884
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "mount_default_fields: [~, ~, ''auto'', ''defaults,nofail'', ''0'', ''2'']" > /etc/cloud/cloud.cfg.d/99_kubernetes.cfg' ]
+
        # We perform a full replacement of some grub conf variables:
        #   GRUB_CMDLINE_LINUX_DEFAULT (add memory cgroup)
        #   GRUB_TIMEOUT (remove boot delay)


### PR DESCRIPTION
The previous jessie image had a broken cloud-init, which would use an
Ubuntu-specific 'nobootwait' argument when mounting disks.  We now
override that in the image.
