### PR TITLE
Kubelet: Always restart container in unknown state.

### DIFF
--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -57,6 +57,10 @@ func ShouldContainerBeRestarted(container *api.Container, pod *api.Pod, podStatu
 	if status.State == ContainerStateRunning {
 		return false
 	}
+	// Always restart container in unknown state now
+	if status.State == ContainerStateUnknown {
+		return true
+	}
 	// Check RestartPolicy for dead container
 	if pod.Spec.RestartPolicy == api.RestartPolicyNever {
 		glog.V(4).Infof("Already ran container %q of pod %q, do nothing", container.Name, format.Pod(pod))

--- a/pkg/kubelet/container/helpers_test.go
+++ b/pkg/kubelet/container/helpers_test.go
@@ -148,6 +148,7 @@ func TestShouldContainerBeRestarted(t *testing.T) {
 				{Name: "alive"},
 				{Name: "succeed"},
 				{Name: "failed"},
+				{Name: "unknown"},
 			},
 		},
 	}
@@ -176,6 +177,10 @@ func TestShouldContainerBeRestarted(t *testing.T) {
 				ExitCode: 2,
 			},
 			{
+				Name:  "unknown",
+				State: ContainerStateUnknown,
+			},
+			{
 				Name:     "failed",
 				State:    ContainerStateExited,
 				ExitCode: 3,
@@ -192,6 +197,7 @@ func TestShouldContainerBeRestarted(t *testing.T) {
 		"alive":      {false, false, false},
 		"succeed":    {false, false, true},
 		"failed":     {false, true, true},
+		"unknown":    {true, true, true},
 	}
 	for _, c := range pod.Spec.Containers {
 		for i, policy := range policies {

--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -345,6 +345,7 @@ func (dm *DockerManager) inspectContainer(id string, podName, podNamespace strin
 		Hash:         hash,
 	}
 	if iResult.State.Running {
+		// Container that are running, restarting and paused
 		status.State = kubecontainer.ContainerStateRunning
 		status.StartedAt = iResult.State.StartedAt
 		if containerName == PodInfraContainerName {
@@ -355,6 +356,7 @@ func (dm *DockerManager) inspectContainer(id string, podName, podNamespace strin
 
 	// Find containers that have exited or failed to start.
 	if !iResult.State.FinishedAt.IsZero() || iResult.State.ExitCode != 0 {
+		// Containers that are exited, dead or created (docker failed to start container)
 		// When a container fails to start State.ExitCode is non-zero, FinishedAt and StartedAt are both zero
 		reason := ""
 		message := iResult.State.Error
@@ -394,8 +396,8 @@ func (dm *DockerManager) inspectContainer(id string, podName, podNamespace strin
 		status.StartedAt = startedAt
 		status.FinishedAt = finishedAt
 	} else {
-		// Non-running containers that are not terminatd could be pasued, or created (but not yet
-		// started), etc. Kubelet doesn't handle these scenarios yet.
+		// Non-running containers that are created (not yet started or kubelet failed before calling
+		// start container function etc.) Kubelet doesn't handle these scenarios yet.
 		status.State = kubecontainer.ContainerStateUnknown
 	}
 	return &status, "", nil


### PR DESCRIPTION
Now if container is in some state which kubelet doesn't handle, it will be set as [`ContainerStateUnknown`](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/container/runtime.go#L206).

For docker, there are 6 states: "paused", "restarting", "running", "dead", "created", "exited". (See  https://github.com/docker/docker/blob/master/container/state.go#L73)

In [current implementation](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/dockertools/manager.go#L347):
- "paused", "restarting" and "running" container => `ContainerStateRunning` => Kubelet never restarts it.
- "dead", "exited", "created" (docker start failed, container ExitCode become non-zero) => `ContainerStateExited` => Kubelet restarts it with respect to `RestartPolicy`
- "created" (docker start hasn't been called) => `ContainerStateUnknown` => Undefined.

Before #21349, container in unknown state:
- Will always be restarted if there is no exited historical container.
- Will be restarted with respect to `RestartPolicy` if there is exited historical container.

This behavior is a little wired and unclear.

After #21349, container in unknown state will always be restarted with respect to `RestartPolicy`. However, @ncdc reports that it will cause container created but failed to be started never be restated again.

This PR makes sure that we _always restart container in unknown state_.

RFC:
- How should we define the map from docker state to kubelet container state?
- How should we deal with container in unknown state?
- Does "always restart container in unknown state" work for other container runtimes?

@kubernetes/sig-node 
