### PR TITLE
Update configmaps doc charaters error

### DIFF
--- a/docs/design/configmap.md
+++ b/docs/design/configmap.md
@@ -222,7 +222,7 @@ kind: ConfigMap
 metadata:
   name: etcd-env-config
 data:
-  number-of-members: 1
+  number-of-members: "1"
   initial-cluster-state: new
   initial-cluster-token: DUMMY_ETCD_INITIAL_CLUSTER_TOKEN
   discovery-token: DUMMY_ETCD_DISCOVERY_TOKEN


### PR DESCRIPTION
Update 1 to "1"
[root@ip-172-18-5-89 kubernetes]# kubectl create -f configmap.yaml 
unable to decode "configmap.yaml": [pos 264]: json: expect char '"' but got char '1'
