### PR TITLE
update mountpath of volume after migration

### DIFF
--- a/pkg/volume/flocker/plugin.go
+++ b/pkg/volume/flocker/plugin.go
@@ -199,9 +199,15 @@ func (b flockerBuilder) SetUpAt(dir string, fsGroup *int64) error {
 		if err := b.updateDatasetPrimary(datasetID, primaryUUID); err != nil {
 			return err
 		}
+		newState, err := b.client.GetDatasetState(datasetID)
+		if err != nil {
+			return fmt.Errorf("The volume '%s' migrated unsuccessfully.", datasetID)
+		}
+		b.flocker.path = newState.Path
+	} else {
+		b.flocker.path = s.Path
 	}
 
-	b.flocker.path = s.Path
 	volumeutil.SetReady(b.getMetaDir())
 	return nil
 }


### PR DESCRIPTION
The mount path and full name of the migrated volume would be changed by Flocker to indicate the new host's ownership. However, the current plugin doesn't update the mount path and cannot find the volume after migration.
