### PR TITLE
Don't sync all objects for replenishment as often as ResourceQuota.

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -240,11 +240,12 @@ func StartControllers(s *options.CMServer, kubeClient *client.Client, kubeconfig
 		api.Kind("ConfigMap"),
 	}
 	resourceQuotaControllerOptions := &resourcequotacontroller.ResourceQuotaControllerOptions{
-		KubeClient:            resourceQuotaControllerClient,
-		ResyncPeriod:          controller.StaticResyncPeriodFunc(s.ResourceQuotaSyncPeriod.Duration),
-		Registry:              resourceQuotaRegistry,
-		GroupKindsToReplenish: groupKindsToReplenish,
-		ControllerFactory:     resourcequotacontroller.NewReplenishmentControllerFactory(resourceQuotaControllerClient),
+		KubeClient:                resourceQuotaControllerClient,
+		ResyncPeriod:              controller.StaticResyncPeriodFunc(s.ResourceQuotaSyncPeriod.Duration),
+		Registry:                  resourceQuotaRegistry,
+		ControllerFactory:         resourcequotacontroller.NewReplenishmentControllerFactory(resourceQuotaControllerClient),
+		ReplenishmentResyncPeriod: ResyncPeriod(s),
+		GroupKindsToReplenish:     groupKindsToReplenish,
 	}
 	go resourcequotacontroller.NewResourceQuotaController(resourceQuotaControllerOptions).Run(s.ConcurrentResourceQuotaSyncs, wait.NeverStop)
 

--- a/pkg/controller/resourcequota/resource_quota_controller.go
+++ b/pkg/controller/resourcequota/resource_quota_controller.go
@@ -45,6 +45,8 @@ type ResourceQuotaControllerOptions struct {
 	Registry quota.Registry
 	// Knows how to build controllers that notify replenishment events
 	ControllerFactory ReplenishmentControllerFactory
+	// Controls full resync of objects monitored for replenihsment.
+	ReplenishmentResyncPeriod controller.ResyncPeriodFunc
 	// List of GroupKind objects that should be monitored for replenishment at
 	// a faster frequency than the quota controller recalculation interval
 	GroupKindsToReplenish []unversioned.GroupKind
@@ -124,7 +126,7 @@ func NewResourceQuotaController(options *ResourceQuotaControllerOptions) *Resour
 	for _, groupKindToReplenish := range options.GroupKindsToReplenish {
 		controllerOptions := &ReplenishmentControllerOptions{
 			GroupKind:         groupKindToReplenish,
-			ResyncPeriod:      options.ResyncPeriod,
+			ResyncPeriod:      options.ReplenishmentResyncPeriod,
 			ReplenishmentFunc: rq.replenishQuota,
 		}
 		replenishmentController, err := options.ControllerFactory.NewController(controllerOptions)

--- a/pkg/controller/resourcequota/resource_quota_controller_test.go
+++ b/pkg/controller/resourcequota/resource_quota_controller_test.go
@@ -113,7 +113,8 @@ func TestSyncResourceQuota(t *testing.T) {
 			api.Kind("ReplicationController"),
 			api.Kind("PersistentVolumeClaim"),
 		},
-		ControllerFactory: NewReplenishmentControllerFactory(kubeClient),
+		ControllerFactory:         NewReplenishmentControllerFactory(kubeClient),
+		ReplenishmentResyncPeriod: controller.NoResyncPeriodFunc,
 	}
 	quotaController := NewResourceQuotaController(resourceQuotaControllerOptions)
 	err := quotaController.syncResourceQuota(resourceQuota)
@@ -198,7 +199,8 @@ func TestSyncResourceQuotaSpecChange(t *testing.T) {
 			api.Kind("ReplicationController"),
 			api.Kind("PersistentVolumeClaim"),
 		},
-		ControllerFactory: NewReplenishmentControllerFactory(kubeClient),
+		ControllerFactory:         NewReplenishmentControllerFactory(kubeClient),
+		ReplenishmentResyncPeriod: controller.NoResyncPeriodFunc,
 	}
 	quotaController := NewResourceQuotaController(resourceQuotaControllerOptions)
 	err := quotaController.syncResourceQuota(resourceQuota)
@@ -274,7 +276,8 @@ func TestSyncResourceQuotaNoChange(t *testing.T) {
 			api.Kind("ReplicationController"),
 			api.Kind("PersistentVolumeClaim"),
 		},
-		ControllerFactory: NewReplenishmentControllerFactory(kubeClient),
+		ControllerFactory:         NewReplenishmentControllerFactory(kubeClient),
+		ReplenishmentResyncPeriod: controller.NoResyncPeriodFunc,
 	}
 	quotaController := NewResourceQuotaController(resourceQuotaControllerOptions)
 	err := quotaController.syncResourceQuota(resourceQuota)


### PR DESCRIPTION
Until now, ResourceQuota controller was doing a full resync of Pods, Services, RCs, ... every 5 minutes, without actually having a good reason for it.
This was making the ResourceQuota controller generating the biggest load on apiserver from all controllers.
This PR is addressing it, but leaving resync of ResourceQuota objects as it was (~5 minutes), but decreasing the full resync period of all other objects to be significantly smaller and also distributed randomly over some period of time (the same what other controllers are doing).

@gmarek - this should make 1000-kubemark passing regularly

@derekwaynecarr - FYI
