### PR TITLE
deflake rc logs test

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -900,6 +900,13 @@ var _ = Describe("Kubectl client", func() {
 			}
 
 			By("confirm that you can get logs from an rc")
+			podNames := []string{}
+			for _, pod := range pods {
+				podNames = append(podNames, pod.Name)
+			}
+			if !checkPodsRunningReady(c, ns, podNames, podStartTimeout) {
+				Failf("Pods for rc %s were not ready", rcName)
+			}
 			_, err = runKubectl("logs", "rc/"+rcName, nsFlag)
 			// a non-nil error is fine as long as we actually found a pod.
 			if err != nil && !strings.Contains(err.Error(), " in pod ") {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/22603.

The RC logs test didn't wait for the pods to be ready before attempt to log them.  Updated the e2e test to wait.

In OpenShift, we've dealt with this situation in our "container" sort of resources by adding a `log` endpoint under the container resource and having a "wait" duration in the log options to wait for readiness.  In this case it would be something like `replicationcontrollers/log`.  Is this a solution we'd be interesting in pursing in kube?

@kubernetes/kubectl 
