### PR TITLE
Default to allow new golang versions

### DIFF
--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -107,14 +107,14 @@ kube::version::load_version_vars() {
   source "${version_file}"
 }
 
-# golang 1.5 wants `-X key=val`, but golang 1.4- REQUIRES `-X key val`
+# golang 1.5+ wants `-X key=val`, but golang 1.4- REQUIRES `-X key val`
 kube::version::ldflag() {
   local key=${1}
   local val=${2}
 
   GO_VERSION=($(go version))
 
-  if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.5') ]]; then
+  if [[ -n $(echo "${GO_VERSION[2]}" | grep -E 'go1.1|go1.2|go1.3|go1.4') ]]; then
     echo "-X ${KUBE_GO_PACKAGE}/pkg/version.${key} ${val}"
   else
     echo "-X ${KUBE_GO_PACKAGE}/pkg/version.${key}=${val}"

--- a/hack/update-gofmt.sh
+++ b/hack/update-gofmt.sh
@@ -24,7 +24,7 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 GO_VERSION=($(go version))
 
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.4|go1.5') ]]; then
+if [[ -n $(echo "${GO_VERSION[2]}" | grep -E 'go1.1|go1.2|go1.3') ]]; then
   echo "Unsupported go version '${GO_VERSION}', skipping gofmt."
   exit 0
 fi

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -24,7 +24,7 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 GO_VERSION=($(go version))
 
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.4|go1.5') ]]; then
+if [[ -n $(echo "${GO_VERSION[2]}" | grep -E 'go1.1|go1.2|go1.3') ]]; then
   echo "Unsupported go version '${GO_VERSION}', skipping gofmt."
   exit 0
 fi


### PR DESCRIPTION
Out tests for features that didn't exist in old golang versions (like
gofmt didn't exist in 1.3 or the linker didn't want an = in 1.4) checked
for the new version. But this means every time there is a new version we
have to update the test. This PR inverts the test. We do it the old way
for the old version and if a new version comes along we just assume it
is going to work the new way.
