### PR TITLE
restricting the version of docker to 1.9.x for vsphere support

### DIFF
--- a/cluster/saltbase/salt/docker/init.sls
+++ b/cluster/saltbase/salt/docker/init.sls
@@ -125,9 +125,14 @@ cbr0:
     - require:
       - cmd: 'apt-update'
 
+# restricting docker version to 1.9. with older version of docker we are facing
+# issue https://github.com/docker/docker/issues/18793.
+# newer version of docker 1.10.0 is not well tested yet.
+# full comments: https://github.com/kubernetes/kubernetes/pull/20851
 docker-engine:
    pkg:
      - installed
+     - version: 1.9.*
      - require:
        - file: /etc/apt/sources.list.d/docker.list
 docker:


### PR DESCRIPTION
for vsphere provider docker currently only supports 1.9.1 release.
The older versions of docker are failing on jessie due to issue https://github.com/docker/docker/issues/18793
and newer version 1.10.x is not properly tested.
