### PR TITLE
include .vscode directory in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@
 *.iml
 
 # Vscode files
-.vscode/**
+.vscode
 
 # This is where the result of the go build goes
 /output/**


### PR DESCRIPTION
Right now the files inside .vscode are ignored but the directory itself isn't.  A `git clean -fd` it will blow it away.

Include the directory itself in .gitignore
