### PR TITLE
Add CONNECT to ignoredVerbs for readLatencyMetrics.

### DIFF
--- a/test/e2e/metrics_util.go
+++ b/test/e2e/metrics_util.go
@@ -199,7 +199,7 @@ func readLatencyMetrics(c *client.Client) (APIResponsiveness, error) {
 
 	ignoredResources := sets.NewString("events")
 	// TODO: figure out why we're getting non-capitalized proxy and fix this.
-	ignoredVerbs := sets.NewString("WATCHLIST", "PROXY", "proxy")
+	ignoredVerbs := sets.NewString("WATCHLIST", "PROXY", "proxy", "CONNECT")
 
 	for _, sample := range samples {
 		// Example line:


### PR DESCRIPTION
Fixes #22660 

cc/ @wojtek-t 
