### PR TITLE
Fix regex in list-feature-tests.sh.

### DIFF
--- a/hack/list-feature-tests.sh
+++ b/hack/list-feature-tests.sh
@@ -20,4 +20,4 @@ set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
-grep "\[Feature:(.+?)\]" "${KUBE_ROOT}"/test/e2e/*.go -Poh | sort | uniq
+grep "\[Feature:\w+\]" "${KUBE_ROOT}"/test/e2e/*.go -Poh | sort | uniq


### PR DESCRIPTION
It was finding the `\[Feature:.+\]` in `e2e.go` and treating that as a label.

Before:

```
[Feature:.+\]
[Feature:ClusterSizeAutoscaling]
[Feature:ComprehensiveNamespaceDraining]
[Feature:Elasticsearch]
[Feature:Example]
[Feature:ExperimentalNodeUpgrade]
[Feature:ExperimentalResourceUsageTracking]
[Feature:FSGroup]
[Feature:HighDensityPerformance]
[Feature:Ingress]
[Feature:InitialResources]
[Feature:ManualPerformance]
[Feature:MasterUpgrade]
[Feature:NodeAffinity]
[Feature:NodeUpgrade]
[Feature:Performance]
[Feature:Reboot]
[Feature:SecurityContext]
[Feature:ServiceLoadBalancer]
[Feature:Upgrade]
[Feature:Volumes]
```

After:

```
[Feature:ClusterSizeAutoscaling]
[Feature:ComprehensiveNamespaceDraining]
[Feature:Elasticsearch]
[Feature:Example]
[Feature:ExperimentalNodeUpgrade]
[Feature:ExperimentalResourceUsageTracking]
[Feature:FSGroup]
[Feature:HighDensityPerformance]
[Feature:Ingress]
[Feature:InitialResources]
[Feature:ManualPerformance]
[Feature:MasterUpgrade]
[Feature:NodeAffinity]
[Feature:NodeUpgrade]
[Feature:Performance]
[Feature:Reboot]
[Feature:SecurityContext]
[Feature:ServiceLoadBalancer]
[Feature:Upgrade]
[Feature:Volumes]
```
