### PR TITLE
Refactor hack/verify-all.sh and run almost all checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,17 +55,7 @@ all:
 #   make verify
 #   make verify BRANCH=branch_x
 verify:
-	hack/verify-gofmt.sh
-	hack/verify-boilerplate.sh
-	hack/verify-codecgen.sh
-	hack/verify-description.sh
-	hack/verify-generated-conversions.sh
-	hack/verify-generated-deep-copies.sh
-	hack/verify-generated-docs.sh
-	hack/verify-swagger-spec.sh
-	hack/verify-flags-underscore.py
-	hack/verify-godeps.sh $(BRANCH)
-	hack/verify-godep-licenses.sh $(BRANCH)
+	KUBE_VERIFY_GIT_BRANCH=$(BRANCH) hack/verify-all.sh -v
 .PHONY: verify
 
 # Build and run tests.

--- a/hack/jenkins/gotest-dockerized.sh
+++ b/hack/jenkins/gotest-dockerized.sh
@@ -21,9 +21,6 @@ set -o xtrace
 
 export REPO_DIR=${REPO_DIR:-$(pwd)}
 
-# Produce a JUnit-style XML test report for Jenkins.
-export KUBE_JUNIT_REPORT_DIR=${WORKSPACE}/_artifacts
-
 # Run the kubekins container, mapping in docker (so we can launch containers),
 # the repo directory, and the artifacts output directory.
 #
@@ -40,8 +37,9 @@ docker run --rm=true \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v "$(which docker)":/bin/docker \
   -v "${REPO_DIR}":/go/src/k8s.io/kubernetes \
-  -v "${KUBE_JUNIT_REPORT_DIR}":/workspace/artifacts \
+  -v "${WORKSPACE}/_artifacts":/workspace/artifacts \
   -v /etc/localtime:/etc/localtime:ro \
-  --env REPO_DIR="${REPO_DIR}" \
+  -e "KUBE_VERIFY_GIT_BRANCH=${KUBE_VERIFY_GIT_BRANCH:-}" \
+  -e "REPO_DIR=${REPO_DIR}" \
   -i gcr.io/google_containers/kubekins-test:0.7 \
   bash -c "cd kubernetes && ./hack/jenkins/test-dockerized.sh"

--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-go.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-go.yaml
@@ -9,6 +9,7 @@
     builders:
         - shell: 'bash <(curl -fsS --retry 3 "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/upload-started.sh")'
         - shell: |
+            export KUBE_VERIFY_GIT_BRANCH='{branch}'
             timeout -k {kill-timeout}m {timeout}m ./hack/jenkins/gotest-dockerized.sh && rc=$? || rc=$?
             {report-rc}
     publishers:

--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-go.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-go.yaml
@@ -9,6 +9,7 @@
     builders:
         - shell: 'bash <(curl -fsS --retry 3 "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/upload-started.sh")'
         - shell: |
+            export KUBE_FORCE_VERIFY_CHECKS='y'
             export KUBE_VERIFY_GIT_BRANCH='{branch}'
             timeout -k {kill-timeout}m {timeout}m ./hack/jenkins/gotest-dockerized.sh && rc=$? || rc=$?
             {report-rc}

--- a/hack/verify-godep-licenses.sh
+++ b/hack/verify-godep-licenses.sh
@@ -19,16 +19,11 @@ set -o nounset
 set -o pipefail
 
 KUBE_ROOT="$(cd "$(dirname "${BASH_SOURCE}")/.." && pwd -P)"
+source "${KUBE_ROOT}/hack/lib/init.sh"
 
-readonly branch="origin/${1:-${KUBE_VERIFY_GIT_BRANCH:-master}}"
-echo "Checking for Godeps changes against ${branch}"
-# make sure the branch is valid, otherwise the next check will pass erroneously.
-if ! git describe "${branch}" >/dev/null; then
-  exit 1
-fi
-# notice this uses ... to find the first shared ancestor
-if ! git diff --name-only "${branch}...HEAD" | grep 'Godeps/' > /dev/null; then
-  echo "No Godeps changes detected."
+readonly branch=${1:-${KUBE_VERIFY_GIT_BRANCH:-master}}
+if ! [[ ${KUBE_FORCE_VERIFY_CHECKS:-} =~ ^[yY]$ ]] && \
+  ! kube::util::has_changes_against_upstream_branch "${branch}" 'Godeps/'; then
   exit 0
 fi
 

--- a/hack/verify-godep-licenses.sh
+++ b/hack/verify-godep-licenses.sh
@@ -20,9 +20,15 @@ set -o pipefail
 
 KUBE_ROOT="$(cd "$(dirname "${BASH_SOURCE}")/.." && pwd -P)"
 
-branch="${1:-master}"
+readonly branch="origin/${1:-${KUBE_VERIFY_GIT_BRANCH:-master}}"
+echo "Checking for Godeps changes against ${branch}"
+# make sure the branch is valid, otherwise the next check will pass erroneously.
+if ! git describe "${branch}" >/dev/null; then
+  exit 1
+fi
 # notice this uses ... to find the first shared ancestor
-if ! git diff origin/"${branch}"...HEAD | grep 'Godeps/' > /dev/null; then
+if ! git diff --name-only "${branch}...HEAD" | grep 'Godeps/' > /dev/null; then
+  echo "No Godeps changes detected."
   exit 0
 fi
 

--- a/hack/verify-godeps.sh
+++ b/hack/verify-godeps.sh
@@ -39,9 +39,15 @@ preload-dep() {
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
-branch="${1:-master}"
+readonly branch="origin/${1:-${KUBE_VERIFY_GIT_BRANCH:-master}}"
+echo "Checking for Godeps changes against ${branch}"
+# make sure the branch is valid, otherwise the next check will pass erroneously.
+if ! git describe "${branch}" >/dev/null; then
+  exit 1
+fi
 # notice this uses ... to find the first shared ancestor
-if ! git diff origin/"${branch}"...HEAD | grep 'Godeps/' > /dev/null; then
+if ! git diff --name-only "${branch}...HEAD" | grep 'Godeps/' > /dev/null; then
+  echo "No Godeps changes detected."
   exit 0
 fi
 

--- a/hack/verify-godeps.sh
+++ b/hack/verify-godeps.sh
@@ -39,15 +39,9 @@ preload-dep() {
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
-readonly branch="origin/${1:-${KUBE_VERIFY_GIT_BRANCH:-master}}"
-echo "Checking for Godeps changes against ${branch}"
-# make sure the branch is valid, otherwise the next check will pass erroneously.
-if ! git describe "${branch}" >/dev/null; then
-  exit 1
-fi
-# notice this uses ... to find the first shared ancestor
-if ! git diff --name-only "${branch}...HEAD" | grep 'Godeps/' > /dev/null; then
-  echo "No Godeps changes detected."
+readonly branch=${1:-${KUBE_VERIFY_GIT_BRANCH:-master}}
+if ! [[ ${KUBE_FORCE_VERIFY_CHECKS:-} =~ ^[yY]$ ]] && \
+  ! kube::util::has_changes_against_upstream_branch "${branch}" 'Godeps/'; then
   exit 0
 fi
 

--- a/shippable.yml
+++ b/shippable.yml
@@ -44,18 +44,7 @@ install:
   - ./hack/build-go.sh
   - godep go install ./...
   - ./hack/install-etcd.sh
-  - ./hack/verify-gofmt.sh
-  - ./hack/verify-boilerplate.sh
-  - ./hack/verify-description.sh
-  - ./hack/verify-flags-underscore.py
-  - ./hack/verify-godeps.sh ${BASE_BRANCH}
-  - ./hack/verify-godep-licenses.sh ${BASE_BRANCH}
-  - ./hack/travis/install-std-race.sh
-  - ./hack/verify-generated-conversions.sh
-  - ./hack/verify-generated-deep-copies.sh
-  - ./hack/verify-generated-docs.sh
-  - ./hack/verify-generated-swagger-docs.sh
-  - ./hack/verify-swagger-spec.sh
+  - make verify BRANCH=${BASE_BRANCH}
 
 script:
   # Disable coverage collection on pull requests


### PR DESCRIPTION
The reasons why checks are skipped is now more explicit. Output is also improved a bit, giving both the check name and the runtime on the pass/fail line.

The verify-godep\* scripts have some logic to skip running unless necessary, but it wasn't fully robust, and wasn't set up to work properly on Jenkins. That should be fixed now.

This also makes `make verify`, Travis, and Shippable all use hack/verify-all.sh instead of calling scripts explicitly, as we had been doing on Jenkins. Everything should now be consistent.

Some timing information:
**Note: this includes running the full godeps checks. Normally these would exit instantaneously.**

Run 1:

```
SUCCESS  hack/../hack/verify-api-reference-docs.sh      22s
SUCCESS  hack/../hack/verify-boilerplate.sh     0s
SUCCESS  hack/../hack/verify-codecgen.sh        201s
SUCCESS  hack/../hack/verify-codegen.sh 18s
SUCCESS  hack/../hack/verify-description.sh     4s
SUCCESS  hack/../hack/verify-generated-conversions.sh   23s
SUCCESS  hack/../hack/verify-generated-deep-copies.sh   8s
SUCCESS  hack/../hack/verify-generated-docs.sh  43s
SUCCESS  hack/../hack/verify-generated-swagger-docs.sh  36s
SUCCESS  hack/../hack/verify-godep-licenses.sh  46s
SUCCESS  hack/../hack/verify-godeps.sh  330s
SUCCESS  hack/../hack/verify-gofmt.sh   7s
SUCCESS  hack/../hack/verify-import-boss.sh     14s
SUCCESS  hack/../hack/verify-swagger-spec.sh    6s
SUCCESS  hack/../hack/verify-symbols.sh 17s
SUCCESS  hack/../hack/verify-flags-underscore.py        24s
```

Run 2:

```
SUCCESS  hack/../hack/verify-api-reference-docs.sh      23s
SUCCESS  hack/../hack/verify-boilerplate.sh     1s
SUCCESS  hack/../hack/verify-codecgen.sh        243s
SUCCESS  hack/../hack/verify-codegen.sh 17s
SUCCESS  hack/../hack/verify-description.sh     3s
SUCCESS  hack/../hack/verify-generated-conversions.sh   22s
SUCCESS  hack/../hack/verify-generated-deep-copies.sh   8s
SUCCESS  hack/../hack/verify-generated-docs.sh  55s
SUCCESS  hack/../hack/verify-generated-swagger-docs.sh  43s
SUCCESS  hack/../hack/verify-godep-licenses.sh  33s
SUCCESS  hack/../hack/verify-godeps.sh  331s
SUCCESS  hack/../hack/verify-gofmt.sh   8s
SUCCESS  hack/../hack/verify-import-boss.sh     10s
SUCCESS  hack/../hack/verify-swagger-spec.sh    8s
SUCCESS  hack/../hack/verify-symbols.sh 16s
SUCCESS  hack/../hack/verify-flags-underscore.py        25s
```

Run 3 (Godeps checks skipped):

```
SUCCESS  hack/../hack/verify-api-reference-docs.sh      17s
SUCCESS  hack/../hack/verify-boilerplate.sh     1s
SUCCESS  hack/../hack/verify-codecgen.sh        253s
SUCCESS  hack/../hack/verify-codegen.sh 16s
SUCCESS  hack/../hack/verify-description.sh     4s
SUCCESS  hack/../hack/verify-generated-conversions.sh   21s
SUCCESS  hack/../hack/verify-generated-deep-copies.sh   7s
SUCCESS  hack/../hack/verify-generated-docs.sh  50s
SUCCESS  hack/../hack/verify-generated-swagger-docs.sh  40s
SUCCESS  hack/../hack/verify-godep-licenses.sh  0s
SUCCESS  hack/../hack/verify-godeps.sh  0s
SUCCESS  hack/../hack/verify-gofmt.sh   9s
SUCCESS  hack/../hack/verify-import-boss.sh     13s
SUCCESS  hack/../hack/verify-swagger-spec.sh    7s
SUCCESS  hack/../hack/verify-symbols.sh 17s
SUCCESS  hack/../hack/verify-flags-underscore.py        26s
```

cc @kubernetes/sig-testing @eparis @smarterclayton (per TODO)
