### PR TITLE
pod_infra_container for non-intel arch

### DIFF
--- a/build/pause/Makefile
+++ b/build/pause/Makefile
@@ -16,8 +16,12 @@
 
 TAG = 2.0
 
-ARCH = amd64
-IMAGE = pause
+ARCH = $(shell go env GOARCH)
+ifeq ("${ARCH}", "amd64")
+	IMAGE = pause
+else
+	IMAGE = pause-${ARCH}
+endif
 # ARCH = arm
 # IMAGE = pause-arm
 

--- a/build/pause/prepare.sh
+++ b/build/pause/prepare.sh
@@ -22,6 +22,11 @@ ARCH=$1
 # Build the binary.
 CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} godep go build -a -installsuffix cgo -ldflags '-w' ./pause.go
 
-# Run goupx to shrink binary size.
-go get github.com/pwaller/goupx
-goupx pause
+
+#Binary shrinking via upx is not supported for ppc64le architecture
+if [ "${ARCH}" != "ppc64le" ]
+then
+	# Run goupx to shrink binary size.
+	go get github.com/pwaller/goupx
+	goupx pause
+fi

--- a/build/pause/prepare.sh
+++ b/build/pause/prepare.sh
@@ -20,11 +20,11 @@ set -x
 ARCH=$1
 
 # Build the binary.
-CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} godep go build -a -installsuffix cgo -ldflags '-w' ./pause.go
+CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -installsuffix cgo -ldflags '-w' ./pause.go
 
 
 #Binary shrinking via upx is not supported for ppc64le architecture
-if [ "${ARCH}" != "ppc64le" ]
+if [[ ${ARCH} == "amd64" || ${ARCH} == "arm" ]];
 then
 	# Run goupx to shrink binary size.
 	go get github.com/pwaller/goupx


### PR DESCRIPTION
This patch enables creation of pod_infra_container for non-intel archs. Fixes #22683
