### PR TITLE
Fix mysql cinder example

### DIFF
--- a/examples/mysql-cinder-pd/mysql.yaml
+++ b/examples/mysql-cinder-pd/mysql.yaml
@@ -11,6 +11,9 @@ spec:
           cpu: 0.5
       image: mysql
       name: mysql
+      args:
+        - "--ignore-db-dir"
+        - "lost+found"
       env:
         - name: MYSQL_ROOT_PASSWORD
           # change this

--- a/examples/mysql-cinder-pd/mysql.yaml
+++ b/examples/mysql-cinder-pd/mysql.yaml
@@ -2,10 +2,10 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: mysql
-  labels: 
+  labels:
     name: mysql
-spec: 
-  containers: 
+spec:
+  containers:
     - resources:
         limits :
           cpu: 0.5
@@ -15,7 +15,7 @@ spec:
         - name: MYSQL_ROOT_PASSWORD
           # change this
           value: yourpassword
-      ports: 
+      ports:
         - containerPort: 3306
           name: mysql
       volumeMounts:


### PR DESCRIPTION
When a cinder volume is created there is no filesystem on it, the example specifies an ext4 volume, so it gets formatted by the kubelet, leaving a `lost+found` directory on the root dir of the volume (CoreOS 835.9.0). `mysqld --initialize` which is used by the mysql docker image refuses to initialize on non-empty `/var/lib/mysql` dirs. The mysql pod won't start.

See also: https://github.com/docker-library/mysql/issues/71

Adding the args: `--ingore-db-dir lost+found` to the container spec fixes this.
