### PR TITLE
Fix docs README.md links to kubernetes.github.io

### DIFF
--- a/docs/admin/README.md
+++ b/docs/admin/README.md
@@ -32,7 +32,7 @@ Documentation for other releases can be found at
 
 <!-- END MUNGE: UNVERSIONED_WARNING -->
 
-This file has moved to: http://kubernetes.github.io/docs/admin/README/
+This file has moved to: http://kubernetes.github.io/docs/admin/
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->

--- a/docs/admin/limitrange/README.md
+++ b/docs/admin/limitrange/README.md
@@ -32,7 +32,7 @@ Documentation for other releases can be found at
 
 <!-- END MUNGE: UNVERSIONED_WARNING -->
 
-This file has moved to: http://kubernetes.github.io/docs/admin/limitrange/README/
+This file has moved to: http://kubernetes.github.io/docs/admin/limitrange/
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->

--- a/docs/admin/namespaces/README.md
+++ b/docs/admin/namespaces/README.md
@@ -32,7 +32,7 @@ Documentation for other releases can be found at
 
 <!-- END MUNGE: UNVERSIONED_WARNING -->
 
-This file has moved to: http://kubernetes.github.io/docs/admin/namespaces/README/
+This file has moved to: http://kubernetes.github.io/docs/admin/namespaces/
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->

--- a/docs/admin/resourcequota/README.md
+++ b/docs/admin/resourcequota/README.md
@@ -32,7 +32,7 @@ Documentation for other releases can be found at
 
 <!-- END MUNGE: UNVERSIONED_WARNING -->
 
-This file has moved to: http://kubernetes.github.io/docs/admin/resourcequota/README/
+This file has moved to: http://kubernetes.github.io/docs/admin/resourcequota/
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->

--- a/docs/getting-started-guides/README.md
+++ b/docs/getting-started-guides/README.md
@@ -32,7 +32,7 @@ Documentation for other releases can be found at
 
 <!-- END MUNGE: UNVERSIONED_WARNING -->
 
-This file has moved to: http://kubernetes.github.io/docs/getting-started-guides/README/
+This file has moved to: http://kubernetes.github.io/docs/getting-started-guides/
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->

--- a/docs/getting-started-guides/coreos/azure/README.md
+++ b/docs/getting-started-guides/coreos/azure/README.md
@@ -32,7 +32,7 @@ Documentation for other releases can be found at
 
 <!-- END MUNGE: UNVERSIONED_WARNING -->
 
-This file has moved to: http://kubernetes.github.io/docs/getting-started-guides/coreos/azure/README/
+This file has moved to: http://kubernetes.github.io/docs/getting-started-guides/coreos/azure/
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->

--- a/docs/getting-started-guides/rkt/README.md
+++ b/docs/getting-started-guides/rkt/README.md
@@ -32,7 +32,7 @@ Documentation for other releases can be found at
 
 <!-- END MUNGE: UNVERSIONED_WARNING -->
 
-This file has moved to: http://kubernetes.github.io/docs/getting-started-guides/rkt/README/
+This file has moved to: http://kubernetes.github.io/docs/getting-started-guides/rkt/
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -32,7 +32,7 @@ Documentation for other releases can be found at
 
 <!-- END MUNGE: UNVERSIONED_WARNING -->
 
-This file has moved to: http://kubernetes.github.io/docs/user-guide/README/
+This file has moved to: http://kubernetes.github.io/docs/user-guide/
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->

--- a/docs/user-guide/configmap/README.md
+++ b/docs/user-guide/configmap/README.md
@@ -27,7 +27,7 @@ Documentation for other releases can be found at
 
 <!-- END MUNGE: UNVERSIONED_WARNING -->
 
-This file has moved to: http://kubernetes.github.io/docs/user-guide/configmap/README/
+This file has moved to: http://kubernetes.github.io/docs/user-guide/configmap/
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->

--- a/docs/user-guide/downward-api/README.md
+++ b/docs/user-guide/downward-api/README.md
@@ -32,7 +32,7 @@ Documentation for other releases can be found at
 
 <!-- END MUNGE: UNVERSIONED_WARNING -->
 
-This file has moved to: http://kubernetes.github.io/docs/user-guide/downward-api/README/
+This file has moved to: http://kubernetes.github.io/docs/user-guide/downward-api/
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->

--- a/docs/user-guide/downward-api/volume/README.md
+++ b/docs/user-guide/downward-api/volume/README.md
@@ -32,7 +32,7 @@ Documentation for other releases can be found at
 
 <!-- END MUNGE: UNVERSIONED_WARNING -->
 
-This file has moved to: http://kubernetes.github.io/docs/user-guide/downward-api/volume/README/
+This file has moved to: http://kubernetes.github.io/docs/user-guide/downward-api/volume/
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->

--- a/docs/user-guide/environment-guide/README.md
+++ b/docs/user-guide/environment-guide/README.md
@@ -32,7 +32,7 @@ Documentation for other releases can be found at
 
 <!-- END MUNGE: UNVERSIONED_WARNING -->
 
-This file has moved to: http://kubernetes.github.io/docs/user-guide/environment-guide/README/
+This file has moved to: http://kubernetes.github.io/docs/user-guide/environment-guide/
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->

--- a/docs/user-guide/environment-guide/containers/README.md
+++ b/docs/user-guide/environment-guide/containers/README.md
@@ -32,7 +32,7 @@ Documentation for other releases can be found at
 
 <!-- END MUNGE: UNVERSIONED_WARNING -->
 
-This file has moved to: http://kubernetes.github.io/docs/user-guide/environment-guide/containers/README/
+This file has moved to: http://kubernetes.github.io/docs/user-guide/environment-guide/containers/
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->

--- a/docs/user-guide/horizontal-pod-autoscaling/README.md
+++ b/docs/user-guide/horizontal-pod-autoscaling/README.md
@@ -32,7 +32,7 @@ Documentation for other releases can be found at
 
 <!-- END MUNGE: UNVERSIONED_WARNING -->
 
-This file has moved to: http://kubernetes.github.io/docs/user-guide/horizontal-pod-autoscaling/README/
+This file has moved to: http://kubernetes.github.io/docs/user-guide/horizontal-pod-autoscaling/
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->

--- a/docs/user-guide/liveness/README.md
+++ b/docs/user-guide/liveness/README.md
@@ -32,7 +32,7 @@ Documentation for other releases can be found at
 
 <!-- END MUNGE: UNVERSIONED_WARNING -->
 
-This file has moved to: http://kubernetes.github.io/docs/user-guide/liveness/README/
+This file has moved to: http://kubernetes.github.io/docs/user-guide/liveness/
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->

--- a/docs/user-guide/logging-demo/README.md
+++ b/docs/user-guide/logging-demo/README.md
@@ -32,7 +32,7 @@ Documentation for other releases can be found at
 
 <!-- END MUNGE: UNVERSIONED_WARNING -->
 
-This file has moved to: http://kubernetes.github.io/docs/user-guide/logging-demo/README/
+This file has moved to: http://kubernetes.github.io/docs/user-guide/logging-demo/
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->

--- a/docs/user-guide/node-selection/README.md
+++ b/docs/user-guide/node-selection/README.md
@@ -32,7 +32,7 @@ Documentation for other releases can be found at
 
 <!-- END MUNGE: UNVERSIONED_WARNING -->
 
-This file has moved to: http://kubernetes.github.io/docs/user-guide/node-selection/README/
+This file has moved to: http://kubernetes.github.io/docs/user-guide/node-selection/
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->

--- a/docs/user-guide/persistent-volumes/README.md
+++ b/docs/user-guide/persistent-volumes/README.md
@@ -32,7 +32,7 @@ Documentation for other releases can be found at
 
 <!-- END MUNGE: UNVERSIONED_WARNING -->
 
-This file has moved to: http://kubernetes.github.io/docs/user-guide/persistent-volumes/README/
+This file has moved to: http://kubernetes.github.io/docs/user-guide/persistent-volumes/
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->

--- a/docs/user-guide/resourcequota/README.md
+++ b/docs/user-guide/resourcequota/README.md
@@ -32,7 +32,7 @@ Documentation for other releases can be found at
 
 <!-- END MUNGE: UNVERSIONED_WARNING -->
 
-This file has moved to: http://kubernetes.github.io/docs/user-guide/resourcequota/README/
+This file has moved to: http://kubernetes.github.io/docs/user-guide/resourcequota/
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->

--- a/docs/user-guide/secrets/README.md
+++ b/docs/user-guide/secrets/README.md
@@ -32,7 +32,7 @@ Documentation for other releases can be found at
 
 <!-- END MUNGE: UNVERSIONED_WARNING -->
 
-This file has moved to: http://kubernetes.github.io/docs/user-guide/secrets/README/
+This file has moved to: http://kubernetes.github.io/docs/user-guide/secrets/
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->

--- a/docs/user-guide/update-demo/README.md
+++ b/docs/user-guide/update-demo/README.md
@@ -32,7 +32,7 @@ Documentation for other releases can be found at
 
 <!-- END MUNGE: UNVERSIONED_WARNING -->
 
-This file has moved to: http://kubernetes.github.io/docs/user-guide/update-demo/README/
+This file has moved to: http://kubernetes.github.io/docs/user-guide/update-demo/
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->

--- a/docs/user-guide/walkthrough/README.md
+++ b/docs/user-guide/walkthrough/README.md
@@ -32,7 +32,7 @@ Documentation for other releases can be found at
 
 <!-- END MUNGE: UNVERSIONED_WARNING -->
 
-This file has moved to: http://kubernetes.github.io/docs/user-guide/walkthrough/README/
+This file has moved to: http://kubernetes.github.io/docs/user-guide/walkthrough/
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->


### PR DESCRIPTION
kubernetes.github.io uses index not README for it's base dir. So we were
linking to the wrong place.
