### PR TITLE
Add the PreviousContext field in the cmd config file

### DIFF
--- a/pkg/client/unversioned/clientcmd/api/types.go
+++ b/pkg/client/unversioned/clientcmd/api/types.go
@@ -41,6 +41,8 @@ type Config struct {
 	Contexts map[string]*Context `json:"contexts"`
 	// CurrentContext is the name of the context that you would like to use by default
 	CurrentContext string `json:"current-context"`
+	// PreviousContext is the name of the context previously used
+	PreviousContext string `json:"previous-context"`
 	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields
 	Extensions map[string]runtime.Object `json:"extensions,omitempty"`
 }

--- a/pkg/client/unversioned/clientcmd/api/v1/conversion.go
+++ b/pkg/client/unversioned/clientcmd/api/v1/conversion.go
@@ -53,6 +53,7 @@ func init() {
 
 		func(in *Config, out *api.Config, s conversion.Scope) error {
 			out.CurrentContext = in.CurrentContext
+			out.PreviousContext = in.PreviousContext
 			if err := s.Convert(&in.Preferences, &out.Preferences, 0); err != nil {
 				return err
 			}
@@ -77,6 +78,7 @@ func init() {
 		},
 		func(in *api.Config, out *Config, s conversion.Scope) error {
 			out.CurrentContext = in.CurrentContext
+			out.PreviousContext = in.PreviousContext
 			if err := s.Convert(&in.Preferences, &out.Preferences, 0); err != nil {
 				return err
 			}

--- a/pkg/client/unversioned/clientcmd/api/v1/types.go
+++ b/pkg/client/unversioned/clientcmd/api/v1/types.go
@@ -40,6 +40,8 @@ type Config struct {
 	Contexts []NamedContext `json:"contexts"`
 	// CurrentContext is the name of the context that you would like to use by default
 	CurrentContext string `json:"current-context"`
+	// PreviousContext is the name of the context previously used
+	PreviousContext string `json:"previous-context"`
 	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields
 	Extensions []NamedExtension `json:"extensions,omitempty"`
 }

--- a/pkg/kubectl/cmd/config/config.go
+++ b/pkg/kubectl/cmd/config/config.go
@@ -347,6 +347,7 @@ func writeCurrentContext(configAccess ConfigAccess, newCurrentContext string) er
 	if configAccess.IsExplicitFile() {
 		file := configAccess.GetExplicitFile()
 		currConfig := getConfigFromFileOrDie(file)
+		currConfig.PreviousContext = currConfig.CurrentContext
 		currConfig.CurrentContext = newCurrentContext
 		if err := clientcmd.WriteToFile(*currConfig, file); err != nil {
 			return err
@@ -358,6 +359,7 @@ func writeCurrentContext(configAccess ConfigAccess, newCurrentContext string) er
 	if len(newCurrentContext) > 0 {
 		destinationFile := configAccess.GetDefaultFilename()
 		config := getConfigFromFileOrDie(destinationFile)
+		config.PreviousContext = config.CurrentContext
 		config.CurrentContext = newCurrentContext
 
 		if err := clientcmd.WriteToFile(*config, destinationFile); err != nil {
@@ -373,6 +375,7 @@ func writeCurrentContext(configAccess ConfigAccess, newCurrentContext string) er
 			currConfig := getConfigFromFileOrDie(file)
 
 			if len(currConfig.CurrentContext) > 0 {
+				currConfig.PreviousContext = currConfig.CurrentContext
 				currConfig.CurrentContext = newCurrentContext
 				if err := clientcmd.WriteToFile(*currConfig, file); err != nil {
 					return err


### PR DESCRIPTION
It's meant to store the current context right before switching
to another one. So that we can quickly go back to the previous
context from command line, for instance.
