### PR TITLE
Hyperkube: don't parse args for all servers

### DIFF
--- a/cmd/hyperkube/hyperkube.go
+++ b/cmd/hyperkube/hyperkube.go
@@ -154,14 +154,16 @@ func (hk *HyperKube) Run(args []string) error {
 		return err
 	}
 
-	s.Flags().AddFlagSet(hk.Flags())
-	err = s.Flags().Parse(args)
-	if err != nil || hk.helpFlagVal {
-		if err != nil {
-			hk.Printf("Error: %v\n\n", err)
+	if s.ParseArgs {
+		s.Flags().AddFlagSet(hk.Flags())
+		err = s.Flags().Parse(args)
+		if err != nil || hk.helpFlagVal {
+			if err != nil {
+				hk.Printf("Error: %v\n\n", err)
+			}
+			s.Usage()
+			return err
 		}
-		s.Usage()
-		return err
 	}
 
 	verflag.PrintAndExitIfRequested()

--- a/cmd/hyperkube/kube-apiserver.go
+++ b/cmd/hyperkube/kube-apiserver.go
@@ -34,6 +34,7 @@ func NewKubeAPIServer() *Server {
 		Run: func(_ *Server, args []string) error {
 			return app.Run(s)
 		},
+		ParseArgs: true,
 	}
 	s.AddFlags(hks.Flags())
 	return &hks

--- a/cmd/hyperkube/kube-controller-manager.go
+++ b/cmd/hyperkube/kube-controller-manager.go
@@ -34,6 +34,7 @@ func NewKubeControllerManager() *Server {
 		Run: func(_ *Server, args []string) error {
 			return app.Run(s)
 		},
+		ParseArgs: true,
 	}
 	s.AddFlags(hks.Flags())
 	return &hks

--- a/cmd/hyperkube/kube-proxy.go
+++ b/cmd/hyperkube/kube-proxy.go
@@ -39,6 +39,7 @@ func NewKubeProxy() *Server {
 		services and forwarding it to the appropriate pods. It generally runs on
 		nodes next to the Kubelet and proxies traffic from local pods to remote pods.
 		It is also used when handling incoming external traffic.`,
+		ParseArgs: true,
 	}
 
 	config.AddFlags(hks.Flags())

--- a/cmd/hyperkube/kube-scheduler.go
+++ b/cmd/hyperkube/kube-scheduler.go
@@ -34,6 +34,7 @@ func NewScheduler() *Server {
 		Run: func(_ *Server, _ []string) error {
 			return app.Run(s)
 		},
+		ParseArgs: true,
 	}
 	s.AddFlags(hks.Flags())
 	return &hks

--- a/cmd/hyperkube/kubectl.go
+++ b/cmd/hyperkube/kubectl.go
@@ -35,5 +35,6 @@ func NewKubectlServer() *Server {
 			os.Exit(0)
 			return nil
 		},
+		ParseArgs: false,
 	}
 }

--- a/cmd/hyperkube/kubelet.go
+++ b/cmd/hyperkube/kubelet.go
@@ -36,6 +36,7 @@ func NewKubelet() *Server {
 		Run: func(_ *Server, _ []string) error {
 			return app.Run(s, nil)
 		},
+		ParseArgs: true,
 	}
 	s.AddFlags(hks.Flags())
 	return &hks

--- a/cmd/hyperkube/server.go
+++ b/cmd/hyperkube/server.go
@@ -34,6 +34,7 @@ type Server struct {
 	SimpleUsage string        // One line description of the server.
 	Long        string        // Longer free form description of the server
 	Run         serverRunFunc // Run the server.  This is not expected to return.
+	ParseArgs   bool          // Not all commands have their flags defined during parsing. Make it explicit.
 
 	flags *pflag.FlagSet // Flags for the command (and all dependents)
 	name  string


### PR DESCRIPTION
Kubectl consists of many subcommands.
Each subcommand has its own way of setting flags.
Parsing of args of kubectl is not done under cmd/kubectl directory.
It is done inside of pkg/kubectl.
When kubectl is added to hyperkube as a server, its args are parsed when kubectl's flag are not yet defined.
So when running kubectl with any flag, the flag is not recognized.

This PR adds support for disabling the parsing inside of hyperkube when a server is created.

Commands with enabled arg parsing:
- kube-apiserver
- kube-controller-manager
- kube-proxy
- kube-scheduler
- kubelet

Commands with disabled arg parsing:
- kubectl
