### PR TITLE
Generate protobuf-related files in Docker

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -75,7 +75,6 @@ readonly DOCKER_MOUNT_ARGS_BASE=(
   --volume "${OUTPUT_BINPATH}:${REMOTE_OUTPUT_BINPATH}"
   --volume /etc/localtime:/etc/localtime:ro
 )
-# DOCKER_MOUNT_ARGS=("${DOCKER_MOUNT_ARGS_BASE[@]}" --volumes-from "${KUBE_BUILD_DATA_CONTAINER_NAME}")
 
 # We create a Docker data container to cache incremental build artifacts.  We
 # need to cache both the go tree in _output and the go tree under Godeps.

--- a/cmd/libs/go2idl/go-to-protobuf/build-image/Dockerfile
+++ b/cmd/libs/go2idl/go-to-protobuf/build-image/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file creates a standard build environment for building Kubernetes
+FROM gcr.io/google_containers/kube-cross:KUBE_BUILD_IMAGE_CROSS_TAG
+
+# Mark this as a kube-build container
+RUN touch /kube-build-image
+
+WORKDIR /go/src/k8s.io/kubernetes
+
+# Install goimports tool
+RUN go get golang.org/x/tools/cmd/goimports

--- a/hack/after-build/update-generated-protobuf.sh
+++ b/hack/after-build/update-generated-protobuf.sh
@@ -21,7 +21,10 @@ set -o pipefail
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
-# TODO: preinstall protobuf
+kube::golang::setup_env
+
+hack/build-go.sh cmd/libs/go2idl/go-to-protobuf cmd/libs/go2idl/go-to-protobuf/protoc-gen-gogo
+
 if [[ -z "$(which protoc)" || "$(protoc --version)" != "libprotoc 3.0."* ]]; then
   echo "Generating protobuf requires protoc 3.0.0-beta1 or newer. Please download and"
   echo "install the platform appropriate Protobuf package for your OS: "
@@ -29,7 +32,6 @@ if [[ -z "$(which protoc)" || "$(protoc --version)" != "libprotoc 3.0."* ]]; the
   echo "  https://github.com/google/protobuf/releases"
   echo
   echo "WARNING: Protobuf changes are not being validated"
-  # TODO: make error when protobuf is installed
   exit 0
 fi
 
@@ -38,7 +40,8 @@ gotoprotobuf=$(kube::util::find-binary "go-to-protobuf")
 # requires the 'proto' tag to build (will remove when ready)
 # searches for the protoc-gen-gogo extension in the output directory
 # satisfies import of github.com/gogo/protobuf/gogoproto/gogo.proto and the core Google protobuf types
-PATH="${KUBE_ROOT}/_output/local/go/bin:${PATH}" "${gotoprotobuf}" \
+PATH="${KUBE_ROOT}/_output/local/go/bin:${PATH}" \
+  "${gotoprotobuf}" \
   --conditional="proto" \
   --proto-import="${KUBE_ROOT}/Godeps/_workspace/src" \
   --proto-import="${KUBE_ROOT}/third_party/protobuf"

--- a/hack/update-generated-protobuf.sh
+++ b/hack/update-generated-protobuf.sh
@@ -19,12 +19,36 @@ set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${KUBE_ROOT}/hack/lib/init.sh"
+source "${KUBE_ROOT}/build/common.sh"
 
 kube::golang::setup_env
 
-"${KUBE_ROOT}/hack/build-go.sh" cmd/libs/go2idl/go-to-protobuf cmd/libs/go2idl/go-to-protobuf/protoc-gen-gogo
+function prereqs() {
+  kube::log::status "Verifying Prerequisites...."
+  kube::build::ensure_docker_in_path || return 1
+  if kube::build::is_osx; then
+      kube::build::docker_available_on_osx || return 1
+  fi
+  kube::build::ensure_docker_daemon_connectivity || return 1
 
-"${KUBE_ROOT}/hack/after-build/update-generated-protobuf.sh" "$@"
+  KUBE_ROOT_HASH=$(kube::build::short_hash "$KUBE_ROOT/go-to-protobuf")
+  KUBE_BUILD_IMAGE_TAG="build-${KUBE_ROOT_HASH}"
+  KUBE_BUILD_IMAGE="${KUBE_BUILD_IMAGE_REPO}:${KUBE_BUILD_IMAGE_TAG}"
+  KUBE_BUILD_CONTAINER_NAME="kube-build-${KUBE_ROOT_HASH}"
+  KUBE_BUILD_DATA_CONTAINER_NAME="kube-build-data-${KUBE_ROOT_HASH}"
+  DOCKER_MOUNT_ARGS=(
+    --volume "${KUBE_ROOT}:/go/src/${KUBE_GO_PACKAGE}"
+    --volume /etc/localtime:/etc/localtime:ro
+    --volumes-from "${KUBE_BUILD_DATA_CONTAINER_NAME}"
+	)
+  LOCAL_OUTPUT_BUILD_CONTEXT="${LOCAL_OUTPUT_IMAGE_STAGING}/${KUBE_BUILD_IMAGE}"
+}
+
+prereqs
+mkdir -p "${LOCAL_OUTPUT_BUILD_CONTEXT}"
+cp "${KUBE_ROOT}/cmd/libs/go2idl/go-to-protobuf/build-image/Dockerfile" "${LOCAL_OUTPUT_BUILD_CONTEXT}/Dockerfile"
+kube::build::update_dockerfile
+kube::build::docker_build "${KUBE_BUILD_IMAGE}" "${LOCAL_OUTPUT_BUILD_CONTEXT}" 'false'
+kube::build::run_build_command hack/after-build/update-generated-protobuf.sh "$@"
 
 # ex: ts=2 sw=2 et filetype=sh


### PR DESCRIPTION
Thanks to it we don't require developers to install protoc in the expected version on their workstations and make the generation process much more portable.
