### PR TITLE
add user-agent defaulting for discovery

### DIFF
--- a/pkg/client/typed/discovery/discovery_client.go
+++ b/pkg/client/typed/discovery/discovery_client.go
@@ -212,6 +212,9 @@ func setDiscoveryDefaults(config *restclient.Config) error {
 	config.APIPath = ""
 	config.GroupVersion = nil
 	config.Codec = runtime.NoopEncoder{api.Codecs.UniversalDecoder()}
+	if len(config.UserAgent) == 0 {
+		config.UserAgent = restclient.DefaultKubernetesUserAgent()
+	}
 	return nil
 }
 


### PR DESCRIPTION
The discovery client wasn't setting the user-agent.  Update the defaulting to work like the others.
