### PR TITLE
Selector operator strings should all be lowercase to be consistent with other operators.

### DIFF
--- a/pkg/labels/selector.go
+++ b/pkg/labels/selector.go
@@ -72,8 +72,8 @@ const (
 	NotEqualsOperator    Operator = "!="
 	NotInOperator        Operator = "notin"
 	ExistsOperator       Operator = "exists"
-	GreaterThanOperator  Operator = "Gt"
-	LessThanOperator     Operator = "Lt"
+	GreaterThanOperator  Operator = "gt"
+	LessThanOperator     Operator = "lt"
 )
 
 func NewSelector() Selector {


### PR DESCRIPTION
cc @davidopp 
