### PR TITLE
MESOS: added proxy-kubeconfig flag

### DIFF
--- a/contrib/mesos/pkg/minion/server.go
+++ b/contrib/mesos/pkg/minion/server.go
@@ -68,6 +68,7 @@ type MinionServer struct {
 	logVerbosity    int32 // see glog.Level
 
 	runProxy                       bool
+	proxyKubeconfig                string
 	proxyLogV                      int
 	proxyBindall                   bool
 	proxyMode                      string
@@ -149,7 +150,9 @@ func (ms *MinionServer) launchProxyServer() {
 		"--conntrack-max=" + strconv.Itoa(ms.conntrackMax),
 		"--conntrack-tcp-timeout-established=" + strconv.Itoa(ms.conntrackTCPTimeoutEstablished),
 	}
-
+	if ms.proxyKubeconfig != "" {
+		args = append(args, fmt.Sprintf("--kubeconfig=%s", ms.proxyKubeconfig))
+	}
 	if ms.clientConfig.Host != "" {
 		args = append(args, fmt.Sprintf("--master=%s", ms.clientConfig.Host))
 	}
@@ -359,6 +362,7 @@ func (ms *MinionServer) AddMinionFlags(fs *pflag.FlagSet) {
 
 	// proxy flags
 	fs.BoolVar(&ms.runProxy, "run-proxy", ms.runProxy, "Maintain a running kube-proxy instance as a child proc of this kubelet-executor.")
+	fs.StringVar(&ms.proxyKubeconfig, "proxy-kubeconfig", ms.proxyKubeconfig, "Path to kubeconfig file used by the child kube-proxy.")
 	fs.IntVar(&ms.proxyLogV, "proxy-logv", ms.proxyLogV, "Log verbosity of the child kube-proxy.")
 	fs.BoolVar(&ms.proxyBindall, "proxy-bindall", ms.proxyBindall, "When true will cause kube-proxy to bind to 0.0.0.0.")
 	fs.StringVar(&ms.proxyMode, "proxy-mode", ms.proxyMode, "Which proxy mode to use: 'userspace' (older) or 'iptables' (faster). If the iptables proxy is selected, regardless of how, but the system's kernel or iptables versions are insufficient, this always falls back to the userspace proxy.")

--- a/contrib/mesos/pkg/scheduler/service/service.go
+++ b/contrib/mesos/pkg/scheduler/service/service.go
@@ -134,10 +134,11 @@ type SchedulerServer struct {
 	launchGracePeriod              time.Duration
 	kubeletEnableDebuggingHandlers bool
 
-	runProxy     bool
-	proxyBindall bool
-	proxyLogV    int
-	proxyMode    string
+	runProxy        bool
+	proxyBindall    bool
+	proxyKubeconfig string
+	proxyLogV       int
+	proxyMode       string
 
 	minionPathOverride    string
 	minionLogMaxSize      resource.Quantity
@@ -309,6 +310,7 @@ func (s *SchedulerServer) addCoreFlags(fs *pflag.FlagSet) {
 
 	fs.BoolVar(&s.proxyBindall, "proxy-bindall", s.proxyBindall, "When true pass -proxy-bindall to the executor.")
 	fs.BoolVar(&s.runProxy, "run-proxy", s.runProxy, "Run the kube-proxy as a side process of the executor.")
+	fs.StringVar(&s.proxyKubeconfig, "proxy-kubeconfig", s.proxyKubeconfig, "Path to kubeconfig file with authorization and master location information used by the proxy.")
 	fs.IntVar(&s.proxyLogV, "proxy-logv", s.proxyLogV, "Logging verbosity of spawned minion proxy processes.")
 	fs.StringVar(&s.proxyMode, "proxy-mode", s.proxyMode, "Which proxy mode to use: 'userspace' (older) or 'iptables' (faster). If the iptables proxy is selected, regardless of how, but the system's kernel or iptables versions are insufficient, this always falls back to the userspace proxy.")
 
@@ -405,6 +407,12 @@ func (s *SchedulerServer) prepareExecutorInfo(hks hyperkube.Interface) (*mesos.E
 
 		ci.Arguments = append(ci.Arguments, fmt.Sprintf("--run-proxy=%v", s.runProxy))
 		ci.Arguments = append(ci.Arguments, fmt.Sprintf("--proxy-bindall=%v", s.proxyBindall))
+		if s.proxyKubeconfig != "" {
+			//TODO(jdef) should probably support non-local files, e.g. hdfs:///some/config/file
+			uri, basename := s.serveFrameworkArtifact(s.proxyKubeconfig)
+			ci.Uris = append(ci.Uris, &mesos.CommandInfo_URI{Value: proto.String(uri)})
+			ci.Arguments = append(ci.Arguments, fmt.Sprintf("--proxy-kubeconfig=%v", basename))
+		}
 		ci.Arguments = append(ci.Arguments, fmt.Sprintf("--proxy-logv=%d", s.proxyLogV))
 		ci.Arguments = append(ci.Arguments, fmt.Sprintf("--proxy-mode=%v", s.proxyMode))
 
@@ -459,9 +467,18 @@ func (s *SchedulerServer) prepareExecutorInfo(hks hyperkube.Interface) (*mesos.E
 
 	if s.kubeletKubeconfig != "" {
 		//TODO(jdef) should probably support non-local files, e.g. hdfs:///some/config/file
-		uri, basename := s.serveFrameworkArtifact(s.kubeletKubeconfig)
-		ci.Uris = append(ci.Uris, &mesos.CommandInfo_URI{Value: proto.String(uri)})
-		ci.Arguments = append(ci.Arguments, fmt.Sprintf("--kubeconfig=%s", basename))
+		if s.kubeletKubeconfig != s.proxyKubeconfig {
+			if filepath.Base(s.kubeletKubeconfig) == filepath.Base(s.proxyKubeconfig) {
+				// scheduler serves kubelet-kubeconfig and proxy-kubeconfig by their basename
+				// we currently don't support the case where the 2 kubeconfig files have the same
+				// basename but different absolute name, e.g., /kubelet/kubeconfig and /proxy/kubeconfig
+				return nil, fmt.Errorf("if kubelet-kubeconfig and proxy-kubeconfig are different, they must have different basenames")
+			}
+			// allows kubelet-kubeconfig and proxy-kubeconfig to point to the same file
+			uri, _ := s.serveFrameworkArtifact(s.kubeletKubeconfig)
+			ci.Uris = append(ci.Uris, &mesos.CommandInfo_URI{Value: proto.String(uri)})
+		}
+		ci.Arguments = append(ci.Arguments, fmt.Sprintf("--kubeconfig=%s", filepath.Base(s.kubeletKubeconfig)))
 	}
 	appendOptional := func(name string, value string) {
 		if value != "" {

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -288,6 +288,7 @@ private-mountns
 prom-push-gateway
 proto-import
 proxy-bindall
+proxy-kubeconfig
 proxy-logv
 proxy-mode
 proxy-port-range


### PR DESCRIPTION
Implements #22583 

Couple things to note:
- `--kubeconfig`, `--kubelet-kubeconfig`, `--proxy-kubeconfig` are all independent of one another
- `--kubeconfig`, `--kubelet-kubeconfig`, and `--proxy-kubeconfig` can point to different files or the same file (whatever security policy works for you)
- `--kubelet-kubeconfig` and `--proxy-kubeconfig` will be served from `km scheduler`
