### PR TITLE
Pass ResourceVersion in Scale object back to RC before updating RC so that it can be used to check for conflicts.

### DIFF
--- a/pkg/registry/experimental/controller/etcd/etcd.go
+++ b/pkg/registry/experimental/controller/etcd/etcd.go
@@ -88,6 +88,7 @@ func (r *ScaleREST) Update(ctx api.Context, obj runtime.Object) (runtime.Object,
 		return nil, false, errors.NewNotFound(extensions.Resource("replicationcontrollers/scale"), scale.Name)
 	}
 	rc.Spec.Replicas = scale.Spec.Replicas
+	rc.ResourceVersion = scale.ResourceVersion
 	rc, err = (*r.registry).UpdateController(ctx, rc)
 	if err != nil {
 		return nil, false, errors.NewConflict(extensions.Resource("replicationcontrollers/scale"), scale.Name, err)


### PR DESCRIPTION
cc @liggitt 
