### PR TITLE
modify the holder identity of controller manager and kube-scheduler

### DIFF
--- a/cluster/saltbase/salt/kube-controller-manager/kube-controller-manager.manifest
+++ b/cluster/saltbase/salt/kube-controller-manager/kube-controller-manager.manifest
@@ -71,7 +71,6 @@
   "namespace": "kube-system"
 },
 "spec":{
-"hostNetwork": true,
 "containers":[
     {
     "name": "kube-controller-manager",
@@ -95,6 +94,13 @@
       "initialDelaySeconds": 15,
       "timeoutSeconds": 15
     },
+    "ports": [
+      {
+        "name": "http",
+        "hostPort": 10252,
+        "containerPort": 10252
+      }
+    ],
     "volumeMounts": [
         {{cloud_config_mount}}
         {{additional_cloud_config_mount}}

--- a/cluster/saltbase/salt/kube-scheduler/kube-scheduler.manifest
+++ b/cluster/saltbase/salt/kube-scheduler/kube-scheduler.manifest
@@ -20,7 +20,6 @@
   "namespace": "kube-system"
 },
 "spec":{
-"hostNetwork": true,
 "containers":[
     {
     "name": "kube-scheduler",
@@ -44,6 +43,13 @@
       "initialDelaySeconds": 15,
       "timeoutSeconds": 15
     },
+    "ports": [
+      {
+        "name": "http",
+        "hostPort": 10251,
+        "containerPort": 10251
+      }
+    ],
     "volumeMounts": [
         {
           "name": "logfile",


### PR DESCRIPTION
It is a good option to use hostname plus process id as the holder identity. related with https://github.com/kubernetes/kubernetes/issues/22775
