### PR TITLE
fixed truncation of roles variable for ubuntu

### DIFF
--- a/cluster/ubuntu/config-default.sh
+++ b/cluster/ubuntu/config-default.sh
@@ -21,7 +21,11 @@
 export nodes=${nodes:-"vcap@10.10.103.250 vcap@10.10.103.162 vcap@10.10.103.223"}
 
 # Define all your nodes role: a(master) or i(minion) or ai(both master and minion), must be the order same 
-role=${roles:-"ai i i"}
+# Note that default env value comes from $role not $roles
+# This is because it is converted to an array type below in other scripts
+# and if it was called $roles this would result in a double array conversion
+# if this script is sourced twice, causing the array to be truncated.
+role=${role:-"ai i i"}
 # If it practically impossible to set an array as an environment variable
 # from a script, so assume variable is a string then convert it to an array
 export roles=($role)


### PR DESCRIPTION
You 100% reproducible will get the following error when trying to setup a kub cluster on ubuntu currently:

`./../cluster/../cluster/ubuntu/util.sh: line 48: roles[${ii}]: unbound variable 
`

The roles variable is getting truncated in cluster/ubuntu/config-default.sh. This is a bug introduced in this pull request: https://github.com/kubernetes/kubernetes/pull/22249

Explanation:

The script takes the roles variable, and turns it into an array, and then it exports it. Therefore the script is not idempotent, and sourcing the script twice will cause the $roles variable to get double arrayed, which truncates ("ai i i") -> ("ai").

This PR essentially just reverses the above one. I tried various other clever ways of fixing it (detecting if $roles was already an array, trying to not let the config-default be sourced twice), but none of them worked in all cases. It seems the original author of the script intentionally made the $roles variable named $role rather than $roles, because there is no way it can both be a string type (when first passed in from shell) and then later an array type (when it is being passed around all the other scripts). So there is no good way except to have 2 different names. I added a comment so no one tries to reverse this later.

The observed call sequence is:

/ubuntu/utils.sh ->
kube-up
-> source config-default.sh
-> detect-master
->  source config-default.sh (here $roles gets truncated to a 1 element array)
