### PR TITLE
Update to support latest godep

### DIFF
--- a/docs/devel/development.md
+++ b/docs/devel/development.md
@@ -166,9 +166,9 @@ See [Faster Reviews](faster_reviews.md) for more details.
 
 Kubernetes uses [godep](https://github.com/tools/godep) to manage dependencies.
 It is not strictly required for building Kubernetes but it is required when
-managing dependencies under the Godeps/ tree, and is required by a number of the
-build and test scripts. Please make sure that ``godep`` is installed and in your
-``$PATH``.
+managing dependencies under the vendor/ tree, and is required by a number of the
+build and test scripts. Please make sure that `godep` is installed and in your
+`$PATH`, and that `godep version` says it is at least v63.
 
 ### Installing godep
 
@@ -186,15 +186,28 @@ from mercurial.
 ```sh
 export GOPATH=$HOME/go-tools
 mkdir -p $GOPATH
-go get github.com/tools/godep
+go get -u github.com/tools/godep
 ```
 
-3) Add $GOPATH/bin to your path. Typically you'd add this to your ~/.profile:
+3) Add this $GOPATH/bin to your path. Typically you'd add this to your ~/.profile:
 
 ```sh
 export GOPATH=$HOME/go-tools
 export PATH=$PATH:$GOPATH/bin
 ```
+
+Note:
+At this time, godep version >= v63 is known to work in the Kubernetes project
+
+To check your version of godep:
+
+```sh
+$ godep version
+godep v66 (linux/amd64/go1.6.2)
+```
+
+If it is not a valid version try, make sure you have updated the godep repo
+with `go get -u github.com/tools/godep`.
 
 ### Using godep
 
@@ -204,8 +217,8 @@ instructions in [godep's documentation](https://github.com/tools/godep).
 
 1) Devote a directory to this endeavor:
 
-_Devoting a separate directory is not required, but it is helpful to separate
-dependency updates from other changes._
+_Devoting a separate directory is not strictly required, but it is helpful to
+separate dependency updates from other changes._
 
 ```sh
 export KPATH=$HOME/code/kubernetes
@@ -218,11 +231,8 @@ git clone https://path/to/your/fork .
 2) Set up your GOPATH.
 
 ```sh
-# Option A: this will let your builds see packages that exist elsewhere on your system.
-export GOPATH=$KPATH:$GOPATH
-# Option B: This will *not* let your local builds see packages that exist elsewhere on your system.
+# This will *not* let your local builds see packages that exist elsewhere on your system.
 export GOPATH=$KPATH
-# Option B is recommended if you're going to mess with the dependencies.
 ```
 
 3) Populate your new GOPATH.
@@ -237,32 +247,34 @@ godep restore
 ```sh
 # To add a new dependency, do:
 cd $KPATH/src/k8s.io/kubernetes
-go get path/to/dependency
-# Change code in Kubernetes to use the dependency.
-godep save ./...
+godep get path/to/dependency
+# Now change code in Kubernetes to use the dependency.
+hack/godep-save.sh
+
 
 # To update an existing dependency, do:
 cd $KPATH/src/k8s.io/kubernetes
 go get -u path/to/dependency
 # Change code in Kubernetes accordingly if necessary.
-godep update path/to/dependency/...
+godep update path/to/dependency
 ```
 
 _If `go get -u path/to/dependency` fails with compilation errors, instead try
 `go get -d -u path/to/dependency` to fetch the dependencies without compiling
-them. This can happen when updating the cadvisor dependency._
+them. This is unusual, but has been observed._
 
 
 5) Before sending your PR, it's a good idea to sanity check that your
-Godeps.json file is ok by running `hack/verify-godeps.sh`
+Godeps.json file and the contents of `vendor/ `are ok by running `hack/verify-godeps.sh`
 
-_If hack/verify-godeps.sh fails after a `godep update`, it is possible that a
+_If `hack/verify-godeps.sh` fails after a `godep update`, it is possible that a
 transitive dependency was added or removed but not updated by godeps. It then
-may be necessary to perform a `godep save ./...` to pick up the transitive
+may be necessary to perform a `hack/godep-save.sh` to pick up the transitive
 dependency changes._
 
-It is sometimes expedient to manually fix the /Godeps/godeps.json file to
-minimize the changes.
+It is sometimes expedient to manually fix the /Godeps/Godeps.json file to
+minimize the changes. However without great care this can lead to failures
+with `hack/verify-godeps.sh`. This must pass for every PR.
 
 Please send dependency updates in separate commits within your PR, for easier
 reviewing.

--- a/docs/devel/development.md
+++ b/docs/devel/development.md
@@ -196,17 +196,6 @@ export GOPATH=$HOME/go-tools
 export PATH=$PATH:$GOPATH/bin
 ```
 
-Note:
-At this time, godep update in the Kubernetes project only works properly if your
-version of godep is < 54.
-
-To check your version of godep:
-
-```sh
-$ godep version
-godep v53 (linux/amd64/go1.5.3)
-```
-
 ### Using godep
 
 Here's a quick walkthrough of one way to use godeps to add or update a

--- a/hack/godep-save.sh
+++ b/hack/godep-save.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+GODEP="${GODEP:-godep}"
+
+# Some things we want in godeps aren't code dependencies, so ./...
+# won't pick them up.
+REQUIRED_BINS=(
+  "github.com/ugorji/go/codec/codecgen"
+  "github.com/onsi/ginkgo/ginkgo"
+  "./..."
+)
+
+pushd "${KUBE_ROOT}" > /dev/null
+  GO15VENDOREXPERIMENT=1 ${GODEP} save "${REQUIRED_BINS[@]}"
+popd > /dev/null

--- a/hack/verify-godeps.sh
+++ b/hack/verify-godeps.sh
@@ -88,8 +88,7 @@ rm -rf ./Godeps ./vendor
 git init > /dev/null 2>&1
 
 # Recreate the Godeps using the nice clean set we just downloaded
-# TODO(thockin, eparis): Move this in to a common script with hack/godep-save.sh
-"${GODEP}" save github.com/ugorji/go/codec/codecgen github.com/onsi/ginkgo/ginkgo ./...
+hack/godep-save.sh
 
 # Test for diffs
 if ! _out="$(diff -Naupr --ignore-matching-lines='^\s*\"GoVersion\":' --ignore-matching-lines='^\s*\"Comment\":' ${KUBE_ROOT}/Godeps/Godeps.json ${_kubetmp}/Godeps/Godeps.json)"; then

--- a/hack/verify-godeps.sh
+++ b/hack/verify-godeps.sh
@@ -95,7 +95,7 @@ git init > /dev/null 2>&1
 hack/godep-save.sh
 
 # Test for diffs
-if ! _out="$(diff -Naupr --ignore-matching-lines='^\s*\"GoVersion\":' --ignore-matching-lines='^\s*\"Comment\":' ${KUBE_ROOT}/Godeps/Godeps.json ${_kubetmp}/Godeps/Godeps.json)"; then
+if ! _out="$(diff -Naupr --ignore-matching-lines='^\s*\"GoVersion\":' --ignore-matching-line='^\s*\"GodepVersion\":' --ignore-matching-lines='^\s*\"Comment\":' ${KUBE_ROOT}/Godeps/Godeps.json ${_kubetmp}/Godeps/Godeps.json)"; then
   echo "Your Godeps.json is different:"
   echo "${_out}"
   exit 1

--- a/hack/verify-godeps.sh
+++ b/hack/verify-godeps.sh
@@ -70,10 +70,14 @@ cd "${_kubetmp}"
 # Build the godep tool
 go get -u github.com/tools/godep 2>/dev/null
 GODEP="${GOPATH}/bin/godep"
-pushd "${GOPATH}/src/github.com/tools/godep" > /dev/null
-  git checkout v63
-  "${GODEP}" go install
-popd > /dev/null
+pin-godep() {
+  pushd "${GOPATH}/src/github.com/tools/godep" > /dev/null
+    git checkout "$1"
+    "${GODEP}" go install
+  popd > /dev/null
+}
+# Use to following if we ever need to pin godep to a specific version again
+#pin-godep 'v63'
 
 # Fill out that nice clean place with the kube godeps
 echo "Starting to download all kubernetes godeps. This takes a while"


### PR DESCRIPTION
godep v53 and earlier included all subdirs of includes in ./...
godep v54 and later only includes the exact packages required.

So all of the 'extra' packages which were subdirs but were dead code are removed.

That bit us because both codecgen and ginkgo are binaries which we got by chance in Godeps. When godep started tracking exactly what was needed instead of just grabbing entire subdirs we lost those binaries. To solve that problem godeps now have to be built with `godep save ginko codecgen ./...` so that that it explicitly pulls in those two packages. Because no one will ever remember that, I created a script in hack which lists those deps explicitly.

The better import tacking also means that it lists every single package included (transitively) in Godeps.json. Which I believe makes the godep license concatenator from @karlkfi explode in size.

But from an actual 'code that was built' PoV, and easy way to test is to see if a build with and without this PR have any difference. They should be identical.

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/22807)

<!-- Reviewable:end -->
