### PR TITLE
Rename CPU /stats/summary metrics

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -38,7 +38,7 @@ spec:
               memory: {{ heapster_memory }}
           command:
             - /heapster
-            - --source=kubernetes.summary_api:''
+            - --source=kubernetes:''
             - --sink=gcm
             - --metric_resolution=60s
           volumeMounts:

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -38,7 +38,7 @@ spec:
               memory: {{ heapster_memory }}
           command:
             - /heapster
-            - --source=kubernetes.summary_api:''
+            - --source=kubernetes:''
             - --sink=influxdb:http://monitoring-influxdb:8086
             - --sink=gcm:?metrics=autoscaling
             - --metric_resolution=60s

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -38,7 +38,7 @@ spec:
               memory: {{ heapster_memory }}
           command:
             - /heapster
-            - --source=kubernetes.summary_api:''
+            - --source=kubernetes:''
             - --sink=influxdb:http://monitoring-influxdb:8086
             - --metric_resolution=60s
         - image: gcr.io/google_containers/heapster:v0.20.0-alpha11

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -38,5 +38,5 @@ spec:
               memory: {{ heapster_memory }}
           command:
             - /heapster
-            - --source=kubernetes.summary_api:''
+            - --source=kubernetes:''
             - --metric_resolution=60s

--- a/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -28,7 +28,7 @@ spec:
               memory: 300Mi
           command:
             - /heapster
-            - --source=kubernetes.summary_api:''
+            - --source=kubernetes:''
             - --sink=gcm
             - --sink=gcmautoscaling
             - --sink=gcl

--- a/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -28,7 +28,7 @@ spec:
               memory: 300Mi
           command:
             - /heapster
-            - --source=kubernetes.summary_api:''
+            - --source=kubernetes:''
             - --sink=gcl
             - --sink=gcmautoscaling
             - --sink=influxdb:http://monitoring-influxdb:8086

--- a/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -28,7 +28,7 @@ spec:
               memory: 300Mi
           command:
             - /heapster
-            - --source=kubernetes.summary_api:''
+            - --source=kubernetes:''
             - --sink=influxdb:http://monitoring-influxdb:8086
             - --stats_resolution=30s
             - --sink_frequency=1m

--- a/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -28,4 +28,4 @@ spec:
               memory: 300Mi
           command:
             - /heapster
-            - --source=kubernetes.summary_api:''
+            - --source=kubernetes:''

--- a/pkg/kubelet/api/v1alpha1/stats/types.go
+++ b/pkg/kubelet/api/v1alpha1/stats/types.go
@@ -119,9 +119,9 @@ type CPUStats struct {
 	Time unversioned.Time `json:"time"`
 	// Total CPU usage (sum of all cores) averaged over the sample window.
 	// The "core" unit can be interpreted as CPU core-nanoseconds per second.
-	UsageNanoCores *uint64 `json:"usageNanoCores,omitempty"`
+	CoreUsageRate *uint64 `json:"coreUsageRate,omitempty"`
 	// Cumulative CPU usage (sum of all cores) since object creation.
-	UsageCoreNanoSeconds *uint64 `json:"usageCoreNanoSeconds,omitempty"`
+	CumulativeCoreNanoseconds *uint64 `json:"cumulativeCoreNanoseconds,omitempty"`
 }
 
 // MemoryStats contains data about memory usage.

--- a/pkg/kubelet/server/stats/summary.go
+++ b/pkg/kubelet/server/stats/summary.go
@@ -266,10 +266,10 @@ func (sb *summaryBuilder) containerInfoV2ToStats(
 			Time: unversioned.NewTime(cstat.Timestamp),
 		}
 		if cstat.CpuInst != nil {
-			cpuStats.UsageNanoCores = &cstat.CpuInst.Usage.Total
+			cpuStats.CoreUsageRate = &cstat.CpuInst.Usage.Total
 		}
 		if cstat.Cpu != nil {
-			cpuStats.UsageCoreNanoSeconds = &cstat.Cpu.Usage.Total
+			cpuStats.CumulativeCoreNanoseconds = &cstat.Cpu.Usage.Total
 		}
 		cStats.CPU = &cpuStats
 	}

--- a/pkg/kubelet/server/stats/summary_test.go
+++ b/pkg/kubelet/server/stats/summary_test.go
@@ -34,8 +34,8 @@ import (
 
 const (
 	// Offsets from seed value in generated container stats.
-	offsetCPUUsageCores = iota
-	offsetCPUUsageCoreSeconds
+	offsetCPUCoreUsageRate = iota
+	offsetCPUCumulativeCoreNanoseconds
 	offsetMemPageFaults
 	offsetMemMajorPageFaults
 	offsetMemUsageBytes
@@ -280,8 +280,8 @@ func summaryTestContainerInfo(seed int, podName string, podNamespace string, con
 		},
 		CustomMetrics: generateCustomMetrics(spec.CustomMetrics),
 	}
-	stats.Cpu.Usage.Total = uint64(seed + offsetCPUUsageCoreSeconds)
-	stats.CpuInst.Usage.Total = uint64(seed + offsetCPUUsageCores)
+	stats.Cpu.Usage.Total = uint64(seed + offsetCPUCumulativeCoreNanoseconds)
+	stats.CpuInst.Usage.Total = uint64(seed + offsetCPUCoreUsageRate)
 	return v2.ContainerInfo{
 		Spec:  spec,
 		Stats: []*v2.ContainerStats{&stats},
@@ -302,8 +302,8 @@ func checkNetworkStats(t *testing.T, label string, seed int, stats *kubestats.Ne
 
 func checkCPUStats(t *testing.T, label string, seed int, stats *kubestats.CPUStats) {
 	assert.EqualValues(t, testTime(timestamp, seed).Unix(), stats.Time.Time.Unix(), label+".CPU.Time")
-	assert.EqualValues(t, seed+offsetCPUUsageCores, *stats.UsageNanoCores, label+".CPU.UsageCores")
-	assert.EqualValues(t, seed+offsetCPUUsageCoreSeconds, *stats.UsageCoreNanoSeconds, label+".CPU.UsageCoreSeconds")
+	assert.EqualValues(t, seed+offsetCPUCoreUsageRate, *stats.CoreUsageRate, label+".CPU.CoreUsageRate")
+	assert.EqualValues(t, seed+offsetCPUCumulativeCoreNanoseconds, *stats.CumulativeCoreNanoseconds, label+".CPU.CumulativeCoreNanoseconds")
 }
 
 func checkMemoryStats(t *testing.T, label string, seed int, stats *kubestats.MemoryStats) {

--- a/test/e2e_node/kubelet_test.go
+++ b/test/e2e_node/kubelet_test.go
@@ -182,8 +182,8 @@ var _ = Describe("Kubelet", func() {
 
 				By("Having resources for node")
 				Expect(summary.Node.NodeName).To(Equal(*nodeName))
-				Expect(summary.Node.CPU.UsageCoreNanoSeconds).NotTo(BeNil())
-				Expect(*summary.Node.CPU.UsageCoreNanoSeconds).NotTo(BeZero())
+				Expect(summary.Node.CPU.CumulativeCoreNanoseconds).NotTo(BeNil())
+				Expect(*summary.Node.CPU.CumulativeCoreNanoseconds).NotTo(BeZero())
 
 				Expect(summary.Node.Memory.UsageBytes).NotTo(BeNil())
 				Expect(*summary.Node.Memory.UsageBytes).NotTo(BeZero())
@@ -270,8 +270,8 @@ func ExpectContainerStatsNotEmpty(container *stats.ContainerStats) {
 	// TODO: Test Network
 
 	Expect(container.CPU).NotTo(BeNil(), spew.Sdump(container))
-	Expect(container.CPU.UsageCoreNanoSeconds).NotTo(BeNil(), spew.Sdump(container))
-	Expect(*container.CPU.UsageCoreNanoSeconds).NotTo(BeZero(), spew.Sdump(container))
+	Expect(container.CPU.CumulativeCoreNanoseconds).NotTo(BeNil(), spew.Sdump(container))
+	Expect(*container.CPU.CumulativeCoreNanoseconds).NotTo(BeZero(), spew.Sdump(container))
 
 	Expect(container.Memory).NotTo(BeNil(), spew.Sdump(container))
 	Expect(container.Memory.UsageBytes).NotTo(BeNil(), spew.Sdump(container))


### PR DESCRIPTION
In the new /stats/summary endpoint, rename UsageNanoCores and UsageCoreNanoSeconds to UsageRate and CumulativeNanoseconds respectively, ideally merging this into 1.2. Rationale:
- UsageNanoCores and UsageCoreNanoSeconds are significantly different in what they represent - one is nanoseconds sampled over time, the other is cumulative nanoseconds used since creation of the container - but the current names do not make this distinction clear at all.
- Clarify that UsageNanoCores is a rate by naming it UsageRate and that UsageCoreNanoSeconds is since the creation of the container by naming it CumulativeNanoseconds.
- Remove "Cores" since the fields are already namespace under "CPU".
- The API has not yet been released, so now is the ideal time to do a rename.

Apologies from the late bomb, and punting on this is not the end of the world, but it'd really be nice to get this backwards-incompatible rename out of the way.

I'm not attached to the new names so happy to take further suggestions.

@dchen1107 @timstclair @vishh @bgrant0607 
