### PR TITLE
Implement network plugin capabilities hook and shaping capability

### DIFF
--- a/pkg/kubelet/network/cni/cni.go
+++ b/pkg/kubelet/network/cni/cni.go
@@ -38,6 +38,8 @@ const (
 )
 
 type cniNetworkPlugin struct {
+	network.NoopNetworkPlugin
+
 	defaultNetwork *cniNetwork
 	host           network.Host
 }
@@ -94,9 +96,6 @@ func getDefaultCNINetwork(pluginDir, vendorCNIDirPrefix string) (*cniNetwork, er
 func (plugin *cniNetworkPlugin) Init(host network.Host) error {
 	plugin.host = host
 	return nil
-}
-
-func (plugin *cniNetworkPlugin) Event(name string, details map[string]interface{}) {
 }
 
 func (plugin *cniNetworkPlugin) Name() string {

--- a/pkg/kubelet/network/exec/exec.go
+++ b/pkg/kubelet/network/exec/exec.go
@@ -72,6 +72,8 @@ import (
 )
 
 type execNetworkPlugin struct {
+	network.NoopNetworkPlugin
+
 	execName string
 	execPath string
 	host     network.Host
@@ -118,9 +120,6 @@ func (plugin *execNetworkPlugin) getExecutable() string {
 	parts := strings.Split(plugin.execName, "/")
 	execName := parts[len(parts)-1]
 	return path.Join(plugin.execPath, execName)
-}
-
-func (plugin *execNetworkPlugin) Event(name string, details map[string]interface{}) {
 }
 
 func (plugin *execNetworkPlugin) Name() string {

--- a/pkg/kubelet/network/kubenet/kubenet_linux.go
+++ b/pkg/kubelet/network/kubenet/kubenet_linux.go
@@ -41,6 +41,8 @@ const (
 )
 
 type kubenetNetworkPlugin struct {
+	network.NoopNetworkPlugin
+
 	host      network.Host
 	netConfig *libcni.NetworkConfig
 	cniConfig *libcni.CNIConfig

--- a/pkg/kubelet/network/kubenet/kubenet_unsupported.go
+++ b/pkg/kubelet/network/kubenet/kubenet_unsupported.go
@@ -26,6 +26,7 @@ import (
 )
 
 type kubenetNetworkPlugin struct {
+	network.NoopNetworkPlugin
 }
 
 func NewPlugin() network.NetworkPlugin {
@@ -34,8 +35,6 @@ func NewPlugin() network.NetworkPlugin {
 
 func (plugin *kubenetNetworkPlugin) Init(host network.Host) error {
 	return fmt.Errorf("Kubenet is not supported in this build")
-}
-func (plugin *kubenetNetworkPlugin) Event(name string, details map[string]interface{}) {
 }
 
 func (plugin *kubenetNetworkPlugin) Name() string {

--- a/pkg/kubelet/network/plugins.go
+++ b/pkg/kubelet/network/plugins.go
@@ -94,7 +94,7 @@ type Host interface {
 func InitNetworkPlugin(plugins []NetworkPlugin, networkPluginName string, host Host) (NetworkPlugin, error) {
 	if networkPluginName == "" {
 		// default to the no_op plugin
-		plug := &noopNetworkPlugin{}
+		plug := &NoopNetworkPlugin{}
 		if err := plug.Init(host); err != nil {
 			return nil, err
 		}
@@ -137,12 +137,12 @@ func UnescapePluginName(in string) string {
 	return strings.Replace(in, "~", "/", -1)
 }
 
-type noopNetworkPlugin struct {
+type NoopNetworkPlugin struct {
 }
 
 const sysctlBridgeCallIptables = "net/bridge/bridge-nf-call-iptables"
 
-func (plugin *noopNetworkPlugin) Init(host Host) error {
+func (plugin *NoopNetworkPlugin) Init(host Host) error {
 	// Set bridge-nf-call-iptables=1 to maintain compatibility with older
 	// kubernetes versions to ensure the iptables-based kube proxy functions
 	// correctly.  Other plugins are responsible for setting this correctly
@@ -159,21 +159,21 @@ func (plugin *noopNetworkPlugin) Init(host Host) error {
 	return nil
 }
 
-func (plugin *noopNetworkPlugin) Event(name string, details map[string]interface{}) {
+func (plugin *NoopNetworkPlugin) Event(name string, details map[string]interface{}) {
 }
 
-func (plugin *noopNetworkPlugin) Name() string {
+func (plugin *NoopNetworkPlugin) Name() string {
 	return DefaultPluginName
 }
 
-func (plugin *noopNetworkPlugin) SetUpPod(namespace string, name string, id kubecontainer.DockerID) error {
+func (plugin *NoopNetworkPlugin) SetUpPod(namespace string, name string, id kubecontainer.DockerID) error {
 	return nil
 }
 
-func (plugin *noopNetworkPlugin) TearDownPod(namespace string, name string, id kubecontainer.DockerID) error {
+func (plugin *NoopNetworkPlugin) TearDownPod(namespace string, name string, id kubecontainer.DockerID) error {
 	return nil
 }
 
-func (plugin *noopNetworkPlugin) Status(namespace string, name string, id kubecontainer.DockerID) (*PodNetworkStatus, error) {
+func (plugin *NoopNetworkPlugin) Status(namespace string, name string, id kubecontainer.DockerID) (*PodNetworkStatus, error) {
 	return nil, nil
 }

--- a/pkg/kubelet/network/plugins.go
+++ b/pkg/kubelet/network/plugins.go
@@ -29,6 +29,7 @@ import (
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	utilexec "k8s.io/kubernetes/pkg/util/exec"
+	utilsets "k8s.io/kubernetes/pkg/util/sets"
 	utilsysctl "k8s.io/kubernetes/pkg/util/sysctl"
 	"k8s.io/kubernetes/pkg/util/validation"
 )
@@ -39,6 +40,12 @@ const DefaultPluginName = "kubernetes.io/no-op"
 // controller manager's --allocate-node-cidrs=true option
 const NET_PLUGIN_EVENT_POD_CIDR_CHANGE = "pod-cidr-change"
 const NET_PLUGIN_EVENT_POD_CIDR_CHANGE_DETAIL_CIDR = "pod-cidr"
+
+// Plugin capabilities
+const (
+	// Indicates the plugin handles Kubernetes bandwidth shaping annotations internally
+	NET_PLUGIN_CAPABILITY_SHAPING int = 1
+)
 
 // Plugin is an interface to network plugins for the kubelet
 type NetworkPlugin interface {
@@ -53,6 +60,9 @@ type NetworkPlugin interface {
 	// Name returns the plugin's name. This will be used when searching
 	// for a plugin by name, e.g.
 	Name() string
+
+	// Returns a set of NET_PLUGIN_CAPABILITY_*
+	Capabilities() utilsets.Int
 
 	// SetUpPod is the method called after the infra container of
 	// the pod has been created but before the other containers of the
@@ -164,6 +174,10 @@ func (plugin *NoopNetworkPlugin) Event(name string, details map[string]interface
 
 func (plugin *NoopNetworkPlugin) Name() string {
 	return DefaultPluginName
+}
+
+func (plugin *NoopNetworkPlugin) Capabilities() utilsets.Int {
+	return utilsets.NewInt()
 }
 
 func (plugin *NoopNetworkPlugin) SetUpPod(namespace string, name string, id kubecontainer.DockerID) error {


### PR DESCRIPTION
Allow network plugins to declare that they handle shaping and that
Kuberenetes should not.  I've got an OpenShift PR that handles shaping in OVS but the kubelet code sends nasty pod events because it doesn't think shaping is used since --reconcile-cbr0 is not used with most network plugins.

See https://github.com/openshift/openshift-sdn/pull/266 for the OpenShift implementation.
