### PR TITLE
Jenkins: Add the ability to selectively disable an e2e job

### DIFF
--- a/hack/jenkins/job-configs/global.yaml
+++ b/hack/jenkins/job-configs/global.yaml
@@ -125,6 +125,7 @@
 # Default email recipients are set in Jenkins global config
 - defaults:
     name: global
+    disable_job: false
     emails: '$DEFAULT_RECIPIENTS'
     cron-string: 'H/30 * * * *'
     # How long to wait after sending TERM to send KILL (minutes)

--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
@@ -15,7 +15,7 @@
     description: '{description} Test owner: {test-owner}.'
     logrotate:
         daysToKeep: 7
-    disabled: false
+    disabled: '{obj:disable_job}'
     builders:
         - shell: |
             {provider-env}
@@ -479,6 +479,9 @@
             description: 'Run slow E2E tests on latest Trusty build.'
             timeout: 270
         - 'dev-slow':
+            # Constantly failing due to a known issue of the image. Disabled
+            # until the issue is resolved.
+            disable_job: true
             description: 'Run slow E2E tests on latest Trusty dev build.'
             timeout: 270
         - 'beta-slow':


### PR DESCRIPTION
Also, disable kubernetes-e2e-gce-trusty-dev-slow for now as it is failing
constantly due to a known issue.

@spxtr 

cc/ @andyzheng0831
