### PR TITLE
set readonlyrootfilesystem in the security context provider and add t…

### DIFF
--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -566,12 +566,11 @@ func (dm *DockerManager) runContainer(
 	}
 
 	hc := &docker.HostConfig{
-		Binds:          binds,
-		NetworkMode:    netMode,
-		IpcMode:        ipcMode,
-		UTSMode:        utsMode,
-		PidMode:        pidMode,
-		ReadonlyRootfs: readOnlyRootFilesystem(container),
+		Binds:       binds,
+		NetworkMode: netMode,
+		IpcMode:     ipcMode,
+		UTSMode:     utsMode,
+		PidMode:     pidMode,
 		// Memory and CPU are set here for newer versions of Docker (1.6+).
 		Memory:      memoryLimit,
 		MemorySwap:  -1,
@@ -827,11 +826,6 @@ func (dm *DockerManager) podInfraContainerChanged(pod *api.Pod, podInfraContaine
 // pod must not be nil
 func usesHostNetwork(pod *api.Pod) bool {
 	return pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.HostNetwork
-}
-
-// determine if the container root should be a read only filesystem.
-func readOnlyRootFilesystem(container *api.Container) bool {
-	return container.SecurityContext != nil && container.SecurityContext.ReadOnlyRootFilesystem != nil && *container.SecurityContext.ReadOnlyRootFilesystem
 }
 
 // container must not be nil

--- a/pkg/securitycontext/provider.go
+++ b/pkg/securitycontext/provider.go
@@ -94,6 +94,8 @@ func (p SimpleSecurityContextProvider) ModifyHostConfig(pod *api.Pod, container 
 		hostConfig.SecurityOpt = modifySecurityOption(hostConfig.SecurityOpt, dockerLabelType, effectiveSC.SELinuxOptions.Type)
 		hostConfig.SecurityOpt = modifySecurityOption(hostConfig.SecurityOpt, dockerLabelLevel, effectiveSC.SELinuxOptions.Level)
 	}
+
+	hostConfig.ReadonlyRootfs = readOnlyRootFilesystem(container)
 }
 
 // modifySecurityOption adds the security option of name to the config array with value in the form
@@ -159,6 +161,11 @@ func DetermineEffectiveSecurityContext(pod *api.Pod, container *api.Container) *
 		*effectiveSc.RunAsNonRoot = *containerSc.RunAsNonRoot
 	}
 
+	if containerSc.ReadOnlyRootFilesystem != nil {
+		effectiveSc.ReadOnlyRootFilesystem = new(bool)
+		*effectiveSc.ReadOnlyRootFilesystem = *containerSc.ReadOnlyRootFilesystem
+	}
+
 	return effectiveSc
 }
 
@@ -184,4 +191,9 @@ func securityContextFromPodSecurityContext(pod *api.Pod) *api.SecurityContext {
 	}
 
 	return synthesized
+}
+
+// determine if the container root should be a read only filesystem.
+func readOnlyRootFilesystem(container *api.Container) bool {
+	return container.SecurityContext != nil && container.SecurityContext.ReadOnlyRootFilesystem != nil && *container.SecurityContext.ReadOnlyRootFilesystem
 }


### PR DESCRIPTION
…ests that ensure DetermineEffectiveSecurityContext retains container settings

Minor refactoring to move SC related setting to the SC provider.  Not required for 1.2.

@pmorie PTAL
