### PR TITLE
Catch UnicodeEncodeError in the test history generator.

### DIFF
--- a/hack/jenkins/test-history/gen_json.py
+++ b/hack/jenkins/test-history/gen_json.py
@@ -111,7 +111,6 @@ def gcs_get_tests(path):
     except zlib.error:
         # Don't fail if it's not gzipped.
         pass
-    data = data.decode('utf-8')
 
     try:
         root = ET.fromstring(data)


### PR DESCRIPTION
One of our tests prints out an error message that makes the xml parser raise UnicodeEncodeError. Not a whole lot we can do about it besides ignore it.

Probably this isn't a problem in python 3 :)
