### PR TITLE
Trusty: fix several bugs

### DIFF
--- a/cluster/gce/trusty/master.yaml
+++ b/cluster/gce/trusty/master.yaml
@@ -144,7 +144,6 @@ script
 		--system-cgroups=/system \
 		--runtime-cgroups=/docker-daemon \
 		--kubelet-cgroups=/kubelet \
-		--babysit-daemons=true \
 		${KUBELET_CMD_FLAGS} 1>>/var/log/kubelet.log 2>&1
 end script
 
@@ -161,10 +160,7 @@ Content-Disposition: attachment; filename="kube-docker.conf"
 
 description "Restart docker daemon"
 
-# The condition "stopped kube-install-additional-packages" is to avoid
-# breaking nsenter installation, which is through a docker container.
-# It can be removed if we find a better way to install nsenter.
-start on started kubelet and stopped kube-install-additional-packages
+start on started kubelet
 
 script
 	set -o errexit
@@ -255,6 +251,9 @@ script
 	set -o errexit
 	set -o nounset
 
+	# Wait for a minute to let docker and kubelet processes finish initialization.
+	# TODO(andyzheng0831): replace it with a more reliable method if possible.
+	sleep 60
 	. /etc/kube-configure.sh
 	. /etc/kube-env
 	health_monitoring

--- a/cluster/gce/trusty/node.yaml
+++ b/cluster/gce/trusty/node.yaml
@@ -143,7 +143,6 @@ script
 		--system-cgroups=/system \
 		--runtime-cgroups=/docker-daemon \
 		--kubelet-cgroups=/kubelet \
-		--babysit-daemons=true \
 		${KUBELET_CMD_FLAGS} 1>>/var/log/kubelet.log 2>&1
 end script
 
@@ -160,10 +159,7 @@ Content-Disposition: attachment; filename="kube-docker.conf"
 
 description "Restart docker daemon"
 
-# The condition "stopped kube-install-additional-packages" is to avoid
-# breaking nsenter installation, which is through a docker container.
-# It can be removed if we find a better way to install nsenter.
-start on started kubelet and stopped kube-install-additional-packages
+start on started kubelet
 
 script
 	set -o errexit


### PR DESCRIPTION
This PR fixes several racing cases that make health check incorrectly kills docker daemon and kubelet too fast (the issue #22842). In addition, it removes a deprecated kubelet flag. It also revises the way to get host name, i.e., via GCE metadata server. That is the most accurate way in GCE because the instance host name comes from GCE DHCP server.
