### PR TITLE
Support addon Deployments, make heapster a deployment with a nanny.

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -9,7 +9,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.0.0
+  name: heapster
   namespace: kube-system
   labels:
     k8s-app: heapster
@@ -88,7 +88,7 @@ spec:
             - --memory=200Mi
             - --extra-memory=3Mi
             - --threshold=5
-            - --deployment=heapster-v1.0.0-beta1
+            - --deployment=heapster
             - --container=heapster
             - --poll-period=300000
         - image: gcr.io/google_containers/addon-resizer:1.0
@@ -116,7 +116,7 @@ spec:
             - --memory=200Mi
             - --extra-memory=3Mi
             - --threshold=5
-            - --deployment=heapster-v1.0.0-beta1
+            - --deployment=heapster
             - --container=eventer
             - --poll-period=300000
       volumes:

--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -1,9 +1,11 @@
 {% set metrics_memory = "200Mi" -%}
 {% set eventer_memory = "200Mi" -%}
+{% set metrics_memory_per_node = 4 -%}
+{% set eventer_memory_per_node = 500 -%}
 {% set num_nodes = pillar.get('num_nodes', -1) -%}
 {% if num_nodes >= 0 -%}
-  {% set metrics_memory = (200 + num_nodes * 4)|string + "Mi" -%}
-  {% set eventer_memory = (200 * 1024 + num_nodes * 500)|string + "Ki" -%}
+  {% set metrics_memory = (200 + num_nodes * metrics_memory_per_node)|string + "Mi" -%}
+  {% set eventer_memory = (200 * 1024 + num_nodes * eventer_memory_per_node)|string + "Ki" -%}
 {% endif -%}
 
 apiVersion: extensions/v1beta1
@@ -85,8 +87,8 @@ spec:
             - /pod_nanny
             - --cpu=100m
             - --extra-cpu=0m
-            - --memory=200Mi
-            - --extra-memory=3Mi
+            - --memory={{ metrics_memory }}
+            - --extra-memory={{metrics_memory_per_node}}Mi
             - --threshold=5
             - --deployment=heapster
             - --container=heapster
@@ -113,8 +115,8 @@ spec:
             - /pod_nanny
             - --cpu=100m
             - --extra-cpu=0m
-            - --memory=200Mi
-            - --extra-memory=3Mi
+            - --memory={{eventer_memory}}
+            - --extra-memory={{eventer_memory_per_node}}Ki
             - --threshold=5
             - --deployment=heapster
             - --container=eventer

--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -6,8 +6,8 @@
   {% set eventer_memory = (200 * 1024 + num_nodes * 500)|string + "Ki" -%}
 {% endif -%}
 
-apiVersion: v1
-kind: ReplicationController
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
   name: heapster-v1.0.0
   namespace: kube-system
@@ -17,7 +17,8 @@ metadata:
 spec:
   replicas: 1
   selector:
-    k8s-app: heapster
+    matchLabels:
+      k8s-app: heapster
   template:
     metadata:
       labels:
@@ -62,6 +63,62 @@ spec:
             - name: ssl-certs
               mountPath: /etc/ssl/certs
               readOnly: true
+        - image: gcr.io/google_containers/addon-resizer:1.0
+          name: heapster-nanny
+          resources:
+            limits:
+              cpu: 50m
+              memory: 100Mi
+            requests:
+              cpu: 50m
+              memory: 100Mi
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /pod_nanny
+            - --cpu=100m
+            - --extra-cpu=0m
+            - --memory=200Mi
+            - --extra-memory=3Mi
+            - --threshold=5
+            - --deployment=heapster-v1.0.0-beta1
+            - --container=heapster
+            - --poll-period=300000
+        - image: gcr.io/google_containers/addon-resizer:1.0
+          name: eventer-nanny
+          resources:
+            limits:
+              cpu: 50m
+              memory: 100Mi
+            requests:
+              cpu: 50m
+              memory: 100Mi
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /pod_nanny
+            - --cpu=100m
+            - --extra-cpu=0m
+            - --memory=200Mi
+            - --extra-memory=3Mi
+            - --threshold=5
+            - --deployment=heapster-v1.0.0-beta1
+            - --container=eventer
+            - --poll-period=300000
       volumes:
         - name: ssl-certs
           hostPath:

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -9,7 +9,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.0.0
+  name: heapster
   namespace: kube-system
   labels:
     k8s-app: heapster
@@ -89,7 +89,7 @@ spec:
             - --memory=200Mi
             - --extra-memory=3Mi
             - --threshold=5
-            - --deployment=heapster-v1.0.0-beta1
+            - --deployment=heapster
             - --container=heapster
             - --poll-period=300000
         - image: gcr.io/google_containers/addon-resizer:1.0
@@ -117,7 +117,7 @@ spec:
             - --memory=200Mi
             - --extra-memory=3Mi
             - --threshold=5
-            - --deployment=heapster-v1.0.0-beta1
+            - --deployment=heapster
             - --container=eventer
             - --poll-period=300000
       volumes:

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -1,9 +1,11 @@
 {% set metrics_memory = "200Mi" -%}
 {% set eventer_memory = "200Mi" -%}
+{% set metrics_memory_per_node = 4 -%}
+{% set eventer_memory_per_node = 500 -%}
 {% set num_nodes = pillar.get('num_nodes', -1) -%}
 {% if num_nodes >= 0 -%}
-  {% set metrics_memory = (200 + num_nodes * 4)|string + "Mi" -%}
-  {% set eventer_memory = (200 * 1024 + num_nodes * 500)|string + "Ki" -%}
+  {% set metrics_memory = (200 + num_nodes * metrics_memory_per_node)|string + "Mi" -%}
+  {% set eventer_memory = (200 * 1024 + num_nodes * eventer_memory_per_node)|string + "Ki" -%}
 {% endif -%}
 
 apiVersion: extensions/v1beta1
@@ -86,8 +88,8 @@ spec:
             - /pod_nanny
             - --cpu=100m
             - --extra-cpu=0m
-            - --memory=200Mi
-            - --extra-memory=3Mi
+            - --memory={{ metrics_memory }}
+            - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
             - --deployment=heapster
             - --container=heapster
@@ -114,8 +116,8 @@ spec:
             - /pod_nanny
             - --cpu=100m
             - --extra-cpu=0m
-            - --memory=200Mi
-            - --extra-memory=3Mi
+            - --memory={{ eventer_memory }}
+            - --extra-memory={{ eventer_memory_per_node }}Ki
             - --threshold=5
             - --deployment=heapster
             - --container=eventer

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -6,8 +6,8 @@
   {% set eventer_memory = (200 * 1024 + num_nodes * 500)|string + "Ki" -%}
 {% endif -%}
 
-apiVersion: v1
-kind: ReplicationController
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
   name: heapster-v1.0.0
   namespace: kube-system
@@ -17,7 +17,8 @@ metadata:
 spec:
   replicas: 1
   selector:
-    k8s-app: heapster
+    matchLabels:
+      k8s-app: heapster
   template:
     metadata:
       labels:
@@ -63,6 +64,62 @@ spec:
             - name: ssl-certs
               mountPath: /etc/ssl/certs
               readOnly: true
+        - image: gcr.io/google_containers/addon-resizer:1.0
+          name: heapster-nanny
+          resources:
+            limits:
+              cpu: 50m
+              memory: 100Mi
+            requests:
+              cpu: 50m
+              memory: 100Mi
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /pod_nanny
+            - --cpu=100m
+            - --extra-cpu=0m
+            - --memory=200Mi
+            - --extra-memory=3Mi
+            - --threshold=5
+            - --deployment=heapster-v1.0.0-beta1
+            - --container=heapster
+            - --poll-period=300000
+        - image: gcr.io/google_containers/addon-resizer:1.0
+          name: eventer-nanny
+          resources:
+            limits:
+              cpu: 50m
+              memory: 100Mi
+            requests:
+              cpu: 50m
+              memory: 100Mi
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /pod_nanny
+            - --cpu=100m
+            - --extra-cpu=0m
+            - --memory=200Mi
+            - --extra-memory=3Mi
+            - --threshold=5
+            - --deployment=heapster-v1.0.0-beta1
+            - --container=eventer
+            - --poll-period=300000
       volumes:
         - name: ssl-certs
           hostPath:

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -1,9 +1,11 @@
 {% set metrics_memory = "200Mi" -%}
 {% set eventer_memory = "200Mi" -%}
+{% set metrics_memory_per_node = 4 -%}
+{% set eventer_memory_per_node = 500 -%}
 {% set num_nodes = pillar.get('num_nodes', -1) -%}
 {% if num_nodes >= 0 -%}
-  {% set metrics_memory = (200 + num_nodes * 4)|string + "Mi" -%}
-  {% set eventer_memory = (200 * 1024 + num_nodes * 500)|string + "Ki" -%}
+  {% set metrics_memory = (200 + num_nodes * metrics_memory_per_node)|string + "Mi" -%}
+  {% set eventer_memory = (200 * 1024 + num_nodes * eventer_memory_per_node)|string + "Ki" -%}
 {% endif -%}
 
 apiVersion: extensions/v1beta1
@@ -77,8 +79,8 @@ spec:
             - /pod_nanny
             - --cpu=100m
             - --extra-cpu=0m
-            - --memory=200Mi
-            - --extra-memory=3Mi
+            - --memory={{ metrics_memory }}
+            - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
             - --deployment=heapster
             - --container=heapster
@@ -105,8 +107,8 @@ spec:
             - /pod_nanny
             - --cpu=100m
             - --extra-cpu=0m
-            - --memory=200Mi
-            - --extra-memory=3Mi
+            - --memory={{ eventer_memory }}
+            - --extra-memory={{ eventer_memory_per_node }}Ki
             - --threshold=5
             - --deployment=heapster
             - --container=eventer

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -9,7 +9,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.0.0
+  name: heapster
   namespace: kube-system
   labels:
     k8s-app: heapster
@@ -80,7 +80,7 @@ spec:
             - --memory=200Mi
             - --extra-memory=3Mi
             - --threshold=5
-            - --deployment=heapster-v1.0.0-beta1
+            - --deployment=heapster
             - --container=heapster
             - --poll-period=300000
         - image: gcr.io/google_containers/addon-resizer:1.0
@@ -108,7 +108,7 @@ spec:
             - --memory=200Mi
             - --extra-memory=3Mi
             - --threshold=5
-            - --deployment=heapster-v1.0.0-beta1
+            - --deployment=heapster
             - --container=eventer
             - --poll-period=300000
 

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -6,8 +6,8 @@
   {% set eventer_memory = (200 * 1024 + num_nodes * 500)|string + "Ki" -%}
 {% endif -%}
 
-apiVersion: v1
-kind: ReplicationController
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
   name: heapster-v1.0.0
   namespace: kube-system
@@ -17,7 +17,8 @@ metadata:
 spec:
   replicas: 1
   selector:
-    k8s-app: heapster
+    matchLabels:
+      k8s-app: heapster
   template:
     metadata:
       labels:
@@ -54,3 +55,60 @@ spec:
             - /eventer
             - --source=kubernetes:''
             - --sink=influxdb:http://monitoring-influxdb:8086
+        - image: gcr.io/google_containers/addon-resizer:1.0
+          name: heapster-nanny
+          resources:
+            limits:
+              cpu: 50m
+              memory: 100Mi
+            requests:
+              cpu: 50m
+              memory: 100Mi
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /pod_nanny
+            - --cpu=100m
+            - --extra-cpu=0m
+            - --memory=200Mi
+            - --extra-memory=3Mi
+            - --threshold=5
+            - --deployment=heapster-v1.0.0-beta1
+            - --container=heapster
+            - --poll-period=300000
+        - image: gcr.io/google_containers/addon-resizer:1.0
+          name: eventer-nanny
+          resources:
+            limits:
+              cpu: 50m
+              memory: 100Mi
+            requests:
+              cpu: 50m
+              memory: 100Mi
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /pod_nanny
+            - --cpu=100m
+            - --extra-cpu=0m
+            - --memory=200Mi
+            - --extra-memory=3Mi
+            - --threshold=5
+            - --deployment=heapster-v1.0.0-beta1
+            - --container=eventer
+            - --poll-period=300000
+

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -1,7 +1,8 @@
 {% set metrics_memory = "200Mi" -%}
+{% set metrics_memory_per_node = 4 -%}
 {% set num_nodes = pillar.get('num_nodes', -1) -%}
 {% if num_nodes >= 0 -%}
-  {% set metrics_memory = (200 + num_nodes * 4)|string + "Mi" -%}
+  {% set metrics_memory = (200 + num_nodes * metrics_memory_per_node)|string + "Mi" -%}
 {% endif -%}
 
 apiVersion: extensions/v1beta1
@@ -60,8 +61,8 @@ spec:
             - /pod_nanny
             - --cpu=100m
             - --extra-cpu=0m
-            - --memory=200Mi
-            - --extra-memory=3Mi
+            - --memory={{ metrics_memory }}
+            - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
             - --deployment=heapster
             - --container=heapster

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -7,7 +7,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.0.0
+  name: heapster
   namespace: kube-system
   labels:
     k8s-app: heapster
@@ -63,6 +63,6 @@ spec:
             - --memory=200Mi
             - --extra-memory=3Mi
             - --threshold=5
-            - --deployment=heapster-v1.0.0-beta1
+            - --deployment=heapster
             - --container=heapster
             - --poll-period=300000

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -4,8 +4,8 @@
   {% set metrics_memory = (200 + num_nodes * 4)|string + "Mi" -%}
 {% endif -%}
 
-apiVersion: v1
-kind: ReplicationController
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
   name: heapster-v1.0.0
   namespace: kube-system
@@ -15,7 +15,8 @@ metadata:
 spec:
   replicas: 1
   selector:
-    k8s-app: heapster
+    matchLabels:
+      k8s-app: heapster
   template:
     metadata:
       labels:
@@ -37,3 +38,31 @@ spec:
             - /heapster
             - --source=kubernetes.summary_api:''
             - --metric_resolution=60s
+        - image: gcr.io/google_containers/addon-resizer:1.0
+          name: heapster-nanny
+          resources:
+            limits:
+              cpu: 50m
+              memory: 100Mi
+            requests:
+              cpu: 50m
+              memory: 100Mi
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /pod_nanny
+            - --cpu=100m
+            - --extra-cpu=0m
+            - --memory=200Mi
+            - --extra-memory=3Mi
+            - --threshold=5
+            - --deployment=heapster-v1.0.0-beta1
+            - --container=heapster
+            - --poll-period=300000

--- a/cluster/saltbase/salt/kube-addons/kube-addon-update.sh
+++ b/cluster/saltbase/salt/kube-addons/kube-addon-update.sh
@@ -475,13 +475,13 @@ function update-addons() {
     local -r addon_path=$1
     # be careful, reconcile-objects uses global variables
     reconcile-objects ${addon_path} ReplicationController "-" &
-    reconcile-objects ${addon_path} Deployment "-" &
 
     # We don't expect names to be versioned for the following kinds, so
     # we match the entire name, ignoring version suffix.
     # That's why we pass an empty string as the version separator.
     # If the description differs on disk, the object should be recreated.
     # This is not implemented in this version.
+    reconcile-objects ${addon_path} Deployment "" &
     reconcile-objects ${addon_path} Service "" &
     reconcile-objects ${addon_path} PersistentVolume "" &
     reconcile-objects ${addon_path} PersistentVolumeClaim "" &

--- a/cluster/saltbase/salt/kube-addons/kube-addon-update.sh
+++ b/cluster/saltbase/salt/kube-addons/kube-addon-update.sh
@@ -475,6 +475,7 @@ function update-addons() {
     local -r addon_path=$1
     # be careful, reconcile-objects uses global variables
     reconcile-objects ${addon_path} ReplicationController "-" &
+    reconcile-objects ${addon_path} Deployment "-" &
 
     # We don't expect names to be versioned for the following kinds, so
     # we match the entire name, ignoring version suffix.


### PR DESCRIPTION
1. Heapster uses a deployment here.
2. Changed kube-addon-update.sh to include deployments (this seems like a transitional change while we're moving all addons to deployments).
3. Adding a nanny to resize heapster with the number of nodes.
