### PR TITLE
Add generalized performance data type in e2e test

### DIFF
--- a/test/e2e/framework/metrics_util.go
+++ b/test/e2e/framework/metrics_util.go
@@ -287,7 +287,10 @@ func HighLatencyRequests(c *client.Client) (int, error) {
 		}
 	}
 
+	// TODO(random-liu): Remove the log when we migrate to new perfdash
 	Logf("API calls latencies: %s", PrettyPrintJSON(metrics))
+	// Log perf data
+	PrintPerfData(ApiCallToPerfData(metrics))
 
 	return badMetrics, nil
 }

--- a/test/e2e/kubelet_perf.go
+++ b/test/e2e/kubelet_perf.go
@@ -99,11 +99,16 @@ func runResourceTrackingTest(f *framework.Framework, podsPerNode int, nodeNames 
 	logPodsOnNodes(f.Client, nodeNames.List())
 	usageSummary, err := rm.GetLatest()
 	Expect(err).NotTo(HaveOccurred())
+	// TODO(random-liu): Remove the original log when we migrate to new perfdash
 	framework.Logf("%s", rm.FormatResourceUsage(usageSummary))
+	// Log perf result
+	framework.PrintPerfData(framework.ResourceUsageToPerfData(rm.GetMasterNodeLatest(usageSummary)))
 	verifyMemoryLimits(f.Client, expectedMemory, usageSummary)
 
 	cpuSummary := rm.GetCPUSummary()
 	framework.Logf("%s", rm.FormatCPUSummary(cpuSummary))
+	// Log perf result
+	framework.PrintPerfData(framework.CPUUsageToPerfData(rm.GetMasterNodeCPUSummary(cpuSummary)))
 	verifyCPULimits(expectedCPU, cpuSummary)
 
 	By("Deleting the RC")
@@ -243,7 +248,7 @@ var _ = framework.KubeDescribe("Kubelet [Serial] [Slow]", func() {
 			itArg := testArg
 			podsPerNode := itArg.podsPerNode
 			name := fmt.Sprintf(
-				"for %d pods per node over %v", podsPerNode, monitoringTime)
+				"resource tracking for %d pods per node", podsPerNode)
 			It(name, func() {
 				runResourceTrackingTest(f, podsPerNode, nodeNames, rm, itArg.cpuLimits, itArg.memLimits)
 			})
@@ -254,7 +259,7 @@ var _ = framework.KubeDescribe("Kubelet [Serial] [Slow]", func() {
 		for i := range density {
 			podsPerNode := density[i]
 			name := fmt.Sprintf(
-				"for %d pods per node over %v", podsPerNode, monitoringTime)
+				"resource tracking for %d pods per node", podsPerNode)
 			It(name, func() {
 				runResourceTrackingTest(f, podsPerNode, nodeNames, rm, nil, nil)
 			})

--- a/test/e2e/perftype/perftype.go
+++ b/test/e2e/perftype/perftype.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package perftype
+
+// TODO(random-liu): Replace this with prometheus' data model.
+
+// The following performance data structures are generalized and well-formatted.
+// They can be pretty printed in json format and be analyzed by other performance
+// analyzing tools, such as Perfdash (k8s.io/contrib/perfdash).
+
+// DataItem is the data point.
+type DataItem struct {
+	// Data is a map from bucket to real data point (e.g. "Perc90" -> 23.5). Notice
+	// that all data items with the same label conbination should have the same buckets.
+	Data map[string]float64 `json:"data"`
+	// Unit is the data unit. Notice that all data items with the same label combination
+	// should have the same unit.
+	Unit string `json:"unit"`
+	// Labels is the labels of the data item.
+	Labels map[string]string `json:"labels"`
+}
+
+// PerfData contains all data items generated in current test.
+type PerfData struct {
+	DataItems []DataItem `json:"dataItems"`
+}
+
+// PerfResultTag is the prefix of generated perfdata. Analyzing tools can find the perf result
+// with this tag.
+const PerfResultTag = "[Result:Performance]"


### PR DESCRIPTION
For kubernetes/contrib/issues/564 and #15554.

This PR added two files in e2e test:
1) `perftype/perftype.go`: This file contains generalized performance data type. The type can be pretty printed in Json format and analyzed by other performance analyzing tools, such as [Perfdash](https://github.com/kubernetes/contrib/tree/master/perfdash).
2) `perf_util.go`: This file contains functions which convert e2e performance test result into new performance data type.

The new performance data type is now used in _Density test, Load test and Kubelet resource tracking_. It's easy to support other e2e performance test by adding new convert function in `perf_util.go`.

@gmarek @yujuhong 
/cc @kubernetes/sig-testing
