### PR TITLE
Move TestRuntimeCache into non-test go file

### DIFF
--- a/pkg/kubelet/container/runtime_cache_fake.go
+++ b/pkg/kubelet/container/runtime_cache_fake.go
@@ -16,8 +16,10 @@ limitations under the License.
 
 package container
 
-// TestRunTimeCache embeds runtimeCache with some additional methods for
-// testing.
+// TestRunTimeCache embeds runtimeCache with some additional methods for testing.
+// It must be declared in the container package to have visibility to runtimeCache.
+// It cannot be in a "..._test.go" file in order for runtime_cache_test.go to have cross-package visibility to it.
+// (cross-package declarations in test files cannot be used from dot imports if this package is vendored)
 type TestRuntimeCache struct {
 	runtimeCache
 }


### PR DESCRIPTION
The dot import from runtime_cache_test.go doesn't pick up things declared in *_test.go files when k8s is in a Godeps path, which makes the runtime_cache_test fail.

This odd structure (exporting a private type in a _test file for use in another _test file declared in a different package and dot importing the original package) was added in https://github.com/kubernetes/kubernetes/pull/21953/
