### PR TITLE
Fix cpu and resource summary log in kubelet stat.

### DIFF
--- a/test/e2e/kubelet_stats.go
+++ b/test/e2e/kubelet_stats.go
@@ -575,7 +575,7 @@ func (r *resourceMonitor) LogLatest() {
 	if err != nil {
 		Logf("%v", err)
 	}
-	Logf(r.FormatResourceUsage(summary))
+	Logf("%s", r.FormatResourceUsage(summary))
 }
 
 func (r *resourceMonitor) FormatResourceUsage(s resourceUsagePerNode) string {
@@ -647,7 +647,7 @@ func (r *resourceMonitor) FormatCPUSummary(summary nodesCPUSummary) string {
 
 func (r *resourceMonitor) LogCPUSummary() {
 	summary := r.GetCPUSummary()
-	Logf(r.FormatCPUSummary(summary))
+	Logf("%s", r.FormatCPUSummary(summary))
 }
 
 func (r *resourceMonitor) GetCPUSummary() nodesCPUSummary {


### PR DESCRIPTION
[`LogCPUSummary()`](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/kubelet_stats.go#L648) always prints log like this, because the string returned by `FormatCPUSummary` contains '%' [here](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/kubelet_stats.go#L623):

```
5th%!t(MISSING)h%!t(MISSING)h%!t(MISSING)h%!t(MISSING)h%!t(MISSING)h%!t(MISSING)h%!
(MISSING)"/"              0.000 0.000 0.259 0.259 0.259 0.259 0.259
"/docker-daemon" 0.000 0.000 0.023 0.023 0.023 0.023 0.023
"/kubelet"       0.000 0.000 0.044 0.044 0.044 0.044 0.044
"/system"        0.000 0.000 0.008 0.008 0.008 0.008 0.008
```

This PR fixes the small issue.

@yujuhong 
