### PR TITLE
Allow starting test etcd with http

### DIFF
--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -69,7 +69,7 @@ import (
 
 // setUp is a convience function for setting up for (most) tests.
 func setUp(t *testing.T) (*Master, *etcdtesting.EtcdTestServer, Config, *assert.Assertions) {
-	server := etcdtesting.NewEtcdTestClientServer(t)
+	server := etcdtesting.NewUnsecuredEtcdTestClientServer(t)
 
 	master := &Master{
 		GenericAPIServer: &genericapiserver.GenericAPIServer{},

--- a/pkg/registry/registrytest/etcd.go
+++ b/pkg/registry/registrytest/etcd.go
@@ -37,7 +37,7 @@ import (
 )
 
 func NewEtcdStorage(t *testing.T, group string) (storage.Interface, *etcdtesting.EtcdTestServer) {
-	server := etcdtesting.NewEtcdTestClientServer(t)
+	server := etcdtesting.NewUnsecuredEtcdTestClientServer(t)
 	storage := etcdstorage.NewEtcdStorage(server.Client, testapi.Groups[group].StorageCodec(), etcdtest.PathPrefix(), false, etcdtest.DeserializationCacheSize)
 	return storage, server
 }


### PR DESCRIPTION
There are cases where we'll want to start a test etcd without https (external tools monitoring tests, tests with lots of parallelism, etc). This makes it an option.

Helps with https://github.com/kubernetes/kubernetes/issues/23127

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/22919)

<!-- Reviewable:end -->
