### PR TITLE
Increase gce-slow timeout

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
@@ -89,7 +89,7 @@
                 export PROJECT="k8s-jkns-e2e-gce"
         - 'gce-slow':
             description: 'Runs slow tests on GCE, sequentially.'
-            timeout: 60
+            timeout: 150
             job-env: |
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
@@ -242,7 +242,7 @@
                 export PROJECT="k8s-jkns-e2e-gce-1-2"
     jobs:
         - 'kubernetes-e2e-{suffix}'
- 
+
 - project:
     name: kubernetes-e2e-gke-1.1
     trigger-job: 'kubernetes-build-1.1'


### PR DESCRIPTION
There are issues open about the performance of most of the tests in gce-slow (most frequent offenders: https://github.com/kubernetes/kubernetes/issues/14204 and MaxContainerBackOff which is designed to test exponential backoff), yet we close the CQ on slow suite timeout. 

Increasing to 150 because we plan on growing this suite to accomodate gce loadbalancer tests in the next release.
