### PR TITLE
change probe timeout to 20s for quickly timeout

### DIFF
--- a/pkg/apiserver/validator.go
+++ b/pkg/apiserver/validator.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	probeTimeOut = time.Minute
+	probeTimeOut = 20 * time.Second
 )
 
 // TODO: this basic interface is duplicated in N places.  consolidate?

--- a/pkg/genericapiserver/genericapiserver.go
+++ b/pkg/genericapiserver/genericapiserver.go
@@ -58,6 +58,7 @@ import (
 
 const (
 	DefaultEtcdPathPrefix = "/registry"
+	globalTimeout         = time.Minute
 )
 
 // StorageDestinations is a mapping from API group & resource to
@@ -662,7 +663,7 @@ func (s *GenericAPIServer) Run(options *ServerRunOptions) {
 		if longRunningRequestCheck(req) {
 			return nil, ""
 		}
-		return time.After(time.Minute), ""
+		return time.After(globalTimeout), ""
 	}
 
 	if secureLocation != "" {


### PR DESCRIPTION
Just as we discussed here #22540, it should be better for us to change the global timeout to a smaller value. @lavalamp ptal.
