### PR TITLE
Allow up to 39 PVs attached to AWS node

### DIFF
--- a/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
+++ b/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"strconv"
 
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/aws"
 	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/plugin/pkg/scheduler"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
@@ -30,10 +31,6 @@ import (
 
 	"github.com/golang/glog"
 )
-
-// Amazon recommends having no more that 40 volumes attached to an instance,
-// and at least one of those is for the system root volume.
-const DefaultMaxEBSVolumes = 39
 
 // GCE instances can have up to 16 PD volumes attached.
 const DefaultMaxGCEPDVolumes = 16
@@ -117,7 +114,7 @@ func defaultPredicates() sets.String {
 			"MaxEBSVolumeCount",
 			func(args factory.PluginFactoryArgs) algorithm.FitPredicate {
 				// TODO: allow for generically parameterized scheduler predicates, because this is a bit ugly
-				maxVols := getMaxVols(DefaultMaxEBSVolumes)
+				maxVols := getMaxVols(aws.DefaultMaxEBSVolumes)
 				return predicates.NewMaxPDVolumeCountPredicate(predicates.EBSVolumeFilter, maxVols, args.PVInfo, args.PVCInfo)
 			},
 		),


### PR DESCRIPTION
The devices are named /dev/xvdba - /dev/xvdcm, leaving /dev/sda - /dev/sdz for the
system.

AWS docs says:
- up to 40 devices are supported
- _recommended_ devices for EBS are /dev/sd[f-p]
- the same page it says that /dev/xvd[b-c][a-z] are _available_
  http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html#available-ec2-device-names

So, let's use all the _available_ devices, respecting limit of 40 devices.

Additional patches in this PR ensure that user gets some meaningful error when a node cannot attach more volumes to run a pod. When admin increases KUBE_MAX_PD_VOLS to 50. Only 39 pods are `Running`, the rest is `ContainerCreating` forever (or until some volumes are detached from the node) with "Too many EBS volumes attached to node" error:

```
$ kubectl describe pod
Events:
  FirstSeen     LastSeen        Count   From                                    SubobjectPath   Type            Reason          Message
  ---------     --------        -----   ----                                    -------------   --------        ------          -------
  8m            8m              1       {default-scheduler }                                    Normal          Scheduled       Successfully assigned pod-40 to ip-172-18-0-64.ec2.internal
  57s           57s             1       {kubelet ip-172-18-0-64.ec2.internal}                   Warning         FailedMount     Unable to mount volumes for pod "pod-40_default(1cf42d02-e9f0-11e5-94e6-0eed93379351)": Could not attach EBS Disk "vol-095e42aa": Too many EBS volumes attached to node XYZ.
  57s           57s             1       {kubelet ip-172-18-0-64.ec2.internal}                   Warning         FailedSync      Error syncing pod, skipping: Could not attach EBS Disk "vol-095e42aa": Too many EBS volumes attached to node XYZ.
```

@justinsb @kubernetes/sig-storage @kubernetes/rh-storage 
