### PR TITLE
Up scalability-1.1 to 1.2.

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
@@ -255,6 +255,33 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="k8s-jkns-e2e-gce-serial-1-2"
+        - 'gce-scalability-release-1.2':
+            timeout: 120
+            description: 'Run scalability E2E tests on GCE from the release-1.2 branch.'
+            job-env: |
+                export E2E_NAME="e2e-scalability-1-2"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Performance\] \
+                                         --gather-resource-usage=true \
+                                         --gather-metrics-at-teardown=true \
+                                         --gather-logs-sizes=true \
+                                         --output-print-type=json"
+                # Use the 1.1 project for now, since it has quota.
+                export PROJECT="k8s-e2e-gce-scalability-1-1"
+                export FAIL_ON_GCP_RESOURCE_LEAK="false"
+                # Override GCE defaults.
+                export MASTER_SIZE="n1-standard-4"
+                export NODE_SIZE="n1-standard-2"
+                export NODE_DISK_SIZE="50GB"
+                export NUM_NODES="100"
+                export REGISTER_MASTER="true"
+                # Reduce logs verbosity
+                export TEST_CLUSTER_LOG_LEVEL="--v=2"
+                # TODO: Remove when we figure out the reason for occasional failures #19048
+                export KUBELET_TEST_LOG_LEVEL="--v=4"
+                # Increase resync period to simulate production
+                export TEST_CLUSTER_RESYNC_PERIOD="--min-resync-period=12h"
+                # Increase delete collection parallelism
+                export TEST_CLUSTER_DELETE_COLLECTION_WORKERS="--delete-collection-workers=16"
     jobs:
         - 'kubernetes-e2e-{suffix}'
  
@@ -371,9 +398,6 @@
         - 'gce-disruptive-1.1':
             timeout: 180
             description: 'Run disruptive E2E tests on GCE from the current release branch.'
-        - 'gce-scalability-1.1':
-            timeout: 210
-            description: 'Run scalability E2E tests on GCE from the current release branch.'
     jobs:
         - 'kubernetes-e2e-{suffix}'
 


### PR DESCRIPTION
ref #22672

I'm still using the 1-1 GCE project, since it has quota. If you think that's a bad idea, let me know.

Please don't apply LGTM label, since I'll need to go in and manually delete the 1.1 job once this goes in.
