### PR TITLE
add admission control flag to vsphere provider

### DIFF
--- a/cluster/vsphere/config-default.sh
+++ b/cluster/vsphere/config-default.sh
@@ -34,6 +34,10 @@ NODE_CPU=1
 
 SERVICE_CLUSTER_IP_RANGE="10.244.240.0/20"  # formerly PORTAL_NET
 
+# Admission Controllers to invoke prior to persisting objects in cluster
+export ADMISSION_CONTROL="NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,SecurityContextDeny"
+
+
 # Optional: Enable node logging.
 ENABLE_NODE_LOGGING=false
 LOGGING_DESTINATION=elasticsearch

--- a/cluster/vsphere/templates/create-dynamic-salt-files.sh
+++ b/cluster/vsphere/templates/create-dynamic-salt-files.sh
@@ -123,6 +123,7 @@ dns_domain: $DNS_DOMAIN
 e2e_storage_test_environment: "${E2E_STORAGE_TEST_ENVIRONMENT:-false}"
 cluster_cidr: "$NODE_IP_RANGES"
 allocate_node_cidrs: "${ALLOCATE_NODE_CIDRS:-true}"
+admission_control: '$(echo "$ADMISSION_CONTROL" | sed -e "s/'/''/g")'
 EOF
 
 mkdir -p /srv/salt-overlay/salt/nginx

--- a/cluster/vsphere/util.sh
+++ b/cluster/vsphere/util.sh
@@ -368,6 +368,7 @@ function kube-up {
     echo "readonly NODE_INSTANCE_PREFIX='${INSTANCE_PREFIX}-node'"
     echo "readonly NODE_IP_RANGES='${NODE_IP_RANGES}'"
     echo "readonly SERVICE_CLUSTER_IP_RANGE='${SERVICE_CLUSTER_IP_RANGE}'"
+    echo "readonly ADMISSION_CONTROL='${ADMISSION_CONTROL:-}'"
     echo "readonly ENABLE_NODE_LOGGING='${ENABLE_NODE_LOGGING:-false}'"
     echo "readonly LOGGING_DESTINATION='${LOGGING_DESTINATION:-}'"
     echo "readonly ENABLE_CLUSTER_DNS='${ENABLE_CLUSTER_DNS:-false}'"
@@ -426,7 +427,7 @@ function kube-up {
   remote-pgrep ${KUBE_MASTER_IP} "salt-master"
 
   printf "Waiting for all packages to be installed on ${KUBE_MASTER} ...\n"
-  kube-check  ${KUBE_MASTER_IP} 'sudo salt "kubernetes-master" state.highstate -t 30 | grep -E "Failed:[[:space:]]+0"'
+  kube-check  ${KUBE_MASTER_IP} 'sudo salt '"${KUBE_MASTER}"' state.highstate -t 30 | grep -E "Failed:[[:space:]]+0"'
 
   local i
   for (( i=0; i<${#NODE_NAMES[@]}; i++)); do


### PR DESCRIPTION
For vsphere deployment, the heapster and dashboard containers were not able to start. Looking at the log and seems like it is not able to find the service account. 

Compare with other providers, it appears that admission control flag are provided in other providers, but not in vsphere. 

This change is to add the admission control flag to vsphere script.

Also minor change from hardcoded "kuberneter-master" to MASTER_NAME environment variable. Otherwise, script won't work if user use different INSTANCE_PREFIX
