### PR TITLE
test kubectl run with default args

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -861,6 +861,48 @@ var _ = Describe("Kubectl client", func() {
 		})
 	})
 
+	Describe("Kubectl run default", func() {
+		var nsFlag string
+		var name string
+
+		var cleanUp func()
+
+		BeforeEach(func() {
+			nsFlag = fmt.Sprintf("--namespace=%v", ns)
+			gte, err := serverVersionGTE(deploymentsVersion, c)
+			if err != nil {
+				Failf("Failed to get server version: %v", err)
+			}
+			if gte {
+				name = "e2e-test-nginx-deployment"
+				cleanUp = func() { runKubectlOrDie("delete", "deployment", name, nsFlag) }
+			} else {
+				name = "e2e-test-nginx-rc"
+				cleanUp = func() { runKubectlOrDie("delete", "rc", name, nsFlag) }
+			}
+		})
+
+		AfterEach(func() {
+			cleanUp()
+		})
+
+		It("should create an rc or deployment from an image [Conformance]", func() {
+			By("running the image " + nginxImage)
+			runKubectlOrDie("run", name, "--image="+nginxImage, nsFlag)
+			By("verifying the pod controlled by " + name + " gets created")
+			label := labels.SelectorFromSet(labels.Set(map[string]string{"run": name}))
+			podlist, err := waitForPodsWithLabel(c, ns, label)
+			if err != nil {
+				Failf("Failed getting pod controlled by %s: %v", name, err)
+			}
+			pods := podlist.Items
+			if pods == nil || len(pods) != 1 || len(pods[0].Spec.Containers) != 1 || pods[0].Spec.Containers[0].Image != nginxImage {
+				runKubectlOrDie("get", "pods", "-L", "run", nsFlag)
+				Failf("Failed creating 1 pod with expected image %s. Number of pods = %v", nginxImage, len(pods))
+			}
+		})
+	})
+
 	Describe("Kubectl run rc", func() {
 		var nsFlag string
 		var rcName string
@@ -913,7 +955,6 @@ var _ = Describe("Kubectl client", func() {
 				Failf("Failed getting logs by rc %s: %v", rcName, err)
 			}
 		})
-
 	})
 
 	Describe("Kubectl run deployment", func() {
@@ -933,7 +974,7 @@ var _ = Describe("Kubectl client", func() {
 			SkipUnlessServerVersionGTE(deploymentsVersion, c)
 
 			By("running the image " + nginxImage)
-			runKubectlOrDie("run", dName, "--image="+nginxImage, nsFlag)
+			runKubectlOrDie("run", dName, "--image="+nginxImage, "--generator=deployment/v1beta1", nsFlag)
 			By("verifying the deployment " + dName + " was created")
 			d, err := c.Extensions().Deployments(ns).Get(dName)
 			if err != nil {
@@ -956,7 +997,6 @@ var _ = Describe("Kubectl client", func() {
 				Failf("Failed creating 1 pod with expected image %s. Number of pods = %v", nginxImage, len(pods))
 			}
 		})
-
 	})
 
 	Describe("Kubectl run job", func() {
@@ -1009,7 +1049,6 @@ var _ = Describe("Kubectl client", func() {
 				Failf("Failed creating a job with correct restart policy for --restart=OnFailure")
 			}
 		})
-
 	})
 
 	Describe("Kubectl run --rm job", func() {


### PR DESCRIPTION
This does a generic test that `kubectl run nginx --name=nginx` creates a pod with the expected container, regardless of what generator it uses. Also made the deployments generator explicit in case we change the default in the future. Verified passing with a client at head and a server at 1.1.8. Ref #21421
