### PR TITLE
Trusty: support developer workflow on base image

### DIFF
--- a/cluster/gce/trusty/master.yaml
+++ b/cluster/gce/trusty/master.yaml
@@ -124,15 +124,11 @@ script
 	echo "Start kubelet upstart job"
 	. /etc/kube-configure.sh
 	. /etc/kube-env
-	BINARY_PATH="/usr/bin/kubelet"
-	if [ "${TEST_CLUSTER:-}" = "true" ]; then
-		BINARY_PATH="/usr/local/bin/kubelet"
-	fi
 	# Assemble command line flags based on env variables, which will put the string
 	# of flags in variable KUBELET_CMD_FLAGS
 	assemble_kubelet_flags
 	
-	${BINARY_PATH} \
+	/usr/bin/kubelet \
 		--enable-debugging-handlers=false \
 		--cloud-provider=gce \
 		--config=/etc/kubernetes/manifests \
@@ -219,11 +215,7 @@ script
 
 	. /etc/kube-env
 	export HOME="/root"
-	if [ "${TEST_CLUSTER:-}" = "true" ]; then
-		export KUBECTL_BIN="/usr/local/bin/kubectl"
-	else
-		export KUBECTL_BIN="/usr/bin/kubectl"
-	fi
+	export KUBECTL_BIN="/usr/bin/kubectl"
 	export TOKEN_DIR="/etc/srv/kubernetes"
 	export kubelet_kubeconfig_file="/var/lib/kubelet/kubeconfig"
 	export TRUSTY_MASTER="true"

--- a/cluster/gce/trusty/node.yaml
+++ b/cluster/gce/trusty/node.yaml
@@ -122,15 +122,11 @@ script
 	echo "Start kubelet upstart job"
 	. /etc/kube-configure.sh
 	. /etc/kube-env
-	BINARY_PATH="/usr/bin/kubelet"
-	if [ "${TEST_CLUSTER:-}" = "true" ]; then
-		BINARY_PATH="/usr/local/bin/kubelet"
-	fi
 	# Assemble command line flags based on env variables, which will put the string
 	# of flags in variable KUBELET_CMD_FLAGS.
 	assemble_kubelet_flags
 
-	${BINARY_PATH} \
+	/usr/bin/kubelet \
 		--api-servers=https://${KUBERNETES_MASTER_NAME} \
 		--enable-debugging-handlers=true \
 		--cloud-provider=gce \


### PR DESCRIPTION
This change will be helpful in two aspects: (1) Running k8s head in GKE e2e tests; (2) Allow k8s developers to manually run k8s e2e against their local changes. This change also simplifies the logic: no matter test or non-test cluster, binaries are in /usr/bin.

@roberthbailey @dchen1107 @vishh 

cc/ @fabioy @wonderfly FYI

I have tested this change in four combinations of configurations:
- Image: trusty or customized image
- Cluster type: test cluster created by "go run hack/e2e.go -v --up" or non-test cluster created by "cluster/kube-up.sh"
