### PR TITLE
Renaming api/errors/etcd to api/errors/storage 

### DIFF
--- a/pkg/api/errors/storage/doc.go
+++ b/pkg/api/errors/storage/doc.go
@@ -15,4 +15,4 @@ limitations under the License.
 */
 
 // Package etcd provides conversion of etcd errors to API errors.
-package etcd
+package storage

--- a/pkg/api/errors/storage/storage.go
+++ b/pkg/api/errors/storage/storage.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package etcd
+package storage
 
 import (
 	"k8s.io/kubernetes/pkg/api/errors"

--- a/pkg/registry/deployment/etcd/etcd.go
+++ b/pkg/registry/deployment/etcd/etcd.go
@@ -21,7 +21,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
-	etcderr "k8s.io/kubernetes/pkg/api/errors/etcd"
+	storeerr "k8s.io/kubernetes/pkg/api/errors/storage"
 	"k8s.io/kubernetes/pkg/api/rest"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	extvalidation "k8s.io/kubernetes/pkg/apis/extensions/validation"
@@ -148,8 +148,8 @@ func (r *RollbackREST) Create(ctx api.Context, obj runtime.Object) (out runtime.
 
 func (r *RollbackREST) rollbackDeployment(ctx api.Context, deploymentID string, config *extensions.RollbackConfig, annotations map[string]string) (err error) {
 	if _, err = r.setDeploymentRollback(ctx, deploymentID, config, annotations); err != nil {
-		err = etcderr.InterpretGetError(err, extensions.Resource("deployments"), deploymentID)
-		err = etcderr.InterpretUpdateError(err, extensions.Resource("deployments"), deploymentID)
+		err = storeerr.InterpretGetError(err, extensions.Resource("deployments"), deploymentID)
+		err = storeerr.InterpretUpdateError(err, extensions.Resource("deployments"), deploymentID)
 		if _, ok := err.(*errors.StatusError); !ok {
 			err = errors.NewConflict(extensions.Resource("deployments/rollback"), deploymentID, err)
 		}

--- a/pkg/registry/deployment/etcd/etcd_test.go
+++ b/pkg/registry/deployment/etcd/etcd_test.go
@@ -22,7 +22,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
-	etcderrors "k8s.io/kubernetes/pkg/api/errors/etcd"
+	storeerr "k8s.io/kubernetes/pkg/api/errors/storage"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/fields"
@@ -366,7 +366,7 @@ func TestEtcdCreateDeploymentRollbackNoDeployment(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected not-found-error but got nothing")
 	}
-	if !errors.IsNotFound(etcderrors.InterpretGetError(err, extensions.Resource("deployments"), name)) {
+	if !errors.IsNotFound(storeerr.InterpretGetError(err, extensions.Resource("deployments"), name)) {
 		t.Fatalf("Unexpected error returned: %#v", err)
 	}
 
@@ -374,7 +374,7 @@ func TestEtcdCreateDeploymentRollbackNoDeployment(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected not-found-error but got nothing")
 	}
-	if !errors.IsNotFound(etcderrors.InterpretGetError(err, extensions.Resource("deployments"), name)) {
+	if !errors.IsNotFound(storeerr.InterpretGetError(err, extensions.Resource("deployments"), name)) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 }

--- a/pkg/registry/pod/etcd/etcd.go
+++ b/pkg/registry/pod/etcd/etcd.go
@@ -23,7 +23,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
-	etcderr "k8s.io/kubernetes/pkg/api/errors/etcd"
+	storeerr "k8s.io/kubernetes/pkg/api/errors/storage"
 	"k8s.io/kubernetes/pkg/api/rest"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/api/validation"
@@ -175,8 +175,8 @@ func (r *BindingREST) setPodHostAndAnnotations(ctx api.Context, podID, oldMachin
 // assignPod assigns the given pod to the given machine.
 func (r *BindingREST) assignPod(ctx api.Context, podID string, machine string, annotations map[string]string) (err error) {
 	if _, err = r.setPodHostAndAnnotations(ctx, podID, "", machine, annotations); err != nil {
-		err = etcderr.InterpretGetError(err, api.Resource("pods"), podID)
-		err = etcderr.InterpretUpdateError(err, api.Resource("pods"), podID)
+		err = storeerr.InterpretGetError(err, api.Resource("pods"), podID)
+		err = storeerr.InterpretUpdateError(err, api.Resource("pods"), podID)
 		if _, ok := err.(*errors.StatusError); !ok {
 			err = errors.NewConflict(api.Resource("pods/binding"), podID, err)
 		}

--- a/pkg/registry/pod/etcd/etcd_test.go
+++ b/pkg/registry/pod/etcd/etcd_test.go
@@ -24,7 +24,7 @@ import (
 	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
-	etcderrors "k8s.io/kubernetes/pkg/api/errors/etcd"
+	storeerr "k8s.io/kubernetes/pkg/api/errors/storage"
 	"k8s.io/kubernetes/pkg/api/rest"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -422,7 +422,7 @@ func TestEtcdCreateBindingNoPod(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected not-found-error but got nothing")
 	}
-	if !errors.IsNotFound(etcderrors.InterpretGetError(err, api.Resource("pods"), "foo")) {
+	if !errors.IsNotFound(storeerr.InterpretGetError(err, api.Resource("pods"), "foo")) {
 		t.Fatalf("Unexpected error returned: %#v", err)
 	}
 
@@ -430,7 +430,7 @@ func TestEtcdCreateBindingNoPod(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected not-found-error but got nothing")
 	}
-	if !errors.IsNotFound(etcderrors.InterpretGetError(err, api.Resource("pods"), "foo")) {
+	if !errors.IsNotFound(storeerr.InterpretGetError(err, api.Resource("pods"), "foo")) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 }

--- a/pkg/registry/service/allocator/etcd/etcd.go
+++ b/pkg/registry/service/allocator/etcd/etcd.go
@@ -23,7 +23,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	k8serr "k8s.io/kubernetes/pkg/api/errors"
-	etcderr "k8s.io/kubernetes/pkg/api/errors/etcd"
+	storeerr "k8s.io/kubernetes/pkg/api/errors/storage"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/registry/service"
 	"k8s.io/kubernetes/pkg/registry/service/allocator"
@@ -164,7 +164,7 @@ func (e *Etcd) tryUpdate(fn func() error) error {
 			return existing, nil
 		}),
 	)
-	return etcderr.InterpretUpdateError(err, e.resource, "")
+	return storeerr.InterpretUpdateError(err, e.resource, "")
 }
 
 // Refresh reloads the RangeAllocation from etcd.
@@ -177,7 +177,7 @@ func (e *Etcd) Refresh() (*api.RangeAllocation, error) {
 		if storage.IsNotFound(err) {
 			return nil, nil
 		}
-		return nil, etcderr.InterpretGetError(err, e.resource, "")
+		return nil, storeerr.InterpretGetError(err, e.resource, "")
 	}
 
 	return existing, nil
@@ -188,7 +188,7 @@ func (e *Etcd) Refresh() (*api.RangeAllocation, error) {
 func (e *Etcd) Get() (*api.RangeAllocation, error) {
 	existing := &api.RangeAllocation{}
 	if err := e.storage.Get(context.TODO(), e.baseKey, existing, true); err != nil {
-		return nil, etcderr.InterpretGetError(err, e.resource, "")
+		return nil, storeerr.InterpretGetError(err, e.resource, "")
 	}
 	return existing, nil
 }
@@ -216,7 +216,7 @@ func (e *Etcd) CreateOrUpdate(snapshot *api.RangeAllocation) error {
 		}),
 	)
 	if err != nil {
-		return etcderr.InterpretUpdateError(err, e.resource, "")
+		return storeerr.InterpretUpdateError(err, e.resource, "")
 	}
 	err = e.alloc.Restore(snapshot.Range, snapshot.Data)
 	if err == nil {


### PR DESCRIPTION
Continuation of #17546.  api/errors no longer contains any errors directly tied to etcd that are not reinterpreted by the storage layer.  

/cc @wojtek-t 
