### PR TITLE
cassandra: update replica count to 1 to match tutorial text

### DIFF
--- a/examples/cassandra/README.md
+++ b/examples/cassandra/README.md
@@ -183,7 +183,7 @@ metadata:
   # labels:
     # app: cassandra
 spec:
-  replicas: 2
+  replicas: 1
   # The selector will be applied automatically
   # from the labels in the pod template, if not set.
   # selector:

--- a/examples/cassandra/cassandra-controller.yaml
+++ b/examples/cassandra/cassandra-controller.yaml
@@ -7,7 +7,7 @@ metadata:
   # labels:
     # app: cassandra
 spec:
-  replicas: 2
+  replicas: 1
   # The selector will be applied automatically
   # from the labels in the pod template, if not set.
   # selector:


### PR DESCRIPTION
I noticed that the replica count was wrong (i.e. didn't match the actual text/flow) as I was reading through the tutorial. Hope its okay to make this pull request without and issue first since its just small fix.
