### PR TITLE
Fix for issue #22932 infinite pod restarts with CNI

### DIFF
--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -807,7 +807,7 @@ func (dm *DockerManager) podInfraContainerChanged(pod *api.Pod, podInfraContaine
 			glog.V(4).Infof("host: %v, %v", pod.Spec.SecurityContext.HostNetwork, networkMode)
 			return true, nil
 		}
-	} else {
+	} else if dm.networkPlugin.Name() != "cni" && dm.networkPlugin.Name() != "kubenet" {
 		// Docker only exports ports from the pod infra container. Let's
 		// collect all of the relevant ports and export them.
 		for _, container := range pod.Spec.Containers {


### PR DESCRIPTION
This fixes an [issue](https://github.com/kubernetes/kubernetes/issues/22932) when using CNI where the hash of a Container object will differ between creation and change checks due to the docker image exporting ports.
We make sure the Container generated in [DockerManager. podInfraContainerChanged](https://github.com/kubernetes/kubernetes/blob/bc62096ad5ea8ce15156b39cfd2333bc6f589905/pkg/kubelet/dockertools/manager.go#L805) uses the same logic as in [DockerManager. createPodInfraContainer](https://github.com/kubernetes/kubernetes/blob/bc62096ad5ea8ce15156b39cfd2333bc6f589905/pkg/kubelet/dockertools/manager.go#L1584) when it comes to adding Dockers own exported ports

Fixes #22932
