### PR TITLE
tighten StorageDestination types and errors

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -143,6 +143,7 @@ func updateEtcdOverrides(overrides []string, storageVersions map[string]string, 
 		}
 		group := apiresource[0]
 		resource := apiresource[1]
+		groupResource := unversioned.GroupResource{Group: group, Resource: resource}
 
 		apigroup, err := registered.Group(group)
 		if err != nil {
@@ -166,7 +167,7 @@ func updateEtcdOverrides(overrides []string, storageVersions map[string]string, 
 			glog.Fatalf("Invalid storage version or misconfigured etcd for %s: %v", tokens[0], err)
 		}
 
-		storageDestinations.AddStorageOverride(group, resource, etcdOverrideStorage)
+		storageDestinations.AddStorageOverride(groupResource, etcdOverrideStorage)
 	}
 }
 

--- a/examples/apiserver/apiserver.go
+++ b/examples/apiserver/apiserver.go
@@ -23,6 +23,7 @@ import (
 	testgroupetcd "k8s.io/kubernetes/examples/apiserver/rest"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/rest"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apimachinery"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/genericapiserver"
@@ -78,8 +79,13 @@ func Run() error {
 	if err != nil {
 		return fmt.Errorf("Unable to init etcd: %v", err)
 	}
+
+	storage, err := storageDestinations.Get(unversioned.GroupResource{Group: groupName, Resource: "testtype"})
+	if err != nil {
+		return err
+	}
 	restStorageMap := map[string]rest.Storage{
-		"testtypes": testgroupetcd.NewREST(storageDestinations.Get(groupName, "testtype"), s.StorageDecorator()),
+		"testtypes": testgroupetcd.NewREST(storage, s.StorageDecorator()),
 	}
 	apiGroupInfo := genericapiserver.APIGroupInfo{
 		GroupMeta: *groupMeta,

--- a/pkg/genericapiserver/destinations.go
+++ b/pkg/genericapiserver/destinations.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genericapiserver
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/storage"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	"github.com/golang/glog"
+	"golang.org/x/net/context"
+)
+
+// StorageDestinations is a mapping from API group & resource to
+// the underlying storage interfaces.
+type StorageDestinations struct {
+	APIGroups map[string]*StorageDestinationsForAPIGroup
+}
+
+type StorageDestinationsForAPIGroup struct {
+	Default   storage.Interface
+	Overrides map[string]storage.Interface
+}
+
+func NewStorageDestinations() StorageDestinations {
+	return StorageDestinations{
+		APIGroups: map[string]*StorageDestinationsForAPIGroup{},
+	}
+}
+
+// AddAPIGroup replaces 'group' if it's already registered.
+func (s *StorageDestinations) AddAPIGroup(group string, defaultStorage storage.Interface) {
+	glog.Infof("Adding storage destination for group %v", group)
+	s.APIGroups[group] = &StorageDestinationsForAPIGroup{
+		Default:   defaultStorage,
+		Overrides: map[string]storage.Interface{},
+	}
+}
+
+func (s *StorageDestinations) AddStorageOverride(groupResource unversioned.GroupResource, override storage.Interface) {
+	group := groupResource.Group
+	if _, ok := s.APIGroups[group]; !ok {
+		s.AddAPIGroup(group, nil)
+	}
+	if s.APIGroups[group].Overrides == nil {
+		s.APIGroups[group].Overrides = map[string]storage.Interface{}
+	}
+	s.APIGroups[group].Overrides[groupResource.Resource] = override
+}
+
+// Get finds the storage destination for the given group and resource. It will
+// return an error if the group has no storage destination configured.
+func (s *StorageDestinations) Get(groupResource unversioned.GroupResource) (storage.Interface, error) {
+	apigroup, ok := s.APIGroups[groupResource.Group]
+	if !ok {
+		return nil, &NoDestinationFoundError{GroupResources: []unversioned.GroupResource{groupResource}, AvailableGroups: sets.StringKeySet(s.APIGroups)}
+	}
+
+	if client, exists := apigroup.Overrides[groupResource.Resource]; exists {
+		return client, nil
+	}
+	return apigroup.Default, nil
+}
+
+// Search is like Get, but can be used to search a list of groups. It tries the
+// groups in order and returns an error if none of them exist. The intention is for
+// this to be used for resources that move between groups.
+func (s *StorageDestinations) Search(resources []unversioned.GroupResource) (storage.Interface, error) {
+	for _, resource := range resources {
+		storage, err := s.Get(resource)
+		if IsNoDestinationFoundError(err) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		return storage, nil
+	}
+
+	return nil, &NoDestinationFoundError{GroupResources: resources, AvailableGroups: sets.StringKeySet(s.APIGroups)}
+}
+
+// Get all backends for all registered storage destinations.
+// Used for getting all instances for health validations.
+func (s *StorageDestinations) Backends() []string {
+	backends := sets.String{}
+	for _, group := range s.APIGroups {
+		if group.Default != nil {
+			for _, backend := range group.Default.Backends(context.TODO()) {
+				backends.Insert(backend)
+			}
+		}
+		if group.Overrides != nil {
+			for _, storage := range group.Overrides {
+				for _, backend := range storage.Backends(context.TODO()) {
+					backends.Insert(backend)
+				}
+			}
+		}
+	}
+	return backends.List()
+}
+
+type NoDestinationFoundError struct {
+	GroupResources  []unversioned.GroupResource
+	AvailableGroups sets.String
+}
+
+func (e *NoDestinationFoundError) Error() string {
+	return fmt.Sprintf("No storage defined for: '%v'. Defined groups: %v", e.GroupResources, e.AvailableGroups.List())
+}
+
+func IsNoDestinationFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	_, ok := err.(*NoDestinationFoundError)
+	return ok
+}

--- a/pkg/genericapiserver/genericapiserver.go
+++ b/pkg/genericapiserver/genericapiserver.go
@@ -42,7 +42,6 @@ import (
 	genericetcd "k8s.io/kubernetes/pkg/registry/generic/etcd"
 	ipallocator "k8s.io/kubernetes/pkg/registry/service/ipallocator"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/storage"
 	"k8s.io/kubernetes/pkg/ui"
 	"k8s.io/kubernetes/pkg/util"
 	utilnet "k8s.io/kubernetes/pkg/util/net"
@@ -53,114 +52,12 @@ import (
 	"github.com/emicklei/go-restful"
 	"github.com/emicklei/go-restful/swagger"
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 )
 
 const (
 	DefaultEtcdPathPrefix = "/registry"
 	globalTimeout         = time.Minute
 )
-
-// StorageDestinations is a mapping from API group & resource to
-// the underlying storage interfaces.
-type StorageDestinations struct {
-	APIGroups map[string]*StorageDestinationsForAPIGroup
-}
-
-type StorageDestinationsForAPIGroup struct {
-	Default   storage.Interface
-	Overrides map[string]storage.Interface
-}
-
-func NewStorageDestinations() StorageDestinations {
-	return StorageDestinations{
-		APIGroups: map[string]*StorageDestinationsForAPIGroup{},
-	}
-}
-
-// AddAPIGroup replaces 'group' if it's already registered.
-func (s *StorageDestinations) AddAPIGroup(group string, defaultStorage storage.Interface) {
-	glog.Infof("Adding storage destination for group %v", group)
-	s.APIGroups[group] = &StorageDestinationsForAPIGroup{
-		Default:   defaultStorage,
-		Overrides: map[string]storage.Interface{},
-	}
-}
-
-func (s *StorageDestinations) AddStorageOverride(group, resource string, override storage.Interface) {
-	if _, ok := s.APIGroups[group]; !ok {
-		s.AddAPIGroup(group, nil)
-	}
-	if s.APIGroups[group].Overrides == nil {
-		s.APIGroups[group].Overrides = map[string]storage.Interface{}
-	}
-	s.APIGroups[group].Overrides[resource] = override
-}
-
-// Get finds the storage destination for the given group and resource. It will
-// Fatalf if the group has no storage destination configured.
-func (s *StorageDestinations) Get(group, resource string) storage.Interface {
-	apigroup, ok := s.APIGroups[group]
-	if !ok {
-		// TODO: return an error like a normal function. For now,
-		// Fatalf is better than just logging an error, because this
-		// condition guarantees future problems and this is a less
-		// mysterious failure point.
-		glog.Fatalf("No storage defined for API group: '%s'. Defined groups: %#v", group, s.APIGroups)
-		return nil
-	}
-	if apigroup.Overrides != nil {
-		if client, exists := apigroup.Overrides[resource]; exists {
-			return client
-		}
-	}
-	return apigroup.Default
-}
-
-// Search is like Get, but can be used to search a list of groups. It tries the
-// groups in order (and Fatalf's if none of them exist). The intention is for
-// this to be used for resources that move between groups.
-func (s *StorageDestinations) Search(groups []string, resource string) storage.Interface {
-	for _, group := range groups {
-		apigroup, ok := s.APIGroups[group]
-		if !ok {
-			continue
-		}
-		if apigroup.Overrides != nil {
-			if client, exists := apigroup.Overrides[resource]; exists {
-				return client
-			}
-		}
-		return apigroup.Default
-	}
-	// TODO: return an error like a normal function. For now,
-	// Fatalf is better than just logging an error, because this
-	// condition guarantees future problems and this is a less
-	// mysterious failure point.
-	glog.Fatalf("No storage defined for any of the groups: %v. Defined groups: %#v", groups, s.APIGroups)
-	return nil
-}
-
-// Get all backends for all registered storage destinations.
-// Used for getting all instances for health validations.
-func (s *StorageDestinations) Backends() []string {
-	backends := sets.String{}
-	for _, group := range s.APIGroups {
-		if group.Default != nil {
-			for _, backend := range group.Default.Backends(context.TODO()) {
-				backends.Insert(backend)
-			}
-		}
-		if group.Overrides != nil {
-			for _, storage := range group.Overrides {
-				for _, backend := range storage.Backends(context.TODO()) {
-					backends.Insert(backend)
-				}
-			}
-		}
-	}
-	return backends.List()
-}
 
 // Specifies the overrides for various API group versions.
 // This can be used to enable/disable entire group versions or specific resources.


### PR DESCRIPTION
This allows proper delegation inside of the `StorageDestination` types and tightens the API to express exactly which bits of information it wants instead of series of strings.

@liggitt this starts to unwind the stick bits you were messing with during the rebase.
