### PR TITLE
fix incorrect db label

### DIFF
--- a/examples/rethinkdb/driver-service.yaml
+++ b/examples/rethinkdb/driver-service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    db: influxdb
+    db: rethinkdb
   name: rethinkdb-driver
 spec:
   ports:


### PR DESCRIPTION
The rethinkdb example driver-service was incorrectly labeled as db:
`influxdb`
