### PR TITLE
azure: add kube-down, remove need for tenant-id

### DIFF
--- a/cluster/azure/config-default.sh
+++ b/cluster/azure/config-default.sh
@@ -31,10 +31,6 @@ AZURE_USERNAME="${AZURE_USERNAME:-"kube"}"
 # Initial number of worker nodes to provision
 NUM_NODES=${NUM_NODES:-3}
 
-# The Azure Active Directoy (AAD) TenantID to which the subscription belongs.
-# This should be a GUID.
-AZURE_TENANT_ID="${AZURE_TENANT_ID:-}"
-
 # The target Azure subscription ID
 # This should be a GUID.
 AZURE_SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID:-}"


### PR DESCRIPTION
Adds support for tearing down the Azure Kubernetes cluster.

Remove the need for the user to specify the tenant id up front.
