### PR TITLE
Trusty: Support hybrid cluster with nodes on ContainerVM

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -689,6 +689,11 @@ function create-nodes-template() {
 
   local template_name="${NODE_INSTANCE_PREFIX}-template"
 
+  # For master on trusty, we support running nodes on ContainerVM or trusty.
+  if [[ "${OS_DISTRIBUTION}" == "trusty" ]] && \
+     [[ "${NODE_IMAGE}" == container* ]]; then
+    source "${KUBE_ROOT}/cluster/gce/debian/helper.sh"
+  fi
   create-node-instance-template $template_name
 }
 


### PR DESCRIPTION
@roberthbailey @dchen1107 please review it.

cc/ @wonderfly @fabioy FYI.

This change is for supporting hybrid cluster in trusty. Since our current need is to run master on trusty and nodes on ContainerVM, I intentionally did not support the reverse case, i.e., nodes on trusty and master on ContainerVM. I still put the hybrid mode under the framework of "trusty", so as to minimize impact on other distros. Therefore, users need to set "KUBE_OS_DISTRIBUTION=trusty".

When setting the following three variables, the cluster will run on trusty
- KUBE_OS_DISTRIBUTION=trusty
- KUBE_GCE_MASTER_PROJECT=<image-project>
- KUBE_GCE_MASTER_IMAGE=<imageg>

To run in the hybrid mode, set additional two variables:
- KUBE_GCE_NODE_PROJECT=google-containers
- KUBE_GCE_NODE_IMAGE=<ContainerVM image>

I have run e2e against the hybrid cluster using the following settings:
export KUBE_OS_DISTRIBUTION=trusty
export KUBE_GCE_MASTER_PROJECT=ubuntu-os-cloud
export KUBE_GCE_MASTER_IMAGE=ubuntu-1404-trusty-v20160314
export KUBE_GCE_NODE_PROJECT=google-containers
export KUBE_GCE_NODE_IMAGE=container-v1-2-v20160218

go run hack/e2e.go -v --up
go run ./hack/e2e.go -v --test '--test_args=--ginkgo.skip=[Slow]|[Serial]|[Disruptive]|[Flaky]|[Feature:.+]'

Summarizing 1 Failure:

[Fail] [k8s.io] Addon update [BeforeEach] should propagate add-on file changes 
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/addon_update.go:358

Ran 159 of 266 Specs in 4323.580 seconds
FAIL! -- 158 Passed | 1 Failed | 0 Pending | 107 Skipped --- FAIL: TestE2E (4324.07s)

The failure is expected.

I also ran cluster/kube-up.sh for the hybrid mode and verified all kube-system pods running.
