### PR TITLE
Stop the users from rolling back a paused deployment in kubectl rollout undo

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -1287,9 +1287,16 @@ __EOF__
   kubectl rollout undo deployment nginx-deployment "${kube_flags[@]}"
   sleep 1
   kube::test::get_object_assert deployment "{{range.items}}{{$deployment_image_field}}:{{end}}" 'nginx:latest:'
+  # Pause the deployment
+  kubectl-with-retry rollout pause deployment nginx-deployment "${kube_flags[@]}"
+  # A paused deployment cannot be rolled back
+  ! kubectl rollout undo deployment nginx-deployment "${kube_flags[@]}"
+  # Resume the deployment
+  kubectl-with-retry rollout resume deployment nginx-deployment "${kube_flags[@]}"
+  # The resumed deployment can now be rolled back
+  kubectl rollout undo deployment nginx-deployment "${kube_flags[@]}"
   # Clean up
   kubectl delete deployment nginx-deployment "${kube_flags[@]}"
-  kubectl delete rs -l pod-template-hash "${kube_flags[@]}"
 
 
   ######################

--- a/pkg/kubectl/rollback.go
+++ b/pkg/kubectl/rollback.go
@@ -49,6 +49,10 @@ type DeploymentRollbacker struct {
 }
 
 func (r *DeploymentRollbacker) Rollback(namespace, name string, updatedAnnotations map[string]string, toRevision int64, obj runtime.Object) (string, error) {
+	d := obj.(*extensions.Deployment)
+	if d.Spec.Paused {
+		return "", fmt.Errorf("you cannot rollback a paused deployment; resume it first with 'kubectl rollout resume' and try again")
+	}
 	deploymentRollback := &extensions.DeploymentRollback{
 		Name:               name,
 		UpdatedAnnotations: updatedAnnotations,


### PR DESCRIPTION
Fixes #23022

Rolling back a paused deployment now gives you error:

``` console
$ kubectl rollout undo deployment/nginx-deployment
error: you cannot rollback a paused deployment; resume it first with 'kubectl rollout resume' and try again
```

Before this, `kubectl rollout undo` will wait for rollback events to happen and never return.

@bgrant0607 @kargakis @kubernetes/kubectl @kubernetes/sig-config 
