### PR TITLE
Add IPv6 address support for pods - does NOT include services

### DIFF
--- a/pkg/api/endpoints/util_test.go
+++ b/pkg/api/endpoints/util_test.go
@@ -67,6 +67,16 @@ func TestPackSubsets(t *testing.T) {
 				Ports:     []api.EndpointPort{{Port: 111}},
 			}},
 		}, {
+			name: "one set, one ip, one port (IPv6)",
+			given: []api.EndpointSubset{{
+				Addresses: []api.EndpointAddress{{IP: "beef::1:2:3:4"}},
+				Ports:     []api.EndpointPort{{Port: 111}},
+			}},
+			expect: []api.EndpointSubset{{
+				Addresses: []api.EndpointAddress{{IP: "beef::1:2:3:4"}},
+				Ports:     []api.EndpointPort{{Port: 111}},
+			}},
+		}, {
 			name: "one set, one notReady ip, one port",
 			given: []api.EndpointSubset{{
 				NotReadyAddresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
@@ -167,6 +177,16 @@ func TestPackSubsets(t *testing.T) {
 			}},
 			expect: []api.EndpointSubset{{
 				Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
+				Ports:     []api.EndpointPort{{Port: 111}},
+			}},
+		}, {
+			name: "one set, dup ips, one port (IPv6)",
+			given: []api.EndpointSubset{{
+				Addresses: []api.EndpointAddress{{IP: "beef::1"}, {IP: "beef::1"}},
+				Ports:     []api.EndpointPort{{Port: 111}},
+			}},
+			expect: []api.EndpointSubset{{
+				Addresses: []api.EndpointAddress{{IP: "beef::1"}},
 				Ports:     []api.EndpointPort{{Port: 111}},
 			}},
 		}, {

--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -301,6 +301,11 @@ func (dm *DockerManager) determineContainerIP(podNamespace, podName string, cont
 
 	if container.NetworkSettings != nil {
 		result = container.NetworkSettings.IPAddress
+
+		// Fall back to IPv6 address if no IPv4 address is present
+		if result == "" {
+			result = container.NetworkSettings.GlobalIPv6Address
+		}
 	}
 
 	if dm.networkPlugin.Name() != network.DefaultPluginName {
@@ -1214,6 +1219,15 @@ func (dm *DockerManager) GetContainerIP(containerID, interfaceName string) (stri
 	args := []string{"-t", fmt.Sprintf("%d", containerPid), "-n", "--", "bash", "-c", extractIPCmd}
 	command := exec.Command("nsenter", args...)
 	out, err := command.CombinedOutput()
+
+	// Fall back to IPv6 address if no IPv4 address is present
+	if err == nil && string(out) == "" {
+		extractIPCmd = fmt.Sprintf("ip -6 addr show %s scope global | grep inet6 | awk -F\" \" '{print $2}'", interfaceName)
+		args = []string{"-t", fmt.Sprintf("%d", containerPid), "-n", "--", "bash", "-c", extractIPCmd}
+		command = exec.Command("nsenter", args...)
+		out, err = command.CombinedOutput()
+	}
+
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This allows a container to have an IPv6 address only and extracts the address via nsenter and iproute2 or the docker client directly. An IPv6 address is now correctly reported when describing a pod.

@thockin @kubernetes/sig-network

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/23090)

<!-- Reviewable:end -->
