### PR TITLE
aws: Install 'swapspace' to prevent out-of-memory

### DIFF
--- a/cluster/aws/templates/configure-vm-aws.sh
+++ b/cluster/aws/templates/configure-vm-aws.sh
@@ -50,8 +50,15 @@ remove-docker-artifacts() {
   :
 }
 
+install-extra-master-packages() {
+  # Install swapspace to ensure we don't run out of memory
+  apt-get-install swapspace
+}
+
 # Finds the master PD device
 find-master-pd() {
+  install-extra-master-packages
+
   if ( grep "/mnt/master-pd" /proc/mounts ); then
     echo "Master PD already mounted; won't remount"
     MASTER_PD_DEVICE=""


### PR DESCRIPTION
The swapspace package will automatically allocate swap space in the situation that we run out of memory on the node.

This could affect the kubelet's ability to judge resource usage, so I have only included it in the master codepath.

This is a proposed fix for #23117

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/23119)

<!-- Reviewable:end -->
