### PR TITLE
Added vsphere support for vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -77,6 +77,12 @@ $kube_provider_boxes = {
       :box_name => 'kube-fedora23',
       :box_url => 'https://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_fedora-23_chef-provisionerless.box'
     }
+  },
+  :vsphere => {
+    'fedora' => {
+      :box_name => 'vsphere-dummy',
+      :box_url => 'https://github.com/deromka/vagrant-vsphere/blob/master/vsphere-dummy.box?raw=true'
+    }
   }
 }
 
@@ -205,6 +211,58 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         exit
       }).strip
     end
+
+    # Then try vsphere
+    config.vm.provider :vsphere do |vsphere, override|
+      setvmboxandurl(override, :vsphere)
+
+       #config.vm.hostname = ENV['MASTER_NAME']
+
+       config.ssh.username = ENV['MASTER_USER']
+       config.ssh.password = ENV['MASTER_PASSWD']
+
+       config.ssh.pty = true
+       config.ssh.insert_key = true
+       #config.ssh.private_key_path = '~/.ssh/id_rsa_vsphere'
+      
+      # Don't attempt to update the tools on the image (this can
+      # be done manually if necessary)
+      # vsphere.update_guest_tools = false # v.customize ['set', :id, '--tools-autoupdate', 'off']
+
+      # The vSphere host we're going to connect to
+      vsphere.host = ENV['VAGRANT_VSPHERE_URL']
+
+      # The ESX host for the new VM
+      vsphere.compute_resource_name = ENV['VAGRANT_VSPHERE_RESOURCE_POOL']
+
+      # The resource pool for the new VM
+      #vsphere.resource_pool_name = 'Comp'
+
+      # path to folder where new VM should be created, if not specified template's parent folder will be used
+      vsphere.vm_base_path = ENV['VAGRANT_VSPHERE_BASE_PATH']
+
+      # The template we're going to clone
+      vsphere.template_name = ENV['VAGRANT_VSPHERE_TEMPLATE_NAME']
+
+      # The name of the new machine
+      #vsphere.name = ENV['MASTER_NAME']
+
+      # vSphere login
+      vsphere.user = ENV['VAGRANT_VSPHERE_USERNAME']
+
+      # vSphere password
+      vsphere.password = ENV['VAGRANT_VSPHERE_PASSWORD']
+
+      # cpu count
+      vsphere.cpu_count = $vm_cpus
+
+      # memory in MB
+      vsphere.memory_mb = vm_mem
+
+      # If you don't have SSL configured correctly, set this to 'true'
+      vsphere.insecure = ENV['VAGRANT_VSPHERE_INSECURE']
+    end
+
 
     # Don't attempt to update Virtualbox Guest Additions (requires gcc)
     if Vagrant.has_plugin?("vagrant-vbguest") then

--- a/cluster/vagrant/config-default.sh
+++ b/cluster/vagrant/config-default.sh
@@ -51,8 +51,8 @@ CLUSTER_IP_RANGE="${CLUSTER_IP_RANGE:-10.246.0.0/16}"
 SERVICE_CLUSTER_IP_RANGE=10.247.0.0/16  # formerly PORTAL_NET
 
 # Since this isn't exposed on the network, default to a simple user/passwd
-MASTER_USER=vagrant
-MASTER_PASSWD=vagrant
+MASTER_USER="${MASTER_USER:-vagrant}"
+MASTER_PASSWD="${MASTER_PASSWD:-vagrant}"
 
 # Admission Controllers to invoke prior to persisting objects in cluster
 ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
@@ -110,3 +110,6 @@ OPENCONTRAIL_KUBERNETES_TAG="${OPENCONTRAIL_KUBERNETES_TAG:-master}"
 OPENCONTRAIL_PUBLIC_SUBNET="${OPENCONTRAIL_PUBLIC_SUBNET:-10.1.0.0/16}"
 # Optional: if set to true, kube-up will configure the cluster to run e2e tests.
 E2E_STORAGE_TEST_ENVIRONMENT=${KUBE_E2E_STORAGE_TEST_ENVIRONMENT:-false}
+
+# Default fallback NETWORK_IF_NAME, will be used in case when no 'VAGRANT-BEGIN' comments were defined in network-script
+export DEFAULT_NETWORK_IF_NAME="eth0"

--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -21,6 +21,8 @@ set -o pipefail
 # Set the host name explicitly
 # See: https://github.com/mitchellh/vagrant/issues/2430
 hostnamectl set-hostname ${MASTER_NAME}
+# Set the variable to empty value explicitly
+if_to_edit=""
 
 if [[ "$(grep 'VERSION_ID' /etc/os-release)" =~ ^VERSION_ID=23 ]]; then
   # Disable network interface being managed by Network Manager (needed for Fedora 21+)
@@ -33,7 +35,13 @@ if [[ "$(grep 'VERSION_ID' /etc/os-release)" =~ ^VERSION_ID=23 ]]; then
   systemctl restart network
 fi
 
+# needed for vsphere support
+# handle the case when no 'VAGRANT-BEGIN' comment was defined in network-scripts
+# set the NETWORK_IF_NAME to have a default value in such case
 NETWORK_IF_NAME=`echo ${if_to_edit} | awk -F- '{ print $3 }'`
+if [[ -z "$NETWORK_IF_NAME" ]]; then
+  NETWORK_IF_NAME=${DEFAULT_NETWORK_IF_NAME}
+fi
 
 function release_not_found() {
   echo "It looks as if you don't have a compiled version of Kubernetes.  If you" >&2

--- a/cluster/vagrant/provision-network-master.sh
+++ b/cluster/vagrant/provision-network-master.sh
@@ -65,6 +65,12 @@ EOF
     NETWORK_CONF_PATH=/etc/sysconfig/network-scripts/
     if_to_edit=$( find ${NETWORK_CONF_PATH}ifcfg-* | xargs grep -l VAGRANT-BEGIN )
     NETWORK_IF_NAME=`echo ${if_to_edit} | awk -F- '{ print $3 }'`
+    # needed for vsphere support
+    # handle the case when no 'VAGRANT-BEGIN' comment was defined in network-scripts
+    # set the NETWORK_IF_NAME to have a default value in such case
+    if [[ -z "$NETWORK_IF_NAME" ]]; then
+      NETWORK_IF_NAME=${DEFAULT_NETWORK_IF_NAME}
+    fi
     cat <<EOF >/etc/sysconfig/flanneld
 FLANNEL_ETCD="${FLANNEL_ETCD_URL}"
 FLANNEL_ETCD_KEY="/coreos.com/network"

--- a/cluster/vagrant/provision-network-node.sh
+++ b/cluster/vagrant/provision-network-node.sh
@@ -30,6 +30,12 @@ function provision-network-node {
     NETWORK_CONF_PATH=/etc/sysconfig/network-scripts/
     if_to_edit=$( find ${NETWORK_CONF_PATH}ifcfg-* | xargs grep -l VAGRANT-BEGIN )
     NETWORK_IF_NAME=`echo ${if_to_edit} | awk -F- '{ print $3 }'`
+    # needed for vsphere support
+    # handle the case when no 'VAGRANT-BEGIN' comment was defined in network-scripts
+    # set the NETWORK_IF_NAME to have a default value in such case
+    if [[ -z "$NETWORK_IF_NAME" ]]; then
+      NETWORK_IF_NAME=${DEFAULT_NETWORK_IF_NAME}
+    fi
     cat <<EOF >/etc/sysconfig/flanneld
 FLANNEL_ETCD="${FLANNEL_ETCD_URL}"
 FLANNEL_ETCD_KEY="/coreos.com/network"

--- a/cluster/vagrant/provision-node.sh
+++ b/cluster/vagrant/provision-node.sh
@@ -21,6 +21,7 @@ set -o pipefail
 # Set the host name explicitly
 # See: https://github.com/mitchellh/vagrant/issues/2430
 hostnamectl set-hostname ${NODE_NAME}
+if_to_edit=""
 
 if [[ "$(grep 'VERSION_ID' /etc/os-release)" =~ ^VERSION_ID=23 ]]; then
   # Disable network interface being managed by Network Manager (needed for Fedora 21+)
@@ -33,7 +34,13 @@ if [[ "$(grep 'VERSION_ID' /etc/os-release)" =~ ^VERSION_ID=23 ]]; then
   systemctl restart network
 fi
 
+# needed for vsphere support
+# handle the case when no 'VAGRANT-BEGIN' comment was defined in network-scripts
+# set the NETWORK_IF_NAME to have a default value in such case
 NETWORK_IF_NAME=`echo ${if_to_edit} | awk -F- '{ print $3 }'`
+if [[ -z "$NETWORK_IF_NAME" ]]; then
+  NETWORK_IF_NAME=${DEFAULT_NETWORK_IF_NAME}
+fi
 
 # Setup hosts file to support ping by hostname to master
 if [ ! "$(cat /etc/hosts | grep $MASTER_NAME)" ]; then

--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -53,6 +53,7 @@ function verify-prereqs {
       prlctl parallels vagrant-parallels
       VBoxManage virtualbox ''
       virsh libvirt vagrant-libvirt
+      '' vsphere vagrant-vsphere
   )
   local provider_found=''
   local provider_bin


### PR DESCRIPTION
Since the native vsphere support (using govc library) requires admin permissions on ESX/vCenter, not everyone can have such permissions. So I'm adding a vsphere support using vagrant using vagrant-vsphere plugin
