### PR TITLE
validate-cluster.sh: Don't use ignored and deprecated option '--api-v…

### DIFF
--- a/cluster/validate-cluster.sh
+++ b/cluster/validate-cluster.sh
@@ -89,7 +89,7 @@ while true; do
   # Echo the output and gather 2 counts:
   #  - Total number of componentstatuses.
   #  - Number of "healthy" components.
-  cs_status=$("${KUBE_ROOT}/cluster/kubectl.sh" get componentstatuses -o template --template='{{range .items}}{{with index .conditions 0}}{{.type}}:{{.status}},{{end}}{{end}}' --api-version=v1) || true
+  cs_status=$("${KUBE_ROOT}/cluster/kubectl.sh" get componentstatuses -o template --template='{{range .items}}{{with index .conditions 0}}{{.type}}:{{.status}},{{end}}{{end}}') || true
   componentstatuses=$(echo "${cs_status}" | tr "," "\n" | grep -c 'Healthy:') || true
   healthy=$(echo "${cs_status}" | tr "," "\n" | grep -c 'Healthy:True') || true
 


### PR DESCRIPTION
…ersion'

When using this flag, this error is shown:

```
Flag --api-version has been deprecated, flag is no longer respected and will be deleted in the next release
```

Stop using the flag in the validate-cluster.sh script and avoid the warning.
