### PR TITLE
Increase kubernetes-test-go timeout to 50 min for 1.2 and master

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-go.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-go.yaml
@@ -73,10 +73,10 @@
     suffix:
         - 'go':
             branch: 'master'
-            timeout: 45
+            timeout: 50
         - 'go-release-1.2':
             branch: 'release-1.2'
-            timeout: 45
+            timeout: 50
         - 'go-release-1.1':
             branch: 'release-1.1'
             timeout: 30


### PR DESCRIPTION
Helps with #23127
