### PR TITLE
Decrease frequency of 1.1 and 1.0 jobs.

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
@@ -366,6 +366,7 @@
         - 'gke-1.1':
             timeout: 150
             description: 'Run E2E tests on GKE from the current release branch.'
+            cron-string: 'H */6 * * *'
         - 'gke-prod':
             timeout: 180
             description: |
@@ -428,6 +429,7 @@
     branch: 'release-1.1'
     runner: '{old-runner-1-1}'
     post-env: ''
+    cron-string: 'H */6 * * *'
     suffix:
         - 'gce-release-1.1':
             timeout: 175
@@ -445,6 +447,7 @@
     branch: 'release-1.0'
     runner: '{old-runner-1-0}'
     post-env: ''
+    cron-string: 'H */12 * * *'
     suffix:
         - 'gce-release-1.0':
             timeout: 150

--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
@@ -57,7 +57,7 @@
         - junit-publisher
         - log-parser
     triggers:
-        - timed: 'H/30 * * * *'
+        - timed: '{cron-string}'
     wrappers:
         - ansicolor:
             colormap: xterm
@@ -145,6 +145,7 @@
             post-env: ''
             soak-deploy: ''
             soak-continuous: ''
+            cron-string: 'H */6 * * *'
         - 'gke':
             deploy-description: |
                 Deploy Kubernetes to a GKE soak cluster using the staging GKE


### PR DESCRIPTION
I slowed most 1.1 jobs down to once every 6 hours and the 1.0 jobs to once every 12 hours. I didn't touch `gke-prod` or the trusty jobs.

They will still run every time a new build happens.
