### PR TITLE
kubelet: send all recevied pods in one update

### DIFF
--- a/pkg/kubelet/config/config.go
+++ b/pkg/kubelet/config/config.go
@@ -238,16 +238,7 @@ func (s *podStorage) merge(source string, change interface{}) (adds, updates, de
 			}
 			recordFirstSeenTime(ref)
 			pods[name] = ref
-			// If a pod is not found in the cache, and it's also not in the
-			// pending phase, it implies that kubelet may have restarted.
-			// Treat this pod as update so that kubelet wouldn't reject the
-			// pod in the admission process.
-			if ref.Status.Phase != api.PodPending {
-				updatePods = append(updatePods, ref)
-			} else {
-				// this is an add
-				addPods = append(addPods, ref)
-			}
+			addPods = append(addPods, ref)
 		}
 	}
 

--- a/pkg/kubelet/config/config_test.go
+++ b/pkg/kubelet/config/config_test.go
@@ -74,9 +74,6 @@ func CreateValidPod(name, namespace string) *api.Pod {
 				},
 			},
 		},
-		Status: api.PodStatus{
-			Phase: api.PodPending,
-		},
 	}
 }
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2386,6 +2386,10 @@ func (kl *Kubelet) syncLoopIteration(updates <-chan kubetypes.PodUpdate, handler
 		switch u.Op {
 		case kubetypes.ADD:
 			glog.V(2).Infof("SyncLoop (ADD, %q): %q", u.Source, format.Pods(u.Pods))
+			// After restarting, kubelet will get all existing pods through
+			// ADD as if they are new pods. These pods will then go through the
+			// admission process and *may* be rejcted. This can be resolved
+			// once we have checkpointing.
 			handler.HandlePodAdditions(u.Pods)
 		case kubetypes.UPDATE:
 			glog.V(2).Infof("SyncLoop (UPDATE, %q): %q", u.Source, format.Pods(u.Pods))


### PR DESCRIPTION
The kubelet sync loop relies on getting one update as the signal that the
specific source is ready. This change ensures that we don't send multiple
updates (ADD, UPDATE) for the first batch of pods. This is required to prevent
the cleanup routine from killing pods prematurely.

This fixes one issue seen in #23104
