### PR TITLE
Validate minimum CPU limits to be >= 10m

### DIFF
--- a/docs/proposals/resource-qos.md
+++ b/docs/proposals/resource-qos.md
@@ -61,6 +61,7 @@ For each resource, containers can specify a resource request and limit, 0 <= req
 ### Compressible Resource Guarantees
 
 - For now, we are only supporting CPU.
+- Minimum CPU limit is 10 milli cores (`10m`). This a limitation of the Linux kernel.
 - Containers are guaranteed to get the amount of CPU they request, they may or may not get additional CPU time (depending on the other jobs running).
 - Excess CPU resources will be distributed based on the amount of CPU requested. For example, suppose container A requests for 60% of the CPU, and container B requests for 30% of the CPU. Suppose that both containers are trying to use as much CPU as they can. Then the extra 10% of CPU will be distributed to A and B in a 2:1 ratio (implementation discussed in later sections).
 - Containers will be throttled if they exceed their limit. If limit is unspecified, then the containers can use excess CPU when available.

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -50,7 +50,8 @@ const (
 	milliCPUToCPU = 1000
 
 	// 100000 is equivalent to 100ms
-	quotaPeriod = 100000
+	quotaPeriod   = 100000
+	minQuotaPerod = 1000
 )
 
 // DockerInterface is an abstract interface for testability.  It abstracts the interface of docker.Client.
@@ -316,6 +317,11 @@ func milliCPUToQuota(milliCPU int64) (quota int64, period int64) {
 
 	// we then convert your milliCPU to a value normalized over a period
 	quota = (milliCPU * quotaPeriod) / milliCPUToCPU
+
+	// quota needs to be a minimum of 1ms.
+	if quota < minQuotaPerod {
+		quota = minQuotaPerod
+	}
 
 	return
 }

--- a/pkg/kubelet/dockertools/docker_test.go
+++ b/pkg/kubelet/dockertools/docker_test.go
@@ -840,6 +840,21 @@ func TestMilliCPUToQuota(t *testing.T) {
 			period: int64(0),
 		},
 		{
+			input:  int64(5),
+			quota:  int64(1000),
+			period: int64(100000),
+		},
+		{
+			input:  int64(9),
+			quota:  int64(1000),
+			period: int64(100000),
+		},
+		{
+			input:  int64(10),
+			quota:  int64(1000),
+			period: int64(100000),
+		},
+		{
 			input:  int64(200),
 			quota:  int64(20000),
 			period: int64(100000),


### PR DESCRIPTION
- Make kubelet default to 10ms for CPU quota if limit < 10m for
  backwards compat.
- Update documentation

Fixes #23113 

cc @bgrant0607 
