### PR TITLE
Use versioned object when computing patch

### DIFF
--- a/pkg/apiserver/resthandler.go
+++ b/pkg/apiserver/resthandler.go
@@ -567,11 +567,11 @@ func patchResource(ctx api.Context, admit updateAdmissionFunc, timeout time.Dura
 				return nil, err
 			}
 
-			currentPatch, err := strategicpatch.CreateStrategicMergePatch(originalObjJS, currentObjectJS, patcher.New())
+			currentPatch, err := strategicpatch.CreateStrategicMergePatch(originalObjJS, currentObjectJS, versionedObj)
 			if err != nil {
 				return nil, err
 			}
-			originalPatch, err := strategicpatch.CreateStrategicMergePatch(originalObjJS, originalPatchedObjJS, patcher.New())
+			originalPatch, err := strategicpatch.CreateStrategicMergePatch(originalObjJS, originalPatchedObjJS, versionedObj)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/apiserver/resthandler_test.go
+++ b/pkg/apiserver/resthandler_test.go
@@ -204,7 +204,7 @@ func (tc *patchTestCase) Run(t *testing.T) {
 			continue
 
 		case api.StrategicMergePatchType:
-			patch, err = strategicpatch.CreateStrategicMergePatch(originalObjJS, changedJS, &api.Pod{})
+			patch, err = strategicpatch.CreateStrategicMergePatch(originalObjJS, changedJS, versionedObj)
 			if err != nil {
 				t.Errorf("%s: unexpected error: %v", tc.name, err)
 				return


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/23173

When a patch is submitted, if a conflict is encountered while applying the patch, the API server recomputes the patch and attempts to reapply it.

It is currently doing so using the object returned from `patcher.New()`, which is an internal object (e.g. `&api.Pod{}`).

It should be using the external `versionedObject` as the schema to map json key names in the patches to types.

The only reason this mostly works today is that the k8s internal types still have json tags AND their schemas are largely identical to the versioned type definitions. When either of these are not the case, this returns an error like this:

```
Error from server: unable to find api field in struct TypeName for the json field "metadata"
```

We hit this in OpenShift because our internal API types do not have JSON tags
