### PR TITLE
use '/usr/bin/env bash' in update/verify-godep-licenses.sh

### DIFF
--- a/hack/update-godep-licenses.sh
+++ b/hack/update-godep-licenses.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2015 The Kubernetes Authors All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/hack/verify-godep-licenses.sh
+++ b/hack/verify-godep-licenses.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2015 The Kubernetes Authors All rights reserved.
 #


### PR DESCRIPTION
### The problem

These two files assumes on "/bin/bash".
mac osx still uses bash 3 while those scripts are assuming bash 4.
Installing custom bash will solve the problem but require the script to change.
### Solution

This PR will change the script to use user preferred bash.
