### PR TITLE
Styling the update-demo static page

### DIFF
--- a/docs/user-guide/update-demo/local/index.html
+++ b/docs/user-guide/update-demo/local/index.html
@@ -23,14 +23,26 @@ limitations under the License.
 <body ng-controller="ButtonsCtrl">
   <div ng-repeat="server in servers" class="pod">
     <img src="/api/v1/proxy/namespaces/default/pods/{{server.podName}}/{{server.image}}" height="100px" width="100px" />
-    <b>ID:</b> {{server.podName}}<br>
-    <b>Host:</b> <a href="/api/v1/proxy/namespaces/default/pods/{{server.podName}}/data.json">{{server.host}}</a><br>
-    <b>Status:</b> {{server.status}}<br>
-    <b>Image:</b> {{server.dockerImage}}<br>
-    <b>Labels:</b>
-    <ul>
-      <li ng-repeat="(key,value) in server.labels">{{key}}={{value}}</li>
-    </ul>
+    <div class="k8s-example-update-demo-card-section">
+      <span class="k8s-title">ID</span> <span>{{server.podName}}</span>
+    </div>
+    <div class="k8s-example-update-demo-card-section">
+      <span class="k8s-title">Host</span> <span><a href="/api/v1/proxy/namespaces/default/pods/{{server.podName}}/data.json">{{server.host}}</a></span>
+    </div>
+    <div class="k8s-example-update-demo-card-section">
+      <span class="k8s-title">Status</span> <span>{{server.status}}</span>
+    </div>
+    <div class="k8s-example-update-demo-card-section">
+      <span class="k8s-title">Image</span> <span>{{server.dockerImage}}</span>
+    </div>
+    <div class="k8s-example-update-demo-card-section">
+      <span class="k8s-title">Labels</span>
+      <span>
+        <ul>
+          <li ng-repeat="(key,value) in server.labels">{{key}}={{value}}</li>
+        </ul>
+      </span>
+    </div>
   </div>
 </body>
 </html>

--- a/docs/user-guide/update-demo/local/style.css
+++ b/docs/user-guide/update-demo/local/style.css
@@ -19,9 +19,9 @@ img {
   width: 100px;
   float: right;
   background-size: 100px 100px;
-  background-color: black;
   margin-left: 10px;
   border: none;
+  border-radius: 50%;
 }
 
 ul {
@@ -33,8 +33,27 @@ ul {
   font-family: Roboto, Open Sans, arial;
   border: 1px solid black;
   border-radius: 5px;
+  border: 1px groove #DCDDDE;
   padding: 10px;
   margin: 10px;
   display: inline-block;
-  background-color: #D1D1D1;
+  box-shadow: 3px 3px 3px 1px #CFCFCF;
+  background-color: #FFFFFF;
+}
+
+body {
+  background-color: #E8E8E8;
+}
+
+.k8s-example-update-demo-card-section {
+  color: black;
+  font-size: 13px;
+}
+
+.k8s-example-update-demo-card-section .k8s-title {
+  color: #7D7D7D;
+}
+
+.k8s-example-update-demo-card-section .k8s-card-id {
+  font-size: bigger;
 }


### PR DESCRIPTION
Not a css expert myself but I styled the [update-demo](http://kubernetes.io/docs/user-guide/update-demo/) page a bit while writing a Kubernetes blog-post using this example. 

Before:
![screenshot from 2016-03-17 18 21 16](https://cloud.githubusercontent.com/assets/4876867/13865837/114be34c-ec6d-11e5-814a-648fae1420d3.png)

After:
![screenshot from 2016-03-17 18 20 45](https://cloud.githubusercontent.com/assets/4876867/13865847/22ead004-ec6d-11e5-8816-3f1484b588fe.png)

@kubernetes/examples @bryk

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/kubernetes/23171)

<!-- Reviewable:end -->
