### PR TITLE
Remove the restart-kube-proxy and restart-apiserver functions

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -1601,16 +1601,6 @@ function ssh-to-node {
   ssh -oLogLevel=quiet -oConnectTimeout=30 -oStrictHostKeyChecking=no -i "${AWS_SSH_KEY}" ${SSH_USER}@${ip} "${cmd}"
 }
 
-# Restart the kube-proxy on a node ($1)
-function restart-kube-proxy {
-  ssh-to-node "$1" "sudo /etc/init.d/kube-proxy restart"
-}
-
-# Restart the kube-apiserver on a node ($1)
-function restart-apiserver {
-  ssh-to-node "$1" "sudo /etc/init.d/kube-apiserver restart"
-}
-
 # Perform preparations required to run e2e tests
 function prepare-e2e() {
   # (AWS runs detect-project, I don't think we need to anything)

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -1342,20 +1342,6 @@ function ssh-to-node {
   gcloud compute ssh --ssh-flag="-o LogLevel=quiet" --ssh-flag="-o ConnectTimeout=30" --project "${PROJECT}" --zone="${ZONE}" "${node}" --command "${cmd}"
 }
 
-# Restart the kube-proxy on a node ($1)
-function restart-kube-proxy {
-  if [[ "${OS_DISTRIBUTION}" == "trusty" ]]; then
-    ssh-to-node "$1" "sudo initctl restart kube-proxy"
-  else
-    ssh-to-node "$1" "sudo /etc/init.d/kube-proxy restart"
-  fi
-}
-
-# Restart the kube-apiserver on a node ($1)
-function restart-apiserver {
-  ssh-to-node "$1" "sudo docker ps | grep /kube-apiserver | cut -d ' ' -f 1 | xargs sudo docker kill"
-}
-
 # Perform preparations required to run e2e tests
 function prepare-e2e() {
   detect-project

--- a/cluster/gke/util.sh
+++ b/cluster/gke/util.sh
@@ -171,7 +171,7 @@ function test-setup() {
   "${KUBE_ROOT}/cluster/kube-up.sh"
 
   detect-nodes >&2
- 
+
   # At this point, CLUSTER_NAME should have been used, so its value is final.
   NODE_TAG=$($GCLOUD compute instances describe ${NODE_NAMES[0]} --project="${PROJECT}" --zone="${ZONE}" | grep -o "gke-${CLUSTER_NAME}-.\{8\}-node" | head -1)
   OLD_NODE_TAG="k8s-${CLUSTER_NAME}-node"
@@ -270,18 +270,6 @@ function ssh-to-node() {
   done
   # Then actually try the command.
   gcloud compute ssh --ssh-flag="-o LogLevel=quiet" --ssh-flag="-o ConnectTimeout=30" --project "${PROJECT}" --zone="${ZONE}" "${node}" --command "${cmd}"
-}
-
-# Restart the kube-proxy on a node ($1)
-function restart-kube-proxy() {
-  echo "... in gke:restart-kube-proxy()"  >&2
-  ssh-to-node "$1" "sudo /etc/init.d/kube-proxy restart"
-}
-
-# Restart the kube-proxy on master ($1)
-function restart-apiserver() {
-  echo "... in gke:restart-apiserver()"  >&2
-  ssh-to-node "$1" "sudo docker ps | grep /kube-apiserver | cut -d ' ' -f 1 | xargs sudo docker kill"
 }
 
 # Execute after running tests to perform any required clean-up.  This is called

--- a/cluster/libvirt-coreos/util.sh
+++ b/cluster/libvirt-coreos/util.sh
@@ -371,16 +371,6 @@ function ssh-to-node {
   ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ControlMaster=no "core@$machine" "$cmd"
 }
 
-# Restart the kube-proxy on a node ($1)
-function restart-kube-proxy {
-  ssh-to-node "$1" "sudo systemctl restart kube-proxy"
-}
-
-# Restart the apiserver
-function restart-apiserver {
-  ssh-to-node "$1" "sudo systemctl restart kube-apiserver"
-}
-
 # Perform preparations required to run e2e tests
 function prepare-e2e() {
     echo "libvirt-coreos doesn't need special preparations for e2e tests" 1>&2

--- a/cluster/mesos/docker/util.sh
+++ b/cluster/mesos/docker/util.sh
@@ -334,16 +334,6 @@ function ssh-to-node {
   echo "TODO: ssh-to-node" 1>&2
 }
 
-# Restart the kube-proxy on a node ($1)
-function restart-kube-proxy {
-  echo "TODO: restart-kube-proxy" 1>&2
-}
-
-# Restart the apiserver
-function restart-apiserver {
-  echo "TODO: restart-apiserver" 1>&2
-}
-
 # Waits for a kube-system pod (of the provided name) to have the phase/status "Running".
 function cluster::mesos::docker::await_ready {
   local pod_name="$1"

--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -377,16 +377,6 @@ function ssh-to-node {
   vagrant ssh "${machine}" -c "${cmd}"
 }
 
-# Restart the kube-proxy on a node ($1)
-function restart-kube-proxy {
-  ssh-to-node "$1" "sudo systemctl restart kube-proxy"
-}
-
-# Restart the apiserver
-function restart-apiserver {
-  ssh-to-node "$1" "sudo systemctl restart kube-apiserver"
-}
-
 # Perform preparations required to run e2e tests
 function prepare-e2e() {
   echo "Vagrant doesn't need special preparations for e2e tests" 1>&2


### PR DESCRIPTION
These were previously used by some of our shell e2e tests but appear to now be dead code. The functions to restart the kube-proxy are now wrong anyway, because in 1.2 kube-proxy runs in a container so `sudo /etc/init.d/kube-proxy restart` won't have any affect. 

/cc @karlkfi @justinsb @derekwaynecarr 
