### PR TITLE
Add unit test for JobUpdateStatus and fix erroneous test for DaemonSetStatusUpdate

### DIFF
--- a/pkg/apis/extensions/validation/validation_test.go
+++ b/pkg/apis/extensions/validation/validation_test.go
@@ -354,11 +354,14 @@ func TestValidateDaemonSetStatusUpdate(t *testing.T) {
 			t.Errorf("expected success: %v", errs)
 		}
 	}
-
 	errorCases := map[string]dsUpdateTest{
 		"negative values": {
 			old: extensions.DaemonSet{
-				ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: api.NamespaceDefault},
+				ObjectMeta: api.ObjectMeta{
+					Name:            "abc",
+					Namespace:       api.NamespaceDefault,
+					ResourceVersion: "10",
+				},
 				Status: extensions.DaemonSetStatus{
 					CurrentNumberScheduled: 1,
 					NumberMisscheduled:     2,
@@ -366,7 +369,11 @@ func TestValidateDaemonSetStatusUpdate(t *testing.T) {
 				},
 			},
 			update: extensions.DaemonSet{
-				ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: api.NamespaceDefault},
+				ObjectMeta: api.ObjectMeta{
+					Name:            "abc",
+					Namespace:       api.NamespaceDefault,
+					ResourceVersion: "10",
+				},
 				Status: extensions.DaemonSetStatus{
 					CurrentNumberScheduled: -1,
 					NumberMisscheduled:     -1,
@@ -377,7 +384,7 @@ func TestValidateDaemonSetStatusUpdate(t *testing.T) {
 	}
 
 	for testName, errorCase := range errorCases {
-		if errs := ValidateDaemonSetStatusUpdate(&errorCase.old, &errorCase.update); len(errs) == 0 {
+		if errs := ValidateDaemonSetStatusUpdate(&errorCase.update, &errorCase.old); len(errs) == 0 {
 			t.Errorf("expected failure: %s", testName)
 		}
 	}
@@ -1159,6 +1166,82 @@ func TestValidateJob(t *testing.T) {
 			if err.Field != s[0] || !strings.Contains(err.Error(), s[1]) {
 				t.Errorf("unexpected error: %v, expected: %s", err, k)
 			}
+		}
+	}
+}
+
+func TestValidateJobUpdateStatus(t *testing.T) {
+	type testcase struct {
+		old    extensions.Job
+		update extensions.Job
+	}
+
+	successCases := []testcase{
+		{
+			old: extensions.Job{
+				ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: api.NamespaceDefault},
+				Status: extensions.JobStatus{
+					Active:    1,
+					Succeeded: 2,
+					Failed:    3,
+				},
+			},
+			update: extensions.Job{
+				ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: api.NamespaceDefault},
+				Status: extensions.JobStatus{
+					Active:    1,
+					Succeeded: 1,
+					Failed:    3,
+				},
+			},
+		},
+	}
+
+	for _, successCase := range successCases {
+		successCase.old.ObjectMeta.ResourceVersion = "1"
+		successCase.update.ObjectMeta.ResourceVersion = "1"
+		if errs := ValidateJobUpdateStatus(&successCase.update, &successCase.old); len(errs) != 0 {
+			t.Errorf("expected success: %v", errs)
+		}
+	}
+
+	errorCases := map[string]testcase{
+		"[status.active: Invalid value: -1: must be greater than or equal to 0, status.succeeded: Invalid value: -2: must be greater than or equal to 0]": {
+			old: extensions.Job{
+				ObjectMeta: api.ObjectMeta{
+					Name:            "abc",
+					Namespace:       api.NamespaceDefault,
+					ResourceVersion: "10",
+				},
+				Status: extensions.JobStatus{
+					Active:    1,
+					Succeeded: 2,
+					Failed:    3,
+				},
+			},
+			update: extensions.Job{
+				ObjectMeta: api.ObjectMeta{
+					Name:            "abc",
+					Namespace:       api.NamespaceDefault,
+					ResourceVersion: "10",
+				},
+				Status: extensions.JobStatus{
+					Active:    -1,
+					Succeeded: -2,
+					Failed:    3,
+				},
+			},
+		},
+	}
+
+	for testName, errorCase := range errorCases {
+		errs := ValidateJobUpdateStatus(&errorCase.update, &errorCase.old)
+		if len(errs) == 0 {
+			t.Errorf("expected failure: %s", testName)
+			continue
+		}
+		if errs.ToAggregate().Error() != testName {
+			t.Errorf("expected '%s' got '%s'", errs.ToAggregate().Error(), testName)
 		}
 	}
 }


### PR DESCRIPTION
@soltysh @erictune 

This PR contains
1. Basic test for JobUpdateStatus (missing).
2. TestValidateDaemonSetStatusUpdate minor bugs: current errorCase is not failing for negative value but because there's no ResourceVersion :)  (and parameters needs to be swapped).

Leaving out (for the moment) `ValidateJobUpdate` unit tests 'cause it's not totally clear to me what should be done for ManualSelector (which is out of validation)
Is it an ImmutableField as well?
I'm OK to do (eventually in a follow-up).
