### PR TITLE
Correct a typo in env vars

### DIFF
--- a/hack/jenkins/e2e-runner.sh
+++ b/hack/jenkins/e2e-runner.sh
@@ -152,8 +152,8 @@ echo "--------------------------------------------------------------------------
 if [[ "${JENKINS_USE_TRUSTY_IMAGES:-}" =~ ^[yY]$ ]]; then
   trusty_image_project="$(get_trusty_image_project)"
   trusty_image="$(get_latest_trusty_image "${trusty_image_project}" "head")"
-  export KUBE_MASTER_IMAGE_PROJECT="${trusty_image_project}"
-  export KUBE_MASTER_IMAGE="${trusty_image}"
+  export KUBE_GCE_MASTER_PROJECT="${trusty_image_project}"
+  export KUBE_GCE_MASTER_IMAGE="${trusty_image}"
   export KUBE_OS_DISTRIBUTION="trusty"
 fi
 


### PR DESCRIPTION
I should have used `KUBE_GCE_MASTER_PROJECT` and `KUBE_GCE_MASTER_IMAGE`.

@spxtr Can you do a quick review for this PR?

cc/ @andyzheng0831 
