### PR TITLE
Pin to godep v58 in Jenkins unit/integration

### DIFF
--- a/hack/jenkins/test-dockerized.sh
+++ b/hack/jenkins/test-dockerized.sh
@@ -29,6 +29,15 @@ export PATH=${GOPATH}/bin:${PWD}/third_party/etcd:/usr/local/go/bin:${PATH}
 go get github.com/tools/godep
 go get github.com/jstemmer/go-junit-report
 
+# godep v59+ has issues with our GOPATH munging, so pin to v58 for now.
+# https://github.com/kubernetes/kubernetes/issues/23200
+(
+  cd ${GOPATH}/src/github.com/tools/godep
+  git checkout v58
+  godep go install
+)
+godep version
+
 # Enable the Go race detector.
 export KUBE_RACE=-race
 # Disable coverage report


### PR DESCRIPTION
Alternative temporary workaround for #23200.

Not tested yet, so I have no idea if this does what I want.

@kubernetes/goog-testing @krousey 
