### PR TITLE
rkt: Unmarshal the ENTRYPOINT/CMD from jsons instead of strings.

### DIFF
--- a/pkg/kubelet/rkt/rkt_test.go
+++ b/pkg/kubelet/rkt/rkt_test.go
@@ -766,8 +766,16 @@ func baseApp(t *testing.T) *appctypes.App {
 
 func baseImageManifest(t *testing.T) *appcschema.ImageManifest {
 	img := &appcschema.ImageManifest{App: baseApp(t)}
-	img.Annotations.Set(*appctypes.MustACIdentifier(appcDockerEntrypoint), "/bin/foo")
-	img.Annotations.Set(*appctypes.MustACIdentifier(appcDockerCmd), "bar")
+	entrypoint, err := json.Marshal([]string{"/bin/foo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd, err := json.Marshal([]string{"bar"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	img.Annotations.Set(*appctypes.MustACIdentifier(appcDockerEntrypoint), string(entrypoint))
+	img.Annotations.Set(*appctypes.MustACIdentifier(appcDockerCmd), string(cmd))
 	return img
 }
 


### PR DESCRIPTION
Using json makes this robust to ENTRYPOINT/CMD that contains space.

Also removed 'RemainAfterExit' option, originally this option is
useful when we implement GetPods() by 'systemctl list-units'.
However since we are using rkt API service now, it's no longer needed.

cc @sjpotter @yujuhong @Random-Liu 
