### PR TITLE
Removing URL query param from swagger UI to fix the XSS issue

### DIFF
--- a/pkg/ui/data/swagger/datafile.go
+++ b/pkg/ui/data/swagger/datafile.go
@@ -2679,12 +2679,7 @@ var _third_party_swagger_ui_index_html = []byte(`<!DOCTYPE html>
   <script src='lib/swagger-oauth.js' type='text/javascript'></script>
   <script type="text/javascript">
     $(function () {
-      var url = window.location.search.match(/url=([^&]+)/);
-      if (url && url.length > 1) {
-        url = decodeURIComponent(url[1]);
-      } else {
-        url = "../../swaggerapi";
-      }
+      var url = "../../swaggerapi";
       window.swaggerUi = new SwaggerUi({
         url: url,
         dom_id: "swagger-ui-container",
@@ -2763,7 +2758,7 @@ func third_party_swagger_ui_index_html() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "third_party/swagger-ui/index.html", size: 3720, mode: os.FileMode(416), modTime: time.Unix(1458251987, 0)}
+	info := bindata_file_info{name: "third_party/swagger-ui/index.html", size: 3561, mode: os.FileMode(416), modTime: time.Unix(1458347707, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/third_party/swagger-ui/README.md
+++ b/third_party/swagger-ui/README.md
@@ -17,6 +17,8 @@ https://github.com/swagger-api/swagger-ui#how-to-use-it
 https://github.com/swagger-api/swagger-ui#how-to-use-it
 - Modified swagger-ui.js to list resources and operations in sorted order: https://github.com/kubernetes/kubernetes/pull/3421
 - Set supportedSubmitMethods: [] in index.html to remove "Try it out" buttons.
+- Remove the url query param to fix XSS issue:
+  https://github.com/kubernetes/kubernetes/pull/23234
 
 LICENSE file has been created for compliance purposes.
 Not included in original distribution.

--- a/third_party/swagger-ui/index.html
+++ b/third_party/swagger-ui/index.html
@@ -24,12 +24,7 @@
   <script src='lib/swagger-oauth.js' type='text/javascript'></script>
   <script type="text/javascript">
     $(function () {
-      var url = window.location.search.match(/url=([^&]+)/);
-      if (url && url.length > 1) {
-        url = decodeURIComponent(url[1]);
-      } else {
-        url = "../../swaggerapi";
-      }
+      var url = "../../swaggerapi";
       window.swaggerUi = new SwaggerUi({
         url: url,
         dom_id: "swagger-ui-container",


### PR DESCRIPTION
Removing the URL query param from swagger UI to fix the reported XSS issue: https://github.com/swagger-api/swagger-ui/issues/830#issuecomment-198042820.

Note that we are now disabling swagger UI by default, so this is not as critical. But it will still be good to fix the XSS for those who want to enable swagger UI on their master.

Note that there might be more XSS issues (indeed https://github.com/swagger-api/swagger-ui/issues/830 had reported a bunch of them), but there was a clear repro for only this one.

@bgrant0607 @kubernetes/docs 
