### PR TITLE
Remove deep-copy pre-commit hook that no longer exists

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -146,18 +146,6 @@ else
 fi
 echo "${reset}"
 
-echo -ne "Checking for deep-copies that need updating... "
-if ! hack/after-build/verify-generated-deep-copies.sh > /dev/null; then
-  echo "${red}ERROR!"
-  echo "Some deep-copy functions need regeneration."
-  echo "To regenerate deep-copies, run:"
-  echo "  hack/update-generated-deep-copies.sh"
-  exit_code=1
-else
-  echo "${green}OK"
-fi
-echo "${reset}"
-
 echo -ne "Checking for swagger type documentation that need updating... "
 if ! hack/after-build/verify-generated-swagger-docs.sh > /dev/null; then
   echo "${red}ERROR!"


### PR DESCRIPTION
I cannot commit changes because the reference to this deleted code still exists in hooks/pre-commit. It looks like we can just delete it?

https://github.com/kubernetes/kubernetes/pull/23110 moved deep-copy into run-codegen.sh and https://github.com/kubernetes/kubernetes/pull/23179 deleted it entirely.

@lavalamp @wojtek-t 
