### PR TITLE
Use kube-system namespace

### DIFF
--- a/cluster/images/hyperkube/etcd.json
+++ b/cluster/images/hyperkube/etcd.json
@@ -1,7 +1,10 @@
 {
   "apiVersion": "v1",
   "kind": "Pod",
-  "metadata": {"name":"k8s-etcd"},
+  "metadata": {
+    "name": "k8s-etcd",
+    "namespace": "kube-system"
+  },
   "spec": {
     "hostNetwork": true,
     "containers": [

--- a/cluster/images/hyperkube/kube-proxy.json
+++ b/cluster/images/hyperkube/kube-proxy.json
@@ -1,7 +1,10 @@
 {
   "apiVersion": "v1",
   "kind": "Pod",
-  "metadata": {"name":"k8s-proxy"},
+  "metadata": {
+    "name": "k8s-proxy",
+    "namespace": "kube-system"
+  },
   "spec": {
     "hostNetwork": true,
     "containers": [

--- a/cluster/images/hyperkube/master-multi.json
+++ b/cluster/images/hyperkube/master-multi.json
@@ -1,7 +1,10 @@
 {
 "apiVersion": "v1",
 "kind": "Pod",
-"metadata": {"name":"k8s-master"},
+"metadata": {
+  "name": "k8s-master",
+  "namespace": "kube-system"
+},
 "spec":{
   "hostNetwork": true,
   "containers":[

--- a/cluster/images/hyperkube/master.json
+++ b/cluster/images/hyperkube/master.json
@@ -1,7 +1,10 @@
 {
 "apiVersion": "v1",
 "kind": "Pod",
-"metadata": {"name":"k8s-master"},
+"metadata": {
+  "name": "k8s-master",
+  "namespace": "kube-system"
+},
 "spec":{
   "hostNetwork": true,
   "containers":[

--- a/cluster/images/hyperkube/turnup.sh
+++ b/cluster/images/hyperkube/turnup.sh
@@ -20,7 +20,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-K8S_VERSION=${K8S_VERSION:-"1.2.0-alpha.7"}
+K8S_VERSION=${K8S_VERSION:-"1.2.0"}
 
 docker run \
   --volume=/:/rootfs:ro \
@@ -41,3 +41,9 @@ docker run \
     --cluster-dns=10.0.0.10 \
     --cluster-domain=cluster.local \
     --allow-privileged=true --v=2
+
+until $(kubectl cluster-info &> /dev/null); do
+    sleep 1
+done
+
+kubectl create ns kube-system


### PR DESCRIPTION
Fixes #23153.

Sadly, kube-system isn't automatically created, so people need to make
sure to create it in their turnup scripts.  Also after creating
kube-system it can take 10+ seconds for master and proxy to show up.

I tested the equivalent of these changes locally, but not these changes
themselves as I don't have a dev/build env up, so please read carefully
and maybe try them out!
