### PR TITLE
kube-scheduler: cleanup duplicate GetAlgorithmProvider()

### DIFF
--- a/plugin/cmd/kube-scheduler/app/server.go
+++ b/plugin/cmd/kube-scheduler/app/server.go
@@ -176,11 +176,5 @@ func createConfig(s *options.SchedulerServer, configFactory *factory.ConfigFacto
 	}
 
 	// if the config file isn't provided, use the specified (or default) provider
-	// check of algorithm provider is registered and fail fast
-	_, err := factory.GetAlgorithmProvider(s.AlgorithmProvider)
-	if err != nil {
-		return nil, err
-	}
-
 	return configFactory.CreateFromProvider(s.AlgorithmProvider)
 }


### PR DESCRIPTION
See [here](https://github.com/kubernetes/kubernetes/blob/ae88f08af09b8e721913544dcc2afdc31f98635e/plugin/pkg/scheduler/factory/factory.go#L177-L180).
The check is duplicate since CreateFromProvider will also do it.
