### PR TITLE
Move e2e test jobs for Trusty dev to 1.2

### DIFF
--- a/hack/jenkins/e2e-runner.sh
+++ b/hack/jenkins/e2e-runner.sh
@@ -143,19 +143,19 @@ function get_latest_trusty_image() {
     rm -rf .gsutil &> /dev/null
 }
 
-echo "--------------------------------------------------------------------------------"
-echo "Test Environment:"
-printenv | sort
-echo "--------------------------------------------------------------------------------"
-
 # We get the image project and name for Trusty dynamically.
 if [[ "${JENKINS_USE_TRUSTY_IMAGES:-}" =~ ^[yY]$ ]]; then
   trusty_image_project="$(get_trusty_image_project)"
-  trusty_image="$(get_latest_trusty_image "${trusty_image_project}" "head")"
+  trusty_image="$(get_latest_trusty_image "${trusty_image_project}" "dev")"
   export KUBE_GCE_MASTER_PROJECT="${trusty_image_project}"
   export KUBE_GCE_MASTER_IMAGE="${trusty_image}"
   export KUBE_OS_DISTRIBUTION="trusty"
 fi
+
+echo "--------------------------------------------------------------------------------"
+echo "Test Environment:"
+printenv | sort
+echo "--------------------------------------------------------------------------------"
 
 # We get the Kubernetes tarballs unless we are going to use old ones
 if [[ "${JENKINS_USE_EXISTING_BINARIES:-}" =~ ^[yY]$ ]]; then

--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
@@ -556,9 +556,18 @@
 # NOTE: From here on all jobs use Trusty as the image for master and/or nodes.
 # Please add templates/groups/projects/jobs that use ContainerVm above/below
 # this section (search "End of Trusty jobs" for the ending separator).
+#
+# This section contains three types of jobs (all run e2e tests on GCE):
+#   * Jobs that use a "green" Trusty image to test k8s continuous builds (hence
+#     the "ci" in job names). We use these to guard k8s and Trusty
+#     compatibility.
+#   * Jobs that use a released k8s version to test Trusty's continuous builds
+#     (dev, beta and stable). We use these to qualify Trusty image releases.
+#   * Jobs that run tests against GKE endpoints with Trusty images. We use these
+#     to soak Trusty release candidate before pushing to GKE production.
 
-# Template for e2e test jobs that run on GCE with Trusty images against
-# kubernetes HEAD.
+# e2e test jobs that run on GCE with a "green" Trusty image and kubernetes'
+# continuous builds (currently only targeting `master` and `release-1.2`).
 - job-template:
     name: 'kubernetes-e2e-gce-trusty-ci-{suffix}'
     <<: *e2e_job_defaults
@@ -579,8 +588,6 @@
                 def k8sVersionMatcher = manager.getLogMatcher("Using\\spublished\\sversion\\s(.*)\\s\\(from.*")
                 if(k8sVersionMatcher?.matches()) manager.addShortText("<br><b>Kubernetes version: " + k8sVersionMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
 
-# CI jobs that run on GCE with both master and nodes running Trusty images. We
-# use these to guard k8s+Trusty compatibility.
 - project:
     name: kubernetes-e2e-gce-trusty-ci-master
     trigger-job: 'kubernetes-build'
@@ -640,10 +647,10 @@
     jobs:
         - 'kubernetes-e2e-gce-trusty-ci-{suffix}'
 
-# Template for e2e test jobs that run on GCE with Trusty images against last
-# released k8s version. We use these jobs to test Trusty's continuous build.
+# Template for e2e test jobs that run on GCE with a released k8s version and
+# Trusty's continuous builds (dev only).
 - job-template:
-    name: 'kubernetes-e2e-gce-trusty-{suffix}'
+    name: 'kubernetes-e2e-gce-trusty-dev-{suffix}'
     <<: *e2e_job_defaults
     triggers:
         - timed: 'H H/8 * * *'
@@ -651,6 +658,55 @@
         - e2e-publishers:
             recipients: '{emails}'
         - description-setter:
+            regexp: KUBE_GCE_MASTER_IMAGE=(.*)
+        - groovy-postbuild:
+            script: |
+                def trustyImageMatcher = manager.getLogMatcher("KUBE_GCE_MASTER_IMAGE=(.*)")
+                if(trustyImageMatcher?.matches()) manager.addShortText("<b>Trusty Image: " + trustyImageMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
+                def k8sVersionMatcher = manager.getLogMatcher("Using\\spublished\\sversion\\s(.*)\\s\\(from.*")
+                if(k8sVersionMatcher?.matches()) manager.addShortText("<br><b>Kubernetes version: " + k8sVersionMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
+
+- project:
+    name: kubernetes-e2e-gce-trusty-dev
+    test-owner: 'wonderfly@google.com'
+    branch: 'release-1.2'
+    emails: 'wonderfly@google.com,qzheng@google.com'
+    provider-env: |
+        {gce-provider-env}
+        export JENKINS_PUBLISHED_VERSION="release/stable-1.2"
+        export JENKINS_USE_TRUSTY_IMAGES="y"
+    suffix:
+        - 'release':
+            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with the latest Trusty build and the latest k8s 1.2 release.'
+            timeout: 30
+            job-env: |
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export PROJECT="k8s-e2e-gce-trusty-dev"
+        - 'slow':
+            description: 'Run slow E2E tests on GCE with the latest Trusty build with the latest k8s 1.2 release.'
+            timeout: 60
+            job-env: |
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
+                                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export PROJECT="k8s-e2e-gce-trusty-dev-slow"
+    jobs:
+        - 'kubernetes-e2e-gce-trusty-dev-{suffix}'
+
+# Template for e2e test jobs that run on GCE with a released k8s version and
+# Trusty's continuous builds (beta and stable only work with k8s 1.1).
+- job-template:
+    name: 'kubernetes-e2e-gce-trusty-{suffix}'
+    <<: *e2e_job_defaults
+    triggers:
+        # Trusty beta and stable images are built once per day.
+        - timed: '@daily'
+    publishers:
+        - e2e-publishers:
+            recipients: '{emails}'
+        - description-setter:
+            # In 1.1, only nodes run Trusty.
             regexp: KUBE_GCE_MINION_IMAGE=(.*)
         - groovy-postbuild:
             script: |
@@ -659,43 +715,25 @@
                 def k8sVersionMatcher = manager.getLogMatcher("Using\\spublished\\sversion\\s(.*)\\s\\(from.*")
                 if(k8sVersionMatcher?.matches()) manager.addShortText("<br><b>Kubernetes version: " + k8sVersionMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
 
-# Jobs that run e2e tests on GCE with Trusty images against the latest k8s
-# release.
 - project:
-    name: kubernetes-e2e-gce-trusty
+    name: kubernetes-e2e-gce-trusty-1-1
     test-owner: 'wonderfly@google.com'
     branch: 'release-1.1'
     emails: 'wonderfly@google.com,qzheng@google.com'
     runner: '{old-runner-1-1}'
     post-env: ''
     suffix:
-        - 'head-release':
-            description: 'Continuously test Trusty build against latest k8s release.'
-            timeout: 150
-        - 'dev-release':
-            description: 'Continuously test Trusty dev build against latest k8s release.'
-            timeout: 150
         - 'beta-release':
-            description: 'Continuously test Trusty beta build against latest k8s release.'
+            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with the latest Trusty beta build and the latest k8s 1.1 release.'
             timeout: 150
-        - 'stable-release':
-            description: 'Continuously test Trusty stable build against latest k8s release.'
-            timeout: 150
-        - 'head-slow':
-            description: 'Run slow E2E tests on latest Trusty build.'
-            timeout: 270
-        - 'dev-slow':
-            # Constantly failing due to a known issue of the image. Disabled
-            # until the issue is resolved.
-            # TODO(wonderfly): Re-enable it once the internal issue is fixed.
-            disable_job: true
-            description: 'Run slow E2E tests on latest Trusty dev build.'
-            timeout: 270
         - 'beta-slow':
-            description: 'Run slow E2E tests on latest Trusty beta build.'
+            description: 'Run slow E2E tests on GCE with the latest Trusty beta build with the latest k8s 1.1 release.'
             timeout: 270
+        - 'stable-release':
+            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with the latest Trusty stable build and the latest k8s 1.1 release.'
+            timeout: 150
         - 'stable-slow':
-            description: 'Run slow E2E tests on latest Trusty stable build.'
+            description: 'Run slow E2E tests on GCE with the latest Trusty stable build with the latest k8s 1.1 release.'
             timeout: 270
     jobs:
         - 'kubernetes-e2e-gce-trusty-{suffix}'


### PR DESCRIPTION
After this change, jobs that use Trusty dev images will test against the
`release-1.2` branch, and use Trusty images for both the master and the nodes.
Trusty beta and stable jobs are kept in the `release-1.1` branch, and only use
Trusty images on nodes.

Tested on my local Jenkins instance.
@spxtr @andyzheng0831 
