### PR TITLE
storage: add custom storage error

### DIFF
--- a/pkg/registry/pod/etcd/etcd_test.go
+++ b/pkg/registry/pod/etcd/etcd_test.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"testing"
 
-	etcd "github.com/coreos/etcd/client"
 	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
@@ -140,7 +139,7 @@ type FailDeletionStorage struct {
 
 func (f FailDeletionStorage) Delete(ctx context.Context, key string, out runtime.Object) error {
 	*f.Called = true
-	return etcd.Error{Code: etcd.ErrorCodeKeyNotFound}
+	return storage.NewKeyNotFoundError(key, 0)
 }
 
 func newFailDeleteStorage(t *testing.T, called *bool) (*REST, *etcdtesting.EtcdTestServer) {

--- a/pkg/storage/etcd/etcd_helper_test.go
+++ b/pkg/storage/etcd/etcd_helper_test.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/kubernetes/pkg/storage"
 	"k8s.io/kubernetes/pkg/storage/etcd/etcdtest"
 	etcdtesting "k8s.io/kubernetes/pkg/storage/etcd/testing"
-	etcdutil "k8s.io/kubernetes/pkg/storage/etcd/util"
 	storagetesting "k8s.io/kubernetes/pkg/storage/testing"
 )
 
@@ -251,7 +250,7 @@ func TestGetNotFoundErr(t *testing.T) {
 
 	var got api.Pod
 	err := helper.Get(context.TODO(), boguskey, &got, false)
-	if !etcdutil.IsEtcdNotFound(err) {
+	if !storage.IsNotFound(err) {
 		t.Errorf("Unexpected reponse on key=%v, err=%v", key, err)
 	}
 }

--- a/pkg/storage/etcd/etcd_watcher.go
+++ b/pkg/storage/etcd/etcd_watcher.go
@@ -221,7 +221,7 @@ func etcdGetInitialWatchState(ctx context.Context, client etcd.KeysAPI, key stri
 	if err != nil {
 		if !etcdutil.IsEtcdNotFound(err) {
 			utilruntime.HandleError(fmt.Errorf("watch was unable to retrieve the current index for the provided key (%q): %v", key, err))
-			return resourceVersion, err
+			return resourceVersion, toStorageErr(err, key, 0)
 		}
 		if etcdError, ok := err.(etcd.Error); ok {
 			resourceVersion = etcdError.Index


### PR DESCRIPTION
The current storage package provides the [following API](https://github.com/kubernetes/kubernetes/blob/a428246960b83eb568bef1056dcc30d8ca0254bd/pkg/storage/errors.go#L23-L45) for exposing error:

``` Go
func IsNotFound(err error) bool {
    // TODO: add alternate storage error here
    return etcdutil.IsEtcdNotFound(err)
}

func IsNodeExist(err error) bool ...
func IsUnreachable(err error) bool ...
func IsTestFailed(err error) bool ...
```

It's tied to etcd v2's error types. This is bad when we need to return error from different implementation such v3's.

This PR attempts to fix that by providing an abstraction ontop called StorageError. It's compatible with storage API which is the only thing users should know. Each implementation is responsible for parsing its details and return storage errors.
