### PR TITLE
remove cadvisor salt

### DIFF
--- a/cluster/saltbase/salt/cadvisor/init.sls
+++ b/cluster/saltbase/salt/cadvisor/init.sls
@@ -1,3 +1,0 @@
-delete_cadvisor_manifest:
-  file.absent:
-    - name: /etc/kubernetes/manifests/cadvisor.manifest

--- a/cluster/saltbase/salt/top.sls
+++ b/cluster/saltbase/salt/top.sls
@@ -19,7 +19,6 @@ base:
     - cni
 {% endif %}
     - helpers
-    - cadvisor
     - kube-client-tools
     - kube-node-unpacker
     - kubelet
@@ -55,7 +54,6 @@ base:
     - kube-controller-manager
     - kube-scheduler
     - supervisor
-    - cadvisor
     - kube-client-tools
     - kube-master-addons
     - kube-admission-controls


### PR DESCRIPTION
We have been removing cadviosr.manifest for over a year to cleanup
the old deployment style. I think we are ok at this point.
