### PR TITLE
+ Support for etcd TLS in kube2sky

### DIFF
--- a/cluster/addons/dns/kube2sky/Changelog
+++ b/cluster/addons/dns/kube2sky/Changelog
@@ -1,3 +1,6 @@
+## Version 1.15 (Mar 25 2016 Dmitri Shelenin <dmitri@gravitational.com>)
+- Add flags to connect to a secure etcd instance.
+
 ## Version 1.14 (Mar 4 2016 Abhishek Shah <abshah@google.com>)
 - If Endpoint has hostnames-map annotation (endpoints.net.beta.kubernetes.io/hostnames-map),
   the hostnames supplied via the annotation will be used to generate A Records for Headless Service.

--- a/cluster/addons/dns/kube2sky/Makefile
+++ b/cluster/addons/dns/kube2sky/Makefile
@@ -18,7 +18,7 @@
 
 .PHONY: all kube2sky container push clean test
 
-TAG = 1.14
+TAG = 1.15
 PREFIX = gcr.io/google_containers
 
 all: container

--- a/cluster/addons/dns/kube2sky/README.md
+++ b/cluster/addons/dns/kube2sky/README.md
@@ -24,7 +24,13 @@ example, if this is set to `kubernetes.io`, then a service named "nifty" in the
 `--etcd-mutation-timeout`: For how long the application will keep retrying etcd
 mutation (insertion or removal of a dns entry) before giving up and crashing.
 
-`--etcd-server`: The etcd server that is being used by skydns.
+`--etcd-servers`: List of etcd servers that are being used by skydns.
+
+`--etcd-cafile`: x509 PEM-encoded Certificate Authority file to use for certificate verification.
+
+`--etcd-certfile`: x509 PEM-encoded SSL certificate to use for client to etcd communication.
+
+`--etcd-keyfile`: x509 PEM-encoded SSL key to use for client to etcd communication.
 
 `--kube-master-url`: URL of kubernetes master. Required if `--kubecfg_file` is not set.
 
@@ -33,5 +39,121 @@ mutation (insertion or removal of a dns entry) before giving up and crashing.
 `--log-dir`: If non empty, write log files in this directory
 
 `--logtostderr`: Logs to stderr instead of files
+
+## Secure communication with etcd
+
+New set of flags enable kube2sky to communicate with secure etcd instances.
+
+Please refer to official documentation about [etcd security].
+
+Here's an example ReplicationController configuration for setting up DNS with secure etcd:
+
+```yaml
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: kube-dns-v9
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+    version: v9
+    kubernetes.io/cluster-service: "true"
+spec:
+  replicas: 1
+  selector:
+    k8s-app: kube-dns
+    version: v9
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-dns
+        version: v9
+        kubernetes.io/cluster-service: "true"
+    spec:
+      hostNetwork: true
+      containers:
+      - name: kube2sky
+        image: gcr.io/google_containers/kube2sky:1.15
+        imagePullPolicy: Always
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+        args:
+        # command = "/kube2sky"
+        - --domain=cluster.local
+        - --etcd-servers=https://127.0.0.1:2379
+        - --etcd-cafile=/etc/ssl/certs/ca.pem
+        - --etcd-certfile=/etc/ssl/certs/etcd.pem
+        - --etcd-keyfile=/etc/ssl/certs/etcd-key.pem
+        volumeMounts:
+        - mountPath: /etc/ssl/certs
+          name: ssl-certs-etcd
+          readOnly: true
+      - name: skydns
+        image: gcr.io/google_containers/skydns:2015-10-13-8c72f8c
+        imagePullPolicy: Always
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+        args:
+        # command = "/skydns"
+        - -machines=https://127.0.0.1:2379
+        - -addr=0.0.0.0:53
+        - -ns-rotate=false
+        - -ca-cert=/etc/ssl/certs/ca.pem
+        - -tls-pem=/etc/ssl/certs/etcd.pem
+        - -tls-key=/etc/ssl/certs/etcd-key.pem
+        - -domain=cluster.local
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /etc/ssl/certs/
+          name: ssl-certs-etcd
+          readOnly: true
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 1
+          timeoutSeconds: 5
+      - name: healthz
+        image: gcr.io/google_containers/exechealthz:1.1
+        resources:
+          limits:
+            cpu: 10m
+            memory: 20Mi
+        args:
+        - -cmd=nslookup kubernetes.default.svc.cluster.local 127.0.0.1 >/dev/null
+        - -port=8080
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+      volumes:
+      - name: etcd-storage
+        emptyDir: {}
+      - name: ssl-certs-etcd
+        hostPath:
+          path: /etc/ssl/certs/
+      dnsPolicy: Default
+```
+
+[//]: # (Footnotes and references)
+
+[etcd security]: <https://github.com/coreos/etcd/blob/master/Documentation/security.md>
 
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/cluster/addons/dns/kube2sky/README.md?pixel)]()

--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -1,22 +1,22 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: kube-dns-v11
+  name: kube-dns-v12
   namespace: kube-system
   labels:
     k8s-app: kube-dns
-    version: v11
+    version: v12
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: {{ pillar['dns_replicas'] }}
   selector:
     k8s-app: kube-dns
-    version: v11
+    version: v12
   template:
     metadata:
       labels:
         k8s-app: kube-dns
-        version: v11
+        version: v12
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
@@ -47,7 +47,7 @@ spec:
         - name: etcd-storage
           mountPath: /var/etcd/data
       - name: kube2sky
-        image: gcr.io/google_containers/kube2sky:1.14
+        image: gcr.io/google_containers/kube2sky:1.15
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in

--- a/pkg/storage/etcd/etcd_helper.go
+++ b/pkg/storage/etcd/etcd_helper.go
@@ -57,7 +57,7 @@ func (c *EtcdStorageConfig) GetType() string {
 
 // implements storage.Config
 func (c *EtcdStorageConfig) NewStorage() (storage.Interface, error) {
-	etcdClient, err := c.Config.newEtcdClient()
+	etcdClient, err := c.Config.NewEtcdClient()
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ type EtcdConfig struct {
 	Quorum     bool
 }
 
-func (c *EtcdConfig) newEtcdClient() (etcd.Client, error) {
+func (c *EtcdConfig) NewEtcdClient() (etcd.Client, error) {
 	t, err := c.newHttpTransport()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR adds support for etcd TLS.

I tried to make as little changes to the existing functionality as possible - only augmenting where required to enable TLS.
Last attempt at adding TLS to kube2sky (https://github.com/kubernetes/kubernetes/pull/14883), discusses `-etcd-config` command line argument which, as far as I can tell, is now defunct although still referred to in the api server command line.
