### PR TITLE
Allows ABAC authorizor to reload policy file when the file is changed

### DIFF
--- a/pkg/apiserver/authz.go
+++ b/pkg/apiserver/authz.go
@@ -105,7 +105,7 @@ func NewAuthorizerFromAuthorizationConfig(authorizationModes []string, config Au
 			if config.PolicyFile == "" {
 				return nil, errors.New("ABAC's authorization policy file not passed")
 			}
-			abacAuthorizer, err := abac.NewFromFile(config.PolicyFile)
+			abacAuthorizer, err := abac.New(config.PolicyFile)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/auth/authorizer/abac/abac.go
+++ b/pkg/auth/authorizer/abac/abac.go
@@ -100,6 +100,7 @@ func New(path string) (*ABACPolicy, error) {
 								} else {
 									abacPolicy.Auth.Store(tmpPlist)
 									glog.Infof("ABAC policy is successfully reloaded")
+									lastModifiedTime = &modTime
 									close(done)
 								}
 							}


### PR DESCRIPTION
Refers to #22988 and #23095 
