### PR TITLE
Kubelet: Allocatable resources check for negative value

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -902,6 +902,9 @@ func parseResourceList(m utilconfig.ConfigurationMap) (api.ResourceList, error) 
 			if err != nil {
 				return nil, err
 			}
+			if q.Amount.Sign() == -1 {
+				return nil, fmt.Errorf("resource quantity for %q cannot be negative: %v", k, v)
+			}
 			rl[api.ResourceName(k)] = *q
 		default:
 			return nil, fmt.Errorf("cannot reserve %q resource", k)


### PR DESCRIPTION
When setting kube/system-resources for a node, negative quantities can result in node's allocatable being higher then node's capacity. Let's check the quantity and return error if it is negative.
