### PR TITLE
examples/guestbook/php-redis: don't reopen stdio fds

### DIFF
--- a/examples/guestbook/php-redis/Dockerfile
+++ b/examples/guestbook/php-redis/Dockerfile
@@ -19,6 +19,13 @@ RUN apt-get install -y php-pear
 RUN pear channel-discover pear.nrk.io
 RUN pear install nrk/Predis
 
+# If the container's stdio is connected to systemd-journald,
+# /proc/self/fd/{1,2} are Unix sockets and apache will not be able to open()
+# them. Use "cat" to write directly to the already opened fds without opening
+# them again.
+RUN sed -i 's#ErrorLog /proc/self/fd/2#ErrorLog "|$/bin/cat 1>\&2"#' /etc/apache2/apache2.conf
+RUN sed -i 's#CustomLog /proc/self/fd/1 combined#CustomLog "|/bin/cat" combined#' /etc/apache2/apache2.conf
+
 ADD guestbook.php /var/www/html/guestbook.php
 ADD controllers.js /var/www/html/controllers.js
 ADD index.html /var/www/html/index.html


### PR DESCRIPTION
/etc/apache2/apache2.conf was configured to log in this way:

> ErrorLog /proc/self/fd/2
> CustomLog /proc/self/fd/1 combined

This causes apache to reopen the already-opened fds. It works fine when
the file descriptors are pipes or ttys but it fails when they are Unix
sockets because sockets cannot be opened with the open() syscall. The
issue happens when apache is connected to systemd-journald, like in the
rkt container run-time.

This patch uses "cat" to directly write to the stdio fds without
reopening them. apache2.conf now looks like:

> ErrorLog "|$/bin/cat 1>&2"
> CustomLog "|/bin/cat" combined

It works both with Docker and rkt (tested with and without
--interactive).

Symptoms:

> [ 2673.478868] apache2-foreground[4]: (6)No such device or address:
> AH00091: apache2: could not open error log file /proc/self/fd/2.

See also: https://github.com/coreos/rkt/issues/2300

---

/cc @sjpotter @yifan-gu @jonboulle
