### PR TITLE
Additional logging for the creation of ELBs

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -2143,6 +2143,7 @@ func (s *AWSCloud) EnsureLoadBalancer(apiService *api.Service, hosts []string, a
 			// TODO: Unify the two annotations
 			return nil, fmt.Errorf("source-range annotation cannot be combined with the internal-elb annotation")
 		}
+		glog.V(2).Infof("Creating %v as an internal load balancer", name)
 		internalELB = true
 	}
 

--- a/pkg/cloudprovider/providers/aws/aws_loadbalancer.go
+++ b/pkg/cloudprovider/providers/aws/aws_loadbalancer.go
@@ -29,6 +29,7 @@ import (
 )
 
 func (s *AWSCloud) ensureLoadBalancer(namespacedName types.NamespacedName, loadBalancerName string, listeners []*elb.Listener, subnetIDs []string, securityGroupIDs []string, internalELB bool) (*elb.LoadBalancerDescription, error) {
+	glog.V(2).Infof("ensureLoadBalancer(%v, %v, %v, %v, %v, %v)", namespacedName, loadBalancerName, listeners, subnetIDs, securityGroupIDs, internalELB)
 	loadBalancer, err := s.describeLoadBalancer(loadBalancerName)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Hi @justinsb few extra log statements that helped me when my ELBs weren't being created as internal.

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/23382)

<!-- Reviewable:end -->
