### PR TITLE
When checking for leak look only at additional resources

### DIFF
--- a/hack/jenkins/e2e-runner.sh
+++ b/hack/jenkins/e2e-runner.sh
@@ -328,7 +328,9 @@ fi
 # * started and destroyed (normal e2e)
 # * neither started nor destroyed (soak test)
 if [[ "${E2E_UP:-}" == "${E2E_DOWN:-}" && -f "${gcp_resources_before}" && -f "${gcp_resources_after}" ]]; then
-  if ! diff -sw -U0 -F'^\[.*\]$' "${gcp_resources_before}" "${gcp_resources_after}" && [[ "${FAIL_ON_GCP_RESOURCE_LEAK:-}" == "true" ]]; then
+  difference=$(diff -sw -U0 -F'^\[.*\]$' "${gcp_resources_before}" "${gcp_resources_after}") || true
+  if [[ -n $(echo "${difference}" | tail -n +3 | grep -E "^\+") ]] && [[ "${FAIL_ON_GCP_RESOURCE_LEAK:-}" == "true" ]]; then
+    echo "${difference}"
     echo "!!! FAIL: Google Cloud Platform resources leaked while running tests!"
     exit 1
   fi


### PR DESCRIPTION
This should help with "fake" leaks, when run deletes stuff that was leaked in a previous one.

cc @zmerlynn @ixdy @wojtek-t 
