### PR TITLE
Speedup load test

### DIFF
--- a/test/e2e/load.go
+++ b/test/e2e/load.go
@@ -126,17 +126,17 @@ var _ = KubeDescribe("Load capacity", func() {
 
 			// We would like to spread creating replication controllers over time
 			// to make it possible to create/schedule them in the meantime.
-			// Currently we assume 5 pods/second average throughput.
+			// Currently we assume 10 pods/second average throughput.
 			// We may want to revisit it in the future.
-			creatingTime := time.Duration(totalPods/5) * time.Second
+			creatingTime := time.Duration(totalPods/10) * time.Second
 			createAllRC(configs, creatingTime)
 			By("============================================================================")
 
 			// We would like to spread scaling replication controllers over time
 			// to make it possible to create/schedule & delete them in the meantime.
-			// Currently we assume that 5 pods/second average throughput.
+			// Currently we assume that 10 pods/second average throughput.
 			// The expected number of created/deleted pods is less than totalPods/3.
-			scalingTime := time.Duration(totalPods/15) * time.Second
+			scalingTime := time.Duration(totalPods/30) * time.Second
 			scaleAllRC(configs, scalingTime)
 			By("============================================================================")
 


### PR DESCRIPTION
This speeds up load test by ~30% (which translates to ~1h30m for 1000-node clusters).
