### PR TITLE
Change the e2e util.extractRT to return a non-nil Response.

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -3235,7 +3235,7 @@ type extractRT struct {
 
 func (rt *extractRT) RoundTrip(req *http.Request) (*http.Response, error) {
 	rt.Header = req.Header
-	return nil, nil
+	return &http.Response{}, nil
 }
 
 // headersForConfig extracts any http client logic necessary for the provided


### PR DESCRIPTION
A RoundTripper that returns a nil Response with a nil error goes against standard Go style, and potentially breaks any RoundTripper expecting that style that wraps it (e.g. the oauth Transport).
