### PR TITLE
cherrypick script: hub -F${filename} doesn't work, it needs a space

### DIFF
--- a/hack/cherry_pick_pull.sh
+++ b/hack/cherry_pick_pull.sh
@@ -152,7 +152,7 @@ Automated cherry pick of ${PULLSUBJ}
 Cherry pick of ${PULLSUBJ} on ${rel}.
 EOF
 
-  hub pull-request -F"${prtext}" -h "${GITHUB_USER}:${NEWBRANCH}" -b "kubernetes:${rel}"
+  hub pull-request -F "${prtext}" -h "${GITHUB_USER}:${NEWBRANCH}" -b "kubernetes:${rel}"
 }
 
 if git remote -v | grep ^origin | grep kubernetes/kubernetes.git; then


### PR DESCRIPTION
Otherwise the script fails with:

```
+++ Creating a pull request on github
invalid argument: -F/tmp/prtext.aExk

+++ Returning you to the release-1.2 branch and cleaning up.
```
