### PR TITLE
Disable gke-trusty-prod and gke-trusty-staging

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
@@ -768,6 +768,8 @@
     suffix:
         - 'gke-trusty-prod':
             timeout: 180
+            # Failing constantly due to a known issue.
+            disable_job: true
             description: |
                 Run e2e tests with Trusty as node image using the following config:<br>
                 - provider: GKE<br>


### PR DESCRIPTION
The job is constantly failing due to a known issue. Temporarily disable them until fixed.

@jlowdermilk Can you review and manually merge this? My experience with the commit queue hasn't been pleasant.

cc/ @andyzheng0831 
