### PR TITLE
Support differentiation of OS distro in e2e tests

### DIFF
--- a/cluster/gce/trusty/master.yaml
+++ b/cluster/gce/trusty/master.yaml
@@ -219,8 +219,11 @@ script
 	export TOKEN_DIR="/etc/srv/kubernetes"
 	export kubelet_kubeconfig_file="/var/lib/kubelet/kubeconfig"
 	export TRUSTY_MASTER="true"
+	if [ -n "${TEST_ADDON_CHECK_INTERVAL_SEC:-}" ]; then
+		export TEST_ADDON_CHECK_INTERVAL_SEC=${TEST_ADDON_CHECK_INTERVAL_SEC}
+	fi
 	# Run the script to start and monitoring addon manifest changes.
-	exec /var/lib/cloud/scripts/kubernetes/kube-addons.sh
+	exec /var/lib/cloud/scripts/kubernetes/kube-addons.sh 1>>/var/log/kube-addons.log 2>&1
 end script
 
 # Wait for 10s to start it again.

--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -102,6 +102,7 @@ export PATH=$(dirname "${e2e_test}"):"${PATH}"
   --repo-root="${KUBE_ROOT}" \
   --node-instance-group="${NODE_INSTANCE_GROUP:-}" \
   --prefix="${KUBE_GCE_INSTANCE_PREFIX:-e2e}" \
+  ${KUBE_OS_DISTRIBUTION:+"--os-distro=${KUBE_OS_DISTRIBUTION}"} \
   ${NUM_NODES:+"--num-nodes=${NUM_NODES}"} \
   ${E2E_CLEAN_START:+"--clean-start=true"} \
   ${E2E_MIN_STARTUP_PODS:+"--minStartupPods=${E2E_MIN_STARTUP_PODS}"} \

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -284,6 +284,7 @@ oidc-issuer-url
 oidc-username-claim
 only-idl
 oom-score-adj
+os-distro
 out-version
 outofdisk-transition-frequency
 output-base

--- a/test/e2e/addon_update.go
+++ b/test/e2e/addon_update.go
@@ -210,13 +210,27 @@ var _ = KubeDescribe("Addon update", func() {
 		// Reduce the addon update intervals so that we have faster response
 		// to changes in the addon directory.
 		// do not use "service" command because it clears the environment variables
-		sshExecAndVerify(sshClient, "sudo TEST_ADDON_CHECK_INTERVAL_SEC=1 /etc/init.d/kube-addons restart")
+		switch testContext.OSDistro {
+		case "debian":
+			sshExecAndVerify(sshClient, "sudo TEST_ADDON_CHECK_INTERVAL_SEC=1 /etc/init.d/kube-addons restart")
+		case "trusty":
+			sshExecAndVerify(sshClient, "sudo initctl restart kube-addons TEST_ADDON_CHECK_INTERVAL_SEC=1")
+		default:
+			Failf("Unsupported OS distro type %s", testContext.OSDistro)
+		}
 	})
 
 	AfterEach(func() {
 		if sshClient != nil {
 			// restart addon_update with the default options
-			sshExec(sshClient, "sudo /etc/init.d/kube-addons restart")
+			switch testContext.OSDistro {
+			case "debian":
+				sshExec(sshClient, "sudo /etc/init.d/kube-addons restart")
+			case "trusty":
+				sshExec(sshClient, "sudo initctl restart kube-addons")
+			default:
+				Failf("Unsupported OS distro type %s", testContext.OSDistro)
+			}
 			sshClient.Close()
 		}
 	})

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -72,6 +72,7 @@ func RegisterFlags() {
 	flag.StringVar(&testContext.OutputDir, "e2e-output-dir", "/tmp", "Output directory for interesting/useful test data, like performance data, benchmarks, and other metrics.")
 	flag.StringVar(&testContext.ReportDir, "report-dir", "", "Path to the directory where the JUnit XML reports should be saved. Default is empty, which doesn't generate these reports.")
 	flag.StringVar(&testContext.prefix, "prefix", "e2e", "A prefix to be added to cloud resources created during testing.")
+	flag.StringVar(&testContext.OSDistro, "os-distro", "debian", "The OS distribution of cluster VM instances (debian, trusty, or coreos).")
 
 	// TODO: Flags per provider?  Rename gce-project/gce-zone?
 	flag.StringVar(&cloudConfig.MasterName, "kube-master", "", "Name of the kubernetes master. Only required if provider is gce or gke")

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -190,6 +190,7 @@ type TestContextType struct {
 	MinStartupPods        int
 	UpgradeTarget         string
 	PrometheusPushGateway string
+	OSDistro              string
 	VerifyServiceAccount  bool
 	DeleteNamespace       bool
 	CleanStart            bool


### PR DESCRIPTION
This change fixes issue #23221 by adding a flag "os-distro" in e2e testing framework. This flag inherits the value of env variable OS_DISTRIBUTION. The change also fixes the e2e test case of addon update for trusty by revising the testing code and kube-addons job in trusty master support.

I verified it by running 'go run hack/e2e.go --v --test --test_args="--ginkgo.focus=should\spropagate\sadd-on\sfile\schanges"'. Now this test case can pass on trusty.

@ixdy @roberthbailey @dchen1107 please review this change.

cc/ @wonderfly @fabioy FYI
