### PR TITLE
Heapster patch release to 1.0.2

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -9,7 +9,7 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: heapster-v1.0.0
+  name: heapster-v1.0.2
   namespace: kube-system
   labels:
     k8s-app: heapster
@@ -25,7 +25,7 @@ spec:
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v1.0.0
+        - image: gcr.io/google_containers/heapster:v1.0.2
           name: heapster
           resources:
             # keep request = limit to keep this container in guaranteed class
@@ -44,7 +44,7 @@ spec:
             - name: ssl-certs
               mountPath: /etc/ssl/certs
               readOnly: true
-        - image: gcr.io/google_containers/heapster:v1.0.0
+        - image: gcr.io/google_containers/heapster:v1.0.2
           name: eventer
           resources:
             # keep request = limit to keep this container in guaranteed class

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -9,7 +9,7 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: heapster-v1.0.0
+  name: heapster-v1.0.2
   namespace: kube-system
   labels:
     k8s-app: heapster
@@ -25,7 +25,7 @@ spec:
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v1.0.0
+        - image: gcr.io/google_containers/heapster:v1.0.2
           name: heapster
           resources:
             # keep request = limit to keep this container in guaranteed class
@@ -45,7 +45,7 @@ spec:
             - name: ssl-certs
               mountPath: /etc/ssl/certs
               readOnly: true
-        - image: gcr.io/google_containers/heapster:v1.0.0
+        - image: gcr.io/google_containers/heapster:v1.0.2
           name: eventer
           resources:
             # keep request = limit to keep this container in guaranteed class

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -9,7 +9,7 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: heapster-v1.0.0
+  name: heapster-v1.0.2
   namespace: kube-system
   labels:
     k8s-app: heapster
@@ -25,7 +25,7 @@ spec:
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v1.0.0
+        - image: gcr.io/google_containers/heapster:v1.0.2
           name: heapster
           resources:
             # keep request = limit to keep this container in guaranteed class
@@ -40,7 +40,7 @@ spec:
             - --source=kubernetes.summary_api:''
             - --sink=influxdb:http://monitoring-influxdb:8086
             - --metric_resolution=60s
-        - image: gcr.io/google_containers/heapster:v1.0.0
+        - image: gcr.io/google_containers/heapster:v1.0.2
           name: eventer
           resources:
             # keep request = limit to keep this container in guaranteed class

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -7,7 +7,7 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: heapster-v1.0.0
+  name: heapster-v1.0.2
   namespace: kube-system
   labels:
     k8s-app: heapster
@@ -23,7 +23,7 @@ spec:
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v1.0.0
+        - image: gcr.io/google_containers/heapster:v1.0.2
           name: heapster
           resources:
             # keep request = limit to keep this container in guaranteed class


### PR DESCRIPTION
Updates to Heapster to 1.0.2. The release is described https://github.com/kubernetes/heapster/releases/tag/v1.0.2

The problems which were fixed:
- lack of label required by GKE to draw graphs (xref b/27899686)
- wrong method of comparing timestamps while converting cumulative metrics to corresponding rates ones which may lead for example to broke HPA
- flaky GCE metadata server which may cause lack of metrics in GCM on GCE (https://github.com/GoogleCloudPlatform/gcloud-golang/issues/194)
