### PR TITLE
set KillMode for kubelet to process, fix for #13511

### DIFF
--- a/cluster/aws/coreos/node.yaml
+++ b/cluster/aws/coreos/node.yaml
@@ -76,6 +76,7 @@ coreos:
         --container-runtime=${KUBERNETES_CONTAINER_RUNTIME}
         Restart=always
         RestartSec=10
+        KillMode=process
 
     - name: kube-proxy.service
       command: start

--- a/cluster/centos/node/scripts/kubelet.sh
+++ b/cluster/centos/node/scripts/kubelet.sh
@@ -65,6 +65,7 @@ Requires=docker.service
 EnvironmentFile=-/opt/kubernetes/cfg/kubelet
 ExecStart=/opt/kubernetes/bin/kubelet ${KUBE_PROXY_OPTS}
 Restart=on-failure
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target

--- a/cluster/gce/coreos/master.yaml
+++ b/cluster/gce/coreos/master.yaml
@@ -135,6 +135,7 @@ coreos:
         --reconcile-cidr=false
         Restart=always
         RestartSec=10
+        KillMode=process
         
     - name: docker.service
       drop-ins:

--- a/cluster/gce/coreos/node.yaml
+++ b/cluster/gce/coreos/node.yaml
@@ -112,6 +112,7 @@ coreos:
         --configure-cbr0=${KUBERNETES_CONFIGURE_CBR0}
         Restart=always
         RestartSec=10
+        KillMode=process
 
     - name: kube-proxy.service
       command: start

--- a/cluster/rackspace/cloud-config/node-cloud-config.yaml
+++ b/cluster/rackspace/cloud-config/node-cloud-config.yaml
@@ -159,6 +159,7 @@ coreos:
         --v=2
         Restart=always
         RestartSec=5
+        KillMode=process
     - name: kube-proxy.service
       command: start
       content: |

--- a/cluster/saltbase/salt/kubelet/kubelet.service
+++ b/cluster/saltbase/salt/kubelet/kubelet.service
@@ -6,6 +6,7 @@ Documentation=https://github.com/kubernetes/kubernetes
 EnvironmentFile=/etc/sysconfig/kubelet
 ExecStart=/usr/local/bin/kubelet "$DAEMON_ARGS"
 Restart=always
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Restart kubelet process, not the resource group, more details [RHEL admin manual](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/sect-Managing_Services_with_systemd-Unit_Files.html) and https://github.com/kubernetes/kubernetes/issues/13511
New Ubuntu LTS 16.04 will have systemd by default, which may increase amount of complains and bug like we had. I propose to upstream the configuration. 
