### PR TITLE
AWS: SSL support for ELB listeners through annotations

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -2133,12 +2133,12 @@ func buildListener(port api.ServicePort, annotations map[string]string) (*elb.Li
 	if certID != "" {
 		instanceProtocol = annotations[ServiceAnnotationLoadBalancerBEProtocol]
 		if instanceProtocol == "" {
-			protocol = "https"
-			instanceProtocol = "http"
+			protocol = "ssl"
+			instanceProtocol = "tcp"
 		} else {
 			protocol = backendProtocolMapping[instanceProtocol]
 			if protocol == "" {
-				return nil, fmt.Errorf("Invalid backend protocol %s in %s", instanceProtocol, certID)
+				return nil, fmt.Errorf("Invalid backend protocol %s for %s in %s", instanceProtocol, certID, ServiceAnnotationLoadBalancerBEProtocol)
 			}
 		}
 		listener.SSLCertificateId = &certID

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -1200,7 +1200,7 @@ func TestDescribeLoadBalancerOnEnsure(t *testing.T) {
 	c.EnsureLoadBalancer(&api.Service{ObjectMeta: api.ObjectMeta{Name: "myservice", UID: "id"}}, []string{}, map[string]string{})
 }
 
-func TestGetListener(t *testing.T) {
+func TestBuildListener(t *testing.T) {
 	tests := []struct {
 		name string
 

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -1216,8 +1216,13 @@ func TestBuildListener(t *testing.T) {
 	}{
 		{
 			"No cert or BE protocol annotation, passthrough",
-			80, 8000, "", "",
+			80, 7999, "", "",
 			false, "tcp", "tcp", "",
+		},
+		{
+			"Cert annotation without BE protocol specified, SSL->TCP",
+			80, 8000, "", "cert",
+			false, "ssl", "tcp", "cert",
 		},
 		{
 			"BE protocol without cert annotation, passthrough",
@@ -1265,7 +1270,7 @@ func TestBuildListener(t *testing.T) {
 		if test.certAnnotation != "" {
 			annotations[ServiceAnnotationLoadBalancerCertificate] = test.certAnnotation
 		}
-		l, err := getListener(api.ServicePort{
+		l, err := buildListener(api.ServicePort{
 			NodePort: int32(test.instancePort),
 			Port:     int32(test.lbPort),
 			Protocol: api.Protocol("tcp"),

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -1266,8 +1266,8 @@ func TestGetListener(t *testing.T) {
 			annotations[ServiceAnnotationLoadBalancerCertificate] = test.certAnnotation
 		}
 		l, err := getListener(api.ServicePort{
-			NodePort: int(test.instancePort),
-			Port:     int(test.lbPort),
+			NodePort: int32(test.instancePort),
+			Port:     int32(test.lbPort),
 			Protocol: api.Protocol("tcp"),
 		}, annotations)
 		if test.expectError {


### PR DESCRIPTION
In the API, ports have only either TCP or UDP as their protocols, but ELB distinguishes HTTPS->HTTP[S]? from SSL->(SSL|TCP). 

Per #24978, this is implemented through two separate annotations:

`service.beta.kubernetes.io/aws-load-balancer-ssl-cert=arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012`
`service.beta.kubernetes.io/aws-load-balancer-backend-protocol=(https|http|ssl|tcp)`

Mixing plain-text and encrypted listeners will be in a separate PR, implementing #24978's `aws-load-balancer-ssl-ports=LIST`
