### PR TITLE
Create a new Deployment in kube-system for every version.

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -11,21 +11,23 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.1.0-beta1
+  name: heapster-v1.1.0.beta1
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
+    version: v1.1.0.beta1
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
+      version: v1.1.0.beta1
   template:
     metadata:
       labels:
         k8s-app: heapster
-        kubernetes.io/cluster-service: "true"
+        version: v1.1.0.beta1
     spec:
       containers:
         - image: gcr.io/google_containers/heapster:v1.1.0-beta1
@@ -90,7 +92,7 @@ spec:
             - --memory={{ metrics_memory }}
             - --extra-memory={{metrics_memory_per_node}}Mi
             - --threshold=5
-            - --deployment=heapster-v1.1.0-beta1
+            - --deployment=heapster-v1.1.0.beta1
             - --container=heapster
             - --poll-period=300000
         - image: gcr.io/google_containers/addon-resizer:1.0
@@ -118,7 +120,7 @@ spec:
             - --memory={{eventer_memory}}
             - --extra-memory={{eventer_memory_per_node}}Ki
             - --threshold=5
-            - --deployment=heapster-v1.1.0-beta1
+            - --deployment=heapster-v1.1.0.beta1
             - --container=eventer
             - --poll-period=300000
       volumes:

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -11,21 +11,23 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.1.0-beta1
+  name: heapster-v1.1.0.beta1
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
+    version: v1.1.0.beta1
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
+      version: v1.1.0.beta1
   template:
     metadata:
       labels:
         k8s-app: heapster
-        kubernetes.io/cluster-service: "true"
+        version: v1.1.0.beta1
     spec:
       containers:
         - image: gcr.io/google_containers/heapster:v1.1.0-beta1
@@ -91,7 +93,7 @@ spec:
             - --memory={{ metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.1.0-beta1
+            - --deployment=heapster-v1.1.0.beta1
             - --container=heapster
             - --poll-period=300000
         - image: gcr.io/google_containers/addon-resizer:1.0
@@ -119,7 +121,7 @@ spec:
             - --memory={{ eventer_memory }}
             - --extra-memory={{ eventer_memory_per_node }}Ki
             - --threshold=5
-            - --deployment=heapster-v1.1.0-beta1
+            - --deployment=heapster-v1.1.0.beta1
             - --container=eventer
             - --poll-period=300000
       volumes:

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -11,21 +11,23 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.1.0-beta1
+  name: heapster-v1.1.0.beta1
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
+    version: v1.1.0.beta1
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
+      version: v1.1.0.beta1
   template:
     metadata:
       labels:
         k8s-app: heapster
-        kubernetes.io/cluster-service: "true"
+        version: v1.1.0.beta1
     spec:
       containers:
         - image: gcr.io/google_containers/heapster:v1.1.0-beta1
@@ -82,7 +84,7 @@ spec:
             - --memory={{ metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.1.0-beta1
+            - --deployment=heapster-v1.1.0.beta1
             - --container=heapster
             - --poll-period=300000
         - image: gcr.io/google_containers/addon-resizer:1.0
@@ -110,7 +112,7 @@ spec:
             - --memory={{ eventer_memory }}
             - --extra-memory={{ eventer_memory_per_node }}Ki
             - --threshold=5
-            - --deployment=heapster-v1.1.0-beta1
+            - --deployment=heapster-v1.1.0.beta1
             - --container=eventer
             - --poll-period=300000
 

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -8,21 +8,23 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.1.0-beta1
+  name: heapster-v1.1.0.beta1
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
+    version: v1.1.0.beta1
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
+      version: v1.1.0.beta1
   template:
     metadata:
       labels:
         k8s-app: heapster
-        kubernetes.io/cluster-service: "true"
+        version: v1.1.0.beta1
     spec:
       containers:
         - image: gcr.io/google_containers/heapster:v1.1.0-beta1
@@ -64,6 +66,6 @@ spec:
             - --memory={{ metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.1.0-beta1
+            - --deployment=heapster-v1.1.0.beta1
             - --container=heapster
             - --poll-period=300000

--- a/cluster/saltbase/salt/kube-addons/kube-addon-update.sh
+++ b/cluster/saltbase/salt/kube-addons/kube-addon-update.sh
@@ -475,13 +475,13 @@ function update-addons() {
     local -r addon_path=$1
     # be careful, reconcile-objects uses global variables
     reconcile-objects ${addon_path} ReplicationController "-" &
+    reconcile-objects ${addon_path} Deployment "-" &
 
     # We don't expect names to be versioned for the following kinds, so
     # we match the entire name, ignoring version suffix.
     # That's why we pass an empty string as the version separator.
     # If the description differs on disk, the object should be recreated.
     # This is not implemented in this version.
-    reconcile-objects ${addon_path} Deployment "" &
     reconcile-objects ${addon_path} Service "" &
     reconcile-objects ${addon_path} PersistentVolume "" &
     reconcile-objects ${addon_path} PersistentVolumeClaim "" &


### PR DESCRIPTION
It appears that version numbers have already been properly added to these files. Small change to delete an old deployment entirely, so we can make a new one per version (like replication controllers).

We'll want to change this back once the kube-addons support deployments in a later version.
