### PR TITLE
add missing attributes to authorization interface

### DIFF
--- a/pkg/apiserver/handlers.go
+++ b/pkg/apiserver/handlers.go
@@ -398,17 +398,12 @@ func (r *requestAttributeGetter) GetAttribs(req *http.Request) authorizer.Attrib
 	attribs.Path = requestInfo.Path
 	attribs.Verb = requestInfo.Verb
 
-	// If the request was for a resource in an API group, include that info
 	attribs.APIGroup = requestInfo.APIGroup
-
-	// If a path follows the conventions of the REST object store, then
-	// we can extract the resource.  Otherwise, not.
+	attribs.APIVersion = requestInfo.APIVersion
 	attribs.Resource = requestInfo.Resource
-
-	// If the request specifies a namespace, then the namespace is filled in.
-	// Assumes there is no empty string namespace.  Unspecified results
-	// in empty (does not understand defaulting rules.)
+	attribs.Subresource = requestInfo.Subresource
 	attribs.Namespace = requestInfo.Namespace
+	attribs.Name = requestInfo.Name
 
 	return &attribs
 }

--- a/pkg/apiserver/handlers_test.go
+++ b/pkg/apiserver/handlers_test.go
@@ -284,6 +284,8 @@ func TestGetAttribs(t *testing.T) {
 				Path:            "/api/v1/nodes/mynode",
 				ResourceRequest: true,
 				Resource:        "nodes",
+				APIVersion:      "v1",
+				Name:            "mynode",
 			},
 		},
 		"namespaced resource": {
@@ -295,6 +297,8 @@ func TestGetAttribs(t *testing.T) {
 				ResourceRequest: true,
 				Namespace:       "myns",
 				Resource:        "pods",
+				APIVersion:      "v1",
+				Name:            "mypod",
 			},
 		},
 		"API group resource": {
@@ -305,6 +309,7 @@ func TestGetAttribs(t *testing.T) {
 				Path:            "/apis/extensions/v1beta1/namespaces/myns/jobs",
 				ResourceRequest: true,
 				APIGroup:        extensions.GroupName,
+				APIVersion:      "v1beta1",
 				Namespace:       "myns",
 				Resource:        "jobs",
 			},

--- a/pkg/auth/authorizer/interfaces.go
+++ b/pkg/auth/authorizer/interfaces.go
@@ -48,8 +48,18 @@ type Attributes interface {
 	// The kind of object, if a request is for a REST object.
 	GetResource() string
 
+	// GetSubresource returns the subresource being requested, if present
+	GetSubresource() string
+
+	// GetName returns the name of the object as parsed off the request.  This will not be present for all request types, but
+	// will be present for: get, update, delete
+	GetName() string
+
 	// The group of the resource, if a request is for a REST object.
 	GetAPIGroup() string
+
+	// GetAPIVersion returns the version of the group requested, if a request is for a REST object.
+	GetAPIVersion() string
 
 	// IsResourceRequest returns true for requests to API resources, like /api/v1/nodes,
 	// and false for non-resource endpoints like /api, /healthz, and /swaggerapi
@@ -83,7 +93,10 @@ type AttributesRecord struct {
 	Verb            string
 	Namespace       string
 	APIGroup        string
+	APIVersion      string
 	Resource        string
+	Subresource     string
+	Name            string
 	ResourceRequest bool
 	Path            string
 }
@@ -112,8 +125,20 @@ func (a AttributesRecord) GetResource() string {
 	return a.Resource
 }
 
+func (a AttributesRecord) GetSubresource() string {
+	return a.Subresource
+}
+
+func (a AttributesRecord) GetName() string {
+	return a.Name
+}
+
 func (a AttributesRecord) GetAPIGroup() string {
 	return a.APIGroup
+}
+
+func (a AttributesRecord) GetAPIVersion() string {
+	return a.APIVersion
 }
 
 func (a AttributesRecord) IsResourceRequest() bool {


### PR DESCRIPTION
Plumb through missing attributes for authorization decisions.  The request parser picked them up a while back, but they were never wired up in kube.

This simply allows authorizers to use them, it doesn't require them to.

@kubernetes/kube-iam 
