### PR TITLE
genericapiserver: Moving InstallSwaggerAPI to Run

### DIFF
--- a/pkg/genericapiserver/genericapiserver.go
+++ b/pkg/genericapiserver/genericapiserver.go
@@ -616,15 +616,12 @@ func (s *GenericAPIServer) init(c *Config) {
 	s.installGroupsDiscoveryHandler()
 }
 
-// Exposes the given group versions in API.
+// Exposes the given group versions in API. Helper method to install multiple group versions at once.
 func (s *GenericAPIServer) InstallAPIGroups(groupsInfo []APIGroupInfo) error {
 	for _, apiGroupInfo := range groupsInfo {
-		if err := s.installAPIGroup(&apiGroupInfo); err != nil {
+		if err := s.InstallAPIGroup(&apiGroupInfo); err != nil {
 			return err
 		}
-	}
-	if s.enableSwaggerSupport {
-		s.InstallSwaggerAPI()
 	}
 	return nil
 }
@@ -652,7 +649,10 @@ func (s *GenericAPIServer) installGroupsDiscoveryHandler() {
 }
 
 func (s *GenericAPIServer) Run(options *ServerRunOptions) {
-	// We serve on 2 ports.  See docs/accessing_the_api.md
+	if s.enableSwaggerSupport {
+		s.InstallSwaggerAPI()
+	}
+	// We serve on 2 ports. See docs/accessing_the_api.md
 	secureLocation := ""
 	if options.SecurePort != 0 {
 		secureLocation = net.JoinHostPort(options.BindAddress.String(), strconv.Itoa(options.SecurePort))
@@ -768,7 +768,8 @@ func shouldGenSelfSignedCerts(certPath, keyPath string) bool {
 	return true
 }
 
-func (s *GenericAPIServer) installAPIGroup(apiGroupInfo *APIGroupInfo) error {
+// Exposes the given group version in API.
+func (s *GenericAPIServer) InstallAPIGroup(apiGroupInfo *APIGroupInfo) error {
 	apiPrefix := s.APIGroupPrefix
 	if apiGroupInfo.IsLegacyGroup {
 		apiPrefix = s.APIPrefix

--- a/test/integration/kubectl_test.go
+++ b/test/integration/kubectl_test.go
@@ -46,6 +46,8 @@ func TestKubectlValidation(t *testing.T) {
 	defer components.Stop(true, true)
 	ctx := clientcmdapi.NewContext()
 	cfg := clientcmdapi.NewConfig()
+	// Enable swagger api on master.
+	components.KubeMaster.InstallSwaggerAPI()
 	cluster := clientcmdapi.NewCluster()
 	cluster.Server = components.ApiServer.URL
 	cluster.InsecureSkipTLSVerify = true


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/pull/21190#discussion_r57494673

Moving InstallSwaggerAPI() from InstallAPIGroups() to Run(). This allows the use of InstallAPIGroups() multiple times or using InstallAPIGroup() directly.

cc @jianhuiz @kubernetes/sig-api-machinery 
