### PR TITLE
Expose GCE client constructor to downstream clients.

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -94,7 +94,7 @@ type Config struct {
 }
 
 func init() {
-	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) { return newGCECloud(config) })
+	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) { return NewGCECloud(config) })
 }
 
 // Raw access to the underlying GCE service, probably should only be used for e2e tests
@@ -200,8 +200,14 @@ func getZonesForRegion(svc *compute.Service, projectID, region string) ([]string
 	return zones, nil
 }
 
-// newGCECloud creates a new instance of GCECloud.
-func newGCECloud(config io.Reader) (*GCECloud, error) {
+// NewGCECloud creates a new instance of GCECloud.
+//
+// Warning: invoking this method directly in non-GCE environments is not
+// guaranteed to throw an error. Clients that are not aware of which
+// cloudprovider they're running on should invoke GetCloudProvider instead.
+// That works better because we initialize a map of known cloud providers
+// at import time, so eg: on AWS the map won't contain the GCE provider.
+func NewGCECloud(config io.Reader) (*GCECloud, error) {
 	projectID, zone, err := getProjectAndZone()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
We introduced a liveness probe for the L7 controller to fight flake in resolving the metadata server (https://github.com/kubernetes/kubernetes/issues/16985). This causes problems when the controller is scheduled on nodes with inadequate scope. This change just exposes the client creation method so we don't need to restart, to re-import modules, to recreate the client. 
