### PR TITLE
Honor incoming OUT_DIR from the Makefile.

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -60,7 +60,8 @@ readonly KUBE_BUILD_IMAGE_CROSS_TAG="v1.4.2-1"
 # *_OUTPUT_BINPATH - location where final binaries are placed.  If the remote
 #                    is really remote, this is the stuff that has to be copied
 #                    back.
-readonly LOCAL_OUTPUT_ROOT="${KUBE_ROOT}/_output"
+# OUT_DIR can come in from the Makefile, so honor it.
+readonly LOCAL_OUTPUT_ROOT="${KUBE_ROOT}/${OUT_DIR:-_output}"
 readonly LOCAL_OUTPUT_SUBPATH="${LOCAL_OUTPUT_ROOT}/dockerized"
 readonly LOCAL_OUTPUT_BINPATH="${LOCAL_OUTPUT_SUBPATH}/bin"
 readonly LOCAL_OUTPUT_IMAGE_STAGING="${LOCAL_OUTPUT_ROOT}/images"


### PR DESCRIPTION
This PR allows OUT_DIR, set (and modifiable) in the top level Makefile is honored by all the scripts that include common.sh.  It also means that any script called directly can now modify the output directory default of _output.
