### PR TITLE
Hyperkube: SNAT all proxied traffic by default to fix SkyDNS

### DIFF
--- a/cluster/images/hyperkube/kube-proxy.json
+++ b/cluster/images/hyperkube/kube-proxy.json
@@ -13,7 +13,8 @@
                 "proxy",
                 "--master=http://127.0.0.1:8080",
                 "--v=2",
-                "--resource-container=\"\""
+                "--resource-container=\"\"",
+                "--masquerade-all=true"
         ],
         "securityContext": {
           "privileged": true


### PR DESCRIPTION
I followed the steps to deploy DNS on local Hyperkube-provisioned cluster (v1.2.1-beta.1) from http://kubernetes.io/docs/getting-started-guides/docker-multinode/deployDNS/, but the resolver didn't work. Investigating the issue with

>  dig @10.0.0.10 foo

 from any pod I'd got following errors:

> ;; reply from unexpected source: 172.17.0.7#53, expected 10.0.0.10#53

Turning on --masquerade-all on kube-proxy helps, so I'm proposing to make this the default behavior when using Hyperkube

I'm not sure if it can cause any regressions so please review
