### PR TITLE
Run node test jobs every 30 minutes instead of daily.  This is critic…

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-jenkins/node-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/node-e2e.yaml
@@ -90,7 +90,7 @@
     triggers:
         - pollscm:
             cron: 'H/5 * * * *'
-        - timed: '@daily'
+        - timed: 'H/30 * * * *'
     wrappers:
         - ansicolor:
             colormap: xterm


### PR DESCRIPTION
…al for the kubelet e2e as it is a merge queue blocker.
