### PR TITLE
Allow lazy binding in credential providers; don't use it in AWS yet

### DIFF
--- a/pkg/credentialprovider/aws/aws_credentials.go
+++ b/pkg/credentialprovider/aws/aws_credentials.go
@@ -119,6 +119,11 @@ func (p *ecrProvider) Enabled() bool {
 	return true
 }
 
+// LazyProvide implements DockerConfigProvider.LazyProvide. Should never be called.
+func (p *ecrProvider) LazyProvide() *credentialprovider.DockerConfigEntry {
+	return nil
+}
+
 // Provide implements DockerConfigProvider.Provide, refreshing ECR tokens on demand
 func (p *ecrProvider) Provide() credentialprovider.DockerConfig {
 	cfg := credentialprovider.DockerConfig{}

--- a/pkg/credentialprovider/config.go
+++ b/pkg/credentialprovider/config.go
@@ -46,6 +46,7 @@ type DockerConfigEntry struct {
 	Username string
 	Password string
 	Email    string
+	Provider DockerConfigProvider
 }
 
 var (

--- a/pkg/credentialprovider/gcp/jwt.go
+++ b/pkg/credentialprovider/gcp/jwt.go
@@ -82,6 +82,11 @@ func (j *jwtProvider) Enabled() bool {
 	return true
 }
 
+// LazyProvide implements DockerConfigProvider. Should never be called.
+func (j *jwtProvider) LazyProvide() *credentialprovider.DockerConfigEntry {
+	return nil
+}
+
 // Provide implements DockerConfigProvider
 func (j *jwtProvider) Provide() credentialprovider.DockerConfig {
 	cfg := credentialprovider.DockerConfig{}

--- a/pkg/credentialprovider/gcp/metadata.go
+++ b/pkg/credentialprovider/gcp/metadata.go
@@ -104,6 +104,11 @@ func (g *metadataProvider) Enabled() bool {
 	return err == nil
 }
 
+// LazyProvide implements DockerConfigProvider. Should never be called.
+func (g *dockerConfigKeyProvider) LazyProvide() *credentialprovider.DockerConfigEntry {
+	return nil
+}
+
 // Provide implements DockerConfigProvider
 func (g *dockerConfigKeyProvider) Provide() credentialprovider.DockerConfig {
 	// Read the contents of the google-dockercfg metadata key and
@@ -115,6 +120,11 @@ func (g *dockerConfigKeyProvider) Provide() credentialprovider.DockerConfig {
 	}
 
 	return credentialprovider.DockerConfig{}
+}
+
+// LazyProvide implements DockerConfigProvider. Should never be called.
+func (g *dockerConfigUrlKeyProvider) LazyProvide() *credentialprovider.DockerConfigEntry {
+	return nil
 }
 
 // Provide implements DockerConfigProvider
@@ -164,6 +174,11 @@ func (g *containerRegistryProvider) Enabled() bool {
 // that is returned by GCE metadata.
 type tokenBlob struct {
 	AccessToken string `json:"access_token"`
+}
+
+// LazyProvide implements DockerConfigProvider. Should never be called.
+func (g *containerRegistryProvider) LazyProvide() *credentialprovider.DockerConfigEntry {
+	return nil
 }
 
 // Provide implements DockerConfigProvider

--- a/pkg/credentialprovider/keyring_test.go
+++ b/pkg/credentialprovider/keyring_test.go
@@ -462,6 +462,11 @@ func (d *testProvider) Enabled() bool {
 	return true
 }
 
+// LazyProvide implements dockerConfigProvider. Should never be called.
+func (d *testProvider) LazyProvide() *DockerConfigEntry {
+	return nil
+}
+
 // Provide implements dockerConfigProvider
 func (d *testProvider) Provide() DockerConfig {
 	d.Count += 1

--- a/pkg/credentialprovider/provider.go
+++ b/pkg/credentialprovider/provider.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/glog"
 )
 
@@ -30,6 +31,19 @@ import (
 type DockerConfigProvider interface {
 	Enabled() bool
 	Provide() DockerConfig
+	// LazyProvide() gets called after URL matches have been performed, so the
+	// location used as the key in DockerConfig would be redundant.
+	LazyProvide() *DockerConfigEntry
+}
+
+func LazyProvide(creds LazyAuthConfiguration) docker.AuthConfiguration {
+	if creds.Provider != nil {
+		entry := *creds.Provider.LazyProvide()
+		return DockerConfigEntryToLazyAuthConfiguration(entry).AuthConfiguration
+	} else {
+		return creds.AuthConfiguration
+	}
+
 }
 
 // A DockerConfigProvider that simply reads the .dockercfg file
@@ -73,9 +87,19 @@ func (d *defaultDockerConfigProvider) Provide() DockerConfig {
 	return DockerConfig{}
 }
 
+// LazyProvide implements dockerConfigProvider. Should never be called.
+func (d *defaultDockerConfigProvider) LazyProvide() *DockerConfigEntry {
+	return nil
+}
+
 // Enabled implements dockerConfigProvider
 func (d *CachingDockerConfigProvider) Enabled() bool {
 	return d.Provider.Enabled()
+}
+
+// LazyProvide implements dockerConfigProvider. Should never be called.
+func (d *CachingDockerConfigProvider) LazyProvide() *DockerConfigEntry {
+	return nil
 }
 
 // Provide implements dockerConfigProvider

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -187,7 +187,7 @@ func (p dockerPuller) Pull(image string, secrets []api.Secret) error {
 
 	var pullErrs []error
 	for _, currentCreds := range creds {
-		err := p.client.PullImage(opts, currentCreds)
+		err := p.client.PullImage(opts, credentialprovider.LazyProvide(currentCreds))
 		// If there was no error, return success
 		if err == nil {
 			return nil

--- a/pkg/kubelet/rkt/image.go
+++ b/pkg/kubelet/rkt/image.go
@@ -178,7 +178,7 @@ func (r *Runtime) getImageManifest(image string) (*appcschema.ImageManifest, err
 
 // TODO(yifan): This is very racy, unefficient, and unsafe, we need to provide
 // different namespaces. See: https://github.com/coreos/rkt/issues/836.
-func (r *Runtime) writeDockerAuthConfig(image string, credsSlice []docker.AuthConfiguration) error {
+func (r *Runtime) writeDockerAuthConfig(image string, credsSlice []credentialprovider.LazyAuthConfiguration) error {
 	if len(credsSlice) == 0 {
 		return nil
 	}
@@ -186,7 +186,7 @@ func (r *Runtime) writeDockerAuthConfig(image string, credsSlice []docker.AuthCo
 	creds := docker.AuthConfiguration{}
 	// TODO handle multiple creds
 	if len(credsSlice) >= 1 {
-		creds = credsSlice[0]
+		creds = credentialprovider.LazyProvide(credsSlice[0])
 	}
 
 	registry := "index.docker.io"


### PR DESCRIPTION
This is step one for cross-region ECR support and has no visible effects yet.
I'm not crazy about the name LazyProvide. Perhaps the interface method could
remain like that and the package method of the same name could become
LateBind(). I still don't understand why the credential provider has a
DockerConfigEntry that has the same fields but is distinct from
docker.AuthConfiguration. I had to write a converter now that we do that in
more than one place.

In step two, I'll add another intermediate, lazy provider for each AWS region,
whose empty LazyAuthConfiguration will have a refresh time of months or years.
Behind the scenes, it'll use an actual ecrProvider with the usual ~12 hour
credentials, that will get created (and later refreshed) only when kubelet is
attempting to pull an image. If we simply turned ecrProvider directly into a
lazy provider, we would bypass all the caching and get new credentials for
each image pulled.
