### PR TITLE
don't ship kube-registry-proxy and pause images in tars.

### DIFF
--- a/cluster/addons/python-image/Makefile
+++ b/cluster/addons/python-image/Makefile
@@ -1,0 +1,25 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+IMAGE=gcr.io/google_containers/python
+VERSION=v1
+
+.PHONY: build push
+
+build:
+	docker build -t "$(IMAGE):$(VERSION)" .
+
+push:
+	gcloud docker push "$(IMAGE):$(VERSION)"
+

--- a/cluster/saltbase/install.sh
+++ b/cluster/saltbase/install.sh
@@ -65,10 +65,8 @@ done
 echo "+++ Install binaries from tar: $1"
 tar -xz -C "${KUBE_TEMP}" -f "$1"
 mkdir -p /srv/salt-new/salt/kube-bins
-mkdir -p /srv/salt-new/salt/kube-addons-images
 mkdir -p /srv/salt-new/salt/kube-docs
 cp -v "${KUBE_TEMP}/kubernetes/server/bin/"* /srv/salt-new/salt/kube-bins/
-cp -v "${KUBE_TEMP}/kubernetes/addons/"* /srv/salt-new/salt/kube-addons-images/
 cp -v "${KUBE_TEMP}/kubernetes/LICENSES" /srv/salt-new/salt/kube-docs/
 
 kube_bin_dir="/srv/salt-new/salt/kube-bins";

--- a/cluster/saltbase/salt/kube-addons/kube-addons.sh
+++ b/cluster/saltbase/salt/kube-addons/kube-addons.sh
@@ -28,7 +28,7 @@ trusty_master=${TRUSTY_MASTER:-false}
 function ensure_python() {
   if ! python --version > /dev/null 2>&1; then    
     echo "No python on the machine, will use a python image"
-    local -r PYTHON_IMAGE=python:2.7-slim-pyyaml
+    local -r PYTHON_IMAGE=gcr.io/google_containers/python:v1
     export PYTHON="docker run --interactive --rm --net=none ${PYTHON_IMAGE} python"
   else
     export PYTHON=python
@@ -136,38 +136,10 @@ function create-resource-from-string() {
   return 1;
 }
 
-# $1 is the directory containing all of the docker images
-function load-docker-images() {
-  local success
-  local restart_docker
-  while true; do
-    success=true
-    restart_docker=false
-    for image in "$1/"*; do
-      timeout 30 docker load -i "${image}" &>/dev/null
-      rc=$?
-      if [[ "$rc" == 124 ]]; then
-        restart_docker=true
-      elif [[ "$rc" != 0 ]]; then
-        success=false
-      fi
-    done
-    if [[ "$success" == "true" ]]; then break; fi
-    if [[ "$restart_docker" == "true" ]]; then service docker restart; fi
-    sleep 15
-  done
-}
-
 # The business logic for whether a given object should be created
 # was already enforced by salt, and /etc/kubernetes/addons is the
 # managed result is of that. Start everything below that directory.
 echo "== Kubernetes addon manager started at $(date -Is) with ADDON_CHECK_INTERVAL_SEC=${ADDON_CHECK_INTERVAL_SEC} =="
-
-# Load any images that we may need. This is not needed for trusty master and
-# the way it restarts docker daemon does not work for trusty.
-if [[ "${trusty_master}" == "false" ]]; then
-  load-docker-images /srv/salt/kube-addons-images
-fi
 
 ensure_python
 


### PR DESCRIPTION
pause is built into containervm. if it's not on the machine we should just pull
it. nobody that I'm aware of uses kube-registry-proxy and it makes build/deployment
more complicated and slower.
