### PR TITLE
Do not log errors when events are forbidden during namespace deletion

### DIFF
--- a/pkg/client/record/event.go
+++ b/pkg/client/record/event.go
@@ -192,7 +192,11 @@ func recordEvent(sink EventSink, event *api.Event, patch []byte, updateExistingE
 		glog.Errorf("Unable to construct event '%#v': '%v' (will not retry!)", event, err)
 		return true
 	case *errors.StatusError:
-		if errors.IsAlreadyExists(err) {
+		// if the event already exists, or if the event is forbidden by the server, we do not
+		// log an error.  forbidden events happen most frequently when a client attempts to create
+		// an event in a namespace that is undergoing termination.  it's rejection is part of normal
+		// server activity, and having error log for normal system behavior causes confusion.
+		if errors.IsAlreadyExists(err) || errors.IsForbidden(err) {
 			glog.V(5).Infof("Server rejected event '%#v': '%v' (will not retry!)", event, err)
 		} else {
 			glog.Errorf("Server rejected event '%#v': '%v' (will not retry!)", event, err)


### PR DESCRIPTION
It is common for a server to reject creation of an `Event` with a `Forbidden` response when a `Namespace` is being terminated.  It should not be logged as an error as it causes confusion when reviewing the logs.

For example, its common to get messages in the `kubelet` log when a namespace is undergoing termination which just causes a lot of noise:

```
E0330 16:53:15.804285   24468 event.go:198] Server rejected event '&api.Event{TypeMeta:unversioned.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:api.ObjectMeta{Name:"test-ff4fn.1440ba5ed2783661", GenerateName:"", Namespace:"e2e-tests-nodestress-98dl9", SelfLink:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:unversioned.Time{Time:time.Time{sec:0, nsec:0, loc:(*time.Location)(nil)}}, DeletionTimestamp:(*unversioned.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil)}, InvolvedObject:api.ObjectReference{Kind:"Pod", Namespace:"e2e-tests-nodestress-98dl9", Name:"test-ff4fn", UID:"d90a3434-f6b7-11e5-8e8f-28d2444e470d", APIVersion:"v1", ResourceVersion:"95869", FieldPath:"spec.containers{test}"}, Reason:"Killing", Message:"Killing container with docker id 36fd77e25fcf: Need to kill pod.", Source:api.EventSource{Component:"kubelet", Host:"127.0.0.1"}, FirstTimestamp:unversioned.Time{Time:time.Time{sec:63594967995, nsec:688826465, loc:(*time.Location)(0x2ef0e40)}}, LastTimestamp:unversioned.Time{Time:time.Time{sec:63594967995, nsec:688826465, loc:(*time.Location)(0x2ef0e40)}}, Count:1, Type:"Normal"}': 'events "test-ff4fn.1440ba5ed2783661" is forbidden: Unable to create new content in namespace e2e-tests-nodestress-98dl9 because it is being terminated.' (will not retry!)
```

/cc @kubernetes/rh-cluster-infra 
