### PR TITLE
Change kube-proxy & fluentd CPU request to 20m/80m.

### DIFF
--- a/cluster/gce/trusty/node.yaml
+++ b/cluster/gce/trusty/node.yaml
@@ -215,7 +215,7 @@ script
 	sed -i -e "s/{{pillar\['kube_docker_registry'\]}}/${kube_docker_registry}/g" ${tmp_file}
 	sed -i -e "s/{{pillar\['kube-proxy_docker_tag'\]}}/${kube_proxy_docker_tag}/g" ${tmp_file}
 	sed -i -e "s/{{test_args}}/${test_args}/g" ${tmp_file}
-	sed -i -e "s/{{ cpurequest }}/200m/g" ${tmp_file}
+	sed -i -e "s/{{ cpurequest }}/20m/g" ${tmp_file}
 	sed -i -e "s/{{log_level}}/${log_level}/g" ${tmp_file}
 	sed -i -e "s/{{api_servers_with_port}}/${api_servers}/g" ${tmp_file}
 

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -14,7 +14,9 @@ spec:
       limits:
         memory: 200Mi
       requests:
-        cpu: 100m
+        # Any change here should be accompanied by a proportional change in CPU
+        # requests of other per-node add-ons (e.g. kube-proxy).
+        cpu: 80m
         memory: 200Mi
     env:
     - name: FLUENTD_ARGS

--- a/cluster/saltbase/salt/kube-proxy/init.sls
+++ b/cluster/saltbase/salt/kube-proxy/init.sls
@@ -17,7 +17,12 @@
     - makedirs: true
     - dir_mode: 755
     - context:
-        cpurequest: '200m'
+        # 20m might cause kube-proxy CPU starvation on full nodes, resulting in
+        # delayed service updates. But, giving it more would be a breaking change 
+        # to the overhead requirements for existing clusters.
+        # Any change here should be accompanied by a proportional change in CPU
+        # requests of other per-node add-ons (e.g. fluentd).
+        cpurequest: '20m'
     - require:
       - service: docker
       - service: kubelet


### PR DESCRIPTION
On 1.1.8, our per-node CPU overhead was 100m (fluentd 100m, kube-proxy unaccounted). To stay at that number, we should adjust fluentd to 80m, and give kube-proxy 20m.

Fixes the "failure to schedule kube-dns" part of #23556.
