### PR TITLE
Allow v1.1 cluster dns example to pass against v1.2 cluster

### DIFF
--- a/test/e2e/examples.go
+++ b/test/e2e/examples.go
@@ -529,7 +529,7 @@ var _ = Describe("Examples e2e", func() {
 			_, err = lookForStringInPodExec(namespaces[0].Name, podName, []string{"python", "-c", queryDns}, "ok", dnsReadyTimeout)
 			Expect(err).NotTo(HaveOccurred(), "waiting for output from pod exec")
 
-			updatedPodYaml := prepareResourceWithReplacedString(frontendPodYaml, "dns-backend.development.cluster.local", fmt.Sprintf("dns-backend.%s.cluster.local", namespaces[0].Name))
+			updatedPodYaml := prepareResourceWithReplacedString(frontendPodYaml, "dns-backend.development.cluster.local", fmt.Sprintf("dns-backend.%s.svc.cluster.local", namespaces[0].Name))
 
 			// create a pod in each namespace
 			for _, ns := range namespaces {


### PR DESCRIPTION
Basically manual cherry-pick of #19947, but that happened after the
cluster dns test was split out from examples.go into
example_cluster_dns.go
