### PR TITLE
Remove retries from most oidc tests.

### DIFF
--- a/pkg/apiserver/authenticator/authn.go
+++ b/pkg/apiserver/authenticator/authn.go
@@ -138,7 +138,15 @@ func newAuthenticatorFromTokenFile(tokenAuthFile string) (authenticator.Request,
 
 // newAuthenticatorFromOIDCIssuerURL returns an authenticator.Request or an error.
 func newAuthenticatorFromOIDCIssuerURL(issuerURL, clientID, caFile, usernameClaim, groupsClaim string) (authenticator.Request, error) {
-	tokenAuthenticator, err := oidc.New(issuerURL, clientID, caFile, usernameClaim, groupsClaim)
+	tokenAuthenticator, err := oidc.New(oidc.OIDCOptions{
+		IssuerURL:     issuerURL,
+		ClientID:      clientID,
+		CAFile:        caFile,
+		UsernameClaim: usernameClaim,
+		GroupsClaim:   groupsClaim,
+		MaxRetries:    oidc.DefaultRetries,
+		RetryBackoff:  oidc.DefaultBackoff,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/pkg/auth/authenticator/token/oidc/oidc.go
+++ b/plugin/pkg/auth/authenticator/token/oidc/oidc.go
@@ -34,10 +34,22 @@ import (
 	"k8s.io/kubernetes/pkg/util/net"
 )
 
-var (
-	maxRetries   = 5
-	retryBackoff = time.Second * 3
+const (
+	DefaultRetries = 5
+	DefaultBackoff = time.Second * 3
 )
+
+type OIDCOptions struct {
+	IssuerURL     string
+	ClientID      string
+	CAFile        string
+	UsernameClaim string
+	GroupsClaim   string
+
+	// 0 disables retry
+	MaxRetries   int
+	RetryBackoff time.Duration
+}
 
 type OIDCAuthenticator struct {
 	clientConfig     oidc.ClientConfig
@@ -45,27 +57,29 @@ type OIDCAuthenticator struct {
 	usernameClaim    string
 	groupsClaim      string
 	stopSyncProvider chan struct{}
+	maxRetries       int
+	retryBackoff     time.Duration
 }
 
 // New creates a new OpenID Connect client with the given issuerURL and clientID.
 // NOTE(yifan): For now we assume the server provides the "jwks_uri" so we don't
 // need to manager the key sets by ourselves.
-func New(issuerURL, clientID, caFile, usernameClaim, groupsClaim string) (*OIDCAuthenticator, error) {
+func New(opts OIDCOptions) (*OIDCAuthenticator, error) {
 	var cfg oidc.ProviderConfig
 	var err error
 	var roots *x509.CertPool
 
-	url, err := url.Parse(issuerURL)
+	url, err := url.Parse(opts.IssuerURL)
 	if err != nil {
 		return nil, err
 	}
 
 	if url.Scheme != "https" {
-		return nil, fmt.Errorf("'oidc-issuer-url' (%q) has invalid scheme (%q), require 'https'", issuerURL, url.Scheme)
+		return nil, fmt.Errorf("'oidc-issuer-url' (%q) has invalid scheme (%q), require 'https'", opts.IssuerURL, url.Scheme)
 	}
 
-	if caFile != "" {
-		roots, err = crypto.CertPoolFromFile(caFile)
+	if opts.CAFile != "" {
+		roots, err = crypto.CertPoolFromFile(opts.CAFile)
 		if err != nil {
 			glog.Errorf("Failed to read the CA file: %v", err)
 		}
@@ -84,12 +98,21 @@ func New(issuerURL, clientID, caFile, usernameClaim, groupsClaim string) (*OIDCA
 	hc := &http.Client{}
 	hc.Transport = tr
 
+	maxRetries := opts.MaxRetries
+	if maxRetries < 0 {
+		maxRetries = DefaultRetries
+	}
+	retryBackoff := opts.RetryBackoff
+	if retryBackoff < 0 {
+		retryBackoff = DefaultBackoff
+	}
+
 	for i := 0; i <= maxRetries; i++ {
 		if i == maxRetries {
 			return nil, fmt.Errorf("failed to fetch provider config after %v retries", maxRetries)
 		}
 
-		cfg, err = oidc.FetchProviderConfig(hc, strings.TrimSuffix(issuerURL, "/"))
+		cfg, err = oidc.FetchProviderConfig(hc, strings.TrimSuffix(opts.IssuerURL, "/"))
 		if err == nil {
 			break
 		}
@@ -97,11 +120,11 @@ func New(issuerURL, clientID, caFile, usernameClaim, groupsClaim string) (*OIDCA
 		time.Sleep(retryBackoff)
 	}
 
-	glog.Infof("Fetched provider config from %s: %#v", issuerURL, cfg)
+	glog.Infof("Fetched provider config from %s: %#v", opts.IssuerURL, cfg)
 
 	ccfg := oidc.ClientConfig{
 		HTTPClient:     hc,
-		Credentials:    oidc.ClientCredentials{ID: clientID},
+		Credentials:    oidc.ClientCredentials{ID: opts.ClientID},
 		ProviderConfig: cfg,
 	}
 
@@ -113,9 +136,17 @@ func New(issuerURL, clientID, caFile, usernameClaim, groupsClaim string) (*OIDCA
 	// SyncProviderConfig will start a goroutine to periodically synchronize the provider config.
 	// The synchronization interval is set by the expiration length of the config, and has a mininum
 	// and maximum threshold.
-	stop := client.SyncProviderConfig(issuerURL)
+	stop := client.SyncProviderConfig(opts.IssuerURL)
 
-	return &OIDCAuthenticator{ccfg, client, usernameClaim, groupsClaim, stop}, nil
+	return &OIDCAuthenticator{
+		ccfg,
+		client,
+		opts.UsernameClaim,
+		opts.GroupsClaim,
+		stop,
+		maxRetries,
+		retryBackoff,
+	}, nil
 }
 
 // AuthenticateToken decodes and verifies a JWT using the OIDC client, if the verification succeeds,


### PR DESCRIPTION
This cuts these tests down from 11 seconds to 2 seconds on my computer. On Jenkins they're taking 15 seconds each, we'll see how far this cuts that.
