### PR TITLE
rkt: Update the directory path for saving auth config.

### DIFF
--- a/pkg/kubelet/rkt/image.go
+++ b/pkg/kubelet/rkt/image.go
@@ -196,11 +196,15 @@ func (r *Runtime) writeDockerAuthConfig(image string, credsSlice []docker.AuthCo
 		registry = strings.Split(image, "/")[0]
 	}
 
-	localConfigDir := rktLocalConfigDir
-	if r.config.LocalConfigDir != "" {
-		localConfigDir = r.config.LocalConfigDir
+	configDir := r.config.UserConfigDir
+	if configDir == "" {
+		configDir = r.config.LocalConfigDir
 	}
-	authDir := path.Join(localConfigDir, "auth.d")
+	if configDir == "" {
+		return fmt.Errorf("No user or local config dir is specified")
+	}
+
+	authDir := path.Join(configDir, "auth.d")
 	if _, err := os.Stat(authDir); os.IsNotExist(err) {
 		if err := os.Mkdir(authDir, 0600); err != nil {
 			glog.Errorf("rkt: Cannot create auth dir: %v", err)


### PR DESCRIPTION
Since #23308 is merged, now we have more stable way to determine where to store the auth configs.

cc @yujuhong @sjpotter
