### PR TITLE
allow kubectl subcmds to process multiple resources

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -856,6 +856,166 @@ __EOF__
   # Clean up
   kubectl delete deployment nginx "${kube_flags[@]}"
 
+
+  #####################################
+  # Recursive Resources via directory #
+  #####################################
+
+  ### Create multiple busybox PODs recursively from directory of YAML files
+  # Pre-condition: no POD exists
+  create_and_use_new_namespace
+  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
+  # Command
+  output_message=$(! kubectl create -f hack/testdata/recursive/pod --recursive 2>&1 "${kube_flags[@]}")
+  # Post-condition: busybox0 & busybox1 PODs are created, and since busybox2 is malformed, it should error
+  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" 'busybox0:busybox1:'
+  kube::test::if_has_string "${output_message}" 'error validating data: kind not set'
+
+  ## Replace multiple busybox PODs recursively from directory of YAML files
+  # Pre-condition: busybox0 & busybox1 PODs exist
+  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" 'busybox0:busybox1:'
+  # Command
+  output_message=$(! kubectl replace -f hack/testdata/recursive/pod-modify --recursive 2>&1 "${kube_flags[@]}")
+  # Post-condition: busybox0 & busybox1 PODs are replaced, and since busybox2 is malformed, it should error
+  kube::test::get_object_assert pods "{{range.items}}{{${labels_field}.status}}:{{end}}" 'replaced:replaced:'
+  kube::test::if_has_string "${output_message}" 'error validating data: kind not set'
+
+  ## Describe multiple busybox PODs recursively from directory of YAML files
+  # Pre-condition: busybox0 & busybox1 PODs exist
+  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" 'busybox0:busybox1:'
+  # Command
+  output_message=$(! kubectl describe -f hack/testdata/recursive/pod --recursive 2>&1 "${kube_flags[@]}")
+  # Post-condition: busybox0 & busybox1 PODs are described, and since busybox2 is malformed, it should error
+  kube::test::if_has_string "${output_message}" "app=busybox0"
+  kube::test::if_has_string "${output_message}" "app=busybox1"
+  kube::test::if_has_string "${output_message}" "Object 'Kind' is missing"
+
+  ## Annotate multiple busybox PODs recursively from directory of YAML files
+  # Pre-condition: busybox0 & busybox1 PODs exist
+  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" 'busybox0:busybox1:'
+  # Command
+  output_message=$(! kubectl annotate -f hack/testdata/recursive/pod annotatekey='annotatevalue' --recursive 2>&1 "${kube_flags[@]}")
+  # Post-condition: busybox0 & busybox1 PODs are annotated, and since busybox2 is malformed, it should error
+  kube::test::get_object_assert pods "{{range.items}}{{${annotations_field}.annotatekey}}:{{end}}" 'annotatevalue:annotatevalue:'
+  kube::test::if_has_string "${output_message}" "Object 'Kind' is missing"
+
+  ## Apply multiple busybox PODs recursively from directory of YAML files
+  # Pre-condition: busybox0 & busybox1 PODs exist
+  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" 'busybox0:busybox1:'
+  # Command
+  output_message=$(! kubectl apply -f hack/testdata/recursive/pod-modify --recursive 2>&1 "${kube_flags[@]}")
+  # Post-condition: busybox0 & busybox1 PODs are updated, and since busybox2 is malformed, it should error
+  kube::test::get_object_assert pods "{{range.items}}{{${labels_field}.status}}:{{end}}" 'replaced:replaced:'
+  kube::test::if_has_string "${output_message}" 'error validating data: kind not set'
+
+  ## Convert multiple busybox PODs recursively from directory of YAML files
+  # Pre-condition: busybox0 & busybox1 PODs exist
+  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" 'busybox0:busybox1:'
+  # Command
+  output_message=$(! kubectl convert -f hack/testdata/recursive/pod --recursive 2>&1 "${kube_flags[@]}")
+  # Post-condition: busybox0 & busybox1 PODs are converted, and since busybox2 is malformed, it should error
+  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" 'busybox0:busybox1:'
+  kube::test::if_has_string "${output_message}" "Object 'Kind' is missing"
+
+  ## Get multiple busybox PODs recursively from directory of YAML files
+  # Pre-condition: busybox0 & busybox1 PODs exist
+  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" 'busybox0:busybox1:'
+  # Command
+  output_message1=$(kubectl get -f hack/testdata/recursive/pod --recursive 2>&1 "${kube_flags[@]}" -o go-template="{{range.items}}{{$id_field}}:{{end}}")
+  output_message2=$(! kubectl get -f hack/testdata/recursive/pod --recursive 2>&1 "${kube_flags[@]}")
+  # Post-condition: busybox0 & busybox1 PODs are retrieved, but because busybox2 is malformed, it should not show up
+  kube::test::if_has_string "${output_message1}" "busybox0:busybox1:"
+  kube::test::if_has_string "${output_message2}" "Object 'Kind' is missing"
+
+  ## Label multiple busybox PODs recursively from directory of YAML files
+  # Pre-condition: busybox0 & busybox1 PODs exist
+  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" 'busybox0:busybox1:'
+  # Command
+  output_message=$(! kubectl label -f hack/testdata/recursive/pod mylabel='myvalue' --recursive 2>&1 "${kube_flags[@]}")
+  echo $output_message
+  # Post-condition: busybox0 & busybox1 PODs are labeled, but because busybox2 is malformed, it should not show up
+  kube::test::get_object_assert pods "{{range.items}}{{${labels_field}.mylabel}}:{{end}}" 'myvalue:myvalue:'
+  kube::test::if_has_string "${output_message}" "Object 'Kind' is missing"
+
+  ## Patch multiple busybox PODs recursively from directory of YAML files
+  # Pre-condition: busybox0 & busybox1 PODs exist
+  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" 'busybox0:busybox1:'
+  # Command
+  output_message=$(! kubectl patch -f hack/testdata/recursive/pod -p='{"spec":{"containers":[{"name":"busybox","image":"prom/busybox"}]}}' --recursive 2>&1 "${kube_flags[@]}")
+  echo $output_message
+  # Post-condition: busybox0 & busybox1 PODs are patched, but because busybox2 is malformed, it should not show up
+  kube::test::get_object_assert pods "{{range.items}}{{$image_field}}:{{end}}" 'prom/busybox:prom/busybox:'
+  kube::test::if_has_string "${output_message}" "Object 'Kind' is missing"
+
+  ### Delete multiple busybox PODs recursively from directory of YAML files
+  # Pre-condition: busybox0 & busybox1 PODs exist
+  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" 'busybox0:busybox1:'
+  # Command
+  output_message=$(! kubectl delete -f hack/testdata/recursive/pod --recursive --grace-period=0 2>&1 "${kube_flags[@]}")
+  # Post-condition: busybox0 & busybox1 PODs are deleted, and since busybox2 is malformed, it should error
+  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
+  kube::test::if_has_string "${output_message}" "Object 'Kind' is missing"
+
+  ### Create replication controller recursively from directory of YAML files
+  # Pre-condition: no replication controller exists
+  kube::test::get_object_assert rc "{{range.items}}{{$id_field}}:{{end}}" ''
+  # Command
+  ! kubectl create -f hack/testdata/recursive/rc --recursive "${kube_flags[@]}"
+  # Post-condition: frontend replication controller is created
+  kube::test::get_object_assert rc "{{range.items}}{{$id_field}}:{{end}}" 'busybox0:busybox1:'
+
+  ### Autoscale multiple replication controllers recursively from directory of YAML files
+  # Pre-condition: busybox0 & busybox1 replication controllers exist & 1
+  # replica each
+  kube::test::get_object_assert rc "{{range.items}}{{$id_field}}:{{end}}" 'busybox0:busybox1:'
+  kube::test::get_object_assert 'rc busybox0' "{{$rc_replicas_field}}" '1'
+  kube::test::get_object_assert 'rc busybox1' "{{$rc_replicas_field}}" '1'
+  # Command
+  output_message=$(! kubectl autoscale --min=1 --max=2 -f hack/testdata/recursive/rc --recursive 2>&1 "${kube_flags[@]}")
+  # Post-condition: busybox0 & busybox replication controllers are autoscaled
+  # with min. of 1 replica & max of 2 replicas, and since busybox2 is malformed, it should error
+  kube::test::get_object_assert 'hpa busybox0' "{{$hpa_min_field}} {{$hpa_max_field}} {{$hpa_cpu_field}}" '1 2 80'
+  kube::test::get_object_assert 'hpa busybox1' "{{$hpa_min_field}} {{$hpa_max_field}} {{$hpa_cpu_field}}" '1 2 80'
+  kube::test::if_has_string "${output_message}" "Object 'Kind' is missing"
+  kubectl delete hpa busybox0 "${kube_flags[@]}"
+  kubectl delete hpa busybox1 "${kube_flags[@]}"
+
+  ### Expose multiple replication controllers as service recursively from directory of YAML files
+  # Pre-condition: busybox0 & busybox1 replication controllers exist & 1
+  # replica each
+  kube::test::get_object_assert rc "{{range.items}}{{$id_field}}:{{end}}" 'busybox0:busybox1:'
+  kube::test::get_object_assert 'rc busybox0' "{{$rc_replicas_field}}" '1'
+  kube::test::get_object_assert 'rc busybox1' "{{$rc_replicas_field}}" '1'
+  # Command
+  output_message=$(! kubectl expose -f hack/testdata/recursive/rc --recursive --port=80 2>&1 "${kube_flags[@]}")
+  # Post-condition: service exists and the port is unnamed
+  kube::test::get_object_assert 'service busybox0' "{{$port_name}} {{$port_field}}" '<no value> 80'
+  kube::test::get_object_assert 'service busybox1' "{{$port_name}} {{$port_field}}" '<no value> 80'
+  kube::test::if_has_string "${output_message}" "Object 'Kind' is missing"
+
+  ### Scale multiple replication controllers recursively from directory of YAML files
+  # Pre-condition: busybox0 & busybox1 replication controllers exist & 1
+  # replica each
+  kube::test::get_object_assert rc "{{range.items}}{{$id_field}}:{{end}}" 'busybox0:busybox1:'
+  kube::test::get_object_assert 'rc busybox0' "{{$rc_replicas_field}}" '1'
+  kube::test::get_object_assert 'rc busybox1' "{{$rc_replicas_field}}" '1'
+  # Command
+  output_message=$(! kubectl scale --current-replicas=1 --replicas=2 -f hack/testdata/recursive/rc --recursive 2>&1 "${kube_flags[@]}")
+  # Post-condition: busybox0 & busybox replication controllers are scaled to 2 # replicas, and since busybox2 is malformed, it should error
+  kube::test::get_object_assert 'rc busybox0' "{{$rc_replicas_field}}" '2'
+  kube::test::get_object_assert 'rc busybox1' "{{$rc_replicas_field}}" '2'
+  kube::test::if_has_string "${output_message}" "Object 'Kind' is missing"
+
+  ### Delete multiple busybox replication controllers recursively from directory of YAML files
+  # Pre-condition: busybox0 & busybox1 PODs exist
+  kube::test::get_object_assert rc "{{range.items}}{{$id_field}}:{{end}}" 'busybox0:busybox1:'
+  # Command
+  output_message=$(! kubectl delete -f hack/testdata/recursive/rc --recursive --grace-period=0 2>&1 "${kube_flags[@]}")
+  # Post-condition: busybox0 & busybox1 replication controllers are deleted, and since busybox2 is malformed, it should error
+  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
+  kube::test::if_has_string "${output_message}" "Object 'Kind' is missing"
+
+
   ##############
   # Namespaces #
   ##############

--- a/hack/testdata/recursive/deployment/deployment/nginx-broken.yaml
+++ b/hack/testdata/recursive/deployment/deployment/nginx-broken.yaml
@@ -1,0 +1,18 @@
+apiVersion: extensions/v1beta1
+ind: Deployment
+metadata:
+  name: nginx2-deployment
+  labels:
+    app: nginx2-deployment
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: nginx2
+    spec:
+      containers:
+      - name: nginx
+        image: gcr.io/google-containers/nginx:1.7.9
+        ports:
+        - containerPort: 80

--- a/hack/testdata/recursive/deployment/deployment/nginx.yaml
+++ b/hack/testdata/recursive/deployment/deployment/nginx.yaml
@@ -1,0 +1,18 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx1-deployment
+  labels:
+    app: nginx1-deployment
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: nginx1
+    spec:
+      containers:
+      - name: nginx
+        image: gcr.io/google-containers/nginx:1.7.9
+        ports:
+        - containerPort: 80

--- a/hack/testdata/recursive/deployment/nginx.yaml
+++ b/hack/testdata/recursive/deployment/nginx.yaml
@@ -1,0 +1,18 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx0-deployment
+  labels:
+    app: nginx0-deployment
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: nginx0
+    spec:
+      containers:
+      - name: nginx
+        image: gcr.io/google-containers/nginx:1.7.9
+        ports:
+        - containerPort: 80

--- a/hack/testdata/recursive/pod-modify/busybox.yaml
+++ b/hack/testdata/recursive/pod-modify/busybox.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox0
+  labels:
+    app: busybox0
+    status: replaced
+spec:
+  containers:
+  - image: busybox
+    command:
+      - sleep
+      - "3600"
+    imagePullPolicy: IfNotPresent
+    name: busybox
+  restartPolicy: Always

--- a/hack/testdata/recursive/pod-modify/pod/busybox-broken.yaml
+++ b/hack/testdata/recursive/pod-modify/pod/busybox-broken.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+ind: Pod
+metadata:
+  name: busybox2
+  labels:
+    app: busybox2
+    status: replaced
+spec:
+  containers:
+  - image: busybox
+    command:
+      - sleep
+      - "3600"
+    imagePullPolicy: IfNotPresent
+    name: busybox
+  restartPolicy: Always

--- a/hack/testdata/recursive/pod-modify/pod/busybox.yaml
+++ b/hack/testdata/recursive/pod-modify/pod/busybox.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox1
+  labels:
+    app: busybox1
+    status: replaced
+spec:
+  containers:
+  - image: busybox
+    command:
+      - sleep
+      - "3600"
+    imagePullPolicy: IfNotPresent
+    name: busybox
+  restartPolicy: Always

--- a/hack/testdata/recursive/pod/busybox.yaml
+++ b/hack/testdata/recursive/pod/busybox.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox0
+  labels:
+    app: busybox0
+spec:
+  containers:
+  - image: busybox
+    command:
+      - sleep
+      - "3600"
+    imagePullPolicy: IfNotPresent
+    name: busybox
+  restartPolicy: Always

--- a/hack/testdata/recursive/pod/pod/busybox-broken.yaml
+++ b/hack/testdata/recursive/pod/pod/busybox-broken.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+ind: Pod
+metadata:
+  name: busybox2
+  labels:
+    app: busybox2
+spec:
+  containers:
+  - image: busybox
+    command:
+      - sleep
+      - "3600"
+    imagePullPolicy: IfNotPresent
+    name: busybox
+  restartPolicy: Always

--- a/hack/testdata/recursive/pod/pod/busybox.yaml
+++ b/hack/testdata/recursive/pod/pod/busybox.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox1
+  labels:
+    app: busybox1
+spec:
+  containers:
+  - image: busybox
+    command:
+      - sleep
+      - "3600"
+    imagePullPolicy: IfNotPresent
+    name: busybox
+  restartPolicy: Always

--- a/hack/testdata/recursive/rc/busybox.yaml
+++ b/hack/testdata/recursive/rc/busybox.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: busybox0
+  labels:
+    app: busybox0
+spec:
+  replicas: 1
+  selector:
+    app: busybox0
+  template:
+    metadata:
+      name: busybox0
+      labels:
+        app: busybox0
+    spec:
+      containers:
+      - image: busybox
+        command:
+          - sleep
+          - "3600"
+        imagePullPolicy: IfNotPresent
+        name: busybox
+      restartPolicy: Always

--- a/hack/testdata/recursive/rc/rc/busybox-broken.yaml
+++ b/hack/testdata/recursive/rc/rc/busybox-broken.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+ind: ReplicationController
+metadata:
+  name: busybox2
+  labels:
+    app: busybox2
+spec:
+  replicas: 1
+  selector:
+    app: busybox2
+  template:
+    metadata:
+      name: busybox2
+      labels:
+        app: busybox2
+    spec:
+      containers:
+      - image: busybox
+        command:
+          - sleep
+          - "3600"
+        imagePullPolicy: IfNotPresent
+        name: busybox
+      restartPolicy: Always

--- a/hack/testdata/recursive/rc/rc/busybox.yaml
+++ b/hack/testdata/recursive/rc/rc/busybox.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: busybox1
+  labels:
+    app: busybox1
+spec:
+  replicas: 1
+  selector:
+    app: busybox1
+  template:
+    metadata:
+      name: busybox1
+      labels:
+        app: busybox1
+    spec:
+      containers:
+      - image: busybox
+        command:
+          - sleep
+          - "3600"
+        imagePullPolicy: IfNotPresent
+        name: busybox
+      restartPolicy: Always


### PR DESCRIPTION
~~autoscale, expose & patch~~ Many kubectl subcommands were limited to processing one resource at a time.

This PR allows those subcommands to process multiple resources.

This PR is in reference to https://github.com/kubernetes/kubernetes/pull/23116#issuecomment-202360784 by @deads2k 
