### PR TITLE
Fix goroutine leak

### DIFF
--- a/pkg/util/interrupt/interrupt.go
+++ b/pkg/util/interrupt/interrupt.go
@@ -65,6 +65,7 @@ func (h *Handler) Signal(s os.Signal) {
 func (h *Handler) Run(fn func() error) error {
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, childSignals...)
+	defer close(ch)
 	defer signal.Stop(ch)
 	go func() {
 		sig, ok := <-ch


### PR DESCRIPTION
The goroutine started in `Run` would block forever if we go out of the
scope of `Run` without having received a signal. The `if` block is
unreachable code, since no code would ever close `ch`.

The reason it can block forever is that we have no code closing `ch` to
notify the goroutine to terminate. After calling `signal.Stop(ch)`, we
know that the runtime won't send anything through the `ch` channel, so
the receive operation will block forever, leaking the blocked goroutine.

Signed-off-by: Rodolfo Carvalho rcarvalh@redhat.com
