### PR TITLE
Add KUBERNETES_RELEASE option to get-kube.sh

### DIFF
--- a/cluster/get-kube.sh
+++ b/cluster/get-kube.sh
@@ -39,6 +39,7 @@
 #
 #  Set KUBERNETES_SKIP_DOWNLOAD to non-empty to skip downloading a release.
 #  Set KUBERNETES_SKIP_CONFIRM to skip the installation confirmation prompt.
+#  Set KUBERNETES_RELEASE to the release you want to use (e.g. 'v1.2.0'). See https://github.com/kubernetes/kubernetes/releases for release options
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -74,7 +75,7 @@ function get_latest_version_number {
   fi
 }
 
-release=$(get_latest_version_number)
+release=${KUBERNETES_RELEASE:-$(get_latest_version_number)}
 release_url=https://storage.googleapis.com/kubernetes-release/release/${release}/kubernetes.tar.gz
 
 uname=$(uname)


### PR DESCRIPTION
This pull request adds an option to get-kube.sh to allow specification of the kubernetes version to install on the cluster.  If not specified, previous functionality remains the same - get_latest_version_number is called which queries https://storage.googleapis.com/kubernetes-release/release/stable.txt
