### PR TITLE
Kubelet: Refactor container related functions in DockerInterface

### DIFF
--- a/contrib/mesos/pkg/executor/executor.go
+++ b/contrib/mesos/pkg/executor/executor.go
@@ -28,7 +28,7 @@ import (
 
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 
-	"github.com/fsouza/go-dockerclient"
+	dockertypes "github.com/docker/engine-api/types"
 	"github.com/gogo/protobuf/proto"
 	log "github.com/golang/glog"
 	bindings "github.com/mesos/mesos-go/executor"
@@ -655,14 +655,13 @@ func (k *Executor) doShutdown(driver bindings.ExecutorDriver) {
 // Destroy existing k8s containers
 func (k *Executor) killKubeletContainers() {
 	if containers, err := dockertools.GetKubeletDockerContainers(k.dockerClient, true); err == nil {
-		opts := docker.RemoveContainerOptions{
+		opts := dockertypes.ContainerRemoveOptions{
 			RemoveVolumes: true,
 			Force:         true,
 		}
 		for _, container := range containers {
-			opts.ID = container.ID
-			log.V(2).Infof("Removing container: %v", opts.ID)
-			if err := k.dockerClient.RemoveContainer(opts); err != nil {
+			log.V(2).Infof("Removing container: %v", container.ID)
+			if err := k.dockerClient.RemoveContainer(container.ID, opts); err != nil {
 				log.Warning(err)
 			}
 		}

--- a/pkg/kubelet/dockertools/container_gc.go
+++ b/pkg/kubelet/dockertools/container_gc.go
@@ -145,14 +145,20 @@ func (cgc *containerGC) evictableContainers(minAge time.Duration) (containersByE
 			continue
 		} else if data.State.Running {
 			continue
-		} else if newestGCTime.Before(data.Created) {
+		}
+
+		created, err := parseDockerTimestamp(data.Created)
+		if err != nil {
+			glog.Errorf("Failed to parse Created timestamp %q for container %q", data.Created, container.ID)
+		}
+		if newestGCTime.Before(created) {
 			continue
 		}
 
 		containerInfo := containerGCInfo{
 			id:         container.ID,
 			name:       container.Names[0],
-			createTime: data.Created,
+			createTime: created,
 		}
 
 		containerName, _, err := ParseDockerName(container.Names[0])

--- a/pkg/kubelet/dockertools/container_gc.go
+++ b/pkg/kubelet/dockertools/container_gc.go
@@ -24,7 +24,7 @@ import (
 	"sort"
 	"time"
 
-	docker "github.com/fsouza/go-dockerclient"
+	dockertypes "github.com/docker/engine-api/types"
 	"github.com/golang/glog"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/types"
@@ -111,7 +111,7 @@ func (cgc *containerGC) removeOldestN(containers []containerGCInfo, toRemove int
 	// Remove from oldest to newest (last to first).
 	numToKeep := len(containers) - toRemove
 	for i := numToKeep; i < len(containers); i++ {
-		err := cgc.client.RemoveContainer(docker.RemoveContainerOptions{ID: containers[i].id, RemoveVolumes: true})
+		err := cgc.client.RemoveContainer(containers[i].id, dockertypes.ContainerRemoveOptions{RemoveVolumes: true})
 		if err != nil {
 			glog.Warningf("Failed to remove dead container %q: %v", containers[i].name, err)
 		}
@@ -195,7 +195,7 @@ func (cgc *containerGC) GarbageCollect(gcPolicy kubecontainer.ContainerGCPolicy)
 	// Remove unidentified containers.
 	for _, container := range unidentifiedContainers {
 		glog.Infof("Removing unidentified dead container %q with ID %q", container.name, container.id)
-		err = cgc.client.RemoveContainer(docker.RemoveContainerOptions{ID: container.id, RemoveVolumes: true})
+		err = cgc.client.RemoveContainer(container.id, dockertypes.ContainerRemoveOptions{RemoveVolumes: true})
 		if err != nil {
 			glog.Warningf("Failed to remove unidentified dead container %q: %v", container.name, err)
 		}

--- a/pkg/kubelet/dockertools/container_gc_test.go
+++ b/pkg/kubelet/dockertools/container_gc_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-	docker "github.com/fsouza/go-dockerclient"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/kubernetes/pkg/api"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -44,26 +43,22 @@ func makeTime(id int) time.Time {
 }
 
 // Makes a container with the specified properties.
-func makeContainer(id, uid, name string, running bool, created time.Time) *docker.Container {
-	return &docker.Container{
-		Name: fmt.Sprintf("/k8s_%s_bar_new_%s_42", name, uid),
-		State: docker.State{
-			Running: running,
-		},
-		ID:      id,
-		Created: created,
+func makeContainer(id, uid, name string, running bool, created time.Time) *FakeContainer {
+	return &FakeContainer{
+		Name:      fmt.Sprintf("/k8s_%s_bar_new_%s_42", name, uid),
+		Running:   running,
+		ID:        id,
+		CreatedAt: created,
 	}
 }
 
 // Makes a container with unidentified name and specified properties.
-func makeUndefinedContainer(id string, running bool, created time.Time) *docker.Container {
-	return &docker.Container{
-		Name: "/k8s_unidentified",
-		State: docker.State{
-			Running: running,
-		},
-		ID:      id,
-		Created: created,
+func makeUndefinedContainer(id string, running bool, created time.Time) *FakeContainer {
+	return &FakeContainer{
+		Name:      "/k8s_unidentified",
+		Running:   running,
+		ID:        id,
+		CreatedAt: created,
 	}
 }
 
@@ -96,7 +91,7 @@ func verifyStringArrayEqualsAnyOrder(t *testing.T, actual, expected []string) {
 
 func TestGarbageCollectZeroMaxContainers(t *testing.T) {
 	gc, fakeDocker := newTestContainerGC(t)
-	fakeDocker.SetFakeContainers([]*docker.Container{
+	fakeDocker.SetFakeContainers([]*FakeContainer{
 		makeContainer("1876", "foo", "POD", false, makeTime(0)),
 	})
 	addPods(gc.podGetter, "foo")
@@ -107,7 +102,7 @@ func TestGarbageCollectZeroMaxContainers(t *testing.T) {
 
 func TestGarbageCollectNoMaxPerPodContainerLimit(t *testing.T) {
 	gc, fakeDocker := newTestContainerGC(t)
-	fakeDocker.SetFakeContainers([]*docker.Container{
+	fakeDocker.SetFakeContainers([]*FakeContainer{
 		makeContainer("1876", "foo", "POD", false, makeTime(0)),
 		makeContainer("2876", "foo1", "POD", false, makeTime(1)),
 		makeContainer("3876", "foo2", "POD", false, makeTime(2)),
@@ -122,7 +117,7 @@ func TestGarbageCollectNoMaxPerPodContainerLimit(t *testing.T) {
 
 func TestGarbageCollectNoMaxLimit(t *testing.T) {
 	gc, fakeDocker := newTestContainerGC(t)
-	fakeDocker.SetFakeContainers([]*docker.Container{
+	fakeDocker.SetFakeContainers([]*FakeContainer{
 		makeContainer("1876", "foo", "POD", false, makeTime(0)),
 		makeContainer("2876", "foo1", "POD", false, makeTime(0)),
 		makeContainer("3876", "foo2", "POD", false, makeTime(0)),
@@ -136,12 +131,12 @@ func TestGarbageCollectNoMaxLimit(t *testing.T) {
 
 func TestGarbageCollect(t *testing.T) {
 	tests := []struct {
-		containers      []*docker.Container
+		containers      []*FakeContainer
 		expectedRemoved []string
 	}{
 		// Don't remove containers started recently.
 		{
-			containers: []*docker.Container{
+			containers: []*FakeContainer{
 				makeContainer("1876", "foo", "POD", false, time.Now()),
 				makeContainer("2876", "foo", "POD", false, time.Now()),
 				makeContainer("3876", "foo", "POD", false, time.Now()),
@@ -149,7 +144,7 @@ func TestGarbageCollect(t *testing.T) {
 		},
 		// Remove oldest containers.
 		{
-			containers: []*docker.Container{
+			containers: []*FakeContainer{
 				makeContainer("1876", "foo", "POD", false, makeTime(0)),
 				makeContainer("2876", "foo", "POD", false, makeTime(1)),
 				makeContainer("3876", "foo", "POD", false, makeTime(2)),
@@ -158,7 +153,7 @@ func TestGarbageCollect(t *testing.T) {
 		},
 		// Only remove non-running containers.
 		{
-			containers: []*docker.Container{
+			containers: []*FakeContainer{
 				makeContainer("1876", "foo", "POD", true, makeTime(0)),
 				makeContainer("2876", "foo", "POD", false, makeTime(1)),
 				makeContainer("3876", "foo", "POD", false, makeTime(2)),
@@ -168,13 +163,13 @@ func TestGarbageCollect(t *testing.T) {
 		},
 		// Less than maxContainerCount doesn't delete any.
 		{
-			containers: []*docker.Container{
+			containers: []*FakeContainer{
 				makeContainer("1876", "foo", "POD", false, makeTime(0)),
 			},
 		},
 		// maxContainerCount applies per (UID,container) pair.
 		{
-			containers: []*docker.Container{
+			containers: []*FakeContainer{
 				makeContainer("1876", "foo", "POD", false, makeTime(0)),
 				makeContainer("2876", "foo", "POD", false, makeTime(1)),
 				makeContainer("3876", "foo", "POD", false, makeTime(2)),
@@ -189,7 +184,7 @@ func TestGarbageCollect(t *testing.T) {
 		},
 		// Remove non-running unidentified Kubernetes containers.
 		{
-			containers: []*docker.Container{
+			containers: []*FakeContainer{
 				makeUndefinedContainer("1876", true, makeTime(0)),
 				makeUndefinedContainer("2876", false, makeTime(0)),
 				makeContainer("3876", "foo", "POD", false, makeTime(0)),
@@ -198,7 +193,7 @@ func TestGarbageCollect(t *testing.T) {
 		},
 		// Max limit applied and tries to keep from every pod.
 		{
-			containers: []*docker.Container{
+			containers: []*FakeContainer{
 				makeContainer("1876", "foo", "POD", false, makeTime(0)),
 				makeContainer("2876", "foo", "POD", false, makeTime(1)),
 				makeContainer("3876", "foo1", "POD", false, makeTime(0)),
@@ -214,7 +209,7 @@ func TestGarbageCollect(t *testing.T) {
 		},
 		// If more pods than limit allows, evicts oldest pod.
 		{
-			containers: []*docker.Container{
+			containers: []*FakeContainer{
 				makeContainer("1876", "foo", "POD", false, makeTime(1)),
 				makeContainer("2876", "foo", "POD", false, makeTime(2)),
 				makeContainer("3876", "foo1", "POD", false, makeTime(1)),
@@ -230,7 +225,7 @@ func TestGarbageCollect(t *testing.T) {
 		},
 		// Containers for deleted pods should be GC'd.
 		{
-			containers: []*docker.Container{
+			containers: []*FakeContainer{
 				makeContainer("1876", "foo", "POD", false, makeTime(1)),
 				makeContainer("2876", "foo", "POD", false, makeTime(2)),
 				makeContainer("3876", "deleted", "POD", false, makeTime(1)),

--- a/pkg/kubelet/dockertools/convert.go
+++ b/pkg/kubelet/dockertools/convert.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	dockertypes "github.com/docker/engine-api/types"
 	docker "github.com/fsouza/go-dockerclient"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
@@ -32,7 +33,7 @@ const (
 )
 
 func mapState(state string) kubecontainer.ContainerState {
-	// Parse the state string in docker.APIContainers. This could break when
+	// Parse the state string in dockertypes.Container. This could break when
 	// we upgrade docker.
 	switch {
 	case strings.HasPrefix(state, statusRunningPrefix):
@@ -44,8 +45,8 @@ func mapState(state string) kubecontainer.ContainerState {
 	}
 }
 
-// Converts docker.APIContainers to kubecontainer.Container.
-func toRuntimeContainer(c *docker.APIContainers) (*kubecontainer.Container, error) {
+// Converts dockertypes.Container to kubecontainer.Container.
+func toRuntimeContainer(c *dockertypes.Container) (*kubecontainer.Container, error) {
 	if c == nil {
 		return nil, fmt.Errorf("unable to convert a nil pointer to a runtime container")
 	}

--- a/pkg/kubelet/dockertools/convert_test.go
+++ b/pkg/kubelet/dockertools/convert_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	dockertypes "github.com/docker/engine-api/types"
 	docker "github.com/fsouza/go-dockerclient"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
@@ -43,7 +44,7 @@ func TestMapState(t *testing.T) {
 }
 
 func TestToRuntimeContainer(t *testing.T) {
-	original := &docker.APIContainers{
+	original := &dockertypes.Container{
 		ID:      "ab2cdf",
 		Image:   "bar_image",
 		Created: 12345,

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -61,9 +61,9 @@ type DockerInterface interface {
 	ListContainers(options dockertypes.ContainerListOptions) ([]dockertypes.Container, error)
 	InspectContainer(id string) (*dockertypes.ContainerJSON, error)
 	CreateContainer(dockertypes.ContainerCreateConfig) (*dockertypes.ContainerCreateResponse, error)
-	StartContainer(id string, hostConfig *docker.HostConfig) error
-	StopContainer(id string, timeout uint) error
-	RemoveContainer(opts docker.RemoveContainerOptions) error
+	StartContainer(id string) error
+	StopContainer(id string, timeout int) error
+	RemoveContainer(id string, opts dockertypes.ContainerRemoveOptions) error
 	InspectImage(image string) (*docker.Image, error)
 	ListImages(opts docker.ListImagesOptions) ([]docker.APIImages, error)
 	PullImage(opts docker.PullImageOptions, auth docker.AuthConfiguration) error

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -59,7 +59,7 @@ const (
 // DockerInterface is an abstract interface for testability.  It abstracts the interface of docker.Client.
 type DockerInterface interface {
 	ListContainers(options dockertypes.ContainerListOptions) ([]dockertypes.Container, error)
-	InspectContainer(id string) (*docker.Container, error)
+	InspectContainer(id string) (*dockertypes.ContainerJSON, error)
 	CreateContainer(docker.CreateContainerOptions) (*docker.Container, error)
 	StartContainer(id string, hostConfig *docker.HostConfig) error
 	StopContainer(id string, timeout uint) error

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/docker/docker/pkg/jsonmessage"
 	dockerapi "github.com/docker/engine-api/client"
+	dockertypes "github.com/docker/engine-api/types"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
@@ -57,7 +58,7 @@ const (
 
 // DockerInterface is an abstract interface for testability.  It abstracts the interface of docker.Client.
 type DockerInterface interface {
-	ListContainers(options docker.ListContainersOptions) ([]docker.APIContainers, error)
+	ListContainers(options dockertypes.ContainerListOptions) ([]dockertypes.Container, error)
 	InspectContainer(id string) (*docker.Container, error)
 	CreateContainer(docker.CreateContainerOptions) (*docker.Container, error)
 	StartContainer(id string, hostConfig *docker.HostConfig) error
@@ -346,9 +347,9 @@ func milliCPUToShares(milliCPU int64) int64 {
 // GetKubeletDockerContainers lists all container or just the running ones.
 // Returns a list of docker containers that we manage
 // TODO: Move this function with dockerCache to DockerManager.
-func GetKubeletDockerContainers(client DockerInterface, allContainers bool) ([]*docker.APIContainers, error) {
-	result := []*docker.APIContainers{}
-	containers, err := client.ListContainers(docker.ListContainersOptions{All: allContainers})
+func GetKubeletDockerContainers(client DockerInterface, allContainers bool) ([]*dockertypes.Container, error) {
+	result := []*dockertypes.Container{}
+	containers, err := client.ListContainers(dockertypes.ContainerListOptions{All: allContainers})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -60,7 +60,7 @@ const (
 type DockerInterface interface {
 	ListContainers(options dockertypes.ContainerListOptions) ([]dockertypes.Container, error)
 	InspectContainer(id string) (*dockertypes.ContainerJSON, error)
-	CreateContainer(docker.CreateContainerOptions) (*docker.Container, error)
+	CreateContainer(dockertypes.ContainerCreateConfig) (*dockertypes.ContainerCreateResponse, error)
 	StartContainer(id string, hostConfig *docker.HostConfig) error
 	StopContainer(id string, timeout uint) error
 	RemoveContainer(opts docker.RemoveContainerOptions) error

--- a/pkg/kubelet/dockertools/docker_test.go
+++ b/pkg/kubelet/dockertools/docker_test.go
@@ -83,7 +83,7 @@ func findPodContainer(dockerContainers []*dockertypes.Container, podFullName str
 
 func TestGetContainerID(t *testing.T) {
 	fakeDocker := NewFakeDockerClient()
-	fakeDocker.SetFakeRunningContainers([]*docker.Container{
+	fakeDocker.SetFakeRunningContainers([]*FakeContainer{
 		{
 			ID:   "foobar",
 			Name: "/k8s_foo_qux_ns_1234_42",

--- a/pkg/kubelet/dockertools/docker_test.go
+++ b/pkg/kubelet/dockertools/docker_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/docker/docker/pkg/jsonmessage"
 	dockertypes "github.com/docker/engine-api/types"
+	dockernat "github.com/docker/go-connections/nat"
 	docker "github.com/fsouza/go-dockerclient"
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	"k8s.io/kubernetes/cmd/kubelet/app/options"
@@ -744,37 +745,37 @@ func TestMakePortsAndBindings(t *testing.T) {
 	}
 
 	// Construct expected bindings
-	expectPortBindings := map[string][]docker.PortBinding{
+	expectPortBindings := map[string][]dockernat.PortBinding{
 		"80/tcp": {
-			docker.PortBinding{
+			dockernat.PortBinding{
 				HostPort: "8080",
 				HostIP:   "127.0.0.1",
 			},
 		},
 		"443/tcp": {
-			docker.PortBinding{
+			dockernat.PortBinding{
 				HostPort: "443",
 				HostIP:   "",
 			},
-			docker.PortBinding{
+			dockernat.PortBinding{
 				HostPort: "446",
 				HostIP:   "",
 			},
 		},
 		"443/udp": {
-			docker.PortBinding{
+			dockernat.PortBinding{
 				HostPort: "446",
 				HostIP:   "",
 			},
 		},
 		"444/udp": {
-			docker.PortBinding{
+			dockernat.PortBinding{
 				HostPort: "444",
 				HostIP:   "",
 			},
 		},
 		"445/tcp": {
-			docker.PortBinding{
+			dockernat.PortBinding{
 				HostPort: "445",
 				HostIP:   "",
 			},

--- a/pkg/kubelet/dockertools/exec.go
+++ b/pkg/kubelet/dockertools/exec.go
@@ -23,6 +23,7 @@ import (
 	"os/exec"
 	"time"
 
+	dockertypes "github.com/docker/engine-api/types"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/glog"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -30,14 +31,14 @@ import (
 
 // ExecHandler knows how to execute a command in a running Docker container.
 type ExecHandler interface {
-	ExecInContainer(client DockerInterface, container *docker.Container, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool) error
+	ExecInContainer(client DockerInterface, container *dockertypes.ContainerJSON, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool) error
 }
 
 // NsenterExecHandler executes commands in Docker containers using nsenter.
 type NsenterExecHandler struct{}
 
 // TODO should we support nsenter in a container, running with elevated privs and --pid=host?
-func (*NsenterExecHandler) ExecInContainer(client DockerInterface, container *docker.Container, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool) error {
+func (*NsenterExecHandler) ExecInContainer(client DockerInterface, container *dockertypes.ContainerJSON, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool) error {
 	nsenter, err := exec.LookPath("nsenter")
 	if err != nil {
 		return fmt.Errorf("exec unavailable - unable to locate nsenter")
@@ -98,7 +99,7 @@ func (*NsenterExecHandler) ExecInContainer(client DockerInterface, container *do
 // NativeExecHandler executes commands in Docker containers using Docker's exec API.
 type NativeExecHandler struct{}
 
-func (*NativeExecHandler) ExecInContainer(client DockerInterface, container *docker.Container, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool) error {
+func (*NativeExecHandler) ExecInContainer(client DockerInterface, container *dockertypes.ContainerJSON, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool) error {
 	createOpts := docker.CreateExecOptions{
 		Container:    container.ID,
 		Cmd:          cmd,

--- a/pkg/kubelet/dockertools/fake_docker_client.go
+++ b/pkg/kubelet/dockertools/fake_docker_client.go
@@ -328,11 +328,7 @@ func (f *FakeDockerClient) CreateContainer(c dockertypes.ContainerCreateConfig) 
 
 // StartContainer is a test-spy implementation of DockerInterface.StartContainer.
 // It adds an entry "start" to the internal method call record.
-// The HostConfig at StartContainer will be deprecated from docker 1.10. Now in
-// docker manager the HostConfig is set when ContainerCreate().
-// TODO(random-liu): Remove the HostConfig here when it is completely removed in
-// docker 1.12.
-func (f *FakeDockerClient) StartContainer(id string, _ *docker.HostConfig) error {
+func (f *FakeDockerClient) StartContainer(id string) error {
 	f.Lock()
 	defer f.Unlock()
 	f.called = append(f.called, "start")
@@ -355,7 +351,7 @@ func (f *FakeDockerClient) StartContainer(id string, _ *docker.HostConfig) error
 
 // StopContainer is a test-spy implementation of DockerInterface.StopContainer.
 // It adds an entry "stop" to the internal method call record.
-func (f *FakeDockerClient) StopContainer(id string, timeout uint) error {
+func (f *FakeDockerClient) StopContainer(id string, timeout int) error {
 	f.Lock()
 	defer f.Unlock()
 	f.called = append(f.called, "stop")
@@ -393,7 +389,7 @@ func (f *FakeDockerClient) StopContainer(id string, timeout uint) error {
 	return nil
 }
 
-func (f *FakeDockerClient) RemoveContainer(opts docker.RemoveContainerOptions) error {
+func (f *FakeDockerClient) RemoveContainer(id string, opts dockertypes.ContainerRemoveOptions) error {
 	f.Lock()
 	defer f.Unlock()
 	f.called = append(f.called, "remove")
@@ -402,10 +398,10 @@ func (f *FakeDockerClient) RemoveContainer(opts docker.RemoveContainerOptions) e
 		return err
 	}
 	for i := range f.ExitedContainerList {
-		if f.ExitedContainerList[i].ID == opts.ID {
-			delete(f.ContainerMap, opts.ID)
+		if f.ExitedContainerList[i].ID == id {
+			delete(f.ContainerMap, id)
 			f.ExitedContainerList = append(f.ExitedContainerList[:i], f.ExitedContainerList[i+1:]...)
-			f.Removed = append(f.Removed, opts.ID)
+			f.Removed = append(f.Removed, id)
 			return nil
 		}
 
@@ -423,7 +419,7 @@ func (f *FakeDockerClient) Logs(opts docker.LogsOptions) error {
 	return f.popError("logs")
 }
 
-// PullImage is a test-spy implementation of DockerInterface.StopContainer.
+// PullImage is a test-spy implementation of DockerInterface.PullImage.
 // It adds an entry "pull" to the internal method call record.
 func (f *FakeDockerClient) PullImage(opts docker.PullImageOptions, auth docker.AuthConfiguration) error {
 	f.Lock()

--- a/pkg/kubelet/dockertools/instrumented_docker.go
+++ b/pkg/kubelet/dockertools/instrumented_docker.go
@@ -19,6 +19,7 @@ package dockertools
 import (
 	"time"
 
+	dockertypes "github.com/docker/engine-api/types"
 	docker "github.com/fsouza/go-dockerclient"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 )
@@ -48,7 +49,7 @@ func recordError(operation string, err error) {
 	}
 }
 
-func (in instrumentedDockerInterface) ListContainers(options docker.ListContainersOptions) ([]docker.APIContainers, error) {
+func (in instrumentedDockerInterface) ListContainers(options dockertypes.ContainerListOptions) ([]dockertypes.Container, error) {
 	const operation = "list_containers"
 	defer recordOperation(operation, time.Now())
 

--- a/pkg/kubelet/dockertools/instrumented_docker.go
+++ b/pkg/kubelet/dockertools/instrumented_docker.go
@@ -67,7 +67,7 @@ func (in instrumentedDockerInterface) InspectContainer(id string) (*dockertypes.
 	return out, err
 }
 
-func (in instrumentedDockerInterface) CreateContainer(opts docker.CreateContainerOptions) (*docker.Container, error) {
+func (in instrumentedDockerInterface) CreateContainer(opts dockertypes.ContainerCreateConfig) (*dockertypes.ContainerCreateResponse, error) {
 	const operation = "create_container"
 	defer recordOperation(operation, time.Now())
 

--- a/pkg/kubelet/dockertools/instrumented_docker.go
+++ b/pkg/kubelet/dockertools/instrumented_docker.go
@@ -58,7 +58,7 @@ func (in instrumentedDockerInterface) ListContainers(options dockertypes.Contain
 	return out, err
 }
 
-func (in instrumentedDockerInterface) InspectContainer(id string) (*docker.Container, error) {
+func (in instrumentedDockerInterface) InspectContainer(id string) (*dockertypes.ContainerJSON, error) {
 	const operation = "inspect_container"
 	defer recordOperation(operation, time.Now())
 

--- a/pkg/kubelet/dockertools/instrumented_docker.go
+++ b/pkg/kubelet/dockertools/instrumented_docker.go
@@ -76,16 +76,16 @@ func (in instrumentedDockerInterface) CreateContainer(opts dockertypes.Container
 	return out, err
 }
 
-func (in instrumentedDockerInterface) StartContainer(id string, hostConfig *docker.HostConfig) error {
+func (in instrumentedDockerInterface) StartContainer(id string) error {
 	const operation = "start_container"
 	defer recordOperation(operation, time.Now())
 
-	err := in.client.StartContainer(id, hostConfig)
+	err := in.client.StartContainer(id)
 	recordError(operation, err)
 	return err
 }
 
-func (in instrumentedDockerInterface) StopContainer(id string, timeout uint) error {
+func (in instrumentedDockerInterface) StopContainer(id string, timeout int) error {
 	const operation = "stop_container"
 	defer recordOperation(operation, time.Now())
 
@@ -94,11 +94,11 @@ func (in instrumentedDockerInterface) StopContainer(id string, timeout uint) err
 	return err
 }
 
-func (in instrumentedDockerInterface) RemoveContainer(opts docker.RemoveContainerOptions) error {
+func (in instrumentedDockerInterface) RemoveContainer(id string, opts dockertypes.ContainerRemoveOptions) error {
 	const operation = "remove_container"
 	defer recordOperation(operation, time.Now())
 
-	err := in.client.RemoveContainer(opts)
+	err := in.client.RemoveContainer(id, opts)
 	recordError(operation, err)
 	return err
 }

--- a/pkg/kubelet/dockertools/kube_docker_client.go
+++ b/pkg/kubelet/dockertools/kube_docker_client.go
@@ -132,22 +132,18 @@ func (d *kubeDockerClient) CreateContainer(opts dockertypes.ContainerCreateConfi
 	return &createResp, nil
 }
 
-// TODO(random-liu): The HostConfig at container start is deprecated, will remove this in the following refactoring.
-func (d *kubeDockerClient) StartContainer(id string, _ *docker.HostConfig) error {
+func (d *kubeDockerClient) StartContainer(id string) error {
 	return d.client.ContainerStart(getDefaultContext(), id)
 }
 
 // Stopping an already stopped container will not cause an error in engine-api.
-func (d *kubeDockerClient) StopContainer(id string, timeout uint) error {
-	return d.client.ContainerStop(getDefaultContext(), id, int(timeout))
+func (d *kubeDockerClient) StopContainer(id string, timeout int) error {
+	return d.client.ContainerStop(getDefaultContext(), id, timeout)
 }
 
-func (d *kubeDockerClient) RemoveContainer(opts docker.RemoveContainerOptions) error {
-	return d.client.ContainerRemove(getDefaultContext(), dockertypes.ContainerRemoveOptions{
-		ContainerID:   opts.ID,
-		RemoveVolumes: opts.RemoveVolumes,
-		Force:         opts.Force,
-	})
+func (d *kubeDockerClient) RemoveContainer(id string, opts dockertypes.ContainerRemoveOptions) error {
+	opts.ContainerID = id
+	return d.client.ContainerRemove(getDefaultContext(), opts)
 }
 
 func (d *kubeDockerClient) InspectImage(image string) (*docker.Image, error) {

--- a/pkg/kubelet/dockertools/kube_docker_client.go
+++ b/pkg/kubelet/dockertools/kube_docker_client.go
@@ -100,21 +100,14 @@ func convertEnv(src interface{}) (*docker.Env, error) {
 	return env, nil
 }
 
-func (k *kubeDockerClient) ListContainers(options docker.ListContainersOptions) ([]docker.APIContainers, error) {
-	containers, err := k.client.ContainerList(getDefaultContext(), dockertypes.ContainerListOptions{
-		Size:   options.Size,
-		All:    options.All,
-		Limit:  options.Limit,
-		Since:  options.Since,
-		Before: options.Before,
-		Filter: convertFilters(options.Filters),
-	})
+func (k *kubeDockerClient) ListContainers(options dockertypes.ContainerListOptions) ([]dockertypes.Container, error) {
+	containers, err := k.client.ContainerList(getDefaultContext(), options)
 	if err != nil {
 		return nil, err
 	}
-	apiContainers := []docker.APIContainers{}
-	if err := convertType(&containers, &apiContainers); err != nil {
-		return nil, err
+	apiContainers := []dockertypes.Container{}
+	for _, c := range containers {
+		apiContainers = append(apiContainers, dockertypes.Container(c))
 	}
 	return apiContainers, nil
 }

--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/coreos/go-semver/semver"
+	dockertypes "github.com/docker/engine-api/types"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/glog"
 	cadvisorapi "github.com/google/cadvisor/info/v1"
@@ -695,7 +696,7 @@ func setEntrypointAndCommand(container *api.Container, opts *kubecontainer.RunCo
 
 // A helper function to get the KubeletContainerName and hash from a docker
 // container.
-func getDockerContainerNameInfo(c *docker.APIContainers) (*KubeletContainerName, uint64, error) {
+func getDockerContainerNameInfo(c *dockertypes.Container) (*KubeletContainerName, uint64, error) {
 	if len(c.Names) == 0 {
 		return nil, 0, fmt.Errorf("cannot parse empty docker container name: %#v", c.Names)
 	}
@@ -707,7 +708,7 @@ func getDockerContainerNameInfo(c *docker.APIContainers) (*KubeletContainerName,
 }
 
 // Get pod UID, name, and namespace by examining the container names.
-func getPodInfoFromContainer(c *docker.APIContainers) (types.UID, string, string, error) {
+func getPodInfoFromContainer(c *dockertypes.Container) (types.UID, string, string, error) {
 	dockerName, _, err := getDockerContainerNameInfo(c)
 	if err != nil {
 		return types.UID(""), "", "", err
@@ -779,8 +780,8 @@ func (dm *DockerManager) GetPods(all bool) ([]*kubecontainer.Pod, error) {
 	}
 
 	// Convert map to list.
-	for _, c := range pods {
-		result = append(result, c)
+	for _, p := range pods {
+		result = append(result, p)
 	}
 	return result, nil
 }
@@ -2150,7 +2151,7 @@ func (dm *DockerManager) GetPodStatus(uid types.UID, name, namespace string) (*k
 	// However, there may be some old containers without these labels, so at least now we can't do that.
 	// TODO(random-liu): Do only one list and pass in the list result in the future
 	// TODO(random-liu): Add filter when we are sure that all the containers have the labels
-	containers, err := dm.client.ListContainers(docker.ListContainersOptions{All: true})
+	containers, err := dm.client.ListContainers(dockertypes.ContainerListOptions{All: true})
 	if err != nil {
 		return podStatus, err
 	}

--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -674,7 +674,7 @@ func (dm *DockerManager) runContainer(
 	}
 	dm.recorder.Eventf(ref, api.EventTypeNormal, kubecontainer.CreatedContainer, "Created container with docker id %v", utilstrings.ShortenString(createResp.ID, 12))
 
-	if err = dm.client.StartContainer(createResp.ID, nil); err != nil {
+	if err = dm.client.StartContainer(createResp.ID); err != nil {
 		dm.recorder.Eventf(ref, api.EventTypeWarning, kubecontainer.FailedToStartContainer,
 			"Failed to start container with docker id %v with error: %v", utilstrings.ShortenString(createResp.ID, 12), err)
 		return kubecontainer.ContainerID{}, err
@@ -1397,7 +1397,7 @@ func (dm *DockerManager) killContainer(containerID kubecontainer.ContainerID, co
 	if gracePeriod < minimumGracePeriodInSeconds {
 		gracePeriod = minimumGracePeriodInSeconds
 	}
-	err := dm.client.StopContainer(ID, uint(gracePeriod))
+	err := dm.client.StopContainer(ID, int(gracePeriod))
 	if err == nil {
 		glog.V(2).Infof("Container %q exited after %s", name, unversioned.Now().Sub(start.Time))
 	} else {

--- a/pkg/kubelet/dockertools/manager_test.go
+++ b/pkg/kubelet/dockertools/manager_test.go
@@ -31,6 +31,7 @@ import (
 
 	dockertypes "github.com/docker/engine-api/types"
 	dockercontainer "github.com/docker/engine-api/types/container"
+	dockerstrslice "github.com/docker/engine-api/types/strslice"
 	docker "github.com/fsouza/go-dockerclient"
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	"github.com/stretchr/testify/assert"
@@ -164,13 +165,13 @@ func TestSetEntrypointAndCommand(t *testing.T) {
 		name      string
 		container *api.Container
 		envs      []kubecontainer.EnvVar
-		expected  *docker.CreateContainerOptions
+		expected  *dockertypes.ContainerCreateConfig
 	}{
 		{
 			name:      "none",
 			container: &api.Container{},
-			expected: &docker.CreateContainerOptions{
-				Config: &docker.Config{},
+			expected: &dockertypes.ContainerCreateConfig{
+				Config: &dockercontainer.Config{},
 			},
 		},
 		{
@@ -178,9 +179,9 @@ func TestSetEntrypointAndCommand(t *testing.T) {
 			container: &api.Container{
 				Command: []string{"foo", "bar"},
 			},
-			expected: &docker.CreateContainerOptions{
-				Config: &docker.Config{
-					Entrypoint: []string{"foo", "bar"},
+			expected: &dockertypes.ContainerCreateConfig{
+				Config: &dockercontainer.Config{
+					Entrypoint: dockerstrslice.StrSlice([]string{"foo", "bar"}),
 				},
 			},
 		},
@@ -199,9 +200,9 @@ func TestSetEntrypointAndCommand(t *testing.T) {
 					Value: "boo",
 				},
 			},
-			expected: &docker.CreateContainerOptions{
-				Config: &docker.Config{
-					Entrypoint: []string{"foo", "zoo", "boo"},
+			expected: &dockertypes.ContainerCreateConfig{
+				Config: &dockercontainer.Config{
+					Entrypoint: dockerstrslice.StrSlice([]string{"foo", "zoo", "boo"}),
 				},
 			},
 		},
@@ -210,8 +211,8 @@ func TestSetEntrypointAndCommand(t *testing.T) {
 			container: &api.Container{
 				Args: []string{"foo", "bar"},
 			},
-			expected: &docker.CreateContainerOptions{
-				Config: &docker.Config{
+			expected: &dockertypes.ContainerCreateConfig{
+				Config: &dockercontainer.Config{
 					Cmd: []string{"foo", "bar"},
 				},
 			},
@@ -231,9 +232,9 @@ func TestSetEntrypointAndCommand(t *testing.T) {
 					Value: "trap",
 				},
 			},
-			expected: &docker.CreateContainerOptions{
-				Config: &docker.Config{
-					Cmd: []string{"zap", "hap", "trap"},
+			expected: &dockertypes.ContainerCreateConfig{
+				Config: &dockercontainer.Config{
+					Cmd: dockerstrslice.StrSlice([]string{"zap", "hap", "trap"}),
 				},
 			},
 		},
@@ -243,10 +244,10 @@ func TestSetEntrypointAndCommand(t *testing.T) {
 				Command: []string{"foo"},
 				Args:    []string{"bar", "baz"},
 			},
-			expected: &docker.CreateContainerOptions{
-				Config: &docker.Config{
-					Entrypoint: []string{"foo"},
-					Cmd:        []string{"bar", "baz"},
+			expected: &dockertypes.ContainerCreateConfig{
+				Config: &dockercontainer.Config{
+					Entrypoint: dockerstrslice.StrSlice([]string{"foo"}),
+					Cmd:        dockerstrslice.StrSlice([]string{"bar", "baz"}),
 				},
 			},
 		},
@@ -270,10 +271,10 @@ func TestSetEntrypointAndCommand(t *testing.T) {
 					Value: "roo",
 				},
 			},
-			expected: &docker.CreateContainerOptions{
-				Config: &docker.Config{
-					Entrypoint: []string{"boo--zoo", "foo", "roo"},
-					Cmd:        []string{"foo", "zoo", "boo"},
+			expected: &dockertypes.ContainerCreateConfig{
+				Config: &dockercontainer.Config{
+					Entrypoint: dockerstrslice.StrSlice([]string{"boo--zoo", "foo", "roo"}),
+					Cmd:        dockerstrslice.StrSlice([]string{"foo", "zoo", "boo"}),
 				},
 			},
 		},
@@ -284,8 +285,8 @@ func TestSetEntrypointAndCommand(t *testing.T) {
 			Envs: tc.envs,
 		}
 
-		actualOpts := &docker.CreateContainerOptions{
-			Config: &docker.Config{},
+		actualOpts := dockertypes.ContainerCreateConfig{
+			Config: &dockercontainer.Config{},
 		}
 		setEntrypointAndCommand(tc.container, opts, actualOpts)
 

--- a/pkg/kubelet/network/cni/cni_test.go
+++ b/pkg/kubelet/network/cni/cni_test.go
@@ -30,7 +30,6 @@ import (
 
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 
-	docker "github.com/fsouza/go-dockerclient"
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 
 	"k8s.io/kubernetes/cmd/kubelet/app/options"
@@ -132,10 +131,10 @@ func (fnh *fakeNetworkHost) GetKubeClient() clientset.Interface {
 
 func (nh *fakeNetworkHost) GetRuntime() kubecontainer.Runtime {
 	dm, fakeDockerClient := newTestDockerManager()
-	fakeDockerClient.SetFakeRunningContainers([]*docker.Container{
+	fakeDockerClient.SetFakeRunningContainers([]*dockertools.FakeContainer{
 		{
-			ID:    "test_infra_container",
-			State: docker.State{Pid: 12345},
+			ID:  "test_infra_container",
+			Pid: 12345,
 		},
 	})
 	return dm

--- a/pkg/securitycontext/fake.go
+++ b/pkg/securitycontext/fake.go
@@ -19,7 +19,7 @@ package securitycontext
 import (
 	"k8s.io/kubernetes/pkg/api"
 
-	docker "github.com/fsouza/go-dockerclient"
+	dockercontainer "github.com/docker/engine-api/types/container"
 )
 
 // ValidSecurityContextWithContainerDefaults creates a valid security context provider based on
@@ -39,7 +39,7 @@ func NewFakeSecurityContextProvider() SecurityContextProvider {
 
 type FakeSecurityContextProvider struct{}
 
-func (p FakeSecurityContextProvider) ModifyContainerConfig(pod *api.Pod, container *api.Container, config *docker.Config) {
+func (p FakeSecurityContextProvider) ModifyContainerConfig(pod *api.Pod, container *api.Container, config *dockercontainer.Config) {
 }
-func (p FakeSecurityContextProvider) ModifyHostConfig(pod *api.Pod, container *api.Container, hostConfig *docker.HostConfig) {
+func (p FakeSecurityContextProvider) ModifyHostConfig(pod *api.Pod, container *api.Container, hostConfig *dockercontainer.HostConfig) {
 }

--- a/pkg/securitycontext/provider.go
+++ b/pkg/securitycontext/provider.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/kubelet/leaky"
 
-	docker "github.com/fsouza/go-dockerclient"
+	dockercontainer "github.com/docker/engine-api/types/container"
 )
 
 // NewSimpleSecurityContextProvider creates a new SimpleSecurityContextProvider.
@@ -37,7 +37,7 @@ type SimpleSecurityContextProvider struct{}
 // ModifyContainerConfig is called before the Docker createContainer call.
 // The security context provider can make changes to the Config with which
 // the container is created.
-func (p SimpleSecurityContextProvider) ModifyContainerConfig(pod *api.Pod, container *api.Container, config *docker.Config) {
+func (p SimpleSecurityContextProvider) ModifyContainerConfig(pod *api.Pod, container *api.Container, config *dockercontainer.Config) {
 	effectiveSC := DetermineEffectiveSecurityContext(pod, container)
 	if effectiveSC == nil {
 		return
@@ -50,7 +50,7 @@ func (p SimpleSecurityContextProvider) ModifyContainerConfig(pod *api.Pod, conta
 // ModifyHostConfig is called before the Docker runContainer call.
 // The security context provider can make changes to the HostConfig, affecting
 // security options, whether the container is privileged, volume binds, etc.
-func (p SimpleSecurityContextProvider) ModifyHostConfig(pod *api.Pod, container *api.Container, hostConfig *docker.HostConfig) {
+func (p SimpleSecurityContextProvider) ModifyHostConfig(pod *api.Pod, container *api.Container, hostConfig *dockercontainer.HostConfig) {
 	// Apply pod security context
 	if container.Name != leaky.PodInfraContainerName && pod.Spec.SecurityContext != nil {
 		// TODO: We skip application of supplemental groups to the

--- a/pkg/securitycontext/types.go
+++ b/pkg/securitycontext/types.go
@@ -19,21 +19,21 @@ package securitycontext
 import (
 	"k8s.io/kubernetes/pkg/api"
 
-	docker "github.com/fsouza/go-dockerclient"
+	dockercontainer "github.com/docker/engine-api/types/container"
 )
 
 type SecurityContextProvider interface {
 	// ModifyContainerConfig is called before the Docker createContainer call.
 	// The security context provider can make changes to the Config with which
 	// the container is created.
-	ModifyContainerConfig(pod *api.Pod, container *api.Container, config *docker.Config)
+	ModifyContainerConfig(pod *api.Pod, container *api.Container, config *dockercontainer.Config)
 
 	// ModifyHostConfig is called before the Docker createContainer call.
 	// The security context provider can make changes to the HostConfig, affecting
 	// security options, whether the container is privileged, volume binds, etc.
 	// An error is returned if it's not possible to secure the container as requested
 	// with a security context.
-	ModifyHostConfig(pod *api.Pod, container *api.Container, hostConfig *docker.HostConfig)
+	ModifyHostConfig(pod *api.Pod, container *api.Container, hostConfig *dockercontainer.HostConfig)
 }
 
 const (


### PR DESCRIPTION
For #23563.
Based on #23506, will rebase after #23506 is merged.

The last 4 commits of this PR are new.
This PR refactors all container lifecycle related functions in DockerInterface, including:
- ListContainers
- InspectContainer
- CreateContainer
- StartContainer
- StopContainer
- RemoveContainer

@kubernetes/sig-node 
