### PR TITLE
Ignore .config/gcloud-staging/ in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,7 +82,7 @@ doc_tmp/
 /_gopath/
 
 # Config directories created by gcloud and gsutil on Jenkins
-/.config/gcloud/
+/.config/gcloud*/
 /.gsutil/
 
 # CoreOS stuff


### PR DESCRIPTION
I noticed that our CI builds are being marked `-dirty`. Looking at the Jenkins workspace:

``` console
$ git status
# Not currently on any branch.
# Untracked files:
#   (use "git add <file>..." to include in what will be committed)
#
#       .config/
#       upload-finished.sh
nothing added to commit but untracked files present (use "git add" to track)
$ ls .config/
gcloud-staging
```

We already ignored `.config/gcloud`, but I guess using the CI build of gcloud is creating `gcloud-staging` as well, so we should ignore it, too.

I'm fixing the `upload-finished.sh` bit in #23415.

cc @spxtr @jlowdermilk 
