### PR TITLE
add jenkins project for kubenet

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
@@ -155,6 +155,16 @@
                 export MULTIZONE="true"
                 export E2E_ZONES="us-central1-a us-central1-b us-central1-f" # Where the nodes reside.  Master is in the first one.
                 export KUBE_GCE_ZONE="us-central1-a" # Where the master resides - hangover due to legacy scripts.
+        - 'gce-kubenet':
+            description: 'Run all non-flaky, non-slow, non-disruptive, non-feature tests on GCE using kubenet as network provider'
+            timeout: 120
+            emails: 'mixia@google.com'
+            test-owner: 'mixia'
+            job-env: |
+                export PROJECT="k8s-jkns-e2e-gce-kubenet"
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export NETWORK_PROVIDER="kubenet"
     jobs:
         - 'kubernetes-e2e-{suffix}'
 


### PR DESCRIPTION
added a jenkins project for gce using kubenet as network provider

`k8s-jkns-e2e-gce-kubenet` has been created and configured 
