### PR TITLE
keep deprecated flag stage1-image with rkt

### DIFF
--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -807,7 +807,7 @@ func (r *Runtime) preparePod(pod *api.Pod, pullSecrets []api.Secret) (string, *k
 	// Run 'rkt prepare' to get the rkt UUID.
 	cmds := []string{"prepare", "--quiet", "--pod-manifest", manifestFile.Name()}
 	if r.config.Stage1Image != "" {
-		cmds = append(cmds, "--stage1-image", r.config.Stage1Image)
+		cmds = append(cmds, "--stage1-path", r.config.Stage1Image)
 	}
 	output, err := r.runCommand(cmds...)
 	if err != nil {


### PR DESCRIPTION
With `minimumRktBinVersion = "1.2.1"` and keep deprecated `--stage1-image` option flag (from rkt config), this option should be switched silently to `--stage1-path` in kubelet.
