### PR TITLE
Kubelet: Change the docker label key to follow the label naming convention

### DIFF
--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -331,8 +331,7 @@ func (dm *DockerManager) inspectContainer(id string, podName, podNamespace strin
 	}
 	containerName := dockerName.ContainerName
 
-	var containerInfo *labelledContainerInfo
-	containerInfo = getContainerInfoFromLabel(iResult.Config.Labels)
+	containerInfo := getContainerInfoFromLabel(iResult.Config.Labels)
 
 	status := kubecontainer.ContainerStatus{
 		Name:         containerName,
@@ -522,7 +521,7 @@ func (dm *DockerManager) runContainer(
 		// TODO: This is hacky because the Kubelet should be parameterized to encode a specific version
 		//   and needs to be able to migrate this whenever we deprecate v1. Should be a member of DockerManager.
 		if data, err := runtime.Encode(api.Codecs.LegacyCodec(unversioned.GroupVersion{Group: api.GroupName, Version: "v1"}), pod); err == nil {
-			labels[kubernetesPodLabel] = string(data)
+			labels[podLabel] = string(data)
 		} else {
 			glog.Errorf("Failed to encode pod: %s for prestop hook", pod.Name)
 		}
@@ -1222,7 +1221,7 @@ func (dm *DockerManager) GetContainerIP(containerID, interfaceName string) (stri
 
 // TODO(random-liu): Change running pod to pod status in the future. We can't do it now, because kubelet also uses this function without pod status.
 // We can only deprecate this after refactoring kubelet.
-// TODO(random-liu): After using pod status for KillPod(), we can also remove the kubernetesPodLabel, because all the needed information should have
+// TODO(random-liu): After using pod status for KillPod(), we can also remove the podLabel, because all the needed information should have
 // been extract from new labels and stored in pod status.
 func (dm *DockerManager) KillPod(pod *api.Pod, runningPod kubecontainer.Pod) error {
 	result := dm.killPodWithSyncResult(pod, runningPod)
@@ -1425,10 +1424,10 @@ func containerAndPodFromLabels(inspect *docker.Container) (pod *api.Pod, contain
 	labels := inspect.Config.Labels
 
 	// the pod data may not be set
-	if body, found := labels[kubernetesPodLabel]; found {
+	if body, found := labels[podLabel]; found {
 		pod = &api.Pod{}
 		if err = runtime.DecodeInto(api.Codecs.UniversalDecoder(), []byte(body), pod); err == nil {
-			name := labels[kubernetesContainerNameLabel]
+			name := labels[containerNameLabel]
 			for ix := range pod.Spec.Containers {
 				if pod.Spec.Containers[ix].Name == name {
 					container = &pod.Spec.Containers[ix]
@@ -1446,7 +1445,7 @@ func containerAndPodFromLabels(inspect *docker.Container) (pod *api.Pod, contain
 	// attempt to find the default grace period if we didn't commit a pod, but set the generic metadata
 	// field (the one used by kill)
 	if pod == nil {
-		if period, ok := labels[kubernetesPodTerminationGracePeriodLabel]; ok {
+		if period, ok := labels[podTerminationGracePeriodLabel]; ok {
 			if seconds, err := strconv.ParseInt(period, 10, 64); err == nil {
 				pod = &api.Pod{}
 				pod.DeletionGracePeriodSeconds = &seconds

--- a/pkg/kubelet/dockertools/manager_test.go
+++ b/pkg/kubelet/dockertools/manager_test.go
@@ -503,8 +503,8 @@ func TestKillContainerInPodWithPreStop(t *testing.T) {
 			Name: "/k8s_foo_qux_new_1234_42",
 			Config: &docker.Config{
 				Labels: map[string]string{
-					kubernetesPodLabel:           string(podString),
-					kubernetesContainerNameLabel: "foo",
+					podLabel:           string(podString),
+					containerNameLabel: "foo",
 				},
 			},
 		},


### PR DESCRIPTION
Fixes #23706

This PR changes all the docker label names to conform to the K8s and docker label naming convention.
- K8s naming convention: http://kubernetes.io/docs/user-guide/identifiers/
- Docker label naming convention: https://docs.docker.com/engine/userguide/labels-custom-metadata/ 

This change is backward compatible. If no new labels are found, we'll try to fetch information from old labels.

/cc @yujuhong @yifan-gu 
