### PR TITLE
add nameserver for skydns

### DIFF
--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -100,6 +100,7 @@ spec:
         - -addr=0.0.0.0:53
         - -ns-rotate=false
         - -domain={{ pillar['dns_domain'] }}.
+        - -nameservers=8.8.8.8:53,8.8.4.4:53
         ports:
         - containerPort: 53
           name: dns


### PR DESCRIPTION
In ubuntu 14.04,the default nameserver is 127.0.1.1 and skydns uses it as default nameserver.
It will failed when skydns forwards dns request to 127.0.1.1.
We can use "8.8.8.8:53,8.8.4.4:53" as default nameserver used by skydns.
