### PR TITLE
Fix expired event logic to use 404 instead of 500

### DIFF
--- a/pkg/client/record/event.go
+++ b/pkg/client/record/event.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 
 	"github.com/golang/glog"
+	"net/http"
 )
 
 const maxTriesPerEvent = 12
@@ -153,12 +154,11 @@ func recordToSink(sink EventSink, event *api.Event, eventCorrelator *EventCorrel
 
 func isKeyNotFoundError(err error) bool {
 	statusErr, _ := err.(*errors.StatusError)
-	// At the moment the server is returning 500 instead of a more specific
-	// error. When changing this remember that it should be backward compatible
-	// with old api servers that may be still returning 500.
-	if statusErr != nil && statusErr.Status().Code == 500 {
+
+	if statusErr != nil && statusErr.Status().Code == http.StatusNotFound {
 		return true
 	}
+
 	return false
 }
 


### PR DESCRIPTION
It seems this logic was never updated once apiserver started returning 404s for expired (missing) events.

This change corrects it to use a 404 so events will get resent correctly if they were expired in etcd.

Fixes #23637.
