### PR TITLE
A pod never terminated if a container image registry was unavailable

### DIFF
--- a/pkg/kubelet/container/image_puller.go
+++ b/pkg/kubelet/container/image_puller.go
@@ -110,7 +110,7 @@ func (puller *imagePuller) PullImage(pod *api.Pod, container *api.Container, pul
 		puller.logIt(ref, api.EventTypeWarning, "Failed", logPrefix, fmt.Sprintf("Failed to pull image %q: %v", container.Image, err), glog.Warning)
 		puller.backOff.Next(backOffKey, puller.backOff.Clock.Now())
 		if err == RegistryUnavailable {
-			msg := fmt.Sprintf("image pull failed for %s because the registry is temporarily unavailable.", container.Image)
+			msg := fmt.Sprintf("image pull failed for %s because the registry is unavailable.", container.Image)
 			return err, msg
 		} else {
 			return ErrImagePull, err.Error()

--- a/pkg/kubelet/container/serialized_image_puller.go
+++ b/pkg/kubelet/container/serialized_image_puller.go
@@ -122,7 +122,7 @@ func (puller *serializedImagePuller) PullImage(pod *api.Pod, container *api.Cont
 		puller.logIt(ref, api.EventTypeWarning, FailedToPullImage, logPrefix, fmt.Sprintf("Failed to pull image %q: %v", container.Image, err), glog.Warning)
 		puller.backOff.Next(backOffKey, puller.backOff.Clock.Now())
 		if err == RegistryUnavailable {
-			msg := fmt.Sprintf("image pull failed for %s because the registry is temporarily unavailable.", container.Image)
+			msg := fmt.Sprintf("image pull failed for %s because the registry is unavailable.", container.Image)
 			return err, msg
 		} else {
 			return ErrImagePull, err.Error()

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -3392,7 +3392,8 @@ func (kl *Kubelet) convertStatusToAPIStatus(pod *api.Pod, podStatus *kubecontain
 		} else if reason == kubecontainer.ErrImagePullBackOff ||
 			reason == kubecontainer.ErrImageInspect ||
 			reason == kubecontainer.ErrImagePull ||
-			reason == kubecontainer.ErrImageNeverPull {
+			reason == kubecontainer.ErrImageNeverPull ||
+			reason == kubecontainer.RegistryUnavailable {
 			// mark it as waiting, reason will be filled bellow
 			containerStatus.State = api.ContainerState{Waiting: &api.ContainerStateWaiting{}}
 		} else if reason == kubecontainer.ErrRunContainer {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/23742
Fixes https://github.com/kubernetes/kubernetes/issues/22045

Pods will now show proper status when this happens as well:

```
$ cluster/kubectl.sh get pods --all-namespaces 
NAMESPACE   NAME                   READY     STATUS                RESTARTS   AGE
test        foo-4072956304-1g8qs   0/1       RegistryUnavailable   0          7s
test        foo-4072956304-i045g   0/1       RegistryUnavailable   0          7s
test        foo-4072956304-qem2n   0/1       RegistryUnavailable   0          7s
```

Where as previously they would never report a reason.

I also removed the "temporary" part of the message because we have no idea if its temporary or permanent.

/cc @kubernetes/sig-node @kubernetes/rh-cluster-infra 
