### PR TITLE
Standardize Jenkins job names to release-X.Y.

### DIFF
--- a/hack/jenkins/job-configs/global.yaml
+++ b/hack/jenkins/job-configs/global.yaml
@@ -136,7 +136,6 @@
         fi
         echo "Exiting with code: ${{rc}}"
         exit ${{rc}}
-    branch: 'master'
     job-env: ''
     runner: bash <(curl -fsS --retry 3  "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/dockerized-e2e-runner.sh")
     legacy-runner: bash <(curl -fsS --retry 3  "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/e2e-runner.sh")

--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
@@ -47,13 +47,13 @@
         - 'build':
             branch: 'master'
             timeout: 50
-        - 'build-1.0':
+        - 'build-release-1.0':
             branch: 'release-1.0'
             timeout: 30
-        - 'build-1.1':
+        - 'build-release-1.1':
             branch: 'release-1.1'
             timeout: 30
-        - 'build-1.2':
+        - 'build-release-1.2':
             branch: 'release-1.2'
             timeout: 30
     jobs:

--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
@@ -239,8 +239,8 @@
         - 'kubernetes-e2e-{suffix}'
 
 - project:
-    name: kubernetes-e2e-gce-1-2
-    trigger-job: 'kubernetes-build-1.2'
+    name: kubernetes-e2e-gce-release-1-2
+    trigger-job: 'kubernetes-build-release-1.2'
     test-owner: 'Build Cop'
     provider-env: |
         {gce-provider-env}
@@ -319,8 +319,8 @@
         - 'kubernetes-e2e-{suffix}'
 
 - project:
-    name: kubernetes-e2e-gke-1-2
-    trigger-job: 'kubernetes-build-1.2'
+    name: kubernetes-e2e-gke-release-1-2
+    trigger-job: 'kubernetes-build-release-1.2'
     test-owner: 'Build Cop'
     provider-env: |
         {gke-provider-env}
@@ -364,7 +364,7 @@
 - project:
     name: kubernetes-e2e-gke-version-pinned
     # TODO(spxtr) This should float with the current release, or something.
-    trigger-job: 'kubernetes-build-1.2'
+    trigger-job: 'kubernetes-build-release-1.2'
     test-owner: 'GKE on-call'
     provider-env: |
         {gke-provider-env}
@@ -435,15 +435,14 @@
         - 'kubernetes-e2e-{suffix}'
 
 - project:
-    name: kubernetes-e2e-gke-1.1
-    trigger-job: 'kubernetes-build-1.1'
+    name: kubernetes-e2e-gke-release-1.1
+    trigger-job: 'kubernetes-build-release-1.1'
     test-owner: 'Build Cop'
-    branch: 'release-1.1'
     jenkins_node: 'master'
     runner: '{old-runner-1-1}'
     post-env: ''
     suffix:
-        - 'gke-1.1':
+        - 'gke-release-1.1':
             timeout: 150
             description: 'Run E2E tests on GKE from the 1.1 release branch.'
             cron-string: 'H */6 * * *'
@@ -452,10 +451,9 @@
 
 
 - project:
-    name: kubernetes-e2e-gce-1.1
-    trigger-job: 'kubernetes-build-1.1'
+    name: kubernetes-e2e-gce-release-1.1
+    trigger-job: 'kubernetes-build-release-1.1'
     test-owner: 'Build Cop'
-    branch: 'release-1.1'
     jenkins_node: 'master'
     runner: '{old-runner-1-1}'
     post-env: ''
@@ -469,9 +467,8 @@
 
 - project:
     name: kubernetes-e2e-1.0
-    trigger-job: 'kubernetes-build-1.0'
+    trigger-job: 'kubernetes-build-release-1.0'
     test-owner: 'Build Cop'
-    branch: 'release-1.0'
     jenkins_node: 'master'
     runner: '{old-runner-1-0}'
     post-env: ''
@@ -578,7 +575,6 @@
     trigger-job: ''
     description: 'Starts and deletes empty 1000 node cluster and runs Density 30 test on it. Does allow few Nodes to fail during startup.'
     timeout: 480
-    branch: 'master'
     suffix: 'gce-enormous-cluster'
     provider-env: '{gce-provider-env}'
     job-env: |
@@ -682,7 +678,7 @@
 
 - project:
     name: kubernetes-e2e-gce-trusty-ci-1-2
-    trigger-job: 'kubernetes-build-1.2'
+    trigger-job: 'kubernetes-build-release-1.2'
     test-owner: 'wonderfly@google.com'
     emails: 'wonderfly@google.com,qzheng@google.com'
     provider-env: |
@@ -740,7 +736,6 @@
 - project:
     name: kubernetes-e2e-gce-trusty-dev
     test-owner: 'wonderfly@google.com'
-    branch: 'release-1.2'
     emails: 'wonderfly@google.com,qzheng@google.com'
     provider-env: |
         {gce-provider-env}
@@ -797,7 +792,6 @@
 - project:
     name: kubernetes-e2e-gce-trusty-1-1
     test-owner: 'wonderfly@google.com'
-    branch: 'release-1.1'
     emails: 'wonderfly@google.com,qzheng@google.com'
     jenkins_node: 'master'
     runner: '{old-runner-1-1}'
@@ -825,7 +819,7 @@
 # the OS dependendent test cases will use Trusty in their assertions.
 - project:
     name: kubernetes-e2e-gke-trusty
-    trigger-job: 'kubernetes-build-1.2'
+    trigger-job: 'kubernetes-build-release-1.2'
     test-owner: 'wonderfly@google.com'
     provider-env: |
         {gke-provider-env}

--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
@@ -101,30 +101,28 @@
                 If a kubernetes-soak-weekly-deploy-gce build is enqueued,
                 builds will be blocked and remain in the queue until the
                 deployment is complete.<br>
-            branch: 'master'
             provider-env: '{gce-provider-env}'
             job-env: |
                 export PROJECT="k8s-jkns-gce-soak"
         - 'gce-2':
             deploy-description: Clone of kubernetes-soak-weekly-deploy-gce.
             e2e-description: Clone of kubernetes-soak-continuous-e2e-gce.
-            branch: 'master'
             provider-env: '{gce-provider-env}'
             job-env: |
                 export HAIRPIN_MODE="hairpin-veth"
                 export PROJECT="k8s-jkns-gce-soak-2"
-        - 'gce-1.2':
+        - 'gce-release-1.2':
             deploy-description: |
                 Deploy Kubernetes to soak cluster using the latest successful
                 release-1.2 Kubernetes build every week.<br>
-                If a kubernetes-soak-continuous-e2e-gce-1.2 build is running,
-                this deployment build will be blocked and remain in the queue
-                until the test run is complete.<br>
+                If a kubernetes-soak-continuous-e2e-gce-release-1.2 build is
+                running, this deployment build will be blocked and remain in
+                the queue until the test run is complete.<br>
             e2e-description: |
                 Assumes Kubernetes soak cluster is already deployed.<br>
-                If a kubernetes-soak-weekly-deploy-gce-1.2 build is enqueued,
-                builds will be blocked and remain in the queue until the
-                deployment is complete.<br>
+                If a kubernetes-soak-weekly-deploy-gce-release-1.2 build is
+                enqueued, builds will be blocked and remain in the queue until
+                the deployment is complete.<br>
             provider-env: '{gce-provider-env}'
             job-env: |
                 export PROJECT="k8s-jkns-gce-soak-1-2"
@@ -148,7 +146,6 @@
                 If a kubernetes-soak-weekly-deploy-gke build is enqueued,
                 builds will be blocked and remain in the queue until the
                 deployment is complete.<br>
-            branch: 'master'
             provider-env: '{gke-provider-env}'
             job-env: |
                 export PROJECT="k8s-jkns-gke-soak"


### PR DESCRIPTION
#23021 cc @david-mcmahon

This makes jobs use `kubernetes-blablabla-release-x.y`. There will be a PR in the 1.1 branch to rename some of the cases in e2e.sh.
- kubernetes-build-1.2 -> kubernetes-build-release-1.2
- kubernetes-build-1.1 -> kubernetes-build-release-1.1
- kubernetes-build-1.0 -> kubernetes-build-release-1.0
- kubernetes-e2e-gke-1.1 -> kubernetes-e2e-gke-release-1.1
- kubernetes-e2e-gce-disruptive-1.1 -> kubernetes-e2e-gce-disruptive-release-1.1
- kubernetes-soak-weekly-deploy-gce-1.2 -> kubernetes-soak-weekly-deploy-gce-release-1.2
- kubernetes-soak-weekly-deploy-gce-1.1 -> kubernetes-soak-weekly-deploy-gce-release-1.1
- kubernetes-soak-continuous-e2e-gce-1.2 -> kubernetes-soak-continuous-e2e-gce-release-1.2
- kubernetes-soak-continuous-e2e-gce-1.1 -> kubernetes-soak-continuous-e2e-gce-release-1.1

Please do not apply lgtm tag, I'll need to manually merge the two PRs at once and delete the old jobs.
