### PR TITLE
Explicitly fail Jenkins build if git tree is dirty after build

### DIFF
--- a/hack/jenkins/build.sh
+++ b/hack/jenkins/build.sh
@@ -60,3 +60,9 @@ go run ./hack/e2e.go -v --build
 }
 
 sha256sum _output/release-tars/kubernetes*.tar.gz
+
+if [[ -n $(git status --porcelain 2>/dev/null) ]]; then
+  echo "!!! Tree is dirty after build!"
+  git status
+  exit 1
+fi


### PR DESCRIPTION
We've been unintentionally marking Jenkins CI builds as `-dirty` for a few days due to the `upload-*.sh` scripts and using the Google Cloud SDK CI build.

Usually it's due to some new file introduced by tools which we should add to `.gitignore`, though it usually doesn't get fixed until I notice that we've been marking builds `-dirty` for a while. If we explicitly fail on dirty builds, hopefully we'll notice and fix sooner.

cc @kubernetes/goog-testing @david-mcmahon 
