### PR TITLE
Disable autoscaling Jenkins job.

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
@@ -92,6 +92,8 @@
                 export PROJECT="k8s-jkns-e2e-gce-ci-reboot"
         - 'gce-autoscaling':
             description: 'Run autoscaling E2E tests on GCE.'
+            # Issue: #23716
+            disable_job: true
             timeout: 210
             job-env: |
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:ClusterSizeAutoscaling\]|\[Feature:InitialResources\] \


### PR DESCRIPTION
#23716

If nobody is going to notice when the job is failing for two weeks, lets not waste money and Jenkins VM resources running it.
