### PR TITLE
Explicitly use go 1.6.0 instead of go 1.6 for unit/integration image.

### DIFF
--- a/hack/jenkins/gotest-dockerized.sh
+++ b/hack/jenkins/gotest-dockerized.sh
@@ -42,5 +42,5 @@ docker run --rm=true \
   -e "KUBE_FORCE_VERIFY_CHECKS=${KUBE_FORCE_VERIFY_CHECKS:-}" \
   -e "KUBE_VERIFY_GIT_BRANCH=${KUBE_VERIFY_GIT_BRANCH:-}" \
   -e "REPO_DIR=${REPO_DIR}" \
-  -i gcr.io/google_containers/kubekins-test:0.9 \
+  -i gcr.io/google_containers/kubekins-test:0.10 \
   bash -c "cd kubernetes && ./hack/jenkins/test-dockerized.sh"

--- a/hack/jenkins/test-image/Dockerfile
+++ b/hack/jenkins/test-image/Dockerfile
@@ -15,7 +15,7 @@
 # This file creates a build environment for building and running kubernetes
 # unit and integration tests
 
-FROM golang:1.6
+FROM golang:1.6.0
 MAINTAINER  Jeff Lowdermilk <jeffml@google.com>
 
 ENV WORKSPACE               /workspace

--- a/hack/jenkins/test-image/Makefile
+++ b/hack/jenkins/test-image/Makefile
@@ -14,7 +14,7 @@
 
 all: push
 
-TAG = 0.9
+TAG = 0.10
 
 container:
 	docker build -t gcr.io/google_containers/kubekins-test .


### PR DESCRIPTION
It's actually the same image, so I don't technically need to advance the tag, but might as well.
#23302
