### PR TITLE
Ensure object returned by volume getCloudProvider incorporates cloud config

### DIFF
--- a/test/e2e/volume_provisioning.go
+++ b/test/e2e/volume_provisioning.go
@@ -50,7 +50,7 @@ var _ = KubeDescribe("Dynamic provisioning", func() {
 
 	KubeDescribe("DynamicProvisioner", func() {
 		It("should create and delete persistent volumes", func() {
-			SkipUnlessProviderIs("openstack", "gce", "aws")
+			SkipUnlessProviderIs("openstack", "gce", "aws", "gke")
 			By("creating a claim with a dynamic provisioning annotation")
 			claim := createClaim(ns)
 			defer func() {


### PR DESCRIPTION
This PR addresses https://github.com/kubernetes/kubernetes/issues/23517.

**Problem**
The existing GCE PD and AWS EBS volume plugin code were fetching cloud provider without specifying a cloud config: `cloudprovider.GetCloudProvider("gce", nil)`
This caused the cloud provider to use default auth mechanism, which is not acceptable for the provisioning controller running on GKE master.

**Fix**
This PR does the following:
- Modifies the GCE PD and AWS EBS volume plugin code to use the cloud provider object pre-constructed by the binary with a cloud config.
- Enable provisioning E2E test for GKE (to catch future issues).

Thanks to @cjcullen for debugging and finding the root cause!  :+1: 

This should be cherry-picked into the v1.2 branch for the next release.
