### PR TITLE
AWS kube-down: don't fail if ELB not in VPC - #23784

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -151,7 +151,7 @@ function get_igw_id {
 function get_elbs_in_vpc {
   # ELB doesn't seem to be on the same platform as the rest of AWS; doesn't support filtering
   aws elb --output json describe-load-balancers  | \
-    python -c "import json,sys; lst = [str(lb['LoadBalancerName']) for lb in json.load(sys.stdin)['LoadBalancerDescriptions'] if lb['VPCId'] == '$1']; print('\n'.join(lst))"
+    python -c "import json,sys; lst = [str(lb['LoadBalancerName']) for lb in json.load(sys.stdin)['LoadBalancerDescriptions'] if 'VPCId' in lb and lb['VPCId'] == '$1']; print('\n'.join(lst))"
 }
 
 function get_instanceid_from_name {


### PR DESCRIPTION
Prevent python undefined key error.

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
KeyError: 'VPCId'
```

Fixes #23784

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/23785)

<!-- Reviewable:end -->
