### PR TITLE
Update mergo with explicit MergeWithOverwrite() behavior

### DIFF
--- a/Godeps/_workspace/src/github.com/imdario/mergo/README.md
+++ b/Godeps/_workspace/src/github.com/imdario/mergo/README.md
@@ -8,8 +8,31 @@ Also a lovely [comune](http://en.wikipedia.org/wiki/Mergo) (municipality) in the
 
 ## Status
 
-It is ready for production use. It works fine although it may use more of testing. Here some projects in the wild using Mergo:
+It is ready for production use. It works fine after extensive use in the wild.
 
+[![Build Status][1]][2]
+[![GoDoc][3]][4]
+[![GoCard][5]][6]
+
+[1]: https://travis-ci.org/imdario/mergo.png
+[2]: https://travis-ci.org/imdario/mergo
+[3]: https://godoc.org/github.com/imdario/mergo?status.svg
+[4]: https://godoc.org/github.com/imdario/mergo
+[5]: https://goreportcard.com/badge/imdario/mergo
+[6]: https://goreportcard.com/report/github.com/imdario/mergo
+
+### Important note
+
+Mergo is intended to assign **only** zero value fields on destination with source value. Since April 6th it works like this. Before it didn't work properly, causing some random overwrites. After some issues and PRs I found it didn't merge as I designed it. Thanks to [imdario/mergo#8](https://github.com/imdario/mergo/pull/8) overwriting functions were added and the wrong behavior was clearly detected.
+
+If you were using Mergo **before** April 6th 2015, please check your project works as intended after updating your local copy with ```go get -u github.com/imdario/mergo```. I apologize for any issue caused by its previous behavior and any future bug that Mergo could cause (I hope it won't!) in existing projects after the change (release 0.2.0).
+
+### Mergo in the wild
+
+- [docker/docker](https://github.com/docker/docker/)
+- [GoogleCloudPlatform/kubernetes](https://github.com/GoogleCloudPlatform/kubernetes)
+- [imdario/zas](https://github.com/imdario/zas)
+- [soniah/dnsmadeeasy](https://github.com/soniah/dnsmadeeasy)
 - [EagerIO/Stout](https://github.com/EagerIO/Stout)
 - [lynndylanhurley/defsynth-api](https://github.com/lynndylanhurley/defsynth-api)
 - [russross/canvasassignments](https://github.com/russross/canvasassignments)
@@ -17,12 +40,16 @@ It is ready for production use. It works fine although it may use more of testin
 - [casualjim/exeggutor](https://github.com/casualjim/exeggutor)
 - [divshot/gitling](https://github.com/divshot/gitling)
 - [RWJMurphy/gorl](https://github.com/RWJMurphy/gorl)
-
-[![Build Status][1]][2]
-[![GoDoc](https://godoc.org/github.com/imdario/mergo?status.svg)](https://godoc.org/github.com/imdario/mergo)
-
-[1]: https://travis-ci.org/imdario/mergo.png
-[2]: https://travis-ci.org/imdario/mergo
+- [andrerocker/deploy42](https://github.com/andrerocker/deploy42)
+- [elwinar/rambler](https://github.com/elwinar/rambler)
+- [tmaiaroto/gopartman](https://github.com/tmaiaroto/gopartman)
+- [jfbus/impressionist](https://github.com/jfbus/impressionist)
+- [Jmeyering/zealot](https://github.com/Jmeyering/zealot)
+- [godep-migrator/rigger-host](https://github.com/godep-migrator/rigger-host)
+- [Dronevery/MultiwaySwitch-Go](https://github.com/Dronevery/MultiwaySwitch-Go)
+- [thoas/picfit](https://github.com/thoas/picfit)
+- [mantasmatelis/whooplist-server](https://github.com/mantasmatelis/whooplist-server)
+- [jnuthong/item_search](https://github.com/jnuthong/item_search)
 
 ## Installation
 
@@ -50,6 +77,39 @@ Additionally, you can map a map[string]interface{} to a struct (and otherwise, f
 Warning: if you map a struct to map, it won't do it recursively. Don't expect Mergo to map struct members of your struct as map[string]interface{}. They will be just assigned as values.
 
 More information and examples in [godoc documentation](http://godoc.org/github.com/imdario/mergo).
+
+### Nice example
+
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/imdario/mergo"
+)
+
+type Foo struct {
+	A string
+	B int64
+}
+
+func main() {
+	src := Foo{
+		A: "one",
+	}
+
+	dest := Foo{
+		A: "two",
+		B: 2,
+	}
+
+	mergo.Merge(&dest, src)
+
+	fmt.Println(dest)
+	// Will print
+	// {two 2}
+}
+```
 
 Note: if test are failing due missing package, please execute:
 

--- a/Godeps/_workspace/src/github.com/imdario/mergo/map.go
+++ b/Godeps/_workspace/src/github.com/imdario/mergo/map.go
@@ -31,7 +31,7 @@ func isExported(field reflect.StructField) bool {
 // Traverses recursively both values, assigning src's fields values to dst.
 // The map argument tracks comparisons that have already been seen, which allows
 // short circuiting on recursive types.
-func deepMap(dst, src reflect.Value, visited map[uintptr]*visit, depth int) (err error) {
+func deepMap(dst, src reflect.Value, visited map[uintptr]*visit, depth int, overwrite bool) (err error) {
 	if dst.CanAddr() {
 		addr := dst.UnsafeAddr()
 		h := 17 * addr
@@ -57,7 +57,7 @@ func deepMap(dst, src reflect.Value, visited map[uintptr]*visit, depth int) (err
 			}
 			fieldName := field.Name
 			fieldName = changeInitialCase(fieldName, unicode.ToLower)
-			if v, ok := dstMap[fieldName]; !ok || isEmptyValue(reflect.ValueOf(v)) {
+			if v, ok := dstMap[fieldName]; !ok || (isEmptyValue(reflect.ValueOf(v)) || overwrite) {
 				dstMap[fieldName] = src.Field(i).Interface()
 			}
 		}
@@ -89,12 +89,12 @@ func deepMap(dst, src reflect.Value, visited map[uintptr]*visit, depth int) (err
 				continue
 			}
 			if srcKind == dstKind {
-				if err = deepMerge(dstElement, srcElement, visited, depth+1); err != nil {
+				if err = deepMerge(dstElement, srcElement, visited, depth+1, overwrite); err != nil {
 					return
 				}
 			} else {
 				if srcKind == reflect.Map {
-					if err = deepMap(dstElement, srcElement, visited, depth+1); err != nil {
+					if err = deepMap(dstElement, srcElement, visited, depth+1, overwrite); err != nil {
 						return
 					}
 				} else {
@@ -118,6 +118,16 @@ func deepMap(dst, src reflect.Value, visited map[uintptr]*visit, depth int) (err
 // This is separated method from Merge because it is cleaner and it keeps sane
 // semantics: merging equal types, mapping different (restricted) types.
 func Map(dst, src interface{}) error {
+	return _map(dst, src, false)
+}
+
+// MapWithOverwrite will do the same as Map except that non-empty dst attributes will be overriden by
+// non-empty src attribute values.
+func MapWithOverwrite(dst, src interface{}) error {
+	return _map(dst, src, true)
+}
+
+func _map(dst, src interface{}, overwrite bool) error {
 	var (
 		vDst, vSrc reflect.Value
 		err        error
@@ -128,7 +138,7 @@ func Map(dst, src interface{}) error {
 	// To be friction-less, we redirect equal-type arguments
 	// to deepMerge. Only because arguments can be anything.
 	if vSrc.Kind() == vDst.Kind() {
-		return deepMerge(vDst, vSrc, make(map[uintptr]*visit), 0)
+		return deepMerge(vDst, vSrc, make(map[uintptr]*visit), 0, overwrite)
 	}
 	switch vSrc.Kind() {
 	case reflect.Struct:
@@ -142,5 +152,5 @@ func Map(dst, src interface{}) error {
 	default:
 		return ErrNotSupported
 	}
-	return deepMap(vDst, vSrc, make(map[uintptr]*visit), 0)
+	return deepMap(vDst, vSrc, make(map[uintptr]*visit), 0, overwrite)
 }

--- a/Godeps/_workspace/src/github.com/imdario/mergo/merge.go
+++ b/Godeps/_workspace/src/github.com/imdario/mergo/merge.go
@@ -15,7 +15,7 @@ import (
 // Traverses recursively both values, assigning src's fields values to dst.
 // The map argument tracks comparisons that have already been seen, which allows
 // short circuiting on recursive types.
-func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int) (err error) {
+func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, overwrite bool) (err error) {
 	if !src.IsValid() {
 		return
 	}
@@ -35,7 +35,7 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int) (e
 	switch dst.Kind() {
 	case reflect.Struct:
 		for i, n := 0, dst.NumField(); i < n; i++ {
-			if err = deepMerge(dst.Field(i), src.Field(i), visited, depth+1); err != nil {
+			if err = deepMerge(dst.Field(i), src.Field(i), visited, depth+1, overwrite); err != nil {
 				return
 			}
 		}
@@ -46,15 +46,31 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int) (e
 				continue
 			}
 			dstElement := dst.MapIndex(key)
-			switch reflect.TypeOf(srcElement.Interface()).Kind() {
-			case reflect.Struct:
+			switch srcElement.Kind() {
+			case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Slice:
+				if srcElement.IsNil() {
+					continue
+				}
 				fallthrough
-			case reflect.Map:
-				if err = deepMerge(dstElement, srcElement, visited, depth+1); err != nil {
-					return
+			default:
+				if !srcElement.CanInterface() {
+					continue
+				}
+				switch reflect.TypeOf(srcElement.Interface()).Kind() {
+				case reflect.Struct:
+					fallthrough
+				case reflect.Ptr:
+					fallthrough
+				case reflect.Map:
+					if err = deepMerge(dstElement, srcElement, visited, depth+1, overwrite); err != nil {
+						return
+					}
 				}
 			}
-			if !dstElement.IsValid() {
+			if !isEmptyValue(srcElement) && (overwrite || (!dstElement.IsValid() || isEmptyValue(dst))) {
+				if dst.IsNil() {
+					dst.Set(reflect.MakeMap(dst.Type()))
+				}
 				dst.SetMapIndex(key, srcElement)
 			}
 		}
@@ -63,28 +79,36 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int) (e
 	case reflect.Interface:
 		if src.IsNil() {
 			break
-		} else if dst.IsNil() {
-			if dst.CanSet() && isEmptyValue(dst) {
+		} else if dst.IsNil() || overwrite {
+			if dst.CanSet() && (overwrite || isEmptyValue(dst)) {
 				dst.Set(src)
 			}
-		} else if err = deepMerge(dst.Elem(), src.Elem(), visited, depth+1); err != nil {
+		} else if err = deepMerge(dst.Elem(), src.Elem(), visited, depth+1, overwrite); err != nil {
 			return
 		}
 	default:
-		if dst.CanSet() && !isEmptyValue(src) {
+		if dst.CanSet() && !isEmptyValue(src) && (overwrite || isEmptyValue(dst)) {
 			dst.Set(src)
 		}
 	}
 	return
 }
 
-// Merge sets fields' values in dst from src if they have a zero
-// value of their type.
-// dst and src must be valid same-type structs and dst must be
-// a pointer to struct.
-// It won't merge unexported (private) fields and will do recursively
-// any exported field.
+// Merge will fill any empty for value type attributes on the dst struct using corresponding
+// src attributes if they themselves are not empty. dst and src must be valid same-type structs
+// and dst must be a pointer to struct.
+// It won't merge unexported (private) fields and will do recursively any exported field.
 func Merge(dst, src interface{}) error {
+	return merge(dst, src, false)
+}
+
+// MergeWithOverwrite will do the same as Merge except that non-empty dst attributes will be overriden by
+// non-empty src attribute values.
+func MergeWithOverwrite(dst, src interface{}) error {
+	return merge(dst, src, true)
+}
+
+func merge(dst, src interface{}, overwrite bool) error {
 	var (
 		vDst, vSrc reflect.Value
 		err        error
@@ -95,5 +119,5 @@ func Merge(dst, src interface{}) error {
 	if vDst.Type() != vSrc.Type() {
 		return ErrDifferentArgumentsTypes
 	}
-	return deepMerge(vDst, vSrc, make(map[uintptr]*visit), 0)
+	return deepMerge(vDst, vSrc, make(map[uintptr]*visit), 0, overwrite)
 }

--- a/pkg/client/unversioned/clientcmd/client_config.go
+++ b/pkg/client/unversioned/clientcmd/client_config.go
@@ -104,20 +104,17 @@ func (config *DirectClientConfig) ClientConfig() (*restclient.Config, error) {
 	if restclient.IsConfigTransportTLS(*clientConfig) {
 		var err error
 
-		// mergo is a first write wins for map value and a last writing wins for interface values
-		// NOTE: This behavior changed with https://github.com/imdario/mergo/commit/d304790b2ed594794496464fadd89d2bb266600a.
-		//       Our mergo.Merge version is older than this change.
 		userAuthPartialConfig, err := getUserIdentificationPartialConfig(configAuthInfo, config.fallbackReader)
 		if err != nil {
 			return nil, err
 		}
-		mergo.Merge(clientConfig, userAuthPartialConfig)
+		mergo.MergeWithOverwrite(clientConfig, userAuthPartialConfig)
 
 		serverAuthPartialConfig, err := getServerIdentificationPartialConfig(configAuthInfo, configClusterInfo)
 		if err != nil {
 			return nil, err
 		}
-		mergo.Merge(clientConfig, serverAuthPartialConfig)
+		mergo.MergeWithOverwrite(clientConfig, serverAuthPartialConfig)
 	}
 
 	return clientConfig, nil
@@ -137,7 +134,7 @@ func getServerIdentificationPartialConfig(configAuthInfo clientcmdapi.AuthInfo, 
 	configClientConfig.CAFile = configClusterInfo.CertificateAuthority
 	configClientConfig.CAData = configClusterInfo.CertificateAuthorityData
 	configClientConfig.Insecure = configClusterInfo.InsecureSkipTLSVerify
-	mergo.Merge(mergedConfig, configClientConfig)
+	mergo.MergeWithOverwrite(mergedConfig, configClientConfig)
 
 	return mergedConfig, nil
 }
@@ -175,8 +172,8 @@ func getUserIdentificationPartialConfig(configAuthInfo clientcmdapi.AuthInfo, fa
 		promptedConfig := makeUserIdentificationConfig(*promptedAuthInfo)
 		previouslyMergedConfig := mergedConfig
 		mergedConfig = &restclient.Config{}
-		mergo.Merge(mergedConfig, promptedConfig)
-		mergo.Merge(mergedConfig, previouslyMergedConfig)
+		mergo.MergeWithOverwrite(mergedConfig, promptedConfig)
+		mergo.MergeWithOverwrite(mergedConfig, previouslyMergedConfig)
 	}
 
 	return mergedConfig, nil
@@ -274,9 +271,9 @@ func (config *DirectClientConfig) getContext() clientcmdapi.Context {
 
 	var mergedContext clientcmdapi.Context
 	if configContext, exists := contexts[contextName]; exists {
-		mergo.Merge(&mergedContext, configContext)
+		mergo.MergeWithOverwrite(&mergedContext, configContext)
 	}
-	mergo.Merge(&mergedContext, config.overrides.Context)
+	mergo.MergeWithOverwrite(&mergedContext, config.overrides.Context)
 
 	return mergedContext
 }
@@ -287,9 +284,9 @@ func (config *DirectClientConfig) getAuthInfo() clientcmdapi.AuthInfo {
 
 	var mergedAuthInfo clientcmdapi.AuthInfo
 	if configAuthInfo, exists := authInfos[authInfoName]; exists {
-		mergo.Merge(&mergedAuthInfo, configAuthInfo)
+		mergo.MergeWithOverwrite(&mergedAuthInfo, configAuthInfo)
 	}
-	mergo.Merge(&mergedAuthInfo, config.overrides.AuthInfo)
+	mergo.MergeWithOverwrite(&mergedAuthInfo, config.overrides.AuthInfo)
 
 	return mergedAuthInfo
 }
@@ -299,12 +296,12 @@ func (config *DirectClientConfig) getCluster() clientcmdapi.Cluster {
 	clusterInfoName := config.getClusterName()
 
 	var mergedClusterInfo clientcmdapi.Cluster
-	mergo.Merge(&mergedClusterInfo, DefaultCluster)
-	mergo.Merge(&mergedClusterInfo, EnvVarCluster)
+	mergo.MergeWithOverwrite(&mergedClusterInfo, EnvVarCluster)
+	mergo.MergeWithOverwrite(&mergedClusterInfo, DefaultCluster)
 	if configClusterInfo, exists := clusterInfos[clusterInfoName]; exists {
-		mergo.Merge(&mergedClusterInfo, configClusterInfo)
+		mergo.MergeWithOverwrite(&mergedClusterInfo, configClusterInfo)
 	}
-	mergo.Merge(&mergedClusterInfo, config.overrides.ClusterInfo)
+	mergo.MergeWithOverwrite(&mergedClusterInfo, config.overrides.ClusterInfo)
 	// An override of --insecure-skip-tls-verify=true and no accompanying CA/CA data should clear already-set CA/CA data
 	// otherwise, a kubeconfig containing a CA reference would return an error that "CA and insecure-skip-tls-verify couldn't both be set"
 	caLen := len(config.overrides.ClusterInfo.CertificateAuthority)

--- a/pkg/client/unversioned/clientcmd/client_config_test.go
+++ b/pkg/client/unversioned/clientcmd/client_config_test.go
@@ -20,28 +20,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/imdario/mergo"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
 )
-
-func TestOldMergoLib(t *testing.T) {
-	type T struct {
-		X string
-	}
-	dst := T{X: "one"}
-	src := T{X: "two"}
-	mergo.Merge(&dst, &src)
-	if dst.X != "two" {
-		// mergo.Merge changed in an incompatible way with
-		//
-		//   https://github.com/imdario/mergo/commit/d304790b2ed594794496464fadd89d2bb266600a
-		//
-		// We have to stay with the old version which still does eager
-		// copying from src to dst in structs.
-		t.Errorf("mergo.Merge library found with incompatible, new behavior")
-	}
-}
 
 func createValidTestConfig() *clientcmdapi.Config {
 	const (

--- a/pkg/client/unversioned/clientcmd/loader.go
+++ b/pkg/client/unversioned/clientcmd/loader.go
@@ -143,7 +143,7 @@ func (rules *ClientConfigLoadingRules) Load() (*clientcmdapi.Config, error) {
 	// first merge all of our maps
 	mapConfig := clientcmdapi.NewConfig()
 	for _, kubeconfig := range kubeconfigs {
-		mergo.Merge(mapConfig, kubeconfig)
+		mergo.MergeWithOverwrite(mapConfig, kubeconfig)
 	}
 
 	// merge all of the struct values in the reverse order so that priority is given correctly
@@ -151,14 +151,14 @@ func (rules *ClientConfigLoadingRules) Load() (*clientcmdapi.Config, error) {
 	nonMapConfig := clientcmdapi.NewConfig()
 	for i := len(kubeconfigs) - 1; i >= 0; i-- {
 		kubeconfig := kubeconfigs[i]
-		mergo.Merge(nonMapConfig, kubeconfig)
+		mergo.MergeWithOverwrite(nonMapConfig, kubeconfig)
 	}
 
 	// since values are overwritten, but maps values are not, we can merge the non-map config on top of the map config and
 	// get the values we expect.
 	config := clientcmdapi.NewConfig()
-	mergo.Merge(config, mapConfig)
-	mergo.Merge(config, nonMapConfig)
+	mergo.MergeWithOverwrite(config, mapConfig)
+	mergo.MergeWithOverwrite(config, nonMapConfig)
 
 	if rules.ResolvePaths() {
 		if err := ResolveLocalPaths(config); err != nil {


### PR DESCRIPTION
mergo changed its merge behavior and made overwriting explicit
with a specific function call. This is different from the old
copy of mergo included in the kubernetes godeps.

Updating to the recent mergo makes pkg/client work for non-local
callers of the code.

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/23789)

<!-- Reviewable:end -->
