### PR TITLE
Add kubectl env var default overrides

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -416,6 +416,16 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 				framework.Failf("Container port output missing expected value. Wanted:'%s', got: %s", nginxDefaultOutput, body)
 			}
 		})
+
+		It("should support env var overrides", func() {
+			By(fmt.Sprintf("setting KUBERNETES_NAMESPACE=%q", ns))
+			output := framework.NewKubectlCommand("get", "pod").
+				WithEnv(append(os.Environ(), fmt.Sprintf("KUBERNETES_NAMESPACE=%s", ns))).
+				ExecOrDie()
+			if !strings.Contains(output, simplePodName) {
+				framework.Failf("Failed finding the simple pod %q", simplePodName)
+			}
+		})
 	})
 
 	framework.KubeDescribe("Kubectl api-versions", func() {


### PR DESCRIPTION
The default for the following values is "". Setting the respective environment variable will override this. Hence, the order of overriding is:

  flag, env var, kubeconfig

These env vars are added:
- KUBERNETES_CONTEXT
- KUBERNETES_CLUSTER
- KUBERNETES_USER
- KUBERNETES_NAMESPACE

Use-case:

Set KUBERNETES_NAMESPACE to "kube-system" in one terminal tab for Kubernetes
system administration (visualized with a custom zsh prompt):

<img width="757" alt="bildschirmfoto 2016-04-04 um 09 51 45" src="https://cloud.githubusercontent.com/assets/730123/14241285/f17c683e-fa4a-11e5-90ec-9a3d324d2bdc.png">

Set it differently or leave it empty in another tab for regular operation.

Currently, this can only be archieved by passing "--namespace kube-system" in
each command in the first tab.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/23810)

<!-- Reviewable:end -->
