### PR TITLE
support NETWORK_PROVIDER=cni for KUBERNETES_PROVIDER=vagrant

### DIFF
--- a/cluster/saltbase/salt/cni/init.sls
+++ b/cluster/saltbase/salt/cni/init.sls
@@ -5,6 +5,13 @@
     - mode: 755
     - makedirs: True
 
+/etc/cni/net.d:
+  file.directory:
+    - user: root
+    - group: root
+    - mode: 755
+    - makedirs: True
+
 # These are all available CNI network plugins.
 cni-tar:
   archive:
@@ -18,3 +25,17 @@ cni-tar:
     - archive_format: tar
     - if_missing: /opt/cni/bin
 
+{% if grains['cloud'] is defined and grains.cloud in [ 'vagrant' ]  %}
+# Install local CNI network plugins in a Vagrant environment
+cmd-local-cni-plugins:
+   cmd.run:
+      - name: |
+         cp -v /vagrant/cluster/network-plugins/cni/bin/* /opt/cni/bin/.
+         chmod +x /opt/cni/bin/*
+cmd-local-cni-config:
+   cmd.run:
+      - name: |
+         cp -v /vagrant/cluster/network-plugins/cni/config/* /etc/cni/net.d/.
+         chown root:root /etc/cni/net.d/*
+         chmod 744 /etc/cni/net.d/*
+{% endif -%}

--- a/cluster/saltbase/salt/docker/docker-defaults
+++ b/cluster/saltbase/salt/docker/docker-defaults
@@ -7,6 +7,9 @@
 {% if pillar.get('network_provider', '').lower() == 'kubenet' %}
   {% set bridge_opts = "" %}
 {% endif -%}
+{% if pillar.get('network_provider', '').lower() == 'cni' %}
+  {% set bridge_opts = "" %}
+{% endif -%}
 {% set log_level = "--log-level=warn" -%}
 {% if pillar['docker_test_log_level'] is defined -%}
   {% set log_level = pillar['docker_test_log_level'] -%}

--- a/cluster/saltbase/salt/kubelet/default
+++ b/cluster/saltbase/salt/kubelet/default
@@ -144,6 +144,8 @@
 {% set network_plugin = "" -%}
 {% if pillar.get('network_provider', '').lower() == 'opencontrail' %}
   {% set network_plugin = "--network-plugin=opencontrail" %}
+{% elif pillar.get('network_provider', '').lower() == 'cni' %}
+  {% set network_plugin = "--network-plugin=cni --network-plugin-dir=/etc/cni/net.d/" %}
 {% elif pillar.get('network_provider', '').lower() == 'kubenet' %}
   {% set network_plugin = "--network-plugin=kubenet" -%}
   {% if reconcile_cidr_args == '' -%}

--- a/cluster/saltbase/salt/top.sls
+++ b/cluster/saltbase/salt/top.sls
@@ -17,6 +17,8 @@ base:
     - flannel
 {% elif pillar.get('network_provider', '').lower() == 'kubenet' %}
     - cni
+{% elif pillar.get('network_provider', '').lower() == 'cni' %}
+    - cni
 {% endif %}
     - helpers
     - kube-client-tools
@@ -48,6 +50,8 @@ base:
     - flannel-server
     - flannel
 {% elif pillar.get('network_provider', '').lower() == 'kubenet' %}
+    - cni
+{% elif pillar.get('network_provider', '').lower() == 'cni' %}
     - cni
 {% endif %}
     - kube-apiserver


### PR DESCRIPTION
While trying to develop CNI plugins for K8's, I found the docs referenced the support of --network-plugin=cni for kubelet, but this wasn't surfaced up via salt to support env NETWORK_PROVIDER=cni before a kube-up deployment.

This PR is my attempt at adding CNI support to the kube-up happy path, following a lot of similar work for NETWORK_PROVIDER=kubenet which already exists.

Also, I've added the ability to consume CNI plugin's (binaries) and configuration files from the local cluster/network-plugins directory into the necessary locations as referenced here for CNI:
http://kubernetes.io/docs/admin/network-plugins 
This allows a local developer to easily work on CNI plugin development while following the existing kube-up.sh docs and process.

In general, i've struggled to find any authoritative information or answers to my questions in slack regarding CNI progress / correct integration, so comments encouraged here!
