### PR TITLE
Set CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS on GCE e2e runs.

### DIFF
--- a/hack/jenkins/job-configs/global.yaml
+++ b/hack/jenkins/job-configs/global.yaml
@@ -146,6 +146,7 @@
         export E2E_MIN_STARTUP_PODS="1"
         export KUBE_GCE_ZONE="us-central1-f"
         export FAIL_ON_GCP_RESOURCE_LEAK="true"
+        export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
     gke-provider-env: |
         export KUBERNETES_PROVIDER="gke"
         export ZONE="us-central1-f"


### PR DESCRIPTION
This should help us debug the large number of gcloud crashes we are
seeing.

See #23461
