### PR TITLE
Set fake docker client to minimum required version.

### DIFF
--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -292,9 +292,7 @@ func getDockerClient(dockerEndpoint string) (*dockerapi.Client, error) {
 // will be returned. The program exits if error occurs.
 func ConnectToDockerOrDie(dockerEndpoint string) DockerInterface {
 	if dockerEndpoint == "fake://" {
-		return &FakeDockerClient{
-			VersionInfo: docker.Env{"ApiVersion=1.18", "Version=1.6.0"},
-		}
+		return NewFakeDockerClient()
 	}
 	client, err := getDockerClient(dockerEndpoint)
 	if err != nil {

--- a/pkg/kubelet/dockertools/fake_docker_client.go
+++ b/pkg/kubelet/dockertools/fake_docker_client.go
@@ -55,8 +55,12 @@ type FakeDockerClient struct {
 	EnableSleep   bool
 }
 
+// We don't check docker version now, just set the docker version of fake docker client to 1.8.1.
+// Notice that if someday we also have minimum docker version requirement, this should also be updated.
+const fakeDockerVersion = "1.8.1"
+
 func NewFakeDockerClient() *FakeDockerClient {
-	return NewFakeDockerClientWithVersion("1.8.1", "1.20")
+	return NewFakeDockerClientWithVersion(fakeDockerVersion, minimumDockerAPIVersion)
 }
 
 func NewFakeDockerClientWithVersion(version, apiVersion string) *FakeDockerClient {


### PR DESCRIPTION
Set the version of fake docker client to minimum required version, so as to avoid https://github.com/kubernetes/kubernetes/pull/23613#issuecomment-205436818 happening again.

@yujuhong @wojtek-t @gmarek 
