### PR TITLE
invalid arg during applying SELinux label

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -305,7 +305,7 @@ function start_kubelet {
          which chcon > /dev/null ; then
          if [[ ! $(ls -Zd /var/lib/kubelet) =~ system_u:object_r:svirt_sandbox_file_t:s0 ]] ; then
             echo "Applying SELinux label to /var/lib/kubelet directory."
-            if ! chcon -R system_u:object_r:svirt_sandbox_file_t:s0 /var/lib/kubelet; then
+            if ! sudo chcon -Rt svirt_sandbox_file_t /var/lib/kubelet; then
                echo "Failed to apply selinux label to /var/lib/kubelet."
             fi
 	 fi


### PR DESCRIPTION
Tested with Ubuntu 16.04 with SELINUX support. Actually, after `chcon`with long label got: `chcon: failed to set type security context component to ‘system_u:object_r:svirt_sandbox_file_t:s0’: Invalid argument`
