### PR TITLE
Implement a simpler unversioned.Time serialization

### DIFF
--- a/cmd/libs/go2idl/go-to-protobuf/protobuf/namer.go
+++ b/cmd/libs/go2idl/go-to-protobuf/protobuf/namer.go
@@ -131,7 +131,11 @@ func assignGoTypeToProtoPackage(p *protobufPackage, t *types.Type, local, global
 			continue
 		}
 		field := &protoField{}
-		if err := protobufTagToField(reflect.StructTag(m.Tags).Get("protobuf"), field, m, t, p.ProtoTypeName()); err == nil && field.Type != nil {
+		tag := reflect.StructTag(m.Tags).Get("protobuf")
+		if tag == "-" {
+			continue
+		}
+		if err := protobufTagToField(tag, field, m, t, p.ProtoTypeName()); err == nil && field.Type != nil {
 			assignGoTypeToProtoPackage(p, field.Type, local, global)
 			continue
 		}

--- a/pkg/api/unversioned/time.go
+++ b/pkg/api/unversioned/time.go
@@ -28,8 +28,9 @@ import (
 // of the factory methods that the time package offers.
 //
 // +protobuf.options.marshal=false
+// +protobuf.as=Timestamp
 type Time struct {
-	time.Time `protobuf:"Timestamp,1,req,name=time"`
+	time.Time `protobuf:"-"`
 }
 
 // NewTime returns a wrapped instance of the provided time

--- a/pkg/api/unversioned/time_proto.go
+++ b/pkg/api/unversioned/time_proto.go
@@ -22,15 +22,9 @@ import (
 	"time"
 )
 
-// ProtoTime is a struct that is equivalent to Time, but intended for
+// Timestamp is a struct that is equivalent to Time, but intended for
 // protobuf marshalling/unmarshalling. It is generated into a serialization
 // that matches Time. Do not use in Go structs.
-type ProtoTime struct {
-	// Represents the time of an event.
-	Timestamp Timestamp `json:"timestamp"`
-}
-
-// Timestamp is a protobuf Timestamp compatible representation of time.Time
 type Timestamp struct {
 	// Represents seconds of UTC time since Unix epoch
 	// 1970-01-01T00:00:00Z. Must be from from 0001-01-01T00:00:00Z to
@@ -39,20 +33,18 @@ type Timestamp struct {
 	// Non-negative fractions of a second at nanosecond resolution. Negative
 	// second values with fractions must still have non-negative nanos values
 	// that count forward in time. Must be from 0 to 999,999,999
-	// inclusive.
+	// inclusive. This field may be limited in precision depending on context.
 	Nanos int32 `json:"nanos"`
 }
 
-// ProtoTime returns the Time as a new ProtoTime value.
-func (m *Time) ProtoTime() *ProtoTime {
+// Timestamp returns the Time as a new Timestamp value.
+func (m *Time) ProtoTime() *Timestamp {
 	if m == nil {
-		return &ProtoTime{}
+		return &Timestamp{}
 	}
-	return &ProtoTime{
-		Timestamp: Timestamp{
-			Seconds: m.Time.Unix(),
-			Nanos:   int32(m.Time.Nanosecond()),
-		},
+	return &Timestamp{
+		Seconds: m.Time.Unix(),
+		Nanos:   int32(m.Time.Nanosecond()),
 	}
 }
 
@@ -61,11 +53,11 @@ func (m *Time) Size() (n int) { return m.ProtoTime().Size() }
 
 // Reset implements the protobuf marshalling interface.
 func (m *Time) Unmarshal(data []byte) error {
-	p := ProtoTime{}
+	p := Timestamp{}
 	if err := p.Unmarshal(data); err != nil {
 		return err
 	}
-	m.Time = time.Unix(p.Timestamp.Seconds, int64(p.Timestamp.Nanos))
+	m.Time = time.Unix(p.Seconds, int64(p.Nanos))
 	return nil
 }
 


### PR DESCRIPTION
Enhance go-to-protobuf to allow a message for a type to be generated with another type's fields.

@wojtek-t 

Split from #23806
