### PR TITLE
IPerf container to support network perfomance testing

### DIFF
--- a/test/images/iperf/Dockerfile
+++ b/test/images/iperf/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM fedora
+MAINTAINER jay@apache.org
+RUN dnf install -y git gcc gcc-c++ make
+RUN git clone https://github.com/esnet/iperf.git
+RUN cd iperf && git checkout 2.0.4-RELEASE && ./configure && make && make install && rm -rf iperf
+RUN ls -altrh /usr/local/bin/iperf

--- a/test/images/iperf/README.md
+++ b/test/images/iperf/README.md
@@ -1,0 +1,8 @@
+This is a dockerfile which we curate inside of kubernetes for running iperf as a service.
+
+Eventually we would like to update it to iperf3.
+
+Possibly we might even start using a pure go based iperf and maintain the same cmd line abstraction.
+
+
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/test/images/iperf/README.md?pixel)]()


### PR DESCRIPTION
Simple iperf container.

Issue:
We want to run iperf from the e2e tests for a network baseline, but there are no gcr images for this.

Solution:
Curate our own iperf container from source in kubernetes and copy it as a top level microservice.  So long as these are injected into GCR, we can then run this container from the e2e tests.

 cc @sig-testing this can be used along side #22869 
