### PR TITLE
Fixed typo: kuberntes -> kubernetes

### DIFF
--- a/cluster/gce/trusty/master.yaml
+++ b/cluster/gce/trusty/master.yaml
@@ -57,7 +57,7 @@ script
 	create_dirs
 	echo "Mount master PD"
 	mount_master_pd
-	echo "Creating kuberntes master auth file"
+	echo "Creating kubernetes master auth file"
 	create_master_auth
 	echo "Creating master instance kubelet auth file"
   create_master_kubelet_auth

--- a/docs/proposals/release-notes.md
+++ b/docs/proposals/release-notes.md
@@ -132,7 +132,7 @@ With v1.2.0, the release notes were moved from their previous [github releases](
 location to [CHANGELOG.md](../../CHANGELOG.md).  Going forward this seems like a good plan.
 Other projects do similarly.
 
-The kuberntes.tar.gz download link is also displayed along with the release notes
+The kubernetes.tar.gz download link is also displayed along with the release notes
 in [CHANGELOG.md](../../CHANGELOG.md).
 
 Is there any reason to continue publishing anything to github releases if


### PR DESCRIPTION
"Kubernetes" was misspelled in a couple of places.
