### PR TITLE
the component status health check should check whether the scheme of backend storage url is https or not

### DIFF
--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -513,7 +513,13 @@ func (m *Master) getServersToValidate(c *Config) map[string]apiserver.Server {
 			port = 4001
 		}
 		// TODO: etcd health checking should be abstracted in the storage tier
-		serversToValidate[fmt.Sprintf("etcd-%d", ix)] = apiserver.Server{Addr: addr, Port: port, Path: "/health", Validate: etcdutil.EtcdHealthCheck}
+		serversToValidate[fmt.Sprintf("etcd-%d", ix)] = apiserver.Server{
+			Addr:        addr,
+			EnableHTTPS: etcdUrl.Scheme == "https",
+			Port:        port,
+			Path:        "/health",
+			Validate:    etcdutil.EtcdHealthCheck,
+		}
 	}
 	return serversToValidate
 }


### PR DESCRIPTION
fix https://github.com/kubernetes/kubernetes/issues/23897, when querying the component status of etcd (backend storage), the scheme of url is not checked and use `http` always, this commit aims to fix this.
