### PR TITLE
Move /resetMetrics to DELETE /metrics

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -46,7 +46,6 @@ import (
 
 	"github.com/emicklei/go-restful"
 	"github.com/golang/glog"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 func init() {
@@ -171,7 +170,6 @@ func (g *APIGroupVersion) newInstaller() *APIInstaller {
 func InstallSupport(mux Mux, ws *restful.WebService, checks ...healthz.HealthzChecker) {
 	// TODO: convert healthz and metrics to restful and remove container arg
 	healthz.InstallHandler(mux, checks...)
-	mux.Handle("/metrics", prometheus.Handler())
 
 	// Set up a service to return the git code version.
 	ws.Path("/version")

--- a/test/e2e/framework/metrics_util.go
+++ b/test/e2e/framework/metrics_util.go
@@ -315,7 +315,7 @@ func VerifyPodStartupLatency(latency PodStartupLatency) error {
 // Resets latency metrics in apiserver.
 func ResetMetrics(c *client.Client) error {
 	Logf("Resetting latency metrics in apiserver...")
-	body, err := c.Get().AbsPath("/resetMetrics").DoRaw()
+	body, err := c.Delete().AbsPath("/metrics").DoRaw()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Reduces the surface area of the API server slightly and allows
downstream components to have deleteable metrics. After this change
genericapiserver will _not_ have metrics unless the caller defines it
(allows different apiserver implementations to make that choice on their
own).

@wojtek-t
