### PR TITLE
Temp downgrade heapster from v1.1.0.beta1 to v1.0.2 for cherrypick

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -11,26 +11,26 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.1.0.beta1
+  name: heapster-v1.0.2
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
-    version: v1.1.0.beta1
+    version: v1.0.2
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.1.0.beta1
+      version: v1.0.2
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.1.0.beta1
+        version: v1.0.2
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v1.1.0-beta1
+        - image: gcr.io/google_containers/heapster:v1.0.2
           name: heapster
           resources:
             # keep request = limit to keep this container in guaranteed class
@@ -49,7 +49,7 @@ spec:
             - name: ssl-certs
               mountPath: /etc/ssl/certs
               readOnly: true
-        - image: gcr.io/google_containers/heapster:v1.1.0-beta1
+        - image: gcr.io/google_containers/heapster:v1.0.2
           name: eventer
           resources:
             # keep request = limit to keep this container in guaranteed class
@@ -92,7 +92,7 @@ spec:
             - --memory={{ metrics_memory }}
             - --extra-memory={{metrics_memory_per_node}}Mi
             - --threshold=5
-            - --deployment=heapster-v1.1.0.beta1
+            - --deployment=heapster-v1.0.2
             - --container=heapster
             - --poll-period=300000
         - image: gcr.io/google_containers/addon-resizer:1.0
@@ -120,7 +120,7 @@ spec:
             - --memory={{eventer_memory}}
             - --extra-memory={{eventer_memory_per_node}}Ki
             - --threshold=5
-            - --deployment=heapster-v1.1.0.beta1
+            - --deployment=heapster-v1.0.2
             - --container=eventer
             - --poll-period=300000
       volumes:

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -11,26 +11,26 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.1.0.beta1
+  name: heapster-v1.0.2
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
-    version: v1.1.0.beta1
+    version: v1.0.2
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.1.0.beta1
+      version: v1.0.2
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.1.0.beta1
+        version: v1.0.2
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v1.1.0-beta1
+        - image: gcr.io/google_containers/heapster:v1.0.2
           name: heapster
           resources:
             # keep request = limit to keep this container in guaranteed class
@@ -50,7 +50,7 @@ spec:
             - name: ssl-certs
               mountPath: /etc/ssl/certs
               readOnly: true
-        - image: gcr.io/google_containers/heapster:v1.1.0-beta1
+        - image: gcr.io/google_containers/heapster:v1.0.2
           name: eventer
           resources:
             # keep request = limit to keep this container in guaranteed class
@@ -93,7 +93,7 @@ spec:
             - --memory={{ metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.1.0.beta1
+            - --deployment=heapster-v1.0.2
             - --container=heapster
             - --poll-period=300000
         - image: gcr.io/google_containers/addon-resizer:1.0
@@ -121,7 +121,7 @@ spec:
             - --memory={{ eventer_memory }}
             - --extra-memory={{ eventer_memory_per_node }}Ki
             - --threshold=5
-            - --deployment=heapster-v1.1.0.beta1
+            - --deployment=heapster-v1.0.2
             - --container=eventer
             - --poll-period=300000
       volumes:

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -11,26 +11,26 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.1.0.beta1
+  name: heapster-v1.0.2
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
-    version: v1.1.0.beta1
+    version: v1.0.2
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.1.0.beta1
+      version: v1.0.2
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.1.0.beta1
+        version: v1.0.2
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v1.1.0-beta1
+        - image: gcr.io/google_containers/heapster:v1.0.2
           name: heapster
           resources:
             # keep request = limit to keep this container in guaranteed class
@@ -45,7 +45,7 @@ spec:
             - --source=kubernetes.summary_api:''
             - --sink=influxdb:http://monitoring-influxdb:8086
             - --metric_resolution=60s
-        - image: gcr.io/google_containers/heapster:v1.1.0-beta1
+        - image: gcr.io/google_containers/heapster:v1.0.2
           name: eventer
           resources:
             # keep request = limit to keep this container in guaranteed class
@@ -84,7 +84,7 @@ spec:
             - --memory={{ metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.1.0.beta1
+            - --deployment=heapster-v1.0.2
             - --container=heapster
             - --poll-period=300000
         - image: gcr.io/google_containers/addon-resizer:1.0
@@ -112,7 +112,7 @@ spec:
             - --memory={{ eventer_memory }}
             - --extra-memory={{ eventer_memory_per_node }}Ki
             - --threshold=5
-            - --deployment=heapster-v1.1.0.beta1
+            - --deployment=heapster-v1.0.2
             - --container=eventer
             - --poll-period=300000
 

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -8,26 +8,26 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.1.0.beta1
+  name: heapster-v1.0.2
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
-    version: v1.1.0.beta1
+    version: v1.0.2
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.1.0.beta1
+      version: v1.0.2
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.1.0.beta1
+        version: v1.0.2
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v1.1.0-beta1
+        - image: gcr.io/google_containers/heapster:v1.0.2
           name: heapster
           resources:
             # keep request = limit to keep this container in guaranteed class
@@ -66,6 +66,6 @@ spec:
             - --memory={{ metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.1.0.beta1
+            - --deployment=heapster-v1.0.2
             - --container=heapster
             - --poll-period=300000


### PR DESCRIPTION
For cherrypick #22893 & #23512 to release-1.2 only (we don't want to upgrade heapster in 1.2 when cherrypicking, see #23941). Will revert the change afterwards. 

@Q-Lee @roberthbailey @bgrant0607 @davidopp @mikedanese 
