### PR TITLE
Use tagged gcr.io redis image for pkg/api tests

### DIFF
--- a/pkg/api/validation/testdata/v1/invalidPod.yaml
+++ b/pkg/api/validation/testdata/v1/invalidPod.yaml
@@ -7,5 +7,5 @@ metadata:
 spec:
   containers:
   - args: "this is a bad command"
-    image: redis
+    image: gcr.io/fake_project/fake_image:fake_tag
     name: master

--- a/pkg/api/validation/testdata/v1/invalidPod1.json
+++ b/pkg/api/validation/testdata/v1/invalidPod1.json
@@ -11,7 +11,7 @@
     "containers": [
       {
         "name": "master",
-        "image": "redis",
+	"image": "gcr.io/fake_project/fake_image:fake_tag",
         "args": "this is a bad command"
       }
     ]

--- a/pkg/api/validation/testdata/v1/invalidPod2.json
+++ b/pkg/api/validation/testdata/v1/invalidPod2.json
@@ -14,7 +14,7 @@
     "containers": [
       {
         "name": "apache-php",
-        "image": "php:5.6.2-apache",
+        "image": "gcr.io/fake_project/fake_image:fake_tag",
         "ports": [
           {
             "name": "apache",

--- a/pkg/api/validation/testdata/v1/invalidPod3.json
+++ b/pkg/api/validation/testdata/v1/invalidPod3.json
@@ -14,7 +14,7 @@
     "containers": [
       {
         "name": "apache-php",
-        "image": "php:5.6.2-apache",
+	"image": "gcr.io/fake_project/fake_image:fake_tag",
         "ports": [
           {
             "name": "apache",

--- a/pkg/api/validation/testdata/v1/validPod.yaml
+++ b/pkg/api/validation/testdata/v1/validPod.yaml
@@ -12,5 +12,5 @@ spec:
     - an
     - ok
     - command
-    image: redis
+    image: gcr.io/fake_project/fake_image:fake_tag
     name: master


### PR DESCRIPTION
Migrate pkg/api/validation/testdata redis images to use tagged gcr.io version for https://github.com/kubernetes/kubernetes/issues/13288 and https://github.com/kubernetes/kubernetes/issues/20836
