### PR TITLE
fix e2e flake #23952

### DIFF
--- a/test/e2e/generated_clientset.go
+++ b/test/e2e/generated_clientset.go
@@ -129,7 +129,9 @@ var _ = KubeDescribe("Generated release_1_2 clientset", func() {
 		deleted := false
 		timeout := false
 		var lastPod *api.Pod
-		timer := time.After(30 * time.Second)
+		// The 30s grace period is not an upper-bound of the time it takes to
+		// delete the pod from etcd.
+		timer := time.After(60 * time.Second)
 		for !deleted && !timeout {
 			select {
 			case event, _ := <-w.ResultChan():


### PR DESCRIPTION
Fix #23952.

In the flaky test, the pod is deleted with grace-period=30, but there is no guarantee that the pod is going to be deleted from etcd in 30s, thus the flake.

This piece of test is copied from the pod e2e test: https://github.com/kubernetes/kubernetes/blob/master/test/e2e/pods.go#L380. In that test, the total timeout is actually larger than 30s, because there is some extra logic (< 30s) between the time when the deletion is requested, and when the timer is started.

Given that there is no flake reported for the test in pods.go, extending the timeout to 60s should fix the flake.
