### PR TITLE
Update hack/test-cmd.sh to use tagged, gcr.io images

### DIFF
--- a/hack/testdata/deployment-revision1.yaml
+++ b/hack/testdata/deployment-revision1.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: gcr.io/google-containers/nginx:1.7.9
+        image: gcr.io/google-containers/nginx:test-cmd
         ports:
         - containerPort: 80

--- a/hack/testdata/multi-resource-json-modify.json
+++ b/hack/testdata/multi-resource-json-modify.json
@@ -43,7 +43,7 @@
        "spec":{
          "containers":[{
            "name": "mock-container",
-           "image": "kubernetes/pause",
+           "image": "gcr.io/google-containers/pause:2.0",
            "ports":[{
              "containerPort":9949,
              "protocol":"TCP"

--- a/hack/testdata/multi-resource-json.json
+++ b/hack/testdata/multi-resource-json.json
@@ -41,7 +41,7 @@
        "spec":{
          "containers":[{
            "name": "mock-container",
-           "image": "kubernetes/pause",
+           "image": "gcr.io/google-containers/pause:2.0",
            "ports":[{
              "containerPort":9949,
              "protocol":"TCP"

--- a/hack/testdata/multi-resource-list-modify.json
+++ b/hack/testdata/multi-resource-list-modify.json
@@ -47,7 +47,7 @@
                "spec":{
                   "containers":[{
                     "name": "mock-container",
-                    "image": "kubernetes/pause",
+                    "image": "gcr.io/google-containers/pause:2.0",
                     "ports":[{
                         "containerPort":9949,
                         "protocol":"TCP"

--- a/hack/testdata/multi-resource-list.json
+++ b/hack/testdata/multi-resource-list.json
@@ -45,7 +45,7 @@
                "spec":{
                   "containers":[{
                     "name": "mock-container",
-                    "image": "kubernetes/pause",
+                    "image": "gcr.io/google-containers/pause:2.0",
                     "ports":[{
                         "containerPort":9949,
                         "protocol":"TCP"

--- a/hack/testdata/multi-resource-rclist-modify.json
+++ b/hack/testdata/multi-resource-rclist-modify.json
@@ -26,7 +26,7 @@
                "spec":{
                   "containers":[{
                     "name": "mock-container",
-                    "image": "kubernetes/pause",
+                    "image": "gcr.io/google-containers/pause:2.0",
                     "ports":[{
                         "containerPort":9949,
                         "protocol":"TCP"
@@ -60,7 +60,7 @@
             "spec":{
               "containers":[{
                 "name": "mock-container",
-                "image": "kubernetes/pause",
+                "image": "gcr.io/google-containers/pause:2.0",
                 "ports":[{
                   "containerPort":9949,
                   "protocol":"TCP"

--- a/hack/testdata/multi-resource-rclist.json
+++ b/hack/testdata/multi-resource-rclist.json
@@ -26,7 +26,7 @@
                "spec":{
                   "containers":[{
                     "name": "mock-container",
-                    "image": "kubernetes/pause",
+                    "image": "gcr.io/google-containers/pause:2.0",
                     "ports":[{
                         "containerPort":9949,
                         "protocol":"TCP"
@@ -60,7 +60,7 @@
             "spec":{
               "containers":[{
                 "name": "mock-container",
-                "image": "kubernetes/pause",
+                "image": "gcr.io/google-containers/pause:2.0",
                 "ports":[{
                   "containerPort":9949,
                   "protocol":"TCP"

--- a/hack/testdata/multi-resource-yaml-modify.yaml
+++ b/hack/testdata/multi-resource-yaml-modify.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: mock-container
-        image: kubernetes/pause
+        image: gcr.io/google-containers/pause:2.0
         ports:
         - containerPort: 9949
           protocol: TCP

--- a/hack/testdata/multi-resource-yaml.yaml
+++ b/hack/testdata/multi-resource-yaml.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: mock-container
-        image: kubernetes/pause
+        image: gcr.io/google-containers/pause:2.0
         ports:
         - containerPort: 9949
           protocol: TCP

--- a/hack/testdata/pod-apply.yaml
+++ b/hack/testdata/pod-apply.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: kubernetes/pause
+    image: gcr.io/google-containers/pause:2.0

--- a/hack/testdata/pod-with-large-name.yaml
+++ b/hack/testdata/pod-with-large-name.yaml
@@ -8,4 +8,4 @@ metadata:
 spec:
   containers:
   - name: kubernetes-serve-hostname
-    image: gcr.io/google_containers/serve_hostname
+    image: gcr.io/google_containers/serve_hostname:v1.4

--- a/hack/testdata/pod.yaml
+++ b/hack/testdata/pod.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: kubernetes/pause
+    image: gcr.io/google-containers/pause:2.0


### PR DESCRIPTION
Migrate hack/test-cmd.sh and related test data to use tagged, gcr.io versions of the images for #13288 and #20836
