### PR TITLE
Refactor E2E framework & utils to test/e2e/framework package

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -65,7 +65,7 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/scheduler"
 	_ "k8s.io/kubernetes/plugin/pkg/scheduler/algorithmprovider"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/factory"
-	"k8s.io/kubernetes/test/e2e"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/integration"
 	"k8s.io/kubernetes/test/integration/framework"
 

--- a/docs/devel/writing-good-e2e-tests.md
+++ b/docs/devel/writing-good-e2e-tests.md
@@ -180,7 +180,7 @@ right thing.
 
 Here are a few pointers:
 
-+ [E2e Framework](../../test/e2e/framework.go):
++ [E2e Framework](../../test/e2e/framework/framework.go):
    Familiarise yourself with this test framework and how to use it.
    Amongst others, it automatically creates uniquely named namespaces
    within which your tests can run to avoid name clashes, and reliably
@@ -194,7 +194,7 @@ Here are a few pointers:
    should always use this framework.  Trying other home-grown
    approaches to avoiding name clashes and resource leaks has proven
    to be a very bad idea.
-+ [E2e utils library](../../test/e2e/util.go):
++ [E2e utils library](../../test/e2e/framework/util.go):
    This handy library provides tons of reusable code for a host of
    commonly needed test functionality, including waiting for resources
    to enter specified states, safely and consistently retrying failed

--- a/hack/verify-flags/exceptions.txt
+++ b/hack/verify-flags/exceptions.txt
@@ -79,7 +79,7 @@ pkg/util/oom/oom_linux.go:// Writes 'value' to /proc/<pid>/oom_score_adj for all
 pkg/util/oom/oom_linux.go:// Writes 'value' to /proc/<pid>/oom_score_adj. PID = 0 means self
 test/e2e/configmap.go:						Command: []string{"/mt", "--break_on_expected_content=false", "--retry_time=120", "--file_content_in_loop=/etc/configmap-volume/data-1"},
 test/e2e/downwardapi_volume.go:			Command: []string{"/mt", "--break_on_expected_content=false", "--retry_time=120", "--file_content_in_loop=" + filePath},
-test/e2e/es_cluster_logging.go:		Failf("No cluster_name field in Elasticsearch response: %v", esResponse)
+test/e2e/es_cluster_logging.go:		framework.Failf("No cluster_name field in Elasticsearch response: %v", esResponse)
 test/e2e/es_cluster_logging.go:	// Check to see if have a cluster_name field.
 test/e2e/es_cluster_logging.go:	clusterName, ok := esResponse["cluster_name"]
 test/e2e/host_path.go:			fmt.Sprintf("--file_content_in_loop=%v", filePath),

--- a/test/e2e/batch_v1_jobs.go
+++ b/test/e2e/batch_v1_jobs.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -43,8 +44,8 @@ const (
 	v1JobSelectorKey = "job-name"
 )
 
-var _ = KubeDescribe("V1Job", func() {
-	f := NewDefaultFramework("v1job")
+var _ = framework.KubeDescribe("V1Job", func() {
+	f := framework.NewDefaultFramework("v1job")
 	parallelism := 2
 	completions := 4
 	lotsOfFailures := 5 // more than completions
@@ -105,7 +106,7 @@ var _ = KubeDescribe("V1Job", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Ensuring job shows many failures")
-		err = wait.Poll(poll, v1JobTimeout, func() (bool, error) {
+		err = wait.Poll(framework.Poll, v1JobTimeout, func() (bool, error) {
 			curr, err := f.Client.Batch().Jobs(f.Namespace.Name).Get(job.Name)
 			if err != nil {
 				return false, err
@@ -274,7 +275,7 @@ func deleteV1Job(c *client.Client, ns, name string) error {
 // Wait for all pods to become Running.  Only use when pods will run for a long time, or it will be racy.
 func waitForAllPodsRunningV1(c *client.Client, ns, jobName string, parallelism int) error {
 	label := labels.SelectorFromSet(labels.Set(map[string]string{v1JobSelectorKey: jobName}))
-	return wait.Poll(poll, v1JobTimeout, func() (bool, error) {
+	return wait.Poll(framework.Poll, v1JobTimeout, func() (bool, error) {
 		options := api.ListOptions{LabelSelector: label}
 		pods, err := c.Pods(ns).List(options)
 		if err != nil {
@@ -292,7 +293,7 @@ func waitForAllPodsRunningV1(c *client.Client, ns, jobName string, parallelism i
 
 // Wait for job to reach completions.
 func waitForV1JobFinish(c *client.Client, ns, jobName string, completions int) error {
-	return wait.Poll(poll, v1JobTimeout, func() (bool, error) {
+	return wait.Poll(framework.Poll, v1JobTimeout, func() (bool, error) {
 		curr, err := c.Batch().Jobs(ns).Get(jobName)
 		if err != nil {
 			return false, err
@@ -303,7 +304,7 @@ func waitForV1JobFinish(c *client.Client, ns, jobName string, completions int) e
 
 // Wait for job fail.
 func waitForV1JobFail(c *client.Client, ns, jobName string) error {
-	return wait.Poll(poll, v1JobTimeout, func() (bool, error) {
+	return wait.Poll(framework.Poll, v1JobTimeout, func() (bool, error) {
 		curr, err := c.Batch().Jobs(ns).Get(jobName)
 		if err != nil {
 			return false, err

--- a/test/e2e/cadvisor.go
+++ b/test/e2e/cadvisor.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 )
@@ -31,9 +32,9 @@ const (
 	sleepDuration = 10 * time.Second
 )
 
-var _ = KubeDescribe("Cadvisor", func() {
+var _ = framework.KubeDescribe("Cadvisor", func() {
 
-	f := NewDefaultFramework("cadvisor")
+	f := framework.NewDefaultFramework("cadvisor")
 
 	It("should be healthy on every node.", func() {
 		CheckCadvisorHealthOnAllNodes(f.Client, 5*time.Minute)
@@ -44,7 +45,7 @@ func CheckCadvisorHealthOnAllNodes(c *client.Client, timeout time.Duration) {
 	// It should be OK to list unschedulable Nodes here.
 	By("getting list of nodes")
 	nodeList, err := c.Nodes().List(api.ListOptions{})
-	expectNoError(err)
+	framework.ExpectNoError(err)
 	var errors []error
 	retries := maxRetries
 	for {
@@ -65,8 +66,8 @@ func CheckCadvisorHealthOnAllNodes(c *client.Client, timeout time.Duration) {
 		if retries--; retries <= 0 {
 			break
 		}
-		Logf("failed to retrieve kubelet stats -\n %v", errors)
+		framework.Logf("failed to retrieve kubelet stats -\n %v", errors)
 		time.Sleep(sleepDuration)
 	}
-	Failf("Failed after retrying %d times for cadvisor to be healthy on all nodes. Errors:\n%v", maxRetries, errors)
+	framework.Failf("Failed after retrying %d times for cadvisor to be healthy on all nodes. Errors:\n%v", maxRetries, errors)
 }

--- a/test/e2e/daemon_restart.go
+++ b/test/e2e/daemon_restart.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/watch"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -55,10 +56,10 @@ const (
 )
 
 // nodeExec execs the given cmd on node via SSH. Note that the nodeName is an sshable name,
-// eg: the name returned by getMasterHost(). This is also not guaranteed to work across
+// eg: the name returned by framework.GetMasterHost(). This is also not guaranteed to work across
 // cloud providers since it involves ssh.
-func nodeExec(nodeName, cmd string) (SSHResult, error) {
-	result, err := SSH(cmd, fmt.Sprintf("%v:%v", nodeName, sshPort), testContext.Provider)
+func nodeExec(nodeName, cmd string) (framework.SSHResult, error) {
+	result, err := framework.SSH(cmd, fmt.Sprintf("%v:%v", nodeName, sshPort), framework.TestContext.Provider)
 	Expect(err).NotTo(HaveOccurred())
 	return result, err
 }
@@ -75,8 +76,8 @@ type restartDaemonConfig struct {
 
 // NewRestartConfig creates a restartDaemonConfig for the given node and daemon.
 func NewRestartConfig(nodeName, daemonName string, healthzPort int, pollInterval, pollTimeout time.Duration) *restartDaemonConfig {
-	if !providerIs("gce") {
-		Logf("WARNING: SSH through the restart config might not work on %s", testContext.Provider)
+	if !framework.ProviderIs("gce") {
+		framework.Logf("WARNING: SSH through the restart config might not work on %s", framework.TestContext.Provider)
 	}
 	return &restartDaemonConfig{
 		nodeName:     nodeName,
@@ -93,31 +94,31 @@ func (r *restartDaemonConfig) String() string {
 
 // waitUp polls healthz of the daemon till it returns "ok" or the polling hits the pollTimeout
 func (r *restartDaemonConfig) waitUp() {
-	Logf("Checking if %v is up by polling for a 200 on its /healthz endpoint", r)
+	framework.Logf("Checking if %v is up by polling for a 200 on its /healthz endpoint", r)
 	healthzCheck := fmt.Sprintf(
 		"curl -s -o /dev/null -I -w \"%%{http_code}\" http://localhost:%v/healthz", r.healthzPort)
 
 	err := wait.Poll(r.pollInterval, r.pollTimeout, func() (bool, error) {
 		result, err := nodeExec(r.nodeName, healthzCheck)
-		expectNoError(err)
+		framework.ExpectNoError(err)
 		if result.Code == 0 {
 			httpCode, err := strconv.Atoi(result.Stdout)
 			if err != nil {
-				Logf("Unable to parse healthz http return code: %v", err)
+				framework.Logf("Unable to parse healthz http return code: %v", err)
 			} else if httpCode == 200 {
 				return true, nil
 			}
 		}
-		Logf("node %v exec command, '%v' failed with exitcode %v: \n\tstdout: %v\n\tstderr: %v",
+		framework.Logf("node %v exec command, '%v' failed with exitcode %v: \n\tstdout: %v\n\tstderr: %v",
 			r.nodeName, healthzCheck, result.Code, result.Stdout, result.Stderr)
 		return false, nil
 	})
-	expectNoError(err, "%v did not respond with a 200 via %v within %v", r, healthzCheck, r.pollTimeout)
+	framework.ExpectNoError(err, "%v did not respond with a 200 via %v within %v", r, healthzCheck, r.pollTimeout)
 }
 
 // kill sends a SIGTERM to the daemon
 func (r *restartDaemonConfig) kill() {
-	Logf("Killing %v", r)
+	framework.Logf("Killing %v", r)
 	nodeExec(r.nodeName, fmt.Sprintf("pgrep %v | xargs -I {} sudo kill {}", r.daemonName))
 }
 
@@ -163,7 +164,7 @@ func replacePods(pods []*api.Pod, store cache.Store) {
 	for i := range pods {
 		found = append(found, pods[i])
 	}
-	expectNoError(store.Replace(found, "0"))
+	framework.ExpectNoError(store.Replace(found, "0"))
 }
 
 // getContainerRestarts returns the count of container restarts across all pods matching the given labelSelector,
@@ -171,26 +172,26 @@ func replacePods(pods []*api.Pod, store cache.Store) {
 func getContainerRestarts(c *client.Client, ns string, labelSelector labels.Selector) (int, []string) {
 	options := api.ListOptions{LabelSelector: labelSelector}
 	pods, err := c.Pods(ns).List(options)
-	expectNoError(err)
+	framework.ExpectNoError(err)
 	failedContainers := 0
 	containerRestartNodes := sets.NewString()
 	for _, p := range pods.Items {
-		for _, v := range FailedContainers(&p) {
-			failedContainers = failedContainers + v.restarts
+		for _, v := range framework.FailedContainers(&p) {
+			failedContainers = failedContainers + v.Restarts
 			containerRestartNodes.Insert(p.Spec.NodeName)
 		}
 	}
 	return failedContainers, containerRestartNodes.List()
 }
 
-var _ = KubeDescribe("DaemonRestart [Disruptive]", func() {
+var _ = framework.KubeDescribe("DaemonRestart [Disruptive]", func() {
 
-	framework := NewDefaultFramework("daemonrestart")
+	f := framework.NewDefaultFramework("daemonrestart")
 	rcName := "daemonrestart" + strconv.Itoa(numPods) + "-" + string(util.NewUUID())
 	labelSelector := labels.Set(map[string]string{"name": rcName}).AsSelector()
 	existingPods := cache.NewStore(cache.MetaNamespaceKeyFunc)
 	var ns string
-	var config RCConfig
+	var config framework.RCConfig
 	var controller *controllerframework.Controller
 	var newPods cache.Store
 	var stopCh chan struct{}
@@ -199,20 +200,20 @@ var _ = KubeDescribe("DaemonRestart [Disruptive]", func() {
 	BeforeEach(func() {
 		// These tests require SSH
 		// TODO(11834): Enable this test in GKE once experimental API there is switched on
-		SkipUnlessProviderIs("gce", "aws")
-		ns = framework.Namespace.Name
+		framework.SkipUnlessProviderIs("gce", "aws")
+		ns = f.Namespace.Name
 
 		// All the restart tests need an rc and a watch on pods of the rc.
 		// Additionally some of them might scale the rc during the test.
-		config = RCConfig{
-			Client:      framework.Client,
+		config = framework.RCConfig{
+			Client:      f.Client,
 			Name:        rcName,
 			Namespace:   ns,
 			Image:       "gcr.io/google_containers/pause:2.0",
 			Replicas:    numPods,
 			CreatedPods: &[]*api.Pod{},
 		}
-		Expect(RunRC(config)).NotTo(HaveOccurred())
+		Expect(framework.RunRC(config)).NotTo(HaveOccurred())
 		replacePods(*config.CreatedPods, existingPods)
 
 		stopCh = make(chan struct{})
@@ -221,11 +222,11 @@ var _ = KubeDescribe("DaemonRestart [Disruptive]", func() {
 			&cache.ListWatch{
 				ListFunc: func(options api.ListOptions) (runtime.Object, error) {
 					options.LabelSelector = labelSelector
-					return framework.Client.Pods(ns).List(options)
+					return f.Client.Pods(ns).List(options)
 				},
 				WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
 					options.LabelSelector = labelSelector
-					return framework.Client.Pods(ns).Watch(options)
+					return f.Client.Pods(ns).Watch(options)
 				},
 			},
 			&api.Pod{},
@@ -252,7 +253,7 @@ var _ = KubeDescribe("DaemonRestart [Disruptive]", func() {
 	It("Controller Manager should not create/delete replicas across restart", func() {
 
 		restarter := NewRestartConfig(
-			getMasterHost(), "kube-controller", ports.ControllerManagerPort, restartPollInterval, restartTimeout)
+			framework.GetMasterHost(), "kube-controller", ports.ControllerManagerPort, restartPollInterval, restartTimeout)
 		restarter.restart()
 
 		// The intent is to ensure the replication controller manager has observed and reported status of
@@ -260,7 +261,7 @@ var _ = KubeDescribe("DaemonRestart [Disruptive]", func() {
 		// that it had the opportunity to create/delete pods, if it were going to do so. Scaling the RC
 		// to the same size achieves this, because the scale operation advances the RC's sequence number
 		// and awaits it to be observed and reported back in the RC's status.
-		ScaleRC(framework.Client, ns, rcName, numPods, true)
+		framework.ScaleRC(f.Client, ns, rcName, numPods, true)
 
 		// Only check the keys, the pods can be different if the kubelet updated it.
 		// TODO: Can it really?
@@ -274,14 +275,14 @@ var _ = KubeDescribe("DaemonRestart [Disruptive]", func() {
 		}
 		if len(newKeys.List()) != len(existingKeys.List()) ||
 			!newKeys.IsSuperset(existingKeys) {
-			Failf("RcManager created/deleted pods after restart \n\n %+v", tracker)
+			framework.Failf("RcManager created/deleted pods after restart \n\n %+v", tracker)
 		}
 	})
 
 	It("Scheduler should continue assigning pods to nodes across restart", func() {
 
 		restarter := NewRestartConfig(
-			getMasterHost(), "kube-scheduler", ports.SchedulerPort, restartPollInterval, restartTimeout)
+			framework.GetMasterHost(), "kube-scheduler", ports.SchedulerPort, restartPollInterval, restartTimeout)
 
 		// Create pods while the scheduler is down and make sure the scheduler picks them up by
 		// scaling the rc to the same size.
@@ -289,28 +290,28 @@ var _ = KubeDescribe("DaemonRestart [Disruptive]", func() {
 		restarter.kill()
 		// This is best effort to try and create pods while the scheduler is down,
 		// since we don't know exactly when it is restarted after the kill signal.
-		expectNoError(ScaleRC(framework.Client, ns, rcName, numPods+5, false))
+		framework.ExpectNoError(framework.ScaleRC(f.Client, ns, rcName, numPods+5, false))
 		restarter.waitUp()
-		expectNoError(ScaleRC(framework.Client, ns, rcName, numPods+5, true))
+		framework.ExpectNoError(framework.ScaleRC(f.Client, ns, rcName, numPods+5, true))
 	})
 
 	It("Kubelet should not restart containers across restart", func() {
 
-		nodeIPs, err := getNodePublicIps(framework.Client)
-		expectNoError(err)
-		preRestarts, badNodes := getContainerRestarts(framework.Client, ns, labelSelector)
+		nodeIPs, err := getNodePublicIps(f.Client)
+		framework.ExpectNoError(err)
+		preRestarts, badNodes := getContainerRestarts(f.Client, ns, labelSelector)
 		if preRestarts != 0 {
-			Logf("WARNING: Non-zero container restart count: %d across nodes %v", preRestarts, badNodes)
+			framework.Logf("WARNING: Non-zero container restart count: %d across nodes %v", preRestarts, badNodes)
 		}
 		for _, ip := range nodeIPs {
 			restarter := NewRestartConfig(
 				ip, "kubelet", ports.KubeletReadOnlyPort, restartPollInterval, restartTimeout)
 			restarter.restart()
 		}
-		postRestarts, badNodes := getContainerRestarts(framework.Client, ns, labelSelector)
+		postRestarts, badNodes := getContainerRestarts(f.Client, ns, labelSelector)
 		if postRestarts != preRestarts {
-			dumpNodeDebugInfo(framework.Client, badNodes)
-			Failf("Net container restart count went from %v -> %v after kubelet restart on nodes %v \n\n %+v", preRestarts, postRestarts, badNodes, tracker)
+			framework.DumpNodeDebugInfo(f.Client, badNodes)
+			framework.Failf("Net container restart count went from %v -> %v after kubelet restart on nodes %v \n\n %+v", preRestarts, postRestarts, badNodes, tracker)
 		}
 	})
 })

--- a/test/e2e/dashboard.go
+++ b/test/e2e/dashboard.go
@@ -23,12 +23,13 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-var _ = KubeDescribe("Kubernetes Dashboard", func() {
+var _ = framework.KubeDescribe("Kubernetes Dashboard", func() {
 	const (
 		uiServiceName = "kubernetes-dashboard"
 		uiAppName     = uiServiceName
@@ -37,36 +38,36 @@ var _ = KubeDescribe("Kubernetes Dashboard", func() {
 		serverStartTimeout = 1 * time.Minute
 	)
 
-	f := NewDefaultFramework(uiServiceName)
+	f := framework.NewDefaultFramework(uiServiceName)
 
 	It("should check that the kubernetes-dashboard instance is alive", func() {
 		By("Checking whether the kubernetes-dashboard service exists.")
-		err := waitForService(f.Client, uiNamespace, uiServiceName, true, poll, serviceStartTimeout)
+		err := framework.WaitForService(f.Client, uiNamespace, uiServiceName, true, framework.Poll, framework.ServiceStartTimeout)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Checking to make sure the kubernetes-dashboard pods are running")
 		selector := labels.SelectorFromSet(labels.Set(map[string]string{"k8s-app": uiAppName}))
-		err = waitForPodsWithLabelRunning(f.Client, uiNamespace, selector)
+		err = framework.WaitForPodsWithLabelRunning(f.Client, uiNamespace, selector)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Checking to make sure we get a response from the kubernetes-dashboard.")
-		err = wait.Poll(poll, serverStartTimeout, func() (bool, error) {
+		err = wait.Poll(framework.Poll, serverStartTimeout, func() (bool, error) {
 			var status int
-			proxyRequest, errProxy := getServicesProxyRequest(f.Client, f.Client.Get())
+			proxyRequest, errProxy := framework.GetServicesProxyRequest(f.Client, f.Client.Get())
 			if errProxy != nil {
-				Logf("Get services proxy request failed: %v", errProxy)
+				framework.Logf("Get services proxy request failed: %v", errProxy)
 			}
 			// Query against the proxy URL for the kube-ui service.
 			err := proxyRequest.Namespace(uiNamespace).
 				Name(uiServiceName).
-				Timeout(singleCallTimeout).
+				Timeout(framework.SingleCallTimeout).
 				Do().
 				StatusCode(&status).
 				Error()
 			if status != http.StatusOK {
-				Logf("Unexpected status from kubernetes-dashboard: %v", status)
+				framework.Logf("Unexpected status from kubernetes-dashboard: %v", status)
 			} else if err != nil {
-				Logf("Request to kube-ui failed: %v", err)
+				framework.Logf("Request to kube-ui failed: %v", err)
 			}
 			// Don't return err here as it aborts polling.
 			return status == http.StatusOK, nil
@@ -77,7 +78,7 @@ var _ = KubeDescribe("Kubernetes Dashboard", func() {
 		var status int
 		err = f.Client.Get().
 			AbsPath("/ui").
-			Timeout(singleCallTimeout).
+			Timeout(framework.SingleCallTimeout).
 			Do().
 			StatusCode(&status).
 			Error()

--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/intstr"
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/watch"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -46,8 +47,8 @@ const (
 	redisImageName = "redis"
 )
 
-var _ = KubeDescribe("Deployment", func() {
-	f := NewDefaultFramework("deployment")
+var _ = framework.KubeDescribe("Deployment", func() {
+	f := framework.NewDefaultFramework("deployment")
 
 	It("deployment should create new pods", func() {
 		testNewDeployment(f)
@@ -174,25 +175,25 @@ func stopDeployment(c *clientset.Clientset, oldC client.Interface, ns, deploymen
 	deployment, err := c.Extensions().Deployments(ns).Get(deploymentName)
 	Expect(err).NotTo(HaveOccurred())
 
-	Logf("deleting deployment %s", deploymentName)
+	framework.Logf("deleting deployment %s", deploymentName)
 	reaper, err := kubectl.ReaperFor(extensions.Kind("Deployment"), oldC)
 	Expect(err).NotTo(HaveOccurred())
 	timeout := 1 * time.Minute
 	err = reaper.Stop(ns, deployment.Name, timeout, api.NewDeleteOptions(0))
 	Expect(err).NotTo(HaveOccurred())
 
-	Logf("ensuring deployment %s was deleted", deploymentName)
+	framework.Logf("ensuring deployment %s was deleted", deploymentName)
 	_, err = c.Extensions().Deployments(ns).Get(deployment.Name)
 	Expect(err).To(HaveOccurred())
 	Expect(errors.IsNotFound(err)).To(BeTrue())
-	Logf("ensuring deployment %s RSes were deleted", deploymentName)
+	framework.Logf("ensuring deployment %s RSes were deleted", deploymentName)
 	selector, err := unversioned.LabelSelectorAsSelector(deployment.Spec.Selector)
 	Expect(err).NotTo(HaveOccurred())
 	options := api.ListOptions{LabelSelector: selector}
 	rss, err := c.Extensions().ReplicaSets(ns).List(options)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(rss.Items).Should(HaveLen(0))
-	Logf("ensuring deployment %s pods were deleted", deploymentName)
+	framework.Logf("ensuring deployment %s pods were deleted", deploymentName)
 	var pods *api.PodList
 	if err := wait.PollImmediate(time.Second, wait.ForeverTestTimeout, func() (bool, error) {
 		pods, err = c.Core().Pods(ns).List(api.ListOptions{})
@@ -204,11 +205,11 @@ func stopDeployment(c *clientset.Clientset, oldC client.Interface, ns, deploymen
 		}
 		return false, nil
 	}); err != nil {
-		Failf("Err : %s\n. Failed to remove deployment %s pods : %+v", err, deploymentName, pods)
+		framework.Failf("Err : %s\n. Failed to remove deployment %s pods : %+v", err, deploymentName, pods)
 	}
 }
 
-func testNewDeployment(f *Framework) {
+func testNewDeployment(f *framework.Framework) {
 	ns := f.Namespace.Name
 	// TODO: remove unversionedClient when the refactoring is done. Currently some
 	// functions like verifyPod still expects a unversioned#Client.
@@ -217,7 +218,7 @@ func testNewDeployment(f *Framework) {
 	deploymentName := "test-new-deployment"
 	podLabels := map[string]string{"name": nginxImageName}
 	replicas := 1
-	Logf("Creating simple deployment %s", deploymentName)
+	framework.Logf("Creating simple deployment %s", deploymentName)
 	d := newDeployment(deploymentName, replicas, podLabels, nginxImageName, nginxImage, extensions.RollingUpdateDeploymentStrategyType, nil)
 	d.Annotations = map[string]string{"test": "should-copy-to-replica-set", kubectl.LastAppliedConfigAnnotation: "should-not-copy-to-replica-set"}
 	_, err := c.Extensions().Deployments(ns).Create(d)
@@ -225,10 +226,10 @@ func testNewDeployment(f *Framework) {
 	defer stopDeployment(c, f.Client, ns, deploymentName)
 
 	// Wait for it to be updated to revision 1
-	err = waitForDeploymentRevisionAndImage(c, ns, deploymentName, "1", nginxImage)
+	err = framework.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, "1", nginxImage)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = waitForDeploymentStatus(c, ns, deploymentName, replicas, replicas-1, replicas+1, 0)
+	err = framework.WaitForDeploymentStatus(c, ns, deploymentName, replicas, replicas-1, replicas+1, 0)
 	Expect(err).NotTo(HaveOccurred())
 
 	deployment, err := c.Extensions().Deployments(ns).Get(deploymentName)
@@ -242,7 +243,7 @@ func testNewDeployment(f *Framework) {
 	Expect(deployment.Annotations[kubectl.LastAppliedConfigAnnotation]).Should(Equal("should-not-copy-to-replica-set"))
 }
 
-func testRollingUpdateDeployment(f *Framework) {
+func testRollingUpdateDeployment(f *framework.Framework) {
 	ns := f.Namespace.Name
 	// TODO: remove unversionedClient when the refactoring is done. Currently some
 	// functions like verifyPod still expects a unversioned#Client.
@@ -260,24 +261,24 @@ func testRollingUpdateDeployment(f *Framework) {
 	_, err := c.Extensions().ReplicaSets(ns).Create(newRS(rsName, replicas, rsPodLabels, nginxImageName, nginxImage))
 	Expect(err).NotTo(HaveOccurred())
 	// Verify that the required pods have come up.
-	err = verifyPods(unversionedClient, ns, "sample-pod", false, 3)
+	err = framework.VerifyPods(unversionedClient, ns, "sample-pod", false, 3)
 	if err != nil {
-		Logf("error in waiting for pods to come up: %s", err)
+		framework.Logf("error in waiting for pods to come up: %s", err)
 		Expect(err).NotTo(HaveOccurred())
 	}
 
 	// Create a deployment to delete nginx pods and instead bring up redis pods.
 	deploymentName := "test-rolling-update-deployment"
-	Logf("Creating deployment %s", deploymentName)
+	framework.Logf("Creating deployment %s", deploymentName)
 	_, err = c.Extensions().Deployments(ns).Create(newDeployment(deploymentName, replicas, deploymentPodLabels, redisImageName, redisImage, extensions.RollingUpdateDeploymentStrategyType, nil))
 	Expect(err).NotTo(HaveOccurred())
 	defer stopDeployment(c, f.Client, ns, deploymentName)
 
 	// Wait for it to be updated to revision 1
-	err = waitForDeploymentRevisionAndImage(c, ns, deploymentName, "1", redisImage)
+	err = framework.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, "1", redisImage)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = waitForDeploymentStatus(c, ns, deploymentName, replicas, replicas-1, replicas+1, 0)
+	err = framework.WaitForDeploymentStatus(c, ns, deploymentName, replicas, replicas-1, replicas+1, 0)
 	Expect(err).NotTo(HaveOccurred())
 
 	// There should be 1 old RS (nginx-controller, which is adopted)
@@ -292,7 +293,7 @@ func testRollingUpdateDeployment(f *Framework) {
 	Expect(len(allOldRSs[0].Spec.Template.Labels[extensions.DefaultDeploymentUniqueLabelKey])).Should(BeNumerically(">", 0))
 }
 
-func testRollingUpdateDeploymentEvents(f *Framework) {
+func testRollingUpdateDeploymentEvents(f *framework.Framework) {
 	ns := f.Namespace.Name
 	// TODO: remove unversionedClient when the refactoring is done. Currently some
 	// functions like verifyPod still expects a unversioned#Client.
@@ -316,32 +317,32 @@ func testRollingUpdateDeploymentEvents(f *Framework) {
 	_, err := c.Extensions().ReplicaSets(ns).Create(rs)
 	Expect(err).NotTo(HaveOccurred())
 	// Verify that the required pods have come up.
-	err = verifyPods(unversionedClient, ns, "sample-pod-2", false, 1)
+	err = framework.VerifyPods(unversionedClient, ns, "sample-pod-2", false, 1)
 	if err != nil {
-		Logf("error in waiting for pods to come up: %s", err)
+		framework.Logf("error in waiting for pods to come up: %s", err)
 		Expect(err).NotTo(HaveOccurred())
 	}
 
 	// Create a deployment to delete nginx pods and instead bring up redis pods.
 	deploymentName := "test-rolling-scale-deployment"
-	Logf("Creating deployment %s", deploymentName)
+	framework.Logf("Creating deployment %s", deploymentName)
 	_, err = c.Extensions().Deployments(ns).Create(newDeployment(deploymentName, replicas, deploymentPodLabels, redisImageName, redisImage, extensions.RollingUpdateDeploymentStrategyType, nil))
 	Expect(err).NotTo(HaveOccurred())
 	defer stopDeployment(c, f.Client, ns, deploymentName)
 
 	// Wait for it to be updated to revision 3546343826724305833
-	err = waitForDeploymentRevisionAndImage(c, ns, deploymentName, "3546343826724305833", redisImage)
+	err = framework.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, "3546343826724305833", redisImage)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = waitForDeploymentStatus(c, ns, deploymentName, replicas, replicas-1, replicas+1, 0)
+	err = framework.WaitForDeploymentStatus(c, ns, deploymentName, replicas, replicas-1, replicas+1, 0)
 	Expect(err).NotTo(HaveOccurred())
 	// Verify that the pods were scaled up and down as expected. We use events to verify that.
 	deployment, err := c.Extensions().Deployments(ns).Get(deploymentName)
 	Expect(err).NotTo(HaveOccurred())
-	waitForEvents(unversionedClient, ns, deployment, 2)
+	framework.WaitForEvents(unversionedClient, ns, deployment, 2)
 	events, err := c.Core().Events(ns).Search(deployment)
 	if err != nil {
-		Logf("error in listing events: %s", err)
+		framework.Logf("error in listing events: %s", err)
 		Expect(err).NotTo(HaveOccurred())
 	}
 	// There should be 2 events, one to scale up the new ReplicaSet and then to scale down
@@ -354,7 +355,7 @@ func testRollingUpdateDeploymentEvents(f *Framework) {
 	Expect(events.Items[1].Message).Should(Equal(fmt.Sprintf("Scaled down replica set %s to 0", rsName)))
 }
 
-func testRecreateDeployment(f *Framework) {
+func testRecreateDeployment(f *framework.Framework) {
 	ns := f.Namespace.Name
 	// TODO: remove unversionedClient when the refactoring is done. Currently some
 	// functions like verifyPod still expects a unversioned#Client.
@@ -372,33 +373,33 @@ func testRecreateDeployment(f *Framework) {
 	_, err := c.Extensions().ReplicaSets(ns).Create(newRS(rsName, replicas, rsPodLabels, nginxImageName, nginxImage))
 	Expect(err).NotTo(HaveOccurred())
 	// Verify that the required pods have come up.
-	err = verifyPods(unversionedClient, ns, "sample-pod-3", false, 3)
+	err = framework.VerifyPods(unversionedClient, ns, "sample-pod-3", false, 3)
 	if err != nil {
-		Logf("error in waiting for pods to come up: %s", err)
+		framework.Logf("error in waiting for pods to come up: %s", err)
 		Expect(err).NotTo(HaveOccurred())
 	}
 
 	// Create a deployment to delete nginx pods and instead bring up redis pods.
 	deploymentName := "test-recreate-deployment"
-	Logf("Creating deployment %s", deploymentName)
+	framework.Logf("Creating deployment %s", deploymentName)
 	_, err = c.Extensions().Deployments(ns).Create(newDeployment(deploymentName, replicas, deploymentPodLabels, redisImageName, redisImage, extensions.RecreateDeploymentStrategyType, nil))
 	Expect(err).NotTo(HaveOccurred())
 	defer stopDeployment(c, f.Client, ns, deploymentName)
 
 	// Wait for it to be updated to revision 1
-	err = waitForDeploymentRevisionAndImage(c, ns, deploymentName, "1", redisImage)
+	err = framework.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, "1", redisImage)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = waitForDeploymentStatus(c, ns, deploymentName, replicas, 0, replicas, 0)
+	err = framework.WaitForDeploymentStatus(c, ns, deploymentName, replicas, 0, replicas, 0)
 	Expect(err).NotTo(HaveOccurred())
 
 	// Verify that the pods were scaled up and down as expected. We use events to verify that.
 	deployment, err := c.Extensions().Deployments(ns).Get(deploymentName)
 	Expect(err).NotTo(HaveOccurred())
-	waitForEvents(unversionedClient, ns, deployment, 2)
+	framework.WaitForEvents(unversionedClient, ns, deployment, 2)
 	events, err := c.Core().Events(ns).Search(deployment)
 	if err != nil {
-		Logf("error in listing events: %s", err)
+		framework.Logf("error in listing events: %s", err)
 		Expect(err).NotTo(HaveOccurred())
 	}
 	// There should be 2 events, one to scale up the new ReplicaSet and then to scale down the old ReplicaSet.
@@ -411,7 +412,7 @@ func testRecreateDeployment(f *Framework) {
 }
 
 // testDeploymentCleanUpPolicy tests that deployment supports cleanup policy
-func testDeploymentCleanUpPolicy(f *Framework) {
+func testDeploymentCleanUpPolicy(f *framework.Framework) {
 	ns := f.Namespace.Name
 	unversionedClient := f.Client
 	c := adapter.FromUnversionedClient(unversionedClient)
@@ -428,15 +429,15 @@ func testDeploymentCleanUpPolicy(f *Framework) {
 	Expect(err).NotTo(HaveOccurred())
 
 	// Verify that the required pods have come up.
-	err = verifyPods(unversionedClient, ns, "cleanup-pod", false, 1)
+	err = framework.VerifyPods(unversionedClient, ns, "cleanup-pod", false, 1)
 	if err != nil {
-		Logf("error in waiting for pods to come up: %s", err)
+		framework.Logf("error in waiting for pods to come up: %s", err)
 		Expect(err).NotTo(HaveOccurred())
 	}
 
 	// Create a deployment to delete nginx pods and instead bring up redis pods.
 	deploymentName := "test-cleanup-deployment"
-	Logf("Creating deployment %s", deploymentName)
+	framework.Logf("Creating deployment %s", deploymentName)
 
 	pods, err := c.Pods(ns).List(api.ListOptions{LabelSelector: labels.Everything()})
 	if err != nil {
@@ -459,14 +460,14 @@ func testDeploymentCleanUpPolicy(f *Framework) {
 				}
 				numPodCreation--
 				if numPodCreation < 0 {
-					Failf("Expect only one pod creation, the second creation event: %#v\n", event)
+					framework.Failf("Expect only one pod creation, the second creation event: %#v\n", event)
 				}
 				pod, ok := event.Object.(*api.Pod)
 				if !ok {
 					Fail("Expect event Object to be a pod")
 				}
 				if pod.Spec.Containers[0].Name != redisImageName {
-					Failf("Expect the created pod to have container name %s, got pod %#v\n", redisImageName, pod)
+					framework.Failf("Expect the created pod to have container name %s, got pod %#v\n", redisImageName, pod)
 				}
 			case <-stopCh:
 				return
@@ -477,14 +478,14 @@ func testDeploymentCleanUpPolicy(f *Framework) {
 	Expect(err).NotTo(HaveOccurred())
 	defer stopDeployment(c, f.Client, ns, deploymentName)
 
-	err = waitForDeploymentOldRSsNum(c, ns, deploymentName, *revisionHistoryLimit)
+	err = framework.WaitForDeploymentOldRSsNum(c, ns, deploymentName, *revisionHistoryLimit)
 	Expect(err).NotTo(HaveOccurred())
 	close(stopCh)
 }
 
 // testRolloverDeployment tests that deployment supports rollover.
 // i.e. we can change desired state and kick off rolling update, then change desired state again before it finishes.
-func testRolloverDeployment(f *Framework) {
+func testRolloverDeployment(f *framework.Framework) {
 	ns := f.Namespace.Name
 	// TODO: remove unversionedClient when the refactoring is done. Currently some
 	// functions like verifyPod still expects a unversioned#Client.
@@ -502,14 +503,14 @@ func testRolloverDeployment(f *Framework) {
 	_, err := c.Extensions().ReplicaSets(ns).Create(newRS(rsName, rsReplicas, rsPodLabels, nginxImageName, nginxImage))
 	Expect(err).NotTo(HaveOccurred())
 	// Verify that the required pods have come up.
-	err = verifyPods(unversionedClient, ns, podName, false, rsReplicas)
+	err = framework.VerifyPods(unversionedClient, ns, podName, false, rsReplicas)
 	if err != nil {
-		Logf("error in waiting for pods to come up: %s", err)
+		framework.Logf("error in waiting for pods to come up: %s", err)
 		Expect(err).NotTo(HaveOccurred())
 	}
 	// Wait for the required pods to be ready for at least minReadySeconds (be available)
 	deploymentMinReadySeconds := 5
-	err = waitForPodsReady(c, ns, podName, deploymentMinReadySeconds)
+	err = framework.WaitForPodsReady(c, ns, podName, deploymentMinReadySeconds)
 	Expect(err).NotTo(HaveOccurred())
 
 	// Create a deployment to delete nginx pods and instead bring up redis-slave pods.
@@ -517,7 +518,7 @@ func testRolloverDeployment(f *Framework) {
 	deploymentReplicas := 4
 	deploymentImage := "gcr.io/google_samples/gb-redisslave:v1"
 	deploymentStrategyType := extensions.RollingUpdateDeploymentStrategyType
-	Logf("Creating deployment %s", deploymentName)
+	framework.Logf("Creating deployment %s", deploymentName)
 	newDeployment := newDeployment(deploymentName, deploymentReplicas, deploymentPodLabels, deploymentImageName, deploymentImage, deploymentStrategyType, nil)
 	newDeployment.Spec.MinReadySeconds = deploymentMinReadySeconds
 	newDeployment.Spec.Strategy.RollingUpdate = &extensions.RollingUpdateDeployment{
@@ -532,7 +533,7 @@ func testRolloverDeployment(f *Framework) {
 	deployment, err := c.Extensions().Deployments(ns).Get(deploymentName)
 	Expect(err).NotTo(HaveOccurred())
 	// Make sure the deployment starts to scale up and down replica sets
-	waitForPartialEvents(unversionedClient, ns, deployment, 2)
+	framework.WaitForPartialEvents(unversionedClient, ns, deployment, 2)
 	// Check if it's updated to revision 1 correctly
 	_, newRS := checkDeploymentRevision(c, ns, deploymentName, "1", deploymentImageName, deploymentImage)
 
@@ -540,25 +541,25 @@ func testRolloverDeployment(f *Framework) {
 	// If the deployment already finished here, the test would fail. When this happens, increase its minReadySeconds or replicas to prevent it.
 	Expect(newRS.Spec.Replicas).Should(BeNumerically("<", deploymentReplicas))
 	updatedDeploymentImageName, updatedDeploymentImage := redisImageName, redisImage
-	deployment, err = updateDeploymentWithRetries(c, ns, newDeployment.Name, func(update *extensions.Deployment) {
+	deployment, err = framework.UpdateDeploymentWithRetries(c, ns, newDeployment.Name, func(update *extensions.Deployment) {
 		update.Spec.Template.Spec.Containers[0].Name = updatedDeploymentImageName
 		update.Spec.Template.Spec.Containers[0].Image = updatedDeploymentImage
 	})
 	Expect(err).NotTo(HaveOccurred())
 
 	// Use observedGeneration to determine if the controller noticed the pod template update.
-	err = waitForObservedDeployment(c, ns, deploymentName, deployment.Generation)
+	err = framework.WaitForObservedDeployment(c, ns, deploymentName, deployment.Generation)
 	Expect(err).NotTo(HaveOccurred())
 
 	// Wait for it to be updated to revision 2
-	err = waitForDeploymentRevisionAndImage(c, ns, deploymentName, "2", updatedDeploymentImage)
+	err = framework.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, "2", updatedDeploymentImage)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = waitForDeploymentStatus(c, ns, deploymentName, deploymentReplicas, deploymentReplicas-1, deploymentReplicas+1, deploymentMinReadySeconds)
+	err = framework.WaitForDeploymentStatus(c, ns, deploymentName, deploymentReplicas, deploymentReplicas-1, deploymentReplicas+1, deploymentMinReadySeconds)
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func testPausedDeployment(f *Framework) {
+func testPausedDeployment(f *framework.Framework) {
 	ns := f.Namespace.Name
 	// TODO: remove unversionedClient when the refactoring is done. Currently some
 	// functions like verifyPod still expects a unversioned#Client.
@@ -568,7 +569,7 @@ func testPausedDeployment(f *Framework) {
 	podLabels := map[string]string{"name": nginxImageName}
 	d := newDeployment(deploymentName, 1, podLabels, nginxImageName, nginxImage, extensions.RollingUpdateDeploymentStrategyType, nil)
 	d.Spec.Paused = true
-	Logf("Creating paused deployment %s", deploymentName)
+	framework.Logf("Creating paused deployment %s", deploymentName)
 	_, err := c.Extensions().Deployments(ns).Create(d)
 	Expect(err).NotTo(HaveOccurred())
 	defer stopDeployment(c, f.Client, ns, deploymentName)
@@ -585,13 +586,13 @@ func testPausedDeployment(f *Framework) {
 	}
 
 	// Update the deployment to run
-	deployment, err = updateDeploymentWithRetries(c, ns, d.Name, func(update *extensions.Deployment) {
+	deployment, err = framework.UpdateDeploymentWithRetries(c, ns, d.Name, func(update *extensions.Deployment) {
 		update.Spec.Paused = false
 	})
 	Expect(err).NotTo(HaveOccurred())
 
 	// Use observedGeneration to determine if the controller noticed the resume.
-	err = waitForObservedDeployment(c, ns, deploymentName, deployment.Generation)
+	err = framework.WaitForObservedDeployment(c, ns, deploymentName, deployment.Generation)
 	Expect(err).NotTo(HaveOccurred())
 
 	selector, err := unversioned.LabelSelectorAsSelector(deployment.Spec.Selector)
@@ -612,18 +613,18 @@ func testPausedDeployment(f *Framework) {
 
 	// Pause the deployment and delete the replica set.
 	// The paused deployment shouldn't recreate a new one.
-	deployment, err = updateDeploymentWithRetries(c, ns, d.Name, func(update *extensions.Deployment) {
+	deployment, err = framework.UpdateDeploymentWithRetries(c, ns, d.Name, func(update *extensions.Deployment) {
 		update.Spec.Paused = true
 	})
 	Expect(err).NotTo(HaveOccurred())
 
 	// Use observedGeneration to determine if the controller noticed the pause.
-	err = waitForObservedDeployment(c, ns, deploymentName, deployment.Generation)
+	err = framework.WaitForObservedDeployment(c, ns, deploymentName, deployment.Generation)
 	Expect(err).NotTo(HaveOccurred())
 
 	newRS, err := deploymentutil.GetNewReplicaSet(deployment, c)
 	Expect(err).NotTo(HaveOccurred())
-	Expect(DeleteReplicaSet(unversionedClient, ns, newRS.Name)).NotTo(HaveOccurred())
+	Expect(framework.DeleteReplicaSet(unversionedClient, ns, newRS.Name)).NotTo(HaveOccurred())
 
 	deployment, err = c.Extensions().Deployments(ns).Get(deploymentName)
 	Expect(err).NotTo(HaveOccurred())
@@ -643,7 +644,7 @@ func testPausedDeployment(f *Framework) {
 // testRollbackDeployment tests that a deployment is created (revision 1) and updated (revision 2), and
 // then rollback to revision 1 (should update template to revision 1, and then update revision 1 to 3),
 // and then rollback to last revision.
-func testRollbackDeployment(f *Framework) {
+func testRollbackDeployment(f *framework.Framework) {
 	ns := f.Namespace.Name
 	unversionedClient := f.Client
 	c := adapter.FromUnversionedClient(unversionedClient)
@@ -655,7 +656,7 @@ func testRollbackDeployment(f *Framework) {
 	deploymentReplicas := 1
 	deploymentImage := nginxImage
 	deploymentStrategyType := extensions.RollingUpdateDeploymentStrategyType
-	Logf("Creating deployment %s", deploymentName)
+	framework.Logf("Creating deployment %s", deploymentName)
 	d := newDeployment(deploymentName, deploymentReplicas, deploymentPodLabels, deploymentImageName, deploymentImage, deploymentStrategyType, nil)
 	createAnnotation := map[string]string{"action": "create", "author": "minion"}
 	d.Annotations = createAnnotation
@@ -664,21 +665,21 @@ func testRollbackDeployment(f *Framework) {
 	defer stopDeployment(c, f.Client, ns, deploymentName)
 
 	// Wait for it to be updated to revision 1
-	err = waitForDeploymentRevisionAndImage(c, ns, deploymentName, "1", deploymentImage)
+	err = framework.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, "1", deploymentImage)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = waitForDeploymentStatus(c, ns, deploymentName, deploymentReplicas, deploymentReplicas-1, deploymentReplicas+1, 0)
+	err = framework.WaitForDeploymentStatus(c, ns, deploymentName, deploymentReplicas, deploymentReplicas-1, deploymentReplicas+1, 0)
 	Expect(err).NotTo(HaveOccurred())
 
 	// Current newRS annotation should be "create"
-	err = checkNewRSAnnotations(c, ns, deploymentName, createAnnotation)
+	err = framework.CheckNewRSAnnotations(c, ns, deploymentName, createAnnotation)
 	Expect(err).NotTo(HaveOccurred())
 
 	// 2. Update the deployment to create redis pods.
 	updatedDeploymentImage := redisImage
 	updatedDeploymentImageName := redisImageName
 	updateAnnotation := map[string]string{"action": "update", "log": "I need to update it"}
-	deployment, err := updateDeploymentWithRetries(c, ns, d.Name, func(update *extensions.Deployment) {
+	deployment, err := framework.UpdateDeploymentWithRetries(c, ns, d.Name, func(update *extensions.Deployment) {
 		update.Spec.Template.Spec.Containers[0].Name = updatedDeploymentImageName
 		update.Spec.Template.Spec.Containers[0].Image = updatedDeploymentImage
 		update.Annotations = updateAnnotation
@@ -686,62 +687,62 @@ func testRollbackDeployment(f *Framework) {
 	Expect(err).NotTo(HaveOccurred())
 
 	// Use observedGeneration to determine if the controller noticed the pod template update.
-	err = waitForObservedDeployment(c, ns, deploymentName, deployment.Generation)
+	err = framework.WaitForObservedDeployment(c, ns, deploymentName, deployment.Generation)
 	Expect(err).NotTo(HaveOccurred())
 
 	// Wait for it to be updated to revision 2
-	err = waitForDeploymentRevisionAndImage(c, ns, deploymentName, "2", updatedDeploymentImage)
+	err = framework.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, "2", updatedDeploymentImage)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = waitForDeploymentStatus(c, ns, deploymentName, deploymentReplicas, deploymentReplicas-1, deploymentReplicas+1, 0)
+	err = framework.WaitForDeploymentStatus(c, ns, deploymentName, deploymentReplicas, deploymentReplicas-1, deploymentReplicas+1, 0)
 	Expect(err).NotTo(HaveOccurred())
 
 	// Current newRS annotation should be "update"
-	err = checkNewRSAnnotations(c, ns, deploymentName, updateAnnotation)
+	err = framework.CheckNewRSAnnotations(c, ns, deploymentName, updateAnnotation)
 	Expect(err).NotTo(HaveOccurred())
 
 	// 3. Update the deploymentRollback to rollback to revision 1
 	revision := int64(1)
-	Logf("rolling back deployment %s to revision %d", deploymentName, revision)
+	framework.Logf("rolling back deployment %s to revision %d", deploymentName, revision)
 	rollback := newDeploymentRollback(deploymentName, nil, revision)
 	err = c.Extensions().Deployments(ns).Rollback(rollback)
 	Expect(err).NotTo(HaveOccurred())
 
 	// Wait for the deployment to start rolling back
-	err = waitForDeploymentRollbackCleared(c, ns, deploymentName)
+	err = framework.WaitForDeploymentRollbackCleared(c, ns, deploymentName)
 	Expect(err).NotTo(HaveOccurred())
 	// TODO: report RollbackDone in deployment status and check it here
 
 	// Wait for it to be updated to revision 3
-	err = waitForDeploymentRevisionAndImage(c, ns, deploymentName, "3", deploymentImage)
+	err = framework.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, "3", deploymentImage)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = waitForDeploymentStatus(c, ns, deploymentName, deploymentReplicas, deploymentReplicas-1, deploymentReplicas+1, 0)
+	err = framework.WaitForDeploymentStatus(c, ns, deploymentName, deploymentReplicas, deploymentReplicas-1, deploymentReplicas+1, 0)
 	Expect(err).NotTo(HaveOccurred())
 
 	// Current newRS annotation should be "create", after the rollback
-	err = checkNewRSAnnotations(c, ns, deploymentName, createAnnotation)
+	err = framework.CheckNewRSAnnotations(c, ns, deploymentName, createAnnotation)
 	Expect(err).NotTo(HaveOccurred())
 
 	// 4. Update the deploymentRollback to rollback to last revision
 	revision = 0
-	Logf("rolling back deployment %s to last revision", deploymentName)
+	framework.Logf("rolling back deployment %s to last revision", deploymentName)
 	rollback = newDeploymentRollback(deploymentName, nil, revision)
 	err = c.Extensions().Deployments(ns).Rollback(rollback)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = waitForDeploymentRollbackCleared(c, ns, deploymentName)
+	err = framework.WaitForDeploymentRollbackCleared(c, ns, deploymentName)
 	Expect(err).NotTo(HaveOccurred())
 
 	// Wait for it to be updated to revision 4
-	err = waitForDeploymentRevisionAndImage(c, ns, deploymentName, "4", updatedDeploymentImage)
+	err = framework.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, "4", updatedDeploymentImage)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = waitForDeploymentStatus(c, ns, deploymentName, deploymentReplicas, deploymentReplicas-1, deploymentReplicas+1, 0)
+	err = framework.WaitForDeploymentStatus(c, ns, deploymentName, deploymentReplicas, deploymentReplicas-1, deploymentReplicas+1, 0)
 	Expect(err).NotTo(HaveOccurred())
 
 	// Current newRS annotation should be "update", after the rollback
-	err = checkNewRSAnnotations(c, ns, deploymentName, updateAnnotation)
+	err = framework.CheckNewRSAnnotations(c, ns, deploymentName, updateAnnotation)
 	Expect(err).NotTo(HaveOccurred())
 }
 
@@ -752,7 +753,7 @@ func testRollbackDeployment(f *Framework) {
 // becomes v3. Then rollback the deployment to v10 (doesn't exist in history) should fail.
 // Finally, rollback the deployment (v3) to v3 should be no-op.
 // TODO: When we finished reporting rollback status in deployment status, check the rollback status here in each case.
-func testRollbackDeploymentRSNoRevision(f *Framework) {
+func testRollbackDeploymentRSNoRevision(f *framework.Framework) {
 	ns := f.Namespace.Name
 	c := adapter.FromUnversionedClient(f.Client)
 	podName := "nginx"
@@ -776,17 +777,17 @@ func testRollbackDeploymentRSNoRevision(f *Framework) {
 	deploymentReplicas := 1
 	deploymentImage := nginxImage
 	deploymentStrategyType := extensions.RollingUpdateDeploymentStrategyType
-	Logf("Creating deployment %s", deploymentName)
+	framework.Logf("Creating deployment %s", deploymentName)
 	d := newDeployment(deploymentName, deploymentReplicas, deploymentPodLabels, deploymentImageName, deploymentImage, deploymentStrategyType, nil)
 	_, err = c.Extensions().Deployments(ns).Create(d)
 	Expect(err).NotTo(HaveOccurred())
 	defer stopDeployment(c, f.Client, ns, deploymentName)
 
 	// Wait for it to be updated to revision 1
-	err = waitForDeploymentRevisionAndImage(c, ns, deploymentName, "1", deploymentImage)
+	err = framework.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, "1", deploymentImage)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = waitForDeploymentStatus(c, ns, deploymentName, deploymentReplicas, deploymentReplicas-1, deploymentReplicas+1, 0)
+	err = framework.WaitForDeploymentStatus(c, ns, deploymentName, deploymentReplicas, deploymentReplicas-1, deploymentReplicas+1, 0)
 	Expect(err).NotTo(HaveOccurred())
 
 	// Check that the replica set we created still doesn't contain revision information
@@ -797,13 +798,13 @@ func testRollbackDeploymentRSNoRevision(f *Framework) {
 	// 2. Update the deploymentRollback to rollback to last revision
 	//    Since there's only 1 revision in history, it should stay as revision 1
 	revision := int64(0)
-	Logf("rolling back deployment %s to last revision", deploymentName)
+	framework.Logf("rolling back deployment %s to last revision", deploymentName)
 	rollback := newDeploymentRollback(deploymentName, nil, revision)
 	err = c.Extensions().Deployments(ns).Rollback(rollback)
 	Expect(err).NotTo(HaveOccurred())
 
 	// Wait for the deployment to start rolling back
-	err = waitForDeploymentRollbackCleared(c, ns, deploymentName)
+	err = framework.WaitForDeploymentRollbackCleared(c, ns, deploymentName)
 	Expect(err).NotTo(HaveOccurred())
 	// TODO: report RollbackRevisionNotFound in deployment status and check it here
 
@@ -814,53 +815,53 @@ func testRollbackDeploymentRSNoRevision(f *Framework) {
 	// 3. Update the deployment to create redis pods.
 	updatedDeploymentImage := redisImage
 	updatedDeploymentImageName := redisImageName
-	deployment, err := updateDeploymentWithRetries(c, ns, d.Name, func(update *extensions.Deployment) {
+	deployment, err := framework.UpdateDeploymentWithRetries(c, ns, d.Name, func(update *extensions.Deployment) {
 		update.Spec.Template.Spec.Containers[0].Name = updatedDeploymentImageName
 		update.Spec.Template.Spec.Containers[0].Image = updatedDeploymentImage
 	})
 	Expect(err).NotTo(HaveOccurred())
 
 	// Use observedGeneration to determine if the controller noticed the pod template update.
-	err = waitForObservedDeployment(c, ns, deploymentName, deployment.Generation)
+	err = framework.WaitForObservedDeployment(c, ns, deploymentName, deployment.Generation)
 	Expect(err).NotTo(HaveOccurred())
 
 	// Wait for it to be updated to revision 2
-	err = waitForDeploymentRevisionAndImage(c, ns, deploymentName, "2", updatedDeploymentImage)
+	err = framework.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, "2", updatedDeploymentImage)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = waitForDeploymentStatus(c, ns, deploymentName, deploymentReplicas, deploymentReplicas-1, deploymentReplicas+1, 0)
+	err = framework.WaitForDeploymentStatus(c, ns, deploymentName, deploymentReplicas, deploymentReplicas-1, deploymentReplicas+1, 0)
 	Expect(err).NotTo(HaveOccurred())
 
 	// 4. Update the deploymentRollback to rollback to revision 1
 	revision = 1
-	Logf("rolling back deployment %s to revision %d", deploymentName, revision)
+	framework.Logf("rolling back deployment %s to revision %d", deploymentName, revision)
 	rollback = newDeploymentRollback(deploymentName, nil, revision)
 	err = c.Extensions().Deployments(ns).Rollback(rollback)
 	Expect(err).NotTo(HaveOccurred())
 
 	// Wait for the deployment to start rolling back
-	err = waitForDeploymentRollbackCleared(c, ns, deploymentName)
+	err = framework.WaitForDeploymentRollbackCleared(c, ns, deploymentName)
 	Expect(err).NotTo(HaveOccurred())
 	// TODO: report RollbackDone in deployment status and check it here
 
 	// The pod template should be updated to the one in revision 1
 	// Wait for it to be updated to revision 3
-	err = waitForDeploymentRevisionAndImage(c, ns, deploymentName, "3", deploymentImage)
+	err = framework.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, "3", deploymentImage)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = waitForDeploymentStatus(c, ns, deploymentName, deploymentReplicas, deploymentReplicas-1, deploymentReplicas+1, 0)
+	err = framework.WaitForDeploymentStatus(c, ns, deploymentName, deploymentReplicas, deploymentReplicas-1, deploymentReplicas+1, 0)
 	Expect(err).NotTo(HaveOccurred())
 
 	// 5. Update the deploymentRollback to rollback to revision 10
 	//    Since there's no revision 10 in history, it should stay as revision 3
 	revision = 10
-	Logf("rolling back deployment %s to revision %d", deploymentName, revision)
+	framework.Logf("rolling back deployment %s to revision %d", deploymentName, revision)
 	rollback = newDeploymentRollback(deploymentName, nil, revision)
 	err = c.Extensions().Deployments(ns).Rollback(rollback)
 	Expect(err).NotTo(HaveOccurred())
 
 	// Wait for the deployment to start rolling back
-	err = waitForDeploymentRollbackCleared(c, ns, deploymentName)
+	err = framework.WaitForDeploymentRollbackCleared(c, ns, deploymentName)
 	Expect(err).NotTo(HaveOccurred())
 	// TODO: report RollbackRevisionNotFound in deployment status and check it here
 
@@ -871,13 +872,13 @@ func testRollbackDeploymentRSNoRevision(f *Framework) {
 	// 6. Update the deploymentRollback to rollback to revision 3
 	//    Since it's already revision 3, it should be no-op
 	revision = 3
-	Logf("rolling back deployment %s to revision %d", deploymentName, revision)
+	framework.Logf("rolling back deployment %s to revision %d", deploymentName, revision)
 	rollback = newDeploymentRollback(deploymentName, nil, revision)
 	err = c.Extensions().Deployments(ns).Rollback(rollback)
 	Expect(err).NotTo(HaveOccurred())
 
 	// Wait for the deployment to start rolling back
-	err = waitForDeploymentRollbackCleared(c, ns, deploymentName)
+	err = framework.WaitForDeploymentRollbackCleared(c, ns, deploymentName)
 	Expect(err).NotTo(HaveOccurred())
 	// TODO: report RollbackTemplateUnchanged in deployment status and check it here
 
@@ -886,7 +887,7 @@ func testRollbackDeploymentRSNoRevision(f *Framework) {
 	checkDeploymentRevision(c, ns, deploymentName, "3", deploymentImageName, deploymentImage)
 }
 
-func testDeploymentLabelAdopted(f *Framework) {
+func testDeploymentLabelAdopted(f *framework.Framework) {
 	ns := f.Namespace.Name
 	// TODO: remove unversionedClient when the refactoring is done. Currently some
 	// functions like verifyPod still expects a unversioned#Client.
@@ -902,25 +903,25 @@ func testDeploymentLabelAdopted(f *Framework) {
 	_, err := c.Extensions().ReplicaSets(ns).Create(newRS(rsName, replicas, podLabels, podName, image))
 	Expect(err).NotTo(HaveOccurred())
 	// Verify that the required pods have come up.
-	err = verifyPods(unversionedClient, ns, podName, false, 3)
+	err = framework.VerifyPods(unversionedClient, ns, podName, false, 3)
 	if err != nil {
-		Logf("error in waiting for pods to come up: %s", err)
+		framework.Logf("error in waiting for pods to come up: %s", err)
 		Expect(err).NotTo(HaveOccurred())
 	}
 
 	// Create a nginx deployment to adopt the old rs.
 	deploymentName := "test-adopted-deployment"
-	Logf("Creating deployment %s", deploymentName)
+	framework.Logf("Creating deployment %s", deploymentName)
 	_, err = c.Extensions().Deployments(ns).Create(newDeployment(deploymentName, replicas, podLabels, podName, image, extensions.RollingUpdateDeploymentStrategyType, nil))
 	Expect(err).NotTo(HaveOccurred())
 	defer stopDeployment(c, f.Client, ns, deploymentName)
 
 	// Wait for it to be updated to revision 1
-	err = waitForDeploymentRevisionAndImage(c, ns, deploymentName, "1", image)
+	err = framework.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, "1", image)
 	Expect(err).NotTo(HaveOccurred())
 
 	// The RS and pods should be relabeled before the status is updated by syncRollingUpdateDeployment
-	err = waitForDeploymentStatus(c, ns, deploymentName, replicas, replicas-1, replicas+1, 0)
+	err = framework.WaitForDeploymentStatus(c, ns, deploymentName, replicas, replicas-1, replicas+1, 0)
 	Expect(err).NotTo(HaveOccurred())
 
 	// There should be no old RSs (overlapping RS)
@@ -933,7 +934,7 @@ func testDeploymentLabelAdopted(f *Framework) {
 	// New RS should contain pod-template-hash in its selector, label, and template label
 	newRS, err := deploymentutil.GetNewReplicaSet(deployment, c)
 	Expect(err).NotTo(HaveOccurred())
-	err = checkRSHashLabel(newRS)
+	err = framework.CheckRSHashLabel(newRS)
 	Expect(err).NotTo(HaveOccurred())
 	// All pods targeted by the deployment should contain pod-template-hash in their labels, and there should be only 3 pods
 	selector, err := unversioned.LabelSelectorAsSelector(deployment.Spec.Selector)
@@ -941,7 +942,7 @@ func testDeploymentLabelAdopted(f *Framework) {
 	options := api.ListOptions{LabelSelector: selector}
 	pods, err := c.Core().Pods(ns).List(options)
 	Expect(err).NotTo(HaveOccurred())
-	err = checkPodHashLabel(pods)
+	err = framework.CheckPodHashLabel(pods)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(len(pods.Items)).Should(Equal(replicas))
 }

--- a/test/e2e/docker_containers.go
+++ b/test/e2e/docker_containers.go
@@ -20,22 +20,23 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 )
 
-var _ = KubeDescribe("Docker Containers", func() {
-	framework := NewDefaultFramework("containers")
+var _ = framework.KubeDescribe("Docker Containers", func() {
+	f := framework.NewDefaultFramework("containers")
 	var c *client.Client
 	var ns string
 
 	BeforeEach(func() {
-		c = framework.Client
-		ns = framework.Namespace.Name
+		c = f.Client
+		ns = f.Namespace.Name
 	})
 
 	It("should use the image defaults if command and args are blank [Conformance]", func() {
-		testContainerOutput("use defaults", c, entrypointTestPod(), 0, []string{
+		framework.TestContainerOutput("use defaults", c, entrypointTestPod(), 0, []string{
 			"[/ep default arguments]",
 		}, ns)
 	})
@@ -44,7 +45,7 @@ var _ = KubeDescribe("Docker Containers", func() {
 		pod := entrypointTestPod()
 		pod.Spec.Containers[0].Args = []string{"override", "arguments"}
 
-		testContainerOutput("override arguments", c, pod, 0, []string{
+		framework.TestContainerOutput("override arguments", c, pod, 0, []string{
 			"[/ep override arguments]",
 		}, ns)
 	})
@@ -55,7 +56,7 @@ var _ = KubeDescribe("Docker Containers", func() {
 		pod := entrypointTestPod()
 		pod.Spec.Containers[0].Command = []string{"/ep-2"}
 
-		testContainerOutput("override command", c, pod, 0, []string{
+		framework.TestContainerOutput("override command", c, pod, 0, []string{
 			"[/ep-2]",
 		}, ns)
 	})
@@ -65,7 +66,7 @@ var _ = KubeDescribe("Docker Containers", func() {
 		pod.Spec.Containers[0].Command = []string{"/ep-2"}
 		pod.Spec.Containers[0].Args = []string{"override", "arguments"}
 
-		testContainerOutput("override all", c, pod, 0, []string{
+		framework.TestContainerOutput("override all", c, pod, 0, []string{
 			"[/ep-2 override arguments]",
 		}, ns)
 	})

--- a/test/e2e/downward_api.go
+++ b/test/e2e/downward_api.go
@@ -21,12 +21,13 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 )
 
-var _ = KubeDescribe("Downward API", func() {
-	framework := NewDefaultFramework("downward-api")
+var _ = framework.KubeDescribe("Downward API", func() {
+	f := framework.NewDefaultFramework("downward-api")
 
 	It("should provide pod name and namespace as env vars [Conformance]", func() {
 		podName := "downward-api-" + string(util.NewUUID())
@@ -53,10 +54,10 @@ var _ = KubeDescribe("Downward API", func() {
 
 		expectations := []string{
 			fmt.Sprintf("POD_NAME=%v", podName),
-			fmt.Sprintf("POD_NAMESPACE=%v", framework.Namespace.Name),
+			fmt.Sprintf("POD_NAMESPACE=%v", f.Namespace.Name),
 		}
 
-		testDownwardAPI(framework, podName, env, expectations)
+		testDownwardAPI(f, podName, env, expectations)
 	})
 
 	It("should provide pod IP as an env var", func() {
@@ -77,11 +78,11 @@ var _ = KubeDescribe("Downward API", func() {
 			"POD_IP=(?:\\d+)\\.(?:\\d+)\\.(?:\\d+)\\.(?:\\d+)",
 		}
 
-		testDownwardAPI(framework, podName, env, expectations)
+		testDownwardAPI(f, podName, env, expectations)
 	})
 })
 
-func testDownwardAPI(framework *Framework, podName string, env []api.EnvVar, expectations []string) {
+func testDownwardAPI(f *framework.Framework, podName string, env []api.EnvVar, expectations []string) {
 	pod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Name:   podName,
@@ -100,5 +101,5 @@ func testDownwardAPI(framework *Framework, podName string, env []api.EnvVar, exp
 		},
 	}
 
-	framework.TestContainerOutputRegexp("downward api env vars", pod, 0, expectations)
+	f.TestContainerOutputRegexp("downward api env vars", pod, 0, expectations)
 }

--- a/test/e2e/downwardapi_volume.go
+++ b/test/e2e/downwardapi_volume.go
@@ -22,21 +22,22 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-var _ = KubeDescribe("Downward API volume", func() {
+var _ = framework.KubeDescribe("Downward API volume", func() {
 	// How long to wait for a log pod to be displayed
 	const podLogTimeout = 45 * time.Second
 
-	f := NewDefaultFramework("downward-api")
+	f := framework.NewDefaultFramework("downward-api")
 	It("should provide podname only [Conformance]", func() {
 		podName := "downwardapi-volume-" + string(util.NewUUID())
 		pod := downwardAPIVolumePodForSimpleTest(podName, "/etc/podname")
 
-		testContainerOutput("downward API volume plugin", f.Client, pod, 0, []string{
+		framework.TestContainerOutput("downward API volume plugin", f.Client, pod, 0, []string{
 			fmt.Sprintf("%s\n", podName),
 		}, f.Namespace.Name)
 	})
@@ -50,7 +51,7 @@ var _ = KubeDescribe("Downward API volume", func() {
 			RunAsUser: &uid,
 			FSGroup:   &gid,
 		}
-		testContainerOutput("downward API volume plugin", f.Client, pod, 0, []string{
+		framework.TestContainerOutput("downward API volume plugin", f.Client, pod, 0, []string{
 			fmt.Sprintf("%s\n", podName),
 		}, f.Namespace.Name)
 	})
@@ -71,15 +72,15 @@ var _ = KubeDescribe("Downward API volume", func() {
 		_, err := f.Client.Pods(f.Namespace.Name).Create(pod)
 		Expect(err).NotTo(HaveOccurred())
 
-		expectNoError(waitForPodRunningInNamespace(f.Client, pod.Name, f.Namespace.Name))
+		framework.ExpectNoError(framework.WaitForPodRunningInNamespace(f.Client, pod.Name, f.Namespace.Name))
 
 		pod, err = f.Client.Pods(f.Namespace.Name).Get(pod.Name)
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() (string, error) {
-			return getPodLogs(f.Client, f.Namespace.Name, pod.Name, containerName)
+			return framework.GetPodLogs(f.Client, f.Namespace.Name, pod.Name, containerName)
 		},
-			podLogTimeout, poll).Should(ContainSubstring("key1=\"value1\"\n"))
+			podLogTimeout, framework.Poll).Should(ContainSubstring("key1=\"value1\"\n"))
 
 		//modify labels
 		pod.Labels["key3"] = "value3"
@@ -88,9 +89,9 @@ var _ = KubeDescribe("Downward API volume", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() (string, error) {
-			return getPodLogs(f.Client, f.Namespace.Name, pod.Name, containerName)
+			return framework.GetPodLogs(f.Client, f.Namespace.Name, pod.Name, containerName)
 		},
-			podLogTimeout, poll).Should(ContainSubstring("key3=\"value3\"\n"))
+			podLogTimeout, framework.Poll).Should(ContainSubstring("key3=\"value3\"\n"))
 
 	})
 
@@ -108,15 +109,15 @@ var _ = KubeDescribe("Downward API volume", func() {
 		By("Creating the pod")
 		_, err := f.Client.Pods(f.Namespace.Name).Create(pod)
 		Expect(err).NotTo(HaveOccurred())
-		expectNoError(waitForPodRunningInNamespace(f.Client, pod.Name, f.Namespace.Name))
+		framework.ExpectNoError(framework.WaitForPodRunningInNamespace(f.Client, pod.Name, f.Namespace.Name))
 
 		pod, err = f.Client.Pods(f.Namespace.Name).Get(pod.Name)
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() (string, error) {
-			return getPodLogs(f.Client, f.Namespace.Name, pod.Name, containerName)
+			return framework.GetPodLogs(f.Client, f.Namespace.Name, pod.Name, containerName)
 		},
-			podLogTimeout, poll).Should(ContainSubstring("builder=\"bar\"\n"))
+			podLogTimeout, framework.Poll).Should(ContainSubstring("builder=\"bar\"\n"))
 
 		//modify annotations
 		pod.Annotations["builder"] = "foo"
@@ -125,9 +126,9 @@ var _ = KubeDescribe("Downward API volume", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() (string, error) {
-			return getPodLogs(f.Client, f.Namespace.Name, pod.Name, containerName)
+			return framework.GetPodLogs(f.Client, f.Namespace.Name, pod.Name, containerName)
 		},
-			podLogTimeout, poll).Should(ContainSubstring("builder=\"foo\"\n"))
+			podLogTimeout, framework.Poll).Should(ContainSubstring("builder=\"foo\"\n"))
 
 	})
 })

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -17,7 +17,6 @@ limitations under the License.
 package e2e
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"path"
@@ -34,7 +33,6 @@ import (
 	"golang.org/x/oauth2/google"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	gcecloud "k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/runtime"
@@ -48,78 +46,32 @@ const (
 )
 
 var (
-	cloudConfig = &testContext.CloudConfig
+	cloudConfig = &framework.TestContext.CloudConfig
 )
 
-func RegisterFlags() {
-	// Turn on verbose by default to get spec names
-	config.DefaultReporterConfig.Verbose = true
-
-	// Turn on EmitSpecProgress to get spec progress (especially on interrupt)
-	config.GinkgoConfig.EmitSpecProgress = true
-
-	// Randomize specs as well as suites
-	config.GinkgoConfig.RandomizeAllSpecs = true
-
-	flag.StringVar(&testContext.KubeConfig, clientcmd.RecommendedConfigPathFlag, os.Getenv(clientcmd.RecommendedConfigPathEnvVar), "Path to kubeconfig containing embedded authinfo.")
-	flag.StringVar(&testContext.KubeContext, clientcmd.FlagContext, "", "kubeconfig context to use/override. If unset, will use value from 'current-context'")
-	flag.StringVar(&testContext.KubeVolumeDir, "volume-dir", "/var/lib/kubelet", "Path to the directory containing the kubelet volumes.")
-	flag.StringVar(&testContext.CertDir, "cert-dir", "", "Path to the directory containing the certs. Default is empty, which doesn't use certs.")
-	flag.StringVar(&testContext.Host, "host", "", "The host, or apiserver, to connect to")
-	flag.StringVar(&testContext.RepoRoot, "repo-root", "../../", "Root directory of kubernetes repository, for finding test files.")
-	flag.StringVar(&testContext.Provider, "provider", "", "The name of the Kubernetes provider (gce, gke, local, vagrant, etc.)")
-	flag.StringVar(&testContext.KubectlPath, "kubectl-path", "kubectl", "The kubectl binary to use. For development, you might use 'cluster/kubectl.sh' here.")
-	flag.StringVar(&testContext.OutputDir, "e2e-output-dir", "/tmp", "Output directory for interesting/useful test data, like performance data, benchmarks, and other metrics.")
-	flag.StringVar(&testContext.ReportDir, "report-dir", "", "Path to the directory where the JUnit XML reports should be saved. Default is empty, which doesn't generate these reports.")
-	flag.StringVar(&testContext.ReportPrefix, "report-prefix", "", "Optional prefix for JUnit XML reports. Default is empty, which doesn't prepend anything to the default name.")
-	flag.StringVar(&testContext.prefix, "prefix", "e2e", "A prefix to be added to cloud resources created during testing.")
-	flag.StringVar(&testContext.OSDistro, "os-distro", "debian", "The OS distribution of cluster VM instances (debian, trusty, or coreos).")
-
-	// TODO: Flags per provider?  Rename gce-project/gce-zone?
-	flag.StringVar(&cloudConfig.MasterName, "kube-master", "", "Name of the kubernetes master. Only required if provider is gce or gke")
-	flag.StringVar(&cloudConfig.ProjectID, "gce-project", "", "The GCE project being used, if applicable")
-	flag.StringVar(&cloudConfig.Zone, "gce-zone", "", "GCE zone being used, if applicable")
-	flag.StringVar(&cloudConfig.ServiceAccount, "gce-service-account", "", "GCE service account to use for GCE API calls, if applicable")
-	flag.StringVar(&cloudConfig.Cluster, "gke-cluster", "", "GKE name of cluster being used, if applicable")
-	flag.StringVar(&cloudConfig.NodeInstanceGroup, "node-instance-group", "", "Name of the managed instance group for nodes. Valid only for gce, gke or aws")
-	flag.IntVar(&cloudConfig.NumNodes, "num-nodes", -1, "Number of nodes in the cluster")
-
-	flag.StringVar(&cloudConfig.ClusterTag, "cluster-tag", "", "Tag used to identify resources.  Only required if provider is aws.")
-	flag.IntVar(&testContext.MinStartupPods, "minStartupPods", 0, "The number of pods which we need to see in 'Running' state with a 'Ready' condition of true, before we try running tests. This is useful in any cluster which needs some base pod-based services running before it can be used.")
-	flag.StringVar(&testContext.UpgradeTarget, "upgrade-target", "ci/latest", "Version to upgrade to (e.g. 'release/stable', 'release/latest', 'ci/latest', '0.19.1', '0.19.1-669-gabac8c8') if doing an upgrade test.")
-	flag.StringVar(&testContext.PrometheusPushGateway, "prom-push-gateway", "", "The URL to prometheus gateway, so that metrics can be pushed during e2es and scraped by prometheus. Typically something like 127.0.0.1:9091.")
-	flag.BoolVar(&testContext.VerifyServiceAccount, "e2e-verify-service-account", true, "If true tests will verify the service account before running.")
-	flag.BoolVar(&testContext.DeleteNamespace, "delete-namespace", true, "If true tests will delete namespace after completion. It is only designed to make debugging easier, DO NOT turn it off by default.")
-	flag.BoolVar(&testContext.CleanStart, "clean-start", false, "If true, purge all namespaces except default and system before running tests. This serves to cleanup test namespaces from failed/interrupted e2e runs in a long-lived cluster.")
-	flag.BoolVar(&testContext.GatherKubeSystemResourceUsageData, "gather-resource-usage", false, "If set to true framework will be monitoring resource usage of system add-ons in (some) e2e tests.")
-	flag.BoolVar(&testContext.GatherLogsSizes, "gather-logs-sizes", false, "If set to true framework will be monitoring logs sizes on all machines running e2e tests.")
-	flag.BoolVar(&testContext.GatherMetricsAfterTest, "gather-metrics-at-teardown", false, "If set to true framwork will gather metrics from all components after each test.")
-	flag.StringVar(&testContext.OutputPrintType, "output-print-type", "hr", "Comma separated list: 'hr' for human readable summaries 'json' for JSON ones.")
-}
-
-// setupProviderConfig validates and sets up cloudConfig based on testContext.Provider.
+// setupProviderConfig validates and sets up cloudConfig based on framework.TestContext.Provider.
 func setupProviderConfig() error {
-	switch testContext.Provider {
+	switch framework.TestContext.Provider {
 	case "":
 		glog.Info("The --provider flag is not set.  Treating as a conformance test.  Some tests may not be run.")
 
 	case "gce", "gke":
 		var err error
-		Logf("Fetching cloud provider for %q\r\n", testContext.Provider)
+		framework.Logf("Fetching cloud provider for %q\r\n", framework.TestContext.Provider)
 		var tokenSource oauth2.TokenSource
 		tokenSource = nil
 		if cloudConfig.ServiceAccount != "" {
 			// Use specified service account for auth
-			Logf("Using service account %q as token source.", cloudConfig.ServiceAccount)
+			framework.Logf("Using service account %q as token source.", cloudConfig.ServiceAccount)
 			tokenSource = google.ComputeTokenSource(cloudConfig.ServiceAccount)
 		}
-		zone := testContext.CloudConfig.Zone
+		zone := framework.TestContext.CloudConfig.Zone
 		region, err := gcecloud.GetGCERegion(zone)
 		if err != nil {
 			return fmt.Errorf("error parsing GCE/GKE region from zone %q: %v", zone, err)
 		}
 		managedZones := []string{zone} // Only single-zone for now
-		cloudConfig.Provider, err = gcecloud.CreateGCECloud(testContext.CloudConfig.ProjectID, region, zone, managedZones, "" /* networkUrl */, tokenSource, false /* useMetadataServer */)
+		cloudConfig.Provider, err = gcecloud.CreateGCECloud(framework.TestContext.CloudConfig.ProjectID, region, zone, managedZones, "" /* networkUrl */, tokenSource, false /* useMetadataServer */)
 		if err != nil {
 			return fmt.Errorf("Error building GCE/GKE provider: %v", err)
 		}
@@ -235,8 +187,8 @@ var _ = ginkgo.SynchronizedAfterSuite(func() {
 	RunCleanupActions()
 }, func() {
 	// Run only Ginkgo on node 1
-	if testContext.ReportDir != "" {
-		CoreDump(testContext.ReportDir)
+	if framework.TestContext.ReportDir != "" {
+		CoreDump(framework.TestContext.ReportDir)
 	}
 })
 
@@ -264,13 +216,13 @@ func RunE2ETests(t *testing.T) {
 
 	// Run tests through the Ginkgo runner with output to console + JUnit for Jenkins
 	var r []ginkgo.Reporter
-	if testContext.ReportDir != "" {
+	if framework.TestContext.ReportDir != "" {
 		// TODO: we should probably only be trying to create this directory once
 		// rather than once-per-Ginkgo-node.
-		if err := os.MkdirAll(testContext.ReportDir, 0755); err != nil {
+		if err := os.MkdirAll(framework.TestContext.ReportDir, 0755); err != nil {
 			glog.Errorf("Failed creating report directory: %v", err)
 		} else {
-			r = append(r, reporters.NewJUnitReporter(path.Join(testContext.ReportDir, fmt.Sprintf("junit_%v%02d.xml", testContext.ReportPrefix, config.GinkgoConfig.ParallelNode))))
+			r = append(r, reporters.NewJUnitReporter(path.Join(framework.TestContext.ReportDir, fmt.Sprintf("junit_%v%02d.xml", framework.TestContext.ReportPrefix, config.GinkgoConfig.ParallelNode))))
 		}
 	}
 	glog.Infof("Starting e2e run %q on Ginkgo node %d", runId, config.GinkgoConfig.ParallelNode)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -18,10 +18,12 @@ package e2e
 
 import (
 	"testing"
+
+	"k8s.io/kubernetes/test/e2e/framework"
 )
 
 func init() {
-	RegisterFlags()
+	framework.RegisterFlags()
 }
 
 func TestE2E(t *testing.T) {

--- a/test/e2e/empty_dir.go
+++ b/test/e2e/empty_dir.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 )
@@ -33,9 +34,9 @@ const (
 	testImageNonRootUid = "gcr.io/google_containers/mounttest-user:0.3"
 )
 
-var _ = KubeDescribe("EmptyDir volumes", func() {
+var _ = framework.KubeDescribe("EmptyDir volumes", func() {
 
-	f := NewDefaultFramework("emptydir")
+	f := framework.NewDefaultFramework("emptydir")
 
 	Context("when FSGroup is specified [Feature:FSGroup]", func() {
 		It("new files should be created with FSGroup ownership when container is root", func() {
@@ -117,7 +118,7 @@ const (
 	volumeName    = "test-volume"
 )
 
-func doTestSetgidFSGroup(f *Framework, image string, medium api.StorageMedium) {
+func doTestSetgidFSGroup(f *framework.Framework, image string, medium api.StorageMedium) {
 	var (
 		volumePath = "/test-volume"
 		filePath   = path.Join(volumePath, "test-file")
@@ -147,7 +148,7 @@ func doTestSetgidFSGroup(f *Framework, image string, medium api.StorageMedium) {
 	f.TestContainerOutput(msg, pod, 0, out)
 }
 
-func doTestVolumeModeFSGroup(f *Framework, image string, medium api.StorageMedium) {
+func doTestVolumeModeFSGroup(f *framework.Framework, image string, medium api.StorageMedium) {
 	var (
 		volumePath = "/test-volume"
 		source     = &api.EmptyDirVolumeSource{Medium: medium}
@@ -172,7 +173,7 @@ func doTestVolumeModeFSGroup(f *Framework, image string, medium api.StorageMediu
 	f.TestContainerOutput(msg, pod, 0, out)
 }
 
-func doTest0644FSGroup(f *Framework, image string, medium api.StorageMedium) {
+func doTest0644FSGroup(f *framework.Framework, image string, medium api.StorageMedium) {
 	var (
 		volumePath = "/test-volume"
 		filePath   = path.Join(volumePath, "test-file")
@@ -200,7 +201,7 @@ func doTest0644FSGroup(f *Framework, image string, medium api.StorageMedium) {
 	f.TestContainerOutput(msg, pod, 0, out)
 }
 
-func doTestVolumeMode(f *Framework, image string, medium api.StorageMedium) {
+func doTestVolumeMode(f *framework.Framework, image string, medium api.StorageMedium) {
 	var (
 		volumePath = "/test-volume"
 		source     = &api.EmptyDirVolumeSource{Medium: medium}
@@ -222,7 +223,7 @@ func doTestVolumeMode(f *Framework, image string, medium api.StorageMedium) {
 	f.TestContainerOutput(msg, pod, 0, out)
 }
 
-func doTest0644(f *Framework, image string, medium api.StorageMedium) {
+func doTest0644(f *framework.Framework, image string, medium api.StorageMedium) {
 	var (
 		volumePath = "/test-volume"
 		filePath   = path.Join(volumePath, "test-file")
@@ -247,7 +248,7 @@ func doTest0644(f *Framework, image string, medium api.StorageMedium) {
 	f.TestContainerOutput(msg, pod, 0, out)
 }
 
-func doTest0666(f *Framework, image string, medium api.StorageMedium) {
+func doTest0666(f *framework.Framework, image string, medium api.StorageMedium) {
 	var (
 		volumePath = "/test-volume"
 		filePath   = path.Join(volumePath, "test-file")
@@ -272,7 +273,7 @@ func doTest0666(f *Framework, image string, medium api.StorageMedium) {
 	f.TestContainerOutput(msg, pod, 0, out)
 }
 
-func doTest0777(f *Framework, image string, medium api.StorageMedium) {
+func doTest0777(f *framework.Framework, image string, medium api.StorageMedium) {
 	var (
 		volumePath = "/test-volume"
 		filePath   = path.Join(volumePath, "test-file")

--- a/test/e2e/empty_dir_wrapper.go
+++ b/test/e2e/empty_dir_wrapper.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/intstr"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	"strconv"
 
@@ -28,8 +29,8 @@ import (
 
 // This test will create a pod with a secret volume and gitRepo volume
 // Thus requests a secret, a git server pod, and a git server service
-var _ = KubeDescribe("EmptyDir wrapper volumes", func() {
-	f := NewDefaultFramework("emptydir-wrapper")
+var _ = framework.KubeDescribe("EmptyDir wrapper volumes", func() {
+	f := framework.NewDefaultFramework("emptydir-wrapper")
 
 	It("should becomes running", func() {
 		name := "emptydir-wrapper-test-" + string(util.NewUUID())
@@ -48,7 +49,7 @@ var _ = KubeDescribe("EmptyDir wrapper volumes", func() {
 
 		var err error
 		if secret, err = f.Client.Secrets(f.Namespace.Name).Create(secret); err != nil {
-			Failf("unable to create test secret %s: %v", secret.Name, err)
+			framework.Failf("unable to create test secret %s: %v", secret.Name, err)
 		}
 
 		gitServerPodName := "git-server-" + string(util.NewUUID())
@@ -76,7 +77,7 @@ var _ = KubeDescribe("EmptyDir wrapper volumes", func() {
 		}
 
 		if gitServerPod, err = f.Client.Pods(f.Namespace.Name).Create(gitServerPod); err != nil {
-			Failf("unable to create test git server pod %s: %v", gitServerPod.Name, err)
+			framework.Failf("unable to create test git server pod %s: %v", gitServerPod.Name, err)
 		}
 
 		// Portal IP and port
@@ -99,7 +100,7 @@ var _ = KubeDescribe("EmptyDir wrapper volumes", func() {
 		}
 
 		if gitServerSvc, err = f.Client.Services(f.Namespace.Name).Create(gitServerSvc); err != nil {
-			Failf("unable to create test git server service %s: %v", gitServerSvc.Name, err)
+			framework.Failf("unable to create test git server service %s: %v", gitServerSvc.Name, err)
 		}
 
 		gitVolumeName := "git-volume"
@@ -152,28 +153,28 @@ var _ = KubeDescribe("EmptyDir wrapper volumes", func() {
 		}
 
 		if pod, err = f.Client.Pods(f.Namespace.Name).Create(pod); err != nil {
-			Failf("unable to create pod %v: %v", pod.Name, err)
+			framework.Failf("unable to create pod %v: %v", pod.Name, err)
 		}
 
 		defer func() {
 			By("Cleaning up the secret")
 			if err := f.Client.Secrets(f.Namespace.Name).Delete(secret.Name); err != nil {
-				Failf("unable to delete secret %v: %v", secret.Name, err)
+				framework.Failf("unable to delete secret %v: %v", secret.Name, err)
 			}
 			By("Cleaning up the git server pod")
 			if err = f.Client.Pods(f.Namespace.Name).Delete(gitServerPod.Name, api.NewDeleteOptions(0)); err != nil {
-				Failf("unable to delete git server pod %v: %v", gitServerPod.Name, err)
+				framework.Failf("unable to delete git server pod %v: %v", gitServerPod.Name, err)
 			}
 			By("Cleaning up the git server svc")
 			if err = f.Client.Services(f.Namespace.Name).Delete(gitServerSvc.Name); err != nil {
-				Failf("unable to delete git server svc %v: %v", gitServerSvc.Name, err)
+				framework.Failf("unable to delete git server svc %v: %v", gitServerSvc.Name, err)
 			}
 			By("Cleaning up the git vol pod")
 			if err = f.Client.Pods(f.Namespace.Name).Delete(pod.Name, api.NewDeleteOptions(0)); err != nil {
-				Failf("unable to delete git vol pod %v: %v", pod.Name, err)
+				framework.Failf("unable to delete git vol pod %v: %v", pod.Name, err)
 			}
 		}()
 
-		expectNoError(waitForPodRunningInNamespace(f.Client, pod.Name, f.Namespace.Name))
+		framework.ExpectNoError(framework.WaitForPodRunningInNamespace(f.Client, pod.Name, f.Namespace.Name))
 	})
 })

--- a/test/e2e/example_cluster_dns.go
+++ b/test/e2e/example_cluster_dns.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -41,17 +42,17 @@ try:
 except:
 	print 'err'`
 
-var _ = KubeDescribe("ClusterDns [Feature:Example]", func() {
-	framework := NewDefaultFramework("cluster-dns")
+var _ = framework.KubeDescribe("ClusterDns [Feature:Example]", func() {
+	f := framework.NewDefaultFramework("cluster-dns")
 
 	var c *client.Client
 	BeforeEach(func() {
-		c = framework.Client
+		c = f.Client
 	})
 
 	It("should create pod that uses dns [Conformance]", func() {
 		mkpath := func(file string) string {
-			return filepath.Join(testContext.RepoRoot, "examples/cluster-dns", file)
+			return filepath.Join(framework.TestContext.RepoRoot, "examples/cluster-dns", file)
 		}
 
 		// contrary to the example, this test does not use contexts, for simplicity
@@ -75,22 +76,22 @@ var _ = KubeDescribe("ClusterDns [Feature:Example]", func() {
 		namespaces := []*api.Namespace{nil, nil}
 		for i := range namespaces {
 			var err error
-			namespaces[i], err = framework.CreateNamespace(fmt.Sprintf("dnsexample%d", i), nil)
+			namespaces[i], err = f.CreateNamespace(fmt.Sprintf("dnsexample%d", i), nil)
 			Expect(err).NotTo(HaveOccurred())
 		}
 
 		for _, ns := range namespaces {
-			runKubectlOrDie("create", "-f", backendRcYaml, getNsCmdFlag(ns))
+			framework.RunKubectlOrDie("create", "-f", backendRcYaml, getNsCmdFlag(ns))
 		}
 
 		for _, ns := range namespaces {
-			runKubectlOrDie("create", "-f", backendSvcYaml, getNsCmdFlag(ns))
+			framework.RunKubectlOrDie("create", "-f", backendSvcYaml, getNsCmdFlag(ns))
 		}
 
 		// wait for objects
 		for _, ns := range namespaces {
-			waitForRCPodsRunning(c, ns.Name, backendRcName)
-			waitForService(c, ns.Name, backendSvcName, true, poll, serviceStartTimeout)
+			framework.WaitForRCPodsRunning(c, ns.Name, backendRcName)
+			framework.WaitForService(c, ns.Name, backendSvcName, true, framework.Poll, framework.ServiceStartTimeout)
 		}
 		// it is not enough that pods are running because they may be set to running, but
 		// the application itself may have not been initialized. Just query the application.
@@ -99,11 +100,11 @@ var _ = KubeDescribe("ClusterDns [Feature:Example]", func() {
 			options := api.ListOptions{LabelSelector: label}
 			pods, err := c.Pods(ns.Name).List(options)
 			Expect(err).NotTo(HaveOccurred())
-			err = podsResponding(c, ns.Name, backendPodName, false, pods)
+			err = framework.PodsResponding(c, ns.Name, backendPodName, false, pods)
 			Expect(err).NotTo(HaveOccurred(), "waiting for all pods to respond")
-			Logf("found %d backend pods responding in namespace %s", len(pods.Items), ns.Name)
+			framework.Logf("found %d backend pods responding in namespace %s", len(pods.Items), ns.Name)
 
-			err = serviceResponding(c, ns.Name, backendSvcName)
+			err = framework.ServiceResponding(c, ns.Name, backendSvcName)
 			Expect(err).NotTo(HaveOccurred(), "waiting for the service to respond")
 		}
 
@@ -120,31 +121,31 @@ var _ = KubeDescribe("ClusterDns [Feature:Example]", func() {
 		pods, err := c.Pods(namespaces[0].Name).List(options)
 
 		if err != nil || pods == nil || len(pods.Items) == 0 {
-			Failf("no running pods found")
+			framework.Failf("no running pods found")
 		}
 		podName := pods.Items[0].Name
 
 		queryDns := fmt.Sprintf(queryDnsPythonTemplate, backendSvcName+"."+namespaces[0].Name)
-		_, err = lookForStringInPodExec(namespaces[0].Name, podName, []string{"python", "-c", queryDns}, "ok", dnsReadyTimeout)
+		_, err = framework.LookForStringInPodExec(namespaces[0].Name, podName, []string{"python", "-c", queryDns}, "ok", dnsReadyTimeout)
 		Expect(err).NotTo(HaveOccurred(), "waiting for output from pod exec")
 
 		updatedPodYaml := prepareResourceWithReplacedString(frontendPodYaml, "dns-backend.development.cluster.local", fmt.Sprintf("dns-backend.%s.svc.cluster.local", namespaces[0].Name))
 
 		// create a pod in each namespace
 		for _, ns := range namespaces {
-			newKubectlCommand("create", "-f", "-", getNsCmdFlag(ns)).withStdinData(updatedPodYaml).execOrDie()
+			framework.NewKubectlCommand("create", "-f", "-", getNsCmdFlag(ns)).WithStdinData(updatedPodYaml).ExecOrDie()
 		}
 
 		// wait until the pods have been scheduler, i.e. are not Pending anymore. Remember
 		// that we cannot wait for the pods to be running because our pods terminate by themselves.
 		for _, ns := range namespaces {
-			err := waitForPodNotPending(c, ns.Name, frontendPodName)
-			expectNoError(err)
+			err := framework.WaitForPodNotPending(c, ns.Name, frontendPodName)
+			framework.ExpectNoError(err)
 		}
 
 		// wait for pods to print their result
 		for _, ns := range namespaces {
-			_, err := lookForStringInLog(ns.Name, frontendPodName, frontendPodContainerName, podOutput, podStartTimeout)
+			_, err := framework.LookForStringInLog(ns.Name, frontendPodName, frontendPodContainerName, podOutput, framework.PodStartTimeout)
 			Expect(err).NotTo(HaveOccurred())
 		}
 	})

--- a/test/e2e/example_k8petstore.go
+++ b/test/e2e/example_k8petstore.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -33,7 +34,7 @@ import (
 
 const (
 	k8bpsContainerVersion         = "r.2.8.19"       // Container version, see the examples/k8petstore dockerfiles for details.
-	k8bpsThroughputDummy          = "0"              // Polling time = 0, since we poll in ginkgo rather than using the shell script tests.
+	k8bpsThroughputDummy          = "0"              // Polling time = 0, since we framework.Poll in ginkgo rather than using the shell script tests.
 	k8bpsRedisSlaves              = "1"              // Number of redis slaves.
 	k8bpsDontRunTest              = "0"              // Don't bother embedded test.
 	k8bpsStartupTimeout           = 30 * time.Second // Amount of elapsed time before petstore transactions are being stored.
@@ -47,7 +48,7 @@ const (
 // readTransactions reads # of transactions from the k8petstore web server endpoint.
 // for more details see the source of the k8petstore web server.
 func readTransactions(c *client.Client, ns string) (error, int) {
-	proxyRequest, errProxy := getServicesProxyRequest(c, c.Get())
+	proxyRequest, errProxy := framework.GetServicesProxyRequest(c, c.Get())
 	if errProxy != nil {
 		return errProxy, -1
 	}
@@ -68,11 +69,11 @@ func readTransactions(c *client.Client, ns string) (error, int) {
 func runK8petstore(restServers int, loadGenerators int, c *client.Client, ns string, finalTransactionsExpected int, maxTime time.Duration) {
 
 	var err error = nil
-	k8bpsScriptLocation := filepath.Join(testContext.RepoRoot, "examples/k8petstore/k8petstore-nodeport.sh")
+	k8bpsScriptLocation := filepath.Join(framework.TestContext.RepoRoot, "examples/k8petstore/k8petstore-nodeport.sh")
 
 	cmd := exec.Command(
 		k8bpsScriptLocation,
-		testContext.KubectlPath,
+		framework.TestContext.KubectlPath,
 		k8bpsContainerVersion,
 		k8bpsThroughputDummy,
 		strconv.Itoa(restServers),
@@ -85,25 +86,25 @@ func runK8petstore(restServers int, loadGenerators int, c *client.Client, ns str
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	Logf("Starting k8petstore application....")
+	framework.Logf("Starting k8petstore application....")
 	// Run the k8petstore app, and log / fail if it returns any errors.
 	// This should return quickly, assuming containers are downloaded.
 	if err = cmd.Start(); err != nil {
-		Failf("%v", err)
+		framework.Failf("%v", err)
 	}
 	// Make sure there are no command errors.
 	if err = cmd.Wait(); err != nil {
 		if exiterr, ok := err.(*exec.ExitError); ok {
 			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
-				Logf("Exit Status: %d", status.ExitStatus())
+				framework.Logf("Exit Status: %d", status.ExitStatus())
 			}
 		}
 	}
 	Expect(err).NotTo(HaveOccurred())
-	Logf("... Done starting k8petstore ")
+	framework.Logf("... Done starting k8petstore ")
 
 	totalTransactions := 0
-	Logf("Start polling, timeout is %v seconds", maxTime)
+	framework.Logf("Start polling, timeout is %v seconds", maxTime)
 
 	// How long until the FIRST transactions are created.
 	startupTimeout := time.After(time.Duration(k8bpsStartupTimeout))
@@ -113,18 +114,18 @@ func runK8petstore(restServers int, loadGenerators int, c *client.Client, ns str
 	tick := time.Tick(2 * time.Second)
 	var ready = false
 
-	Logf("Now waiting %v seconds to see progress (transactions  > 3)", k8bpsStartupTimeout)
+	framework.Logf("Now waiting %v seconds to see progress (transactions  > 3)", k8bpsStartupTimeout)
 T:
 	for {
 		select {
 		case <-transactionsCompleteTimeout:
-			Logf("Completion timeout %v reached, %v transactions not complete.  Breaking!", time.Duration(maxTime), finalTransactionsExpected)
+			framework.Logf("Completion timeout %v reached, %v transactions not complete.  Breaking!", time.Duration(maxTime), finalTransactionsExpected)
 			break T
 		case <-tick:
 			// Don't fail if there's an error.  We expect a few failures might happen in the cloud.
 			err, totalTransactions = readTransactions(c, ns)
 			if err == nil {
-				Logf("PetStore : Time: %v, %v = total petstore transactions stored into redis.", time.Now(), totalTransactions)
+				framework.Logf("PetStore : Time: %v, %v = total petstore transactions stored into redis.", time.Now(), totalTransactions)
 				if totalTransactions >= k8bpsMinTransactionsOnStartup {
 					ready = true
 				}
@@ -133,14 +134,14 @@ T:
 				}
 			} else {
 				if ready {
-					Logf("Blip: during polling: %v", err)
+					framework.Logf("Blip: during polling: %v", err)
 				} else {
-					Logf("Not ready yet: %v", err)
+					framework.Logf("Not ready yet: %v", err)
 				}
 			}
 		case <-startupTimeout:
 			if !ready {
-				Logf("Startup Timeout %v reached: Its been too long and we still haven't started accumulating %v transactions!", startupTimeout, k8bpsMinTransactionsOnStartup)
+				framework.Logf("Startup Timeout %v reached: Its been too long and we still haven't started accumulating %v transactions!", startupTimeout, k8bpsMinTransactionsOnStartup)
 				break T
 			}
 		}
@@ -152,19 +153,19 @@ T:
 	Ω(totalTransactions).Should(BeNumerically(">", finalTransactionsExpected))
 }
 
-var _ = KubeDescribe("Pet Store [Feature:Example]", func() {
+var _ = framework.KubeDescribe("Pet Store [Feature:Example]", func() {
 
 	BeforeEach(func() {
 		// The shell scripts in k8petstore break on jenkins... Pure golang rewrite is in progress.
-		SkipUnlessProviderIs("local")
+		framework.SkipUnlessProviderIs("local")
 	})
 
 	// The number of nodes dictates total number of generators/transaction expectations.
 	var nodeCount int
-	f := NewDefaultFramework("petstore")
+	f := framework.NewDefaultFramework("petstore")
 
 	It(fmt.Sprintf("should scale to persist a nominal number ( %v ) of transactions in %v seconds", k8bpsSmokeTestFinalTransactions, k8bpsSmokeTestTimeout), func() {
-		nodes := ListSchedulableNodesOrDie(f.Client)
+		nodes := framework.ListSchedulableNodesOrDie(f.Client)
 		nodeCount = len(nodes.Items)
 
 		loadGenerators := nodeCount

--- a/test/e2e/expansion.go
+++ b/test/e2e/expansion.go
@@ -19,14 +19,15 @@ package e2e
 import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 )
 
 // These tests exercise the Kubernetes expansion syntax $(VAR).
 // For more information, see: docs/design/expansion.md
-var _ = KubeDescribe("Variable Expansion", func() {
-	framework := NewDefaultFramework("var-expansion")
+var _ = framework.KubeDescribe("Variable Expansion", func() {
+	f := framework.NewDefaultFramework("var-expansion")
 
 	It("should allow composing env vars into new env vars [Conformance]", func() {
 		podName := "var-expansion-" + string(util.NewUUID())
@@ -61,7 +62,7 @@ var _ = KubeDescribe("Variable Expansion", func() {
 			},
 		}
 
-		framework.TestContainerOutput("env composition", pod, 0, []string{
+		f.TestContainerOutput("env composition", pod, 0, []string{
 			"FOO=foo-value",
 			"BAR=bar-value",
 			"FOOBAR=foo-value;;bar-value",
@@ -93,7 +94,7 @@ var _ = KubeDescribe("Variable Expansion", func() {
 			},
 		}
 
-		framework.TestContainerOutput("substitution in container's command", pod, 0, []string{
+		f.TestContainerOutput("substitution in container's command", pod, 0, []string{
 			"test-value",
 		})
 	})
@@ -124,7 +125,7 @@ var _ = KubeDescribe("Variable Expansion", func() {
 			},
 		}
 
-		framework.TestContainerOutput("substitution in container's args", pod, 0, []string{
+		f.TestContainerOutput("substitution in container's args", pod, 0, []string{
 			"test-value",
 		})
 	})

--- a/test/e2e/framework/cleanup.go
+++ b/test/e2e/framework/cleanup.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 The Kubernetes Authors All rights reserved.
+Copyright 2016 The Kubernetes Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/cleanup.go
+++ b/test/e2e/framework/cleanup.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import "sync"
+
+type CleanupActionHandle *int
+
+var cleanupActionsLock sync.Mutex
+var cleanupActions = map[CleanupActionHandle]func(){}
+
+// AddCleanupAction installs a function that will be called in the event of the
+// whole test being terminated.  This allows arbitrary pieces of the overall
+// test to hook into SynchronizedAfterSuite().
+func AddCleanupAction(fn func()) CleanupActionHandle {
+	p := CleanupActionHandle(new(int))
+	cleanupActionsLock.Lock()
+	defer cleanupActionsLock.Unlock()
+	cleanupActions[p] = fn
+	return p
+}
+
+// RemoveCleanupAction removes a function that was installed by
+// AddCleanupAction.
+func RemoveCleanupAction(p CleanupActionHandle) {
+	cleanupActionsLock.Lock()
+	defer cleanupActionsLock.Unlock()
+	delete(cleanupActions, p)
+}
+
+// RunCleanupActions runs all functions installed by AddCleanupAction.  It does
+// not remove them (see RemoveCleanupAction) but it does run unlocked, so they
+// may remove themselves.
+func RunCleanupActions() {
+	list := []func(){}
+	func() {
+		cleanupActionsLock.Lock()
+		defer cleanupActionsLock.Unlock()
+		for _, fn := range cleanupActions {
+			list = append(list, fn)
+		}
+	}()
+	// Run unlocked.
+	for _, fn := range list {
+		fn()
+	}
+}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package framework
 
 import (
 	"bytes"

--- a/test/e2e/framework/kubelet_stats.go
+++ b/test/e2e/framework/kubelet_stats.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package framework
 
 import (
 	"bytes"

--- a/test/e2e/framework/log_size_monitoring.go
+++ b/test/e2e/framework/log_size_monitoring.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package framework
 
 import (
 	"bytes"

--- a/test/e2e/framework/log_size_monitoring.go
+++ b/test/e2e/framework/log_size_monitoring.go
@@ -101,7 +101,7 @@ func (s *LogsSizeDataSummary) PrintHumanReadable() string {
 }
 
 func (s *LogsSizeDataSummary) PrintJSON() string {
-	return prettyPrintJSON(*s)
+	return PrettyPrintJSON(*s)
 }
 
 type LogsSizeData struct {
@@ -144,8 +144,8 @@ func (d *LogsSizeData) AddNewData(ip, path string, timestamp time.Time, size int
 // NewLogsVerifier creates a new LogsSizeVerifier which will stop when stopChannel is closed
 func NewLogsVerifier(c *client.Client, stopChannel chan bool) *LogsSizeVerifier {
 	nodeAddresses, err := NodeSSHHosts(c)
-	expectNoError(err)
-	masterAddress := getMasterHost() + ":22"
+	ExpectNoError(err)
+	masterAddress := GetMasterHost() + ":22"
 
 	workChannel := make(chan WorkItem, len(nodeAddresses)+1)
 	workers := make([]*LogSizeGatherer, workersNo)
@@ -241,7 +241,7 @@ func (g *LogSizeGatherer) Work() bool {
 	sshResult, err := SSH(
 		fmt.Sprintf("ls -l %v | awk '{print $9, $5}' | tr '\n' ' '", strings.Join(workItem.paths, " ")),
 		workItem.ip,
-		testContext.Provider,
+		TestContext.Provider,
 	)
 	if err != nil {
 		Logf("Error while trying to SSH to %v, skipping probe. Error: %v", workItem.ip, err)

--- a/test/e2e/framework/metrics_util.go
+++ b/test/e2e/framework/metrics_util.go
@@ -91,7 +91,7 @@ func (m *MetricsForE2E) PrintHumanReadable() string {
 
 func (m *MetricsForE2E) PrintJSON() string {
 	m.filterMetrics()
-	return prettyPrintJSON(*m)
+	return PrettyPrintJSON(*m)
 }
 
 var InterestingApiServerMetrics = []string{
@@ -287,7 +287,7 @@ func HighLatencyRequests(c *client.Client) (int, error) {
 		}
 	}
 
-	Logf("API calls latencies: %s", prettyPrintJSON(metrics))
+	Logf("API calls latencies: %s", PrettyPrintJSON(metrics))
 
 	return badMetrics, nil
 }
@@ -295,7 +295,7 @@ func HighLatencyRequests(c *client.Client) (int, error) {
 // Verifies whether 50, 90 and 99th percentiles of PodStartupLatency are
 // within the threshold.
 func VerifyPodStartupLatency(latency PodStartupLatency) error {
-	Logf("Pod startup latency: %s", prettyPrintJSON(latency))
+	Logf("Pod startup latency: %s", PrettyPrintJSON(latency))
 
 	if latency.Latency.Perc50 > podStartupThreshold {
 		return fmt.Errorf("too high pod startup latency 50th percentile: %v", latency.Latency.Perc50)
@@ -310,9 +310,9 @@ func VerifyPodStartupLatency(latency PodStartupLatency) error {
 }
 
 // Resets latency metrics in apiserver.
-func resetMetrics(c *client.Client) error {
+func ResetMetrics(c *client.Client) error {
 	Logf("Resetting latency metrics in apiserver...")
-	body, err := c.Get().AbsPath("/resetMetrics").DoRaw()
+	body, err := c.Get().AbsPath("/ResetMetrics").DoRaw()
 	if err != nil {
 		return err
 	}
@@ -337,7 +337,7 @@ func getSchedulingLatency(c *client.Client) (SchedulingLatency, error) {
 
 	// Check if master Node is registered
 	nodes, err := c.Nodes().List(api.ListOptions{})
-	expectNoError(err)
+	ExpectNoError(err)
 
 	var data string
 	var masterRegistered = false
@@ -351,16 +351,16 @@ func getSchedulingLatency(c *client.Client) (SchedulingLatency, error) {
 			Prefix("proxy").
 			Namespace(api.NamespaceSystem).
 			Resource("pods").
-			Name(fmt.Sprintf("kube-scheduler-%v:%v", testContext.CloudConfig.MasterName, ports.SchedulerPort)).
+			Name(fmt.Sprintf("kube-scheduler-%v:%v", TestContext.CloudConfig.MasterName, ports.SchedulerPort)).
 			Suffix("metrics").
 			Do().Raw()
 
-		expectNoError(err)
+		ExpectNoError(err)
 		data = string(rawData)
 	} else {
 		// If master is not registered fall back to old method of using SSH.
 		cmd := "curl http://localhost:10251/metrics"
-		sshResult, err := SSH(cmd, getMasterHost()+":22", testContext.Provider)
+		sshResult, err := SSH(cmd, GetMasterHost()+":22", TestContext.Provider)
 		if err != nil || sshResult.Code != 0 {
 			return result, fmt.Errorf("unexpected error (code: %d) in ssh connection to master: %#v", sshResult.Code, err)
 		}
@@ -401,13 +401,13 @@ func VerifySchedulerLatency(c *client.Client) error {
 	if err != nil {
 		return err
 	}
-	Logf("Scheduling latency: %s", prettyPrintJSON(latency))
+	Logf("Scheduling latency: %s", PrettyPrintJSON(latency))
 
 	// TODO: Add some reasonable checks once we know more about the values.
 	return nil
 }
 
-func prettyPrintJSON(metrics interface{}) string {
+func PrettyPrintJSON(metrics interface{}) string {
 	output := &bytes.Buffer{}
 	if err := json.NewEncoder(output).Encode(metrics); err != nil {
 		Logf("Error building encoder: %v", err)
@@ -446,8 +446,8 @@ func extractMetricSamples(metricsBlob string) ([]*model.Sample, error) {
 	}
 }
 
-// podLatencyData encapsulates pod startup latency information.
-type podLatencyData struct {
+// PodLatencyData encapsulates pod startup latency information.
+type PodLatencyData struct {
 	// Name of the pod
 	Name string
 	// Node this pod was running on
@@ -456,13 +456,13 @@ type podLatencyData struct {
 	Latency time.Duration
 }
 
-type latencySlice []podLatencyData
+type LatencySlice []PodLatencyData
 
-func (a latencySlice) Len() int           { return len(a) }
-func (a latencySlice) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a latencySlice) Less(i, j int) bool { return a[i].Latency < a[j].Latency }
+func (a LatencySlice) Len() int           { return len(a) }
+func (a LatencySlice) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a LatencySlice) Less(i, j int) bool { return a[i].Latency < a[j].Latency }
 
-func extractLatencyMetrics(latencies []podLatencyData) LatencyMetric {
+func ExtractLatencyMetrics(latencies []PodLatencyData) LatencyMetric {
 	length := len(latencies)
 	perc50 := latencies[int(math.Ceil(float64(length*50)/100))-1].Latency
 	perc90 := latencies[int(math.Ceil(float64(length*90)/100))-1].Latency
@@ -470,9 +470,9 @@ func extractLatencyMetrics(latencies []podLatencyData) LatencyMetric {
 	return LatencyMetric{Perc50: perc50, Perc90: perc90, Perc99: perc99}
 }
 
-// logSuspiciousLatency logs metrics/docker errors from all nodes that had slow startup times
+// LogSuspiciousLatency logs metrics/docker errors from all nodes that had slow startup times
 // If latencyDataLag is nil then it will be populated from latencyData
-func logSuspiciousLatency(latencyData []podLatencyData, latencyDataLag []podLatencyData, nodeCount int, c *client.Client) {
+func LogSuspiciousLatency(latencyData []PodLatencyData, latencyDataLag []PodLatencyData, nodeCount int, c *client.Client) {
 	if latencyDataLag == nil {
 		latencyDataLag = latencyData
 	}
@@ -489,15 +489,15 @@ func logSuspiciousLatency(latencyData []podLatencyData, latencyDataLag []podLate
 // the given time.Duration. Since the arrays are sorted we are looking at the last
 // element which will always be the highest. If the latency is higher than the max Failf
 // is called.
-func testMaximumLatencyValue(latencies []podLatencyData, max time.Duration, name string) {
+func testMaximumLatencyValue(latencies []PodLatencyData, max time.Duration, name string) {
 	highestLatency := latencies[len(latencies)-1]
 	if !(highestLatency.Latency <= max) {
 		Failf("%s were not all under %s: %#v", name, max.String(), latencies)
 	}
 }
 
-func printLatencies(latencies []podLatencyData, header string) {
-	metrics := extractLatencyMetrics(latencies)
+func PrintLatencies(latencies []PodLatencyData, header string) {
+	metrics := ExtractLatencyMetrics(latencies)
 	Logf("10%% %s: %v", header, latencies[(len(latencies)*9)/10:])
 	Logf("perc50: %v, perc90: %v, perc99: %v", metrics.Perc50, metrics.Perc90, metrics.Perc99)
 }

--- a/test/e2e/framework/prompush.go
+++ b/test/e2e/framework/prompush.go
@@ -39,11 +39,11 @@ var prom_registered = false
 
 // Reusable function for pushing metrics to prometheus.  Handles initialization and so on.
 func promPushRunningPending(running, pending int) error {
-	if testContext.PrometheusPushGateway == "" {
+	if TestContext.PrometheusPushGateway == "" {
 		return nil
 	} else {
 		// Register metrics if necessary
-		if !prom_registered && testContext.PrometheusPushGateway != "" {
+		if !prom_registered && TestContext.PrometheusPushGateway != "" {
 			prometheus.Register(runningMetric)
 			prometheus.Register(pendingMetric)
 			prom_registered = true
@@ -57,7 +57,7 @@ func promPushRunningPending(running, pending int) error {
 		if err := prometheus.Push(
 			"e2e",
 			"none",
-			testContext.PrometheusPushGateway, //i.e. "127.0.0.1:9091"
+			TestContext.PrometheusPushGateway, //i.e. "127.0.0.1:9091"
 		); err != nil {
 			fmt.Println("failed at pushing to pushgateway ", err)
 			return err

--- a/test/e2e/framework/prompush.go
+++ b/test/e2e/framework/prompush.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 //This is a utility for prometheus pushing functionality.
-package e2e
+package framework
 
 import (
 	"fmt"

--- a/test/e2e/framework/resource_usage_gatherer.go
+++ b/test/e2e/framework/resource_usage_gatherer.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package framework
 
 import (
 	"bytes"

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -98,7 +98,7 @@ func RegisterFlags() {
 	flag.StringVar(&TestContext.KubectlPath, "kubectl-path", "kubectl", "The kubectl binary to use. For development, you might use 'cluster/kubectl.sh' here.")
 	flag.StringVar(&TestContext.OutputDir, "e2e-output-dir", "/tmp", "Output directory for interesting/useful test data, like performance data, benchmarks, and other metrics.")
 	flag.StringVar(&TestContext.ReportDir, "report-dir", "", "Path to the directory where the JUnit XML reports should be saved. Default is empty, which doesn't generate these reports.")
-	flag.StringVar(&testContext.ReportPrefix, "report-prefix", "", "Optional prefix for JUnit XML reports. Default is empty, which doesn't prepend anything to the default name.")
+	flag.StringVar(&TestContext.ReportPrefix, "report-prefix", "", "Optional prefix for JUnit XML reports. Default is empty, which doesn't prepend anything to the default name.")
 	flag.StringVar(&TestContext.Prefix, "prefix", "e2e", "A prefix to be added to cloud resources created during testing.")
 	flag.StringVar(&TestContext.OSDistro, "os-distro", "debian", "The OS distribution of cluster VM instances (debian, trusty, or coreos).")
 

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"flag"
+	"os"
+
+	"github.com/onsi/ginkgo/config"
+	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
+	"k8s.io/kubernetes/pkg/cloudprovider"
+)
+
+type TestContextType struct {
+	KubeConfig            string
+	KubeContext           string
+	KubeVolumeDir         string
+	CertDir               string
+	Host                  string
+	RepoRoot              string
+	Provider              string
+	CloudConfig           CloudConfig
+	KubectlPath           string
+	OutputDir             string
+	ReportDir             string
+	ReportPrefix          string
+	Prefix                string
+	MinStartupPods        int
+	UpgradeTarget         string
+	PrometheusPushGateway string
+	OSDistro              string
+	VerifyServiceAccount  bool
+	DeleteNamespace       bool
+	CleanStart            bool
+	// If set to true framework will start a goroutine monitoring resource usage of system add-ons.
+	// It will read the data every 30 seconds from all Nodes and print summary during afterEach.
+	GatherKubeSystemResourceUsageData bool
+	GatherLogsSizes                   bool
+	GatherMetricsAfterTest            bool
+	// Currently supported values are 'hr' for human-readable and 'json'. It's a comma separated list.
+	OutputPrintType string
+	// CreateTestingNS is responsible for creating namespace used for executing e2e tests.
+	// It accepts namespace base name, which will be prepended with e2e prefix, kube client
+	// and labels to be applied to a namespace.
+	CreateTestingNS CreateTestingNSFn
+}
+
+type CloudConfig struct {
+	ProjectID         string
+	Zone              string
+	Cluster           string
+	MasterName        string
+	NodeInstanceGroup string
+	NumNodes          int
+	ClusterTag        string
+	ServiceAccount    string
+
+	Provider cloudprovider.Interface
+}
+
+var TestContext TestContextType
+
+func SetTestContext(t TestContextType) {
+	TestContext = t
+}
+
+func RegisterFlags() {
+	// Turn on verbose by default to get spec names
+	config.DefaultReporterConfig.Verbose = true
+
+	// Turn on EmitSpecProgress to get spec progress (especially on interrupt)
+	config.GinkgoConfig.EmitSpecProgress = true
+
+	// Randomize specs as well as suites
+	config.GinkgoConfig.RandomizeAllSpecs = true
+
+	flag.StringVar(&TestContext.KubeConfig, clientcmd.RecommendedConfigPathFlag, os.Getenv(clientcmd.RecommendedConfigPathEnvVar), "Path to kubeconfig containing embedded authinfo.")
+	flag.StringVar(&TestContext.KubeContext, clientcmd.FlagContext, "", "kubeconfig context to use/override. If unset, will use value from 'current-context'")
+	flag.StringVar(&TestContext.KubeVolumeDir, "volume-dir", "/var/lib/kubelet", "Path to the directory containing the kubelet volumes.")
+	flag.StringVar(&TestContext.CertDir, "cert-dir", "", "Path to the directory containing the certs. Default is empty, which doesn't use certs.")
+	flag.StringVar(&TestContext.Host, "host", "", "The host, or apiserver, to connect to")
+	flag.StringVar(&TestContext.RepoRoot, "repo-root", "../../", "Root directory of kubernetes repository, for finding test files.")
+	flag.StringVar(&TestContext.Provider, "provider", "", "The name of the Kubernetes provider (gce, gke, local, vagrant, etc.)")
+	flag.StringVar(&TestContext.KubectlPath, "kubectl-path", "kubectl", "The kubectl binary to use. For development, you might use 'cluster/kubectl.sh' here.")
+	flag.StringVar(&TestContext.OutputDir, "e2e-output-dir", "/tmp", "Output directory for interesting/useful test data, like performance data, benchmarks, and other metrics.")
+	flag.StringVar(&TestContext.ReportDir, "report-dir", "", "Path to the directory where the JUnit XML reports should be saved. Default is empty, which doesn't generate these reports.")
+	flag.StringVar(&testContext.ReportPrefix, "report-prefix", "", "Optional prefix for JUnit XML reports. Default is empty, which doesn't prepend anything to the default name.")
+	flag.StringVar(&TestContext.Prefix, "prefix", "e2e", "A prefix to be added to cloud resources created during testing.")
+	flag.StringVar(&TestContext.OSDistro, "os-distro", "debian", "The OS distribution of cluster VM instances (debian, trusty, or coreos).")
+
+	// TODO: Flags per provider?  Rename gce-project/gce-zone?
+	cloudConfig := &TestContext.CloudConfig
+	flag.StringVar(&cloudConfig.MasterName, "kube-master", "", "Name of the kubernetes master. Only required if provider is gce or gke")
+	flag.StringVar(&cloudConfig.ProjectID, "gce-project", "", "The GCE project being used, if applicable")
+	flag.StringVar(&cloudConfig.Zone, "gce-zone", "", "GCE zone being used, if applicable")
+	flag.StringVar(&cloudConfig.ServiceAccount, "gce-service-account", "", "GCE service account to use for GCE API calls, if applicable")
+	flag.StringVar(&cloudConfig.Cluster, "gke-cluster", "", "GKE name of cluster being used, if applicable")
+	flag.StringVar(&cloudConfig.NodeInstanceGroup, "node-instance-group", "", "Name of the managed instance group for nodes. Valid only for gce, gke or aws")
+	flag.IntVar(&cloudConfig.NumNodes, "num-nodes", -1, "Number of nodes in the cluster")
+
+	flag.StringVar(&cloudConfig.ClusterTag, "cluster-tag", "", "Tag used to identify resources.  Only required if provider is aws.")
+	flag.IntVar(&TestContext.MinStartupPods, "minStartupPods", 0, "The number of pods which we need to see in 'Running' state with a 'Ready' condition of true, before we try running tests. This is useful in any cluster which needs some base pod-based services running before it can be used.")
+	flag.StringVar(&TestContext.UpgradeTarget, "upgrade-target", "ci/latest", "Version to upgrade to (e.g. 'release/stable', 'release/latest', 'ci/latest', '0.19.1', '0.19.1-669-gabac8c8') if doing an upgrade test.")
+	flag.StringVar(&TestContext.PrometheusPushGateway, "prom-push-gateway", "", "The URL to prometheus gateway, so that metrics can be pushed during e2es and scraped by prometheus. Typically something like 127.0.0.1:9091.")
+	flag.BoolVar(&TestContext.VerifyServiceAccount, "e2e-verify-service-account", true, "If true tests will verify the service account before running.")
+	flag.BoolVar(&TestContext.DeleteNamespace, "delete-namespace", true, "If true tests will delete namespace after completion. It is only designed to make debugging easier, DO NOT turn it off by default.")
+	flag.BoolVar(&TestContext.CleanStart, "clean-start", false, "If true, purge all namespaces except default and system before running tests. This serves to Cleanup test namespaces from failed/interrupted e2e runs in a long-lived cluster.")
+	flag.BoolVar(&TestContext.GatherKubeSystemResourceUsageData, "gather-resource-usage", false, "If set to true framework will be monitoring resource usage of system add-ons in (some) e2e tests.")
+	flag.BoolVar(&TestContext.GatherLogsSizes, "gather-logs-sizes", false, "If set to true framework will be monitoring logs sizes on all machines running e2e tests.")
+	flag.BoolVar(&TestContext.GatherMetricsAfterTest, "gather-metrics-at-teardown", false, "If set to true framwork will gather metrics from all components after each test.")
+	flag.StringVar(&TestContext.OutputPrintType, "output-print-type", "hr", "Comma separated list: 'hr' for human readable summaries 'json' for JSON ones.")
+}

--- a/test/e2e/google_compute.go
+++ b/test/e2e/google_compute.go
@@ -24,6 +24,8 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+
+	"k8s.io/kubernetes/test/e2e/framework"
 )
 
 // TODO: These should really just use the GCE API client library or at least use
@@ -36,12 +38,12 @@ func createGCEStaticIP(name string) (string, error) {
 	// NAME           REGION      ADDRESS       STATUS
 	// test-static-ip us-central1 104.197.143.7 RESERVED
 
-	glog.Infof("Creating static IP with name %q in project %q", name, testContext.CloudConfig.ProjectID)
+	glog.Infof("Creating static IP with name %q in project %q", name, framework.TestContext.CloudConfig.ProjectID)
 	var outputBytes []byte
 	var err error
 	for attempts := 0; attempts < 4; attempts++ {
 		outputBytes, err = exec.Command("gcloud", "compute", "addresses", "create",
-			name, "--project", testContext.CloudConfig.ProjectID,
+			name, "--project", framework.TestContext.CloudConfig.ProjectID,
 			"--region", "us-central1", "-q").CombinedOutput()
 		if err == nil {
 			break
@@ -76,7 +78,7 @@ func deleteGCEStaticIP(name string) error {
 	// test-static-ip us-central1 104.197.143.7 RESERVED
 
 	outputBytes, err := exec.Command("gcloud", "compute", "addresses", "delete",
-		name, "--project", testContext.CloudConfig.ProjectID,
+		name, "--project", framework.TestContext.CloudConfig.ProjectID,
 		"--region", "us-central1", "-q").CombinedOutput()
 	if err != nil {
 		// Ditch the error, since the stderr in the output is what actually contains

--- a/test/e2e/host_path.go
+++ b/test/e2e/host_path.go
@@ -25,20 +25,21 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 )
 
 //TODO : Consolidate this code with the code for emptyDir.
 //This will require some smart.
-var _ = KubeDescribe("hostPath", func() {
-	framework := NewDefaultFramework("hostpath")
+var _ = framework.KubeDescribe("hostPath", func() {
+	f := framework.NewDefaultFramework("hostpath")
 	var c *client.Client
 	var namespace *api.Namespace
 
 	BeforeEach(func() {
-		c = framework.Client
-		namespace = framework.Namespace
+		c = f.Client
+		namespace = f.Namespace
 
 		//cleanup before running the test.
 		_ = os.Remove("/tmp/test-file")
@@ -55,7 +56,7 @@ var _ = KubeDescribe("hostPath", func() {
 			fmt.Sprintf("--fs_type=%v", volumePath),
 			fmt.Sprintf("--file_mode=%v", volumePath),
 		}
-		testContainerOutput("hostPath mode", c, pod, 0, []string{
+		framework.TestContainerOutput("hostPath mode", c, pod, 0, []string{
 			"mode of file \"/test-volume\": dtrwxrwxrwx", // we expect the sticky bit (mode flag t) to be set for the dir
 		},
 			namespace.Name)
@@ -82,7 +83,7 @@ var _ = KubeDescribe("hostPath", func() {
 		}
 		//Read the content of the file with the second container to
 		//verify volumes  being shared properly among containers within the pod.
-		testContainerOutput("hostPath r/w", c, pod, 1, []string{
+		framework.TestContainerOutput("hostPath r/w", c, pod, 1, []string{
 			"content of file \"/test-volume/test-file\": mount-tester new file",
 		}, namespace.Name,
 		)

--- a/test/e2e/ingress_utils.go
+++ b/test/e2e/ingress_utils.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	utilnet "k8s.io/kubernetes/pkg/util/net"
+	"k8s.io/kubernetes/test/e2e/framework"
 )
 
 const (
@@ -125,7 +126,7 @@ func createSecret(kubeClient *client.Client, ing *extensions.Ingress) (host stri
 	var k, c bytes.Buffer
 	tls := ing.Spec.TLS[0]
 	host = strings.Join(tls.Hosts, ",")
-	Logf("Generating RSA cert for host %v", host)
+	framework.Logf("Generating RSA cert for host %v", host)
 
 	if err = generateRSACerts(host, true, &k, &c); err != nil {
 		return
@@ -141,7 +142,7 @@ func createSecret(kubeClient *client.Client, ing *extensions.Ingress) (host stri
 			api.TLSPrivateKeyKey: key,
 		},
 	}
-	Logf("Creating secret %v in ns %v with hosts %v for ingress %v", secret.Name, secret.Namespace, host, ing.Name)
+	framework.Logf("Creating secret %v in ns %v with hosts %v for ingress %v", secret.Name, secret.Namespace, host, ing.Name)
 	_, err = kubeClient.Secrets(ing.Namespace).Create(secret)
 	return host, cert, key, err
 }

--- a/test/e2e/initial_resources.go
+++ b/test/e2e/initial_resources.go
@@ -23,14 +23,15 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/test/e2e/framework"
 )
 
 // [Feature:InitialResources]: Initial resources is an experimental feature, so
 // these tests are not run by default.
 //
 // Flaky issue #20272
-var _ = KubeDescribe("Initial Resources [Feature:InitialResources] [Flaky]", func() {
-	f := NewDefaultFramework("initial-resources")
+var _ = framework.KubeDescribe("Initial Resources [Feature:InitialResources] [Flaky]", func() {
+	f := framework.NewDefaultFramework("initial-resources")
 
 	It("should set initial resources based on historical data", func() {
 		// TODO(piosz): Add cleanup data in InfluxDB that left from previous tests.
@@ -50,7 +51,7 @@ var _ = KubeDescribe("Initial Resources [Feature:InitialResources] [Flaky]", fun
 	})
 })
 
-func runPod(f *Framework, name, image string) *api.Pod {
+func runPod(f *framework.Framework, name, image string) *api.Pod {
 	pod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Name: name,
@@ -65,7 +66,7 @@ func runPod(f *Framework, name, image string) *api.Pod {
 		},
 	}
 	createdPod, err := f.Client.Pods(f.Namespace.Name).Create(pod)
-	expectNoError(err)
-	expectNoError(waitForPodRunningInNamespace(f.Client, name, f.Namespace.Name))
+	framework.ExpectNoError(err)
+	framework.ExpectNoError(framework.WaitForPodRunningInNamespace(f.Client, name, f.Namespace.Name))
 	return createdPod
 }

--- a/test/e2e/job.go
+++ b/test/e2e/job.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -39,8 +40,8 @@ const (
 	jobSelectorKey = "job"
 )
 
-var _ = KubeDescribe("Job", func() {
-	f := NewDefaultFramework("job")
+var _ = framework.KubeDescribe("Job", func() {
+	f := framework.NewDefaultFramework("job")
 	parallelism := 2
 	completions := 4
 	lotsOfFailures := 5 // more than completions
@@ -101,7 +102,7 @@ var _ = KubeDescribe("Job", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Ensuring job shows many failures")
-		err = wait.Poll(poll, jobTimeout, func() (bool, error) {
+		err = wait.Poll(framework.Poll, jobTimeout, func() (bool, error) {
 			curr, err := f.Client.Extensions().Jobs(f.Namespace.Name).Get(job.Name)
 			if err != nil {
 				return false, err
@@ -271,7 +272,7 @@ func deleteJob(c *client.Client, ns, name string) error {
 // Wait for all pods to become Running.  Only use when pods will run for a long time, or it will be racy.
 func waitForAllPodsRunning(c *client.Client, ns, jobName string, parallelism int) error {
 	label := labels.SelectorFromSet(labels.Set(map[string]string{jobSelectorKey: jobName}))
-	return wait.Poll(poll, jobTimeout, func() (bool, error) {
+	return wait.Poll(framework.Poll, jobTimeout, func() (bool, error) {
 		options := api.ListOptions{LabelSelector: label}
 		pods, err := c.Pods(ns).List(options)
 		if err != nil {
@@ -289,7 +290,7 @@ func waitForAllPodsRunning(c *client.Client, ns, jobName string, parallelism int
 
 // Wait for job to reach completions.
 func waitForJobFinish(c *client.Client, ns, jobName string, completions int) error {
-	return wait.Poll(poll, jobTimeout, func() (bool, error) {
+	return wait.Poll(framework.Poll, jobTimeout, func() (bool, error) {
 		curr, err := c.Extensions().Jobs(ns).Get(jobName)
 		if err != nil {
 			return false, err
@@ -300,7 +301,7 @@ func waitForJobFinish(c *client.Client, ns, jobName string, completions int) err
 
 // Wait for job fail.
 func waitForJobFail(c *client.Client, ns, jobName string) error {
-	return wait.Poll(poll, jobTimeout, func() (bool, error) {
+	return wait.Poll(framework.Poll, jobTimeout, func() (bool, error) {
 		curr, err := c.Extensions().Jobs(ns).Get(jobName)
 		if err != nil {
 			return false, err

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -48,6 +48,7 @@ import (
 	utilnet "k8s.io/kubernetes/pkg/util/net"
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/version"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -111,135 +112,135 @@ var (
 	podProbeParametersVersion = version.MustParse("v1.2.0-alpha.4")
 )
 
-var _ = KubeDescribe("Kubectl client", func() {
+var _ = framework.KubeDescribe("Kubectl client", func() {
 	defer GinkgoRecover()
-	framework := NewDefaultFramework("kubectl")
+	f := framework.NewDefaultFramework("kubectl")
 	var c *client.Client
 	var ns string
 	BeforeEach(func() {
-		c = framework.Client
-		ns = framework.Namespace.Name
+		c = f.Client
+		ns = f.Namespace.Name
 	})
 
-	KubeDescribe("Update Demo", func() {
+	framework.KubeDescribe("Update Demo", func() {
 		var updateDemoRoot, nautilusPath, kittenPath string
 		BeforeEach(func() {
-			updateDemoRoot = filepath.Join(testContext.RepoRoot, "docs/user-guide/update-demo")
+			updateDemoRoot = filepath.Join(framework.TestContext.RepoRoot, "docs/user-guide/update-demo")
 			nautilusPath = filepath.Join(updateDemoRoot, "nautilus-rc.yaml")
 			kittenPath = filepath.Join(updateDemoRoot, "kitten-rc.yaml")
 		})
 		It("should create and stop a replication controller [Conformance]", func() {
-			defer cleanup(nautilusPath, ns, updateDemoSelector)
+			defer framework.Cleanup(nautilusPath, ns, updateDemoSelector)
 
 			By("creating a replication controller")
-			runKubectlOrDie("create", "-f", nautilusPath, fmt.Sprintf("--namespace=%v", ns))
-			validateController(c, nautilusImage, 2, "update-demo", updateDemoSelector, getUDData("nautilus.jpg", ns), ns)
+			framework.RunKubectlOrDie("create", "-f", nautilusPath, fmt.Sprintf("--namespace=%v", ns))
+			framework.ValidateController(c, nautilusImage, 2, "update-demo", updateDemoSelector, getUDData("nautilus.jpg", ns), ns)
 		})
 
 		It("should scale a replication controller [Conformance]", func() {
-			defer cleanup(nautilusPath, ns, updateDemoSelector)
+			defer framework.Cleanup(nautilusPath, ns, updateDemoSelector)
 
 			By("creating a replication controller")
-			runKubectlOrDie("create", "-f", nautilusPath, fmt.Sprintf("--namespace=%v", ns))
-			validateController(c, nautilusImage, 2, "update-demo", updateDemoSelector, getUDData("nautilus.jpg", ns), ns)
+			framework.RunKubectlOrDie("create", "-f", nautilusPath, fmt.Sprintf("--namespace=%v", ns))
+			framework.ValidateController(c, nautilusImage, 2, "update-demo", updateDemoSelector, getUDData("nautilus.jpg", ns), ns)
 			By("scaling down the replication controller")
-			runKubectlOrDie("scale", "rc", "update-demo-nautilus", "--replicas=1", "--timeout=5m", fmt.Sprintf("--namespace=%v", ns))
-			validateController(c, nautilusImage, 1, "update-demo", updateDemoSelector, getUDData("nautilus.jpg", ns), ns)
+			framework.RunKubectlOrDie("scale", "rc", "update-demo-nautilus", "--replicas=1", "--timeout=5m", fmt.Sprintf("--namespace=%v", ns))
+			framework.ValidateController(c, nautilusImage, 1, "update-demo", updateDemoSelector, getUDData("nautilus.jpg", ns), ns)
 			By("scaling up the replication controller")
-			runKubectlOrDie("scale", "rc", "update-demo-nautilus", "--replicas=2", "--timeout=5m", fmt.Sprintf("--namespace=%v", ns))
-			validateController(c, nautilusImage, 2, "update-demo", updateDemoSelector, getUDData("nautilus.jpg", ns), ns)
+			framework.RunKubectlOrDie("scale", "rc", "update-demo-nautilus", "--replicas=2", "--timeout=5m", fmt.Sprintf("--namespace=%v", ns))
+			framework.ValidateController(c, nautilusImage, 2, "update-demo", updateDemoSelector, getUDData("nautilus.jpg", ns), ns)
 		})
 
 		It("should do a rolling update of a replication controller [Conformance]", func() {
 			By("creating the initial replication controller")
-			runKubectlOrDie("create", "-f", nautilusPath, fmt.Sprintf("--namespace=%v", ns))
-			validateController(c, nautilusImage, 2, "update-demo", updateDemoSelector, getUDData("nautilus.jpg", ns), ns)
+			framework.RunKubectlOrDie("create", "-f", nautilusPath, fmt.Sprintf("--namespace=%v", ns))
+			framework.ValidateController(c, nautilusImage, 2, "update-demo", updateDemoSelector, getUDData("nautilus.jpg", ns), ns)
 			By("rolling-update to new replication controller")
-			runKubectlOrDie("rolling-update", "update-demo-nautilus", "--update-period=1s", "-f", kittenPath, fmt.Sprintf("--namespace=%v", ns))
-			validateController(c, kittenImage, 2, "update-demo", updateDemoSelector, getUDData("kitten.jpg", ns), ns)
+			framework.RunKubectlOrDie("rolling-update", "update-demo-nautilus", "--update-period=1s", "-f", kittenPath, fmt.Sprintf("--namespace=%v", ns))
+			framework.ValidateController(c, kittenImage, 2, "update-demo", updateDemoSelector, getUDData("kitten.jpg", ns), ns)
 			// Everything will hopefully be cleaned up when the namespace is deleted.
 		})
 	})
 
-	KubeDescribe("Guestbook application", func() {
+	framework.KubeDescribe("Guestbook application", func() {
 		var guestbookPath string
 
 		BeforeEach(func() {
-			guestbookPath = filepath.Join(testContext.RepoRoot, "examples/guestbook")
+			guestbookPath = filepath.Join(framework.TestContext.RepoRoot, "examples/guestbook")
 		})
 
 		It("should create and stop a working application [Conformance]", func() {
-			SkipUnlessServerVersionGTE(nodePortsOptionalVersion, c)
+			framework.SkipUnlessServerVersionGTE(nodePortsOptionalVersion, c)
 
-			defer cleanup(guestbookPath, ns, frontendSelector, redisMasterSelector, redisSlaveSelector)
+			defer framework.Cleanup(guestbookPath, ns, frontendSelector, redisMasterSelector, redisSlaveSelector)
 
 			By("creating all guestbook components")
-			runKubectlOrDie("create", "-f", guestbookPath, fmt.Sprintf("--namespace=%v", ns))
+			framework.RunKubectlOrDie("create", "-f", guestbookPath, fmt.Sprintf("--namespace=%v", ns))
 
 			By("validating guestbook app")
 			validateGuestbookApp(c, ns)
 		})
 	})
 
-	KubeDescribe("Simple pod", func() {
+	framework.KubeDescribe("Simple pod", func() {
 		var podPath string
 
 		BeforeEach(func() {
-			podPath = filepath.Join(testContext.RepoRoot, "test", "e2e", "testing-manifests", "kubectl", "pod-with-readiness-probe.yaml")
+			podPath = filepath.Join(framework.TestContext.RepoRoot, "test", "e2e", "testing-manifests", "kubectl", "pod-with-readiness-probe.yaml")
 			By(fmt.Sprintf("creating the pod from %v", podPath))
-			runKubectlOrDie("create", "-f", podPath, fmt.Sprintf("--namespace=%v", ns))
-			checkPodsRunningReady(c, ns, []string{simplePodName}, podStartTimeout)
+			framework.RunKubectlOrDie("create", "-f", podPath, fmt.Sprintf("--namespace=%v", ns))
+			framework.CheckPodsRunningReady(c, ns, []string{simplePodName}, framework.PodStartTimeout)
 		})
 		AfterEach(func() {
-			cleanup(podPath, ns, simplePodSelector)
+			framework.Cleanup(podPath, ns, simplePodSelector)
 		})
 
 		It("should support exec", func() {
 			By("executing a command in the container")
-			execOutput := runKubectlOrDie("exec", fmt.Sprintf("--namespace=%v", ns), simplePodName, "echo", "running", "in", "container")
+			execOutput := framework.RunKubectlOrDie("exec", fmt.Sprintf("--namespace=%v", ns), simplePodName, "echo", "running", "in", "container")
 			if e, a := "running in container", execOutput; e != a {
-				Failf("Unexpected kubectl exec output. Wanted %q, got %q", e, a)
+				framework.Failf("Unexpected kubectl exec output. Wanted %q, got %q", e, a)
 			}
 
 			By("executing a command in the container with noninteractive stdin")
-			execOutput = newKubectlCommand("exec", fmt.Sprintf("--namespace=%v", ns), "-i", simplePodName, "cat").
-				withStdinData("abcd1234").
-				execOrDie()
+			execOutput = framework.NewKubectlCommand("exec", fmt.Sprintf("--namespace=%v", ns), "-i", simplePodName, "cat").
+				WithStdinData("abcd1234").
+				ExecOrDie()
 			if e, a := "abcd1234", execOutput; e != a {
-				Failf("Unexpected kubectl exec output. Wanted %q, got %q", e, a)
+				framework.Failf("Unexpected kubectl exec output. Wanted %q, got %q", e, a)
 			}
 
 			// pretend that we're a user in an interactive shell
 			r, closer, err := newBlockingReader("echo hi\nexit\n")
 			if err != nil {
-				Failf("Error creating blocking reader: %v", err)
+				framework.Failf("Error creating blocking reader: %v", err)
 			}
 			// NOTE this is solely for test cleanup!
 			defer closer.Close()
 
 			By("executing a command in the container with pseudo-interactive stdin")
-			execOutput = newKubectlCommand("exec", fmt.Sprintf("--namespace=%v", ns), "-i", simplePodName, "bash").
-				withStdinReader(r).
-				execOrDie()
+			execOutput = framework.NewKubectlCommand("exec", fmt.Sprintf("--namespace=%v", ns), "-i", simplePodName, "bash").
+				WithStdinReader(r).
+				ExecOrDie()
 			if e, a := "hi", execOutput; e != a {
-				Failf("Unexpected kubectl exec output. Wanted %q, got %q", e, a)
+				framework.Failf("Unexpected kubectl exec output. Wanted %q, got %q", e, a)
 			}
 		})
 
 		It("should support exec through an HTTP proxy", func() {
 			// Note: We are skipping local since we want to verify an apiserver with HTTPS.
 			// At this time local only supports plain HTTP.
-			SkipIfProviderIs("local")
+			framework.SkipIfProviderIs("local")
 			// Fail if the variable isn't set
-			if testContext.Host == "" {
-				Failf("--host variable must be set to the full URI to the api server on e2e run.")
+			if framework.TestContext.Host == "" {
+				framework.Failf("--host variable must be set to the full URI to the api server on e2e run.")
 			}
 
 			// Make sure the apiServer is set to what kubectl requires
-			apiServer := testContext.Host
+			apiServer := framework.TestContext.Host
 			apiServerUrl, err := url.Parse(apiServer)
 			if err != nil {
-				Failf("Unable to parse URL %s. Error=%s", apiServer, err)
+				framework.Failf("Unable to parse URL %s. Error=%s", apiServer, err)
 			}
 			apiServerUrl.Scheme = "https"
 			if !strings.Contains(apiServer, ":443") {
@@ -251,49 +252,49 @@ var _ = KubeDescribe("Kubectl client", func() {
 			By("Finding a static kubectl for upload")
 			testStaticKubectlPath, err := findBinary("kubectl", "linux/386")
 			if err != nil {
-				Logf("No kubectl found: %v.\nAttempting a local build...", err)
+				framework.Logf("No kubectl found: %v.\nAttempting a local build...", err)
 				// Fall back to trying to build a local static kubectl
-				kubectlContainerPath := path.Join(testContext.RepoRoot, "/examples/kubectl-container/")
-				if _, err := os.Stat(path.Join(testContext.RepoRoot, "hack/build-go.sh")); err != nil {
-					Failf("Can't build static kubectl due to missing hack/build-go.sh. Error=%s", err)
+				kubectlContainerPath := path.Join(framework.TestContext.RepoRoot, "/examples/kubectl-container/")
+				if _, err := os.Stat(path.Join(framework.TestContext.RepoRoot, "hack/build-go.sh")); err != nil {
+					framework.Failf("Can't build static kubectl due to missing hack/build-go.sh. Error=%s", err)
 				}
 				By("Building a static kubectl for upload")
 				staticKubectlBuild := exec.Command("make", "-C", kubectlContainerPath)
 				if out, err := staticKubectlBuild.Output(); err != nil {
-					Failf("Unable to create static kubectl. Error=%s, Output=%q", err, out)
+					framework.Failf("Unable to create static kubectl. Error=%s, Output=%q", err, out)
 				}
 				// Verify the static kubectl path
 				testStaticKubectlPath = path.Join(kubectlContainerPath, "kubectl")
 				_, err := os.Stat(testStaticKubectlPath)
 				if err != nil {
-					Failf("static kubectl path could not be found in %s. Error=%s", testStaticKubectlPath, err)
+					framework.Failf("static kubectl path could not be found in %s. Error=%s", testStaticKubectlPath, err)
 				}
 			}
 			By(fmt.Sprintf("Using the kubectl in %s", testStaticKubectlPath))
 
 			// Verify the kubeconfig path
-			kubeConfigFilePath := testContext.KubeConfig
+			kubeConfigFilePath := framework.TestContext.KubeConfig
 			_, err = os.Stat(kubeConfigFilePath)
 			if err != nil {
-				Failf("kube config path could not be accessed. Error=%s", err)
+				framework.Failf("kube config path could not be accessed. Error=%s", err)
 			}
 			// start exec-proxy-tester container
-			netexecPodPath := filepath.Join(testContext.RepoRoot, "test/images/netexec/pod.yaml")
+			netexecPodPath := filepath.Join(framework.TestContext.RepoRoot, "test/images/netexec/pod.yaml")
 
 			// Add "validate=false" if the server version is less than 1.2.
 			// More details: https://github.com/kubernetes/kubernetes/issues/22884.
 			validateFlag := "--validate=true"
-			gte, err := serverVersionGTE(podProbeParametersVersion, c)
+			gte, err := framework.ServerVersionGTE(podProbeParametersVersion, c)
 			if err != nil {
-				Failf("Failed to get server version: %v", err)
+				framework.Failf("Failed to get server version: %v", err)
 			}
 			if !gte {
 				validateFlag = "--validate=false"
 			}
-			runKubectlOrDie("create", "-f", netexecPodPath, fmt.Sprintf("--namespace=%v", ns), validateFlag)
-			checkPodsRunningReady(c, ns, []string{netexecContainer}, podStartTimeout)
+			framework.RunKubectlOrDie("create", "-f", netexecPodPath, fmt.Sprintf("--namespace=%v", ns), validateFlag)
+			framework.CheckPodsRunningReady(c, ns, []string{netexecContainer}, framework.PodStartTimeout)
 			// Clean up
-			defer cleanup(netexecPodPath, ns, netexecPodSelector)
+			defer framework.Cleanup(netexecPodPath, ns, netexecPodSelector)
 			// Upload kubeconfig
 			type NetexecOutput struct {
 				Output string `json:"output"`
@@ -305,12 +306,12 @@ var _ = KubeDescribe("Kubectl client", func() {
 			By("uploading kubeconfig to netexec")
 			pipeConfigReader, postConfigBodyWriter, err := newStreamingUpload(kubeConfigFilePath)
 			if err != nil {
-				Failf("unable to create streaming upload. Error: %s", err)
+				framework.Failf("unable to create streaming upload. Error: %s", err)
 			}
 
-			subResourceProxyAvailable, err := serverVersionGTE(subResourcePodProxyVersion, c)
+			subResourceProxyAvailable, err := framework.ServerVersionGTE(framework.SubResourcePodProxyVersion, c)
 			if err != nil {
-				Failf("Unable to determine server version.  Error: %s", err)
+				framework.Failf("Unable to determine server version.  Error: %s", err)
 			}
 
 			var resp []byte
@@ -336,18 +337,18 @@ var _ = KubeDescribe("Kubectl client", func() {
 					Do().Raw()
 			}
 			if err != nil {
-				Failf("Unable to upload kubeconfig to the remote exec server due to error: %s", err)
+				framework.Failf("Unable to upload kubeconfig to the remote exec server due to error: %s", err)
 			}
 
 			if err := json.Unmarshal(resp, &uploadConfigOutput); err != nil {
-				Failf("Unable to read the result from the netexec server. Error: %s", err)
+				framework.Failf("Unable to read the result from the netexec server. Error: %s", err)
 			}
 			kubecConfigRemotePath := uploadConfigOutput.Output
 
 			// Upload
 			pipeReader, postBodyWriter, err := newStreamingUpload(testStaticKubectlPath)
 			if err != nil {
-				Failf("unable to create streaming upload. Error: %s", err)
+				framework.Failf("unable to create streaming upload. Error: %s", err)
 			}
 
 			By("uploading kubectl to netexec")
@@ -375,35 +376,35 @@ var _ = KubeDescribe("Kubectl client", func() {
 					Do().Raw()
 			}
 			if err != nil {
-				Failf("Unable to upload kubectl binary to the remote exec server due to error: %s", err)
+				framework.Failf("Unable to upload kubectl binary to the remote exec server due to error: %s", err)
 			}
 
 			if err := json.Unmarshal(resp, &uploadOutput); err != nil {
-				Failf("Unable to read the result from the netexec server. Error: %s", err)
+				framework.Failf("Unable to read the result from the netexec server. Error: %s", err)
 			}
 			uploadBinaryName := uploadOutput.Output
 			// Verify that we got the expected response back in the body
 			if !strings.HasPrefix(uploadBinaryName, "/uploads/") {
-				Failf("Unable to upload kubectl binary to remote exec server. /uploads/ not in response. Response: %s", uploadBinaryName)
+				framework.Failf("Unable to upload kubectl binary to remote exec server. /uploads/ not in response. Response: %s", uploadBinaryName)
 			}
 
 			for _, proxyVar := range []string{"https_proxy", "HTTPS_PROXY"} {
 				By("Running kubectl in netexec via an HTTP proxy using " + proxyVar)
 				// start the proxy container
-				goproxyPodPath := filepath.Join(testContext.RepoRoot, "test/images/goproxy/pod.yaml")
-				runKubectlOrDie("create", "-f", goproxyPodPath, fmt.Sprintf("--namespace=%v", ns))
-				checkPodsRunningReady(c, ns, []string{goproxyContainer}, podStartTimeout)
+				goproxyPodPath := filepath.Join(framework.TestContext.RepoRoot, "test/images/goproxy/pod.yaml")
+				framework.RunKubectlOrDie("create", "-f", goproxyPodPath, fmt.Sprintf("--namespace=%v", ns))
+				framework.CheckPodsRunningReady(c, ns, []string{goproxyContainer}, framework.PodStartTimeout)
 
 				// get the proxy address
 				goproxyPod, err := c.Pods(ns).Get(goproxyContainer)
 				if err != nil {
-					Failf("Unable to get the goproxy pod. Error: %s", err)
+					framework.Failf("Unable to get the goproxy pod. Error: %s", err)
 				}
 				proxyAddr := fmt.Sprintf("http://%s:8080", goproxyPod.Status.PodIP)
 
 				shellCommand := fmt.Sprintf("%s=%s .%s --kubeconfig=%s --server=%s --namespace=%s exec nginx echo running in container",
 					proxyVar, proxyAddr, uploadBinaryName, kubecConfigRemotePath, apiServer, ns)
-				Logf("About to remote exec: %v", shellCommand)
+				framework.Logf("About to remote exec: %v", shellCommand)
 				// Execute kubectl on remote exec server.
 				var netexecShellOutput []byte
 				if subResourceProxyAvailable {
@@ -426,78 +427,78 @@ var _ = KubeDescribe("Kubectl client", func() {
 						Do().Raw()
 				}
 				if err != nil {
-					Failf("Unable to execute kubectl binary on the remote exec server due to error: %s", err)
+					framework.Failf("Unable to execute kubectl binary on the remote exec server due to error: %s", err)
 				}
 
 				var netexecOuput NetexecOutput
 				if err := json.Unmarshal(netexecShellOutput, &netexecOuput); err != nil {
-					Failf("Unable to read the result from the netexec server. Error: %s", err)
+					framework.Failf("Unable to read the result from the netexec server. Error: %s", err)
 				}
 
 				// Get (and print!) the proxy logs here, so
 				// they'll be present in case the below check
 				// fails the test, to help diagnose #19500 if
 				// it recurs.
-				proxyLog := runKubectlOrDie("log", "goproxy", fmt.Sprintf("--namespace=%v", ns))
+				proxyLog := framework.RunKubectlOrDie("log", "goproxy", fmt.Sprintf("--namespace=%v", ns))
 
 				// Verify we got the normal output captured by the exec server
 				expectedExecOutput := "running in container\n"
 				if netexecOuput.Output != expectedExecOutput {
-					Failf("Unexpected kubectl exec output. Wanted %q, got  %q", expectedExecOutput, netexecOuput.Output)
+					framework.Failf("Unexpected kubectl exec output. Wanted %q, got  %q", expectedExecOutput, netexecOuput.Output)
 				}
 
 				// Verify the proxy server logs saw the connection
-				expectedProxyLog := fmt.Sprintf("Accepting CONNECT to %s", strings.TrimRight(strings.TrimLeft(testContext.Host, "https://"), "/api"))
+				expectedProxyLog := fmt.Sprintf("Accepting CONNECT to %s", strings.TrimRight(strings.TrimLeft(framework.TestContext.Host, "https://"), "/api"))
 
 				if !strings.Contains(proxyLog, expectedProxyLog) {
-					Failf("Missing expected log result on proxy server for %s. Expected: %q, got %q", proxyVar, expectedProxyLog, proxyLog)
+					framework.Failf("Missing expected log result on proxy server for %s. Expected: %q, got %q", proxyVar, expectedProxyLog, proxyLog)
 				}
 				// Clean up the goproxyPod
-				cleanup(goproxyPodPath, ns, goproxyPodSelector)
+				framework.Cleanup(goproxyPodPath, ns, goproxyPodSelector)
 			}
 		})
 
 		It("should support inline execution and attach", func() {
-			SkipUnlessServerVersionGTE(jobsVersion, c)
+			framework.SkipUnlessServerVersionGTE(jobsVersion, c)
 
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 
 			By("executing a command with run and attach with stdin")
-			runOutput := newKubectlCommand(nsFlag, "run", "run-test", "--image="+busyboxImage, "--restart=Never", "--attach=true", "--stdin", "--", "sh", "-c", "cat && echo 'stdin closed'").
-				withStdinData("abcd1234").
-				execOrDie()
+			runOutput := framework.NewKubectlCommand(nsFlag, "run", "run-test", "--image="+busyboxImage, "--restart=Never", "--attach=true", "--stdin", "--", "sh", "-c", "cat && echo 'stdin closed'").
+				WithStdinData("abcd1234").
+				ExecOrDie()
 			Expect(runOutput).To(ContainSubstring("abcd1234"))
 			Expect(runOutput).To(ContainSubstring("stdin closed"))
 			Expect(c.Extensions().Jobs(ns).Delete("run-test", nil)).To(BeNil())
 
 			By("executing a command with run and attach without stdin")
-			runOutput = newKubectlCommand(fmt.Sprintf("--namespace=%v", ns), "run", "run-test-2", "--image="+busyboxImage, "--restart=Never", "--attach=true", "--leave-stdin-open=true", "--", "sh", "-c", "cat && echo 'stdin closed'").
-				withStdinData("abcd1234").
-				execOrDie()
+			runOutput = framework.NewKubectlCommand(fmt.Sprintf("--namespace=%v", ns), "run", "run-test-2", "--image="+busyboxImage, "--restart=Never", "--attach=true", "--leave-stdin-open=true", "--", "sh", "-c", "cat && echo 'stdin closed'").
+				WithStdinData("abcd1234").
+				ExecOrDie()
 			Expect(runOutput).ToNot(ContainSubstring("abcd1234"))
 			Expect(runOutput).To(ContainSubstring("stdin closed"))
 			Expect(c.Extensions().Jobs(ns).Delete("run-test-2", nil)).To(BeNil())
 
 			By("executing a command with run and attach with stdin with open stdin should remain running")
-			runOutput = newKubectlCommand(nsFlag, "run", "run-test-3", "--image="+busyboxImage, "--restart=Never", "--attach=true", "--leave-stdin-open=true", "--stdin", "--", "sh", "-c", "cat && echo 'stdin closed'").
-				withStdinData("abcd1234\n").
-				execOrDie()
+			runOutput = framework.NewKubectlCommand(nsFlag, "run", "run-test-3", "--image="+busyboxImage, "--restart=Never", "--attach=true", "--leave-stdin-open=true", "--stdin", "--", "sh", "-c", "cat && echo 'stdin closed'").
+				WithStdinData("abcd1234\n").
+				ExecOrDie()
 			Expect(runOutput).ToNot(ContainSubstring("stdin closed"))
 			runTestPod, _, err := util.GetFirstPod(c, ns, labels.SelectorFromSet(map[string]string{"run": "run-test-3"}))
 			if err != nil {
 				os.Exit(1)
 			}
-			if !checkPodsRunningReady(c, ns, []string{runTestPod.Name}, time.Minute) {
-				Failf("Pod %q of Job %q should still be running", runTestPod.Name, "run-test-3")
+			if !framework.CheckPodsRunningReady(c, ns, []string{runTestPod.Name}, time.Minute) {
+				framework.Failf("Pod %q of Job %q should still be running", runTestPod.Name, "run-test-3")
 			}
 
 			// NOTE: we cannot guarantee our output showed up in the container logs before stdin was closed, so we have
 			// to loop test.
 			err = wait.PollImmediate(time.Second, time.Minute, func() (bool, error) {
-				if !checkPodsRunningReady(c, ns, []string{runTestPod.Name}, 1*time.Second) {
-					Failf("Pod %q of Job %q should still be running", runTestPod.Name, "run-test-3")
+				if !framework.CheckPodsRunningReady(c, ns, []string{runTestPod.Name}, 1*time.Second) {
+					framework.Failf("Pod %q of Job %q should still be running", runTestPod.Name, "run-test-3")
 				}
-				logOutput := runKubectlOrDie(nsFlag, "logs", runTestPod.Name)
+				logOutput := framework.RunKubectlOrDie(nsFlag, "logs", runTestPod.Name)
 				Expect(logOutput).ToNot(ContainSubstring("stdin closed"))
 				return strings.Contains(logOutput, "abcd1234"), nil
 			})
@@ -517,79 +518,79 @@ var _ = KubeDescribe("Kubectl client", func() {
 			By("curling local port output")
 			localAddr := fmt.Sprintf("http://localhost:%d", cmd.port)
 			body, err := curl(localAddr)
-			Logf("got: %s", body)
+			framework.Logf("got: %s", body)
 			if err != nil {
-				Failf("Failed http.Get of forwarded port (%s): %v", localAddr, err)
+				framework.Failf("Failed http.Get of forwarded port (%s): %v", localAddr, err)
 			}
 			if !strings.Contains(body, nginxDefaultOutput) {
-				Failf("Container port output missing expected value. Wanted:'%s', got: %s", nginxDefaultOutput, body)
+				framework.Failf("Container port output missing expected value. Wanted:'%s', got: %s", nginxDefaultOutput, body)
 			}
 		})
 	})
 
-	KubeDescribe("Kubectl api-versions", func() {
+	framework.KubeDescribe("Kubectl api-versions", func() {
 		It("should check if v1 is in available api versions [Conformance]", func() {
 			By("validating api verions")
-			output := runKubectlOrDie("api-versions")
+			output := framework.RunKubectlOrDie("api-versions")
 			if !strings.Contains(output, "v1") {
-				Failf("No v1 in kubectl api-versions")
+				framework.Failf("No v1 in kubectl api-versions")
 			}
 		})
 	})
 
-	KubeDescribe("Kubectl apply", func() {
+	framework.KubeDescribe("Kubectl apply", func() {
 		It("should apply a new configuration to an existing RC", func() {
 			mkpath := func(file string) string {
-				return filepath.Join(testContext.RepoRoot, "examples/guestbook-go", file)
+				return filepath.Join(framework.TestContext.RepoRoot, "examples/guestbook-go", file)
 			}
 			controllerJson := mkpath("redis-master-controller.json")
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 			By("creating Redis RC")
-			runKubectlOrDie("create", "-f", controllerJson, nsFlag)
+			framework.RunKubectlOrDie("create", "-f", controllerJson, nsFlag)
 			By("applying a modified configuration")
 			stdin := modifyReplicationControllerConfiguration(controllerJson)
-			newKubectlCommand("apply", "-f", "-", nsFlag).
-				withStdinReader(stdin).
-				execOrDie()
+			framework.NewKubectlCommand("apply", "-f", "-", nsFlag).
+				WithStdinReader(stdin).
+				ExecOrDie()
 			By("checking the result")
 			forEachReplicationController(c, ns, "app", "redis", validateReplicationControllerConfiguration)
 		})
 	})
 
-	KubeDescribe("Kubectl cluster-info", func() {
+	framework.KubeDescribe("Kubectl cluster-info", func() {
 		It("should check if Kubernetes master services is included in cluster-info [Conformance]", func() {
 			By("validating cluster-info")
-			output := runKubectlOrDie("cluster-info")
+			output := framework.RunKubectlOrDie("cluster-info")
 			// Can't check exact strings due to terminal control commands (colors)
 			requiredItems := []string{"Kubernetes master", "is running at"}
-			if providerIs("gce", "gke") {
+			if framework.ProviderIs("gce", "gke") {
 				requiredItems = append(requiredItems, "KubeDNS", "Heapster")
 			}
 			for _, item := range requiredItems {
 				if !strings.Contains(output, item) {
-					Failf("Missing %s in kubectl cluster-info", item)
+					framework.Failf("Missing %s in kubectl cluster-info", item)
 				}
 			}
 		})
 	})
 
-	KubeDescribe("Kubectl describe", func() {
+	framework.KubeDescribe("Kubectl describe", func() {
 		It("should check if kubectl describe prints relevant information for rc and pods [Conformance]", func() {
-			SkipUnlessServerVersionGTE(nodePortsOptionalVersion, c)
+			framework.SkipUnlessServerVersionGTE(nodePortsOptionalVersion, c)
 
 			mkpath := func(file string) string {
-				return filepath.Join(testContext.RepoRoot, "examples/guestbook-go", file)
+				return filepath.Join(framework.TestContext.RepoRoot, "examples/guestbook-go", file)
 			}
 			controllerJson := mkpath("redis-master-controller.json")
 			serviceJson := mkpath("redis-master-service.json")
 
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
-			runKubectlOrDie("create", "-f", controllerJson, nsFlag)
-			runKubectlOrDie("create", "-f", serviceJson, nsFlag)
+			framework.RunKubectlOrDie("create", "-f", controllerJson, nsFlag)
+			framework.RunKubectlOrDie("create", "-f", serviceJson, nsFlag)
 
 			// Pod
 			forEachPod(c, ns, "app", "redis", func(pod api.Pod) {
-				output := runKubectlOrDie("describe", "pod", pod.Name, nsFlag)
+				output := framework.RunKubectlOrDie("describe", "pod", pod.Name, nsFlag)
 				requiredStrings := [][]string{
 					{"Name:", "redis-master-"},
 					{"Namespace:", ns},
@@ -606,7 +607,7 @@ var _ = KubeDescribe("Kubectl client", func() {
 			})
 
 			// Rc
-			output := runKubectlOrDie("describe", "rc", "redis-master", nsFlag)
+			output := framework.RunKubectlOrDie("describe", "rc", "redis-master", nsFlag)
 			requiredStrings := [][]string{
 				{"Name:", "redis-master"},
 				{"Namespace:", ns},
@@ -624,7 +625,7 @@ var _ = KubeDescribe("Kubectl client", func() {
 			checkOutput(output, requiredStrings)
 
 			// Service
-			output = runKubectlOrDie("describe", "service", "redis-master", nsFlag)
+			output = framework.RunKubectlOrDie("describe", "service", "redis-master", nsFlag)
 			requiredStrings = [][]string{
 				{"Name:", "redis-master"},
 				{"Namespace:", ns},
@@ -642,7 +643,7 @@ var _ = KubeDescribe("Kubectl client", func() {
 			nodes, err := c.Nodes().List(api.ListOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			node := nodes.Items[0]
-			output = runKubectlOrDie("describe", "node", node.Name)
+			output = framework.RunKubectlOrDie("describe", "node", node.Name)
 			requiredStrings = [][]string{
 				{"Name:", node.Name},
 				{"Labels:"},
@@ -661,7 +662,7 @@ var _ = KubeDescribe("Kubectl client", func() {
 			checkOutput(output, requiredStrings)
 
 			// Namespace
-			output = runKubectlOrDie("describe", "namespace", ns)
+			output = framework.RunKubectlOrDie("describe", "namespace", ns)
 			requiredStrings = [][]string{
 				{"Name:", ns},
 				{"Labels:"},
@@ -672,10 +673,10 @@ var _ = KubeDescribe("Kubectl client", func() {
 		})
 	})
 
-	KubeDescribe("Kubectl expose", func() {
+	framework.KubeDescribe("Kubectl expose", func() {
 		It("should create services for rc [Conformance]", func() {
 			mkpath := func(file string) string {
-				return filepath.Join(testContext.RepoRoot, "examples/guestbook-go", file)
+				return filepath.Join(framework.TestContext.RepoRoot, "examples/guestbook-go", file)
 			}
 			controllerJson := mkpath("redis-master-controller.json")
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
@@ -683,24 +684,24 @@ var _ = KubeDescribe("Kubectl client", func() {
 			redisPort := 6379
 
 			By("creating Redis RC")
-			runKubectlOrDie("create", "-f", controllerJson, nsFlag)
+			framework.RunKubectlOrDie("create", "-f", controllerJson, nsFlag)
 			forEachPod(c, ns, "app", "redis", func(pod api.Pod) {
-				lookForStringInLog(ns, pod.Name, "redis-master", "The server is now ready to accept connections", podStartTimeout)
+				framework.LookForStringInLog(ns, pod.Name, "redis-master", "The server is now ready to accept connections", framework.PodStartTimeout)
 			})
 			validateService := func(name string, servicePort int, timeout time.Duration) {
-				err := wait.Poll(poll, timeout, func() (bool, error) {
+				err := wait.Poll(framework.Poll, timeout, func() (bool, error) {
 					endpoints, err := c.Endpoints(ns).Get(name)
 					if err != nil {
 						if apierrs.IsNotFound(err) {
 							err = nil
 						}
-						Logf("Get endpoints failed (interval %v): %v", poll, err)
+						framework.Logf("Get endpoints failed (interval %v): %v", framework.Poll, err)
 						return false, err
 					}
 
 					uidToPort := getContainerPortsByPodUID(endpoints)
 					if len(uidToPort) == 0 {
-						Logf("No endpoint found, retrying")
+						framework.Logf("No endpoint found, retrying")
 						return false, nil
 					}
 					if len(uidToPort) > 1 {
@@ -708,7 +709,7 @@ var _ = KubeDescribe("Kubectl client", func() {
 					}
 					for _, port := range uidToPort {
 						if port[0] != redisPort {
-							Failf("Wrong endpoint port: %d", port[0])
+							framework.Failf("Wrong endpoint port: %d", port[0])
 						}
 					}
 					return true, nil
@@ -719,41 +720,41 @@ var _ = KubeDescribe("Kubectl client", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				if len(service.Spec.Ports) != 1 {
-					Failf("1 port is expected")
+					framework.Failf("1 port is expected")
 				}
 				port := service.Spec.Ports[0]
 				if port.Port != servicePort {
-					Failf("Wrong service port: %d", port.Port)
+					framework.Failf("Wrong service port: %d", port.Port)
 				}
 				if port.TargetPort.IntValue() != redisPort {
-					Failf("Wrong target port: %d")
+					framework.Failf("Wrong target port: %d")
 				}
 			}
 
 			By("exposing RC")
-			runKubectlOrDie("expose", "rc", "redis-master", "--name=rm2", "--port=1234", fmt.Sprintf("--target-port=%d", redisPort), nsFlag)
-			waitForService(c, ns, "rm2", true, poll, serviceStartTimeout)
-			validateService("rm2", 1234, serviceStartTimeout)
+			framework.RunKubectlOrDie("expose", "rc", "redis-master", "--name=rm2", "--port=1234", fmt.Sprintf("--target-port=%d", redisPort), nsFlag)
+			framework.WaitForService(c, ns, "rm2", true, framework.Poll, framework.ServiceStartTimeout)
+			validateService("rm2", 1234, framework.ServiceStartTimeout)
 
 			By("exposing service")
-			runKubectlOrDie("expose", "service", "rm2", "--name=rm3", "--port=2345", fmt.Sprintf("--target-port=%d", redisPort), nsFlag)
-			waitForService(c, ns, "rm3", true, poll, serviceStartTimeout)
-			validateService("rm3", 2345, serviceStartTimeout)
+			framework.RunKubectlOrDie("expose", "service", "rm2", "--name=rm3", "--port=2345", fmt.Sprintf("--target-port=%d", redisPort), nsFlag)
+			framework.WaitForService(c, ns, "rm3", true, framework.Poll, framework.ServiceStartTimeout)
+			validateService("rm3", 2345, framework.ServiceStartTimeout)
 		})
 	})
 
-	KubeDescribe("Kubectl label", func() {
+	framework.KubeDescribe("Kubectl label", func() {
 		var podPath string
 		var nsFlag string
 		BeforeEach(func() {
-			podPath = filepath.Join(testContext.RepoRoot, "docs/user-guide/pod.yaml")
+			podPath = filepath.Join(framework.TestContext.RepoRoot, "docs/user-guide/pod.yaml")
 			By("creating the pod")
 			nsFlag = fmt.Sprintf("--namespace=%v", ns)
-			runKubectlOrDie("create", "-f", podPath, nsFlag)
-			checkPodsRunningReady(c, ns, []string{simplePodName}, podStartTimeout)
+			framework.RunKubectlOrDie("create", "-f", podPath, nsFlag)
+			framework.CheckPodsRunningReady(c, ns, []string{simplePodName}, framework.PodStartTimeout)
 		})
 		AfterEach(func() {
-			cleanup(podPath, ns, simplePodSelector)
+			framework.Cleanup(podPath, ns, simplePodSelector)
 		})
 
 		It("should update the label on a resource [Conformance]", func() {
@@ -761,67 +762,67 @@ var _ = KubeDescribe("Kubectl client", func() {
 			labelValue := "testing-label-value"
 
 			By("adding the label " + labelName + " with value " + labelValue + " to a pod")
-			runKubectlOrDie("label", "pods", simplePodName, labelName+"="+labelValue, nsFlag)
+			framework.RunKubectlOrDie("label", "pods", simplePodName, labelName+"="+labelValue, nsFlag)
 			By("verifying the pod has the label " + labelName + " with the value " + labelValue)
-			output := runKubectlOrDie("get", "pod", simplePodName, "-L", labelName, nsFlag)
+			output := framework.RunKubectlOrDie("get", "pod", simplePodName, "-L", labelName, nsFlag)
 			if !strings.Contains(output, labelValue) {
-				Failf("Failed updating label " + labelName + " to the pod " + simplePodName)
+				framework.Failf("Failed updating label " + labelName + " to the pod " + simplePodName)
 			}
 
 			By("removing the label " + labelName + " of a pod")
-			runKubectlOrDie("label", "pods", simplePodName, labelName+"-", nsFlag)
+			framework.RunKubectlOrDie("label", "pods", simplePodName, labelName+"-", nsFlag)
 			By("verifying the pod doesn't have the label " + labelName)
-			output = runKubectlOrDie("get", "pod", simplePodName, "-L", labelName, nsFlag)
+			output = framework.RunKubectlOrDie("get", "pod", simplePodName, "-L", labelName, nsFlag)
 			if strings.Contains(output, labelValue) {
-				Failf("Failed removing label " + labelName + " of the pod " + simplePodName)
+				framework.Failf("Failed removing label " + labelName + " of the pod " + simplePodName)
 			}
 		})
 	})
 
-	KubeDescribe("Kubectl logs", func() {
+	framework.KubeDescribe("Kubectl logs", func() {
 		var rcPath string
 		var nsFlag string
 		containerName := "redis-master"
 		BeforeEach(func() {
 			mkpath := func(file string) string {
-				return filepath.Join(testContext.RepoRoot, "examples/guestbook-go", file)
+				return filepath.Join(framework.TestContext.RepoRoot, "examples/guestbook-go", file)
 			}
 			rcPath = mkpath("redis-master-controller.json")
 			By("creating an rc")
 			nsFlag = fmt.Sprintf("--namespace=%v", ns)
-			runKubectlOrDie("create", "-f", rcPath, nsFlag)
+			framework.RunKubectlOrDie("create", "-f", rcPath, nsFlag)
 		})
 		AfterEach(func() {
-			cleanup(rcPath, ns, simplePodSelector)
+			framework.Cleanup(rcPath, ns, simplePodSelector)
 		})
 
 		It("should be able to retrieve and filter logs [Conformance]", func() {
-			SkipUnlessServerVersionGTE(extendedPodLogFilterVersion, c)
+			framework.SkipUnlessServerVersionGTE(extendedPodLogFilterVersion, c)
 
 			forEachPod(c, ns, "app", "redis", func(pod api.Pod) {
 				By("checking for a matching strings")
-				_, err := lookForStringInLog(ns, pod.Name, containerName, "The server is now ready to accept connections", podStartTimeout)
+				_, err := framework.LookForStringInLog(ns, pod.Name, containerName, "The server is now ready to accept connections", framework.PodStartTimeout)
 				Expect(err).NotTo(HaveOccurred())
 
 				By("limiting log lines")
-				out := runKubectlOrDie("log", pod.Name, containerName, nsFlag, "--tail=1")
+				out := framework.RunKubectlOrDie("log", pod.Name, containerName, nsFlag, "--tail=1")
 				Expect(len(out)).NotTo(BeZero())
 				Expect(len(strings.Split(out, "\n"))).To(Equal(1))
 
 				By("limiting log bytes")
-				out = runKubectlOrDie("log", pod.Name, containerName, nsFlag, "--limit-bytes=1")
+				out = framework.RunKubectlOrDie("log", pod.Name, containerName, nsFlag, "--limit-bytes=1")
 				Expect(len(strings.Split(out, "\n"))).To(Equal(1))
 				Expect(len(out)).To(Equal(1))
 
 				By("exposing timestamps")
-				out = runKubectlOrDie("log", pod.Name, containerName, nsFlag, "--tail=1", "--timestamps")
+				out = framework.RunKubectlOrDie("log", pod.Name, containerName, nsFlag, "--tail=1", "--timestamps")
 				lines := strings.Split(out, "\n")
 				Expect(len(lines)).To(Equal(1))
 				words := strings.Split(lines[0], " ")
 				Expect(len(words)).To(BeNumerically(">", 1))
 				if _, err := time.Parse(time.RFC3339Nano, words[0]); err != nil {
 					if _, err := time.Parse(time.RFC3339, words[0]); err != nil {
-						Failf("expected %q to be RFC3339 or RFC3339Nano", words[0])
+						framework.Failf("expected %q to be RFC3339 or RFC3339Nano", words[0])
 					}
 				}
 
@@ -830,27 +831,27 @@ var _ = KubeDescribe("Kubectl client", func() {
 				// because the granularity is only 1 second and
 				// it could end up rounding the wrong way.
 				time.Sleep(2500 * time.Millisecond) // ensure that startup logs on the node are seen as older than 1s
-				recent_out := runKubectlOrDie("log", pod.Name, containerName, nsFlag, "--since=1s")
+				recent_out := framework.RunKubectlOrDie("log", pod.Name, containerName, nsFlag, "--since=1s")
 				recent := len(strings.Split(recent_out, "\n"))
-				older_out := runKubectlOrDie("log", pod.Name, containerName, nsFlag, "--since=24h")
+				older_out := framework.RunKubectlOrDie("log", pod.Name, containerName, nsFlag, "--since=24h")
 				older := len(strings.Split(older_out, "\n"))
 				Expect(recent).To(BeNumerically("<", older), "expected recent(%v) to be less than older(%v)\nrecent lines:\n%v\nolder lines:\n%v\n", recent, older, recent_out, older_out)
 			})
 		})
 	})
 
-	KubeDescribe("Kubectl patch", func() {
+	framework.KubeDescribe("Kubectl patch", func() {
 		It("should add annotations for pods in rc [Conformance]", func() {
 			mkpath := func(file string) string {
-				return filepath.Join(testContext.RepoRoot, "examples/guestbook-go", file)
+				return filepath.Join(framework.TestContext.RepoRoot, "examples/guestbook-go", file)
 			}
 			controllerJson := mkpath("redis-master-controller.json")
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 			By("creating Redis RC")
-			runKubectlOrDie("create", "-f", controllerJson, nsFlag)
+			framework.RunKubectlOrDie("create", "-f", controllerJson, nsFlag)
 			By("patching all pods")
 			forEachPod(c, ns, "app", "redis", func(pod api.Pod) {
-				runKubectlOrDie("patch", "pod", pod.Name, nsFlag, "-p", "{\"metadata\":{\"annotations\":{\"x\":\"y\"}}}")
+				framework.RunKubectlOrDie("patch", "pod", pod.Name, nsFlag, "-p", "{\"metadata\":{\"annotations\":{\"x\":\"y\"}}}")
 			})
 
 			By("checking annotations")
@@ -862,25 +863,25 @@ var _ = KubeDescribe("Kubectl client", func() {
 					}
 				}
 				if !found {
-					Failf("Added annotation not found")
+					framework.Failf("Added annotation not found")
 				}
 			})
 		})
 	})
 
-	KubeDescribe("Kubectl version", func() {
+	framework.KubeDescribe("Kubectl version", func() {
 		It("should check is all data is printed [Conformance]", func() {
-			version := runKubectlOrDie("version")
+			version := framework.RunKubectlOrDie("version")
 			requiredItems := []string{"Client Version:", "Server Version:", "Major:", "Minor:", "GitCommit:"}
 			for _, item := range requiredItems {
 				if !strings.Contains(version, item) {
-					Failf("Required item %s not found in %s", item, version)
+					framework.Failf("Required item %s not found in %s", item, version)
 				}
 			}
 		})
 	})
 
-	KubeDescribe("Kubectl run default", func() {
+	framework.KubeDescribe("Kubectl run default", func() {
 		var nsFlag string
 		var name string
 
@@ -888,16 +889,16 @@ var _ = KubeDescribe("Kubectl client", func() {
 
 		BeforeEach(func() {
 			nsFlag = fmt.Sprintf("--namespace=%v", ns)
-			gte, err := serverVersionGTE(deploymentsVersion, c)
+			gte, err := framework.ServerVersionGTE(deploymentsVersion, c)
 			if err != nil {
-				Failf("Failed to get server version: %v", err)
+				framework.Failf("Failed to get server version: %v", err)
 			}
 			if gte {
 				name = "e2e-test-nginx-deployment"
-				cleanUp = func() { runKubectlOrDie("delete", "deployment", name, nsFlag) }
+				cleanUp = func() { framework.RunKubectlOrDie("delete", "deployment", name, nsFlag) }
 			} else {
 				name = "e2e-test-nginx-rc"
-				cleanUp = func() { runKubectlOrDie("delete", "rc", name, nsFlag) }
+				cleanUp = func() { framework.RunKubectlOrDie("delete", "rc", name, nsFlag) }
 			}
 		})
 
@@ -907,22 +908,22 @@ var _ = KubeDescribe("Kubectl client", func() {
 
 		It("should create an rc or deployment from an image [Conformance]", func() {
 			By("running the image " + nginxImage)
-			runKubectlOrDie("run", name, "--image="+nginxImage, nsFlag)
+			framework.RunKubectlOrDie("run", name, "--image="+nginxImage, nsFlag)
 			By("verifying the pod controlled by " + name + " gets created")
 			label := labels.SelectorFromSet(labels.Set(map[string]string{"run": name}))
-			podlist, err := waitForPodsWithLabel(c, ns, label)
+			podlist, err := framework.WaitForPodsWithLabel(c, ns, label)
 			if err != nil {
-				Failf("Failed getting pod controlled by %s: %v", name, err)
+				framework.Failf("Failed getting pod controlled by %s: %v", name, err)
 			}
 			pods := podlist.Items
 			if pods == nil || len(pods) != 1 || len(pods[0].Spec.Containers) != 1 || pods[0].Spec.Containers[0].Image != nginxImage {
-				runKubectlOrDie("get", "pods", "-L", "run", nsFlag)
-				Failf("Failed creating 1 pod with expected image %s. Number of pods = %v", nginxImage, len(pods))
+				framework.RunKubectlOrDie("get", "pods", "-L", "run", nsFlag)
+				framework.Failf("Failed creating 1 pod with expected image %s. Number of pods = %v", nginxImage, len(pods))
 			}
 		})
 	})
 
-	KubeDescribe("Kubectl run rc", func() {
+	framework.KubeDescribe("Kubectl run rc", func() {
 		var nsFlag string
 		var rcName string
 
@@ -932,32 +933,32 @@ var _ = KubeDescribe("Kubectl client", func() {
 		})
 
 		AfterEach(func() {
-			runKubectlOrDie("delete", "rc", rcName, nsFlag)
+			framework.RunKubectlOrDie("delete", "rc", rcName, nsFlag)
 		})
 
 		It("should create an rc from an image [Conformance]", func() {
 			By("running the image " + nginxImage)
-			runKubectlOrDie("run", rcName, "--image="+nginxImage, "--generator=run/v1", nsFlag)
+			framework.RunKubectlOrDie("run", rcName, "--image="+nginxImage, "--generator=run/v1", nsFlag)
 			By("verifying the rc " + rcName + " was created")
 			rc, err := c.ReplicationControllers(ns).Get(rcName)
 			if err != nil {
-				Failf("Failed getting rc %s: %v", rcName, err)
+				framework.Failf("Failed getting rc %s: %v", rcName, err)
 			}
 			containers := rc.Spec.Template.Spec.Containers
 			if containers == nil || len(containers) != 1 || containers[0].Image != nginxImage {
-				Failf("Failed creating rc %s for 1 pod with expected image %s", rcName, nginxImage)
+				framework.Failf("Failed creating rc %s for 1 pod with expected image %s", rcName, nginxImage)
 			}
 
 			By("verifying the pod controlled by rc " + rcName + " was created")
 			label := labels.SelectorFromSet(labels.Set(map[string]string{"run": rcName}))
-			podlist, err := waitForPodsWithLabel(c, ns, label)
+			podlist, err := framework.WaitForPodsWithLabel(c, ns, label)
 			if err != nil {
-				Failf("Failed getting pod controlled by rc %s: %v", rcName, err)
+				framework.Failf("Failed getting pod controlled by rc %s: %v", rcName, err)
 			}
 			pods := podlist.Items
 			if pods == nil || len(pods) != 1 || len(pods[0].Spec.Containers) != 1 || pods[0].Spec.Containers[0].Image != nginxImage {
-				runKubectlOrDie("get", "pods", "-L", "run", nsFlag)
-				Failf("Failed creating 1 pod with expected image %s. Number of pods = %v", nginxImage, len(pods))
+				framework.RunKubectlOrDie("get", "pods", "-L", "run", nsFlag)
+				framework.Failf("Failed creating 1 pod with expected image %s. Number of pods = %v", nginxImage, len(pods))
 			}
 
 			By("confirm that you can get logs from an rc")
@@ -965,18 +966,18 @@ var _ = KubeDescribe("Kubectl client", func() {
 			for _, pod := range pods {
 				podNames = append(podNames, pod.Name)
 			}
-			if !checkPodsRunningReady(c, ns, podNames, podStartTimeout) {
-				Failf("Pods for rc %s were not ready", rcName)
+			if !framework.CheckPodsRunningReady(c, ns, podNames, framework.PodStartTimeout) {
+				framework.Failf("Pods for rc %s were not ready", rcName)
 			}
-			_, err = runKubectl("logs", "rc/"+rcName, nsFlag)
+			_, err = framework.RunKubectl("logs", "rc/"+rcName, nsFlag)
 			// a non-nil error is fine as long as we actually found a pod.
 			if err != nil && !strings.Contains(err.Error(), " in pod ") {
-				Failf("Failed getting logs by rc %s: %v", rcName, err)
+				framework.Failf("Failed getting logs by rc %s: %v", rcName, err)
 			}
 		})
 	})
 
-	KubeDescribe("Kubectl run deployment", func() {
+	framework.KubeDescribe("Kubectl run deployment", func() {
 		var nsFlag string
 		var dName string
 
@@ -986,39 +987,39 @@ var _ = KubeDescribe("Kubectl client", func() {
 		})
 
 		AfterEach(func() {
-			runKubectlOrDie("delete", "deployment", dName, nsFlag)
+			framework.RunKubectlOrDie("delete", "deployment", dName, nsFlag)
 		})
 
 		It("should create a deployment from an image [Conformance]", func() {
-			SkipUnlessServerVersionGTE(deploymentsVersion, c)
+			framework.SkipUnlessServerVersionGTE(deploymentsVersion, c)
 
 			By("running the image " + nginxImage)
-			runKubectlOrDie("run", dName, "--image="+nginxImage, "--generator=deployment/v1beta1", nsFlag)
+			framework.RunKubectlOrDie("run", dName, "--image="+nginxImage, "--generator=deployment/v1beta1", nsFlag)
 			By("verifying the deployment " + dName + " was created")
 			d, err := c.Extensions().Deployments(ns).Get(dName)
 			if err != nil {
-				Failf("Failed getting deployment %s: %v", dName, err)
+				framework.Failf("Failed getting deployment %s: %v", dName, err)
 			}
 			containers := d.Spec.Template.Spec.Containers
 			if containers == nil || len(containers) != 1 || containers[0].Image != nginxImage {
-				Failf("Failed creating deployment %s for 1 pod with expected image %s", dName, nginxImage)
+				framework.Failf("Failed creating deployment %s for 1 pod with expected image %s", dName, nginxImage)
 			}
 
 			By("verifying the pod controlled by deployment " + dName + " was created")
 			label := labels.SelectorFromSet(labels.Set(map[string]string{"run": dName}))
-			podlist, err := waitForPodsWithLabel(c, ns, label)
+			podlist, err := framework.WaitForPodsWithLabel(c, ns, label)
 			if err != nil {
-				Failf("Failed getting pod controlled by deployment %s: %v", dName, err)
+				framework.Failf("Failed getting pod controlled by deployment %s: %v", dName, err)
 			}
 			pods := podlist.Items
 			if pods == nil || len(pods) != 1 || len(pods[0].Spec.Containers) != 1 || pods[0].Spec.Containers[0].Image != nginxImage {
-				runKubectlOrDie("get", "pods", "-L", "run", nsFlag)
-				Failf("Failed creating 1 pod with expected image %s. Number of pods = %v", nginxImage, len(pods))
+				framework.RunKubectlOrDie("get", "pods", "-L", "run", nsFlag)
+				framework.Failf("Failed creating 1 pod with expected image %s. Number of pods = %v", nginxImage, len(pods))
 			}
 		})
 	})
 
-	KubeDescribe("Kubectl run job", func() {
+	framework.KubeDescribe("Kubectl run job", func() {
 		var nsFlag string
 		var jobName string
 
@@ -1028,62 +1029,62 @@ var _ = KubeDescribe("Kubectl client", func() {
 		})
 
 		AfterEach(func() {
-			runKubectlOrDie("delete", "jobs", jobName, nsFlag)
+			framework.RunKubectlOrDie("delete", "jobs", jobName, nsFlag)
 		})
 
 		It("should create a job from an image when restart is OnFailure [Conformance]", func() {
-			SkipUnlessServerVersionGTE(jobsVersion, c)
+			framework.SkipUnlessServerVersionGTE(jobsVersion, c)
 
 			By("running the image " + nginxImage)
-			runKubectlOrDie("run", jobName, "--restart=OnFailure", "--image="+nginxImage, nsFlag)
+			framework.RunKubectlOrDie("run", jobName, "--restart=OnFailure", "--image="+nginxImage, nsFlag)
 			By("verifying the job " + jobName + " was created")
 			job, err := c.Extensions().Jobs(ns).Get(jobName)
 			if err != nil {
-				Failf("Failed getting job %s: %v", jobName, err)
+				framework.Failf("Failed getting job %s: %v", jobName, err)
 			}
 			containers := job.Spec.Template.Spec.Containers
 			if containers == nil || len(containers) != 1 || containers[0].Image != nginxImage {
-				Failf("Failed creating job %s for 1 pod with expected image %s", jobName, nginxImage)
+				framework.Failf("Failed creating job %s for 1 pod with expected image %s", jobName, nginxImage)
 			}
 			if job.Spec.Template.Spec.RestartPolicy != api.RestartPolicyOnFailure {
-				Failf("Failed creating a job with correct restart policy for --restart=OnFailure")
+				framework.Failf("Failed creating a job with correct restart policy for --restart=OnFailure")
 			}
 		})
 
 		It("should create a job from an image when restart is Never [Conformance]", func() {
-			SkipUnlessServerVersionGTE(jobsVersion, c)
+			framework.SkipUnlessServerVersionGTE(jobsVersion, c)
 
 			By("running the image " + nginxImage)
-			runKubectlOrDie("run", jobName, "--restart=Never", "--image="+nginxImage, nsFlag)
+			framework.RunKubectlOrDie("run", jobName, "--restart=Never", "--image="+nginxImage, nsFlag)
 			By("verifying the job " + jobName + " was created")
 			job, err := c.Extensions().Jobs(ns).Get(jobName)
 			if err != nil {
-				Failf("Failed getting job %s: %v", jobName, err)
+				framework.Failf("Failed getting job %s: %v", jobName, err)
 			}
 			containers := job.Spec.Template.Spec.Containers
 			if containers == nil || len(containers) != 1 || containers[0].Image != nginxImage {
-				Failf("Failed creating job %s for 1 pod with expected image %s", jobName, nginxImage)
+				framework.Failf("Failed creating job %s for 1 pod with expected image %s", jobName, nginxImage)
 			}
 			if job.Spec.Template.Spec.RestartPolicy != api.RestartPolicyNever {
-				Failf("Failed creating a job with correct restart policy for --restart=OnFailure")
+				framework.Failf("Failed creating a job with correct restart policy for --restart=OnFailure")
 			}
 		})
 	})
 
-	KubeDescribe("Kubectl run --rm job", func() {
+	framework.KubeDescribe("Kubectl run --rm job", func() {
 		nsFlag := fmt.Sprintf("--namespace=%v", ns)
 		jobName := "e2e-test-rm-busybox-job"
 
 		It("should create a job from an image, then delete the job [Conformance]", func() {
-			SkipUnlessServerVersionGTE(jobsVersion, c)
+			framework.SkipUnlessServerVersionGTE(jobsVersion, c)
 
 			By("executing a command with run --rm and attach with stdin")
 			t := time.NewTimer(runJobTimeout)
 			defer t.Stop()
-			runOutput := newKubectlCommand(nsFlag, "run", jobName, "--image="+busyboxImage, "--rm=true", "--restart=Never", "--attach=true", "--stdin", "--", "sh", "-c", "cat && echo 'stdin closed'").
-				withStdinData("abcd1234").
-				withTimeout(t.C).
-				execOrDie()
+			runOutput := framework.NewKubectlCommand(nsFlag, "run", jobName, "--image="+busyboxImage, "--rm=true", "--restart=Never", "--attach=true", "--stdin", "--", "sh", "-c", "cat && echo 'stdin closed'").
+				WithStdinData("abcd1234").
+				WithTimeout(t.C).
+				ExecOrDie()
 			Expect(runOutput).To(ContainSubstring("abcd1234"))
 			Expect(runOutput).To(ContainSubstring("stdin closed"))
 
@@ -1094,25 +1095,25 @@ var _ = KubeDescribe("Kubectl client", func() {
 		})
 	})
 
-	KubeDescribe("Proxy server", func() {
+	framework.KubeDescribe("Proxy server", func() {
 		// TODO: test proxy options (static, prefix, etc)
 		It("should support proxy with --port 0 [Conformance]", func() {
 			By("starting the proxy server")
 			port, cmd, err := startProxyServer()
 			if cmd != nil {
-				defer tryKill(cmd)
+				defer framework.TryKill(cmd)
 			}
 			if err != nil {
-				Failf("Failed to start proxy server: %v", err)
+				framework.Failf("Failed to start proxy server: %v", err)
 			}
 			By("curling proxy /api/ output")
 			localAddr := fmt.Sprintf("http://localhost:%d/api/", port)
 			apiVersions, err := getAPIVersions(localAddr)
 			if err != nil {
-				Failf("Expected at least one supported apiversion, got error %v", err)
+				framework.Failf("Expected at least one supported apiversion, got error %v", err)
 			}
 			if len(apiVersions.Versions) < 1 {
-				Failf("Expected at least one supported apiversion, got %v", apiVersions)
+				framework.Failf("Expected at least one supported apiversion, got %v", apiVersions)
 			}
 		})
 
@@ -1120,27 +1121,27 @@ var _ = KubeDescribe("Kubectl client", func() {
 			By("Starting the proxy")
 			tmpdir, err := ioutil.TempDir("", "kubectl-proxy-unix")
 			if err != nil {
-				Failf("Failed to create temporary directory: %v", err)
+				framework.Failf("Failed to create temporary directory: %v", err)
 			}
 			path := filepath.Join(tmpdir, "test")
 			defer os.Remove(path)
 			defer os.Remove(tmpdir)
-			cmd := kubectlCmd("proxy", fmt.Sprintf("--unix-socket=%s", path))
-			stdout, stderr, err := startCmdAndStreamOutput(cmd)
+			cmd := framework.KubectlCmd("proxy", fmt.Sprintf("--unix-socket=%s", path))
+			stdout, stderr, err := framework.StartCmdAndStreamOutput(cmd)
 			if err != nil {
-				Failf("Failed to start kubectl command: %v", err)
+				framework.Failf("Failed to start kubectl command: %v", err)
 			}
 			defer stdout.Close()
 			defer stderr.Close()
-			defer tryKill(cmd)
+			defer framework.TryKill(cmd)
 			buf := make([]byte, 128)
 			if _, err = stdout.Read(buf); err != nil {
-				Failf("Expected output from kubectl proxy: %v", err)
+				framework.Failf("Expected output from kubectl proxy: %v", err)
 			}
 			By("retrieving proxy /api/ output")
 			_, err = curlUnix("http://unused/api", path)
 			if err != nil {
-				Failf("Failed get of /api at %s: %v", path, err)
+				framework.Failf("Failed get of /api at %s: %v", path, err)
 			}
 		})
 	})
@@ -1155,11 +1156,11 @@ func checkOutput(output string, required [][]string) {
 			currentLine++
 		}
 		if currentLine == len(outputLines) {
-			Failf("Failed to find %s in %s", requirement[0], output)
+			framework.Failf("Failed to find %s in %s", requirement[0], output)
 		}
 		for _, item := range requirement[1:] {
 			if !strings.Contains(outputLines[currentLine], item) {
-				Failf("Failed to find %s in %s", item, outputLines[currentLine])
+				framework.Failf("Failed to find %s in %s", item, outputLines[currentLine])
 			}
 		}
 	}
@@ -1179,8 +1180,8 @@ func getAPIVersions(apiEndpoint string) (*unversioned.APIVersions, error) {
 
 func startProxyServer() (int, *exec.Cmd, error) {
 	// Specifying port 0 indicates we want the os to pick a random port.
-	cmd := kubectlCmd("proxy", "-p", "0")
-	stdout, stderr, err := startCmdAndStreamOutput(cmd)
+	cmd := framework.KubectlCmd("proxy", "-p", "0")
+	stdout, stderr, err := framework.StartCmdAndStreamOutput(cmd)
 	if err != nil {
 		return -1, nil, err
 	}
@@ -1230,19 +1231,19 @@ func curl(url string) (string, error) {
 }
 
 func validateGuestbookApp(c *client.Client, ns string) {
-	Logf("Waiting for frontend to serve content.")
+	framework.Logf("Waiting for frontend to serve content.")
 	if !waitForGuestbookResponse(c, "get", "", `{"data": ""}`, guestbookStartupTimeout, ns) {
-		Failf("Frontend service did not start serving content in %v seconds.", guestbookStartupTimeout.Seconds())
+		framework.Failf("Frontend service did not start serving content in %v seconds.", guestbookStartupTimeout.Seconds())
 	}
 
-	Logf("Trying to add a new entry to the guestbook.")
+	framework.Logf("Trying to add a new entry to the guestbook.")
 	if !waitForGuestbookResponse(c, "set", "TestEntry", `{"message": "Updated"}`, guestbookResponseTimeout, ns) {
-		Failf("Cannot added new entry in %v seconds.", guestbookResponseTimeout.Seconds())
+		framework.Failf("Cannot added new entry in %v seconds.", guestbookResponseTimeout.Seconds())
 	}
 
-	Logf("Verifying that added entry can be retrieved.")
+	framework.Logf("Verifying that added entry can be retrieved.")
 	if !waitForGuestbookResponse(c, "get", "", `{"data": "TestEntry"}`, guestbookResponseTimeout, ns) {
-		Failf("Entry to guestbook wasn't correctly added in %v seconds.", guestbookResponseTimeout.Seconds())
+		framework.Failf("Entry to guestbook wasn't correctly added in %v seconds.", guestbookResponseTimeout.Seconds())
 	}
 }
 
@@ -1253,13 +1254,13 @@ func waitForGuestbookResponse(c *client.Client, cmd, arg, expectedResponse strin
 		if err == nil && res == expectedResponse {
 			return true
 		}
-		Logf("Failed to get response from guestbook. err: %v, response: %s", err, res)
+		framework.Logf("Failed to get response from guestbook. err: %v, response: %s", err, res)
 	}
 	return false
 }
 
 func makeRequestToGuestbook(c *client.Client, cmd, value string, ns string) (string, error) {
-	proxyRequest, errProxy := getServicesProxyRequest(c, c.Get())
+	proxyRequest, errProxy := framework.GetServicesProxyRequest(c, c.Get())
 	if errProxy != nil {
 		return "", errProxy
 	}
@@ -1283,12 +1284,12 @@ const applyTestLabel = "kubectl.kubernetes.io/apply-test"
 func readBytesFromFile(filename string) []byte {
 	file, err := os.Open(filename)
 	if err != nil {
-		Failf(err.Error())
+		framework.Failf(err.Error())
 	}
 
 	data, err := ioutil.ReadAll(file)
 	if err != nil {
-		Failf(err.Error())
+		framework.Failf(err.Error())
 	}
 
 	return data
@@ -1298,7 +1299,7 @@ func readReplicationControllerFromFile(filename string) *api.ReplicationControll
 	data := readBytesFromFile(filename)
 	rc := api.ReplicationController{}
 	if err := yaml.Unmarshal(data, &rc); err != nil {
-		Failf(err.Error())
+		framework.Failf(err.Error())
 	}
 
 	return &rc
@@ -1311,7 +1312,7 @@ func modifyReplicationControllerConfiguration(filename string) io.Reader {
 	rc.Spec.Template.Labels[applyTestLabel] = "ADDED"
 	data, err := json.Marshal(rc)
 	if err != nil {
-		Failf("json marshal failed: %s\n", err)
+		framework.Failf("json marshal failed: %s\n", err)
 	}
 
 	return bytes.NewReader(data)
@@ -1320,7 +1321,7 @@ func modifyReplicationControllerConfiguration(filename string) io.Reader {
 func forEachReplicationController(c *client.Client, ns, selectorKey, selectorValue string, fn func(api.ReplicationController)) {
 	var rcs *api.ReplicationControllerList
 	var err error
-	for t := time.Now(); time.Since(t) < podListTimeout; time.Sleep(poll) {
+	for t := time.Now(); time.Since(t) < framework.PodListTimeout; time.Sleep(framework.Poll) {
 		label := labels.SelectorFromSet(labels.Set(map[string]string{selectorKey: selectorValue}))
 		options := api.ListOptions{LabelSelector: label}
 		rcs, err = c.ReplicationControllers(ns).List(options)
@@ -1331,7 +1332,7 @@ func forEachReplicationController(c *client.Client, ns, selectorKey, selectorVal
 	}
 
 	if rcs == nil || len(rcs.Items) == 0 {
-		Failf("No replication controllers found")
+		framework.Failf("No replication controllers found")
 	}
 
 	for _, rc := range rcs.Items {
@@ -1342,11 +1343,11 @@ func forEachReplicationController(c *client.Client, ns, selectorKey, selectorVal
 func validateReplicationControllerConfiguration(rc api.ReplicationController) {
 	if rc.Name == "redis-master" {
 		if _, ok := rc.Annotations[kubectl.LastAppliedConfigAnnotation]; !ok {
-			Failf("Annotation not found in modified configuration:\n%v\n", rc)
+			framework.Failf("Annotation not found in modified configuration:\n%v\n", rc)
 		}
 
 		if value, ok := rc.Labels[applyTestLabel]; !ok || value != "ADDED" {
-			Failf("Added label %s not found in modified configuration:\n%v\n", applyTestLabel, rc)
+			framework.Failf("Added label %s not found in modified configuration:\n%v\n", applyTestLabel, rc)
 		}
 	}
 }
@@ -1358,8 +1359,8 @@ func getUDData(jpgExpected string, ns string) func(*client.Client, string) error
 
 	// getUDData validates data.json in the update-demo (returns nil if data is ok).
 	return func(c *client.Client, podID string) error {
-		Logf("validating pod %s", podID)
-		subResourceProxyAvailable, err := serverVersionGTE(subResourcePodProxyVersion, c)
+		framework.Logf("validating pod %s", podID)
+		subResourceProxyAvailable, err := framework.ServerVersionGTE(framework.SubResourcePodProxyVersion, c)
 		if err != nil {
 			return err
 		}
@@ -1386,12 +1387,12 @@ func getUDData(jpgExpected string, ns string) func(*client.Client, string) error
 		if err != nil {
 			return err
 		}
-		Logf("got data: %s", body)
+		framework.Logf("got data: %s", body)
 		var data updateDemoData
 		if err := json.Unmarshal(body, &data); err != nil {
 			return err
 		}
-		Logf("Unmarshalled json jpg/img => %s , expecting %s .", data, jpgExpected)
+		framework.Logf("Unmarshalled json jpg/img => %s , expecting %s .", data, jpgExpected)
 		if strings.Contains(data.Image, jpgExpected) {
 			return nil
 		} else {
@@ -1443,17 +1444,17 @@ func streamingUpload(file *os.File, fileName string, postBodyWriter *multipart.W
 	// Set up the form file
 	fileWriter, err := postBodyWriter.CreateFormFile("file", fileName)
 	if err != nil {
-		Failf("Unable to to write file at %s to buffer. Error: %s", fileName, err)
+		framework.Failf("Unable to to write file at %s to buffer. Error: %s", fileName, err)
 	}
 
 	// Copy kubectl binary into the file writer
 	if _, err := io.Copy(fileWriter, file); err != nil {
-		Failf("Unable to to copy file at %s into the file writer. Error: %s", fileName, err)
+		framework.Failf("Unable to to copy file at %s into the file writer. Error: %s", fileName, err)
 	}
 
 	// Nothing more should be written to this instance of the postBodyWriter
 	if err := postBodyWriter.Close(); err != nil {
-		Failf("Unable to close the writer for file upload. Error: %s", err)
+		framework.Failf("Unable to close the writer for file upload. Error: %s", err)
 	}
 }
 
@@ -1471,7 +1472,7 @@ func findBinary(binName string, platform string) (string, error) {
 	var binPath string
 
 	for _, pre := range binPrefixes {
-		tryPath := path.Join(testContext.RepoRoot, pre, platform, binName)
+		tryPath := path.Join(framework.TestContext.RepoRoot, pre, platform, binName)
 		fi, err := os.Stat(tryPath)
 		if err != nil {
 			continue

--- a/test/e2e/kubelet.go
+++ b/test/e2e/kubelet.go
@@ -25,15 +25,16 @@ import (
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 const (
-	// Interval to poll /runningpods on a node
+	// Interval to framework.Poll /runningpods on a node
 	pollInterval = 1 * time.Second
-	// Interval to poll /stats/container on a node
+	// Interval to framework.Poll /stats/container on a node
 	containerStatsPollingInterval = 5 * time.Second
 )
 
@@ -41,10 +42,10 @@ const (
 // podNamePrefix and namespace.
 func getPodMatches(c *client.Client, nodeName string, podNamePrefix string, namespace string) sets.String {
 	matches := sets.NewString()
-	Logf("Checking pods on node %v via /runningpods endpoint", nodeName)
-	runningPods, err := GetKubeletPods(c, nodeName)
+	framework.Logf("Checking pods on node %v via /runningpods endpoint", nodeName)
+	runningPods, err := framework.GetKubeletPods(c, nodeName)
 	if err != nil {
-		Logf("Error checking running pods on %v: %v", nodeName, err)
+		framework.Logf("Error checking running pods on %v: %v", nodeName, err)
 		return matches
 	}
 	for _, pod := range runningPods.Items {
@@ -81,25 +82,25 @@ func waitTillNPodsRunningOnNodes(c *client.Client, nodeNames sets.String, podNam
 		if seen.Len() == targetNumPods {
 			return true, nil
 		}
-		Logf("Waiting for %d pods to be running on the node; %d are currently running;", targetNumPods, seen.Len())
+		framework.Logf("Waiting for %d pods to be running on the node; %d are currently running;", targetNumPods, seen.Len())
 		return false, nil
 	})
 }
 
-var _ = KubeDescribe("kubelet", func() {
+var _ = framework.KubeDescribe("kubelet", func() {
 	var numNodes int
 	var nodeNames sets.String
-	framework := NewDefaultFramework("kubelet")
-	var resourceMonitor *resourceMonitor
+	f := framework.NewDefaultFramework("kubelet")
+	var resourceMonitor *framework.ResourceMonitor
 
 	BeforeEach(func() {
-		nodes := ListSchedulableNodesOrDie(framework.Client)
+		nodes := framework.ListSchedulableNodesOrDie(f.Client)
 		numNodes = len(nodes.Items)
 		nodeNames = sets.NewString()
 		for _, node := range nodes.Items {
 			nodeNames.Insert(node.Name)
 		}
-		resourceMonitor = newResourceMonitor(framework.Client, targetContainers(), containerStatsPollingInterval)
+		resourceMonitor = framework.NewResourceMonitor(f.Client, framework.TargetContainers(), containerStatsPollingInterval)
 		resourceMonitor.Start()
 	})
 
@@ -107,7 +108,7 @@ var _ = KubeDescribe("kubelet", func() {
 		resourceMonitor.Stop()
 	})
 
-	KubeDescribe("Clean up pods on node", func() {
+	framework.KubeDescribe("Clean up pods on node", func() {
 		type DeleteTest struct {
 			podsPerNode int
 			timeout     time.Duration
@@ -123,23 +124,23 @@ var _ = KubeDescribe("kubelet", func() {
 				By(fmt.Sprintf("Creating a RC of %d pods and wait until all pods of this RC are running", totalPods))
 				rcName := fmt.Sprintf("cleanup%d-%s", totalPods, string(util.NewUUID()))
 
-				Expect(RunRC(RCConfig{
-					Client:    framework.Client,
+				Expect(framework.RunRC(framework.RCConfig{
+					Client:    f.Client,
 					Name:      rcName,
-					Namespace: framework.Namespace.Name,
+					Namespace: f.Namespace.Name,
 					Image:     "gcr.io/google_containers/pause:2.0",
 					Replicas:  totalPods,
 				})).NotTo(HaveOccurred())
 				// Perform a sanity check so that we know all desired pods are
 				// running on the nodes according to kubelet. The timeout is set to
-				// only 30 seconds here because RunRC already waited for all pods to
+				// only 30 seconds here because framework.RunRC already waited for all pods to
 				// transition to the running status.
-				Expect(waitTillNPodsRunningOnNodes(framework.Client, nodeNames, rcName, framework.Namespace.Name, totalPods,
+				Expect(waitTillNPodsRunningOnNodes(f.Client, nodeNames, rcName, f.Namespace.Name, totalPods,
 					time.Second*30)).NotTo(HaveOccurred())
 				resourceMonitor.LogLatest()
 
 				By("Deleting the RC")
-				DeleteRC(framework.Client, framework.Namespace.Name, rcName)
+				framework.DeleteRC(f.Client, f.Namespace.Name, rcName)
 				// Check that the pods really are gone by querying /runningpods on the
 				// node. The /runningpods handler checks the container runtime (or its
 				// cache) and  returns a list of running pods. Some possible causes of
@@ -148,9 +149,9 @@ var _ = KubeDescribe("kubelet", func() {
 				//   - a bug in graceful termination (if it is enabled)
 				//   - docker slow to delete pods (or resource problems causing slowness)
 				start := time.Now()
-				Expect(waitTillNPodsRunningOnNodes(framework.Client, nodeNames, rcName, framework.Namespace.Name, 0,
+				Expect(waitTillNPodsRunningOnNodes(f.Client, nodeNames, rcName, f.Namespace.Name, 0,
 					itArg.timeout)).NotTo(HaveOccurred())
-				Logf("Deleting %d pods on %d nodes completed in %v after the RC was deleted", totalPods, len(nodeNames),
+				framework.Logf("Deleting %d pods on %d nodes completed in %v after the RC was deleted", totalPods, len(nodeNames),
 					time.Since(start))
 				resourceMonitor.LogCPUSummary()
 			})

--- a/test/e2e/kubelet_etc_hosts.go
+++ b/test/e2e/kubelet_etc_hosts.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/test/e2e/framework"
 )
 
 const (
@@ -37,11 +38,11 @@ const (
 type KubeletManagedHostConfig struct {
 	hostNetworkPod *api.Pod
 	pod            *api.Pod
-	f              *Framework
+	f              *framework.Framework
 }
 
-var _ = KubeDescribe("KubeletManagedEtcHosts", func() {
-	f := NewDefaultFramework("e2e-kubelet-etc-hosts")
+var _ = framework.KubeDescribe("KubeletManagedEtcHosts", func() {
+	f := framework.NewDefaultFramework("e2e-kubelet-etc-hosts")
 	config := &KubeletManagedHostConfig{
 		f: f,
 	}
@@ -94,12 +95,12 @@ func (config *KubeletManagedHostConfig) createPodWithHostNetwork() {
 func (config *KubeletManagedHostConfig) createPod(podSpec *api.Pod) *api.Pod {
 	createdPod, err := config.getPodClient().Create(podSpec)
 	if err != nil {
-		Failf("Failed to create %s pod: %v", podSpec.Name, err)
+		framework.Failf("Failed to create %s pod: %v", podSpec.Name, err)
 	}
-	expectNoError(config.f.WaitForPodRunning(podSpec.Name))
+	framework.ExpectNoError(config.f.WaitForPodRunning(podSpec.Name))
 	createdPod, err = config.getPodClient().Get(podSpec.Name)
 	if err != nil {
-		Failf("Failed to retrieve %s pod: %v", podSpec.Name, err)
+		framework.Failf("Failed to retrieve %s pod: %v", podSpec.Name, err)
 	}
 	return createdPod
 }
@@ -111,31 +112,31 @@ func (config *KubeletManagedHostConfig) getPodClient() client.PodInterface {
 func assertEtcHostsIsKubeletManaged(etcHostsContent string) {
 	isKubeletManaged := strings.Contains(etcHostsContent, etcHostsPartialContent)
 	if !isKubeletManaged {
-		Failf("/etc/hosts file should be kubelet managed, but is not: %q", etcHostsContent)
+		framework.Failf("/etc/hosts file should be kubelet managed, but is not: %q", etcHostsContent)
 	}
 }
 
 func assertEtcHostsIsNotKubeletManaged(etcHostsContent string) {
 	isKubeletManaged := strings.Contains(etcHostsContent, etcHostsPartialContent)
 	if isKubeletManaged {
-		Failf("/etc/hosts file should not be kubelet managed, but is: %q", etcHostsContent)
+		framework.Failf("/etc/hosts file should not be kubelet managed, but is: %q", etcHostsContent)
 	}
 }
 
 func (config *KubeletManagedHostConfig) getEtcHostsContent(podName, containerName string) string {
-	cmd := kubectlCmd("exec", fmt.Sprintf("--namespace=%v", config.f.Namespace.Name), podName, "-c", containerName, "cat", "/etc/hosts")
-	stdout, stderr, err := startCmdAndStreamOutput(cmd)
+	cmd := framework.KubectlCmd("exec", fmt.Sprintf("--namespace=%v", config.f.Namespace.Name), podName, "-c", containerName, "cat", "/etc/hosts")
+	stdout, stderr, err := framework.StartCmdAndStreamOutput(cmd)
 	if err != nil {
-		Failf("Failed to retrieve /etc/hosts, err: %q", err)
+		framework.Failf("Failed to retrieve /etc/hosts, err: %q", err)
 	}
 	defer stdout.Close()
 	defer stderr.Close()
 
 	buf := make([]byte, 1000)
 	var n int
-	Logf("reading from `kubectl exec` command's stdout")
+	framework.Logf("reading from `kubectl exec` command's stdout")
 	if n, err = stdout.Read(buf); err != nil {
-		Failf("Failed to read from kubectl exec stdout: %v", err)
+		framework.Failf("Failed to read from kubectl exec stdout: %v", err)
 	}
 	return string(buf[:n])
 }

--- a/test/e2e/kubelet_perf.go
+++ b/test/e2e/kubelet_perf.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/stats"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -41,33 +42,33 @@ const (
 
 type resourceTest struct {
 	podsPerNode int
-	cpuLimits   containersCPUSummary
-	memLimits   resourceUsagePerContainer
+	cpuLimits   framework.ContainersCPUSummary
+	memLimits   framework.ResourceUsagePerContainer
 }
 
 func logPodsOnNodes(c *client.Client, nodeNames []string) {
 	for _, n := range nodeNames {
-		podList, err := GetKubeletRunningPods(c, n)
+		podList, err := framework.GetKubeletRunningPods(c, n)
 		if err != nil {
-			Logf("Unable to retrieve kubelet pods for node %v", n)
+			framework.Logf("Unable to retrieve kubelet pods for node %v", n)
 			continue
 		}
-		Logf("%d pods are running on node %v", len(podList.Items), n)
+		framework.Logf("%d pods are running on node %v", len(podList.Items), n)
 	}
 }
 
-func runResourceTrackingTest(framework *Framework, podsPerNode int, nodeNames sets.String, rm *resourceMonitor,
-	expectedCPU map[string]map[float64]float64, expectedMemory resourceUsagePerContainer) {
+func runResourceTrackingTest(f *framework.Framework, podsPerNode int, nodeNames sets.String, rm *framework.ResourceMonitor,
+	expectedCPU map[string]map[float64]float64, expectedMemory framework.ResourceUsagePerContainer) {
 	numNodes := nodeNames.Len()
 	totalPods := podsPerNode * numNodes
 	By(fmt.Sprintf("Creating a RC of %d pods and wait until all pods of this RC are running", totalPods))
 	rcName := fmt.Sprintf("resource%d-%s", totalPods, string(util.NewUUID()))
 
 	// TODO: Use a more realistic workload
-	Expect(RunRC(RCConfig{
-		Client:    framework.Client,
+	Expect(framework.RunRC(framework.RCConfig{
+		Client:    f.Client,
 		Name:      rcName,
-		Namespace: framework.Namespace.Name,
+		Namespace: f.Namespace.Name,
 		Image:     "gcr.io/google_containers/pause:2.0",
 		Replicas:  totalPods,
 	})).NotTo(HaveOccurred())
@@ -78,38 +79,38 @@ func runResourceTrackingTest(framework *Framework, podsPerNode int, nodeNames se
 
 	By("Start monitoring resource usage")
 	// Periodically dump the cpu summary until the deadline is met.
-	// Note that without calling resourceMonitor.Reset(), the stats
+	// Note that without calling framework.ResourceMonitor.Reset(), the stats
 	// would occupy increasingly more memory. This should be fine
 	// for the current test duration, but we should reclaim the
 	// entries if we plan to monitor longer (e.g., 8 hours).
 	deadline := time.Now().Add(monitoringTime)
 	for time.Now().Before(deadline) {
 		timeLeft := deadline.Sub(time.Now())
-		Logf("Still running...%v left", timeLeft)
+		framework.Logf("Still running...%v left", timeLeft)
 		if timeLeft < reportingPeriod {
 			time.Sleep(timeLeft)
 		} else {
 			time.Sleep(reportingPeriod)
 		}
-		logPodsOnNodes(framework.Client, nodeNames.List())
+		logPodsOnNodes(f.Client, nodeNames.List())
 	}
 
 	By("Reporting overall resource usage")
-	logPodsOnNodes(framework.Client, nodeNames.List())
+	logPodsOnNodes(f.Client, nodeNames.List())
 	usageSummary, err := rm.GetLatest()
 	Expect(err).NotTo(HaveOccurred())
-	Logf("%s", rm.FormatResourceUsage(usageSummary))
-	verifyMemoryLimits(framework.Client, expectedMemory, usageSummary)
+	framework.Logf("%s", rm.FormatResourceUsage(usageSummary))
+	verifyMemoryLimits(f.Client, expectedMemory, usageSummary)
 
 	cpuSummary := rm.GetCPUSummary()
-	Logf("%s", rm.FormatCPUSummary(cpuSummary))
+	framework.Logf("%s", rm.FormatCPUSummary(cpuSummary))
 	verifyCPULimits(expectedCPU, cpuSummary)
 
 	By("Deleting the RC")
-	DeleteRC(framework.Client, framework.Namespace.Name, rcName)
+	framework.DeleteRC(f.Client, f.Namespace.Name, rcName)
 }
 
-func verifyMemoryLimits(c *client.Client, expected resourceUsagePerContainer, actual resourceUsagePerNode) {
+func verifyMemoryLimits(c *client.Client, expected framework.ResourceUsagePerContainer, actual framework.ResourceUsagePerNode) {
 	if expected == nil {
 		return
 	}
@@ -132,20 +133,20 @@ func verifyMemoryLimits(c *client.Client, expected resourceUsagePerContainer, ac
 		}
 		if len(nodeErrs) > 0 {
 			errList = append(errList, fmt.Sprintf("node %v:\n %s", nodeName, strings.Join(nodeErrs, ", ")))
-			heapStats, err := getKubeletHeapStats(c, nodeName)
+			heapStats, err := framework.GetKubeletHeapStats(c, nodeName)
 			if err != nil {
-				Logf("Unable to get heap stats from %q", nodeName)
+				framework.Logf("Unable to get heap stats from %q", nodeName)
 			} else {
-				Logf("Heap stats on %q\n:%v", nodeName, heapStats)
+				framework.Logf("Heap stats on %q\n:%v", nodeName, heapStats)
 			}
 		}
 	}
 	if len(errList) > 0 {
-		Failf("Memory usage exceeding limits:\n %s", strings.Join(errList, "\n"))
+		framework.Failf("Memory usage exceeding limits:\n %s", strings.Join(errList, "\n"))
 	}
 }
 
-func verifyCPULimits(expected containersCPUSummary, actual nodesCPUSummary) {
+func verifyCPULimits(expected framework.ContainersCPUSummary, actual framework.NodesCPUSummary) {
 	if expected == nil {
 		return
 	}
@@ -175,30 +176,30 @@ func verifyCPULimits(expected containersCPUSummary, actual nodesCPUSummary) {
 		}
 	}
 	if len(errList) > 0 {
-		Failf("CPU usage exceeding limits:\n %s", strings.Join(errList, "\n"))
+		framework.Failf("CPU usage exceeding limits:\n %s", strings.Join(errList, "\n"))
 	}
 }
 
 // Slow by design (1 hour)
-var _ = KubeDescribe("Kubelet [Serial] [Slow]", func() {
+var _ = framework.KubeDescribe("Kubelet [Serial] [Slow]", func() {
 	var nodeNames sets.String
-	framework := NewDefaultFramework("kubelet-perf")
-	var rm *resourceMonitor
+	f := framework.NewDefaultFramework("kubelet-perf")
+	var rm *framework.ResourceMonitor
 
 	BeforeEach(func() {
-		nodes := ListSchedulableNodesOrDie(framework.Client)
+		nodes := framework.ListSchedulableNodesOrDie(f.Client)
 		nodeNames = sets.NewString()
 		for _, node := range nodes.Items {
 			nodeNames.Insert(node.Name)
 		}
-		rm = newResourceMonitor(framework.Client, targetContainers(), containerStatsPollingPeriod)
+		rm = framework.NewResourceMonitor(f.Client, framework.TargetContainers(), containerStatsPollingPeriod)
 		rm.Start()
 	})
 
 	AfterEach(func() {
 		rm.Stop()
 	})
-	KubeDescribe("regular resource usage tracking", func() {
+	framework.KubeDescribe("regular resource usage tracking", func() {
 		// We assume that the scheduler will make reasonable scheduling choices
 		// and assign ~N pods on the node.
 		// Although we want to track N pods per node, there are N + add-on pods
@@ -210,27 +211,27 @@ var _ = KubeDescribe("Kubelet [Serial] [Slow]", func() {
 		rTests := []resourceTest{
 			{
 				podsPerNode: 0,
-				cpuLimits: containersCPUSummary{
+				cpuLimits: framework.ContainersCPUSummary{
 					stats.SystemContainerKubelet: {0.50: 0.06, 0.95: 0.08},
 					stats.SystemContainerRuntime: {0.50: 0.05, 0.95: 0.06},
 				},
 				// We set the memory limits generously because the distribution
 				// of the addon pods affect the memory usage on each node.
-				memLimits: resourceUsagePerContainer{
-					stats.SystemContainerKubelet: &containerResourceUsage{MemoryRSSInBytes: 70 * 1024 * 1024},
-					stats.SystemContainerRuntime: &containerResourceUsage{MemoryRSSInBytes: 85 * 1024 * 1024},
+				memLimits: framework.ResourceUsagePerContainer{
+					stats.SystemContainerKubelet: &framework.ContainerResourceUsage{MemoryRSSInBytes: 70 * 1024 * 1024},
+					stats.SystemContainerRuntime: &framework.ContainerResourceUsage{MemoryRSSInBytes: 85 * 1024 * 1024},
 				},
 			},
 			{
 				podsPerNode: 35,
-				cpuLimits: containersCPUSummary{
+				cpuLimits: framework.ContainersCPUSummary{
 					stats.SystemContainerKubelet: {0.50: 0.12, 0.95: 0.14},
 					stats.SystemContainerRuntime: {0.50: 0.06, 0.95: 0.08},
 				},
 				// We set the memory limits generously because the distribution
 				// of the addon pods affect the memory usage on each node.
-				memLimits: resourceUsagePerContainer{
-					stats.SystemContainerRuntime: &containerResourceUsage{MemoryRSSInBytes: 100 * 1024 * 1024},
+				memLimits: framework.ResourceUsagePerContainer{
+					stats.SystemContainerRuntime: &framework.ContainerResourceUsage{MemoryRSSInBytes: 100 * 1024 * 1024},
 				},
 			},
 			{
@@ -244,18 +245,18 @@ var _ = KubeDescribe("Kubelet [Serial] [Slow]", func() {
 			name := fmt.Sprintf(
 				"for %d pods per node over %v", podsPerNode, monitoringTime)
 			It(name, func() {
-				runResourceTrackingTest(framework, podsPerNode, nodeNames, rm, itArg.cpuLimits, itArg.memLimits)
+				runResourceTrackingTest(f, podsPerNode, nodeNames, rm, itArg.cpuLimits, itArg.memLimits)
 			})
 		}
 	})
-	KubeDescribe("experimental resource usage tracking [Feature:ExperimentalResourceUsageTracking]", func() {
+	framework.KubeDescribe("experimental resource usage tracking [Feature:ExperimentalResourceUsageTracking]", func() {
 		density := []int{100}
 		for i := range density {
 			podsPerNode := density[i]
 			name := fmt.Sprintf(
 				"for %d pods per node over %v", podsPerNode, monitoringTime)
 			It(name, func() {
-				runResourceTrackingTest(framework, podsPerNode, nodeNames, rm, nil, nil)
+				runResourceTrackingTest(f, podsPerNode, nodeNames, rm, nil, nil)
 			})
 		}
 	})

--- a/test/e2e/kubeproxy.go
+++ b/test/e2e/kubeproxy.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/intstr"
 	utilnet "k8s.io/kubernetes/pkg/util/net"
 	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
 )
 
 const (
@@ -63,15 +64,15 @@ type KubeProxyTestConfig struct {
 	testContainerPod     *api.Pod
 	hostTestContainerPod *api.Pod
 	endpointPods         []*api.Pod
-	f                    *Framework
+	f                    *framework.Framework
 	nodePortService      *api.Service
 	loadBalancerService  *api.Service
 	externalAddrs        []string
 	nodes                []api.Node
 }
 
-var _ = KubeDescribe("KubeProxy", func() {
-	f := NewDefaultFramework("e2e-kubeproxy")
+var _ = framework.KubeDescribe("KubeProxy", func() {
+	f := framework.NewDefaultFramework("e2e-kubeproxy")
 	config := &KubeProxyTestConfig{
 		f: f,
 	}
@@ -238,7 +239,7 @@ func (config *KubeProxyTestConfig) dialFromContainer(protocol, containerIP, targ
 		tries)
 
 	By(fmt.Sprintf("Dialing from container. Running command:%s", cmd))
-	stdout := RunHostCmdOrDie(config.f.Namespace.Name, config.hostTestContainerPod.Name, cmd)
+	stdout := framework.RunHostCmdOrDie(config.f.Namespace.Name, config.hostTestContainerPod.Name, cmd)
 	var output map[string][]string
 	err := json.Unmarshal([]byte(stdout), &output)
 	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Could not unmarshal curl response: %s", stdout))
@@ -258,14 +259,14 @@ func (config *KubeProxyTestConfig) dialFromNode(protocol, targetIP string, targe
 	// hitting any other.
 	forLoop := fmt.Sprintf("for i in $(seq 1 %d); do %s; echo; sleep %v; done | grep -v '^\\s*$' |sort | uniq -c | wc -l", tries, cmd, hitEndpointRetryDelay)
 	By(fmt.Sprintf("Dialing from node. command:%s", forLoop))
-	stdout := RunHostCmdOrDie(config.f.Namespace.Name, config.hostTestContainerPod.Name, forLoop)
+	stdout := framework.RunHostCmdOrDie(config.f.Namespace.Name, config.hostTestContainerPod.Name, forLoop)
 	Expect(strconv.Atoi(strings.TrimSpace(stdout))).To(BeNumerically("==", expectedCount))
 }
 
 func (config *KubeProxyTestConfig) getSelfURL(path string, expected string) {
 	cmd := fmt.Sprintf("curl -s --connect-timeout 1 http://localhost:10249%s", path)
 	By(fmt.Sprintf("Getting kube-proxy self URL %s", path))
-	stdout := RunHostCmdOrDie(config.f.Namespace.Name, config.hostTestContainerPod.Name, cmd)
+	stdout := framework.RunHostCmdOrDie(config.f.Namespace.Name, config.hostTestContainerPod.Name, cmd)
 	Expect(strings.Contains(stdout, expected)).To(BeTrue())
 }
 
@@ -421,23 +422,23 @@ func (config *KubeProxyTestConfig) waitForLoadBalancerIngressSetup() {
 
 func (config *KubeProxyTestConfig) createTestPods() {
 	testContainerPod := config.createTestPodSpec()
-	hostTestContainerPod := NewHostExecPodSpec(config.f.Namespace.Name, hostTestPodName)
+	hostTestContainerPod := framework.NewHostExecPodSpec(config.f.Namespace.Name, hostTestPodName)
 
 	config.createPod(testContainerPod)
 	config.createPod(hostTestContainerPod)
 
-	expectNoError(config.f.WaitForPodRunning(testContainerPod.Name))
-	expectNoError(config.f.WaitForPodRunning(hostTestContainerPod.Name))
+	framework.ExpectNoError(config.f.WaitForPodRunning(testContainerPod.Name))
+	framework.ExpectNoError(config.f.WaitForPodRunning(hostTestContainerPod.Name))
 
 	var err error
 	config.testContainerPod, err = config.getPodClient().Get(testContainerPod.Name)
 	if err != nil {
-		Failf("Failed to retrieve %s pod: %v", testContainerPod.Name, err)
+		framework.Failf("Failed to retrieve %s pod: %v", testContainerPod.Name, err)
 	}
 
 	config.hostTestContainerPod, err = config.getPodClient().Get(hostTestContainerPod.Name)
 	if err != nil {
-		Failf("Failed to retrieve %s pod: %v", hostTestContainerPod.Name, err)
+		framework.Failf("Failed to retrieve %s pod: %v", hostTestContainerPod.Name, err)
 	}
 }
 
@@ -445,7 +446,7 @@ func (config *KubeProxyTestConfig) createService(serviceSpec *api.Service) *api.
 	_, err := config.getServiceClient().Create(serviceSpec)
 	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to create %s service: %v", serviceSpec.Name, err))
 
-	err = waitForService(config.f.Client, config.f.Namespace.Name, serviceSpec.Name, true, 5*time.Second, 45*time.Second)
+	err = framework.WaitForService(config.f.Client, config.f.Namespace.Name, serviceSpec.Name, true, 5*time.Second, 45*time.Second)
 	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("error while waiting for service:%s err: %v", serviceSpec.Name, err))
 
 	createdService, err := config.getServiceClient().Get(serviceSpec.Name)
@@ -462,11 +463,11 @@ func (config *KubeProxyTestConfig) setup() {
 	}
 
 	By("Getting node addresses")
-	nodeList := ListSchedulableNodesOrDie(config.f.Client)
-	config.externalAddrs = NodeAddresses(nodeList, api.NodeExternalIP)
+	nodeList := framework.ListSchedulableNodesOrDie(config.f.Client)
+	config.externalAddrs = framework.NodeAddresses(nodeList, api.NodeExternalIP)
 	if len(config.externalAddrs) < 2 {
 		// fall back to legacy IPs
-		config.externalAddrs = NodeAddresses(nodeList, api.NodeLegacyHostIP)
+		config.externalAddrs = framework.NodeAddresses(nodeList, api.NodeLegacyHostIP)
 	}
 	Expect(len(config.externalAddrs)).To(BeNumerically(">=", 2), fmt.Sprintf("At least two nodes necessary with an external or LegacyHostIP"))
 	config.nodes = nodeList.Items
@@ -500,7 +501,7 @@ func (config *KubeProxyTestConfig) cleanup() {
 }
 
 func (config *KubeProxyTestConfig) createNetProxyPods(podName string, selector map[string]string) []*api.Pod {
-	nodes := ListSchedulableNodesOrDie(config.f.Client)
+	nodes := framework.ListSchedulableNodesOrDie(config.f.Client)
 
 	// create pods, one for each node
 	createdPods := make([]*api.Pod, 0, len(nodes.Items))
@@ -515,9 +516,9 @@ func (config *KubeProxyTestConfig) createNetProxyPods(podName string, selector m
 	// wait that all of them are up
 	runningPods := make([]*api.Pod, 0, len(nodes.Items))
 	for _, p := range createdPods {
-		expectNoError(config.f.WaitForPodReady(p.Name))
+		framework.ExpectNoError(config.f.WaitForPodReady(p.Name))
 		rp, err := config.getPodClient().Get(p.Name)
-		expectNoError(err)
+		framework.ExpectNoError(err)
 		runningPods = append(runningPods, rp)
 	}
 
@@ -529,14 +530,14 @@ func (config *KubeProxyTestConfig) deleteNetProxyPod() {
 	config.getPodClient().Delete(pod.Name, api.NewDeleteOptions(0))
 	config.endpointPods = config.endpointPods[1:]
 	// wait for pod being deleted.
-	err := waitForPodToDisappear(config.f.Client, config.f.Namespace.Name, pod.Name, labels.Everything(), time.Second, wait.ForeverTestTimeout)
+	err := framework.WaitForPodToDisappear(config.f.Client, config.f.Namespace.Name, pod.Name, labels.Everything(), time.Second, wait.ForeverTestTimeout)
 	if err != nil {
-		Failf("Failed to delete %s pod: %v", pod.Name, err)
+		framework.Failf("Failed to delete %s pod: %v", pod.Name, err)
 	}
 	// wait for endpoint being removed.
-	err = waitForServiceEndpointsNum(config.f.Client, config.f.Namespace.Name, nodePortServiceName, len(config.endpointPods), time.Second, wait.ForeverTestTimeout)
+	err = framework.WaitForServiceEndpointsNum(config.f.Client, config.f.Namespace.Name, nodePortServiceName, len(config.endpointPods), time.Second, wait.ForeverTestTimeout)
 	if err != nil {
-		Failf("Failed to remove endpoint from service: %s", nodePortServiceName)
+		framework.Failf("Failed to remove endpoint from service: %s", nodePortServiceName)
 	}
 	// wait for kube-proxy to catch up with the pod being deleted.
 	time.Sleep(5 * time.Second)
@@ -545,7 +546,7 @@ func (config *KubeProxyTestConfig) deleteNetProxyPod() {
 func (config *KubeProxyTestConfig) createPod(pod *api.Pod) *api.Pod {
 	createdPod, err := config.getPodClient().Create(pod)
 	if err != nil {
-		Failf("Failed to create %s pod: %v", pod.Name, err)
+		framework.Failf("Failed to create %s pod: %v", pod.Name, err)
 	}
 	return createdPod
 }

--- a/test/e2e/limit_range.go
+++ b/test/e2e/limit_range.go
@@ -21,13 +21,14 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-var _ = KubeDescribe("LimitRange", func() {
-	f := NewDefaultFramework("limitrange")
+var _ = framework.KubeDescribe("LimitRange", func() {
+	f := framework.NewDefaultFramework("limitrange")
 
 	It("should create a LimitRange with defaults and ensure pod has those defaults applied.", func() {
 		By("Creating a LimitRange")
@@ -63,7 +64,7 @@ var _ = KubeDescribe("LimitRange", func() {
 			err = equalResourceRequirement(expected, pod.Spec.Containers[i].Resources)
 			if err != nil {
 				// Print the pod to help in debugging.
-				Logf("Pod %+v does not have the expected requirements", pod)
+				framework.Logf("Pod %+v does not have the expected requirements", pod)
 				Expect(err).NotTo(HaveOccurred())
 			}
 		}
@@ -84,7 +85,7 @@ var _ = KubeDescribe("LimitRange", func() {
 			err = equalResourceRequirement(expected, pod.Spec.Containers[i].Resources)
 			if err != nil {
 				// Print the pod to help in debugging.
-				Logf("Pod %+v does not have the expected requirements", pod)
+				framework.Logf("Pod %+v does not have the expected requirements", pod)
 				Expect(err).NotTo(HaveOccurred())
 			}
 		}
@@ -103,12 +104,12 @@ var _ = KubeDescribe("LimitRange", func() {
 })
 
 func equalResourceRequirement(expected api.ResourceRequirements, actual api.ResourceRequirements) error {
-	Logf("Verifying requests: expected %s with actual %s", expected.Requests, actual.Requests)
+	framework.Logf("Verifying requests: expected %s with actual %s", expected.Requests, actual.Requests)
 	err := equalResourceList(expected.Requests, actual.Requests)
 	if err != nil {
 		return err
 	}
-	Logf("Verifying limits: expected %v with actual %v", expected.Limits, actual.Limits)
+	framework.Logf("Verifying limits: expected %v with actual %v", expected.Limits, actual.Limits)
 	err = equalResourceList(expected.Limits, actual.Limits)
 	if err != nil {
 		return err

--- a/test/e2e/mesos.go
+++ b/test/e2e/mesos.go
@@ -24,30 +24,31 @@ import (
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-var _ = KubeDescribe("Mesos", func() {
-	framework := NewDefaultFramework("pods")
+var _ = framework.KubeDescribe("Mesos", func() {
+	f := framework.NewDefaultFramework("pods")
 	var c *client.Client
 	var ns string
 
 	BeforeEach(func() {
-		SkipUnlessProviderIs("mesos/docker")
-		c = framework.Client
-		ns = framework.Namespace.Name
+		framework.SkipUnlessProviderIs("mesos/docker")
+		c = f.Client
+		ns = f.Namespace.Name
 	})
 
 	It("applies slave attributes as labels", func() {
-		nodeClient := framework.Client.Nodes()
+		nodeClient := f.Client.Nodes()
 
 		rackA := labels.SelectorFromSet(map[string]string{"k8s.mesosphere.io/attribute-rack": "1"})
 		options := api.ListOptions{LabelSelector: rackA}
 		nodes, err := nodeClient.List(options)
 		if err != nil {
-			Failf("Failed to query for node: %v", err)
+			framework.Failf("Failed to query for node: %v", err)
 		}
 		Expect(len(nodes.Items)).To(Equal(1))
 
@@ -61,14 +62,14 @@ var _ = KubeDescribe("Mesos", func() {
 	})
 
 	It("starts static pods on every node in the mesos cluster", func() {
-		client := framework.Client
-		expectNoError(allNodesReady(client, wait.ForeverTestTimeout), "all nodes ready")
+		client := f.Client
+		framework.ExpectNoError(framework.AllNodesReady(client, wait.ForeverTestTimeout), "all nodes ready")
 
-		nodelist := ListSchedulableNodesOrDie(framework.Client)
+		nodelist := framework.ListSchedulableNodesOrDie(f.Client)
 
 		const ns = "static-pods"
 		numpods := len(nodelist.Items)
-		expectNoError(waitForPodsRunningReady(ns, numpods, wait.ForeverTestTimeout),
+		framework.ExpectNoError(framework.WaitForPodsRunningReady(ns, numpods, wait.ForeverTestTimeout),
 			fmt.Sprintf("number of static pods in namespace %s is %d", ns, numpods))
 	})
 
@@ -98,13 +99,13 @@ var _ = KubeDescribe("Mesos", func() {
 				},
 			},
 		})
-		expectNoError(err)
+		framework.ExpectNoError(err)
 
-		expectNoError(waitForPodRunningInNamespace(c, podName, ns))
+		framework.ExpectNoError(framework.WaitForPodRunningInNamespace(c, podName, ns))
 		pod, err := c.Pods(ns).Get(podName)
-		expectNoError(err)
+		framework.ExpectNoError(err)
 
-		nodeClient := framework.Client.Nodes()
+		nodeClient := f.Client.Nodes()
 
 		// schedule onto node with rack=2 being assigned to the "public" role
 		rack2 := labels.SelectorFromSet(map[string]string{
@@ -112,7 +113,7 @@ var _ = KubeDescribe("Mesos", func() {
 		})
 		options := api.ListOptions{LabelSelector: rack2}
 		nodes, err := nodeClient.List(options)
-		expectNoError(err)
+		framework.ExpectNoError(err)
 
 		Expect(nodes.Items[0].Name).To(Equal(pod.Spec.NodeName))
 	})

--- a/test/e2e/monitoring.go
+++ b/test/e2e/monitoring.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"time"
 
 	influxdb "github.com/influxdb/influxdb/client"
@@ -234,12 +233,6 @@ func validatePodsAndNodes(c *client.Client, expectedPods, expectedNodes []string
 		return false
 	}
 	return true
-}
-
-func getMasterHost() string {
-	masterUrl, err := url.Parse(testContext.Host)
-	expectNoError(err)
-	return masterUrl.Host
 }
 
 func testMonitoringUsingHeapsterInfluxdb(c *client.Client) {

--- a/test/e2e/nodeoutofdisk.go
+++ b/test/e2e/nodeoutofdisk.go
@@ -27,6 +27,7 @@ import (
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -64,19 +65,19 @@ const (
 // 7. Observe that the pod in pending status schedules on that node.
 //
 // Flaky issue #20015.  We have no clear path for how to test this functionality in a non-flaky way.
-var _ = KubeDescribe("NodeOutOfDisk [Serial] [Flaky] [Disruptive]", func() {
+var _ = framework.KubeDescribe("NodeOutOfDisk [Serial] [Flaky] [Disruptive]", func() {
 	var c *client.Client
 	var unfilledNodeName, recoveredNodeName string
-	framework := NewDefaultFramework("node-outofdisk")
+	f := framework.NewDefaultFramework("node-outofdisk")
 
 	BeforeEach(func() {
-		c = framework.Client
+		c = f.Client
 
-		nodelist := ListSchedulableNodesOrDie(c)
+		nodelist := framework.ListSchedulableNodesOrDie(c)
 
 		// Skip this test on small clusters.  No need to fail since it is not a use
 		// case that any cluster of small size needs to support.
-		SkipUnlessNodeCountIsAtLeast(2)
+		framework.SkipUnlessNodeCountIsAtLeast(2)
 
 		unfilledNodeName = nodelist.Items[0].Name
 		for _, node := range nodelist.Items[1:] {
@@ -86,7 +87,7 @@ var _ = KubeDescribe("NodeOutOfDisk [Serial] [Flaky] [Disruptive]", func() {
 
 	AfterEach(func() {
 
-		nodelist := ListSchedulableNodesOrDie(c)
+		nodelist := framework.ListSchedulableNodesOrDie(c)
 		Expect(len(nodelist.Items)).ToNot(BeZero())
 		for _, node := range nodelist.Items {
 			if unfilledNodeName == node.Name || recoveredNodeName == node.Name {
@@ -98,11 +99,11 @@ var _ = KubeDescribe("NodeOutOfDisk [Serial] [Flaky] [Disruptive]", func() {
 
 	It("runs out of disk space", func() {
 		unfilledNode, err := c.Nodes().Get(unfilledNodeName)
-		expectNoError(err)
+		framework.ExpectNoError(err)
 
 		By(fmt.Sprintf("Calculating CPU availability on node %s", unfilledNode.Name))
 		milliCpu, err := availCpu(c, unfilledNode)
-		expectNoError(err)
+		framework.ExpectNoError(err)
 
 		// Per pod CPU should be just enough to fit only (numNodeOODPods - 1) pods on the given
 		// node. We compute this value by dividing the available CPU capacity on the node by
@@ -111,7 +112,7 @@ var _ = KubeDescribe("NodeOutOfDisk [Serial] [Flaky] [Disruptive]", func() {
 		// subtracting 1% from the value, we directly use 0.99 as the multiplier.
 		podCPU := int64(float64(milliCpu/(numNodeOODPods-1)) * 0.99)
 
-		ns := framework.Namespace.Name
+		ns := f.Namespace.Name
 		podClient := c.Pods(ns)
 
 		By("Creating pods and waiting for all but one pods to be scheduled")
@@ -120,9 +121,9 @@ var _ = KubeDescribe("NodeOutOfDisk [Serial] [Flaky] [Disruptive]", func() {
 			name := fmt.Sprintf("pod-node-outofdisk-%d", i)
 			createOutOfDiskPod(c, ns, name, podCPU)
 
-			expectNoError(framework.WaitForPodRunning(name))
+			framework.ExpectNoError(f.WaitForPodRunning(name))
 			pod, err := podClient.Get(name)
-			expectNoError(err)
+			framework.ExpectNoError(err)
 			Expect(pod.Spec.NodeName).To(Equal(unfilledNodeName))
 		}
 
@@ -140,7 +141,7 @@ var _ = KubeDescribe("NodeOutOfDisk [Serial] [Flaky] [Disruptive]", func() {
 			}.AsSelector()
 			options := api.ListOptions{FieldSelector: selector}
 			schedEvents, err := c.Events(ns).List(options)
-			expectNoError(err)
+			framework.ExpectNoError(err)
 
 			if len(schedEvents.Items) > 0 {
 				return true, nil
@@ -149,7 +150,7 @@ var _ = KubeDescribe("NodeOutOfDisk [Serial] [Flaky] [Disruptive]", func() {
 			}
 		})
 
-		nodelist := ListSchedulableNodesOrDie(c)
+		nodelist := framework.ListSchedulableNodesOrDie(c)
 		Expect(len(nodelist.Items)).To(BeNumerically(">", 1))
 
 		nodeToRecover := nodelist.Items[1]
@@ -159,9 +160,9 @@ var _ = KubeDescribe("NodeOutOfDisk [Serial] [Flaky] [Disruptive]", func() {
 		recoveredNodeName = nodeToRecover.Name
 
 		By(fmt.Sprintf("Verifying that pod %s schedules on node %s", pendingPodName, recoveredNodeName))
-		expectNoError(framework.WaitForPodRunning(pendingPodName))
+		framework.ExpectNoError(f.WaitForPodRunning(pendingPodName))
 		pendingPod, err := podClient.Get(pendingPodName)
-		expectNoError(err)
+		framework.ExpectNoError(err)
 		Expect(pendingPod.Spec.NodeName).To(Equal(recoveredNodeName))
 	})
 })
@@ -191,7 +192,7 @@ func createOutOfDiskPod(c *client.Client, ns, name string, milliCPU int64) {
 	}
 
 	_, err := podClient.Create(pod)
-	expectNoError(err)
+	framework.ExpectNoError(err)
 }
 
 // availCpu calculates the available CPU on a given node by subtracting the CPU requested by
@@ -218,7 +219,7 @@ func availCpu(c *client.Client, node *api.Node) (int64, error) {
 // is in turn obtained internally from cadvisor.
 func availSize(c *client.Client, node *api.Node) (uint64, error) {
 	statsResource := fmt.Sprintf("api/v1/proxy/nodes/%s/stats/", node.Name)
-	Logf("Querying stats for node %s using url %s", node.Name, statsResource)
+	framework.Logf("Querying stats for node %s using url %s", node.Name, statsResource)
 	res, err := c.Get().AbsPath(statsResource).Timeout(time.Minute).Do().Raw()
 	if err != nil {
 		return 0, fmt.Errorf("error querying cAdvisor API: %v", err)
@@ -236,21 +237,21 @@ func availSize(c *client.Client, node *api.Node) (uint64, error) {
 // below the lowDiskSpaceThreshold mark.
 func fillDiskSpace(c *client.Client, node *api.Node) {
 	avail, err := availSize(c, node)
-	expectNoError(err, "Node %s: couldn't obtain available disk size %v", node.Name, err)
+	framework.ExpectNoError(err, "Node %s: couldn't obtain available disk size %v", node.Name, err)
 
 	fillSize := (avail - lowDiskSpaceThreshold + (100 * mb))
 
-	Logf("Node %s: disk space available %d bytes", node.Name, avail)
+	framework.Logf("Node %s: disk space available %d bytes", node.Name, avail)
 	By(fmt.Sprintf("Node %s: creating a file of size %d bytes to fill the available disk space", node.Name, fillSize))
 
 	cmd := fmt.Sprintf("fallocate -l %d test.img", fillSize)
-	expectNoError(issueSSHCommand(cmd, testContext.Provider, node))
+	framework.ExpectNoError(framework.IssueSSHCommand(cmd, framework.TestContext.Provider, node))
 
-	ood := waitForNodeToBe(c, node.Name, api.NodeOutOfDisk, true, nodeOODTimeOut)
+	ood := framework.WaitForNodeToBe(c, node.Name, api.NodeOutOfDisk, true, nodeOODTimeOut)
 	Expect(ood).To(BeTrue(), "Node %s did not run out of disk within %v", node.Name, nodeOODTimeOut)
 
 	avail, err = availSize(c, node)
-	Logf("Node %s: disk space available %d bytes", node.Name, avail)
+	framework.Logf("Node %s: disk space available %d bytes", node.Name, avail)
 	Expect(avail < lowDiskSpaceThreshold).To(BeTrue())
 }
 
@@ -258,8 +259,8 @@ func fillDiskSpace(c *client.Client, node *api.Node) {
 func recoverDiskSpace(c *client.Client, node *api.Node) {
 	By(fmt.Sprintf("Recovering disk space on node %s", node.Name))
 	cmd := "rm -f test.img"
-	expectNoError(issueSSHCommand(cmd, testContext.Provider, node))
+	framework.ExpectNoError(framework.IssueSSHCommand(cmd, framework.TestContext.Provider, node))
 
-	ood := waitForNodeToBe(c, node.Name, api.NodeOutOfDisk, false, nodeOODTimeOut)
+	ood := framework.WaitForNodeToBe(c, node.Name, api.NodeOutOfDisk, false, nodeOODTimeOut)
 	Expect(ood).To(BeTrue(), "Node %s's out of disk condition status did not change to false within %v", node.Name, nodeOODTimeOut)
 }

--- a/test/e2e/pd.go
+++ b/test/e2e/pd.go
@@ -38,6 +38,7 @@ import (
 	awscloud "k8s.io/kubernetes/pkg/cloudprovider/providers/aws"
 	gcecloud "k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/test/e2e/framework"
 )
 
 const (
@@ -45,19 +46,19 @@ const (
 	gcePDDetachPollTime = 10 * time.Second
 )
 
-var _ = KubeDescribe("Pod Disks", func() {
+var _ = framework.KubeDescribe("Pod Disks", func() {
 	var (
 		podClient client.PodInterface
 		host0Name string
 		host1Name string
 	)
-	framework := NewDefaultFramework("pod-disks")
+	f := framework.NewDefaultFramework("pod-disks")
 
 	BeforeEach(func() {
-		SkipUnlessNodeCountIsAtLeast(2)
+		framework.SkipUnlessNodeCountIsAtLeast(2)
 
-		podClient = framework.Client.Pods(framework.Namespace.Name)
-		nodes := ListSchedulableNodesOrDie(framework.Client)
+		podClient = f.Client.Pods(f.Namespace.Name)
+		nodes := framework.ListSchedulableNodesOrDie(f.Client)
 
 		Expect(len(nodes.Items)).To(BeNumerically(">=", 2), "Requires at least 2 nodes")
 
@@ -68,11 +69,11 @@ var _ = KubeDescribe("Pod Disks", func() {
 	})
 
 	It("should schedule a pod w/ a RW PD, remove it, then schedule it on another host [Slow]", func() {
-		SkipUnlessProviderIs("gce", "gke", "aws")
+		framework.SkipUnlessProviderIs("gce", "gke", "aws")
 
 		By("creating PD")
 		diskName, err := createPDWithRetry()
-		expectNoError(err, "Error creating PD")
+		framework.ExpectNoError(err, "Error creating PD")
 
 		host0Pod := testPDPod([]string{diskName}, host0Name, false /* readOnly */, 1 /* numContainers */)
 		host1Pod := testPDPod([]string{diskName}, host1Name, false /* readOnly */, 1 /* numContainers */)
@@ -89,43 +90,43 @@ var _ = KubeDescribe("Pod Disks", func() {
 
 		By("submitting host0Pod to kubernetes")
 		_, err = podClient.Create(host0Pod)
-		expectNoError(err, fmt.Sprintf("Failed to create host0Pod: %v", err))
+		framework.ExpectNoError(err, fmt.Sprintf("Failed to create host0Pod: %v", err))
 
-		expectNoError(framework.WaitForPodRunningSlow(host0Pod.Name))
+		framework.ExpectNoError(f.WaitForPodRunningSlow(host0Pod.Name))
 
 		testFile := "/testpd1/tracker"
 		testFileContents := fmt.Sprintf("%v", mathrand.Int())
 
-		expectNoError(framework.WriteFileViaContainer(host0Pod.Name, containerName, testFile, testFileContents))
-		Logf("Wrote value: %v", testFileContents)
+		framework.ExpectNoError(f.WriteFileViaContainer(host0Pod.Name, containerName, testFile, testFileContents))
+		framework.Logf("Wrote value: %v", testFileContents)
 
 		By("deleting host0Pod")
-		expectNoError(podClient.Delete(host0Pod.Name, api.NewDeleteOptions(0)), "Failed to delete host0Pod")
+		framework.ExpectNoError(podClient.Delete(host0Pod.Name, api.NewDeleteOptions(0)), "Failed to delete host0Pod")
 
 		By("submitting host1Pod to kubernetes")
 		_, err = podClient.Create(host1Pod)
-		expectNoError(err, "Failed to create host1Pod")
+		framework.ExpectNoError(err, "Failed to create host1Pod")
 
-		expectNoError(framework.WaitForPodRunningSlow(host1Pod.Name))
+		framework.ExpectNoError(f.WaitForPodRunningSlow(host1Pod.Name))
 
-		v, err := framework.ReadFileViaContainer(host1Pod.Name, containerName, testFile)
-		expectNoError(err)
-		Logf("Read value: %v", v)
+		v, err := f.ReadFileViaContainer(host1Pod.Name, containerName, testFile)
+		framework.ExpectNoError(err)
+		framework.Logf("Read value: %v", v)
 
 		Expect(strings.TrimSpace(v)).To(Equal(strings.TrimSpace(testFileContents)))
 
 		By("deleting host1Pod")
-		expectNoError(podClient.Delete(host1Pod.Name, api.NewDeleteOptions(0)), "Failed to delete host1Pod")
+		framework.ExpectNoError(podClient.Delete(host1Pod.Name, api.NewDeleteOptions(0)), "Failed to delete host1Pod")
 
 		return
 	})
 
 	It("should schedule a pod w/ a readonly PD on two hosts, then remove both. [Slow]", func() {
-		SkipUnlessProviderIs("gce", "gke")
+		framework.SkipUnlessProviderIs("gce", "gke")
 
 		By("creating PD")
 		diskName, err := createPDWithRetry()
-		expectNoError(err, "Error creating PD")
+		framework.ExpectNoError(err, "Error creating PD")
 
 		rwPod := testPDPod([]string{diskName}, host0Name, false /* readOnly */, 1 /* numContainers */)
 		host0ROPod := testPDPod([]string{diskName}, host0Name, true /* readOnly */, 1 /* numContainers */)
@@ -143,36 +144,36 @@ var _ = KubeDescribe("Pod Disks", func() {
 
 		By("submitting rwPod to ensure PD is formatted")
 		_, err = podClient.Create(rwPod)
-		expectNoError(err, "Failed to create rwPod")
-		expectNoError(framework.WaitForPodRunningSlow(rwPod.Name))
-		expectNoError(podClient.Delete(rwPod.Name, api.NewDeleteOptions(0)), "Failed to delete host0Pod")
-		expectNoError(waitForPDDetach(diskName, host0Name))
+		framework.ExpectNoError(err, "Failed to create rwPod")
+		framework.ExpectNoError(f.WaitForPodRunningSlow(rwPod.Name))
+		framework.ExpectNoError(podClient.Delete(rwPod.Name, api.NewDeleteOptions(0)), "Failed to delete host0Pod")
+		framework.ExpectNoError(waitForPDDetach(diskName, host0Name))
 
 		By("submitting host0ROPod to kubernetes")
 		_, err = podClient.Create(host0ROPod)
-		expectNoError(err, "Failed to create host0ROPod")
+		framework.ExpectNoError(err, "Failed to create host0ROPod")
 
 		By("submitting host1ROPod to kubernetes")
 		_, err = podClient.Create(host1ROPod)
-		expectNoError(err, "Failed to create host1ROPod")
+		framework.ExpectNoError(err, "Failed to create host1ROPod")
 
-		expectNoError(framework.WaitForPodRunningSlow(host0ROPod.Name))
+		framework.ExpectNoError(f.WaitForPodRunningSlow(host0ROPod.Name))
 
-		expectNoError(framework.WaitForPodRunningSlow(host1ROPod.Name))
+		framework.ExpectNoError(f.WaitForPodRunningSlow(host1ROPod.Name))
 
 		By("deleting host0ROPod")
-		expectNoError(podClient.Delete(host0ROPod.Name, api.NewDeleteOptions(0)), "Failed to delete host0ROPod")
+		framework.ExpectNoError(podClient.Delete(host0ROPod.Name, api.NewDeleteOptions(0)), "Failed to delete host0ROPod")
 
 		By("deleting host1ROPod")
-		expectNoError(podClient.Delete(host1ROPod.Name, api.NewDeleteOptions(0)), "Failed to delete host1ROPod")
+		framework.ExpectNoError(podClient.Delete(host1ROPod.Name, api.NewDeleteOptions(0)), "Failed to delete host1ROPod")
 	})
 
 	It("should schedule a pod w/ a RW PD shared between multiple containers, write to PD, delete pod, verify contents, and repeat in rapid succession [Slow]", func() {
-		SkipUnlessProviderIs("gce", "gke", "aws")
+		framework.SkipUnlessProviderIs("gce", "gke", "aws")
 
 		By("creating PD")
 		diskName, err := createPDWithRetry()
-		expectNoError(err, "Error creating PD")
+		framework.ExpectNoError(err, "Error creating PD")
 		numContainers := 4
 
 		host0Pod := testPDPod([]string{diskName}, host0Name, false /* readOnly */, numContainers)
@@ -187,43 +188,43 @@ var _ = KubeDescribe("Pod Disks", func() {
 
 		fileAndContentToVerify := make(map[string]string)
 		for i := 0; i < 3; i++ {
-			Logf("PD Read/Writer Iteration #%v", i)
+			framework.Logf("PD Read/Writer Iteration #%v", i)
 			By("submitting host0Pod to kubernetes")
 			_, err = podClient.Create(host0Pod)
-			expectNoError(err, fmt.Sprintf("Failed to create host0Pod: %v", err))
+			framework.ExpectNoError(err, fmt.Sprintf("Failed to create host0Pod: %v", err))
 
-			expectNoError(framework.WaitForPodRunningSlow(host0Pod.Name))
+			framework.ExpectNoError(f.WaitForPodRunningSlow(host0Pod.Name))
 
 			// randomly select a container and read/verify pd contents from it
 			containerName := fmt.Sprintf("mycontainer%v", mathrand.Intn(numContainers)+1)
-			verifyPDContentsViaContainer(framework, host0Pod.Name, containerName, fileAndContentToVerify)
+			verifyPDContentsViaContainer(f, host0Pod.Name, containerName, fileAndContentToVerify)
 
 			// Randomly select a container to write a file to PD from
 			containerName = fmt.Sprintf("mycontainer%v", mathrand.Intn(numContainers)+1)
 			testFile := fmt.Sprintf("/testpd1/tracker%v", i)
 			testFileContents := fmt.Sprintf("%v", mathrand.Int())
 			fileAndContentToVerify[testFile] = testFileContents
-			expectNoError(framework.WriteFileViaContainer(host0Pod.Name, containerName, testFile, testFileContents))
-			Logf("Wrote value: \"%v\" to PD %q from pod %q container %q", testFileContents, diskName, host0Pod.Name, containerName)
+			framework.ExpectNoError(f.WriteFileViaContainer(host0Pod.Name, containerName, testFile, testFileContents))
+			framework.Logf("Wrote value: \"%v\" to PD %q from pod %q container %q", testFileContents, diskName, host0Pod.Name, containerName)
 
 			// Randomly select a container and read/verify pd contents from it
 			containerName = fmt.Sprintf("mycontainer%v", mathrand.Intn(numContainers)+1)
-			verifyPDContentsViaContainer(framework, host0Pod.Name, containerName, fileAndContentToVerify)
+			verifyPDContentsViaContainer(f, host0Pod.Name, containerName, fileAndContentToVerify)
 
 			By("deleting host0Pod")
-			expectNoError(podClient.Delete(host0Pod.Name, api.NewDeleteOptions(0)), "Failed to delete host0Pod")
+			framework.ExpectNoError(podClient.Delete(host0Pod.Name, api.NewDeleteOptions(0)), "Failed to delete host0Pod")
 		}
 	})
 
 	It("should schedule a pod w/two RW PDs both mounted to one container, write to PD, verify contents, delete pod, recreate pod, verify contents, and repeat in rapid succession [Slow]", func() {
-		SkipUnlessProviderIs("gce", "gke", "aws")
+		framework.SkipUnlessProviderIs("gce", "gke", "aws")
 
 		By("creating PD1")
 		disk1Name, err := createPDWithRetry()
-		expectNoError(err, "Error creating PD1")
+		framework.ExpectNoError(err, "Error creating PD1")
 		By("creating PD2")
 		disk2Name, err := createPDWithRetry()
-		expectNoError(err, "Error creating PD2")
+		framework.ExpectNoError(err, "Error creating PD2")
 
 		host0Pod := testPDPod([]string{disk1Name, disk2Name}, host0Name, false /* readOnly */, 1 /* numContainers */)
 
@@ -239,15 +240,15 @@ var _ = KubeDescribe("Pod Disks", func() {
 		containerName := "mycontainer"
 		fileAndContentToVerify := make(map[string]string)
 		for i := 0; i < 3; i++ {
-			Logf("PD Read/Writer Iteration #%v", i)
+			framework.Logf("PD Read/Writer Iteration #%v", i)
 			By("submitting host0Pod to kubernetes")
 			_, err = podClient.Create(host0Pod)
-			expectNoError(err, fmt.Sprintf("Failed to create host0Pod: %v", err))
+			framework.ExpectNoError(err, fmt.Sprintf("Failed to create host0Pod: %v", err))
 
-			expectNoError(framework.WaitForPodRunningSlow(host0Pod.Name))
+			framework.ExpectNoError(f.WaitForPodRunningSlow(host0Pod.Name))
 
 			// Read/verify pd contents for both disks from container
-			verifyPDContentsViaContainer(framework, host0Pod.Name, containerName, fileAndContentToVerify)
+			verifyPDContentsViaContainer(f, host0Pod.Name, containerName, fileAndContentToVerify)
 
 			// Write a file to both PDs from container
 			testFilePD1 := fmt.Sprintf("/testpd1/tracker%v", i)
@@ -256,16 +257,16 @@ var _ = KubeDescribe("Pod Disks", func() {
 			testFilePD2Contents := fmt.Sprintf("%v", mathrand.Int())
 			fileAndContentToVerify[testFilePD1] = testFilePD1Contents
 			fileAndContentToVerify[testFilePD2] = testFilePD2Contents
-			expectNoError(framework.WriteFileViaContainer(host0Pod.Name, containerName, testFilePD1, testFilePD1Contents))
-			Logf("Wrote value: \"%v\" to PD1 (%q) from pod %q container %q", testFilePD1Contents, disk1Name, host0Pod.Name, containerName)
-			expectNoError(framework.WriteFileViaContainer(host0Pod.Name, containerName, testFilePD2, testFilePD2Contents))
-			Logf("Wrote value: \"%v\" to PD2 (%q) from pod %q container %q", testFilePD2Contents, disk2Name, host0Pod.Name, containerName)
+			framework.ExpectNoError(f.WriteFileViaContainer(host0Pod.Name, containerName, testFilePD1, testFilePD1Contents))
+			framework.Logf("Wrote value: \"%v\" to PD1 (%q) from pod %q container %q", testFilePD1Contents, disk1Name, host0Pod.Name, containerName)
+			framework.ExpectNoError(f.WriteFileViaContainer(host0Pod.Name, containerName, testFilePD2, testFilePD2Contents))
+			framework.Logf("Wrote value: \"%v\" to PD2 (%q) from pod %q container %q", testFilePD2Contents, disk2Name, host0Pod.Name, containerName)
 
 			// Read/verify pd contents for both disks from container
-			verifyPDContentsViaContainer(framework, host0Pod.Name, containerName, fileAndContentToVerify)
+			verifyPDContentsViaContainer(f, host0Pod.Name, containerName, fileAndContentToVerify)
 
 			By("deleting host0Pod")
-			expectNoError(podClient.Delete(host0Pod.Name, api.NewDeleteOptions(0)), "Failed to delete host0Pod")
+			framework.ExpectNoError(podClient.Delete(host0Pod.Name, api.NewDeleteOptions(0)), "Failed to delete host0Pod")
 		}
 	})
 })
@@ -275,10 +276,10 @@ func createPDWithRetry() (string, error) {
 	var err error
 	for start := time.Now(); time.Since(start) < 180*time.Second; time.Sleep(5 * time.Second) {
 		if newDiskName, err = createPD(); err != nil {
-			Logf("Couldn't create a new PD. Sleeping 5 seconds (%v)", err)
+			framework.Logf("Couldn't create a new PD. Sleeping 5 seconds (%v)", err)
 			continue
 		}
-		Logf("Successfully created a new PD: %q.", newDiskName)
+		framework.Logf("Successfully created a new PD: %q.", newDiskName)
 		break
 	}
 	return newDiskName, err
@@ -288,30 +289,30 @@ func deletePDWithRetry(diskName string) {
 	var err error
 	for start := time.Now(); time.Since(start) < 180*time.Second; time.Sleep(5 * time.Second) {
 		if err = deletePD(diskName); err != nil {
-			Logf("Couldn't delete PD %q. Sleeping 5 seconds (%v)", diskName, err)
+			framework.Logf("Couldn't delete PD %q. Sleeping 5 seconds (%v)", diskName, err)
 			continue
 		}
-		Logf("Successfully deleted PD %q.", diskName)
+		framework.Logf("Successfully deleted PD %q.", diskName)
 		break
 	}
-	expectNoError(err, "Error deleting PD")
+	framework.ExpectNoError(err, "Error deleting PD")
 }
 
-func verifyPDContentsViaContainer(f *Framework, podName, containerName string, fileAndContentToVerify map[string]string) {
+func verifyPDContentsViaContainer(f *framework.Framework, podName, containerName string, fileAndContentToVerify map[string]string) {
 	for filePath, expectedContents := range fileAndContentToVerify {
 		v, err := f.ReadFileViaContainer(podName, containerName, filePath)
 		if err != nil {
-			Logf("Error reading file: %v", err)
+			framework.Logf("Error reading file: %v", err)
 		}
-		expectNoError(err)
-		Logf("Read file %q with content: %v", filePath, v)
+		framework.ExpectNoError(err)
+		framework.Logf("Read file %q with content: %v", filePath, v)
 		Expect(strings.TrimSpace(v)).To(Equal(strings.TrimSpace(expectedContents)))
 	}
 }
 
 func createPD() (string, error) {
-	if testContext.Provider == "gce" || testContext.Provider == "gke" {
-		pdName := fmt.Sprintf("%s-%s", testContext.prefix, string(util.NewUUID()))
+	if framework.TestContext.Provider == "gce" || framework.TestContext.Provider == "gke" {
+		pdName := fmt.Sprintf("%s-%s", framework.TestContext.Prefix, string(util.NewUUID()))
 
 		gceCloud, err := getGCECloud()
 		if err != nil {
@@ -319,12 +320,12 @@ func createPD() (string, error) {
 		}
 
 		tags := map[string]string{}
-		err = gceCloud.CreateDisk(pdName, testContext.CloudConfig.Zone, 10 /* sizeGb */, tags)
+		err = gceCloud.CreateDisk(pdName, framework.TestContext.CloudConfig.Zone, 10 /* sizeGb */, tags)
 		if err != nil {
 			return "", err
 		}
 		return pdName, nil
-	} else if testContext.Provider == "aws" {
+	} else if framework.TestContext.Provider == "aws" {
 		client := ec2.New(session.New())
 
 		request := &ec2.CreateVolumeInput{}
@@ -347,7 +348,7 @@ func createPD() (string, error) {
 }
 
 func deletePD(pdName string) error {
-	if testContext.Provider == "gce" || testContext.Provider == "gke" {
+	if framework.TestContext.Provider == "gce" || framework.TestContext.Provider == "gke" {
 		gceCloud, err := getGCECloud()
 		if err != nil {
 			return err
@@ -361,10 +362,10 @@ func deletePD(pdName string) error {
 				return nil
 			}
 
-			Logf("Error deleting PD %q: %v", pdName, err)
+			framework.Logf("Error deleting PD %q: %v", pdName, err)
 		}
 		return err
-	} else if testContext.Provider == "aws" {
+	} else if framework.TestContext.Provider == "aws" {
 		client := ec2.New(session.New())
 
 		tokens := strings.Split(pdName, "/")
@@ -374,7 +375,7 @@ func deletePD(pdName string) error {
 		_, err := client.DeleteVolume(request)
 		if err != nil {
 			if awsError, ok := err.(awserr.Error); ok && awsError.Code() == "InvalidVolume.NotFound" {
-				Logf("Volume deletion implicitly succeeded because volume %q does not exist.", pdName)
+				framework.Logf("Volume deletion implicitly succeeded because volume %q does not exist.", pdName)
 			} else {
 				return fmt.Errorf("error deleting EBS volumes: %v", err)
 			}
@@ -386,7 +387,7 @@ func deletePD(pdName string) error {
 }
 
 func detachPD(hostName, pdName string) error {
-	if testContext.Provider == "gce" || testContext.Provider == "gke" {
+	if framework.TestContext.Provider == "gce" || framework.TestContext.Provider == "gke" {
 		instanceName := strings.Split(hostName, ".")[0]
 
 		gceCloud, err := getGCECloud()
@@ -401,11 +402,11 @@ func detachPD(hostName, pdName string) error {
 				return nil
 			}
 
-			Logf("Error detaching PD %q: %v", pdName, err)
+			framework.Logf("Error detaching PD %q: %v", pdName, err)
 		}
 
 		return err
-	} else if testContext.Provider == "aws" {
+	} else if framework.TestContext.Provider == "aws" {
 		client := ec2.New(session.New())
 
 		tokens := strings.Split(pdName, "/")
@@ -462,7 +463,7 @@ func testPDPod(diskNames []string, targetHost string, readOnly bool, numContaine
 		},
 	}
 
-	if testContext.Provider == "gce" || testContext.Provider == "gke" {
+	if framework.TestContext.Provider == "gce" || framework.TestContext.Provider == "gke" {
 		pod.Spec.Volumes = make([]api.Volume, len(diskNames))
 		for k, diskName := range diskNames {
 			pod.Spec.Volumes[k].Name = fmt.Sprintf("testpd%v", k+1)
@@ -474,7 +475,7 @@ func testPDPod(diskNames []string, targetHost string, readOnly bool, numContaine
 				},
 			}
 		}
-	} else if testContext.Provider == "aws" {
+	} else if framework.TestContext.Provider == "aws" {
 		pod.Spec.Volumes = make([]api.Volume, len(diskNames))
 		for k, diskName := range diskNames {
 			pod.Spec.Volumes[k].Name = fmt.Sprintf("testpd%v", k+1)
@@ -487,7 +488,7 @@ func testPDPod(diskNames []string, targetHost string, readOnly bool, numContaine
 			}
 		}
 	} else {
-		panic("Unknown provider: " + testContext.Provider)
+		panic("Unknown provider: " + framework.TestContext.Provider)
 	}
 
 	return pod
@@ -495,7 +496,7 @@ func testPDPod(diskNames []string, targetHost string, readOnly bool, numContaine
 
 // Waits for specified PD to to detach from specified hostName
 func waitForPDDetach(diskName, hostName string) error {
-	if testContext.Provider == "gce" || testContext.Provider == "gke" {
+	if framework.TestContext.Provider == "gce" || framework.TestContext.Provider == "gke" {
 		gceCloud, err := getGCECloud()
 		if err != nil {
 			return err
@@ -504,17 +505,17 @@ func waitForPDDetach(diskName, hostName string) error {
 		for start := time.Now(); time.Since(start) < gcePDDetachTimeout; time.Sleep(gcePDDetachPollTime) {
 			diskAttached, err := gceCloud.DiskIsAttached(diskName, hostName)
 			if err != nil {
-				Logf("Error waiting for PD %q to detach from node %q. 'DiskIsAttached(...)' failed with %v", diskName, hostName, err)
+				framework.Logf("Error waiting for PD %q to detach from node %q. 'DiskIsAttached(...)' failed with %v", diskName, hostName, err)
 				return err
 			}
 
 			if !diskAttached {
 				// Specified disk does not appear to be attached to specified node
-				Logf("GCE PD %q appears to have successfully detached from %q.", diskName, hostName)
+				framework.Logf("GCE PD %q appears to have successfully detached from %q.", diskName, hostName)
 				return nil
 			}
 
-			Logf("Waiting for GCE PD %q to detach from %q.", diskName, hostName)
+			framework.Logf("Waiting for GCE PD %q to detach from %q.", diskName, hostName)
 		}
 
 		return fmt.Errorf("Gave up waiting for GCE PD %q to detach from %q after %v", diskName, hostName, gcePDDetachTimeout)
@@ -524,10 +525,10 @@ func waitForPDDetach(diskName, hostName string) error {
 }
 
 func getGCECloud() (*gcecloud.GCECloud, error) {
-	gceCloud, ok := testContext.CloudConfig.Provider.(*gcecloud.GCECloud)
+	gceCloud, ok := framework.TestContext.CloudConfig.Provider.(*gcecloud.GCECloud)
 
 	if !ok {
-		return nil, fmt.Errorf("failed to convert CloudConfig.Provider to GCECloud: %#v", testContext.CloudConfig.Provider)
+		return nil, fmt.Errorf("failed to convert CloudConfig.Provider to GCECloud: %#v", framework.TestContext.CloudConfig.Provider)
 	}
 
 	return gceCloud, nil

--- a/test/e2e/persistent_volumes.go
+++ b/test/e2e/persistent_volumes.go
@@ -26,18 +26,19 @@ import (
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/test/e2e/framework"
 )
 
 // This test needs privileged containers, which are disabled by default.  Run
 // the test with "go run hack/e2e.go ... --ginkgo.focus=[Feature:Volumes]"
-var _ = KubeDescribe("PersistentVolumes [Feature:Volumes]", func() {
-	framework := NewDefaultFramework("pv")
+var _ = framework.KubeDescribe("PersistentVolumes [Feature:Volumes]", func() {
+	f := framework.NewDefaultFramework("pv")
 	var c *client.Client
 	var ns string
 
 	BeforeEach(func() {
-		c = framework.Client
-		ns = framework.Namespace.Name
+		c = f.Client
+		ns = f.Namespace.Name
 	})
 
 	It("NFS volume can be created, bound, retrieved, unbound, and used by a pod", func() {
@@ -54,47 +55,47 @@ var _ = KubeDescribe("PersistentVolumes [Feature:Volumes]", func() {
 
 		pod := startVolumeServer(c, config)
 		serverIP := pod.Status.PodIP
-		Logf("NFS server IP address: %v", serverIP)
+		framework.Logf("NFS server IP address: %v", serverIP)
 
 		pv := makePersistentVolume(serverIP)
 		pvc := makePersistentVolumeClaim(ns)
 
-		Logf("Creating PersistentVolume using NFS")
+		framework.Logf("Creating PersistentVolume using NFS")
 		pv, err := c.PersistentVolumes().Create(pv)
 		Expect(err).NotTo(HaveOccurred())
 
-		Logf("Creating PersistentVolumeClaim")
+		framework.Logf("Creating PersistentVolumeClaim")
 		pvc, err = c.PersistentVolumeClaims(ns).Create(pvc)
 		Expect(err).NotTo(HaveOccurred())
 
 		// allow the binder a chance to catch up.  should not be more than 20s.
-		waitForPersistentVolumePhase(api.VolumeBound, c, pv.Name, 1*time.Second, 30*time.Second)
+		framework.WaitForPersistentVolumePhase(api.VolumeBound, c, pv.Name, 1*time.Second, 30*time.Second)
 
 		pv, err = c.PersistentVolumes().Get(pv.Name)
 		Expect(err).NotTo(HaveOccurred())
 		if pv.Spec.ClaimRef == nil {
-			Failf("Expected PersistentVolume to be bound, but got nil ClaimRef: %+v", pv)
+			framework.Failf("Expected PersistentVolume to be bound, but got nil ClaimRef: %+v", pv)
 		}
 
-		Logf("Deleting PersistentVolumeClaim to trigger PV Recycling")
+		framework.Logf("Deleting PersistentVolumeClaim to trigger PV Recycling")
 		err = c.PersistentVolumeClaims(ns).Delete(pvc.Name)
 		Expect(err).NotTo(HaveOccurred())
 
 		// allow the recycler a chance to catch up.  it has to perform NFS scrub, which can be slow in e2e.
-		waitForPersistentVolumePhase(api.VolumeAvailable, c, pv.Name, 5*time.Second, 300*time.Second)
+		framework.WaitForPersistentVolumePhase(api.VolumeAvailable, c, pv.Name, 5*time.Second, 300*time.Second)
 
 		pv, err = c.PersistentVolumes().Get(pv.Name)
 		Expect(err).NotTo(HaveOccurred())
 		if pv.Spec.ClaimRef != nil {
-			Failf("Expected PersistentVolume to be unbound, but found non-nil ClaimRef: %+v", pv)
+			framework.Failf("Expected PersistentVolume to be unbound, but found non-nil ClaimRef: %+v", pv)
 		}
 
 		// The NFS Server pod we're using contains an index.html file
 		// Verify the file was really scrubbed from the volume
 		podTemplate := makeCheckPod(ns, serverIP)
 		checkpod, err := c.Pods(ns).Create(podTemplate)
-		expectNoError(err, "Failed to create checker pod: %v", err)
-		err = waitForPodSuccessInNamespace(c, checkpod.Name, checkpod.Spec.Containers[0].Name, checkpod.Namespace)
+		framework.ExpectNoError(err, "Failed to create checker pod: %v", err)
+		err = framework.WaitForPodSuccessInNamespace(c, checkpod.Name, checkpod.Spec.Containers[0].Name, checkpod.Namespace)
 		Expect(err).NotTo(HaveOccurred())
 	})
 })

--- a/test/e2e/pods.go
+++ b/test/e2e/pods.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/intstr"
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/watch"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -54,7 +55,7 @@ var (
 func runLivenessTest(c *client.Client, ns string, podDescr *api.Pod, expectNumRestarts int, timeout time.Duration) {
 	By(fmt.Sprintf("Creating pod %s in namespace %s", podDescr.Name, ns))
 	_, err := c.Pods(ns).Create(podDescr)
-	expectNoError(err, fmt.Sprintf("creating pod %s", podDescr.Name))
+	framework.ExpectNoError(err, fmt.Sprintf("creating pod %s", podDescr.Name))
 
 	// At the end of the test, clean up by removing the pod.
 	defer func() {
@@ -65,16 +66,16 @@ func runLivenessTest(c *client.Client, ns string, podDescr *api.Pod, expectNumRe
 	// Wait until the pod is not pending. (Here we need to check for something other than
 	// 'Pending' other than checking for 'Running', since when failures occur, we go to
 	// 'Terminated' which can cause indefinite blocking.)
-	expectNoError(waitForPodNotPending(c, ns, podDescr.Name),
+	framework.ExpectNoError(framework.WaitForPodNotPending(c, ns, podDescr.Name),
 		fmt.Sprintf("starting pod %s in namespace %s", podDescr.Name, ns))
-	Logf("Started pod %s in namespace %s", podDescr.Name, ns)
+	framework.Logf("Started pod %s in namespace %s", podDescr.Name, ns)
 
 	// Check the pod's current state and verify that restartCount is present.
 	By("checking the pod's current state and verifying that restartCount is present")
 	pod, err := c.Pods(ns).Get(podDescr.Name)
-	expectNoError(err, fmt.Sprintf("getting pod %s in namespace %s", podDescr.Name, ns))
+	framework.ExpectNoError(err, fmt.Sprintf("getting pod %s in namespace %s", podDescr.Name, ns))
 	initialRestartCount := api.GetExistingContainerStatus(pod.Status.ContainerStatuses, "liveness").RestartCount
-	Logf("Initial restart count of pod %s is %d", podDescr.Name, initialRestartCount)
+	framework.Logf("Initial restart count of pod %s is %d", podDescr.Name, initialRestartCount)
 
 	// Wait for the restart state to be as desired.
 	deadline := time.Now().Add(timeout)
@@ -82,13 +83,13 @@ func runLivenessTest(c *client.Client, ns string, podDescr *api.Pod, expectNumRe
 	observedRestarts := 0
 	for start := time.Now(); time.Now().Before(deadline); time.Sleep(2 * time.Second) {
 		pod, err = c.Pods(ns).Get(podDescr.Name)
-		expectNoError(err, fmt.Sprintf("getting pod %s", podDescr.Name))
+		framework.ExpectNoError(err, fmt.Sprintf("getting pod %s", podDescr.Name))
 		restartCount := api.GetExistingContainerStatus(pod.Status.ContainerStatuses, "liveness").RestartCount
 		if restartCount != lastRestartCount {
-			Logf("Restart count of pod %s/%s is now %d (%v elapsed)",
+			framework.Logf("Restart count of pod %s/%s is now %d (%v elapsed)",
 				ns, podDescr.Name, restartCount, time.Since(start))
 			if restartCount < lastRestartCount {
-				Failf("Restart count should increment monotonically: restart cont of pod %s/%s changed from %d to %d",
+				framework.Failf("Restart count should increment monotonically: restart cont of pod %s/%s changed from %d to %d",
 					ns, podDescr.Name, lastRestartCount, restartCount)
 			}
 		}
@@ -104,7 +105,7 @@ func runLivenessTest(c *client.Client, ns string, podDescr *api.Pod, expectNumRe
 	// If we expected n restarts (n > 0), fail if we observed < n restarts.
 	if (expectNumRestarts == 0 && observedRestarts > 0) || (expectNumRestarts > 0 &&
 		observedRestarts < expectNumRestarts) {
-		Failf("pod %s/%s - expected number of restarts: %t, found restarts: %t",
+		framework.Failf("pod %s/%s - expected number of restarts: %t, found restarts: %t",
 			ns, podDescr.Name, expectNumRestarts, observedRestarts)
 	}
 }
@@ -115,12 +116,12 @@ func testHostIP(c *client.Client, ns string, pod *api.Pod) {
 	By("creating pod")
 	defer podClient.Delete(pod.Name, api.NewDeleteOptions(0))
 	if _, err := podClient.Create(pod); err != nil {
-		Failf("Failed to create pod: %v", err)
+		framework.Failf("Failed to create pod: %v", err)
 	}
 	By("ensuring that pod is running and has a hostIP")
 	// Wait for the pods to enter the running state. Waiting loops until the pods
 	// are running so non-running pods cause a timeout for this test.
-	err := waitForPodRunningInNamespace(c, pod.Name, ns)
+	err := framework.WaitForPodRunningInNamespace(c, pod.Name, ns)
 	Expect(err).NotTo(HaveOccurred())
 	// Try to make sure we get a hostIP for each pod.
 	hostIPTimeout := 2 * time.Minute
@@ -129,56 +130,56 @@ func testHostIP(c *client.Client, ns string, pod *api.Pod) {
 		p, err := podClient.Get(pod.Name)
 		Expect(err).NotTo(HaveOccurred())
 		if p.Status.HostIP != "" {
-			Logf("Pod %s has hostIP: %s", p.Name, p.Status.HostIP)
+			framework.Logf("Pod %s has hostIP: %s", p.Name, p.Status.HostIP)
 			break
 		}
 		if time.Since(t) >= hostIPTimeout {
-			Failf("Gave up waiting for hostIP of pod %s after %v seconds",
+			framework.Failf("Gave up waiting for hostIP of pod %s after %v seconds",
 				p.Name, time.Since(t).Seconds())
 		}
-		Logf("Retrying to get the hostIP of pod %s", p.Name)
+		framework.Logf("Retrying to get the hostIP of pod %s", p.Name)
 		time.Sleep(5 * time.Second)
 	}
 }
 
-func runPodFromStruct(framework *Framework, pod *api.Pod) {
+func runPodFromStruct(f *framework.Framework, pod *api.Pod) {
 	By("submitting the pod to kubernetes")
 
-	podClient := framework.Client.Pods(framework.Namespace.Name)
+	podClient := f.Client.Pods(f.Namespace.Name)
 	pod, err := podClient.Create(pod)
 	if err != nil {
-		Failf("Failed to create pod: %v", err)
+		framework.Failf("Failed to create pod: %v", err)
 	}
 
-	expectNoError(framework.WaitForPodRunning(pod.Name))
+	framework.ExpectNoError(f.WaitForPodRunning(pod.Name))
 
 	By("verifying the pod is in kubernetes")
 	pod, err = podClient.Get(pod.Name)
 	if err != nil {
-		Failf("failed to get pod: %v", err)
+		framework.Failf("failed to get pod: %v", err)
 	}
 }
 
-func startPodAndGetBackOffs(framework *Framework, pod *api.Pod, podName string, containerName string, sleepAmount time.Duration) (time.Duration, time.Duration) {
-	runPodFromStruct(framework, pod)
+func startPodAndGetBackOffs(f *framework.Framework, pod *api.Pod, podName string, containerName string, sleepAmount time.Duration) (time.Duration, time.Duration) {
+	runPodFromStruct(f, pod)
 	time.Sleep(sleepAmount)
 
 	By("getting restart delay-0")
-	_, err := getRestartDelay(framework.Client, pod, framework.Namespace.Name, podName, containerName)
+	_, err := getRestartDelay(f.Client, pod, f.Namespace.Name, podName, containerName)
 	if err != nil {
-		Failf("timed out waiting for container restart in pod=%s/%s", podName, containerName)
+		framework.Failf("timed out waiting for container restart in pod=%s/%s", podName, containerName)
 	}
 
 	By("getting restart delay-1")
-	delay1, err := getRestartDelay(framework.Client, pod, framework.Namespace.Name, podName, containerName)
+	delay1, err := getRestartDelay(f.Client, pod, f.Namespace.Name, podName, containerName)
 	if err != nil {
-		Failf("timed out waiting for container restart in pod=%s/%s", podName, containerName)
+		framework.Failf("timed out waiting for container restart in pod=%s/%s", podName, containerName)
 	}
 
 	By("getting restart delay-2")
-	delay2, err := getRestartDelay(framework.Client, pod, framework.Namespace.Name, podName, containerName)
+	delay2, err := getRestartDelay(f.Client, pod, f.Namespace.Name, podName, containerName)
 	if err != nil {
-		Failf("timed out waiting for container restart in pod=%s/%s", podName, containerName)
+		framework.Failf("timed out waiting for container restart in pod=%s/%s", podName, containerName)
 	}
 	return delay1, delay2
 }
@@ -188,29 +189,29 @@ func getRestartDelay(c *client.Client, pod *api.Pod, ns string, name string, con
 	for time.Since(beginTime) < (2 * maxBackOffTolerance) { // may just miss the 1st MaxContainerBackOff delay
 		time.Sleep(time.Second)
 		pod, err := c.Pods(ns).Get(name)
-		expectNoError(err, fmt.Sprintf("getting pod %s", name))
+		framework.ExpectNoError(err, fmt.Sprintf("getting pod %s", name))
 		status, ok := api.GetContainerStatus(pod.Status.ContainerStatuses, containerName)
 		if !ok {
-			Logf("getRestartDelay: status missing")
+			framework.Logf("getRestartDelay: status missing")
 			continue
 		}
 
 		if status.State.Waiting == nil && status.State.Running != nil && status.LastTerminationState.Terminated != nil && status.State.Running.StartedAt.Time.After(beginTime) {
 			startedAt := status.State.Running.StartedAt.Time
 			finishedAt := status.LastTerminationState.Terminated.FinishedAt.Time
-			Logf("getRestartDelay: restartCount = %d, finishedAt=%s restartedAt=%s (%s)", status.RestartCount, finishedAt, startedAt, startedAt.Sub(finishedAt))
+			framework.Logf("getRestartDelay: restartCount = %d, finishedAt=%s restartedAt=%s (%s)", status.RestartCount, finishedAt, startedAt, startedAt.Sub(finishedAt))
 			return startedAt.Sub(finishedAt), nil
 		}
 	}
 	return 0, fmt.Errorf("timeout getting pod restart delay")
 }
 
-var _ = KubeDescribe("Pods", func() {
-	framework := NewDefaultFramework("pods")
+var _ = framework.KubeDescribe("Pods", func() {
+	f := framework.NewDefaultFramework("pods")
 
 	It("should get a host IP [Conformance]", func() {
 		name := "pod-hostip-" + string(util.NewUUID())
-		testHostIP(framework.Client, framework.Namespace.Name, &api.Pod{
+		testHostIP(f.Client, f.Namespace.Name, &api.Pod{
 			ObjectMeta: api.ObjectMeta{
 				Name: name,
 			},
@@ -226,7 +227,7 @@ var _ = KubeDescribe("Pods", func() {
 	})
 
 	It("should be schedule with cpu and memory limits [Conformance]", func() {
-		podClient := framework.Client.Pods(framework.Namespace.Name)
+		podClient := f.Client.Pods(f.Namespace.Name)
 
 		By("creating the pod")
 		name := "pod-update-" + string(util.NewUUID())
@@ -257,13 +258,13 @@ var _ = KubeDescribe("Pods", func() {
 		defer podClient.Delete(pod.Name, nil)
 		_, err := podClient.Create(pod)
 		if err != nil {
-			Failf("Error creating a pod: %v", err)
+			framework.Failf("Error creating a pod: %v", err)
 		}
-		expectNoError(framework.WaitForPodRunning(pod.Name))
+		framework.ExpectNoError(f.WaitForPodRunning(pod.Name))
 	})
 
 	It("should be submitted and removed [Conformance]", func() {
-		podClient := framework.Client.Pods(framework.Namespace.Name)
+		podClient := f.Client.Pods(f.Namespace.Name)
 
 		By("creating the pod")
 		name := "pod-update-" + string(util.NewUUID())
@@ -301,7 +302,7 @@ var _ = KubeDescribe("Pods", func() {
 		options := api.ListOptions{LabelSelector: selector}
 		pods, err := podClient.List(options)
 		if err != nil {
-			Failf("Failed to query for pods: %v", err)
+			framework.Failf("Failed to query for pods: %v", err)
 		}
 		Expect(len(pods.Items)).To(Equal(0))
 		options = api.ListOptions{
@@ -310,7 +311,7 @@ var _ = KubeDescribe("Pods", func() {
 		}
 		w, err := podClient.Watch(options)
 		if err != nil {
-			Failf("Failed to set up watch: %v", err)
+			framework.Failf("Failed to set up watch: %v", err)
 		}
 
 		By("submitting the pod to kubernetes")
@@ -320,7 +321,7 @@ var _ = KubeDescribe("Pods", func() {
 		defer podClient.Delete(pod.Name, api.NewDeleteOptions(0))
 		_, err = podClient.Create(pod)
 		if err != nil {
-			Failf("Failed to create pod: %v", err)
+			framework.Failf("Failed to create pod: %v", err)
 		}
 
 		By("verifying the pod is in kubernetes")
@@ -328,7 +329,7 @@ var _ = KubeDescribe("Pods", func() {
 		options = api.ListOptions{LabelSelector: selector}
 		pods, err = podClient.List(options)
 		if err != nil {
-			Failf("Failed to query for pods: %v", err)
+			framework.Failf("Failed to query for pods: %v", err)
 		}
 		Expect(len(pods.Items)).To(Equal(1))
 
@@ -336,27 +337,27 @@ var _ = KubeDescribe("Pods", func() {
 		select {
 		case event, _ := <-w.ResultChan():
 			if event.Type != watch.Added {
-				Failf("Failed to observe pod creation: %v", event)
+				framework.Failf("Failed to observe pod creation: %v", event)
 			}
-		case <-time.After(podStartTimeout):
+		case <-time.After(framework.PodStartTimeout):
 			Fail("Timeout while waiting for pod creation")
 		}
 
 		// We need to wait for the pod to be scheduled, otherwise the deletion
 		// will be carried out immediately rather than gracefully.
-		expectNoError(framework.WaitForPodRunning(pod.Name))
+		framework.ExpectNoError(f.WaitForPodRunning(pod.Name))
 
 		By("deleting the pod gracefully")
 		if err := podClient.Delete(pod.Name, api.NewDeleteOptions(30)); err != nil {
-			Failf("Failed to delete pod: %v", err)
+			framework.Failf("Failed to delete pod: %v", err)
 		}
 
 		By("verifying the kubelet observed the termination notice")
 		pod, err = podClient.Get(pod.Name)
 		Expect(wait.Poll(time.Second*5, time.Second*30, func() (bool, error) {
-			podList, err := GetKubeletPods(framework.Client, pod.Spec.NodeName)
+			podList, err := framework.GetKubeletPods(f.Client, pod.Spec.NodeName)
 			if err != nil {
-				Logf("Unable to retrieve kubelet pods for node %v: %v", pod.Spec.NodeName, err)
+				framework.Logf("Unable to retrieve kubelet pods for node %v: %v", pod.Spec.NodeName, err)
 				return false, nil
 			}
 			for _, kubeletPod := range podList.Items {
@@ -364,12 +365,12 @@ var _ = KubeDescribe("Pods", func() {
 					continue
 				}
 				if kubeletPod.ObjectMeta.DeletionTimestamp == nil {
-					Logf("deletion has not yet been observed")
+					framework.Logf("deletion has not yet been observed")
 					return false, nil
 				}
 				return true, nil
 			}
-			Logf("no pod exists with the name we were looking for, assuming the termination request was observed and completed")
+			framework.Logf("no pod exists with the name we were looking for, assuming the termination request was observed and completed")
 			return true, nil
 		})).NotTo(HaveOccurred(), "kubelet never observed the termination notice")
 
@@ -406,7 +407,7 @@ var _ = KubeDescribe("Pods", func() {
 	})
 
 	It("should be updated [Conformance]", func() {
-		podClient := framework.Client.Pods(framework.Namespace.Name)
+		podClient := f.Client.Pods(f.Namespace.Name)
 
 		By("creating the pod")
 		name := "pod-update-" + string(util.NewUUID())
@@ -446,10 +447,10 @@ var _ = KubeDescribe("Pods", func() {
 		}()
 		pod, err := podClient.Create(pod)
 		if err != nil {
-			Failf("Failed to create pod: %v", err)
+			framework.Failf("Failed to create pod: %v", err)
 		}
 
-		expectNoError(framework.WaitForPodRunning(pod.Name))
+		framework.ExpectNoError(f.WaitForPodRunning(pod.Name))
 
 		By("verifying the pod is in kubernetes")
 		selector := labels.SelectorFromSet(labels.Set(map[string]string{"time": value}))
@@ -458,7 +459,7 @@ var _ = KubeDescribe("Pods", func() {
 		Expect(len(pods.Items)).To(Equal(1))
 
 		// Standard get, update retry loop
-		expectNoError(wait.Poll(time.Millisecond*500, time.Second*30, func() (bool, error) {
+		framework.ExpectNoError(wait.Poll(time.Millisecond*500, time.Second*30, func() (bool, error) {
 			By("updating the pod")
 			value = strconv.Itoa(time.Now().Nanosecond())
 			if pod == nil { // on retries we need to re-get
@@ -470,29 +471,29 @@ var _ = KubeDescribe("Pods", func() {
 			pod.Labels["time"] = value
 			pod, err = podClient.Update(pod)
 			if err == nil {
-				Logf("Successfully updated pod")
+				framework.Logf("Successfully updated pod")
 				return true, nil
 			}
 			if errors.IsConflict(err) {
-				Logf("Conflicting update to pod, re-get and re-update: %v", err)
+				framework.Logf("Conflicting update to pod, re-get and re-update: %v", err)
 				pod = nil // re-get it when we retry
 				return false, nil
 			}
 			return false, fmt.Errorf("failed to update pod: %v", err)
 		}))
 
-		expectNoError(framework.WaitForPodRunning(pod.Name))
+		framework.ExpectNoError(f.WaitForPodRunning(pod.Name))
 
 		By("verifying the updated pod is in kubernetes")
 		selector = labels.SelectorFromSet(labels.Set(map[string]string{"time": value}))
 		options = api.ListOptions{LabelSelector: selector}
 		pods, err = podClient.List(options)
 		Expect(len(pods.Items)).To(Equal(1))
-		Logf("Pod update OK")
+		framework.Logf("Pod update OK")
 	})
 
 	It("should allow activeDeadlineSeconds to be updated [Conformance]", func() {
-		podClient := framework.Client.Pods(framework.Namespace.Name)
+		podClient := f.Client.Pods(f.Namespace.Name)
 
 		By("creating the pod")
 		name := "pod-update-activedeadlineseconds-" + string(util.NewUUID())
@@ -532,10 +533,10 @@ var _ = KubeDescribe("Pods", func() {
 		}()
 		pod, err := podClient.Create(pod)
 		if err != nil {
-			Failf("Failed to create pod: %v", err)
+			framework.Failf("Failed to create pod: %v", err)
 		}
 
-		expectNoError(framework.WaitForPodRunning(pod.Name))
+		framework.ExpectNoError(f.WaitForPodRunning(pod.Name))
 
 		By("verifying the pod is in kubernetes")
 		selector := labels.SelectorFromSet(labels.Set(map[string]string{"time": value}))
@@ -544,7 +545,7 @@ var _ = KubeDescribe("Pods", func() {
 		Expect(len(pods.Items)).To(Equal(1))
 
 		// Standard get, update retry loop
-		expectNoError(wait.Poll(time.Millisecond*500, time.Second*30, func() (bool, error) {
+		framework.ExpectNoError(wait.Poll(time.Millisecond*500, time.Second*30, func() (bool, error) {
 			By("updating the pod")
 			value = strconv.Itoa(time.Now().Nanosecond())
 			if pod == nil { // on retries we need to re-get
@@ -557,18 +558,18 @@ var _ = KubeDescribe("Pods", func() {
 			pod.Spec.ActiveDeadlineSeconds = &newDeadline
 			pod, err = podClient.Update(pod)
 			if err == nil {
-				Logf("Successfully updated pod")
+				framework.Logf("Successfully updated pod")
 				return true, nil
 			}
 			if errors.IsConflict(err) {
-				Logf("Conflicting update to pod, re-get and re-update: %v", err)
+				framework.Logf("Conflicting update to pod, re-get and re-update: %v", err)
 				pod = nil // re-get it when we retry
 				return false, nil
 			}
 			return false, fmt.Errorf("failed to update pod: %v", err)
 		}))
 
-		expectNoError(framework.WaitForPodTerminated(pod.Name, "DeadlineExceeded"))
+		framework.ExpectNoError(f.WaitForPodTerminated(pod.Name, "DeadlineExceeded"))
 	})
 
 	It("should contain environment variables for services [Conformance]", func() {
@@ -590,12 +591,12 @@ var _ = KubeDescribe("Pods", func() {
 				},
 			},
 		}
-		defer framework.Client.Pods(framework.Namespace.Name).Delete(serverPod.Name, api.NewDeleteOptions(0))
-		_, err := framework.Client.Pods(framework.Namespace.Name).Create(serverPod)
+		defer f.Client.Pods(f.Namespace.Name).Delete(serverPod.Name, api.NewDeleteOptions(0))
+		_, err := f.Client.Pods(f.Namespace.Name).Create(serverPod)
 		if err != nil {
-			Failf("Failed to create serverPod: %v", err)
+			framework.Failf("Failed to create serverPod: %v", err)
 		}
-		expectNoError(framework.WaitForPodRunning(serverPod.Name))
+		framework.ExpectNoError(f.WaitForPodRunning(serverPod.Name))
 
 		// This service exposes port 8080 of the test pod as a service on port 8765
 		// TODO(filbranden): We would like to use a unique service name such as:
@@ -622,10 +623,10 @@ var _ = KubeDescribe("Pods", func() {
 				},
 			},
 		}
-		defer framework.Client.Services(framework.Namespace.Name).Delete(svc.Name)
-		_, err = framework.Client.Services(framework.Namespace.Name).Create(svc)
+		defer f.Client.Services(f.Namespace.Name).Delete(svc.Name)
+		_, err = f.Client.Services(f.Namespace.Name).Create(svc)
 		if err != nil {
-			Failf("Failed to create service: %v", err)
+			framework.Failf("Failed to create service: %v", err)
 		}
 
 		// Make a client pod that verifies that it has the service environment variables.
@@ -647,7 +648,7 @@ var _ = KubeDescribe("Pods", func() {
 			},
 		}
 
-		framework.TestContainerOutput("service env", pod, 0, []string{
+		f.TestContainerOutput("service env", pod, 0, []string{
 			"FOOSERVICE_SERVICE_HOST=",
 			"FOOSERVICE_SERVICE_PORT=",
 			"FOOSERVICE_PORT=",
@@ -659,7 +660,7 @@ var _ = KubeDescribe("Pods", func() {
 	})
 
 	It("should be restarted with a docker exec \"cat /tmp/health\" liveness probe [Conformance]", func() {
-		runLivenessTest(framework.Client, framework.Namespace.Name, &api.Pod{
+		runLivenessTest(f.Client, f.Namespace.Name, &api.Pod{
 			ObjectMeta: api.ObjectMeta{
 				Name:   "liveness-exec",
 				Labels: map[string]string{"test": "liveness"},
@@ -686,7 +687,7 @@ var _ = KubeDescribe("Pods", func() {
 	})
 
 	It("should *not* be restarted with a docker exec \"cat /tmp/health\" liveness probe [Conformance]", func() {
-		runLivenessTest(framework.Client, framework.Namespace.Name, &api.Pod{
+		runLivenessTest(f.Client, f.Namespace.Name, &api.Pod{
 			ObjectMeta: api.ObjectMeta{
 				Name:   "liveness-exec",
 				Labels: map[string]string{"test": "liveness"},
@@ -713,7 +714,7 @@ var _ = KubeDescribe("Pods", func() {
 	})
 
 	It("should be restarted with a /healthz http liveness probe [Conformance]", func() {
-		runLivenessTest(framework.Client, framework.Namespace.Name, &api.Pod{
+		runLivenessTest(f.Client, f.Namespace.Name, &api.Pod{
 			ObjectMeta: api.ObjectMeta{
 				Name:   "liveness-http",
 				Labels: map[string]string{"test": "liveness"},
@@ -742,7 +743,7 @@ var _ = KubeDescribe("Pods", func() {
 
 	// Slow by design (5 min)
 	It("should have monotonically increasing restart count [Conformance] [Slow]", func() {
-		runLivenessTest(framework.Client, framework.Namespace.Name, &api.Pod{
+		runLivenessTest(f.Client, f.Namespace.Name, &api.Pod{
 			ObjectMeta: api.ObjectMeta{
 				Name:   "liveness-http",
 				Labels: map[string]string{"test": "liveness"},
@@ -770,7 +771,7 @@ var _ = KubeDescribe("Pods", func() {
 	})
 
 	It("should *not* be restarted with a /healthz http liveness probe [Conformance]", func() {
-		runLivenessTest(framework.Client, framework.Namespace.Name, &api.Pod{
+		runLivenessTest(f.Client, f.Namespace.Name, &api.Pod{
 			ObjectMeta: api.ObjectMeta{
 				Name:   "liveness-http",
 				Labels: map[string]string{"test": "liveness"},
@@ -785,7 +786,7 @@ var _ = KubeDescribe("Pods", func() {
 						Args: []string{
 							"-service=liveness-http",
 							"-peers=1",
-							"-namespace=" + framework.Namespace.Name},
+							"-namespace=" + f.Namespace.Name},
 						Ports: []api.ContainerPort{{ContainerPort: 8080}},
 						LivenessProbe: &api.Probe{
 							Handler: api.Handler{
@@ -805,11 +806,11 @@ var _ = KubeDescribe("Pods", func() {
 	})
 
 	It("should support remote command execution over websockets", func() {
-		config, err := loadConfig()
+		config, err := framework.LoadConfig()
 		if err != nil {
-			Failf("Unable to get base config: %v", err)
+			framework.Failf("Unable to get base config: %v", err)
 		}
-		podClient := framework.Client.Pods(framework.Namespace.Name)
+		podClient := f.Client.Pods(f.Namespace.Name)
 
 		By("creating the pod")
 		name := "pod-exec-websocket-" + string(util.NewUUID())
@@ -835,13 +836,13 @@ var _ = KubeDescribe("Pods", func() {
 		}()
 		pod, err = podClient.Create(pod)
 		if err != nil {
-			Failf("Failed to create pod: %v", err)
+			framework.Failf("Failed to create pod: %v", err)
 		}
 
-		expectNoError(framework.WaitForPodRunning(pod.Name))
+		framework.ExpectNoError(f.WaitForPodRunning(pod.Name))
 
-		req := framework.Client.Get().
-			Namespace(framework.Namespace.Name).
+		req := f.Client.Get().
+			Namespace(f.Namespace.Name).
 			Resource("pods").
 			Name(pod.Name).
 			Suffix("exec").
@@ -852,9 +853,9 @@ var _ = KubeDescribe("Pods", func() {
 			Param("command", "/etc/resolv.conf")
 
 		url := req.URL()
-		ws, err := OpenWebSocketForURL(url, config, []string{"channel.k8s.io"})
+		ws, err := framework.OpenWebSocketForURL(url, config, []string{"channel.k8s.io"})
 		if err != nil {
-			Failf("Failed to open websocket to %s: %v", url.String(), err)
+			framework.Failf("Failed to open websocket to %s: %v", url.String(), err)
 		}
 		defer ws.Close()
 
@@ -865,30 +866,30 @@ var _ = KubeDescribe("Pods", func() {
 				if err == io.EOF {
 					break
 				}
-				Failf("Failed to read completely from websocket %s: %v", url.String(), err)
+				framework.Failf("Failed to read completely from websocket %s: %v", url.String(), err)
 			}
 			if len(msg) == 0 {
 				continue
 			}
 			if msg[0] != 1 {
-				Failf("Got message from server that didn't start with channel 1 (STDOUT): %v", msg)
+				framework.Failf("Got message from server that didn't start with channel 1 (STDOUT): %v", msg)
 			}
 			buf.Write(msg[1:])
 		}
 		if buf.Len() == 0 {
-			Failf("Unexpected output from server")
+			framework.Failf("Unexpected output from server")
 		}
 		if !strings.Contains(buf.String(), "nameserver") {
-			Failf("Expected to find 'nameserver' in %q", buf.String())
+			framework.Failf("Expected to find 'nameserver' in %q", buf.String())
 		}
 	})
 
 	It("should support retrieving logs from the container over websockets", func() {
-		config, err := loadConfig()
+		config, err := framework.LoadConfig()
 		if err != nil {
-			Failf("Unable to get base config: %v", err)
+			framework.Failf("Unable to get base config: %v", err)
 		}
-		podClient := framework.Client.Pods(framework.Namespace.Name)
+		podClient := f.Client.Pods(f.Namespace.Name)
 
 		By("creating the pod")
 		name := "pod-logs-websocket-" + string(util.NewUUID())
@@ -914,13 +915,13 @@ var _ = KubeDescribe("Pods", func() {
 		}()
 		pod, err = podClient.Create(pod)
 		if err != nil {
-			Failf("Failed to create pod: %v", err)
+			framework.Failf("Failed to create pod: %v", err)
 		}
 
-		expectNoError(framework.WaitForPodRunning(pod.Name))
+		framework.ExpectNoError(f.WaitForPodRunning(pod.Name))
 
-		req := framework.Client.Get().
-			Namespace(framework.Namespace.Name).
+		req := f.Client.Get().
+			Namespace(f.Namespace.Name).
 			Resource("pods").
 			Name(pod.Name).
 			Suffix("log").
@@ -928,9 +929,9 @@ var _ = KubeDescribe("Pods", func() {
 
 		url := req.URL()
 
-		ws, err := OpenWebSocketForURL(url, config, []string{"binary.k8s.io"})
+		ws, err := framework.OpenWebSocketForURL(url, config, []string{"binary.k8s.io"})
 		if err != nil {
-			Failf("Failed to open websocket to %s: %v", url.String(), err)
+			framework.Failf("Failed to open websocket to %s: %v", url.String(), err)
 		}
 		defer ws.Close()
 		buf := &bytes.Buffer{}
@@ -940,7 +941,7 @@ var _ = KubeDescribe("Pods", func() {
 				if err == io.EOF {
 					break
 				}
-				Failf("Failed to read completely from websocket %s: %v", url.String(), err)
+				framework.Failf("Failed to read completely from websocket %s: %v", url.String(), err)
 			}
 			if len(msg) == 0 {
 				continue
@@ -948,14 +949,14 @@ var _ = KubeDescribe("Pods", func() {
 			buf.Write(msg)
 		}
 		if buf.String() != "container is alive\n" {
-			Failf("Unexpected websocket logs:\n%s", buf.String())
+			framework.Failf("Unexpected websocket logs:\n%s", buf.String())
 		}
 	})
 
 	It("should have their auto-restart back-off timer reset on image update [Slow]", func() {
 		podName := "pod-back-off-image"
 		containerName := "back-off"
-		podClient := framework.Client.Pods(framework.Namespace.Name)
+		podClient := f.Client.Pods(f.Namespace.Name)
 		pod := &api.Pod{
 			ObjectMeta: api.ObjectMeta{
 				Name:   podName,
@@ -977,35 +978,35 @@ var _ = KubeDescribe("Pods", func() {
 			podClient.Delete(pod.Name, api.NewDeleteOptions(0))
 		}()
 
-		delay1, delay2 := startPodAndGetBackOffs(framework, pod, podName, containerName, buildBackOffDuration)
+		delay1, delay2 := startPodAndGetBackOffs(f, pod, podName, containerName, buildBackOffDuration)
 
 		By("updating the image")
 		pod, err := podClient.Get(pod.Name)
 		if err != nil {
-			Failf("failed to get pod: %v", err)
+			framework.Failf("failed to get pod: %v", err)
 		}
 		pod.Spec.Containers[0].Image = "gcr.io/google_containers/nginx:1.7.9"
 		pod, err = podClient.Update(pod)
 		if err != nil {
-			Failf("error updating pod=%s/%s %v", podName, containerName, err)
+			framework.Failf("error updating pod=%s/%s %v", podName, containerName, err)
 		}
 		time.Sleep(syncLoopFrequency)
-		expectNoError(framework.WaitForPodRunning(pod.Name))
+		framework.ExpectNoError(f.WaitForPodRunning(pod.Name))
 
 		By("get restart delay after image update")
-		delayAfterUpdate, err := getRestartDelay(framework.Client, pod, framework.Namespace.Name, podName, containerName)
+		delayAfterUpdate, err := getRestartDelay(f.Client, pod, f.Namespace.Name, podName, containerName)
 		if err != nil {
-			Failf("timed out waiting for container restart in pod=%s/%s", podName, containerName)
+			framework.Failf("timed out waiting for container restart in pod=%s/%s", podName, containerName)
 		}
 
 		if delayAfterUpdate > 2*delay2 || delayAfterUpdate > 2*delay1 {
-			Failf("updating image did not reset the back-off value in pod=%s/%s d3=%s d2=%s d1=%s", podName, containerName, delayAfterUpdate, delay1, delay2)
+			framework.Failf("updating image did not reset the back-off value in pod=%s/%s d3=%s d2=%s d1=%s", podName, containerName, delayAfterUpdate, delay1, delay2)
 		}
 	})
 
 	// Slow issue #19027 (20 mins)
 	It("should cap back-off at MaxContainerBackOff [Slow]", func() {
-		podClient := framework.Client.Pods(framework.Namespace.Name)
+		podClient := f.Client.Pods(f.Namespace.Name)
 		podName := "back-off-cap"
 		containerName := "back-off-cap"
 		pod := &api.Pod{
@@ -1029,7 +1030,7 @@ var _ = KubeDescribe("Pods", func() {
 			podClient.Delete(pod.Name, api.NewDeleteOptions(0))
 		}()
 
-		runPodFromStruct(framework, pod)
+		runPodFromStruct(f, pod)
 		time.Sleep(2 * kubelet.MaxContainerBackOff) // it takes slightly more than 2*x to get to a back-off of x
 
 		// wait for a delay == capped delay of MaxContainerBackOff
@@ -1039,9 +1040,9 @@ var _ = KubeDescribe("Pods", func() {
 			err    error
 		)
 		for i := 0; i < 3; i++ {
-			delay1, err = getRestartDelay(framework.Client, pod, framework.Namespace.Name, podName, containerName)
+			delay1, err = getRestartDelay(f.Client, pod, f.Namespace.Name, podName, containerName)
 			if err != nil {
-				Failf("timed out waiting for container restart in pod=%s/%s", podName, containerName)
+				framework.Failf("timed out waiting for container restart in pod=%s/%s", podName, containerName)
 			}
 
 			if delay1 < kubelet.MaxContainerBackOff {
@@ -1050,17 +1051,17 @@ var _ = KubeDescribe("Pods", func() {
 		}
 
 		if (delay1 < kubelet.MaxContainerBackOff) || (delay1 > maxBackOffTolerance) {
-			Failf("expected %s back-off got=%s in delay1", kubelet.MaxContainerBackOff, delay1)
+			framework.Failf("expected %s back-off got=%s in delay1", kubelet.MaxContainerBackOff, delay1)
 		}
 
 		By("getting restart delay after a capped delay")
-		delay2, err := getRestartDelay(framework.Client, pod, framework.Namespace.Name, podName, containerName)
+		delay2, err := getRestartDelay(f.Client, pod, f.Namespace.Name, podName, containerName)
 		if err != nil {
-			Failf("timed out waiting for container restart in pod=%s/%s", podName, containerName)
+			framework.Failf("timed out waiting for container restart in pod=%s/%s", podName, containerName)
 		}
 
 		if delay2 < kubelet.MaxContainerBackOff || delay2 > maxBackOffTolerance { // syncloop cumulative drift
-			Failf("expected %s back-off got=%s on delay2", kubelet.MaxContainerBackOff, delay2)
+			framework.Failf("expected %s back-off got=%s on delay2", kubelet.MaxContainerBackOff, delay2)
 		}
 	})
 
@@ -1071,12 +1072,12 @@ var _ = KubeDescribe("Pods", func() {
 	// all providers), we can enable these tests.
 	/*
 		It("should support remote command execution", func() {
-			clientConfig, err := loadConfig()
+			clientConfig, err := framework.LoadConfig()
 			if err != nil {
-				Failf("Failed to create client config: %v", err)
+				framework.Failf("Failed to create client config: %v", err)
 			}
 
-			podClient := framework.Client.Pods(framework.Namespace.Name)
+			podClient := f.Client.Pods(f.Namespace.Name)
 
 			By("creating the pod")
 			name := "pod-exec-" + string(util.NewUUID())
@@ -1102,7 +1103,7 @@ var _ = KubeDescribe("Pods", func() {
 			By("submitting the pod to kubernetes")
 			_, err = podClient.Create(pod)
 			if err != nil {
-				Failf("Failed to create pod: %v", err)
+				framework.Failf("Failed to create pod: %v", err)
 			}
 			defer func() {
 				// We call defer here in case there is a problem with
@@ -1112,45 +1113,45 @@ var _ = KubeDescribe("Pods", func() {
 			}()
 
 			By("waiting for the pod to start running")
-			expectNoError(framework.WaitForPodRunning(pod.Name))
+			framework.ExpectNoError(f.WaitForPodRunning(pod.Name))
 
 			By("verifying the pod is in kubernetes")
 			selector := labels.SelectorFromSet(labels.Set(map[string]string{"time": value}))
 			options := api.ListOptions{LabelSelector: selector}
 			pods, err := podClient.List(options)
 			if err != nil {
-				Failf("Failed to query for pods: %v", err)
+				framework.Failf("Failed to query for pods: %v", err)
 			}
 			Expect(len(pods.Items)).To(Equal(1))
 
 			pod = &pods.Items[0]
 			By(fmt.Sprintf("executing command on host %s pod %s in container %s",
 				pod.Status.Host, pod.Name, pod.Spec.Containers[0].Name))
-			req := framework.Client.Get().
+			req := f.Client.Get().
 				Prefix("proxy").
 				Resource("nodes").
 				Name(pod.Status.Host).
-				Suffix("exec", framework.Namespace.Name, pod.Name, pod.Spec.Containers[0].Name)
+				Suffix("exec", f.Namespace.Name, pod.Name, pod.Spec.Containers[0].Name)
 
 			out := &bytes.Buffer{}
 			e := remotecommand.New(req, clientConfig, []string{"whoami"}, nil, out, nil, false)
 			err = e.Execute()
 			if err != nil {
-				Failf("Failed to execute command on host %s pod %s in container %s: %v",
+				framework.Failf("Failed to execute command on host %s pod %s in container %s: %v",
 					pod.Status.Host, pod.Name, pod.Spec.Containers[0].Name, err)
 			}
 			if e, a := "root\n", out.String(); e != a {
-				Failf("exec: whoami: expected '%s', got '%s'", e, a)
+				framework.Failf("exec: whoami: expected '%s', got '%s'", e, a)
 			}
 		})
 
 		It("should support port forwarding", func() {
-			clientConfig, err := loadConfig()
+			clientConfig, err := framework.LoadConfig()
 			if err != nil {
-				Failf("Failed to create client config: %v", err)
+				framework.Failf("Failed to create client config: %v", err)
 			}
 
-			podClient := framework.Client.Pods(framework.Namespace.Name)
+			podClient := f.Client.Pods(f.Namespace.Name)
 
 			By("creating the pod")
 			name := "pod-portforward-" + string(util.NewUUID())
@@ -1177,7 +1178,7 @@ var _ = KubeDescribe("Pods", func() {
 			By("submitting the pod to kubernetes")
 			_, err = podClient.Create(pod)
 			if err != nil {
-				Failf("Failed to create pod: %v", err)
+				framework.Failf("Failed to create pod: %v", err)
 			}
 			defer func() {
 				// We call defer here in case there is a problem with
@@ -1187,14 +1188,14 @@ var _ = KubeDescribe("Pods", func() {
 			}()
 
 			By("waiting for the pod to start running")
-			expectNoError(framework.WaitForPodRunning(pod.Name))
+			framework.ExpectNoError(f.WaitForPodRunning(pod.Name))
 
 			By("verifying the pod is in kubernetes")
 			selector := labels.SelectorFromSet(labels.Set(map[string]string{"time": value}))
 			options := api.ListOptions{LabelSelector: selector}
 			pods, err := podClient.List(options)
 			if err != nil {
-				Failf("Failed to query for pods: %v", err)
+				framework.Failf("Failed to query for pods: %v", err)
 			}
 			Expect(len(pods.Items)).To(Equal(1))
 
@@ -1202,16 +1203,16 @@ var _ = KubeDescribe("Pods", func() {
 			By(fmt.Sprintf("initiating port forwarding to host %s pod %s in container %s",
 				pod.Status.Host, pod.Name, pod.Spec.Containers[0].Name))
 
-			req := framework.Client.Get().
+			req := f.Client.Get().
 				Prefix("proxy").
 				Resource("nodes").
 				Name(pod.Status.Host).
-				Suffix("portForward", framework.Namespace.Name, pod.Name)
+				Suffix("portForward", f.Namespace.Name, pod.Name)
 
 			stopChan := make(chan struct{})
 			pf, err := portforward.New(req, clientConfig, []string{"5678:80"}, stopChan)
 			if err != nil {
-				Failf("Error creating port forwarder: %s", err)
+				framework.Failf("Error creating port forwarder: %s", err)
 			}
 
 			errorChan := make(chan error)
@@ -1224,11 +1225,11 @@ var _ = KubeDescribe("Pods", func() {
 
 			resp, err := http.Get("http://localhost:5678/")
 			if err != nil {
-				Failf("Error with http get to localhost:5678: %s", err)
+				framework.Failf("Error with http get to localhost:5678: %s", err)
 			}
 			body, err := ioutil.ReadAll(resp.Body)
 			if err != nil {
-				Failf("Error reading response body: %s", err)
+				framework.Failf("Error reading response body: %s", err)
 			}
 
 			titleRegex := regexp.MustCompile("<title>(.+)</title>")
@@ -1237,7 +1238,7 @@ var _ = KubeDescribe("Pods", func() {
 				Fail("Unable to locate page title in response HTML")
 			}
 			if e, a := "Welcome to nginx on Debian!", matches[1]; e != a {
-				Failf("<title>: expected '%s', got '%s'", e, a)
+				framework.Failf("<title>: expected '%s', got '%s'", e, a)
 			}
 		})
 	*/

--- a/test/e2e/portforward.go
+++ b/test/e2e/portforward.go
@@ -29,6 +29,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 )
@@ -90,7 +91,7 @@ type portForwardCommand struct {
 func (c *portForwardCommand) Stop() {
 	// SIGINT signals that kubectl port-forward should gracefully terminate
 	if err := c.cmd.Process.Signal(syscall.SIGINT); err != nil {
-		Logf("error sending SIGINT to kubectl port-forward: %v", err)
+		framework.Logf("error sending SIGINT to kubectl port-forward: %v", err)
 	}
 
 	// try to wait for a clean exit
@@ -108,41 +109,41 @@ func (c *portForwardCommand) Stop() {
 			// success
 			return
 		}
-		Logf("error waiting for kubectl port-forward to exit: %v", err)
+		framework.Logf("error waiting for kubectl port-forward to exit: %v", err)
 	case <-expired.C:
-		Logf("timed out waiting for kubectl port-forward to exit")
+		framework.Logf("timed out waiting for kubectl port-forward to exit")
 	}
 
-	Logf("trying to forcibly kill kubectl port-forward")
-	tryKill(c.cmd)
+	framework.Logf("trying to forcibly kill kubectl port-forward")
+	framework.TryKill(c.cmd)
 }
 
 func runPortForward(ns, podName string, port int) *portForwardCommand {
-	cmd := kubectlCmd("port-forward", fmt.Sprintf("--namespace=%v", ns), podName, fmt.Sprintf(":%d", port))
+	cmd := framework.KubectlCmd("port-forward", fmt.Sprintf("--namespace=%v", ns), podName, fmt.Sprintf(":%d", port))
 	// This is somewhat ugly but is the only way to retrieve the port that was picked
 	// by the port-forward command. We don't want to hard code the port as we have no
 	// way of guaranteeing we can pick one that isn't in use, particularly on Jenkins.
-	Logf("starting port-forward command and streaming output")
-	_, stderr, err := startCmdAndStreamOutput(cmd)
+	framework.Logf("starting port-forward command and streaming output")
+	_, stderr, err := framework.StartCmdAndStreamOutput(cmd)
 	if err != nil {
-		Failf("Failed to start port-forward command: %v", err)
+		framework.Failf("Failed to start port-forward command: %v", err)
 	}
 
 	buf := make([]byte, 128)
 	var n int
-	Logf("reading from `kubectl port-forward` command's stderr")
+	framework.Logf("reading from `kubectl port-forward` command's stderr")
 	if n, err = stderr.Read(buf); err != nil {
-		Failf("Failed to read from kubectl port-forward stderr: %v", err)
+		framework.Failf("Failed to read from kubectl port-forward stderr: %v", err)
 	}
 	portForwardOutput := string(buf[:n])
 	match := portForwardRegexp.FindStringSubmatch(portForwardOutput)
 	if len(match) != 2 {
-		Failf("Failed to parse kubectl port-forward output: %s", portForwardOutput)
+		framework.Failf("Failed to parse kubectl port-forward output: %s", portForwardOutput)
 	}
 
 	listenPort, err := strconv.Atoi(match[1])
 	if err != nil {
-		Failf("Error converting %s to an int: %v", match[1], err)
+		framework.Failf("Error converting %s to an int: %v", match[1], err)
 	}
 
 	return &portForwardCommand{
@@ -151,42 +152,42 @@ func runPortForward(ns, podName string, port int) *portForwardCommand {
 	}
 }
 
-var _ = KubeDescribe("Port forwarding", func() {
-	framework := NewDefaultFramework("port-forwarding")
+var _ = framework.KubeDescribe("Port forwarding", func() {
+	f := framework.NewDefaultFramework("port-forwarding")
 
-	KubeDescribe("With a server that expects a client request", func() {
+	framework.KubeDescribe("With a server that expects a client request", func() {
 		It("should support a client that connects, sends no data, and disconnects [Conformance]", func() {
 			By("creating the target pod")
 			pod := pfPod("abc", "1", "1", "1")
-			if _, err := framework.Client.Pods(framework.Namespace.Name).Create(pod); err != nil {
-				Failf("Couldn't create pod: %v", err)
+			if _, err := f.Client.Pods(f.Namespace.Name).Create(pod); err != nil {
+				framework.Failf("Couldn't create pod: %v", err)
 			}
-			if err := framework.WaitForPodRunning(pod.Name); err != nil {
-				Failf("Pod did not start running: %v", err)
+			if err := f.WaitForPodRunning(pod.Name); err != nil {
+				framework.Failf("Pod did not start running: %v", err)
 			}
 
 			By("Running 'kubectl port-forward'")
-			cmd := runPortForward(framework.Namespace.Name, pod.Name, 80)
+			cmd := runPortForward(f.Namespace.Name, pod.Name, 80)
 			defer cmd.Stop()
 
 			By("Dialing the local port")
 			conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", cmd.port))
 			if err != nil {
-				Failf("Couldn't connect to port %d: %v", cmd.port, err)
+				framework.Failf("Couldn't connect to port %d: %v", cmd.port, err)
 			}
 
 			By("Closing the connection to the local port")
 			conn.Close()
 
 			By("Waiting for the target pod to stop running")
-			if err := framework.WaitForPodNoLongerRunning(pod.Name); err != nil {
-				Failf("Pod did not stop running: %v", err)
+			if err := f.WaitForPodNoLongerRunning(pod.Name); err != nil {
+				framework.Failf("Pod did not stop running: %v", err)
 			}
 
 			By("Retrieving logs from the target pod")
-			logOutput, err := getPodLogs(framework.Client, framework.Namespace.Name, pod.Name, "portforwardtester")
+			logOutput, err := framework.GetPodLogs(f.Client, f.Namespace.Name, pod.Name, "portforwardtester")
 			if err != nil {
-				Failf("Error retrieving logs: %v", err)
+				framework.Failf("Error retrieving logs: %v", err)
 			}
 
 			By("Verifying logs")
@@ -197,25 +198,25 @@ var _ = KubeDescribe("Port forwarding", func() {
 		It("should support a client that connects, sends data, and disconnects [Conformance]", func() {
 			By("creating the target pod")
 			pod := pfPod("abc", "10", "10", "100")
-			if _, err := framework.Client.Pods(framework.Namespace.Name).Create(pod); err != nil {
-				Failf("Couldn't create pod: %v", err)
+			if _, err := f.Client.Pods(f.Namespace.Name).Create(pod); err != nil {
+				framework.Failf("Couldn't create pod: %v", err)
 			}
-			if err := framework.WaitForPodRunning(pod.Name); err != nil {
-				Failf("Pod did not start running: %v", err)
+			if err := f.WaitForPodRunning(pod.Name); err != nil {
+				framework.Failf("Pod did not start running: %v", err)
 			}
 
 			By("Running 'kubectl port-forward'")
-			cmd := runPortForward(framework.Namespace.Name, pod.Name, 80)
+			cmd := runPortForward(f.Namespace.Name, pod.Name, 80)
 			defer cmd.Stop()
 
 			By("Dialing the local port")
 			addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("127.0.0.1:%d", cmd.port))
 			if err != nil {
-				Failf("Error resolving tcp addr: %v", err)
+				framework.Failf("Error resolving tcp addr: %v", err)
 			}
 			conn, err := net.DialTCP("tcp", nil, addr)
 			if err != nil {
-				Failf("Couldn't connect to port %d: %v", cmd.port, err)
+				framework.Failf("Couldn't connect to port %d: %v", cmd.port, err)
 			}
 			defer func() {
 				By("Closing the connection to the local port")
@@ -231,22 +232,22 @@ var _ = KubeDescribe("Port forwarding", func() {
 			By("Reading data from the local port")
 			fromServer, err := ioutil.ReadAll(conn)
 			if err != nil {
-				Failf("Unexpected error reading data from the server: %v", err)
+				framework.Failf("Unexpected error reading data from the server: %v", err)
 			}
 
 			if e, a := strings.Repeat("x", 100), string(fromServer); e != a {
-				Failf("Expected %q from server, got %q", e, a)
+				framework.Failf("Expected %q from server, got %q", e, a)
 			}
 
 			By("Waiting for the target pod to stop running")
-			if err := framework.WaitForPodNoLongerRunning(pod.Name); err != nil {
-				Failf("Pod did not stop running: %v", err)
+			if err := f.WaitForPodNoLongerRunning(pod.Name); err != nil {
+				framework.Failf("Pod did not stop running: %v", err)
 			}
 
 			By("Retrieving logs from the target pod")
-			logOutput, err := getPodLogs(framework.Client, framework.Namespace.Name, pod.Name, "portforwardtester")
+			logOutput, err := framework.GetPodLogs(f.Client, f.Namespace.Name, pod.Name, "portforwardtester")
 			if err != nil {
-				Failf("Error retrieving logs: %v", err)
+				framework.Failf("Error retrieving logs: %v", err)
 			}
 
 			By("Verifying logs")
@@ -255,25 +256,25 @@ var _ = KubeDescribe("Port forwarding", func() {
 			verifyLogMessage(logOutput, "^Done$")
 		})
 	})
-	KubeDescribe("With a server that expects no client request", func() {
+	framework.KubeDescribe("With a server that expects no client request", func() {
 		It("should support a client that connects, sends no data, and disconnects [Conformance]", func() {
 			By("creating the target pod")
 			pod := pfPod("", "10", "10", "100")
-			if _, err := framework.Client.Pods(framework.Namespace.Name).Create(pod); err != nil {
-				Failf("Couldn't create pod: %v", err)
+			if _, err := f.Client.Pods(f.Namespace.Name).Create(pod); err != nil {
+				framework.Failf("Couldn't create pod: %v", err)
 			}
-			if err := framework.WaitForPodRunning(pod.Name); err != nil {
-				Failf("Pod did not start running: %v", err)
+			if err := f.WaitForPodRunning(pod.Name); err != nil {
+				framework.Failf("Pod did not start running: %v", err)
 			}
 
 			By("Running 'kubectl port-forward'")
-			cmd := runPortForward(framework.Namespace.Name, pod.Name, 80)
+			cmd := runPortForward(f.Namespace.Name, pod.Name, 80)
 			defer cmd.Stop()
 
 			By("Dialing the local port")
 			conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", cmd.port))
 			if err != nil {
-				Failf("Couldn't connect to port %d: %v", cmd.port, err)
+				framework.Failf("Couldn't connect to port %d: %v", cmd.port, err)
 			}
 			defer func() {
 				By("Closing the connection to the local port")
@@ -283,22 +284,22 @@ var _ = KubeDescribe("Port forwarding", func() {
 			By("Reading data from the local port")
 			fromServer, err := ioutil.ReadAll(conn)
 			if err != nil {
-				Failf("Unexpected error reading data from the server: %v", err)
+				framework.Failf("Unexpected error reading data from the server: %v", err)
 			}
 
 			if e, a := strings.Repeat("x", 100), string(fromServer); e != a {
-				Failf("Expected %q from server, got %q", e, a)
+				framework.Failf("Expected %q from server, got %q", e, a)
 			}
 
 			By("Waiting for the target pod to stop running")
-			if err := framework.WaitForPodNoLongerRunning(pod.Name); err != nil {
-				Failf("Pod did not stop running: %v", err)
+			if err := f.WaitForPodNoLongerRunning(pod.Name); err != nil {
+				framework.Failf("Pod did not stop running: %v", err)
 			}
 
 			By("Retrieving logs from the target pod")
-			logOutput, err := getPodLogs(framework.Client, framework.Namespace.Name, pod.Name, "portforwardtester")
+			logOutput, err := framework.GetPodLogs(f.Client, f.Namespace.Name, pod.Name, "portforwardtester")
 			if err != nil {
-				Failf("Error retrieving logs: %v", err)
+				framework.Failf("Error retrieving logs: %v", err)
 			}
 
 			By("Verifying logs")
@@ -316,5 +317,5 @@ func verifyLogMessage(log, expected string) {
 			return
 		}
 	}
-	Failf("Missing %q from log: %s", expected, log)
+	framework.Failf("Missing %q from log: %s", expected, log)
 }

--- a/test/e2e/privileged.go
+++ b/test/e2e/privileged.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/test/e2e/framework"
 )
 
 const (
@@ -43,17 +44,17 @@ const (
 
 type PrivilegedPodTestConfig struct {
 	privilegedPod *api.Pod
-	f             *Framework
+	f             *framework.Framework
 	hostExecPod   *api.Pod
 }
 
-var _ = KubeDescribe("PrivilegedPod", func() {
-	f := NewDefaultFramework("e2e-privilegedpod")
+var _ = framework.KubeDescribe("PrivilegedPod", func() {
+	f := framework.NewDefaultFramework("e2e-privilegedpod")
 	config := &PrivilegedPodTestConfig{
 		f: f,
 	}
 	It("should test privileged pod", func() {
-		config.hostExecPod = LaunchHostExecPod(config.f.Client, config.f.Namespace.Name, "hostexec")
+		config.hostExecPod = framework.LaunchHostExecPod(config.f.Client, config.f.Namespace.Name, "hostexec")
 
 		By("Creating a privileged pod")
 		config.createPrivilegedPod()
@@ -69,14 +70,14 @@ var _ = KubeDescribe("PrivilegedPod", func() {
 func (config *PrivilegedPodTestConfig) runPrivilegedCommandOnPrivilegedContainer() {
 	outputMap := config.dialFromContainer(config.privilegedPod.Status.PodIP, privilegedHttpPort)
 	if len(outputMap["error"]) > 0 {
-		Failf("Privileged command failed unexpectedly on privileged container, output:%v", outputMap)
+		framework.Failf("Privileged command failed unexpectedly on privileged container, output:%v", outputMap)
 	}
 }
 
 func (config *PrivilegedPodTestConfig) runPrivilegedCommandOnNonPrivilegedContainer() {
 	outputMap := config.dialFromContainer(config.privilegedPod.Status.PodIP, notPrivilegedHttpPort)
 	if len(outputMap["error"]) == 0 {
-		Failf("Privileged command should have failed on non-privileged container, output:%v", outputMap)
+		framework.Failf("Privileged command should have failed on non-privileged container, output:%v", outputMap)
 	}
 }
 
@@ -89,11 +90,11 @@ func (config *PrivilegedPodTestConfig) dialFromContainer(containerIP string, con
 		v.Encode())
 
 	By(fmt.Sprintf("Exec-ing into container over http. Running command:%s", cmd))
-	stdout := RunHostCmdOrDie(config.hostExecPod.Namespace, config.hostExecPod.Name, cmd)
+	stdout := framework.RunHostCmdOrDie(config.hostExecPod.Namespace, config.hostExecPod.Name, cmd)
 	var output map[string]string
 	err := json.Unmarshal([]byte(stdout), &output)
 	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Could not unmarshal curl response: %s", stdout))
-	Logf("Deserialized output is %v", stdout)
+	framework.Logf("Deserialized output is %v", stdout)
 	return output
 }
 
@@ -147,12 +148,12 @@ func (config *PrivilegedPodTestConfig) createPrivilegedPod() {
 func (config *PrivilegedPodTestConfig) createPod(pod *api.Pod) *api.Pod {
 	createdPod, err := config.getPodClient().Create(pod)
 	if err != nil {
-		Failf("Failed to create %q pod: %v", pod.Name, err)
+		framework.Failf("Failed to create %q pod: %v", pod.Name, err)
 	}
-	expectNoError(config.f.WaitForPodRunning(pod.Name))
+	framework.ExpectNoError(config.f.WaitForPodRunning(pod.Name))
 	createdPod, err = config.getPodClient().Get(pod.Name)
 	if err != nil {
-		Failf("Failed to retrieve %q pod: %v", pod.Name, err)
+		framework.Failf("Failed to retrieve %q pod: %v", pod.Name, err)
 	}
 	return createdPod
 }

--- a/test/e2e/rc.go
+++ b/test/e2e/rc.go
@@ -24,30 +24,31 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-var _ = KubeDescribe("ReplicationController", func() {
-	framework := NewDefaultFramework("replication-controller")
+var _ = framework.KubeDescribe("ReplicationController", func() {
+	f := framework.NewDefaultFramework("replication-controller")
 
 	It("should serve a basic image on each replica with a public image [Conformance]", func() {
-		ServeImageOrFail(framework, "basic", "gcr.io/google_containers/serve_hostname:v1.4")
+		ServeImageOrFail(f, "basic", "gcr.io/google_containers/serve_hostname:v1.4")
 	})
 
 	It("should serve a basic image on each replica with a private image", func() {
 		// requires private images
-		SkipUnlessProviderIs("gce", "gke")
+		framework.SkipUnlessProviderIs("gce", "gke")
 
-		ServeImageOrFail(framework, "private", "b.gcr.io/k8s_authenticated_test/serve_hostname:v1.4")
+		ServeImageOrFail(f, "private", "b.gcr.io/k8s_authenticated_test/serve_hostname:v1.4")
 	})
 })
 
 // A basic test to check the deployment of an image using
 // a replication controller. The image serves its hostname
 // which is checked for each replica.
-func ServeImageOrFail(f *Framework, test string, image string) {
+func ServeImageOrFail(f *framework.Framework, test string, image string) {
 	name := "my-hostname-" + test + "-" + string(util.NewUUID())
 	replicas := 2
 
@@ -85,15 +86,15 @@ func ServeImageOrFail(f *Framework, test string, image string) {
 	// Cleanup the replication controller when we are done.
 	defer func() {
 		// Resize the replication controller to zero to get rid of pods.
-		if err := DeleteRC(f.Client, f.Namespace.Name, controller.Name); err != nil {
-			Logf("Failed to cleanup replication controller %v: %v.", controller.Name, err)
+		if err := framework.DeleteRC(f.Client, f.Namespace.Name, controller.Name); err != nil {
+			framework.Logf("Failed to cleanup replication controller %v: %v.", controller.Name, err)
 		}
 	}()
 
 	// List the pods, making sure we observe all the replicas.
 	label := labels.SelectorFromSet(labels.Set(map[string]string{"name": name}))
 
-	pods, err := podsCreated(f.Client, f.Namespace.Name, name, replicas)
+	pods, err := framework.PodsCreated(f.Client, f.Namespace.Name, name, replicas)
 
 	By("Ensuring each pod is running")
 
@@ -111,8 +112,8 @@ func ServeImageOrFail(f *Framework, test string, image string) {
 	By("Trying to dial each unique pod")
 	retryTimeout := 2 * time.Minute
 	retryInterval := 5 * time.Second
-	err = wait.Poll(retryInterval, retryTimeout, podProxyResponseChecker{f.Client, f.Namespace.Name, label, name, true, pods}.checkAllResponses)
+	err = wait.Poll(retryInterval, retryTimeout, framework.PodProxyResponseChecker(f.Client, f.Namespace.Name, label, name, true, pods).CheckAllResponses)
 	if err != nil {
-		Failf("Did not get expected responses within the timeout period of %.2f seconds.", retryTimeout.Seconds())
+		framework.Failf("Did not get expected responses within the timeout period of %.2f seconds.", retryTimeout.Seconds())
 	}
 }

--- a/test/e2e/replica_set.go
+++ b/test/e2e/replica_set.go
@@ -26,29 +26,30 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-var _ = KubeDescribe("ReplicaSet", func() {
-	framework := NewDefaultFramework("replicaset")
+var _ = framework.KubeDescribe("ReplicaSet", func() {
+	f := framework.NewDefaultFramework("replicaset")
 
 	It("should serve a basic image on each replica with a public image [Conformance]", func() {
-		ReplicaSetServeImageOrFail(framework, "basic", "gcr.io/google_containers/serve_hostname:v1.4")
+		ReplicaSetServeImageOrFail(f, "basic", "gcr.io/google_containers/serve_hostname:v1.4")
 	})
 
 	It("should serve a basic image on each replica with a private image", func() {
 		// requires private images
-		SkipUnlessProviderIs("gce", "gke")
+		framework.SkipUnlessProviderIs("gce", "gke")
 
-		ReplicaSetServeImageOrFail(framework, "private", "b.gcr.io/k8s_authenticated_test/serve_hostname:v1.4")
+		ReplicaSetServeImageOrFail(f, "private", "b.gcr.io/k8s_authenticated_test/serve_hostname:v1.4")
 	})
 })
 
 // A basic test to check the deployment of an image using a ReplicaSet. The
 // image serves its hostname which is checked for each replica.
-func ReplicaSetServeImageOrFail(f *Framework, test string, image string) {
+func ReplicaSetServeImageOrFail(f *framework.Framework, test string, image string) {
 	name := "my-hostname-" + test + "-" + string(util.NewUUID())
 	replicas := 2
 
@@ -85,15 +86,15 @@ func ReplicaSetServeImageOrFail(f *Framework, test string, image string) {
 	// Cleanup the ReplicaSet when we are done.
 	defer func() {
 		// Resize the ReplicaSet to zero to get rid of pods.
-		if err := DeleteReplicaSet(f.Client, f.Namespace.Name, rs.Name); err != nil {
-			Logf("Failed to cleanup ReplicaSet %v: %v.", rs.Name, err)
+		if err := framework.DeleteReplicaSet(f.Client, f.Namespace.Name, rs.Name); err != nil {
+			framework.Logf("Failed to cleanup ReplicaSet %v: %v.", rs.Name, err)
 		}
 	}()
 
 	// List the pods, making sure we observe all the replicas.
 	label := labels.SelectorFromSet(labels.Set(map[string]string{"name": name}))
 
-	pods, err := podsCreated(f.Client, f.Namespace.Name, name, replicas)
+	pods, err := framework.PodsCreated(f.Client, f.Namespace.Name, name, replicas)
 	Expect(err).NotTo(HaveOccurred())
 
 	By("Ensuring each pod is running")
@@ -112,8 +113,8 @@ func ReplicaSetServeImageOrFail(f *Framework, test string, image string) {
 	By("Trying to dial each unique pod")
 	retryTimeout := 2 * time.Minute
 	retryInterval := 5 * time.Second
-	err = wait.Poll(retryInterval, retryTimeout, podProxyResponseChecker{f.Client, f.Namespace.Name, label, name, true, pods}.checkAllResponses)
+	err = wait.Poll(retryInterval, retryTimeout, framework.PodProxyResponseChecker(f.Client, f.Namespace.Name, label, name, true, pods).CheckAllResponses)
 	if err != nil {
-		Failf("Did not get expected responses within the timeout period of %.2f seconds.", retryTimeout.Seconds())
+		framework.Failf("Did not get expected responses within the timeout period of %.2f seconds.", retryTimeout.Seconds())
 	}
 }

--- a/test/e2e/resource_quota.go
+++ b/test/e2e/resource_quota.go
@@ -25,6 +25,7 @@ import (
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/util/intstr"
 	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -35,8 +36,8 @@ const (
 	resourceQuotaTimeout = 30 * time.Second
 )
 
-var _ = KubeDescribe("ResourceQuota", func() {
-	f := NewDefaultFramework("resourcequota")
+var _ = framework.KubeDescribe("ResourceQuota", func() {
+	f := framework.NewDefaultFramework("resourcequota")
 
 	It("should create a ResourceQuota and ensure its status is promptly calculated.", func() {
 		By("Creating a ResourceQuota")
@@ -712,7 +713,7 @@ func deleteResourceQuota(c *client.Client, namespace, name string) error {
 
 // wait for resource quota status to show the expected used resources value
 func waitForResourceQuota(c *client.Client, ns, quotaName string, used api.ResourceList) error {
-	return wait.Poll(poll, resourceQuotaTimeout, func() (bool, error) {
+	return wait.Poll(framework.Poll, resourceQuotaTimeout, func() (bool, error) {
 		resourceQuota, err := c.ResourceQuotas(ns).Get(quotaName)
 		if err != nil {
 			return false, err
@@ -724,7 +725,7 @@ func waitForResourceQuota(c *client.Client, ns, quotaName string, used api.Resou
 		// verify that the quota shows the expected used resource values
 		for k, v := range used {
 			if actualValue, found := resourceQuota.Status.Used[k]; !found || (actualValue.Cmp(v) != 0) {
-				Logf("resource %s, expected %s, actual %s", k, v.String(), actualValue.String())
+				framework.Logf("resource %s, expected %s, actual %s", k, v.String(), actualValue.String())
 				return false, nil
 			}
 		}

--- a/test/e2e/secrets.go
+++ b/test/e2e/secrets.go
@@ -21,12 +21,13 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 )
 
-var _ = KubeDescribe("Secrets", func() {
-	f := NewDefaultFramework("secrets")
+var _ = framework.KubeDescribe("Secrets", func() {
+	f := framework.NewDefaultFramework("secrets")
 
 	It("should be consumable from pods in volume [Conformance]", func() {
 		name := "secret-test-" + string(util.NewUUID())
@@ -49,12 +50,12 @@ var _ = KubeDescribe("Secrets", func() {
 		defer func() {
 			By("Cleaning up the secret")
 			if err := f.Client.Secrets(f.Namespace.Name).Delete(secret.Name); err != nil {
-				Failf("unable to delete secret %v: %v", secret.Name, err)
+				framework.Failf("unable to delete secret %v: %v", secret.Name, err)
 			}
 		}()
 		var err error
 		if secret, err = f.Client.Secrets(f.Namespace.Name).Create(secret); err != nil {
-			Failf("unable to create test secret %s: %v", secret.Name, err)
+			framework.Failf("unable to create test secret %s: %v", secret.Name, err)
 		}
 
 		pod := &api.Pod{
@@ -92,7 +93,7 @@ var _ = KubeDescribe("Secrets", func() {
 			},
 		}
 
-		testContainerOutput("consume secrets", f.Client, pod, 0, []string{
+		framework.TestContainerOutput("consume secrets", f.Client, pod, 0, []string{
 			"content of file \"/etc/secret-volume/data-1\": value-1",
 			"mode of file \"/etc/secret-volume/data-1\": -r--r--r--",
 		}, f.Namespace.Name)
@@ -115,12 +116,12 @@ var _ = KubeDescribe("Secrets", func() {
 		defer func() {
 			By("Cleaning up the secret")
 			if err := f.Client.Secrets(f.Namespace.Name).Delete(secret.Name); err != nil {
-				Failf("unable to delete secret %v: %v", secret.Name, err)
+				framework.Failf("unable to delete secret %v: %v", secret.Name, err)
 			}
 		}()
 		var err error
 		if secret, err = f.Client.Secrets(f.Namespace.Name).Create(secret); err != nil {
-			Failf("unable to create test secret %s: %v", secret.Name, err)
+			framework.Failf("unable to create test secret %s: %v", secret.Name, err)
 		}
 
 		pod := &api.Pod{
@@ -152,7 +153,7 @@ var _ = KubeDescribe("Secrets", func() {
 			},
 		}
 
-		testContainerOutput("consume secrets", f.Client, pod, 0, []string{
+		framework.TestContainerOutput("consume secrets", f.Client, pod, 0, []string{
 			"SECRET_DATA=value-1",
 		}, f.Namespace.Name)
 	})

--- a/test/e2e/security_context.go
+++ b/test/e2e/security_context.go
@@ -27,6 +27,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -57,15 +58,15 @@ func scTestPod(hostIPC bool, hostPID bool) *api.Pod {
 	return pod
 }
 
-var _ = KubeDescribe("Security Context [Feature:SecurityContext]", func() {
-	framework := NewDefaultFramework("security-context")
+var _ = framework.KubeDescribe("Security Context [Feature:SecurityContext]", func() {
+	f := framework.NewDefaultFramework("security-context")
 
 	It("should support pod.Spec.SecurityContext.SupplementalGroups", func() {
 		pod := scTestPod(false, false)
 		pod.Spec.Containers[0].Command = []string{"id", "-G"}
 		pod.Spec.SecurityContext.SupplementalGroups = []int64{1234, 5678}
 		groups := []string{"1234", "5678"}
-		framework.TestContainerOutput("pod.Spec.SecurityContext.SupplementalGroups", pod, 0, groups)
+		f.TestContainerOutput("pod.Spec.SecurityContext.SupplementalGroups", pod, 0, groups)
 	})
 
 	It("should support pod.Spec.SecurityContext.RunAsUser", func() {
@@ -74,7 +75,7 @@ var _ = KubeDescribe("Security Context [Feature:SecurityContext]", func() {
 		pod.Spec.SecurityContext.RunAsUser = &uid
 		pod.Spec.Containers[0].Command = []string{"sh", "-c", "id -u"}
 
-		framework.TestContainerOutput("pod.Spec.SecurityContext.RunAsUser", pod, 0, []string{
+		f.TestContainerOutput("pod.Spec.SecurityContext.RunAsUser", pod, 0, []string{
 			fmt.Sprintf("%v", uid),
 		})
 	})
@@ -88,26 +89,26 @@ var _ = KubeDescribe("Security Context [Feature:SecurityContext]", func() {
 		pod.Spec.Containers[0].SecurityContext.RunAsUser = &overrideUid
 		pod.Spec.Containers[0].Command = []string{"sh", "-c", "id -u"}
 
-		framework.TestContainerOutput("pod.Spec.SecurityContext.RunAsUser", pod, 0, []string{
+		f.TestContainerOutput("pod.Spec.SecurityContext.RunAsUser", pod, 0, []string{
 			fmt.Sprintf("%v", overrideUid),
 		})
 	})
 
 	It("should support volume SELinux relabeling", func() {
-		testPodSELinuxLabeling(framework, false, false)
+		testPodSELinuxLabeling(f, false, false)
 	})
 
 	It("should support volume SELinux relabeling when using hostIPC", func() {
-		testPodSELinuxLabeling(framework, true, false)
+		testPodSELinuxLabeling(f, true, false)
 	})
 
 	It("should support volume SELinux relabeling when using hostPID", func() {
-		testPodSELinuxLabeling(framework, false, true)
+		testPodSELinuxLabeling(f, false, true)
 	})
 
 })
 
-func testPodSELinuxLabeling(framework *Framework, hostIPC bool, hostPID bool) {
+func testPodSELinuxLabeling(f *framework.Framework, hostIPC bool, hostPID bool) {
 	// Write and read a file with an empty_dir volume
 	// with a pod with the MCS label s0:c0,c1
 	pod := scTestPod(hostIPC, hostPID)
@@ -134,28 +135,28 @@ func testPodSELinuxLabeling(framework *Framework, hostIPC bool, hostPID bool) {
 	}
 	pod.Spec.Containers[0].Command = []string{"sleep", "6000"}
 
-	client := framework.Client.Pods(framework.Namespace.Name)
+	client := f.Client.Pods(f.Namespace.Name)
 	_, err := client.Create(pod)
 
-	expectNoError(err, "Error creating pod %v", pod)
+	framework.ExpectNoError(err, "Error creating pod %v", pod)
 	defer client.Delete(pod.Name, nil)
-	expectNoError(waitForPodRunningInNamespace(framework.Client, pod.Name, framework.Namespace.Name))
+	framework.ExpectNoError(framework.WaitForPodRunningInNamespace(f.Client, pod.Name, f.Namespace.Name))
 
 	testContent := "hello"
 	testFilePath := mountPath + "/TEST"
-	err = framework.WriteFileViaContainer(pod.Name, pod.Spec.Containers[0].Name, testFilePath, testContent)
+	err = f.WriteFileViaContainer(pod.Name, pod.Spec.Containers[0].Name, testFilePath, testContent)
 	Expect(err).To(BeNil())
-	content, err := framework.ReadFileViaContainer(pod.Name, pod.Spec.Containers[0].Name, testFilePath)
+	content, err := f.ReadFileViaContainer(pod.Name, pod.Spec.Containers[0].Name, testFilePath)
 	Expect(err).To(BeNil())
 	Expect(content).To(ContainSubstring(testContent))
 
-	foundPod, err := framework.Client.Pods(framework.Namespace.Name).Get(pod.Name)
+	foundPod, err := f.Client.Pods(f.Namespace.Name).Get(pod.Name)
 	Expect(err).NotTo(HaveOccurred())
 
 	// Confirm that the file can be accessed from a second
 	// pod using host_path with the same MCS label
-	volumeHostPath := fmt.Sprintf("%s/pods/%s/volumes/kubernetes.io~empty-dir/%s", testContext.KubeVolumeDir, foundPod.UID, volumeName)
-	By(fmt.Sprintf("confirming a container with the same label can read the file under --volume-dir=%s", testContext.KubeVolumeDir))
+	volumeHostPath := fmt.Sprintf("%s/pods/%s/volumes/kubernetes.io~empty-dir/%s", framework.TestContext.KubeVolumeDir, foundPod.UID, volumeName)
+	By(fmt.Sprintf("confirming a container with the same label can read the file under --volume-dir=%s", framework.TestContext.KubeVolumeDir))
 	pod = scTestPod(hostIPC, hostPID)
 	pod.Spec.NodeName = foundPod.Spec.NodeName
 	volumeMounts := []api.VolumeMount{
@@ -181,7 +182,7 @@ func testPodSELinuxLabeling(framework *Framework, hostIPC bool, hostPID bool) {
 		Level: "s0:c0,c1",
 	}
 
-	framework.TestContainerOutput("Pod with same MCS label reading test file", pod, 0, []string{testContent})
+	f.TestContainerOutput("Pod with same MCS label reading test file", pod, 0, []string{testContent})
 	// Confirm that the same pod with a different MCS
 	// label cannot access the volume
 	pod = scTestPod(hostIPC, hostPID)
@@ -192,12 +193,12 @@ func testPodSELinuxLabeling(framework *Framework, hostIPC bool, hostPID bool) {
 		Level: "s0:c2,c3",
 	}
 	_, err = client.Create(pod)
-	expectNoError(err, "Error creating pod %v", pod)
+	framework.ExpectNoError(err, "Error creating pod %v", pod)
 	defer client.Delete(pod.Name, nil)
 
-	err = framework.WaitForPodRunning(pod.Name)
-	expectNoError(err, "Error waiting for pod to run %v", pod)
+	err = f.WaitForPodRunning(pod.Name)
+	framework.ExpectNoError(err, "Error waiting for pod to run %v", pod)
 
-	content, err = framework.ReadFileViaContainer(pod.Name, "test-container", testFilePath)
+	content, err = f.ReadFileViaContainer(pod.Name, "test-container", testFilePath)
 	Expect(content).NotTo(ContainSubstring(testContent))
 }

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -39,6 +39,7 @@ import (
 	utilnet "k8s.io/kubernetes/pkg/util/net"
 	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
 )
 
 // Maximum time a kube-proxy daemon on a node is allowed to not
@@ -61,14 +62,14 @@ const loadBalancerCreateTimeout = 20 * time.Minute
 // This should match whatever the default/configured range is
 var ServiceNodePortRange = utilnet.PortRange{Base: 30000, Size: 2768}
 
-var _ = KubeDescribe("Services", func() {
-	f := NewDefaultFramework("services")
+var _ = framework.KubeDescribe("Services", func() {
+	f := framework.NewDefaultFramework("services")
 
 	var c *client.Client
 
 	BeforeEach(func() {
 		var err error
-		c, err = loadClient()
+		c, err = framework.LoadClient()
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -225,8 +226,8 @@ var _ = KubeDescribe("Services", func() {
 
 	It("should be able to up and down services", func() {
 		// TODO: use the ServiceTestJig here
-		// this test uses NodeSSHHosts that does not work if a Node only reports LegacyHostIP
-		SkipUnlessProviderIs(providersWithSSH...)
+		// this test uses framework.NodeSSHHosts that does not work if a Node only reports LegacyHostIP
+		framework.SkipUnlessProviderIs(framework.ProvidersWithSSH...)
 		ns := f.Namespace.Name
 		numPods, servicePort := 3, 80
 
@@ -237,27 +238,27 @@ var _ = KubeDescribe("Services", func() {
 		podNames2, svc2IP, err := startServeHostnameService(c, ns, "service2", servicePort, numPods)
 		Expect(err).NotTo(HaveOccurred())
 
-		hosts, err := NodeSSHHosts(c)
+		hosts, err := framework.NodeSSHHosts(c)
 		Expect(err).NotTo(HaveOccurred())
 		if len(hosts) == 0 {
-			Failf("No ssh-able nodes")
+			framework.Failf("No ssh-able nodes")
 		}
 		host := hosts[0]
 
 		By("verifying service1 is up")
-		expectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames1, svc1IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames1, svc1IP, servicePort))
 
 		By("verifying service2 is up")
-		expectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames2, svc2IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames2, svc2IP, servicePort))
 
 		// Stop service 1 and make sure it is gone.
 		By("stopping service1")
-		expectNoError(stopServeHostnameService(c, ns, "service1"))
+		framework.ExpectNoError(stopServeHostnameService(c, ns, "service1"))
 
 		By("verifying service1 is not up")
-		expectNoError(verifyServeHostnameServiceDown(c, host, svc1IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceDown(c, host, svc1IP, servicePort))
 		By("verifying service2 is still up")
-		expectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames2, svc2IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames2, svc2IP, servicePort))
 
 		// Start another service and verify both are up.
 		By("creating service3 in namespace " + ns)
@@ -265,19 +266,19 @@ var _ = KubeDescribe("Services", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		if svc2IP == svc3IP {
-			Failf("service IPs conflict: %v", svc2IP)
+			framework.Failf("service IPs conflict: %v", svc2IP)
 		}
 
 		By("verifying service2 is still up")
-		expectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames2, svc2IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames2, svc2IP, servicePort))
 
 		By("verifying service3 is up")
-		expectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames3, svc3IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames3, svc3IP, servicePort))
 	})
 
 	It("should work after restarting kube-proxy [Disruptive]", func() {
 		// TODO: use the ServiceTestJig here
-		SkipUnlessProviderIs("gce", "gke")
+		framework.SkipUnlessProviderIs("gce", "gke")
 
 		ns := f.Namespace.Name
 		numPods, servicePort := 3, 80
@@ -285,88 +286,88 @@ var _ = KubeDescribe("Services", func() {
 		svc1 := "service1"
 		svc2 := "service2"
 
-		defer func() { expectNoError(stopServeHostnameService(c, ns, svc1)) }()
+		defer func() { framework.ExpectNoError(stopServeHostnameService(c, ns, svc1)) }()
 		podNames1, svc1IP, err := startServeHostnameService(c, ns, svc1, servicePort, numPods)
 		Expect(err).NotTo(HaveOccurred())
 
-		defer func() { expectNoError(stopServeHostnameService(c, ns, svc2)) }()
+		defer func() { framework.ExpectNoError(stopServeHostnameService(c, ns, svc2)) }()
 		podNames2, svc2IP, err := startServeHostnameService(c, ns, svc2, servicePort, numPods)
 		Expect(err).NotTo(HaveOccurred())
 
 		if svc1IP == svc2IP {
-			Failf("VIPs conflict: %v", svc1IP)
+			framework.Failf("VIPs conflict: %v", svc1IP)
 		}
 
-		hosts, err := NodeSSHHosts(c)
+		hosts, err := framework.NodeSSHHosts(c)
 		Expect(err).NotTo(HaveOccurred())
 		if len(hosts) == 0 {
-			Failf("No ssh-able nodes")
+			framework.Failf("No ssh-able nodes")
 		}
 		host := hosts[0]
 
-		expectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames1, svc1IP, servicePort))
-		expectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames2, svc2IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames1, svc1IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames2, svc2IP, servicePort))
 
 		By("Restarting kube-proxy")
-		if err := restartKubeProxy(host); err != nil {
-			Failf("error restarting kube-proxy: %v", err)
+		if err := framework.RestartKubeProxy(host); err != nil {
+			framework.Failf("error restarting kube-proxy: %v", err)
 		}
-		expectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames1, svc1IP, servicePort))
-		expectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames2, svc2IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames1, svc1IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames2, svc2IP, servicePort))
 
 		By("Removing iptable rules")
-		result, err := SSH(`
+		result, err := framework.SSH(`
 			sudo iptables -t nat -F KUBE-SERVICES || true;
 			sudo iptables -t nat -F KUBE-PORTALS-HOST || true;
-			sudo iptables -t nat -F KUBE-PORTALS-CONTAINER || true`, host, testContext.Provider)
+			sudo iptables -t nat -F KUBE-PORTALS-CONTAINER || true`, host, framework.TestContext.Provider)
 		if err != nil || result.Code != 0 {
-			LogSSHResult(result)
-			Failf("couldn't remove iptable rules: %v", err)
+			framework.LogSSHResult(result)
+			framework.Failf("couldn't remove iptable rules: %v", err)
 		}
-		expectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames1, svc1IP, servicePort))
-		expectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames2, svc2IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames1, svc1IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames2, svc2IP, servicePort))
 	})
 
 	It("should work after restarting apiserver [Disruptive]", func() {
 		// TODO: use the ServiceTestJig here
-		// TODO: restartApiserver doesn't work in GKE - fix it and reenable this test.
-		SkipUnlessProviderIs("gce")
+		// TODO: framework.RestartApiserver doesn't work in GKE - fix it and reenable this test.
+		framework.SkipUnlessProviderIs("gce")
 
 		ns := f.Namespace.Name
 		numPods, servicePort := 3, 80
 
-		defer func() { expectNoError(stopServeHostnameService(c, ns, "service1")) }()
+		defer func() { framework.ExpectNoError(stopServeHostnameService(c, ns, "service1")) }()
 		podNames1, svc1IP, err := startServeHostnameService(c, ns, "service1", servicePort, numPods)
 		Expect(err).NotTo(HaveOccurred())
 
-		hosts, err := NodeSSHHosts(c)
+		hosts, err := framework.NodeSSHHosts(c)
 		Expect(err).NotTo(HaveOccurred())
 		if len(hosts) == 0 {
-			Failf("No ssh-able nodes")
+			framework.Failf("No ssh-able nodes")
 		}
 		host := hosts[0]
 
-		expectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames1, svc1IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames1, svc1IP, servicePort))
 
 		// Restart apiserver
-		if err := restartApiserver(); err != nil {
-			Failf("error restarting apiserver: %v", err)
+		if err := framework.RestartApiserver(); err != nil {
+			framework.Failf("error restarting apiserver: %v", err)
 		}
-		if err := waitForApiserverUp(c); err != nil {
-			Failf("error while waiting for apiserver up: %v", err)
+		if err := framework.WaitForApiserverUp(c); err != nil {
+			framework.Failf("error while waiting for apiserver up: %v", err)
 		}
-		expectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames1, svc1IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames1, svc1IP, servicePort))
 
 		// Create a new service and check if it's not reusing IP.
-		defer func() { expectNoError(stopServeHostnameService(c, ns, "service2")) }()
+		defer func() { framework.ExpectNoError(stopServeHostnameService(c, ns, "service2")) }()
 		podNames2, svc2IP, err := startServeHostnameService(c, ns, "service2", servicePort, numPods)
 		Expect(err).NotTo(HaveOccurred())
 
 		if svc1IP == svc2IP {
-			Failf("VIPs conflict: %v", svc1IP)
+			framework.Failf("VIPs conflict: %v", svc1IP)
 		}
-		expectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames1, svc1IP, servicePort))
-		expectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames2, svc2IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames1, svc1IP, servicePort))
+		framework.ExpectNoError(verifyServeHostnameServiceUp(c, ns, host, podNames2, svc2IP, servicePort))
 	})
 
 	// TODO: Run this test against the userspace proxy and nodes
@@ -393,24 +394,24 @@ var _ = KubeDescribe("Services", func() {
 		jig.TestReachableHTTP(nodeIP, nodePort, kubeProxyLagTimeout)
 
 		By("verifying the node port is locked")
-		hostExec := LaunchHostExecPod(f.Client, f.Namespace.Name, "hostexec")
+		hostExec := framework.LaunchHostExecPod(f.Client, f.Namespace.Name, "hostexec")
 		// Even if the node-ip:node-port check above passed, this hostexec pod
 		// might fall on a node with a laggy kube-proxy.
 		cmd := fmt.Sprintf(`for i in $(seq 1 300); do if ss -ant46 'sport = :%d' | grep ^LISTEN; then exit 0; fi; sleep 1; done; exit 1`, nodePort)
-		stdout, err := RunHostCmd(hostExec.Namespace, hostExec.Name, cmd)
+		stdout, err := framework.RunHostCmd(hostExec.Namespace, hostExec.Name, cmd)
 		if err != nil {
-			Failf("expected node port %d to be in use, stdout: %v. err: %v", nodePort, stdout, err)
+			framework.Failf("expected node port %d to be in use, stdout: %v. err: %v", nodePort, stdout, err)
 		}
 	})
 
 	It("should be able to change the type and ports of a service [Slow]", func() {
 		// requires cloud load-balancer support
-		SkipUnlessProviderIs("gce", "gke", "aws")
+		framework.SkipUnlessProviderIs("gce", "gke", "aws")
 
-		loadBalancerSupportsUDP := !providerIs("aws")
+		loadBalancerSupportsUDP := !framework.ProviderIs("aws")
 
 		loadBalancerLagTimeout := loadBalancerLagTimeoutDefault
-		if providerIs("aws") {
+		if framework.ProviderIs("aws") {
 			loadBalancerLagTimeout = loadBalancerLagTimeoutAWS
 		}
 
@@ -419,13 +420,13 @@ var _ = KubeDescribe("Services", func() {
 
 		serviceName := "mutability-test"
 		ns1 := f.Namespace.Name // LB1 in ns1 on TCP
-		Logf("namespace for TCP test: %s", ns1)
+		framework.Logf("namespace for TCP test: %s", ns1)
 
 		By("creating a second namespace")
 		namespacePtr, err := f.CreateNamespace("services", nil)
 		Expect(err).NotTo(HaveOccurred())
 		ns2 := namespacePtr.Name // LB2 in ns2 on UDP
-		Logf("namespace for UDP test: %s", ns2)
+		framework.Logf("namespace for UDP test: %s", ns2)
 
 		jig := NewServiceTestJig(c, serviceName)
 		nodeIP := pickNodeIP(jig.Client) // for later
@@ -443,10 +444,10 @@ var _ = KubeDescribe("Services", func() {
 
 		By("verifying that TCP and UDP use the same port")
 		if tcpService.Spec.Ports[0].Port != udpService.Spec.Ports[0].Port {
-			Failf("expected to use the same port for TCP and UDP")
+			framework.Failf("expected to use the same port for TCP and UDP")
 		}
 		svcPort := tcpService.Spec.Ports[0].Port
-		Logf("service port (TCP and UDP): %d", svcPort)
+		framework.Logf("service port (TCP and UDP): %d", svcPort)
 
 		By("creating a pod to be part of the TCP service " + serviceName)
 		jig.RunOrFail(ns1, nil)
@@ -462,7 +463,7 @@ var _ = KubeDescribe("Services", func() {
 		})
 		jig.SanityCheckService(tcpService, api.ServiceTypeNodePort)
 		tcpNodePort := tcpService.Spec.Ports[0].NodePort
-		Logf("TCP node port: %d", tcpNodePort)
+		framework.Logf("TCP node port: %d", tcpNodePort)
 
 		By("changing the UDP service to type=NodePort")
 		udpService = jig.UpdateServiceOrFail(ns2, udpService.Name, func(s *api.Service) {
@@ -470,7 +471,7 @@ var _ = KubeDescribe("Services", func() {
 		})
 		jig.SanityCheckService(udpService, api.ServiceTypeNodePort)
 		udpNodePort := udpService.Spec.Ports[0].NodePort
-		Logf("UDP node port: %d", udpNodePort)
+		framework.Logf("UDP node port: %d", udpNodePort)
 
 		By("hitting the TCP service's NodePort")
 		jig.TestReachableHTTP(nodeIP, tcpNodePort, kubeProxyLagTimeout)
@@ -482,20 +483,20 @@ var _ = KubeDescribe("Services", func() {
 
 		requestedIP := ""
 		staticIPName := ""
-		if providerIs("gce", "gke") {
+		if framework.ProviderIs("gce", "gke") {
 			By("creating a static load balancer IP")
-			staticIPName = fmt.Sprintf("e2e-external-lb-test-%s", runId)
+			staticIPName = fmt.Sprintf("e2e-external-lb-test-%s", framework.RunId)
 			requestedIP, err = createGCEStaticIP(staticIPName)
 			Expect(err).NotTo(HaveOccurred())
 			defer func() {
 				if staticIPName != "" {
 					// Release GCE static IP - this is not kube-managed and will not be automatically released.
 					if err := deleteGCEStaticIP(staticIPName); err != nil {
-						Logf("failed to release static IP %s: %v", staticIPName, err)
+						framework.Logf("failed to release static IP %s: %v", staticIPName, err)
 					}
 				}
 			}()
-			Logf("Allocated static load balancer IP: %s", requestedIP)
+			framework.Logf("Allocated static load balancer IP: %s", requestedIP)
 		}
 
 		By("changing the TCP service to type=LoadBalancer")
@@ -516,15 +517,15 @@ var _ = KubeDescribe("Services", func() {
 		tcpService = jig.WaitForLoadBalancerOrFail(ns1, tcpService.Name)
 		jig.SanityCheckService(tcpService, api.ServiceTypeLoadBalancer)
 		if tcpService.Spec.Ports[0].NodePort != tcpNodePort {
-			Failf("TCP Spec.Ports[0].NodePort changed (%d -> %d) when not expected", tcpNodePort, tcpService.Spec.Ports[0].NodePort)
+			framework.Failf("TCP Spec.Ports[0].NodePort changed (%d -> %d) when not expected", tcpNodePort, tcpService.Spec.Ports[0].NodePort)
 		}
 		if requestedIP != "" && getIngressPoint(&tcpService.Status.LoadBalancer.Ingress[0]) != requestedIP {
-			Failf("unexpected TCP Status.LoadBalancer.Ingress (expected %s, got %s)", requestedIP, getIngressPoint(&tcpService.Status.LoadBalancer.Ingress[0]))
+			framework.Failf("unexpected TCP Status.LoadBalancer.Ingress (expected %s, got %s)", requestedIP, getIngressPoint(&tcpService.Status.LoadBalancer.Ingress[0]))
 		}
 		tcpIngressIP := getIngressPoint(&tcpService.Status.LoadBalancer.Ingress[0])
-		Logf("TCP load balancer: %s", tcpIngressIP)
+		framework.Logf("TCP load balancer: %s", tcpIngressIP)
 
-		if providerIs("gce", "gke") {
+		if framework.ProviderIs("gce", "gke") {
 			// Do this as early as possible, which overrides the `defer` above.
 			// This is mostly out of fear of leaking the IP in a timeout case
 			// (as of this writing we're not 100% sure where the leaks are
@@ -534,7 +535,7 @@ var _ = KubeDescribe("Services", func() {
 				// Deleting it after it is attached "demotes" it to an
 				// ephemeral IP, which can be auto-released.
 				if err := deleteGCEStaticIP(staticIPName); err != nil {
-					Failf("failed to release static IP %s: %v", staticIPName, err)
+					framework.Failf("failed to release static IP %s: %v", staticIPName, err)
 				}
 				staticIPName = ""
 			}
@@ -547,14 +548,14 @@ var _ = KubeDescribe("Services", func() {
 			udpService = jig.WaitForLoadBalancerOrFail(ns2, udpService.Name)
 			jig.SanityCheckService(udpService, api.ServiceTypeLoadBalancer)
 			if udpService.Spec.Ports[0].NodePort != udpNodePort {
-				Failf("UDP Spec.Ports[0].NodePort changed (%d -> %d) when not expected", udpNodePort, udpService.Spec.Ports[0].NodePort)
+				framework.Failf("UDP Spec.Ports[0].NodePort changed (%d -> %d) when not expected", udpNodePort, udpService.Spec.Ports[0].NodePort)
 			}
 			udpIngressIP = getIngressPoint(&udpService.Status.LoadBalancer.Ingress[0])
-			Logf("UDP load balancer: %s", udpIngressIP)
+			framework.Logf("UDP load balancer: %s", udpIngressIP)
 
 			By("verifying that TCP and UDP use different load balancers")
 			if tcpIngressIP == udpIngressIP {
-				Failf("Load balancers are not different: %s", getIngressPoint(&tcpService.Status.LoadBalancer.Ingress[0]))
+				framework.Failf("Load balancers are not different: %s", getIngressPoint(&tcpService.Status.LoadBalancer.Ingress[0]))
 			}
 		}
 
@@ -580,12 +581,12 @@ var _ = KubeDescribe("Services", func() {
 		tcpNodePortOld := tcpNodePort
 		tcpNodePort = tcpService.Spec.Ports[0].NodePort
 		if tcpNodePort == tcpNodePortOld {
-			Failf("TCP Spec.Ports[0].NodePort (%d) did not change", tcpNodePort)
+			framework.Failf("TCP Spec.Ports[0].NodePort (%d) did not change", tcpNodePort)
 		}
 		if getIngressPoint(&tcpService.Status.LoadBalancer.Ingress[0]) != tcpIngressIP {
-			Failf("TCP Status.LoadBalancer.Ingress changed (%s -> %s) when not expected", tcpIngressIP, getIngressPoint(&tcpService.Status.LoadBalancer.Ingress[0]))
+			framework.Failf("TCP Status.LoadBalancer.Ingress changed (%s -> %s) when not expected", tcpIngressIP, getIngressPoint(&tcpService.Status.LoadBalancer.Ingress[0]))
 		}
-		Logf("TCP node port: %d", tcpNodePort)
+		framework.Logf("TCP node port: %d", tcpNodePort)
 
 		By("changing the UDP service's NodePort")
 		udpService = jig.ChangeServiceNodePortOrFail(ns2, udpService.Name, udpNodePort)
@@ -597,12 +598,12 @@ var _ = KubeDescribe("Services", func() {
 		udpNodePortOld := udpNodePort
 		udpNodePort = udpService.Spec.Ports[0].NodePort
 		if udpNodePort == udpNodePortOld {
-			Failf("UDP Spec.Ports[0].NodePort (%d) did not change", udpNodePort)
+			framework.Failf("UDP Spec.Ports[0].NodePort (%d) did not change", udpNodePort)
 		}
 		if loadBalancerSupportsUDP && getIngressPoint(&udpService.Status.LoadBalancer.Ingress[0]) != udpIngressIP {
-			Failf("UDP Status.LoadBalancer.Ingress changed (%s -> %s) when not expected", udpIngressIP, getIngressPoint(&udpService.Status.LoadBalancer.Ingress[0]))
+			framework.Failf("UDP Status.LoadBalancer.Ingress changed (%s -> %s) when not expected", udpIngressIP, getIngressPoint(&udpService.Status.LoadBalancer.Ingress[0]))
 		}
-		Logf("UDP node port: %d", udpNodePort)
+		framework.Logf("UDP node port: %d", udpNodePort)
 
 		By("hitting the TCP service's new NodePort")
 		jig.TestReachableHTTP(nodeIP, tcpNodePort, kubeProxyLagTimeout)
@@ -634,13 +635,13 @@ var _ = KubeDescribe("Services", func() {
 		svcPortOld := svcPort
 		svcPort = tcpService.Spec.Ports[0].Port
 		if svcPort == svcPortOld {
-			Failf("TCP Spec.Ports[0].Port (%d) did not change", svcPort)
+			framework.Failf("TCP Spec.Ports[0].Port (%d) did not change", svcPort)
 		}
 		if tcpService.Spec.Ports[0].NodePort != tcpNodePort {
-			Failf("TCP Spec.Ports[0].NodePort (%d) changed", tcpService.Spec.Ports[0].NodePort)
+			framework.Failf("TCP Spec.Ports[0].NodePort (%d) changed", tcpService.Spec.Ports[0].NodePort)
 		}
 		if getIngressPoint(&tcpService.Status.LoadBalancer.Ingress[0]) != tcpIngressIP {
-			Failf("TCP Status.LoadBalancer.Ingress changed (%s -> %s) when not expected", tcpIngressIP, getIngressPoint(&tcpService.Status.LoadBalancer.Ingress[0]))
+			framework.Failf("TCP Status.LoadBalancer.Ingress changed (%s -> %s) when not expected", tcpIngressIP, getIngressPoint(&tcpService.Status.LoadBalancer.Ingress[0]))
 		}
 
 		By("changing the UDP service's port")
@@ -653,16 +654,16 @@ var _ = KubeDescribe("Services", func() {
 			jig.SanityCheckService(udpService, api.ServiceTypeNodePort)
 		}
 		if udpService.Spec.Ports[0].Port != svcPort {
-			Failf("UDP Spec.Ports[0].Port (%d) did not change", udpService.Spec.Ports[0].Port)
+			framework.Failf("UDP Spec.Ports[0].Port (%d) did not change", udpService.Spec.Ports[0].Port)
 		}
 		if udpService.Spec.Ports[0].NodePort != udpNodePort {
-			Failf("UDP Spec.Ports[0].NodePort (%d) changed", udpService.Spec.Ports[0].NodePort)
+			framework.Failf("UDP Spec.Ports[0].NodePort (%d) changed", udpService.Spec.Ports[0].NodePort)
 		}
 		if loadBalancerSupportsUDP && getIngressPoint(&udpService.Status.LoadBalancer.Ingress[0]) != udpIngressIP {
-			Failf("UDP Status.LoadBalancer.Ingress changed (%s -> %s) when not expected", udpIngressIP, getIngressPoint(&udpService.Status.LoadBalancer.Ingress[0]))
+			framework.Failf("UDP Status.LoadBalancer.Ingress changed (%s -> %s) when not expected", udpIngressIP, getIngressPoint(&udpService.Status.LoadBalancer.Ingress[0]))
 		}
 
-		Logf("service port (TCP and UDP): %d", svcPort)
+		framework.Logf("service port (TCP and UDP): %d", svcPort)
 
 		By("hitting the TCP service's NodePort")
 		jig.TestReachableHTTP(nodeIP, tcpNodePort, kubeProxyLagTimeout)
@@ -727,7 +728,7 @@ var _ = KubeDescribe("Services", func() {
 			defer GinkgoRecover()
 			errs := t.Cleanup()
 			if len(errs) != 0 {
-				Failf("errors in cleanup: %v", errs)
+				framework.Failf("errors in cleanup: %v", errs)
 			}
 		}()
 
@@ -738,14 +739,14 @@ var _ = KubeDescribe("Services", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		if result.Spec.Type != api.ServiceTypeNodePort {
-			Failf("got unexpected Spec.Type for new service: %v", result)
+			framework.Failf("got unexpected Spec.Type for new service: %v", result)
 		}
 		if len(result.Spec.Ports) != 1 {
-			Failf("got unexpected len(Spec.Ports) for new service: %v", result)
+			framework.Failf("got unexpected len(Spec.Ports) for new service: %v", result)
 		}
 		port := result.Spec.Ports[0]
 		if port.NodePort == 0 {
-			Failf("got unexpected Spec.Ports[0].nodePort for new service: %v", result)
+			framework.Failf("got unexpected Spec.Ports[0].nodePort for new service: %v", result)
 		}
 
 		By("creating service " + serviceName2 + " with conflicting NodePort")
@@ -755,7 +756,7 @@ var _ = KubeDescribe("Services", func() {
 		service2.Spec.Ports[0].NodePort = port.NodePort
 		result2, err := t.CreateService(service2)
 		if err == nil {
-			Failf("Created service with conflicting NodePort: %v", result2)
+			framework.Failf("Created service with conflicting NodePort: %v", result2)
 		}
 		expectedErr := fmt.Sprintf("%d.*port is already allocated", port.NodePort)
 		Expect(fmt.Sprintf("%v", err)).To(MatchRegexp(expectedErr))
@@ -779,7 +780,7 @@ var _ = KubeDescribe("Services", func() {
 			defer GinkgoRecover()
 			errs := t.Cleanup()
 			if len(errs) != 0 {
-				Failf("errors in cleanup: %v", errs)
+				framework.Failf("errors in cleanup: %v", errs)
 			}
 		}()
 
@@ -791,17 +792,17 @@ var _ = KubeDescribe("Services", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		if service.Spec.Type != api.ServiceTypeNodePort {
-			Failf("got unexpected Spec.Type for new service: %v", service)
+			framework.Failf("got unexpected Spec.Type for new service: %v", service)
 		}
 		if len(service.Spec.Ports) != 1 {
-			Failf("got unexpected len(Spec.Ports) for new service: %v", service)
+			framework.Failf("got unexpected len(Spec.Ports) for new service: %v", service)
 		}
 		port := service.Spec.Ports[0]
 		if port.NodePort == 0 {
-			Failf("got unexpected Spec.Ports[0].nodePort for new service: %v", service)
+			framework.Failf("got unexpected Spec.Ports[0].nodePort for new service: %v", service)
 		}
 		if !ServiceNodePortRange.Contains(port.NodePort) {
-			Failf("got unexpected (out-of-range) port for new service: %v", service)
+			framework.Failf("got unexpected (out-of-range) port for new service: %v", service)
 		}
 
 		outOfRangeNodePort := 0
@@ -817,7 +818,7 @@ var _ = KubeDescribe("Services", func() {
 			s.Spec.Ports[0].NodePort = outOfRangeNodePort
 		})
 		if err == nil {
-			Failf("failed to prevent update of service with out-of-range NodePort: %v", result)
+			framework.Failf("failed to prevent update of service with out-of-range NodePort: %v", result)
 		}
 		expectedErr := fmt.Sprintf("%d.*port is not in the valid range", outOfRangeNodePort)
 		Expect(fmt.Sprintf("%v", err)).To(MatchRegexp(expectedErr))
@@ -832,7 +833,7 @@ var _ = KubeDescribe("Services", func() {
 		service.Spec.Ports[0].NodePort = outOfRangeNodePort
 		service, err = t.CreateService(service)
 		if err == nil {
-			Failf("failed to prevent create of service with out-of-range NodePort (%d): %v", outOfRangeNodePort, service)
+			framework.Failf("failed to prevent create of service with out-of-range NodePort (%d): %v", outOfRangeNodePort, service)
 		}
 		Expect(fmt.Sprintf("%v", err)).To(MatchRegexp(expectedErr))
 	})
@@ -847,7 +848,7 @@ var _ = KubeDescribe("Services", func() {
 			defer GinkgoRecover()
 			errs := t.Cleanup()
 			if len(errs) != 0 {
-				Failf("errors in cleanup: %v", errs)
+				framework.Failf("errors in cleanup: %v", errs)
 			}
 		}()
 
@@ -859,17 +860,17 @@ var _ = KubeDescribe("Services", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		if service.Spec.Type != api.ServiceTypeNodePort {
-			Failf("got unexpected Spec.Type for new service: %v", service)
+			framework.Failf("got unexpected Spec.Type for new service: %v", service)
 		}
 		if len(service.Spec.Ports) != 1 {
-			Failf("got unexpected len(Spec.Ports) for new service: %v", service)
+			framework.Failf("got unexpected len(Spec.Ports) for new service: %v", service)
 		}
 		port := service.Spec.Ports[0]
 		if port.NodePort == 0 {
-			Failf("got unexpected Spec.Ports[0].nodePort for new service: %v", service)
+			framework.Failf("got unexpected Spec.Ports[0].nodePort for new service: %v", service)
 		}
 		if !ServiceNodePortRange.Contains(port.NodePort) {
-			Failf("got unexpected (out-of-range) port for new service: %v", service)
+			framework.Failf("got unexpected (out-of-range) port for new service: %v", service)
 		}
 		nodePort := port.NodePort
 
@@ -877,19 +878,19 @@ var _ = KubeDescribe("Services", func() {
 		err = t.DeleteService(serviceName)
 		Expect(err).NotTo(HaveOccurred())
 
-		hostExec := LaunchHostExecPod(f.Client, f.Namespace.Name, "hostexec")
+		hostExec := framework.LaunchHostExecPod(f.Client, f.Namespace.Name, "hostexec")
 		cmd := fmt.Sprintf(`! ss -ant46 'sport = :%d' | tail -n +2 | grep LISTEN`, nodePort)
 		var stdout string
-		if pollErr := wait.PollImmediate(poll, kubeProxyLagTimeout, func() (bool, error) {
+		if pollErr := wait.PollImmediate(framework.Poll, kubeProxyLagTimeout, func() (bool, error) {
 			var err error
-			stdout, err = RunHostCmd(hostExec.Namespace, hostExec.Name, cmd)
+			stdout, err = framework.RunHostCmd(hostExec.Namespace, hostExec.Name, cmd)
 			if err != nil {
-				Logf("expected node port (%d) to not be in use, stdout: %v", nodePort, stdout)
+				framework.Logf("expected node port (%d) to not be in use, stdout: %v", nodePort, stdout)
 				return false, nil
 			}
 			return true, nil
 		}); pollErr != nil {
-			Failf("expected node port (%d) to not be in use in %v, stdout: %v", nodePort, kubeProxyLagTimeout, stdout)
+			framework.Failf("expected node port (%d) to not be in use in %v, stdout: %v", nodePort, kubeProxyLagTimeout, stdout)
 		}
 
 		By(fmt.Sprintf("creating service "+serviceName+" with same NodePort %d", nodePort))
@@ -942,10 +943,10 @@ func getContainerPortsByPodUID(endpoints *api.Endpoints) PortsByPodUID {
 					if err != nil {
 						continue
 					}
-					Logf("Mapped mesos host port %d to container port %d via annotation %s=%s", hostPort, containerPort, key, mesosContainerPortString)
+					framework.Logf("Mapped mesos host port %d to container port %d via annotation %s=%s", hostPort, containerPort, key, mesosContainerPortString)
 				}
 
-				// Logf("Found pod %v, host port %d and container port %d", addr.TargetRef.UID, hostPort, containerPort)
+				// framework.Logf("Found pod %v, host port %d and container port %d", addr.TargetRef.UID, hostPort, containerPort)
 				if _, ok := m[addr.TargetRef.UID]; !ok {
 					m[addr.TargetRef.UID] = make([]int, 0)
 				}
@@ -965,78 +966,78 @@ func translatePodNameToUIDOrFail(c *client.Client, ns string, expectedEndpoints 
 	for name, portList := range expectedEndpoints {
 		pod, err := c.Pods(ns).Get(name)
 		if err != nil {
-			Failf("failed to get pod %s, that's pretty weird. validation failed: %s", name, err)
+			framework.Failf("failed to get pod %s, that's pretty weird. validation failed: %s", name, err)
 		}
 		portsByUID[pod.ObjectMeta.UID] = portList
 	}
-	// Logf("successfully translated pod names to UIDs: %v -> %v on namespace %s", expectedEndpoints, portsByUID, ns)
+	// framework.Logf("successfully translated pod names to UIDs: %v -> %v on namespace %s", expectedEndpoints, portsByUID, ns)
 	return portsByUID
 }
 
 func validatePortsOrFail(endpoints PortsByPodUID, expectedEndpoints PortsByPodUID) {
 	if len(endpoints) != len(expectedEndpoints) {
 		// should not happen because we check this condition before
-		Failf("invalid number of endpoints got %v, expected %v", endpoints, expectedEndpoints)
+		framework.Failf("invalid number of endpoints got %v, expected %v", endpoints, expectedEndpoints)
 	}
 	for podUID := range expectedEndpoints {
 		if _, ok := endpoints[podUID]; !ok {
-			Failf("endpoint %v not found", podUID)
+			framework.Failf("endpoint %v not found", podUID)
 		}
 		if len(endpoints[podUID]) != len(expectedEndpoints[podUID]) {
-			Failf("invalid list of ports for uid %v. Got %v, expected %v", podUID, endpoints[podUID], expectedEndpoints[podUID])
+			framework.Failf("invalid list of ports for uid %v. Got %v, expected %v", podUID, endpoints[podUID], expectedEndpoints[podUID])
 		}
 		sort.Ints(endpoints[podUID])
 		sort.Ints(expectedEndpoints[podUID])
 		for index := range endpoints[podUID] {
 			if endpoints[podUID][index] != expectedEndpoints[podUID][index] {
-				Failf("invalid list of ports for uid %v. Got %v, expected %v", podUID, endpoints[podUID], expectedEndpoints[podUID])
+				framework.Failf("invalid list of ports for uid %v. Got %v, expected %v", podUID, endpoints[podUID], expectedEndpoints[podUID])
 			}
 		}
 	}
 }
 
 func validateEndpointsOrFail(c *client.Client, namespace, serviceName string, expectedEndpoints PortsByPodName) {
-	By(fmt.Sprintf("waiting up to %v for service %s in namespace %s to expose endpoints %v", serviceStartTimeout, serviceName, namespace, expectedEndpoints))
+	By(fmt.Sprintf("waiting up to %v for service %s in namespace %s to expose endpoints %v", framework.ServiceStartTimeout, serviceName, namespace, expectedEndpoints))
 	i := 1
-	for start := time.Now(); time.Since(start) < serviceStartTimeout; time.Sleep(1 * time.Second) {
+	for start := time.Now(); time.Since(start) < framework.ServiceStartTimeout; time.Sleep(1 * time.Second) {
 		endpoints, err := c.Endpoints(namespace).Get(serviceName)
 		if err != nil {
-			Logf("Get endpoints failed (%v elapsed, ignoring for 5s): %v", time.Since(start), err)
+			framework.Logf("Get endpoints failed (%v elapsed, ignoring for 5s): %v", time.Since(start), err)
 			continue
 		}
-		// Logf("Found endpoints %v", endpoints)
+		// framework.Logf("Found endpoints %v", endpoints)
 
 		portsByPodUID := getContainerPortsByPodUID(endpoints)
-		// Logf("Found port by pod UID %v", portsByPodUID)
+		// framework.Logf("Found port by pod UID %v", portsByPodUID)
 
 		expectedPortsByPodUID := translatePodNameToUIDOrFail(c, namespace, expectedEndpoints)
 		if len(portsByPodUID) == len(expectedEndpoints) {
 			validatePortsOrFail(portsByPodUID, expectedPortsByPodUID)
-			Logf("successfully validated that service %s in namespace %s exposes endpoints %v (%v elapsed)",
+			framework.Logf("successfully validated that service %s in namespace %s exposes endpoints %v (%v elapsed)",
 				serviceName, namespace, expectedEndpoints, time.Since(start))
 			return
 		}
 
 		if i%5 == 0 {
-			Logf("Unexpected endpoints: found %v, expected %v (%v elapsed, will retry)", portsByPodUID, expectedEndpoints, time.Since(start))
+			framework.Logf("Unexpected endpoints: found %v, expected %v (%v elapsed, will retry)", portsByPodUID, expectedEndpoints, time.Since(start))
 		}
 		i++
 	}
 
 	if pods, err := c.Pods(api.NamespaceAll).List(api.ListOptions{}); err == nil {
 		for _, pod := range pods.Items {
-			Logf("Pod %s\t%s\t%s\t%s", pod.Namespace, pod.Name, pod.Spec.NodeName, pod.DeletionTimestamp)
+			framework.Logf("Pod %s\t%s\t%s\t%s", pod.Namespace, pod.Name, pod.Spec.NodeName, pod.DeletionTimestamp)
 		}
 	} else {
-		Logf("Can't list pod debug info: %v", err)
+		framework.Logf("Can't list pod debug info: %v", err)
 	}
-	Failf("Timed out waiting for service %s in namespace %s to expose endpoints %v (%v elapsed)", serviceName, namespace, expectedEndpoints, serviceStartTimeout)
+	framework.Failf("Timed out waiting for service %s in namespace %s to expose endpoints %v (%v elapsed)", serviceName, namespace, expectedEndpoints, framework.ServiceStartTimeout)
 }
 
 // createExecPodOrFail creates a simple busybox pod in a sleep loop used as a
 // vessel for kubectl exec commands.
 func createExecPodOrFail(c *client.Client, ns, name string) {
-	Logf("Creating new exec pod")
+	framework.Logf("Creating new exec pod")
 	immediate := int64(0)
 	pod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{
@@ -1056,7 +1057,7 @@ func createExecPodOrFail(c *client.Client, ns, name string) {
 	}
 	_, err := c.Pods(ns).Create(pod)
 	Expect(err).NotTo(HaveOccurred())
-	err = wait.PollImmediate(poll, 5*time.Minute, func() (bool, error) {
+	err = wait.PollImmediate(framework.Poll, 5*time.Minute, func() (bool, error) {
 		retrievedPod, err := c.Pods(pod.Namespace).Get(pod.Name)
 		if err != nil {
 			return false, nil
@@ -1108,7 +1109,7 @@ func collectAddresses(nodes *api.NodeList, addressType api.NodeAddressType) []st
 }
 
 func getNodePublicIps(c *client.Client) ([]string, error) {
-	nodes := ListSchedulableNodesOrDie(c)
+	nodes := framework.ListSchedulableNodesOrDie(c)
 
 	ips := collectAddresses(nodes, api.NodeExternalIP)
 	if len(ips) == 0 {
@@ -1121,7 +1122,7 @@ func pickNodeIP(c *client.Client) string {
 	publicIps, err := getNodePublicIps(c)
 	Expect(err).NotTo(HaveOccurred())
 	if len(publicIps) == 0 {
-		Failf("got unexpected number (%d) of public IPs", len(publicIps))
+		framework.Failf("got unexpected number (%d) of public IPs", len(publicIps))
 	}
 	ip := publicIps[0]
 	return ip
@@ -1130,25 +1131,25 @@ func pickNodeIP(c *client.Client) string {
 func testReachableHTTP(ip string, port int, request string, expect string) (bool, error) {
 	url := fmt.Sprintf("http://%s:%d%s", ip, port, request)
 	if ip == "" {
-		Failf("Got empty IP for reachability check (%s)", url)
+		framework.Failf("Got empty IP for reachability check (%s)", url)
 		return false, nil
 	}
 	if port == 0 {
-		Failf("Got port==0 for reachability check (%s)", url)
+		framework.Failf("Got port==0 for reachability check (%s)", url)
 		return false, nil
 	}
 
-	Logf("Testing HTTP reachability of %v", url)
+	framework.Logf("Testing HTTP reachability of %v", url)
 
 	resp, err := httpGetNoConnectionPool(url)
 	if err != nil {
-		Logf("Got error testing for reachability of %s: %v", url, err)
+		framework.Logf("Got error testing for reachability of %s: %v", url, err)
 		return false, nil
 	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		Logf("Got error reading response from %s: %v", url, err)
+		framework.Logf("Got error reading response from %s: %v", url, err)
 		return false, nil
 	}
 	if resp.StatusCode != 200 {
@@ -1157,26 +1158,26 @@ func testReachableHTTP(ip string, port int, request string, expect string) (bool
 	if !strings.Contains(string(body), expect) {
 		return false, fmt.Errorf("received response body without expected substring %q: %s", expect, string(body))
 	}
-	Logf("Successfully reached %v", url)
+	framework.Logf("Successfully reached %v", url)
 	return true, nil
 }
 
 func testNotReachableHTTP(ip string, port int) (bool, error) {
 	url := fmt.Sprintf("http://%s:%d", ip, port)
 	if ip == "" {
-		Failf("Got empty IP for non-reachability check (%s)", url)
+		framework.Failf("Got empty IP for non-reachability check (%s)", url)
 		return false, nil
 	}
 	if port == 0 {
-		Failf("Got port==0 for non-reachability check (%s)", url)
+		framework.Failf("Got port==0 for non-reachability check (%s)", url)
 		return false, nil
 	}
 
-	Logf("Testing HTTP non-reachability of %v", url)
+	framework.Logf("Testing HTTP non-reachability of %v", url)
 
 	resp, err := httpGetNoConnectionPool(url)
 	if err != nil {
-		Logf("Confirmed that %s is not reachable", url)
+		framework.Logf("Confirmed that %s is not reachable", url)
 		return true, nil
 	}
 	resp.Body.Close()
@@ -1186,15 +1187,15 @@ func testNotReachableHTTP(ip string, port int) (bool, error) {
 func testReachableUDP(ip string, port int, request string, expect string) (bool, error) {
 	uri := fmt.Sprintf("udp://%s:%d", ip, port)
 	if ip == "" {
-		Failf("Got empty IP for reachability check (%s)", uri)
+		framework.Failf("Got empty IP for reachability check (%s)", uri)
 		return false, nil
 	}
 	if port == 0 {
-		Failf("Got port==0 for reachability check (%s)", uri)
+		framework.Failf("Got port==0 for reachability check (%s)", uri)
 		return false, nil
 	}
 
-	Logf("Testing UDP reachability of %v", uri)
+	framework.Logf("Testing UDP reachability of %v", uri)
 
 	con, err := net.Dial("udp", ip+":"+strconv.Itoa(port))
 	if err != nil {
@@ -1222,32 +1223,32 @@ func testReachableUDP(ip string, port int, request string, expect string) (bool,
 		return false, fmt.Errorf("Failed to retrieve %q, got %q", expect, string(buf))
 	}
 
-	Logf("Successfully reached %v", uri)
+	framework.Logf("Successfully reached %v", uri)
 	return true, nil
 }
 
 func testNotReachableUDP(ip string, port int, request string) (bool, error) {
 	uri := fmt.Sprintf("udp://%s:%d", ip, port)
 	if ip == "" {
-		Failf("Got empty IP for reachability check (%s)", uri)
+		framework.Failf("Got empty IP for reachability check (%s)", uri)
 		return false, nil
 	}
 	if port == 0 {
-		Failf("Got port==0 for reachability check (%s)", uri)
+		framework.Failf("Got port==0 for reachability check (%s)", uri)
 		return false, nil
 	}
 
-	Logf("Testing UDP non-reachability of %v", uri)
+	framework.Logf("Testing UDP non-reachability of %v", uri)
 
 	con, err := net.Dial("udp", ip+":"+strconv.Itoa(port))
 	if err != nil {
-		Logf("Confirmed that %s is not reachable", uri)
+		framework.Logf("Confirmed that %s is not reachable", uri)
 		return true, nil
 	}
 
 	_, err = con.Write([]byte(fmt.Sprintf("%s\n", request)))
 	if err != nil {
-		Logf("Confirmed that %s is not reachable", uri)
+		framework.Logf("Confirmed that %s is not reachable", uri)
 		return true, nil
 	}
 
@@ -1260,7 +1261,7 @@ func testNotReachableUDP(ip string, port int, request string) (bool, error) {
 
 	_, err = con.Read(buf)
 	if err != nil {
-		Logf("Confirmed that %s is not reachable", uri)
+		framework.Logf("Confirmed that %s is not reachable", uri)
 		return true, nil
 	}
 
@@ -1293,18 +1294,18 @@ func startServeHostnameService(c *client.Client, ns, name string, port, replicas
 
 	var createdPods []*api.Pod
 	maxContainerFailures := 0
-	config := RCConfig{
+	config := framework.RCConfig{
 		Client:               c,
 		Image:                "gcr.io/google_containers/serve_hostname:v1.4",
 		Name:                 name,
 		Namespace:            ns,
 		PollInterval:         3 * time.Second,
-		Timeout:              podReadyBeforeTimeout,
+		Timeout:              framework.PodReadyBeforeTimeout,
 		Replicas:             replicas,
 		CreatedPods:          &createdPods,
 		MaxContainerFailures: &maxContainerFailures,
 	}
-	err = RunRC(config)
+	err = framework.RunRC(config)
 	if err != nil {
 		return podNames, "", err
 	}
@@ -1330,7 +1331,7 @@ func startServeHostnameService(c *client.Client, ns, name string, port, replicas
 }
 
 func stopServeHostnameService(c *client.Client, ns, name string) error {
-	if err := DeleteRC(c, ns, name); err != nil {
+	if err := framework.DeleteRC(c, ns, name); err != nil {
 		return err
 	}
 	if err := c.Services(ns).Delete(name); err != nil {
@@ -1360,22 +1361,22 @@ func verifyServeHostnameServiceUp(c *client.Client, ns, host string, expectedPod
 		// verify service from node
 		func() string {
 			cmd := "set -e; " + buildCommand("wget -q --timeout=0.2 --tries=1 -O -")
-			Logf("Executing cmd %q on host %v", cmd, host)
-			result, err := SSH(cmd, host, testContext.Provider)
+			framework.Logf("Executing cmd %q on host %v", cmd, host)
+			result, err := framework.SSH(cmd, host, framework.TestContext.Provider)
 			if err != nil || result.Code != 0 {
-				LogSSHResult(result)
-				Logf("error while SSH-ing to node: %v", err)
+				framework.LogSSHResult(result)
+				framework.Logf("error while SSH-ing to node: %v", err)
 			}
 			return result.Stdout
 		},
 		// verify service from pod
 		func() string {
 			cmd := buildCommand("wget -q -T 1 -O -")
-			Logf("Executing cmd %q in pod %v/%v", cmd, ns, execPodName)
+			framework.Logf("Executing cmd %q in pod %v/%v", cmd, ns, execPodName)
 			// TODO: Use exec-over-http via the netexec pod instead of kubectl exec.
-			output, err := RunHostCmd(ns, execPodName, cmd)
+			output, err := framework.RunHostCmd(ns, execPodName, cmd)
 			if err != nil {
-				Logf("error while kubectl execing %q in pod %v/%v: %v\nOutput: %v", cmd, ns, execPodName, err, output)
+				framework.Logf("error while kubectl execing %q in pod %v/%v: %v\nOutput: %v", cmd, ns, execPodName, err, output)
 			}
 			return output
 		},
@@ -1401,12 +1402,12 @@ func verifyServeHostnameServiceUp(c *client.Client, ns, host string, expectedPod
 			// and we need a better way to track how often it occurs.
 			if gotEndpoints.IsSuperset(expectedEndpoints) {
 				if !gotEndpoints.Equal(expectedEndpoints) {
-					Logf("Ignoring unexpected output wgetting endpoints of service %s: %v", serviceIP, gotEndpoints.Difference(expectedEndpoints))
+					framework.Logf("Ignoring unexpected output wgetting endpoints of service %s: %v", serviceIP, gotEndpoints.Difference(expectedEndpoints))
 				}
 				passed = true
 				break
 			}
-			Logf("Unable to reach the following endpoints of service %s: %v", serviceIP, expectedEndpoints.Difference(gotEndpoints))
+			framework.Logf("Unable to reach the following endpoints of service %s: %v", serviceIP, expectedEndpoints.Difference(gotEndpoints))
 		}
 		if !passed {
 			// Sort the lists so they're easier to visually diff.
@@ -1425,15 +1426,15 @@ func verifyServeHostnameServiceDown(c *client.Client, host string, serviceIP str
 		"curl -s --connect-timeout 2 http://%s:%d && exit 99", serviceIP, servicePort)
 
 	for start := time.Now(); time.Since(start) < time.Minute; time.Sleep(5 * time.Second) {
-		result, err := SSH(command, host, testContext.Provider)
+		result, err := framework.SSH(command, host, framework.TestContext.Provider)
 		if err != nil {
-			LogSSHResult(result)
-			Logf("error while SSH-ing to node: %v", err)
+			framework.LogSSHResult(result)
+			framework.Logf("error while SSH-ing to node: %v", err)
 		}
 		if result.Code != 99 {
 			return nil
 		}
-		Logf("service still alive - still waiting")
+		framework.Logf("service still alive - still waiting")
 	}
 	return fmt.Errorf("waiting for service to be down timed out")
 }
@@ -1505,7 +1506,7 @@ func (j *ServiceTestJig) CreateTCPServiceOrFail(namespace string, tweak func(svc
 	}
 	result, err := j.Client.Services(namespace).Create(svc)
 	if err != nil {
-		Failf("Failed to create TCP Service %q: %v", svc.Name, err)
+		framework.Failf("Failed to create TCP Service %q: %v", svc.Name, err)
 	}
 	return result
 }
@@ -1520,14 +1521,14 @@ func (j *ServiceTestJig) CreateUDPServiceOrFail(namespace string, tweak func(svc
 	}
 	result, err := j.Client.Services(namespace).Create(svc)
 	if err != nil {
-		Failf("Failed to create UDP Service %q: %v", svc.Name, err)
+		framework.Failf("Failed to create UDP Service %q: %v", svc.Name, err)
 	}
 	return result
 }
 
 func (j *ServiceTestJig) SanityCheckService(svc *api.Service, svcType api.ServiceType) {
 	if svc.Spec.Type != svcType {
-		Failf("unexpected Spec.Type (%s) for service, expected %s", svc.Spec.Type, svcType)
+		framework.Failf("unexpected Spec.Type (%s) for service, expected %s", svc.Spec.Type, svcType)
 	}
 	expectNodePorts := false
 	if svcType != api.ServiceTypeClusterIP {
@@ -1536,11 +1537,11 @@ func (j *ServiceTestJig) SanityCheckService(svc *api.Service, svcType api.Servic
 	for i, port := range svc.Spec.Ports {
 		hasNodePort := (port.NodePort != 0)
 		if hasNodePort != expectNodePorts {
-			Failf("unexpected Spec.Ports[%d].NodePort (%d) for service", i, port.NodePort)
+			framework.Failf("unexpected Spec.Ports[%d].NodePort (%d) for service", i, port.NodePort)
 		}
 		if hasNodePort {
 			if !ServiceNodePortRange.Contains(port.NodePort) {
-				Failf("out-of-range nodePort (%d) for service", port.NodePort)
+				framework.Failf("out-of-range nodePort (%d) for service", port.NodePort)
 			}
 		}
 	}
@@ -1550,12 +1551,12 @@ func (j *ServiceTestJig) SanityCheckService(svc *api.Service, svcType api.Servic
 	}
 	hasIngress := len(svc.Status.LoadBalancer.Ingress) != 0
 	if hasIngress != expectIngress {
-		Failf("unexpected number of Status.LoadBalancer.Ingress (%d) for service", len(svc.Status.LoadBalancer.Ingress))
+		framework.Failf("unexpected number of Status.LoadBalancer.Ingress (%d) for service", len(svc.Status.LoadBalancer.Ingress))
 	}
 	if hasIngress {
 		for i, ing := range svc.Status.LoadBalancer.Ingress {
 			if ing.IP == "" && ing.Hostname == "" {
-				Failf("unexpected Status.LoadBalancer.Ingress[%d] for service: %#v", i, ing)
+				framework.Failf("unexpected Status.LoadBalancer.Ingress[%d] for service: %#v", i, ing)
 			}
 		}
 	}
@@ -1589,7 +1590,7 @@ func (j *ServiceTestJig) UpdateService(namespace, name string, update func(*api.
 func (j *ServiceTestJig) UpdateServiceOrFail(namespace, name string, update func(*api.Service)) *api.Service {
 	svc, err := j.UpdateService(namespace, name, update)
 	if err != nil {
-		Failf(err.Error())
+		framework.Failf(err.Error())
 	}
 	return svc
 }
@@ -1605,21 +1606,21 @@ func (j *ServiceTestJig) ChangeServiceNodePortOrFail(namespace, name string, ini
 			s.Spec.Ports[0].NodePort = newPort
 		})
 		if err != nil && strings.Contains(err.Error(), "provided port is already allocated") {
-			Logf("tried nodePort %d, but it is in use, will try another", newPort)
+			framework.Logf("tried nodePort %d, but it is in use, will try another", newPort)
 			continue
 		}
 		// Otherwise err was nil or err was a real error
 		break
 	}
 	if err != nil {
-		Failf("Could not change the nodePort: %v", err)
+		framework.Failf("Could not change the nodePort: %v", err)
 	}
 	return service
 }
 
 func (j *ServiceTestJig) WaitForLoadBalancerOrFail(namespace, name string) *api.Service {
 	var service *api.Service
-	Logf("Waiting up to %v for service %q to have a LoadBalancer", loadBalancerCreateTimeout, name)
+	framework.Logf("Waiting up to %v for service %q to have a LoadBalancer", loadBalancerCreateTimeout, name)
 	pollFunc := func() (bool, error) {
 		svc, err := j.Client.Services(namespace).Get(name)
 		if err != nil {
@@ -1631,8 +1632,8 @@ func (j *ServiceTestJig) WaitForLoadBalancerOrFail(namespace, name string) *api.
 		}
 		return false, nil
 	}
-	if err := wait.PollImmediate(poll, loadBalancerCreateTimeout, pollFunc); err != nil {
-		Failf("Timeout waiting for service %q to have a load balancer", name)
+	if err := wait.PollImmediate(framework.Poll, loadBalancerCreateTimeout, pollFunc); err != nil {
+		framework.Failf("Timeout waiting for service %q to have a load balancer", name)
 	}
 	return service
 }
@@ -1640,13 +1641,13 @@ func (j *ServiceTestJig) WaitForLoadBalancerOrFail(namespace, name string) *api.
 func (j *ServiceTestJig) WaitForLoadBalancerDestroyOrFail(namespace, name string, ip string, port int) *api.Service {
 	// TODO: once support ticket 21807001 is resolved, reduce this timeout back to something reasonable
 	defer func() {
-		if err := EnsureLoadBalancerResourcesDeleted(ip, strconv.Itoa(port)); err != nil {
-			Logf("Failed to delete cloud resources for service: %s %d (%v)", ip, port, err)
+		if err := framework.EnsureLoadBalancerResourcesDeleted(ip, strconv.Itoa(port)); err != nil {
+			framework.Logf("Failed to delete cloud resources for service: %s %d (%v)", ip, port, err)
 		}
 	}()
 
 	var service *api.Service
-	Logf("Waiting up to %v for service %q to have no LoadBalancer", loadBalancerCreateTimeout, name)
+	framework.Logf("Waiting up to %v for service %q to have no LoadBalancer", loadBalancerCreateTimeout, name)
 	pollFunc := func() (bool, error) {
 		svc, err := j.Client.Services(namespace).Get(name)
 		if err != nil {
@@ -1658,33 +1659,33 @@ func (j *ServiceTestJig) WaitForLoadBalancerDestroyOrFail(namespace, name string
 		}
 		return false, nil
 	}
-	if err := wait.PollImmediate(poll, loadBalancerCreateTimeout, pollFunc); err != nil {
-		Failf("Timeout waiting for service %q to have no load balancer", name)
+	if err := wait.PollImmediate(framework.Poll, loadBalancerCreateTimeout, pollFunc); err != nil {
+		framework.Failf("Timeout waiting for service %q to have no load balancer", name)
 	}
 	return service
 }
 
 func (j *ServiceTestJig) TestReachableHTTP(host string, port int, timeout time.Duration) {
-	if err := wait.PollImmediate(poll, timeout, func() (bool, error) { return testReachableHTTP(host, port, "/echo?msg=hello", "hello") }); err != nil {
-		Failf("Could not reach HTTP service through %v:%v after %v: %v", host, port, timeout, err)
+	if err := wait.PollImmediate(framework.Poll, timeout, func() (bool, error) { return testReachableHTTP(host, port, "/echo?msg=hello", "hello") }); err != nil {
+		framework.Failf("Could not reach HTTP service through %v:%v after %v: %v", host, port, timeout, err)
 	}
 }
 
 func (j *ServiceTestJig) TestNotReachableHTTP(host string, port int, timeout time.Duration) {
-	if err := wait.PollImmediate(poll, timeout, func() (bool, error) { return testNotReachableHTTP(host, port) }); err != nil {
-		Failf("Could still reach HTTP service through %v:%v after %v: %v", host, port, timeout, err)
+	if err := wait.PollImmediate(framework.Poll, timeout, func() (bool, error) { return testNotReachableHTTP(host, port) }); err != nil {
+		framework.Failf("Could still reach HTTP service through %v:%v after %v: %v", host, port, timeout, err)
 	}
 }
 
 func (j *ServiceTestJig) TestReachableUDP(host string, port int, timeout time.Duration) {
-	if err := wait.PollImmediate(poll, timeout, func() (bool, error) { return testReachableUDP(host, port, "echo hello", "hello") }); err != nil {
-		Failf("Could not reach UDP service through %v:%v after %v: %v", host, port, timeout, err)
+	if err := wait.PollImmediate(framework.Poll, timeout, func() (bool, error) { return testReachableUDP(host, port, "echo hello", "hello") }); err != nil {
+		framework.Failf("Could not reach UDP service through %v:%v after %v: %v", host, port, timeout, err)
 	}
 }
 
 func (j *ServiceTestJig) TestNotReachableUDP(host string, port int, timeout time.Duration) {
-	if err := wait.PollImmediate(poll, timeout, func() (bool, error) { return testNotReachableUDP(host, port, "echo hello") }); err != nil {
-		Failf("Could still reach UDP service through %v:%v after %v: %v", host, port, timeout, err)
+	if err := wait.PollImmediate(framework.Poll, timeout, func() (bool, error) { return testNotReachableUDP(host, port, "echo hello") }); err != nil {
+		framework.Failf("Could still reach UDP service through %v:%v after %v: %v", host, port, timeout, err)
 	}
 }
 
@@ -1748,14 +1749,14 @@ func (j *ServiceTestJig) RunOrFail(namespace string, tweak func(rc *api.Replicat
 	}
 	result, err := j.Client.ReplicationControllers(namespace).Create(rc)
 	if err != nil {
-		Failf("Failed to created RC %q: %v", rc.Name, err)
+		framework.Failf("Failed to created RC %q: %v", rc.Name, err)
 	}
 	pods, err := j.waitForPodsCreated(namespace, rc.Spec.Replicas)
 	if err != nil {
-		Failf("Failed to create pods: %v", err)
+		framework.Failf("Failed to create pods: %v", err)
 	}
 	if err := j.waitForPodsReady(namespace, pods); err != nil {
-		Failf("Failed waiting for pods to be running: %v", err)
+		framework.Failf("Failed waiting for pods to be running: %v", err)
 	}
 	return result
 }
@@ -1764,7 +1765,7 @@ func (j *ServiceTestJig) waitForPodsCreated(namespace string, replicas int) ([]s
 	timeout := 2 * time.Minute
 	// List the pods, making sure we observe all the replicas.
 	label := labels.SelectorFromSet(labels.Set(j.Labels))
-	Logf("Waiting up to %v for %d pods to be created", timeout, replicas)
+	framework.Logf("Waiting up to %v for %d pods to be created", timeout, replicas)
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(2 * time.Second) {
 		options := api.ListOptions{LabelSelector: label}
 		pods, err := j.Client.Pods(namespace).List(options)
@@ -1780,17 +1781,17 @@ func (j *ServiceTestJig) waitForPodsCreated(namespace string, replicas int) ([]s
 			found = append(found, pod.Name)
 		}
 		if len(found) == replicas {
-			Logf("Found all %d pods", replicas)
+			framework.Logf("Found all %d pods", replicas)
 			return found, nil
 		}
-		Logf("Found %d/%d pods - will retry", len(found), replicas)
+		framework.Logf("Found %d/%d pods - will retry", len(found), replicas)
 	}
 	return nil, fmt.Errorf("Timeout waiting for %d pods to be created", replicas)
 }
 
 func (j *ServiceTestJig) waitForPodsReady(namespace string, pods []string) error {
 	timeout := 2 * time.Minute
-	if !checkPodsRunningReady(j.Client, namespace, pods, timeout) {
+	if !framework.CheckPodsRunningReady(j.Client, namespace, pods, timeout) {
 		return fmt.Errorf("Timeout waiting for %d pods to be ready", len(pods))
 	}
 	return nil
@@ -1854,10 +1855,10 @@ func (t *ServiceTestFixture) CreateWebserverRC(replicas int) *api.ReplicationCon
 	rcSpec := rcByNamePort(t.name, replicas, t.image, 80, api.ProtocolTCP, t.Labels)
 	rcAct, err := t.createRC(rcSpec)
 	if err != nil {
-		Failf("Failed to create rc %s: %v", rcSpec.Name, err)
+		framework.Failf("Failed to create rc %s: %v", rcSpec.Name, err)
 	}
-	if err := verifyPods(t.Client, t.Namespace, t.name, false, replicas); err != nil {
-		Failf("Failed to create %d pods with name %s: %v", replicas, t.name, err)
+	if err := framework.VerifyPods(t.Client, t.Namespace, t.name, false, replicas); err != nil {
+		framework.Failf("Failed to create %d pods with name %s: %v", replicas, t.name, err)
 	}
 	return rcAct
 }

--- a/test/e2e/service_accounts.go
+++ b/test/e2e/service_accounts.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/version"
 	"k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -33,29 +34,29 @@ import (
 
 var serviceAccountTokenNamespaceVersion = version.MustParse("v1.2.0")
 
-var _ = KubeDescribe("ServiceAccounts", func() {
-	f := NewDefaultFramework("svcaccounts")
+var _ = framework.KubeDescribe("ServiceAccounts", func() {
+	f := framework.NewDefaultFramework("svcaccounts")
 
 	It("should ensure a single API token exists", func() {
 		// wait for the service account to reference a single secret
 		var secrets []api.ObjectReference
-		expectNoError(wait.Poll(time.Millisecond*500, time.Second*10, func() (bool, error) {
+		framework.ExpectNoError(wait.Poll(time.Millisecond*500, time.Second*10, func() (bool, error) {
 			By("waiting for a single token reference")
 			sa, err := f.Client.ServiceAccounts(f.Namespace.Name).Get("default")
 			if apierrors.IsNotFound(err) {
-				Logf("default service account was not found")
+				framework.Logf("default service account was not found")
 				return false, nil
 			}
 			if err != nil {
-				Logf("error getting default service account: %v", err)
+				framework.Logf("error getting default service account: %v", err)
 				return false, err
 			}
 			switch len(sa.Secrets) {
 			case 0:
-				Logf("default service account has no secret references")
+				framework.Logf("default service account has no secret references")
 				return false, nil
 			case 1:
-				Logf("default service account has a single secret reference")
+				framework.Logf("default service account has a single secret reference")
 				secrets = sa.Secrets
 				return true, nil
 			default:
@@ -68,32 +69,32 @@ var _ = KubeDescribe("ServiceAccounts", func() {
 			By("ensuring the single token reference persists")
 			time.Sleep(2 * time.Second)
 			sa, err := f.Client.ServiceAccounts(f.Namespace.Name).Get("default")
-			expectNoError(err)
+			framework.ExpectNoError(err)
 			Expect(sa.Secrets).To(Equal(secrets))
 		}
 
 		// delete the referenced secret
 		By("deleting the service account token")
-		expectNoError(f.Client.Secrets(f.Namespace.Name).Delete(secrets[0].Name))
+		framework.ExpectNoError(f.Client.Secrets(f.Namespace.Name).Delete(secrets[0].Name))
 
 		// wait for the referenced secret to be removed, and another one autocreated
-		expectNoError(wait.Poll(time.Millisecond*500, serviceAccountProvisionTimeout, func() (bool, error) {
+		framework.ExpectNoError(wait.Poll(time.Millisecond*500, framework.ServiceAccountProvisionTimeout, func() (bool, error) {
 			By("waiting for a new token reference")
 			sa, err := f.Client.ServiceAccounts(f.Namespace.Name).Get("default")
 			if err != nil {
-				Logf("error getting default service account: %v", err)
+				framework.Logf("error getting default service account: %v", err)
 				return false, err
 			}
 			switch len(sa.Secrets) {
 			case 0:
-				Logf("default service account has no secret references")
+				framework.Logf("default service account has no secret references")
 				return false, nil
 			case 1:
 				if sa.Secrets[0] == secrets[0] {
-					Logf("default service account still has the deleted secret reference")
+					framework.Logf("default service account still has the deleted secret reference")
 					return false, nil
 				}
-				Logf("default service account has a new single secret reference")
+				framework.Logf("default service account has a new single secret reference")
 				secrets = sa.Secrets
 				return true, nil
 			default:
@@ -106,7 +107,7 @@ var _ = KubeDescribe("ServiceAccounts", func() {
 			By("ensuring the single token reference persists")
 			time.Sleep(2 * time.Second)
 			sa, err := f.Client.ServiceAccounts(f.Namespace.Name).Get("default")
-			expectNoError(err)
+			framework.ExpectNoError(err)
 			Expect(sa.Secrets).To(Equal(secrets))
 		}
 
@@ -114,26 +115,26 @@ var _ = KubeDescribe("ServiceAccounts", func() {
 		By("deleting the reference to the service account token")
 		{
 			sa, err := f.Client.ServiceAccounts(f.Namespace.Name).Get("default")
-			expectNoError(err)
+			framework.ExpectNoError(err)
 			sa.Secrets = nil
 			_, updateErr := f.Client.ServiceAccounts(f.Namespace.Name).Update(sa)
-			expectNoError(updateErr)
+			framework.ExpectNoError(updateErr)
 		}
 
 		// wait for another one to be autocreated
-		expectNoError(wait.Poll(time.Millisecond*500, serviceAccountProvisionTimeout, func() (bool, error) {
+		framework.ExpectNoError(wait.Poll(time.Millisecond*500, framework.ServiceAccountProvisionTimeout, func() (bool, error) {
 			By("waiting for a new token to be created and added")
 			sa, err := f.Client.ServiceAccounts(f.Namespace.Name).Get("default")
 			if err != nil {
-				Logf("error getting default service account: %v", err)
+				framework.Logf("error getting default service account: %v", err)
 				return false, err
 			}
 			switch len(sa.Secrets) {
 			case 0:
-				Logf("default service account has no secret references")
+				framework.Logf("default service account has no secret references")
 				return false, nil
 			case 1:
-				Logf("default service account has a new single secret reference")
+				framework.Logf("default service account has a new single secret reference")
 				secrets = sa.Secrets
 				return true, nil
 			default:
@@ -146,7 +147,7 @@ var _ = KubeDescribe("ServiceAccounts", func() {
 			By("ensuring the single token reference persists")
 			time.Sleep(2 * time.Second)
 			sa, err := f.Client.ServiceAccounts(f.Namespace.Name).Get("default")
-			expectNoError(err)
+			framework.ExpectNoError(err)
 			Expect(sa.Secrets).To(Equal(secrets))
 		}
 	})
@@ -156,25 +157,25 @@ var _ = KubeDescribe("ServiceAccounts", func() {
 		var rootCAContent string
 
 		// Standard get, update retry loop
-		expectNoError(wait.Poll(time.Millisecond*500, serviceAccountProvisionTimeout, func() (bool, error) {
+		framework.ExpectNoError(wait.Poll(time.Millisecond*500, framework.ServiceAccountProvisionTimeout, func() (bool, error) {
 			By("getting the auto-created API token")
 			sa, err := f.Client.ServiceAccounts(f.Namespace.Name).Get("default")
 			if apierrors.IsNotFound(err) {
-				Logf("default service account was not found")
+				framework.Logf("default service account was not found")
 				return false, nil
 			}
 			if err != nil {
-				Logf("error getting default service account: %v", err)
+				framework.Logf("error getting default service account: %v", err)
 				return false, err
 			}
 			if len(sa.Secrets) == 0 {
-				Logf("default service account has no secret references")
+				framework.Logf("default service account has no secret references")
 				return false, nil
 			}
 			for _, secretRef := range sa.Secrets {
 				secret, err := f.Client.Secrets(f.Namespace.Name).Get(secretRef.Name)
 				if err != nil {
-					Logf("Error getting secret %s: %v", secretRef.Name, err)
+					framework.Logf("Error getting secret %s: %v", secretRef.Name, err)
 					continue
 				}
 				if secret.Type == api.SecretTypeServiceAccountToken {
@@ -184,7 +185,7 @@ var _ = KubeDescribe("ServiceAccounts", func() {
 				}
 			}
 
-			Logf("default service account has no secret references to valid service account tokens")
+			framework.Logf("default service account has no secret references to valid service account tokens")
 			return false, nil
 		}))
 
@@ -213,7 +214,7 @@ var _ = KubeDescribe("ServiceAccounts", func() {
 			},
 		}
 
-		supportsTokenNamespace, _ := serverVersionGTE(serviceAccountTokenNamespaceVersion, f.Client)
+		supportsTokenNamespace, _ := framework.ServerVersionGTE(serviceAccountTokenNamespaceVersion, f.Client)
 		if supportsTokenNamespace {
 			pod.Spec.Containers = append(pod.Spec.Containers, api.Container{
 				Name:  "namespace-test",

--- a/test/e2e/ubernetes_lite.go
+++ b/test/e2e/ubernetes_lite.go
@@ -29,34 +29,35 @@ import (
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/intstr"
 	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/kubernetes/test/e2e/framework"
 )
 
-var _ = KubeDescribe("Ubernetes Lite", func() {
-	framework := NewDefaultFramework("ubernetes-lite")
+var _ = framework.KubeDescribe("Ubernetes Lite", func() {
+	f := framework.NewDefaultFramework("ubernetes-lite")
 	var zoneCount int
 	var err error
 	image := "gcr.io/google_containers/serve_hostname:v1.4"
 	BeforeEach(func() {
 		if zoneCount <= 0 {
-			zoneCount, err = getZoneCount(framework.Client)
+			zoneCount, err = getZoneCount(f.Client)
 			Expect(err).NotTo(HaveOccurred())
 		}
 		By(fmt.Sprintf("Checking for multi-zone cluster.  Zone count = %d", zoneCount))
-		SkipUnlessAtLeast(zoneCount, 2, "Zone count is %d, only run for multi-zone clusters, skipping test")
-		SkipUnlessProviderIs("gce", "gke", "aws")
+		framework.SkipUnlessAtLeast(zoneCount, 2, "Zone count is %d, only run for multi-zone clusters, skipping test")
+		framework.SkipUnlessProviderIs("gce", "gke", "aws")
 		// TODO: SkipUnlessDefaultScheduler() // Non-default schedulers might not spread
 	})
 	It("should spread the pods of a service across zones", func() {
-		SpreadServiceOrFail(framework, (2*zoneCount)+1, image)
+		SpreadServiceOrFail(f, (2*zoneCount)+1, image)
 	})
 
 	It("should spread the pods of a replication controller across zones", func() {
-		SpreadRCOrFail(framework, (2*zoneCount)+1, image)
+		SpreadRCOrFail(f, (2*zoneCount)+1, image)
 	})
 })
 
 // Check that the pods comprising a service get spread evenly across available zones
-func SpreadServiceOrFail(f *Framework, replicaCount int, image string) {
+func SpreadServiceOrFail(f *framework.Framework, replicaCount int, image string) {
 	// First create the service
 	serviceName := "test-service"
 	serviceSpec := &api.Service{
@@ -92,11 +93,11 @@ func SpreadServiceOrFail(f *Framework, replicaCount int, image string) {
 			},
 		},
 	}
-	startPods(f.Client, replicaCount, f.Namespace.Name, serviceName, *podSpec, false)
+	framework.StartPods(f.Client, replicaCount, f.Namespace.Name, serviceName, *podSpec, false)
 
 	// Wait for all of them to be scheduled
 	selector := labels.SelectorFromSet(labels.Set(map[string]string{"service": serviceName}))
-	pods, err := waitForPodsWithLabelScheduled(f.Client, f.Namespace.Name, selector)
+	pods, err := framework.WaitForPodsWithLabelScheduled(f.Client, f.Namespace.Name, selector)
 	Expect(err).NotTo(HaveOccurred())
 
 	// Now make sure they're spread across zones
@@ -180,7 +181,7 @@ func checkZoneSpreading(c *client.Client, pods *api.PodList, zoneNames []string)
 }
 
 // Check that the pods comprising a replication controller get spread evenly across available zones
-func SpreadRCOrFail(f *Framework, replicaCount int, image string) {
+func SpreadRCOrFail(f *framework.Framework, replicaCount int, image string) {
 	name := "ubelite-spread-rc-" + string(util.NewUUID())
 	By(fmt.Sprintf("Creating replication controller %s", name))
 	controller, err := f.Client.ReplicationControllers(f.Namespace.Name).Create(&api.ReplicationController{
@@ -213,18 +214,18 @@ func SpreadRCOrFail(f *Framework, replicaCount int, image string) {
 	// Cleanup the replication controller when we are done.
 	defer func() {
 		// Resize the replication controller to zero to get rid of pods.
-		if err := DeleteRC(f.Client, f.Namespace.Name, controller.Name); err != nil {
-			Logf("Failed to cleanup replication controller %v: %v.", controller.Name, err)
+		if err := framework.DeleteRC(f.Client, f.Namespace.Name, controller.Name); err != nil {
+			framework.Logf("Failed to cleanup replication controller %v: %v.", controller.Name, err)
 		}
 	}()
 	// List the pods, making sure we observe all the replicas.
 	selector := labels.SelectorFromSet(labels.Set(map[string]string{"name": name}))
-	pods, err := podsCreated(f.Client, f.Namespace.Name, name, replicaCount)
+	pods, err := framework.PodsCreated(f.Client, f.Namespace.Name, name, replicaCount)
 	Expect(err).NotTo(HaveOccurred())
 
 	// Wait for all of them to be scheduled
 	By(fmt.Sprintf("Waiting for %d replicas of %s to be scheduled.  Selector: %v", replicaCount, name, selector))
-	pods, err = waitForPodsWithLabelScheduled(f.Client, f.Namespace.Name, selector)
+	pods, err = framework.WaitForPodsWithLabelScheduled(f.Client, f.Namespace.Name, selector)
 	Expect(err).NotTo(HaveOccurred())
 
 	// Now make sure they're spread across zones

--- a/test/e2e/volumes.go
+++ b/test/e2e/volumes.go
@@ -49,6 +49,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	"github.com/golang/glog"
 	. "github.com/onsi/ginkgo"
@@ -140,13 +141,13 @@ func startVolumeServer(client *client.Client, config VolumeTestConfig) *api.Pod 
 		},
 	}
 	_, err := podClient.Create(serverPod)
-	expectNoError(err, "Failed to create %s pod: %v", serverPod.Name, err)
+	framework.ExpectNoError(err, "Failed to create %s pod: %v", serverPod.Name, err)
 
-	expectNoError(waitForPodRunningInNamespace(client, serverPod.Name, config.namespace))
+	framework.ExpectNoError(framework.WaitForPodRunningInNamespace(client, serverPod.Name, config.namespace))
 
 	By("locating the server pod")
 	pod, err := podClient.Get(serverPod.Name)
-	expectNoError(err, "Cannot locate the server pod %v: %v", serverPod.Name, err)
+	framework.ExpectNoError(err, "Cannot locate the server pod %v: %v", serverPod.Name, err)
 
 	By("sleeping a bit to give the server time to start")
 	time.Sleep(20 * time.Second)
@@ -164,16 +165,16 @@ func volumeTestCleanup(client *client.Client, config VolumeTestConfig) {
 	err := podClient.Delete(config.prefix+"-client", nil)
 	if err != nil {
 		// Log the error before failing test: if the test has already failed,
-		// expectNoError() won't print anything to logs!
+		// framework.ExpectNoError() won't print anything to logs!
 		glog.Warningf("Failed to delete client pod: %v", err)
-		expectNoError(err, "Failed to delete client pod: %v", err)
+		framework.ExpectNoError(err, "Failed to delete client pod: %v", err)
 	}
 
 	if config.serverImage != "" {
 		err = podClient.Delete(config.prefix+"-server", nil)
 		if err != nil {
 			glog.Warningf("Failed to delete server pod: %v", err)
-			expectNoError(err, "Failed to delete server pod: %v", err)
+			framework.ExpectNoError(err, "Failed to delete server pod: %v", err)
 		}
 	}
 }
@@ -234,18 +235,18 @@ func testVolumeClient(client *client.Client, config VolumeTestConfig, volume api
 		clientPod.Spec.SecurityContext.FSGroup = fsGroup
 	}
 	if _, err := podsNamespacer.Create(clientPod); err != nil {
-		Failf("Failed to create %s pod: %v", clientPod.Name, err)
+		framework.Failf("Failed to create %s pod: %v", clientPod.Name, err)
 	}
-	expectNoError(waitForPodRunningInNamespace(client, clientPod.Name, config.namespace))
+	framework.ExpectNoError(framework.WaitForPodRunningInNamespace(client, clientPod.Name, config.namespace))
 
 	By("Checking that text file contents are perfect.")
-	_, err := lookForStringInPodExec(config.namespace, clientPod.Name, []string{"cat", "/opt/index.html"}, expectedContent, time.Minute)
+	_, err := framework.LookForStringInPodExec(config.namespace, clientPod.Name, []string{"cat", "/opt/index.html"}, expectedContent, time.Minute)
 	Expect(err).NotTo(HaveOccurred(), "failed: finding the contents of the mounted file.")
 
 	if fsGroup != nil {
 
 		By("Checking fsGroup is correct.")
-		_, err = lookForStringInPodExec(config.namespace, clientPod.Name, []string{"ls", "-ld", "/opt"}, strconv.Itoa(int(*fsGroup)), time.Minute)
+		_, err = framework.LookForStringInPodExec(config.namespace, clientPod.Name, []string{"ls", "-ld", "/opt"}, strconv.Itoa(int(*fsGroup)), time.Minute)
 		Expect(err).NotTo(HaveOccurred(), "failed: getting the right priviliges in the file %v", int(*fsGroup))
 	}
 }
@@ -303,8 +304,8 @@ func injectHtml(client *client.Client, config VolumeTestConfig, volume api.Volum
 	}()
 
 	injectPod, err := podClient.Create(injectPod)
-	expectNoError(err, "Failed to create injector pod: %v", err)
-	err = waitForPodSuccessInNamespace(client, injectPod.Name, injectPod.Spec.Containers[0].Name, injectPod.Namespace)
+	framework.ExpectNoError(err, "Failed to create injector pod: %v", err)
+	err = framework.WaitForPodSuccessInNamespace(client, injectPod.Name, injectPod.Spec.Containers[0].Name, injectPod.Namespace)
 	Expect(err).NotTo(HaveOccurred())
 }
 
@@ -315,24 +316,24 @@ func deleteCinderVolume(name string) error {
 	var err error
 	timeout := time.Second * 120
 
-	Logf("Waiting up to %v for removal of cinder volume %s", timeout, name)
+	framework.Logf("Waiting up to %v for removal of cinder volume %s", timeout, name)
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(5 * time.Second) {
 		output, err = exec.Command("cinder", "delete", name).CombinedOutput()
 		if err == nil {
-			Logf("Cinder volume %s deleted", name)
+			framework.Logf("Cinder volume %s deleted", name)
 			return nil
 		} else {
-			Logf("Failed to delete volume %s: %v", name, err)
+			framework.Logf("Failed to delete volume %s: %v", name, err)
 		}
 	}
-	Logf("Giving up deleting volume %s: %v\n%s", name, err, string(output[:]))
+	framework.Logf("Giving up deleting volume %s: %v\n%s", name, err, string(output[:]))
 	return err
 }
 
 // These tests need privileged containers, which are disabled by default.  Run
 // the test with "go run hack/e2e.go ... --ginkgo.focus=[Feature:Volumes]"
-var _ = KubeDescribe("Volumes [Feature:Volumes]", func() {
-	framework := NewDefaultFramework("volume")
+var _ = framework.KubeDescribe("Volumes [Feature:Volumes]", func() {
+	f := framework.NewDefaultFramework("volume")
 
 	// If 'false', the test won't clear its volumes upon completion. Useful for debugging,
 	// note that namespace deletion is handled by delete-namespace flag
@@ -342,15 +343,15 @@ var _ = KubeDescribe("Volumes [Feature:Volumes]", func() {
 	var namespace *api.Namespace
 
 	BeforeEach(func() {
-		c = framework.Client
-		namespace = framework.Namespace
+		c = f.Client
+		namespace = f.Namespace
 	})
 
 	////////////////////////////////////////////////////////////////////////
 	// NFS
 	////////////////////////////////////////////////////////////////////////
 
-	KubeDescribe("NFS", func() {
+	framework.KubeDescribe("NFS", func() {
 		It("should be mountable", func() {
 			config := VolumeTestConfig{
 				namespace:   namespace.Name,
@@ -366,7 +367,7 @@ var _ = KubeDescribe("Volumes [Feature:Volumes]", func() {
 			}()
 			pod := startVolumeServer(c, config)
 			serverIP := pod.Status.PodIP
-			Logf("NFS server IP address: %v", serverIP)
+			framework.Logf("NFS server IP address: %v", serverIP)
 
 			volume := api.VolumeSource{
 				NFS: &api.NFSVolumeSource{
@@ -384,7 +385,7 @@ var _ = KubeDescribe("Volumes [Feature:Volumes]", func() {
 	// Gluster
 	////////////////////////////////////////////////////////////////////////
 
-	KubeDescribe("GlusterFS", func() {
+	framework.KubeDescribe("GlusterFS", func() {
 		It("should be mountable", func() {
 			config := VolumeTestConfig{
 				namespace:   namespace.Name,
@@ -400,7 +401,7 @@ var _ = KubeDescribe("Volumes [Feature:Volumes]", func() {
 			}()
 			pod := startVolumeServer(c, config)
 			serverIP := pod.Status.PodIP
-			Logf("Gluster server IP address: %v", serverIP)
+			framework.Logf("Gluster server IP address: %v", serverIP)
 
 			// create Endpoints for the server
 			endpoints := api.Endpoints{
@@ -438,7 +439,7 @@ var _ = KubeDescribe("Volumes [Feature:Volumes]", func() {
 			}()
 
 			if _, err := endClient.Create(&endpoints); err != nil {
-				Failf("Failed to create endpoints for Gluster server: %v", err)
+				framework.Failf("Failed to create endpoints for Gluster server: %v", err)
 			}
 
 			volume := api.VolumeSource{
@@ -463,7 +464,7 @@ var _ = KubeDescribe("Volumes [Feature:Volumes]", func() {
 	// are installed on all nodes!
 	// Run the test with "go run hack/e2e.go ... --ginkgo.focus=iSCSI"
 
-	KubeDescribe("iSCSI", func() {
+	framework.KubeDescribe("iSCSI", func() {
 		It("should be mountable", func() {
 			config := VolumeTestConfig{
 				namespace:   namespace.Name,
@@ -483,7 +484,7 @@ var _ = KubeDescribe("Volumes [Feature:Volumes]", func() {
 			}()
 			pod := startVolumeServer(c, config)
 			serverIP := pod.Status.PodIP
-			Logf("iSCSI server IP address: %v", serverIP)
+			framework.Logf("iSCSI server IP address: %v", serverIP)
 
 			volume := api.VolumeSource{
 				ISCSI: &api.ISCSIVolumeSource{
@@ -505,7 +506,7 @@ var _ = KubeDescribe("Volumes [Feature:Volumes]", func() {
 	// Ceph RBD
 	////////////////////////////////////////////////////////////////////////
 
-	KubeDescribe("Ceph RBD", func() {
+	framework.KubeDescribe("Ceph RBD", func() {
 		It("should be mountable", func() {
 			config := VolumeTestConfig{
 				namespace:   namespace.Name,
@@ -526,7 +527,7 @@ var _ = KubeDescribe("Volumes [Feature:Volumes]", func() {
 			}()
 			pod := startVolumeServer(c, config)
 			serverIP := pod.Status.PodIP
-			Logf("Ceph server IP address: %v", serverIP)
+			framework.Logf("Ceph server IP address: %v", serverIP)
 
 			// create secrets for the server
 			secret := api.Secret{
@@ -552,7 +553,7 @@ var _ = KubeDescribe("Volumes [Feature:Volumes]", func() {
 			}()
 
 			if _, err := secClient.Create(&secret); err != nil {
-				Failf("Failed to create secrets for Ceph RBD: %v", err)
+				framework.Failf("Failed to create secrets for Ceph RBD: %v", err)
 			}
 
 			volume := api.VolumeSource{
@@ -578,7 +579,7 @@ var _ = KubeDescribe("Volumes [Feature:Volumes]", func() {
 	// Ceph
 	////////////////////////////////////////////////////////////////////////
 
-	KubeDescribe("CephFS", func() {
+	framework.KubeDescribe("CephFS", func() {
 		It("should be mountable", func() {
 			config := VolumeTestConfig{
 				namespace:   namespace.Name,
@@ -594,7 +595,7 @@ var _ = KubeDescribe("Volumes [Feature:Volumes]", func() {
 			}()
 			pod := startVolumeServer(c, config)
 			serverIP := pod.Status.PodIP
-			Logf("Ceph server IP address: %v", serverIP)
+			framework.Logf("Ceph server IP address: %v", serverIP)
 			By("sleeping a bit to give ceph server time to initialize")
 			time.Sleep(20 * time.Second)
 
@@ -617,14 +618,14 @@ var _ = KubeDescribe("Volumes [Feature:Volumes]", func() {
 			defer func() {
 				if clean {
 					if err := c.Secrets(namespace.Name).Delete(secret.Name); err != nil {
-						Failf("unable to delete secret %v: %v", secret.Name, err)
+						framework.Failf("unable to delete secret %v: %v", secret.Name, err)
 					}
 				}
 			}()
 
 			var err error
 			if secret, err = c.Secrets(namespace.Name).Create(secret); err != nil {
-				Failf("unable to create test secret %s: %v", secret.Name, err)
+				framework.Failf("unable to create test secret %s: %v", secret.Name, err)
 			}
 
 			volume := api.VolumeSource{
@@ -649,7 +650,7 @@ var _ = KubeDescribe("Volumes [Feature:Volumes]", func() {
 	// and that the usual OpenStack authentication env. variables are set
 	// (OS_USERNAME, OS_PASSWORD, OS_TENANT_NAME at least).
 
-	KubeDescribe("Cinder", func() {
+	framework.KubeDescribe("Cinder", func() {
 		It("should be mountable", func() {
 			config := VolumeTestConfig{
 				namespace: namespace.Name,
@@ -661,7 +662,7 @@ var _ = KubeDescribe("Volumes [Feature:Volumes]", func() {
 			By("creating a test Cinder volume")
 			output, err := exec.Command("cinder", "create", "--display-name="+volumeName, "1").CombinedOutput()
 			outputString := string(output[:])
-			Logf("cinder output:\n%s", outputString)
+			framework.Logf("cinder output:\n%s", outputString)
 			Expect(err).NotTo(HaveOccurred())
 
 			defer func() {
@@ -687,12 +688,12 @@ var _ = KubeDescribe("Volumes [Feature:Volumes]", func() {
 				volumeID = fields[3]
 				break
 			}
-			Logf("Volume ID: %s", volumeID)
+			framework.Logf("Volume ID: %s", volumeID)
 			Expect(volumeID).NotTo(Equal(""))
 
 			defer func() {
 				if clean {
-					Logf("Running volumeTestCleanup")
+					framework.Logf("Running volumeTestCleanup")
 					volumeTestCleanup(c, config)
 				}
 			}()

--- a/test/soak/serve_hostnames/serve_hostnames.go
+++ b/test/soak/serve_hostnames/serve_hostnames.go
@@ -37,7 +37,7 @@ import (
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/intstr"
-	"k8s.io/kubernetes/test/e2e"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
 var (


### PR DESCRIPTION
Refactor E2E framework & utils to test/e2e/framework package to pave the way for further refactoring and code sharing with the node e2e suite.

I've split this PR into 2 commits to try to make it more manageable: The first moves the code to the framework package (which builds on it's own), and the second fixes the test/e2e package. Unfortunately the code is so tangled up that moving it all at once this way is much easier than separating out individual pieces. Although the separation would probably be a worthwhile exercise on it's own, the goal here is to unblock the e2e_node hackathon.

One way I could reduce the number of changes is by importing the framework package as `.`. I didn't do this since I think it's not great practice - but I'm open to making this change if you (reviewers) think otherwise.

LMK if there's any way I can help to make this more reviewable.

@kubernetes/sig-node @kubernetes/sig-testing @vishh @pwittrock @jayunit100 
