### PR TITLE
add HOME env variable for kube-addons service

### DIFF
--- a/cluster/saltbase/salt/kube-addons/kube-addons.service
+++ b/cluster/saltbase/salt/kube-addons/kube-addons.service
@@ -3,6 +3,7 @@ Description=Kubernetes Addon Object Manager
 Documentation=https://github.com/kubernetes/kubernetes
 
 [Service]
+Environment=HOME=/root
 ExecStart=/etc/kubernetes/kube-addons.sh
 
 [Install]


### PR DESCRIPTION
Fix https://github.com/kubernetes/kubernetes/issues/23973.

Briefly, systemd service does not know the `HOME` environment variable which causes the kubectl write schema file into `/.kube` while it is expected to be `/root/.kube`.
