### PR TITLE
Trusty: Do not create the docker-daemon cgroup

### DIFF
--- a/cluster/gce/trusty/master.yaml
+++ b/cluster/gce/trusty/master.yaml
@@ -138,7 +138,6 @@ script
 		--configure-cbr0=${ALLOCATE_NODE_CIDRS} \
 		--cgroup-root=/ \
 		--system-cgroups=/system \
-		--runtime-cgroups=/docker-daemon \
 		--kubelet-cgroups=/kubelet \
 		--babysit-daemons=true \
 		${KUBELET_CMD_FLAGS} 1>>/var/log/kubelet.log 2>&1

--- a/cluster/gce/trusty/node.yaml
+++ b/cluster/gce/trusty/node.yaml
@@ -137,7 +137,6 @@ script
 		--configure-cbr0=true \
 		--cgroup-root=/ \
 		--system-cgroups=/system \
-		--runtime-cgroups=/docker-daemon \
 		--kubelet-cgroups=/kubelet \
 		--babysit-daemons=true \
 		${KUBELET_CMD_FLAGS} 1>>/var/log/kubelet.log 2>&1


### PR DESCRIPTION
This is a part of fix for issue #23956. But only when #23961 is also fixed, the Jenkins testing on our image will be green.

@dchen1107 @vishh please review this. Please also add "release note" and "cherrypick-candidate" labels, and mark it as milestone 1.2, as we also need to add this correct logic in 1.2 releases.

cc/ @wonderfly @roberthbailey @fabioy FYI.
