### PR TITLE
Run kubernetes-e2e-g[ck]e-flaky inside Docker

### DIFF
--- a/hack/jenkins/dockerized-e2e-runner.sh
+++ b/hack/jenkins/dockerized-e2e-runner.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Save environment variables in $WORKSPACE/env.list and then run the Jenkins e2e
+# test runner inside the kubekins-test Docker image.
+
+env -u HOME -u PATH -u PWD -u WORKSPACE >${WORKSPACE}/env.list
+docker run --rm=true -i \
+  -v "${WORKSPACE}/_artifacts":/workspace/_artifacts \
+  -v /etc/localtime:/etc/localtime:ro \
+  -v /var/lib/jenkins/gce_keys:/workspace/.ssh:ro \
+  --env-file "${WORKSPACE}/env.list" \
+  -e "HOME=/workspace" \
+  -e "WORKSPACE=/workspace" \
+  gcr.io/google_containers/kubekins-test:0.9 \
+  bash -c "bash <(curl -fsS --retry 3 'https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/e2e-runner.sh')"

--- a/hack/jenkins/job-configs/global.yaml
+++ b/hack/jenkins/job-configs/global.yaml
@@ -138,6 +138,7 @@
     branch: 'master'
     job-env: ''
     runner: bash <(curl -fsS --retry 3  "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/e2e-runner.sh")
+    dockerized-runner: bash <(curl -fsS --retry 3  "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/dockerized-e2e-runner.sh")
     old-runner-1-1: bash <(curl -fsS --retry 3  "https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.1/hack/jenkins/e2e.sh")
     old-runner-1-0: bash <(curl -fsS --retry 3  "https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.0/hack/jenkins/e2e.sh")
     provider-env: ''

--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
@@ -15,6 +15,8 @@
     description: '{description} Test owner: {test-owner}.'
     logrotate:
         daysToKeep: 7
+    node: '{jenkins_node}'
+    jenkins_node: 'master'
     disabled: '{obj:disable_job}'
     builders:
         - shell: |
@@ -105,6 +107,8 @@
                 export KUBE_ADMISSION_CONTROL="NamespaceLifecycle,InitialResources,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota"
         - 'gce-flaky':
             description: 'Run the flaky tests on GCE, sequentially.'
+            jenkins_node: 'e2e'
+            runner: '{dockerized-runner}'
             timeout: 180
             job-env: |
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Flaky\] \
@@ -213,6 +217,8 @@
                 - client (kubectl): ci/latest.txt<br>
                 - cluster (k8s): ci/latest.txt<br>
                 - tests: ci/latest.txt
+            jenkins_node: 'e2e'
+            runner: '{dockerized-runner}'
             timeout: 300
             job-env: |
                 export PROJECT="k8s-jkns-e2e-gke-ci-flaky"


### PR DESCRIPTION
This is the most minimal set of changes to get `hack/jenkins/e2e-runner.sh` running inside Docker, which gives us more confidence that we don't have dependencies on the Jenkins master.

I'm starting with the flaky builds so that we don't block merges if things are broken. (Hopefully they are not.) We can slowly roll it out to other builds if everything is working.

Items I haven't addressed yet:
- I'm not sure if using a custom `CLOUDSDK_BUCKET` works. There's a reference to `/var/lib/jenkins` inside that conditional that I don't fully understand.
- I haven't dealt with AWS keys. We probably need to put them in a Jenkins credential and then write them into a file in the workspace or something.
- The `release-*` branches will probably need to keep running outside Docker, unless we backport fixes. Same for upgrades?
- I'd like to avoid calling `env` and passing nearly the entire environment through, though I don't have a good idea of how to easily munge our YAML to save the environment variables we set into a file instead of exporting them.
- The post-build `upload-to-gcs.sh` stuff still happens outside Docker - eventually it'd be nice to have that all happen as a part of the containerized image.

Still, this is hopefully some progress, maybe?

@kubernetes/sig-testing 
