### PR TITLE
Clarify release-note label requirement for non-master PRs.

### DIFF
--- a/docs/devel/pull-requests.md
+++ b/docs/devel/pull-requests.md
@@ -86,7 +86,7 @@ This section applies only to pull requests on the master branch.
 
 The only exception to these rules is when a PR is not a cherry-pick and is
 targeted directly to the non-master branch.  In this case, a `release-note-*`
-label is optional (and not enforced).
+label is required for that non-master PR.
 
 ### Reviewing pre-release notes
 

--- a/docs/proposals/release-notes.md
+++ b/docs/proposals/release-notes.md
@@ -121,7 +121,7 @@ will be collected from that cherry-pick PR.
 
 The only exception to this rule is when a PR is not a cherry-pick and is
 targeted directly to the non-master branch.  In this case, a `release-note-*`
-label is optional (and not enforced).
+label is required for that non-master PR.
 
 1. New labels added to github: `release-note-none`, maybe others for new release note categories - see Layout section below
 1. A [new munger](https://github.com/kubernetes/kubernetes/issues/23409) that will:


### PR DESCRIPTION
I missed adding this change to the last PR by a few seconds.
