### PR TITLE
Add workaround for gsutil bug

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -228,8 +228,7 @@ function upload-server-tars() {
       echo "Creating ${staging_bucket}"
       # The `-o ...` bit is a temporary workaround for
       # https://github.com/GoogleCloudPlatform/gsutil/issues/348
-      # It can safely be removed once that issue is resolved and it's likely
-      # users have updated thir gsutil installations.
+      # It can safely be removed once that issue is resolved.
       gsutil -o "GSUtil:prefer_api=xml" mb -l "${region}" "${staging_bucket}"
     fi
 

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -226,7 +226,11 @@ function upload-server-tars() {
     # Ensure the buckets are created
     if ! gsutil ls "${staging_bucket}" ; then
       echo "Creating ${staging_bucket}"
-      gsutil mb -l "${region}" "${staging_bucket}"
+      # The `-o ...` bit is a temporary workaround for
+      # https://github.com/GoogleCloudPlatform/gsutil/issues/348
+      # It can safely be removed once that issue is resolved and it's likely
+      # users have updated thir gsutil installations.
+      gsutil -o "GSUtil:prefer_api=xml" mb -l "${region}" "${staging_bucket}"
     fi
 
     local staging_path="${staging_bucket}/${INSTANCE_PREFIX}-devel"


### PR DESCRIPTION
This allows `./cluster/kube-up.sh` to operate when using a service
account.

Fixes #23933 

I manually tested that `./cluster/kube-up.sh` succeeded after this change on a GCE project where the staging bucket didn't exist, running via a service account.
