### PR TITLE
fix relative working dirctory of KUBE_ROOT

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -39,8 +39,6 @@ WAIT_FOR_URL_API_SERVER=${WAIT_FOR_URL_API_SERVER:-10}
 ENABLE_DAEMON=${ENABLE_DAEMON:-false}
 HOSTNAME_OVERRIDE=${HOSTNAME_OVERRIDE:-"127.0.0.1"}
 
-cd "${KUBE_ROOT}"
-
 if [ "$(id -u)" != "0" ]; then
     echo "WARNING : This script MAY be run as root for docker socket / iptables functionality; if failures occur, retry as root." 2>&1
 fi


### PR DESCRIPTION
fix relative working dirctory of `KUBE_ROOT`, do not need to change to `KUBE_ROOT` in the first place

Signed-off-by: Crazykev zcq8989@gmail.com
