### PR TITLE
Only keep 7 days' worth of logs for kubernetes-update-jenkins-jobs

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-update-jenkins-jobs.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-update-jenkins-jobs.yaml
@@ -1,6 +1,8 @@
 - job:
     name: kubernetes-update-jenkins-jobs
     description: 'Update Jenkins jobs based on configs in https://github.com/kubernetes/kubernetes/tree/master/hack/jenkins/job-configs. Test owner: spxtr.'
+    logrotate:
+        daysToKeep: 7
     node: master
     triggers:
         - timed: 'H/15 * * * *'

--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-update-jenkins-jobs.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-update-jenkins-jobs.yaml
@@ -1,6 +1,8 @@
 - job:
     name: kubernetes-update-jenkins-jobs
     description: 'Update Jenkins jobs based on configs in https://github.com/kubernetes/kubernetes/tree/master/hack/jenkins/job-configs. Test owner: spxtr.'
+    logrotate:
+        daysToKeep: 7
     triggers:
         - timed: 'H/15 * * * *'
     builders:


### PR DESCRIPTION
We had logs on Jenkins going back to December, which was making it rather sad.
