### PR TITLE
WIP: validation.ValidatePodUpdate: activeDeadlineSeconds must a positive integer

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -46,6 +46,7 @@ import (
 var RepairMalformedUpdates bool = true
 
 const isNegativeErrorMsg string = `must be greater than or equal to 0`
+const isNotPositiveErrorMsg string = `must be greater than 0`
 const isInvalidQuotaResource string = `must be a standard resource for quota`
 const fieldImmutableErrorMsg string = `field is immutable`
 const cIdentifierErrorMsg string = `must be a C identifier (matching regex ` + validation.CIdentifierFmt + `): e.g. "my_name" or "MyName"`
@@ -1422,7 +1423,7 @@ func ValidatePodSpec(spec *api.PodSpec, fldPath *field.Path) field.ErrorList {
 
 	if spec.ActiveDeadlineSeconds != nil {
 		if *spec.ActiveDeadlineSeconds <= 0 {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("activeDeadlineSeconds"), spec.ActiveDeadlineSeconds, "must be greater than 0"))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("activeDeadlineSeconds"), spec.ActiveDeadlineSeconds, isNotPositiveErrorMsg))
 		}
 	}
 	return allErrs
@@ -2683,14 +2684,14 @@ func ValidatePodLogOptions(opts *api.PodLogOptions) field.ErrorList {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("tailLines"), *opts.TailLines, isNegativeErrorMsg))
 	}
 	if opts.LimitBytes != nil && *opts.LimitBytes < 1 {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("limitBytes"), *opts.LimitBytes, "must be greater than 0"))
+		allErrs = append(allErrs, field.Invalid(field.NewPath("limitBytes"), *opts.LimitBytes, isNotPositiveErrorMsg))
 	}
 	switch {
 	case opts.SinceSeconds != nil && opts.SinceTime != nil:
 		allErrs = append(allErrs, field.Forbidden(field.NewPath(""), "at most one of `sinceTime` or `sinceSeconds` may be specified"))
 	case opts.SinceSeconds != nil:
 		if *opts.SinceSeconds < 1 {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("sinceSeconds"), *opts.SinceSeconds, "must be greater than 0"))
+			allErrs = append(allErrs, field.Invalid(field.NewPath("sinceSeconds"), *opts.SinceSeconds, isNotPositiveErrorMsg))
 		}
 	}
 	return allErrs

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -1576,11 +1576,11 @@ func ValidatePodUpdate(newPod, oldPod *api.Pod) field.ErrorList {
 
 	// validate updated spec.activeDeadlineSeconds.  two types of updates are allowed:
 	// 1.  from nil to a positive value
-	// 2.  from a positive value to a lesser, non-negative value
+	// 2.  from a positive value to a lesser, positive value
 	if newPod.Spec.ActiveDeadlineSeconds != nil {
 		newActiveDeadlineSeconds := *newPod.Spec.ActiveDeadlineSeconds
-		if newActiveDeadlineSeconds < 0 {
-			allErrs = append(allErrs, field.Invalid(specPath.Child("activeDeadlineSeconds"), newActiveDeadlineSeconds, isNegativeErrorMsg))
+		if newActiveDeadlineSeconds <= 0 {
+			allErrs = append(allErrs, field.Invalid(specPath.Child("activeDeadlineSeconds"), newActiveDeadlineSeconds, isNotPositiveErrorMsg))
 			return allErrs
 		}
 		if oldPod.Spec.ActiveDeadlineSeconds != nil {


### PR DESCRIPTION
Based on v1.PodSpec documentation [1], spec.activeDeadlineSeconds must a positive integer.

The current code inside of ValidatePodUpdate allows the activeDeadlineSeconds to be non-negative. This is against the documentation.

At the same time the patch replaces all `"must be greater than 0"` literals with `isNotPositiveErrorMsg` const.

[1] http://kubernetes.io/docs/api-reference/v1/definitions/#_v1_podspec.

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/24042)

<!-- Reviewable:end -->
