### PR TITLE
add config-test.sh to cluster/centos so we can run e2e test on centos/fedora/rhel

### DIFF
--- a/cluster/centos/config-test.sh
+++ b/cluster/centos/config-test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## for CentOS/Fedora/RHEL cluster in test mode
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${KUBE_ROOT}/cluster/centos/config-default.sh"


### PR DESCRIPTION
so I can run e2e test on centos locally using the following command

``` console
KUBERNETES_PROVIDER=centos KUBERNETES_CONFORMANCE_TEST=y ./cluster/test-e2e.sh
```
