### PR TITLE
Expose SummaryProvider for reuse by other parts of kubelet

### DIFF
--- a/pkg/kubelet/server/stats/handler.go
+++ b/pkg/kubelet/server/stats/handler.go
@@ -55,8 +55,8 @@ type handler struct {
 	summaryProvider SummaryProvider
 }
 
-func CreateHandlers(provider StatsProvider, resourceAnalyzer ResourceAnalyzer) *restful.WebService {
-	h := &handler{provider, NewSummaryProvider(provider, resourceAnalyzer)}
+func CreateHandlers(provider StatsProvider, summaryProvider SummaryProvider) *restful.WebService {
+	h := &handler{provider, summaryProvider}
 
 	ws := &restful.WebService{}
 	ws.Path("/stats/").

--- a/pkg/kubelet/server/stats/resource_analyzer.go
+++ b/pkg/kubelet/server/stats/resource_analyzer.go
@@ -23,18 +23,22 @@ type ResourceAnalyzer interface {
 	Start()
 
 	fsResourceAnalyzerInterface
+	SummaryProvider
 }
 
 // resourceAnalyzer implements ResourceAnalyzer
 type resourceAnalyzer struct {
 	*fsResourceAnalyzer
+	SummaryProvider
 }
 
 var _ ResourceAnalyzer = &resourceAnalyzer{}
 
 // NewResourceAnalyzer returns a new ResourceAnalyzer
 func NewResourceAnalyzer(statsProvider StatsProvider, calVolumeFrequency time.Duration) ResourceAnalyzer {
-	return &resourceAnalyzer{newFsResourceAnalyzer(statsProvider, calVolumeFrequency)}
+	fsAnalyzer := newFsResourceAnalyzer(statsProvider, calVolumeFrequency)
+	summaryProvider := NewSummaryProvider(statsProvider, fsAnalyzer)
+	return &resourceAnalyzer{fsAnalyzer, summaryProvider}
 }
 
 // Start starts background functions necessary for the ResourceAnalyzer to function


### PR DESCRIPTION
To support out of resource killing in the kubelet, we will introduce a new top-level module that will ensure node stability by checking if eviction thresholds have been met for memory and file-system usage on the node.  In addition, it will then need information about pod memory and disk usage in order to make an eviction selection.  Currently, this information is collected in `SummaryProvider` but it's hidden away and not available for re-use by other top-level modules of the kubelet.  This initial refactor adds the ability to get summary stat information from the `ResourceAnalyzer` so it can be reused by other top-level modules.

I suspect we will further re-factor this area as code evolves, but this unblocks further progress on out-of-resource killing.

/cc @vishh @timothysc @kubernetes/sig-node @kubernetes/rh-cluster-infra 
