### PR TITLE
Allowing type object in kubectl swagger validation

### DIFF
--- a/pkg/api/validation/schema.go
+++ b/pkg/api/validation/schema.go
@@ -282,7 +282,10 @@ func (s *SwaggerSchema) validateField(value interface{}, fieldName, fieldType st
 		if _, ok := value.(bool); !ok {
 			return append(allErrs, NewInvalidTypeError(reflect.Bool, reflect.TypeOf(value).Kind(), fieldName))
 		}
+	// API servers before release 1.3 produce swagger spec with `type: "any"` as the fallback type, while newer servers produce spec with `type: "object"`.
+	// We have both here so that kubectl can work with both old and new api servers.
 	case "any":
+	case "object":
 	default:
 		return append(allErrs, fmt.Errorf("unexpected type: %v", fieldType))
 	}


### PR DESCRIPTION
Allowing `"type": "object"` in kubectl swagger validation.

We will cherrypick this in 1.2
This allows 1.2 kubectl to work with 1.3 api server which will use `"type":"object"` instead of `"type":"any"`.
Ref https://github.com/kubernetes/kubernetes/issues/4700#issuecomment-194719759

cc @bgrant0607 
