### PR TITLE
Compute Jenkins job config XML changes easily

### DIFF
--- a/hack/jenkins/diff-job-config-patch.sh
+++ b/hack/jenkins/diff-job-config-patch.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Uses the kubekins-job-builder Docker image to compute the differences in
+# the Jenkins job config XML, comparing the current git branch against upstream
+# master. The filename containing the diff is printed at the end, assuming
+# everything parsed successfully.
+
+# Note: anecdotal evidence suggests this doesn't work correctly on OS X.
+# If you find that there is no diff being generated, you may want to try setting
+# OUTPUT_DIR to some directory in your home directory.
+
+# When running this script from inside Docker, you must set REPO_ROOT to point
+# to the path to the repository on the host, and DOCKER_VOLUME_OUTPUT_DIR must
+# point to the path of $OUTPUT_DIR on the host. This is due to the way volume
+# mounts work in Docker-in-Docker.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+readonly JOB_CONFIGS_ROOT="hack/jenkins/job-configs"
+readonly JOB_BUILDER_IMAGE='gcr.io/google_containers/kubekins-job-builder:1'
+
+KUBE_ROOT=$(cd $(dirname "${BASH_SOURCE}")/../.. && pwd)
+REPO_DIR=${REPO_DIR:-"${KUBE_ROOT}"}
+
+readonly output_dir=${OUTPUT_DIR:=$(mktemp -d -t JJB-XXXXX)}
+readonly docker_volume_output_dir=${DOCKER_VOLUME_OUTPUT_DIR:="${output_dir}"}
+readonly diff_file="${output_dir}/diff.txt"
+
+mkdir -p "${output_dir}/upstream" "${output_dir}/patch"
+
+echo "Saving output in ${output_dir}"
+
+readonly common_commands="\
+  git describe --long --tags --abbrev=14 >/output/gitversion.txt && \
+  git rev-parse --abbrev-ref HEAD >/output/gitbranch.txt && \
+  jenkins-jobs test \
+    '${JOB_CONFIGS_ROOT}:${JOB_CONFIGS_ROOT}/kubernetes-jenkins' \
+    -o /output/kubernetes-jenkins && \
+  jenkins-jobs test \
+    '${JOB_CONFIGS_ROOT}:${JOB_CONFIGS_ROOT}/kubernetes-jenkins-pull' \
+    -o /output/kubernetes-jenkins-pull"
+
+docker run --rm=true -i \
+  -v "${docker_volume_output_dir}/upstream:/output" \
+  "${JOB_BUILDER_IMAGE}" \
+  bash -c "git checkout master && git pull && ${common_commands}"
+
+docker run --rm=true -i \
+  -v "${docker_volume_output_dir}/patch:/output" \
+  -v "${REPO_DIR}:/kubernetes:ro" \
+  "${JOB_BUILDER_IMAGE}" \
+  bash -c "${common_commands}"
+
+diff -ruN "${output_dir}/upstream" "${output_dir}/patch" >"${diff_file}" || true
+echo
+echo "  *** Diff saved in ${diff_file} ***"

--- a/hack/jenkins/gotest-dockerized.sh
+++ b/hack/jenkins/gotest-dockerized.sh
@@ -20,6 +20,8 @@ set -o pipefail
 set -o xtrace
 
 export REPO_DIR=${REPO_DIR:-$(pwd)}
+export HOST_ARTIFACTS_DIR=${WORKSPACE}/_artifacts
+mkdir -p "${HOST_ARTIFACTS_DIR}"
 
 # Run the kubekins container, mapping in docker (so we can launch containers),
 # the repo directory, and the artifacts output directory.
@@ -42,5 +44,6 @@ docker run --rm=true \
   -e "KUBE_FORCE_VERIFY_CHECKS=${KUBE_FORCE_VERIFY_CHECKS:-}" \
   -e "KUBE_VERIFY_GIT_BRANCH=${KUBE_VERIFY_GIT_BRANCH:-}" \
   -e "REPO_DIR=${REPO_DIR}" \
+  -e "HOST_ARTIFACTS_DIR=${HOST_ARTIFACTS_DIR}" \
   -i gcr.io/google_containers/kubekins-test:0.9 \
   bash -c "cd kubernetes && ./hack/jenkins/test-dockerized.sh"

--- a/hack/jenkins/test-dockerized.sh
+++ b/hack/jenkins/test-dockerized.sh
@@ -42,6 +42,7 @@ export KUBE_RACE=-race
 export KUBE_COVER="n"
 # Produce a JUnit-style XML test report for Jenkins.
 export KUBE_JUNIT_REPORT_DIR=${WORKSPACE}/artifacts
+export ARTIFACTS_DIR=${WORKSPACE}/artifacts
 # Save the verbose stdout as well.
 export KUBE_KEEP_VERBOSE_TEST_OUTPUT=y
 export KUBE_TIMEOUT='-timeout 300s'

--- a/hack/verify-jenkins-job-configs.sh
+++ b/hack/verify-jenkins-job-configs.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Tests the Jenkins job configs and computes a diff of any changes when there
+# have been local changes of the configs.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${KUBE_ROOT}/hack/lib/init.sh"
+
+readonly branch=${1:-${KUBE_VERIFY_GIT_BRANCH:-master}}
+if ! [[ ${KUBE_FORCE_VERIFY_CHECKS:-} =~ ^[yY]$ ]] && \
+  ! kube::util::has_changes_against_upstream_branch "${branch}" 'hack/jenkins/job-configs/'; then
+  exit 0
+fi
+
+# By using ARTIFACTS_DIR, we can write the diff out to the artifacts directory
+# (and then up to GCS) when running on Jenkins.
+export OUTPUT_DIR="${ARTIFACTS_DIR:+${ARTIFACTS_DIR}/jjb}"
+# When running inside Docker (e.g. on Jenkins) we'll need to reference the
+# host's artifacts directory for the Docker-in-Docker volume mount to work.
+export DOCKER_VOLUME_OUTPUT_DIR="${HOST_ARTIFACTS_DIR:+${HOST_ARTIFACTS_DIR}/jjb}"
+
+# This script should pass, assuming the configs are not broken. Diffs won't
+# cause failures.
+"${KUBE_ROOT}/hack/jenkins/diff-job-config-patch.sh"


### PR DESCRIPTION
The first commit adds a script which uses the `kubekins-job-builder` image to compute the XML and then generate a diff, comparing the local branch vs. upstream/master.

The second commit adds a small verify check script which only runs if there are `hack/jenkins/job-config` changes (using the same logic from the godeps verify checks). As an added bonus, it'll throw the generated diff and XML files into the artifacts directory, so we get that diff computed automatically and uploaded to GCS on all PRs that affect job configs.

@kubernetes/sig-testing @pwittrock 
