### PR TITLE
don't source the kube-env in addon-manager

### DIFF
--- a/cluster/gce/trusty/master.yaml
+++ b/cluster/gce/trusty/master.yaml
@@ -202,8 +202,6 @@ script
 	. /etc/kube-env
 	export HOME="/root"
 	export KUBECTL_BIN="/usr/bin/kubectl"
-	export TOKEN_DIR="/etc/srv/kubernetes"
-	export kubelet_kubeconfig_file="/var/lib/kubelet/kubeconfig"
 	export TRUSTY_MASTER="true"
 	if [ -n "${TEST_ADDON_CHECK_INTERVAL_SEC:-}" ]; then
 		export TEST_ADDON_CHECK_INTERVAL_SEC=${TEST_ADDON_CHECK_INTERVAL_SEC}

--- a/cluster/saltbase/salt/kube-addons/kube-addons.sh
+++ b/cluster/saltbase/salt/kube-addons/kube-addons.sh
@@ -76,19 +76,6 @@ echo "== Kubernetes addon manager started at $(date -Is) with ADDON_CHECK_INTERV
 
 ensure_python
 
-# Load the kube-env, which has all the environment variables we care
-# about, in a flat yaml format.
-kube_env_yaml="/var/cache/kubernetes-install/kube_env.yaml"
-if [ ! -e "${kubelet_kubeconfig_file}" ]; then
-  eval $(${PYTHON} -c '''
-import pipes,sys,yaml
-
-for k,v in yaml.load(sys.stdin).iteritems():
-  print("readonly {var}={value}".format(var = k, value = pipes.quote(str(v))))
-''' < "${kube_env_yaml}")
-fi
-
-
 # Create the namespace that will be used to host the cluster-level add-ons.
 start_addon /etc/kubernetes/addons/namespace.yaml 100 10 "" &
 


### PR DESCRIPTION
This was added in https://github.com/kubernetes/kubernetes/commit/2feb658ed7a6a9f9726b04ac4c890b5dee14c0a8 which became unused after #23603 but wasn't removed
