### PR TITLE
Allow cluster DNS e2e verification to be overriden

### DIFF
--- a/test/e2e/dns.go
+++ b/test/e2e/dns.go
@@ -260,8 +260,6 @@ var _ = framework.KubeDescribe("DNS", func() {
 	f := framework.NewDefaultFramework("dns")
 
 	It("should provide DNS for the cluster [Conformance]", func() {
-		verifyDNSPodIsRunning(f)
-
 		// All the names we need to be able to resolve.
 		// TODO: Spin up a separate test service and test that dns works for that service.
 		namesToResolve := []string{
@@ -288,8 +286,6 @@ var _ = framework.KubeDescribe("DNS", func() {
 	})
 
 	It("should provide DNS for services [Conformance]", func() {
-		verifyDNSPodIsRunning(f)
-
 		// Create a test headless service.
 		By("Creating a test headless service")
 		testServiceSelector := map[string]string{
@@ -338,8 +334,6 @@ var _ = framework.KubeDescribe("DNS", func() {
 	})
 
 	It("should provide DNS for pods for Hostname and Subdomain Annotation", func() {
-		verifyDNSPodIsRunning(f)
-
 		// Create a test headless service.
 		By("Creating a test headless service")
 		testServiceSelector := map[string]string{


### PR DESCRIPTION
Alternate DNS implementations may be conformant without implementing DNS
as a pod.  This allows the e2e test to provide an alternate verify step.

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/24128)

<!-- Reviewable:end -->
