### PR TITLE
Resource name constants were incorrect in versioned types.go

### DIFF
--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -2686,13 +2686,13 @@ const (
 	// ResourceServicesLoadBalancers, number
 	ResourceServicesLoadBalancers ResourceName = "services.loadbalancers"
 	// CPU request, in cores. (500m = .5 cores)
-	ResourceCPURequest ResourceName = "cpu.request"
-	// CPU limit, in cores. (500m = .5 cores)
-	ResourceCPULimit ResourceName = "cpu.limit"
+	ResourceRequestsCPU ResourceName = "requests.cpu"
 	// Memory request, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
-	ResourceMemoryRequest ResourceName = "memory.request"
+	ResourceRequestsMemory ResourceName = "requests.memory"
+	// CPU limit, in cores. (500m = .5 cores)
+	ResourceLimitsCPU ResourceName = "limits.cpu"
 	// Memory limit, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
-	ResourceMemoryLimit ResourceName = "memory.limit"
+	ResourceLimitsMemory ResourceName = "limits.memory"
 )
 
 // A ResourceQuotaScope defines a filter that must match each object tracked by a quota


### PR DESCRIPTION
The constant field names and actual values to quota requests and limits for cpu and memory were incorrect in the v1 types.go file.

Important to note for reviewer:
- the constant fields here are unused in the project at this time
- the values those unused constant fields mapped to are not actually supported by the project
- there is no backwards compatibility concern, but if/when we look to convert to using versioned clients, we should have the correct constant fields and values.

The correct values were here:
https://github.com/kubernetes/kubernetes/blob/master/pkg/api/types.go#L2213

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/24136)

<!-- Reviewable:end -->
