### PR TITLE
update gb-frontend image. New image includes the change in PR # 23381.

### DIFF
--- a/examples/guestbook/README.md
+++ b/examples/guestbook/README.md
@@ -539,7 +539,7 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: gcr.io/google_samples/gb-frontend:v3
+        image: gcr.io/google-samples/gb-frontend:v4
         resources:
           requests:
             cpu: 100m

--- a/examples/guestbook/all-in-one/frontend.yaml
+++ b/examples/guestbook/all-in-one/frontend.yaml
@@ -43,7 +43,7 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: gcr.io/google_samples/gb-frontend:v3
+        image: gcr.io/google-samples/gb-frontend:v4
         resources:
           requests:
             cpu: 100m

--- a/examples/guestbook/all-in-one/guestbook-all-in-one.yaml
+++ b/examples/guestbook/all-in-one/guestbook-all-in-one.yaml
@@ -20,7 +20,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: redis-master
-  # these labels can be applied automatically 
+  # these labels can be applied automatically
   # from the labels in the pod template if not set
   # labels:
   #   app: redis
@@ -30,7 +30,7 @@ spec:
   # this replicas value is default
   # modify it according to your case
   replicas: 1
-  # selector can be applied automatically 
+  # selector can be applied automatically
   # from the labels in the pod template if not set
   # selector:
   #   matchLabels:
@@ -162,7 +162,7 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: gcr.io/google_samples/gb-frontend:v3
+        image: gcr.io/google-samples/gb-frontend:v4
         resources:
           requests:
             cpu: 100m

--- a/examples/guestbook/frontend-deployment.yaml
+++ b/examples/guestbook/frontend-deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: gcr.io/google_samples/gb-frontend:v3
+        image: gcr.io/google-samples/gb-frontend:v4
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
Update to use the gcr.io/google-samples/gb-frontend:v4 image. New image includes the change in https://github.com/kubernetes/kubernetes/pull/23381.
