### PR TITLE
make optional generic etcd fields optional

### DIFF
--- a/pkg/registry/generic/etcd/etcd.go
+++ b/pkg/registry/generic/etcd/etcd.go
@@ -409,10 +409,18 @@ func (e *Etcd) Delete(ctx api.Context, name string, options *api.DeleteOptions) 
 	if options.Preconditions != nil {
 		preconditions.UID = options.Preconditions.UID
 	}
-	graceful, pendingGraceful, err := rest.BeforeDelete(e.DeleteStrategy, ctx, obj, options)
-	if err != nil {
-		return nil, err
+
+	// DeleteStrategy is doc'ed as optional, but without one you can't be graceful or you'll panic
+	// tolerate an optional field being optional
+	graceful := false
+	pendingGraceful := false
+	if e.DeleteStrategy != nil {
+		graceful, pendingGraceful, err = rest.BeforeDelete(e.DeleteStrategy, ctx, obj, options)
+		if err != nil {
+			return nil, err
+		}
 	}
+
 	if pendingGraceful {
 		return e.finalizeDelete(obj, false)
 	}


### PR DESCRIPTION
`DeleteStrategy` is supposed to be optional if you don't support graceful delete.  This makes the code tolerate it as optional.
