### PR TITLE
Fix log dump for new gcloud

### DIFF
--- a/cluster/gke/util.sh
+++ b/cluster/gke/util.sh
@@ -231,6 +231,9 @@ function detect-node-names {
     "${NODE_INSTANCE_GROUP}" --zone "${ZONE}" --project "${PROJECT}" \
     --format=yaml | grep instance: | cut -d ' ' -f 2))
 
+  # Strip path if return value is selflink
+  NODE_NAMES=($(for i in ${NODE_NAMES[@]}; do basename "$i"; done))
+
   echo "NODE_NAMES=${NODE_NAMES[*]}"
 }
 


### PR DESCRIPTION
`gcloud compute instance-groups managed list-instances` at CI has self-link for instance instead of just name. Fixes #24120
