### PR TITLE
Restart job 5m after the previous failure.

### DIFF
--- a/hack/jenkins/job-configs/global.yaml
+++ b/hack/jenkins/job-configs/global.yaml
@@ -121,7 +121,8 @@
     name: global
     disable_job: false
     emails: '$DEFAULT_RECIPIENTS'
-    cron-string: 'H/30 * * * *'
+    cron-string: 'H/30 * * * *'  # Set a 30m floor to start jobs.
+    sq-cron-string: 'H/5 * * * *'  # Lower floor to 5m for blocking jobs.
     # How long to wait after sending TERM to send KILL (minutes)
     kill-timeout: 15
     # Just to be safe, use the Jenkins timeout after a long time.

--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
@@ -62,6 +62,7 @@
     provider-env: '{gce-provider-env}'
     suffix:
         - 'gce':
+            cron-string: '{sq-cron-string}'
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE in parallel.'
             timeout: 50  # See #21138
             job-env: |
@@ -72,6 +73,7 @@
                 export GINKGO_PARALLEL="y"
                 export PROJECT="k8s-jkns-e2e-gce"
         - 'gce-slow':
+            cron-string: '{sq-cron-string}'
             description: 'Runs slow tests on GCE, sequentially.'
             timeout: 150  #  See #24072
             job-env: |
@@ -115,6 +117,7 @@
                                          --ginkgo.skip=\[Feature:.+\]"
                 export PROJECT="k8s-jkns-e2e-gce-flaky"
         - 'gce-scalability':
+            cron-string: '{sq-cron-string}'
             description: 'Run the performance/scalability tests on GCE. A larger cluster is used.'
             timeout: 120
             # TODO: Run this twice a day after we make kubemark-500 a blocking suite.
@@ -181,6 +184,7 @@
     provider-env: '{gke-provider-env}'
     suffix:
         - 'gke':
+            cron-string: '{sq-cron-string}'
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GKE in parallel (against GKE test endpoint)'
             timeout: 50  # See #21138
             job-env: |
@@ -188,6 +192,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
         - 'gke-slow':
+            cron-string: '{sq-cron-string}'
             description: 'Run slow E2E tests on GKE using the latest successful build.'
             timeout: 150  #  See #24072
             job-env: |

--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
@@ -40,7 +40,7 @@
         - '5-gce':
             description: 'Run minimal Kubemark to make sure it is not broken.'
             timeout: 60
-            cron-string: 'H/5 * * * *'
+            cron-string: '{sq-cron-string}'
             job-env: |
                 export E2E_NAME="kubemark-5"
                 export PROJECT="k8s-jenkins-kubemark"

--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-go.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-go.yaml
@@ -73,6 +73,7 @@
     suffix:
         - 'go':
             branch: 'master'
+            cron-string: '{sq-cron-string}'
             timeout: 80
         - 'go-release-1.2':
             branch: 'release-1.2'

--- a/hack/jenkins/job-configs/kubernetes-jenkins/node-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/node-e2e.yaml
@@ -150,6 +150,7 @@
             owner: 'pszczesniak@google.com'
             shell: 'make test-unit test-integration'
         - 'kubelet':
+            cron-string: '{sq-cron-string}'
             repoName: 'kubernetes/kubernetes'
             gitbasedir: 'k8s.io/kubernetes'
             owner: 'pwittroc@google.com'


### PR DESCRIPTION
If a job flakes at the beginning of it scripts, it will likely sit around doing nothing for 30m blocking the merge queue. Decreasing this to 5m.
