### PR TITLE
Fix unintended change of Service.spec.ports[].nodePort during kubectl apply

### DIFF
--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -1784,7 +1784,7 @@ type LoadBalancerIngress struct {
 type ServiceSpec struct {
 	// The list of ports that are exposed by this service.
 	// More info: http://releases.k8s.io/HEAD/docs/user-guide/services.md#virtual-ips-and-service-proxies
-	Ports []ServicePort `json:"ports"`
+	Ports []ServicePort `json:"ports" patchStrategy:"merge" patchMergeKey:"port"`
 
 	// This service will route traffic to pods having labels matching this selector.
 	// Label keys and values that must match in order to receive traffic for this service.

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -555,6 +555,25 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 			By("checking the result")
 			forEachReplicationController(c, ns, "app", "redis", validateReplicationControllerConfiguration)
 		})
+		It("should reuse nodePort when apply to an existing SVC", func() {
+			mkpath := func(file string) string {
+				return filepath.Join(framework.TestContext.RepoRoot, "examples/guestbook-go", file)
+			}
+			serviceJson := mkpath("redis-master-service.json")
+			nsFlag := fmt.Sprintf("--namespace=%v", ns)
+			By("creating Redis SVC")
+			framework.RunKubectlOrDie("create", "-f", serviceJson, nsFlag)
+			By("getting the original nodePort")
+			originalNodePort := framework.RunKubectlOrDie("get", "service", "redis-master", nsFlag, "-o", "jsonpath={.spec.ports[0].nodePort}")
+			By("applying the same configuration")
+			framework.RunKubectlOrDie("apply", "-f", serviceJson, nsFlag)
+			By("getting the nodePort after applying configuration")
+			currentNodePort := framework.RunKubectlOrDie("get", "service", "redis-master", nsFlag, "-o", "jsonpath={.spec.ports[0].nodePort}")
+			By("checking the result")
+			if originalNodePort != currentNodePort {
+				framework.Failf("nodePort should keep the same")
+			}
+		})
 	})
 
 	framework.KubeDescribe("Kubectl cluster-info", func() {


### PR DESCRIPTION
Please refer #23551 for more detail. @bgrant0607 I think this simple fix should be ok to reuse nodePort. @thockin ptal.

Release note: Fix unintended change of `Service.spec.ports[].nodePort` during `kubectl apply`.
