### PR TITLE
Increase 5 node kubemark to a 60m timeout, schedule every 5m

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
@@ -40,8 +40,8 @@
     suffix:
         - '5-gce':
             description: 'Run minimal Kubemark to make sure it is not broken.'
-            timeout: 30
-            cron-string: 'H/30 * * * *'
+            timeout: 60
+            cron-string: 'H/5 * * * *'
             job-env: |
                 export E2E_NAME="kubemark-5"
                 export PROJECT="k8s-jenkins-kubemark"


### PR DESCRIPTION
Closes https://github.com/kubernetes/kubernetes/issues/24183 and should reduce mergebot flakes

http://kubekins.dls.corp.google.com/view/Submit%20Queue/job/kubernetes-kubemark-5-gce/1354/consoleFull is an example where everything seemed to be running find but ran out of time after 30m, which is only slightly slower than its average passing runtime of 20m. I'm increasing to 3x average runtime.
