### PR TITLE
Don't remove kubemark binaries

### DIFF
--- a/test/kubemark/start-kubemark-master.sh
+++ b/test/kubemark/start-kubemark-master.sh
@@ -58,5 +58,3 @@ until [ "$(curl 127.0.0.1:8080/healthz 2> /dev/null)" == "ok" ]; do
 	sleep 1
 done
 kubernetes/server/bin/kube-controller-manager --master=127.0.0.1:8080 --service-account-private-key-file=/srv/kubernetes/server.key --root-ca-file=/srv/kubernetes/ca.crt --v=2 &> /var/log/kube-controller-manager.log &
-
-rm -rf kubernetes


### PR DESCRIPTION
If you want to experiment a bit with kubemark (e.g. relaunch the component with different flags), it's roughly impossible now. If we have binaries, this is much easier.
