### PR TITLE
kubectl: Accept both a username and token in a kubeconfig file

### DIFF
--- a/pkg/kubectl/cmd/config/create_authinfo.go
+++ b/pkg/kubectl/cmd/config/create_authinfo.go
@@ -209,8 +209,8 @@ func (o createAuthInfoOptions) validate() error {
 	if len(o.token.Value()) > 0 {
 		methods = append(methods, fmt.Sprintf("--%v", clientcmd.FlagBearerToken))
 	}
-	if len(o.username.Value()) > 0 || len(o.password.Value()) > 0 {
-		methods = append(methods, fmt.Sprintf("--%v/--%v", clientcmd.FlagUsername, clientcmd.FlagPassword))
+	if len(o.password.Value()) > 0 {
+		methods = append(methods, fmt.Sprintf("--%v", clientcmd.FlagPassword))
 	}
 	if len(methods) > 1 {
 		return fmt.Errorf("you cannot specify more than one authentication method at the same time: %v", strings.Join(methods, ", "))


### PR DESCRIPTION
When setting a bearer token in a kubeconfig file, and a tool has
used a username to set that token (such as with oc login) it's
useful to be able to save the username along side the token.

This allows such tooling to display the user name again when
prompting for the password and getting a new bearer token to
store in the kubeconfig.

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/24196)

<!-- Reviewable:end -->
