### PR TITLE
Add easy-rsa to hyperkube container

### DIFF
--- a/cluster/images/hyperkube/Dockerfile
+++ b/cluster/images/hyperkube/Dockerfile
@@ -50,6 +50,9 @@ COPY safe_format_and_mount /usr/share/google/safe_format_and_mount
 COPY setup-files.sh /setup-files.sh
 COPY make-ca-cert.sh /make-ca-cert.sh
 
+# easy-rsa package required by make-ca-cert
+ADD https://storage.googleapis.com/kubernetes-release/easy-rsa/easy-rsa.tar.gz /root/kube/
+
 # Make scripts executable
 RUN chmod a+rx \
         /hyperkube \


### PR DESCRIPTION
Otherwise gets downloaded a runtime, which kind of breaks the container model.

See [comment](https://github.com/kubernetes/kubernetes/issues/20514#issuecomment-195835786) in #20514 - this causes dockerized install of k8s to fail if you're behind a proxy. make-ca-cert.sh already looks for a local copy of easy-rsa.tar.gz before downloading it, so this drops the tarball in the expected place in the container.
