### PR TITLE
Make test-history use batch operations for build and test results

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-history.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-history.yaml
@@ -2,8 +2,8 @@
     name: kubernetes-test-summary
     description: 'Create a daily test summary and upload to GCS. Test owner: spxtr.'
     triggers:
-        # Run every night at midnight at a random minute.
-        - timed: 'H 0 * * *'
+        # Run every hour
+        - timed: '1 * * * *'
     scm:
         - git:
             url: https://www.github.com/kubernetes/kubernetes

--- a/hack/jenkins/test-history/gen_history
+++ b/hack/jenkins/test-history/gen_history
@@ -19,9 +19,15 @@
 
 set -o errexit
 set -o nounset
+set -o xtrace
 
 readonly jenkins="$1"
 readonly datestr=$(date +"%Y-%m-%d")
+
+# Download previous json report, for incremental report generation
+# This will fail when the day rolls over -- meaning a new report will be
+# generated.
+gsutil -q cp -a "${gcs_acl}" -z json "gs://${bucket}/logs/${datestr}.json" "tests.json" || true
 
 # Create JSON report
 time python gen_json.py "${jenkins}" kubernetes

--- a/hack/jenkins/test-history/gen_html.py
+++ b/hack/jenkins/test-history/gen_html.py
@@ -197,7 +197,7 @@ def main(args):
                 f.write(html)
     html = html_header()
     html.append('<h1>Kubernetes Tests</h1>')
-    html.append('Last updated %s' % time.strftime('%F'))
+    html.append('Last updated %s' % time.strftime('%F %T %Z'))
     if options.prefixes:
         html.append('<h2>All suites starting with:</h2>')
         html.extend(gen_metadata_links(prefix_metadata))


### PR DESCRIPTION
This makes gen_json.py much faster. Now, it spends most of its time
listing directories on GCS and downloading the individual junit xml
files.

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/24221)

<!-- Reviewable:end -->
