### PR TITLE
Fix spacing in usage_from_stdin and info_from_stdin (issue #24186).

### DIFF
--- a/cluster/lib/logging.sh
+++ b/cluster/lib/logging.sh
@@ -106,7 +106,7 @@ kube::log::usage() {
 kube::log::usage_from_stdin() {
   local messages=()
   while read -r line; do
-    messages+=$line
+    messages+=("$line")
   done
 
   kube::log::usage "${messages[@]}"
@@ -129,7 +129,7 @@ kube::log::progress() {
 kube::log::info_from_stdin() {
   local messages=()
   while read -r line; do
-    messages+=$line
+    messages+=("$line")
   done
 
   kube::log::info "${messages[@]}"

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -264,10 +264,8 @@ kube::golang::setup_env() {
 
   if [[ -z "$(which go)" ]]; then
     kube::log::usage_from_stdin <<EOF
-
 Can't find 'go' in PATH, please fix and retry.
 See http://golang.org/doc/install for installation instructions.
-
 EOF
     exit 2
   fi
@@ -280,11 +278,9 @@ EOF
     go_version=($(go version))
     if [[ "${go_version[2]}" < "go1.4" ]]; then
       kube::log::usage_from_stdin <<EOF
-
 Detected go version: ${go_version[*]}.
 Kubernetes requires go version 1.4 or greater.
 Please install Go version 1.4 or later.
-
 EOF
       exit 2
     fi


### PR DESCRIPTION
If "a" is a bash array, then the syntax to append the contents of $line as a
new element to the array is a+=("$line"), not messages+=$line

Using the former syntax just seems to append to the first element, creating a
long string and thus losing newline information.

Fixing this allows us to drop some empty lines from invocations of
usage_from_stdin.
