### PR TITLE
hack: change update-swagger-spec.sh apiserver defaults

### DIFF
--- a/hack/after-build/update-swagger-spec.sh
+++ b/hack/after-build/update-swagger-spec.sh
@@ -51,7 +51,7 @@ kube::etcd::start
 
 # Start kube-apiserver
 kube::log::status "Starting kube-apiserver"
-KUBE_API_VERSIONS="v1,autoscaling/v1,batch/v1,extensions/v1beta1" "${KUBE_OUTPUT_HOSTBIN}/kube-apiserver" \
+"${KUBE_OUTPUT_HOSTBIN}/kube-apiserver" \
   --insecure-bind-address="127.0.0.1" \
   --bind-address="127.0.0.1" \
   --insecure-port="${API_PORT}" \


### PR DESCRIPTION
Removing the explicit list of KUBE_API_VERSIONS will cause the apiserver
to enable all APIs by default. This change reduces the amount of script
hacking needed to add new API groups in the future.
