### PR TITLE
hack: specify --advertise-address in hack/local-up-cluster.sh

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -266,6 +266,7 @@ function start_apiserver {
       --admission-control="${ADMISSION_CONTROL}" \
       --insecure-bind-address="${API_HOST}" \
       --insecure-port="${API_PORT}" \
+      --advertise-address="${API_HOST}" \
       --etcd-servers="http://127.0.0.1:4001" \
       --service-cluster-ip-range="10.0.0.0/24" \
       --cors-allowed-origins="${API_CORS_ALLOWED_ORIGINS}" >"${APISERVER_LOG}" 2>&1 &


### PR DESCRIPTION
This fixes the bug where the script fails to launch an apiserver on a
machine without active networking (issue #24272).
