### PR TITLE
expose WriteRawJSON for composition downstream

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -351,7 +351,7 @@ func AddSupportedResourcesWebService(s runtime.NegotiatedSerializer, ws *restful
 
 // handleVersion writes the server's version information.
 func handleVersion(req *restful.Request, resp *restful.Response) {
-	writeRawJSON(http.StatusOK, version.Get(), resp.ResponseWriter)
+	WriteRawJSON(http.StatusOK, version.Get(), resp.ResponseWriter)
 }
 
 // APIVersionHandler returns a handler which will list the provided versions as available.
@@ -430,7 +430,7 @@ func writeNegotiated(s runtime.NegotiatedSerializer, gv unversioned.GroupVersion
 	serializer, contentType, err := negotiateOutputSerializer(req, s)
 	if err != nil {
 		status := errToAPIStatus(err)
-		writeRawJSON(int(status.Code), status, w)
+		WriteRawJSON(int(status.Code), status, w)
 		return
 	}
 
@@ -469,8 +469,8 @@ func errorJSONFatal(err error, codec runtime.Encoder, w http.ResponseWriter) int
 	return code
 }
 
-// writeRawJSON writes a non-API object in JSON.
-func writeRawJSON(statusCode int, object interface{}, w http.ResponseWriter) {
+// WriteRawJSON writes a non-API object in JSON.
+func WriteRawJSON(statusCode int, object interface{}, w http.ResponseWriter) {
 	output, err := json.MarshalIndent(object, "", "  ")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -2966,7 +2966,7 @@ func (m *marshalError) MarshalJSON() ([]byte, error) {
 
 func TestWriteRAWJSONMarshalError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		writeRawJSON(http.StatusOK, &marshalError{errors.New("Undecodable")}, w)
+		WriteRawJSON(http.StatusOK, &marshalError{errors.New("Undecodable")}, w)
 	}))
 	// TODO: Uncomment when fix #19254
 	// defer server.Close()

--- a/pkg/apiserver/index.go
+++ b/pkg/apiserver/index.go
@@ -41,6 +41,6 @@ func IndexHandler(container *restful.Container, muxHelper *MuxHelper) func(http.
 		// Extract the paths handled using mux handler.
 		handledPaths = append(handledPaths, muxHelper.RegisteredPaths...)
 		sort.Strings(handledPaths)
-		writeRawJSON(status, unversioned.RootPaths{Paths: handledPaths}, w)
+		WriteRawJSON(status, unversioned.RootPaths{Paths: handledPaths}, w)
 	}
 }


### PR DESCRIPTION
When extending the API server, there are some API endpoints that needs raw JSON output.  Version information as a for instance.  This exposes the method for consistent output when used downstream.
