### PR TITLE
Make cluster/get-kube-local.sh ready for use

### DIFF
--- a/cluster/get-kube-local.sh
+++ b/cluster/get-kube-local.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2015 The Kubernetes Authors All rights reserved.
+# Copyright 2016 The Kubernetes Authors All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,43 +20,56 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_HOST=${KUBE_HOST:-localhost}
+## MAIN
 
-declare -r RED="\033[0;31m"
-declare -r GREEN="\033[0;32m"
-declare -r YELLOW="\033[0;33m"
+kube::main::start(){
+  KUBE_VERSION=${KUBE_VERSION:-$(kube::util::get_latest_version)}
+  KUBE_PLATFORM=$(kube::util::host_platform)
+  KUBE_ARCH=${KUBE_PLATFORM##*/}
 
-function echo_green {
-  echo -e "${GREEN}$1"; tput sgr0
+  kube::util::install_kubectl
+
+  KUBECTL=${KUBECTL:-$(which kubectl)}
+
+  kube::main::docker
+
+  cat <<'EOF'
+
+Now your brand-new Kubernetes cluster should be up and running!
+Data is stored in /var/lib/kubelet, and all Kubernetes components are inside containers
+The apiserver is running at localhost:8080, which means it is not visible to other computers on the network.
+
+To get started with your new one-node cluster, use `kubectl`:
+
+  kubectl get nodes
+  kubectl get pods
+  kubectl get services
+  kubectl version
+
+To run a sample pod to test it's working, run this (use an image other than `nginx` for other architectures):
+
+  kubectl run nginx --image=nginx --port=80 --expose
+  kubectl get pods
+  kubectl get services
+
+You'll notice that a new service is created at an internal ip, let's curl it
+
+  curl $(kubectl get svc nginx --template={{.spec.clusterIP}})
+
+To shut everything (all containers) down, run this (you might have to use `sudo`):
+
+  docker rm $(docker ps -aq)
+  umount $(cat /proc/mounts | grep /var/lib/kubelet | awk '{print $2}') 
+  rm -rf /var/lib/kubelet
+
+For more information, visit kubernetes.io
+EOF
 }
 
-function echo_red {
-  echo -e "${RED}$1"; tput sgr0
-}
-
-function echo_yellow {
-  echo -e "${YELLOW}$1"; tput sgr0
-}
-
-function run {
-  # For a moment we need to change bash options to capture message if a command fails.
-  set +o errexit
-  output=$($1 2>&1)
-  exit_code=$?
-  set -o errexit
-  if [ $exit_code -eq 0 ]; then
-    echo_green "SUCCESS"
-  else
-    echo_red "FAILED"
-    echo $output >&2
-    exit 1
-  fi
-}
-
-function create_cluster {
-  echo "Creating a local cluster:"
-  echo -e -n "\tStarting kubelet..."
-  run "docker run \
+kube::main::docker() {
+  kube::log::normal "Creating a local cluster:"
+  kube::log::indented "Starting kubelet..."
+  kube::util::run "docker run -d \
   --volume=/:/rootfs:ro \
   --volume=/sys:/sys:ro \
   --volume=/var/lib/docker/:/var/lib/docker:rw \
@@ -65,12 +78,10 @@ function create_cluster {
   --net=host \
   --pid=host \
   --privileged=true \
-  -d \
-  gcr.io/google_containers/hyperkube-${arch}:${release} \
+  gcr.io/google_containers/hyperkube-${KUBE_ARCH}:${KUBE_VERSION} \
     /hyperkube kubelet \
       --containerized \
       --hostname-override="127.0.0.1" \
-      --address="0.0.0.0" \
       --api-servers=http://localhost:8080 \
       --config=/etc/kubernetes/manifests \
       --allow-privileged=true \
@@ -78,91 +89,136 @@ function create_cluster {
       --cluster-domain=cluster.local \
       --v=2"
 
-  echo -e -n "\tWaiting for master components to start..."
-  while true; do
-    local running_count=$(kubectl -s=http://${KUBE_HOST}:8080 get pods --no-headers 2>/dev/null | grep "Running" | wc -l)
-    # We expect to have 3 running pods - etcd, master and kube-proxy.
-    if [ "$running_count" -ge 3 ]; then
-      break
-    fi
+  kube::log::indented "Waiting for master components to start..."
+
+  # We expect to have at least 3 running pods - etcd, master and kube-proxy.
+  while (($(${KUBECTL} get pods --no-headers 2>/dev/null | grep "Running" | wc -l) < 3)); do
     echo -n "."
-    sleep 1
+    sleep 2
   done
-  echo_green "SUCCESS"
-  echo_green "Cluster created!"
-  echo ""
-  kubectl -s http://${KUBE_HOST}:8080 clusterinfo
+
+  kube::log::green "SUCCESS"
+  kube::log::green "Cluster created!"
 }
 
-function get_latest_version_number {
-  local -r latest_url="https://storage.googleapis.com/kubernetes-release/release/stable.txt"
-  if [[ $(which wget) ]]; then
-    wget -qO- ${latest_url}
-  elif [[ $(which curl) ]]; then
-    curl -Ss ${latest_url}
+## UTILS
+
+# Installs kubectl for the specific os/arch
+kube::util::install_kubectl(){
+
+  kubectl_url="https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/${KUBE_PLATFORM}/kubectl"
+
+  if [[ ! -f $(which kubectl 2>&1) ]]; then
+    echo -n "Downloading kubectl binary to /usr/local/bin/kubectl..."
+
+    # Download kubectl to /usr/local/bin and 
+    kube::util::curl ${kubectl_url} > /usr/local/bin/kubectl
+    chmod a+x /usr/local/bin/kubectl
   else
-    echo_red "Couldn't find curl or wget.  Bailing out."
+
+    # TODO: We should detect version of kubectl binary if it's too old and download newer version.
+    kube::log::normal "Detected existing kubectl binary. Skipping download."
+  fi
+}
+
+kube::util::get_latest_version() {
+
+  # Curl for the latest stable version
+  kube::util::curl "https://storage.googleapis.com/kubernetes-release/release/stable.txt"
+}
+
+# This figures out the host platform without relying on golang. We need this as
+# we don't want a golang install to be a prerequisite to building yet we need
+# this info to figure out where the final binaries are placed.
+kube::util::host_platform() {
+  local host_os
+  local host_arch
+  case "$(uname -s)" in
+    Linux)
+      host_os=linux;;
+    *)
+      kube::log::red "Unsupported host OS. Must be linux."
+      exit 1;;
+  esac
+
+  case "$(uname -m)" in
+    x86_64*)
+      host_arch=amd64;;
+    i?86_64*)
+      host_arch=amd64;;
+    amd64*)
+      host_arch=amd64;;
+    aarch64*)
+      host_arch=arm64;;
+    arm64*)
+      host_arch=arm64;;
+    arm*)
+      host_arch=arm;;
+    ppc64le*)
+      host_arch=ppc64le;;
+    *)  
+      kube::log::red "Unsupported host arch. Must be x86_64, arm, arm64 or ppc64le."
+      exit 1;;
+  esac
+  echo "${host_os}/${host_arch}"
+}
+
+kube::util::run() {
+
+  # For a moment we need to change bash options to capture message if a command fails.
+  set +o errexit
+  output=$($1 2>&1)
+  exit_code=$?
+  set -o errexit
+
+  if [[ ${exit_code} == 0 ]]; then
+    kube::log::green "SUCCESS"
+  else
+    kube::log::red "FAILED"
+    echo ${output} >&2
+    exit 1
+  fi
+}
+
+# Wraps curl or wget in a helper function.
+# Output is redirected to stdout
+kube::util::curl(){
+  if [[ $(which curl 2>&1) ]]; then
+    curl -sSL $1
+  elif [[ $(which wget 2>&1) ]]; then
+    wget -qO- $1
+  else
+    kube::log::red "Couldn't find curl or wget."
+    kube::log::red "Bailing out."
     exit 4
   fi
 }
 
-latest_release=$(get_latest_version_number)
-release=${KUBE_VERSION:-${latest_release}}
+## LOGGING
 
-uname=$(uname)
-if [[ "${uname}" == "Darwin" ]]; then
-  platform="darwin"
-elif [[ "${uname}" == "Linux" ]]; then
-  platform="linux"
-else
-  echo_red "Unknown, unsupported platform: (${uname})."
-  echo_red "Supported platforms: Linux, Darwin."
-  echo_red "Bailing out."
-  exit 2
-fi
+declare -r RED="\033[0;31m"
+declare -r GREEN="\033[0;32m"
+declare -r YELLOW="\033[0;33m"
 
-machine=$(uname -m)
-if [[ "${machine}" == "x86_64" ]]; then
-  arch="amd64"
-elif [[ "${machine}" == "i686" ]]; then
-  arch="386"
-elif [[ "${machine}" == "arm*" ]]; then
-  arch="arm"
-elif [[ "${machine}" == "s390x*" ]]; then
-  arch="s390x"
-else
-  echo_red "Unknown, unsupported architecture (${machine})."
-  echo_red "Supported architectures x86_64, i686, arm, s390x."
-  echo_red "Bailing out."
-  exit 3
-fi
+kube::log::green(){
+  echo -e "${GREEN}$1"; tput sgr0
+}
 
-kubectl_url="https://storage.googleapis.com/kubernetes-release/release/${release}/bin/${platform}/${arch}/kubectl"
+kube::log::yellow(){
+  echo -e "${YELLOW}$1"; tput sgr0
+}
 
-if [[ $(ls . | grep ^kubectl$ | wc -l) -lt 1 ]]; then
-  echo -n "Downloading kubectl binary..."
-  if [[ $(which wget) ]]; then
-    run "wget ${kubectl_url}"
-  elif [[ $(which curl) ]]; then
-    run "curl -OL ${kubectl_url}"
-  else
-    echo_red "Couldn't find curl or wget.  Bailing out."
-    exit 1
-  fi
-  chmod a+x kubectl
-  echo ""
-else
-  # TODO: We should detect version of kubectl binary if it too old
-  # download newer version.
-  echo "Detected existing kubectl binary. Skipping download."
-fi
+kube::log::red(){
+  echo -e "${RED}$1"; tput sgr0
+}
 
-create_cluster
+kube::log::normal(){
+  echo $1
+}
+kube::log::indented(){
+  echo -e -n "\t${1}"
+}
 
-echo ""
-echo ""
-echo "To list the nodes in your cluster run"
-echo_yellow "\tkubectl -s=http://${KUBE_HOST}:8080 get nodes"
-echo ""
-echo "To run your first pod run"
-echo_yellow "\tkubectl -s http://${KUBE_HOST}:8080 run nginx --image=nginx --port=80"
+
+# Execute the script
+kube::main::start


### PR DESCRIPTION
Rewrite `cluster/get-kube-local.sh` to make it more user-friendly and suitable for real use.
Ran this on my Pi, and it works OOTB on `amd64` and `arm`. (`arm64` and `ppc64le` as soon as `v1.3.0-alpha.3` is released.)

We should also consider this (`curl -s http://get.k8s.io/local | bash`) be a replacement for the `docker.md` guide, so we could point to the script which does everything automatically
Part of: #19030
@fgrzadkowski @vishh @pwittrock @johndmulhausen @mikedanese @marun

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/24278)

<!-- Reviewable:end -->
