### PR TITLE
Shorten cluster names in GKE Jenkins on Trusty

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
@@ -832,7 +832,7 @@
                 export PROJECT="kubekins-e2e-gke-trusty-test"
                 export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/rc"
                 export JENKINS_USE_SERVER_VERSION="y"
-                export E2E_NAME="jkns-gke-e2e-test-trusty"
+                export E2E_NAME="gke-e2e-test-trusty"
                 export KUBE_OS_DISTRIBUTION="trusty"
         - 'gke-trusty-subnet':
             description: 'Run E2E tests on GKE test endpoint in a subnet.'
@@ -844,7 +844,7 @@
                 export PROJECT="k8s-e2e-gke-trusty-subnet"
                 export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/rc"
                 export JENKINS_USE_SERVER_VERSION="y"
-                export E2E_NAME="jkns-gke-e2e-subnet-trusty"
+                export E2E_NAME="gke-e2e-subnet-trusty"
                 export KUBE_OS_DISTRIBUTION="trusty"
         - 'gke-trusty-staging':
             description: 'Run E2E tests on GKE staging endpoint.'
@@ -854,7 +854,7 @@
                 export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/rc"
                 export JENKINS_USE_SERVER_VERSION="y"
                 export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://staging-container.sandbox.googleapis.com/"
-                export E2E_NAME="jkns-gke-e2e-staging-trusty"
+                export E2E_NAME="gke-e2e-staging-trusty"
                 export KUBE_OS_DISTRIBUTION="trusty"
         - 'gke-trusty-staging-parallel':
             description: 'Run E2E tests on GKE staging endpoint in parallel.'
@@ -866,7 +866,7 @@
                 export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://staging-container.sandbox.googleapis.com/"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
-                export E2E_NAME="jkns-gke-e2e-staging-parallel-trusty"
+                export E2E_NAME="gke-e2e-staging-pa-trusty"
                 export KUBE_OS_DISTRIBUTION="trusty"
         - 'gke-trusty-prod':
             # Failing constantly due to a known issue (tracked internally).
@@ -878,7 +878,7 @@
                 export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/rc"
                 export JENKINS_USE_SERVER_VERSION="y"
                 export KUBE_GCE_ZONE="asia-east1-b"
-                export E2E_NAME="jkns-gke-e2e-prod-trusty"
+                export E2E_NAME="gke-e2e-prod-trusty"
                 export KUBE_OS_DISTRIBUTION="trusty"
         - 'gke-trusty-prod-parallel':
             # Failing constantly due to a known issue (tracked internally).
@@ -892,7 +892,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export KUBE_GCE_ZONE="asia-east1-b"
-                export E2E_NAME="jkns-gke-e2e-prod-parallel-trusty"
+                export E2E_NAME="gke-e2e-prod-pa-trusty"
                 export KUBE_OS_DISTRIBUTION="trusty"
     jobs:
         - 'kubernetes-e2e-{suffix}'


### PR DESCRIPTION
We identified an issue that the PD tests in GKE Jenkins on Trusty fail because the PD name is longer than the limit of 63 characters. The PD name embeds the "E2E_NAME" env variable exported in the Jenkins job configuration. This PR shortens that string for all GKE Jenkins on Trusty. As a result, the PD name will meet the limit requirement.
