### PR TITLE
Add timeout to e2e network connectivity checks

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -3687,7 +3687,7 @@ func LaunchWebserverPod(f *Framework, podName, nodeName string) (ip string) {
 // CheckConnectivityToHost launches a pod running wget on the
 // specified node to test connectivity to the specified host.  An
 // error will be returned if the host is not reachable from the pod.
-func CheckConnectivityToHost(f *Framework, nodeName, podName, host string) error {
+func CheckConnectivityToHost(f *Framework, nodeName, podName, host string, timeout int) error {
 	contName := fmt.Sprintf("%s-container", podName)
 	pod := &api.Pod{
 		TypeMeta: unversioned.TypeMeta{
@@ -3701,7 +3701,7 @@ func CheckConnectivityToHost(f *Framework, nodeName, podName, host string) error
 				{
 					Name:    contName,
 					Image:   "gcr.io/google_containers/busybox:1.24",
-					Command: []string{"wget", "-s", host},
+					Command: []string{"wget", fmt.Sprintf("--timeout=%d", timeout), "-s", host},
 				},
 			},
 			NodeName:      nodeName,

--- a/test/e2e/networking.go
+++ b/test/e2e/networking.go
@@ -51,7 +51,7 @@ var _ = framework.KubeDescribe("Networking", func() {
 
 	It("should provide Internet connection for containers [Conformance]", func() {
 		By("Running container which tries to wget google.com")
-		framework.ExpectNoError(framework.CheckConnectivityToHost(f, "", "wget-test", "google.com"))
+		framework.ExpectNoError(framework.CheckConnectivityToHost(f, "", "wget-test", "google.com", 30))
 	})
 
 	// First test because it has no dependencies on variables created later on.
@@ -216,6 +216,8 @@ var _ = framework.KubeDescribe("Networking", func() {
 	// Marked with [Flaky] until the tests prove themselves stable.
 	framework.KubeDescribe("[Flaky] Granular Checks", func() {
 
+		connectivityTimeout := 10
+
 		It("should function for pod communication on a single node", func() {
 
 			By("Picking a node")
@@ -229,7 +231,7 @@ var _ = framework.KubeDescribe("Networking", func() {
 			ip := framework.LaunchWebserverPod(f, podName, node.Name)
 
 			By("Checking that the webserver is accessible from a pod on the same node")
-			framework.ExpectNoError(framework.CheckConnectivityToHost(f, node.Name, "same-node-wget", ip))
+			framework.ExpectNoError(framework.CheckConnectivityToHost(f, node.Name, "same-node-wget", ip, connectivityTimeout))
 		})
 
 		It("should function for pod communication between nodes", func() {
@@ -253,7 +255,7 @@ var _ = framework.KubeDescribe("Networking", func() {
 			ip := framework.LaunchWebserverPod(f, podName, node1.Name)
 
 			By("Checking that the webserver is accessible from a pod on a different node")
-			framework.ExpectNoError(framework.CheckConnectivityToHost(f, node2.Name, "different-node-wget", ip))
+			framework.ExpectNoError(framework.CheckConnectivityToHost(f, node2.Name, "different-node-wget", ip, connectivityTimeout))
 		})
 	})
 })


### PR DESCRIPTION
Some e2e tests use wget to check connectivity, and the default e2e
timeout is 900s.  This change allows the timeout to be specified on a
check-by-check basis.  This will also make the check useful for negative
checks (like those used by openshift to validate isolation) since a
short timeout is suggested where connectivity is not expected.
