### PR TITLE
Allow setting the Host header in a httpGet probe

### DIFF
--- a/pkg/probe/http/http.go
+++ b/pkg/probe/http/http.go
@@ -64,6 +64,9 @@ func DoHTTPProbe(url *url.URL, headers http.Header, client HTTPGetInterface) (pr
 		return probe.Failure, err.Error(), nil
 	}
 	req.Header = headers
+	if headers.Get("Host") != "" {
+		req.Host = headers.Get("Host")
+	}
 	res, err := client.Do(req)
 	if err != nil {
 		// Convert errors into failures to catch timeouts.

--- a/pkg/probe/http/http_test.go
+++ b/pkg/probe/http/http_test.go
@@ -86,6 +86,20 @@ func TestHTTPProbeChecker(t *testing.T) {
 			},
 		},
 		{
+			// Echo handler that returns the contents of Host in the body
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(200)
+				w.Write([]byte(r.Host))
+			},
+			http.Header{
+				"Host": {"muffins.cupcakes.org"},
+			},
+			probe.Success,
+			[]string{
+				"muffins.cupcakes.org",
+			},
+		},
+		{
 			handleReq(FailureCode, "fail body"),
 			nil,
 			probe.Failure,


### PR DESCRIPTION
Fixes #24288
