### PR TITLE
add labels to kube component static pods

### DIFF
--- a/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
+++ b/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
@@ -109,7 +109,11 @@
 "kind": "Pod",
 "metadata": {
   "name":"kube-apiserver",
-  "namespace": "kube-system"
+  "namespace": "kube-system",
+  "labels": {
+    "tier": "control-plane",
+    "component": "kube-apiserver"
+  }
 },
 "spec":{
 "hostNetwork": true,

--- a/cluster/saltbase/salt/kube-controller-manager/kube-controller-manager.manifest
+++ b/cluster/saltbase/salt/kube-controller-manager/kube-controller-manager.manifest
@@ -68,7 +68,11 @@
 "kind": "Pod",
 "metadata": {
   "name":"kube-controller-manager",
-  "namespace": "kube-system"
+  "namespace": "kube-system",
+  "labels": {
+    "tier": "control-plane",
+    "component": "kube-controller-manager"
+  }
 },
 "spec":{
 "hostNetwork": true,

--- a/cluster/saltbase/salt/kube-proxy/kube-proxy.manifest
+++ b/cluster/saltbase/salt/kube-proxy/kube-proxy.manifest
@@ -26,6 +26,9 @@ kind: Pod
 metadata:
   name: kube-proxy
   namespace: kube-system
+  labels:
+    tier: node
+    component: kube-proxy
 spec:
   hostNetwork: true
   containers:

--- a/cluster/saltbase/salt/kube-scheduler/kube-scheduler.manifest
+++ b/cluster/saltbase/salt/kube-scheduler/kube-scheduler.manifest
@@ -17,7 +17,11 @@
 "kind": "Pod",
 "metadata": {
   "name":"kube-scheduler",
-  "namespace": "kube-system"
+  "namespace": "kube-system",
+  "labels": {
+    "tier": "control-plane",
+    "component": "kube-scheduler"
+  }
 },
 "spec":{
 "hostNetwork": true,


### PR DESCRIPTION
```
$ k --namespace=kube-system get po -l 'tier in (control-plane)' 
NAME                                 READY     STATUS    RESTARTS   AGE
kube-apiserver-k-7-master            1/1       Running   2          1m
kube-controller-manager-k-7-master   1/1       Running   1          1m
kube-scheduler-k-7-master            1/1       Running   0          54s
$ k --namespace=kube-system get po -l 'tier in (node)'         
NAME                         READY     STATUS    RESTARTS   AGE
kube-proxy-k-7-minion-eheu   1/1       Running   0          1m
kube-proxy-k-7-minion-mwo9   1/1       Running   0          1m
kube-proxy-k-7-minion-xw6m   1/1       Running   0          1m
```

cc @bgrant0607 @thockin @gmarek 

Fixes #21267
