### PR TITLE
Don't clean up files on image-based tests since the instance will be …

### DIFF
--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -91,7 +91,7 @@ type LogReporter struct{}
 func (lr *LogReporter) SpecSuiteWillBegin(config config.GinkgoConfigType, summary *types.SuiteSummary) {
 	b := &bytes.Buffer{}
 	b.WriteString("******************************************************\n")
-	glog.V(2).Infof(b.String())
+	glog.V(0).Infof(b.String())
 }
 
 func (lr *LogReporter) BeforeSuiteDidRun(setupSummary *types.SetupSummary) {}
@@ -115,5 +115,5 @@ func (lr *LogReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) {
 		b.WriteString(fmt.Sprintf("etcd output:\n%s\n", e2es.etcdCombinedOut.String()))
 	}
 	b.WriteString("******************************************************\n")
-	glog.V(2).Infof(b.String())
+	glog.V(0).Infof(b.String())
 }

--- a/test/e2e_node/e2e_service.go
+++ b/test/e2e_node/e2e_service.go
@@ -155,7 +155,7 @@ func (es *e2eService) startServer(cmd *healthCheckCommand) error {
 	go func() {
 		err := cmd.Run()
 		if err != nil {
-			cmdErrorChan <- fmt.Errorf("%s Exited with status %v.  Output:\n%v", cmd, err, *cmd.OutputBuffer)
+			cmdErrorChan <- fmt.Errorf("%s Failed with error \"%v\".  Command output:\n%s", cmd, err, *cmd.OutputBuffer)
 		}
 		close(cmdErrorChan)
 	}()

--- a/test/e2e_node/runner/run_e2e.go
+++ b/test/e2e_node/runner/run_e2e.go
@@ -122,7 +122,7 @@ func main() {
 			fmt.Printf("Initializing e2e tests using host %s.\n", host)
 			running++
 			go func(host string) {
-				results <- testHost(host, archive)
+				results <- testHost(host, archive, *cleanup)
 			}(host)
 		}
 	}
@@ -150,8 +150,8 @@ func main() {
 }
 
 // Run tests in archive against host
-func testHost(host, archive string) *TestResult {
-	output, err := e2e_node.RunRemote(archive, host, *cleanup)
+func testHost(host, archive string, deleteFiles bool) *TestResult {
+	output, err := e2e_node.RunRemote(archive, host, deleteFiles)
 	return &TestResult{
 		output: output,
 		err:    err,
@@ -171,7 +171,7 @@ func testImage(image, archive string) *TestResult {
 			err: fmt.Errorf("Unable to create gce instance with running docker daemon for image %s.  %v", image, err),
 		}
 	}
-	return testHost(host, archive)
+	return testHost(host, archive, false)
 }
 
 // Provision a gce instance using image


### PR DESCRIPTION
…deleted anyway and this is flaky on CoreOS.
