### PR TITLE
Remove soak and disruptive 1.1 Jenkins jobs.

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
@@ -462,9 +462,6 @@
         - 'gce-release-1.1':
             timeout: 175
             description: 'Run E2E tests on GCE from the current release branch.'
-        - 'gce-disruptive-1.1':
-            timeout: 180
-            description: 'Run disruptive E2E tests on GCE from the current release branch.'
     jobs:
         - 'kubernetes-e2e-{suffix}'
 

--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
@@ -127,25 +127,6 @@
             job-env: |
                 export PROJECT="k8s-jkns-gce-soak-1-2"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
-        - 'gce-1.1':
-            deploy-description: |
-                Deploy Kubernetes to soak cluster using the latest successful
-                current release CI-produced Kubernetes build every week.<br>
-                If a kubernetes-soak-continuous-e2e-gce-1.1 build is running,
-                this deployment build will be blocked and remain in the queue
-                until the test run is complete.<br>
-            e2e-description: |
-                Assumes Kubernetes soak current-release cluster is already
-                deployed.<br>
-                If a kubernetes-soak-weekly-deploy-gce-1.1 build is enqueued,
-                builds will be blocked and remain in the queue until the
-                deployment is complete.<br>
-            branch: 'release-1.1'
-            runner: '{old-runner-1-1}'
-            post-env: ''
-            soak-deploy: ''
-            soak-continuous: ''
-            cron-string: 'H */6 * * *'
         - 'gke':
             deploy-description: |
                 Deploy Kubernetes to a GKE soak cluster using the staging GKE


### PR DESCRIPTION
They're both in the kubernetes-jenkins project, not their own. The disruptive one isn't a critical build, and I don't think the soak should be critical at all, since it's never green for a week anyway and I don't think we ever plan for it to be.
