### PR TITLE
Revert "Revert "Run most GCE, GKE, and Kubemark e2e jobs inside Docker""

### DIFF
--- a/hack/jenkins/job-configs/global.yaml
+++ b/hack/jenkins/job-configs/global.yaml
@@ -138,8 +138,8 @@
         exit ${{rc}}
     branch: 'master'
     job-env: ''
-    runner: bash <(curl -fsS --retry 3  "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/e2e-runner.sh")
-    dockerized-runner: bash <(curl -fsS --retry 3  "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/dockerized-e2e-runner.sh")
+    runner: bash <(curl -fsS --retry 3  "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/dockerized-e2e-runner.sh")
+    legacy-runner: bash <(curl -fsS --retry 3  "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/e2e-runner.sh")
     old-runner-1-1: bash <(curl -fsS --retry 3  "https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.1/hack/jenkins/e2e.sh")
     # XXX This is a hack to run only the tests we care about, without importing all of the skip list vars from the v1.1 e2e.sh.
     default-skip-list-1-1: Autoscaling\sSuite|resource\susage\stracking|Nodes|Etcd\sFailure|MasterCerts|experimental\sresource\susage\stracking|ServiceLoadBalancer|Shell|Daemon\sset|Deployment|Skipped|Restart\sshould\srestart\sall\snodes|Example|Reboot|ServiceLoadBalancer|DaemonRestart\sController\sManager|Daemon\sset\sshould\srun\sand\sstop\scomplex\sdaemon|Resource\susage\sof\ssystem\scontainers|allows\sscheduling\sof\spods\son\sa\sminion\safter\sit\srejoins\sthe\scluster

--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
@@ -15,8 +15,7 @@
     description: '{description} Test owner: {test-owner}.'
     logrotate:
         daysToKeep: 7
-    node: '{jenkins_node}'
-    jenkins_node: 'master'
+    jenkins_node: 'e2e'
     disabled: '{obj:disable_job}'
     builders:
         - shell: |
@@ -46,6 +45,7 @@
 - job-template:
     name: 'kubernetes-e2e-{suffix}'
     <<: *e2e_job_defaults
+    node: '{jenkins_node}'
     triggers:
         - reverse:
             jobs: '{trigger-job}'
@@ -109,8 +109,6 @@
                 export KUBE_ADMISSION_CONTROL="NamespaceLifecycle,InitialResources,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota"
         - 'gce-flaky':
             description: 'Run the flaky tests on GCE, sequentially.'
-            jenkins_node: 'e2e'
-            runner: '{dockerized-runner}'
             timeout: 180
             job-env: |
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Flaky\] \
@@ -222,8 +220,6 @@
                 - client (kubectl): ci/latest.txt<br>
                 - cluster (k8s): ci/latest.txt<br>
                 - tests: ci/latest.txt
-            jenkins_node: 'e2e'
-            runner: '{dockerized-runner}'
             timeout: 300
             job-env: |
                 export PROJECT="k8s-jkns-e2e-gke-ci-flaky"
@@ -444,6 +440,7 @@
     trigger-job: 'kubernetes-build-1.1'
     test-owner: 'Build Cop'
     branch: 'release-1.1'
+    jenkins_node: 'master'
     runner: '{old-runner-1-1}'
     post-env: ''
     suffix:
@@ -460,6 +457,7 @@
     trigger-job: 'kubernetes-build-1.1'
     test-owner: 'Build Cop'
     branch: 'release-1.1'
+    jenkins_node: 'master'
     runner: '{old-runner-1-1}'
     post-env: ''
     cron-string: 'H */6 * * *'
@@ -478,6 +476,7 @@
     trigger-job: 'kubernetes-build-1.0'
     test-owner: 'Build Cop'
     branch: 'release-1.0'
+    jenkins_node: 'master'
     runner: '{old-runner-1-0}'
     post-env: ''
     cron-string: 'H */12 * * *'
@@ -549,6 +548,8 @@
     cron-string: '@daily'
     trigger-job: ''
     timeout: 240
+    jenkins_node: 'master'
+    runner: '{legacy-runner}'
     provider-env: |
         {aws-provider-env}
         export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
@@ -629,6 +630,7 @@
 - job-template:
     name: 'kubernetes-e2e-gce-trusty-ci-{suffix}'
     <<: *e2e_job_defaults
+    node: '{jenkins_node}'
     triggers:
         - reverse:
             jobs: '{trigger-job}'
@@ -724,6 +726,7 @@
 - job-template:
     name: 'kubernetes-e2e-gce-trusty-dev-{suffix}'
     <<: *e2e_job_defaults
+    node: '{jenkins_node}'
     triggers:
         - timed: 'H H/8 * * *'
     publishers:
@@ -778,6 +781,7 @@
 - job-template:
     name: 'kubernetes-e2e-gce-trusty-{suffix}'
     <<: *e2e_job_defaults
+    node: '{jenkins_node}'
     triggers:
         # Trusty beta and stable images are built once per day.
         - timed: '@daily'
@@ -799,6 +803,7 @@
     test-owner: 'wonderfly@google.com'
     branch: 'release-1.1'
     emails: 'wonderfly@google.com,qzheng@google.com'
+    jenkins_node: 'master'
     runner: '{old-runner-1-1}'
     post-env: ''
     suffix:

--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
@@ -3,6 +3,7 @@
     description: '{description} Test owner: gmarek'
     logrotate:
         daysToKeep: 7
+    node: 'e2e'
     builders:
         - shell: |
             {provider-env}

--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
@@ -3,13 +3,14 @@
     description: '{deploy-description} Test owner: {test-owner}'
     logrotate:
         daysToKeep: 14
+    node: 'master'
     builders:
         - shell: |
             {provider-env}
             {soak-deploy}
             {job-env}
             {post-env}
-            timeout -k {kill-timeout}m 90m {runner} && rc=$? || rc=$?
+            timeout -k {kill-timeout}m 90m {legacy-runner} && rc=$? || rc=$?
             {report-rc}
     properties:
         - build-blocker:
@@ -36,13 +37,14 @@
     workspace: '/var/lib/jenkins/jobs/kubernetes-soak-weekly-deploy-{suffix}/workspace'
     logrotate:
         daysToKeep: 7
+    node: 'master'
     builders:
         - shell: |
             {provider-env}
             {soak-continuous}
             {job-env}
             {post-env}
-            timeout -k {kill-timeout}m 360m {runner} && rc=$? || rc=$?
+            timeout -k {kill-timeout}m 360m {legacy-runner} && rc=$? || rc=$?
             {report-rc}
     properties:
         - build-blocker:

--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-upgrades.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-upgrades.yaml
@@ -12,6 +12,7 @@
     project-type: multijob
     triggers:
         - timed: '@hourly'
+    node: 'master'
     builders:
         # TODO(ihmccreery) In theory, we could get ourselves into trouble by
         # editing these things in the middle of a run.  Jenkins Job Builder
@@ -61,6 +62,7 @@
     description: 'Deploy a cluster at {version-old} to be tested and upgraded to {version-new}. Test owner: ihmccreery.'
     logrotate:
         daysToKeep: 7
+    node: 'master'
     builders:
         - shell: |
             # per-provider variables
@@ -97,6 +99,7 @@
     workspace: /var/lib/jenkins/jobs/kubernetes-upgrade-{provider}-{version-old}-{version-new}-step1-deploy/workspace/
     logrotate:
         daysToKeep: 7
+    node: 'master'
     builders:
         - shell: |
             # per-provider variables

--- a/hack/jenkins/job-configs/kubernetes-jenkins/node-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/node-e2e.yaml
@@ -14,7 +14,6 @@
     node: 'node'
     logrotate:
         numToKeep: 200
-    node: node
     builders:
          - docker-build-publish:
              repoName: '{repoName}'
@@ -64,7 +63,6 @@
     node: 'node'
     logrotate:
         numToKeep: 200
-    node: node
     builders:
          - shell: |
               #!/bin/bash


### PR DESCRIPTION
This reverts commit b2f8b1962fd7f58139efdc8a76670a8327bc3ff7.

Round 2 here we go! This time I have two slaves set up with 25 executors each, plus the metadata server fix is in.
