### PR TITLE
Avoid relying on events in deployment rollover e2e test

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -2523,6 +2523,24 @@ func WaitForDeploymentStatus(c clientset.Interface, ns, deploymentName string, d
 	return nil
 }
 
+// WaitForDeploymentUpdatedReplicasLTE waits for given deployment to be observed by the controller and has at least a number of updatedReplicas
+func WaitForDeploymentUpdatedReplicasLTE(c clientset.Interface, ns, deploymentName string, minUpdatedReplicas int, desiredGeneration int64) error {
+	err := wait.Poll(Poll, 5*time.Minute, func() (bool, error) {
+		deployment, err := c.Extensions().Deployments(ns).Get(deploymentName)
+		if err != nil {
+			return false, err
+		}
+		if deployment.Status.ObservedGeneration >= desiredGeneration && deployment.Status.UpdatedReplicas >= minUpdatedReplicas {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("error waiting for deployment %s to have at least %d updpatedReplicas: %v", deploymentName, minUpdatedReplicas, err)
+	}
+	return nil
+}
+
 // WaitForDeploymentRollbackCleared waits for given deployment either started rolling back or doesn't need to rollback.
 // Note that rollback should be cleared shortly, so we only wait for 1 minute here to fail early.
 func WaitForDeploymentRollbackCleared(c clientset.Interface, ns, deploymentName string) error {
@@ -2696,7 +2714,7 @@ func UpdateDeploymentWithRetries(c *clientset.Clientset, namespace, name string,
 		// Apply the update, then attempt to push it to the apiserver.
 		applyUpdate(deployment)
 		if deployment, err = deployments.Update(deployment); err == nil {
-			Logf("updating deployment %s", name)
+			Logf("Updating deployment %s", name)
 			return true, nil
 		}
 		return false, nil


### PR DESCRIPTION
Fixes #22028

@kubernetes/sig-config 
