### PR TITLE
Fix session ended hint for kubectl run

### DIFF
--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -343,6 +343,7 @@ func handleAttachPod(f *cmdutil.Factory, c *client.Client, pod *api.Pod, opts *A
 	opts.Client = c
 	opts.PodName = pod.Name
 	opts.Namespace = pod.Namespace
+	opts.CommandName = "kubectl attach"
 	if err := opts.Run(); err != nil {
 		fmt.Fprintf(opts.Out, "Error attaching, falling back to logs: %v\n", err)
 		req, err := f.LogsForObject(pod, &api.PodLogOptions{Container: opts.GetContainerName(pod)})


### PR DESCRIPTION
Fixes #23602

Before:

``` console
$ kubectl run -i --tty busybox --image=busybox 
Waiting for pod default/busybox-3797442026-mt8zk to be running, status is Pending, pod ready: false
Hit enter for command prompt
/ # 
/ # exit
Session ended, resume using ' busybox-3797442026-mt8zk -c busybox -i -t' command when the pod is running
                             ↑
                      (incomplete command)
```

After:

``` console
Session ended, resume using 'kubectl attach busybox-3797442026-mt8zk -c busybox -i -t' command when the pod is running
```

@kubernetes/kubectl 
