### PR TITLE
RateLimitedQueue TestTryOrdering could fail under load

### DIFF
--- a/pkg/controller/node/rate_limited_queue.go
+++ b/pkg/controller/node/rate_limited_queue.go
@@ -164,7 +164,7 @@ func (q *RateLimitedTimedQueue) Try(fn ActionFunc) {
 	for ok {
 		// rate limit the queue checking
 		if !q.limiter.TryAccept() {
-			glog.V(10).Info("Try rate limitted...")
+			glog.V(10).Info("Try rate limited...")
 			// Try again later
 			break
 		}


### PR DESCRIPTION
Remove the possibility of contention in the test by providing a
synthetic Now() function.

Fixes #24125
