### PR TITLE
Disable the version cache to fix #24298.

### DIFF
--- a/pkg/kubelet/dockertools/fake_manager.go
+++ b/pkg/kubelet/dockertools/fake_manager.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/network"
 	proberesults "k8s.io/kubernetes/pkg/kubelet/prober/results"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
-	"k8s.io/kubernetes/pkg/kubelet/util/cache"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/flowcontrol"
 	"k8s.io/kubernetes/pkg/util/oom"
@@ -53,9 +52,6 @@ func NewFakeDockerManager(
 		burst, containerLogsDir, osInterface, networkPlugin, runtimeHelper, httpClient, &NativeExecHandler{},
 		fakeOOMAdjuster, fakeProcFs, false, imageBackOff, false, false, true)
 	dm.dockerPuller = &FakeDockerPuller{}
-	dm.versionCache = cache.NewVersionCache(func() (kubecontainer.Version, kubecontainer.Version, error) {
-		return dm.getVersionInfo()
-	})
 	return dm
 }
 

--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -253,15 +253,6 @@ func NewDockerManager(
 		optf(dm)
 	}
 
-	// initialize versionCache with a updater
-	dm.versionCache = cache.NewVersionCache(func() (kubecontainer.Version, kubecontainer.Version, error) {
-		return dm.getVersionInfo()
-	})
-	// update version cache periodically.
-	if dm.machineInfo != nil {
-		dm.versionCache.UpdateCachePeriodly(dm.machineInfo.MachineID)
-	}
-
 	return dm
 }
 
@@ -1581,26 +1572,13 @@ func (dm *DockerManager) calculateOomScoreAdj(container *api.Container) int {
 	return oomScoreAdj
 }
 
-// getCachedVersionInfo gets cached version info of docker runtime.
-func (dm *DockerManager) getCachedVersionInfo() (kubecontainer.Version, kubecontainer.Version, error) {
-	apiVersion, daemonVersion, err := dm.versionCache.Get(dm.machineInfo.MachineID)
-	if err != nil {
-		glog.Errorf("Failed to get cached docker api version %v ", err)
-	}
-	// If we got nil versions, try to update version info.
-	if apiVersion == nil || daemonVersion == nil {
-		dm.versionCache.Update(dm.machineInfo.MachineID)
-	}
-	return apiVersion, daemonVersion, err
-}
-
 // checkDockerAPIVersion checks current docker API version against expected version.
 // Return:
 // 1 : newer than expected version
 // -1: older than expected version
 // 0 : same version
 func (dm *DockerManager) checkDockerAPIVersion(expectedVersion string) (int, error) {
-	apiVersion, _, err := dm.getCachedVersionInfo()
+	apiVersion, _, err := dm.getVersionInfo()
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
Fixes #24298.

Since #24298 frequently blocks PRs, it has been bumped up to P0. This PR fixes the issue with minimum change by disabling the version cache. This would only cause very little performance regression, see  https://github.com/kubernetes/kubernetes/issues/24298#issuecomment-210622540. 
#24376 will have a better fix with a new `ObjectCache`, but may need a little more work later. :)

We could merge this one first to fix the issue, and finally go with #24376.

@wojtek-t @yujuhong @resouer 
