### PR TITLE
golint fixes for AWS cloudprovider

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws_instancegroups.go
+++ b/pkg/cloudprovider/providers/aws/aws_instancegroups.go
@@ -25,7 +25,7 @@ import (
 )
 
 // AWSCloud implements InstanceGroups
-var _ InstanceGroups = &AWSCloud{}
+var _ InstanceGroups = &Cloud{}
 
 // ResizeInstanceGroup sets the size of the specificed instancegroup Exported
 // so it can be used by the e2e tests, which don't want to instantiate a full
@@ -44,8 +44,8 @@ func ResizeInstanceGroup(asg ASG, instanceGroupName string, size int) error {
 
 // Implement InstanceGroups.ResizeInstanceGroup
 // Set the size to the fixed size
-func (a *AWSCloud) ResizeInstanceGroup(instanceGroupName string, size int) error {
-	return ResizeInstanceGroup(a.asg, instanceGroupName, size)
+func (c *Cloud) ResizeInstanceGroup(instanceGroupName string, size int) error {
+	return ResizeInstanceGroup(c.asg, instanceGroupName, size)
 }
 
 // DescribeInstanceGroup gets info about the specified instancegroup
@@ -72,8 +72,8 @@ func DescribeInstanceGroup(asg ASG, instanceGroupName string) (InstanceGroupInfo
 
 // Implement InstanceGroups.DescribeInstanceGroup
 // Queries the cloud provider for information about the specified instance group
-func (a *AWSCloud) DescribeInstanceGroup(instanceGroupName string) (InstanceGroupInfo, error) {
-	return DescribeInstanceGroup(a.asg, instanceGroupName)
+func (c *Cloud) DescribeInstanceGroup(instanceGroupName string) (InstanceGroupInfo, error) {
+	return DescribeInstanceGroup(c.asg, instanceGroupName)
 }
 
 // awsInstanceGroup implements InstanceGroupInfo

--- a/pkg/cloudprovider/providers/aws/aws_loadbalancer.go
+++ b/pkg/cloudprovider/providers/aws/aws_loadbalancer.go
@@ -30,8 +30,8 @@ import (
 
 const ProxyProtocolPolicyName = "k8s-proxyprotocol-enabled"
 
-func (s *AWSCloud) ensureLoadBalancer(namespacedName types.NamespacedName, loadBalancerName string, listeners []*elb.Listener, subnetIDs []string, securityGroupIDs []string, internalELB, proxyProtocol bool) (*elb.LoadBalancerDescription, error) {
-	loadBalancer, err := s.describeLoadBalancer(loadBalancerName)
+func (c *Cloud) ensureLoadBalancer(namespacedName types.NamespacedName, loadBalancerName string, listeners []*elb.Listener, subnetIDs []string, securityGroupIDs []string, internalELB, proxyProtocol bool) (*elb.LoadBalancerDescription, error) {
+	loadBalancer, err := c.describeLoadBalancer(loadBalancerName)
 	if err != nil {
 		return nil, err
 	}
@@ -55,25 +55,25 @@ func (s *AWSCloud) ensureLoadBalancer(namespacedName types.NamespacedName, loadB
 		createRequest.SecurityGroups = stringPointerArray(securityGroupIDs)
 
 		createRequest.Tags = []*elb.Tag{
-			{Key: aws.String(TagNameKubernetesCluster), Value: aws.String(s.getClusterName())},
+			{Key: aws.String(TagNameKubernetesCluster), Value: aws.String(c.getClusterName())},
 			{Key: aws.String(TagNameKubernetesService), Value: aws.String(namespacedName.String())},
 		}
 
 		glog.Infof("Creating load balancer for %v with name: ", namespacedName, loadBalancerName)
-		_, err := s.elb.CreateLoadBalancer(createRequest)
+		_, err := c.elb.CreateLoadBalancer(createRequest)
 		if err != nil {
 			return nil, err
 		}
 
 		if proxyProtocol {
-			err = s.createProxyProtocolPolicy(loadBalancerName)
+			err = c.createProxyProtocolPolicy(loadBalancerName)
 			if err != nil {
 				return nil, err
 			}
 
 			for _, listener := range listeners {
 				glog.V(2).Infof("Adjusting AWS loadbalancer proxy protocol on node port %d. Setting to true", *listener.InstancePort)
-				err := s.setBackendPolicies(loadBalancerName, *listener.InstancePort, []*string{aws.String(ProxyProtocolPolicyName)})
+				err := c.setBackendPolicies(loadBalancerName, *listener.InstancePort, []*string{aws.String(ProxyProtocolPolicyName)})
 				if err != nil {
 					return nil, err
 				}
@@ -97,7 +97,7 @@ func (s *AWSCloud) ensureLoadBalancer(namespacedName types.NamespacedName, loadB
 				request.LoadBalancerName = aws.String(loadBalancerName)
 				request.Subnets = stringSetToPointers(removals)
 				glog.V(2).Info("Detaching load balancer from removed subnets")
-				_, err := s.elb.DetachLoadBalancerFromSubnets(request)
+				_, err := c.elb.DetachLoadBalancerFromSubnets(request)
 				if err != nil {
 					return nil, fmt.Errorf("error detaching AWS loadbalancer from subnets: %v", err)
 				}
@@ -109,7 +109,7 @@ func (s *AWSCloud) ensureLoadBalancer(namespacedName types.NamespacedName, loadB
 				request.LoadBalancerName = aws.String(loadBalancerName)
 				request.Subnets = stringSetToPointers(additions)
 				glog.V(2).Info("Attaching load balancer to added subnets")
-				_, err := s.elb.AttachLoadBalancerToSubnets(request)
+				_, err := c.elb.AttachLoadBalancerToSubnets(request)
 				if err != nil {
 					return nil, fmt.Errorf("error attaching AWS loadbalancer to subnets: %v", err)
 				}
@@ -128,7 +128,7 @@ func (s *AWSCloud) ensureLoadBalancer(namespacedName types.NamespacedName, loadB
 				request.LoadBalancerName = aws.String(loadBalancerName)
 				request.SecurityGroups = stringPointerArray(securityGroupIDs)
 				glog.V(2).Info("Applying updated security groups to load balancer")
-				_, err := s.elb.ApplySecurityGroupsToLoadBalancer(request)
+				_, err := c.elb.ApplySecurityGroupsToLoadBalancer(request)
 				if err != nil {
 					return nil, fmt.Errorf("error applying AWS loadbalancer security groups: %v", err)
 				}
@@ -188,7 +188,7 @@ func (s *AWSCloud) ensureLoadBalancer(namespacedName types.NamespacedName, loadB
 				request.LoadBalancerName = aws.String(loadBalancerName)
 				request.LoadBalancerPorts = removals
 				glog.V(2).Info("Deleting removed load balancer listeners")
-				_, err := s.elb.DeleteLoadBalancerListeners(request)
+				_, err := c.elb.DeleteLoadBalancerListeners(request)
 				if err != nil {
 					return nil, fmt.Errorf("error deleting AWS loadbalancer listeners: %v", err)
 				}
@@ -200,7 +200,7 @@ func (s *AWSCloud) ensureLoadBalancer(namespacedName types.NamespacedName, loadB
 				request.LoadBalancerName = aws.String(loadBalancerName)
 				request.Listeners = additions
 				glog.V(2).Info("Creating added load balancer listeners")
-				_, err := s.elb.CreateLoadBalancerListeners(request)
+				_, err := c.elb.CreateLoadBalancerListeners(request)
 				if err != nil {
 					return nil, fmt.Errorf("error creating AWS loadbalancer listeners: %v", err)
 				}
@@ -219,7 +219,7 @@ func (s *AWSCloud) ensureLoadBalancer(namespacedName types.NamespacedName, loadB
 				// back if a policy of the same name already exists. However, the aws-sdk does not
 				// seem to return an error to us in these cases. Therefore this will issue an API
 				// request every time.
-				err := s.createProxyProtocolPolicy(loadBalancerName)
+				err := c.createProxyProtocolPolicy(loadBalancerName)
 				if err != nil {
 					return nil, err
 				}
@@ -252,7 +252,7 @@ func (s *AWSCloud) ensureLoadBalancer(namespacedName types.NamespacedName, loadB
 
 				if setPolicy {
 					glog.V(2).Infof("Adjusting AWS loadbalancer proxy protocol on node port %d. Setting to %t", instancePort, proxyProtocol)
-					err := s.setBackendPolicies(loadBalancerName, instancePort, proxyPolicies)
+					err := c.setBackendPolicies(loadBalancerName, instancePort, proxyPolicies)
 					if err != nil {
 						return nil, err
 					}
@@ -266,7 +266,7 @@ func (s *AWSCloud) ensureLoadBalancer(namespacedName types.NamespacedName, loadB
 			for instancePort, found := range foundBackends {
 				if !found {
 					glog.V(2).Infof("Adjusting AWS loadbalancer proxy protocol on node port %d. Setting to false", instancePort)
-					err := s.setBackendPolicies(loadBalancerName, instancePort, []*string{})
+					err := c.setBackendPolicies(loadBalancerName, instancePort, []*string{})
 					if err != nil {
 						return nil, err
 					}
@@ -277,7 +277,7 @@ func (s *AWSCloud) ensureLoadBalancer(namespacedName types.NamespacedName, loadB
 	}
 
 	if dirty {
-		loadBalancer, err = s.describeLoadBalancer(loadBalancerName)
+		loadBalancer, err = c.describeLoadBalancer(loadBalancerName)
 		if err != nil {
 			glog.Warning("Unable to retrieve load balancer after creation/update")
 			return nil, err
@@ -288,7 +288,7 @@ func (s *AWSCloud) ensureLoadBalancer(namespacedName types.NamespacedName, loadB
 }
 
 // Makes sure that the health check for an ELB matches the configured listeners
-func (s *AWSCloud) ensureLoadBalancerHealthCheck(loadBalancer *elb.LoadBalancerDescription, listeners []*elb.Listener) error {
+func (c *Cloud) ensureLoadBalancerHealthCheck(loadBalancer *elb.LoadBalancerDescription, listeners []*elb.Listener) error {
 	actual := loadBalancer.HealthCheck
 
 	// Default AWS settings
@@ -332,7 +332,7 @@ func (s *AWSCloud) ensureLoadBalancerHealthCheck(loadBalancer *elb.LoadBalancerD
 	request.HealthCheck = healthCheck
 	request.LoadBalancerName = loadBalancer.LoadBalancerName
 
-	_, err := s.elb.ConfigureHealthCheck(request)
+	_, err := c.elb.ConfigureHealthCheck(request)
 	if err != nil {
 		return fmt.Errorf("error configuring load-balancer health-check: %v", err)
 	}
@@ -341,7 +341,7 @@ func (s *AWSCloud) ensureLoadBalancerHealthCheck(loadBalancer *elb.LoadBalancerD
 }
 
 // Makes sure that exactly the specified hosts are registered as instances with the load balancer
-func (s *AWSCloud) ensureLoadBalancerInstances(loadBalancerName string, lbInstances []*elb.Instance, instances []*ec2.Instance) error {
+func (c *Cloud) ensureLoadBalancerInstances(loadBalancerName string, lbInstances []*elb.Instance, instances []*ec2.Instance) error {
 	expected := sets.NewString()
 	for _, instance := range instances {
 		expected.Insert(orEmpty(instance.InstanceId))
@@ -373,7 +373,7 @@ func (s *AWSCloud) ensureLoadBalancerInstances(loadBalancerName string, lbInstan
 		registerRequest := &elb.RegisterInstancesWithLoadBalancerInput{}
 		registerRequest.Instances = addInstances
 		registerRequest.LoadBalancerName = aws.String(loadBalancerName)
-		_, err := s.elb.RegisterInstancesWithLoadBalancer(registerRequest)
+		_, err := c.elb.RegisterInstancesWithLoadBalancer(registerRequest)
 		if err != nil {
 			return err
 		}
@@ -384,7 +384,7 @@ func (s *AWSCloud) ensureLoadBalancerInstances(loadBalancerName string, lbInstan
 		deregisterRequest := &elb.DeregisterInstancesFromLoadBalancerInput{}
 		deregisterRequest.Instances = removeInstances
 		deregisterRequest.LoadBalancerName = aws.String(loadBalancerName)
-		_, err := s.elb.DeregisterInstancesFromLoadBalancer(deregisterRequest)
+		_, err := c.elb.DeregisterInstancesFromLoadBalancer(deregisterRequest)
 		if err != nil {
 			return err
 		}
@@ -394,7 +394,7 @@ func (s *AWSCloud) ensureLoadBalancerInstances(loadBalancerName string, lbInstan
 	return nil
 }
 
-func (s *AWSCloud) createProxyProtocolPolicy(loadBalancerName string) error {
+func (c *Cloud) createProxyProtocolPolicy(loadBalancerName string) error {
 	request := &elb.CreateLoadBalancerPolicyInput{
 		LoadBalancerName: aws.String(loadBalancerName),
 		PolicyName:       aws.String(ProxyProtocolPolicyName),
@@ -407,7 +407,7 @@ func (s *AWSCloud) createProxyProtocolPolicy(loadBalancerName string) error {
 		},
 	}
 	glog.V(2).Info("Creating proxy protocol policy on load balancer")
-	_, err := s.elb.CreateLoadBalancerPolicy(request)
+	_, err := c.elb.CreateLoadBalancerPolicy(request)
 	if err != nil {
 		return fmt.Errorf("error creating proxy protocol policy on load balancer: %v", err)
 	}
@@ -415,7 +415,7 @@ func (s *AWSCloud) createProxyProtocolPolicy(loadBalancerName string) error {
 	return nil
 }
 
-func (s *AWSCloud) setBackendPolicies(loadBalancerName string, instancePort int64, policies []*string) error {
+func (c *Cloud) setBackendPolicies(loadBalancerName string, instancePort int64, policies []*string) error {
 	request := &elb.SetLoadBalancerPoliciesForBackendServerInput{
 		InstancePort:     aws.Int64(instancePort),
 		LoadBalancerName: aws.String(loadBalancerName),
@@ -426,7 +426,7 @@ func (s *AWSCloud) setBackendPolicies(loadBalancerName string, instancePort int6
 	} else {
 		glog.V(2).Infof("Removing AWS loadbalancer backend policies on node port %d", instancePort)
 	}
-	_, err := s.elb.SetLoadBalancerPoliciesForBackendServer(request)
+	_, err := c.elb.SetLoadBalancerPoliciesForBackendServer(request)
 	if err != nil {
 		return fmt.Errorf("error adjusting AWS loadbalancer backend policies: %v", err)
 	}

--- a/pkg/cloudprovider/providers/aws/aws_routes.go
+++ b/pkg/cloudprovider/providers/aws/aws_routes.go
@@ -25,14 +25,14 @@ import (
 	"k8s.io/kubernetes/pkg/cloudprovider"
 )
 
-func (s *AWSCloud) findRouteTable(clusterName string) (*ec2.RouteTable, error) {
+func (c *Cloud) findRouteTable(clusterName string) (*ec2.RouteTable, error) {
 	// This should be unnecessary (we already filter on TagNameKubernetesCluster,
 	// and something is broken if cluster name doesn't match, but anyway...
 	// TODO: All clouds should be cluster-aware by default
 	filters := []*ec2.Filter{newEc2Filter("tag:"+TagNameKubernetesCluster, clusterName)}
-	request := &ec2.DescribeRouteTablesInput{Filters: s.addFilters(filters)}
+	request := &ec2.DescribeRouteTablesInput{Filters: c.addFilters(filters)}
 
-	tables, err := s.ec2.DescribeRouteTables(request)
+	tables, err := c.ec2.DescribeRouteTables(request)
 	if err != nil {
 		return nil, err
 	}
@@ -49,8 +49,8 @@ func (s *AWSCloud) findRouteTable(clusterName string) (*ec2.RouteTable, error) {
 
 // ListRoutes implements Routes.ListRoutes
 // List all routes that match the filter
-func (s *AWSCloud) ListRoutes(clusterName string) ([]*cloudprovider.Route, error) {
-	table, err := s.findRouteTable(clusterName)
+func (c *Cloud) ListRoutes(clusterName string) ([]*cloudprovider.Route, error) {
+	table, err := c.findRouteTable(clusterName)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func (s *AWSCloud) ListRoutes(clusterName string) ([]*cloudprovider.Route, error
 		instanceIDs = append(instanceIDs, &instanceID)
 	}
 
-	instances, err := s.getInstancesByIDs(instanceIDs)
+	instances, err := c.getInstancesByIDs(instanceIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -95,12 +95,12 @@ func (s *AWSCloud) ListRoutes(clusterName string) ([]*cloudprovider.Route, error
 }
 
 // Sets the instance attribute "source-dest-check" to the specified value
-func (s *AWSCloud) configureInstanceSourceDestCheck(instanceID string, sourceDestCheck bool) error {
+func (c *Cloud) configureInstanceSourceDestCheck(instanceID string, sourceDestCheck bool) error {
 	request := &ec2.ModifyInstanceAttributeInput{}
 	request.InstanceId = aws.String(instanceID)
 	request.SourceDestCheck = &ec2.AttributeBooleanValue{Value: aws.Bool(sourceDestCheck)}
 
-	_, err := s.ec2.ModifyInstanceAttribute(request)
+	_, err := c.ec2.ModifyInstanceAttribute(request)
 	if err != nil {
 		return fmt.Errorf("error configuring source-dest-check on instance %s: %v", instanceID, err)
 	}
@@ -109,20 +109,20 @@ func (s *AWSCloud) configureInstanceSourceDestCheck(instanceID string, sourceDes
 
 // CreateRoute implements Routes.CreateRoute
 // Create the described route
-func (s *AWSCloud) CreateRoute(clusterName string, nameHint string, route *cloudprovider.Route) error {
-	instance, err := s.getInstanceByNodeName(route.TargetInstance)
+func (c *Cloud) CreateRoute(clusterName string, nameHint string, route *cloudprovider.Route) error {
+	instance, err := c.getInstanceByNodeName(route.TargetInstance)
 	if err != nil {
 		return err
 	}
 
 	// In addition to configuring the route itself, we also need to configure the instance to accept that traffic
 	// On AWS, this requires turning source-dest checks off
-	err = s.configureInstanceSourceDestCheck(orEmpty(instance.InstanceId), false)
+	err = c.configureInstanceSourceDestCheck(orEmpty(instance.InstanceId), false)
 	if err != nil {
 		return err
 	}
 
-	table, err := s.findRouteTable(clusterName)
+	table, err := c.findRouteTable(clusterName)
 	if err != nil {
 		return err
 	}
@@ -147,7 +147,7 @@ func (s *AWSCloud) CreateRoute(clusterName string, nameHint string, route *cloud
 		request.DestinationCidrBlock = deleteRoute.DestinationCidrBlock
 		request.RouteTableId = table.RouteTableId
 
-		_, err = s.ec2.DeleteRoute(request)
+		_, err = c.ec2.DeleteRoute(request)
 		if err != nil {
 			return fmt.Errorf("error deleting blackholed AWS route (%s): %v", aws.StringValue(deleteRoute.DestinationCidrBlock), err)
 		}
@@ -159,7 +159,7 @@ func (s *AWSCloud) CreateRoute(clusterName string, nameHint string, route *cloud
 	request.InstanceId = instance.InstanceId
 	request.RouteTableId = table.RouteTableId
 
-	_, err = s.ec2.CreateRoute(request)
+	_, err = c.ec2.CreateRoute(request)
 	if err != nil {
 		return fmt.Errorf("error creating AWS route (%s): %v", route.DestinationCIDR, err)
 	}
@@ -169,8 +169,8 @@ func (s *AWSCloud) CreateRoute(clusterName string, nameHint string, route *cloud
 
 // DeleteRoute implements Routes.DeleteRoute
 // Delete the specified route
-func (s *AWSCloud) DeleteRoute(clusterName string, route *cloudprovider.Route) error {
-	table, err := s.findRouteTable(clusterName)
+func (c *Cloud) DeleteRoute(clusterName string, route *cloudprovider.Route) error {
+	table, err := c.findRouteTable(clusterName)
 	if err != nil {
 		return err
 	}
@@ -179,7 +179,7 @@ func (s *AWSCloud) DeleteRoute(clusterName string, route *cloudprovider.Route) e
 	request.DestinationCidrBlock = aws.String(route.DestinationCIDR)
 	request.RouteTableId = table.RouteTableId
 
-	_, err = s.ec2.DeleteRoute(request)
+	_, err = c.ec2.DeleteRoute(request)
 	if err != nil {
 		return fmt.Errorf("error deleting AWS route (%s): %v", route.DestinationCIDR, err)
 	}

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -43,7 +43,7 @@ func TestReadAWSCloudConfig(t *testing.T) {
 		name string
 
 		reader io.Reader
-		aws    AWSServices
+		aws    Services
 
 		expectError bool
 		zone        string
@@ -198,7 +198,7 @@ func TestNewAWSCloud(t *testing.T) {
 		name string
 
 		reader      io.Reader
-		awsServices AWSServices
+		awsServices Services
 
 		expectError bool
 		region      string
@@ -508,7 +508,7 @@ func (a *FakeASG) DescribeAutoScalingGroups(*autoscaling.DescribeAutoScalingGrou
 	panic("Not implemented")
 }
 
-func mockInstancesResp(selfInstance *ec2.Instance, instances []*ec2.Instance) (*AWSCloud, *FakeAWSServices) {
+func mockInstancesResp(selfInstance *ec2.Instance, instances []*ec2.Instance) (*Cloud, *FakeAWSServices) {
 	awsServices := NewFakeAWSServices()
 	awsServices.instances = instances
 	awsServices.selfInstance = selfInstance
@@ -519,7 +519,7 @@ func mockInstancesResp(selfInstance *ec2.Instance, instances []*ec2.Instance) (*
 	return awsCloud, awsServices
 }
 
-func mockAvailabilityZone(availabilityZone string) *AWSCloud {
+func mockAvailabilityZone(availabilityZone string) *Cloud {
 	awsServices := NewFakeAWSServices().withAz(availabilityZone)
 	awsCloud, err := newAWSCloud(nil, awsServices)
 	if err != nil {

--- a/pkg/volume/aws_ebs/aws_util.go
+++ b/pkg/volume/aws_ebs/aws_util.go
@@ -166,8 +166,8 @@ func pathExists(path string) (bool, error) {
 }
 
 // Return cloud provider
-func getCloudProvider(cloudProvider cloudprovider.Interface) (*aws.AWSCloud, error) {
-	awsCloudProvider, ok := cloudProvider.(*aws.AWSCloud)
+func getCloudProvider(cloudProvider cloudprovider.Interface) (*aws.Cloud, error) {
+	awsCloudProvider, ok := cloudProvider.(*aws.Cloud)
 	if !ok || awsCloudProvider == nil {
 		return nil, fmt.Errorf("Failed to get AWS Cloud Provider. GetCloudProvider returned %v instead", cloudProvider)
 	}

--- a/plugin/pkg/admission/persistentvolume/label/admission.go
+++ b/plugin/pkg/admission/persistentvolume/label/admission.go
@@ -136,7 +136,7 @@ func (l *persistentVolumeLabel) getEBSVolumes() (aws.Volumes, error) {
 		if err != nil || cloudProvider == nil {
 			return nil, err
 		}
-		awsCloudProvider, ok := cloudProvider.(*aws.AWSCloud)
+		awsCloudProvider, ok := cloudProvider.(*aws.Cloud)
 		if !ok {
 			// GetCloudProvider has gone very wrong
 			return nil, fmt.Errorf("error retrieving AWS cloud provider")


### PR DESCRIPTION
Among other things, golint doesn't like receivers that are inconsistently named or called "self". Or structs named aws.AWSservices, aws.AWSCloud, etc.
