### PR TITLE
client-gen: use serializer instead of codec for versioned client

### DIFF
--- a/cmd/libs/go2idl/client-gen/generators/client_generator.go
+++ b/cmd/libs/go2idl/client-gen/generators/client_generator.go
@@ -100,6 +100,7 @@ func packageForGroup(gv unversioned.GroupVersion, typeList []*types.Type, packag
 				},
 				outputPackage: outputPackagePath,
 				group:         gv.Group,
+				version:       gv.Version,
 				types:         typeList,
 				imports:       generator.NewImportTracker(),
 			})

--- a/cmd/libs/go2idl/client-gen/generators/generator_for_group.go
+++ b/cmd/libs/go2idl/client-gen/generators/generator_for_group.go
@@ -30,6 +30,7 @@ type genGroup struct {
 	generator.DefaultGen
 	outputPackage string
 	group         string
+	version       string
 	// types in this group
 	types   []*types.Type
 	imports namer.ImportTracker
@@ -49,7 +50,8 @@ func (g *genGroup) Namers(c *generator.Context) namer.NameSystems {
 }
 
 func (g *genGroup) Imports(c *generator.Context) (imports []string) {
-	return g.imports.ImportLines()
+	imports = append(imports, g.imports.ImportLines()...)
+	return
 }
 
 func (g *genGroup) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {
@@ -84,6 +86,7 @@ func (g *genGroup) GenerateType(c *generator.Context, t *types.Type, w io.Writer
 		"GroupOrDie":                 c.Universe.Variable(types.Name{Package: pkgRegistered, Name: "GroupOrDie"}),
 		"apiPath":                    apiPath(g.group),
 		"codecs":                     c.Universe.Variable(types.Name{Package: pkgAPI, Name: "Codecs"}),
+		"Errorf":                     c.Universe.Variable(types.Name{Package: "fmt", Name: "Errorf"}),
 	}
 	sw.Do(groupInterfaceTemplate, m)
 	sw.Do(groupClientTemplate, m)
@@ -103,7 +106,11 @@ func (g *genGroup) GenerateType(c *generator.Context, t *types.Type, w io.Writer
 	sw.Do(newClientForConfigTemplate, m)
 	sw.Do(newClientForConfigOrDieTemplate, m)
 	sw.Do(newClientForRESTClientTemplate, m)
-	sw.Do(setClientDefaultsTemplate, m)
+	if g.version == "unversioned" {
+		sw.Do(setInternalVersionClientDefaultsTemplate, m)
+	} else {
+		sw.Do(setClientDefaultsTemplate, m)
+	}
 
 	return sw.Error()
 }
@@ -167,7 +174,7 @@ func New(c *$.RESTClient|raw$) *$.Group$Client {
 	return &$.Group$Client{c}
 }
 `
-var setClientDefaultsTemplate = `
+var setInternalVersionClientDefaultsTemplate = `
 func setConfigDefaults(config *$.Config|raw$) error {
 	// if $.group$ group is not registered, return an error
 	g, err := $.latestGroup|raw$("$.canonicalGroup$")
@@ -185,6 +192,39 @@ func setConfigDefaults(config *$.Config|raw$) error {
 	//}
 
 	config.Codec = $.codecs|raw$.LegacyCodec(*config.GroupVersion)
+	if config.QPS == 0 {
+		config.QPS = 5
+	}
+	if config.Burst == 0 {
+		config.Burst = 10
+	}
+	return nil
+}
+`
+
+var setClientDefaultsTemplate = `
+func setConfigDefaults(config *$.Config|raw$) error {
+	// if $.group$ group is not registered, return an error
+	g, err := $.latestGroup|raw$("$.canonicalGroup$")
+	if err != nil {
+		return err
+	}
+	config.APIPath = $.apiPath$
+	if config.UserAgent == "" {
+		config.UserAgent = $.DefaultKubernetesUserAgent|raw$()
+	}
+	// TODO: Unconditionally set the config.Version, until we fix the config.
+	//if config.Version == "" {
+	copyGroupVersion := g.GroupVersion
+	config.GroupVersion = &copyGroupVersion
+	//}
+
+	codec, ok := $.codecs|raw$.SerializerForFileExtension("json")
+	if !ok {
+		return $.Errorf|raw$("unable to find serializer for JSON")
+	}
+	config.Codec = codec
+
 	if config.QPS == 0 {
 		config.QPS = 5
 	}

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/core_client.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/core_client.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	fmt "fmt"
 	api "k8s.io/kubernetes/pkg/api"
 	registered "k8s.io/kubernetes/pkg/apimachinery/registered"
 	restclient "k8s.io/kubernetes/pkg/client/restclient"
@@ -149,7 +150,12 @@ func setConfigDefaults(config *restclient.Config) error {
 	config.GroupVersion = &copyGroupVersion
 	//}
 
-	config.Codec = api.Codecs.LegacyCodec(*config.GroupVersion)
+	codec, ok := api.Codecs.SerializerForFileExtension("json")
+	if !ok {
+		return fmt.Errorf("unable to find serializer for JSON")
+	}
+	config.Codec = codec
+
 	if config.QPS == 0 {
 		config.QPS = 5
 	}

--- a/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/extensions_client.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/extensions_client.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	fmt "fmt"
 	api "k8s.io/kubernetes/pkg/api"
 	registered "k8s.io/kubernetes/pkg/apimachinery/registered"
 	restclient "k8s.io/kubernetes/pkg/client/restclient"
@@ -114,7 +115,12 @@ func setConfigDefaults(config *restclient.Config) error {
 	config.GroupVersion = &copyGroupVersion
 	//}
 
-	config.Codec = api.Codecs.LegacyCodec(*config.GroupVersion)
+	codec, ok := api.Codecs.SerializerForFileExtension("json")
+	if !ok {
+		return fmt.Errorf("unable to find serializer for JSON")
+	}
+	config.Codec = codec
+
 	if config.QPS == 0 {
 		config.QPS = 5
 	}


### PR DESCRIPTION
For a versioned client, because the output of every client method is a versioned object, so it should use a serializer instead of a codec that does conversion.

@lavalamp @krousey 
