### PR TITLE
fix for test with coverage not working on osx

### DIFF
--- a/hack/run-go-test.sh
+++ b/hack/run-go-test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+PKG=$@
+PKG_OUT=${PKG//\//_}
+set -o pipefail;go test "${goflags[@]:+${goflags[@]}}" \
+  ${KUBE_RACE} \
+  ${KUBE_TIMEOUT} \
+  -cover -covermode="${KUBE_COVERMODE}" \
+  -coverprofile="${cover_report_dir}/${PKG}/${cover_profile}" \
+  "${KUBE_GO_PACKAGE}/${PKG}" \
+  ${testargs[@]:+${testargs[@]}} \
+| tee ${junit_filename_prefix:+"${junit_filename_prefix}-${PKG_OUT}.stdout"} \
+| grep "${go_test_grep_pattern}"

--- a/hack/run-go-test.sh
+++ b/hack/run-go-test.sh
@@ -1,12 +1,36 @@
 #!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This shell script is called by test-go.sh, when running coverage test
+# it accept target paths as input, and it requires the following environment variables:
+# KUBE_GO_PACKAGE, KUBE_RACE, KUBE_TIMEOUT, KUBE_COVERMODE,
+# GOFLAGS, COVER_REPORT_DIR, COVER_PROFILE, TESTARGS,
+# JUNIT_FILENAME_PREFIX, GO_TEST_GREP_PATTERN
+
 PKG=$@
 PKG_OUT=${PKG//\//_}
-set -o pipefail;go test "${goflags[@]:+${goflags[@]}}" \
+set -o pipefail
+set -o nounset
+set -o errexit
+go test "${GOFLAGS[@]:+${GOFLAGS[@]}}" \
   ${KUBE_RACE} \
   ${KUBE_TIMEOUT} \
   -cover -covermode="${KUBE_COVERMODE}" \
-  -coverprofile="${cover_report_dir}/${PKG}/${cover_profile}" \
+  -coverprofile="${COVER_REPORT_DIR}/${PKG}/${COVER_PROFILE}" \
   "${KUBE_GO_PACKAGE}/${PKG}" \
-  ${testargs[@]:+${testargs[@]}} \
-| tee ${junit_filename_prefix:+"${junit_filename_prefix}-${PKG_OUT}.stdout"} \
-| grep "${go_test_grep_pattern}"
+  "${TESTARGS[@]:+${TESTARGS[@]}}" \
+  | tee ${JUNIT_FILENAME_PREFIX:+"${JUNIT_FILENAME_PREFIX}-${PKG_OUT}.stdout"} \
+  | grep "${GO_TEST_GREP_PATTERN}"


### PR DESCRIPTION
This is a fix for #20223.
I tried different solutions and current one is the best from my perspective.
**Root cause**
The defect is caused by the different on xargs on GNU and BSD, in GNU it works fine while on BSD, the -I option has a strict limit that the length of parameter can not be longer than 255.
**Solution**
Option 1: move the bash -c call to different places, this is the current solution. Several changes are included in the patch, and it's pretty tricky.
1) move the bash -c call to a function named run_go_test and moved the function to hack/lib/golang.sh. The reason is test-go.sh can not be sourced, and golang.sh is the best place I can find.
In addition, this change only applies to osx, as the xargs behavior on mac and linux are different.

2) The function call needs parameters, we can not use function parameters to pass them, as it will exceed the limit of 255, which will break xargs, so I export all required parameters instead.

3) I read the code and found the go_test_grep_pattern should be regular expression, but it was not working on both linux and osx, as -p or -e flag is missing. Like you will always get the whole error content on linux no matter if KUBE_JUNIT_REPORT_DIR is set or not.

4) we can not use .\* as default grep pattern on osx, otherwise it will list all content of the current directory.

Option 2: I also tried to re-write the function by avoiding using xargs, but as we need to leverage the multi-core functions, so we have to write our own processes pool to utilize the CPU resources, and it is not a easy job to manage forked process, monitoring the status and return code.  So this option was dropped.

As this is critical logic for testing, so please help to review very carefully to avoid any regression. 
Thanks in advance.

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/24402)

<!-- Reviewable:end -->
