### PR TITLE
kubectl: use platform-agnostic helper in edit

### DIFF
--- a/pkg/kubectl/cmd/edit.go
+++ b/pkg/kubectl/cmd/edit.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
+	"path/filepath"
 	gruntime "runtime"
 	"strings"
 
@@ -227,7 +227,7 @@ outter:
 
 			// launch the editor
 			editedDiff := edited
-			edited, file, err = edit.LaunchTempFile(fmt.Sprintf("%s-edit-", path.Base(os.Args[0])), ext, buf)
+			edited, file, err = edit.LaunchTempFile(fmt.Sprintf("%s-edit-", filepath.Base(os.Args[0])), ext, buf)
 			if err != nil {
 				return preservedFile(err, results.file, errOut)
 			}
@@ -350,7 +350,7 @@ outter:
 			// 3. invalid: retry those on the spot by looping ie. reloading the editor
 			if results.retryable > 0 {
 				fmt.Fprintln(errOut, errorMsg)
-				fmt.Fprintf(errOut, "You can run `%s replace -f %s` to try this update again.\n", path.Base(os.Args[0]), file)
+				fmt.Fprintf(errOut, "You can run `%s replace -f %s` to try this update again.\n", filepath.Base(os.Args[0]), file)
 				continue outter
 			}
 			if results.notfound > 0 {


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/issues/22371 still stands for
Windows clients since path.Base is not platform-agnostic[1].

Use filepath.Base instead[2].

[1] https://golang.org/src/path/path.go?s=4482:4511#L166
[2] https://golang.org/src/path/filepath/path.go?s=12257:12286#L409

cc: @kubernetes/kubectl 
