### PR TITLE
Duplicate the pkg/client/record to handle v1 event

### DIFF
--- a/pkg/api/v1/ref.go
+++ b/pkg/api/v1/ref.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+var (
+	// Errors that could be returned by GetReference.
+	ErrNilObject  = errors.New("can't reference a nil object")
+	ErrNoSelfLink = errors.New("selfLink was empty, can't make reference")
+)
+
+// GetReference returns an ObjectReference which refers to the given
+// object, or an error if the object doesn't follow the conventions
+// that would allow this.
+// TODO: should take a meta.Interface see http://issue.k8s.io/7127
+func GetReference(obj runtime.Object) (*ObjectReference, error) {
+	if obj == nil {
+		return nil, ErrNilObject
+	}
+	if ref, ok := obj.(*ObjectReference); ok {
+		// Don't make a reference to a reference.
+		return ref, nil
+	}
+	meta, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	gvk := obj.GetObjectKind().GroupVersionKind()
+
+	// if the object referenced is actually persisted, we can just get kind from meta
+	// if we are building an object reference to something not yet persisted, we should fallback to scheme
+	var kind string
+	if gvk != nil {
+		kind = gvk.Kind
+	}
+	if len(kind) == 0 {
+		// TODO: this is wrong
+		gvk, err := api.Scheme.ObjectKind(obj)
+		if err != nil {
+			return nil, err
+		}
+		kind = gvk.Kind
+	}
+
+	// if the object referenced is actually persisted, we can also get version from meta
+	var version string
+	if gvk != nil {
+		version = gvk.GroupVersion().String()
+	}
+	if len(version) == 0 {
+		selfLink := meta.GetSelfLink()
+		if len(selfLink) == 0 {
+			return nil, ErrNoSelfLink
+		}
+		selfLinkUrl, err := url.Parse(selfLink)
+		if err != nil {
+			return nil, err
+		}
+		// example paths: /<prefix>/<version>/*
+		parts := strings.Split(selfLinkUrl.Path, "/")
+		if len(parts) < 3 {
+			return nil, fmt.Errorf("unexpected self link format: '%v'; got version '%v'", selfLink, version)
+		}
+		version = parts[2]
+	}
+
+	return &ObjectReference{
+		Kind:            kind,
+		APIVersion:      version,
+		Name:            meta.GetName(),
+		Namespace:       meta.GetNamespace(),
+		UID:             meta.GetUID(),
+		ResourceVersion: meta.GetResourceVersion(),
+	}, nil
+}
+
+// GetPartialReference is exactly like GetReference, but allows you to set the FieldPath.
+func GetPartialReference(obj runtime.Object, fieldPath string) (*ObjectReference, error) {
+	ref, err := GetReference(obj)
+	if err != nil {
+		return nil, err
+	}
+	ref.FieldPath = fieldPath
+	return ref, nil
+}
+
+// IsAnAPIObject allows clients to preemptively get a reference to an API object and pass it to places that
+// intend only to get a reference to that object. This simplifies the event recording interface.
+func (obj *ObjectReference) SetGroupVersionKind(gvk *unversioned.GroupVersionKind) {
+	obj.APIVersion, obj.Kind = gvk.ToAPIVersionAndKind()
+}
+func (obj *ObjectReference) GroupVersionKind() *unversioned.GroupVersionKind {
+	return unversioned.FromAPIVersionAndKind(obj.APIVersion, obj.Kind)
+}

--- a/pkg/api/v1/ref_test.go
+++ b/pkg/api/v1/ref_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+type FakeAPIObject struct{}
+
+func (obj *FakeAPIObject) GetObjectKind() unversioned.ObjectKind { return unversioned.EmptyObjectKind }
+
+type ExtensionAPIObject struct {
+	unversioned.TypeMeta
+	ObjectMeta
+}
+
+func (obj *ExtensionAPIObject) GetObjectKind() unversioned.ObjectKind { return &obj.TypeMeta }
+
+func TestGetReference(t *testing.T) {
+
+	// when vendoring kube, if you don't force the set of registered versions (like this hack/test-go.sh does)
+	// then you run into trouble because the types aren't registered in the scheme by anything.  This does the
+	// register manually to allow unit test execution
+	if _, err := api.Scheme.ObjectKind(&Pod{}); err != nil {
+		AddToScheme(api.Scheme)
+	}
+
+	table := map[string]struct {
+		obj       runtime.Object
+		ref       *ObjectReference
+		fieldPath string
+		shouldErr bool
+	}{
+		"pod": {
+			obj: &Pod{
+				ObjectMeta: ObjectMeta{
+					Name:            "foo",
+					UID:             "bar",
+					ResourceVersion: "42",
+					SelfLink:        "/api/version1/pods/foo",
+				},
+			},
+			fieldPath: ".desiredState.containers[0]",
+			ref: &ObjectReference{
+				Kind:            "Pod",
+				APIVersion:      "version1",
+				Name:            "foo",
+				UID:             "bar",
+				ResourceVersion: "42",
+				FieldPath:       ".desiredState.containers[0]",
+			},
+		},
+		"serviceList": {
+			obj: &ServiceList{
+				ListMeta: unversioned.ListMeta{
+					ResourceVersion: "42",
+					SelfLink:        "/api/version2/services",
+				},
+			},
+			ref: &ObjectReference{
+				Kind:            "ServiceList",
+				APIVersion:      "version2",
+				ResourceVersion: "42",
+			},
+		},
+		"extensionAPIObject": {
+			obj: &ExtensionAPIObject{
+				TypeMeta: unversioned.TypeMeta{
+					Kind: "ExtensionAPIObject",
+				},
+				ObjectMeta: ObjectMeta{
+					Name:            "foo",
+					UID:             "bar",
+					ResourceVersion: "42",
+					SelfLink:        "/custom_prefix/version1/extensions/foo",
+				},
+			},
+			ref: &ObjectReference{
+				Kind:            "ExtensionAPIObject",
+				APIVersion:      "version1",
+				Name:            "foo",
+				UID:             "bar",
+				ResourceVersion: "42",
+			},
+		},
+		"badSelfLink": {
+			obj: &ServiceList{
+				ListMeta: unversioned.ListMeta{
+					ResourceVersion: "42",
+					SelfLink:        "version2/services",
+				},
+			},
+			shouldErr: true,
+		},
+		"error": {
+			obj:       &FakeAPIObject{},
+			ref:       nil,
+			shouldErr: true,
+		},
+		"errorNil": {
+			obj:       nil,
+			ref:       nil,
+			shouldErr: true,
+		},
+	}
+
+	for name, item := range table {
+		ref, err := GetPartialReference(item.obj, item.fieldPath)
+		if e, a := item.shouldErr, (err != nil); e != a {
+			t.Errorf("%v: expected %v, got %v, err %v", name, e, a, err)
+			continue
+		}
+		if e, a := item.ref, ref; !reflect.DeepEqual(e, a) {
+			t.Errorf("%v: expected %#v, got %#v", name, e, a)
+		}
+	}
+}

--- a/pkg/api/v1/register.go
+++ b/pkg/api/v1/register.go
@@ -139,3 +139,4 @@ func (obj *RangeAllocation) GetObjectKind() unversioned.ObjectKind           { r
 func (obj *ExportOptions) GetObjectKind() unversioned.ObjectKind             { return &obj.TypeMeta }
 func (obj *ConfigMap) GetObjectKind() unversioned.ObjectKind                 { return &obj.TypeMeta }
 func (obj *ConfigMapList) GetObjectKind() unversioned.ObjectKind             { return &obj.TypeMeta }
+func (obj *ObjectReference) GetObjectKind() unversioned.ObjectKind           { return obj }

--- a/pkg/client/record/v1/doc.go
+++ b/pkg/client/record/v1/doc.go
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package record has all client logic for recording and reporting events.
+// Package v1 has all client logic for recording and reporting events.
 
-// This package is a temporary duplication of the record/v1 package, the only
-// difference is that this package operates on the unversioned Event. We will
-// remove this package when we convert components to use a versioned client set.
-package record
+// Packaage record is a temporary duplication of this package, the only
+// difference is that the record package operates on the unversioned Event. We
+// will remove the record package when we convert components to use a versioned
+// client set.
+package v1

--- a/pkg/client/record/v1/event.go
+++ b/pkg/client/record/v1/event.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
@@ -293,14 +294,14 @@ func (recorder *recorderImpl) PastEventf(object runtime.Object, timestamp unvers
 	recorder.generateEvent(object, timestamp, eventtype, reason, fmt.Sprintf(messageFmt, args...))
 }
 
-func (recorder *recorderImpl) makeEvent(ref *api.ObjectReference, eventtype, reason, message string) *v1.Event {
+func (recorder *recorderImpl) makeEvent(ref *v1.ObjectReference, eventtype, reason, message string) *v1.Event {
 	t := unversioned.Time{Time: recorder.clock.Now()}
 	namespace := ref.Namespace
 	if namespace == "" {
 		namespace = api.NamespaceDefault
 	}
 	return &v1.Event{
-		ObjectMeta: api.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      fmt.Sprintf("%v.%x", ref.Name, t.UnixNano()),
 			Namespace: namespace,
 		},

--- a/pkg/client/record/v1/event.go
+++ b/pkg/client/record/v1/event.go
@@ -19,6 +19,7 @@ package v1
 import (
 	"fmt"
 	"math/rand"
+	"runtime/debug"
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
@@ -256,6 +257,7 @@ func (recorder *recorderImpl) generateEvent(object runtime.Object, timestamp unv
 	ref, err := v1.GetReference(object)
 	if err != nil {
 		glog.Errorf("Could not construct reference to: '%#v' due to: '%v'. Will not report event: '%v' '%v' '%v'", object, err, eventtype, reason, message)
+		debug.PrintStack()
 		return
 	}
 

--- a/pkg/client/record/v1/event.go
+++ b/pkg/client/record/v1/event.go
@@ -1,0 +1,315 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util"
+	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
+	"k8s.io/kubernetes/pkg/watch"
+
+	"github.com/golang/glog"
+)
+
+const maxTriesPerEvent = 12
+
+var defaultSleepDuration = 10 * time.Second
+
+const maxQueuedEvents = 1000
+
+// EventSink knows how to store events (client.Client implements it.)
+// EventSink must respect the namespace that will be embedded in 'event'.
+// It is assumed that EventSink will return the same sorts of errors as
+// pkg/client's REST client.
+type EventSink interface {
+	Create(event *api.Event) (*api.Event, error)
+	Update(event *api.Event) (*api.Event, error)
+	Patch(oldEvent *api.Event, data []byte) (*api.Event, error)
+}
+
+// EventRecorder knows how to record events on behalf of an EventSource.
+type EventRecorder interface {
+	// Event constructs an event from the given information and puts it in the queue for sending.
+	// 'object' is the object this event is about. Event will make a reference-- or you may also
+	// pass a reference to the object directly.
+	// 'type' of this event, and can be one of Normal, Warning. New types could be added in future
+	// 'reason' is the reason this event is generated. 'reason' should be short and unique; it
+	// should be in UpperCamelCase format (starting with a capital letter). "reason" will be used
+	// to automate handling of events, so imagine people writing switch statements to handle them.
+	// You want to make that easy.
+	// 'message' is intended to be human readable.
+	//
+	// The resulting event will be created in the same namespace as the reference object.
+	Event(object runtime.Object, eventtype, reason, message string)
+
+	// Eventf is just like Event, but with Sprintf for the message field.
+	Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{})
+
+	// PastEventf is just like Eventf, but with an option to specify the event's 'timestamp' field.
+	PastEventf(object runtime.Object, timestamp unversioned.Time, eventtype, reason, messageFmt string, args ...interface{})
+}
+
+// EventBroadcaster knows how to receive events and send them to any EventSink, watcher, or log.
+type EventBroadcaster interface {
+	// StartEventWatcher starts sending events received from this EventBroadcaster to the given
+	// event handler function. The return value can be ignored or used to stop recording, if
+	// desired.
+	StartEventWatcher(eventHandler func(*api.Event)) watch.Interface
+
+	// StartRecordingToSink starts sending events received from this EventBroadcaster to the given
+	// sink. The return value can be ignored or used to stop recording, if desired.
+	StartRecordingToSink(sink EventSink) watch.Interface
+
+	// StartLogging starts sending events received from this EventBroadcaster to the given logging
+	// function. The return value can be ignored or used to stop recording, if desired.
+	StartLogging(logf func(format string, args ...interface{})) watch.Interface
+
+	// NewRecorder returns an EventRecorder that can be used to send events to this EventBroadcaster
+	// with the event source set to the given event source.
+	NewRecorder(source api.EventSource) EventRecorder
+}
+
+// Creates a new event broadcaster.
+func NewBroadcaster() EventBroadcaster {
+	return &eventBroadcasterImpl{watch.NewBroadcaster(maxQueuedEvents, watch.DropIfChannelFull), defaultSleepDuration}
+}
+
+func NewBroadcasterForTests(sleepDuration time.Duration) EventBroadcaster {
+	return &eventBroadcasterImpl{watch.NewBroadcaster(maxQueuedEvents, watch.DropIfChannelFull), sleepDuration}
+}
+
+type eventBroadcasterImpl struct {
+	*watch.Broadcaster
+	sleepDuration time.Duration
+}
+
+// StartRecordingToSink starts sending events received from the specified eventBroadcaster to the given sink.
+// The return value can be ignored or used to stop recording, if desired.
+// TODO: make me an object with parameterizable queue length and retry interval
+func (eventBroadcaster *eventBroadcasterImpl) StartRecordingToSink(sink EventSink) watch.Interface {
+	// The default math/rand package functions aren't thread safe, so create a
+	// new Rand object for each StartRecording call.
+	randGen := rand.New(rand.NewSource(time.Now().UnixNano()))
+	eventCorrelator := NewEventCorrelator(util.RealClock{})
+	return eventBroadcaster.StartEventWatcher(
+		func(event *api.Event) {
+			recordToSink(sink, event, eventCorrelator, randGen, eventBroadcaster.sleepDuration)
+		})
+}
+
+func recordToSink(sink EventSink, event *api.Event, eventCorrelator *EventCorrelator, randGen *rand.Rand, sleepDuration time.Duration) {
+	// Make a copy before modification, because there could be multiple listeners.
+	// Events are safe to copy like this.
+	eventCopy := *event
+	event = &eventCopy
+	result, err := eventCorrelator.EventCorrelate(event)
+	if err != nil {
+		utilruntime.HandleError(err)
+	}
+	if result.Skip {
+		return
+	}
+	tries := 0
+	for {
+		if recordEvent(sink, result.Event, result.Patch, result.Event.Count > 1, eventCorrelator) {
+			break
+		}
+		tries++
+		if tries >= maxTriesPerEvent {
+			glog.Errorf("Unable to write event '%#v' (retry limit exceeded!)", event)
+			break
+		}
+		// Randomize the first sleep so that various clients won't all be
+		// synced up if the master goes down.
+		if tries == 1 {
+			time.Sleep(time.Duration(float64(sleepDuration) * randGen.Float64()))
+		} else {
+			time.Sleep(sleepDuration)
+		}
+	}
+}
+
+func isKeyNotFoundError(err error) bool {
+	statusErr, _ := err.(*errors.StatusError)
+	// At the moment the server is returning 500 instead of a more specific
+	// error. When changing this remember that it should be backward compatible
+	// with old api servers that may be still returning 500.
+	if statusErr != nil && statusErr.Status().Code == 500 {
+		return true
+	}
+	return false
+}
+
+// recordEvent attempts to write event to a sink. It returns true if the event
+// was successfully recorded or discarded, false if it should be retried.
+// If updateExistingEvent is false, it creates a new event, otherwise it updates
+// existing event.
+func recordEvent(sink EventSink, event *api.Event, patch []byte, updateExistingEvent bool, eventCorrelator *EventCorrelator) bool {
+	var newEvent *api.Event
+	var err error
+	if updateExistingEvent {
+		newEvent, err = sink.Patch(event, patch)
+	}
+	// Update can fail because the event may have been removed and it no longer exists.
+	if !updateExistingEvent || (updateExistingEvent && isKeyNotFoundError(err)) {
+		// Making sure that ResourceVersion is empty on creation
+		event.ResourceVersion = ""
+		newEvent, err = sink.Create(event)
+	}
+	if err == nil {
+		// we need to update our event correlator with the server returned state to handle name/resourceversion
+		eventCorrelator.UpdateState(newEvent)
+		return true
+	}
+
+	// If we can't contact the server, then hold everything while we keep trying.
+	// Otherwise, something about the event is malformed and we should abandon it.
+	switch err.(type) {
+	case *restclient.RequestConstructionError:
+		// We will construct the request the same next time, so don't keep trying.
+		glog.Errorf("Unable to construct event '%#v': '%v' (will not retry!)", event, err)
+		return true
+	case *errors.StatusError:
+		if errors.IsAlreadyExists(err) {
+			glog.V(5).Infof("Server rejected event '%#v': '%v' (will not retry!)", event, err)
+		} else {
+			glog.Errorf("Server rejected event '%#v': '%v' (will not retry!)", event, err)
+		}
+		return true
+	case *errors.UnexpectedObjectError:
+		// We don't expect this; it implies the server's response didn't match a
+		// known pattern. Go ahead and retry.
+	default:
+		// This case includes actual http transport errors. Go ahead and retry.
+	}
+	glog.Errorf("Unable to write event: '%v' (may retry after sleeping)", err)
+	return false
+}
+
+// StartLogging starts sending events received from this EventBroadcaster to the given logging function.
+// The return value can be ignored or used to stop recording, if desired.
+func (eventBroadcaster *eventBroadcasterImpl) StartLogging(logf func(format string, args ...interface{})) watch.Interface {
+	return eventBroadcaster.StartEventWatcher(
+		func(e *api.Event) {
+			logf("Event(%#v): type: '%v' reason: '%v' %v", e.InvolvedObject, e.Type, e.Reason, e.Message)
+		})
+}
+
+// StartEventWatcher starts sending events received from this EventBroadcaster to the given event handler function.
+// The return value can be ignored or used to stop recording, if desired.
+func (eventBroadcaster *eventBroadcasterImpl) StartEventWatcher(eventHandler func(*api.Event)) watch.Interface {
+	watcher := eventBroadcaster.Watch()
+	go func() {
+		defer utilruntime.HandleCrash()
+		for {
+			watchEvent, open := <-watcher.ResultChan()
+			if !open {
+				return
+			}
+			event, ok := watchEvent.Object.(*api.Event)
+			if !ok {
+				// This is all local, so there's no reason this should
+				// ever happen.
+				continue
+			}
+			eventHandler(event)
+		}
+	}()
+	return watcher
+}
+
+// NewRecorder returns an EventRecorder that records events with the given event source.
+func (eventBroadcaster *eventBroadcasterImpl) NewRecorder(source api.EventSource) EventRecorder {
+	return &recorderImpl{source, eventBroadcaster.Broadcaster, util.RealClock{}}
+}
+
+type recorderImpl struct {
+	source api.EventSource
+	*watch.Broadcaster
+	clock util.Clock
+}
+
+func (recorder *recorderImpl) generateEvent(object runtime.Object, timestamp unversioned.Time, eventtype, reason, message string) {
+	ref, err := api.GetReference(object)
+	if err != nil {
+		glog.Errorf("Could not construct reference to: '%#v' due to: '%v'. Will not report event: '%v' '%v' '%v'", object, err, eventtype, reason, message)
+		return
+	}
+
+	if !validateEventType(eventtype) {
+		glog.Errorf("Unsupported event type: '%v'", eventtype)
+		return
+	}
+
+	event := recorder.makeEvent(ref, eventtype, reason, message)
+	event.Source = recorder.source
+
+	go func() {
+		// NOTE: events should be a non-blocking operation
+		defer utilruntime.HandleCrash()
+		recorder.Action(watch.Added, event)
+	}()
+}
+
+func validateEventType(eventtype string) bool {
+	switch eventtype {
+	case api.EventTypeNormal, api.EventTypeWarning:
+		return true
+	}
+	return false
+}
+
+func (recorder *recorderImpl) Event(object runtime.Object, eventtype, reason, message string) {
+	recorder.generateEvent(object, unversioned.Now(), eventtype, reason, message)
+}
+
+func (recorder *recorderImpl) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+	recorder.Event(object, eventtype, reason, fmt.Sprintf(messageFmt, args...))
+}
+
+func (recorder *recorderImpl) PastEventf(object runtime.Object, timestamp unversioned.Time, eventtype, reason, messageFmt string, args ...interface{}) {
+	recorder.generateEvent(object, timestamp, eventtype, reason, fmt.Sprintf(messageFmt, args...))
+}
+
+func (recorder *recorderImpl) makeEvent(ref *api.ObjectReference, eventtype, reason, message string) *api.Event {
+	t := unversioned.Time{Time: recorder.clock.Now()}
+	namespace := ref.Namespace
+	if namespace == "" {
+		namespace = api.NamespaceDefault
+	}
+	return &api.Event{
+		ObjectMeta: api.ObjectMeta{
+			Name:      fmt.Sprintf("%v.%x", ref.Name, t.UnixNano()),
+			Namespace: namespace,
+		},
+		InvolvedObject: *ref,
+		Reason:         reason,
+		Message:        message,
+		FirstTimestamp: t,
+		LastTimestamp:  t,
+		Count:          1,
+		Type:           eventtype,
+	}
+}

--- a/pkg/client/record/v1/event.go
+++ b/pkg/client/record/v1/event.go
@@ -253,7 +253,7 @@ type recorderImpl struct {
 }
 
 func (recorder *recorderImpl) generateEvent(object runtime.Object, timestamp unversioned.Time, eventtype, reason, message string) {
-	ref, err := api.GetReference(object)
+	ref, err := v1.GetReference(object)
 	if err != nil {
 		glog.Errorf("Could not construct reference to: '%#v' due to: '%v'. Will not report event: '%v' '%v' '%v'", object, err, eventtype, reason, message)
 		return

--- a/pkg/client/record/v1/event_test.go
+++ b/pkg/client/record/v1/event_test.go
@@ -24,9 +24,10 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
 	_ "k8s.io/kubernetes/pkg/api/install" // To register api.Pod used in tests below
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	k8sruntime "k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
@@ -116,8 +117,8 @@ func TestEventf(t *testing.T) {
 			UID:       "differentUid",
 		},
 	}
-	testRef, err := api.GetPartialReference(testPod, "spec.containers[2]")
-	testRef2, err := api.GetPartialReference(testPod2, "spec.containers[3]")
+	testRef, err := v1.GetPartialReference(testPod, "spec.containers[2]")
+	testRef2, err := v1.GetPartialReference(testPod2, "spec.containers[3]")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -138,11 +139,11 @@ func TestEventf(t *testing.T) {
 			messageFmt: "some verbose message: %v",
 			elements:   []interface{}{1},
 			expect: &v1.Event{
-				ObjectMeta: api.ObjectMeta{
+				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "baz",
 				},
-				InvolvedObject: api.ObjectReference{
+				InvolvedObject: v1.ObjectReference{
 					Kind:       "Pod",
 					Name:       "foo",
 					Namespace:  "baz",
@@ -156,7 +157,7 @@ func TestEventf(t *testing.T) {
 				Count:   1,
 				Type:    v1.EventTypeNormal,
 			},
-			expectLog:    `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"bar", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[2]"}): type: 'Normal' reason: 'Started' some verbose message: 1`,
+			expectLog:    `Event(v1.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"bar", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[2]"}): type: 'Normal' reason: 'Started' some verbose message: 1`,
 			expectUpdate: false,
 		},
 		{
@@ -166,11 +167,11 @@ func TestEventf(t *testing.T) {
 			messageFmt: "some other verbose message: %v",
 			elements:   []interface{}{1},
 			expect: &v1.Event{
-				ObjectMeta: api.ObjectMeta{
+				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "baz",
 				},
-				InvolvedObject: api.ObjectReference{
+				InvolvedObject: v1.ObjectReference{
 					Kind:       "Pod",
 					Name:       "foo",
 					Namespace:  "baz",
@@ -183,7 +184,7 @@ func TestEventf(t *testing.T) {
 				Count:   1,
 				Type:    v1.EventTypeNormal,
 			},
-			expectLog:    `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"bar", APIVersion:"version", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'Killed' some other verbose message: 1`,
+			expectLog:    `Event(v1.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"bar", APIVersion:"version", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'Killed' some other verbose message: 1`,
 			expectUpdate: false,
 		},
 		{
@@ -193,11 +194,11 @@ func TestEventf(t *testing.T) {
 			messageFmt: "some verbose message: %v",
 			elements:   []interface{}{1},
 			expect: &v1.Event{
-				ObjectMeta: api.ObjectMeta{
+				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "baz",
 				},
-				InvolvedObject: api.ObjectReference{
+				InvolvedObject: v1.ObjectReference{
 					Kind:       "Pod",
 					Name:       "foo",
 					Namespace:  "baz",
@@ -211,7 +212,7 @@ func TestEventf(t *testing.T) {
 				Count:   2,
 				Type:    v1.EventTypeNormal,
 			},
-			expectLog:    `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"bar", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[2]"}): type: 'Normal' reason: 'Started' some verbose message: 1`,
+			expectLog:    `Event(v1.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"bar", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[2]"}): type: 'Normal' reason: 'Started' some verbose message: 1`,
 			expectUpdate: true,
 		},
 		{
@@ -221,11 +222,11 @@ func TestEventf(t *testing.T) {
 			messageFmt: "some verbose message: %v",
 			elements:   []interface{}{1},
 			expect: &v1.Event{
-				ObjectMeta: api.ObjectMeta{
+				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "baz",
 				},
-				InvolvedObject: api.ObjectReference{
+				InvolvedObject: v1.ObjectReference{
 					Kind:       "Pod",
 					Name:       "foo",
 					Namespace:  "baz",
@@ -239,7 +240,7 @@ func TestEventf(t *testing.T) {
 				Count:   1,
 				Type:    v1.EventTypeNormal,
 			},
-			expectLog:    `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"differentUid", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[3]"}): type: 'Normal' reason: 'Started' some verbose message: 1`,
+			expectLog:    `Event(v1.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"differentUid", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[3]"}): type: 'Normal' reason: 'Started' some verbose message: 1`,
 			expectUpdate: false,
 		},
 		{
@@ -249,11 +250,11 @@ func TestEventf(t *testing.T) {
 			messageFmt: "some verbose message: %v",
 			elements:   []interface{}{1},
 			expect: &v1.Event{
-				ObjectMeta: api.ObjectMeta{
+				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "baz",
 				},
-				InvolvedObject: api.ObjectReference{
+				InvolvedObject: v1.ObjectReference{
 					Kind:       "Pod",
 					Name:       "foo",
 					Namespace:  "baz",
@@ -267,7 +268,7 @@ func TestEventf(t *testing.T) {
 				Count:   3,
 				Type:    v1.EventTypeNormal,
 			},
-			expectLog:    `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"bar", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[2]"}): type: 'Normal' reason: 'Started' some verbose message: 1`,
+			expectLog:    `Event(v1.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"bar", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[2]"}): type: 'Normal' reason: 'Started' some verbose message: 1`,
 			expectUpdate: true,
 		},
 		{
@@ -277,11 +278,11 @@ func TestEventf(t *testing.T) {
 			messageFmt: "some verbose message: %v",
 			elements:   []interface{}{1},
 			expect: &v1.Event{
-				ObjectMeta: api.ObjectMeta{
+				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "baz",
 				},
-				InvolvedObject: api.ObjectReference{
+				InvolvedObject: v1.ObjectReference{
 					Kind:       "Pod",
 					Name:       "foo",
 					Namespace:  "baz",
@@ -295,7 +296,7 @@ func TestEventf(t *testing.T) {
 				Count:   1,
 				Type:    v1.EventTypeNormal,
 			},
-			expectLog:    `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"differentUid", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[3]"}): type: 'Normal' reason: 'Stopped' some verbose message: 1`,
+			expectLog:    `Event(v1.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"differentUid", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[3]"}): type: 'Normal' reason: 'Stopped' some verbose message: 1`,
 			expectUpdate: false,
 		},
 		{
@@ -305,11 +306,11 @@ func TestEventf(t *testing.T) {
 			messageFmt: "some verbose message: %v",
 			elements:   []interface{}{1},
 			expect: &v1.Event{
-				ObjectMeta: api.ObjectMeta{
+				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "baz",
 				},
-				InvolvedObject: api.ObjectReference{
+				InvolvedObject: v1.ObjectReference{
 					Kind:       "Pod",
 					Name:       "foo",
 					Namespace:  "baz",
@@ -323,7 +324,7 @@ func TestEventf(t *testing.T) {
 				Count:   2,
 				Type:    v1.EventTypeNormal,
 			},
-			expectLog:    `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"differentUid", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[3]"}): type: 'Normal' reason: 'Stopped' some verbose message: 1`,
+			expectLog:    `Event(v1.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"differentUid", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[3]"}): type: 'Normal' reason: 'Stopped' some verbose message: 1`,
 			expectUpdate: true,
 		},
 	}
@@ -465,7 +466,7 @@ func TestLotsOfEvents(t *testing.T) {
 		loggerCalled <- struct{}{}
 	})
 	recorder := eventBroadcaster.NewRecorder(v1.EventSource{Component: "eventTest"})
-	ref := &api.ObjectReference{
+	ref := &v1.ObjectReference{
 		Kind:       "Pod",
 		Name:       "foo",
 		Namespace:  "baz",
@@ -499,7 +500,7 @@ func TestEventfNoNamespace(t *testing.T) {
 			UID:      "bar",
 		},
 	}
-	testRef, err := api.GetPartialReference(testPod, "spec.containers[2]")
+	testRef, err := v1.GetPartialReference(testPod, "spec.containers[2]")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -520,11 +521,11 @@ func TestEventfNoNamespace(t *testing.T) {
 			messageFmt: "some verbose message: %v",
 			elements:   []interface{}{1},
 			expect: &v1.Event{
-				ObjectMeta: api.ObjectMeta{
+				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "default",
 				},
-				InvolvedObject: api.ObjectReference{
+				InvolvedObject: v1.ObjectReference{
 					Kind:       "Pod",
 					Name:       "foo",
 					Namespace:  "",
@@ -538,7 +539,7 @@ func TestEventfNoNamespace(t *testing.T) {
 				Count:   1,
 				Type:    v1.EventTypeNormal,
 			},
-			expectLog:    `Event(api.ObjectReference{Kind:"Pod", Namespace:"", Name:"foo", UID:"bar", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[2]"}): type: 'Normal' reason: 'Started' some verbose message: 1`,
+			expectLog:    `Event(v1.ObjectReference{Kind:"Pod", Namespace:"", Name:"foo", UID:"bar", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[2]"}): type: 'Normal' reason: 'Started' some verbose message: 1`,
 			expectUpdate: false,
 		},
 	}
@@ -611,8 +612,8 @@ func TestMultiSinkCache(t *testing.T) {
 			UID:       "differentUid",
 		},
 	}
-	testRef, err := api.GetPartialReference(testPod, "spec.containers[2]")
-	testRef2, err := api.GetPartialReference(testPod2, "spec.containers[3]")
+	testRef, err := v1.GetPartialReference(testPod, "spec.containers[2]")
+	testRef2, err := v1.GetPartialReference(testPod2, "spec.containers[3]")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -633,11 +634,11 @@ func TestMultiSinkCache(t *testing.T) {
 			messageFmt: "some verbose message: %v",
 			elements:   []interface{}{1},
 			expect: &v1.Event{
-				ObjectMeta: api.ObjectMeta{
+				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "baz",
 				},
-				InvolvedObject: api.ObjectReference{
+				InvolvedObject: v1.ObjectReference{
 					Kind:       "Pod",
 					Name:       "foo",
 					Namespace:  "baz",
@@ -651,7 +652,7 @@ func TestMultiSinkCache(t *testing.T) {
 				Count:   1,
 				Type:    v1.EventTypeNormal,
 			},
-			expectLog:    `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"bar", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[2]"}): type: 'Normal' reason: 'Started' some verbose message: 1`,
+			expectLog:    `Event(v1.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"bar", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[2]"}): type: 'Normal' reason: 'Started' some verbose message: 1`,
 			expectUpdate: false,
 		},
 		{
@@ -661,11 +662,11 @@ func TestMultiSinkCache(t *testing.T) {
 			messageFmt: "some other verbose message: %v",
 			elements:   []interface{}{1},
 			expect: &v1.Event{
-				ObjectMeta: api.ObjectMeta{
+				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "baz",
 				},
-				InvolvedObject: api.ObjectReference{
+				InvolvedObject: v1.ObjectReference{
 					Kind:       "Pod",
 					Name:       "foo",
 					Namespace:  "baz",
@@ -678,7 +679,7 @@ func TestMultiSinkCache(t *testing.T) {
 				Count:   1,
 				Type:    v1.EventTypeNormal,
 			},
-			expectLog:    `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"bar", APIVersion:"version", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'Killed' some other verbose message: 1`,
+			expectLog:    `Event(v1.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"bar", APIVersion:"version", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'Killed' some other verbose message: 1`,
 			expectUpdate: false,
 		},
 		{
@@ -688,11 +689,11 @@ func TestMultiSinkCache(t *testing.T) {
 			messageFmt: "some verbose message: %v",
 			elements:   []interface{}{1},
 			expect: &v1.Event{
-				ObjectMeta: api.ObjectMeta{
+				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "baz",
 				},
-				InvolvedObject: api.ObjectReference{
+				InvolvedObject: v1.ObjectReference{
 					Kind:       "Pod",
 					Name:       "foo",
 					Namespace:  "baz",
@@ -706,7 +707,7 @@ func TestMultiSinkCache(t *testing.T) {
 				Count:   2,
 				Type:    v1.EventTypeNormal,
 			},
-			expectLog:    `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"bar", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[2]"}): type: 'Normal' reason: 'Started' some verbose message: 1`,
+			expectLog:    `Event(v1.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"bar", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[2]"}): type: 'Normal' reason: 'Started' some verbose message: 1`,
 			expectUpdate: true,
 		},
 		{
@@ -716,11 +717,11 @@ func TestMultiSinkCache(t *testing.T) {
 			messageFmt: "some verbose message: %v",
 			elements:   []interface{}{1},
 			expect: &v1.Event{
-				ObjectMeta: api.ObjectMeta{
+				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "baz",
 				},
-				InvolvedObject: api.ObjectReference{
+				InvolvedObject: v1.ObjectReference{
 					Kind:       "Pod",
 					Name:       "foo",
 					Namespace:  "baz",
@@ -734,7 +735,7 @@ func TestMultiSinkCache(t *testing.T) {
 				Count:   1,
 				Type:    v1.EventTypeNormal,
 			},
-			expectLog:    `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"differentUid", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[3]"}): type: 'Normal' reason: 'Started' some verbose message: 1`,
+			expectLog:    `Event(v1.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"differentUid", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[3]"}): type: 'Normal' reason: 'Started' some verbose message: 1`,
 			expectUpdate: false,
 		},
 		{
@@ -744,11 +745,11 @@ func TestMultiSinkCache(t *testing.T) {
 			messageFmt: "some verbose message: %v",
 			elements:   []interface{}{1},
 			expect: &v1.Event{
-				ObjectMeta: api.ObjectMeta{
+				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "baz",
 				},
-				InvolvedObject: api.ObjectReference{
+				InvolvedObject: v1.ObjectReference{
 					Kind:       "Pod",
 					Name:       "foo",
 					Namespace:  "baz",
@@ -762,7 +763,7 @@ func TestMultiSinkCache(t *testing.T) {
 				Count:   3,
 				Type:    v1.EventTypeNormal,
 			},
-			expectLog:    `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"bar", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[2]"}): type: 'Normal' reason: 'Started' some verbose message: 1`,
+			expectLog:    `Event(v1.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"bar", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[2]"}): type: 'Normal' reason: 'Started' some verbose message: 1`,
 			expectUpdate: true,
 		},
 		{
@@ -772,11 +773,11 @@ func TestMultiSinkCache(t *testing.T) {
 			messageFmt: "some verbose message: %v",
 			elements:   []interface{}{1},
 			expect: &v1.Event{
-				ObjectMeta: api.ObjectMeta{
+				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "baz",
 				},
-				InvolvedObject: api.ObjectReference{
+				InvolvedObject: v1.ObjectReference{
 					Kind:       "Pod",
 					Name:       "foo",
 					Namespace:  "baz",
@@ -790,7 +791,7 @@ func TestMultiSinkCache(t *testing.T) {
 				Count:   1,
 				Type:    v1.EventTypeNormal,
 			},
-			expectLog:    `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"differentUid", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[3]"}): type: 'Normal' reason: 'Stopped' some verbose message: 1`,
+			expectLog:    `Event(v1.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"differentUid", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[3]"}): type: 'Normal' reason: 'Stopped' some verbose message: 1`,
 			expectUpdate: false,
 		},
 		{
@@ -800,11 +801,11 @@ func TestMultiSinkCache(t *testing.T) {
 			messageFmt: "some verbose message: %v",
 			elements:   []interface{}{1},
 			expect: &v1.Event{
-				ObjectMeta: api.ObjectMeta{
+				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "baz",
 				},
-				InvolvedObject: api.ObjectReference{
+				InvolvedObject: v1.ObjectReference{
 					Kind:       "Pod",
 					Name:       "foo",
 					Namespace:  "baz",
@@ -818,7 +819,7 @@ func TestMultiSinkCache(t *testing.T) {
 				Count:   2,
 				Type:    v1.EventTypeNormal,
 			},
-			expectLog:    `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"differentUid", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[3]"}): type: 'Normal' reason: 'Stopped' some verbose message: 1`,
+			expectLog:    `Event(v1.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"differentUid", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[3]"}): type: 'Normal' reason: 'Stopped' some verbose message: 1`,
 			expectUpdate: true,
 		},
 	}

--- a/pkg/client/record/v1/event_test.go
+++ b/pkg/client/record/v1/event_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/api/errors"
 	_ "k8s.io/kubernetes/pkg/api/install" // To register api.Pod used in tests below
 	"k8s.io/kubernetes/pkg/client/restclient"

--- a/pkg/client/record/v1/event_test.go
+++ b/pkg/client/record/v1/event_test.go
@@ -1,0 +1,889 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"strconv"
+	"testing"
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/errors"
+	_ "k8s.io/kubernetes/pkg/api/install" // To register api.Pod used in tests below
+	"k8s.io/kubernetes/pkg/client/restclient"
+	k8sruntime "k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/strategicpatch"
+)
+
+type testEventSink struct {
+	OnCreate func(e *api.Event) (*api.Event, error)
+	OnUpdate func(e *api.Event) (*api.Event, error)
+	OnPatch  func(e *api.Event, p []byte) (*api.Event, error)
+}
+
+// CreateEvent records the event for testing.
+func (t *testEventSink) Create(e *api.Event) (*api.Event, error) {
+	if t.OnCreate != nil {
+		return t.OnCreate(e)
+	}
+	return e, nil
+}
+
+// UpdateEvent records the event for testing.
+func (t *testEventSink) Update(e *api.Event) (*api.Event, error) {
+	if t.OnUpdate != nil {
+		return t.OnUpdate(e)
+	}
+	return e, nil
+}
+
+// PatchEvent records the event for testing.
+func (t *testEventSink) Patch(e *api.Event, p []byte) (*api.Event, error) {
+	if t.OnPatch != nil {
+		return t.OnPatch(e, p)
+	}
+	return e, nil
+}
+
+type OnCreateFunc func(*api.Event) (*api.Event, error)
+
+func OnCreateFactory(testCache map[string]*api.Event, createEvent chan<- *api.Event) OnCreateFunc {
+	return func(event *api.Event) (*api.Event, error) {
+		testCache[getEventKey(event)] = event
+		createEvent <- event
+		return event, nil
+	}
+}
+
+type OnPatchFunc func(*api.Event, []byte) (*api.Event, error)
+
+func OnPatchFactory(testCache map[string]*api.Event, patchEvent chan<- *api.Event) OnPatchFunc {
+	return func(event *api.Event, patch []byte) (*api.Event, error) {
+		cachedEvent, found := testCache[getEventKey(event)]
+		if !found {
+			return nil, fmt.Errorf("unexpected error: couldn't find Event in testCache.")
+		}
+		originalData, err := json.Marshal(cachedEvent)
+		if err != nil {
+			return nil, fmt.Errorf("unexpected error: %v", err)
+		}
+		patched, err := strategicpatch.StrategicMergePatch(originalData, patch, event)
+		if err != nil {
+			return nil, fmt.Errorf("unexpected error: %v", err)
+		}
+		patchedObj := &api.Event{}
+		err = json.Unmarshal(patched, patchedObj)
+		if err != nil {
+			return nil, fmt.Errorf("unexpected error: %v", err)
+		}
+		patchEvent <- patchedObj
+		return patchedObj, nil
+	}
+}
+
+func TestEventf(t *testing.T) {
+	testPod := &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			SelfLink:  "/api/version/pods/foo",
+			Name:      "foo",
+			Namespace: "baz",
+			UID:       "bar",
+		},
+	}
+	testPod2 := &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			SelfLink:  "/api/version/pods/foo",
+			Name:      "foo",
+			Namespace: "baz",
+			UID:       "differentUid",
+		},
+	}
+	testRef, err := api.GetPartialReference(testPod, "spec.containers[2]")
+	testRef2, err := api.GetPartialReference(testPod2, "spec.containers[3]")
+	if err != nil {
+		t.Fatal(err)
+	}
+	table := []struct {
+		obj          k8sruntime.Object
+		eventtype    string
+		reason       string
+		messageFmt   string
+		elements     []interface{}
+		expect       *api.Event
+		expectLog    string
+		expectUpdate bool
+	}{
+		{
+			obj:        testRef,
+			eventtype:  api.EventTypeNormal,
+			reason:     "Started",
+			messageFmt: "some verbose message: %v",
+			elements:   []interface{}{1},
+			expect: &api.Event{
+				ObjectMeta: api.ObjectMeta{
+					Name:      "foo",
+					Namespace: "baz",
+				},
+				InvolvedObject: api.ObjectReference{
+					Kind:       "Pod",
+					Name:       "foo",
+					Namespace:  "baz",
+					UID:        "bar",
+					APIVersion: "version",
+					FieldPath:  "spec.containers[2]",
+				},
+				Reason:  "Started",
+				Message: "some verbose message: 1",
+				Source:  api.EventSource{Component: "eventTest"},
+				Count:   1,
+				Type:    api.EventTypeNormal,
+			},
+			expectLog:    `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"bar", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[2]"}): type: 'Normal' reason: 'Started' some verbose message: 1`,
+			expectUpdate: false,
+		},
+		{
+			obj:        testPod,
+			eventtype:  api.EventTypeNormal,
+			reason:     "Killed",
+			messageFmt: "some other verbose message: %v",
+			elements:   []interface{}{1},
+			expect: &api.Event{
+				ObjectMeta: api.ObjectMeta{
+					Name:      "foo",
+					Namespace: "baz",
+				},
+				InvolvedObject: api.ObjectReference{
+					Kind:       "Pod",
+					Name:       "foo",
+					Namespace:  "baz",
+					UID:        "bar",
+					APIVersion: "version",
+				},
+				Reason:  "Killed",
+				Message: "some other verbose message: 1",
+				Source:  api.EventSource{Component: "eventTest"},
+				Count:   1,
+				Type:    api.EventTypeNormal,
+			},
+			expectLog:    `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"bar", APIVersion:"version", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'Killed' some other verbose message: 1`,
+			expectUpdate: false,
+		},
+		{
+			obj:        testRef,
+			eventtype:  api.EventTypeNormal,
+			reason:     "Started",
+			messageFmt: "some verbose message: %v",
+			elements:   []interface{}{1},
+			expect: &api.Event{
+				ObjectMeta: api.ObjectMeta{
+					Name:      "foo",
+					Namespace: "baz",
+				},
+				InvolvedObject: api.ObjectReference{
+					Kind:       "Pod",
+					Name:       "foo",
+					Namespace:  "baz",
+					UID:        "bar",
+					APIVersion: "version",
+					FieldPath:  "spec.containers[2]",
+				},
+				Reason:  "Started",
+				Message: "some verbose message: 1",
+				Source:  api.EventSource{Component: "eventTest"},
+				Count:   2,
+				Type:    api.EventTypeNormal,
+			},
+			expectLog:    `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"bar", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[2]"}): type: 'Normal' reason: 'Started' some verbose message: 1`,
+			expectUpdate: true,
+		},
+		{
+			obj:        testRef2,
+			eventtype:  api.EventTypeNormal,
+			reason:     "Started",
+			messageFmt: "some verbose message: %v",
+			elements:   []interface{}{1},
+			expect: &api.Event{
+				ObjectMeta: api.ObjectMeta{
+					Name:      "foo",
+					Namespace: "baz",
+				},
+				InvolvedObject: api.ObjectReference{
+					Kind:       "Pod",
+					Name:       "foo",
+					Namespace:  "baz",
+					UID:        "differentUid",
+					APIVersion: "version",
+					FieldPath:  "spec.containers[3]",
+				},
+				Reason:  "Started",
+				Message: "some verbose message: 1",
+				Source:  api.EventSource{Component: "eventTest"},
+				Count:   1,
+				Type:    api.EventTypeNormal,
+			},
+			expectLog:    `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"differentUid", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[3]"}): type: 'Normal' reason: 'Started' some verbose message: 1`,
+			expectUpdate: false,
+		},
+		{
+			obj:        testRef,
+			eventtype:  api.EventTypeNormal,
+			reason:     "Started",
+			messageFmt: "some verbose message: %v",
+			elements:   []interface{}{1},
+			expect: &api.Event{
+				ObjectMeta: api.ObjectMeta{
+					Name:      "foo",
+					Namespace: "baz",
+				},
+				InvolvedObject: api.ObjectReference{
+					Kind:       "Pod",
+					Name:       "foo",
+					Namespace:  "baz",
+					UID:        "bar",
+					APIVersion: "version",
+					FieldPath:  "spec.containers[2]",
+				},
+				Reason:  "Started",
+				Message: "some verbose message: 1",
+				Source:  api.EventSource{Component: "eventTest"},
+				Count:   3,
+				Type:    api.EventTypeNormal,
+			},
+			expectLog:    `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"bar", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[2]"}): type: 'Normal' reason: 'Started' some verbose message: 1`,
+			expectUpdate: true,
+		},
+		{
+			obj:        testRef2,
+			eventtype:  api.EventTypeNormal,
+			reason:     "Stopped",
+			messageFmt: "some verbose message: %v",
+			elements:   []interface{}{1},
+			expect: &api.Event{
+				ObjectMeta: api.ObjectMeta{
+					Name:      "foo",
+					Namespace: "baz",
+				},
+				InvolvedObject: api.ObjectReference{
+					Kind:       "Pod",
+					Name:       "foo",
+					Namespace:  "baz",
+					UID:        "differentUid",
+					APIVersion: "version",
+					FieldPath:  "spec.containers[3]",
+				},
+				Reason:  "Stopped",
+				Message: "some verbose message: 1",
+				Source:  api.EventSource{Component: "eventTest"},
+				Count:   1,
+				Type:    api.EventTypeNormal,
+			},
+			expectLog:    `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"differentUid", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[3]"}): type: 'Normal' reason: 'Stopped' some verbose message: 1`,
+			expectUpdate: false,
+		},
+		{
+			obj:        testRef2,
+			eventtype:  api.EventTypeNormal,
+			reason:     "Stopped",
+			messageFmt: "some verbose message: %v",
+			elements:   []interface{}{1},
+			expect: &api.Event{
+				ObjectMeta: api.ObjectMeta{
+					Name:      "foo",
+					Namespace: "baz",
+				},
+				InvolvedObject: api.ObjectReference{
+					Kind:       "Pod",
+					Name:       "foo",
+					Namespace:  "baz",
+					UID:        "differentUid",
+					APIVersion: "version",
+					FieldPath:  "spec.containers[3]",
+				},
+				Reason:  "Stopped",
+				Message: "some verbose message: 1",
+				Source:  api.EventSource{Component: "eventTest"},
+				Count:   2,
+				Type:    api.EventTypeNormal,
+			},
+			expectLog:    `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"differentUid", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[3]"}): type: 'Normal' reason: 'Stopped' some verbose message: 1`,
+			expectUpdate: true,
+		},
+	}
+
+	testCache := map[string]*api.Event{}
+	logCalled := make(chan struct{})
+	createEvent := make(chan *api.Event)
+	updateEvent := make(chan *api.Event)
+	patchEvent := make(chan *api.Event)
+	testEvents := testEventSink{
+		OnCreate: OnCreateFactory(testCache, createEvent),
+		OnUpdate: func(event *api.Event) (*api.Event, error) {
+			updateEvent <- event
+			return event, nil
+		},
+		OnPatch: OnPatchFactory(testCache, patchEvent),
+	}
+	eventBroadcaster := NewBroadcasterForTests(0)
+	sinkWatcher := eventBroadcaster.StartRecordingToSink(&testEvents)
+
+	clock := util.NewFakeClock(time.Now())
+	recorder := recorderWithFakeClock(api.EventSource{Component: "eventTest"}, eventBroadcaster, clock)
+	for index, item := range table {
+		clock.Step(1 * time.Second)
+		// TODO: uncomment this after we upgrade to Go 1.6.1.
+		// testing.(*common).log() is racing with testing.(*T).report() in Go 1.6.
+		// See #23533 for more details.
+		// logWatcher1 := eventBroadcaster.StartLogging(t.Logf) // Prove that it is useful
+		logWatcher2 := eventBroadcaster.StartLogging(func(formatter string, args ...interface{}) {
+			if e, a := item.expectLog, fmt.Sprintf(formatter, args...); e != a {
+				t.Errorf("Expected '%v', got '%v'", e, a)
+			}
+			logCalled <- struct{}{}
+		})
+		recorder.Eventf(item.obj, item.eventtype, item.reason, item.messageFmt, item.elements...)
+
+		<-logCalled
+
+		// validate event
+		if item.expectUpdate {
+			actualEvent := <-patchEvent
+			validateEvent(string(index), actualEvent, item.expect, t)
+		} else {
+			actualEvent := <-createEvent
+			validateEvent(string(index), actualEvent, item.expect, t)
+		}
+		// TODO: uncomment this after we upgrade to Go 1.6.1.
+		// logWatcher1.Stop()
+		logWatcher2.Stop()
+	}
+	sinkWatcher.Stop()
+}
+
+func recorderWithFakeClock(eventSource api.EventSource, eventBroadcaster EventBroadcaster, clock util.Clock) EventRecorder {
+	return &recorderImpl{eventSource, eventBroadcaster.(*eventBroadcasterImpl).Broadcaster, clock}
+}
+
+func TestWriteEventError(t *testing.T) {
+	type entry struct {
+		timesToSendError int
+		attemptsWanted   int
+		err              error
+	}
+	table := map[string]*entry{
+		"giveUp1": {
+			timesToSendError: 1000,
+			attemptsWanted:   1,
+			err:              &restclient.RequestConstructionError{},
+		},
+		"giveUp2": {
+			timesToSendError: 1000,
+			attemptsWanted:   1,
+			err:              &errors.StatusError{},
+		},
+		"retry1": {
+			timesToSendError: 1000,
+			attemptsWanted:   12,
+			err:              &errors.UnexpectedObjectError{},
+		},
+		"retry2": {
+			timesToSendError: 1000,
+			attemptsWanted:   12,
+			err:              fmt.Errorf("A weird error"),
+		},
+		"succeedEventually": {
+			timesToSendError: 2,
+			attemptsWanted:   2,
+			err:              fmt.Errorf("A weird error"),
+		},
+	}
+
+	eventCorrelator := NewEventCorrelator(util.RealClock{})
+	randGen := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for caseName, ent := range table {
+		attempts := 0
+		sink := &testEventSink{
+			OnCreate: func(event *api.Event) (*api.Event, error) {
+				attempts++
+				if attempts < ent.timesToSendError {
+					return nil, ent.err
+				}
+				return event, nil
+			},
+		}
+		ev := &api.Event{}
+		recordToSink(sink, ev, eventCorrelator, randGen, 0)
+		if attempts != ent.attemptsWanted {
+			t.Errorf("case %v: wanted %d, got %d attempts", caseName, ent.attemptsWanted, attempts)
+		}
+	}
+}
+
+func TestLotsOfEvents(t *testing.T) {
+	recorderCalled := make(chan struct{})
+	loggerCalled := make(chan struct{})
+
+	// Fail each event a few times to ensure there's some load on the tested code.
+	var counts [1000]int
+	testEvents := testEventSink{
+		OnCreate: func(event *api.Event) (*api.Event, error) {
+			num, err := strconv.Atoi(event.Message)
+			if err != nil {
+				t.Error(err)
+				return event, nil
+			}
+			counts[num]++
+			if counts[num] < 5 {
+				return nil, fmt.Errorf("fake error")
+			}
+			recorderCalled <- struct{}{}
+			return event, nil
+		},
+	}
+
+	eventBroadcaster := NewBroadcasterForTests(0)
+	sinkWatcher := eventBroadcaster.StartRecordingToSink(&testEvents)
+	logWatcher := eventBroadcaster.StartLogging(func(formatter string, args ...interface{}) {
+		loggerCalled <- struct{}{}
+	})
+	recorder := eventBroadcaster.NewRecorder(api.EventSource{Component: "eventTest"})
+	ref := &api.ObjectReference{
+		Kind:       "Pod",
+		Name:       "foo",
+		Namespace:  "baz",
+		UID:        "bar",
+		APIVersion: "version",
+	}
+	for i := 0; i < maxQueuedEvents; i++ {
+		// we need to vary the reason to prevent aggregation
+		go recorder.Eventf(ref, api.EventTypeNormal, "Reason-"+string(i), strconv.Itoa(i))
+	}
+	// Make sure no events were dropped by either of the listeners.
+	for i := 0; i < maxQueuedEvents; i++ {
+		<-recorderCalled
+		<-loggerCalled
+	}
+	// Make sure that every event was attempted 5 times
+	for i := 0; i < maxQueuedEvents; i++ {
+		if counts[i] < 5 {
+			t.Errorf("Only attempted to record event '%d' %d times.", i, counts[i])
+		}
+	}
+	sinkWatcher.Stop()
+	logWatcher.Stop()
+}
+
+func TestEventfNoNamespace(t *testing.T) {
+	testPod := &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			SelfLink: "/api/version/pods/foo",
+			Name:     "foo",
+			UID:      "bar",
+		},
+	}
+	testRef, err := api.GetPartialReference(testPod, "spec.containers[2]")
+	if err != nil {
+		t.Fatal(err)
+	}
+	table := []struct {
+		obj          k8sruntime.Object
+		eventtype    string
+		reason       string
+		messageFmt   string
+		elements     []interface{}
+		expect       *api.Event
+		expectLog    string
+		expectUpdate bool
+	}{
+		{
+			obj:        testRef,
+			eventtype:  api.EventTypeNormal,
+			reason:     "Started",
+			messageFmt: "some verbose message: %v",
+			elements:   []interface{}{1},
+			expect: &api.Event{
+				ObjectMeta: api.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+				},
+				InvolvedObject: api.ObjectReference{
+					Kind:       "Pod",
+					Name:       "foo",
+					Namespace:  "",
+					UID:        "bar",
+					APIVersion: "version",
+					FieldPath:  "spec.containers[2]",
+				},
+				Reason:  "Started",
+				Message: "some verbose message: 1",
+				Source:  api.EventSource{Component: "eventTest"},
+				Count:   1,
+				Type:    api.EventTypeNormal,
+			},
+			expectLog:    `Event(api.ObjectReference{Kind:"Pod", Namespace:"", Name:"foo", UID:"bar", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[2]"}): type: 'Normal' reason: 'Started' some verbose message: 1`,
+			expectUpdate: false,
+		},
+	}
+
+	testCache := map[string]*api.Event{}
+	logCalled := make(chan struct{})
+	createEvent := make(chan *api.Event)
+	updateEvent := make(chan *api.Event)
+	patchEvent := make(chan *api.Event)
+	testEvents := testEventSink{
+		OnCreate: OnCreateFactory(testCache, createEvent),
+		OnUpdate: func(event *api.Event) (*api.Event, error) {
+			updateEvent <- event
+			return event, nil
+		},
+		OnPatch: OnPatchFactory(testCache, patchEvent),
+	}
+	eventBroadcaster := NewBroadcasterForTests(0)
+	sinkWatcher := eventBroadcaster.StartRecordingToSink(&testEvents)
+
+	clock := util.NewFakeClock(time.Now())
+	recorder := recorderWithFakeClock(api.EventSource{Component: "eventTest"}, eventBroadcaster, clock)
+
+	for index, item := range table {
+		clock.Step(1 * time.Second)
+		// TODO: uncomment this after we upgrade to Go 1.6.1.
+		// testing.(*common).log() is racing with testing.(*T).report() in Go 1.6.
+		// See #23533 for more details.
+		// logWatcher1 := eventBroadcaster.StartLogging(t.Logf) // Prove that it is useful
+		logWatcher2 := eventBroadcaster.StartLogging(func(formatter string, args ...interface{}) {
+			if e, a := item.expectLog, fmt.Sprintf(formatter, args...); e != a {
+				t.Errorf("Expected '%v', got '%v'", e, a)
+			}
+			logCalled <- struct{}{}
+		})
+		recorder.Eventf(item.obj, item.eventtype, item.reason, item.messageFmt, item.elements...)
+
+		<-logCalled
+
+		// validate event
+		if item.expectUpdate {
+			actualEvent := <-patchEvent
+			validateEvent(string(index), actualEvent, item.expect, t)
+		} else {
+			actualEvent := <-createEvent
+			validateEvent(string(index), actualEvent, item.expect, t)
+		}
+
+		// TODO: uncomment this after we upgrade to Go 1.6.1.
+		// logWatcher1.Stop()
+		logWatcher2.Stop()
+	}
+	sinkWatcher.Stop()
+}
+
+func TestMultiSinkCache(t *testing.T) {
+	testPod := &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			SelfLink:  "/api/version/pods/foo",
+			Name:      "foo",
+			Namespace: "baz",
+			UID:       "bar",
+		},
+	}
+	testPod2 := &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			SelfLink:  "/api/version/pods/foo",
+			Name:      "foo",
+			Namespace: "baz",
+			UID:       "differentUid",
+		},
+	}
+	testRef, err := api.GetPartialReference(testPod, "spec.containers[2]")
+	testRef2, err := api.GetPartialReference(testPod2, "spec.containers[3]")
+	if err != nil {
+		t.Fatal(err)
+	}
+	table := []struct {
+		obj          k8sruntime.Object
+		eventtype    string
+		reason       string
+		messageFmt   string
+		elements     []interface{}
+		expect       *api.Event
+		expectLog    string
+		expectUpdate bool
+	}{
+		{
+			obj:        testRef,
+			eventtype:  api.EventTypeNormal,
+			reason:     "Started",
+			messageFmt: "some verbose message: %v",
+			elements:   []interface{}{1},
+			expect: &api.Event{
+				ObjectMeta: api.ObjectMeta{
+					Name:      "foo",
+					Namespace: "baz",
+				},
+				InvolvedObject: api.ObjectReference{
+					Kind:       "Pod",
+					Name:       "foo",
+					Namespace:  "baz",
+					UID:        "bar",
+					APIVersion: "version",
+					FieldPath:  "spec.containers[2]",
+				},
+				Reason:  "Started",
+				Message: "some verbose message: 1",
+				Source:  api.EventSource{Component: "eventTest"},
+				Count:   1,
+				Type:    api.EventTypeNormal,
+			},
+			expectLog:    `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"bar", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[2]"}): type: 'Normal' reason: 'Started' some verbose message: 1`,
+			expectUpdate: false,
+		},
+		{
+			obj:        testPod,
+			eventtype:  api.EventTypeNormal,
+			reason:     "Killed",
+			messageFmt: "some other verbose message: %v",
+			elements:   []interface{}{1},
+			expect: &api.Event{
+				ObjectMeta: api.ObjectMeta{
+					Name:      "foo",
+					Namespace: "baz",
+				},
+				InvolvedObject: api.ObjectReference{
+					Kind:       "Pod",
+					Name:       "foo",
+					Namespace:  "baz",
+					UID:        "bar",
+					APIVersion: "version",
+				},
+				Reason:  "Killed",
+				Message: "some other verbose message: 1",
+				Source:  api.EventSource{Component: "eventTest"},
+				Count:   1,
+				Type:    api.EventTypeNormal,
+			},
+			expectLog:    `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"bar", APIVersion:"version", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'Killed' some other verbose message: 1`,
+			expectUpdate: false,
+		},
+		{
+			obj:        testRef,
+			eventtype:  api.EventTypeNormal,
+			reason:     "Started",
+			messageFmt: "some verbose message: %v",
+			elements:   []interface{}{1},
+			expect: &api.Event{
+				ObjectMeta: api.ObjectMeta{
+					Name:      "foo",
+					Namespace: "baz",
+				},
+				InvolvedObject: api.ObjectReference{
+					Kind:       "Pod",
+					Name:       "foo",
+					Namespace:  "baz",
+					UID:        "bar",
+					APIVersion: "version",
+					FieldPath:  "spec.containers[2]",
+				},
+				Reason:  "Started",
+				Message: "some verbose message: 1",
+				Source:  api.EventSource{Component: "eventTest"},
+				Count:   2,
+				Type:    api.EventTypeNormal,
+			},
+			expectLog:    `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"bar", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[2]"}): type: 'Normal' reason: 'Started' some verbose message: 1`,
+			expectUpdate: true,
+		},
+		{
+			obj:        testRef2,
+			eventtype:  api.EventTypeNormal,
+			reason:     "Started",
+			messageFmt: "some verbose message: %v",
+			elements:   []interface{}{1},
+			expect: &api.Event{
+				ObjectMeta: api.ObjectMeta{
+					Name:      "foo",
+					Namespace: "baz",
+				},
+				InvolvedObject: api.ObjectReference{
+					Kind:       "Pod",
+					Name:       "foo",
+					Namespace:  "baz",
+					UID:        "differentUid",
+					APIVersion: "version",
+					FieldPath:  "spec.containers[3]",
+				},
+				Reason:  "Started",
+				Message: "some verbose message: 1",
+				Source:  api.EventSource{Component: "eventTest"},
+				Count:   1,
+				Type:    api.EventTypeNormal,
+			},
+			expectLog:    `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"differentUid", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[3]"}): type: 'Normal' reason: 'Started' some verbose message: 1`,
+			expectUpdate: false,
+		},
+		{
+			obj:        testRef,
+			eventtype:  api.EventTypeNormal,
+			reason:     "Started",
+			messageFmt: "some verbose message: %v",
+			elements:   []interface{}{1},
+			expect: &api.Event{
+				ObjectMeta: api.ObjectMeta{
+					Name:      "foo",
+					Namespace: "baz",
+				},
+				InvolvedObject: api.ObjectReference{
+					Kind:       "Pod",
+					Name:       "foo",
+					Namespace:  "baz",
+					UID:        "bar",
+					APIVersion: "version",
+					FieldPath:  "spec.containers[2]",
+				},
+				Reason:  "Started",
+				Message: "some verbose message: 1",
+				Source:  api.EventSource{Component: "eventTest"},
+				Count:   3,
+				Type:    api.EventTypeNormal,
+			},
+			expectLog:    `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"bar", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[2]"}): type: 'Normal' reason: 'Started' some verbose message: 1`,
+			expectUpdate: true,
+		},
+		{
+			obj:        testRef2,
+			eventtype:  api.EventTypeNormal,
+			reason:     "Stopped",
+			messageFmt: "some verbose message: %v",
+			elements:   []interface{}{1},
+			expect: &api.Event{
+				ObjectMeta: api.ObjectMeta{
+					Name:      "foo",
+					Namespace: "baz",
+				},
+				InvolvedObject: api.ObjectReference{
+					Kind:       "Pod",
+					Name:       "foo",
+					Namespace:  "baz",
+					UID:        "differentUid",
+					APIVersion: "version",
+					FieldPath:  "spec.containers[3]",
+				},
+				Reason:  "Stopped",
+				Message: "some verbose message: 1",
+				Source:  api.EventSource{Component: "eventTest"},
+				Count:   1,
+				Type:    api.EventTypeNormal,
+			},
+			expectLog:    `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"differentUid", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[3]"}): type: 'Normal' reason: 'Stopped' some verbose message: 1`,
+			expectUpdate: false,
+		},
+		{
+			obj:        testRef2,
+			eventtype:  api.EventTypeNormal,
+			reason:     "Stopped",
+			messageFmt: "some verbose message: %v",
+			elements:   []interface{}{1},
+			expect: &api.Event{
+				ObjectMeta: api.ObjectMeta{
+					Name:      "foo",
+					Namespace: "baz",
+				},
+				InvolvedObject: api.ObjectReference{
+					Kind:       "Pod",
+					Name:       "foo",
+					Namespace:  "baz",
+					UID:        "differentUid",
+					APIVersion: "version",
+					FieldPath:  "spec.containers[3]",
+				},
+				Reason:  "Stopped",
+				Message: "some verbose message: 1",
+				Source:  api.EventSource{Component: "eventTest"},
+				Count:   2,
+				Type:    api.EventTypeNormal,
+			},
+			expectLog:    `Event(api.ObjectReference{Kind:"Pod", Namespace:"baz", Name:"foo", UID:"differentUid", APIVersion:"version", ResourceVersion:"", FieldPath:"spec.containers[3]"}): type: 'Normal' reason: 'Stopped' some verbose message: 1`,
+			expectUpdate: true,
+		},
+	}
+
+	testCache := map[string]*api.Event{}
+	createEvent := make(chan *api.Event)
+	updateEvent := make(chan *api.Event)
+	patchEvent := make(chan *api.Event)
+	testEvents := testEventSink{
+		OnCreate: OnCreateFactory(testCache, createEvent),
+		OnUpdate: func(event *api.Event) (*api.Event, error) {
+			updateEvent <- event
+			return event, nil
+		},
+		OnPatch: OnPatchFactory(testCache, patchEvent),
+	}
+
+	testCache2 := map[string]*api.Event{}
+	createEvent2 := make(chan *api.Event)
+	updateEvent2 := make(chan *api.Event)
+	patchEvent2 := make(chan *api.Event)
+	testEvents2 := testEventSink{
+		OnCreate: OnCreateFactory(testCache2, createEvent2),
+		OnUpdate: func(event *api.Event) (*api.Event, error) {
+			updateEvent2 <- event
+			return event, nil
+		},
+		OnPatch: OnPatchFactory(testCache2, patchEvent2),
+	}
+
+	eventBroadcaster := NewBroadcasterForTests(0)
+	clock := util.NewFakeClock(time.Now())
+	recorder := recorderWithFakeClock(api.EventSource{Component: "eventTest"}, eventBroadcaster, clock)
+
+	sinkWatcher := eventBroadcaster.StartRecordingToSink(&testEvents)
+	for index, item := range table {
+		clock.Step(1 * time.Second)
+		recorder.Eventf(item.obj, item.eventtype, item.reason, item.messageFmt, item.elements...)
+
+		// validate event
+		if item.expectUpdate {
+			actualEvent := <-patchEvent
+			validateEvent(string(index), actualEvent, item.expect, t)
+		} else {
+			actualEvent := <-createEvent
+			validateEvent(string(index), actualEvent, item.expect, t)
+		}
+	}
+
+	// Another StartRecordingToSink call should start to record events with new clean cache.
+	sinkWatcher2 := eventBroadcaster.StartRecordingToSink(&testEvents2)
+	for index, item := range table {
+		clock.Step(1 * time.Second)
+		recorder.Eventf(item.obj, item.eventtype, item.reason, item.messageFmt, item.elements...)
+
+		// validate event
+		if item.expectUpdate {
+			actualEvent := <-patchEvent2
+			validateEvent(string(index), actualEvent, item.expect, t)
+		} else {
+			actualEvent := <-createEvent2
+			validateEvent(string(index), actualEvent, item.expect, t)
+		}
+	}
+
+	sinkWatcher.Stop()
+	sinkWatcher2.Stop()
+}

--- a/pkg/client/record/v1/events_cache.go
+++ b/pkg/client/record/v1/events_cache.go
@@ -42,7 +42,7 @@ const (
 )
 
 // getEventKey builds unique event key based on source, involvedObject, reason, message
-func getEventKey(event *api.Event) string {
+func getEventKey(event *v1.Event) string {
 	return strings.Join([]string{
 		event.Source.Component,
 		event.Source.Host,
@@ -59,10 +59,10 @@ func getEventKey(event *api.Event) string {
 }
 
 // EventFilterFunc is a function that returns true if the event should be skipped
-type EventFilterFunc func(event *api.Event) bool
+type EventFilterFunc func(event *v1.Event) bool
 
 // DefaultEventFilterFunc returns false for all incoming events
-func DefaultEventFilterFunc(event *api.Event) bool {
+func DefaultEventFilterFunc(event *v1.Event) bool {
 	return false
 }
 
@@ -70,10 +70,10 @@ func DefaultEventFilterFunc(event *api.Event) bool {
 // It returns a tuple of the following:
 // aggregateKey - key the identifies the aggregate group to bucket this event
 // localKey - key that makes this event in the local group
-type EventAggregatorKeyFunc func(event *api.Event) (aggregateKey string, localKey string)
+type EventAggregatorKeyFunc func(event *v1.Event) (aggregateKey string, localKey string)
 
 // EventAggregatorByReasonFunc aggregates events by exact match on event.Source, event.InvolvedObject, event.Type and event.Reason
-func EventAggregatorByReasonFunc(event *api.Event) (string, string) {
+func EventAggregatorByReasonFunc(event *v1.Event) (string, string) {
 	return strings.Join([]string{
 		event.Source.Component,
 		event.Source.Host,
@@ -89,10 +89,10 @@ func EventAggregatorByReasonFunc(event *api.Event) (string, string) {
 }
 
 // EventAggregatorMessageFunc is responsible for producing an aggregation message
-type EventAggregatorMessageFunc func(event *api.Event) string
+type EventAggregatorMessageFunc func(event *v1.Event) string
 
 // EventAggregratorByReasonMessageFunc returns an aggregate message by prefixing the incoming message
-func EventAggregatorByReasonMessageFunc(event *api.Event) string {
+func EventAggregatorByReasonMessageFunc(event *v1.Event) string {
 	return "(events with common reason combined)"
 }
 
@@ -142,7 +142,7 @@ type aggregateRecord struct {
 }
 
 // EventAggregate identifies similar events and groups into a common event if required
-func (e *EventAggregator) EventAggregate(newEvent *api.Event) (*api.Event, error) {
+func (e *EventAggregator) EventAggregate(newEvent *v1.Event) (*v1.Event, error) {
 	aggregateKey, localKey := e.keyFunc(newEvent)
 	now := unversioned.NewTime(e.clock.Now())
 	record := aggregateRecord{localKeys: sets.NewString(), lastTimestamp: now}
@@ -171,7 +171,7 @@ func (e *EventAggregator) EventAggregate(newEvent *api.Event) (*api.Event, error
 	record.localKeys.PopAny()
 
 	// create a new aggregate event
-	eventCopy := &api.Event{
+	eventCopy := &v1.Event{
 		ObjectMeta: api.ObjectMeta{
 			Name:      fmt.Sprintf("%v.%x", newEvent.InvolvedObject.Name, now.UnixNano()),
 			Namespace: newEvent.Namespace,
@@ -216,7 +216,7 @@ func newEventLogger(lruCacheEntries int, clock util.Clock) *eventLogger {
 }
 
 // eventObserve records the event, and determines if its frequency should update
-func (e *eventLogger) eventObserve(newEvent *api.Event) (*api.Event, []byte, error) {
+func (e *eventLogger) eventObserve(newEvent *v1.Event) (*v1.Event, []byte, error) {
 	var (
 		patch []byte
 		err   error
@@ -261,7 +261,7 @@ func (e *eventLogger) eventObserve(newEvent *api.Event) (*api.Event, []byte, err
 }
 
 // updateState updates its internal tracking information based on latest server state
-func (e *eventLogger) updateState(event *api.Event) {
+func (e *eventLogger) updateState(event *v1.Event) {
 	key := getEventKey(event)
 	e.Lock()
 	defer e.Unlock()
@@ -305,7 +305,7 @@ type EventCorrelator struct {
 // EventCorrelateResult is the result of a Correlate
 type EventCorrelateResult struct {
 	// the event after correlation
-	Event *api.Event
+	Event *v1.Event
 	// if provided, perform a strategic patch when updating the record on the server
 	Patch []byte
 	// if true, do no further processing of the event
@@ -342,7 +342,7 @@ func NewEventCorrelator(clock util.Clock) *EventCorrelator {
 }
 
 // EventCorrelate filters, aggregates, counts, and de-duplicates all incoming events
-func (c *EventCorrelator) EventCorrelate(newEvent *api.Event) (*EventCorrelateResult, error) {
+func (c *EventCorrelator) EventCorrelate(newEvent *v1.Event) (*EventCorrelateResult, error) {
 	if c.filterFunc(newEvent) {
 		return &EventCorrelateResult{Skip: true}, nil
 	}
@@ -355,6 +355,6 @@ func (c *EventCorrelator) EventCorrelate(newEvent *api.Event) (*EventCorrelateRe
 }
 
 // UpdateState based on the latest observed state from server
-func (c *EventCorrelator) UpdateState(event *api.Event) {
+func (c *EventCorrelator) UpdateState(event *v1.Event) {
 	c.logger.updateState(event)
 }

--- a/pkg/client/record/v1/events_cache.go
+++ b/pkg/client/record/v1/events_cache.go
@@ -27,6 +27,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/util/strategicpatch"

--- a/pkg/client/record/v1/events_cache.go
+++ b/pkg/client/record/v1/events_cache.go
@@ -1,0 +1,360 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang/groupcache/lru"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/util/strategicpatch"
+)
+
+const (
+	maxLruCacheEntries = 4096
+
+	// if we see the same event that varies only by message
+	// more than 10 times in a 10 minute period, aggregate the event
+	defaultAggregateMaxEvents         = 10
+	defaultAggregateIntervalInSeconds = 600
+)
+
+// getEventKey builds unique event key based on source, involvedObject, reason, message
+func getEventKey(event *api.Event) string {
+	return strings.Join([]string{
+		event.Source.Component,
+		event.Source.Host,
+		event.InvolvedObject.Kind,
+		event.InvolvedObject.Namespace,
+		event.InvolvedObject.Name,
+		string(event.InvolvedObject.UID),
+		event.InvolvedObject.APIVersion,
+		event.Type,
+		event.Reason,
+		event.Message,
+	},
+		"")
+}
+
+// EventFilterFunc is a function that returns true if the event should be skipped
+type EventFilterFunc func(event *api.Event) bool
+
+// DefaultEventFilterFunc returns false for all incoming events
+func DefaultEventFilterFunc(event *api.Event) bool {
+	return false
+}
+
+// EventAggregatorKeyFunc is responsible for grouping events for aggregation
+// It returns a tuple of the following:
+// aggregateKey - key the identifies the aggregate group to bucket this event
+// localKey - key that makes this event in the local group
+type EventAggregatorKeyFunc func(event *api.Event) (aggregateKey string, localKey string)
+
+// EventAggregatorByReasonFunc aggregates events by exact match on event.Source, event.InvolvedObject, event.Type and event.Reason
+func EventAggregatorByReasonFunc(event *api.Event) (string, string) {
+	return strings.Join([]string{
+		event.Source.Component,
+		event.Source.Host,
+		event.InvolvedObject.Kind,
+		event.InvolvedObject.Namespace,
+		event.InvolvedObject.Name,
+		string(event.InvolvedObject.UID),
+		event.InvolvedObject.APIVersion,
+		event.Type,
+		event.Reason,
+	},
+		""), event.Message
+}
+
+// EventAggregatorMessageFunc is responsible for producing an aggregation message
+type EventAggregatorMessageFunc func(event *api.Event) string
+
+// EventAggregratorByReasonMessageFunc returns an aggregate message by prefixing the incoming message
+func EventAggregatorByReasonMessageFunc(event *api.Event) string {
+	return "(events with common reason combined)"
+}
+
+// EventAggregator identifies similar events and aggregates them into a single event
+type EventAggregator struct {
+	sync.RWMutex
+
+	// The cache that manages aggregation state
+	cache *lru.Cache
+
+	// The function that groups events for aggregation
+	keyFunc EventAggregatorKeyFunc
+
+	// The function that generates a message for an aggregate event
+	messageFunc EventAggregatorMessageFunc
+
+	// The maximum number of events in the specified interval before aggregation occurs
+	maxEvents int
+
+	// The amount of time in seconds that must transpire since the last occurrence of a similar event before it's considered new
+	maxIntervalInSeconds int
+
+	// clock is used to allow for testing over a time interval
+	clock util.Clock
+}
+
+// NewEventAggregator returns a new instance of an EventAggregator
+func NewEventAggregator(lruCacheSize int, keyFunc EventAggregatorKeyFunc, messageFunc EventAggregatorMessageFunc,
+	maxEvents int, maxIntervalInSeconds int, clock util.Clock) *EventAggregator {
+	return &EventAggregator{
+		cache:                lru.New(lruCacheSize),
+		keyFunc:              keyFunc,
+		messageFunc:          messageFunc,
+		maxEvents:            maxEvents,
+		maxIntervalInSeconds: maxIntervalInSeconds,
+		clock:                clock,
+	}
+}
+
+// aggregateRecord holds data used to perform aggregation decisions
+type aggregateRecord struct {
+	// we track the number of unique local keys we have seen in the aggregate set to know when to actually aggregate
+	// if the size of this set exceeds the max, we know we need to aggregate
+	localKeys sets.String
+	// The last time at which the aggregate was recorded
+	lastTimestamp unversioned.Time
+}
+
+// EventAggregate identifies similar events and groups into a common event if required
+func (e *EventAggregator) EventAggregate(newEvent *api.Event) (*api.Event, error) {
+	aggregateKey, localKey := e.keyFunc(newEvent)
+	now := unversioned.NewTime(e.clock.Now())
+	record := aggregateRecord{localKeys: sets.NewString(), lastTimestamp: now}
+	e.Lock()
+	defer e.Unlock()
+	value, found := e.cache.Get(aggregateKey)
+	if found {
+		record = value.(aggregateRecord)
+	}
+
+	// if the last event was far enough in the past, it is not aggregated, and we must reset state
+	maxInterval := time.Duration(e.maxIntervalInSeconds) * time.Second
+	interval := now.Time.Sub(record.lastTimestamp.Time)
+	if interval > maxInterval {
+		record = aggregateRecord{localKeys: sets.NewString()}
+	}
+	record.localKeys.Insert(localKey)
+	record.lastTimestamp = now
+	e.cache.Add(aggregateKey, record)
+
+	if record.localKeys.Len() < e.maxEvents {
+		return newEvent, nil
+	}
+
+	// do not grow our local key set any larger than max
+	record.localKeys.PopAny()
+
+	// create a new aggregate event
+	eventCopy := &api.Event{
+		ObjectMeta: api.ObjectMeta{
+			Name:      fmt.Sprintf("%v.%x", newEvent.InvolvedObject.Name, now.UnixNano()),
+			Namespace: newEvent.Namespace,
+		},
+		Count:          1,
+		FirstTimestamp: now,
+		InvolvedObject: newEvent.InvolvedObject,
+		LastTimestamp:  now,
+		Message:        e.messageFunc(newEvent),
+		Type:           newEvent.Type,
+		Reason:         newEvent.Reason,
+		Source:         newEvent.Source,
+	}
+	return eventCopy, nil
+}
+
+// eventLog records data about when an event was observed
+type eventLog struct {
+	// The number of times the event has occurred since first occurrence.
+	count int
+
+	// The time at which the event was first recorded.
+	firstTimestamp unversioned.Time
+
+	// The unique name of the first occurrence of this event
+	name string
+
+	// Resource version returned from previous interaction with server
+	resourceVersion string
+}
+
+// eventLogger logs occurrences of an event
+type eventLogger struct {
+	sync.RWMutex
+	cache *lru.Cache
+	clock util.Clock
+}
+
+// newEventLogger observes events and counts their frequencies
+func newEventLogger(lruCacheEntries int, clock util.Clock) *eventLogger {
+	return &eventLogger{cache: lru.New(lruCacheEntries), clock: clock}
+}
+
+// eventObserve records the event, and determines if its frequency should update
+func (e *eventLogger) eventObserve(newEvent *api.Event) (*api.Event, []byte, error) {
+	var (
+		patch []byte
+		err   error
+	)
+	key := getEventKey(newEvent)
+	eventCopy := *newEvent
+	event := &eventCopy
+
+	e.Lock()
+	defer e.Unlock()
+
+	lastObservation := e.lastEventObservationFromCache(key)
+
+	// we have seen this event before, so we must prepare a patch
+	if lastObservation.count > 0 {
+		// update the event based on the last observation so patch will work as desired
+		event.Name = lastObservation.name
+		event.ResourceVersion = lastObservation.resourceVersion
+		event.FirstTimestamp = lastObservation.firstTimestamp
+		event.Count = lastObservation.count + 1
+
+		eventCopy2 := *event
+		eventCopy2.Count = 0
+		eventCopy2.LastTimestamp = unversioned.NewTime(time.Unix(0, 0))
+
+		newData, _ := json.Marshal(event)
+		oldData, _ := json.Marshal(eventCopy2)
+		patch, err = strategicpatch.CreateStrategicMergePatch(oldData, newData, event)
+	}
+
+	// record our new observation
+	e.cache.Add(
+		key,
+		eventLog{
+			count:           event.Count,
+			firstTimestamp:  event.FirstTimestamp,
+			name:            event.Name,
+			resourceVersion: event.ResourceVersion,
+		},
+	)
+	return event, patch, err
+}
+
+// updateState updates its internal tracking information based on latest server state
+func (e *eventLogger) updateState(event *api.Event) {
+	key := getEventKey(event)
+	e.Lock()
+	defer e.Unlock()
+	// record our new observation
+	e.cache.Add(
+		key,
+		eventLog{
+			count:           event.Count,
+			firstTimestamp:  event.FirstTimestamp,
+			name:            event.Name,
+			resourceVersion: event.ResourceVersion,
+		},
+	)
+}
+
+// lastEventObservationFromCache returns the event from the cache, reads must be protected via external lock
+func (e *eventLogger) lastEventObservationFromCache(key string) eventLog {
+	value, ok := e.cache.Get(key)
+	if ok {
+		observationValue, ok := value.(eventLog)
+		if ok {
+			return observationValue
+		}
+	}
+	return eventLog{}
+}
+
+// EventCorrelator processes all incoming events and performs analysis to avoid overwhelming the system.  It can filter all
+// incoming events to see if the event should be filtered from further processing.  It can aggregate similar events that occur
+// frequently to protect the system from spamming events that are difficult for users to distinguish.  It performs de-duplication
+// to ensure events that are observed multiple times are compacted into a single event with increasing counts.
+type EventCorrelator struct {
+	// the function to filter the event
+	filterFunc EventFilterFunc
+	// the object that performs event aggregation
+	aggregator *EventAggregator
+	// the object that observes events as they come through
+	logger *eventLogger
+}
+
+// EventCorrelateResult is the result of a Correlate
+type EventCorrelateResult struct {
+	// the event after correlation
+	Event *api.Event
+	// if provided, perform a strategic patch when updating the record on the server
+	Patch []byte
+	// if true, do no further processing of the event
+	Skip bool
+}
+
+// NewEventCorrelator returns an EventCorrelator configured with default values.
+//
+// The EventCorrelator is responsible for event filtering, aggregating, and counting
+// prior to interacting with the API server to record the event.
+//
+// The default behavior is as follows:
+//   * No events are filtered from being recorded
+//   * Aggregation is performed if a similar event is recorded 10 times in a
+//     in a 10 minute rolling interval.  A similar event is an event that varies only by
+//     the Event.Message field.  Rather than recording the precise event, aggregation
+//     will create a new event whose message reports that it has combined events with
+//     the same reason.
+//   * Events are incrementally counted if the exact same event is encountered multiple
+//     times.
+func NewEventCorrelator(clock util.Clock) *EventCorrelator {
+	cacheSize := maxLruCacheEntries
+	return &EventCorrelator{
+		filterFunc: DefaultEventFilterFunc,
+		aggregator: NewEventAggregator(
+			cacheSize,
+			EventAggregatorByReasonFunc,
+			EventAggregatorByReasonMessageFunc,
+			defaultAggregateMaxEvents,
+			defaultAggregateIntervalInSeconds,
+			clock),
+		logger: newEventLogger(cacheSize, clock),
+	}
+}
+
+// EventCorrelate filters, aggregates, counts, and de-duplicates all incoming events
+func (c *EventCorrelator) EventCorrelate(newEvent *api.Event) (*EventCorrelateResult, error) {
+	if c.filterFunc(newEvent) {
+		return &EventCorrelateResult{Skip: true}, nil
+	}
+	aggregateEvent, err := c.aggregator.EventAggregate(newEvent)
+	if err != nil {
+		return &EventCorrelateResult{}, err
+	}
+	observedEvent, patch, err := c.logger.eventObserve(aggregateEvent)
+	return &EventCorrelateResult{Event: observedEvent, Patch: patch}, err
+}
+
+// UpdateState based on the latest observed state from server
+func (c *EventCorrelator) UpdateState(event *api.Event) {
+	c.logger.updateState(event)
+}

--- a/pkg/client/record/v1/events_cache.go
+++ b/pkg/client/record/v1/events_cache.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/golang/groupcache/lru"
 
-	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/util"
@@ -173,7 +172,7 @@ func (e *EventAggregator) EventAggregate(newEvent *v1.Event) (*v1.Event, error) 
 
 	// create a new aggregate event
 	eventCopy := &v1.Event{
-		ObjectMeta: api.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      fmt.Sprintf("%v.%x", newEvent.InvolvedObject.Name, now.UnixNano()),
 			Namespace: newEvent.Namespace,
 		},
@@ -237,7 +236,7 @@ func (e *eventLogger) eventObserve(newEvent *v1.Event) (*v1.Event, []byte, error
 		event.Name = lastObservation.name
 		event.ResourceVersion = lastObservation.resourceVersion
 		event.FirstTimestamp = lastObservation.firstTimestamp
-		event.Count = lastObservation.count + 1
+		event.Count = int32(lastObservation.count + 1)
 
 		eventCopy2 := *event
 		eventCopy2.Count = 0
@@ -252,7 +251,7 @@ func (e *eventLogger) eventObserve(newEvent *v1.Event) (*v1.Event, []byte, error
 	e.cache.Add(
 		key,
 		eventLog{
-			count:           event.Count,
+			count:           int(event.Count),
 			firstTimestamp:  event.FirstTimestamp,
 			name:            event.Name,
 			resourceVersion: event.ResourceVersion,
@@ -270,7 +269,7 @@ func (e *eventLogger) updateState(event *v1.Event) {
 	e.cache.Add(
 		key,
 		eventLog{
-			count:           event.Count,
+			count:           int(event.Count),
 			firstTimestamp:  event.FirstTimestamp,
 			name:            event.Name,
 			resourceVersion: event.ResourceVersion,

--- a/pkg/client/record/v1/events_cache_test.go
+++ b/pkg/client/record/v1/events_cache_test.go
@@ -38,34 +38,34 @@ func makeObjectReference(kind, name, namespace string) api.ObjectReference {
 	}
 }
 
-func makeEvent(reason, message string, involvedObject api.ObjectReference) api.Event {
+func makeEvent(reason, message string, involvedObject api.ObjectReference) v1.Event {
 	eventTime := unversioned.Now()
-	event := api.Event{
+	event := v1.Event{
 		Reason:         reason,
 		Message:        message,
 		InvolvedObject: involvedObject,
-		Source: api.EventSource{
+		Source: v1.EventSource{
 			Component: "kubelet",
 			Host:      "kublet.node1",
 		},
 		Count:          1,
 		FirstTimestamp: eventTime,
 		LastTimestamp:  eventTime,
-		Type:           api.EventTypeNormal,
+		Type:           v1.EventTypeNormal,
 	}
 	return event
 }
 
-func makeEvents(num int, template api.Event) []api.Event {
-	events := []api.Event{}
+func makeEvents(num int, template v1.Event) []v1.Event {
+	events := []v1.Event{}
 	for i := 0; i < num; i++ {
 		events = append(events, template)
 	}
 	return events
 }
 
-func makeUniqueEvents(num int) []api.Event {
-	events := []api.Event{}
+func makeUniqueEvents(num int) []v1.Event {
+	events := []v1.Event{}
 	kind := "Pod"
 	for i := 0; i < num; i++ {
 		reason := strings.Join([]string{"reason", string(i)}, "-")
@@ -78,7 +78,7 @@ func makeUniqueEvents(num int) []api.Event {
 	return events
 }
 
-func makeSimilarEvents(num int, template api.Event, messagePrefix string) []api.Event {
+func makeSimilarEvents(num int, template v1.Event, messagePrefix string) []v1.Event {
 	events := makeEvents(num, template)
 	for i := range events {
 		events[i].Message = strings.Join([]string{messagePrefix, string(i), events[i].Message}, "-")
@@ -86,12 +86,12 @@ func makeSimilarEvents(num int, template api.Event, messagePrefix string) []api.
 	return events
 }
 
-func setCount(event api.Event, count int) api.Event {
+func setCount(event v1.Event, count int) v1.Event {
 	event.Count = count
 	return event
 }
 
-func validateEvent(messagePrefix string, actualEvent *api.Event, expectedEvent *api.Event, t *testing.T) (*api.Event, error) {
+func validateEvent(messagePrefix string, actualEvent *v1.Event, expectedEvent *v1.Event, t *testing.T) (*v1.Event, error) {
 	recvEvent := *actualEvent
 	expectCompression := expectedEvent.Count > 1
 	t.Logf("%v - expectedEvent.Count is %d\n", messagePrefix, expectedEvent.Count)
@@ -172,13 +172,13 @@ func TestEventCorrelator(t *testing.T) {
 	similarEvent := makeEvent("similar", "similar message", makeObjectReference("Pod", "my-pod", "my-ns"))
 	aggregateEvent := makeEvent(similarEvent.Reason, EventAggregatorByReasonMessageFunc(&similarEvent), similarEvent.InvolvedObject)
 	scenario := map[string]struct {
-		previousEvents  []api.Event
-		newEvent        api.Event
-		expectedEvent   api.Event
+		previousEvents  []v1.Event
+		newEvent        v1.Event
+		expectedEvent   v1.Event
 		intervalSeconds int
 	}{
 		"create-a-single-event": {
-			previousEvents:  []api.Event{},
+			previousEvents:  []v1.Event{},
 			newEvent:        firstEvent,
 			expectedEvent:   setCount(firstEvent, 1),
 			intervalSeconds: 5,

--- a/pkg/client/record/v1/events_cache_test.go
+++ b/pkg/client/record/v1/events_cache_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/diff"

--- a/pkg/client/record/v1/events_cache_test.go
+++ b/pkg/client/record/v1/events_cache_test.go
@@ -22,14 +22,14 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/diff"
 )
 
-func makeObjectReference(kind, name, namespace string) api.ObjectReference {
-	return api.ObjectReference{
+func makeObjectReference(kind, name, namespace string) v1.ObjectReference {
+	return v1.ObjectReference{
 		Kind:       kind,
 		Name:       name,
 		Namespace:  namespace,
@@ -38,7 +38,7 @@ func makeObjectReference(kind, name, namespace string) api.ObjectReference {
 	}
 }
 
-func makeEvent(reason, message string, involvedObject api.ObjectReference) v1.Event {
+func makeEvent(reason, message string, involvedObject v1.ObjectReference) v1.Event {
 	eventTime := unversioned.Now()
 	event := v1.Event{
 		Reason:         reason,
@@ -86,7 +86,7 @@ func makeSimilarEvents(num int, template v1.Event, messagePrefix string) []v1.Ev
 	return events
 }
 
-func setCount(event v1.Event, count int) v1.Event {
+func setCount(event v1.Event, count int32) v1.Event {
 	event.Count = count
 	return event
 }

--- a/pkg/client/record/v1/events_cache_test.go
+++ b/pkg/client/record/v1/events_cache_test.go
@@ -1,0 +1,254 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/diff"
+)
+
+func makeObjectReference(kind, name, namespace string) api.ObjectReference {
+	return api.ObjectReference{
+		Kind:       kind,
+		Name:       name,
+		Namespace:  namespace,
+		UID:        "C934D34AFB20242",
+		APIVersion: "version",
+	}
+}
+
+func makeEvent(reason, message string, involvedObject api.ObjectReference) api.Event {
+	eventTime := unversioned.Now()
+	event := api.Event{
+		Reason:         reason,
+		Message:        message,
+		InvolvedObject: involvedObject,
+		Source: api.EventSource{
+			Component: "kubelet",
+			Host:      "kublet.node1",
+		},
+		Count:          1,
+		FirstTimestamp: eventTime,
+		LastTimestamp:  eventTime,
+		Type:           api.EventTypeNormal,
+	}
+	return event
+}
+
+func makeEvents(num int, template api.Event) []api.Event {
+	events := []api.Event{}
+	for i := 0; i < num; i++ {
+		events = append(events, template)
+	}
+	return events
+}
+
+func makeUniqueEvents(num int) []api.Event {
+	events := []api.Event{}
+	kind := "Pod"
+	for i := 0; i < num; i++ {
+		reason := strings.Join([]string{"reason", string(i)}, "-")
+		message := strings.Join([]string{"message", string(i)}, "-")
+		name := strings.Join([]string{"pod", string(i)}, "-")
+		namespace := strings.Join([]string{"ns", string(i)}, "-")
+		involvedObject := makeObjectReference(kind, name, namespace)
+		events = append(events, makeEvent(reason, message, involvedObject))
+	}
+	return events
+}
+
+func makeSimilarEvents(num int, template api.Event, messagePrefix string) []api.Event {
+	events := makeEvents(num, template)
+	for i := range events {
+		events[i].Message = strings.Join([]string{messagePrefix, string(i), events[i].Message}, "-")
+	}
+	return events
+}
+
+func setCount(event api.Event, count int) api.Event {
+	event.Count = count
+	return event
+}
+
+func validateEvent(messagePrefix string, actualEvent *api.Event, expectedEvent *api.Event, t *testing.T) (*api.Event, error) {
+	recvEvent := *actualEvent
+	expectCompression := expectedEvent.Count > 1
+	t.Logf("%v - expectedEvent.Count is %d\n", messagePrefix, expectedEvent.Count)
+	// Just check that the timestamp was set.
+	if recvEvent.FirstTimestamp.IsZero() || recvEvent.LastTimestamp.IsZero() {
+		t.Errorf("%v - timestamp wasn't set: %#v", messagePrefix, recvEvent)
+	}
+	actualFirstTimestamp := recvEvent.FirstTimestamp
+	actualLastTimestamp := recvEvent.LastTimestamp
+	if actualFirstTimestamp.Equal(actualLastTimestamp) {
+		if expectCompression {
+			t.Errorf("%v - FirstTimestamp (%q) and LastTimestamp (%q) must be different to indicate event compression happened, but were the same. Actual Event: %#v", messagePrefix, actualFirstTimestamp, actualLastTimestamp, recvEvent)
+		}
+	} else {
+		if expectedEvent.Count == 1 {
+			t.Errorf("%v - FirstTimestamp (%q) and LastTimestamp (%q) must be equal to indicate only one occurrence of the event, but were different. Actual Event: %#v", messagePrefix, actualFirstTimestamp, actualLastTimestamp, recvEvent)
+		}
+	}
+	// Temp clear time stamps for comparison because actual values don't matter for comparison
+	recvEvent.FirstTimestamp = expectedEvent.FirstTimestamp
+	recvEvent.LastTimestamp = expectedEvent.LastTimestamp
+	// Check that name has the right prefix.
+	if n, en := recvEvent.Name, expectedEvent.Name; !strings.HasPrefix(n, en) {
+		t.Errorf("%v - Name '%v' does not contain prefix '%v'", messagePrefix, n, en)
+	}
+	recvEvent.Name = expectedEvent.Name
+	if e, a := expectedEvent, &recvEvent; !reflect.DeepEqual(e, a) {
+		t.Errorf("%v - diff: %s", messagePrefix, diff.ObjectGoPrintDiff(e, a))
+	}
+	recvEvent.FirstTimestamp = actualFirstTimestamp
+	recvEvent.LastTimestamp = actualLastTimestamp
+	return actualEvent, nil
+}
+
+// TestDefaultEventFilterFunc ensures that no events are filtered
+func TestDefaultEventFilterFunc(t *testing.T) {
+	event := makeEvent("end-of-world", "it was fun", makeObjectReference("Pod", "pod1", "other"))
+	if DefaultEventFilterFunc(&event) {
+		t.Fatalf("DefaultEventFilterFunc should always return false")
+	}
+}
+
+// TestEventAggregatorByReasonFunc ensures that two events are aggregated if they vary only by event.message
+func TestEventAggregatorByReasonFunc(t *testing.T) {
+	event1 := makeEvent("end-of-world", "it was fun", makeObjectReference("Pod", "pod1", "other"))
+	event2 := makeEvent("end-of-world", "it was awful", makeObjectReference("Pod", "pod1", "other"))
+	event3 := makeEvent("nevermind", "it was a bug", makeObjectReference("Pod", "pod1", "other"))
+
+	aggKey1, localKey1 := EventAggregatorByReasonFunc(&event1)
+	aggKey2, localKey2 := EventAggregatorByReasonFunc(&event2)
+	aggKey3, _ := EventAggregatorByReasonFunc(&event3)
+
+	if aggKey1 != aggKey2 {
+		t.Errorf("Expected %v equal %v", aggKey1, aggKey2)
+	}
+	if localKey1 == localKey2 {
+		t.Errorf("Expected %v to not equal %v", aggKey1, aggKey3)
+	}
+	if aggKey1 == aggKey3 {
+		t.Errorf("Expected %v to not equal %v", aggKey1, aggKey3)
+	}
+}
+
+// TestEventAggregatorByReasonMessageFunc validates the proper output for an aggregate message
+func TestEventAggregatorByReasonMessageFunc(t *testing.T) {
+	expected := "(events with common reason combined)"
+	event1 := makeEvent("end-of-world", "it was fun", makeObjectReference("Pod", "pod1", "other"))
+	if actual := EventAggregatorByReasonMessageFunc(&event1); expected != actual {
+		t.Errorf("Expected %v got %v", expected, actual)
+	}
+}
+
+// TestEventCorrelator validates proper counting, aggregation of events
+func TestEventCorrelator(t *testing.T) {
+	firstEvent := makeEvent("first", "i am first", makeObjectReference("Pod", "my-pod", "my-ns"))
+	duplicateEvent := makeEvent("duplicate", "me again", makeObjectReference("Pod", "my-pod", "my-ns"))
+	uniqueEvent := makeEvent("unique", "snowflake", makeObjectReference("Pod", "my-pod", "my-ns"))
+	similarEvent := makeEvent("similar", "similar message", makeObjectReference("Pod", "my-pod", "my-ns"))
+	aggregateEvent := makeEvent(similarEvent.Reason, EventAggregatorByReasonMessageFunc(&similarEvent), similarEvent.InvolvedObject)
+	scenario := map[string]struct {
+		previousEvents  []api.Event
+		newEvent        api.Event
+		expectedEvent   api.Event
+		intervalSeconds int
+	}{
+		"create-a-single-event": {
+			previousEvents:  []api.Event{},
+			newEvent:        firstEvent,
+			expectedEvent:   setCount(firstEvent, 1),
+			intervalSeconds: 5,
+		},
+		"the-same-event-should-just-count": {
+			previousEvents:  makeEvents(1, duplicateEvent),
+			newEvent:        duplicateEvent,
+			expectedEvent:   setCount(duplicateEvent, 2),
+			intervalSeconds: 5,
+		},
+		"the-same-event-should-just-count-even-if-more-than-aggregate": {
+			previousEvents:  makeEvents(defaultAggregateMaxEvents, duplicateEvent),
+			newEvent:        duplicateEvent,
+			expectedEvent:   setCount(duplicateEvent, defaultAggregateMaxEvents+1),
+			intervalSeconds: 5,
+		},
+		"create-many-unique-events": {
+			previousEvents:  makeUniqueEvents(30),
+			newEvent:        uniqueEvent,
+			expectedEvent:   setCount(uniqueEvent, 1),
+			intervalSeconds: 5,
+		},
+		"similar-events-should-aggregate-event": {
+			previousEvents:  makeSimilarEvents(defaultAggregateMaxEvents-1, similarEvent, similarEvent.Message),
+			newEvent:        similarEvent,
+			expectedEvent:   setCount(aggregateEvent, 1),
+			intervalSeconds: 5,
+		},
+		"similar-events-many-times-should-count-the-aggregate": {
+			previousEvents:  makeSimilarEvents(defaultAggregateMaxEvents, similarEvent, similarEvent.Message),
+			newEvent:        similarEvent,
+			expectedEvent:   setCount(aggregateEvent, 2),
+			intervalSeconds: 5,
+		},
+		"similar-events-whose-interval-is-greater-than-aggregate-interval-do-not-aggregate": {
+			previousEvents:  makeSimilarEvents(defaultAggregateMaxEvents-1, similarEvent, similarEvent.Message),
+			newEvent:        similarEvent,
+			expectedEvent:   setCount(similarEvent, 1),
+			intervalSeconds: defaultAggregateIntervalInSeconds,
+		},
+	}
+
+	for testScenario, testInput := range scenario {
+		eventInterval := time.Duration(testInput.intervalSeconds) * time.Second
+		clock := util.IntervalClock{Time: time.Now(), Duration: eventInterval}
+		correlator := NewEventCorrelator(&clock)
+		for i := range testInput.previousEvents {
+			event := testInput.previousEvents[i]
+			now := unversioned.NewTime(clock.Now())
+			event.FirstTimestamp = now
+			event.LastTimestamp = now
+			result, err := correlator.EventCorrelate(&event)
+			if err != nil {
+				t.Errorf("scenario %v: unexpected error playing back prevEvents %v", testScenario, err)
+			}
+			correlator.UpdateState(result.Event)
+		}
+
+		// update the input to current clock value
+		now := unversioned.NewTime(clock.Now())
+		testInput.newEvent.FirstTimestamp = now
+		testInput.newEvent.LastTimestamp = now
+		result, err := correlator.EventCorrelate(&testInput.newEvent)
+		if err != nil {
+			t.Errorf("scenario %v: unexpected error correlating input event %v", testScenario, err)
+		}
+
+		_, err = validateEvent(testScenario, result.Event, &testInput.expectedEvent, t)
+		if err != nil {
+			t.Errorf("scenario %v: unexpected error validating result %v", testScenario, err)
+		}
+	}
+}

--- a/pkg/client/record/v1/fake.go
+++ b/pkg/client/record/v1/fake.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+// FakeRecorder is used as a fake during tests.
+type FakeRecorder struct {
+	Events []string
+}
+
+func (f *FakeRecorder) Event(object runtime.Object, eventtype, reason, message string) {
+	f.Events = append(f.Events, fmt.Sprintf("%s %s %s", eventtype, reason, message))
+}
+
+func (f *FakeRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+	f.Events = append(f.Events, fmt.Sprintf(eventtype+" "+reason+" "+messageFmt, args...))
+}
+
+func (f *FakeRecorder) PastEventf(object runtime.Object, timestamp unversioned.Time, eventtype, reason, messageFmt string, args ...interface{}) {
+}


### PR DESCRIPTION
Part of #24155 

We are migrating controllers to use the versioned clients, one blocker is that the pkg/client/record only handles api.Event. Hence, we add a pkg/client/record/v1 to handle the v1.Events. The old `record` package will be removed when all the controllers have migrated to use the versioned clients.
