### PR TITLE
Incremental improvements to kubelet e2e tests

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-jenkins/node-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/node-e2e.yaml
@@ -95,7 +95,7 @@
         - ansicolor:
             colormap: xterm
         - timeout:
-            timeout: 45
+            timeout: 90
             fail: true
         - timestamps
         - inject:

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -82,6 +82,7 @@ var _ = AfterSuite(func() {
 		glog.Infof("Stopping node services...")
 		e2es.stop()
 	}
+	glog.Infof("Tests Finished")
 })
 
 var _ Reporter = &LogReporter{}
@@ -91,7 +92,7 @@ type LogReporter struct{}
 func (lr *LogReporter) SpecSuiteWillBegin(config config.GinkgoConfigType, summary *types.SuiteSummary) {
 	b := &bytes.Buffer{}
 	b.WriteString("******************************************************\n")
-	glog.V(0).Infof(b.String())
+	glog.Infof(b.String())
 }
 
 func (lr *LogReporter) BeforeSuiteDidRun(setupSummary *types.SetupSummary) {}
@@ -115,5 +116,5 @@ func (lr *LogReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) {
 		b.WriteString(fmt.Sprintf("etcd output:\n%s\n", e2es.etcdCombinedOut.String()))
 	}
 	b.WriteString("******************************************************\n")
-	glog.V(0).Infof(b.String())
+	glog.Infof(b.String())
 }

--- a/test/e2e_node/e2e_service.go
+++ b/test/e2e_node/e2e_service.go
@@ -86,7 +86,7 @@ func (es *e2eService) stop() {
 	if es.apiServerCmd != nil {
 		err := es.apiServerCmd.Process.Kill()
 		if err != nil {
-			glog.Errorf("Failed to stop be-apiserver.\n%v", err)
+			glog.Errorf("Failed to stop kube-apiserver.\n%v", err)
 		}
 	}
 	if es.etcdCmd != nil {

--- a/test/e2e_node/privileged_test.go
+++ b/test/e2e_node/privileged_test.go
@@ -22,7 +22,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
@@ -151,7 +150,6 @@ func (config *PrivilegedPodTestConfig) dialFromContainer(containerIP string, con
 	var output map[string]string
 	err = json.Unmarshal([]byte(stdout), &output)
 	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Could not unmarshal curl response: %s", stdout))
-	glog.Infof("Deserialized output is %v", output)
 	return output
 }
 


### PR DESCRIPTION
- Add keep-alive to ssh connection
- Don't try to stop services on image-based runs
- Increase jenkins ci timeout to 90 minutes to accomadate unpredictable go build times
- Remove spammy log statement
