### PR TITLE
Run test-go less often on release branches.

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-go.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-go.yaml
@@ -46,7 +46,7 @@
     triggers:
         - pollscm:
             cron: 'H/2 * * * *'
-        - timed: 'H/30 * * * *'
+        - timed: '{cron-string}'
     wrappers:
         - ansicolor:
             colormap: xterm
@@ -77,9 +77,13 @@
             timeout: 80
         - 'go-release-1.2':
             branch: 'release-1.2'
+            # Every 3 hours
+            cron-string: 'H H/3 * * *'
             timeout: 50
         - 'go-release-1.1':
             branch: 'release-1.1'
+            # Every 6 hours
+            cron-string: 'H H/12 * * *'
             timeout: 30
     jobs:
         - 'kubernetes-test-{suffix}'


### PR DESCRIPTION
I made 1.2 run every 3 hours and 1.1 run every 6 hours. They'll still run right away once a build completes.

I'm going to have to lower the number of executors on the Jenkins slaves that run test-go jobs, since running 3 at a time makes them use up all the CPU and flake.
