### PR TITLE
Remove host port in influxdb-grafana-controller.yaml

### DIFF
--- a/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
@@ -32,9 +32,7 @@ spec:
               memory: 500Mi
           ports: 
             - containerPort: 8083
-              hostPort: 8083
             - containerPort: 8086
-              hostPort: 8086
           volumeMounts:
           - name: influxdb-persistent-storage
             mountPath: /data

--- a/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
@@ -28,9 +28,7 @@ spec:
               memory: 500Mi
           ports: 
             - containerPort: 8083
-              hostPort: 8083
             - containerPort: 8086
-              hostPort: 8086
           volumeMounts:
           - name: influxdb-persistent-storage
             mountPath: /data


### PR DESCRIPTION
There is no valid reason to keep the host ports in the pod spec.
