### PR TITLE
Removing call to update-swagger-spec.sh from update-generated-swagger-docs.sh

### DIFF
--- a/hack/after-build/update-swagger-spec.sh
+++ b/hack/after-build/update-swagger-spec.sh
@@ -21,6 +21,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+echo "Note: This assumes that types_swagger_doc_generated.go has been updated for all API group versions. Please run hack/update-generated-swagger-docs.sh to ensure that."
+
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
 SWAGGER_ROOT_DIR="${KUBE_ROOT}/api/swagger-spec"
 source "${KUBE_ROOT}/hack/lib/init.sh"

--- a/hack/update-api-reference-docs.sh
+++ b/hack/update-api-reference-docs.sh
@@ -21,6 +21,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+echo "Note: This assumes that swagger spec has been updated. Please run hack/update-swagger-spec.sh to ensure that."
+
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 kube::golang::setup_env

--- a/hack/update-generated-swagger-docs.sh
+++ b/hack/update-generated-swagger-docs.sh
@@ -64,5 +64,3 @@ done
 for group_version in "${GROUP_VERSIONS[@]}"; do
   generate_version "${group_version}"
 done
-
-"${KUBE_ROOT}/hack/update-swagger-spec.sh"


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/24233

Right now `update-generated-swagger-docs.sh` calls `update-swagger-spec.sh`, but `verify-generated-swagger-docs.sh` does not verify swagger spec (that is done by `verify-swagger-spec.sh`).
Hence, `verify-swagger-spec` breaks if it is called after `verify-generated-swagger-docs`.

Fixing it by removing the call to `update-swagger-spec.sh` from `update-generated-swagger-docs.sh`.
This will require users to run both `update-swagger-spec` and `update-generated-swagger-docs` when they update api types, but they already need to run many more scripts (`update-api-reference-docs`, `update-codegen`). 
People should mostly be running hack/update-all.sh directly :)
