### PR TITLE
ThirdPartyResourceCodec should implement streaming.Framer

### DIFF
--- a/pkg/registry/thirdpartyresourcedata/codec.go
+++ b/pkg/registry/thirdpartyresourcedata/codec.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/runtime/serializer/streaming"
 )
 
 type thirdPartyObjectConverter struct {
@@ -201,6 +202,11 @@ type thirdPartyResourceDataCodec struct {
 	delegate runtime.Codec
 	kind     string
 }
+
+var (
+	_ runtime.Codec    = &thirdPartyResourceDataCodec{}
+	_ streaming.Framer = &thirdPartyResourceDataCodec{}
+)
 
 func NewCodec(codec runtime.Codec, kind string) runtime.Codec {
 	return &thirdPartyResourceDataCodec{codec, kind}
@@ -408,6 +414,24 @@ func (t *thirdPartyResourceDataCodec) EncodeToStream(obj runtime.Object, stream 
 	default:
 		return fmt.Errorf("unexpected object to encode: %#v", obj)
 	}
+}
+
+// NewFrameWriter calls into the nested encoder to expose its framing
+func (c *thirdPartyResourceDataCodec) NewFrameWriter(w io.Writer) io.Writer {
+	f, ok := c.delegate.(streaming.Framer)
+	if !ok {
+		return nil
+	}
+	return f.NewFrameWriter(w)
+}
+
+// NewFrameReader calls into the nested decoder to expose its framing
+func (c *thirdPartyResourceDataCodec) NewFrameReader(r io.Reader) io.Reader {
+	f, ok := c.delegate.(streaming.Framer)
+	if !ok {
+		return nil
+	}
+	return f.NewFrameReader(r)
 }
 
 func NewObjectCreator(group, version string, delegate runtime.ObjectCreater) runtime.ObjectCreater {


### PR DESCRIPTION
Wrappers must proxy NewFrameReader|Writer for now (until we potentially
refactor the codec factory to separate them).

@wojtek-t spawned #24441 to add more tests for thirdparty watch
