### PR TITLE
genericapiserver: Moving more flags to ServerRunOptions

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -18,7 +18,6 @@ limitations under the License.
 package options
 
 import (
-	"net"
 	"strings"
 	"time"
 
@@ -32,8 +31,6 @@ import (
 	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
 	"k8s.io/kubernetes/pkg/master/ports"
 	etcdstorage "k8s.io/kubernetes/pkg/storage/etcd"
-	"k8s.io/kubernetes/pkg/util/config"
-	utilnet "k8s.io/kubernetes/pkg/util/net"
 
 	"github.com/spf13/pflag"
 )
@@ -41,47 +38,32 @@ import (
 // APIServer runs a kubernetes api server.
 type APIServer struct {
 	*genericapiserver.ServerRunOptions
-	APIGroupPrefix             string
-	APIPrefix                  string
 	AdmissionControl           string
 	AdmissionControlConfigFile string
-	AdvertiseAddress           net.IP
 	AllowPrivileged            bool
 	AuthorizationMode          string
 	AuthorizationConfig        apiserver.AuthorizationConfig
 	BasicAuthFile              string
 	CloudConfigFile            string
 	CloudProvider              string
-	CorsAllowedOriginList      []string
 	DeleteCollectionWorkers    int
 	DeprecatedStorageVersion   string
-	EnableLogsSupport          bool
-	EnableProfiling            bool
-	EnableWatchCache           bool
-	EnableSwaggerUI            bool
 	EtcdServersOverrides       []string
 	EtcdConfig                 etcdstorage.EtcdConfig
 	EventTTL                   time.Duration
-	ExternalHost               string
 	KeystoneURL                string
 	KubeletConfig              kubeletclient.KubeletClientConfig
-	KubernetesServiceNodePort  int
-	MasterCount                int
 	MasterServiceNamespace     string
 	MaxConnectionBytesPerSec   int64
-	MinRequestTimeout          int
 	OIDCCAFile                 string
 	OIDCClientID               string
 	OIDCIssuerURL              string
 	OIDCUsernameClaim          string
 	OIDCGroupsClaim            string
-	RuntimeConfig              config.ConfigurationMap
 	SSHKeyfile                 string
 	SSHUser                    string
 	ServiceAccountKeyFile      string
 	ServiceAccountLookup       bool
-	ServiceClusterIPRange      net.IPNet // TODO: make this a list
-	ServiceNodePortRange       utilnet.PortRange
 	StorageVersions            string
 	// The default values for StorageVersions. StorageVersions overrides
 	// these; you can change this if you want to change the defaults (e.g.,
@@ -95,23 +77,15 @@ type APIServer struct {
 func NewAPIServer() *APIServer {
 	s := APIServer{
 		ServerRunOptions:        genericapiserver.NewServerRunOptions(),
-		APIGroupPrefix:          "/apis",
-		APIPrefix:               "/api",
 		AdmissionControl:        "AlwaysAdmit",
 		AuthorizationMode:       "AlwaysAllow",
 		DeleteCollectionWorkers: 1,
-		EnableLogsSupport:       true,
-		EnableProfiling:         true,
-		EnableWatchCache:        true,
 		EtcdConfig: etcdstorage.EtcdConfig{
 			Prefix: genericapiserver.DefaultEtcdPathPrefix,
 			DeserializationCacheSize: genericapiserver.DefaultDeserializationCacheSize,
 		},
 		EventTTL:               1 * time.Hour,
-		MasterCount:            1,
 		MasterServiceNamespace: api.NamespaceDefault,
-		MinRequestTimeout:      1800,
-		RuntimeConfig:          make(config.ConfigurationMap),
 		StorageVersions:        registered.AllPreferredGroupVersions(),
 		DefaultStorageVersions: registered.AllPreferredGroupVersions(),
 		KubeletConfig: kubeletclient.KubeletClientConfig{
@@ -120,7 +94,6 @@ func NewAPIServer() *APIServer {
 			HTTPTimeout: time.Duration(5) * time.Second,
 		},
 	}
-
 	return &s
 }
 
@@ -166,15 +139,6 @@ func (s *APIServer) AddFlags(fs *pflag.FlagSet) {
 	s.ServerRunOptions.AddFlags(fs)
 	// Note: the weird ""+ in below lines seems to be the only way to get gofmt to
 	// arrange these text blocks sensibly. Grrr.
-	fs.MarkDeprecated("port", "see --insecure-port instead")
-	fs.MarkDeprecated("address", "see --insecure-bind-address instead")
-	fs.IPVar(&s.AdvertiseAddress, "advertise-address", s.AdvertiseAddress, ""+
-		"The IP address on which to advertise the apiserver to members of the cluster. This "+
-		"address must be reachable by the rest of the cluster. If blank, the --bind-address "+
-		"will be used. If --bind-address is unspecified, the host's default interface will "+
-		"be used.")
-	fs.IPVar(&s.BindAddress, "public-address-override", s.BindAddress, "DEPRECATED: see --bind-address instead")
-	fs.MarkDeprecated("public-address-override", "see --bind-address instead")
 	fs.StringVar(&s.APIPrefix, "api-prefix", s.APIPrefix, "The prefix for API requests on the server. Default '/api'.")
 	fs.MarkDeprecated("api-prefix", "--api-prefix is deprecated and will be removed when the v1 API is retired.")
 	fs.StringVar(&s.DeprecatedStorageVersion, "storage-version", s.DeprecatedStorageVersion, "The version to store the legacy v1 resources with. Defaults to server preferred")
@@ -212,24 +176,9 @@ func (s *APIServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.EtcdConfig.CAFile, "etcd-cafile", s.EtcdConfig.CAFile, "SSL Certificate Authority file used to secure etcd communication")
 	fs.BoolVar(&s.EtcdConfig.Quorum, "etcd-quorum-read", s.EtcdConfig.Quorum, "If true, enable quorum read")
 	fs.IntVar(&s.EtcdConfig.DeserializationCacheSize, "deserialization-cache-size", s.EtcdConfig.DeserializationCacheSize, "Number of deserialized json objects to cache in memory.")
-	fs.StringSliceVar(&s.CorsAllowedOriginList, "cors-allowed-origins", s.CorsAllowedOriginList, "List of allowed origins for CORS, comma separated.  An allowed origin can be a regular expression to support subdomain matching.  If this list is empty CORS will not be enabled.")
 	fs.BoolVar(&s.AllowPrivileged, "allow-privileged", s.AllowPrivileged, "If true, allow privileged containers.")
-	fs.IPNetVar(&s.ServiceClusterIPRange, "service-cluster-ip-range", s.ServiceClusterIPRange, "A CIDR notation IP range from which to assign service cluster IPs. This must not overlap with any IP ranges assigned to nodes for pods.")
-	fs.IPNetVar(&s.ServiceClusterIPRange, "portal-net", s.ServiceClusterIPRange, "Deprecated: see --service-cluster-ip-range instead.")
-	fs.MarkDeprecated("portal-net", "see --service-cluster-ip-range instead.")
-	fs.Var(&s.ServiceNodePortRange, "service-node-port-range", "A port range to reserve for services with NodePort visibility.  Example: '30000-32767'.  Inclusive at both ends of the range.")
-	fs.Var(&s.ServiceNodePortRange, "service-node-ports", "Deprecated: see --service-node-port-range instead.")
-	fs.MarkDeprecated("service-node-ports", "see --service-node-port-range instead.")
 	fs.StringVar(&s.MasterServiceNamespace, "master-service-namespace", s.MasterServiceNamespace, "The namespace from which the kubernetes master services should be injected into pods")
-	fs.IntVar(&s.MasterCount, "apiserver-count", s.MasterCount, "The number of apiservers running in the cluster")
 	fs.IntVar(&s.DeleteCollectionWorkers, "delete-collection-workers", s.DeleteCollectionWorkers, "Number of workers spawned for DeleteCollection call. These are used to speed up namespace cleanup.")
-	fs.Var(&s.RuntimeConfig, "runtime-config", "A set of key=value pairs that describe runtime configuration that may be passed to apiserver. apis/<groupVersion> key can be used to turn on/off specific api versions. apis/<groupVersion>/<resource> can be used to turn on/off specific resources. api/all and api/legacy are special keys to control all and legacy api versions respectively.")
-	fs.BoolVar(&s.EnableProfiling, "profiling", s.EnableProfiling, "Enable profiling via web interface host:port/debug/pprof/")
-	// TODO: enable cache in integration tests.
-	fs.BoolVar(&s.EnableWatchCache, "watch-cache", s.EnableWatchCache, "Enable watch caching in the apiserver")
-	fs.BoolVar(&s.EnableSwaggerUI, "enable-swagger-ui", s.EnableSwaggerUI, "Enables swagger ui on the apiserver at /swagger-ui")
-	fs.StringVar(&s.ExternalHost, "external-hostname", s.ExternalHost, "The hostname to use when generating externalized URLs for this master (e.g. Swagger API Docs.)")
-	fs.IntVar(&s.MinRequestTimeout, "min-request-timeout", s.MinRequestTimeout, "An optional field indicating the minimum number of seconds a handler must keep a request open before timing it out. Currently only honored by the watch request handler, which picks a randomized value above this number as the connection timeout, to spread out load.")
 	fs.StringVar(&s.SSHUser, "ssh-user", s.SSHUser, "If non-empty, use secure SSH proxy to the nodes, using this user name")
 	fs.StringVar(&s.SSHKeyfile, "ssh-keyfile", s.SSHKeyfile, "If non-empty, use secure SSH proxy to the nodes, using this user keyfile")
 	fs.Int64Var(&s.MaxConnectionBytesPerSec, "max-connection-bytes-per-sec", s.MaxConnectionBytesPerSec, "If non-zero, throttle each user connection to this number of bytes/sec.  Currently only applies to long-running requests")
@@ -241,8 +190,6 @@ func (s *APIServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.KubeletConfig.CertFile, "kubelet-client-certificate", s.KubeletConfig.CertFile, "Path to a client cert file for TLS.")
 	fs.StringVar(&s.KubeletConfig.KeyFile, "kubelet-client-key", s.KubeletConfig.KeyFile, "Path to a client key file for TLS.")
 	fs.StringVar(&s.KubeletConfig.CAFile, "kubelet-certificate-authority", s.KubeletConfig.CAFile, "Path to a cert. file for the certificate authority.")
-	// See #14282 for details on how to test/try this option out.  TODO remove this comment once this option is tested in CI.
-	fs.IntVar(&s.KubernetesServiceNodePort, "kubernetes-service-node-port", s.KubernetesServiceNodePort, "If non-zero, the Kubernetes master service (which apiserver creates/maintains) will be of type NodePort, using this as the value of the port. If zero, the Kubernetes master service will be of type ClusterIP.")
 	// TODO: delete this flag as soon as we identify and fix all clients that send malformed updates, like #14126.
 	fs.BoolVar(&validation.RepairMalformedUpdates, "repair-malformed-updates", validation.RepairMalformedUpdates, "If true, server will do its best to fix the update request to pass the validation, e.g., setting empty UID in update request to its existing value. This flag can be turned off after we fix all the clients that send malformed updates.")
 	fs.StringSliceVar(&s.WatchCacheSizes, "watch-cache-sizes", s.WatchCacheSizes, "List of watch cache sizes for every resource (pods, nodes, etc.), comma separated. The individual override format: resource#size, where size is a number. It takes effect when watch-cache is enabled.")

--- a/cmd/kube-apiserver/app/server_test.go
+++ b/cmd/kube-apiserver/app/server_test.go
@@ -208,7 +208,9 @@ func TestParseRuntimeConfig(t *testing.T) {
 	}
 	for _, test := range testCases {
 		s := &options.APIServer{
-			RuntimeConfig: test.runtimeConfig,
+			ServerRunOptions: &genericapiserver.ServerRunOptions{
+				RuntimeConfig: test.runtimeConfig,
+			},
 		}
 		actualDisablers, err := parseRuntimeConfig(s)
 

--- a/examples/apiserver/apiserver.go
+++ b/examples/apiserver/apiserver.go
@@ -18,6 +18,7 @@ package apiserver
 
 import (
 	"fmt"
+	"net"
 
 	"k8s.io/kubernetes/cmd/libs/go2idl/client-gen/testdata/apis/testgroup.k8s.io/v1"
 	testgroupetcd "k8s.io/kubernetes/examples/apiserver/rest"
@@ -63,14 +64,18 @@ func NewServerRunOptions() *genericapiserver.ServerRunOptions {
 }
 
 func Run(serverOptions *genericapiserver.ServerRunOptions) error {
-	config := genericapiserver.Config{
+	// Set ServiceClusterIPRange
+	_, serviceClusterIPRange, _ := net.ParseCIDR("10.0.0.0/24")
+	serverOptions.ServiceClusterIPRange = *serviceClusterIPRange
+	genericapiserver.ValidateRunOptions(serverOptions)
+	config := &genericapiserver.Config{
 		EnableIndex:          true,
 		EnableSwaggerSupport: true,
 		APIPrefix:            "/api",
 		APIGroupPrefix:       "/apis",
 		Serializer:           api.Codecs,
 	}
-	s, err := genericapiserver.New(&config)
+	s, err := genericapiserver.New(config)
 	if err != nil {
 		return fmt.Errorf("Error in bringing up the server: %v", err)
 	}

--- a/pkg/genericapiserver/server_run_options.go
+++ b/pkg/genericapiserver/server_run_options.go
@@ -19,6 +19,9 @@ package genericapiserver
 import (
 	"net"
 
+	"k8s.io/kubernetes/pkg/util/config"
+	utilnet "k8s.io/kubernetes/pkg/util/net"
+
 	"github.com/spf13/pflag"
 )
 
@@ -29,27 +32,50 @@ const (
 
 // ServerRunOptions contains the options while running a generic api server.
 type ServerRunOptions struct {
-	BindAddress          net.IP
-	CertDirectory        string
-	ClientCAFile         string
-	InsecureBindAddress  net.IP
-	InsecurePort         int
-	LongRunningRequestRE string
-	MaxRequestsInFlight  int
-	SecurePort           int
-	TLSCertFile          string
-	TLSPrivateKeyFile    string
+	APIGroupPrefix            string
+	APIPrefix                 string
+	BindAddress               net.IP
+	CertDirectory             string
+	AdvertiseAddress          net.IP
+	ClientCAFile              string
+	CorsAllowedOriginList     []string
+	EnableLogsSupport         bool
+	EnableProfiling           bool
+	EnableSwaggerUI           bool
+	EnableWatchCache          bool
+	ExternalHost              string
+	InsecureBindAddress       net.IP
+	InsecurePort              int
+	KubernetesServiceNodePort int
+	LongRunningRequestRE      string
+	MasterCount               int
+	MaxRequestsInFlight       int
+	MinRequestTimeout         int
+	RuntimeConfig             config.ConfigurationMap
+	SecurePort                int
+	ServiceClusterIPRange     net.IPNet // TODO: make this a list
+	ServiceNodePortRange      utilnet.PortRange
+	TLSCertFile               string
+	TLSPrivateKeyFile         string
 }
 
 func NewServerRunOptions() *ServerRunOptions {
 	return &ServerRunOptions{
+		APIGroupPrefix:       "/apis",
+		APIPrefix:            "/api",
 		BindAddress:          net.ParseIP("0.0.0.0"),
 		CertDirectory:        "/var/run/kubernetes",
+		EnableLogsSupport:    true,
+		EnableProfiling:      true,
+		EnableWatchCache:     true,
 		InsecureBindAddress:  net.ParseIP("127.0.0.1"),
 		InsecurePort:         8080,
 		LongRunningRequestRE: defaultLongRunningRequestRE,
-		SecurePort:           6443,
+		MasterCount:          1,
 		MaxRequestsInFlight:  400,
+		MinRequestTimeout:    1800,
+		RuntimeConfig:        make(config.ConfigurationMap),
+		SecurePort:           6443,
 	}
 }
 
@@ -57,31 +83,77 @@ func NewServerRunOptions() *ServerRunOptions {
 func (s *ServerRunOptions) AddFlags(fs *pflag.FlagSet) {
 	// Note: the weird ""+ in below lines seems to be the only way to get gofmt to
 	// arrange these text blocks sensibly. Grrr.
+	fs.IPVar(&s.AdvertiseAddress, "advertise-address", s.AdvertiseAddress, ""+
+		"The IP address on which to advertise the apiserver to members of the cluster. This "+
+		"address must be reachable by the rest of the cluster. If blank, the --bind-address "+
+		"will be used. If --bind-address is unspecified, the host's default interface will "+
+		"be used.")
+
+	fs.IPVar(&s.BindAddress, "public-address-override", s.BindAddress, "DEPRECATED: see --bind-address instead")
+	fs.MarkDeprecated("public-address-override", "see --bind-address instead")
 	fs.IPVar(&s.BindAddress, "bind-address", s.BindAddress, ""+
 		"The IP address on which to listen for the --secure-port port. The "+
 		"associated interface(s) must be reachable by the rest of the cluster, and by CLI/web "+
 		"clients. If blank, all interfaces will be used (0.0.0.0).")
+
 	fs.StringVar(&s.CertDirectory, "cert-dir", s.CertDirectory, "The directory where the TLS certs are located (by default /var/run/kubernetes). "+
 		"If --tls-cert-file and --tls-private-key-file are provided, this flag will be ignored.")
+
 	fs.StringVar(&s.ClientCAFile, "client-ca-file", s.ClientCAFile, "If set, any request presenting a client certificate signed by one of the authorities in the client-ca-file is authenticated with an identity corresponding to the CommonName of the client certificate.")
+	fs.StringSliceVar(&s.CorsAllowedOriginList, "cors-allowed-origins", s.CorsAllowedOriginList, "List of allowed origins for CORS, comma separated.  An allowed origin can be a regular expression to support subdomain matching.  If this list is empty CORS will not be enabled.")
+
+	fs.BoolVar(&s.EnableProfiling, "profiling", s.EnableProfiling, "Enable profiling via web interface host:port/debug/pprof/")
+
+	fs.BoolVar(&s.EnableSwaggerUI, "enable-swagger-ui", s.EnableSwaggerUI, "Enables swagger ui on the apiserver at /swagger-ui")
+
+	// TODO: enable cache in integration tests.
+	fs.BoolVar(&s.EnableWatchCache, "watch-cache", s.EnableWatchCache, "Enable watch caching in the apiserver")
+
+	fs.StringVar(&s.ExternalHost, "external-hostname", s.ExternalHost, "The hostname to use when generating externalized URLs for this master (e.g. Swagger API Docs.)")
+
 	fs.IPVar(&s.InsecureBindAddress, "insecure-bind-address", s.InsecureBindAddress, ""+
 		"The IP address on which to serve the --insecure-port (set to 0.0.0.0 for all interfaces). "+
 		"Defaults to localhost.")
 	fs.IPVar(&s.InsecureBindAddress, "address", s.InsecureBindAddress, "DEPRECATED: see --insecure-bind-address instead")
+	fs.MarkDeprecated("address", "see --insecure-bind-address instead")
+
 	fs.IntVar(&s.InsecurePort, "insecure-port", s.InsecurePort, ""+
 		"The port on which to serve unsecured, unauthenticated access. Default 8080. It is assumed "+
 		"that firewall rules are set up such that this port is not reachable from outside of "+
 		"the cluster and that port 443 on the cluster's public address is proxied to this "+
 		"port. This is performed by nginx in the default setup.")
 	fs.IntVar(&s.InsecurePort, "port", s.InsecurePort, "DEPRECATED: see --insecure-port instead")
+	fs.MarkDeprecated("port", "see --insecure-port instead")
+
+	// See #14282 for details on how to test/try this option out.  TODO remove this comment once this option is tested in CI.
+	fs.IntVar(&s.KubernetesServiceNodePort, "kubernetes-service-node-port", s.KubernetesServiceNodePort, "If non-zero, the Kubernetes master service (which apiserver creates/maintains) will be of type NodePort, using this as the value of the port. If zero, the Kubernetes master service will be of type ClusterIP.")
+
 	fs.StringVar(&s.LongRunningRequestRE, "long-running-request-regexp", s.LongRunningRequestRE, "A regular expression matching long running requests which should be excluded from maximum inflight request handling.")
+
+	fs.IntVar(&s.MasterCount, "apiserver-count", s.MasterCount, "The number of apiservers running in the cluster")
+
 	fs.IntVar(&s.MaxRequestsInFlight, "max-requests-inflight", s.MaxRequestsInFlight, "The maximum number of requests in flight at a given time.  When the server exceeds this, it rejects requests.  Zero for no limit.")
+
+	fs.IntVar(&s.MinRequestTimeout, "min-request-timeout", s.MinRequestTimeout, "An optional field indicating the minimum number of seconds a handler must keep a request open before timing it out. Currently only honored by the watch request handler, which picks a randomized value above this number as the connection timeout, to spread out load.")
+
+	fs.Var(&s.RuntimeConfig, "runtime-config", "A set of key=value pairs that describe runtime configuration that may be passed to apiserver. apis/<groupVersion> key can be used to turn on/off specific api versions. apis/<groupVersion>/<resource> can be used to turn on/off specific resources. api/all and api/legacy are special keys to control all and legacy api versions respectively.")
+
 	fs.IntVar(&s.SecurePort, "secure-port", s.SecurePort, ""+
 		"The port on which to serve HTTPS with authentication and authorization. If 0, "+
 		"don't serve HTTPS at all.")
+
+	fs.IPNetVar(&s.ServiceClusterIPRange, "service-cluster-ip-range", s.ServiceClusterIPRange, "A CIDR notation IP range from which to assign service cluster IPs. This must not overlap with any IP ranges assigned to nodes for pods.")
+	fs.IPNetVar(&s.ServiceClusterIPRange, "portal-net", s.ServiceClusterIPRange, "Deprecated: see --service-cluster-ip-range instead.")
+	fs.MarkDeprecated("portal-net", "see --service-cluster-ip-range instead.")
+
+	fs.Var(&s.ServiceNodePortRange, "service-node-port-range", "A port range to reserve for services with NodePort visibility.  Example: '30000-32767'.  Inclusive at both ends of the range.")
+	fs.Var(&s.ServiceNodePortRange, "service-node-ports", "Deprecated: see --service-node-port-range instead.")
+	fs.MarkDeprecated("service-node-ports", "see --service-node-port-range instead.")
+
 	fs.StringVar(&s.TLSCertFile, "tls-cert-file", s.TLSCertFile, ""+
 		"File containing x509 Certificate for HTTPS.  (CA cert, if any, concatenated after server cert). "+
 		"If HTTPS serving is enabled, and --tls-cert-file and --tls-private-key-file are not provided, "+
 		"a self-signed certificate and key are generated for the public address and saved to /var/run/kubernetes.")
+
 	fs.StringVar(&s.TLSPrivateKeyFile, "tls-private-key-file", s.TLSPrivateKeyFile, "File containing x509 private key matching --tls-cert-file.")
 }


### PR DESCRIPTION
Moving more apiserver flags to generic api server.

With this change, most of the Config is created in genericapiserver.NewConfig(). The plan is to move everything there.
I didnt touch Storage related params as they are being changed in https://github.com/kubernetes/kubernetes/pull/23208.
And I will handle authz and authn in another PR (need to figure out a few things).

cc @lavalamp @kubernetes/sig-api-machinery 
