### PR TITLE
AWS: Add support for ap-northeast-2 region (Seoul)

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -575,6 +575,7 @@ func isRegionValid(region string) bool {
 		"ap-southeast-1",
 		"ap-southeast-2",
 		"ap-northeast-1",
+		"ap-northeast-2",
 		"cn-north-1",
 		"us-gov-west-1",
 		"sa-east-1",


### PR DESCRIPTION
This PR does:
- Support AWS Seoul region: ap-northeast-2. 
  Currently, I can not setup Kubernetes on AWS Seoul.  
  Error Messages: 

> ip-10-0-0-50 core # docker logs 0697db
> I0419 07:57:44.569174       1 aws.go:466] Zone not specified in configuration file; querying AWS metadata service
> F0419 07:57:44.570380       1 controllermanager.go:279] Cloud provider could not be initialized: could not init cloud provider "aws": not a valid AWS zone (unknown region): ap-northeast-2a
