### PR TITLE
Fix kubectl create skydns-rc failure

### DIFF
--- a/cluster/saltbase/salt/kube-addons/kube-addon-update.sh
+++ b/cluster/saltbase/salt/kube-addons/kube-addon-update.sh
@@ -262,7 +262,7 @@ function create-object() {
     log INFO "Creating new ${obj_type} from file ${file_path} in namespace ${namespace}, name: ${obj_name}"
     # this will keep on failing if the ${file_path} disappeared in the meantime.
     # Do not use too many retries.
-    run-until-success "${KUBECTL} create --namespace=${namespace} -f ${file_path}" ${NUM_TRIES} ${DELAY_AFTER_ERROR_SEC}
+    run-until-success "${KUBECTL} create --namespace=${namespace} --validate=false -f ${file_path}" ${NUM_TRIES} ${DELAY_AFTER_ERROR_SEC}
 }
 
 function update-object() {


### PR DESCRIPTION
Currently, kube-addon-updat.sh cannot create skydns rc because of

```
# kubectl create -f skydns-rc.yaml 
error validating "skydns-rc.yaml": error validating data: [found invalid field successThreshold for v1.Probe, found invalid field failureThreshold for v1.Probe]; if you choose to ignore these errors, turn validation off with --validate=false
```

Update the script to fix it. Another way I can think of is adding the related field to v1.probe, I don't know the develop status on it, so head this way firstly.

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/24458)

<!-- Reviewable:end -->
