### PR TITLE
Fix GLBC cluster addon README link

### DIFF
--- a/cluster/addons/cluster-loadbalancing/glbc/README.md
+++ b/cluster/addons/cluster-loadbalancing/glbc/README.md
@@ -1,7 +1,7 @@
 # GCE Load-Balancer Controller (GLBC) Cluster Addon
 
 This cluster addon is composed of:
-* A [Google L7 LoadBalancer Controller](https://github.com/kubernetes/contrib/tree/master/Ingress/controllers/gce)
+* A [Google L7 LoadBalancer Controller](https://github.com/kubernetes/contrib/tree/master/ingress/controllers/gce)
 * A [404 default backend](https://github.com/kubernetes/contrib/tree/master/404-server) Service + RC
 
 It relies on the [Ingress resource](../../../../docs/user-guide/ingress.md) only available in Kubernetes version 1.1 and beyond.


### PR DESCRIPTION
Fix the link to L7 load balancer controller in GLBC cluster addon README.

Fixed #24462.
