### PR TITLE
Remove double assignment of KUBE_ROOT

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -19,8 +19,6 @@ set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
-
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env


### PR DESCRIPTION
`KUBE_ROOT` got assigned twice in the codegen script.
