### PR TITLE
stop changing the root path of the root webservice

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -167,19 +167,22 @@ func (g *APIGroupVersion) newInstaller() *APIInstaller {
 
 // TODO: document all handlers
 // InstallSupport registers the APIServer support functions
-func InstallSupport(mux Mux, ws *restful.WebService, checks ...healthz.HealthzChecker) {
+func InstallSupport(mux Mux, checks ...healthz.HealthzChecker) []*restful.WebService {
 	// TODO: convert healthz and metrics to restful and remove container arg
 	healthz.InstallHandler(mux, checks...)
 
 	// Set up a service to return the git code version.
-	ws.Path("/version")
-	ws.Doc("git code version from which this is built")
-	ws.Route(
-		ws.GET("/").To(handleVersion).
+	versionWS := new(restful.WebService)
+	versionWS.Path("/version")
+	versionWS.Doc("git code version from which this is built")
+	versionWS.Route(
+		versionWS.GET("/").To(handleVersion).
 			Doc("get the code version").
 			Operation("getCodeVersion").
 			Produces(restful.MIME_JSON).
 			Consumes(restful.MIME_JSON))
+
+	return []*restful.WebService{versionWS}
 }
 
 // InstallLogsSupport registers the APIServer log support function into a mux.

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -319,9 +319,10 @@ func handleInternal(storage map[string]rest.Storage, admissionControl admission.
 		}
 	}
 
-	ws := new(restful.WebService)
-	InstallSupport(mux, ws)
-	container.Add(ws)
+	webservices := InstallSupport(mux)
+	for i := range webservices {
+		container.Add(webservices[i])
+	}
 	return &defaultAPIServer{mux, container}
 }
 
@@ -3257,9 +3258,10 @@ func TestXGSubresource(t *testing.T) {
 		panic(fmt.Sprintf("unable to install container %s: %v", group.GroupVersion, err))
 	}
 
-	ws := new(restful.WebService)
-	InstallSupport(mux, ws)
-	container.Add(ws)
+	webservices := InstallSupport(mux)
+	for i := range webservices {
+		container.Add(webservices[i])
+	}
 
 	handler := defaultAPIServer{mux, container}
 	server := httptest.NewServer(handler)

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -226,7 +226,7 @@ func (m *Master) InstallAPIs(c *Config) {
 	}
 
 	// TODO(nikhiljindal): Refactor generic parts of support services (like /versions) to genericapiserver.
-	apiserver.InstallSupport(m.MuxHelper, m.RootWebService, healthzChecks...)
+	webservices := apiserver.InstallSupport(m.MuxHelper, healthzChecks...)
 
 	if c.EnableProfiling {
 		m.MuxHelper.HandleFunc("/metrics", MetricsWithReset)
@@ -234,8 +234,9 @@ func (m *Master) InstallAPIs(c *Config) {
 		m.MuxHelper.HandleFunc("/metrics", defaultMetricsHandler)
 	}
 
-	// Install root web services
-	m.HandlerContainer.Add(m.RootWebService)
+	for i := range webservices {
+		m.HandlerContainer.Add(webservices[i])
+	}
 
 	// allGroups records all supported groups at /apis
 	allGroups := []unversioned.APIGroup{}


### PR DESCRIPTION
We shouldn't mutate the root path of the root webservice (see usage).  Just write the path we want.
