### PR TITLE
Bump kubernetes-test-go timeout.

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-go.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-go.yaml
@@ -74,16 +74,16 @@
         - 'go':
             branch: 'master'
             cron-string: '{sq-cron-string}'
-            timeout: 80
+            timeout: 100
         - 'go-release-1.2':
             branch: 'release-1.2'
             # Every 3 hours
             cron-string: 'H H/3 * * *'
-            timeout: 50
+            timeout: 100
         - 'go-release-1.1':
             branch: 'release-1.1'
             # Every 6 hours
             cron-string: 'H H/12 * * *'
-            timeout: 30
+            timeout: 60
     jobs:
         - 'kubernetes-test-{suffix}'


### PR DESCRIPTION
It looks like the run times got more inconsistent because of load on the VM. Adding another Jenkins slave improved things so we're not constantly timing out, but it still gets a little close to timing out at times.

Average runtime is ~45 mins so I went with a 100 min timeout.

Fixes #24285
