### PR TITLE
Fix goroutine leak in ssh-tunnel healthcheck.

### DIFF
--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -362,8 +362,12 @@ func (l *SSHTunnelList) healthCheck(e sshTunnelEntry) error {
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	})
 	client := &http.Client{Transport: transport}
-	_, err := client.Get(l.healthCheckURL.String())
-	return err
+	resp, err := client.Get(l.healthCheckURL.String())
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
 }
 
 func (l *SSHTunnelList) removeAndReAdd(e sshTunnelEntry) {


### PR DESCRIPTION
Tunnel healthchecks were not closing the HTTP response body, leading to many open goroutines.
