### PR TITLE
Automated cherry pick of #24452 upstream release 1.2

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -2220,6 +2220,11 @@ func (gce *GCECloud) getDiskByNameUnknownZone(diskName string) (*gceDisk, error)
 		if err != nil {
 			return nil, err
 		}
+		// findDiskByName returns (nil,nil) if the disk doesn't exist, so we can't
+		// assume that a disk was found unless disk is non-nil.
+		if disk == nil {
+			continue
+		}
 		if found != nil {
 			return nil, fmt.Errorf("GCE persistent disk name was found in multiple zones: %q", diskName)
 		}


### PR DESCRIPTION
Fixes #24447.

Release note: Fixed bug (#24447) that kept GCE disks from being labeled with the correct zone or deleted in multi-zone (Ubernetes Lite) clusters.

@saad-ali @quinton-hoole @roberthbailey 
