### PR TITLE
Remove dot in generated deepcopy package name

### DIFF
--- a/cmd/libs/go2idl/deepcopy-gen/generators/deepcopy.go
+++ b/cmd/libs/go2idl/deepcopy-gen/generators/deepcopy.go
@@ -84,7 +84,7 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 			path := p.Path
 			packages = append(packages,
 				&generator.DefaultPackage{
-					PackageName: filepath.Base(path),
+					PackageName: strings.Split(filepath.Base(path), ".")[0],
 					PackagePath: path,
 					HeaderText:  header,
 					GeneratorFunc: func(c *generator.Context) (generators []generator.Generator) {


### PR DESCRIPTION
ref https://github.com/kubernetes/kubernetes/pull/20573#issuecomment-212125061

cc @wojtek-t 

I tested with #20573 to verify hack/codegen.sh worked and the generated code compiled.
