### PR TITLE
Don't log private SSH key

### DIFF
--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -233,7 +233,7 @@ func MakePrivateKeySignerFromFile(key string) (ssh.Signer, error) {
 func MakePrivateKeySignerFromBytes(buffer []byte) (ssh.Signer, error) {
 	signer, err := ssh.ParsePrivateKey(buffer)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing SSH key %s: '%v'", buffer, err)
+		return nil, fmt.Errorf("error parsing SSH key: '%v'", err)
 	}
 	return signer, nil
 }


### PR DESCRIPTION
Log files may have more inclusive permissions than private SSH keys, and as such we should not log the key, even if it looks invalid. I accidentally leaked my key this way when posting e2e test logs.
