### PR TITLE
reuse goproxy pod and avoid race between kubectl exec and goproxy readiness

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -388,20 +388,20 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 				framework.Failf("Unable to upload kubectl binary to remote exec server. /uploads/ not in response. Response: %s", uploadBinaryName)
 			}
 
+			By("Starting goproxy pod")
+			goproxyPodPath := filepath.Join(framework.TestContext.RepoRoot, "test/images/goproxy/pod.yaml")
+			framework.RunKubectlOrDie("create", "-f", goproxyPodPath, fmt.Sprintf("--namespace=%v", ns))
+			framework.CheckPodsRunningReady(c, ns, []string{goproxyContainer}, framework.PodStartTimeout)
+
+			// get the proxy address
+			goproxyPod, err := c.Pods(ns).Get(goproxyContainer)
+			if err != nil {
+				framework.Failf("Unable to get the goproxy pod. Error: %s", err)
+			}
+			proxyAddr := fmt.Sprintf("http://%s:8080", goproxyPod.Status.PodIP)
+
 			for _, proxyVar := range []string{"https_proxy", "HTTPS_PROXY"} {
 				By("Running kubectl in netexec via an HTTP proxy using " + proxyVar)
-				// start the proxy container
-				goproxyPodPath := filepath.Join(framework.TestContext.RepoRoot, "test/images/goproxy/pod.yaml")
-				framework.RunKubectlOrDie("create", "-f", goproxyPodPath, fmt.Sprintf("--namespace=%v", ns))
-				framework.CheckPodsRunningReady(c, ns, []string{goproxyContainer}, framework.PodStartTimeout)
-
-				// get the proxy address
-				goproxyPod, err := c.Pods(ns).Get(goproxyContainer)
-				if err != nil {
-					framework.Failf("Unable to get the goproxy pod. Error: %s", err)
-				}
-				proxyAddr := fmt.Sprintf("http://%s:8080", goproxyPod.Status.PodIP)
-
 				shellCommand := fmt.Sprintf("%s=%s .%s --kubeconfig=%s --server=%s --namespace=%s exec nginx echo running in container",
 					proxyVar, proxyAddr, uploadBinaryName, kubecConfigRemotePath, apiServer, ns)
 				framework.Logf("About to remote exec: %v", shellCommand)
@@ -453,9 +453,9 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 				if !strings.Contains(proxyLog, expectedProxyLog) {
 					framework.Failf("Missing expected log result on proxy server for %s. Expected: %q, got %q", proxyVar, expectedProxyLog, proxyLog)
 				}
-				// Clean up the goproxyPod
-				framework.Cleanup(goproxyPodPath, ns, goproxyPodSelector)
 			}
+			// Clean up the goproxyPod
+			framework.Cleanup(goproxyPodPath, ns, goproxyPodSelector)
 		})
 
 		It("should support inline execution and attach", func() {

--- a/test/images/goproxy/pod.yaml
+++ b/test/images/goproxy/pod.yaml
@@ -10,3 +10,7 @@ spec:
     image: gcr.io/google_containers/goproxy:0.1
     ports:
     - containerPort: 8080
+    readinessProbe:
+      tcpSocket:
+        port: 8080
+


### PR DESCRIPTION
I can reproduce the failure locally. `kubectl exec` is initiated right after goproxy pod becomes running and ready. But there is a slight lag (a few seconds) between pod gets ready and goproxy ready to serve traffic. Hence causing the failure. 

ref: #24211
cc: @janetkuo 
