### PR TITLE
Quota ignores pod compute resources on updates

### DIFF
--- a/pkg/quota/evaluator/core/pods.go
+++ b/pkg/quota/evaluator/core/pods.go
@@ -47,7 +47,8 @@ func NewPodEvaluator(kubeClient clientset.Interface) quota.Evaluator {
 		InternalGroupKind: api.Kind("Pod"),
 		InternalOperationResources: map[admission.Operation][]api.ResourceName{
 			admission.Create: allResources,
-			admission.Update: computeResources,
+			// TODO: the quota system can only charge for deltas on compute resources when pods support updates.
+			// admission.Update: computeResources,
 		},
 		GetFuncByNamespace: func(namespace, name string) (runtime.Object, error) {
 			return kubeClient.Core().Pods(namespace).Get(name)


### PR DESCRIPTION
Scenario:
1. define a quota Q that tracks memory and cpu
2. create pod P that uses memory=100Mi, cpu=100m
3. update pod P to use memory=50Mi,cpu=10m

Expected Results:
Step 3 should fail with validation error.
Quota Q should not have changed.

Actual Results:
Step 3 fails validation, but quota Q is decremented to have memory usage down 50Mi and cpu usage down 40m.  This is because the quota was getting updated even though the pod was going to fail validation.

Fix:
Quota should only support modifying pod compute resources when pods themselves support modifying their compute resources.

This also fixes https://github.com/kubernetes/kubernetes/issues/24352

/cc @smarterclayton - this is what we discussed.

fyi: @kubernetes/rh-cluster-infra 
