### PR TITLE
Disable flannel job until it works

### DIFF
--- a/hack/jenkins/diff-job-config-patch.sh
+++ b/hack/jenkins/diff-job-config-patch.sh
@@ -68,5 +68,8 @@ docker run --rm=true -i \
   bash -c "${common_commands}"
 
 diff -ruN "${output_dir}/upstream" "${output_dir}/patch" >"${diff_file}" || true
+if [[ -t 1 ]]; then  # Attached to a terminal?
+  less "${diff_file}"
+fi
 echo
 echo "  *** Diff saved in ${diff_file} ***"

--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
@@ -511,6 +511,7 @@
                 export FAIL_ON_GCP_RESOURCE_LEAK="false"
         - 'gce-flannel':
             description: 'Run E2E tests on GCE using Flannel and the latest successful build. This suite is quarantined in a dedicated project because Flannel integration is experimental.'
+            disable_job: true  # Issue #24520
             # We don't really care to enforce a timeout for flannel tests. Any performance issues will show up in the other GCE builders.
             # This suite is to continuously check that flannel + Kubernetes works.
             timeout: 120


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/issues/24520

See bug, this job is fails every time and has done so for two months. Until someone has time to investigate and fix disable the job on jenkins so we're not wasting resources and reducing system stability.
