### PR TITLE
Add RC and container pors to scheduler benchmark

### DIFF
--- a/plugin/pkg/scheduler/algorithm/priorities/node_affinity.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/node_affinity.go
@@ -42,7 +42,6 @@ func NewNodeAffinityPriority(nodeLister algorithm.NodeLister) algorithm.Priority
 // the node satisfies and the more the preferredSchedulingTerm that is satisfied weights, the higher
 // score the node gets.
 func (s *NodeAffinity) CalculateNodeAffinityPriority(pod *api.Pod, nodeNameToInfo map[string]*schedulercache.NodeInfo, nodeLister algorithm.NodeLister) (schedulerapi.HostPriorityList, error) {
-
 	var maxCount int
 	counts := map[string]int{}
 

--- a/test/component/scheduler/perf/scheduler_bench_test.go
+++ b/test/component/scheduler/perf/scheduler_bench_test.go
@@ -54,7 +54,7 @@ func benchmarkScheduling(numNodes, numScheduledPods int, b *testing.B) {
 	c := schedulerConfigFactory.Client
 
 	makeNodes(c, numNodes)
-	makePods(c, numScheduledPods)
+	makePodsFromRC(c, "rc1", numScheduledPods)
 	for {
 		scheduled := schedulerConfigFactory.ScheduledPodLister.Store.List()
 		if len(scheduled) >= numScheduledPods {
@@ -64,7 +64,7 @@ func benchmarkScheduling(numNodes, numScheduledPods int, b *testing.B) {
 	}
 	// start benchmark
 	b.ResetTimer()
-	makePods(c, b.N)
+	makePodsFromRC(c, "rc2", b.N)
 	for {
 		// This can potentially affect performance of scheduler, since List() is done under mutex.
 		// TODO: Setup watch on apiserver and wait until all pods scheduled.

--- a/test/component/scheduler/perf/scheduler_test.go
+++ b/test/component/scheduler/perf/scheduler_test.go
@@ -42,7 +42,7 @@ func schedulePods(numNodes, numPods int) {
 	c := schedulerConfigFactory.Client
 
 	makeNodes(c, numNodes)
-	makePods(c, numPods)
+	makePodsFromRC(c, "rc1", numPods)
 
 	prev := 0
 	start := time.Now()

--- a/test/component/scheduler/perf/test-performance.sh
+++ b/test/component/scheduler/perf/test-performance.sh
@@ -42,8 +42,8 @@ kube::log::status "performance test start"
 if ${RUN_BENCHMARK:-false}; then
   go test -c -o "perf.test"
   "./perf.test" -test.bench=. -test.run=xxxx -test.cpuprofile=prof.out
+  kube::log::status "benchmark tests finished"
 fi
-kube::log::status "benchmark tests finished"
 # Running density tests. It might take a long time.
 go test -test.run=. -test.timeout=60m
 kube::log::status "density tests finished"


### PR DESCRIPTION
Fix #23263

Ref  #24408
However - scheduler throughput is still ~140 initially, whereas in reality we have 35-40. There are still significant difference we should understand.

@hongchaodeng @xiang90 
