### PR TITLE
Trusty: Handle the new var in kube-proxy manifest

### DIFF
--- a/cluster/gce/trusty/node.yaml
+++ b/cluster/gce/trusty/node.yaml
@@ -195,14 +195,17 @@ script
 	if [ -n "${KUBEPROXY_TEST_LOG_LEVEL:-}" ]; then
 		log_level="${KUBEPROXY_TEST_LOG_LEVEL}"
 	fi
-	api_servers="--master=https:\/\/${KUBERNETES_MASTER_NAME}"
-	sed -i -e "s/{{kubeconfig}}/${kubeconfig}/g" ${tmp_file}
-	sed -i -e "s/{{pillar\['kube_docker_registry'\]}}/${kube_docker_registry}/g" ${tmp_file}
-	sed -i -e "s/{{pillar\['kube-proxy_docker_tag'\]}}/${kube_proxy_docker_tag}/g" ${tmp_file}
-	sed -i -e "s/{{test_args}}/${test_args}/g" ${tmp_file}
-	sed -i -e "s/{{ cpurequest }}/20m/g" ${tmp_file}
-	sed -i -e "s/{{log_level}}/${log_level}/g" ${tmp_file}
-	sed -i -e "s/{{api_servers_with_port}}/${api_servers}/g" ${tmp_file}
+	api_servers="--master=https://${KUBERNETES_MASTER_NAME}"
+	sed -i -e "s@{{kubeconfig}}@${kubeconfig}@g" ${tmp_file}
+	sed -i -e "s@{{pillar\['kube_docker_registry'\]}}@${kube_docker_registry}@g" ${tmp_file}
+	sed -i -e "s@{{pillar\['kube-proxy_docker_tag'\]}}@${kube_proxy_docker_tag}@g" ${tmp_file}
+	sed -i -e "s@{{test_args}}@${test_args}@g" ${tmp_file}
+	sed -i -e "s@{{ cpurequest }}@20m@g" ${tmp_file}
+	sed -i -e "s@{{log_level}}@${log_level}@g" ${tmp_file}
+	sed -i -e "s@{{api_servers_with_port}}@${api_servers}@g" ${tmp_file}
+	if [ -n "${CLUSTER_IP_RANGE:-}" ]; then
+		sed -i -e "s@{{cluster_cidr}}@--cluster-cidr=${CLUSTER_IP_RANGE}@g" ${tmp_file}
+	fi
 
 	mv -f ${tmp_file} /etc/kubernetes/manifests/
 end script


### PR DESCRIPTION
This is to capture the kube-proxy manifest change in PR #24429.

@roberthbailey @fabioy @zmerlynn please review this change and mark it as cherry pick candidate. We need to catch up 1.2.3 release.

cc/ @dchen1107 @wonderfly @cjcullen FYI.

I have verified this fix. Without this fix, kube-proxy pod in Trusty nodes cannot be started correctly, i.e., the command line has an unhadled variable. And some other kube-system pods do not work correctly as kube-proxy is not working well. After applying this fix, kube-proxy can be started correctly, and all kube-system pods run successfully. 
