### PR TITLE
Remove flaky tag from e2e net granular

### DIFF
--- a/test/e2e/networking.go
+++ b/test/e2e/networking.go
@@ -213,8 +213,7 @@ var _ = framework.KubeDescribe("Networking", func() {
 		Expect(string(body)).To(Equal("pass"))
 	})
 
-	// Marked with [Flaky] until the tests prove themselves stable.
-	framework.KubeDescribe("[Flaky] Granular Checks", func() {
+	framework.KubeDescribe("Granular Checks", func() {
 
 		It("should function for pod communication on a single node", func() {
 


### PR DESCRIPTION
The tests are running reliably on every origin merge and can be verified
similarly reliable on kube.

As per @jayunit100 on slack/sig-testing:

```
./cluster/kubectl.sh 2>&1 | grep Passed | grep Failed ; done
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 275 Skipped PASS
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 275 Skipped PASS
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 275 Skipped PASS
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 275 Skipped PASS
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 275 Skipped PASS
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 275 Skipped PASS
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 275 Skipped PASS
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 275 Skipped PASS
```
