### PR TITLE
Newrelic fix

### DIFF
--- a/examples/newrelic/config-to-secret.sh
+++ b/examples/newrelic/config-to-secret.sh
@@ -16,5 +16,5 @@
 
 # Encodes the environment variables into a Kubernetes secret.
 
-BASE64_ENC=$(cat nrconfig.env | base64 --wrap=0)
+BASE64_ENC=$(cat nrconfig.env | base64 | tr -d '\n')
 sed -e "s#{{config_data}}#${BASE64_ENC}#g" ./newrelic-config-template.yaml > newrelic-config.yaml

--- a/examples/newrelic/newrelic-daemonset.yaml
+++ b/examples/newrelic/newrelic-daemonset.yaml
@@ -15,8 +15,6 @@ spec:
       # Filter to specific nodes:
       # nodeSelector:
       #  app: newrelic
-      securityContext:
-        privileged: true
       hostPID: true
       hostIPC: true
       hostNetwork: true
@@ -24,6 +22,8 @@ spec:
         - resources:
             requests:
               cpu: 0.15
+          securityContext:
+            privileged: true
           env:
             - name: NRSYSMOND_logfile
               value: "/var/log/nrsysmond.log"


### PR DESCRIPTION
1. base64 on Mac does not support the **wrap** option.  Easy to support on both Mac and Linux by using **tr** to remove the newline.
2. DaemonSet definition does not conform to latest schema:

> $ kubectl create -f ./newrelic-daemonset.yaml 
> error validating "./newrelic-daemonset.yaml": error validating data: found invalid field privileged for v1.PodSecurityContext; if you choose to ignore these errors, turn validation off with --validate=false
