### PR TITLE
docker daemon complains SHM size must be greater than 0

### DIFF
--- a/pkg/kubelet/dockertools/kube_docker_client.go
+++ b/pkg/kubelet/dockertools/kube_docker_client.go
@@ -55,6 +55,9 @@ type kubeDockerClient struct {
 // Make sure that kubeDockerClient implemented the DockerInterface.
 var _ DockerInterface = &kubeDockerClient{}
 
+// the default ShmSize to use (in bytes) if not specified.
+const defaultShmSize = int64(1024 * 1024 * 64)
+
 // newKubeDockerClient creates an kubeDockerClient from an existing docker client.
 func newKubeDockerClient(dockerClient *dockerapi.Client) DockerInterface {
 	return &kubeDockerClient{
@@ -126,6 +129,11 @@ func (d *kubeDockerClient) InspectContainer(id string) (*dockertypes.ContainerJS
 }
 
 func (d *kubeDockerClient) CreateContainer(opts dockertypes.ContainerCreateConfig) (*dockertypes.ContainerCreateResponse, error) {
+	// we provide an explicit default shm size as to not depend on docker daemon.
+	// TODO: evaluate exposing this as a knob in the API
+	if opts.HostConfig != nil && opts.HostConfig.ShmSize <= 0 {
+		opts.HostConfig.ShmSize = defaultShmSize
+	}
 	createResp, err := d.client.ContainerCreate(getDefaultContext(), opts.Config, opts.HostConfig, opts.NetworkingConfig, opts.Name)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/24588

I am hitting this on Fedora 23 w/ docker 1.9.1 using systemd cgroup-driver.

```
$ docker version
Client:
 Version:         1.9.1
 API version:     1.21
 Package version: docker-1.9.1-9.gitee06d03.fc23.x86_64
 Go version:      go1.5.3
 Git commit:      ee06d03/1.9.1
 Built:           
 OS/Arch:         linux/amd64

Server:
 Version:         1.9.1
 API version:     1.21
 Package version: docker-1.9.1-9.gitee06d03.fc23.x86_64
 Go version:      go1.5.3
 Git commit:      ee06d03/1.9.1
 Built:           
 OS/Arch:         linux/amd64
```

Not sure why I am on the only one hitting it right now, but putting this out here for comment.

/cc @kubernetes/sig-node @kubernetes/rh-cluster-infra @smarterclayton 
