### PR TITLE
Store node information in NodeInfo

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2351,8 +2351,9 @@ func (kl *Kubelet) canAdmitPod(pods []*api.Pod, pod *api.Pod) (bool, string, str
 			otherPods = append(otherPods, p)
 		}
 	}
-	nodeInfo := schedulercache.CreateNodeNameToInfoMap(otherPods)[kl.nodeName]
-	fit, err := predicates.RunGeneralPredicates(pod, kl.nodeName, nodeInfo, node)
+	nodeInfo := schedulercache.NewNodeInfo(otherPods...)
+	nodeInfo.SetNode(node)
+	fit, err := predicates.GeneralPredicates(pod, kl.nodeName, nodeInfo)
 	if !fit {
 		if re, ok := err.(*predicates.PredicateFailureError); ok {
 			reason := re.PredicateName

--- a/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
+++ b/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -84,16 +84,13 @@ func init() {
 	// Fit is determined by resource availability.
 	// This predicate is actually a default predicate, because it is invoked from
 	// predicates.GeneralPredicates()
-	factory.RegisterFitPredicateFactory(
-		"PodFitsResources",
-		func(args factory.PluginFactoryArgs) algorithm.FitPredicate {
-			return predicates.NewResourceFitPredicate(args.NodeInfo)
-		},
-	)
+	factory.RegisterFitPredicate("PodFitsResources", predicates.PodFitsResources)
 	// Fit is determined by the presence of the Host parameter and a string match
 	// This predicate is actually a default predicate, because it is invoked from
 	// predicates.GeneralPredicates()
 	factory.RegisterFitPredicate("HostName", predicates.PodFitsHost)
+	// Fit is determined by node selector query.
+	factory.RegisterFitPredicate("MatchNodeSelector", predicates.PodSelectorMatches)
 }
 
 func defaultPredicates() sets.String {
@@ -104,14 +101,7 @@ func defaultPredicates() sets.String {
 		factory.RegisterFitPredicateFactory(
 			"NoVolumeZoneConflict",
 			func(args factory.PluginFactoryArgs) algorithm.FitPredicate {
-				return predicates.NewVolumeZonePredicate(args.NodeInfo, args.PVInfo, args.PVCInfo)
-			},
-		),
-		// Fit is determined by node selector query.
-		factory.RegisterFitPredicateFactory(
-			"MatchNodeSelector",
-			func(args factory.PluginFactoryArgs) algorithm.FitPredicate {
-				return predicates.NewSelectorMatchPredicate(args.NodeInfo)
+				return predicates.NewVolumeZonePredicate(args.PVInfo, args.PVCInfo)
 			},
 		),
 		// Fit is determined by whether or not there would be too many AWS EBS volumes attached to the node
@@ -134,12 +124,7 @@ func defaultPredicates() sets.String {
 		),
 		// GeneralPredicates are the predicates that are enforced by all Kubernetes components
 		// (e.g. kubelet and all schedulers)
-		factory.RegisterFitPredicateFactory(
-			"GeneralPredicates",
-			func(args factory.PluginFactoryArgs) algorithm.FitPredicate {
-				return predicates.GeneralPredicates(args.NodeInfo)
-			},
-		),
+		factory.RegisterFitPredicate("GeneralPredicates", predicates.GeneralPredicates),
 	)
 }
 

--- a/plugin/pkg/scheduler/factory/plugins.go
+++ b/plugin/pkg/scheduler/factory/plugins.go
@@ -111,7 +111,6 @@ func RegisterCustomFitPredicate(policy schedulerapi.PredicatePolicy) string {
 		} else if policy.Argument.LabelsPresence != nil {
 			predicateFactory = func(args PluginFactoryArgs) algorithm.FitPredicate {
 				return predicates.NewNodeLabelPredicate(
-					args.NodeInfo,
 					policy.Argument.LabelsPresence.Labels,
 					policy.Argument.LabelsPresence.Presence,
 				)

--- a/plugin/pkg/scheduler/schedulercache/interface.go
+++ b/plugin/pkg/scheduler/schedulercache/interface.go
@@ -71,6 +71,15 @@ type Cache interface {
 	// RemovePod removes a pod. The pod's information would be subtracted from assigned node.
 	RemovePod(pod *api.Pod) error
 
+	// AddNode adds overall information about node.
+	AddNode(node *api.Node) error
+
+	// UpdateNode updates overall information about node.
+	UpdateNode(oldNode, newNode *api.Node) error
+
+	// RemoveNode removes overall information about node.
+	RemoveNode(node *api.Node) error
+
 	// GetNodeNameToInfoMap returns a map of node names to node info. The node info contains
 	// aggregated information of pods scheduled (including assumed to be) on this node.
 	GetNodeNameToInfoMap() (map[string]*NodeInfo, error)

--- a/plugin/pkg/scheduler/testing/fake_cache.go
+++ b/plugin/pkg/scheduler/testing/fake_cache.go
@@ -38,6 +38,12 @@ func (f *FakeCache) UpdatePod(oldPod, newPod *api.Pod) error { return nil }
 
 func (f *FakeCache) RemovePod(pod *api.Pod) error { return nil }
 
+func (f *FakeCache) AddNode(node *api.Node) error { return nil }
+
+func (f *FakeCache) UpdateNode(oldNode, newNode *api.Node) error { return nil }
+
+func (f *FakeCache) RemoveNode(node *api.Node) error { return nil }
+
 func (f *FakeCache) GetNodeNameToInfoMap() (map[string]*schedulercache.NodeInfo, error) {
 	return nil, nil
 }

--- a/plugin/pkg/scheduler/testing/pods_to_cache.go
+++ b/plugin/pkg/scheduler/testing/pods_to_cache.go
@@ -35,6 +35,12 @@ func (p PodsToCache) UpdatePod(oldPod, newPod *api.Pod) error { return nil }
 
 func (p PodsToCache) RemovePod(pod *api.Pod) error { return nil }
 
+func (p PodsToCache) AddNode(node *api.Node) error { return nil }
+
+func (p PodsToCache) UpdateNode(oldNode, newNode *api.Node) error { return nil }
+
+func (p PodsToCache) RemoveNode(node *api.Node) error { return nil }
+
 func (p PodsToCache) GetNodeNameToInfoMap() (map[string]*schedulercache.NodeInfo, error) {
 	return schedulercache.CreateNodeNameToInfoMap(p), nil
 }


### PR DESCRIPTION
This is significantly improving scheduler throughput.

On 1000-node cluster:
- empty cluster: ~70pods/s
- full cluster: ~45pods/s
  Drop in throughput is mostly related to priority functions, which I will be looking into next (I already have some PR #24095, but we need for more things before).

This is roughly ~40% increase.
However, we still need better understanding of predicate function, because in my opinion it should be even faster as it is now. I'm going to look into it next week.

@gmarek @hongchaodeng @xiang90 
