### PR TITLE
Trusty: Add debug supports for docker and kubelet

### DIFF
--- a/cluster/gce/trusty/configure-helper.sh
+++ b/cluster/gce/trusty/configure-helper.sh
@@ -181,10 +181,14 @@ assemble_kubelet_flags() {
   fi
   # Add the unconditional flags
   KUBELET_CMD_FLAGS="${KUBELET_CMD_FLAGS} --cloud-provider=gce --allow-privileged=true --cgroup-root=/ --system-cgroups=/system --kubelet-cgroups=/kubelet --babysit-daemons=true --config=/etc/kubernetes/manifests --cluster-dns=${DNS_SERVER_IP} --cluster-domain=${DNS_DOMAIN}"
+  echo "KUBELET_OPTS=\"${KUBELET_CMD_FLAGS}\"" > /etc/default/kubelet
 }
 
 restart_docker_daemon() {
-  readonly DOCKER_OPTS="-p /var/run/docker.pid --bridge=cbr0 --iptables=false --ip-masq=false"
+  DOCKER_OPTS="-p /var/run/docker.pid --bridge=cbr0 --iptables=false --ip-masq=false"
+  if [ "${TEST_CLUSTER:-}" = "true" ]; then
+    DOCKER_OPTS="${DOCKER_OPTS} --debug"
+  fi
   echo "DOCKER_OPTS=\"${DOCKER_OPTS} ${EXTRA_DOCKER_OPTS:-}\"" > /etc/default/docker
   # Make sure the network interface cbr0 is created before restarting docker daemon
   while ! [ -L /sys/class/net/cbr0 ]; do

--- a/cluster/gce/trusty/helper.sh
+++ b/cluster/gce/trusty/helper.sh
@@ -16,11 +16,9 @@
 
 # A library of helper functions and constant for ubuntu os distro
 
-# The code and configuration is for running node instances on Ubuntu images.
-# The master is still on Debian. In addition, the configuration is based on
-# upstart, which is in Ubuntu up to 14.04 LTS (Trusty). Ubuntu 15.04 and above
-# replaced upstart with systemd as the init system. Consequently, the
-# configuration cannot work on these images.
+# The configuration is based on upstart, which is in Ubuntu up to 14.04 LTS (Trusty).
+# Ubuntu 15.04 and above replaced upstart with systemd as the init system.
+# Consequently, the configuration cannot work on these images.
 
 
 # $1: template name (required)

--- a/cluster/gce/trusty/master.yaml
+++ b/cluster/gce/trusty/master.yaml
@@ -60,7 +60,10 @@ script
 	echo "Creating kubernetes master auth file"
 	create_master_auth
 	echo "Creating master instance kubelet auth file"
-  create_master_kubelet_auth
+	create_master_kubelet_auth
+	echo "Assemble kubelet command line"
+	# Kubelet command flags will be written in /etc/default/kubelet
+	assemble_kubelet_flags
 end script
 
 --====================================
@@ -122,12 +125,8 @@ script
 	set -o nounset
 
 	echo "Start kubelet upstart job"
-	. /etc/kube-configure-helper.sh
-	. /etc/kube-env
-	# Assemble command line flags based on env variables, which will put the string
-	# of flags in variable KUBELET_CMD_FLAGS
-	assemble_kubelet_flags
-	/usr/bin/kubelet ${KUBELET_CMD_FLAGS} 1>>/var/log/kubelet.log 2>&1
+	. /etc/default/kubelet
+	/usr/bin/kubelet ${KUBELET_OPTS} 1>>/var/log/kubelet.log 2>&1
 end script
 
 # Wait for 10s to start kubelet again.

--- a/cluster/gce/trusty/node.yaml
+++ b/cluster/gce/trusty/node.yaml
@@ -59,6 +59,9 @@ script
 	create_kubelet_kubeconfig
 	echo "Creating kube-proxy kubeconfig file"
 	create_kubeproxy_kubeconfig
+	echo "Assemble kubelet command line"
+	# Kubelet command flags will be in /etc/default/kubelet
+	assemble_kubelet_flags
 end script
 
 --====================================
@@ -120,12 +123,8 @@ script
 	set -o nounset
 
 	echo "Start kubelet upstart job"
-	. /etc/kube-configure-helper.sh
-	. /etc/kube-env
-	# Assemble command line flags based on env variables, which will put the string
-	# of flags in variable KUBELET_CMD_FLAGS.
-	assemble_kubelet_flags
-	/usr/bin/kubelet ${KUBELET_CMD_FLAGS} 1>>/var/log/kubelet.log 2>&1
+	. /etc/default/kubelet
+	/usr/bin/kubelet ${KUBELET_OPTS} 1>>/var/log/kubelet.log 2>&1
 end script
 
 # Wait for 10s to start kubelet again.
@@ -232,8 +231,7 @@ script
 	start_fluentd
 	# Kube-registry-proxy
 	if [ "${ENABLE_CLUSTER_REGISTRY:-}" = "true" ]; then
-		cp /home/kubernetes/kube-manifests/kubernetes/kube-registry-proxy.yaml \
-       /etc/kubernetes/manifests/
+		cp /home/kubernetes/kube-manifests/kubernetes/kube-registry-proxy.yaml /etc/kubernetes/manifests/
 	fi
 end script
 


### PR DESCRIPTION
This PR adds debug support in two aspects: (1) For a test cluster, docker command will have "--debug" flag. Recently we noticed that this is very helpful in debug e2e test failures; (2) The kubelet command line will be put in /etc/default/kubelet. If a developer wants to test kubelet flags without recreating a cluster, she/he only needs to revise this file and then run "initctl restart kubelet". In addition, this PR fixes a couple of small things like comments and alignment.

Test result:
(1) Manually verified changing /etc/default/kubelet and run "initctl restart kubelet";
(2) Verified docker command line flag "--debug";
(3) e2e on pure trusty cluster and hybrid cluster all passed.

@roberthbailey @dchen1107 @zmerlynn please review it.

cc/ @yujuhong @fabioy @wonderfly FYI.
