### PR TITLE
Log control: Enable a `DebugF` implementation to separate *ginkgo progress logs* from *debug e2e logs* 

### DIFF
--- a/test/e2e/framework/kubelet_stats.go
+++ b/test/e2e/framework/kubelet_stats.go
@@ -264,11 +264,11 @@ func HighLatencyKubeletOperations(c *client.Client, threshold time.Duration, nod
 	latencyMetrics := GetKubeletLatencyMetrics(ms)
 	sort.Sort(latencyMetrics)
 	var badMetrics KubeletLatencyMetrics
-	Logf("\nLatency metrics for node %v", nodeName)
+	Debugf("\nLatency metrics for node %v", nodeName)
 	for _, m := range latencyMetrics {
 		if m.Latency > threshold {
 			badMetrics = append(badMetrics, m)
-			Logf("%+v", m)
+			Debugf("%+v", m)
 		}
 	}
 	return badMetrics, nil

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -80,7 +80,8 @@ func SetTestContext(t TestContextType) {
 }
 
 func RegisterFlags() {
-	// Turn on verbose by default to get spec names
+	// Since we always want to see Ginkgo steps, we make a verbose reporter.
+	// See the Debugf implementation if interested in toggling test verbosity for other logs.
 	config.DefaultReporterConfig.Verbose = true
 
 	// Turn on EmitSpecProgress to get spec progress (especially on interrupt)

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -379,10 +379,10 @@ func logPodStates(pods []api.Pod) {
 		if pod.DeletionGracePeriodSeconds != nil {
 			grace = fmt.Sprintf("%ds", *pod.DeletionGracePeriodSeconds)
 		}
-		Logf("%-[1]*[2]s %-[3]*[4]s %-[5]*[6]s %-[7]*[8]s %[9]s",
+		Debugf("%-[1]*[2]s %-[3]*[4]s %-[5]*[6]s %-[7]*[8]s %[9]s",
 			maxPodW, pod.ObjectMeta.Name, maxNodeW, pod.Spec.NodeName, maxPhaseW, pod.Status.Phase, maxGraceW, grace, pod.Status.Conditions)
 	}
-	Logf("") // Final empty line helps for readability.
+	Debugf("") // Final empty line helps for readability.
 }
 
 // PodRunningReady checks whether pod p's phase is running and it has a ready
@@ -2131,7 +2131,7 @@ func dumpPodDebugInfo(c *client.Client, pods []*api.Pod) {
 	for _, p := range pods {
 		if p.Status.Phase != api.PodRunning {
 			if p.Spec.NodeName != "" {
-				Logf("Pod %v assigned to host %v (IP: %v) in %v", p.Name, p.Spec.NodeName, p.Status.HostIP, p.Status.Phase)
+				Debugf("Pod %v assigned to host %v (IP: %v) in %v", p.Name, p.Spec.NodeName, p.Status.HostIP, p.Status.Phase)
 				badNodes.Insert(p.Spec.NodeName)
 			} else {
 				Logf("Pod %v still unassigned", p.Name)
@@ -2152,7 +2152,7 @@ func DumpAllNamespaceInfo(c *client.Client, namespace string) {
 		sort.Sort(byFirstTimestamp(sortedEvents))
 	}
 	for _, e := range sortedEvents {
-		Logf("At %v - event for %v: %v %v: %v", e.FirstTimestamp, e.InvolvedObject.Name, e.Source, e.Reason, e.Message)
+		Debugf("At %v - event for %v: %v %v: %v", e.FirstTimestamp, e.InvolvedObject.Name, e.Source, e.Reason, e.Message)
 	}
 	// Note that we don't wait for any Cleanup to propagate, which means
 	// that if you delete a bunch of pods right before ending your test,
@@ -2179,7 +2179,7 @@ func (o byFirstTimestamp) Less(i, j int) bool {
 func dumpAllPodInfo(c *client.Client) {
 	pods, err := c.Pods("").List(api.ListOptions{})
 	if err != nil {
-		Logf("unable to fetch pod debug info: %v", err)
+		Debugf("unable to fetch pod debug info: %v", err)
 	}
 	logPodStates(pods.Items)
 }
@@ -2188,7 +2188,7 @@ func dumpAllNodeInfo(c *client.Client) {
 	// It should be OK to list unschedulable Nodes here.
 	nodes, err := c.Nodes().List(api.ListOptions{})
 	if err != nil {
-		Logf("unable to fetch node list: %v", err)
+		Debugf("unable to fetch node list: %v", err)
 		return
 	}
 	names := make([]string, len(nodes.Items))
@@ -2200,26 +2200,26 @@ func dumpAllNodeInfo(c *client.Client) {
 
 func DumpNodeDebugInfo(c *client.Client, nodeNames []string) {
 	for _, n := range nodeNames {
-		Logf("\nLogging node info for node %v", n)
+		Debugf("\nLogging node info for node %v", n)
 		node, err := c.Nodes().Get(n)
 		if err != nil {
 			Logf("Error getting node info %v", err)
 		}
-		Logf("Node Info: %v", node)
+		Debugf("Node Info: %v", node)
 
-		Logf("\nLogging kubelet events for node %v", n)
+		Debugf("\nLogging kubelet events for node %v", n)
 		for _, e := range getNodeEvents(c, n) {
-			Logf("source %v type %v message %v reason %v first ts %v last ts %v, involved obj %+v",
+			Debugf("source %v type %v message %v reason %v first ts %v last ts %v, involved obj %+v",
 				e.Source, e.Type, e.Message, e.Reason, e.FirstTimestamp, e.LastTimestamp, e.InvolvedObject)
 		}
-		Logf("\nLogging pods the kubelet thinks is on node %v", n)
+		Debugf("\nLogging pods the kubelet thinks is on node %v", n)
 		podList, err := GetKubeletPods(c, n)
 		if err != nil {
-			Logf("Unable to retrieve kubelet pods for node %v", n)
+			Debugf("Unable to retrieve kubelet pods for node %v", n)
 			continue
 		}
 		for _, p := range podList.Items {
-			Logf("%v started at %v (%d container statuses recorded)", p.Name, p.Status.StartTime, len(p.Status.ContainerStatuses))
+			Debugf("%v started at %v (%d container statuses recorded)", p.Name, p.Status.StartTime, len(p.Status.ContainerStatuses))
 			for _, c := range p.Status.ContainerStatuses {
 				Logf("\tContainer %v ready: %v, restart count %v",
 					c.Name, c.Ready, c.RestartCount)

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -68,6 +68,7 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 
 	"github.com/blang/semver"
+	"github.com/golang/glog"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/net/websocket"
 
@@ -263,13 +264,20 @@ func log(level string, format string, args ...interface{}) {
 	fmt.Fprintf(GinkgoWriter, nowStamp()+": "+level+": "+format+"\n", args...)
 }
 
+// Used for important logs, controlled by ginkgo, on by default
 func Logf(format string, args ...interface{}) {
 	log("INFO", format, args...)
 }
 
+// If you are debugging e2e tests, run with '-v 3' to see all logging statements.
+// -v is the
+func Debugf(format string, args ...interface{}) {
+	glog.V(3).Infof(format, args...)
+}
+
 func Failf(format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
-	log("INFO", msg)
+	log("FAILURE", msg)
 	Fail(nowStamp()+": "+msg, 1)
 }
 

--- a/test/e2e/service_latency.go
+++ b/test/e2e/service_latency.go
@@ -148,6 +148,7 @@ func runServiceLatencies(f *framework.Framework, inParallel, total int) (output 
 	durations := make(chan time.Duration, total)
 
 	blocker := make(chan struct{}, inParallel)
+	framework.Logf("Creating several service latency pointers...")
 	for i := 0; i < total; i++ {
 		go func() {
 			defer GinkgoRecover()
@@ -330,7 +331,7 @@ func singleServiceLatency(f *framework.Framework, name string, q *endpointQuerie
 	if err != nil {
 		return 0, err
 	}
-	framework.Logf("Created: %v", gotSvc.Name)
+	framework.Debugf("Created: %v", gotSvc.Name)
 	defer f.Client.Services(gotSvc.Namespace).Delete(gotSvc.Name)
 
 	if e := q.request(gotSvc.Name); e == nil {
@@ -338,6 +339,6 @@ func singleServiceLatency(f *framework.Framework, name string, q *endpointQuerie
 	}
 	stopTime := time.Now()
 	d := stopTime.Sub(startTime)
-	framework.Logf("Got endpoints: %v [%v]", gotSvc.Name, d)
+	framework.Debugf("Got endpoints: %v [%v]", gotSvc.Name, d)
 	return d, nil
 }


### PR DESCRIPTION
Fixes #24471 .

Minimal `DebugF` implementation.  @timothysc @kubernetes/sig-testing @kubernetes/sig-scalability 
- keeps CI backward compatible (or at least it should) in terms of verbosity.
- suppresses extra logs by default, but prints a forgiving status update periodically for long running tests that are no verbose (this is very important, imo, for usability on large clusters)
- retains all the ginkgo `Step` output - that is - it doesn't modify ginkgo verbosity, and instead, leverages `glog`.

For full debug, simply use `-v 2` when calling e2es, i.e.  `_output/local/bin/darwin/amd64/e2e.test --kubeconfig=/Users/jayunit100/.kube/config --repo-root=./ --ginkgo.focus="Service endpoints latenc" --kubectl-path=./cluster/kubectl.sh -v 2` 
