### PR TITLE
Use cluster/log-dump.sh to collect base cluster logs in kubemark

### DIFF
--- a/hack/jenkins/e2e-runner.sh
+++ b/hack/jenkins/e2e-runner.sh
@@ -137,6 +137,14 @@ function install_google_cloud_sdk_tarball() {
     export PATH=${install_dir}/google-cloud-sdk/bin:${PATH}
 }
 
+function dump_cluster_logs_and_exit() {
+    local -r exit_status=$?
+    if [[ -x "cluster/log-dump.sh"  ]]; then
+        ./cluster/log-dump.sh "${ARTIFACTS}"
+    fi
+    exit ${exit_status}
+}
+
 ### Pre Set Up ###
 if running_in_docker; then
     curl -fsSL --retry 3 -o "${WORKSPACE}/google-cloud-sdk.tar.gz" 'https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz'
@@ -289,13 +297,7 @@ fi
 if [[ "${E2E_UP,,}" == "true" ]]; then
     # We want to try to gather logs even if kube-up fails, so collect the
     # result here and fail after dumping logs if it's nonzero.
-    go run ./hack/e2e.go ${E2E_OPT:-} -v --up && up_result="$?" || up_result="$?"
-    if [[ "${up_result}" -ne 0 ]]; then
-        if [[ -x "cluster/log-dump.sh"  ]]; then
-            ./cluster/log-dump.sh "${ARTIFACTS}"
-        fi
-        exit "${up_result}"
-    fi
+    go run ./hack/e2e.go ${E2E_OPT:-} -v --up || dump_cluster_logs_and_exit
     go run ./hack/e2e.go -v --ctl="version --match-server-version=false"
     if [[ "${gcp_list_resources}" == "true" ]]; then
       ${gcp_list_resources_script} > "${gcp_resources_cluster_up}"
@@ -333,17 +335,9 @@ if [[ "${USE_KUBEMARK:-}" == "true" ]]; then
   NUM_NODES=${KUBEMARK_NUM_NODES:-$NUM_NODES}
   MASTER_SIZE=${KUBEMARK_MASTER_SIZE:-$MASTER_SIZE}
   # If start-kubemark fails, we trigger empty set of tests that would trigger storing logs from the base cluster.
-  ./test/kubemark/start-kubemark.sh && kubemark_started="$?" || kubemark_started="$?"
-  if [[ "${kubemark_started}" != "0" ]]; then
-    go run ./hack/e2e.go -v --test --test_args="--ginkgo.focus=DO\sNOT\sMATCH\sANYTHING"
-    exit 1
-  fi
+  ./test/kubemark/start-kubemark.sh || dump_cluster_logs_and_exit
   # Similarly, if tests fail, we trigger empty set of tests that would trigger storing logs from the base cluster.
-  ./test/kubemark/run-e2e-tests.sh --ginkgo.focus="${KUBEMARK_TESTS}" --gather-resource-usage="false" && kubemark_succeeded="$?" || kubemark_succeeded="$?"
-  if [[ "${kubemark_succeeded}" != "0" ]]; then
-    go run ./hack/e2e.go -v --test --test_args="--ginkgo.focus=DO\sNOT\sMATCH\sANYTHING"
-    exit 1
-  fi
+  ./test/kubemark/run-e2e-tests.sh --ginkgo.focus="${KUBEMARK_TESTS}" --gather-resource-usage="false" || dump_cluster_logs_and_exit
   ./test/kubemark/stop-kubemark.sh
   NUM_NODES=${NUM_NODES_BKP}
   MASTER_SIZE=${MASTER_SIZE_BKP}


### PR DESCRIPTION
Fixes #24415.

cc @fejta @spxtr @wojtek-t 
