### PR TITLE
UXP Expose volume lstat errors in describe event

### DIFF
--- a/pkg/kubelet/volumes.go
+++ b/pkg/kubelet/volumes.go
@@ -185,7 +185,7 @@ func (kl *Kubelet) getPodVolumes(podUID types.UID) ([]*volumeTuple, error) {
 	podVolDir := kl.getPodVolumesDir(podUID)
 	volumeKindDirs, err := ioutil.ReadDir(podVolDir)
 	if err != nil {
-		glog.Errorf("Could not read directory %s: %v", podVolDir, err)
+		glog.Errorf("could not read volume directory %s: %v", podVolDir, err)
 	}
 	for _, volumeKindDir := range volumeKindDirs {
 		volumeKind := volumeKindDir.Name()
@@ -194,13 +194,15 @@ func (kl *Kubelet) getPodVolumes(podUID types.UID) ([]*volumeTuple, error) {
 		// but skipping dirs means no cleanup for healthy volumes. switching to a no-exit api solves this problem
 		volumeNameDirs, volumeNameDirsStat, err := util.ReadDirNoExit(volumeKindPath)
 		if err != nil {
-			return []*volumeTuple{}, fmt.Errorf("could not read directory %s: %v", volumeKindPath, err)
+			return []*volumeTuple{}, fmt.Errorf("could not read volume directory %s: %v", volumeKindPath, err)
 		}
 		for i, volumeNameDir := range volumeNameDirs {
 			if volumeNameDir != nil {
 				volumes = append(volumes, &volumeTuple{Kind: volumeKind, Name: volumeNameDir.Name()})
 			} else {
-				glog.Errorf("Could not read directory %s: %v", podVolDir, volumeNameDirsStat[i])
+				// failed syscall type error, expose it
+				glog.Errorf("could not read volume directory %s: %v", podVolDir, volumeNameDirsStat[i])
+				return volumes, fmt.Errorf("could not read volume directory %q: %v", volumeKindPath, volumeNameDirsStat[i])
 			}
 		}
 	}
@@ -228,7 +230,15 @@ func (kl *Kubelet) getPodVolumesFromDisk() map[string]cleanerTuple {
 	for _, podUID := range podUIDs {
 		volumes, err := kl.getPodVolumes(podUID)
 		if err != nil {
-			glog.Errorf("%v", err)
+			// add an event to expose underlying volume/syscall
+			// type of errors in the describe
+			pod, ok := kl.podManager.GetPodByUID(podUID)
+			if ok {
+				ref, errGetRef := api.GetReference(pod)
+				if errGetRef == nil && ref != nil {
+					kl.recorder.Event(ref, api.EventTypeWarning, kubecontainer.FailedMountVolume, err.Error())
+				}
+			}
 			continue
 		}
 		for _, volume := range volumes {


### PR DESCRIPTION
Fixes #23982

If a user passes in a bad endpoint (invalid ip) the error being exposed in the `pod describe` is vague, by exposing a more true error, the user will not have to go searching the logs for the issue, in the example below it tells the user that the endoints file is not valid:

Current Behavior:

```
  7s        7s      1   {kubelet 127.0.0.1}         Warning     FailedMount Unable to mount volumes for pod "bb-gluster-pod2_default(a11bc084-fccc-11e5-9f13-52540092b5fb)": glusterfs: mount failed: Mount failed: exit status 1
Mounting arguments: 192.168.122.226:myVol2 /var/lib/kubelet/pods/a11bc084-fccc-11e5-9f13-52540092b5fb/volumes/kubernetes.io~glusterfs/pv-gluster glusterfs [log-file=/var/lib/kubelet/plugins/kubernetes.io/glusterfs/pv-gluster/glusterfs.log]
Output: Mount failed. Please check the log file for more details.
```

New Behavior:
Now volumes.go when trying to read the disks will pick up on this error first indicating that the volume can not be read because it's invalid (no connection to the source volume) which will give a clue to the user to check that particular volumes endpoints and make sure the IP is correct and you can actually access the server/volume, etc...:

```
Events:
  FirstSeen LastSeen    Count   From            SubobjectPath   Type        Reason      Message
  --------- --------    -----   ----            -------------   --------    ------      -------
  2m        2m      1   {default-scheduler }            Normal      Scheduled   Successfully assigned bb-multi-pod1 to 127.0.0.1
  5s        5s      1   {kubelet 127.0.0.1}         Warning     FailedMount Failure: Could not read directory: 
  Path: /var/lib/kubelet/pods/db1ebf34-0801-11e6-b54b-52540092b5fb/volumes/kubernetes.io~glusterfs 
  Error: lstat /var/lib/kubelet/pods/db1ebf34-0801-11e6-b54b-52540092b5fb/volumes/kubernetes.io~glusterfs/pv-gluster2: transport endpoint is not connected 

  13s   13s 1   {kubelet 127.0.0.1}     Warning FailedMount Unable to mount volumes for pod "bb-gluster-pod2_default(34b18c6b-070d-11e6-8e95-52540092b5fb)": glusterfs: mount failed: Mount failed: exit status 1
Mounting arguments: 192.168.234.147:myVol2 /var/lib/kubelet/pods/34b18c6b-070d-11e6-8e95-52540092b5fb/volumes/kubernetes.io~glusterfs/pv-gluster glusterfs [log-file=/var/lib/kubelet/plugins/kubernetes.io/glusterfs/pv-gluster2/glusterfs.log]
Output: Mount failed. Please check the log file for more details.
```
