### PR TITLE
node_e2e: disable serialized image pulls and increase test timeout

### DIFF
--- a/test/e2e_node/e2e_service.go
+++ b/test/e2e_node/e2e_service.go
@@ -145,6 +145,7 @@ func (es *e2eService) startKubeletServer() (*exec.Cmd, error) {
 		"--hostname-override", es.nodeName, // Required because hostname is inconsistent across hosts
 		"--volume-stats-agg-period", "10s", // Aggregate volumes frequently so tests don't need to wait as long
 		"--allow-privileged", "true",
+		"--serialize-image-pulls", "false",
 	)
 	hcc := newHealthCheckCommand(
 		"http://127.0.0.1:10255/healthz",

--- a/test/e2e_node/privileged_test.go
+++ b/test/e2e_node/privileged_test.go
@@ -184,7 +184,7 @@ func newHostExecPodSpec(ns, name string) *api.Pod {
 func waitForPodRunning(c *client.Client, ns string, name string) error {
 	var pod *api.Pod
 	var err error
-	for t := time.Now(); time.Since(t) < time.Minute; time.Sleep(time.Second * 5) {
+	for t := time.Now(); time.Since(t) < time.Minute*2; time.Sleep(time.Second * 5) {
 		pod, err = c.Pods(ns).Get(name)
 		Expect(err).NotTo(HaveOccurred())
 		if pod == nil {


### PR DESCRIPTION
This addresses #24605
