### PR TITLE
Node maintanence API

### DIFF
--- a/pkg/apis/nodelifecycle/types.go
+++ b/pkg/apis/nodelifecycle/types.go
@@ -21,19 +21,19 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 )
 
-type NodeDeployment struct {
+type NodeMaintenance struct {
 	unversioned.TypeMeta `json:",inline"`
 	api.ObjectMeta       `json:"metadata,omitempty"`
 
-	// Specification of the desired behavior of the NodeDeployment.
-	Spec NodeDeploymentSpec `json:"spec,omitempty"`
+	// Specification of the desired behavior of the NodeMaintenance.
+	Spec NodeMaintenanceSpec `json:"spec,omitempty"`
 
-	// Most recently observed status of the NodeDeployment.
-	Status NodeDeploymentStatus `json:"status,omitempty"`
+	// Most recently observed status of the NodeMaintenance.
+	Status NodeMaintenanceStatus `json:"status,omitempty"`
 }
 
-type NodeDeploymentSpec struct {
-	// Nodes this NodeDeployment should operate on.
+type NodeMaintenanceSpec struct {
+	// Nodes this NodeMaintenance should operate on.
 	//
 	// We could also use a NodeSelector, but it gets more confusing as nodes are added with the
 	// new selector; should we operate on them?  It's also nice that this is the same type as
@@ -42,7 +42,7 @@ type NodeDeploymentSpec struct {
 	Nodes []string `json:"nodes,omitempty"`
 
 	// The operation to do on nodes.
-	Operation NodeDeploymentOperation `json:"strategy,omitempty"`
+	Operation NodeMaintenanceOperation `json:"strategy,omitempty"`
 
 	// TODO: maybe add this?
 	//
@@ -60,44 +60,44 @@ type NodeDeploymentSpec struct {
 	RollingBack bool `json:"rollingBack,omitempty"`
 }
 
-// This is significantly different from Deployment's conception of Strategy, which is why I changed it to Operation.
-type NodeDeploymentOperation struct {
-	// Type of NodeDeployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
-	Type NodeDeploymentStrategyType string
+// This is significantly different from Maintenance's conception of Strategy, which is why I changed it to Operation.
+type NodeMaintenanceOperation struct {
+	// Type of NodeMaintenance. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+	Type NodeMaintenanceStrategyType string
 
 	// Type of operation to perform. Can be "Recreate" or "InPlaceNodeUpgrade". Default is Recreate.
-	Operation NodeDeploymentOperationType `json:"type,omitempty"`
+	Operation NodeMaintenanceOperationType `json:"type,omitempty"`
 
 	// Rolling operation config params.
 	//---
 	// TODO: Update this to follow our convention for oneOf, whatever we decide it
 	// to be.
-	RollingUpdate *RollingUpdateNodeDeployment `json:"rollingUpdate,omitempty"`
+	RollingUpdate *RollingUpdateNodeMaintenance `json:"rollingUpdate,omitempty"`
 }
 
-type NodeDeploymentStrategyType string
+type NodeMaintenanceStrategyType string
 
 const (
 	// Kill all existing nodes before creating new ones.
-	RecreateNodeDeploymentStrategyType NodeDeploymentStrategyType = "Recreate"
+	RecreateNodeMaintenanceStrategyType NodeMaintenanceStrategyType = "Recreate"
 
 	// Operate on the nodes one by one.
-	RollingUpdateNodeDeploymentStrategyType NodeDeploymentStrategyType = "RollingUpdate"
+	RollingUpdateNodeMaintenanceStrategyType NodeMaintenanceStrategyType = "RollingUpdate"
 )
 
-type NodeDeploymentOperationType string
+type NodeMaintenanceOperationType string
 
 const (
 	// Recreate nodes one at a time all existing nodes before creating new ones.
-	RecreateNodeDeploymentStrategyType NodeDeploymentOperationType = "RecreateNode"
+	RecreateNodeMaintenanceStrategyType NodeMaintenanceOperationType = "RecreateNode"
 
 	// Do an in-place upgrade of the node, including kernel, which generally involves triggering
 	// an in-place update, copying metadata and rebooting the machine.
-	InPlaceNodeUpgradeNodeDeploymentStrategyType NodeDeploymentOperationType = "InPlaceNodeUpgrade"
+	InPlaceNodeUpgradeNodeMaintenanceStrategyType NodeMaintenanceOperationType = "InPlaceNodeUpgrade"
 )
 
 // Spec to control the desired behavior of rolling operation.
-type RollingUpdateNodeDeployment struct {
+type RollingUpdateNodeMaintenance struct {
 	// The maximum number of nodes that can be unavailable during the rolling operation.
 	// Value can be an absolute number (ex: 5) or a percentage of total pods at the start of update (ex: 10%).
 	// Absolute number is calculated from percentage by rounding up.
@@ -111,7 +111,7 @@ type RollingUpdateNodeDeployment struct {
 	// TODO: MaxSurge intstr.IntOrString `json:"maxSurge,omitempty"` (only for Recreate)
 }
 
-type NodeDeploymentStatus struct {
+type NodeMaintenanceStatus struct {
 	// The generation observed by the node deployment controller.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 

--- a/pkg/apis/nodelifecycle/types.go
+++ b/pkg/apis/nodelifecycle/types.go
@@ -39,7 +39,7 @@ type NodeMaintenanceSpec struct {
 	// new selector; should we operate on them?  It's also nice that this is the same type as
 	// NodesPendingOperation, NodesUndergoingOperation, and NodesPostOperation, because they all
 	// represent the same set of objects.
-	Nodes []string `json:"nodes,omitempty"`
+	Nodes NodeList `json:"nodes,omitempty"`
 
 	// The operation to do on nodes.
 	Operation NodeMaintenanceOperation `json:"strategy,omitempty"`
@@ -113,11 +113,11 @@ type NodeMaintenanceStatus struct {
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
 	// Nodes waiting to be operated on.
-	NodesPendingOperation []string `json:"nodePendingOperation,omitempty"`
+	NodesPendingOperation NodeList `json:"nodePendingOperation,omitempty"`
 
 	// Nodes currently being operated on.
-	NodesUndergoingOperation []string `json:"nodePendingOperation,omitempty"`
+	NodesUndergoingOperation NodeList `json:"nodePendingOperation,omitempty"`
 
 	// Nodes that have already been operated on.
-	NodesPostOperation []string `json:"nodePendingOperation,omitempty"`
+	NodesPostOperation NodeList `json:"nodePendingOperation,omitempty"`
 }

--- a/pkg/apis/nodelifecycle/types.go
+++ b/pkg/apis/nodelifecycle/types.go
@@ -33,52 +33,94 @@ type NodeDeployment struct {
 }
 
 type NodeDeploymentSpec struct {
-	// Number of desired pods. This is a pointer to distinguish between explicit
-	// zero and not specified. Defaults to 1.
-	Replicas int `json:"replicas,omitempty"`
+	// Nodes this NodeDeployment should operate on.
+	//
+	// We could also use a NodeSelector, but it gets more confusing as nodes are added with the
+	// new selector; should we operate on them?  It's also nice that this is the same type as
+	// NodesPendingOperation, NodesUndergoingOperation, and NodesPostOperation, because they all
+	// represent the same set of objects.
+	Nodes []string `json:"nodes,omitempty"`
 
-	// Label selector for pods. Existing ReplicaSets whose pods are
-	// selected by this will be the ones affected by this deployment.
-	Selector *unversioned.LabelSelector `json:"selector,omitempty"`
+	// The operation to do on nodes.
+	Operation NodeDeploymentOperation `json:"strategy,omitempty"`
 
-	// Template describes the pods that will be created.
-	Template api.PodTemplateSpec `json:"template"`
-
-	// The deployment strategy to use to replace existing pods with new ones.
-	Strategy DeploymentStrategy `json:"strategy,omitempty"`
-
+	// TODO: maybe add this?
+	//
 	// Minimum number of seconds for which a newly created pod should be ready
 	// without any of its container crashing, for it to be considered available.
 	// Defaults to 0 (pod will be considered available as soon as it is ready)
-	MinReadySeconds int `json:"minReadySeconds,omitempty"`
-
-	// The number of old ReplicaSets to retain to allow rollback.
-	// This is a pointer to distinguish between explicit zero and not specified.
-	RevisionHistoryLimit *int `json:"revisionHistoryLimit,omitempty"`
+	//
+	// MinReadySeconds int `json:"minReadySeconds,omitempty"`
 
 	// Indicates that the deployment is paused and will not be processed by the
 	// deployment controller.
 	Paused bool `json:"paused,omitempty"`
+
 	// The config this deployment is rolling back to. Will be cleared after rollback is done.
-	RollbackTo *RollbackConfig `json:"rollbackTo,omitempty"`
+	RollingBack bool `json:"rollingBack,omitempty"`
+}
+
+// This is significantly different from Deployment's conception of Strategy, which is why I changed it to Operation.
+type NodeDeploymentOperation struct {
+	// Type of NodeDeployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+	Type NodeDeploymentStrategyType string
+
+	// Type of operation to perform. Can be "Recreate" or "InPlaceNodeUpgrade". Default is Recreate.
+	Operation NodeDeploymentOperationType `json:"type,omitempty"`
+
+	// Rolling operation config params.
+	//---
+	// TODO: Update this to follow our convention for oneOf, whatever we decide it
+	// to be.
+	RollingUpdate *RollingUpdateNodeDeployment `json:"rollingUpdate,omitempty"`
+}
+
+type NodeDeploymentStrategyType string
+
+const (
+	// Kill all existing nodes before creating new ones.
+	RecreateNodeDeploymentStrategyType NodeDeploymentStrategyType = "Recreate"
+
+	// Operate on the nodes one by one.
+	RollingUpdateNodeDeploymentStrategyType NodeDeploymentStrategyType = "RollingUpdate"
+)
+
+type NodeDeploymentOperationType string
+
+const (
+	// Recreate nodes one at a time all existing nodes before creating new ones.
+	RecreateNodeDeploymentStrategyType NodeDeploymentOperationType = "RecreateNode"
+
+	// Do an in-place upgrade of the node, including kernel, which generally involves triggering
+	// an in-place update, copying metadata and rebooting the machine.
+	InPlaceNodeUpgradeNodeDeploymentStrategyType NodeDeploymentOperationType = "InPlaceNodeUpgrade"
+)
+
+// Spec to control the desired behavior of rolling operation.
+type RollingUpdateNodeDeployment struct {
+	// The maximum number of nodes that can be unavailable during the rolling operation.
+	// Value can be an absolute number (ex: 5) or a percentage of total pods at the start of update (ex: 10%).
+	// Absolute number is calculated from percentage by rounding up.
+	// (TODO This can not be 0 if MaxSurge is 0.)
+	// By default, a fixed value of 1 is used.
+	// Example: when this is set to 30%, we can immediately operate on 30%
+	// of the nodes when the rolling update starts. Once some nodes are post-operation, other
+	// nodes can be operated on.
+	MaxUnavailable intstr.IntOrString `json:"maxUnavailable,omitempty"`
+
+	// TODO: MaxSurge intstr.IntOrString `json:"maxSurge,omitempty"` (only for Recreate)
 }
 
 type NodeDeploymentStatus struct {
 	// The generation observed by the node deployment controller.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
-	// Total number of non-terminated pods targeted by this deployment (their labels match the
-	// selector).
-	Replicas int `json:"replicas,omitempty"`
+	// Nodes waiting to be operated on.
+	NodesPendingOperation []string `json:"nodePendingOperation,omitempty"`
 
-	// Total number of non-terminated pods targeted by this deployment that have the desired
-	// template spec.
-	UpdatedReplicas int `json:"updatedReplicas,omitempty"`
+	// Nodes currently being operated on.
+	NodesUndergoingOperation []string `json:"nodePendingOperation,omitempty"`
 
-	// Total number of available pods (ready for at least minReadySeconds) targeted by this
-	// deployment.
-	AvailableReplicas int `json:"availableReplicas,omitempty"`
-
-	// Total number of unavailable pods targeted by this deployment.
-	UnavailableReplicas int `json:"unavailableReplicas,omitempty"`
+	// Nodes that have already been operated on.
+	NodesPostOperation []string `json:"nodePendingOperation,omitempty"`
 }

--- a/pkg/apis/nodelifecycle/types.go
+++ b/pkg/apis/nodelifecycle/types.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodelifecycle
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+)
+
+type NodeDeployment struct {
+	unversioned.TypeMeta `json:",inline"`
+	api.ObjectMeta       `json:"metadata,omitempty"`
+
+	// Specification of the desired behavior of the NodeDeployment.
+	Spec NodeDeploymentSpec `json:"spec,omitempty"`
+
+	// Most recently observed status of the NodeDeployment.
+	Status NodeDeploymentStatus `json:"status,omitempty"`
+}
+
+type NodeDeploymentSpec struct {
+	// Number of desired pods. This is a pointer to distinguish between explicit
+	// zero and not specified. Defaults to 1.
+	Replicas int `json:"replicas,omitempty"`
+
+	// Label selector for pods. Existing ReplicaSets whose pods are
+	// selected by this will be the ones affected by this deployment.
+	Selector *unversioned.LabelSelector `json:"selector,omitempty"`
+
+	// Template describes the pods that will be created.
+	Template api.PodTemplateSpec `json:"template"`
+
+	// The deployment strategy to use to replace existing pods with new ones.
+	Strategy DeploymentStrategy `json:"strategy,omitempty"`
+
+	// Minimum number of seconds for which a newly created pod should be ready
+	// without any of its container crashing, for it to be considered available.
+	// Defaults to 0 (pod will be considered available as soon as it is ready)
+	MinReadySeconds int `json:"minReadySeconds,omitempty"`
+
+	// The number of old ReplicaSets to retain to allow rollback.
+	// This is a pointer to distinguish between explicit zero and not specified.
+	RevisionHistoryLimit *int `json:"revisionHistoryLimit,omitempty"`
+
+	// Indicates that the deployment is paused and will not be processed by the
+	// deployment controller.
+	Paused bool `json:"paused,omitempty"`
+	// The config this deployment is rolling back to. Will be cleared after rollback is done.
+	RollbackTo *RollbackConfig `json:"rollbackTo,omitempty"`
+}
+
+type NodeDeploymentStatus struct {
+	// The generation observed by the node deployment controller.
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
+	// Total number of non-terminated pods targeted by this deployment (their labels match the
+	// selector).
+	Replicas int `json:"replicas,omitempty"`
+
+	// Total number of non-terminated pods targeted by this deployment that have the desired
+	// template spec.
+	UpdatedReplicas int `json:"updatedReplicas,omitempty"`
+
+	// Total number of available pods (ready for at least minReadySeconds) targeted by this
+	// deployment.
+	AvailableReplicas int `json:"availableReplicas,omitempty"`
+
+	// Total number of unavailable pods targeted by this deployment.
+	UnavailableReplicas int `json:"unavailableReplicas,omitempty"`
+}

--- a/pkg/apis/nodelifecycle/types.go
+++ b/pkg/apis/nodelifecycle/types.go
@@ -44,13 +44,10 @@ type NodeMaintenanceSpec struct {
 	// The operation to do on nodes.
 	Operation NodeMaintenanceOperation `json:"strategy,omitempty"`
 
-	// TODO: maybe add this?
-	//
-	// Minimum number of seconds for which a newly created pod should be ready
-	// without any of its container crashing, for it to be considered available.
-	// Defaults to 0 (pod will be considered available as soon as it is ready)
-	//
-	// MinReadySeconds int `json:"minReadySeconds,omitempty"`
+	// Minimum number of seconds for which a node, having undergone some operation, should be
+	// ready for it to be considered post-operation.  Defaults to 0 (node will be considered
+	// available as soon as it is ready).
+	MinReadySeconds int `json:"minReadySeconds,omitempty"`
 
 	// Indicates that the deployment is paused and will not be processed by the
 	// deployment controller.
@@ -64,6 +61,9 @@ type NodeMaintenanceSpec struct {
 type NodeMaintenanceOperation struct {
 	// Type of NodeMaintenance. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
 	Type NodeMaintenanceStrategyType string
+
+	// Whether or not to drain the node of its pods before performing the operation.
+	DrainBeforeOperating bool `json:"drainBeforeOperating,omitempty"`
 
 	// Type of operation to perform. Can be "Recreate" or "InPlaceNodeUpgrade". Default is Recreate.
 	Operation NodeMaintenanceOperationType `json:"type,omitempty"`
@@ -101,14 +101,11 @@ type RollingUpdateNodeMaintenance struct {
 	// The maximum number of nodes that can be unavailable during the rolling operation.
 	// Value can be an absolute number (ex: 5) or a percentage of total pods at the start of update (ex: 10%).
 	// Absolute number is calculated from percentage by rounding up.
-	// (TODO This can not be 0 if MaxSurge is 0.)
 	// By default, a fixed value of 1 is used.
 	// Example: when this is set to 30%, we can immediately operate on 30%
 	// of the nodes when the rolling update starts. Once some nodes are post-operation, other
 	// nodes can be operated on.
 	MaxUnavailable intstr.IntOrString `json:"maxUnavailable,omitempty"`
-
-	// TODO: MaxSurge intstr.IntOrString `json:"maxSurge,omitempty"` (only for Recreate)
 }
 
 type NodeMaintenanceStatus struct {


### PR DESCRIPTION
Proposal for Node Maintenance API, based heavily off of Deployments.

It doesn't yet include any mechanisms for leasing nodes for maintenance, which I'd like to add next.

@bgrant0607 @davidopp @lavalamp Mind providing some quick feedback in case I'm headed in a completely wrong direction?
