### PR TITLE
hack: allow devel builds of go

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -269,7 +269,7 @@ EOF
   if [[ "${TRAVIS:-}" != "true" ]]; then
     local go_version
     go_version=($(go version))
-    if [[ "${go_version[2]}" < "go1.6" ]]; then
+    if [[ "${go_version[2]}" < "go1.6" && "${go_version[2]}" != "devel" ]]; then
       kube::log::usage_from_stdin <<EOF
 Detected go version: ${go_version[*]}.
 Kubernetes requires go version 1.6 or greater.


### PR DESCRIPTION
This is issue https://github.com/kubernetes/kubernetes/issues/6913. It seems reasonable that someone running a devel build is responsible for making sure it's a sane version.

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/24653)

<!-- Reviewable:end -->
