### PR TITLE
mungedocs should not assume upstream remote

### DIFF
--- a/hack/after-build/update-generated-docs.sh
+++ b/hack/after-build/update-generated-docs.sh
@@ -40,7 +40,7 @@ shopt -u dotglob
 kube::util::gen-analytics "${KUBE_ROOT}"
 
 mungedocs=$(kube::util::find-binary "mungedocs")
-"${mungedocs}" "--root-dir=${KUBE_ROOT}/docs/" && ret=0 || ret=$?
+"${mungedocs}" "--upstream=${KUBE_GIT_UPSTREAM}" "--root-dir=${KUBE_ROOT}/docs/" && ret=0 || ret=$?
 if [[ $ret -eq 1 ]]; then
   echo "${KUBE_ROOT}/docs/ requires manual changes.  See preceding errors."
   exit 1
@@ -49,7 +49,7 @@ elif [[ $ret -gt 1 ]]; then
   exit 1
 fi
 
-"${mungedocs}" "--root-dir=${KUBE_ROOT}/examples/" && ret=0 || ret=$?
+"${mungedocs}" "--upstream=${KUBE_GIT_UPSTREAM}" "--root-dir=${KUBE_ROOT}/examples/" && ret=0 || ret=$?
 if [[ $ret -eq 1 ]]; then
   echo "${KUBE_ROOT}/examples/ requires manual changes.  See preceding errors."
   exit 1
@@ -58,7 +58,8 @@ elif [[ $ret -gt 1 ]]; then
   exit 1
 fi
 
-"${mungedocs}" "--skip-munges=unversioned-warning,analytics" \
+"${mungedocs}" "--upstream=${KUBE_GIT_UPSTREAM}" \
+               "--skip-munges=unversioned-warning,analytics" \
                "--norecurse" \
                "--root-dir=${KUBE_ROOT}/" && ret=0 || ret=$?
 if [[ $ret -eq 1 ]]; then

--- a/hack/after-build/verify-generated-docs.sh
+++ b/hack/after-build/verify-generated-docs.sh
@@ -37,7 +37,7 @@ EXAMPLEROOT="${KUBE_ROOT}/examples/"
 # mungedocs --verify can (and should) be run on the real docs, otherwise their
 # links will be distorted. --verify means that it will not make changes.
 # --verbose gives us output we can use for a diff.
-"${mungedocs}" "--verify=true" "--verbose=true" "--root-dir=${DOCROOT}" && ret=0 || ret=$?
+"${mungedocs}" "--verify=true" "--verbose=true" "--upstream=${KUBE_GIT_UPSTREAM}" "--root-dir=${DOCROOT}" && ret=0 || ret=$?
 if [[ $ret -eq 1 ]]; then
   echo "${DOCROOT} is out of date. Please run hack/update-generated-docs.sh"
   exit 1
@@ -47,7 +47,7 @@ if [[ $ret -gt 1 ]]; then
   exit 1
 fi
 
-"${mungedocs}" "--verify=true" "--verbose=true" "--root-dir=${EXAMPLEROOT}" && ret=0 || ret=$?
+"${mungedocs}" "--verify=true" "--verbose=true" "--upstream=${KUBE_GIT_UPSTREAM}" "--root-dir=${EXAMPLEROOT}" && ret=0 || ret=$?
 if [[ $ret -eq 1 ]]; then
   echo "${EXAMPLEROOT} is out of date. Please run hack/update-generated-docs.sh"
   exit 1

--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -40,6 +40,8 @@ source "${KUBE_ROOT}/hack/lib/version.sh"
 source "${KUBE_ROOT}/hack/lib/golang.sh"
 source "${KUBE_ROOT}/hack/lib/etcd.sh"
 
+KUBE_GIT_UPSTREAM="${KUBE_GIT_UPSTREAM:-upstream}"
+
 KUBE_OUTPUT_HOSTBIN="${KUBE_OUTPUT_BINPATH}/$(kube::util::host_platform)"
 
 # emulates "readlink -f" which is not available on BSD (OS X).
@@ -48,7 +50,7 @@ function readlinkdashf {
   # Follow links until there are no more links to follow.
   while readlink "$path"; do
     path="$(readlink $path)"
-  done 
+  done
   # Convert to canonical path.
   path=$(cd "$(dirname "${path}")" && pwd -P)
   echo "$path"


### PR DESCRIPTION
The standard Git convention is "origin", not "upstream", so make it
flexible in the scripts for those who are set up differently.

Makes it difficult to manage forks where upstream is something else.
