### PR TITLE
added claim_binder sync period

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -110,6 +110,7 @@ RKT_STAGE1_IMAGE=${RKT_STAGE1_IMAGE:-""}
 CHAOS_CHANCE=${CHAOS_CHANCE:-0.0}
 CPU_CFS_QUOTA=${CPU_CFS_QUOTA:-false}
 ENABLE_HOSTPATH_PROVISIONER=${ENABLE_HOSTPATH_PROVISIONER:-"false"}
+CLAIM_BINDER_SYNC_PERIOD=${CLAIM_BINDER_SYNC_PERIOD:-"10m"} # current k8s default
 
 function test_apiserver_off {
     # For the common local scenario, fail fast if server is already running.
@@ -288,6 +289,7 @@ function start_controller_manager {
       --root-ca-file="${ROOT_CA_FILE}" \
       --enable-hostpath-provisioner="${ENABLE_HOSTPATH_PROVISIONER}" \
       ${node_cidr_args} \
+      --pvclaimbinder-sync-period="${CLAIM_BINDER_SYNC_PERIOD}" \
       --master="${API_HOST}:${API_PORT}" >"${CTLRMGR_LOG}" 2>&1 &
     CTLRMGR_PID=$!
 }


### PR DESCRIPTION
simple addition to local-up-cluster to support pvclaimbinder-sync-period.
