### PR TITLE
plugin/pkg/auth/authorizer/webhook: log request errors

### DIFF
--- a/plugin/pkg/auth/authorizer/webhook/webhook.go
+++ b/plugin/pkg/auth/authorizer/webhook/webhook.go
@@ -22,6 +22,8 @@ import (
 	"errors"
 	"time"
 
+	"github.com/golang/glog"
+
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/authorization/v1beta1"
 	"k8s.io/kubernetes/pkg/auth/authorizer"
@@ -149,6 +151,8 @@ func (w *WebhookAuthorizer) Authorize(attr authorizer.Attributes) (err error) {
 	} else {
 		result := w.RestClient.Post().Body(r).Do()
 		if err := result.Error(); err != nil {
+			// An error here indicates bad configuration or an outage. Log for debugging.
+			glog.Errorf("Failed to make webhook authorizer request: %v", err)
 			return err
 		}
 		if err := result.Into(r); err != nil {


### PR DESCRIPTION
Currently the API server only checks the errors returned by an
authorizer plugin, it doesn't return or log them[0]. This makes
incorrectly configuring the wehbook authorizer plugin extremely
difficult to debug.

Add a logging statement if the request to the remove service fails
as this indicates misconfiguration.

[0] https://goo.gl/9zZFv4

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/24678)

<!-- Reviewable:end -->
