### PR TITLE
rkt: Symlink net.d to '--network-plugin-dir'.

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/componentconfig"
 	"k8s.io/kubernetes/pkg/kubelet/qos"
-	"k8s.io/kubernetes/pkg/kubelet/rkt"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/master/ports"
 	"k8s.io/kubernetes/pkg/util"
@@ -41,6 +40,8 @@ const (
 
 	defaultPodInfraContainerImageName    = "gcr.io/google_containers/pause"
 	defaultPodInfraContainerImageVersion = "2.0"
+
+	defaultRktAPIServiceEndpoint = "localhost:15441"
 )
 
 // Returns the arch-specific pause image that kubelet should use as the default
@@ -129,7 +130,7 @@ func NewKubeletServer() *KubeletServer {
 			KubeletCgroups:                 "",
 			ResolverConfig:                 kubetypes.ResolvConfDefault,
 			RktPath:                        "",
-			RktAPIEndpoint:                 rkt.DefaultRktAPIServiceEndpoint,
+			RktAPIEndpoint:                 defaultRktAPIServiceEndpoint,
 			RktStage1Image:                 "",
 			RootDirectory:                  defaultRootDir,
 			RuntimeCgroups:                 "",

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -226,6 +226,7 @@ func UnsecuredKubeletConfig(s *options.KubeletServer) (*KubeletConfig, error) {
 		Mounter:                   mounter,
 		NetworkPluginName:         s.NetworkPluginName,
 		NetworkPlugins:            ProbeNetworkPlugins(s.NetworkPluginDir),
+		NetworkPluginDir:          s.NetworkPluginDir,
 		NodeLabels:                s.NodeLabels,
 		NodeStatusUpdateFrequency: s.NodeStatusUpdateFrequency.Duration,
 		NonMasqueradeCIDR:         s.NonMasqueradeCIDR,
@@ -739,6 +740,7 @@ type KubeletConfig struct {
 	Mounter                        mount.Interface
 	NetworkPluginName              string
 	NetworkPlugins                 []network.NetworkPlugin
+	NetworkPluginDir               string
 	NodeName                       string
 	NodeLabels                     map[string]string
 	NodeStatusUpdateFrequency      time.Duration
@@ -831,6 +833,7 @@ func CreateAndInitKubelet(kc *KubeletConfig) (k KubeletBootstrap, pc *config.Pod
 		kc.VolumePlugins,
 		kc.NetworkPlugins,
 		kc.NetworkPluginName,
+		kc.NetworkPluginDir,
 		kc.StreamingConnectionIdleTimeout,
 		kc.Recorder,
 		kc.CAdvisorInterface,

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -182,6 +182,7 @@ func NewMainKubelet(
 	volumePlugins []volume.VolumePlugin,
 	networkPlugins []network.NetworkPlugin,
 	networkPluginName string,
+	networkPluginDir string,
 	streamingConnectionIdleTimeout time.Duration,
 	recorder record.EventRecorder,
 	cadvisorInterface cadvisor.Interface,
@@ -416,9 +417,15 @@ func NewMainKubelet(
 			Stage1Image:     rktStage1Image,
 			InsecureOptions: "image,ondisk",
 		}
+		netConf := &rkt.NetworkPluginConfig{
+			NetworkPluginName: networkPluginName,
+			NetworkPluginDir:  networkPluginDir,
+			NetworkPlugins:    networkPlugins,
+		}
 		rktRuntime, err := rkt.New(
 			rktAPIEndpoint,
 			conf,
+			netConf,
 			klet,
 			recorder,
 			containerRefManager,

--- a/pkg/kubelet/rkt/net_linux.go
+++ b/pkg/kubelet/rkt/net_linux.go
@@ -1,0 +1,119 @@
+// +build linux
+
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rkt
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/kubelet/network"
+	"k8s.io/kubernetes/pkg/kubelet/network/cni"
+	"k8s.io/kubernetes/pkg/kubelet/network/kubenet"
+)
+
+const defaultNetworkName = "default"
+
+type NetworkPluginConfig struct {
+	NetworkPluginName string
+	NetworkPluginDir  string
+	NetworkPlugins    []network.NetworkPlugin
+}
+
+// init symlinks ${RKT_LOCAL_CONFIG}/net.d and ${RKT_LOCAL_CONFIG}/stage1/net.d
+// to network plugin dir, so that the CNI/kubenet config files can be discoverd by rkt.
+// If the plugin is not CNI or kubenet, that it returns an error.
+func (cfg *NetworkPluginConfig) init(c *Config) error {
+	switch cfg.NetworkPluginName {
+	case cni.CNIPluginName, kubenet.KubenetPluginName:
+	default:
+		return fmt.Errorf("network plugin %q is not supported", cfg.NetworkPluginName)
+	}
+
+	if cfg.NetworkPluginDir == "" {
+		return nil
+	}
+
+	// Older rkt version supports only ${LOCAL_CONFIG_DIR}/net.d.
+	// Newer version supports both, and will deprecate the ${LOCAL_CONFIG_DIR}/net.d
+	// in the future.
+	// See https://github.com/coreos/rkt/pull/2312#issuecomment-210548103.
+	netdirs := []string{
+		filepath.Join(c.LocalConfigDir, "stage1", "net.d"),
+		filepath.Join(c.LocalConfigDir, "net.d"),
+	}
+
+	succeeded := false
+	for _, dir := range netdirs {
+		if dir == cfg.NetworkPluginDir {
+			// If the --network-plugin-dir is the net.d itself,
+			// do nothing.
+			continue
+		}
+
+		_, err := os.Lstat(dir)
+		if err == nil {
+			// If the net.d dir already exists, the original directory and all its contents
+			// will be removed.
+			// This is not ideal, the long term solution is to let rkt have the ability
+			// to specify the network config directory.
+			// See https://github.com/coreos/rkt/issues/2249#issuecomment-214528328
+			if err = os.RemoveAll(dir); err != nil {
+				glog.Errorf("rkt: Failed to remove directory %q: %v", dir, err)
+				continue
+			}
+		} else if !os.IsNotExist(err) {
+			glog.Errorf("rkt: Failed to lstat directory %q: %v", dir, err)
+			continue
+		}
+		if err = os.Symlink(cfg.NetworkPluginDir, dir); err != nil {
+			glog.Errorf("rkt: Failed to symlink: %v", err)
+			continue
+		}
+		succeeded = true
+	}
+
+	if !succeeded {
+		return fmt.Errorf("failed to prepare the net.d directory")
+	}
+
+	return nil
+}
+
+// networkName returns the network name that will be passed to
+// rkt by '--net' if rkt runs in a private network.
+// It will return 'kubenet' if the network plugin is kubenet.
+// It will return the first network's name under '--network-plugin-dir' if
+// the '--network-plugin' is cni.
+func (cfg *NetworkPluginConfig) networkName() string {
+	if len(cfg.NetworkPlugins) == 0 {
+		return defaultNetworkName
+	}
+
+	switch cfg.NetworkPluginName {
+	case kubenet.KubenetPluginName:
+		return kubenet.KubenetPluginName
+	case cni.CNIPluginName:
+		return cfg.NetworkPlugins[0].(*cni.CNINetworkPlugin).DefaultNetworkName()
+	}
+
+	glog.Warningf("Network plugin not supported, using %q", defaultNetworkName)
+	return defaultNetworkName
+}

--- a/pkg/kubelet/rkt/net_unsupported.go
+++ b/pkg/kubelet/rkt/net_unsupported.go
@@ -1,0 +1,41 @@
+// +build !linux
+
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rkt
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/kubelet/network"
+)
+
+const defaultNetworkName = "default"
+
+type NetworkPluginConfig struct {
+	NetworkPluginName string
+	NetworkPluginDir  string
+	NetworkPlugins    []network.NetworkPlugin
+}
+
+func (cfg *NetworkPluginConfig) init(c *Config) error {
+	return fmt.Errorf("rkt is not supported in this build")
+}
+
+func (cfg *NetworkPluginConfig) networkName() string {
+	return defaultNetworkName
+}

--- a/pkg/kubelet/rkt/rkt_test.go
+++ b/pkg/kubelet/rkt/rkt_test.go
@@ -570,6 +570,7 @@ func TestGetPodStatus(t *testing.T) {
 		systemd:       fs,
 		runtimeHelper: frh,
 		os:            fos,
+		netConfig:     &NetworkPluginConfig{"", "", nil},
 	}
 
 	ns := func(seconds int64) int64 {
@@ -1123,7 +1124,7 @@ func TestGenerateRunCommand(t *testing.T) {
 			[]string{},
 			"pod-hostname-foo",
 			nil,
-			"/bin/rkt/rkt --insecure-options=image,ondisk --local-config=/var/rkt/local/data --dir=/var/data run-prepared --net=rkt.kubernetes.io --hostname=pod-hostname-foo rkt-uuid-foo",
+			"/bin/rkt/rkt --insecure-options=image,ondisk --local-config=/var/rkt/local/data --dir=/var/data run-prepared --net=default --hostname=pod-hostname-foo rkt-uuid-foo",
 		},
 		// Case #2, returns no dns, with host-net.
 		{
@@ -1161,7 +1162,7 @@ func TestGenerateRunCommand(t *testing.T) {
 			[]string{"."},
 			"pod-hostname-foo",
 			nil,
-			"/bin/rkt/rkt --insecure-options=image,ondisk --local-config=/var/rkt/local/data --dir=/var/data run-prepared --net=rkt.kubernetes.io --dns=127.0.0.1 --dns-search=. --dns-opt=ndots:5 --hostname=pod-hostname-foo rkt-uuid-foo",
+			"/bin/rkt/rkt --insecure-options=image,ondisk --local-config=/var/rkt/local/data --dir=/var/data run-prepared --net=default --dns=127.0.0.1 --dns-search=. --dns-opt=ndots:5 --hostname=pod-hostname-foo rkt-uuid-foo",
 		},
 		// Case #4, returns no dns, dns searches, with host-network.
 		{
@@ -1192,6 +1193,7 @@ func TestGenerateRunCommand(t *testing.T) {
 			InsecureOptions: "image,ondisk",
 			LocalConfigDir:  "/var/rkt/local/data",
 		},
+		netConfig: &NetworkPluginConfig{"", "", nil},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
This symlinks rkt's network config directory (net.d) to the
directory passed by '--network-plugin-dir', so that rkt is able
to read the CNI/kubenet configs users placed in the
'--network-plugin-dir'.

This also changes the network name that rkt pod will use.
Previsouly it's hardcoded as 'rkt.kubernetes.io'. Now it's the
first valid CNI network's name under the '--network-plugin-dir',
which is today's kubernetes CNI plugin's behaviour.

cc @euank @sjpotter @jonboulle @steevj @kubernetes/sig-node @kubernetes/sig-network 

Ref #24672 
