### PR TITLE
Slow down redis polling to ensure no flakiness in kubectl

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -727,8 +727,12 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 
 			framework.Logf("namespace %v", ns)
 			framework.RunKubectlOrDie("create", "-f", controllerJson, nsFlag)
+
+			// It may take a while for the pods to get registered in some cases, wait to be sure.
+			By("Waiting for Redis master to start.")
+			waitFor(1)
 			forEachPod(func(pod api.Pod) {
-				framework.Logf("wait on %v ", ns)
+				framework.Logf("wait on redis-master startup in %v ", ns)
 				framework.LookForStringInLog(ns, pod.Name, "redis-master", "The server is now ready to accept connections", framework.PodStartTimeout)
 			})
 			validateService := func(name string, servicePort int, timeout time.Duration) {


### PR DESCRIPTION
Fixes #24619  (I think the `LookForStringInLog` should give sufficient slack - but it needs to know that the pods were actually created and that may take longer/shorter depending on the state of things)
