### PR TITLE
Protobuf generation should strip side-effect imports

### DIFF
--- a/federation/apis/federation/v1alpha1/generated.pb.go
+++ b/federation/apis/federation/v1alpha1/generated.pb.go
@@ -37,11 +37,10 @@ package v1alpha1
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/gogo/protobuf/gogoproto"
+
 import k8s_io_kubernetes_pkg_api_resource "k8s.io/kubernetes/pkg/api/resource"
 import k8s_io_kubernetes_pkg_api_unversioned "k8s.io/kubernetes/pkg/api/unversioned"
 import k8s_io_kubernetes_pkg_api_v1 "k8s.io/kubernetes/pkg/api/v1"
-import _ "k8s.io/kubernetes/pkg/util/intstr"
 
 import io "io"
 

--- a/pkg/api/resource/generated.pb.go
+++ b/pkg/api/resource/generated.pb.go
@@ -33,8 +33,6 @@ package resource
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/gogo/protobuf/gogoproto"
-import _ "k8s.io/kubernetes/pkg/util/intstr"
 
 import io "io"
 

--- a/pkg/api/unversioned/generated.pb.go
+++ b/pkg/api/unversioned/generated.pb.go
@@ -55,8 +55,6 @@ package unversioned
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/gogo/protobuf/gogoproto"
-import _ "k8s.io/kubernetes/pkg/util/intstr"
 
 import time "time"
 

--- a/pkg/api/v1/generated.pb.go
+++ b/pkg/api/v1/generated.pb.go
@@ -170,7 +170,7 @@ package v1
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/gogo/protobuf/gogoproto"
+
 import k8s_io_kubernetes_pkg_api_resource "k8s.io/kubernetes/pkg/api/resource"
 import k8s_io_kubernetes_pkg_api_unversioned "k8s.io/kubernetes/pkg/api/unversioned"
 import k8s_io_kubernetes_pkg_runtime "k8s.io/kubernetes/pkg/runtime"

--- a/pkg/apis/apps/v1alpha1/generated.pb.go
+++ b/pkg/apis/apps/v1alpha1/generated.pb.go
@@ -35,11 +35,9 @@ package v1alpha1
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/gogo/protobuf/gogoproto"
-import _ "k8s.io/kubernetes/pkg/api/resource"
+
 import k8s_io_kubernetes_pkg_api_unversioned "k8s.io/kubernetes/pkg/api/unversioned"
 import k8s_io_kubernetes_pkg_api_v1 "k8s.io/kubernetes/pkg/api/v1"
-import _ "k8s.io/kubernetes/pkg/util/intstr"
 
 import io "io"
 

--- a/pkg/apis/autoscaling/v1/generated.pb.go
+++ b/pkg/apis/autoscaling/v1/generated.pb.go
@@ -39,11 +39,8 @@ package v1
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/gogo/protobuf/gogoproto"
-import _ "k8s.io/kubernetes/pkg/api/resource"
-import k8s_io_kubernetes_pkg_api_unversioned "k8s.io/kubernetes/pkg/api/unversioned"
 
-import _ "k8s.io/kubernetes/pkg/util/intstr"
+import k8s_io_kubernetes_pkg_api_unversioned "k8s.io/kubernetes/pkg/api/unversioned"
 
 import io "io"
 

--- a/pkg/apis/batch/v1/generated.pb.go
+++ b/pkg/apis/batch/v1/generated.pb.go
@@ -38,11 +38,9 @@ package v1
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/gogo/protobuf/gogoproto"
-import _ "k8s.io/kubernetes/pkg/api/resource"
+
 import k8s_io_kubernetes_pkg_api_unversioned "k8s.io/kubernetes/pkg/api/unversioned"
 import k8s_io_kubernetes_pkg_api_v1 "k8s.io/kubernetes/pkg/api/v1"
-import _ "k8s.io/kubernetes/pkg/util/intstr"
 
 import io "io"
 

--- a/pkg/apis/extensions/v1beta1/generated.pb.go
+++ b/pkg/apis/extensions/v1beta1/generated.pb.go
@@ -92,7 +92,6 @@ package v1beta1
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/gogo/protobuf/gogoproto"
 
 import k8s_io_kubernetes_pkg_api_unversioned "k8s.io/kubernetes/pkg/api/unversioned"
 import k8s_io_kubernetes_pkg_api_v1 "k8s.io/kubernetes/pkg/api/v1"

--- a/pkg/runtime/generated.pb.go
+++ b/pkg/runtime/generated.pb.go
@@ -34,9 +34,6 @@ package runtime
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/gogo/protobuf/gogoproto"
-import _ "k8s.io/kubernetes/pkg/api/resource"
-import _ "k8s.io/kubernetes/pkg/util/intstr"
 
 import io "io"
 

--- a/pkg/util/intstr/generated.pb.go
+++ b/pkg/util/intstr/generated.pb.go
@@ -32,7 +32,6 @@ package intstr
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/gogo/protobuf/gogoproto"
 
 import io "io"
 

--- a/pkg/watch/versioned/generated.pb.go
+++ b/pkg/watch/versioned/generated.pb.go
@@ -32,9 +32,6 @@ package versioned
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/gogo/protobuf/gogoproto"
-
-import _ "k8s.io/kubernetes/pkg/util/intstr"
 
 import io "io"
 


### PR DESCRIPTION
The imports are generated from the IDL, but are not used. Strip them, since the marshallers do not depend on side effects.

@wojtek-t
