### PR TITLE
Incorrect attribute - docs - pod-security-context

### DIFF
--- a/docs/proposals/pod-security-context.md
+++ b/docs/proposals/pod-security-context.md
@@ -40,7 +40,7 @@ order to correctly model pod- and container-level security concerns.
 ## Motivation
 
 Currently, containers have a `SecurityContext` attribute which contains information about the
-security settings the container uses.  In practice many of these attributes are uniform across all
+security settings the container uses.  In practice, many of these attributes are uniform across all
 containers in a pod.  Simultaneously, there is also a need to apply the security context pattern
 at the pod level to correctly model security attributes that apply only at a pod level.
 
@@ -277,7 +277,7 @@ to implement, explain, and support.  Instead, we will approach backward compatib
         securityContext:
           runAsUser: 1001
       - name: b
-        securityContest:
+        securityContext:
           runAsUser: 1002
     ```
 


### PR DESCRIPTION
Pod definition had incorrect spelling on attribute `securityContext`
Also fixed the flow of Motivation introduction paragraph.
