### PR TITLE
kube-proxy userspace, never delete service of lb while there is no en…

### DIFF
--- a/pkg/proxy/userspace/roundrobin.go
+++ b/pkg/proxy/userspace/roundrobin.go
@@ -227,7 +227,6 @@ func (lb *LoadBalancerRR) updateAffinityMap(svcPort proxy.ServicePortName, newEn
 // Registered endpoints are updated if found in the update set or
 // unregistered if missing from the update set.
 func (lb *LoadBalancerRR) OnEndpointsUpdate(allEndpoints []api.Endpoints) {
-	registeredEndpoints := make(map[proxy.ServicePortName]bool)
 	lb.lock.Lock()
 	defer lb.lock.Unlock()
 
@@ -272,7 +271,6 @@ func (lb *LoadBalancerRR) OnEndpointsUpdate(allEndpoints []api.Endpoints) {
 				// Reset the round-robin index.
 				state.index = 0
 			}
-			registeredEndpoints[svcPort] = true
 		}
 	}
 }

--- a/pkg/proxy/userspace/roundrobin.go
+++ b/pkg/proxy/userspace/roundrobin.go
@@ -275,13 +275,6 @@ func (lb *LoadBalancerRR) OnEndpointsUpdate(allEndpoints []api.Endpoints) {
 			registeredEndpoints[svcPort] = true
 		}
 	}
-	// Remove endpoints missing from the update.
-	for k := range lb.services {
-		if _, exists := registeredEndpoints[k]; !exists {
-			glog.V(2).Infof("LoadBalancerRR: Removing endpoints for %s", k)
-			delete(lb.services, k)
-		}
-	}
 }
 
 // Tests whether two slices are equivalent.  This sorts both slices in-place.


### PR DESCRIPTION
kube-proxy userspace, never delete service of lb while there is no endpoint of this service. Delete when the Service object disappears on api-server.
