### PR TITLE
update codegen before update codecgen

### DIFF
--- a/hack/update-all.sh
+++ b/hack/update-all.sh
@@ -52,12 +52,12 @@ fi
 
 BASH_TARGETS="
 	generated-protobuf
-  codecgen
+	codegen
+	codecgen
 	generated-docs
 	generated-swagger-docs
 	swagger-spec
-	api-reference-docs
-	codegen"
+	api-reference-docs"
 
 
 for t in $BASH_TARGETS


### PR DESCRIPTION
Currently if I remove an API field, update-codecgen will complain generated deepcopy functions referring to invalid fields. Running update-codegen before update-codecgen solves the problem.
