### PR TITLE
Add utility for kubelet to log resource lists consistently

### DIFF
--- a/pkg/kubelet/util/format/resources.go
+++ b/pkg/kubelet/util/format/resources.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package format
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"k8s.io/kubernetes/pkg/api"
+)
+
+// ResourceList returns a string representation of a resource list in a human readable format.
+func ResourceList(resources api.ResourceList) string {
+	resourceStrings := make([]string, 0, len(resources))
+	for key, value := range resources {
+		resourceStrings = append(resourceStrings, fmt.Sprintf("%v=%v", key, value.String()))
+	}
+	// sort the results for consistent log output
+	sort.Strings(resourceStrings)
+	return strings.Join(resourceStrings, ",")
+}

--- a/pkg/kubelet/util/format/resources_test.go
+++ b/pkg/kubelet/util/format/resources_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package format
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+)
+
+func TestResourceList(t *testing.T) {
+	resourceList := api.ResourceList{}
+	resourceList[api.ResourceCPU] = resource.MustParse("100m")
+	resourceList[api.ResourceMemory] = resource.MustParse("5Gi")
+	actual := ResourceList(resourceList)
+	expected := "cpu=100m,memory=5Gi"
+	if actual != expected {
+		t.Errorf("Unexpected result, actual: %v, expected: %v", actual, expected)
+	}
+}


### PR DESCRIPTION
This is a simple utility for logging resource lists with standardized output.

I find it useful when logging work in node eviction, similar to kubelet logging convention for pods in same package.

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/24742)

<!-- Reviewable:end -->
