### PR TITLE
Make detect-node-names less brittle for G{C,K}E

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -273,13 +273,16 @@ function upload-server-tars() {
 function detect-node-names {
   detect-project
   INSTANCE_GROUPS=()
-  INSTANCE_GROUPS+=($(gcloud compute instance-groups managed list --zone "${ZONE}" --project "${PROJECT}" | grep ${NODE_INSTANCE_PREFIX} | cut -f1 -d" " || true))
+  INSTANCE_GROUPS+=($(gcloud compute instance-groups managed list \
+    --zone "${ZONE}" --project "${PROJECT}" \
+    --regexp "${NODE_INSTANCE_PREFIX}-.+" \
+    --format='value(instanceGroup)' || true))
   NODE_NAMES=()
   if [[ -n "${INSTANCE_GROUPS[@]:-}" ]]; then
     for group in "${INSTANCE_GROUPS[@]}"; do
       NODE_NAMES+=($(gcloud compute instance-groups managed list-instances \
         "${group}" --zone "${ZONE}" --project "${PROJECT}" \
-        --format=yaml | grep instance: | cut -d ' ' -f 2))
+        --format='value(instance)'))
     done
     echo "INSTANCE_GROUPS=${INSTANCE_GROUPS[*]}" >&2
     echo "NODE_NAMES=${NODE_NAMES[*]}" >&2

--- a/cluster/gke/util.sh
+++ b/cluster/gke/util.sh
@@ -249,10 +249,7 @@ function detect-node-names {
   detect-node-instance-group
   NODE_NAMES=($(gcloud compute instance-groups managed list-instances \
     "${NODE_INSTANCE_GROUP}" --zone "${ZONE}" --project "${PROJECT}" \
-    --format=yaml | grep instance: | cut -d ' ' -f 2))
-
-  # Strip path if return value is selflink
-  NODE_NAMES=($(for i in ${NODE_NAMES[@]}; do basename "$i"; done))
+    --format='value(instance)'))
 
   echo "NODE_NAMES=${NODE_NAMES[*]}"
 }


### PR DESCRIPTION
Use the `--format='value()'` option with `gcloud compute instance-groups managed list{,-instances}` instead of `--format=yaml` with a series of `grep`s and `cut`s. This is hopefully a bit more stable.

Fixes #24120.

cc @kubernetes/sig-testing @jlowdermilk @freehan 
