### PR TITLE
Trusty: Add retry in curl commands

### DIFF
--- a/cluster/gce/trusty/configure.sh
+++ b/cluster/gce/trusty/configure.sh
@@ -24,7 +24,7 @@ download_kube_env() {
   # Fetch kube-env from GCE metadata server.
   readonly tmp_install_dir="/var/cache/kubernetes-install"
   mkdir -p "${tmp_install_dir}"
-  curl --fail --silent --show-error \
+  curl --fail --retry 5 --retry-delay 3 --silent --show-error \
     -H "X-Google-Metadata-Request: True" \
     -o "${tmp_install_dir}/kube_env.yaml" \
     http://metadata.google.internal/computeMetadata/v1/instance/attributes/kube-env

--- a/cluster/gce/trusty/master.yaml
+++ b/cluster/gce/trusty/master.yaml
@@ -19,7 +19,7 @@ script
 	set -o nounset
 
 	# Fetch the script for installing master binary and configuration files.
-	curl --fail --silent --show-error \
+	curl --fail --retry 5 --retry-delay 3 --silent --show-error \
 		-H "X-Google-Metadata-Request: True" \
 		-o /etc/kube-configure.sh \
 		http://metadata.google.internal/computeMetadata/v1/instance/attributes/configure-sh

--- a/cluster/gce/trusty/node.yaml
+++ b/cluster/gce/trusty/node.yaml
@@ -19,7 +19,7 @@ script
 	set -o nounset
 
 	# Fetch the script for installing nodes binary and configuration files.
-	curl --fail --silent --show-error \
+	curl --fail --retry 5 --retry-delay 3 --silent --show-error \
 		-H "X-Google-Metadata-Request: True" \
 		-o /etc/kube-configure.sh \
 		http://metadata.google.internal/computeMetadata/v1/instance/attributes/configure-sh


### PR DESCRIPTION
This fix is for improving robustness in fetch critical metadata files when the metadata server is temporarily unreachable.

@roberthbailey @zmerlynn @dchen1107 please review it.

cc/ @fabioy @wonderfly FYI.
