### PR TITLE
Redo Unstructured to have accessor methods

### DIFF
--- a/pkg/api/meta/interfaces.go
+++ b/pkg/api/meta/interfaces.go
@@ -177,3 +177,5 @@ type RESTMapper interface {
 	AliasesForResource(resource string) ([]string, bool)
 	ResourceSingularizer(resource string) (singular string, err error)
 }
+
+var _ Object = &runtime.Unstructured{}

--- a/pkg/client/typed/dynamic/client.go
+++ b/pkg/client/typed/dynamic/client.go
@@ -157,12 +157,12 @@ func (rc *ResourceClient) Create(obj *runtime.Unstructured) (*runtime.Unstructur
 // Update updates the provided resource.
 func (rc *ResourceClient) Update(obj *runtime.Unstructured) (*runtime.Unstructured, error) {
 	result := new(runtime.Unstructured)
-	if len(obj.Name) == 0 {
+	if len(obj.GetName()) == 0 {
 		return result, errors.New("object missing name")
 	}
 	err := rc.namespace(rc.cl.Put()).
 		Resource(rc.resource.Name).
-		Name(obj.Name).
+		Name(obj.GetName()).
 		Body(obj).
 		Do().
 		Into(result)

--- a/pkg/client/typed/dynamic/client_test.go
+++ b/pkg/client/typed/dynamic/client_test.go
@@ -45,11 +45,6 @@ func getListJSON(version, kind string, items ...[]byte) []byte {
 
 func getObject(version, kind, name string) *runtime.Unstructured {
 	return &runtime.Unstructured{
-		TypeMeta: runtime.TypeMeta{
-			APIVersion: version,
-			Kind:       kind,
-		},
-		Name: name,
 		Object: map[string]interface{}{
 			"apiVersion": version,
 			"kind":       kind,
@@ -88,9 +83,9 @@ func TestList(t *testing.T) {
 				getJSON("vTest", "rTest", "item1"),
 				getJSON("vTest", "rTest", "item2")),
 			want: &runtime.UnstructuredList{
-				TypeMeta: runtime.TypeMeta{
-					APIVersion: "vTest",
-					Kind:       "rTestList",
+				Object: map[string]interface{}{
+					"apiVersion": "vTest",
+					"kind":       "rTestList",
 				},
 				Items: []*runtime.Unstructured{
 					getObject("vTest", "rTest", "item1"),
@@ -106,9 +101,9 @@ func TestList(t *testing.T) {
 				getJSON("vTest", "rTest", "item1"),
 				getJSON("vTest", "rTest", "item2")),
 			want: &runtime.UnstructuredList{
-				TypeMeta: runtime.TypeMeta{
-					APIVersion: "vTest",
-					Kind:       "rTestList",
+				Object: map[string]interface{}{
+					"apiVersion": "vTest",
+					"kind":       "rTestList",
 				},
 				Items: []*runtime.Unstructured{
 					getObject("vTest", "rTest", "item1"),

--- a/pkg/controller/namespace/namespace_controller_utils.go
+++ b/pkg/controller/namespace/namespace_controller_utils.go
@@ -236,7 +236,7 @@ func deleteEachItem(
 	}
 	apiResource := unversioned.APIResource{Name: gvr.Resource, Namespaced: true}
 	for _, item := range unstructuredList.Items {
-		if err = dynamicClient.Resource(&apiResource, namespace).Delete(item.Name, nil); err != nil && !errors.IsNotFound(err) && !errors.IsMethodNotSupported(err) {
+		if err = dynamicClient.Resource(&apiResource, namespace).Delete(item.GetName(), nil); err != nil && !errors.IsNotFound(err) && !errors.IsMethodNotSupported(err) {
 			return err
 		}
 	}

--- a/pkg/runtime/helper_test.go
+++ b/pkg/runtime/helper_test.go
@@ -33,7 +33,13 @@ func TestDecodeList(t *testing.T) {
 				Raw:         []byte(`{"kind":"Pod","apiVersion":"` + testapi.Default.GroupVersion().String() + `","metadata":{"name":"test"}}`),
 				ContentType: runtime.ContentTypeJSON,
 			},
-			&runtime.Unstructured{TypeMeta: runtime.TypeMeta{Kind: "Foo", APIVersion: "Bar"}, Object: map[string]interface{}{"test": "value"}},
+			&runtime.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "Foo",
+					"apiVersion": "Bar",
+					"test":       "value",
+				},
+			},
 		},
 	}
 	if errs := runtime.DecodeList(pl.Items, testapi.Default.Codec()); len(errs) != 0 {

--- a/pkg/runtime/register.go
+++ b/pkg/runtime/register.go
@@ -30,9 +30,10 @@ func (obj *TypeMeta) GroupVersionKind() *unversioned.GroupVersionKind {
 	return unversioned.FromAPIVersionAndKind(obj.APIVersion, obj.Kind)
 }
 
-func (obj *Unknown) GetObjectKind() unversioned.ObjectKind          { return &obj.TypeMeta }
-func (obj *Unstructured) GetObjectKind() unversioned.ObjectKind     { return &obj.TypeMeta }
-func (obj *UnstructuredList) GetObjectKind() unversioned.ObjectKind { return &obj.TypeMeta }
+func (obj *Unknown) GetObjectKind() unversioned.ObjectKind { return &obj.TypeMeta }
+
+func (obj *Unstructured) GetObjectKind() unversioned.ObjectKind     { return obj }
+func (obj *UnstructuredList) GetObjectKind() unversioned.ObjectKind { return obj }
 
 // GetObjectKind implements Object for VersionedObjects, returning an empty ObjectKind
 // interface if no objects are provided, or the ObjectKind interface of the object in the


### PR DESCRIPTION
Add accessor methods that implement pkg/api/unversioned.ObjectKind,
pkg/api/meta.Object, pkg/api/meta.Type and pkg/api/meta.List.

Removed the convenience fields since writing to them was not reflected
in serialized JSON.
