### PR TITLE
gke-large-cluster: Allow up to 1% of 1000 = 10 nodes

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
@@ -248,6 +248,7 @@
                 export ZONE="us-central1-b"
                 export NUM_NODES=1000
                 export MACHINE_TYPE="n1-highmem-2"
+                export ALLOWED_NOTREADY_NODES="10"
     jobs:
         - 'kubernetes-e2e-{suffix}'
 


### PR DESCRIPTION
Per 2016/03/16 GKE release note, CreateCluster can return success with
only 99% success.
