### PR TITLE
rkt: Pass through os argument

### DIFF
--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -199,6 +199,7 @@ func New(
 		livenessManager:     livenessManager,
 		volumeGetter:        volumeGetter,
 		execer:              execer,
+		os:                  os,
 		touchPath:           touchPath,
 	}
 


### PR DESCRIPTION
This was lost in a rebase in #24496 and, while not required to build, is
required to function correctly under rkt (else panics!)

cc @yifan-gu 
