### PR TITLE
Add extensions/replicaset to federation-apiserver

### DIFF
--- a/federation/cmd/federation-apiserver/app/extensions.go
+++ b/federation/cmd/federation-apiserver/app/extensions.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/apimachinery/registered"
+	"k8s.io/kubernetes/pkg/genericapiserver"
+	genericoptions "k8s.io/kubernetes/pkg/genericapiserver/options"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/rest"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	_ "k8s.io/kubernetes/pkg/apis/extensions/install"
+	replicasetetcd "k8s.io/kubernetes/pkg/registry/replicaset/etcd"
+)
+
+func installExtensionsAPIs(s *genericoptions.ServerRunOptions, g *genericapiserver.GenericAPIServer, f genericapiserver.StorageFactory) {
+	replicaSetStorage := replicasetetcd.NewStorage(createRESTOptionsOrDie(s, g, f, extensions.Resource("replicasets")))
+	extensionsResources := map[string]rest.Storage{
+		"replicasets":        replicaSetStorage.ReplicaSet,
+		"replicasets/status": replicaSetStorage.Status,
+		"replicasets/scale":  replicaSetStorage.Scale,
+	}
+	extensionsGroupMeta := registered.GroupOrDie(extensions.GroupName)
+	apiGroupInfo := genericapiserver.APIGroupInfo{
+		GroupMeta: *extensionsGroupMeta,
+		VersionedResourcesStorageMap: map[string]map[string]rest.Storage{
+			"v1beta1": extensionsResources,
+		},
+		OptionsExternalVersion: &registered.GroupOrDie(api.GroupName).GroupVersion,
+		Scheme:                 api.Scheme,
+		ParameterCodec:         api.ParameterCodec,
+		NegotiatedSerializer:   api.Codecs,
+	}
+	if err := g.InstallAPIGroup(&apiGroupInfo); err != nil {
+		glog.Fatalf("Error in registering group versions: %v", err)
+	}
+}

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -144,6 +144,7 @@ func Run(s *genericoptions.ServerRunOptions) error {
 
 	installFederationAPIs(s, m, storageFactory)
 	installCoreAPIs(s, m, storageFactory)
+	installExtensionsAPIs(s, m, storageFactory)
 
 	m.Run(s)
 	return nil


### PR DESCRIPTION
Add extensions/replicaset for federated scheduler (#24038) as all k8s api objects were removed in #23959

Please review only the very last one commit.
#19313 #23653

@nikhiljindal @quinton-hoole, @deepak-vij, @XiaoningDing, @alfred-huangjian @mfanjie @huangyuqi @colhom
