### PR TITLE
Shallow clone for kubernetes-build and kubernetes-test-go jobs.

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
@@ -32,6 +32,7 @@
             browser-url: https://github.com/kubernetes/kubernetes
             wipe-workspace: false
             skip-tag: true
+            shallow-clone: true
     triggers:
         - pollscm:
             cron: 'H/2 * * * *'

--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-go.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-go.yaml
@@ -43,6 +43,7 @@
             browser-url: https://github.com/kubernetes/kubernetes
             wipe-workspace: false
             skip-tag: true
+            shallow-clone: true
     triggers:
         - pollscm:
             cron: 'H/2 * * * *'


### PR DESCRIPTION
This should save us about 160M per clone.
