### PR TITLE
Under high load, defer flushing watches to reduce time spent in syscalls 

### DIFF
--- a/pkg/apiserver/watch.go
+++ b/pkg/apiserver/watch.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/runtime/serializer/streaming"
 	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
+	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/util/wsstream"
 	"k8s.io/kubernetes/pkg/watch"
 	"k8s.io/kubernetes/pkg/watch/versioned"
@@ -166,15 +167,25 @@ func (s *WatchServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("Transfer-Encoding", "chunked")
 	w.WriteHeader(http.StatusOK)
 	flusher.Flush()
+	defer flusher.Flush()
 
+	delay := wait.NewChannelDelayedAction(
+		wait.Interval{Count: 10, Interval: 100 * time.Millisecond},
+		wait.Interval{Count: 100, Interval: 500 * time.Millisecond},
+	)
+
+	watchCh := s.watching.ResultChan()
 	buf := &bytes.Buffer{}
 	for {
 		select {
 		case <-cn.CloseNotify():
 			return
+		case <-delay.After():
+			delay.Done()
+			flusher.Flush()
 		case <-timeoutCh:
 			return
-		case event, ok := <-s.watching.ResultChan():
+		case event, ok := <-watchCh:
 			if !ok {
 				// End of results.
 				return
@@ -196,7 +207,9 @@ func (s *WatchServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 				// client disconnect.
 				return
 			}
-			flusher.Flush()
+			if len(watchCh) == 0 && delay.Run() {
+				flusher.Flush()
+			}
 
 			buf.Reset()
 		}

--- a/pkg/util/wait/delayed_action.go
+++ b/pkg/util/wait/delayed_action.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wait
+
+import (
+	"time"
+)
+
+// nowFn is a function for testing
+var nowFn = time.Now
+
+// timerFn is a function for testing
+var timerFn = createOrResetTimer
+
+// Interval defines an interval over which a certain number of events are expected.
+type Interval struct {
+	Count    int
+	Interval time.Duration
+}
+
+// NewChannelDelayedAction provides efficient aggregation and rate limiting of actions that must be executed,
+// but can tolerate delay. It accepts a series of steps that allow increasingly larger delays at higher
+// rates. Intended to be used in a for{ select{...} } loop on single threaded actions:
+//
+//     delay := NewChannelDelayedAction(Interval{Count: 10, Interval: time.Second})
+//     for {
+//       select {
+//       case <-delay.After():
+//         delay.Done()
+//         // perform a rate limited action
+//       ...
+//       }
+//       if delay.Run() {
+//         // perform a rate limited action
+//       }
+//     }
+//
+// If the for loop runs faster than 10 events per second, Run() will return false and the delay channel will have
+// an item when the wait is over. Done() is required to clear the state in the loop. If the rate drops
+// below 10/sec, then no delays will be used. The rate is calculated over the time necessary to accumulate 10
+// events (not an instaneous rate).
+func NewChannelDelayedAction(steps ...Interval) *ChannelDelayedAction {
+	return &ChannelDelayedAction{steps: steps}
+}
+
+// ChannelDelayedAction allows callers to delay expensive actions inside of for-select loops.
+type ChannelDelayedAction struct {
+	active <-chan time.Time
+	t      *time.Timer
+
+	steps    []Interval
+	count    int
+	interval time.Duration
+	last     time.Time
+}
+
+// After is the channel to listen for delayed actions in a for select loop.
+func (q *ChannelDelayedAction) After() <-chan time.Time {
+	return q.active
+}
+
+// Done indicates that the active channel has been read and that subsequent actions should be on
+// a different interval.
+func (q *ChannelDelayedAction) Done() {
+	q.active = nil
+	q.last = time.Time{}
+}
+
+// Run returns true if the action should be performed, and false if it should be run only when After()
+// returns.
+func (q *ChannelDelayedAction) Run() bool {
+	q.count++
+	if q.active != nil {
+		return false
+	}
+	if q.shouldRun() {
+		return true
+	}
+
+	q.t, q.active = timerFn(q.t, q.interval)
+	return false
+}
+
+// shouldRun returns true if the action should run right away, resetting q.interval and q.count
+// as necessary.
+func (q *ChannelDelayedAction) shouldRun() bool {
+	count := q.count
+
+	// have not accumulated to first threshold, so record start of interval
+	if count < q.steps[0].Count {
+		if q.last.IsZero() {
+			q.last = nowFn()
+		}
+		return true
+	}
+
+	// we're over the first threshold, but we need to have a sufficient rate to be delayed
+	if !q.last.IsZero() {
+		now := nowFn()
+		interval := now.Sub(q.last)
+		if interval == 0 {
+			interval = 1
+		}
+		// check our rate is above the first threshold
+		rate := float32(count) / float32(interval)
+		stepRate := float32(q.steps[0].Count) / float32(q.steps[0].Interval)
+		q.count = 0
+		if rate < stepRate {
+			// no rate high enough, continue to invoke directly
+			q.last = now
+			return true
+		}
+		// move to longer polling
+		q.interval = q.steps[0].Interval
+		return false
+	}
+
+	// find the highest threshold we match
+	for i := len(q.steps) - 1; i >= 0; i-- {
+		if count >= q.steps[i].Count {
+			q.count = 0
+			q.interval = q.steps[i].Interval
+			return false
+		}
+	}
+	return true
+}
+
+func createOrResetTimer(t *time.Timer, interval time.Duration) (*time.Timer, <-chan time.Time) {
+	if t == nil {
+		t = time.NewTimer(interval)
+	} else if t.Reset(interval) {
+		<-t.C
+	}
+	return t, t.C
+}

--- a/pkg/util/wait/delayed_action_test.go
+++ b/pkg/util/wait/delayed_action_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wait
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDelayedAction(t *testing.T) {
+	defer func() { nowFn = time.Now }()
+	now := time.Now()
+	nowFn = func() time.Time { return now }
+
+	// delay when rate is over 10/ms
+	a := NewChannelDelayedAction(Interval{Count: 10, Interval: time.Millisecond}, Interval{Count: 100, Interval: 5 * time.Millisecond})
+	// start off by running immediately because we're below the rate
+	if !a.Run() || a.count != 1 || a.last != now || a.interval != 0 {
+		t.Fatal(a)
+	}
+	if !a.Run() || a.count != 2 || a.last != now || a.interval != 0 {
+		t.Fatal(a)
+	}
+
+	// switch to delaying because there are enough events instanteously
+	a.count = 9
+	if a.Run() || a.count != 0 || a.last != now || a.interval != time.Millisecond || a.active == nil {
+		t.Fatal(a)
+	}
+	if a.Run() || a.count != 1 || a.last != now || a.interval != time.Millisecond || a.active == nil {
+		t.Fatal(a)
+	}
+	<-a.After()
+	a.Done()
+	if !a.last.IsZero() || a.active != nil {
+		t.Fatal(a)
+	}
+
+	// go back to running immediately, count is carried over
+	if !a.Run() || a.count != 2 || a.last != now || a.interval != time.Millisecond {
+		t.Fatal(a)
+	}
+
+	// go back to deferred
+	a.count = 30
+	old := now
+	now = now.Add(2 * time.Millisecond)
+	if a.Run() || a.count != 0 || a.last != old || a.interval != time.Millisecond {
+		t.Fatal(a)
+	}
+	<-a.After()
+	a.Done()
+
+	// jump to a higher rate interval
+	a.count = 100
+	old = now
+	now = now.Add(2 * time.Millisecond)
+	if a.Run() || a.count != 0 || !a.last.IsZero() || a.interval != 5*time.Millisecond {
+		t.Fatal(a)
+	}
+	<-a.After()
+	a.Done()
+
+	// drop down to the lower rate interval
+	a.count = 10
+	old = now
+	now = now.Add(2 * time.Millisecond)
+	if a.Run() || a.count != 0 || !a.last.IsZero() || a.interval != time.Millisecond {
+		t.Fatal(a)
+	}
+	<-a.After()
+	a.Done()
+}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -130,8 +130,18 @@ func (f *Framework) BeforeEach() {
 		Expect(err).NotTo(HaveOccurred())
 		f.Client = c
 	}
+	if f.Client.RESTClient.Client != nil {
+		Logf("client timeout 1 %d", f.Client.RESTClient.Client.Timeout)
+	}
 	f.Clientset_1_2 = adapter_1_2.FromUnversionedClient(f.Client)
+	if f.Client.RESTClient.Client != nil {
+		Logf("client timeout 2 %d", f.Client.RESTClient.Client.Timeout)
+	}
 	f.Clientset_1_3 = adapter_1_3.FromUnversionedClient(f.Client)
+
+	if f.Client.RESTClient.Client != nil {
+		Logf("client timeout 3 %d", f.Client.RESTClient.Client.Timeout)
+	}
 
 	By("Building a namespace api object")
 	namespace, err := f.CreateNamespace(f.BaseName, map[string]string{


### PR DESCRIPTION
Has a significant effect on throughput for overloaded watches. In single
threaded tests watch spends 25% less overall time (33% more throughput)
due to less syscalls to flush. Should not affect overall latency, although
could stand to be tuned / discussed more.

@wojtek-t

Fixes #24729
