### PR TITLE
Update Docker version after cockpit installation

### DIFF
--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -111,6 +111,7 @@ if ! which /usr/libexec/cockpit-ws &>/dev/null; then
   pushd /etc/yum.repos.d
     curl -OL https://copr.fedorainfracloud.org/coprs/g/cockpit/cockpit-preview/repo/fedora-23/msuchy-cockpit-preview-fedora-23.repo
     dnf install -y cockpit cockpit-kubernetes
+    dnf update -y docker
   popd
 
   systemctl enable cockpit.socket


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/24530
The vagrant setup didn't worked for me because `cockpit cockpit-kubernetes` brings their own Docker version (1.7) which doesn't work and the master components doesn't come up. More information about this bug are in my [issue](https://github.com/kubernetes/kubernetes/issues/24530).

My test system:

``` bash
$ uname -a                        
Darwin MyMacBook.local 15.4.0 Darwin Kernel Version 15.4.0: Fri Feb 26 22:08:05 PST 2016; root:xnu-3248.40.184~3/RELEASE_X86_64 x86_64

$ vagrant --version                                                                                                                                                             
Vagrant 1.8.1

$ VBoxManage --version                                                                                                                                                          
5.0.16r105871
```
