### PR TITLE
Make DNS validators return error strings

### DIFF
--- a/cluster/addons/dns/kube2sky/kube2sky.go
+++ b/cluster/addons/dns/kube2sky/kube2sky.go
@@ -208,7 +208,7 @@ func getHostname(address *kapi.EndpointAddress, podHostnames map[string]endpoint
 	if len(address.Hostname) > 0 {
 		return address.Hostname, true
 	}
-	if hostRecord, exists := podHostnames[address.IP]; exists && validation.IsDNS1123Label(hostRecord.HostName) {
+	if hostRecord, exists := podHostnames[address.IP]; exists && len(validation.IsDNS1123Label(hostRecord.HostName)) == 0 {
 		return hostRecord.HostName, true
 	}
 	return "", false

--- a/pkg/api/validation/events.go
+++ b/pkg/api/validation/events.go
@@ -37,8 +37,8 @@ func ValidateEvent(event *api.Event) field.ErrorList {
 		event.Namespace != event.InvolvedObject.Namespace {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("involvedObject", "namespace"), event.InvolvedObject.Namespace, "does not match involvedObject"))
 	}
-	if !validation.IsDNS1123Subdomain(event.Namespace) {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("namespace"), event.Namespace, ""))
+	for _, msg := range validation.IsDNS1123Subdomain(event.Namespace) {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("namespace"), event.Namespace, msg))
 	}
 	return allErrs
 }

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -58,7 +58,6 @@ func InclusiveRangeErrorMsg(lo, hi int) string {
 	return fmt.Sprintf(`must be between %d and %d, inclusive`, lo, hi)
 }
 
-var DNS952LabelErrorMsg string = fmt.Sprintf(`must be a DNS 952 label (at most %d characters, matching regex %s): e.g. "my-name"`, validation.DNS952LabelMaxLength, validation.DNS952LabelFmt)
 var pdPartitionErrorMsg string = InclusiveRangeErrorMsg(1, 255)
 var PortRangeErrorMsg string = InclusiveRangeErrorMsg(1, 65535)
 var IdRangeErrorMsg string = InclusiveRangeErrorMsg(0, math.MaxInt32)
@@ -256,10 +255,7 @@ func NameIsDNS952Label(name string, prefix bool) []string {
 	if prefix {
 		name = maskTrailingDash(name)
 	}
-	if validation.IsDNS952Label(name) {
-		return nil
-	}
-	return []string{DNS952LabelErrorMsg}
+	return validation.IsDNS952Label(name)
 }
 
 // Validates that given value is not negative.

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -58,7 +58,6 @@ func InclusiveRangeErrorMsg(lo, hi int) string {
 	return fmt.Sprintf(`must be between %d and %d, inclusive`, lo, hi)
 }
 
-var DNSSubdomainErrorMsg string = fmt.Sprintf(`must be a DNS subdomain (at most %d characters, matching regex %s): e.g. "example.com"`, validation.DNS1123SubdomainMaxLength, validation.DNS1123SubdomainFmt)
 var DNS952LabelErrorMsg string = fmt.Sprintf(`must be a DNS 952 label (at most %d characters, matching regex %s): e.g. "my-name"`, validation.DNS952LabelMaxLength, validation.DNS952LabelFmt)
 var pdPartitionErrorMsg string = InclusiveRangeErrorMsg(1, 255)
 var PortRangeErrorMsg string = InclusiveRangeErrorMsg(1, 65535)
@@ -241,10 +240,7 @@ func NameIsDNSSubdomain(name string, prefix bool) []string {
 	if prefix {
 		name = maskTrailingDash(name)
 	}
-	if validation.IsDNS1123Subdomain(name) {
-		return nil
-	}
-	return []string{DNSSubdomainErrorMsg}
+	return validation.IsDNS1123Subdomain(name)
 }
 
 // NameIsDNSLabel is a ValidateNameFunc for names that must be a DNS 1123 label.
@@ -3014,7 +3010,7 @@ func ValidateLoadBalancerStatus(status *api.LoadBalancerStatus, fldPath *field.P
 			}
 		}
 		if len(ingress.Hostname) > 0 {
-			for _, msg := range NameIsDNSSubdomain(ingress.Hostname, false) {
+			for _, msg := range validation.IsDNS1123Subdomain(ingress.Hostname) {
 				allErrs = append(allErrs, field.Invalid(idxPath.Child("hostname"), ingress.Hostname, msg))
 			}
 			if isIP := (net.ParseIP(ingress.Hostname) != nil); isIP {

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -90,10 +90,10 @@ func TestValidateObjectMetaNamespaces(t *testing.T) {
 			return nil
 		},
 		field.NewPath("field"))
-	if len(errs) != 1 {
+	if len(errs) != 2 {
 		t.Fatalf("unexpected errors: %v", errs)
 	}
-	if !strings.Contains(errs[0].Error(), "Invalid value") {
+	if !strings.Contains(errs[0].Error(), "Invalid value") || !strings.Contains(errs[1].Error(), "Invalid value") {
 		t.Errorf("unexpected error message: %v", errs)
 	}
 }
@@ -748,12 +748,12 @@ func TestValidateVolumes(t *testing.T) {
 		"name > 63 characters": {
 			[]api.Volume{{Name: strings.Repeat("a", 64), VolumeSource: emptyVS}},
 			field.ErrorTypeInvalid,
-			"name", "must be a DNS label",
+			"name", "must be no more than",
 		},
 		"name not a DNS label": {
 			[]api.Volume{{Name: "a.b.c", VolumeSource: emptyVS}},
 			field.ErrorTypeInvalid,
-			"name", "must be a DNS label",
+			"name", "must match the regex",
 		},
 		"name not unique": {
 			[]api.Volume{{Name: "abc", VolumeSource: emptyVS}, {Name: "abc", VolumeSource: emptyVS}},
@@ -4695,7 +4695,7 @@ func TestValidateLimitRange(t *testing.T) {
 		},
 		"invalid-namespace": {
 			api.LimitRange{ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: "^Invalid"}, Spec: api.LimitRangeSpec{}},
-			DNS1123LabelErrorMsg,
+			"must match the regex",
 		},
 		"duplicate-limit-type": {
 			api.LimitRange{ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: "foo"}, Spec: api.LimitRangeSpec{
@@ -4839,7 +4839,7 @@ func TestValidateLimitRange(t *testing.T) {
 		}
 		for i := range errs {
 			detail := errs[i].Detail
-			if detail != v.D {
+			if !strings.Contains(detail, v.D) {
 				t.Errorf("[%s]: expected error detail either empty or %q, got %q", k, v.D, detail)
 			}
 		}
@@ -5019,7 +5019,7 @@ func TestValidateResourceQuota(t *testing.T) {
 		},
 		"invalid Namespace": {
 			api.ResourceQuota{ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: "^Invalid"}, Spec: spec},
-			DNS1123LabelErrorMsg,
+			"must match the regex",
 		},
 		"negative-limits": {
 			api.ResourceQuota{ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: "foo"}, Spec: negativeSpec},
@@ -5052,7 +5052,7 @@ func TestValidateResourceQuota(t *testing.T) {
 			t.Errorf("expected failure for %s", k)
 		}
 		for i := range errs {
-			if errs[i].Detail != v.D {
+			if !strings.Contains(errs[i].Detail, v.D) {
 				t.Errorf("[%s]: expected error detail either empty or %s, got %s", k, v.D, errs[i].Detail)
 			}
 		}
@@ -5613,7 +5613,7 @@ func TestValidateEndpoints(t *testing.T) {
 		"invalid namespace": {
 			endpoints:   api.Endpoints{ObjectMeta: api.ObjectMeta{Name: "mysvc", Namespace: "no@#invalid.;chars\"allowed"}},
 			errorType:   "FieldValueInvalid",
-			errorDetail: DNS1123LabelErrorMsg,
+			errorDetail: "must match the regex",
 		},
 		"invalid name": {
 			endpoints:   api.Endpoints{ObjectMeta: api.ObjectMeta{Name: "-_Invliad^&Characters", Namespace: "namespace"}},

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -4691,7 +4691,7 @@ func TestValidateLimitRange(t *testing.T) {
 		},
 		"invalid-name": {
 			api.LimitRange{ObjectMeta: api.ObjectMeta{Name: "^Invalid", Namespace: "foo"}, Spec: api.LimitRangeSpec{}},
-			DNSSubdomainErrorMsg,
+			"must match the regex",
 		},
 		"invalid-namespace": {
 			api.LimitRange{ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: "^Invalid"}, Spec: api.LimitRangeSpec{}},
@@ -5015,7 +5015,7 @@ func TestValidateResourceQuota(t *testing.T) {
 		},
 		"invalid Name": {
 			api.ResourceQuota{ObjectMeta: api.ObjectMeta{Name: "^Invalid", Namespace: "foo"}, Spec: spec},
-			DNSSubdomainErrorMsg,
+			"must match the regex",
 		},
 		"invalid Namespace": {
 			api.ResourceQuota{ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: "^Invalid"}, Spec: spec},
@@ -5618,7 +5618,7 @@ func TestValidateEndpoints(t *testing.T) {
 		"invalid name": {
 			endpoints:   api.Endpoints{ObjectMeta: api.ObjectMeta{Name: "-_Invliad^&Characters", Namespace: "namespace"}},
 			errorType:   "FieldValueInvalid",
-			errorDetail: DNSSubdomainErrorMsg,
+			errorDetail: "must match the regex",
 		},
 		"empty addresses": {
 			endpoints: api.Endpoints{

--- a/pkg/apis/extensions/validation/validation.go
+++ b/pkg/apis/extensions/validation/validation.go
@@ -69,8 +69,10 @@ func ValidateThirdPartyResource(obj *extensions.ThirdPartyResource) field.ErrorL
 		version := &obj.Versions[ix]
 		if len(version.Name) == 0 {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("versions").Index(ix).Child("name"), version, "must not be empty"))
-		} else if !validation.IsDNS1123Label(version.Name) {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("versions").Index(ix).Child("name"), version, apivalidation.DNS1123LabelErrorMsg))
+		} else {
+			for _, msg := range validation.IsDNS1123Label(version.Name) {
+				allErrs = append(allErrs, field.Invalid(field.NewPath("versions").Index(ix).Child("name"), version, msg))
+			}
 		}
 		if versions.Has(version.Name) {
 			allErrs = append(allErrs, field.Duplicate(field.NewPath("versions").Index(ix).Child("name"), version))
@@ -413,8 +415,8 @@ func validateIngressBackend(backend *extensions.IngressBackend, fldPath *field.P
 		}
 	}
 	if backend.ServicePort.Type == intstr.String {
-		if !validation.IsDNS1123Label(backend.ServicePort.StrVal) {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("servicePort"), backend.ServicePort.StrVal, apivalidation.DNS1123LabelErrorMsg))
+		for _, msg := range validation.IsDNS1123Label(backend.ServicePort.StrVal) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("servicePort"), backend.ServicePort.StrVal, msg))
 		}
 		if !validation.IsValidPortName(backend.ServicePort.StrVal) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("servicePort"), backend.ServicePort.StrVal, apivalidation.PortNameErrorMsg))

--- a/pkg/apis/extensions/validation/validation.go
+++ b/pkg/apis/extensions/validation/validation.go
@@ -353,7 +353,7 @@ func validateIngressRules(IngressRules []extensions.IngressRule, fldPath *field.
 		if len(ih.Host) > 0 {
 			// TODO: Ports and ips are allowed in the host part of a url
 			// according to RFC 3986, consider allowing them.
-			for _, msg := range apivalidation.NameIsDNSSubdomain(ih.Host, false) {
+			for _, msg := range validation.IsDNS1123Subdomain(ih.Host) {
 				allErrs = append(allErrs, field.Invalid(fldPath.Index(i).Child("host"), ih.Host, msg))
 			}
 			if isIP := (net.ParseIP(ih.Host) != nil); isIP {

--- a/pkg/client/unversioned/clientcmd/validation.go
+++ b/pkg/client/unversioned/clientcmd/validation.go
@@ -260,8 +260,10 @@ func validateContext(contextName string, context clientcmdapi.Context, config cl
 		validationErrors = append(validationErrors, fmt.Errorf("cluster %q was not found for context %q", context.Cluster, contextName))
 	}
 
-	if (len(context.Namespace) != 0) && !validation.IsDNS952Label(context.Namespace) {
-		validationErrors = append(validationErrors, fmt.Errorf("namespace %q for context %q does not conform to the kubernetes DNS952 rules", context.Namespace, contextName))
+	if len(context.Namespace) != 0 {
+		if len(validation.IsDNS1123Label(context.Namespace)) != 0 {
+			validationErrors = append(validationErrors, fmt.Errorf("namespace %q for context %q does not conform to the kubernetes DNS_LABEL rules", context.Namespace, contextName))
+		}
 	}
 
 	return validationErrors

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1312,14 +1312,13 @@ func (kl *Kubelet) GeneratePodHostNameAndDomain(pod *api.Pod) (string, string, e
 	}
 	hostname := pod.Name
 	if len(pod.Spec.Hostname) > 0 {
-		if utilvalidation.IsDNS1123Label(pod.Spec.Hostname) {
-			hostname = pod.Spec.Hostname
-		} else {
-			return "", "", fmt.Errorf("Pod Hostname %q is not a valid DNS label.", pod.Spec.Hostname)
+		if msgs := utilvalidation.IsDNS1123Label(pod.Spec.Hostname); len(msgs) != 0 {
+			return "", "", fmt.Errorf("Pod Hostname %q is not a valid DNS label: %s", pod.Spec.Hostname, strings.Join(msgs, ";"))
 		}
+		hostname = pod.Spec.Hostname
 	} else {
 		hostnameCandidate := podAnnotations[utilpod.PodHostnameAnnotation]
-		if utilvalidation.IsDNS1123Label(hostnameCandidate) {
+		if len(utilvalidation.IsDNS1123Label(hostnameCandidate)) == 0 {
 			// use hostname annotation, if specified.
 			hostname = hostnameCandidate
 		}
@@ -1331,14 +1330,13 @@ func (kl *Kubelet) GeneratePodHostNameAndDomain(pod *api.Pod) (string, string, e
 
 	hostDomain := ""
 	if len(pod.Spec.Subdomain) > 0 {
-		if utilvalidation.IsDNS1123Label(pod.Spec.Subdomain) {
-			hostDomain = fmt.Sprintf("%s.%s.svc.%s", pod.Spec.Subdomain, pod.Namespace, clusterDomain)
-		} else {
-			return "", "", fmt.Errorf("Pod Subdomain %q is not a valid DNS label.", pod.Spec.Subdomain)
+		if msgs := utilvalidation.IsDNS1123Label(pod.Spec.Subdomain); len(msgs) != 0 {
+			return "", "", fmt.Errorf("Pod Subdomain %q is not a valid DNS label: %s", pod.Spec.Subdomain, strings.Join(msgs, ";"))
 		}
+		hostDomain = fmt.Sprintf("%s.%s.svc.%s", pod.Spec.Subdomain, pod.Namespace, clusterDomain)
 	} else {
 		subdomainCandidate := pod.Annotations[utilpod.PodSubdomainAnnotation]
-		if utilvalidation.IsDNS1123Label(subdomainCandidate) {
+		if len(utilvalidation.IsDNS1123Label(subdomainCandidate)) == 0 {
 			hostDomain = fmt.Sprintf("%s.%s.svc.%s", subdomainCandidate, pod.Namespace, clusterDomain)
 		}
 	}

--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -21,7 +21,6 @@ import (
 	"math"
 	"net"
 	"regexp"
-	"strconv"
 	"strings"
 )
 
@@ -30,7 +29,6 @@ const qnameExtCharFmt string = "[-A-Za-z0-9_.]"
 const qualifiedNameFmt string = "(" + qnameCharFmt + qnameExtCharFmt + "*)?" + qnameCharFmt
 const qualifiedNameMaxLength int = 63
 
-var qualifiedNameMaxLengthString = strconv.Itoa(qualifiedNameMaxLength)
 var qualifiedNameRegexp = regexp.MustCompile("^" + qualifiedNameFmt + "$")
 
 // IsQualifiedName tests whether the value passed is what Kubernetes calls a
@@ -48,21 +46,22 @@ func IsQualifiedName(value string) []string {
 		var prefix string
 		prefix, name = parts[0], parts[1]
 		if len(prefix) == 0 {
-			errs = append(errs, "prefix part must be non-empty")
+			errs = append(errs, "prefix part "+EmptyError())
 		} else if !IsDNS1123Subdomain(prefix) {
 			errs = append(errs, fmt.Sprintf("prefix part must be a DNS subdomain (e.g. 'example.com')"))
 		}
 	default:
-		return append(errs, "must match the regex "+qualifiedNameFmt+" with an optional DNS subdomain prefix and '/' (e.g. 'MyName' or 'example.com/MyName'")
+		return append(errs, RegexError(qualifiedNameFmt, "MyName", "my.name", "123-abc")+
+			" with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName'")
 	}
 
 	if len(name) == 0 {
-		errs = append(errs, "name part must be non-empty")
+		errs = append(errs, "name part "+EmptyError())
 	} else if len(name) > qualifiedNameMaxLength {
-		errs = append(errs, "name part must be no more than "+qualifiedNameMaxLengthString+" characters")
+		errs = append(errs, "name part "+MaxLenError(qualifiedNameMaxLength))
 	}
 	if !qualifiedNameRegexp.MatchString(name) {
-		errs = append(errs, "name part must match the regex "+qualifiedNameFmt+" (e.g. 'MyName' or 'my.name' or '123-abc')")
+		errs = append(errs, "name part "+RegexError(qualifiedNameFmt, "MyName", "my.name", "123-abc"))
 	}
 	return errs
 }
@@ -70,7 +69,6 @@ func IsQualifiedName(value string) []string {
 const labelValueFmt string = "(" + qualifiedNameFmt + ")?"
 const LabelValueMaxLength int = 63
 
-var labelValueMaxLengthString = strconv.Itoa(LabelValueMaxLength)
 var labelValueRegexp = regexp.MustCompile("^" + labelValueFmt + "$")
 
 // IsValidLabelValue tests whether the value passed is a valid label value.  If
@@ -79,10 +77,10 @@ var labelValueRegexp = regexp.MustCompile("^" + labelValueFmt + "$")
 func IsValidLabelValue(value string) []string {
 	var errs []string
 	if len(value) > LabelValueMaxLength {
-		errs = append(errs, "must be no more than "+labelValueMaxLengthString+" characters")
+		errs = append(errs, MaxLenError(LabelValueMaxLength))
 	}
 	if !labelValueRegexp.MatchString(value) {
-		errs = append(errs, "must match the regex "+labelValueFmt+" (e.g. 'MyValue' or 'my_value' or '12345')")
+		errs = append(errs, RegexError(labelValueFmt, "MyValue", "my_value", "12345"))
 	}
 	return errs
 }
@@ -94,8 +92,15 @@ var dns1123LabelRegexp = regexp.MustCompile("^" + DNS1123LabelFmt + "$")
 
 // IsDNS1123Label tests for a string that conforms to the definition of a label in
 // DNS (RFC 1123).
-func IsDNS1123Label(value string) bool {
-	return len(value) <= DNS1123LabelMaxLength && dns1123LabelRegexp.MatchString(value)
+func IsDNS1123Label(value string) []string {
+	var errs []string
+	if len(value) > DNS1123LabelMaxLength {
+		errs = append(errs, MaxLenError(DNS1123LabelMaxLength))
+	}
+	if !dns1123LabelRegexp.MatchString(value) {
+		errs = append(errs, RegexError(DNS1123LabelFmt, "my-name", "123-abc"))
+	}
+	return errs
 }
 
 const DNS1123SubdomainFmt string = DNS1123LabelFmt + "(\\." + DNS1123LabelFmt + ")*"
@@ -205,4 +210,32 @@ var httpHeaderNameRegexp = regexp.MustCompile("^" + HTTPHeaderNameFmt + "$")
 // definition of a valid header field name (a stricter subset than RFC7230).
 func IsHTTPHeaderName(value string) bool {
 	return httpHeaderNameRegexp.MatchString(value)
+}
+
+// MaxLenError returns a string explanation of a "string too long" validation
+// failure.
+func MaxLenError(length int) string {
+	return fmt.Sprintf("must be no more than %d characters", length)
+}
+
+// RegexError returns a string explanation of a regex validation failure.
+func RegexError(fmt string, examples ...string) string {
+	s := "must match the regex " + fmt
+	if len(examples) == 0 {
+		return s
+	}
+	s += " (e.g. "
+	for i := range examples {
+		if i > 0 {
+			s += " or "
+		}
+		s += "'" + examples[i] + "'"
+	}
+	return s + ")"
+}
+
+// EmptyError returns a string explanation of a "must not be empty" validation
+// failure.
+func EmptyError() string {
+	return "must be non-empty"
 }

--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -128,8 +128,15 @@ var dns952LabelRegexp = regexp.MustCompile("^" + DNS952LabelFmt + "$")
 
 // IsDNS952Label tests for a string that conforms to the definition of a label in
 // DNS (RFC 952).
-func IsDNS952Label(value string) bool {
-	return len(value) <= DNS952LabelMaxLength && dns952LabelRegexp.MatchString(value)
+func IsDNS952Label(value string) []string {
+	var errs []string
+	if len(value) > DNS952LabelMaxLength {
+		errs = append(errs, MaxLenError(DNS952LabelMaxLength))
+	}
+	if !dns952LabelRegexp.MatchString(value) {
+		errs = append(errs, RegexError(DNS952LabelFmt, "my-name", "abc-123"))
+	}
+	return errs
 }
 
 const CIdentifierFmt string = "[A-Za-z_][A-Za-z0-9_]*"

--- a/pkg/util/validation/validation_test.go
+++ b/pkg/util/validation/validation_test.go
@@ -28,8 +28,8 @@ func TestIsDNS1123Label(t *testing.T) {
 		strings.Repeat("a", 63),
 	}
 	for _, val := range goodValues {
-		if !IsDNS1123Label(val) {
-			t.Errorf("expected true for '%s'", val)
+		if msgs := IsDNS1123Label(val); len(msgs) != 0 {
+			t.Errorf("expected true for '%s': %v", val, msgs)
 		}
 	}
 
@@ -42,7 +42,7 @@ func TestIsDNS1123Label(t *testing.T) {
 		strings.Repeat("a", 64),
 	}
 	for _, val := range badValues {
-		if IsDNS1123Label(val) {
+		if msgs := IsDNS1123Label(val); len(msgs) == 0 {
 			t.Errorf("expected false for '%s'", val)
 		}
 	}

--- a/pkg/util/validation/validation_test.go
+++ b/pkg/util/validation/validation_test.go
@@ -60,8 +60,8 @@ func TestIsDNS1123Subdomain(t *testing.T) {
 		strings.Repeat("a", 253),
 	}
 	for _, val := range goodValues {
-		if !IsDNS1123Subdomain(val) {
-			t.Errorf("expected true for '%s'", val)
+		if msgs := IsDNS1123Subdomain(val); len(msgs) != 0 {
+			t.Errorf("expected true for '%s': %v", val, msgs)
 		}
 	}
 
@@ -80,7 +80,7 @@ func TestIsDNS1123Subdomain(t *testing.T) {
 		strings.Repeat("a", 254),
 	}
 	for _, val := range badValues {
-		if IsDNS1123Subdomain(val) {
+		if msgs := IsDNS1123Subdomain(val); len(msgs) == 0 {
 			t.Errorf("expected false for '%s'", val)
 		}
 	}

--- a/pkg/util/validation/validation_test.go
+++ b/pkg/util/validation/validation_test.go
@@ -92,8 +92,8 @@ func TestIsDNS952Label(t *testing.T) {
 		strings.Repeat("a", 24),
 	}
 	for _, val := range goodValues {
-		if !IsDNS952Label(val) {
-			t.Errorf("expected true for '%s'", val)
+		if msgs := IsDNS952Label(val); len(msgs) != 0 {
+			t.Errorf("expected true for '%s': %v", val, msgs)
 		}
 	}
 
@@ -107,7 +107,7 @@ func TestIsDNS952Label(t *testing.T) {
 		strings.Repeat("a", 25),
 	}
 	for _, val := range badValues {
-		if IsDNS952Label(val) {
+		if msgs := IsDNS952Label(val); len(msgs) == 0 {
 			t.Errorf("expected false for '%s'", val)
 		}
 	}


### PR DESCRIPTION
Part of the larger validation PR, broken out for easier review and merge.  Builds on previous PRs in the series.
