### PR TITLE
Fix node e2e startServer failure output

### DIFF
--- a/test/e2e_node/e2e_service.go
+++ b/test/e2e_node/e2e_service.go
@@ -173,7 +173,7 @@ func (es *e2eService) startServer(cmd *healthCheckCommand) error {
 	go func() {
 		err := cmd.Run()
 		if err != nil {
-			cmdErrorChan <- fmt.Errorf("%s Failed with error \"%v\".  Command output:\n%v", cmd, err, *cmd.OutputBuffer)
+			cmdErrorChan <- fmt.Errorf("%s Failed with error \"%v\".  Command output:\n%s", cmd, err, cmd.OutputBuffer)
 		}
 		close(cmdErrorChan)
 	}()


### PR DESCRIPTION
Correct the display of the output when e.g. starting the kubelet fails in the node e2e tests. This
change makes it display a string instead of an array of decimal values.

@kubernetes/sig-node @kubernetes/rh-cluster-infra 
