### PR TITLE
Revert "Shallow clone for kubernetes-build and kubernetes-test-go jobs."

### DIFF
--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
@@ -32,7 +32,6 @@
             browser-url: https://github.com/kubernetes/kubernetes
             wipe-workspace: false
             skip-tag: true
-            shallow-clone: true
     triggers:
         - pollscm:
             cron: 'H/2 * * * *'

--- a/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-go.yaml
+++ b/hack/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-go.yaml
@@ -43,7 +43,6 @@
             browser-url: https://github.com/kubernetes/kubernetes
             wipe-workspace: false
             skip-tag: true
-            shallow-clone: true
     triggers:
         - pollscm:
             cron: 'H/2 * * * *'


### PR DESCRIPTION
This reverts commit 5121ce3dc37d6206858a9ecdfb362634b187d259.

git describe fails for a shallow clone, so we couldn't get a version, so the build broke. @k8s-oncall this needs to go in ASAP.
