### PR TITLE
Revert "Always use long format in git tag."

### DIFF
--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -49,7 +49,7 @@ kube::version::get_version_vars() {
     fi
 
     # Use git describe to find the version based on annotated tags.
-    if [[ -n ${KUBE_GIT_VERSION-} ]] || KUBE_GIT_VERSION=$("${git[@]}" describe --long --tags --abbrev=14 "${KUBE_GIT_COMMIT}^{commit}" 2>/dev/null); then
+    if [[ -n ${KUBE_GIT_VERSION-} ]] || KUBE_GIT_VERSION=$("${git[@]}" describe --tags --abbrev=14 "${KUBE_GIT_COMMIT}^{commit}" 2>/dev/null); then
       # This translates the "git describe" to an actual semver.org
       # compatible semantic version that looks something like this:
       #   v1.1.0-alpha.0.6+84c76d1142ea4d


### PR DESCRIPTION
Reverts kubernetes/kubernetes#23157

This is causing #24535, meaning builds that should be versioned just `vX.Y.Z`,  `vX.Y.Z-beta.W`, or `vX.Y.Z-alpha.W` instead have build number and hash appended.

cc @spxtr, but let's not merge this until @david-mcmahon okays it.
