### PR TITLE
e2e: add a dummy environment variable in the service tests

### DIFF
--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -1080,6 +1080,9 @@ func createPodOrFail(c *client.Client, ns, name string, labels map[string]string
 					Name:  "test",
 					Image: "gcr.io/google_containers/pause:2.0",
 					Ports: containerPorts,
+					// Add a dummy environment variable to work around a docker issue.
+					// https://github.com/docker/docker/issues/14203
+					Env: []api.EnvVar{{Name: "FOO", Value: " "}},
 				},
 			},
 		},


### PR DESCRIPTION
This works around the docker bug:
https://github.com/docker/docker/issues/14203
