### PR TITLE
Fix DeletingLoadBalancer event generation.

### DIFF
--- a/pkg/controller/service/servicecontroller.go
+++ b/pkg/controller/service/servicecontroller.go
@@ -232,7 +232,7 @@ func (s *ServiceController) processDelta(delta *cache.Delta) (error, time.Durati
 		namespacedName.Name = deltaService.Name
 		cachedService = s.cache.getOrCreate(namespacedName.String())
 	}
-	glog.V(2).Infof("Got new %s delta for service: %+v", delta.Type, deltaService)
+	glog.V(2).Infof("Got new %s delta for service: %v", delta.Type, namespacedName)
 
 	// Ensure that no other goroutine will interfere with our processing of the
 	// service.
@@ -249,7 +249,7 @@ func (s *ServiceController) processDelta(delta *cache.Delta) (error, time.Durati
 		return err, cachedService.nextRetryDelay()
 	} else if errors.IsNotFound(err) {
 		glog.V(2).Infof("Service %v not found, ensuring load balancer is deleted", namespacedName)
-		s.eventRecorder.Event(service, api.EventTypeNormal, "DeletingLoadBalancer", "Deleting load balancer")
+		s.eventRecorder.Event(deltaService, api.EventTypeNormal, "DeletingLoadBalancer", "Deleting load balancer")
 		err := s.balancer.EnsureLoadBalancerDeleted(deltaService)
 		if err != nil {
 			message := "Error deleting load balancer (will retry): " + err.Error()


### PR DESCRIPTION
release-note:

``` release-note
Fix DeletingLoadBalancer event generation.
```

Also patch up a log statement to log the service's namespace and name
rather than potentially just logging `kind:"" apiVersion:""`.

It doesn't work as written because `service` is always nil on this line. If it wasn't, then we wouldn't have taken this branch. `deltaService` is what contains the info that we have about the service.

Example of how the event generation fails as currently written:

```
E0426 22:18:41.726835      10 event.go:257] Could not construct reference to: '&api.Service{TypeMeta:unversioned.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:api.ObjectMeta{Name:"", GenerateName:"", Namespace:"", SelfLink:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:unversioned.Time{Time:time.Time{sec:0, nsec:0, loc:(*time.Location)(nil)}}, DeletionTimestamp:(*unversioned.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil)}, Spec:api.ServiceSpec{Type:"", Ports:[]api.ServicePort(nil), Selector:map[string]string(nil), ClusterIP:"", ExternalIPs:[]string(nil), LoadBalancerIP:"", SessionAffinity:""}, Status:api.ServiceStatus{LoadBalancer:api.LoadBalancerStatus{Ingress:[]api.LoadBalancerIngress(nil)}}}' due to: 'selfLink was empty, can't make reference'. Will not report event: 'Normal' 'DeletingLoadBalancer' 'Deleting load balancer'
```
