### PR TITLE
Improve the speed of do-nothing build.

### DIFF
--- a/hack/cmd/teststale/teststale.go
+++ b/hack/cmd/teststale/teststale.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+var (
+	binary  = flag.String("binary", "", "absolute filesystem path to the test binary")
+	pkgPath = flag.String("package", "", "test package import path in the format used in the import statements without the $GOPATH prefix")
+)
+
+type pkg struct {
+	dir          string
+	target       string
+	stale        bool
+	testGoFiles  []string
+	testImports  []string
+	xTestGoFiles []string
+	xTestImports []string
+}
+
+func newCmd(format string, pkgPaths []string) *exec.Cmd {
+	args := []string{
+		"list",
+		"-f",
+		format,
+	}
+	args = append(args, pkgPaths...)
+	cmd := exec.Command("go", args...)
+	cmd.Env = os.Environ()
+	return cmd
+}
+
+func newPkg(path string) (*pkg, error) {
+	format := "Dir: {{println .Dir}}Target: {{println .Target}}Stale: {{println .Stale}}TestGoFiles: {{println .TestGoFiles}}TestImports: {{println .TestImports}}XTestGoFiles: {{println .XTestGoFiles}}XTestImports: {{println .XTestImports}}"
+	cmd := newCmd(format, []string{path})
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("could not pipe STDOUT: %v", err)
+	}
+
+	// Start executing the command
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("command did not start: %v", err)
+	}
+
+	// Parse the command output
+	scanner := bufio.NewScanner(stdout)
+	scanner.Split(bufio.ScanLines)
+
+	// To be conservative, default to package to be stale
+	p := &pkg{
+		stale: true,
+	}
+
+	// TODO: avoid this stupid code repetition by iterating through struct fields.
+	scanner.Scan()
+	p.dir = strings.TrimPrefix(scanner.Text(), "Dir: ")
+	scanner.Scan()
+	p.target = strings.TrimPrefix(scanner.Text(), "Target: ")
+	scanner.Scan()
+	if strings.TrimPrefix(scanner.Text(), "Stale: ") == "false" {
+		p.stale = false
+	}
+	p.testGoFiles = scanLineList(scanner, "TestGoFiles: ")
+	p.testImports = scanLineList(scanner, "TestImports: ")
+	p.xTestGoFiles = scanLineList(scanner, "XTestGoFiles: ")
+	p.xTestImports = scanLineList(scanner, "XTestImports: ")
+
+	if err := cmd.Wait(); err != nil {
+		return nil, fmt.Errorf("command did not complete: %v", err)
+	}
+	return p, nil
+}
+
+func (p *pkg) isStale(buildTime time.Time) bool {
+	// If the package itself is stale, then we have to rebuild the whole thing anyway.
+	if p.stale {
+		return true
+	}
+
+	// Test for file staleness
+	for _, f := range p.testGoFiles {
+		if isStale(buildTime, filepath.Join(p.dir, f)) {
+			log.Printf("test Go file %s is stale", f)
+			return true
+		}
+	}
+	for _, f := range p.xTestGoFiles {
+		if isStale(buildTime, filepath.Join(p.dir, f)) {
+			log.Printf("external test Go file %s is stale", f)
+			return true
+		}
+	}
+
+	format := "{{.Stale}}"
+	imps := []string{}
+	imps = append(imps, p.testImports...)
+	imps = append(imps, p.xTestImports...)
+
+	cmd := newCmd(format, imps)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		log.Printf("unexpected error with creating stdout pipe: %v", err)
+		return true
+	}
+	// Start executing the command
+	if err := cmd.Start(); err != nil {
+		log.Printf("unexpected error executing command: %v", err)
+		return true
+	}
+
+	// Parse the command output
+	scanner := bufio.NewScanner(stdout)
+	scanner.Split(bufio.ScanLines)
+
+	for i := 0; scanner.Scan(); i++ {
+		if out := scanner.Text(); out != "false" {
+			log.Printf("import %q is stale: %s", imps[i], out)
+			return true
+		}
+	}
+
+	if err := cmd.Wait(); err != nil {
+		log.Printf("unexpected error waiting to finish: %v", err)
+		return true
+	}
+	return false
+}
+
+// scanLineList scans a line, removes the prefix and splits the remaining line into
+// individual strings.
+// TODO: There are ton of intermediate strings being created here. Convert this to
+// a bufio.SplitFunc instead.
+func scanLineList(scanner *bufio.Scanner, prefix string) []string {
+	scanner.Scan()
+	list := strings.TrimPrefix(scanner.Text(), prefix)
+	line := strings.Trim(list, "[]")
+	if len(line) == 0 {
+		return []string{}
+	}
+	return strings.Split(line, " ")
+}
+
+func isStale(buildTime time.Time, filename string) bool {
+	stat, err := os.Stat(filename)
+	if err != nil {
+		return true
+	}
+	return stat.ModTime().After(buildTime)
+}
+
+// IsTestStale checks if the test binary is stale and needs to rebuilt.
+// Some of the ideas here are inspired by how Go does staleness checks.
+func isTestStale(binPath, pkgPath string) bool {
+	bStat, err := os.Stat(binPath)
+	if err != nil {
+		log.Printf("Couldn't obtain the modified time of the binary: %v", err)
+		return true
+	}
+	buildTime := bStat.ModTime()
+
+	p, err := newPkg(pkgPath)
+	if err != nil {
+		log.Printf("Couldn't retrieve the test package information: %v", err)
+		return false
+	}
+
+	return p.isStale(buildTime)
+}
+
+func main() {
+	flag.Parse()
+	if isTestStale(*binary, *pkgPath) {
+		fmt.Println("true")
+	} else {
+		fmt.Println("false")
+	}
+}

--- a/hack/cmd/teststale/teststale.go
+++ b/hack/cmd/teststale/teststale.go
@@ -26,11 +26,12 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"time"
+
+	"github.com/golang/glog"
 )
 
 const usageHelp = "" +
@@ -115,13 +116,13 @@ func (p *pkg) isNewerThan(buildTime time.Time) bool {
 	// Test for file staleness
 	for _, f := range p.TestGoFiles {
 		if isNewerThan(filepath.Join(p.Dir, f), buildTime) {
-			log.Printf("test Go file %s is stale", f)
+			glog.V(4).Infof("test Go file %s is stale", f)
 			return true
 		}
 	}
 	for _, f := range p.XTestGoFiles {
 		if isNewerThan(filepath.Join(p.Dir, f), buildTime) {
-			log.Printf("external test Go file %s is stale", f)
+			glog.V(4).Infof("external test Go file %s is stale", f)
 			return true
 		}
 	}
@@ -138,13 +139,13 @@ func (p *pkg) isNewerThan(buildTime time.Time) bool {
 	// dependencies.
 	pkgs, err := pkgInfo(imps)
 	if err != nil || len(pkgs) < 1 {
-		log.Printf("failed to obtain metadata for packages %s: %v", imps, err)
+		glog.V(4).Infof("failed to obtain metadata for packages %s: %v", imps, err)
 		return true
 	}
 
 	for _, p := range pkgs {
 		if p.Stale {
-			log.Printf("import %q is stale", p.ImportPath)
+			glog.V(4).Infof("import %q is stale", p.ImportPath)
 			return true
 		}
 	}
@@ -165,14 +166,14 @@ func isNewerThan(filename string, buildTime time.Time) bool {
 func isTestStale(binPath, pkgPath string) bool {
 	bStat, err := os.Stat(binPath)
 	if err != nil {
-		log.Printf("Couldn't obtain the modified time of the binary %s: %v", binPath, err)
+		glog.V(4).Infof("Couldn't obtain the modified time of the binary %s: %v", binPath, err)
 		return true
 	}
 	buildTime := bStat.ModTime()
 
 	pkgs, err := pkgInfo([]string{pkgPath})
 	if err != nil || len(pkgs) < 1 {
-		log.Printf("Couldn't retrieve test package information for package %s: %v", pkgPath, err)
+		glog.V(4).Infof("Couldn't retrieve test package information for package %s: %v", pkgPath, err)
 		return false
 	}
 

--- a/hack/cmd/teststale/teststale_test.go
+++ b/hack/cmd/teststale/teststale_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+const (
+	// seed for rand.Source to generate data for files
+	seed int64 = 42
+
+	// 1K binary file
+	binLen = 1024
+
+	// Directory of the test package relative to $GOPATH
+	testImportDir = "example.com/proj/pkg"
+)
+
+var (
+	pastHour = time.Now().Add(-1 * time.Hour)
+
+	// The test package we are testing against
+	testPkg = path.Join(testImportDir, "test")
+)
+
+// fakegolist implements the `golist` interface providing fake package information for testing.
+type fakegolist struct {
+	dir       string
+	importMap map[string]pkg
+	testFiles []string
+	binfile   string
+}
+
+func newFakegolist() (*fakegolist, error) {
+	dir, err := ioutil.TempDir("", "teststale")
+	if err != nil {
+		// test can't proceed without a temp directory.
+		return nil, fmt.Errorf("failed to create a temp directory for testing: %v", err)
+	}
+
+	// Set the temp directory as the $GOPATH
+	if err := os.Setenv("GOPATH", dir); err != nil {
+		// can't proceed without pointing the $GOPATH to the temp directory.
+		return nil, fmt.Errorf("failed to set \"$GOPATH\" pointing to %q: %v", dir, err)
+	}
+
+	// Setup $GOPATH directory layout.
+	// Yeah! I am bored of repeatedly writing "if err != nil {}"!
+	if os.MkdirAll(filepath.Join(dir, "bin"), 0750) != nil ||
+		os.MkdirAll(filepath.Join(dir, "pkg", "linux_amd64"), 0750) != nil ||
+		os.MkdirAll(filepath.Join(dir, "src"), 0750) != nil {
+		return nil, fmt.Errorf("failed to setup the $GOPATH directory structure")
+	}
+
+	// Create a temp file to represent the test binary.
+	binfile, err := ioutil.TempFile("", "testbin")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create the temp file to represent the test binary: %v", err)
+	}
+
+	// Could have used crypto/rand instead, but it doesn't matter.
+	rr := rand.New(rand.NewSource(42))
+	bin := make([]byte, binLen)
+	if _, err = rr.Read(bin); err != nil {
+		return nil, fmt.Errorf("couldn't read from the random source: %v", err)
+	}
+	if _, err := binfile.Write(bin); err != nil {
+		return nil, fmt.Errorf("couldn't write to the binary file %q: %v", binfile.Name(), err)
+	}
+	if err := binfile.Close(); err != nil {
+		// It is arguable whether this should be fatal.
+		return nil, fmt.Errorf("failed to close the binary file %q: %v", binfile.Name(), err)
+	}
+
+	if err := os.Chtimes(binfile.Name(), time.Now(), time.Now()); err != nil {
+		return nil, fmt.Errorf("failed to modify the mtime of the binary file %q: %v", binfile.Name(), err)
+	}
+
+	// Create test source files directory.
+	testdir := filepath.Join(dir, "src", testPkg)
+	if err := os.MkdirAll(testdir, 0750); err != nil {
+		return nil, fmt.Errorf("failed to create test source directory %q: %v", testdir, err)
+	}
+
+	fgl := &fakegolist{
+		dir: dir,
+		importMap: map[string]pkg{
+			"example.com/proj/pkg/test": {
+				Dir:        path.Join(dir, "src", testPkg),
+				ImportPath: testPkg,
+				Target:     path.Join(dir, "pkg", "linux_amd64", testImportDir, "test.a"),
+				Stale:      false,
+				TestGoFiles: []string{
+					"foo_test.go",
+					"bar_test.go",
+				},
+				TestImports: []string{
+					"example.com/proj/pkg/p1",
+					"example.com/proj/pkg/p1/c11",
+					"example.com/proj/pkg/p2",
+					"example.com/proj/cmd/p3/c12/c23",
+					"strings",
+					"testing",
+				},
+				XTestGoFiles: []string{
+					"xfoo_test.go",
+					"xbar_test.go",
+					"xbaz_test.go",
+				},
+				XTestImports: []string{
+					"example.com/proj/pkg/test",
+					"example.com/proj/pkg/p1",
+					"example.com/proj/cmd/p3/c12/c23",
+					"os",
+					"testing",
+				},
+			},
+			"example.com/proj/pkg/p1":         {Stale: false},
+			"example.com/proj/pkg/p1/c11":     {Stale: false},
+			"example.com/proj/pkg/p2":         {Stale: false},
+			"example.com/proj/cmd/p3/c12/c23": {Stale: false},
+			"strings":                         {Stale: false},
+			"testing":                         {Stale: false},
+			"os":                              {Stale: false},
+		},
+		testFiles: []string{
+			"foo_test.go",
+			"bar_test.go",
+			"xfoo_test.go",
+			"xbar_test.go",
+			"xbaz_test.go",
+		},
+		binfile: binfile.Name(),
+	}
+
+	// Create test source files.
+	for _, fn := range fgl.testFiles {
+		fp := filepath.Join(testdir, fn)
+		if _, err := os.Create(fp); err != nil {
+			return nil, fmt.Errorf("failed to create the test file %q: %v", fp, err)
+		}
+		if err := os.Chtimes(fp, time.Now(), pastHour); err != nil {
+			return nil, fmt.Errorf("failed to modify the mtime of the test file %q: %v", binfile.Name(), err)
+		}
+	}
+
+	return fgl, nil
+}
+
+func (fgl *fakegolist) pkgInfo(pkgPaths []string) ([]pkg, error) {
+	var pkgs []pkg
+	for _, path := range pkgPaths {
+		p, ok := fgl.importMap[path]
+		if !ok {
+			return nil, fmt.Errorf("package %q not found", path)
+		}
+		pkgs = append(pkgs, p)
+	}
+	return pkgs, nil
+}
+
+func (fgl *fakegolist) cleanup() {
+	os.RemoveAll(fgl.dir)
+	os.Remove(fgl.binfile)
+}
+
+func TestIsTestStale(t *testing.T) {
+	fgl, err := newFakegolist()
+	if err != nil {
+		t.Fatalf("failed to setup the test: %v", err)
+	}
+	defer fgl.cleanup()
+
+	if isTestStale(fgl, fgl.binfile, testPkg) {
+		t.Errorf("Expected test package %q to be not stale", testPkg)
+	}
+}

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -114,6 +114,7 @@ kube::golang::test_targets() {
     cmd/linkcheck
     examples/k8petstore/web-server/src
     vendor/github.com/onsi/ginkgo/ginkgo
+    hack/cmd/teststale
     test/e2e/e2e.test
     test/e2e_node/e2e_node.test
   )
@@ -443,15 +444,25 @@ kube::golang::build_binaries_for_platform() {
     fi
   fi
 
+  teststale=$(kube::golang::output_filename_for_binary "hack/cmd/teststale" "${platform}")
   for test in "${tests[@]:+${tests[@]}}"; do
     local outfile=$(kube::golang::output_filename_for_binary "${test}" \
       "${platform}")
+
+    local testpkg="$(dirname ${test})"
+    if [[ "$(${teststale} -binary "${outfile}" -package "${testpkg}")" == "false" ]]; then
+      continue
+    fi
+    go install "${goflags[@]:+${goflags[@]}}" \
+        -ldflags "${goldflags}" \
+        "${testpkg}"
+
     mkdir -p "$(dirname ${outfile})"
     go test -c \
       "${goflags[@]:+${goflags[@]}}" \
       -ldflags "${goldflags}" \
       -o "${outfile}" \
-      "$(dirname ${test})"
+      "${testpkg}"
   done
 }
 


### PR DESCRIPTION
As @thockin found out here https://github.com/kubernetes/kubernetes/issues/24518, vast majority of the do-nothing build time is spent in rebuilding the test binaries. There is no staleness check support for test binaries.

This commit implements the staleness checks for test binaries and uses them while building packages.

On my workstation, do-nothing hack/build-go.sh time goes from ~20 secs to ~4 secs, of which only ~1 sec is from doing test binary staleness check now (as opposed to ~17 secs it took to build the test binaries before). I did some experiments to bring this time down to <1 sec. I measured using go test -bench, but it was not very useful in this case. I believe, a vast majority of that ~1 second is being spent in fork/exec and piping the results back to the staleness check program along with the ser-deser involved, but it needs to be validated. Not a proof, but to provide some supporting evidence to this claim, running `go list -f format packages` in the shell takes about 600ms irrespective of what's in the format.

Tests are TBD. I am still trying to figure out how to test this, but I would like to get early feedback

cc @mikedanese @mml 
