### PR TITLE
OS X: Fix hyperkube build by adding empty string to sed invocation

### DIFF
--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -57,13 +57,13 @@ endif
 
 ifeq ($(ARCH),amd64)
 	# When building "normally" for amd64, remove the whole line, it has no part in the amd64 image
-	cd ${TEMP_DIR} && sed -i "/CROSS_BUILD_/d" Dockerfile
+	cd ${TEMP_DIR} && sed -i ""  "/CROSS_BUILD_/d" Dockerfile
 else
 	# When cross-building, only the placeholder "CROSS_BUILD_" should be removed
 	# Register /usr/bin/qemu-ARCH-static as the handler for ARM binaries in the kernel
 	docker run --rm --privileged multiarch/qemu-user-static:register --reset
 	curl -sSL --retry 5 https://github.com/multiarch/qemu-user-static/releases/download/v2.5.0/x86_64_qemu-${QEMUARCH}-static.tar.xz | tar -xJ -C ${TEMP_DIR}
-	cd ${TEMP_DIR} && sed -i "s/CROSS_BUILD_//g" Dockerfile
+	cd ${TEMP_DIR} && sed -i "" "s/CROSS_BUILD_//g" Dockerfile
 endif
 
 	docker build -t ${REGISTRY}/hyperkube-${ARCH}:${VERSION} ${TEMP_DIR}


### PR DESCRIPTION
I could build the hyperkube image on OSX because OSC uses BSD sed where the suffix is mandatory see [here](https://stackoverflow.com/questions/16745988/sed-command-works-fine-on-ubuntu-but-not-mac).

Without this patch a build on OSX resulted in the following error message:

``` bash
make build VERSION=test ARCH=amd64                                                                                                                                 
cp ./* /var/folders/5t/nnk1jrhd6nq_tn8072cw7l3c0000gn/T/tmp.37YX2SQd
cp ../../saltbase/salt/helpers/safe_format_and_mount /var/folders/5t/nnk1jrhd6nq_tn8072cw7l3c0000gn/T/tmp.37YX2SQd
cp ../../saltbase/salt/generate-cert/make-ca-cert.sh /var/folders/5t/nnk1jrhd6nq_tn8072cw7l3c0000gn/T/tmp.37YX2SQd
cp ../../../_output/dockerized/bin/linux/amd64/hyperkube /var/folders/5t/nnk1jrhd6nq_tn8072cw7l3c0000gn/T/tmp.37YX2SQd
cd /var/folders/5t/nnk1jrhd6nq_tn8072cw7l3c0000gn/T/tmp.37YX2SQd && sed -i.back "s|VERSION|test|g" master-multi.json master.json kube-proxy.json
cd /var/folders/5t/nnk1jrhd6nq_tn8072cw7l3c0000gn/T/tmp.37YX2SQd && sed -i.back "s|ARCH|amd64|g" master-multi.json master.json kube-proxy.json etcd.json
cd /var/folders/5t/nnk1jrhd6nq_tn8072cw7l3c0000gn/T/tmp.37YX2SQd && sed -i.back "s|ARCH||g" Dockerfile
cd /var/folders/5t/nnk1jrhd6nq_tn8072cw7l3c0000gn/T/tmp.37YX2SQd && sed -i.back "s|BASEIMAGE|debian:jessie|g" Dockerfile
rm /var/folders/5t/nnk1jrhd6nq_tn8072cw7l3c0000gn/T/tmp.37YX2SQd/*.back
# When building "normally" for amd64, remove the whole line, it has no part in the amd64 image
cd /var/folders/5t/nnk1jrhd6nq_tn8072cw7l3c0000gn/T/tmp.37YX2SQd && sed -i "/CROSS_BUILD_/d" Dockerfile
sed: 1: "Dockerfile": extra characters at the end of D command
make: *** [build] Error 1
```
