### PR TITLE
AWS: Fix detaching volumes of  deleted pods

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -1289,6 +1289,7 @@ func (c *AWSCloud) IsDiskDetached(diskName string) (bool, error) {
 
 // Implements Volumes.AttachDisk
 func (c *AWSCloud) AttachDisk(diskName string, instanceName string, readOnly bool) (string, error) {
+	glog.V(5).Infof("AttachDisk %s", diskName)
 	disk, err := newAWSDisk(c, diskName)
 	if err != nil {
 		return "", err
@@ -1357,6 +1358,8 @@ func (c *AWSCloud) AttachDisk(diskName string, instanceName string, readOnly boo
 
 // Implements Volumes.DetachDisk
 func (aws *AWSCloud) DetachDisk(diskName string, instanceName string, wait bool) (string, error) {
+	glog.V(5).Infof("DetachDisk %s", diskName)
+
 	disk, err := newAWSDisk(aws, diskName)
 	if err != nil {
 		return "", err

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -180,6 +180,9 @@ type Volumes interface {
 	// instanceName can be empty to mean "the instance on which we are running"
 	// Returns the device where the volume was attached
 	DetachDisk(diskName string, instanceName string) (string, error)
+	// Return 'true' if given disk is currently detached.
+	// Returns 'false' in all other cases ("attaching", "attached", "detaching")
+	IsDiskDetached(diskName string) (bool, error)
 
 	// Create a volume with the specified options
 	CreateDisk(volumeOptions *VolumeOptions) (volumeName string, err error)
@@ -1156,6 +1159,33 @@ func (self *awsDisk) describeVolume() (*ec2.Volume, error) {
 	return volumes[0], nil
 }
 
+// getAttachmentStatus returns current attachment status of the volume
+func (self *awsDisk) getAttachmentStatus() (string, error) {
+	info, err := self.describeVolume()
+	if err != nil {
+		return "", err
+	}
+	if len(info.Attachments) > 1 {
+		glog.Warningf("Found multiple attachments for volume: %v", info)
+	}
+	attachmentStatus := ""
+	for _, attachment := range info.Attachments {
+		if attachmentStatus != "" {
+			glog.Warning("Found multiple attachments: ", info)
+		}
+		if attachment.State != nil {
+			attachmentStatus = *attachment.State
+		} else {
+			// Shouldn't happen, but don't panic...
+			glog.Warning("Ignoring nil attachment state: ", attachment)
+		}
+	}
+	if attachmentStatus == "" {
+		attachmentStatus = "detached"
+	}
+	return attachmentStatus, nil
+}
+
 // waitForAttachmentStatus polls until the attachment status is the expected value
 // TODO(justinsb): return (bool, error)
 func (self *awsDisk) waitForAttachmentStatus(status string) error {
@@ -1164,33 +1194,16 @@ func (self *awsDisk) waitForAttachmentStatus(status string) error {
 	maxAttempts := 60
 
 	for {
-		info, err := self.describeVolume()
+		attachmentStatus, err := self.getAttachmentStatus()
 		if err != nil {
 			return err
 		}
-		if len(info.Attachments) > 1 {
-			glog.Warningf("Found multiple attachments for volume: %v", info)
-		}
-		attachmentStatus := ""
-		for _, attachment := range info.Attachments {
-			if attachmentStatus != "" {
-				glog.Warning("Found multiple attachments: ", info)
-			}
-			if attachment.State != nil {
-				attachmentStatus = *attachment.State
-			} else {
-				// Shouldn't happen, but don't panic...
-				glog.Warning("Ignoring nil attachment state: ", attachment)
-			}
-		}
-		if attachmentStatus == "" {
-			attachmentStatus = "detached"
-		}
+
 		if attachmentStatus == status {
 			return nil
 		}
 
-		glog.V(2).Infof("Waiting for volume state: actual=%s, desired=%s", attachmentStatus, status)
+		glog.V(2).Infof("Waiting for volume %s state: actual=%s, desired=%s", self.awsID, attachmentStatus, status)
 
 		attempt++
 		if attempt > maxAttempts {
@@ -1258,6 +1271,16 @@ func (c *AWSCloud) getAwsInstance(nodeName string) (*awsInstance, error) {
 	}
 
 	return awsInstance, nil
+}
+
+func (c *AWSCloud) IsDiskDetached(diskName string) (bool, error) {
+	disk, err := newAWSDisk(c, diskName)
+	if err != nil {
+		return false, err
+	}
+	status, err := disk.getAttachmentStatus()
+	glog.V(5).Infof("IsDiskDetached for %s: %s, %v", diskName, status, err)
+	return status == "detached", err
 }
 
 // Implements Volumes.AttachDisk

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -1340,7 +1340,7 @@ func (c *AWSCloud) AttachDisk(diskName string, instanceName string, readOnly boo
 		if err != nil {
 			attachEnded = true
 			// TODO: Check if the volume was concurrently attached?
-			return "", fmt.Errorf("Error attaching EBS volume: %v", err)
+			return ec2Device, fmt.Errorf("Error attaching EBS volume: %v", err)
 		}
 
 		glog.V(2).Infof("AttachVolume request returned %v", attachResponse)
@@ -1348,7 +1348,10 @@ func (c *AWSCloud) AttachDisk(diskName string, instanceName string, readOnly boo
 
 	err = disk.waitForAttachmentStatus("attached")
 	if err != nil {
-		return "", err
+		// Return the device even if there was an error - it could be time out
+		// and AWS is still trying to attach the volume. Caller may want to
+		// detach it manually.
+		return ec2Device, err
 	}
 
 	attachEnded = true

--- a/plugin/pkg/admission/persistentvolume/label/admission_test.go
+++ b/plugin/pkg/admission/persistentvolume/label/admission_test.go
@@ -37,7 +37,7 @@ func (v *mockVolumes) AttachDisk(diskName string, instanceName string, readOnly 
 	return "", fmt.Errorf("not implemented")
 }
 
-func (v *mockVolumes) DetachDisk(diskName string, instanceName string) (string, error) {
+func (v *mockVolumes) DetachDisk(diskName string, instanceName string, wait bool) (string, error) {
 	return "", fmt.Errorf("not implemented")
 }
 

--- a/plugin/pkg/admission/persistentvolume/label/admission_test.go
+++ b/plugin/pkg/admission/persistentvolume/label/admission_test.go
@@ -41,6 +41,10 @@ func (v *mockVolumes) DetachDisk(diskName string, instanceName string) (string, 
 	return "", fmt.Errorf("not implemented")
 }
 
+func (v *mockVolumes) IsDiskDetached(diskName string) (bool, error) {
+	return false, fmt.Errorf("not implemented")
+}
+
 func (v *mockVolumes) CreateDisk(volumeOptions *aws.VolumeOptions) (volumeName string, err error) {
 	return "", fmt.Errorf("not implemented")
 }


### PR DESCRIPTION
When attachDiskAndVerify gives up waiting for a volume to be attached, AWS may be still trying to attach the volume.

If the pod that wants the volume attached still exists, kubelet will retry attaching the volume on next kubelet sync (and everything is allright).

However, if the pod is deleted, AWS is still trying to attach the volume and it may eventually succeed. We end up with a volume attached to a node and no pod for it. Nobody will detach the volume.

As fix, just fire DetachVolume to AWS when attachDiskAndVerify gives up, without waiting for result. If associated pod still exists, it will try to attach the volume soon. If the pod is deleted, AWS will detach the volume (or stop attaching it).

Fixes: #24807

There are several tiny patches, the last one bringing everything together. I tested it really fixes the referenced issue, still I am open for better suggestions how to fix it in a better way.

@justinsb @kubernetes/sig-storage 
