### PR TITLE
Fixed vSphere kube-up implementation to allow Kubernetes dashboard (UI) to work

### DIFF
--- a/cluster/vsphere/config-default.sh
+++ b/cluster/vsphere/config-default.sh
@@ -57,5 +57,11 @@ DNS_REPLICAS=1
 # Optional: Install Kubernetes UI
 ENABLE_CLUSTER_UI="${KUBE_ENABLE_CLUSTER_UI:-true}"
 
+# We need to configure subject alternate names (SANs) for the master's certificate
+# we generate.  While users will connect via the external IP, pods (like the UI)
+# will connect via the cluster IP, from the SERVICE_CLUSTER_IP_RANGE.
+# In addition to the extra SANS here, we'll also add one for for the service IP.
+MASTER_EXTRA_SANS="DNS:kubernetes,DNS:kubernetes.default,DNS:kubernetes.default.svc,DNS:kubernetes.default.svc.${DNS_DOMAIN}"
+
 # Optional: if set to true, kube-up will configure the cluster to run e2e tests.
 E2E_STORAGE_TEST_ENVIRONMENT=${KUBE_E2E_STORAGE_TEST_ENVIRONMENT:-false}

--- a/cluster/vsphere/templates/create-dynamic-salt-files.sh
+++ b/cluster/vsphere/templates/create-dynamic-salt-files.sh
@@ -112,7 +112,7 @@ node_instance_prefix: $NODE_INSTANCE_PREFIX
 service_cluster_ip_range: $SERVICE_CLUSTER_IP_RANGE
 enable_cluster_monitoring: "${ENABLE_CLUSTER_MONITORING:-none}"
 enable_cluster_logging: "${ENABLE_CLUSTER_LOGGING:false}"
-enable_cluster_ui: "${ENABLE_CLUSTER_UI:false}"
+enable_cluster_ui: "${ENABLE_CLUSTER_UI:true}"
 enable_node_logging: "${ENABLE_NODE_LOGGING:false}"
 logging_destination: $LOGGING_DESTINATION
 elasticsearch_replicas: $ELASTICSEARCH_LOGGING_REPLICAS
@@ -123,6 +123,7 @@ dns_domain: $DNS_DOMAIN
 e2e_storage_test_environment: "${E2E_STORAGE_TEST_ENVIRONMENT:-false}"
 cluster_cidr: "$NODE_IP_RANGES"
 allocate_node_cidrs: "${ALLOCATE_NODE_CIDRS:-true}"
+admission_control: NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
 EOF
 
 mkdir -p /srv/salt-overlay/salt/nginx

--- a/cluster/vsphere/templates/salt-master.sh
+++ b/cluster/vsphere/templates/salt-master.sh
@@ -27,6 +27,7 @@ grains:
     - kubernetes-master
   cbr-cidr: $MASTER_IP_RANGE
   cloud: vsphere
+  master_extra_sans: $MASTER_EXTRA_SANS
 EOF
 
 # Auto accept all keys from minions that try to join


### PR DESCRIPTION
The UI didn't work with vSphere kube-up implementation. This fixes
that by making the following changes:
- Configure the apiserver with admission controls, especially
  ServiceAccount. This will provide the token to the dashboard pod
  that it needs to talk to the apiserver. This will also improve other
  pods that require service accounts.
- Add routes to the master so it can communicate with the pods, so
  hitting the https://MASTER/ui URL will allow it to contact the
  pods.
- Add an extra subject for the cluster IP to the apiserver, so when
  the dashboard communicates with the apiserver, the certificate
  matches the IP address it's using.
