### PR TITLE
Trusty: Fix abnormal DNS pods

### DIFF
--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -1,3 +1,8 @@
+{% set host_network = "false" -%}
+{% if grains['cloud'] is defined and grains['cloud'] in [ 'vsphere', 'photon-controller' ] %}
+  {% set host_network = "true" -%}
+{% endif %}
+
 apiVersion: v1
 kind: ReplicationController
 metadata:
@@ -19,9 +24,7 @@ spec:
         version: v11
         kubernetes.io/cluster-service: "true"
     spec:
-{% if grains['cloud'] is defined and grains['cloud'] in [ 'vsphere', 'photon-controller' ] %}
-      hostNetwork: true
-{% endif %}
+      hostNetwork: {{ host_network }}
       containers:
       - name: etcd
         image: gcr.io/google_containers/etcd-amd64:2.2.1

--- a/cluster/gce/trusty/configure-helper.sh
+++ b/cluster/gce/trusty/configure-helper.sh
@@ -651,8 +651,10 @@ prepare_kube_addons() {
     mv "${addon_dst_dir}/dns/skydns-rc.yaml.in" "${dns_rc_file}"
     mv "${addon_dst_dir}/dns/skydns-svc.yaml.in" "${dns_svc_file}"
     # Replace the salt configurations with variable values.
+    remove_salt_config_comments "${dns_rc_file}"
     sed -i -e "s@{{ *pillar\['dns_replicas'\] *}}@${DNS_REPLICAS}@g" "${dns_rc_file}"
     sed -i -e "s@{{ *pillar\['dns_domain'\] *}}@${DNS_DOMAIN}@g" "${dns_rc_file}"
+    sed -i -e "s@{{ *host_network *}}@false@g" "${dns_rc_file}"
     sed -i -e "s@{{ *pillar\['dns_server'\] *}}@${DNS_SERVER_IP}@g" "${dns_svc_file}"
   fi
   if [ "${ENABLE_CLUSTER_REGISTRY:-}" = "true" ]; then


### PR DESCRIPTION
This PR fixes the breakage of DNS pods in Trusty cluster, which is caused by PR #24124. Our Jenkins caught several e2e test failures related with DNS. After applying this fix, the failed test cases can pass.

@roberthbailey @dchen1107 please review it.

cc/ @fabioy @wonderfly FYI.

cc/ @AlainRoy the way adding the new spec "hostNetwork" in skydns-rc.yaml.in is easy to break the non-salt platform using that yaml file, e.g., cluster/gce/trusty. In this PR, I change to set the value via a variable which is false by default.
