### PR TITLE
Ignore all _output* directories.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,10 +17,8 @@
 .vscode
 
 # This is where the result of the go build goes
-/output/**
-/output
-/_output/**
-/_output
+/output*/
+/_output*/
 
 # Emacs save files
 *~


### PR DESCRIPTION
In the new release tooling we build into multiple _output directories and this caught us on a recent build of 1.2.4-beta.0.

ref: #24837 #23839
