### PR TITLE
kubectl: avoid panic with nil gvk

### DIFF
--- a/pkg/kubectl/resource/mapper.go
+++ b/pkg/kubectl/resource/mapper.go
@@ -52,6 +52,9 @@ type Mapper struct {
 func (m *Mapper) InfoForData(data []byte, source string) (*Info, error) {
 	versions := &runtime.VersionedObjects{}
 	_, gvk, err := m.Decode(data, nil, versions)
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode %q: %v", source, err)
+	}
 	var obj runtime.Object
 	var versioned runtime.Object
 	if registered.IsThirdPartyAPIGroupVersion(gvk.GroupVersion()) {


### PR DESCRIPTION
The decoder will return a nil gvk in case it errors out and getting
the version out of that gvk naturally will panic. Bail out as soon
as we can check that the error is non-nil. kubectl edit was the primary
victim.

@kubernetes/kubectl @brendandburns 
