### PR TITLE
Proper account checking and respect TMPDIR in release process

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -1516,9 +1516,9 @@ function kube::release::docker::release() {
   fi
 }
 
-function kube::release::has_gcloud_account() {
+function kube::release::gcloud_account_is_active() {
   local -r account="${1-}"
-  if [[ -n $(gcloud auth list --filter-account $account 2>/dev/null) ]]; then
+  if [[ -n $(gcloud auth list --filter-account $account 2>/dev/null | grep "active") ]]; then
     return 0
   else
     return 1

--- a/build/push-official-release.sh
+++ b/build/push-official-release.sh
@@ -38,6 +38,7 @@ KUBE_GCS_PUBLISH_VERSION="${KUBE_RELEASE_VERSION}"
 
 KUBE_DOCKER_REGISTRY="gcr.io/google_containers"
 KUBE_DOCKER_IMAGE_TAG="${KUBE_RELEASE_VERSION}"
+KUBE_GCLOUD_PRODUCTION_ACCOUNT="k8s.production.user@gmail.com"
 
 KUBE_ROOT="$(dirname "${BASH_SOURCE}")/.."
 source "${KUBE_ROOT}/build/common.sh"
@@ -47,8 +48,8 @@ if "${KUBE_ROOT}/cluster/kubectl.sh" 'version' | grep 'Client' | grep 'dirty'; t
   exit 1
 fi
 
-if ! kube::release::has_gcloud_account k8s.production.user@gmail.com; then
-  kube::log::error "Pushing images to gcr.io/google_containers requires credentials for account k8s.production.user@gmail.com"
+if ! kube::release::gcloud_account_is_active "${KUBE_GCLOUD_PRODUCTION_ACCOUNT}"; then
+  kube::log::error "Pushing images to gcr.io/google_containers requires being logged in as ${KUBE_GCLOUD_PRODUCTION_ACCOUNT}"
   return 1
 fi
 

--- a/release/build-official-release.sh
+++ b/release/build-official-release.sh
@@ -43,6 +43,7 @@ function sha1() {
 
 declare -r KUBE_GITHUB="https://github.com/kubernetes/kubernetes.git"
 declare -r KUBE_RELEASE_VERSION=${1-}
+declare -r TMPDIR=${TMPDIR:-"/tmp"}
 declare -r KUBE_RELEASE_UMASK=${KUBE_RELEASE_UMASK:-022}
 
 VERSION_REGEX="^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(-(beta|alpha)\\.(0|[1-9][0-9]*))?$"
@@ -65,7 +66,7 @@ else
   KUBE_RELEASE_TYPE="stable"
 fi
 
-declare -r KUBE_BUILD_DIR=$(mktemp -d "/tmp/kubernetes-build-release-${KUBE_RELEASE_VERSION}-XXXXXXX")
+declare -r KUBE_BUILD_DIR=$(mktemp -d "${TMPDIR}/kubernetes-build-release-${KUBE_RELEASE_VERSION}-XXXXXXX")
 
 # Set the default umask for the release. This ensures consistency
 # across our release builds.

--- a/release/cut-official-release.sh
+++ b/release/cut-official-release.sh
@@ -92,11 +92,12 @@ function main() {
   local -r release_umask=${release_umask:-022}
   umask "${release_umask}"
 
+  declare -r TMPDIR=${TMPDIR:-"/tmp"}
   local -r github="https://github.com/kubernetes/kubernetes.git"
-  declare -r DIR=$(mktemp -d "/tmp/kubernetes-${release_type}-release-${new_version}-XXXXXXX")
+  declare -r DIR=$(mktemp -d "${TMPDIR}/kubernetes-${release_type}-release-${new_version}-XXXXXXX")
 
   # Start a tmp file that will hold instructions for the user.
-  declare -r INSTRUCTIONS=$(mktemp "/tmp/kubernetes-${release_type}-release-${new_version}-instructions-XXXXXXX")
+  declare -r INSTRUCTIONS=$(mktemp "${TMPDIR}/kubernetes-${release_type}-release-${new_version}-instructions-XXXXXXX")
   if $DRY_RUN; then
     cat > "${INSTRUCTIONS}" <<- EOM
 Success on dry run!  Do


### PR DESCRIPTION
I ran into both of these issues this week trying to release `v1.3.0-alpha.3`:
1. `/build/push-official-release.sh` requires being _logged in_ as `k8s.production.user`, but it only checked if that user was in the list of credentialed accounts.
2. Now that we build approximately everything under the sun, my `/tmp` didn't have enough space; I needed to override it to use a different directory, hence `TMPDIR`.

cc @fgrzadkowski @david-mcmahon 
