### PR TITLE
GCI/Trusty: Support ABAC authorization

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -904,6 +904,7 @@ function kube::release::package_kube_manifests_tarball() {
   cp "${salt_dir}/etcd/etcd.manifest" "${dst_dir}"
   cp "${salt_dir}/kube-scheduler/kube-scheduler.manifest" "${dst_dir}"
   cp "${salt_dir}/kube-apiserver/kube-apiserver.manifest" "${dst_dir}"
+  cp "${salt_dir}/kube-apiserver/abac-authz-policy.jsonl" "${dst_dir}"
   cp "${salt_dir}/kube-controller-manager/kube-controller-manager.manifest" "${dst_dir}"
   cp "${salt_dir}/kube-addons/namespace.yaml" "${dst_dir}"
   cp "${salt_dir}/kube-addons/kube-addons.sh" "${dst_dir}"


### PR DESCRIPTION
This PR is for supporting the ABAC authorization added in PR #24210. It is tested on GCI and Ubuntu Trusty with two modes, i.e., entire cluster on GCI/Trusty and hybrid mode with only master on GCI/Trusty.
