### PR TITLE
Graceless namespace deletion

### DIFF
--- a/pkg/apis/apps/register.go
+++ b/pkg/apis/apps/register.go
@@ -50,6 +50,7 @@ func addKnownTypes(scheme *runtime.Scheme) {
 		&PetSet{},
 		&PetSetList{},
 		&api.ListOptions{},
+		&api.DeleteOptions{},
 	)
 }
 

--- a/pkg/apis/apps/v1alpha1/register.go
+++ b/pkg/apis/apps/v1alpha1/register.go
@@ -41,6 +41,7 @@ func addKnownTypes(scheme *runtime.Scheme) {
 		&PetSet{},
 		&PetSetList{},
 		&v1.ListOptions{},
+		&v1.DeleteOptions{},
 	)
 	versionedwatch.AddToGroupVersion(scheme, SchemeGroupVersion)
 }

--- a/pkg/apis/autoscaling/register.go
+++ b/pkg/apis/autoscaling/register.go
@@ -51,6 +51,7 @@ func addKnownTypes(scheme *runtime.Scheme) {
 		&extensions.HorizontalPodAutoscaler{},
 		&extensions.HorizontalPodAutoscalerList{},
 		&api.ListOptions{},
+		&api.DeleteOptions{},
 	)
 }
 

--- a/pkg/apis/autoscaling/v1/register.go
+++ b/pkg/apis/autoscaling/v1/register.go
@@ -42,6 +42,7 @@ func addKnownTypes(scheme *runtime.Scheme) {
 		&HorizontalPodAutoscalerList{},
 		&Scale{},
 		&v1.ListOptions{},
+		&v1.DeleteOptions{},
 	)
 	versionedwatch.AddToGroupVersion(scheme, SchemeGroupVersion)
 }

--- a/pkg/apis/batch/register.go
+++ b/pkg/apis/batch/register.go
@@ -49,6 +49,7 @@ func addKnownTypes(scheme *runtime.Scheme) {
 		&Job{},
 		&JobList{},
 		&api.ListOptions{},
+		&api.DeleteOptions{},
 	)
 }
 

--- a/pkg/apis/batch/v1/register.go
+++ b/pkg/apis/batch/v1/register.go
@@ -41,6 +41,7 @@ func addKnownTypes(scheme *runtime.Scheme) {
 		&Job{},
 		&JobList{},
 		&v1.ListOptions{},
+		&v1.DeleteOptions{},
 	)
 	versionedwatch.AddToGroupVersion(scheme, SchemeGroupVersion)
 }

--- a/pkg/apis/extensions/register.go
+++ b/pkg/apis/extensions/register.go
@@ -65,12 +65,14 @@ func addKnownTypes(scheme *runtime.Scheme) {
 		&ThirdPartyResourceDataList{},
 		&Ingress{},
 		&IngressList{},
-		&api.ListOptions{},
 		&ReplicaSet{},
 		&ReplicaSetList{},
-		&api.ExportOptions{},
 		&PodSecurityPolicy{},
 		&PodSecurityPolicyList{},
+
+		&api.ExportOptions{},
+		&api.ListOptions{},
+		&api.DeleteOptions{},
 	)
 }
 

--- a/pkg/apis/extensions/v1beta1/register.go
+++ b/pkg/apis/extensions/v1beta1/register.go
@@ -55,12 +55,14 @@ func addKnownTypes(scheme *runtime.Scheme) {
 		&ThirdPartyResourceDataList{},
 		&Ingress{},
 		&IngressList{},
-		&ListOptions{},
-		&v1.DeleteOptions{},
 		&ReplicaSet{},
 		&ReplicaSetList{},
 		&PodSecurityPolicy{},
 		&PodSecurityPolicyList{},
+
+		&v1.ExportOptions{},
+		&ListOptions{},
+		&v1.DeleteOptions{},
 	)
 	// Add the watch version that applies
 	versionedwatch.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/kubectl/cmd/replace.go
+++ b/pkg/kubectl/cmd/replace.go
@@ -198,12 +198,13 @@ func forceReplace(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []
 	}
 	//Replace will create a resource if it doesn't exist already, so ignore not found error
 	ignoreNotFound := true
+	gracePeriod := cmdutil.GetFlagInt(cmd, "grace-period")
 	// By default use a reaper to delete all related resources.
 	if cmdutil.GetFlagBool(cmd, "cascade") {
 		glog.Warningf("\"cascade\" is set, kubectl will delete and re-create all resources managed by this resource (e.g. Pods created by a ReplicationController). Consider using \"kubectl rolling-update\" if you want to update a ReplicationController together with its Pods.")
-		err = ReapResult(r, f, out, cmdutil.GetFlagBool(cmd, "cascade"), ignoreNotFound, cmdutil.GetFlagDuration(cmd, "timeout"), cmdutil.GetFlagInt(cmd, "grace-period"), shortOutput, mapper)
+		err = ReapResult(r, f, out, cmdutil.GetFlagBool(cmd, "cascade"), ignoreNotFound, cmdutil.GetFlagDuration(cmd, "timeout"), gracePeriod, shortOutput, mapper)
 	} else {
-		err = DeleteResult(r, out, ignoreNotFound, shortOutput, mapper)
+		err = DeleteResult(r, out, ignoreNotFound, gracePeriod, shortOutput, mapper)
 	}
 	if err != nil {
 		return err

--- a/pkg/kubectl/resource/helper.go
+++ b/pkg/kubectl/resource/helper.go
@@ -93,11 +93,15 @@ func (m *Helper) WatchSingle(namespace, name, resourceVersion string) (watch.Int
 		Watch()
 }
 
-func (m *Helper) Delete(namespace, name string) error {
-	return m.RESTClient.Delete().
+func (m *Helper) Delete(namespace, name string, gracePeriod int64) error {
+	req := m.RESTClient.Delete().
 		NamespaceIfScoped(namespace, m.NamespaceScoped).
 		Resource(m.Resource).
-		Name(name).
+		Name(name)
+	if gracePeriod != -1 {
+		req = req.Body(&api.DeleteOptions{GracePeriodSeconds: &gracePeriod})
+	}
+	return req.
 		Do().
 		Error()
 }

--- a/pkg/kubectl/resource/helper_test.go
+++ b/pkg/kubectl/resource/helper_test.go
@@ -103,7 +103,7 @@ func TestHelperDelete(t *testing.T) {
 			RESTClient:      client,
 			NamespaceScoped: true,
 		}
-		err := modifier.Delete("bar", "foo")
+		err := modifier.Delete("bar", "foo", -1)
 		if (err != nil) != test.Err {
 			t.Errorf("unexpected error: %t %v", test.Err, err)
 		}

--- a/pkg/registry/namespace/etcd/etcd_test.go
+++ b/pkg/registry/namespace/etcd/etcd_test.go
@@ -145,7 +145,7 @@ func TestDeleteNamespaceWithIncompleteFinalizers(t *testing.T) {
 		Spec: api.NamespaceSpec{
 			Finalizers: []api.FinalizerName{api.FinalizerKubernetes},
 		},
-		Status: api.NamespaceStatus{Phase: api.NamespaceActive},
+		Status: api.NamespaceStatus{Phase: api.NamespaceTerminating},
 	}
 	if err := storage.Storage.Create(ctx, key, namespace, nil, 0); err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
while digging into https://github.com/kubernetes/kubernetes/issues/24652, I noticed several things I didn't expect:
1. `kubectl delete foo/bar --grace-period=0` doesn't actually pass grace period to the delete request, only to reapers (and only the job and pod reapers use it)
2. the namespace delete rest handler isn't setting deletionGracePeriodSeconds
3. the namespace controller isn't propagating deletionGracePeriodSeconds on the namespace to child resource deletions
4. delete options isn't registered in most api groups, so graceful deletion can't even be done using the dynamic client
