### PR TITLE
GCI: Update the command to get the image

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -33,7 +33,8 @@ elif [[ "${OS_DISTRIBUTION}" == "gci" ]]; then
   # If the user does not set a GCI image for master, we run both master and nodes
   # using the latest GCI dev image.
   if [[ "${MASTER_IMAGE}" != gci* ]]; then
-    MASTER_IMAGE=$(gcloud compute images list | grep "gci-dev" | cut -d ' ' -f1)
+    gci_images=( $(gcloud compute images list --project google-containers | grep "gci-dev" | cut -d ' ' -f1) )
+    MASTER_IMAGE="${gci_images[0]}"
     NODE_IMAGE="${MASTER_IMAGE}"
     NODE_IMAGE_PROJECT="${MASTER_IMAGE_PROJECT}"
   fi


### PR DESCRIPTION
When we announced public GCI, we used the project google-containers to host GCI release images. However, later we encountered a licence issue and the administrators of google-containers project decided to remove this project from gcloud commands. According, we should list GCI images with the flag "--project google-containers". But the same image is listed twice during this transient period. This PR updates the code of getting the GCI image, which works during the transient period and after the google-containers project change finishes.

@roberthbailey @dchen1107 @zmerlynn please review it.

cc/ @wonderfly @fabioy FYI
