### PR TITLE
start etcd compactor in background

### DIFF
--- a/pkg/storage/storagebackend/etcd3.go
+++ b/pkg/storage/storagebackend/etcd3.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/coreos/etcd/clientv3"
+	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/storage"
 	"k8s.io/kubernetes/pkg/storage/etcd3"
 )
@@ -36,5 +37,6 @@ func newETCD3Storage(c Config) (storage.Interface, error) {
 	if err != nil {
 		return nil, err
 	}
+	etcd3.StartCompactor(context.Background(), client)
 	return etcd3.New(client, c.Codec, c.Prefix), nil
 }


### PR DESCRIPTION
ref: #22448

What's in this PR?
- StartCompactor starts a compactor in the background in order to compact keys older than fixed time. We need to compact keys because we can't let on disk data grow forever. We save the most recent 10 minutes data. It should be enough for slow watchers and to tolerate burst. We might keep a longer history (12h) in the future once storage API can take advantage of multi-version key.
- Have only one compaction job for each cluster. Use endpoints from user input to differentiate clusters.
