### PR TITLE
Reduce allocations during conversion, enable new UnsafeConvertToVersion path

### DIFF
--- a/pkg/api/conversion_test.go
+++ b/pkg/api/conversion_test.go
@@ -50,11 +50,11 @@ func BenchmarkPodConversion(b *testing.B) {
 	var result *api.Pod
 	for i := 0; i < b.N; i++ {
 		pod := &items[i%width]
-		versionedObj, err := scheme.ConvertToVersion(pod, *testapi.Default.GroupVersion())
+		versionedObj, err := scheme.UnsafeConvertToVersion(pod, *testapi.Default.GroupVersion())
 		if err != nil {
 			b.Fatalf("Conversion error: %v", err)
 		}
-		obj, err := scheme.ConvertToVersion(versionedObj, testapi.Default.InternalGroupVersion())
+		obj, err := scheme.UnsafeConvertToVersion(versionedObj, testapi.Default.InternalGroupVersion())
 		if err != nil {
 			b.Fatalf("Conversion error: %v", err)
 		}
@@ -76,11 +76,11 @@ func BenchmarkNodeConversion(b *testing.B) {
 	scheme := api.Scheme
 	var result *api.Node
 	for i := 0; i < b.N; i++ {
-		versionedObj, err := scheme.ConvertToVersion(&node, *testapi.Default.GroupVersion())
+		versionedObj, err := scheme.UnsafeConvertToVersion(&node, *testapi.Default.GroupVersion())
 		if err != nil {
 			b.Fatalf("Conversion error: %v", err)
 		}
-		obj, err := scheme.ConvertToVersion(versionedObj, testapi.Default.InternalGroupVersion())
+		obj, err := scheme.UnsafeConvertToVersion(versionedObj, testapi.Default.InternalGroupVersion())
 		if err != nil {
 			b.Fatalf("Conversion error: %v", err)
 		}
@@ -104,11 +104,11 @@ func BenchmarkReplicationControllerConversion(b *testing.B) {
 	scheme := api.Scheme
 	var result *api.ReplicationController
 	for i := 0; i < b.N; i++ {
-		versionedObj, err := scheme.ConvertToVersion(&replicationController, *testapi.Default.GroupVersion())
+		versionedObj, err := scheme.UnsafeConvertToVersion(&replicationController, *testapi.Default.GroupVersion())
 		if err != nil {
 			b.Fatalf("Conversion error: %v", err)
 		}
-		obj, err := scheme.ConvertToVersion(versionedObj, testapi.Default.InternalGroupVersion())
+		obj, err := scheme.UnsafeConvertToVersion(versionedObj, testapi.Default.InternalGroupVersion())
 		if err != nil {
 			b.Fatalf("Conversion error: %v", err)
 		}

--- a/pkg/api/conversion_test.go
+++ b/pkg/api/conversion_test.go
@@ -50,11 +50,11 @@ func BenchmarkPodConversion(b *testing.B) {
 	var result *api.Pod
 	for i := 0; i < b.N; i++ {
 		pod := &items[i%width]
-		versionedObj, err := scheme.ConvertToVersion(pod, testapi.Default.GroupVersion().String())
+		versionedObj, err := scheme.ConvertToVersion(pod, *testapi.Default.GroupVersion())
 		if err != nil {
 			b.Fatalf("Conversion error: %v", err)
 		}
-		obj, err := scheme.ConvertToVersion(versionedObj, testapi.Default.InternalGroupVersion().String())
+		obj, err := scheme.ConvertToVersion(versionedObj, testapi.Default.InternalGroupVersion())
 		if err != nil {
 			b.Fatalf("Conversion error: %v", err)
 		}
@@ -76,11 +76,11 @@ func BenchmarkNodeConversion(b *testing.B) {
 	scheme := api.Scheme
 	var result *api.Node
 	for i := 0; i < b.N; i++ {
-		versionedObj, err := scheme.ConvertToVersion(&node, testapi.Default.GroupVersion().String())
+		versionedObj, err := scheme.ConvertToVersion(&node, *testapi.Default.GroupVersion())
 		if err != nil {
 			b.Fatalf("Conversion error: %v", err)
 		}
-		obj, err := scheme.ConvertToVersion(versionedObj, testapi.Default.InternalGroupVersion().String())
+		obj, err := scheme.ConvertToVersion(versionedObj, testapi.Default.InternalGroupVersion())
 		if err != nil {
 			b.Fatalf("Conversion error: %v", err)
 		}
@@ -104,11 +104,11 @@ func BenchmarkReplicationControllerConversion(b *testing.B) {
 	scheme := api.Scheme
 	var result *api.ReplicationController
 	for i := 0; i < b.N; i++ {
-		versionedObj, err := scheme.ConvertToVersion(&replicationController, testapi.Default.GroupVersion().String())
+		versionedObj, err := scheme.ConvertToVersion(&replicationController, *testapi.Default.GroupVersion())
 		if err != nil {
 			b.Fatalf("Conversion error: %v", err)
 		}
-		obj, err := scheme.ConvertToVersion(versionedObj, testapi.Default.InternalGroupVersion().String())
+		obj, err := scheme.ConvertToVersion(versionedObj, testapi.Default.InternalGroupVersion())
 		if err != nil {
 			b.Fatalf("Conversion error: %v", err)
 		}

--- a/pkg/api/meta/meta.go
+++ b/pkg/api/meta/meta.go
@@ -123,33 +123,21 @@ type objectAccessor struct {
 }
 
 func (obj objectAccessor) GetKind() string {
-	if gvk := obj.GetObjectKind().GroupVersionKind(); gvk != nil {
-		return gvk.Kind
-	}
-	return ""
+	return obj.GetObjectKind().GroupVersionKind().Kind
 }
 
 func (obj objectAccessor) SetKind(kind string) {
 	gvk := obj.GetObjectKind().GroupVersionKind()
-	if gvk == nil {
-		gvk = &unversioned.GroupVersionKind{}
-	}
 	gvk.Kind = kind
 	obj.GetObjectKind().SetGroupVersionKind(gvk)
 }
 
 func (obj objectAccessor) GetAPIVersion() string {
-	if gvk := obj.GetObjectKind().GroupVersionKind(); gvk != nil {
-		return gvk.GroupVersion().String()
-	}
-	return ""
+	return obj.GetObjectKind().GroupVersionKind().GroupVersion().String()
 }
 
 func (obj objectAccessor) SetAPIVersion(version string) {
 	gvk := obj.GetObjectKind().GroupVersionKind()
-	if gvk == nil {
-		gvk = &unversioned.GroupVersionKind{}
-	}
 	gv, err := unversioned.ParseGroupVersion(version)
 	if err != nil {
 		gv = unversioned.GroupVersion{Version: version}

--- a/pkg/api/meta/meta_test.go
+++ b/pkg/api/meta/meta_test.go
@@ -253,10 +253,10 @@ type InternalObject struct {
 }
 
 func (obj *InternalObject) GetObjectKind() unversioned.ObjectKind { return obj }
-func (obj *InternalObject) SetGroupVersionKind(gvk *unversioned.GroupVersionKind) {
+func (obj *InternalObject) SetGroupVersionKind(gvk unversioned.GroupVersionKind) {
 	obj.TypeMeta.APIVersion, obj.TypeMeta.Kind = gvk.ToAPIVersionAndKind()
 }
-func (obj *InternalObject) GroupVersionKind() *unversioned.GroupVersionKind {
+func (obj *InternalObject) GroupVersionKind() unversioned.GroupVersionKind {
 	return unversioned.FromAPIVersionAndKind(obj.TypeMeta.APIVersion, obj.TypeMeta.Kind)
 }
 
@@ -610,10 +610,10 @@ type MyAPIObject struct {
 }
 
 func (obj *MyAPIObject) GetObjectKind() unversioned.ObjectKind { return obj }
-func (obj *MyAPIObject) SetGroupVersionKind(gvk *unversioned.GroupVersionKind) {
+func (obj *MyAPIObject) SetGroupVersionKind(gvk unversioned.GroupVersionKind) {
 	obj.TypeMeta.APIVersion, obj.TypeMeta.Kind = gvk.ToAPIVersionAndKind()
 }
-func (obj *MyAPIObject) GroupVersionKind() *unversioned.GroupVersionKind {
+func (obj *MyAPIObject) GroupVersionKind() unversioned.GroupVersionKind {
 	return unversioned.FromAPIVersionAndKind(obj.TypeMeta.APIVersion, obj.TypeMeta.Kind)
 }
 

--- a/pkg/api/meta/restmapper_test.go
+++ b/pkg/api/meta/restmapper_test.go
@@ -32,7 +32,7 @@ func (fakeConvertor) Convert(in, out interface{}) error {
 	return nil
 }
 
-func (fakeConvertor) ConvertToVersion(in runtime.Object, _ string) (runtime.Object, error) {
+func (fakeConvertor) ConvertToVersion(in runtime.Object, _ unversioned.GroupVersion) (runtime.Object, error) {
 	return in, nil
 }
 

--- a/pkg/api/ref.go
+++ b/pkg/api/ref.go
@@ -54,10 +54,7 @@ func GetReference(obj runtime.Object) (*ObjectReference, error) {
 
 	// if the object referenced is actually persisted, we can just get kind from meta
 	// if we are building an object reference to something not yet persisted, we should fallback to scheme
-	var kind string
-	if gvk != nil {
-		kind = gvk.Kind
-	}
+	kind := gvk.Kind
 	if len(kind) == 0 {
 		// TODO: this is wrong
 		gvk, err := Scheme.ObjectKind(obj)
@@ -68,10 +65,7 @@ func GetReference(obj runtime.Object) (*ObjectReference, error) {
 	}
 
 	// if the object referenced is actually persisted, we can also get version from meta
-	var version string
-	if gvk != nil {
-		version = gvk.GroupVersion().String()
-	}
+	version := gvk.GroupVersion().String()
 	if len(version) == 0 {
 		selfLink := meta.GetSelfLink()
 		if len(selfLink) == 0 {
@@ -111,9 +105,9 @@ func GetPartialReference(obj runtime.Object, fieldPath string) (*ObjectReference
 
 // IsAnAPIObject allows clients to preemptively get a reference to an API object and pass it to places that
 // intend only to get a reference to that object. This simplifies the event recording interface.
-func (obj *ObjectReference) SetGroupVersionKind(gvk *unversioned.GroupVersionKind) {
+func (obj *ObjectReference) SetGroupVersionKind(gvk unversioned.GroupVersionKind) {
 	obj.APIVersion, obj.Kind = gvk.ToAPIVersionAndKind()
 }
-func (obj *ObjectReference) GroupVersionKind() *unversioned.GroupVersionKind {
+func (obj *ObjectReference) GroupVersionKind() unversioned.GroupVersionKind {
 	return unversioned.FromAPIVersionAndKind(obj.APIVersion, obj.Kind)
 }

--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -281,7 +281,7 @@ func TestObjectWatchFraming(t *testing.T) {
 	secret.Data["binary"] = []byte{0x00, 0x10, 0x30, 0x55, 0xff, 0x00}
 	secret.Data["utf8"] = []byte("a string with \u0345 characters")
 	secret.Data["long"] = bytes.Repeat([]byte{0x01, 0x02, 0x03, 0x00}, 1000)
-	converted, _ := api.Scheme.ConvertToVersion(secret, "v1")
+	converted, _ := api.Scheme.ConvertToVersion(secret, v1.SchemeGroupVersion)
 	v1secret := converted.(*v1.Secret)
 	for _, streamingMediaType := range api.Codecs.SupportedStreamingMediaTypes() {
 		s, _ := api.Codecs.StreamingSerializerForMediaType(streamingMediaType, nil)
@@ -358,7 +358,7 @@ func benchmarkItems() []v1.Pod {
 	for i := range items {
 		var pod api.Pod
 		apiObjectFuzzer.Fuzz(&pod)
-		out, err := api.Scheme.ConvertToVersion(&pod, "v1")
+		out, err := api.Scheme.ConvertToVersion(&pod, v1.SchemeGroupVersion)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/api/unversioned/group_version.go
+++ b/pkg/api/unversioned/group_version.go
@@ -259,11 +259,11 @@ func (gvk *GroupVersionKind) ToAPIVersionAndKind() (string, string) {
 // do not use TypeMeta. This method exists to support test types and legacy serializations
 // that have a distinct group and kind.
 // TODO: further reduce usage of this method.
-func FromAPIVersionAndKind(apiVersion, kind string) *GroupVersionKind {
+func FromAPIVersionAndKind(apiVersion, kind string) GroupVersionKind {
 	if gv, err := ParseGroupVersion(apiVersion); err == nil {
-		return &GroupVersionKind{Group: gv.Group, Version: gv.Version, Kind: kind}
+		return GroupVersionKind{Group: gv.Group, Version: gv.Version, Kind: kind}
 	}
-	return &GroupVersionKind{Kind: kind}
+	return GroupVersionKind{Kind: kind}
 }
 
 // All objects that are serialized from a Scheme encode their type information. This interface is used
@@ -273,10 +273,10 @@ func FromAPIVersionAndKind(apiVersion, kind string) *GroupVersionKind {
 type ObjectKind interface {
 	// SetGroupVersionKind sets or clears the intended serialized kind of an object. Passing kind nil
 	// should clear the current setting.
-	SetGroupVersionKind(kind *GroupVersionKind)
+	SetGroupVersionKind(kind GroupVersionKind)
 	// GroupVersionKind returns the stored group, version, and kind of an object, or nil if the object does
 	// not expose or provide these fields.
-	GroupVersionKind() *GroupVersionKind
+	GroupVersionKind() GroupVersionKind
 }
 
 // EmptyObjectKind implements the ObjectKind interface as a noop
@@ -286,7 +286,7 @@ var EmptyObjectKind = emptyObjectKind{}
 type emptyObjectKind struct{}
 
 // SetGroupVersionKind implements the ObjectKind interface
-func (emptyObjectKind) SetGroupVersionKind(gvk *GroupVersionKind) {}
+func (emptyObjectKind) SetGroupVersionKind(gvk GroupVersionKind) {}
 
 // GroupVersionKind implements the ObjectKind interface
-func (emptyObjectKind) GroupVersionKind() *GroupVersionKind { return nil }
+func (emptyObjectKind) GroupVersionKind() GroupVersionKind { return GroupVersionKind{} }

--- a/pkg/api/unversioned/register.go
+++ b/pkg/api/unversioned/register.go
@@ -25,12 +25,12 @@ func Kind(kind string) GroupKind {
 }
 
 // SetGroupVersionKind satisfies the ObjectKind interface for all objects that embed TypeMeta
-func (obj *TypeMeta) SetGroupVersionKind(gvk *GroupVersionKind) {
+func (obj *TypeMeta) SetGroupVersionKind(gvk GroupVersionKind) {
 	obj.APIVersion, obj.Kind = gvk.ToAPIVersionAndKind()
 }
 
 // GroupVersionKind satisfies the ObjectKind interface for all objects that embed TypeMeta
-func (obj *TypeMeta) GroupVersionKind() *GroupVersionKind {
+func (obj *TypeMeta) GroupVersionKind() GroupVersionKind {
 	return FromAPIVersionAndKind(obj.APIVersion, obj.Kind)
 }
 

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -149,7 +149,7 @@ func validateOwnerReference(ownerReference api.OwnerReference, fldPath *field.Pa
 	if len(ownerReference.UID) == 0 {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("uid"), ownerReference.UID, "uid must not be empty"))
 	}
-	if _, ok := BannedOwners[*gvk]; ok {
+	if _, ok := BannedOwners[gvk]; ok {
 		allErrs = append(allErrs, field.Invalid(fldPath, ownerReference, fmt.Sprintf("%s is disallowed from being an owner", gvk)))
 	}
 	return allErrs

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -264,7 +264,7 @@ func (c stripVersionEncoder) EncodeToStream(obj runtime.Object, w io.Writer, ove
 	}
 	gvk.Group = ""
 	gvk.Version = ""
-	roundTrippedObj.GetObjectKind().SetGroupVersionKind(gvk)
+	roundTrippedObj.GetObjectKind().SetGroupVersionKind(*gvk)
 	return c.serializer.EncodeToStream(roundTrippedObj, w)
 }
 

--- a/pkg/apiserver/resthandler.go
+++ b/pkg/apiserver/resthandler.go
@@ -459,7 +459,7 @@ func PatchResource(r rest.Patcher, scope RequestScope, typer runtime.ObjectTyper
 		ctx := scope.ContextFunc(req)
 		ctx = api.WithNamespace(ctx, namespace)
 
-		versionedObj, err := converter.ConvertToVersion(r.New(), scope.Kind.GroupVersion().String())
+		versionedObj, err := converter.ConvertToVersion(r.New(), scope.Kind.GroupVersion())
 		if err != nil {
 			scope.err(err, res.ResponseWriter, req.Request)
 			return

--- a/pkg/apiserver/resthandler_test.go
+++ b/pkg/apiserver/resthandler_test.go
@@ -174,7 +174,7 @@ func (tc *patchTestCase) Run(t *testing.T) {
 
 	namer := &testNamer{namespace, name}
 
-	versionedObj, err := api.Scheme.ConvertToVersion(&api.Pod{}, "v1")
+	versionedObj, err := api.Scheme.ConvertToVersion(&api.Pod{}, unversioned.GroupVersion{Version: "v1"})
 	if err != nil {
 		t.Errorf("%s: unexpected error: %v", tc.name, err)
 		return

--- a/pkg/client/unversioned/clientcmd/api/register.go
+++ b/pkg/client/unversioned/clientcmd/api/register.go
@@ -35,9 +35,9 @@ func init() {
 }
 
 func (obj *Config) GetObjectKind() unversioned.ObjectKind { return obj }
-func (obj *Config) SetGroupVersionKind(gvk *unversioned.GroupVersionKind) {
+func (obj *Config) SetGroupVersionKind(gvk unversioned.GroupVersionKind) {
 	obj.APIVersion, obj.Kind = gvk.ToAPIVersionAndKind()
 }
-func (obj *Config) GroupVersionKind() *unversioned.GroupVersionKind {
+func (obj *Config) GroupVersionKind() unversioned.GroupVersionKind {
 	return unversioned.FromAPIVersionAndKind(obj.APIVersion, obj.Kind)
 }

--- a/pkg/client/unversioned/clientcmd/api/v1/register.go
+++ b/pkg/client/unversioned/clientcmd/api/v1/register.go
@@ -32,9 +32,9 @@ func init() {
 }
 
 func (obj *Config) GetObjectKind() unversioned.ObjectKind { return obj }
-func (obj *Config) SetGroupVersionKind(gvk *unversioned.GroupVersionKind) {
+func (obj *Config) SetGroupVersionKind(gvk unversioned.GroupVersionKind) {
 	obj.APIVersion, obj.Kind = gvk.ToAPIVersionAndKind()
 }
-func (obj *Config) GroupVersionKind() *unversioned.GroupVersionKind {
+func (obj *Config) GroupVersionKind() unversioned.GroupVersionKind {
 	return unversioned.FromAPIVersionAndKind(obj.APIVersion, obj.Kind)
 }

--- a/pkg/conversion/converter.go
+++ b/pkg/conversion/converter.go
@@ -210,9 +210,6 @@ func (c ConversionFuncs) Merge(other ConversionFuncs) ConversionFuncs {
 
 // Meta is supplied by Scheme, when it calls Convert.
 type Meta struct {
-	SrcVersion  string
-	DestVersion string
-
 	// KeyNameMapping is an optional function which may map the listed key (field name)
 	// into a source and destination value.
 	KeyNameMapping FieldMappingFunc

--- a/pkg/conversion/converter_test.go
+++ b/pkg/conversion/converter_test.go
@@ -611,7 +611,7 @@ func TestConverter_meta(t *testing.T) {
 	checks := 0
 	err := c.RegisterConversionFunc(
 		func(in *Foo, out *Bar, s Scope) error {
-			if s.Meta() == nil || s.Meta().SrcVersion != "test" || s.Meta().DestVersion != "passes" {
+			if s.Meta() == nil {
 				t.Errorf("Meta did not get passed!")
 			}
 			checks++
@@ -624,7 +624,7 @@ func TestConverter_meta(t *testing.T) {
 	}
 	err = c.RegisterConversionFunc(
 		func(in *string, out *string, s Scope) error {
-			if s.Meta() == nil || s.Meta().SrcVersion != "test" || s.Meta().DestVersion != "passes" {
+			if s.Meta() == nil {
 				t.Errorf("Meta did not get passed a second time!")
 			}
 			checks++
@@ -634,7 +634,7 @@ func TestConverter_meta(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	err = c.Convert(&Foo{}, &Bar{}, 0, &Meta{SrcVersion: "test", DestVersion: "passes"})
+	err = c.Convert(&Foo{}, &Bar{}, 0, &Meta{})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/pkg/conversion/deep_copy_generated.go
+++ b/pkg/conversion/deep_copy_generated.go
@@ -174,8 +174,6 @@ func DeepCopy_conversion_Equalities(in Equalities, out *Equalities, c *Cloner) e
 }
 
 func DeepCopy_conversion_Meta(in Meta, out *Meta, c *Cloner) error {
-	out.SrcVersion = in.SrcVersion
-	out.DestVersion = in.DestVersion
 	if in.KeyNameMapping == nil {
 		out.KeyNameMapping = nil
 	} else if newVal, err := c.DeepCopy(in.KeyNameMapping); err != nil {

--- a/pkg/kubectl/cmd/annotate.go
+++ b/pkg/kubectl/cmd/annotate.go
@@ -221,7 +221,7 @@ func (o AnnotateOptions) RunAnnotate() error {
 			return err
 		}
 
-		obj, err := info.Mapping.ConvertToVersion(info.Object, info.Mapping.GroupVersionKind.GroupVersion().String())
+		obj, err := info.Mapping.ConvertToVersion(info.Object, info.Mapping.GroupVersionKind.GroupVersion())
 		if err != nil {
 			return err
 		}

--- a/pkg/kubectl/cmd/cmd_test.go
+++ b/pkg/kubectl/cmd/cmd_test.go
@@ -87,24 +87,24 @@ type ExternalType2 struct {
 }
 
 func (obj *internalType) GetObjectKind() unversioned.ObjectKind { return obj }
-func (obj *internalType) SetGroupVersionKind(gvk *unversioned.GroupVersionKind) {
+func (obj *internalType) SetGroupVersionKind(gvk unversioned.GroupVersionKind) {
 	obj.APIVersion, obj.Kind = gvk.ToAPIVersionAndKind()
 }
-func (obj *internalType) GroupVersionKind() *unversioned.GroupVersionKind {
+func (obj *internalType) GroupVersionKind() unversioned.GroupVersionKind {
 	return unversioned.FromAPIVersionAndKind(obj.APIVersion, obj.Kind)
 }
 func (obj *externalType) GetObjectKind() unversioned.ObjectKind { return obj }
-func (obj *externalType) SetGroupVersionKind(gvk *unversioned.GroupVersionKind) {
+func (obj *externalType) SetGroupVersionKind(gvk unversioned.GroupVersionKind) {
 	obj.APIVersion, obj.Kind = gvk.ToAPIVersionAndKind()
 }
-func (obj *externalType) GroupVersionKind() *unversioned.GroupVersionKind {
+func (obj *externalType) GroupVersionKind() unversioned.GroupVersionKind {
 	return unversioned.FromAPIVersionAndKind(obj.APIVersion, obj.Kind)
 }
 func (obj *ExternalType2) GetObjectKind() unversioned.ObjectKind { return obj }
-func (obj *ExternalType2) SetGroupVersionKind(gvk *unversioned.GroupVersionKind) {
+func (obj *ExternalType2) SetGroupVersionKind(gvk unversioned.GroupVersionKind) {
 	obj.APIVersion, obj.Kind = gvk.ToAPIVersionAndKind()
 }
-func (obj *ExternalType2) GroupVersionKind() *unversioned.GroupVersionKind {
+func (obj *ExternalType2) GroupVersionKind() unversioned.GroupVersionKind {
 	return unversioned.FromAPIVersionAndKind(obj.APIVersion, obj.Kind)
 }
 

--- a/pkg/kubectl/cmd/convert.go
+++ b/pkg/kubectl/cmd/convert.go
@@ -167,7 +167,7 @@ func (o *ConvertOptions) RunConvert() error {
 		}
 
 		infos := []*resource.Info{info}
-		objects, err := resource.AsVersionedObject(infos, false, o.outputVersion.String(), o.encoder)
+		objects, err := resource.AsVersionedObject(infos, false, o.outputVersion, o.encoder)
 		if err != nil {
 			return err
 		}

--- a/pkg/kubectl/cmd/edit.go
+++ b/pkg/kubectl/cmd/edit.go
@@ -182,7 +182,7 @@ func RunEdit(f *cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args
 	if err != nil {
 		return err
 	}
-	objs, err := resource.AsVersionedObjects(infos, defaultVersion.String(), encoder)
+	objs, err := resource.AsVersionedObjects(infos, defaultVersion, encoder)
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -246,7 +246,7 @@ func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string
 		if err != nil {
 			return err
 		}
-		obj, err := resource.AsVersionedObject(infos, !singular, version.String(), f.JSONEncoder())
+		obj, err := resource.AsVersionedObject(infos, !singular, version, f.JSONEncoder())
 		if err != nil {
 			return err
 		}
@@ -273,7 +273,7 @@ func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string
 		}
 
 		for ix := range infos {
-			objs[ix], err = infos[ix].Mapping.ConvertToVersion(infos[ix].Object, version.String())
+			objs[ix], err = infos[ix].Mapping.ConvertToVersion(infos[ix].Object, version)
 			if err != nil {
 				allErrs = append(allErrs, err)
 				continue

--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -246,7 +246,7 @@ func RunLabel(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []stri
 			}
 			outputObj = info.Object
 		} else {
-			obj, err := info.Mapping.ConvertToVersion(info.Object, info.Mapping.GroupVersionKind.GroupVersion().String())
+			obj, err := info.Mapping.ConvertToVersion(info.Object, info.Mapping.GroupVersionKind.GroupVersion())
 			if err != nil {
 				return err
 			}

--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -182,7 +182,7 @@ func (p *VersionedPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 		if version.IsEmpty() {
 			continue
 		}
-		converted, err := p.convertor.ConvertToVersion(obj, version.String())
+		converted, err := p.convertor.ConvertToVersion(obj, version)
 		if runtime.IsNotRegisteredError(err) {
 			continue
 		}

--- a/pkg/kubectl/resource_printer_test.go
+++ b/pkg/kubectl/resource_printer_test.go
@@ -105,7 +105,7 @@ func TestPrinter(t *testing.T) {
 		},
 	}
 	emptyListTest := &api.PodList{}
-	testapi, err := api.Scheme.ConvertToVersion(podTest, testapi.Default.GroupVersion().String())
+	testapi, err := api.Scheme.ConvertToVersion(podTest, *testapi.Default.GroupVersion())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/registry/thirdpartyresourcedata/codec.go
+++ b/pkg/registry/thirdpartyresourcedata/codec.go
@@ -40,7 +40,7 @@ type thirdPartyObjectConverter struct {
 	converter runtime.ObjectConvertor
 }
 
-func (t *thirdPartyObjectConverter) ConvertToVersion(in runtime.Object, outVersion string) (out runtime.Object, err error) {
+func (t *thirdPartyObjectConverter) ConvertToVersion(in runtime.Object, outVersion unversioned.GroupVersion) (out runtime.Object, err error) {
 	switch in.(type) {
 	// This seems weird, but in this case the ThirdPartyResourceData is really just a wrapper on the raw 3rd party data.
 	// The actual thing printed/sent to server is the actual raw third party resource data, which only has one version.

--- a/pkg/runtime/codec.go
+++ b/pkg/runtime/codec.go
@@ -162,7 +162,7 @@ func (c *parameterCodec) EncodeParameters(obj Object, to unversioned.GroupVersio
 		return nil, err
 	}
 	if to != gvk.GroupVersion() {
-		out, err := c.convertor.ConvertToVersion(obj, to.String())
+		out, err := c.convertor.ConvertToVersion(obj, to)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/runtime/interfaces.go
+++ b/pkg/runtime/interfaces.go
@@ -161,7 +161,7 @@ type StorageSerializer interface {
 // Non-codec interfaces
 
 type ObjectVersioner interface {
-	ConvertToVersion(in Object, outVersion string) (out Object, err error)
+	ConvertToVersion(in Object, outVersion unversioned.GroupVersion) (out Object, err error)
 }
 
 // ObjectConvertor converts an object to a different version.
@@ -171,7 +171,7 @@ type ObjectConvertor interface {
 	Convert(in, out interface{}) error
 	// ConvertToVersion takes the provided object and converts it the provided version. This
 	// method does not guarantee that the in object is not mutated.
-	ConvertToVersion(in Object, outVersion string) (out Object, err error)
+	ConvertToVersion(in Object, outVersion unversioned.GroupVersion) (out Object, err error)
 	ConvertFieldLabel(version, kind, label, value string) (string, string, error)
 }
 

--- a/pkg/runtime/register.go
+++ b/pkg/runtime/register.go
@@ -21,12 +21,12 @@ import (
 )
 
 // SetGroupVersionKind satisfies the ObjectKind interface for all objects that embed TypeMeta
-func (obj *TypeMeta) SetGroupVersionKind(gvk *unversioned.GroupVersionKind) {
+func (obj *TypeMeta) SetGroupVersionKind(gvk unversioned.GroupVersionKind) {
 	obj.APIVersion, obj.Kind = gvk.ToAPIVersionAndKind()
 }
 
 // GroupVersionKind satisfies the ObjectKind interface for all objects that embed TypeMeta
-func (obj *TypeMeta) GroupVersionKind() *unversioned.GroupVersionKind {
+func (obj *TypeMeta) GroupVersionKind() unversioned.GroupVersionKind {
 	return unversioned.FromAPIVersionAndKind(obj.APIVersion, obj.Kind)
 }
 

--- a/pkg/runtime/scheme.go
+++ b/pkg/runtime/scheme.go
@@ -535,9 +535,9 @@ func (s *Scheme) generateConvertMeta(srcGroupVersion, destGroupVersion unversion
 func setTargetVersion(obj Object, raw *Scheme, gv unversioned.GroupVersion) {
 	if gv.Version == APIVersionInternal {
 		// internal is a special case
-		obj.GetObjectKind().SetGroupVersionKind(nil)
-	} else {
-		gvk, _ := raw.ObjectKind(obj)
-		obj.GetObjectKind().SetGroupVersionKind(&unversioned.GroupVersionKind{Group: gv.Group, Version: gv.Version, Kind: gvk.Kind})
+		obj.GetObjectKind().SetGroupVersionKind(unversioned.GroupVersionKind{})
+		return
 	}
+	gvk, _ := raw.ObjectKind(obj)
+	obj.GetObjectKind().SetGroupVersionKind(unversioned.GroupVersionKind{Group: gv.Group, Version: gv.Version, Kind: gvk.Kind})
 }

--- a/pkg/runtime/scheme.go
+++ b/pkg/runtime/scheme.go
@@ -124,11 +124,8 @@ func (s *Scheme) nameFunc(t reflect.Type) string {
 
 // fromScope gets the input version, desired output version, and desired Scheme
 // from a conversion.Scope.
-func (s *Scheme) fromScope(scope conversion.Scope) (inVersion, outVersion string, scheme *Scheme) {
-	scheme = s
-	inVersion = scope.Meta().SrcVersion
-	outVersion = scope.Meta().DestVersion
-	return inVersion, outVersion, scheme
+func (s *Scheme) fromScope(scope conversion.Scope) *Scheme {
+	return s
 }
 
 // Converter allows access to the converter for the scheme
@@ -532,10 +529,7 @@ func (s *Scheme) ConvertToVersion(in Object, outVersion string) (Object, error) 
 
 // generateConvertMeta constructs the meta value we pass to Convert.
 func (s *Scheme) generateConvertMeta(srcGroupVersion, destGroupVersion unversioned.GroupVersion, in interface{}) (conversion.FieldMatchingFlags, *conversion.Meta) {
-	flags, meta := s.converter.DefaultMeta(reflect.TypeOf(in))
-	meta.SrcVersion = srcGroupVersion.String()
-	meta.DestVersion = destGroupVersion.String()
-	return flags, meta
+	return s.converter.DefaultMeta(reflect.TypeOf(in))
 }
 
 func setTargetVersion(obj Object, raw *Scheme, gv unversioned.GroupVersion) {

--- a/pkg/runtime/scheme_test.go
+++ b/pkg/runtime/scheme_test.go
@@ -65,24 +65,12 @@ func TestScheme(t *testing.T) {
 	// Register functions to verify that scope.Meta() gets set correctly.
 	err := scheme.AddConversionFuncs(
 		func(in *InternalSimple, out *ExternalSimple, scope conversion.Scope) error {
-			if e, a := internalGV.String(), scope.Meta().SrcVersion; e != a {
-				t.Errorf("Expected '%v', got '%v'", e, a)
-			}
-			if e, a := externalGV.String(), scope.Meta().DestVersion; e != a {
-				t.Errorf("Expected '%v', got '%v'", e, a)
-			}
 			scope.Convert(&in.TypeMeta, &out.TypeMeta, 0)
 			scope.Convert(&in.TestString, &out.TestString, 0)
 			internalToExternalCalls++
 			return nil
 		},
 		func(in *ExternalSimple, out *InternalSimple, scope conversion.Scope) error {
-			if e, a := externalGV.String(), scope.Meta().SrcVersion; e != a {
-				t.Errorf("Expected '%v', got '%v'", e, a)
-			}
-			if e, a := internalGV.String(), scope.Meta().DestVersion; e != a {
-				t.Errorf("Expected '%v', got '%v'", e, a)
-			}
 			scope.Convert(&in.TypeMeta, &out.TypeMeta, 0)
 			scope.Convert(&in.TestString, &out.TestString, 0)
 			externalToInternalCalls++
@@ -472,10 +460,10 @@ type ExternalInternalSame struct {
 }
 
 func (obj *MyWeirdCustomEmbeddedVersionKindField) GetObjectKind() unversioned.ObjectKind { return obj }
-func (obj *MyWeirdCustomEmbeddedVersionKindField) SetGroupVersionKind(gvk *unversioned.GroupVersionKind) {
+func (obj *MyWeirdCustomEmbeddedVersionKindField) SetGroupVersionKind(gvk unversioned.GroupVersionKind) {
 	obj.APIVersion, obj.ObjectKind = gvk.ToAPIVersionAndKind()
 }
-func (obj *MyWeirdCustomEmbeddedVersionKindField) GroupVersionKind() *unversioned.GroupVersionKind {
+func (obj *MyWeirdCustomEmbeddedVersionKindField) GroupVersionKind() unversioned.GroupVersionKind {
 	return unversioned.FromAPIVersionAndKind(obj.APIVersion, obj.ObjectKind)
 }
 

--- a/pkg/runtime/scheme_test.go
+++ b/pkg/runtime/scheme_test.go
@@ -530,7 +530,7 @@ func TestKnownTypes(t *testing.T) {
 func TestConvertToVersion(t *testing.T) {
 	s := GetTestScheme()
 	tt := &TestType1{A: "I'm not a pointer object"}
-	other, err := s.ConvertToVersion(tt, "v1")
+	other, err := s.ConvertToVersion(tt, unversioned.GroupVersion{Version: "v1"})
 	if err != nil {
 		t.Fatalf("Failure: %v", err)
 	}
@@ -578,12 +578,12 @@ func TestMetaValues(t *testing.T) {
 
 	s.Log(t)
 
-	out, err := s.ConvertToVersion(simple, externalGV.String())
+	out, err := s.ConvertToVersion(simple, externalGV)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	internal, err := s.ConvertToVersion(out, internalGV.String())
+	internal, err := s.ConvertToVersion(out, internalGV)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/runtime/scheme_test.go
+++ b/pkg/runtime/scheme_test.go
@@ -570,24 +570,12 @@ func TestMetaValues(t *testing.T) {
 	err := s.AddConversionFuncs(
 		func(in *InternalSimple, out *ExternalSimple, scope conversion.Scope) error {
 			t.Logf("internal -> external")
-			if e, a := internalGV.String(), scope.Meta().SrcVersion; e != a {
-				t.Fatalf("Expected '%v', got '%v'", e, a)
-			}
-			if e, a := externalGV.String(), scope.Meta().DestVersion; e != a {
-				t.Fatalf("Expected '%v', got '%v'", e, a)
-			}
 			scope.Convert(&in.TestString, &out.TestString, 0)
 			internalToExternalCalls++
 			return nil
 		},
 		func(in *ExternalSimple, out *InternalSimple, scope conversion.Scope) error {
 			t.Logf("external -> internal")
-			if e, a := externalGV.String(), scope.Meta().SrcVersion; e != a {
-				t.Errorf("Expected '%v', got '%v'", e, a)
-			}
-			if e, a := internalGV.String(), scope.Meta().DestVersion; e != a {
-				t.Fatalf("Expected '%v', got '%v'", e, a)
-			}
 			scope.Convert(&in.TestString, &out.TestString, 0)
 			externalToInternalCalls++
 			return nil
@@ -643,12 +631,6 @@ func TestMetaValuesUnregisteredConvert(t *testing.T) {
 	// Register functions to verify that scope.Meta() gets set correctly.
 	err := s.AddConversionFuncs(
 		func(in *InternalSimple, out *ExternalSimple, scope conversion.Scope) error {
-			if e, a := "unknown/unknown", scope.Meta().SrcVersion; e != a {
-				t.Fatalf("Expected '%v', got '%v'", e, a)
-			}
-			if e, a := "unknown/unknown", scope.Meta().DestVersion; e != a {
-				t.Fatalf("Expected '%v', got '%v'", e, a)
-			}
 			scope.Convert(&in.TestString, &out.TestString, 0)
 			internalToExternalCalls++
 			return nil

--- a/pkg/runtime/serializer/codec_test.go
+++ b/pkg/runtime/serializer/codec_test.go
@@ -129,10 +129,10 @@ var TestObjectFuzzer = fuzz.New().NilChance(.5).NumElements(1, 100).Funcs(
 )
 
 func (obj *MyWeirdCustomEmbeddedVersionKindField) GetObjectKind() unversioned.ObjectKind { return obj }
-func (obj *MyWeirdCustomEmbeddedVersionKindField) SetGroupVersionKind(gvk *unversioned.GroupVersionKind) {
+func (obj *MyWeirdCustomEmbeddedVersionKindField) SetGroupVersionKind(gvk unversioned.GroupVersionKind) {
 	obj.APIVersion, obj.ObjectKind = gvk.ToAPIVersionAndKind()
 }
-func (obj *MyWeirdCustomEmbeddedVersionKindField) GroupVersionKind() *unversioned.GroupVersionKind {
+func (obj *MyWeirdCustomEmbeddedVersionKindField) GroupVersionKind() unversioned.GroupVersionKind {
 	return unversioned.FromAPIVersionAndKind(obj.APIVersion, obj.ObjectKind)
 }
 

--- a/pkg/runtime/serializer/json/json.go
+++ b/pkg/runtime/serializer/json/json.go
@@ -111,7 +111,7 @@ func (s *Serializer) Decode(originalData []byte, gvk *unversioned.GroupVersionKi
 	if unk, ok := into.(*runtime.Unknown); ok && unk != nil {
 		unk.Raw = originalData
 		unk.ContentType = runtime.ContentTypeJSON
-		unk.GetObjectKind().SetGroupVersionKind(actual)
+		unk.GetObjectKind().SetGroupVersionKind(*actual)
 		return unk, actual, nil
 	}
 

--- a/pkg/runtime/serializer/json/json_test.go
+++ b/pkg/runtime/serializer/json/json_test.go
@@ -31,12 +31,12 @@ import (
 type testDecodable struct {
 	Other string
 	Value int `json:"value"`
-	gvk   *unversioned.GroupVersionKind
+	gvk   unversioned.GroupVersionKind
 }
 
-func (d *testDecodable) GetObjectKind() unversioned.ObjectKind                 { return d }
-func (d *testDecodable) SetGroupVersionKind(gvk *unversioned.GroupVersionKind) { d.gvk = gvk }
-func (d *testDecodable) GroupVersionKind() *unversioned.GroupVersionKind       { return d.gvk }
+func (d *testDecodable) GetObjectKind() unversioned.ObjectKind                { return d }
+func (d *testDecodable) SetGroupVersionKind(gvk unversioned.GroupVersionKind) { d.gvk = gvk }
+func (d *testDecodable) GroupVersionKind() unversioned.GroupVersionKind       { return d.gvk }
 
 func TestDecode(t *testing.T) {
 	testCases := []struct {
@@ -76,34 +76,28 @@ func TestDecode(t *testing.T) {
 			errFn:       func(err error) bool { return err.Error() == "fake error" },
 		},
 		{
-			data:       []byte("{}"),
-			defaultGVK: &unversioned.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
-			creater:    &mockCreater{obj: &testDecodable{}},
-			expectedObject: &testDecodable{
-				gvk: nil, // json serializer does NOT set GVK
-			},
-			expectedGVK: &unversioned.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
+			data:           []byte("{}"),
+			defaultGVK:     &unversioned.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
+			creater:        &mockCreater{obj: &testDecodable{}},
+			expectedObject: &testDecodable{},
+			expectedGVK:    &unversioned.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
 		},
 
 		// version without group is not defaulted
 		{
-			data:       []byte(`{"apiVersion":"blah"}`),
-			defaultGVK: &unversioned.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
-			creater:    &mockCreater{obj: &testDecodable{}},
-			expectedObject: &testDecodable{
-				gvk: nil, // json serializer does NOT set GVK
-			},
-			expectedGVK: &unversioned.GroupVersionKind{Kind: "Test", Group: "", Version: "blah"},
+			data:           []byte(`{"apiVersion":"blah"}`),
+			defaultGVK:     &unversioned.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
+			creater:        &mockCreater{obj: &testDecodable{}},
+			expectedObject: &testDecodable{},
+			expectedGVK:    &unversioned.GroupVersionKind{Kind: "Test", Group: "", Version: "blah"},
 		},
 		// group without version is defaulted
 		{
-			data:       []byte(`{"apiVersion":"other/"}`),
-			defaultGVK: &unversioned.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
-			creater:    &mockCreater{obj: &testDecodable{}},
-			expectedObject: &testDecodable{
-				gvk: nil, // json serializer does NOT set GVK
-			},
-			expectedGVK: &unversioned.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
+			data:           []byte(`{"apiVersion":"other/"}`),
+			defaultGVK:     &unversioned.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
+			creater:        &mockCreater{obj: &testDecodable{}},
+			expectedObject: &testDecodable{},
+			expectedGVK:    &unversioned.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
 		},
 
 		// accept runtime.Unknown as into and bypass creator

--- a/pkg/runtime/serializer/protobuf/protobuf_test.go
+++ b/pkg/runtime/serializer/protobuf/protobuf_test.go
@@ -34,12 +34,12 @@ import (
 )
 
 type testObject struct {
-	gvk *unversioned.GroupVersionKind
+	gvk unversioned.GroupVersionKind
 }
 
-func (d *testObject) GetObjectKind() unversioned.ObjectKind                 { return d }
-func (d *testObject) SetGroupVersionKind(gvk *unversioned.GroupVersionKind) { d.gvk = gvk }
-func (d *testObject) GroupVersionKind() *unversioned.GroupVersionKind       { return d.gvk }
+func (d *testObject) GetObjectKind() unversioned.ObjectKind                { return d }
+func (d *testObject) SetGroupVersionKind(gvk unversioned.GroupVersionKind) { d.gvk = gvk }
+func (d *testObject) GroupVersionKind() unversioned.GroupVersionKind       { return d.gvk }
 
 type testMarshalable struct {
 	testObject
@@ -106,7 +106,7 @@ func TestEncode(t *testing.T) {
 		0x22, 0x00, // content-encoding
 	}
 	obj2 := &testMarshalable{
-		testObject: testObject{gvk: &unversioned.GroupVersionKind{Kind: "test", Group: "other", Version: "version"}},
+		testObject: testObject{gvk: unversioned.GroupVersionKind{Kind: "test", Group: "other", Version: "version"}},
 		data:       []byte{0x01, 0x02, 0x03},
 	}
 	wire2 := []byte{

--- a/pkg/runtime/serializer/versioning/versioning.go
+++ b/pkg/runtime/serializer/versioning/versioning.go
@@ -204,7 +204,7 @@ func (c *codec) Decode(data []byte, defaultGVK *unversioned.GroupVersionKind, in
 	}
 
 	// Convert if needed.
-	out, err := c.convertor.ConvertToVersion(obj, targetGV.String())
+	out, err := c.convertor.ConvertToVersion(obj, targetGV)
 	if err != nil {
 		return nil, gvk, err
 	}
@@ -264,7 +264,7 @@ func (c *codec) EncodeToStream(obj runtime.Object, w io.Writer, overrides ...unv
 
 	// Perform a conversion if necessary
 	if gvk.GroupVersion() != targetGV {
-		out, err := c.convertor.ConvertToVersion(obj, targetGV.String())
+		out, err := c.convertor.ConvertToVersion(obj, targetGV)
 		if err != nil {
 			if ok {
 				return err

--- a/pkg/runtime/serializer/versioning/versioning_test.go
+++ b/pkg/runtime/serializer/versioning/versioning_test.go
@@ -65,12 +65,12 @@ func TestDecode(t *testing.T) {
 	}{
 		{
 			serializer:  &mockSerializer{actual: gvk1},
-			convertor:   &checkConvertor{groupVersion: "other/__internal"},
+			convertor:   &checkConvertor{groupVersion: unversioned.GroupVersion{Group: "other", Version: "__internal"}},
 			expectedGVK: gvk1,
 		},
 		{
 			serializer:  &mockSerializer{actual: gvk1, obj: decodable1},
-			convertor:   &checkConvertor{in: decodable1, obj: decodable2, groupVersion: "other/__internal"},
+			convertor:   &checkConvertor{in: decodable1, obj: decodable2, groupVersion: unversioned.GroupVersion{Group: "other", Version: "__internal"}},
 			expectedGVK: gvk1,
 			sameObject:  decodable2,
 		},
@@ -78,7 +78,7 @@ func TestDecode(t *testing.T) {
 		{
 			serializer:  &mockSerializer{actual: gvk1, obj: decodable1},
 			defaultGVK:  &unversioned.GroupVersionKind{Group: "force"},
-			convertor:   &checkConvertor{in: decodable1, obj: decodable2, groupVersion: "force/__internal"},
+			convertor:   &checkConvertor{in: decodable1, obj: decodable2, groupVersion: unversioned.GroupVersion{Group: "force", Version: "__internal"}},
 			expectedGVK: gvk1,
 			sameObject:  decodable2,
 		},
@@ -118,7 +118,7 @@ func TestDecode(t *testing.T) {
 
 			serializer:     &mockSerializer{actual: gvk1, obj: decodable1},
 			copier:         &checkCopy{in: decodable1, obj: decodable1},
-			convertor:      &checkConvertor{in: decodable1, obj: decodable2, groupVersion: "other/__internal"},
+			convertor:      &checkConvertor{in: decodable1, obj: decodable2, groupVersion: unversioned.GroupVersion{Group: "other", Version: "__internal"}},
 			expectedGVK:    gvk1,
 			expectedObject: &runtime.VersionedObjects{Objects: []runtime.Object{decodable1, decodable2}},
 		},
@@ -127,7 +127,7 @@ func TestDecode(t *testing.T) {
 
 			serializer:     &mockSerializer{actual: gvk1, obj: decodable1},
 			copier:         &checkCopy{in: decodable1, obj: nil, err: fmt.Errorf("error on copy")},
-			convertor:      &checkConvertor{in: decodable1, obj: decodable2, groupVersion: "other/__internal"},
+			convertor:      &checkConvertor{in: decodable1, obj: decodable2, groupVersion: unversioned.GroupVersion{Group: "other", Version: "__internal"}},
 			expectedGVK:    gvk1,
 			expectedObject: &runtime.VersionedObjects{Objects: []runtime.Object{decodable1, decodable2}},
 		},
@@ -228,7 +228,7 @@ func (c *checkCopy) Copy(obj runtime.Object) (runtime.Object, error) {
 type checkConvertor struct {
 	err           error
 	in, obj       runtime.Object
-	groupVersion  string
+	groupVersion  unversioned.GroupVersion
 	directConvert bool
 }
 
@@ -244,7 +244,7 @@ func (c *checkConvertor) Convert(in, out interface{}) error {
 	}
 	return c.err
 }
-func (c *checkConvertor) ConvertToVersion(in runtime.Object, outVersion string) (out runtime.Object, err error) {
+func (c *checkConvertor) ConvertToVersion(in runtime.Object, outVersion unversioned.GroupVersion) (out runtime.Object, err error) {
 	if c.directConvert {
 		return nil, fmt.Errorf("unexpected call to ConvertToVersion")
 	}

--- a/pkg/runtime/serializer/versioning/versioning_test.go
+++ b/pkg/runtime/serializer/versioning/versioning_test.go
@@ -30,12 +30,12 @@ import (
 type testDecodable struct {
 	Other string
 	Value int `json:"value"`
-	gvk   *unversioned.GroupVersionKind
+	gvk   unversioned.GroupVersionKind
 }
 
-func (d *testDecodable) GetObjectKind() unversioned.ObjectKind                 { return d }
-func (d *testDecodable) SetGroupVersionKind(gvk *unversioned.GroupVersionKind) { d.gvk = gvk }
-func (d *testDecodable) GroupVersionKind() *unversioned.GroupVersionKind       { return d.gvk }
+func (d *testDecodable) GetObjectKind() unversioned.ObjectKind                { return d }
+func (d *testDecodable) SetGroupVersionKind(gvk unversioned.GroupVersionKind) { d.gvk = gvk }
+func (d *testDecodable) GroupVersionKind() unversioned.GroupVersionKind       { return d.gvk }
 
 func TestDecode(t *testing.T) {
 	gvk1 := &unversioned.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"}

--- a/pkg/runtime/types.go
+++ b/pkg/runtime/types.go
@@ -301,18 +301,18 @@ func (u *Unstructured) SetAnnotations(annotations map[string]string) {
 	u.setNestedMap(annotations, "metadata", "annotations")
 }
 
-func (u *Unstructured) SetGroupVersionKind(gvk *unversioned.GroupVersionKind) {
+func (u *Unstructured) SetGroupVersionKind(gvk unversioned.GroupVersionKind) {
 	u.SetAPIVersion(gvk.GroupVersion().String())
 	u.SetKind(gvk.Kind)
 }
 
-func (u *Unstructured) GroupVersionKind() *unversioned.GroupVersionKind {
+func (u *Unstructured) GroupVersionKind() unversioned.GroupVersionKind {
 	gv, err := unversioned.ParseGroupVersion(u.GetAPIVersion())
 	if err != nil {
-		return nil
+		return unversioned.GroupVersionKind{}
 	}
 	gvk := gv.WithKind(u.GetKind())
-	return &gvk
+	return gvk
 }
 
 // UnstructuredList allows lists that do not have Golang structs
@@ -364,18 +364,18 @@ func (u *UnstructuredList) SetSelfLink(selfLink string) {
 	u.setNestedField(selfLink, "metadata", "selfLink")
 }
 
-func (u *UnstructuredList) SetGroupVersionKind(gvk *unversioned.GroupVersionKind) {
+func (u *UnstructuredList) SetGroupVersionKind(gvk unversioned.GroupVersionKind) {
 	u.SetAPIVersion(gvk.GroupVersion().String())
 	u.SetKind(gvk.Kind)
 }
 
-func (u *UnstructuredList) GroupVersionKind() *unversioned.GroupVersionKind {
+func (u *UnstructuredList) GroupVersionKind() unversioned.GroupVersionKind {
 	gv, err := unversioned.ParseGroupVersion(u.GetAPIVersion())
 	if err != nil {
-		return nil
+		return unversioned.GroupVersionKind{}
 	}
 	gvk := gv.WithKind(u.GetKind())
-	return &gvk
+	return gvk
 }
 
 // VersionedObjects is used by Decoders to give callers a way to access all versions

--- a/pkg/runtime/unstructured.go
+++ b/pkg/runtime/unstructured.go
@@ -45,10 +45,10 @@ func (s unstructuredJSONScheme) Decode(data []byte, _ *unversioned.GroupVersionK
 
 	gvk := obj.GetObjectKind().GroupVersionKind()
 	if len(gvk.Kind) == 0 {
-		return nil, gvk, NewMissingKindErr(string(data))
+		return nil, &gvk, NewMissingKindErr(string(data))
 	}
 
-	return obj, gvk, nil
+	return obj, &gvk, nil
 }
 
 func (unstructuredJSONScheme) EncodeToStream(obj Object, w io.Writer, overrides ...unversioned.GroupVersion) error {


### PR DESCRIPTION
Cleans up the conversion path to avoid a few unnecessary allocations, then creates a new UnsafeConvertToVersion path that will allow encode/decode to bypass copying the object for performance. In that subsequent PR, ConvertToVersion will start to call Copy() and we will refactor conversions to reuse as much of the existing object as possible.

Also changes the unversioned.ObjectKind signature to not require allocations - speeds up a few common paths.
