### PR TITLE
Support struct,array,slice types when sorting kubectl output

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -1781,6 +1781,7 @@ __EOF__
   kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
   # Command
   kubectl get pods --sort-by="{metadata.name}"
+  kubectl get pods --sort-by="{metadata.creationTimestamp}"
 
   ############################
   # Kubectl --all-namespaces #

--- a/pkg/kubectl/sorting_printer_test.go
+++ b/pkg/kubectl/sorting_printer_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	internal "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	api "k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/runtime"
 )
@@ -143,6 +144,48 @@ func TestSortingPrinter(t *testing.T) {
 				},
 			},
 			field: "{.metadata.name}",
+		},
+		{
+			name: "random-order-timestamp",
+			obj: &api.PodList{
+				Items: []api.Pod{
+					{
+						ObjectMeta: api.ObjectMeta{
+							CreationTimestamp: unversioned.Unix(300, 0),
+						},
+					},
+					{
+						ObjectMeta: api.ObjectMeta{
+							CreationTimestamp: unversioned.Unix(100, 0),
+						},
+					},
+					{
+						ObjectMeta: api.ObjectMeta{
+							CreationTimestamp: unversioned.Unix(200, 0),
+						},
+					},
+				},
+			},
+			sort: &api.PodList{
+				Items: []api.Pod{
+					{
+						ObjectMeta: api.ObjectMeta{
+							CreationTimestamp: unversioned.Unix(100, 0),
+						},
+					},
+					{
+						ObjectMeta: api.ObjectMeta{
+							CreationTimestamp: unversioned.Unix(200, 0),
+						},
+					},
+					{
+						ObjectMeta: api.ObjectMeta{
+							CreationTimestamp: unversioned.Unix(300, 0),
+						},
+					},
+				},
+			},
+			field: "{.metadata.creationTimestamp}",
 		},
 		{
 			name: "random-order-numbers",


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/24328.

Briefly, `sorting_printer` only take cares of the following type kinds:
-   `reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64`
-   `reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64`
-   `reflect.Float32, reflect.Float64`
-   `reflect.String`
-   `reflect.Ptr`

This commit aims to add `reflect.Struct, reflect.Slice, reflect.Array`.

/cc @bgrant0607 
