### PR TITLE
Rename a func in manager.go to avoid confusion

### DIFF
--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -544,7 +544,7 @@ func (dm *DockerManager) runContainer(
 		ContainerName: container.Name,
 	}
 
-	securityOpts, err := dm.defaultSecurityOpt()
+	securityOpts, err := dm.getDefaultSecurityOpt()
 	if err != nil {
 		return kubecontainer.ContainerID{}, err
 	}
@@ -976,7 +976,7 @@ func (dm *DockerManager) checkVersionCompatibility() error {
 	return nil
 }
 
-func (dm *DockerManager) defaultSecurityOpt() ([]string, error) {
+func (dm *DockerManager) getDefaultSecurityOpt() ([]string, error) {
 	version, err := dm.APIVersion()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
There is a global variable and a func with the same name `defaultSecurityOpt` in file `manager.go`. This may cause confusion. So, is it better to change the func name to `getDefaultSecurityOpt`?
