### PR TITLE
Expose progress of docker pull via debugging endpoint

### DIFF
--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -100,6 +100,8 @@ type Runtime interface {
 	// stream the log. Set 'follow' to false and specify the number of lines (e.g.
 	// "100" or "all") to tail the log.
 	GetContainerLogs(pod *api.Pod, containerID ContainerID, logOptions *api.PodLogOptions, stdout, stderr io.Writer) (err error)
+	// Gets or watches the progress of an image pull
+	GetImagePullProgress(image ImageSpec, watch bool, w io.Writer) error
 	// ContainerCommandRunner encapsulates the command runner interfaces for testability.
 	ContainerCommandRunner
 	// ContainerAttach encapsulates the attaching to containers for testability

--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -313,6 +313,19 @@ func (f *FakeRuntime) IsImagePresent(image ImageSpec) (bool, error) {
 	return false, f.InspectErr
 }
 
+func (f *FakeRuntime) GetImagePullProgress(image ImageSpec, watch bool, w io.Writer) error {
+	f.Lock()
+	defer f.Unlock()
+
+	f.CalledFunctions = append(f.CalledFunctions, "GetImagePullProgress")
+	for _, i := range f.ImageList {
+		if i.ID == image.Image {
+			return nil
+		}
+	}
+	return f.InspectErr
+}
+
 func (f *FakeRuntime) ListImages() ([]Image, error) {
 	f.Lock()
 	defer f.Unlock()

--- a/pkg/kubelet/container/testing/runtime_mock.go
+++ b/pkg/kubelet/container/testing/runtime_mock.go
@@ -118,6 +118,11 @@ func (r *Mock) IsImagePresent(image ImageSpec) (bool, error) {
 	return args.Get(0).(bool), args.Error(1)
 }
 
+func (r *Mock) GetImagePullProgress(image ImageSpec, watch bool, w io.Writer) error {
+	args := r.Called(image, watch, w)
+	return args.Error(0)
+}
+
 func (r *Mock) ListImages() ([]Image, error) {
 	args := r.Called()
 	return args.Get(0).([]Image), args.Error(1)

--- a/pkg/kubelet/dockertools/fake_docker_client.go
+++ b/pkg/kubelet/dockertools/fake_docker_client.go
@@ -25,6 +25,7 @@ import (
 	"sort"
 	"sync"
 	"time"
+	"io"
 
 	dockertypes "github.com/docker/engine-api/types"
 	dockercontainer "github.com/docker/engine-api/types/container"
@@ -422,7 +423,7 @@ func (f *FakeDockerClient) Logs(id string, opts dockertypes.ContainerLogsOptions
 
 // PullImage is a test-spy implementation of DockerInterface.PullImage.
 // It adds an entry "pull" to the internal method call record.
-func (f *FakeDockerClient) PullImage(imageID string, auth dockertypes.AuthConfig, opts dockertypes.ImagePullOptions) error {
+func (f *FakeDockerClient) PullImage(imageID string, auth dockertypes.AuthConfig, opts dockertypes.ImagePullOptions) (io.ReadCloser, error) {
 	f.Lock()
 	defer f.Unlock()
 	f.called = append(f.called, "pull")
@@ -431,7 +432,7 @@ func (f *FakeDockerClient) PullImage(imageID string, auth dockertypes.AuthConfig
 		authJson, _ := json.Marshal(auth)
 		f.pulled = append(f.pulled, fmt.Sprintf("%s:%s using %s", imageID, opts.Tag, string(authJson)))
 	}
-	return err
+	return nil, err
 }
 
 func (f *FakeDockerClient) Version() (*dockertypes.Version, error) {
@@ -551,4 +552,10 @@ func (f *FakeDockerClient) InjectImageHistory(data map[string][]dockertypes.Imag
 // dockerTimestampToString converts the timestamp to string
 func dockerTimestampToString(t time.Time) string {
 	return t.Format(time.RFC3339Nano)
+}
+
+func (f *FakeDockerPuller) GetPullProgress(image string, watch bool, out io.Writer) error {
+	f.Lock()
+	defer f.Unlock()
+	return nil
 }

--- a/pkg/kubelet/dockertools/image_pull_status.go
+++ b/pkg/kubelet/dockertools/image_pull_status.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockertools
+
+import (
+	"fmt"
+	"io"
+	"github.com/golang/glog"
+	"encoding/json"
+	"strings"
+	"sync"
+)
+
+// Current and total number of bytes downloaded
+type DockerProgressDetail struct {
+	Current int64 `json:"current"`
+	Total int64 `json:"total"`
+}
+
+// Message that Docker produces indicating progress of an image pull, error is usually absent
+type DockerProgressMessage struct {
+	Status string `json:"status"`
+	Err string `json:"error"`
+	Id string `json:"id"`
+	Progress string `json:"progress"`
+	Detail DockerProgressDetail `json:"progressDetail"`
+}
+
+// Message that we send to clients querying the pull status
+// This is just for one layer, we send an array of these
+type LayerProgress struct {
+	Id string `json:"id"`
+	State string `json:"state"`
+	Current int64 `json:"current"`
+	Total int64 `json:"total"`
+}
+
+// Internal struct used to track a watching client
+type watcher struct {
+	w io.Writer
+	finished chan bool
+	err error
+}
+
+// The status of an image pull:
+// Layers is the status of each layer in the image
+// lock is a lock used to ensure that clients don't get garbled or partial updates
+// watchers is a list of all the clients currently watching: a linked list would be more natural as we could easily remove aborted connections - for now we just skip them
+type ImagePullStatus struct {
+	Layers []*LayerProgress `json:"layers"`
+	lock sync.Mutex
+	watchers []*watcher
+}
+
+// Create an empty ImagePullStatus object
+func NewImagePullStatus() *ImagePullStatus {
+	return &ImagePullStatus {
+		Layers: nil,
+		watchers: nil,
+	}
+}
+
+// Allows a client to watch the pull status
+func (ips *ImagePullStatus) Watch(w io.Writer) error {
+	watcher := watcher{
+		w: w,
+		finished: make(chan bool),
+		err: ips.Get(w), // ensure they are up-to-date
+	}
+	// Lock before appending to the list, as another thread may be iterating over it
+	ips.lock.Lock()
+	ips.watchers = append(ips.watchers, &watcher)
+	ips.lock.Unlock()
+	// Block until the download is finished
+	// The client will be sent updates by the MonitorPull function as they arrive from docker
+	_ = <- watcher.finished
+	return watcher.err
+}
+
+// Get a snapshot of the current state of the image pull
+func (ips *ImagePullStatus) Get(w io.Writer) error {
+	// Lock here so that we don't get a partial status
+	ips.lock.Lock()
+	js, err := json.Marshal(ips)
+	ips.lock.Unlock()
+	if err != nil {
+		return err
+	}
+	// Write the status to the client
+	_, err = fmt.Fprintf(w, "%s\n", js)
+	return err
+}
+
+// Listen to a stream from docker and send updates to clients
+func (ips *ImagePullStatus) MonitorPull(r io.ReadCloser)  {
+	defer r.Close()
+	// To decode status updates from docker
+	decoder := json.NewDecoder(r)
+	for {
+		// Get the latest message
+		var msg DockerProgressMessage
+		err := decoder.Decode(&msg)
+		if err != nil {
+			glog.Errorf("%v\n", err)
+			break
+		}
+
+		// This is the status seen when initiating a pull: it doesn't actually tell us anything useful
+		if strings.HasPrefix(msg.Status, "Pulling from") {
+			continue
+		}
+
+		updatedLayer := false
+
+		ips.lock.Lock()
+
+		// Attempt to find & update the layer in question
+		for _, layer := range ips.Layers {
+			if layer.Id == msg.Id {
+				layer.State = msg.Status
+				layer.Current = msg.Detail.Current
+				layer.Total = msg.Detail.Total
+				updatedLayer = true
+				break
+			}
+		}
+
+		// If we didn't find the layer then we need to add a new one
+		if !updatedLayer {
+			if msg.Id != "" {
+				newLayer := LayerProgress {
+					Id: msg.Id,
+					State: msg.Status,
+					Current: msg.Detail.Current,
+					Total: msg.Detail.Total,
+				}
+				ips.Layers = append(ips.Layers, &newLayer)
+			}
+		}
+
+		// Prepare to send out update
+		js, err := json.Marshal(ips)
+		if err != nil {
+			glog.Errorf("%v\n", err)
+			// Unlock here, otherwise the loop will terminate without releasing the lock
+			// This condition will only happen if the stream is corrupted or the connection is broken
+			ips.lock.Unlock()
+			break;
+		}
+
+		// Send the update to all watchers
+		for _, w := range(ips.watchers) {
+			// Skip watchers that have already failed
+			if w.err == nil {
+				_, w.err = fmt.Fprintf(w.w, "%s\n", js)
+			}
+		}
+
+		ips.lock.Unlock()
+
+		if strings.HasPrefix(msg.Status, "Status:") {
+			// Pull is complete
+			break
+		}
+	}
+
+	// Tell everybody that we finished
+	ips.lock.Lock()
+	for _, w := range(ips.watchers) {
+		w.finished <- true
+	}
+	ips.lock.Unlock()
+}

--- a/pkg/kubelet/dockertools/instrumented_docker.go
+++ b/pkg/kubelet/dockertools/instrumented_docker.go
@@ -18,6 +18,7 @@ package dockertools
 
 import (
 	"time"
+	"io"
 
 	dockertypes "github.com/docker/engine-api/types"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
@@ -120,12 +121,12 @@ func (in instrumentedDockerInterface) ListImages(opts dockertypes.ImageListOptio
 	return out, err
 }
 
-func (in instrumentedDockerInterface) PullImage(imageID string, auth dockertypes.AuthConfig, opts dockertypes.ImagePullOptions) error {
+func (in instrumentedDockerInterface) PullImage(imageID string, auth dockertypes.AuthConfig, opts dockertypes.ImagePullOptions) (io.ReadCloser, error) {
 	const operation = "pull_image"
 	defer recordOperation(operation, time.Now())
-	err := in.client.PullImage(imageID, auth, opts)
+	resp, err := in.client.PullImage(imageID, auth, opts)
 	recordError(operation, err)
-	return err
+	return resp, err
 }
 
 func (in instrumentedDockerInterface) RemoveImage(image string, opts dockertypes.ImageRemoveOptions) ([]dockertypes.ImageDelete, error) {

--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -304,6 +304,10 @@ func (dm *DockerManager) GetContainerLogs(pod *api.Pod, containerID kubecontaine
 	return
 }
 
+func (dm *DockerManager) GetImagePullProgress(image kubecontainer.ImageSpec, watch bool, stdout io.Writer) error {
+	return dm.dockerPuller.GetPullProgress(image.Image, watch, stdout)
+}
+
 var (
 	// ErrNoContainersInPod is returned when there are no containers for a given pod
 	ErrNoContainersInPod = errors.New("NoContainersInPod")

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2861,6 +2861,30 @@ func (kl *Kubelet) GetKubeletContainerLogs(podFullName, containerName string, lo
 	return kl.containerRuntime.GetContainerLogs(pod, containerID, logOptions, stdout, stderr)
 }
 
+func (kl *Kubelet) GetKubeletContainerImageProgress(namespace, podName, containerName string, watch bool, w io.Writer) error {
+	pod, ok := kl.GetPodByName(namespace, podName)
+	if !ok {
+		return fmt.Errorf("unable to find pod %q in namespace %q", podName, namespace)
+	}
+
+	var container *api.Container
+	container = nil
+	for _, c := range(pod.Spec.Containers) {
+		if c.Name == containerName {
+			container = &c
+			break
+		}
+	}
+	if container == nil {
+		return fmt.Errorf("unable to find container %q in pod %q in namespace %q", containerName, podName, namespace)
+	}
+
+	img := kubecontainer.ImageSpec {
+		Image: container.Image,
+	}
+	return kl.containerRuntime.GetImagePullProgress(img, watch, w)
+}
+
 // GetHostname Returns the hostname as the kubelet sees it.
 func (kl *Kubelet) GetHostname() string {
 	return kl.hostname

--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -1774,3 +1774,8 @@ func (r *Runtime) GetPodStatus(uid types.UID, name, namespace string) (*kubecont
 func (r *Runtime) ImageStats() (*kubecontainer.ImageStats, error) {
 	return &kubecontainer.ImageStats{}, nil
 }
+
+// FIXME: I need to be implemented
+func (r *Runtime) GetImagePullProgress(image kubecontainer.ImageSpec, watch bool, w io.Writer) error {
+	return nil
+}


### PR DESCRIPTION
Clients may request <debug-address>/<namespace>/<pod>/<container> to get the pull status of images required by that container.

Optionally, the progress may be monitored by adding ?watch

The response is a JSON object (or stream thereof). The structure of which is:
{
  "layers" : [
    {
      "id" : "<image_name>/<tag>",
      "state" : "<pulling/complete/waiting/whatever else docker might use>",
      "current" : <bytes pulled>,
      "total" : <bytes to pull in total>,
    },
    ...
  ]
}

If the pull is already complete, then the response is simply:
{ "status" : "Pull Complete" }

An "error" field will be present if an error occured.
