### PR TITLE
Display line number on JSON errors

### DIFF
--- a/pkg/util/yaml/decoder.go
+++ b/pkg/util/yaml/decoder.go
@@ -20,7 +20,10 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
+	"io/ioutil"
+	"strings"
 	"unicode"
 
 	"github.com/ghodss/yaml"
@@ -203,7 +206,20 @@ func (d *YAMLOrJSONDecoder) Decode(into interface{}) error {
 			d.decoder = NewYAMLToJSONDecoder(buffer)
 		}
 	}
-	return d.decoder.Decode(into)
+	err := d.decoder.Decode(into)
+	if jsonDecoder, ok := d.decoder.(*json.Decoder); ok {
+		if syntax, ok := err.(*json.SyntaxError); ok {
+			data, readErr := ioutil.ReadAll(jsonDecoder.Buffered())
+			if readErr != nil {
+				glog.V(4).Infof("reading stream failed: %v", readErr)
+			}
+			js := string(data)
+			start := strings.LastIndex(js[:syntax.Offset], "\n") + 1
+			line := strings.Count(js[:start], "\n")
+			return fmt.Errorf("json: line %d: %s", line, syntax.Error())
+		}
+	}
+	return err
 }
 
 // GuessJSONStream scans the provided reader up to size, looking


### PR DESCRIPTION
Related issue: https://github.com/kubernetes/kubernetes/issues/12231

This PR will introduce line numbers for all JSON errors in the CLI:

(this is existing error reporting for YAML)

``` console
$ kubectl create -f broken.yaml
yaml: line 8: mapping values are not allowed in this context
```

(this is error reporting proposed in this PR for JSON)

``` console
$ kubectl create -f broken.json
json: line 35: invalid character '{' after object key
```

(and this is the current reporting:)

``` console
$ kubectl create -f broken.json
invalid character '{' after object key
```

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
