### PR TITLE
expose: bump service name length to 63 characters

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -1440,13 +1440,13 @@ __EOF__
 
   ### Try to generate a service with invalid name (exceeding maximum valid size)
   # Pre-condition: use --name flag
-  output_message=$(! kubectl expose -f hack/testdata/pod-with-large-name.yaml --name=invalid-large-service-name --port=8081 2>&1 "${kube_flags[@]}")
+  output_message=$(! kubectl expose -f hack/testdata/pod-with-large-name.yaml --name=invalid-large-service-name-that-has-more-than-63-characters --port=8081 2>&1 "${kube_flags[@]}")
   # Post-condition: should fail due to invalid name
   kube::test::if_has_string "${output_message}" 'metadata.name: Invalid value'
   # Pre-condition: default run without --name flag; should succeed by truncating the inherited name
   output_message=$(kubectl expose -f hack/testdata/pod-with-large-name.yaml --port=8081 2>&1 "${kube_flags[@]}")
   # Post-condition: inherited name from pod has been truncated
-  kube::test::if_has_string "${output_message}" '\"kubernetes-serve-hostnam\" exposed'
+  kube::test::if_has_string "${output_message}" '\"kubernetes-serve-hostname-testing-sixty-three-characters-in-len\" exposed'
   # Clean-up
   kubectl delete svc kubernetes-serve-hostnam "${kube_flags[@]}"
 

--- a/hack/testdata/pod-with-large-name.yaml
+++ b/hack/testdata/pod-with-large-name.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: kubernetes-serve-hostname
+  name: kubernetes-serve-hostname-testing-sixty-three-characters-in-length
   labels:
-    name: kubernetes-serve-hostname
+    name: kubernetes-serve-hostname-testing-sixty-three-characters-in-length
 spec:
   containers:
-  - name: kubernetes-serve-hostname
+  - name: kubernetes-serve-hostname-testing-sixty-three-characters-in-length
     image: gcr.io/google_containers/serve_hostname:v1.4

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -178,7 +178,7 @@ func ValidateReplicationControllerName(name string, prefix bool) (bool, string) 
 // Prefix indicates this name will be used as part of generation, in which case
 // trailing dashes are allowed.
 func ValidateServiceName(name string, prefix bool) (bool, string) {
-	return NameIsDNS952Label(name, prefix)
+	return NameIsDNS1123Label(name, prefix)
 }
 
 // ValidateNodeName can be used to check whether the given node name is valid.

--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -50,7 +50,7 @@ Looks up a deployment, service, replica set, replication controller or pod by na
 for that resource as the selector for a new service on the specified port. A deployment or replica set
 will be exposed as a service only if its selector is convertible to a selector that service supports,
 i.e. when the selector contains only the matchLabels component. Note that if no port is specified via
---port and the exposed resource has multiple ports, all will be re-used by the new service. Also if no 
+--port and the exposed resource has multiple ports, all will be re-used by the new service. Also if no
 labels are specified, the new service will re-use the labels from the resource it exposes.
 
 Possible resources include (case insensitive):` + expose_resources
@@ -166,8 +166,8 @@ func RunExpose(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []str
 
 		params := kubectl.MakeParams(cmd, names)
 		name := info.Name
-		if len(name) > validation.DNS952LabelMaxLength {
-			name = name[:validation.DNS952LabelMaxLength]
+		if len(name) > validation.DNS1123LabelMaxLength {
+			name = name[:validation.DNS1123LabelMaxLength]
 		}
 		params["default-name"] = name
 

--- a/pkg/kubectl/cmd/expose_test.go
+++ b/pkg/kubectl/cmd/expose_test.go
@@ -230,7 +230,7 @@ func TestRunExposeService(t *testing.T) {
 		},
 		{
 			name: "truncate-name",
-			args: []string{"pod", "a-name-that-is-toooo-big-for-a-service"},
+			args: []string{"pod", "a-name-that-is-toooo-big-for-a-service-because-it-can-only-handle-63-characters"},
 			ns:   "test",
 			calls: map[string]string{
 				"GET":  "/namespaces/test/pods/a-name-that-is-toooo-big-for-a-service",
@@ -241,7 +241,7 @@ func TestRunExposeService(t *testing.T) {
 			},
 			flags: map[string]string{"selector": "svc=frompod", "port": "90", "labels": "svc=frompod", "generator": "service/v2"},
 			output: &api.Service{
-				ObjectMeta: api.ObjectMeta{Name: "a-name-that-is-toooo-big", Namespace: "", Labels: map[string]string{"svc": "frompod"}},
+				ObjectMeta: api.ObjectMeta{Name: "a-name-that-is-toooo-big-for-a-service-because-it-can-only-hand", Namespace: "", Labels: map[string]string{"svc": "frompod"}},
 				Spec: api.ServiceSpec{
 					Ports: []api.ServicePort{
 						{
@@ -253,7 +253,7 @@ func TestRunExposeService(t *testing.T) {
 					Selector: map[string]string{"svc": "frompod"},
 				},
 			},
-			expected: "service \"a-name-that-is-toooo-big\" exposed",
+			expected: "service \"a-name-that-is-toooo-big-for-a-service-because-it-can-only-hand\" exposed",
 			status:   200,
 		},
 		{

--- a/pkg/kubelet/envvars/envvars.go
+++ b/pkg/kubelet/envvars/envvars.go
@@ -18,6 +18,7 @@ package envvars
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -60,11 +61,16 @@ func FromServices(services *api.ServiceList) []api.EnvVar {
 }
 
 func makeEnvVariableName(str string) string {
-	// TODO: If we simplify to "all names are DNS1123Subdomains" this
-	// will need two tweaks:
-	//   1) Handle leading digits
-	//   2) Handle dots
-	return strings.ToUpper(strings.Replace(str, "-", "_", -1))
+	envVarName := strings.ToUpper(strings.Replace(strings.Replace(str, ".", "_", -1), "-", "_", -1))
+	if startsWithInt(envVarName) {
+		envVarName = "_" + envVarName
+	}
+	return envVarName
+}
+
+func startsWithInt(str string) bool {
+	match, _ := regexp.MatchString("^[0-9]", str)
+	return match
 }
 
 func makeLinkVariables(service *api.Service) []api.EnvVar {

--- a/pkg/kubelet/envvars/envvars_test.go
+++ b/pkg/kubelet/envvars/envvars_test.go
@@ -79,6 +79,26 @@ func TestFromServices(t *testing.T) {
 					},
 				},
 			},
+			{
+				ObjectMeta: api.ObjectMeta{Name: "1337"},
+				Spec: api.ServiceSpec{
+					Selector:  map[string]string{"bar": "baz"},
+					ClusterIP: "1.2.3.4",
+					Ports: []api.ServicePort{
+						{Port: 8080, Protocol: "TCP"},
+					},
+				},
+			},
+			{
+				ObjectMeta: api.ObjectMeta{Name: "name.with.dots"},
+				Spec: api.ServiceSpec{
+					Selector:  map[string]string{"bar": "baz"},
+					ClusterIP: "1.2.3.4",
+					Ports: []api.ServicePort{
+						{Port: 8080, Protocol: "TCP"},
+					},
+				},
+			},
 		},
 	}
 	vars := envvars.FromServices(&sl)
@@ -115,6 +135,20 @@ func TestFromServices(t *testing.T) {
 		{Name: "Q_U_U_X_PORT_8083_TCP_PROTO", Value: "tcp"},
 		{Name: "Q_U_U_X_PORT_8083_TCP_PORT", Value: "8083"},
 		{Name: "Q_U_U_X_PORT_8083_TCP_ADDR", Value: "9.8.7.6"},
+		{Name: "_1337_SERVICE_HOST", Value: "1.2.3.4"},
+		{Name: "_1337_SERVICE_PORT", Value: "8080"},
+		{Name: "_1337_PORT", Value: "tcp://1.2.3.4:8080"},
+		{Name: "_1337_PORT_8080_TCP", Value: "tcp://1.2.3.4:8080"},
+		{Name: "_1337_PORT_8080_TCP_PROTO", Value: "tcp"},
+		{Name: "_1337_PORT_8080_TCP_PORT", Value: "8080"},
+		{Name: "_1337_PORT_8080_TCP_ADDR", Value: "1.2.3.4"},
+		{Name: "NAME_WITH_DOTS_SERVICE_HOST", Value: "1.2.3.4"},
+		{Name: "NAME_WITH_DOTS_SERVICE_PORT", Value: "8080"},
+		{Name: "NAME_WITH_DOTS_PORT", Value: "tcp://1.2.3.4:8080"},
+		{Name: "NAME_WITH_DOTS_PORT_8080_TCP", Value: "tcp://1.2.3.4:8080"},
+		{Name: "NAME_WITH_DOTS_PORT_8080_TCP_PROTO", Value: "tcp"},
+		{Name: "NAME_WITH_DOTS_PORT_8080_TCP_PORT", Value: "8080"},
+		{Name: "NAME_WITH_DOTS_PORT_8080_TCP_ADDR", Value: "1.2.3.4"},
 	}
 	if len(vars) != len(expected) {
 		t.Errorf("Expected %d env vars, got: %+v", len(expected), vars)


### PR DESCRIPTION
This bumps the maximum service name length to 63 characters, which is the maximum length of a
domain name label as per RFC 1123.

refs https://github.com/kubernetes/kubernetes/issues/12463
