### PR TITLE
Update e2e-runner.sh so it can fetch multiple types of Trusty images

### DIFF
--- a/hack/jenkins/e2e-runner.sh
+++ b/hack/jenkins/e2e-runner.sh
@@ -174,9 +174,9 @@ if [[ -n "${CLOUDSDK_BUCKET:-}" ]]; then
 fi
 
 # We get the image project and name for Trusty dynamically.
-if [[ "${JENKINS_USE_TRUSTY_IMAGES:-}" =~ ^[yY]$ ]]; then
+if [[ -n "${JENKINS_TRUSTY_IMAGE_TYPE:-}" ]]; then
   trusty_image_project="$(get_trusty_image_project)"
-  trusty_image="$(get_latest_trusty_image "${trusty_image_project}" "dev")"
+  trusty_image="$(get_latest_trusty_image "${trusty_image_project}" "${JENKINS_TRUSTY_IMAGE_TYPE}")"
   export KUBE_GCE_MASTER_PROJECT="${trusty_image_project}"
   export KUBE_GCE_MASTER_IMAGE="${trusty_image}"
   export KUBE_OS_DISTRIBUTION="trusty"


### PR DESCRIPTION
Trusty beta images now work with k8s 1.2.

@spxtr, @andyzheng0831 Can you review this?
