### PR TITLE
Add NODE_NAME to started.json.

### DIFF
--- a/hack/jenkins/upload-to-gcs.sh
+++ b/hack/jenkins/upload-to-gcs.sh
@@ -85,7 +85,8 @@ function upload_version() {
     gsutil -q -h "Content-Type:application/json" cp -a "${gcs_acl}" <(
       echo "{"
       echo "    \"version\": \"${version}\","
-      echo "    \"timestamp\": ${timestamp}"
+      echo "    \"timestamp\": ${timestamp},"
+      echo "    \"jenkins-node\": \"${NODE_NAME:-}\""
       echo "}"
     ) "${json_file}" || continue
     break


### PR DESCRIPTION
Sometimes a single Jenkins node gets borked. Lets upload what node we're on before running tests. See [this list of env vars that Jenkins sets for us.](https://wiki.jenkins-ci.org/display/JENKINS/Building+a+software+project#Buildingasoftwareproject-JenkinsSetEnvironmentVariables) I think this info should be added to gubernator.
