### PR TITLE
Use v1.6.2-1 tag for build.

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -48,7 +48,7 @@ readonly KUBE_GCS_DELETE_EXISTING="${KUBE_GCS_DELETE_EXISTING:-n}"
 
 # Constants
 readonly KUBE_BUILD_IMAGE_REPO=kube-build
-readonly KUBE_BUILD_IMAGE_CROSS_TAG="v1.6.0-2"
+readonly KUBE_BUILD_IMAGE_CROSS_TAG="v1.6.2-1"
 # KUBE_BUILD_DATA_CONTAINER_NAME=kube-build-data-<hash>"
 
 # Here we map the output directories across both the local and remote _output

--- a/cluster/images/flannel/Makefile
+++ b/cluster/images/flannel/Makefile
@@ -20,7 +20,7 @@
 TAG?=0.5.5
 ARCH?=amd64
 REGISTRY?=gcr.io/google_containers
-KUBE_CROSS_TAG=v1.6.0-2
+KUBE_CROSS_TAG=v1.6.2-1
 GOARM=6
 TEMP_DIR:=$(shell mktemp -d)
 BASEIMAGE?=gcr.io/google_containers/debian-iptables-${ARCH}:v2


### PR DESCRIPTION
Is there any reason these don't use the VERSION file like everything else? cc @luxas @ixdy 
