### PR TITLE
Use HOSTNAME in Docker build image tag hash

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -154,7 +154,7 @@ function kube::build::verify_prereqs() {
   fi
   kube::build::ensure_docker_daemon_connectivity || return 1
 
-  KUBE_ROOT_HASH=$(kube::build::short_hash "$KUBE_ROOT")
+  KUBE_ROOT_HASH=$(kube::build::short_hash "${HOSTNAME:-}:${KUBE_ROOT}")
   KUBE_BUILD_IMAGE_TAG="build-${KUBE_ROOT_HASH}"
   KUBE_BUILD_IMAGE="${KUBE_BUILD_IMAGE_REPO}:${KUBE_BUILD_IMAGE_TAG}"
   KUBE_BUILD_CONTAINER_NAME="kube-build-${KUBE_ROOT_HASH}"

--- a/hack/after-build/verify-generated-protobuf.sh
+++ b/hack/after-build/verify-generated-protobuf.sh
@@ -36,10 +36,12 @@ for APIROOT in ${APIROOTS}; do
   cp -a "${KUBE_ROOT}/${APIROOT}" "${_tmp}/${APIROOT}"
 done
 
-# We would like to use "sudo" when running on Travis and
-# not use "sudo" when running on Jenkins.
-SUDO="sudo"
-sudo -h > /dev/null || SUDO=""
+# If not running as root, we need to use sudo to restore the original generated
+# protobuf files.
+SUDO=""
+if [[ "$(id -u)" != '0' ]]; then
+  SUDO="sudo"
+fi
 
 "${KUBE_ROOT}/hack/update-generated-protobuf.sh"
 for APIROOT in ${APIROOTS}; do

--- a/hack/update-generated-protobuf.sh
+++ b/hack/update-generated-protobuf.sh
@@ -31,7 +31,7 @@ function prereqs() {
   fi
   kube::build::ensure_docker_daemon_connectivity || return 1
 
-  KUBE_ROOT_HASH=$(kube::build::short_hash "$KUBE_ROOT/go-to-protobuf")
+  KUBE_ROOT_HASH=$(kube::build::short_hash "${HOSTNAME:-}:${REPO_DIR:-${KUBE_ROOT}}/go-to-protobuf")
   KUBE_BUILD_IMAGE_TAG="build-${KUBE_ROOT_HASH}"
   KUBE_BUILD_IMAGE="${KUBE_BUILD_IMAGE_REPO}:${KUBE_BUILD_IMAGE_TAG}"
   KUBE_BUILD_CONTAINER_NAME="kube-build-${KUBE_ROOT_HASH}"


### PR DESCRIPTION
Fixes #24661 by including `$HOSTNAME` when generating the build image tag hash.

When running the verification checks under Docker, the `$KUBE_ROOT` will be identical across builds, so tags will collide unless we add additional uniqueness. By default, the hostname inside a Docker container is its ID, which should be unique enough for us.

I also deleted a misleading error message from the same check.

@kubernetes/sig-testing 
