### PR TITLE
kubelet: do not force update the runtime cache

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2598,12 +2598,6 @@ func (kl *Kubelet) syncLoopIteration(configCh <-chan kubetypes.PodUpdate, handle
 			break
 		}
 		glog.V(2).Infof("SyncLoop (PLEG): %q, event: %#v", format.Pod(pod), e)
-		// Force the container runtime cache to update.
-		if err := kl.runtimeCache.ForceUpdateIfOlder(kl.clock.Now()); err != nil {
-			glog.Errorf("SyncLoop: unable to update runtime cache")
-			// TODO (yujuhong): should we delay the sync until container
-			// runtime can be updated?
-		}
 		handler.HandlePodSyncs([]*api.Pod{pod})
 	case <-syncCh:
 		// Sync pods waiting for sync


### PR DESCRIPTION
Pod workers don't rely on the old runtime cache to sync pods anymore. There is
no need to force update the cache on every container event.
