### PR TITLE
PodWorkers UpdatePod takes options struct

### DIFF
--- a/pkg/kubelet/eviction/types.go
+++ b/pkg/kubelet/eviction/types.go
@@ -19,6 +19,7 @@ package eviction
 import (
 	"time"
 
+	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
 )
 
@@ -49,3 +50,12 @@ type Threshold struct {
 	// GracePeriod represents the amount of time that a threshold must be met before eviction is triggered.
 	GracePeriod time.Duration
 }
+
+// KillPodFunc kills a pod.
+// The pod status is updated, and then it is killed with the specified grace period.
+// This function must block until either the pod is killed or an error is encountered.
+// Arguments:
+// pod - the pod to kill
+// status - the desired status to associate with the pod (i.e. why its killed)
+// gracePeriodOverride - the grace period override to use instead of what is on the pod spec
+type KillPodFunc func(pod *api.Pod, status api.PodStatus, gracePeriodOverride *int64) error

--- a/pkg/kubelet/runonce.go
+++ b/pkg/kubelet/runonce.go
@@ -123,8 +123,12 @@ func (kl *Kubelet) runPod(pod *api.Pod, retryDelay time.Duration) error {
 			glog.Errorf("Failed creating a mirror pod %q: %v", format.Pod(pod), err)
 		}
 		mirrorPod, _ := kl.podManager.GetMirrorPodByPod(pod)
-
-		if err = kl.syncPod(pod, mirrorPod, status, kubetypes.SyncPodUpdate); err != nil {
+		if err = kl.syncPod(syncPodOptions{
+			pod:        pod,
+			mirrorPod:  mirrorPod,
+			podStatus:  status,
+			updateType: kubetypes.SyncPodUpdate,
+		}); err != nil {
 			return fmt.Errorf("error syncing pod %q: %v", format.Pod(pod), err)
 		}
 		if retry >= runOnceMaxRetries {

--- a/pkg/kubelet/types/pod_update.go
+++ b/pkg/kubelet/types/pod_update.go
@@ -104,9 +104,15 @@ func GetPodSource(pod *api.Pod) (string, error) {
 type SyncPodType int
 
 const (
+	// SyncPodSync is when the pod is synced to ensure desired state
 	SyncPodSync SyncPodType = iota
+	// SyncPodUpdate is when the pod is updated from source
 	SyncPodUpdate
+	// SyncPodCreate is when the pod is created from source
 	SyncPodCreate
+	// SyncPodKill is when the pod is killed based on a trigger internal to the kubelet for eviction.
+	// If a SyncPodKill request is made to pod workers, the request is never dropped, and will always be processed.
+	SyncPodKill
 )
 
 func (sp SyncPodType) String() string {
@@ -117,6 +123,8 @@ func (sp SyncPodType) String() string {
 		return "update"
 	case SyncPodSync:
 		return "sync"
+	case SyncPodKill:
+		return "kill"
 	default:
 		return "unknown"
 	}


### PR DESCRIPTION
First commit from https://github.com/kubernetes/kubernetes/pull/24843 

Second commit:
The `PodWorkers.UpdatePod` operation is updated as follows:
- use options struct to pass arguments
- add a pod status func to allow override status
- add pod termination grace period if sync operation requires a kill pod
- add a call-back that is error aware

Third commit:
Add a `killPodNow` to kubelet that does a blocking kill pod call that properly integrates with pod workers.

The plan is to pass `killPodNow` as a function pointer into the out of resource killer.

```
// KillPodFunc kills a pod.
// The pod status is updated, and then it is killed with the specified grace period.
// This function must block until either the pod is killed or an error is encountered.
// Arguments:
// pod - the pod to kill
// status - the desired status to associate with the pod (i.e. why its killed)
// gracePeriodOverride - the grace period override to use instead of what is on the pod spec
type KillPodFunc func(pod *api.Pod, status api.PodStatus, gracePeriodOverride *int64) error
```

You can see it being used here in the WIP out of resource killer PR.

https://github.com/kubernetes/kubernetes/pull/21274/commits/1344f858fba956c285eba6c418a3008576cd3843#diff-92ff0f643237f29824b4929574f84609R277

/cc @vishh @yujuhong @pmorie 
