### PR TITLE
Heredoc fix on k8sm ha document

### DIFF
--- a/contrib/mesos/docs/ha.md
+++ b/contrib/mesos/docs/ha.md
@@ -256,6 +256,7 @@ spec:
   - hostPath:
       path: /etc/kubernetes/manifests
     name: manifest-dst
+EOF
 ```
 
 One must change `$MY_IP` to either `$K8S_1_IP` or `K8S_2_IP` depending


### PR DESCRIPTION
Fix for a missing delimiter on a heredoc in contrib/mesos/docs/ha.md.

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
