### PR TITLE
Fix up quota test now that 19254 is fixed DO NOT MERGE

### DIFF
--- a/test/integration/quota_test.go
+++ b/test/integration/quota_test.go
@@ -59,8 +59,7 @@ func TestQuota(t *testing.T) {
 		<-initializationCh
 		m.Handler.ServeHTTP(w, req)
 	}))
-	// TODO: Uncomment when fix #19254
-	// defer s.Close()
+	defer s.Close()
 	clientset := clientset.NewForConfigOrDie(&restclient.Config{QPS: -1, Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})
 	admission, err := resourcequota.NewResourceQuota(clientset, quotainstall.NewRegistry(clientset), 5)
 	if err != nil {


### PR DESCRIPTION
This test got in the code base at the same time that this PR was in-flight.

https://github.com/kubernetes/kubernetes/pull/24595

This removes the comment per https://github.com/kubernetes/kubernetes/issues/24546

Possibly related to https://github.com/kubernetes/kubernetes/issues/25037, but still investigating.
