### PR TITLE
Revert "Use HOSTNAME in Docker build image tag hash"

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -154,7 +154,7 @@ function kube::build::verify_prereqs() {
   fi
   kube::build::ensure_docker_daemon_connectivity || return 1
 
-  KUBE_ROOT_HASH=$(kube::build::short_hash "${HOSTNAME:-}:${KUBE_ROOT}")
+  KUBE_ROOT_HASH=$(kube::build::short_hash "$KUBE_ROOT")
   KUBE_BUILD_IMAGE_TAG="build-${KUBE_ROOT_HASH}"
   KUBE_BUILD_IMAGE="${KUBE_BUILD_IMAGE_REPO}:${KUBE_BUILD_IMAGE_TAG}"
   KUBE_BUILD_CONTAINER_NAME="kube-build-${KUBE_ROOT_HASH}"

--- a/hack/after-build/verify-generated-protobuf.sh
+++ b/hack/after-build/verify-generated-protobuf.sh
@@ -36,12 +36,10 @@ for APIROOT in ${APIROOTS}; do
   cp -a "${KUBE_ROOT}/${APIROOT}" "${_tmp}/${APIROOT}"
 done
 
-# If not running as root, we need to use sudo to restore the original generated
-# protobuf files.
-SUDO=""
-if [[ "$(id -u)" != '0' ]]; then
-  SUDO="sudo"
-fi
+# We would like to use "sudo" when running on Travis and
+# not use "sudo" when running on Jenkins.
+SUDO="sudo"
+sudo -h > /dev/null || SUDO=""
 
 "${KUBE_ROOT}/hack/update-generated-protobuf.sh"
 for APIROOT in ${APIROOTS}; do

--- a/hack/update-generated-protobuf.sh
+++ b/hack/update-generated-protobuf.sh
@@ -31,7 +31,7 @@ function prereqs() {
   fi
   kube::build::ensure_docker_daemon_connectivity || return 1
 
-  KUBE_ROOT_HASH=$(kube::build::short_hash "${HOSTNAME:-}:${REPO_DIR:-${KUBE_ROOT}}/go-to-protobuf")
+  KUBE_ROOT_HASH=$(kube::build::short_hash "$KUBE_ROOT/go-to-protobuf")
   KUBE_BUILD_IMAGE_TAG="build-${KUBE_ROOT_HASH}"
   KUBE_BUILD_IMAGE="${KUBE_BUILD_IMAGE_REPO}:${KUBE_BUILD_IMAGE_TAG}"
   KUBE_BUILD_CONTAINER_NAME="kube-build-${KUBE_ROOT_HASH}"


### PR DESCRIPTION
Reverts kubernetes/kubernetes#25052 since it seems to break the build (see #25086)
