### PR TITLE
reduce conflict retries

### DIFF
--- a/pkg/storage/etcd/api_object_versioner.go
+++ b/pkg/storage/etcd/api_object_versioner.go
@@ -71,4 +71,28 @@ func (a APIObjectVersioner) ObjectResourceVersion(obj runtime.Object) (uint64, e
 }
 
 // APIObjectVersioner implements Versioner
-var _ storage.Versioner = APIObjectVersioner{}
+var Versioner storage.Versioner = APIObjectVersioner{}
+
+// CompareResourceVersion compares etcd resource versions.  Outside this API they are all strings,
+// but etcd resource versions are special, they're actually ints, so we can easily compare them.
+func (a APIObjectVersioner) CompareResourceVersion(lhs, rhs runtime.Object) int {
+	lhsVersion, err := Versioner.ObjectResourceVersion(lhs)
+	if err != nil {
+		// coder error
+		panic(err)
+	}
+	rhsVersion, err := Versioner.ObjectResourceVersion(rhs)
+	if err != nil {
+		// coder error
+		panic(err)
+	}
+
+	if lhsVersion == rhsVersion {
+		return 0
+	}
+	if lhsVersion < rhsVersion {
+		return -1
+	}
+
+	return 1
+}

--- a/pkg/storage/etcd/api_object_versioner_test.go
+++ b/pkg/storage/etcd/api_object_versioner_test.go
@@ -39,3 +39,20 @@ func TestObjectVersioner(t *testing.T) {
 		t.Errorf("unexpected resource version: %#v", obj)
 	}
 }
+
+func TestCompareResourceVersion(t *testing.T) {
+	five := &storagetesting.TestResource{ObjectMeta: api.ObjectMeta{ResourceVersion: "5"}}
+	six := &storagetesting.TestResource{ObjectMeta: api.ObjectMeta{ResourceVersion: "6"}}
+
+	versioner := APIObjectVersioner{}
+
+	if e, a := -1, versioner.CompareResourceVersion(five, six); e != a {
+		t.Errorf("expected %v got %v", e, a)
+	}
+	if e, a := 1, versioner.CompareResourceVersion(six, five); e != a {
+		t.Errorf("expected %v got %v", e, a)
+	}
+	if e, a := 0, versioner.CompareResourceVersion(six, six); e != a {
+		t.Errorf("expected %v got %v", e, a)
+	}
+}


### PR DESCRIPTION
Eliminates quota admission conflicts due to latent caches on the same API server.

@derekwaynecarr 
