### PR TITLE
Revert "Make comment explain why we need sudo"

### DIFF
--- a/hack/after-build/verify-generated-protobuf.sh
+++ b/hack/after-build/verify-generated-protobuf.sh
@@ -36,12 +36,10 @@ for APIROOT in ${APIROOTS}; do
   cp -a "${KUBE_ROOT}/${APIROOT}" "${_tmp}/${APIROOT}"
 done
 
-# If not running as root, we need to use sudo to restore the original generated
-# protobuf files.
-SUDO=""
-if [[ "$(id -u)" != '0' ]]; then
-  SUDO="sudo"
-fi
+# We would like to use "sudo" when running on Travis and
+# not use "sudo" when running on Jenkins.
+SUDO="sudo"
+sudo -h > /dev/null || SUDO=""
 
 "${KUBE_ROOT}/hack/update-generated-protobuf.sh"
 for APIROOT in ${APIROOTS}; do


### PR DESCRIPTION
This reverts commit 83ac3ea0c9a7c11fb133b3e757a04b6d766870dd.

It was breaking the build.  See #25086
