### PR TITLE
enable recursive processing in kubectl rollout

### DIFF
--- a/pkg/kubectl/cmd/rollout/rollout_pause.go
+++ b/pkg/kubectl/cmd/rollout/rollout_pause.go
@@ -17,7 +17,6 @@ limitations under the License.
 package rollout
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/spf13/cobra"
@@ -27,6 +26,7 @@ import (
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 	"k8s.io/kubernetes/pkg/runtime"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 )
 
 // PauseConfig is the start of the data required to perform the operation.  As new fields are added, add them here instead of
@@ -35,7 +35,7 @@ type PauseConfig struct {
 	PauseObject func(object runtime.Object) (bool, error)
 	Mapper      meta.RESTMapper
 	Typer       runtime.ObjectTyper
-	Info        *resource.Info
+	Infos       []*resource.Info
 
 	Out       io.Writer
 	Filenames []string
@@ -64,8 +64,16 @@ func NewCmdRolloutPause(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 		Long:    pause_long,
 		Example: pause_example,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckErr(opts.CompletePause(f, cmd, out, args))
-			cmdutil.CheckErr(opts.RunPause())
+			allErrs := []error{}
+			err := opts.CompletePause(f, cmd, out, args)
+			if err != nil {
+				allErrs = append(allErrs, err)
+			}
+			err = opts.RunPause()
+			if err != nil {
+				allErrs = append(allErrs, err)
+			}
+			cmdutil.CheckErr(utilerrors.Flatten(utilerrors.NewAggregate(allErrs)))
 		},
 	}
 
@@ -89,32 +97,39 @@ func (o *PauseConfig) CompletePause(f *cmdutil.Factory, cmd *cobra.Command, out 
 		return err
 	}
 
-	infos, err := resource.NewBuilder(o.Mapper, o.Typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true)).
+	r := resource.NewBuilder(o.Mapper, o.Typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true)).
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, o.Recursive, o.Filenames...).
 		ResourceTypeOrNameArgs(true, args...).
-		SingleResourceType().
+		ContinueOnError().
 		Latest().
-		Do().Infos()
+		Flatten().
+		Do()
+	err = r.Err()
 	if err != nil {
 		return err
 	}
-	if len(infos) != 1 {
-		return fmt.Errorf("rollout pause is only supported on individual resources - %d resources were found", len(infos))
+
+	o.Infos, err = r.Infos()
+	if err != nil {
+		return err
 	}
-	o.Info = infos[0]
 	return nil
 }
 
 func (o PauseConfig) RunPause() error {
-	isAlreadyPaused, err := o.PauseObject(o.Info.Object)
-	if err != nil {
-		return err
+	allErrs := []error{}
+	for _, info := range o.Infos {
+		isAlreadyPaused, err := o.PauseObject(info.Object)
+		if err != nil {
+			allErrs = append(allErrs, cmdutil.AddSourceToErr("pausing", info.Source, err))
+			continue
+		}
+		if isAlreadyPaused {
+			cmdutil.PrintSuccess(o.Mapper, false, o.Out, info.Mapping.Resource, info.Name, "already paused")
+			continue
+		}
+		cmdutil.PrintSuccess(o.Mapper, false, o.Out, info.Mapping.Resource, info.Name, "paused")
 	}
-	if isAlreadyPaused {
-		cmdutil.PrintSuccess(o.Mapper, false, o.Out, o.Info.Mapping.Resource, o.Info.Name, "already paused")
-		return nil
-	}
-	cmdutil.PrintSuccess(o.Mapper, false, o.Out, o.Info.Mapping.Resource, o.Info.Name, "paused")
-	return nil
+	return utilerrors.NewAggregate(allErrs)
 }

--- a/pkg/kubectl/cmd/rollout/rollout_undo.go
+++ b/pkg/kubectl/cmd/rollout/rollout_undo.go
@@ -17,7 +17,6 @@ limitations under the License.
 package rollout
 
 import (
-	"fmt"
 	"io"
 
 	"k8s.io/kubernetes/pkg/api/meta"
@@ -25,6 +24,7 @@ import (
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 	"k8s.io/kubernetes/pkg/runtime"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 
 	"github.com/spf13/cobra"
 )
@@ -32,11 +32,11 @@ import (
 // UndoOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
 // referencing the cmd.Flags()
 type UndoOptions struct {
-	Rollbacker kubectl.Rollbacker
-	Mapper     meta.RESTMapper
-	Typer      runtime.ObjectTyper
-	Info       *resource.Info
-	ToRevision int64
+	Rollbackers []kubectl.Rollbacker
+	Mapper      meta.RESTMapper
+	Typer       runtime.ObjectTyper
+	Infos       []*resource.Info
+	ToRevision  int64
 
 	Out       io.Writer
 	Filenames []string
@@ -53,7 +53,7 @@ kubectl rollout undo deployment/abc --to-revision=3`
 )
 
 func NewCmdRolloutUndo(f *cmdutil.Factory, out io.Writer) *cobra.Command {
-	options := &UndoOptions{}
+	opts := &UndoOptions{}
 
 	cmd := &cobra.Command{
 		Use:     "undo (TYPE NAME | TYPE/NAME) [flags]",
@@ -61,15 +61,23 @@ func NewCmdRolloutUndo(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 		Long:    undo_long,
 		Example: undo_example,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckErr(options.CompleteUndo(f, cmd, out, args))
-			cmdutil.CheckErr(options.RunUndo())
+			allErrs := []error{}
+			err := opts.CompleteUndo(f, cmd, out, args)
+			if err != nil {
+				allErrs = append(allErrs, err)
+			}
+			err = opts.RunUndo()
+			if err != nil {
+				allErrs = append(allErrs, err)
+			}
+			cmdutil.CheckErr(utilerrors.Flatten(utilerrors.NewAggregate(allErrs)))
 		},
 	}
 
 	cmd.Flags().Int64("to-revision", 0, "The revision to rollback to. Default to 0 (last revision).")
 	usage := "Filename, directory, or URL to a file identifying the resource to get from a server."
-	kubectl.AddJsonFilenameFlag(cmd, &options.Filenames, usage)
-	cmdutil.AddRecursiveFlag(cmd, &options.Recursive)
+	kubectl.AddJsonFilenameFlag(cmd, &opts.Filenames, usage)
+	cmdutil.AddRecursiveFlag(cmd, &opts.Recursive)
 	return cmd
 }
 
@@ -87,31 +95,43 @@ func (o *UndoOptions) CompleteUndo(f *cmdutil.Factory, cmd *cobra.Command, out i
 		return err
 	}
 
-	infos, err := resource.NewBuilder(o.Mapper, o.Typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true)).
+	r := resource.NewBuilder(o.Mapper, o.Typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true)).
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, o.Recursive, o.Filenames...).
 		ResourceTypeOrNameArgs(true, args...).
+		ContinueOnError().
 		Latest().
 		Flatten().
-		Do().
-		Infos()
+		Do()
+	err = r.Err()
 	if err != nil {
 		return err
 	}
 
-	if len(infos) != 1 {
-		return fmt.Errorf("rollout undo is only supported on individual resources - %d resources were found", len(infos))
-	}
-	o.Info = infos[0]
-	o.Rollbacker, err = f.Rollbacker(o.Info.ResourceMapping())
+	err = r.Visit(func(info *resource.Info, err error) error {
+		if err != nil {
+			return err
+		}
+		rollbacker, err := f.Rollbacker(info.ResourceMapping())
+		if err != nil {
+			return err
+		}
+		o.Infos = append(o.Infos, info)
+		o.Rollbackers = append(o.Rollbackers, rollbacker)
+		return nil
+	})
 	return err
 }
 
 func (o *UndoOptions) RunUndo() error {
-	result, err := o.Rollbacker.Rollback(o.Info.Namespace, o.Info.Name, nil, o.ToRevision, o.Info.Object)
-	if err != nil {
-		return err
+	allErrs := []error{}
+	for ix, info := range o.Infos {
+		result, err := o.Rollbackers[ix].Rollback(info.Namespace, info.Name, nil, o.ToRevision, info.Object)
+		if err != nil {
+			allErrs = append(allErrs, cmdutil.AddSourceToErr("undoing", info.Source, err))
+			continue
+		}
+		cmdutil.PrintSuccess(o.Mapper, false, o.Out, info.Mapping.Resource, info.Name, result)
 	}
-	cmdutil.PrintSuccess(o.Mapper, false, o.Out, o.Info.Mapping.Resource, o.Info.Name, result)
-	return nil
+	return utilerrors.NewAggregate(allErrs)
 }


### PR DESCRIPTION
This PR was split out of https://github.com/kubernetes/kubernetes/pull/23673 per @deads2k's suggestion: https://github.com/kubernetes/kubernetes/pull/23673#discussion-diff-61290415

It makes use of the recursive processing of a directory in `kubectl rollout {undo,pause,resume}` which now also conforms to the [command conventions](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/kubectl-conventions.md#command-implementation-conventions).

`kubectl rollout history` is being omitted for the time being as its encountering what appears to be an anomaly of an issue: https://github.com/kubernetes/kubernetes/issues/24606. Once this issue has been resolved I will modify it to be recursive
