### PR TITLE
Map secret files into dockerized e2e

### DIFF
--- a/hack/jenkins/dockerized-e2e-runner.sh
+++ b/hack/jenkins/dockerized-e2e-runner.sh
@@ -48,7 +48,10 @@ fi
 docker run --rm=true -i \
   -v "${WORKSPACE}/_artifacts":/workspace/_artifacts \
   -v /etc/localtime:/etc/localtime:ro \
-  -v /var/lib/jenkins/gce_keys:/workspace/.ssh:ro \
+  -v /var/lib/jenkins/gce_keys:/workspace/.ssh:ro `# TODO(ixdy): remove when all jobs are using JENKINS_GCE_SSH_KEYFILE` \
+  ${JENKINS_GCE_SSH_KEY_FILE:+-v "${JENKINS_GCE_SSH_KEY_FILE}:/workspace/.ssh/google_compute_engine:ro"} \
+  ${JENKINS_AWS_SSH_KEY_FILE:+-v "${JENKINS_AWS_SSH_KEY_FILE}:/workspace/.ssh/kube_aws_rsa:ro"} \
+  ${JENKINS_AWS_CREDENTIALS_FILE:+-v "${JENKINS_AWS_CREDENTIALS_FILE}:/workspace/.aws/credentials:ro"} \
   --env-file "${WORKSPACE}/env.list" \
   -e "HOME=/workspace" \
   -e "WORKSPACE=/workspace" \


### PR DESCRIPTION
Rather than copying the GCE and AWS private keys/credentials to each Jenkins VM, we can put them in credentials and map them through.

This is one half of the change; if the relevant environment variables are set, we'll mount the files in.

cc @fejta @rmmh @apelisse 
