### PR TITLE
Update salt config to allow Debian Jessie on GCE.

### DIFF
--- a/cluster/saltbase/salt/docker/init.sls
+++ b/cluster/saltbase/salt/docker/init.sls
@@ -214,6 +214,14 @@ net.ipv4.ip_forward:
 {% set override_deb_sha1='' %}
 {% set override_docker_ver='' %}
 
+{% elif grains.get('cloud', '') == 'gce'
+   and grains.get('os_family', '') == 'Debian'
+   and grains.get('oscodename', '') == 'jessie' -%}
+{% set docker_pkg_name='' %}
+{% set override_deb='' %}
+{% set override_deb_sha1='' %}
+{% set override_docker_ver='' %}
+
 {% elif grains.get('cloud', '') == 'aws'
    and grains.get('os_family', '') == 'Debian'
    and grains.get('oscodename', '') == 'jessie' -%}


### PR DESCRIPTION
``` release-note
Add an entry to the salt config to allow Debian jessie on GCE.

As with the existing Wheezy image on GCE, docker is expected
to already be installed in the image.
```

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
