### PR TITLE
e2e: Enable persistent volume test

### DIFF
--- a/test/e2e/persistent_volumes.go
+++ b/test/e2e/persistent_volumes.go
@@ -43,9 +43,7 @@ func persistentVolumeTestCleanup(client *client.Client, config VolumeTestConfig)
 	}
 }
 
-// This test needs privileged containers, which are disabled by default.  Run
-// the test with "go run hack/e2e.go ... --ginkgo.focus=[Feature:Volumes]"
-var _ = framework.KubeDescribe("PersistentVolumes [Feature:Volumes]", func() {
+var _ = framework.KubeDescribe("PersistentVolumes", func() {
 	f := framework.NewDefaultFramework("pv")
 	var c *client.Client
 	var ns string


### PR DESCRIPTION
The test is already there and all packages should be already available on all test machines.

It tests:
- binding
- using bound claim in a pod
- recycling NFS volume

(we should see shortly if all nfs packages are really installed as Jenkins tests it...)
