### PR TITLE
getting emailAddress from TLS cert

### DIFF
--- a/plugin/pkg/auth/authenticator/request/x509/x509.go
+++ b/plugin/pkg/auth/authenticator/request/x509/x509.go
@@ -18,6 +18,7 @@ package x509
 
 import (
 	"crypto/x509"
+	"encoding/asn1"
 	"net/http"
 
 	"k8s.io/kubernetes/pkg/auth/user"
@@ -104,7 +105,13 @@ var DNSNameUserConversion = UserConversionFunc(func(chain []*x509.Certificate) (
 
 // EmailAddressUserConversion builds user info from a certificate chain using the first EmailAddress on the certificate
 var EmailAddressUserConversion = UserConversionFunc(func(chain []*x509.Certificate) (user.Info, bool, error) {
+	var emailAddressOID asn1.ObjectIdentifier = []int{1, 2, 840, 113549, 1, 9, 1}
 	if len(chain[0].EmailAddresses) == 0 {
+		for _, name := range chain[0].Subject.Names {
+			if name.Type.Equal(emailAddressOID) {
+				return &user.DefaultInfo{Name: name.Value.(string)}, true, nil
+			}
+		}
 		return nil, false, nil
 	}
 	return &user.DefaultInfo{Name: chain[0].EmailAddresses[0]}, true, nil


### PR DESCRIPTION
Kubernetes if using TLS cert to perform authentication will use the CommonName field of the cert as the authenticating user. In https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/auth/authenticator/request/x509/x509.go#L106, alternative methods are defined to use emailAddress or DNSName as the authenticating user. The method that uses the emailAddress is not comprehensive as this information can be encoded in different places of the certificate. This PR fixes this.
