### PR TITLE
Make threadSafeMap.ListIndexFuncValues thread safe.

### DIFF
--- a/pkg/client/cache/thread_safe_store.go
+++ b/pkg/client/cache/thread_safe_store.go
@@ -179,6 +179,9 @@ func (c *threadSafeMap) ByIndex(indexName, indexKey string) ([]interface{}, erro
 }
 
 func (c *threadSafeMap) ListIndexFuncValues(indexName string) []string {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
 	index := c.indices[indexName]
 	names := make([]string, 0, len(index))
 	for key := range index {


### PR DESCRIPTION
Surprisingly, this method does not lock and I get data race reports in my persistent volume unit tests (which use this map).
