### PR TITLE
Mark two kubectl tests flaky.

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -614,7 +614,8 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 	})
 
 	framework.KubeDescribe("Kubectl describe", func() {
-		It("should check if kubectl describe prints relevant information for rc and pods [Conformance]", func() {
+		// Flaky issue: #25083
+		It("should check if kubectl describe prints relevant information for rc and pods [Conformance] [Flaky]", func() {
 			framework.SkipUnlessServerVersionGTE(nodePortsOptionalVersion, c)
 
 			mkpath := func(file string) string {
@@ -1040,7 +1041,8 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 			framework.RunKubectlOrDie("delete", "rc", rcName, nsFlag)
 		})
 
-		It("should support rolling-update to same image [Conformance]", func() {
+		// Flaky issue: #25140
+		It("should support rolling-update to same image [Conformance] [Flaky]", func() {
 			By("running the image " + nginxImage)
 			framework.RunKubectlOrDie("run", rcName, "--image="+nginxImage, "--generator=run/v1", nsFlag)
 			By("verifying the rc " + rcName + " was created")


### PR DESCRIPTION
#25083 #25140

The describe test has failed anywhere from 5% to 10% of the time in the last week. This is obviously unacceptable. Its flaky label should be removed once it has proved itself flake-free.

The rolling-update test is new and has failed a couple times already. Remove the flaky label once it's flake-free.
