### PR TITLE
GCE: Prefer preconfigured node tags for firewalls, if available

### DIFF
--- a/cluster/gce/configure-vm.sh
+++ b/cluster/gce/configure-vm.sh
@@ -766,6 +766,13 @@ EOF
 EOF
   fi
 
+  if [[ -n "${NODE_INSTANCE_PREFIX:-}" ]]; then
+    cat <<EOF >>/etc/gce.conf
+node-tags = [${NODE_INSTANCE_PREFIX}]
+EOF
+    CLOUD_CONFIG=/etc/gce.conf
+  fi
+
   if [[ -n "${MULTIZONE:-}" ]]; then
     cat <<EOF >>/etc/gce.conf
 multizone = ${MULTIZONE}

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -72,7 +72,7 @@ func setupProviderConfig() error {
 			return fmt.Errorf("error parsing GCE/GKE region from zone %q: %v", zone, err)
 		}
 		managedZones := []string{zone} // Only single-zone for now
-		cloudConfig.Provider, err = gcecloud.CreateGCECloud(framework.TestContext.CloudConfig.ProjectID, region, zone, managedZones, "" /* networkUrl */, tokenSource, false /* useMetadataServer */)
+		cloudConfig.Provider, err = gcecloud.CreateGCECloud(framework.TestContext.CloudConfig.ProjectID, region, zone, managedZones, "" /* networkUrl */, nil /* nodeTags */, tokenSource, false /* useMetadataServer */)
 		if err != nil {
 			return fmt.Errorf("Error building GCE/GKE provider: %v", err)
 		}


### PR DESCRIPTION
It'd be nice to also refactor the way that we use NODE_TAG on the client side in gce/util.sh and NODE_INSTANCE_PREFIX on the server side in gce/configure-vm.sh, but that can be cleaned up separately.

Note that I'm currently waiting on this to build and deploy to verify it works as intended, so it shouldn't be merged until I can confirm that's done.

@roberthbailey @thockin @fabioy 
