### PR TITLE
Sort resources in quota errors to avoid duplicate events

### DIFF
--- a/plugin/pkg/admission/resourcequota/admission.go
+++ b/plugin/pkg/admission/resourcequota/admission.go
@@ -18,6 +18,7 @@ package resourcequota
 
 import (
 	"io"
+	"sort"
 	"strings"
 	"time"
 
@@ -91,10 +92,17 @@ func (q *quotaAdmission) Admit(a admission.Attributes) (err error) {
 }
 
 // prettyPrint formats a resource list for usage in errors
+// it outputs resources sorted in increasing order
 func prettyPrint(item api.ResourceList) string {
 	parts := []string{}
-	for key, value := range item {
-		constraint := string(key) + "=" + value.String()
+	keys := []string{}
+	for key := range item {
+		keys = append(keys, string(key))
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		value := item[api.ResourceName(key)]
+		constraint := key + "=" + value.String()
 		parts = append(parts, constraint)
 	}
 	return strings.Join(parts, ",")


### PR DESCRIPTION
Bugzilla:
https://bugzilla.redhat.com/show_bug.cgi?id=1333122

Errors describing why a request was rejected to quota would get variable responses (cpu=x,memory=y or memory=x,cpu=y) which caused duplicate events for the same root cause.

/cc @ncdc @jwforres 
