### PR TITLE
Kubectl support for validating nested objects with different ApiGroups

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -1728,6 +1728,21 @@ __EOF__
 
 
   ######################
+  # Lists              #
+  ######################
+
+  kube::log::status "Testing kubectl(${version}:lists)"
+
+  ### Create a List with objects from multiple versions
+  # Command
+  kubectl create -f hack/testdata/list.yaml "${kube_flags[@]}"
+
+  ### Delete the List with objects from multiple versions
+  # Command
+  kubectl delete service/list-service-test deployment/list-deployment-test
+
+
+  ######################
   # Multiple Resources #
   ######################
 

--- a/hack/testdata/list.yaml
+++ b/hack/testdata/list.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: list-service-test
+  spec:
+    ports:
+    - protocol: TCP
+      port: 80
+    selector:
+      app: list-deployment-test
+- apiVersion: extensions/v1beta1
+  kind: Deployment
+  metadata:
+    name: list-deployment-test
+    labels:
+      app: list-deployment-test
+  spec:
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          app: list-deployment-test
+      spec:
+        containers:
+          - name: nginx
+            image: nginx

--- a/pkg/api/validation/schema_test.go
+++ b/pkg/api/validation/schema_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package validation
 
 import (
+	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"strings"
@@ -25,7 +27,9 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/runtime"
+	k8syaml "k8s.io/kubernetes/pkg/util/yaml"
 
 	"github.com/ghodss/yaml"
 )
@@ -39,9 +43,55 @@ func readPod(filename string) ([]byte, error) {
 }
 
 func readSwaggerFile() ([]byte, error) {
-	// TODO this path is broken
-	pathToSwaggerSpec := "../../../api/swagger-spec/" + testapi.Default.GroupVersion().Version + ".json"
+	return readSwaggerApiFile(testapi.Default)
+}
+
+func readSwaggerApiFile(group testapi.TestGroup) ([]byte, error) {
+	// TODO: Figure out a better way of finding these files
+	var pathToSwaggerSpec string
+	if group.GroupVersion().Group == "" {
+		pathToSwaggerSpec = "../../../api/swagger-spec/" + group.GroupVersion().Version + ".json"
+	} else {
+		pathToSwaggerSpec = "../../../api/swagger-spec/" + group.GroupVersion().Group + "_" + group.GroupVersion().Version + ".json"
+	}
+
 	return ioutil.ReadFile(pathToSwaggerSpec)
+}
+
+// Mock delegating Schema.  Not a full fake impl.
+type Factory struct {
+	defaultSchema    Schema
+	extensionsSchema Schema
+}
+
+var _ Schema = &Factory{}
+
+// TODO: Consider using a mocking library instead or fully fleshing this out into a fake impl and putting it in some
+// generally available location
+func (f *Factory) ValidateBytes(data []byte) error {
+	var obj interface{}
+	out, err := k8syaml.ToJSON(data)
+	if err != nil {
+		return err
+	}
+	data = out
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return err
+	}
+	fields, ok := obj.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("error in unmarshaling data %s", string(data))
+	}
+	// Note: This only supports the 2 api versions we expect from the test it is currently supporting.
+	groupVersion := fields["apiVersion"]
+	switch groupVersion {
+	case "v1":
+		return f.defaultSchema.ValidateBytes(data)
+	case "extensions/v1beta1":
+		return f.extensionsSchema.ValidateBytes(data)
+	default:
+		return fmt.Errorf("Unsupported API version %s", groupVersion)
+	}
 }
 
 func loadSchemaForTest() (Schema, error) {
@@ -49,7 +99,30 @@ func loadSchemaForTest() (Schema, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewSwaggerSchemaFromBytes(data)
+	return NewSwaggerSchemaFromBytes(data, nil)
+}
+
+func loadSchemaForTestWithFactory(group testapi.TestGroup, factory Schema) (Schema, error) {
+	data, err := readSwaggerApiFile(group)
+	if err != nil {
+		return nil, err
+	}
+	return NewSwaggerSchemaFromBytes(data, factory)
+}
+
+func NewFactory() (*Factory, error) {
+	f := &Factory{}
+	defaultSchema, err := loadSchemaForTestWithFactory(testapi.Default, f)
+	if err != nil {
+		return nil, err
+	}
+	f.defaultSchema = defaultSchema
+	extensionSchema, err := loadSchemaForTestWithFactory(testapi.Extensions, f)
+	if err != nil {
+		return nil, err
+	}
+	f.extensionsSchema = extensionSchema
+	return f, nil
 }
 
 func TestLoad(t *testing.T) {
@@ -88,6 +161,42 @@ func TestValidateOk(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			}
 		}
+	}
+}
+
+func TestValidateDifferentApiVersions(t *testing.T) {
+	schema, err := loadSchemaForTest()
+	if err != nil {
+		t.Errorf("Failed to load: %v", err)
+	}
+
+	pod := &api.Pod{}
+	pod.APIVersion = "v1"
+	pod.Kind = "Pod"
+
+	deployment := &extensions.Deployment{}
+	deployment.APIVersion = "extensions/v1beta1"
+	deployment.Kind = "Deployment"
+
+	list := &api.List{}
+	list.APIVersion = "v1"
+	list.Kind = "List"
+	list.Items = []runtime.Object{pod, deployment}
+	bytes, err := json.Marshal(list)
+	if err != nil {
+		t.Error(err)
+	}
+	err = schema.ValidateBytes(bytes)
+	if err == nil {
+		t.Error(fmt.Errorf("Expected error when validating different api version and no delegate exists."))
+	}
+	f, err := NewFactory()
+	if err != nil {
+		t.Error(fmt.Errorf("Failed to create Schema factory %v.", err))
+	}
+	err = f.ValidateBytes(bytes)
+	if err != nil {
+		t.Error(fmt.Errorf("Failed to validate object with multiple ApiGroups: %v.", err))
 	}
 }
 
@@ -171,7 +280,7 @@ func TestTypeOAny(t *testing.T) {
 	}
 	// Replace type: "any" in the spec by type: "object" and verify that the validation still passes.
 	newData := strings.Replace(string(data), `"type": "object"`, `"type": "any"`, -1)
-	schema, err := NewSwaggerSchemaFromBytes([]byte(newData))
+	schema, err := NewSwaggerSchemaFromBytes([]byte(newData), nil)
 	if err != nil {
 		t.Errorf("Failed to load: %v", err)
 	}

--- a/pkg/kubectl/cmd/util/factory_test.go
+++ b/pkg/kubectl/cmd/util/factory_test.go
@@ -198,7 +198,7 @@ func loadSchemaForTest() (validation.Schema, error) {
 	if err != nil {
 		return nil, err
 	}
-	return validation.NewSwaggerSchemaFromBytes(data)
+	return validation.NewSwaggerSchemaFromBytes(data, nil)
 }
 
 func TestRefetchSchemaWhenValidationFails(t *testing.T) {
@@ -250,7 +250,7 @@ func TestRefetchSchemaWhenValidationFails(t *testing.T) {
 	}
 
 	// Re-get request, should use HTTP and write
-	if getSchemaAndValidate(c, data, "foo", "bar", dir); err != nil {
+	if getSchemaAndValidate(c, data, "foo", "bar", dir, nil); err != nil {
 		t.Errorf("unexpected error validating: %v", err)
 	}
 	if requests["/swaggerapi/foo/bar"] != 1 {
@@ -295,7 +295,7 @@ func TestValidateCachesSchema(t *testing.T) {
 	}
 
 	// Initial request, should use HTTP and write
-	if getSchemaAndValidate(c, data, "foo", "bar", dir); err != nil {
+	if getSchemaAndValidate(c, data, "foo", "bar", dir, nil); err != nil {
 		t.Errorf("unexpected error validating: %v", err)
 	}
 	if _, err := os.Stat(path.Join(dir, "foo", "bar", schemaFileName)); err != nil {
@@ -306,7 +306,7 @@ func TestValidateCachesSchema(t *testing.T) {
 	}
 
 	// Same version and group, should skip HTTP
-	if getSchemaAndValidate(c, data, "foo", "bar", dir); err != nil {
+	if getSchemaAndValidate(c, data, "foo", "bar", dir, nil); err != nil {
 		t.Errorf("unexpected error validating: %v", err)
 	}
 	if requests["/swaggerapi/foo/bar"] != 2 {
@@ -314,7 +314,7 @@ func TestValidateCachesSchema(t *testing.T) {
 	}
 
 	// Different API group, should go to HTTP and write
-	if getSchemaAndValidate(c, data, "foo", "baz", dir); err != nil {
+	if getSchemaAndValidate(c, data, "foo", "baz", dir, nil); err != nil {
 		t.Errorf("unexpected error validating: %v", err)
 	}
 	if _, err := os.Stat(path.Join(dir, "foo", "baz", schemaFileName)); err != nil {
@@ -325,7 +325,7 @@ func TestValidateCachesSchema(t *testing.T) {
 	}
 
 	// Different version, should go to HTTP and write
-	if getSchemaAndValidate(c, data, "foo2", "bar", dir); err != nil {
+	if getSchemaAndValidate(c, data, "foo2", "bar", dir, nil); err != nil {
 		t.Errorf("unexpected error validating: %v", err)
 	}
 	if _, err := os.Stat(path.Join(dir, "foo2", "bar", schemaFileName)); err != nil {
@@ -336,7 +336,7 @@ func TestValidateCachesSchema(t *testing.T) {
 	}
 
 	// No cache dir, should go straight to HTTP and not write
-	if getSchemaAndValidate(c, data, "foo", "blah", ""); err != nil {
+	if getSchemaAndValidate(c, data, "foo", "blah", "", nil); err != nil {
 		t.Errorf("unexpected error validating: %v", err)
 	}
 	if requests["/swaggerapi/foo/blah"] != 1 {


### PR DESCRIPTION
## Pull Request Guidelines
1. Please read our [contributor guidelines](https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md).
2. See our [developer guide](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md).
3. Follow the instructions for [labeling and writing a release note for this PR](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes) in the block below.

``` release-note
kubectl now supports validation of nested objects with different ApiGroups (e.g. objects in a List)
```

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
#24089
