### PR TITLE
Use --format='value(name)' with gcloud instead of grep/awk/cut

### DIFF
--- a/cluster/gce/delete-stranded-load-balancers.sh
+++ b/cluster/gce/delete-stranded-load-balancers.sh
@@ -18,7 +18,7 @@
 PROJECT=${PROJECT:-kubernetes-jenkins}
 REGION=${REGION:-us-central1}
 
-LIST=$(gcloud --project=${PROJECT} compute target-pools list | sed 1d | awk '{print $1}')
+LIST=$(gcloud --project=${PROJECT} compute target-pools list --format='value(name)')
 
 result=0
 for x in ${LIST}; do

--- a/cluster/gke/util.sh
+++ b/cluster/gke/util.sh
@@ -50,7 +50,7 @@ function prepare-e2e() {
 function detect-project() {
   echo "... in gke:detect-project()" >&2
   if [[ -z "${PROJECT:-}" ]]; then
-    export PROJECT=$("${GCLOUD}" config list project | tail -n 1 | cut -f 3 -d ' ')
+    export PROJECT=$("${GCLOUD}" config list project --format 'value(core.project)')
     echo "... Using project: ${PROJECT}" >&2
   fi
   if [[ -z "${PROJECT:-}" ]]; then
@@ -190,7 +190,7 @@ function test-setup() {
   detect-nodes >&2
 
   # At this point, CLUSTER_NAME should have been used, so its value is final.
-  NODE_TAG=$($GCLOUD compute instances describe ${NODE_NAMES[0]} --project="${PROJECT}" --zone="${ZONE}" | grep -o "gke-${CLUSTER_NAME}-.\{8\}-node" | head -1)
+  NODE_TAG=$($GCLOUD compute instances describe ${NODE_NAMES[0]} --project="${PROJECT}" --zone="${ZONE}" --format='value(tags.items)' | grep -o "gke-${CLUSTER_NAME}-.\{8\}-node")
   OLD_NODE_TAG="k8s-${CLUSTER_NAME}-node"
 
   # Open up port 80 & 8080 so common containers on minions can be reached.
@@ -221,8 +221,8 @@ function detect-master() {
   echo "... in gke:detect-master()" >&2
   detect-project >&2
   KUBE_MASTER_IP=$("${GCLOUD}" ${CMD_GROUP:-} container clusters describe \
-    --project="${PROJECT}" --zone="${ZONE}" "${CLUSTER_NAME}" \
-    | grep endpoint | cut -f 2 -d ' ')
+    --project="${PROJECT}" --zone="${ZONE}" --format='value(endpoint)' \
+    "${CLUSTER_NAME}")
 }
 
 # Assumed vars:
@@ -268,9 +268,10 @@ function detect-node-names {
 #   NODE_INSTANCE_GROUP
 function detect-node-instance-group {
   echo "... in gke:detect-node-instance-group()" >&2
-  NODE_INSTANCE_GROUP=$("${GCLOUD}" ${CMD_GROUP:-} container clusters describe \
-    --project="${PROJECT}" --zone="${ZONE}" "${CLUSTER_NAME}" \
-    | grep instanceGroupManagers | grep "${ZONE}" | cut -d '/' -f 11)
+  local url=$("${GCLOUD}" ${CMD_GROUP:-} container clusters describe \
+    --project="${PROJECT}" --zone="${ZONE}" \
+    --format='value(instanceGroupUrls)' "${CLUSTER_NAME}")
+  NODE_INSTANCE_GROUP="${url##*/}"
 }
 
 # SSH to a node by name ($1) and run a command ($2).

--- a/hack/jenkins/e2e-runner.sh
+++ b/hack/jenkins/e2e-runner.sh
@@ -34,10 +34,7 @@ function fetch_output_tars() {
 }
 
 function fetch_server_version_tars() {
-    local -r msg=$(gcloud ${CMD_GROUP:-} container get-server-config --project=${PROJECT} --zone=${ZONE} | grep defaultClusterVersion)
-    # msg will look like "defaultClusterVersion: 1.0.1". Strip
-    # everything up to, including ": "
-    local -r build_version="v${msg##*: }"
+    local -r build_version="v$(gcloud ${CMD_GROUP:-} container get-server-config --project=${PROJECT} --zone=${ZONE}  --format='value(defaultClusterVersion)')"
     fetch_tars_from_gcs "release" "${build_version}"
     unpack_binaries
 }


### PR DESCRIPTION
Fixing our fragile parsing of `gcloud` is getting old (#24746, #25159, maybe others?).

Instead, let's just get the proper output out of `gcloud` in the first place.
