### PR TITLE
rkt: Support alternate stage1's via annotation

### DIFF
--- a/pkg/kubelet/rkt/mock_rkt/mock_volume_getter.go
+++ b/pkg/kubelet/rkt/mock_rkt/mock_volume_getter.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
 // Generated via `mockgen k8s.io/kubernetes/pkg/kubelet/rkt VolumeGetter > mock_rkt/mock_volume_getter.go`
 // Edited to include required boilerplate
 // Source: k8s.io/kubernetes/pkg/kubelet/rkt (interfaces: VolumeGetter)

--- a/pkg/kubelet/rkt/mock_rkt/mock_volume_getter.go
+++ b/pkg/kubelet/rkt/mock_rkt/mock_volume_getter.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+// Generated via `mockgen k8s.io/kubernetes/pkg/kubelet/rkt VolumeGetter > mock_rkt/mock_volume_getter.go`
+// Edited to include required boilerplate
+// Source: k8s.io/kubernetes/pkg/kubelet/rkt (interfaces: VolumeGetter)
+
+package mock_rkt
+
+import (
+	gomock "github.com/golang/mock/gomock"
+	container "k8s.io/kubernetes/pkg/kubelet/container"
+	types "k8s.io/kubernetes/pkg/types"
+)
+
+// Mock of VolumeGetter interface
+type MockVolumeGetter struct {
+	ctrl     *gomock.Controller
+	recorder *_MockVolumeGetterRecorder
+}
+
+// Recorder for MockVolumeGetter (not exported)
+type _MockVolumeGetterRecorder struct {
+	mock *MockVolumeGetter
+}
+
+func NewMockVolumeGetter(ctrl *gomock.Controller) *MockVolumeGetter {
+	mock := &MockVolumeGetter{ctrl: ctrl}
+	mock.recorder = &_MockVolumeGetterRecorder{mock}
+	return mock
+}
+
+func (_m *MockVolumeGetter) EXPECT() *_MockVolumeGetterRecorder {
+	return _m.recorder
+}
+
+func (_m *MockVolumeGetter) GetVolumes(_param0 types.UID) (container.VolumeMap, bool) {
+	ret := _m.ctrl.Call(_m, "GetVolumes", _param0)
+	ret0, _ := ret[0].(container.VolumeMap)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+func (_mr *_MockVolumeGetterRecorder) GetVolumes(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetVolumes", arg0)
+}


### PR DESCRIPTION
This provides a basic implementation for setting a stage1 on a per-pod
basis via an annotation.

This provides a basic implementation for setting a stage1 on a per-pod
basis via an annotation. See discussion here for how this approach was arrived at: https://github.com/kubernetes/kubernetes/issues/23944#issuecomment-212653776

It's possible this feature should be gated behind additional knobs, such
as a kubelet flag to filter allowed stage1s, or a check akin to what
priviliged gets in the apiserver.
Currently, it checks `AllowPrivileged`, as a means to let people disable
this feature, though overloading it as stage1 and privileged isn't
ideal.

Fixes #23944

Testing done (note, unfortunately done with some additional ./cluster changes merged in):

```
$ cat examples/stage1-fly/fly-me-to-the-moon.yaml
apiVersion: v1
kind: Pod
metadata:
  labels:
    name: exit
  name: exit-fast
  annotations: {"rkt.alpha.kubernetes.io/stage1-name-override": "coreos.com/rkt/stage1-fly:1.3.0"}
spec:
  restartPolicy: Never
  containers:
    - name: exit
      image: busybox
      command: ["sh", "-c", "ps aux"]
$ kubectl create -f examples/stage1-fly
$ ssh core@minion systemctl status -l --no-pager k8s_2f169b2e-c32a-49e9-a5fb-29ae1f6b4783.service
...
failed
...
May 04 23:33:03 minion rkt[2525]: stage0: error writing /etc/rkt-resolv.conf: open /var/lib/rkt/pods/run/2f169b2e-c32a-49e9-a5fb-29ae1f6b4783/stage1/rootfs/etc/rkt-resolv.conf: no such file or directory
...
# Restart kubelet with allow-privileged=false
$ kubectl create -f examples/stage1-fly
$ kubectl describe exit-fast
...
  1m        19s     5   {kubelet euank-e2e-test-minion-dv3u}    spec.containers{exit}   Warning     Failed      Failed to create rkt container with error: cannot make "exit-fast_default(17050ce9-1252-11e6-a52a-42010af00002)": running a custom stage1 requires a privileged security context
....
```

Note as well that the "success" here is rkt spitting out an [error message](https://github.com/coreos/rkt/issues/2141) which indicates that the right stage1 was being used at least.

cc @yifan-gu @aaronlevy
