### PR TITLE
kubectl suggest for get (list, ps), and delete(rm)

### DIFF
--- a/pkg/kubectl/cmd/delete.go
+++ b/pkg/kubectl/cmd/delete.go
@@ -92,6 +92,7 @@ func NewCmdDelete(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 			err := RunDelete(f, out, cmd, args, options)
 			cmdutil.CheckErr(err)
 		},
+		SuggestFor: []string{"rm"},
 		ValidArgs:  validArgs,
 		ArgAliases: argAliases,
 	}

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -92,6 +92,7 @@ func NewCmdGet(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 			err := RunGet(f, out, cmd, args, options)
 			cmdutil.CheckErr(err)
 		},
+		SuggestFor: []string{"list", "ps"},
 		ValidArgs:  validArgs,
 		ArgAliases: argAliases,
 	}


### PR DESCRIPTION
## Pull Request Guidelines
1. Please read our [contributor guidelines](https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md).
2. See our [developer guide](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md).
3. Follow the instructions for [labeling and writing a release note for this PR](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes) in the block below.

``` release-note
kubectl "rm" will suggest using "delete"; "ps" and "list" will suggest "get".
```

**Before**:

``` console
$ kubectl ps 
Error: unknown command "ps" for "kubectl"
Run 'kubectl --help' for usage.
```

**After**:

``` console
$ kubectl ps 
Error: unknown command "ps" for "kubectl"

Did you mean this?
    get

Run 'kubectl --help' for usage.
```

Ref #25180

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
