### PR TITLE
Automatically create the kube-system namespace

### DIFF
--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -503,6 +503,9 @@ func (m *Master) NewBootstrapController() *Controller {
 		EndpointRegistry: m.endpointRegistry,
 		EndpointInterval: 10 * time.Second,
 
+		SystemNamespaces:         []string{api.NamespaceSystem},
+		SystemNamespacesInterval: 1 * time.Minute,
+
 		ServiceClusterIPRegistry: m.serviceClusterIPAllocator,
 		ServiceClusterIPRange:    m.ServiceClusterIPRange,
 		ServiceClusterIPInterval: 3 * time.Minute,

--- a/plugin/pkg/admission/namespace/lifecycle/admission.go
+++ b/plugin/pkg/admission/namespace/lifecycle/admission.go
@@ -36,7 +36,7 @@ const PluginName = "NamespaceLifecycle"
 
 func init() {
 	admission.RegisterPlugin(PluginName, func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
-		return NewLifecycle(client, sets.NewString(api.NamespaceDefault)), nil
+		return NewLifecycle(client, sets.NewString(api.NamespaceDefault, api.NamespaceSystem)), nil
 	})
 }
 


### PR DESCRIPTION
At the same time we ensure that the `default` namespace is present, it also creates `kube-system` if it doesn't exist.

`kube-system` will now exist from the beginning, and will be recreated every 10s if deleted, in the same manner as the `default` ns

This makes UX much better, no need for `kubectl`ing a `kube-system.yaml` file anymore for a function that is essential to Kubernetes (addons). For instance, this makes dashboard deployment much easier when there's no need to check for the `kube-system` ns first.

A follow up in the future may remove places where logic to manually create the kube-system namespace is present.

Also fixed a small bug where `CreateNamespaceIfNeeded` ignored the `ns` parameter and was hardcoded to `api.NamespaceDefault`.

@davidopp @lavalamp @thockin @mikedanese @bryk @cheld @fgrzadkowski @smarterclayton @wojtek-t @dlorenc @vishh @dchen1107 @bgrant0607 @roberthbailey

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/25196)

<!-- Reviewable:end -->
