### PR TITLE
Expose commonly used ports in the etcd image

### DIFF
--- a/cluster/images/etcd/Dockerfile
+++ b/cluster/images/etcd/Dockerfile
@@ -15,5 +15,6 @@
 FROM BASEIMAGE
 MAINTAINER Dawn Chen <dawnchen@google.com>
 
+EXPOSE 2379 2380 4001 7001
 COPY etcd /usr/local/bin/
 COPY etcdctl /usr/local/bin/

--- a/cluster/images/etcd/Dockerfile
+++ b/cluster/images/etcd/Dockerfile
@@ -16,5 +16,4 @@ FROM BASEIMAGE
 MAINTAINER Dawn Chen <dawnchen@google.com>
 
 EXPOSE 2379 2380 4001 7001
-COPY etcd /usr/local/bin/
-COPY etcdctl /usr/local/bin/
+COPY etcd etcdctl /usr/local/bin/


### PR DESCRIPTION
I'd like to expose ports commonly used by etcd in the etcd docker image.
It does not affect kubernetes in any way but it would make it more convenient to use the image for other purposes, outside of kubernetes.

I also merged the two COPY lines to reduce the number of layers.
