### PR TITLE
rkt: When host port is zero, we should not forward the port.

### DIFF
--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -749,6 +749,9 @@ func (r *Runtime) newAppcRuntimeApp(pod *api.Pod, c api.Container, pullSecrets [
 
 	// Set global ports.
 	for _, port := range opts.PortMappings {
+		if port.HostPort == 0 {
+			continue
+		}
 		manifest.Ports = append(manifest.Ports, appctypes.ExposedPort{
 			Name:     convertToACName(port.Name),
 			HostPort: uint(port.HostPort),


### PR DESCRIPTION
Before the commit, rkt will generate the port forward rule for host port 0.

```
$ cat pod 
# Copy of pod.yaml without file extension for test
apiVersion: v1
kind: Pod
metadata:
  name: nginx
  labels:
    name: nginx
spec:
  containers:
  - name: nginx
    image: nginx
    ports:
    - containerPort: 80
      hostPort: 0

$ iptables-save
...
-A RKT-PFWD-DNAT-7bb8e84a -p tcp -m tcp --dport 0 -j DNAT --to-destination 172.16.28.10:80
-A RKT-PFWD-SNAT-7bb8e84a -s 127.0.0.1/32 -d 172.16.28.10/32 -p tcp -m tcp --dport 0 -j MASQUERADE
...
```

After the commit, no such rules are generated.

cc @euank @steevj
