### PR TITLE
Kubectl retry

### DIFF
--- a/pkg/kubectl/cmd/annotate_test.go
+++ b/pkg/kubectl/cmd/annotate_test.go
@@ -504,7 +504,7 @@ func TestAnnotateObjectFromFile(t *testing.T) {
 	cmd := NewCmdAnnotate(f, buf)
 	cmd.SetOutput(buf)
 	options := &AnnotateOptions{}
-	options.filenames = []string{"../../../examples/cassandra/cassandra-controller.yaml"}
+	options.FilenameOptions.Filenames = []string{"../../../examples/cassandra/cassandra-controller.yaml"}
 	args := []string{"a=b", "c-"}
 	if err := options.Complete(f, buf, cmd, args); err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/pkg/kubectl/cmd/apply.go
+++ b/pkg/kubectl/cmd/apply.go
@@ -34,8 +34,7 @@ import (
 // ApplyOptions stores cmd.Flag values for apply.  As new fields are added,
 // add them here instead of referencing the cmd.Flags()
 type ApplyOptions struct {
-	Filenames []string
-	Recursive bool
+	FilenameOptions resource.FilenameParamOptions
 }
 
 const (
@@ -67,10 +66,9 @@ func NewCmdApply(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	}
 
 	usage := "Filename, directory, or URL to file that contains the configuration to apply"
-	kubectl.AddJsonFilenameFlag(cmd, &options.Filenames, usage)
+	cmdutil.AddFilenameParamFlags(cmd, &options.FilenameOptions, usage)
 	cmd.MarkFlagRequired("filename")
 	cmdutil.AddValidateFlags(cmd)
-	cmdutil.AddRecursiveFlag(cmd, &options.Recursive)
 	cmdutil.AddOutputFlagsForMutation(cmd)
 	cmdutil.AddRecordFlag(cmd)
 	cmdutil.AddInclude3rdPartyFlags(cmd)
@@ -102,7 +100,7 @@ func RunApply(f *cmdutil.Factory, cmd *cobra.Command, out io.Writer, options *Ap
 		Schema(schema).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, options.Recursive, options.Filenames...).
+		FilenameParam(enforceNamespace, &options.FilenameOptions).
 		Flatten().
 		Do()
 	err = r.Err()

--- a/pkg/kubectl/cmd/autoscale.go
+++ b/pkg/kubectl/cmd/autoscale.go
@@ -31,8 +31,7 @@ import (
 // AutoscaleOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
 // referencing the cmd.Flags()
 type AutoscaleOptions struct {
-	Filenames []string
-	Recursive bool
+	FilenameParams resource.FilenameParamOptions
 }
 
 const (
@@ -70,8 +69,7 @@ func NewCmdAutoscale(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().String("name", "", "The name for the newly created object. If not specified, the name of the input resource will be used.")
 	cmd.Flags().Bool("dry-run", false, "If true, only print the object that would be sent, without creating it.")
 	usage := "Filename, directory, or URL to a file identifying the resource to autoscale."
-	kubectl.AddJsonFilenameFlag(cmd, &options.Filenames, usage)
-	cmdutil.AddRecursiveFlag(cmd, &options.Recursive)
+	cmdutil.AddFilenameParamFlags(cmd, &options.FilenameParams, usage)
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddRecordFlag(cmd)
 	cmdutil.AddInclude3rdPartyFlags(cmd)
@@ -93,7 +91,7 @@ func RunAutoscale(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []
 	r := resource.NewBuilder(mapper, typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true)).
 		ContinueOnError().
 		NamespaceParam(namespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, options.Recursive, options.Filenames...).
+		FilenameParam(enforceNamespace, &options.FilenameParams).
 		ResourceTypeOrNameArgs(false, args...).
 		Flatten().
 		Do()

--- a/pkg/kubectl/cmd/convert.go
+++ b/pkg/kubectl/cmd/convert.go
@@ -73,8 +73,7 @@ func NewCmdConvert(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	}
 
 	usage := "Filename, directory, or URL to file to need to get converted."
-	kubectl.AddJsonFilenameFlag(cmd, &options.filenames, usage)
-	cmdutil.AddRecursiveFlag(cmd, &options.recursive)
+	cmdutil.AddFilenameParamFlags(cmd, &options.FilenameParams, usage)
 	cmd.MarkFlagRequired("filename")
 	cmdutil.AddValidateFlags(cmd)
 	cmdutil.AddPrinterFlags(cmd)
@@ -86,7 +85,6 @@ func NewCmdConvert(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 // ConvertOptions have the data required to perform the convert operation
 type ConvertOptions struct {
 	builder   *resource.Builder
-	filenames []string
 	local     bool
 
 	encoder runtime.Encoder
@@ -95,7 +93,7 @@ type ConvertOptions struct {
 
 	outputVersion unversioned.GroupVersion
 
-	recursive bool
+	FilenameParams resource.FilenameParamOptions
 }
 
 // Complete collects information required to run Convert command from command line.
@@ -129,7 +127,7 @@ func (o *ConvertOptions) Complete(f *cmdutil.Factory, out io.Writer, cmd *cobra.
 	}
 	o.builder = o.builder.NamespaceParam(cmdNamespace).
 		ContinueOnError().
-		FilenameParam(false, o.recursive, o.filenames...).
+		FilenameParam(false, &o.FilenameParams).
 		Flatten()
 
 	// build the printer

--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -34,8 +34,7 @@ import (
 // CreateOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
 // referencing the cmd.Flags()
 type CreateOptions struct {
-	Filenames []string
-	Recursive bool
+	FilenameParams resource.FilenameParamOptions
 }
 
 const (
@@ -58,7 +57,7 @@ func NewCmdCreate(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 		Long:    create_long,
 		Example: create_example,
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(options.Filenames) == 0 {
+			if len(options.FilenameParams.Filenames) == 0 {
 				cmd.Help()
 				return
 			}
@@ -69,10 +68,9 @@ func NewCmdCreate(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	}
 
 	usage := "Filename, directory, or URL to file to use to create the resource"
-	kubectl.AddJsonFilenameFlag(cmd, &options.Filenames, usage)
+	cmdutil.AddFilenameParamFlags(cmd, &options.FilenameParams, usage)
 	cmd.MarkFlagRequired("filename")
 	cmdutil.AddValidateFlags(cmd)
-	cmdutil.AddRecursiveFlag(cmd, &options.Recursive)
 	cmdutil.AddOutputFlagsForMutation(cmd)
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddRecordFlag(cmd)
@@ -109,7 +107,7 @@ func RunCreate(f *cmdutil.Factory, cmd *cobra.Command, out io.Writer, options *C
 		Schema(schema).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, options.Recursive, options.Filenames...).
+		FilenameParam(enforceNamespace, &options.FilenameParams).
 		Flatten().
 		Do()
 	err = r.Err()

--- a/pkg/kubectl/cmd/delete.go
+++ b/pkg/kubectl/cmd/delete.go
@@ -34,8 +34,7 @@ import (
 // DeleteOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
 // referencing the cmd.Flags()
 type DeleteOptions struct {
-	Filenames []string
-	Recursive bool
+	FilenameParams resource.FilenameParamOptions
 }
 
 const (
@@ -96,8 +95,7 @@ func NewCmdDelete(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 		ArgAliases: argAliases,
 	}
 	usage := "Filename, directory, or URL to a file containing the resource to delete."
-	kubectl.AddJsonFilenameFlag(cmd, &options.Filenames, usage)
-	cmdutil.AddRecursiveFlag(cmd, &options.Recursive)
+	cmdutil.AddFilenameParamFlags(cmd, &options.FilenameParams, usage)
 	cmd.Flags().StringP("selector", "l", "", "Selector (label query) to filter on.")
 	cmd.Flags().Bool("all", false, "[-all] to select all the specified resources.")
 	cmd.Flags().Bool("ignore-not-found", false, "Treat \"resource not found\" as a successful delete. Defaults to \"true\" when --all is specified.")
@@ -120,7 +118,7 @@ func RunDelete(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []str
 	r := resource.NewBuilder(mapper, typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true)).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, options.Recursive, options.Filenames...).
+		FilenameParam(enforceNamespace, &options.FilenameParams).
 		SelectorParam(cmdutil.GetFlagString(cmd, "selector")).
 		SelectAllParam(deleteAll).
 		ResourceTypeOrNameArgs(false, args...).RequireObject(false).

--- a/pkg/kubectl/cmd/delete_test.go
+++ b/pkg/kubectl/cmd/delete_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+	"k8s.io/kubernetes/pkg/kubectl/resource"
 )
 
 func TestDeleteObjectByTuple(t *testing.T) {
@@ -145,7 +146,7 @@ func TestDeleteObjectNotFound(t *testing.T) {
 
 	cmd := NewCmdDelete(f, buf)
 	options := &DeleteOptions{
-		Filenames: []string{"../../../examples/guestbook/legacy/redis-master-controller.yaml"},
+		FilenameParams: resource.FilenameParamOptions{Filenames: []string{"../../../examples/guestbook/legacy/redis-master-controller.yaml"}},
 	}
 	cmd.Flags().Set("cascade", "false")
 	cmd.Flags().Set("output", "name")
@@ -325,7 +326,7 @@ func TestDeleteMultipleObjectContinueOnMissing(t *testing.T) {
 
 	cmd := NewCmdDelete(f, buf)
 	options := &DeleteOptions{
-		Filenames: []string{"../../../examples/guestbook/legacy/redis-master-controller.yaml", "../../../examples/guestbook/frontend-service.yaml"},
+		FilenameParams: resource.FilenameParamOptions{Filenames: []string{"../../../examples/guestbook/legacy/redis-master-controller.yaml", "../../../examples/guestbook/frontend-service.yaml"}},
 	}
 	cmd.Flags().Set("cascade", "false")
 	cmd.Flags().Set("output", "name")

--- a/pkg/kubectl/cmd/describe.go
+++ b/pkg/kubectl/cmd/describe.go
@@ -35,8 +35,7 @@ import (
 // DescribeOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
 // referencing the cmd.Flags()
 type DescribeOptions struct {
-	Filenames []string
-	Recursive bool
+	FilenameParams resource.FilenameParamOptions
 }
 
 const (
@@ -90,8 +89,7 @@ func NewCmdDescribe(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 		ArgAliases: argAliases,
 	}
 	usage := "Filename, directory, or URL to a file containing the resource to describe"
-	kubectl.AddJsonFilenameFlag(cmd, &options.Filenames, usage)
-	cmdutil.AddRecursiveFlag(cmd, &options.Recursive)
+	cmdutil.AddFilenameParamFlags(cmd, &options.FilenameParams, usage)
 	cmd.Flags().StringP("selector", "l", "", "Selector (label query) to filter on")
 	cmdutil.AddInclude3rdPartyFlags(cmd)
 	return cmd
@@ -103,7 +101,7 @@ func RunDescribe(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []s
 	if err != nil {
 		return err
 	}
-	if len(args) == 0 && len(options.Filenames) == 0 {
+	if len(args) == 0 && len(options.FilenameParams.Filenames) == 0 {
 		fmt.Fprint(out, "You must specify the type of resource to describe. ", valid_resources)
 		return cmdutil.UsageError(cmd, "Required resource not specified.")
 	}
@@ -112,7 +110,7 @@ func RunDescribe(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []s
 	r := resource.NewBuilder(mapper, typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true)).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, options.Recursive, options.Filenames...).
+		FilenameParam(enforceNamespace, &options.FilenameParams).
 		SelectorParam(selector).
 		ResourceTypeOrNameArgs(true, args...).
 		Flatten().

--- a/pkg/kubectl/cmd/edit.go
+++ b/pkg/kubectl/cmd/edit.go
@@ -77,8 +77,7 @@ saved copy to include the latest resource version.`
 // EditOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
 // referencing the cmd.Flags()
 type EditOptions struct {
-	Filenames []string
-	Recursive bool
+	FilenameParams resource.FilenameParamOptions
 }
 
 var errExit = fmt.Errorf("exit directly")
@@ -111,8 +110,7 @@ func NewCmdEdit(f *cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 		ArgAliases: argAliases,
 	}
 	usage := "Filename, directory, or URL to file to use to edit the resource"
-	kubectl.AddJsonFilenameFlag(cmd, &options.Filenames, usage)
-	cmdutil.AddRecursiveFlag(cmd, &options.Recursive)
+	cmdutil.AddFilenameParamFlags(cmd, &options.FilenameParams, usage)
 	cmd.Flags().StringP("output", "o", "yaml", "Output format. One of: yaml|json.")
 	cmd.Flags().String("output-version", "", "Output the formatted object with the given group version (for ex: 'extensions/v1beta1').")
 	cmd.Flags().Bool("windows-line-endings", gruntime.GOOS == "windows", "Use Windows line-endings (default Unix line-endings)")
@@ -157,7 +155,7 @@ func RunEdit(f *cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args
 
 	r := resource.NewBuilder(mapper, typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true)).
 		NamespaceParam(cmdNamespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, options.Recursive, options.Filenames...).
+		FilenameParam(enforceNamespace, &options.FilenameParams).
 		ResourceTypeOrNameArgs(true, args...).
 		Latest().
 		Flatten().

--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -34,8 +34,7 @@ import (
 // ExposeOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
 // referencing the cmd.Flags()
 type ExposeOptions struct {
-	Filenames []string
-	Recursive bool
+	FilenameParams resource.FilenameParamOptions
 }
 
 const (
@@ -119,10 +118,10 @@ func NewCmdExposeService(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().String("session-affinity", "", "If non-empty, set the session affinity for the service to this; legal values: 'None', 'ClientIP'")
 
 	usage := "Filename, directory, or URL to a file identifying the resource to expose a service"
-	kubectl.AddJsonFilenameFlag(cmd, &options.Filenames, usage)
-	cmdutil.AddRecursiveFlag(cmd, &options.Recursive)
+	cmdutil.AddFilenameParamFlags(cmd, &options.FilenameParams, usage)
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddRecordFlag(cmd)
+
 	return cmd
 }
 
@@ -136,7 +135,7 @@ func RunExpose(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []str
 	r := resource.NewBuilder(mapper, typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true)).
 		ContinueOnError().
 		NamespaceParam(namespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, options.Recursive, options.Filenames...).
+		FilenameParam(enforceNamespace, &options.FilenameParams).
 		ResourceTypeOrNameArgs(false, args...).
 		Flatten().
 		Do()

--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -39,8 +39,7 @@ import (
 // LabelOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
 // referencing the cmd.Flags()
 type LabelOptions struct {
-	Filenames []string
-	Recursive bool
+	FilenameParams resource.FilenameParamOptions
 }
 
 const (
@@ -99,8 +98,7 @@ func NewCmdLabel(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().Bool("all", false, "select all resources in the namespace of the specified resource types")
 	cmd.Flags().String("resource-version", "", "If non-empty, the labels update will only succeed if this is the current resource-version for the object. Only valid when specifying a single resource.")
 	usage := "Filename, directory, or URL to a file identifying the resource to update the labels"
-	kubectl.AddJsonFilenameFlag(cmd, &options.Filenames, usage)
-	cmdutil.AddRecursiveFlag(cmd, &options.Recursive)
+	cmdutil.AddFilenameParamFlags(cmd, &options.FilenameParams, usage)
 	cmd.Flags().Bool("dry-run", false, "If true, only print the object that would be sent, without sending it.")
 	cmdutil.AddRecordFlag(cmd)
 	cmdutil.AddInclude3rdPartyFlags(cmd)
@@ -189,7 +187,7 @@ func RunLabel(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []stri
 			return cmdutil.UsageError(cmd, "all resources must be specified before label changes: %s", s)
 		}
 	}
-	if len(resources) < 1 && len(options.Filenames) == 0 {
+	if len(resources) < 1 && len(options.FilenameParams.Filenames) == 0 {
 		return cmdutil.UsageError(cmd, "one or more resources must be specified as <resource> <name> or <resource>/<name>")
 	}
 	if len(labelArgs) < 1 {
@@ -214,7 +212,7 @@ func RunLabel(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []stri
 	b := resource.NewBuilder(mapper, typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true)).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, options.Recursive, options.Filenames...).
+		FilenameParam(enforceNamespace, &options.FilenameParams).
 		SelectorParam(selector).
 		ResourceTypeOrNameArgs(all, resources...).
 		Flatten().

--- a/pkg/kubectl/cmd/label_test.go
+++ b/pkg/kubectl/cmd/label_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/kubectl/resource"
 )
 
 func TestValidateLabels(t *testing.T) {
@@ -359,7 +360,7 @@ func TestLabelForResourceFromFile(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 	cmd := NewCmdLabel(f, buf)
 	options := &LabelOptions{
-		Filenames: []string{"../../../examples/cassandra/cassandra-controller.yaml"},
+		FilenameParams: resource.FilenameParamOptions{Filenames: []string{"../../../examples/cassandra/cassandra-controller.yaml"}},
 	}
 
 	err := RunLabel(f, buf, cmd, []string{"a=b"}, options)

--- a/pkg/kubectl/cmd/patch.go
+++ b/pkg/kubectl/cmd/patch.go
@@ -36,8 +36,7 @@ var patchTypes = map[string]api.PatchType{"json": api.JSONPatchType, "merge": ap
 // PatchOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
 // referencing the cmd.Flags()
 type PatchOptions struct {
-	Filenames []string
-	Recursive bool
+	FilenameParams resource.FilenameParamOptions
 }
 
 const (
@@ -94,8 +93,7 @@ func NewCmdPatch(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmdutil.AddInclude3rdPartyFlags(cmd)
 
 	usage := "Filename, directory, or URL to a file identifying the resource to update"
-	kubectl.AddJsonFilenameFlag(cmd, &options.Filenames, usage)
-	cmdutil.AddRecursiveFlag(cmd, &options.Recursive)
+	cmdutil.AddFilenameParamFlags(cmd, &options.FilenameParams, usage)
 	return cmd
 }
 
@@ -128,7 +126,7 @@ func RunPatch(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []stri
 	r := resource.NewBuilder(mapper, typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true)).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, options.Recursive, options.Filenames...).
+		FilenameParam(enforceNamespace, &options.FilenameParams).
 		ResourceTypeOrNameArgs(false, args...).
 		Flatten().
 		Do()

--- a/pkg/kubectl/cmd/rollout/rollout_history.go
+++ b/pkg/kubectl/cmd/rollout/rollout_history.go
@@ -31,8 +31,7 @@ import (
 // HistoryOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
 // referencing the cmd.Flags()
 type HistoryOptions struct {
-	Filenames []string
-	Recursive bool
+	FilenameParams resource.FilenameParamOptions
 }
 
 const (
@@ -59,13 +58,12 @@ func NewCmdRolloutHistory(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 
 	cmd.Flags().Int64("revision", 0, "See the details, including podTemplate of the revision specified")
 	usage := "Filename, directory, or URL to a file identifying the resource to get from a server."
-	kubectl.AddJsonFilenameFlag(cmd, &options.Filenames, usage)
-	cmdutil.AddRecursiveFlag(cmd, &options.Recursive)
+	cmdutil.AddFilenameParamFlags(cmd, &options.FilenameParams, usage)
 	return cmd
 }
 
 func RunHistory(f *cmdutil.Factory, cmd *cobra.Command, out io.Writer, args []string, options *HistoryOptions) error {
-	if len(args) == 0 && len(options.Filenames) == 0 {
+	if len(args) == 0 && len(options.FilenameParams.Filenames) == 0 {
 		return cmdutil.UsageError(cmd, "Required resource not specified.")
 	}
 	revisionDetail := cmdutil.GetFlagInt64(cmd, "revision")
@@ -79,7 +77,7 @@ func RunHistory(f *cmdutil.Factory, cmd *cobra.Command, out io.Writer, args []st
 
 	infos, err := resource.NewBuilder(mapper, typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true)).
 		NamespaceParam(cmdNamespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, options.Recursive, options.Filenames...).
+		FilenameParam(enforceNamespace, &options.FilenameParams).
 		ResourceTypeOrNameArgs(true, args...).
 		Latest().
 		Flatten().

--- a/pkg/kubectl/cmd/rollout/rollout_pause.go
+++ b/pkg/kubectl/cmd/rollout/rollout_pause.go
@@ -23,7 +23,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/kubernetes/pkg/api/meta"
-	"k8s.io/kubernetes/pkg/kubectl"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 	"k8s.io/kubernetes/pkg/runtime"
@@ -38,8 +37,7 @@ type PauseConfig struct {
 	Info        *resource.Info
 
 	Out       io.Writer
-	Filenames []string
-	Recursive bool
+	FilenameParams resource.FilenameParamOptions
 }
 
 const (
@@ -70,13 +68,12 @@ func NewCmdRolloutPause(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	}
 
 	usage := "Filename, directory, or URL to a file identifying the resource to get from a server."
-	kubectl.AddJsonFilenameFlag(cmd, &opts.Filenames, usage)
-	cmdutil.AddRecursiveFlag(cmd, &opts.Recursive)
+	cmdutil.AddFilenameParamFlags(cmd, &opts.FilenameParams, usage)
 	return cmd
 }
 
 func (o *PauseConfig) CompletePause(f *cmdutil.Factory, cmd *cobra.Command, out io.Writer, args []string) error {
-	if len(args) == 0 && len(o.Filenames) == 0 {
+	if len(args) == 0 && len(o.FilenameParams.Filenames) == 0 {
 		return cmdutil.UsageError(cmd, cmd.Use)
 	}
 
@@ -91,7 +88,7 @@ func (o *PauseConfig) CompletePause(f *cmdutil.Factory, cmd *cobra.Command, out 
 
 	infos, err := resource.NewBuilder(o.Mapper, o.Typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true)).
 		NamespaceParam(cmdNamespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, o.Recursive, o.Filenames...).
+		FilenameParam(enforceNamespace, &o.FilenameParams).
 		ResourceTypeOrNameArgs(true, args...).
 		SingleResourceType().
 		Latest().

--- a/pkg/kubectl/cmd/rollout/rollout_undo.go
+++ b/pkg/kubectl/cmd/rollout/rollout_undo.go
@@ -39,8 +39,7 @@ type UndoOptions struct {
 	ToRevision int64
 
 	Out       io.Writer
-	Filenames []string
-	Recursive bool
+	FilenameParams resource.FilenameParamOptions
 }
 
 const (
@@ -68,13 +67,12 @@ func NewCmdRolloutUndo(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 
 	cmd.Flags().Int64("to-revision", 0, "The revision to rollback to. Default to 0 (last revision).")
 	usage := "Filename, directory, or URL to a file identifying the resource to get from a server."
-	kubectl.AddJsonFilenameFlag(cmd, &options.Filenames, usage)
-	cmdutil.AddRecursiveFlag(cmd, &options.Recursive)
+	cmdutil.AddFilenameParamFlags(cmd, &options.FilenameParams, usage)
 	return cmd
 }
 
 func (o *UndoOptions) CompleteUndo(f *cmdutil.Factory, cmd *cobra.Command, out io.Writer, args []string) error {
-	if len(args) == 0 && len(o.Filenames) == 0 {
+	if len(args) == 0 && len(o.FilenameParams.Filenames) == 0 {
 		return cmdutil.UsageError(cmd, "Required resource not specified.")
 	}
 
@@ -89,7 +87,7 @@ func (o *UndoOptions) CompleteUndo(f *cmdutil.Factory, cmd *cobra.Command, out i
 
 	infos, err := resource.NewBuilder(o.Mapper, o.Typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true)).
 		NamespaceParam(cmdNamespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, o.Recursive, o.Filenames...).
+		FilenameParam(enforceNamespace, &o.FilenameParams).
 		ResourceTypeOrNameArgs(true, args...).
 		Latest().
 		Flatten().

--- a/pkg/kubectl/cmd/scale.go
+++ b/pkg/kubectl/cmd/scale.go
@@ -32,8 +32,7 @@ import (
 // ScaleOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
 // referencing the cmd.Flags()
 type ScaleOptions struct {
-	Filenames []string
-	Recursive bool
+	FilenameParams resource.FilenameParamOptions
 }
 
 const (
@@ -87,8 +86,7 @@ func NewCmdScale(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmdutil.AddInclude3rdPartyFlags(cmd)
 
 	usage := "Filename, directory, or URL to a file identifying the resource to set a new size"
-	kubectl.AddJsonFilenameFlag(cmd, &options.Filenames, usage)
-	cmdutil.AddRecursiveFlag(cmd, &options.Recursive)
+	cmdutil.AddFilenameParamFlags(cmd, &options.FilenameParams, usage)
 	return cmd
 }
 
@@ -112,7 +110,7 @@ func RunScale(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []stri
 	r := resource.NewBuilder(mapper, typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true)).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, options.Recursive, options.Filenames...).
+		FilenameParam(enforceNamespace, &options.FilenameParams).
 		ResourceTypeOrNameArgs(false, args...).
 		Flatten().
 		Do()

--- a/pkg/kubectl/cmd/stop.go
+++ b/pkg/kubectl/cmd/stop.go
@@ -21,7 +21,6 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
-	"k8s.io/kubernetes/pkg/kubectl"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 )
@@ -29,8 +28,7 @@ import (
 // StopOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
 // referencing the cmd.Flags()
 type StopOptions struct {
-	Filenames []string
-	Recursive bool
+	FilenameParams resource.FilenameParamOptions
 }
 
 const (
@@ -69,8 +67,7 @@ func NewCmdStop(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 		},
 	}
 	usage := "Filename, directory, or URL to file of resource(s) to be stopped."
-	kubectl.AddJsonFilenameFlag(cmd, &options.Filenames, usage)
-	cmdutil.AddRecursiveFlag(cmd, &options.Recursive)
+	cmdutil.AddFilenameParamFlags(cmd, &options.FilenameParams, usage)
 	cmd.Flags().StringP("selector", "l", "", "Selector (label query) to filter on.")
 	cmd.Flags().Bool("all", false, "[-all] to select all the specified resources.")
 	cmd.Flags().Bool("ignore-not-found", false, "Treat \"resource not found\" as a successful stop.")
@@ -92,7 +89,7 @@ func RunStop(f *cmdutil.Factory, cmd *cobra.Command, args []string, out io.Write
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		ResourceTypeOrNameArgs(false, args...).
-		FilenameParam(enforceNamespace, options.Recursive, options.Filenames...).
+		FilenameParam(enforceNamespace, &options.FilenameParams).
 		SelectorParam(cmdutil.GetFlagString(cmd, "selector")).
 		SelectAllParam(cmdutil.GetFlagBool(cmd, "all")).
 		Flatten().

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -47,6 +47,7 @@ import (
 
 const (
 	ApplyAnnotationsFlag = "save-config"
+	FilenameHttpRetries  = "filename-http-retries"
 )
 
 type debugError interface {
@@ -336,6 +337,10 @@ func addRecursiveFlag(cmd *cobra.Command, options *resource.FilenameParamOptions
 	cmd.Flags().BoolVarP(&options.Recursive, "recursive", "R", options.Recursive, "If true, process directory recursively.")
 }
 
+func addHttpRetryFlag(cmd *cobra.Command, options *resource.FilenameParamOptions) {
+	cmd.Flags().IntVar(&options.FilenameHttpRetries, FilenameHttpRetries, 1, "Retry failed http requests for urls passed to '-f' flags this many times.")
+}
+
 func addFlagJsonFilenameFlag(cmd *cobra.Command, options *resource.FilenameParamOptions, usage string) {
 	kubectl.AddJsonFilenameFlag(cmd, &options.Filenames, usage)
 }
@@ -343,11 +348,13 @@ func addFlagJsonFilenameFlag(cmd *cobra.Command, options *resource.FilenameParam
 func AddFilenameParamFlags(cmd *cobra.Command, options *resource.FilenameParamOptions, usage string) {
 	addFlagJsonFilenameFlag(cmd, options, usage)
 	addRecursiveFlag(cmd, options)
+	addHttpRetryFlag(cmd, options)
 }
 
 func AddFilenameParamFlagsNoRecurse(cmd *cobra.Command, options *resource.FilenameParamOptions, usage string) {
 	addFlagJsonFilenameFlag(cmd, options, usage)
 	options.Recursive = false
+	addHttpRetryFlag(cmd, options)
 }
 
 func AddApplyAnnotationFlags(cmd *cobra.Command) {

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -332,8 +332,22 @@ func AddValidateFlags(cmd *cobra.Command) {
 	cmd.MarkFlagFilename("schema-cache-dir")
 }
 
-func AddRecursiveFlag(cmd *cobra.Command, value *bool) {
-	cmd.Flags().BoolVarP(value, "recursive", "R", *value, "If true, process directory recursively.")
+func addRecursiveFlag(cmd *cobra.Command, options *resource.FilenameParamOptions) {
+	cmd.Flags().BoolVarP(&options.Recursive, "recursive", "R", options.Recursive, "If true, process directory recursively.")
+}
+
+func addFlagJsonFilenameFlag(cmd *cobra.Command, options *resource.FilenameParamOptions, usage string) {
+	kubectl.AddJsonFilenameFlag(cmd, &options.Filenames, usage)
+}
+
+func AddFilenameParamFlags(cmd *cobra.Command, options *resource.FilenameParamOptions, usage string) {
+	addFlagJsonFilenameFlag(cmd, options, usage)
+	addRecursiveFlag(cmd, options)
+}
+
+func AddFilenameParamFlagsNoRecurse(cmd *cobra.Command, options *resource.FilenameParamOptions, usage string) {
+	addFlagJsonFilenameFlag(cmd, options, usage)
+	options.Recursive = false
 }
 
 func AddApplyAnnotationFlags(cmd *cobra.Command) {

--- a/pkg/kubectl/resource/builder.go
+++ b/pkg/kubectl/resource/builder.go
@@ -74,6 +74,7 @@ type Builder struct {
 	schema validation.Schema
 }
 
+
 type resourceTuple struct {
 	Resource string
 	Name     string
@@ -92,14 +93,19 @@ func (b *Builder) Schema(schema validation.Schema) *Builder {
 	return b
 }
 
+type FilenameParamOptions struct {
+	Recursive bool
+	Filenames []string
+}
+
 // FilenameParam groups input in two categories: URLs and files (files, directories, STDIN)
 // If enforceNamespace is false, namespaces in the specs will be allowed to
 // override the default namespace. If it is true, namespaces that don't match
 // will cause an error.
 // If ContinueOnError() is set prior to this method, objects on the path that are not
 // recognized will be ignored (but logged at V(2)).
-func (b *Builder) FilenameParam(enforceNamespace, recursive bool, paths ...string) *Builder {
-	for _, s := range paths {
+func (b *Builder) FilenameParam(enforceNamespace bool, params *FilenameParamOptions) *Builder {
+	for _, s := range params.Filenames {
 		switch {
 		case s == "-":
 			b.Stdin()
@@ -111,7 +117,7 @@ func (b *Builder) FilenameParam(enforceNamespace, recursive bool, paths ...strin
 			}
 			b.URL(url)
 		default:
-			b.Path(recursive, s)
+			b.Path(params.Recursive, s)
 		}
 	}
 

--- a/pkg/kubectl/resource/builder_test.go
+++ b/pkg/kubectl/resource/builder_test.go
@@ -248,9 +248,13 @@ var aRC string = `
 }
 `
 
+func NewFilenameParams(recursive bool, filenames string) *FilenameParamOptions {
+	return &FilenameParamOptions{recursive, []string{filenames}}
+}
+
 func TestPathBuilderAndVersionedObjectNotDefaulted(t *testing.T) {
 	b := NewBuilder(testapi.Default.RESTMapper(), api.Scheme, fakeClient(), testapi.Default.Codec()).
-		FilenameParam(false, false, "../../../docs/user-guide/update-demo/kitten-rc.yaml")
+		FilenameParam(false, NewFilenameParams(false, "../../../docs/user-guide/update-demo/kitten-rc.yaml"))
 
 	test := &testVisitor{}
 	singular := false
@@ -353,7 +357,7 @@ func TestPathBuilderWithMultiple(t *testing.T) {
 
 	for _, test := range tests {
 		b := NewBuilder(testapi.Default.RESTMapper(), api.Scheme, fakeClient(), testapi.Default.Codec()).
-			FilenameParam(false, test.recursive, test.directory).
+			FilenameParam(false, NewFilenameParams(test.recursive, test.directory)).
 			NamespaceParam("test").DefaultNamespace()
 
 		testVisitor := &testVisitor{}
@@ -412,7 +416,7 @@ func TestPathBuilderWithMultipleInvalid(t *testing.T) {
 
 	for _, test := range tests {
 		b := NewBuilder(testapi.Default.RESTMapper(), api.Scheme, fakeClient(), testapi.Default.Codec()).
-			FilenameParam(false, test.recursive, test.directory).
+			FilenameParam(false, NewFilenameParams(test.recursive, test.directory)).
 			NamespaceParam("test").DefaultNamespace()
 
 		testVisitor := &testVisitor{}
@@ -427,7 +431,7 @@ func TestPathBuilderWithMultipleInvalid(t *testing.T) {
 
 func TestDirectoryBuilder(t *testing.T) {
 	b := NewBuilder(testapi.Default.RESTMapper(), api.Scheme, fakeClient(), testapi.Default.Codec()).
-		FilenameParam(false, false, "../../../examples/guestbook/legacy").
+		FilenameParam(false, NewFilenameParams(false, "../../../examples/guestbook/legacy")).
 		NamespaceParam("test").DefaultNamespace()
 
 	test := &testVisitor{}
@@ -457,7 +461,7 @@ func TestNamespaceOverride(t *testing.T) {
 	defer s.Close()
 
 	b := NewBuilder(testapi.Default.RESTMapper(), api.Scheme, fakeClient(), testapi.Default.Codec()).
-		FilenameParam(false, false, s.URL).
+		FilenameParam(false, NewFilenameParams(false, s.URL)).
 		NamespaceParam("test")
 
 	test := &testVisitor{}
@@ -468,7 +472,7 @@ func TestNamespaceOverride(t *testing.T) {
 	}
 
 	b = NewBuilder(testapi.Default.RESTMapper(), api.Scheme, fakeClient(), testapi.Default.Codec()).
-		FilenameParam(true, false, s.URL).
+		FilenameParam(true, NewFilenameParams(false, s.URL)).
 		NamespaceParam("test")
 
 	test = &testVisitor{}
@@ -488,7 +492,7 @@ func TestURLBuilder(t *testing.T) {
 	defer s.Close()
 
 	b := NewBuilder(testapi.Default.RESTMapper(), api.Scheme, fakeClient(), testapi.Default.Codec()).
-		FilenameParam(false, false, s.URL).
+		FilenameParam(false, NewFilenameParams(false, s.URL)).
 		NamespaceParam("foo")
 
 	test := &testVisitor{}
@@ -517,7 +521,7 @@ func TestURLBuilderRequireNamespace(t *testing.T) {
 	defer s.Close()
 
 	b := NewBuilder(testapi.Default.RESTMapper(), api.Scheme, fakeClient(), testapi.Default.Codec()).
-		FilenameParam(false, false, s.URL).
+		FilenameParam(false, NewFilenameParams(false, s.URL)).
 		NamespaceParam("test").RequireNamespace()
 
 	test := &testVisitor{}
@@ -915,7 +919,7 @@ func TestContinueOnErrorVisitor(t *testing.T) {
 func TestSingularObject(t *testing.T) {
 	obj, err := NewBuilder(testapi.Default.RESTMapper(), api.Scheme, fakeClient(), testapi.Default.Codec()).
 		NamespaceParam("test").DefaultNamespace().
-		FilenameParam(false, false, "../../../examples/guestbook/legacy/redis-master-controller.yaml").
+		FilenameParam(false, NewFilenameParams(false, "../../../examples/guestbook/legacy/redis-master-controller.yaml")).
 		Flatten().
 		Do().Object()
 
@@ -935,7 +939,7 @@ func TestSingularObject(t *testing.T) {
 func TestSingularObjectNoExtension(t *testing.T) {
 	obj, err := NewBuilder(testapi.Default.RESTMapper(), api.Scheme, fakeClient(), testapi.Default.Codec()).
 		NamespaceParam("test").DefaultNamespace().
-		FilenameParam(false, false, "../../../examples/pod").
+		FilenameParam(false, NewFilenameParams(false, "../../../examples/pod")).
 		Flatten().
 		Do().Object()
 
@@ -1046,7 +1050,7 @@ func TestWatch(t *testing.T) {
 		}),
 	}), testapi.Default.Codec()).
 		NamespaceParam("test").DefaultNamespace().
-		FilenameParam(false, false, "../../../examples/guestbook/redis-master-service.yaml").Flatten().
+		FilenameParam(false, NewFilenameParams(false, "../../../examples/guestbook/redis-master-service.yaml")).Flatten().
 		Do().Watch("12")
 
 	if err != nil {
@@ -1073,8 +1077,8 @@ func TestWatch(t *testing.T) {
 func TestWatchMultipleError(t *testing.T) {
 	_, err := NewBuilder(testapi.Default.RESTMapper(), api.Scheme, fakeClient(), testapi.Default.Codec()).
 		NamespaceParam("test").DefaultNamespace().
-		FilenameParam(false, false, "../../../examples/guestbook/legacy/redis-master-controller.yaml").Flatten().
-		FilenameParam(false, false, "../../../examples/guestbook/legacy/redis-master-controller.yaml").Flatten().
+		FilenameParam(false, NewFilenameParams(false, "../../../examples/guestbook/legacy/redis-master-controller.yaml")).Flatten().
+		FilenameParam(false, NewFilenameParams(false, "../../../examples/guestbook/legacy/redis-master-controller.yaml")).Flatten().
 		Do().Watch("")
 
 	if err == nil {

--- a/pkg/kubectl/resource/builder_test.go
+++ b/pkg/kubectl/resource/builder_test.go
@@ -249,7 +249,7 @@ var aRC string = `
 `
 
 func NewFilenameParams(recursive bool, filenames string) *FilenameParamOptions {
-	return &FilenameParamOptions{recursive, []string{filenames}}
+	return &FilenameParamOptions{recursive, []string{filenames}, 1}
 }
 
 func TestPathBuilderAndVersionedObjectNotDefaulted(t *testing.T) {


### PR DESCRIPTION
## Pull Request Guidelines
1. Please read our [contributor guidelines](https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md).
2. See our [developer guide](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md).
3. Follow the instructions for [labeling and writing a release note for this PR](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes) in the block below.

``` release-note
Add kubectl flag 'filename-http-retries' to allow retrying failures to get urls passed through '-f'
```

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
