### PR TITLE
Add a better error message to run.sh

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -558,7 +558,7 @@ function kube::build::ensure_data_container() {
 # already been built.  This will sync out all output data from the build.
 function kube::build::run_build_command() {
   kube::log::status "Running build command...."
-  [[ $# != 0 ]] || { echo "Invalid input." >&2; return 4; }
+  [[ $# != 0 ]] || { echo "Invalid input - please specify a command to run." >&2; return 4; }
 
   kube::build::ensure_data_container
   kube::build::prepare_output


### PR DESCRIPTION
I ran build/run.sh w/o any args (by mistake) and it just said
   `Invalid input.`
after several other steps. I had no idea whether I was doing something
wrong or if my env was busted. Clearly, I just forget to include the
command that run.sh was to invoke in the Docker container.  But it took
me time to go track down where this error came from and why. So to help
others I just tweaked the error message to be:
   `Invalid input - please specify a command to run.`

Very minor thing,I know, but if it helps others...

Signed-off-by: Doug Davis dug@us.ibm.com
