### PR TITLE
Don't surround node-tags list with square brackets

### DIFF
--- a/cluster/gce/configure-vm.sh
+++ b/cluster/gce/configure-vm.sh
@@ -778,7 +778,7 @@ EOF
 
   if [[ -n "${NODE_INSTANCE_PREFIX:-}" ]]; then
     cat <<EOF >>/etc/gce.conf
-node-tags = [${NODE_INSTANCE_PREFIX}]
+node-tags = ${NODE_INSTANCE_PREFIX}
 EOF
     CLOUD_CONFIG=/etc/gce.conf
   fi


### PR DESCRIPTION
That's apparently not how gcfg list parsing works... It was ending up with the nodeTags list in gce.go containing one element of value "[tag]". This works properly, ending up with one element of value "tag".

The third time's the charm, right? :/
