### PR TITLE
test/e2e_node: Improve error output

### DIFF
--- a/test/e2e_node/e2e_service.go
+++ b/test/e2e_node/e2e_service.go
@@ -173,7 +173,7 @@ func (es *e2eService) startServer(cmd *healthCheckCommand) error {
 	go func() {
 		err := cmd.Run()
 		if err != nil {
-			cmdErrorChan <- fmt.Errorf("%s Failed with error \"%v\".  Command output:\n%v", cmd, err, *cmd.OutputBuffer)
+			cmdErrorChan <- fmt.Errorf("%s Failed with error \"%v\".  Command output:\n%s", cmd, err, cmd.OutputBuffer.String())
 		}
 		close(cmdErrorChan)
 	}()


### PR DESCRIPTION
Strings are easier to read than byte arrays. For me at least. `115 101 114 118 101 114 46 103 111` for :computer:, `server.go` for :man:.
