### PR TITLE
Rename a function parameter name in authn.go

### DIFF
--- a/pkg/apiserver/authenticator/authn.go
+++ b/pkg/apiserver/authenticator/authn.go
@@ -179,8 +179,8 @@ func newAuthenticatorFromClientCAFile(clientCAFile string) (authenticator.Reques
 }
 
 // newAuthenticatorFromTokenFile returns an authenticator.Request or an error
-func newAuthenticatorFromKeystoneURL(keystoneConfigFile string) (authenticator.Request, error) {
-	keystoneAuthenticator, err := keystone.NewKeystoneAuthenticator(keystoneConfigFile)
+func newAuthenticatorFromKeystoneURL(keystoneURL string) (authenticator.Request, error) {
+	keystoneAuthenticator, err := keystone.NewKeystoneAuthenticator(keystoneURL)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Renamed the paramater name for newAuthenticatorFromKeystoneURL function in authn.go to keystoneURL. Earlier it was keystoneConfigFile which does not make sense because we are passing just an URL not configfile.
