### PR TITLE
volume recycler: Don't start a new recycler pod if one already exists.

### DIFF
--- a/pkg/controller/persistentvolume/controller.go
+++ b/pkg/controller/persistentvolume/controller.go
@@ -865,7 +865,7 @@ func (ctrl *PersistentVolumeController) recycleVolumeOperation(arg interface{}) 
 	}
 
 	// Plugin found
-	recycler, err := plugin.NewRecycler(spec)
+	recycler, err := plugin.NewRecycler(volume.Name, spec)
 	if err != nil {
 		// Cannot create recycler
 		strerr := fmt.Sprintf("Failed to create recycler: %v", err)

--- a/pkg/controller/persistentvolume/framework_test.go
+++ b/pkg/controller/persistentvolume/framework_test.go
@@ -882,6 +882,9 @@ type mockVolumePlugin struct {
 }
 
 var _ vol.VolumePlugin = &mockVolumePlugin{}
+var _ vol.RecyclableVolumePlugin = &mockVolumePlugin{}
+var _ vol.DeletableVolumePlugin = &mockVolumePlugin{}
+var _ vol.ProvisionableVolumePlugin = &mockVolumePlugin{}
 
 func (plugin *mockVolumePlugin) Init(host vol.VolumeHost) error {
 	return nil
@@ -981,7 +984,7 @@ func (plugin *mockVolumePlugin) GetMetrics() (*vol.Metrics, error) {
 
 // Recycler interfaces
 
-func (plugin *mockVolumePlugin) NewRecycler(spec *vol.Spec) (vol.Recycler, error) {
+func (plugin *mockVolumePlugin) NewRecycler(pvName string, spec *vol.Spec) (vol.Recycler, error) {
 	if len(plugin.recycleCalls) > 0 {
 		// mockVolumePlugin directly implements Recycler interface
 		glog.V(4).Infof("mock plugin NewRecycler called, returning mock recycler")

--- a/pkg/volume/host_path/host_path_test.go
+++ b/pkg/volume/host_path/host_path_test.go
@@ -77,7 +77,7 @@ func TestRecycler(t *testing.T) {
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}
-	recycler, err := plug.NewRecycler(spec)
+	recycler, err := plug.NewRecycler("pv-name", spec)
 	if err != nil {
 		t.Errorf("Failed to make a new Recyler: %v", err)
 	}

--- a/pkg/volume/nfs/nfs_test.go
+++ b/pkg/volume/nfs/nfs_test.go
@@ -91,7 +91,7 @@ func TestRecycler(t *testing.T) {
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}
-	recycler, err := plug.NewRecycler(spec)
+	recycler, err := plug.NewRecycler("pv-name", spec)
 	if err != nil {
 		t.Errorf("Failed to make a new Recyler: %v", err)
 	}
@@ -103,7 +103,7 @@ func TestRecycler(t *testing.T) {
 	}
 }
 
-func newMockRecycler(spec *volume.Spec, host volume.VolumeHost, config volume.VolumeConfig) (volume.Recycler, error) {
+func newMockRecycler(pvName string, spec *volume.Spec, host volume.VolumeHost, config volume.VolumeConfig) (volume.Recycler, error) {
 	return &mockRecycler{
 		path: spec.PersistentVolume.Spec.NFS.Path,
 	}, nil

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -101,7 +101,7 @@ type RecyclableVolumePlugin interface {
 	VolumePlugin
 	// NewRecycler creates a new volume.Recycler which knows how to reclaim this resource
 	// after the volume's release from a PersistentVolumeClaim
-	NewRecycler(spec *Spec) (Recycler, error)
+	NewRecycler(pvName string, spec *Spec) (Recycler, error)
 }
 
 // DeletableVolumePlugin is an extended interface of VolumePlugin and is used by persistent volumes that want
@@ -237,6 +237,9 @@ type VolumeConfig struct {
 	// Gi of capacity in the persistent volume.
 	// Example: 5Gi volume x 30s increment = 150s + 30s minimum = 180s ActiveDeadlineSeconds for recycler pod
 	RecyclerTimeoutIncrement int
+
+	// PVName is name of the PersistentVolume instance that is being recycled. It is used to generate unique recycler pod name.
+	PVName string
 
 	// OtherAttributes stores config as strings.  These strings are opaque to the system and only understood by the binary
 	// hosting the plugin and the plugin itself.

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -199,7 +199,7 @@ func (plugin *FakeVolumePlugin) NewDetacher() (Detacher, error) {
 	return plugin.getFakeVolume(&plugin.Detachers), nil
 }
 
-func (plugin *FakeVolumePlugin) NewRecycler(spec *Spec) (Recycler, error) {
+func (plugin *FakeVolumePlugin) NewRecycler(pvName string, spec *Spec) (Recycler, error) {
 	return &fakeRecycler{"/attributesTransferredFromSpec", MetricsNil{}}, nil
 }
 
@@ -312,7 +312,7 @@ func (fr *fakeRecycler) GetPath() string {
 	return fr.path
 }
 
-func NewFakeRecycler(spec *Spec, host VolumeHost, config VolumeConfig) (Recycler, error) {
+func NewFakeRecycler(pvName string, spec *Spec, host VolumeHost, config VolumeConfig) (Recycler, error) {
 	if spec.PersistentVolume == nil || spec.PersistentVolume.Spec.HostPath == nil {
 		return nil, fmt.Errorf("fakeRecycler only supports spec.PersistentVolume.Spec.HostPath")
 	}

--- a/pkg/volume/util_test.go
+++ b/pkg/volume/util_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/resource"
 )
 
@@ -29,7 +30,6 @@ func TestRecyclerSuccess(t *testing.T) {
 	client := &mockRecyclerClient{}
 	recycler := &api.Pod{
 		ObjectMeta: api.ObjectMeta{
-			Name:      "recycler-test",
 			Namespace: api.NamespaceDefault,
 		},
 		Status: api.PodStatus{
@@ -37,7 +37,7 @@ func TestRecyclerSuccess(t *testing.T) {
 		},
 	}
 
-	err := internalRecycleVolumeByWatchingPodUntilCompletion(recycler, client)
+	err := internalRecycleVolumeByWatchingPodUntilCompletion("pv-name", recycler, client)
 	if err != nil {
 		t.Errorf("Unexpected error watching recycler pod: %+v", err)
 	}
@@ -50,7 +50,6 @@ func TestRecyclerFailure(t *testing.T) {
 	client := &mockRecyclerClient{}
 	recycler := &api.Pod{
 		ObjectMeta: api.ObjectMeta{
-			Name:      "recycler-test",
 			Namespace: api.NamespaceDefault,
 		},
 		Status: api.PodStatus{
@@ -59,7 +58,7 @@ func TestRecyclerFailure(t *testing.T) {
 		},
 	}
 
-	err := internalRecycleVolumeByWatchingPodUntilCompletion(recycler, client)
+	err := internalRecycleVolumeByWatchingPodUntilCompletion("pv-name", recycler, client)
 	if err == nil {
 		t.Fatalf("Expected pod failure but got nil error returned")
 	}
@@ -73,14 +72,67 @@ func TestRecyclerFailure(t *testing.T) {
 	}
 }
 
+func TestRecyclerAlreadyExists(t *testing.T) {
+	// Test that internalRecycleVolumeByWatchingPodUntilCompletion does not
+	// start a new recycler when an old one is already running.
+
+	// Old recycler is running and fails with "foo" error message
+	oldRecycler := &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "recycler-test",
+			Namespace: api.NamespaceDefault,
+		},
+		Status: api.PodStatus{
+			Phase:   api.PodFailed,
+			Message: "foo",
+		},
+	}
+
+	// New recycler _would_ succeed if it was run
+	newRecycler := &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "recycler-test",
+			Namespace: api.NamespaceDefault,
+		},
+		Status: api.PodStatus{
+			Phase:   api.PodSucceeded,
+			Message: "bar",
+		},
+	}
+
+	client := &mockRecyclerClient{
+		pod: oldRecycler,
+	}
+
+	err := internalRecycleVolumeByWatchingPodUntilCompletion("pv-name", newRecycler, client)
+	if err == nil {
+		t.Fatalf("Expected pod failure but got nil error returned")
+	}
+
+	// Check the recycler failed with "foo" error message, i.e. it was the
+	// old recycler that finished and not the new one.
+	if err != nil {
+		if !strings.Contains(err.Error(), "foo") {
+			t.Errorf("Expected pod.Status.Message %s but got %s", oldRecycler.Status.Message, err)
+		}
+	}
+	if !client.deletedCalled {
+		t.Errorf("Expected deferred client.Delete to be called on recycler pod")
+	}
+}
+
 type mockRecyclerClient struct {
 	pod           *api.Pod
 	deletedCalled bool
 }
 
 func (c *mockRecyclerClient) CreatePod(pod *api.Pod) (*api.Pod, error) {
-	c.pod = pod
-	return c.pod, nil
+	if c.pod == nil {
+		c.pod = pod
+		return c.pod, nil
+	}
+	// Simulate "already exists" error
+	return nil, errors.NewAlreadyExists(api.Resource("pods"), pod.Name)
 }
 
 func (c *mockRecyclerClient) GetPod(name, namespace string) (*api.Pod, error) {
@@ -96,7 +148,7 @@ func (c *mockRecyclerClient) DeletePod(name, namespace string) error {
 	return nil
 }
 
-func (c *mockRecyclerClient) WatchPod(name, namespace, resourceVersion string, stopChannel chan struct{}) func() *api.Pod {
+func (c *mockRecyclerClient) WatchPod(name, namespace string, stopChannel chan struct{}) func() *api.Pod {
 	return func() *api.Pod {
 		return c.pod
 	}


### PR DESCRIPTION
Recycling is a long duration process and when the recycler controller is restarted in the meantime, it should not start a new recycler pod if there is one already running.

This means that the recycler pod must have deterministic name based on name of the recycled PV, we then get name conflicts when creating the pod.

Two things need to be changed:
- recycler controller and recycler plugins must pass the PV.Name to place, where the pod is created. This is most of the patch and it should be pretty straightforward.
- create recycler pod with deterministic name and check "already exists" error.

When at it, remove useless 'resourceVersion' argument and make log messages starting with lowercase.

There is an unit test to check the behavior + there is an e2e test that checks that regular recycling is not broken (it does not try to run two recycler pods in parallel as the recycler is single-threaded now).
