### PR TITLE
Retry fetching http urls passed to '-f' in kubectl.

### DIFF
--- a/pkg/kubectl/resource/visitor.go
+++ b/pkg/kubectl/resource/visitor.go
@@ -225,7 +225,7 @@ type URLVisitor struct {
 }
 
 func (v *URLVisitor) Visit(fn VisitorFunc) error {
-	body, err := v.readHttpWithRetries(httpgetImpl, time.Second, v.URL.String())
+	body, err := readHttpWithRetries(httpgetImpl, time.Second, v.URL.String())
 	if err != nil {
 		return err
 	}
@@ -235,7 +235,7 @@ func (v *URLVisitor) Visit(fn VisitorFunc) error {
 }
 
 // readHttpWithRetries tries to http.Get the v.URL 3 times before giving up.
-func (v *URLVisitor) readHttpWithRetries(get httpget, duration time.Duration, u string) (io.ReadCloser, error) {
+func readHttpWithRetries(get httpget, duration time.Duration, u string) (io.ReadCloser, error) {
 	var err error
 	var body io.ReadCloser
 	for i := 0; i < 3; i++ {

--- a/pkg/kubectl/resource/visitor_test.go
+++ b/pkg/kubectl/resource/visitor_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVisitorHttpGet(t *testing.T) {
+	instance := &URLVisitor{}
+
+	// Test retries on errors
+	i := 0
+	expectedErr := fmt.Errorf("Failed to get http")
+	actualBytes, actualErr := instance.readHttpWithRetries(func(url string) (int, string, io.ReadCloser, error) {
+		assert.Equal(t, "hello", url)
+		i++
+		if i > 2 {
+			return 0, "", nil, expectedErr
+		}
+		return 0, "", nil, fmt.Errorf("Unexpected error")
+	}, 0, "hello")
+	assert.Equal(t, expectedErr, actualErr)
+	assert.Nil(t, actualBytes)
+	assert.Equal(t, 3, i)
+
+	// Test that 500s are retried.
+	i = 0
+	actualBytes, actualErr = instance.readHttpWithRetries(func(url string) (int, string, io.ReadCloser, error) {
+		assert.Equal(t, "hello", url)
+		i++
+		return 501, "Status", nil, nil
+	}, 0, "hello")
+	assert.Error(t, actualErr)
+	assert.Nil(t, actualBytes)
+	assert.Equal(t, 3, i)
+
+	// Test that 300s are not retried
+	i = 0
+	actualBytes, actualErr = instance.readHttpWithRetries(func(url string) (int, string, io.ReadCloser, error) {
+		assert.Equal(t, "hello", url)
+		i++
+		return 300, "Status", nil, nil
+	}, 0, "hello")
+	assert.Error(t, actualErr)
+	assert.Nil(t, actualBytes)
+	assert.Equal(t, 1, i)
+
+	// Test Success
+	i = 0
+	b := bytes.Buffer{}
+	actualBytes, actualErr = instance.readHttpWithRetries(func(url string) (int, string, io.ReadCloser, error) {
+		assert.Equal(t, "hello", url)
+		i++
+		if i > 1 {
+			return 200, "Status", ioutil.NopCloser(&b), nil
+		}
+		return 501, "Status", nil, nil
+	}, 0, "hello")
+	assert.Nil(t, actualErr)
+	assert.NotNil(t, actualBytes)
+	assert.Equal(t, 2, i)
+}

--- a/pkg/kubectl/resource/visitor_test.go
+++ b/pkg/kubectl/resource/visitor_test.go
@@ -27,12 +27,10 @@ import (
 )
 
 func TestVisitorHttpGet(t *testing.T) {
-	instance := &URLVisitor{}
-
 	// Test retries on errors
 	i := 0
 	expectedErr := fmt.Errorf("Failed to get http")
-	actualBytes, actualErr := instance.readHttpWithRetries(func(url string) (int, string, io.ReadCloser, error) {
+	actualBytes, actualErr := readHttpWithRetries(func(url string) (int, string, io.ReadCloser, error) {
 		assert.Equal(t, "hello", url)
 		i++
 		if i > 2 {
@@ -46,7 +44,7 @@ func TestVisitorHttpGet(t *testing.T) {
 
 	// Test that 500s are retried.
 	i = 0
-	actualBytes, actualErr = instance.readHttpWithRetries(func(url string) (int, string, io.ReadCloser, error) {
+	actualBytes, actualErr = readHttpWithRetries(func(url string) (int, string, io.ReadCloser, error) {
 		assert.Equal(t, "hello", url)
 		i++
 		return 501, "Status", nil, nil
@@ -57,7 +55,7 @@ func TestVisitorHttpGet(t *testing.T) {
 
 	// Test that 300s are not retried
 	i = 0
-	actualBytes, actualErr = instance.readHttpWithRetries(func(url string) (int, string, io.ReadCloser, error) {
+	actualBytes, actualErr = readHttpWithRetries(func(url string) (int, string, io.ReadCloser, error) {
 		assert.Equal(t, "hello", url)
 		i++
 		return 300, "Status", nil, nil
@@ -69,7 +67,7 @@ func TestVisitorHttpGet(t *testing.T) {
 	// Test Success
 	i = 0
 	b := bytes.Buffer{}
-	actualBytes, actualErr = instance.readHttpWithRetries(func(url string) (int, string, io.ReadCloser, error) {
+	actualBytes, actualErr = readHttpWithRetries(func(url string) (int, string, io.ReadCloser, error) {
 		assert.Equal(t, "hello", url)
 		i++
 		if i > 1 {


### PR DESCRIPTION
## Pull Request Guidelines
1. Please read our [contributor guidelines](https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md).
2. See our [developer guide](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md).
3. Follow the instructions for [labeling and writing a release note for this PR](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes) in the block below.

``` release-note
* kubectl now retries failed http gets for urls passed through the '-f' flag.
```

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()

Closes #24089.
