### PR TITLE
test: Call forgotten resttest test

### DIFF
--- a/pkg/api/rest/resttest/resttest.go
+++ b/pkg/api/rest/resttest/resttest.go
@@ -139,6 +139,7 @@ func (t *Tester) TestCreate(valid runtime.Object, createFn CreateFunc, getFn Get
 		t.testCreateDiscardsObjectNamespace(copyOrDie(valid))
 		t.testCreateIgnoresContextNamespace(copyOrDie(valid))
 		t.testCreateIgnoresMismatchedNamespace(copyOrDie(valid))
+		t.testCreateResetsUserData(copyOrDie(valid))
 	} else {
 		t.testCreateRejectsMismatchedNamespace(copyOrDie(valid))
 	}


### PR DESCRIPTION
PR #3789 introduced this test, but it was never called.

This test was created, but never called.
Written, but never run.
It has neither flaked nor asserted. At its inception it was deserted.
My change gives this test a chance, to at long last finally pass.

The resttest stuff is a bit complicated and I'm not totally sure I put it in the right place  @smarterclayton, want to double check this change makes sense?
