### PR TITLE
Add a service annotation that allows endpoints for unready pods

### DIFF
--- a/pkg/controller/petset/fakes.go
+++ b/pkg/controller/petset/fakes.go
@@ -253,6 +253,9 @@ func (f *fakePetClient) setHealthy(index int) error {
 	}
 	f.pets[index].pod.Status.Phase = api.PodRunning
 	f.pets[index].pod.Annotations[PetSetInitAnnotation] = "true"
+	f.pets[index].pod.Status.Conditions = []api.PodCondition{
+		{Type: api.PodReady, Status: api.ConditionTrue},
+	}
 	return nil
 }
 

--- a/pkg/controller/petset/pet.go
+++ b/pkg/controller/petset/pet.go
@@ -299,7 +299,7 @@ func (d *defaultPetHealthChecker) isHealthy(pod *api.Pod) bool {
 	if err != nil {
 		return false
 	}
-	return b
+	return b && api.IsPodReady(pod)
 }
 
 // isDying returns true if the pod has a non-nil deletion timestamp. Since the


### PR DESCRIPTION
See https://github.com/kubernetes/kubernetes/issues/25283 for context 
@smarterclayton @thockin yes?

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/25284)

<!-- Reviewable:end -->
