### PR TITLE
Add Pod labels to docker ontainer labels.

### DIFF
--- a/pkg/kubelet/dockertools/labels.go
+++ b/pkg/kubelet/dockertools/labels.go
@@ -25,6 +25,7 @@ import (
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/custommetrics"
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
+	kubelabels "k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/types"
 )
@@ -106,6 +107,12 @@ func newLabels(container *api.Container, pod *api.Pod, restartCount int, enableC
 			glog.Errorf("Unable to marshal lifecycle PreStop handler for container %q of pod %q: %v", container.Name, format.Pod(pod), err)
 		} else {
 			labels[kubernetesContainerPreStopHandlerLabel] = string(rawPreStop)
+		}
+	}
+
+	for k, v := range pod.ObjectMeta.Labels {
+		if !kubelabels.IsInternal(k) {
+			labels[k] = v
 		}
 	}
 

--- a/pkg/kubelet/dockertools/labels_test.go
+++ b/pkg/kubelet/dockertools/labels_test.go
@@ -61,6 +61,10 @@ func TestLabels(t *testing.T) {
 			Namespace: "test_pod_namespace",
 			UID:       "test_pod_uid",
 			DeletionGracePeriodSeconds: &deletionGracePeriod,
+			Labels: map[string]string{
+				"foo":               "bar",
+				"x-kubernetes.io/y": "z",
+			},
 		},
 		Spec: api.PodSpec{
 			Containers:                    []api.Container{*container},
@@ -80,8 +84,17 @@ func TestLabels(t *testing.T) {
 		PreStopHandler:         container.Lifecycle.PreStop,
 	}
 
-	// Test whether we can get right information from label
 	labels := newLabels(container, pod, restartCount, false)
+
+	// Test whether pod labels are added
+	if v, ok := labels["foo"]; !ok || v != "bar" {
+		t.Errorf("expected labels[%v] to be %v but was %v", "foo", "bar", v)
+	}
+	if _, ok := labels["x-kubernetes.io/y"]; ok {
+		t.Errorf("expected labels to not have label %v but it did", "x-kubernetes.io/y")
+	}
+
+	// Test whether we can get right information from label
 	containerInfo := getContainerInfoFromLabel(labels)
 	if !reflect.DeepEqual(containerInfo, expected) {
 		t.Errorf("expected %v, got %v", expected, containerInfo)

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 )
 
+const InternalNamespace = "kubernetes.io"
+
 // Labels allows you to present labels independently from their storage.
 type Labels interface {
 	// Has returns whether the provided label exists.
@@ -68,4 +70,9 @@ func FormatLabels(labelMap map[string]string) string {
 		l = "<none>"
 	}
 	return l
+}
+
+func IsInternal(name string) bool {
+	idx := strings.IndexRune(name, '/')
+	return idx >= len(InternalNamespace) && strings.HasSuffix(name[0:idx], InternalNamespace)
 }

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -58,3 +58,22 @@ func TestLabelGet(t *testing.T) {
 		t.Errorf("Set.Get is broken")
 	}
 }
+
+func TestIsInternal(t *testing.T) {
+	cases := map[string]bool{
+		"x-kubernetes.io/y": true,
+		"kubernetes.io/y":   true,
+		"kubernetes.io/":    true,
+		"x/kubernetes.io/y": false,
+		"kubernetes.io":     false,
+		"x/y":               false,
+		"x":                 false,
+		"":                  false,
+	}
+
+	for name, ok := range cases {
+		if IsInternal(name) != ok {
+			t.Errorf("case[%v]: expected %v got %v", name, ok, !ok)
+		}
+	}
+}


### PR DESCRIPTION
This adds user-defined Pod labels to launched Docker containers.

It's helpful to have identifying information available for logging and administrative purposes outside of kube, without having to query kube or keep an external mapping of container/pod IDs to labels.
