### PR TITLE
Provide more info when running hack/local-up-cluster.sh

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -424,6 +424,10 @@ To start using your cluster, open up another terminal/tab and run:
   cluster/kubectl.sh config set-context local --cluster=local
   cluster/kubectl.sh config use-context local
   cluster/kubectl.sh
+
+Don't forget to remove ~/.kube/schema directory if you have regenerated swagger schemas.
+Otherwise you can get validation errors when running kubectl create and alike commands.
+Checkout --schema-cache-dir="~/.kube/schema" flag of kubectl create.
 EOF
 }
 


### PR DESCRIPTION
Warn user to checkout ~/.kube/schema directory as well when swagger schema gets regenerated.
Cached schema becomes outdated causing validation errors when running kubectl create, kubectl replace and alike commands for updated objects.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/25302)

<!-- Reviewable:end -->
