### PR TITLE
Hack update all remove dollar symbol

### DIFF
--- a/hack/update-all.sh
+++ b/hack/update-all.sh
@@ -72,7 +72,7 @@ do
 		fi
 	else
 		if ! bash "$KUBE_ROOT/hack/update-$t.sh"; then
-			echo -e "${color_red}$Updating $t FAILED${color_norm}"
+			echo -e "${color_red}Updating $t FAILED${color_norm}"
 			if ! $ALL; then
 				exit 1
 			fi


### PR DESCRIPTION
When not running ./hack/update in silent mode, the script fails due to undefined `$Updating` variable.
