### PR TITLE
Allow handlers earlier in a request flow to inject a UID for an object

### DIFF
--- a/pkg/api/context.go
+++ b/pkg/api/context.go
@@ -22,6 +22,7 @@ import (
 
 	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/auth/user"
+	"k8s.io/kubernetes/pkg/types"
 )
 
 // Context carries values across API boundaries.
@@ -49,11 +50,16 @@ type Context interface {
 // The key type is unexported to prevent collisions
 type key int
 
-// namespaceKey is the context key for the request namespace.
-const namespaceKey key = 0
+const (
+	// namespaceKey is the context key for the request namespace.
+	namespaceKey key = iota
 
-// userKey is the context key for the request user.
-const userKey key = 1
+	// userKey is the context key for the request user.
+	userKey
+
+	// uidKey is the context key for the uid to assign to an object on create.
+	uidKey
+)
 
 // NewContext instantiates a base context object for request flows.
 func NewContext() Context {
@@ -118,4 +124,15 @@ func WithUser(parent Context, user user.Info) Context {
 func UserFrom(ctx Context) (user.Info, bool) {
 	user, ok := ctx.Value(userKey).(user.Info)
 	return user, ok
+}
+
+// WithUID returns a copy of parent in which the uid value is set
+func WithUID(parent Context, uid types.UID) Context {
+	return WithValue(parent, uidKey, uid)
+}
+
+// UIDFrom returns the value of the uid key on the ctx
+func UIDFrom(ctx Context) (types.UID, bool) {
+	uid, ok := ctx.Value(uidKey).(types.UID)
+	return uid, ok
 }

--- a/pkg/api/meta.go
+++ b/pkg/api/meta.go
@@ -29,7 +29,13 @@ import (
 // FillObjectMetaSystemFields populates fields that are managed by the system on ObjectMeta.
 func FillObjectMetaSystemFields(ctx Context, meta *ObjectMeta) {
 	meta.CreationTimestamp = unversioned.Now()
-	meta.UID = util.NewUUID()
+	// allows admission controllers to assign a UID earlier in the request processing
+	// to support tracking resources pending creation.
+	uid, found := UIDFrom(ctx)
+	if !found {
+		uid = util.NewUUID()
+	}
+	meta.UID = uid
 	meta.SelfLink = ""
 }
 

--- a/pkg/api/meta_test.go
+++ b/pkg/api/meta_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util"
 )
 
 var _ meta.Object = &api.ObjectMeta{}
@@ -41,6 +42,14 @@ func TestFillObjectMetaSystemFields(t *testing.T) {
 		t.Errorf("resource.CreationTimestamp is zero")
 	} else if len(resource.UID) == 0 {
 		t.Errorf("resource.UID missing")
+	}
+	// verify we can inject a UID
+	uid := util.NewUUID()
+	ctx = api.WithUID(ctx, uid)
+	resource = api.ObjectMeta{}
+	api.FillObjectMetaSystemFields(ctx, &resource)
+	if resource.UID != uid {
+		t.Errorf("resource.UID expected: %v, actual: %v", uid, resource.UID)
 	}
 }
 


### PR DESCRIPTION
This lets admission controllers specify a stable UID for an object prior to its creation.  That lets the admission controller then record a reference to the object on another resource using that stable UID prior to the object being created.  This would be a prerequisite for supporting quota reservations.

/cc @smarterclayton @lavalamp @deads2k 
