### PR TITLE
add index template for es aggregations

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-image/Dockerfile
+++ b/cluster/addons/fluentd-elasticsearch/es-image/Dockerfile
@@ -30,7 +30,10 @@ RUN cd / && \
     tar xf elasticsearch-1.5.2.tar.gz && \
     rm elasticsearch-1.5.2.tar.gz
 
+RUN mkdir -p /elasticsearch-1.5.2/config/templates
+
 COPY elasticsearch.yml /elasticsearch-1.5.2/config/elasticsearch.yml
+COPY template-k8s-logstash.json /elasticsearch-1.5.2/config/templates/template-k8s-logstash.json
 COPY run.sh /
 COPY elasticsearch_logging_discovery /
 

--- a/cluster/addons/fluentd-elasticsearch/es-image/template-k8s-logstash.json
+++ b/cluster/addons/fluentd-elasticsearch/es-image/template-k8s-logstash.json
@@ -1,0 +1,22 @@
+{
+  "template_k8s_logstash" : {
+    "template" : "logstash-*",
+    "settings" : {
+      "index.refresh_interval" : "5s"
+    },
+    "mappings" : {
+      "_default_" : {
+        "dynamic_templates" : [ {
+          "kubernetes_field" : {
+            "path_match" : "kubernetes.*",
+            "mapping" : {
+              "type" : "string",
+              "index" : "not_analyzed"
+            }
+          }
+        } ]
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
This index template helps us to do es aggregations of namespace_name, pod_name and container_name. Then after doing eggs, we will get the whole name not all the spilt pieces.  
fix #25127  
