### PR TITLE
Kubelet: Checkpoint container information into one container info label.

### DIFF
--- a/pkg/kubelet/dockertools/manager_test.go
+++ b/pkg/kubelet/dockertools/manager_test.go
@@ -459,7 +459,7 @@ func TestKillContainerInPodWithPreStop(t *testing.T) {
 			Name: "/k8s_foo_qux_new_1234_42",
 			Config: &dockercontainer.Config{
 				Labels: map[string]string{
-					kubernetesPodLabel:                 string(podString),
+					podLabel: string(podString),
 					types.KubernetesContainerNameLabel: "foo",
 				},
 			},


### PR DESCRIPTION
Fixes #23706 (No uppercases in labels now)
Fixes #24702

This PR:
- **Divide all information needs to be checkpointed into two parts**:
  - containerMeta: all fields in `containerMeta` will be stored in separate labels. We may also want to use these labels as list filters in the future. The `containerMeta` should be seldom or even never changed.
  - containerInfo: the `containerInfo` will be saved in one label as a whole.
- **Checkpoint last container status into container info label.** With this, we can remove historical containers as soon as the new container is created (see #25239). However, because kubelet may still work with old containers which don't have this label, we still can't rely on this for now. Currently, we only use the `lastStatus` to calculate the restart count. @yujuhong @dchen1107 Can we assume that people will always drain node before updating kubelet? If so we can start relying on labels.
- **Add label version.** Whenever we make any incompatible changes to the labels, we should bump up the label version and try to support backward compatibility relying on label version.

Notice that with this PR, kubelet will stop reading _restart count_ and _termination message path_ from labels added in v1.2. It means that if someone does kubelet live upgrade from v1.2 to v1.3, the termination message of old containers will be lost, and restart count of the new container will be recalculated from 0.

We could add some code to prevent this, but that will make the code a bit more complex. Because restart count is just best effort and termination message path is seldom used, can we just ignore that like what we have done in v1.2? WDYT? @yujuhong

@yujuhong @vishh 
/cc @kubernetes/sig-node

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/25326)

<!-- Reviewable:end -->
