### PR TITLE
bugfix: prevent API server cache list/watch from other namespaces

### DIFF
--- a/pkg/storage/cacher.go
+++ b/pkg/storage/cacher.go
@@ -357,7 +357,7 @@ func filterFunction(key string, keyFunc func(runtime.Object) (string, error), fi
 			glog.Errorf("invalid object for filter: %v", obj)
 			return false
 		}
-		if !strings.HasPrefix(objKey, key) {
+		if !strings.HasPrefix(objKey+"/", key+"/") {
 			return false
 		}
 		return filter(obj)


### PR DESCRIPTION
The previous code has a issue: 

Assume we have two namespaces `ns1` and `ns11`, when client list/watch key `/registry/pods/ns1`, API server cache will also return pods in `ns11`, since `ns1` is a prefix of `ns11`

This PR fix this issue. @wojtek-t 
