### PR TITLE
Fix the docker download url and user can define docker version to use for centos provider

### DIFF
--- a/cluster/centos/build.sh
+++ b/cluster/centos/build.sh
@@ -52,8 +52,8 @@ function download-releases() {
   echo "Download kubernetes release v${K8S_VERSION} ..."
   curl -L ${K8S_DOWNLOAD_URL} -o ${RELEASES_DIR}/kubernetes.tar.gz
 
-  echo "Download docker-latest ..."
-  curl -L https://get.docker.com/builds/Linux/x86_64/docker-latest -o ${RELEASES_DIR}/docker
+  echo "Download docker release v${DOCKER_VERSION} ..."
+  curl -L ${DOCKER_DOWNLOAD_URL} -o ${RELEASES_DIR}/docker
 }
 
 function unpack-releases() {

--- a/cluster/centos/config-build.sh
+++ b/cluster/centos/config-build.sh
@@ -28,6 +28,9 @@ ETCD_VERSION=${ETCD_VERSION:-"2.2.1"}
 # Define k8s version to use.
 K8S_VERSION=${K8S_VERSION:-"1.1.1"}
 
+# Define docker version to use.
+DOCKER_VERSION=${DOCKER_VERSION:-"1.10.3"}
+
 FLANNEL_DOWNLOAD_URL=\
 "https://github.com/coreos/flannel/releases/download/v${FLANNEL_VERSION}/flannel-${FLANNEL_VERSION}-linux-amd64.tar.gz"
 
@@ -36,3 +39,6 @@ ETCD_DOWNLOAD_URL=\
 
 K8S_DOWNLOAD_URL=\
 "https://github.com/kubernetes/kubernetes/releases/download/v${K8S_VERSION}/kubernetes.tar.gz"
+
+DOCKER_DOWNLOAD_URL=\
+"https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}"

--- a/cluster/centos/config-build.sh
+++ b/cluster/centos/config-build.sh
@@ -29,7 +29,7 @@ ETCD_VERSION=${ETCD_VERSION:-"2.2.1"}
 K8S_VERSION=${K8S_VERSION:-"1.1.1"}
 
 # Define docker version to use.
-DOCKER_VERSION=${DOCKER_VERSION:-"1.10.3"}
+DOCKER_VERSION=${DOCKER_VERSION:-"1.9.1"}
 
 FLANNEL_DOWNLOAD_URL=\
 "https://github.com/coreos/flannel/releases/download/v${FLANNEL_VERSION}/flannel-${FLANNEL_VERSION}-linux-amd64.tar.gz"


### PR DESCRIPTION
The current docker download url ( https://get.docker.com/builds/Linux/x86_64/docker-latest ) is not available now, fix the link with a user defined docker version.

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()

Signed-off-by: Jian Ming Zhang zhangjm@cn.ibm.com
