### PR TITLE
Automatically download the latest stable release version of Kubernetes.

### DIFF
--- a/cluster/get-kube.sh
+++ b/cluster/get-kube.sh
@@ -72,7 +72,7 @@ function get_latest_version_number {
   elif [[ $(which curl) ]]; then
     curl -Ss ${latest_url}
   else
-    echo "Couldn't find curl or wget.  Bailing out."
+    echo "Couldn't find curl or wget.  Bailing out." >&2
     exit 4
   fi
 }

--- a/cluster/ubuntu/download-release.sh
+++ b/cluster/ubuntu/download-release.sh
@@ -42,7 +42,7 @@ grep -q "^${FLANNEL_VERSION}\$" binaries/.flannel 2>/dev/null || {
 }
 
 # ectd
-ETCD_VERSION=${ETCD_VERSION:-"2.2.1"}
+ETCD_VERSION=${ETCD_VERSION:-"2.3.1"}
 ETCD="etcd-v${ETCD_VERSION}-linux-amd64"
 echo "Prepare etcd ${ETCD_VERSION} release ..."
 grep -q "^${ETCD_VERSION}\$" binaries/.etcd 2>/dev/null || {
@@ -52,8 +52,21 @@ grep -q "^${ETCD_VERSION}\$" binaries/.etcd 2>/dev/null || {
   echo ${ETCD_VERSION} > binaries/.etcd
 }
 
+function get_latest_version_number {
+  local -r latest_url="https://storage.googleapis.com/kubernetes-release/release/stable.txt"
+  if [[ $(which wget) ]]; then
+    wget -qO- ${latest_url}
+  elif [[ $(which curl) ]]; then
+    curl -Ss ${latest_url}
+  else
+    echo "Couldn't find curl or wget.  Bailing out." >&2
+    exit 4
+  fi
+}
+
+KUBE_VERSION=$(get_latest_version_number | sed 's/^v//')
+
 # k8s
-KUBE_VERSION=${KUBE_VERSION:-"1.2.0"}
 echo "Prepare kubernetes ${KUBE_VERSION} release ..."
 grep -q "^${KUBE_VERSION}\$" binaries/.kubernetes 2>/dev/null || {
   curl -L https://github.com/kubernetes/kubernetes/releases/download/v${KUBE_VERSION}/kubernetes.tar.gz -o kubernetes.tar.gz


### PR DESCRIPTION
The ubuntu version of download-release.sh included in the binary release downloads the released .tar.gz file again. Right now the version of the downloaded file is manually encoded within the script. This change fetches the released version automatically, similar to the shell script available on the main Kubernetes site below:

https://get.k8s.io/

Ideally the installation on bare metal ubuntu should work with the files available in the already downloaded package.

@mikedanese 
