### PR TITLE
GCI/Trusty: Fix the running of kube-addon-manager

### DIFF
--- a/cluster/gce/trusty/configure-helper.sh
+++ b/cluster/gce/trusty/configure-helper.sh
@@ -590,8 +590,8 @@ setup_addon_manifests() {
   chmod 644 "${dst_dir}"/*
 }
 
-# Prepares the manifests of k8s addons static pods.
-prepare_kube_addons() {
+# Prepares the manifests of k8s addons, and starts the addon manager.
+start_kube_addons() {
   addon_src_dir="/home/kubernetes/kube-manifests/kubernetes/gci-trusty"
   addon_dst_dir="/etc/kubernetes/addons"
   # Set up manifests of other addons.
@@ -623,7 +623,6 @@ prepare_kube_addons() {
     sed -i -e "s@{{ *metrics_memory_per_node *}}@${metrics_memory_per_node}@g" "${controller_yaml}"
     sed -i -e "s@{{ *eventer_memory_per_node *}}@${eventer_memory_per_node}@g" "${controller_yaml}"
   fi
-  cp "${addon_src_dir}/namespace.yaml" "${addon_dst_dir}"
   if [ "${ENABLE_L7_LOADBALANCING:-}" = "glbc" ]; then
     setup_addon_manifests "addons" "cluster-loadbalancing/glbc"
   fi

--- a/cluster/gce/trusty/configure.sh
+++ b/cluster/gce/trusty/configure.sh
@@ -22,18 +22,18 @@
 
 download_kube_env() {
   # Fetch kube-env from GCE metadata server.
-  readonly tmp_install_dir="/var/cache/kubernetes-install"
-  mkdir -p "${tmp_install_dir}"
+  readonly tmp_kube_env="/tmp/kube-env.yaml"
   curl --fail --retry 5 --retry-delay 3 --silent --show-error \
     -H "X-Google-Metadata-Request: True" \
-    -o "${tmp_install_dir}/kube_env.yaml" \
+    -o "${tmp_kube_env}" \
     http://metadata.google.internal/computeMetadata/v1/instance/attributes/kube-env
   # Convert the yaml format file into a shell-style file.
   eval $(python -c '''
 import pipes,sys,yaml
 for k,v in yaml.load(sys.stdin).iteritems():
   print("readonly {var}={value}".format(var = k, value = pipes.quote(str(v))))
-''' < "${tmp_install_dir}/kube_env.yaml" > /etc/kube-env)
+''' < "${tmp_kube_env}" > /etc/kube-env)
+  rm -f "${tmp_kube_env}"
 }
 
 validate_hash() {

--- a/cluster/gce/trusty/master.yaml
+++ b/cluster/gce/trusty/master.yaml
@@ -177,7 +177,7 @@ script
 	start_kube_apiserver
 	start_kube_controller_manager
 	start_kube_scheduler
-	prepare_kube_addons
+	start_kube_addons
 end script
 
 --====================================


### PR DESCRIPTION
This PR fixes the issue that kube-addon-master (added in #23600) is not started. Without this fix, no kube-system pods can be running correctly. As a result, the GCI-based Jenkins testing k8s head has been down for a couple of days. The root cause is that we stopped to use namespace.yaml, but configure-helper.sh still tries to copy it. This PR also gets rid of /var/cache/kubernetes-install/kube_env.yaml, as it is not needed anymore after #24108.

@mikedanese @roberthbailey @dchen1107 please review it. If possible please mark it as P1, as it blocks GCI-based Jenkins tests.

cc/ @kubernetes/goog-image @fabioy FYI
