### PR TITLE
AWS kube-up: Remove SecurityContextDeny admission controller (to mirror GCE)

### DIFF
--- a/cluster/aws/config-default.sh
+++ b/cluster/aws/config-default.sh
@@ -134,7 +134,7 @@ fi
 
 # Admission Controllers to invoke prior to persisting objects in cluster
 # If we included ResourceQuota, we should keep it at the end of the list to prevent incremeting quota usage prematurely.
-ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,PersistentVolumeLabel,ResourceQuota
+ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,ResourceQuota
 
 # Optional: Enable/disable public IP assignment for minions.
 # Important Note: disable only if you have setup a NAT instance for internet access and configured appropriate routes!

--- a/cluster/aws/config-test.sh
+++ b/cluster/aws/config-test.sh
@@ -120,7 +120,7 @@ fi
 
 # Admission Controllers to invoke prior to persisting objects in cluster
 # If we included ResourceQuota, we should keep it at the end of the list to prevent incremeting quota usage prematurely.
-ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,PersistentVolumeLabel,ResourceQuota
+ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,ResourceQuota
 
 # Optional: Enable/disable public IP assignment for minions.
 # Important Note: disable only if you have setup a NAT instance for internet access and configured appropriate routes!


### PR DESCRIPTION
This PR allows the user to tune the ADMISSION_CONTROL options for AWS environments (much like local-up-cluser.sh). The main impetus is to allow users to exclude the SecurityContextDeny admission controller which causes e2e AWS based tests to fail with `pod.Spec.SecurityContext.SELinuxOptions is forbidden`.

Now AWS e2e tests are happy and can actually go green.
