### PR TITLE
OpenStack Keystone Token Authentication

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -198,12 +198,18 @@ func Run(s *options.APIServer) error {
 		ServiceAccountLookup:        s.ServiceAccountLookup,
 		ServiceAccountTokenGetter:   serviceAccountGetter,
 		KeystoneURL:                 s.KeystoneURL,
+		KeystoneConfig:              s.KeystoneConfig,
+		KeystoneAuthMode:            s.KeystoneAuthMode,
 		WebhookTokenAuthnConfigFile: s.WebhookTokenAuthnConfigFile,
 		WebhookTokenAuthnCacheTTL:   s.WebhookTokenAuthnCacheTTL,
 	})
 
 	if err != nil {
 		glog.Fatalf("Invalid Authentication Config: %v", err)
+	}
+
+	if len(s.KeystoneConfig) > 0 && (s.KeystoneAuthMode != "token" && s.KeystoneAuthMode != "password") {
+		glog.Fatalf("Invalid KeystoneAuthorization mode=%s. It must be either token or password", s.KeystoneAuthMode)
 	}
 
 	authorizationModeNames := strings.Split(s.AuthorizationMode, ",")

--- a/docs/admin/kube-apiserver.md
+++ b/docs/admin/kube-apiserver.md
@@ -18,11 +18,6 @@
 If you are using a released version of Kubernetes, you should
 refer to the docs that go with that version.
 
-<!-- TAG RELEASE_LINK, added by the munger automatically -->
-<strong>
-The latest release of this document can be found
-[here](http://releases.k8s.io/release-1.2/docs/admin/kube-apiserver.md).
-
 Documentation for other releases can be found at
 [releases.k8s.io](http://releases.k8s.io).
 </strong>
@@ -82,6 +77,8 @@ kube-apiserver
       --etcd-servers=[]: List of etcd servers to connect with (http://ip:port), comma separated.
       --etcd-servers-overrides=[]: Per-resource etcd servers overrides, comma separated. The individual override format: group/resource#servers, where servers are http://ip:port, semicolon separated.
       --event-ttl=1h0m0s: Amount of time to retain events. Default 1 hour.
+      --experimental-keystone-auth-mode="": If passed, selects between token and password modes
+      --experimental-keystone-config="": If passed, activates the keystone authentication plugin
       --experimental-keystone-url="": If passed, activates the keystone authentication plugin
       --external-hostname="": The hostname to use when generating externalized URLs for this master (e.g. Swagger API Docs.)
       --google-json-key="": The Google Cloud Platform Service Account JSON Key to use for authentication.

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -103,6 +103,7 @@ func Run(s *genericoptions.ServerRunOptions) error {
 		OIDCUsernameClaim: s.OIDCUsernameClaim,
 		OIDCGroupsClaim:   s.OIDCGroupsClaim,
 		KeystoneURL:       s.KeystoneURL,
+		KeystoneConfig:    s.KeystoneConfig,
 	})
 	if err != nil {
 		glog.Fatalf("Invalid Authentication Config: %v", err)

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -135,6 +135,8 @@ executor-path
 executor-suicide-timeout
 experimental-flannel-overlay
 experimental-keystone-url
+experimental-keystone-auth-mode
+experimental-keystone-config
 experimental-nvidia-gpus
 experimental-prefix
 external-hostname

--- a/pkg/genericapiserver/options/server_run_options.go
+++ b/pkg/genericapiserver/options/server_run_options.go
@@ -76,6 +76,8 @@ type ServerRunOptions struct {
 	InsecureBindAddress       net.IP
 	InsecurePort              int
 	KeystoneURL               string
+	KeystoneConfig            string
+	KeystoneAuthMode          string
 	KubernetesServiceNodePort int
 	LongRunningRequestRE      string
 	MasterCount               int
@@ -278,6 +280,8 @@ func (s *ServerRunOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.MarkDeprecated("port", "see --insecure-port instead")
 
 	fs.StringVar(&s.KeystoneURL, "experimental-keystone-url", s.KeystoneURL, "If passed, activates the keystone authentication plugin")
+	fs.StringVar(&s.KeystoneConfig, "experimental-keystone-config", s.KeystoneConfig, "If passed, activates the keystone authentication plugin")
+	fs.StringVar(&s.KeystoneAuthMode, "experimental-keystone-auth-mode", s.KeystoneAuthMode, "If passed, selects between token and password modes")
 
 	// See #14282 for details on how to test/try this option out.  TODO remove this comment once this option is tested in CI.
 	fs.IntVar(&s.KubernetesServiceNodePort, "kubernetes-service-node-port", s.KubernetesServiceNodePort, "If non-zero, the Kubernetes master service (which apiserver creates/maintains) will be of type NodePort, using this as the value of the port. If zero, the Kubernetes master service will be of type ClusterIP.")

--- a/pkg/util/openstack/client.go
+++ b/pkg/util/openstack/client.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/rackspace/gophercloud"
+	"github.com/rackspace/gophercloud/openstack"
+	"gopkg.in/gcfg.v1"
+)
+
+type KeystoneAuthOpts struct {
+	AuthUrl    string `gcfg:"auth-url"`
+	Username   string
+	UserId     string `gcfg:"user-id"`
+	Password   string
+	ApiKey     string `gcfg:"api-key"`
+	TenantId   string `gcfg:"tenant-id"`
+	TenantName string `gcfg:"tenant-name"`
+	DomainId   string `gcfg:"domain-id"`
+	DomainName string `gcfg:"domain-name"`
+	Region     string
+}
+
+type Config struct {
+	Global KeystoneAuthOpts `gcfg:"Global"`
+}
+
+func (cfg KeystoneAuthOpts) ToAuthOptions() gophercloud.AuthOptions {
+	return gophercloud.AuthOptions{
+		IdentityEndpoint: cfg.AuthUrl,
+		Username:         cfg.Username,
+		UserID:           cfg.UserId,
+		Password:         cfg.Password,
+		APIKey:           cfg.ApiKey,
+		TenantID:         cfg.TenantId,
+		TenantName:       cfg.TenantName,
+		DomainID:         cfg.DomainId,
+		DomainName:       cfg.DomainName,
+
+		// Persistent service, so we need to be able to renew tokens.
+		AllowReauth: true,
+	}
+}
+
+func ReadConfig(config io.Reader) (Config, error) {
+	if config == nil {
+		err := fmt.Errorf("no OpenStack config file given")
+		return Config{}, err
+	}
+
+	var cfg Config
+	err := gcfg.ReadInto(&cfg, config)
+	return cfg, err
+}
+
+func ConfigToProvider(config io.Reader) (Config, *gophercloud.ProviderClient, error) {
+	cfg, err := ReadConfig(config)
+	if err != nil {
+		return cfg, nil, err
+	}
+	provider, err := openstack.AuthenticatedClient(cfg.Global.ToAuthOptions())
+	if err != nil {
+		return cfg, nil, err
+	}
+	return cfg, provider, nil
+}
+
+func ConfigFileToProvider(configPath string) (Config, *gophercloud.ProviderClient, error) {
+	var cf *os.File
+	var err error
+	cf, err = os.Open(configPath)
+	if err != nil {
+		glog.Fatalf("Couldn't open configuration %s: %#v",
+			configPath, err)
+	}
+	defer cf.Close()
+	cfg, provider, err := ConfigToProvider(cf)
+	if err != nil {
+		return cfg, nil, err
+	}
+	if !strings.HasPrefix(cfg.Global.AuthUrl, "https") {
+		return cfg, nil, errors.New("Auth URL should be secure and start with https")
+	}
+	if cfg.Global.AuthUrl == "" {
+		return cfg, nil, errors.New("Auth URL is empty")
+	}
+	return cfg, provider, nil
+}

--- a/plugin/pkg/auth/authenticator/token/keystone/apicall.go
+++ b/plugin/pkg/auth/authenticator/token/keystone/apicall.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keystone
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+
+	"github.com/golang/glog"
+	"github.com/rackspace/gophercloud"
+	"github.com/rackspace/gophercloud/openstack"
+	openstackutil "k8s.io/kubernetes/pkg/util/openstack"
+)
+
+type apiCallValidator struct {
+	configPath string
+}
+
+func newAPICallValidator(configPath string) (*apiCallValidator, error) {
+
+	return &apiCallValidator{configPath: configPath}, nil
+}
+
+func (a *apiCallValidator) support(token string) bool {
+	return true
+}
+
+func (a *apiCallValidator) validate(token string) (string, string, []string, bool, error) {
+	//FIXME kfox1111: To enhance performance, cache admin token/client.
+	glog.V(3).Infof("Starting Keystone Token Auth.")
+	cfg, provider, err := openstackutil.ConfigFileToProvider(a.configPath)
+	if err != nil {
+		return "", "", nil, false, errors.New("Internal error getting the Keystone provider")
+	}
+
+	glog.V(3).Infof("Getting OpenStack Identity Provider...")
+	client, err := openstack.NewIdentityAdminV3(provider, gophercloud.EndpointOpts{
+		Region: cfg.Global.Region,
+	})
+	if err != nil {
+		return "", "", nil, false, err
+	}
+	response, err := client.Request("GET", client.ServiceURL("auth", "tokens"), gophercloud.RequestOpts{
+		MoreHeaders: map[string]string{"X-Subject-Token": token},
+		OkCodes:     []int{200, 203},
+	})
+	if err != nil {
+		return "", "", nil, false, err
+	}
+	defer response.Body.Close()
+	bodyBytes, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		glog.V(3).Infof("Cannot get HTTP response body from keystone token validate: %v", err)
+		return "", "", nil, false, err
+	}
+	obj := struct {
+		Token struct {
+			User struct {
+				Id string `json:"id"`
+			} `json:"user"`
+			Project struct {
+				Id string `json:"id"`
+			} `json:"project"`
+			Roles []struct {
+				Name string `json:"name"`
+			} `json:"roles"`
+		} `json:"token"`
+	}{}
+	err = json.Unmarshal(bodyBytes, &obj)
+	if err != nil {
+		return "", "", nil, false, err
+	}
+	var roles []string
+	if obj.Token.Roles != nil && len(obj.Token.Roles) > 0 {
+		roles = make([]string, len(obj.Token.Roles))
+		for i := 0; i < len(obj.Token.Roles); i++ {
+			roles[i] = obj.Token.Roles[i].Name
+		}
+	} else {
+		roles = make([]string, 0)
+	}
+	valid := response.StatusCode == 200 || response.StatusCode == 203
+	return obj.Token.User.Id, obj.Token.Project.Id, roles, valid, nil
+}

--- a/plugin/pkg/auth/authenticator/token/keystone/doc.go
+++ b/plugin/pkg/auth/authenticator/token/keystone/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package keystone provides authentication via keystone.
+// For details about keystone and how to use the plugin, refer to
+// https://github.com/kubernetes/kubernetes.github.io/blob/master/docs/admin/authentication.md
+package keystone

--- a/plugin/pkg/auth/authenticator/token/keystone/keystone.go
+++ b/plugin/pkg/auth/authenticator/token/keystone/keystone.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keystone
+
+import (
+	"errors"
+
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/auth/user"
+)
+
+// KeystoneAuthenticator contacts openstack keystone to validate user's credentials passed in the request.
+// The keystone endpoint is passed during apiserver startup
+type KeystoneAuthenticator struct {
+	configPath       string
+	apiCallValidator validator
+}
+
+func (keystoneAuthenticator *KeystoneAuthenticator) AuthenticateToken(token string) (user.Info, bool, error) {
+	//FIXME kfox1111: To enhance performance, cache admin token/client.
+	glog.V(3).Infof("Starting Keystone Token Auth.")
+	userid, projectid, roles, valid, err := keystoneAuthenticator.apiCallValidator.validate(token)
+	if err != nil {
+		return nil, false, err
+	}
+	extra := make(map[string][]string, 3)
+	extra["alpha.kubernetes.io/keystone_authn"] = []string{"true"}
+	extra["alpha.kubernetes.io/keystone_project_id"] = []string{projectid}
+	extra["alpha.kubernetes.io/keystone_roles"] = roles
+	return &user.DefaultInfo{Name: userid, Extra: extra}, valid, nil
+}
+
+// NewKeystoneAuthenticator returns a token authenticator that validates credentials using OpenStack Keystone
+func NewKeystoneAuthenticator(configPath string) (*KeystoneAuthenticator, error) {
+	apiCallValidator, err := newAPICallValidator(configPath)
+	if err != nil {
+		glog.V(2).Infof("Initialization of Keystone api call validator failed: %s", err)
+		return nil, err
+	}
+	if configPath != "" {
+		return &KeystoneAuthenticator{configPath, apiCallValidator}, nil
+	}
+	return nil, errors.New("configPath is empty")
+}

--- a/plugin/pkg/auth/authenticator/token/keystone/types.go
+++ b/plugin/pkg/auth/authenticator/token/keystone/types.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keystone
+
+// validator is an interface describes an actor to check whether the given token
+// is valid or not
+type validator interface {
+	// check whether the token is valid, if not, tell why, and if it is valid, then
+	// extract the information that has been encoded in this token.
+	validate(token string) (string, string, []string, bool, error)
+	// support tell whether this kind of token is supported or not
+	support(token string) bool
+}


### PR DESCRIPTION
``` release-note
Extends experimental keystone auth support to support token validation.
```

This change modifies the api-server to support validation of
OpenStack Keystone tokens, allowing many different types of
Keystone supported authentication plugins to be used.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/25391)

<!-- Reviewable:end -->
