### PR TITLE
AWS kube-up: Increase timeout waiting for docker start

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -1322,7 +1322,7 @@ function check-cluster() {
         local output=`check-minion ${minion_ip}`
         echo $output
         if [[ "${output}" != "working" ]]; then
-          if (( attempt > 9 )); then
+          if (( attempt > 20 )); then
             echo
             echo -e "${color_red}Your cluster is unlikely to work correctly." >&2
             echo "Please run ./cluster/kube-down.sh and re-create the" >&2


### PR DESCRIPTION
Apparently our cluster start time increased, to the point where users
are reporting spurious timeouts (#23623) and users are reporting that
increasing the timeout fixes the issue (thanks @paralin for the
suggestion and @jlfields for confirming).

Fix #23623
