### PR TITLE
Quota integration test improvements

### DIFF
--- a/test/integration/quota_test.go
+++ b/test/integration/quota_test.go
@@ -43,6 +43,10 @@ import (
 	"k8s.io/kubernetes/test/integration/framework"
 )
 
+func init() {
+	requireEtcd()
+}
+
 // 1.2 code gets:
 // 	quota_test.go:95: Took 4.218619579s to scale up without quota
 // 	quota_test.go:199: unexpected error: timed out waiting for the condition, ended with 342 pods (1 minute)
@@ -59,13 +63,15 @@ func TestQuota(t *testing.T) {
 		<-initializationCh
 		m.Handler.ServeHTTP(w, req)
 	}))
-	// TODO: Uncomment when fix #19254
-	// defer s.Close()
+	// TODO: https://github.com/kubernetes/kubernetes/issues/25412
+	//defer s.Close()
+	admissionCh := make(chan struct{})
 	clientset := clientset.NewForConfigOrDie(&restclient.Config{QPS: -1, Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})
-	admission, err := resourcequota.NewResourceQuota(clientset, quotainstall.NewRegistry(clientset), 5)
+	admission, err := resourcequota.NewResourceQuota(clientset, quotainstall.NewRegistry(clientset), 5, admissionCh)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer close(admissionCh)
 
 	masterConfig := framework.NewIntegrationTestMasterConfig()
 	masterConfig.AdmissionControl = admission
@@ -78,16 +84,12 @@ func TestQuota(t *testing.T) {
 	controllerCh := make(chan struct{})
 	defer close(controllerCh)
 
-	go replicationcontroller.NewReplicationManagerFromClient(clientset, controller.NoResyncPeriodFunc, replicationcontroller.BurstReplicas, 4096).
+	go replicationcontroller.NewReplicationManagerFromClientForIntegration(clientset, controller.NoResyncPeriodFunc, replicationcontroller.BurstReplicas, 4096).
 		Run(3, controllerCh)
 
 	resourceQuotaRegistry := quotainstall.NewRegistry(clientset)
 	groupKindsToReplenish := []unversioned.GroupKind{
 		api.Kind("Pod"),
-		api.Kind("Service"),
-		api.Kind("ReplicationController"),
-		api.Kind("PersistentVolumeClaim"),
-		api.Kind("Secret"),
 	}
 	resourceQuotaControllerOptions := &resourcequotacontroller.ResourceQuotaControllerOptions{
 		KubeClient:                clientset,
@@ -118,8 +120,8 @@ func TestQuota(t *testing.T) {
 	scale(t, "quotaed", clientset)
 	endTime = time.Now()
 	t.Logf("Took %v to scale up with quota", endTime.Sub(startTime))
-
 }
+
 func waitForQuota(t *testing.T, quota *api.ResourceQuota, clientset *clientset.Clientset) {
 	w, err := clientset.Core().ResourceQuotas(quota.Namespace).Watch(api.SingleObject(api.ObjectMeta{Name: quota.Name}))
 	if err != nil {
@@ -152,7 +154,7 @@ func waitForQuota(t *testing.T, quota *api.ResourceQuota, clientset *clientset.C
 }
 
 func scale(t *testing.T, namespace string, clientset *clientset.Clientset) {
-	target := 1000
+	target := 100
 	rc := &api.ReplicationController{
 		ObjectMeta: api.ObjectMeta{
 			Name:      "foo",


### PR DESCRIPTION
This PR does the following:
- allow a replication manager to get created that does not record events
- improve the shutdown behavior of replication manager and resource quota to ensure doWork funcs exit properly
- update quota integration test to use non event generating replication manager, reduce number of pods to provision

I am hoping this combination of changes should fix the referenced flake.

Fixes https://github.com/kubernetes/kubernetes/issues/25037
