### PR TITLE
etcd_watcher: make Deleted Event.Object's version consistent

### DIFF
--- a/pkg/storage/etcd/etcd_watcher.go
+++ b/pkg/storage/etcd/etcd_watcher.go
@@ -399,6 +399,9 @@ func (w *etcdWatcher) sendModify(res *etcd.Response) {
 	if res.PrevNode != nil && res.PrevNode.Value != "" {
 		// Ignore problems reading the old object.
 		if oldObj, err = w.decodeObject(res.PrevNode); err == nil {
+			if err := w.versioner.UpdateObject(oldObj, res.Node.ModifiedIndex); err != nil {
+				utilruntime.HandleError(fmt.Errorf("failure to version api object (%d) %#v: %v", res.Node.ModifiedIndex, oldObj, err))
+			}
 			oldObjPasses = w.filter(oldObj)
 		}
 	}


### PR DESCRIPTION
### What's the problem?

In [sendDelete()](https://github.com/kubernetes/kubernetes/blob/995f022808d1407897a5b23373484ac683534390/pkg/storage/etcd/etcd_watcher.go#L437-L442), Deleted Event.Object's resource version will be set to the latest resource version. This is actually an assumption made by cacher that all later events should have objects with larger verions; See [here](https://github.com/kubernetes/kubernetes/blob/995f022808d1407897a5b23373484ac683534390/pkg/storage/cacher.go#L579-L581).

In sendModify(), it could also return Deleted event. However, the resource version is still the old version, which is inconsistent behavior with sendDelete().
### What's this PR?

This PR sets the version of oldObj in sendModify() to be the latest version.
Provided unit test for it.
