### PR TITLE
[GarbageCollector] Let the dynamic client take runtime.Object instead of v1.ListOptions

### DIFF
--- a/pkg/client/typed/dynamic/client.go
+++ b/pkg/client/typed/dynamic/client.go
@@ -109,11 +109,11 @@ func (rc *ResourceClient) namespace(req *restclient.Request) *restclient.Request
 }
 
 // List returns a list of objects for this resource.
-func (rc *ResourceClient) List(opts v1.ListOptions) (*runtime.UnstructuredList, error) {
+func (rc *ResourceClient) List(opts runtime.Object) (*runtime.UnstructuredList, error) {
 	result := new(runtime.UnstructuredList)
 	err := rc.namespace(rc.cl.Get()).
 		Resource(rc.resource.Name).
-		VersionedParams(&opts, parameterEncoder).
+		VersionedParams(opts, parameterEncoder).
 		Do().
 		Into(result)
 	return result, err
@@ -141,10 +141,10 @@ func (rc *ResourceClient) Delete(name string, opts *v1.DeleteOptions) error {
 }
 
 // DeleteCollection deletes a collection of objects.
-func (rc *ResourceClient) DeleteCollection(deleteOptions *v1.DeleteOptions, listOptions v1.ListOptions) error {
+func (rc *ResourceClient) DeleteCollection(deleteOptions *v1.DeleteOptions, listOptions runtime.Object) error {
 	return rc.namespace(rc.cl.Delete()).
 		Resource(rc.resource.Name).
-		VersionedParams(&listOptions, parameterEncoder).
+		VersionedParams(listOptions, parameterEncoder).
 		Body(deleteOptions).
 		Do().
 		Error()
@@ -177,10 +177,10 @@ func (rc *ResourceClient) Update(obj *runtime.Unstructured) (*runtime.Unstructur
 }
 
 // Watch returns a watch.Interface that watches the resource.
-func (rc *ResourceClient) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (rc *ResourceClient) Watch(opts runtime.Object) (watch.Interface, error) {
 	return rc.namespace(rc.cl.Get().Prefix("watch")).
 		Resource(rc.resource.Name).
-		VersionedParams(&opts, parameterEncoder).
+		VersionedParams(opts, parameterEncoder).
 		Watch()
 }
 

--- a/pkg/client/typed/dynamic/client_test.go
+++ b/pkg/client/typed/dynamic/client_test.go
@@ -133,7 +133,7 @@ func TestList(t *testing.T) {
 		}
 		defer srv.Close()
 
-		got, err := cl.Resource(resource, tc.namespace).List(v1.ListOptions{})
+		got, err := cl.Resource(resource, tc.namespace).List(&v1.ListOptions{})
 		if err != nil {
 			t.Errorf("unexpected error when listing %q: %v", tc.name, err)
 			continue
@@ -287,7 +287,7 @@ func TestDeleteCollection(t *testing.T) {
 		}
 		defer srv.Close()
 
-		err = cl.Resource(resource, tc.namespace).DeleteCollection(nil, v1.ListOptions{})
+		err = cl.Resource(resource, tc.namespace).DeleteCollection(nil, &v1.ListOptions{})
 		if err != nil {
 			t.Errorf("unexpected error when deleting collection %q: %v", tc.name, err)
 			continue
@@ -461,7 +461,7 @@ func TestWatch(t *testing.T) {
 		}
 		defer srv.Close()
 
-		watcher, err := cl.Resource(resource, tc.namespace).Watch(v1.ListOptions{})
+		watcher, err := cl.Resource(resource, tc.namespace).Watch(&v1.ListOptions{})
 		if err != nil {
 			t.Errorf("unexpected error when watching %q: %v", tc.name, err)
 			continue

--- a/pkg/controller/namespace/namespace_controller_utils.go
+++ b/pkg/controller/namespace/namespace_controller_utils.go
@@ -156,7 +156,7 @@ func deleteCollection(
 	}
 
 	apiResource := unversioned.APIResource{Name: gvr.Resource, Namespaced: true}
-	err := dynamicClient.Resource(&apiResource, namespace).DeleteCollection(nil, v1.ListOptions{})
+	err := dynamicClient.Resource(&apiResource, namespace).DeleteCollection(nil, &v1.ListOptions{})
 
 	if err == nil {
 		return true, nil
@@ -198,7 +198,7 @@ func listCollection(
 	}
 
 	apiResource := unversioned.APIResource{Name: gvr.Resource, Namespaced: true}
-	unstructuredList, err := dynamicClient.Resource(&apiResource, namespace).List(v1.ListOptions{})
+	unstructuredList, err := dynamicClient.Resource(&apiResource, namespace).List(&v1.ListOptions{})
 	if err == nil {
 		return unstructuredList, true, nil
 	}

--- a/test/integration/dynamic_client_test.go
+++ b/test/integration/dynamic_client_test.go
@@ -90,7 +90,7 @@ func TestDynamicClient(t *testing.T) {
 	}
 
 	// check dynamic list
-	unstructuredList, err := dynamicClient.Resource(&resource, framework.TestNS).List(v1.ListOptions{})
+	unstructuredList, err := dynamicClient.Resource(&resource, framework.TestNS).List(&v1.ListOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error when listing pods: %v", err)
 	}


### PR DESCRIPTION
so that I can pass whatever version of ListOptions to the List/Watch/DeleteCollection methods.

cc @krousey

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/25423)

<!-- Reviewable:end -->
