### PR TITLE
Block master branch from being run on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-language: bash
+language: go
 
-script:
-    - echo "Travis is disabled on master. See issue 23611."
-    - echo "https://github.com/kubernetes/kubernetes/issues/23611"
+branches:
+  except:
+    - master


### PR DESCRIPTION
This PR prevents the `master` branch from building/booting a VM on Travis altogether. 😄 

(This is in regards to issue #23611.)
