### PR TITLE
Add a defensive sanity check to protobuf marshal

### DIFF
--- a/pkg/runtime/types_proto.go
+++ b/pkg/runtime/types_proto.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package runtime
 
+import (
+	"fmt"
+)
+
 type ProtobufMarshaller interface {
 	MarshalTo(data []byte) (int, error)
 }
@@ -43,6 +47,11 @@ func (m *Unknown) NestedMarshalTo(data []byte, b ProtobufMarshaller, size uint64
 		n2, err := b.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
+		}
+		if uint64(n2) != size {
+			// programmer error: the Size() method for protobuf does not match the results of MarshalTo, which means the proto
+			// struct returned would be wrong.
+			return 0, fmt.Errorf("the Size() value of %T was %d, but NestedMarshalTo wrote %d bytes to data", b, size, n2)
 		}
 		i += n2
 	}


### PR DESCRIPTION
This prevents programmer error from resulting in objects serialized to
the wire that are incorrectly designed. The normal path guards against
this, but the runtime.Unknown NestedMarshalTo fast path (which avoids an
allocation) doesn't have the same defensive guard.

@wojtek-t this will fail until #25347 is merged, and may expose other
problems as well. Will test tonight to see what else is broken.

<!-- Reviewable:start -->

---

This change is [<img src="http://reviewable.k8s.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](http://reviewable.k8s.io/reviews/kubernetes/kubernetes/25436)

<!-- Reviewable:end -->
