### PR TITLE
Corrects some misspellings in comments

### DIFF
--- a/pkg/client/restclient/plugin.go
+++ b/pkg/client/restclient/plugin.go
@@ -37,7 +37,7 @@ type AuthProvider interface {
 
 // Factory generates an AuthProvider plugin.
 //  clusterAddress is the address of the current cluster.
-//  config is the inital configuration for this plugin.
+//  config is the initial configuration for this plugin.
 //  persister allows the plugin to save updated configuration.
 type Factory func(clusterAddress string, config map[string]string, persister AuthProviderConfigPersister) (AuthProvider, error)
 

--- a/pkg/client/unversioned/clientcmd/client_config_test.go
+++ b/pkg/client/unversioned/clientcmd/client_config_test.go
@@ -217,7 +217,7 @@ func TestCreateCleanWithPrefix(t *testing.T) {
 		{"anything", "anything"},
 	}
 
-	// WARNING: EnvVarCluster.Server is set during package loading time and can not be overriden by os.Setenv inside this test
+	// WARNING: EnvVarCluster.Server is set during package loading time and can not be overridden by os.Setenv inside this test
 	EnvVarCluster.Server = ""
 	tt = append(tt, struct{ server, host string }{"", "http://localhost:8080"})
 

--- a/pkg/client/unversioned/clientcmd/loader.go
+++ b/pkg/client/unversioned/clientcmd/loader.go
@@ -260,7 +260,7 @@ func (rules *ClientConfigLoadingRules) GetDefaultFilename() string {
 			return filename
 		}
 	}
-	// If none exists, use the first from precendence.
+	// If none exists, use the first from precedence.
 	if len(rules.Precedence) > 0 {
 		return rules.Precedence[0]
 	}

--- a/pkg/controller/volume/cache/attach_detach_volume_cache.go
+++ b/pkg/controller/volume/cache/attach_detach_volume_cache.go
@@ -124,7 +124,7 @@ type volume struct {
 	name string
 
 	// attachedNodes is a map containing the set of nodes this volume has
-	// succesfully been attached to. The key in this map is the name of the
+	// successfully been attached to. The key in this map is the name of the
 	// node and the value is a node object containing more information about
 	// the node.
 	attachedNodes map[string]node

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -123,7 +123,7 @@ type Factory struct {
 	SwaggerSchema func(unversioned.GroupVersionKind) (*swagger.ApiDeclaration, error)
 	// Returns the default namespace to use in cases where no
 	// other namespace is specified and whether the namespace was
-	// overriden.
+	// overridden.
 	DefaultNamespace func() (string, bool, error)
 	// Generators returns the generators for the provided command
 	Generators func(cmdName string) map[string]kubectl.Generator

--- a/pkg/kubelet/network/kubenet/kubenet_linux.go
+++ b/pkg/kubelet/network/kubenet/kubenet_linux.go
@@ -370,7 +370,7 @@ func (plugin *kubenetNetworkPlugin) GetPodNetworkStatus(namespace string, name s
 	if err != nil {
 		return nil, err
 	}
-	// Try to retrieve ip inside container netwrok namespace
+	// Try to retrieve ip inside container network namespace
 	output, err := plugin.execer.Command(nsenterPath, fmt.Sprintf("--net=%s", netnsPath), "-F", "--",
 		"ip", "-o", "-4", "addr", "show", "dev", network.DefaultInterfaceName).CombinedOutput()
 	if err != nil {

--- a/pkg/master/ports/ports.go
+++ b/pkg/master/ports/ports.go
@@ -18,7 +18,7 @@ package ports
 
 const (
 	// ProxyPort is the default port for the proxy healthz server.
-	// May be overriden by a flag at startup.
+	// May be overridden by a flag at startup.
 	ProxyStatusPort = 10249
 	// KubeletPort is the default port for the kubelet server on each host machine.
 	// May be overridden by a flag at startup.

--- a/pkg/runtime/serializer/protobuf/protobuf.go
+++ b/pkg/runtime/serializer/protobuf/protobuf.go
@@ -31,7 +31,7 @@ import (
 
 var (
 	// protoEncodingPrefix serves as a magic number for an encoded protobuf message on this serializer. All
-	// proto messages serialized by this schema will be precedeed by the bytes 0x6b 0x38 0x73, with the fourth
+	// proto messages serialized by this schema will be preceded by the bytes 0x6b 0x38 0x73, with the fourth
 	// byte being reserved for the encoding style. The only encoding style defined is 0x00, which means that
 	// the rest of the byte stream is a message of type k8s.io.kubernetes.pkg.runtime.Unknown (proto2).
 	//


### PR DESCRIPTION
This should help to make
https://goreportcard.com/report/k8s.io/kubernetes#misspell
look a little nicer.
