### PR TITLE
Check existence of kubernetes dir for get-kube.sh

### DIFF
--- a/cluster/get-kube.sh
+++ b/cluster/get-kube.sh
@@ -65,6 +65,18 @@ if [[ "${KUBERNETES_SKIP_DOWNLOAD-}" ]]; then
   exit 0
 fi
 
+if [[ -d "./kubernetes" ]]; then
+  if [[ -n "${KUBERNETES_SKIP_CONFIRM-}" ]]; then
+    echo "'kubernetes' directory already exist. Should we skip download step and start to create cluster based on it? [Y]/n"
+    read confirm
+    if [[ "$confirm" == "y" ]]; then
+      echo "Skipping download step."
+      create_cluster
+      exit 0
+    fi
+  fi
+fi
+
 function get_latest_version_number {
   local -r latest_url="https://storage.googleapis.com/kubernetes-release/release/stable.txt"
   if [[ $(which wget) ]]; then


### PR DESCRIPTION
[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()

There are a lot of references to https://get.k8s.io/ over the internet.
Most of such references do not describe KUBERNETES_SKIP_DOWNLOAD env variable
and newbies can get into a situation described below:
- execute `wget -q -O - https://get.k8s.io | bash`
- receive a failure due too missed packages or some configs
- fix the issue
- try again `wget -q -O - https://get.k8s.io | bash`

In this case, get-kube.sh will not check that kubernetes directory already
exist and repeat download again.
Lets make get-kube.sh more user-friendly and check existence of kubernetes dir
