### PR TITLE
Add a flag to disable dumpig logs after e2e test failure

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -95,6 +95,7 @@ dockercfg-path
 driver-port
 drop-embedded-fields
 dry-run
+dump-logs-on-failure
 duration-sec
 e2e-output-dir
 e2e-verify-service-account

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -204,7 +204,7 @@ func (f *Framework) AfterEach() {
 	}()
 
 	// Print events if the test failed.
-	if CurrentGinkgoTestDescription().Failed {
+	if CurrentGinkgoTestDescription().Failed && TestContext.DumpLogsOnFailure {
 		DumpAllNamespaceInfo(f.Client, f.Namespace.Name)
 	}
 

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -58,6 +58,8 @@ type TestContextType struct {
 	// It accepts namespace base name, which will be prepended with e2e prefix, kube client
 	// and labels to be applied to a namespace.
 	CreateTestingNS CreateTestingNSFn
+	// If set to true test will dump data about the namespace in which test was running.
+	DumpLogsOnFailure bool
 }
 
 type CloudConfig struct {
@@ -125,4 +127,5 @@ func RegisterFlags() {
 	flag.BoolVar(&TestContext.GatherLogsSizes, "gather-logs-sizes", false, "If set to true framework will be monitoring logs sizes on all machines running e2e tests.")
 	flag.BoolVar(&TestContext.GatherMetricsAfterTest, "gather-metrics-at-teardown", false, "If set to true framwork will gather metrics from all components after each test.")
 	flag.StringVar(&TestContext.OutputPrintType, "output-print-type", "hr", "Comma separated list: 'hr' for human readable summaries 'json' for JSON ones.")
+	flag.BoolVar(&TestContext.DumpLogsOnFailure, "dump-logs-on-failure", true, "If set to true test will dump data about the namespace in which test was running.")
 }


### PR DESCRIPTION
cc @kubernetes/sig-testing 
