### PR TITLE
Add ExtKeyClientAuth to the ExtKeyUsage field in GenerateSelfSignedCert.

### DIFF
--- a/pkg/util/crypto/crypto.go
+++ b/pkg/util/crypto/crypto.go
@@ -54,7 +54,7 @@ func GenerateSelfSignedCert(host, certPath, keyPath string, alternateIPs []net.I
 		NotAfter:  time.Now().Add(time.Hour * 24 * 365),
 
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		BasicConstraintsValid: true,
 		IsCA: true,
 	}


### PR DESCRIPTION
## Pull Request Guidelines
1. Please read our [contributor guidelines](https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md).
2. See our [developer guide](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md).
3. Follow the instructions for [labeling and writing a release note for this PR](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes) in the block below.

``` release-note
* Use the release-note-* labels to set the release note state 
* Clear this block to use the PR title as the release note 
-OR-
* Enter your extended release note here
```

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()

This change allows the generated certificates to be used for both client and server authentication. They can then be used by kubecfg when talking to the API server.
