### PR TITLE
Fixes #23529 Remove speter.net/go/exp/math/dec/inf from Godep since it is deprecated and in vendor

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1146,10 +1146,6 @@
 			"ImportPath": "k8s.io/heapster/metrics/api/v1/types",
 			"Comment": "v1.1.0-beta1-15-gde510e4",
 			"Rev": "de510e4bdcdea96722b5bde19ff0b7a142939485"
-		},
-		{
-			"ImportPath": "speter.net/go/exp/math/dec/inf",
-			"Rev": "42ca6cd68aa922bc3f32f1e056e61b65945d9ad7"
 		}
 	]
 }


### PR DESCRIPTION
Fixes #23529 

Since imports from code.google.com is deprecated, the code is not found. 
"Error getting package files from code.google.com."

Since the directory is vendored, I removed it from godep. The other option would be to replace the import with the working import, gopkg.in/inf.v0.

Tested by removing from godeps.json, ran godep save and then make.
