### PR TITLE
SplitHostPort is needed since Request.RemoteAddr has the host:port format

### DIFF
--- a/pkg/util/net/http.go
+++ b/pkg/util/net/http.go
@@ -153,8 +153,14 @@ func GetClientIP(req *http.Request) net.IP {
 	}
 
 	// Fallback to Remote Address in request, which will give the correct client IP when there is no proxy.
-	ip := net.ParseIP(req.RemoteAddr)
-	return ip
+	// Remote Address in Go's HTTP server is in the form host:port so we need to split that first.
+	host, _, err := net.SplitHostPort(req.RemoteAddr)
+	if err == nil {
+		return net.ParseIP(host)
+	}
+
+	// Fallback if Remote Address was just IP.
+	return net.ParseIP(req.RemoteAddr)
 }
 
 var defaultProxyFuncPointer = fmt.Sprintf("%p", http.ProxyFromEnvironment)

--- a/pkg/util/net/http_test.go
+++ b/pkg/util/net/http_test.go
@@ -76,7 +76,8 @@ func TestGetClientIP(t *testing.T) {
 		},
 		{
 			Request: http.Request{
-				RemoteAddr: ipString,
+				// RemoteAddr is in the form host:port
+				RemoteAddr: ipString + ":1234",
 			},
 			ExpectedIP: ip,
 		},
@@ -90,6 +91,7 @@ func TestGetClientIP(t *testing.T) {
 				Header: map[string][]string{
 					"X-Forwarded-For": {invalidIPString},
 				},
+				// RemoteAddr is in the form host:port
 				RemoteAddr: ipString,
 			},
 			ExpectedIP: ip,
@@ -98,7 +100,7 @@ func TestGetClientIP(t *testing.T) {
 
 	for i, test := range testCases {
 		if a, e := GetClientIP(&test.Request), test.ExpectedIP; reflect.DeepEqual(e, a) != true {
-			t.Fatalf("test case %d failed. expected: %v, actual: %v", i+1, e, a)
+			t.Fatalf("test case %d failed. expected: %v, actual: %v", i, e, a)
 		}
 	}
 }


### PR DESCRIPTION
@smarterclayton ptal
[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
