### PR TITLE
Extend a timeout to (hopefully) fix a flake.

### DIFF
--- a/test/integration/scheduler_test.go
+++ b/test/integration/scheduler_test.go
@@ -259,7 +259,7 @@ func DoTestUnschedulableNodes(t *testing.T, restClient *client.Client, nodeStore
 		mod.makeSchedulable(t, schedNode, nodeStore, restClient)
 
 		// Wait until the pod is scheduled.
-		err = wait.Poll(time.Second, wait.ForeverTestTimeout, podScheduled(restClient, myPod.Namespace, myPod.Name))
+		err = wait.Poll(time.Second, wait.ForeverTestTimeout*5 /* 2.5 minutes */, podScheduled(restClient, myPod.Namespace, myPod.Name))
 		if err != nil {
 			t.Errorf("Test %d: failed to schedule a pod: %v", i, err)
 		} else {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/12312 (I hope)

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
