### PR TITLE
[WIP]Fed service controller

### DIFF
--- a/federation/client/cache/cluster_cache.go
+++ b/federation/client/cache/cluster_cache.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors All rights reserved.
+Copyright 2014 The Kubernetes Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package cache
 import (
 	federation_v1alpha1 "k8s.io/kubernetes/federation/apis/federation/v1alpha1"
 	kubeCache "k8s.io/kubernetes/pkg/client/cache"
+	"github.com/golang/glog"
 )
 
 // StoreToClusterLister makes a Store have the List method of the unversioned.ClusterInterface
@@ -32,4 +33,32 @@ func (s *StoreToClusterLister) List() (clusters federation_v1alpha1.ClusterList,
 		clusters.Items = append(clusters.Items, *(m.(*federation_v1alpha1.Cluster)))
 	}
 	return clusters, nil
+}
+
+// ClusterConditionPredicate is a function that indicates whether the given cluster's conditions meet
+// some set of criteria defined by the function.
+type ClusterConditionPredicate func(cluster federation_v1alpha1.Cluster) bool
+
+// storeToClusterConditionLister filters and returns nodes matching the given type and status from the store.
+type storeToClusterConditionLister struct {
+	store     kubeCache.Store
+	predicate ClusterConditionPredicate
+}
+
+// ClusterCondition returns a storeToClusterConditionLister
+func (s *StoreToClusterLister) ClusterCondition(predicate ClusterConditionPredicate) storeToClusterConditionLister {
+	return storeToClusterConditionLister{s.Store, predicate}
+}
+
+// List returns a list of clusters that match the conditions defined by the predicate functions in the storeToClusterConditionLister.
+func (s storeToClusterConditionLister) List() (clusters federation_v1alpha1.ClusterList, err error) {
+	for _, m := range s.store.List() {
+		cluster := *m.(*federation_v1alpha1.Cluster)
+		if s.predicate(cluster) {
+			clusters.Items = append(clusters.Items, cluster)
+		} else {
+			glog.V(5).Infof("Cluster %s matches none of the conditions", cluster.Name)
+		}
+	}
+	return
 }

--- a/federation/cmd/federation-controller-manager/app/options/options.go
+++ b/federation/cmd/federation-controller-manager/app/options/options.go
@@ -32,6 +32,18 @@ type ControllerManagerConfiguration struct {
 	Port int `json:"port"`
 	// address is the IP address to serve on (set to 0.0.0.0 for all interfaces).
 	Address string `json:"address"`
+	// dnsProvider is the provider for dns services.
+	DnsProvider          string `json:"dnsProvider"`
+	// dnsConfigFile is the path to the dns provider configuration file.
+	DnsConfigFile        string `json:"ndsConfigFile"`
+	// concurrentSubRCSyncs is the number of sub replication controllers that are
+	// allowed to sync concurrently. Larger number = more responsive replica
+	// management, but more CPU (and network) load.
+	ConcurrentSubRCSyncs int `json:"concurrentSubRCSyncs"`
+	// concurrentServiceSyncs is the number of services that are
+	// allowed to sync concurrently. Larger number = more responsive service
+	// management, but more CPU (and network) load.
+	ConcurrentServiceSyncs int `json:"concurrentServiceSyncs"`
 	// clusterMonitorPeriod is the period for syncing ClusterStatus in cluster controller.
 	ClusterMonitorPeriod unversioned.Duration `json:"clusterMonitorPeriod"`
 	// APIServerQPS is the QPS to use while talking with federation apiserver.
@@ -65,6 +77,7 @@ func NewCMServer() *CMServer {
 		ControllerManagerConfiguration: ControllerManagerConfiguration{
 			Port:                 FederatedControllerManagerPort,
 			Address:              "0.0.0.0",
+			ConcurrentServiceSyncs: 10,
 			ClusterMonitorPeriod: unversioned.Duration{Duration: 40 * time.Second},
 			APIServerQPS:         20.0,
 			APIServerBurst:       30,
@@ -78,6 +91,7 @@ func NewCMServer() *CMServer {
 func (s *CMServer) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&s.Port, "port", s.Port, "The port that the controller-manager's http service runs on")
 	fs.Var(componentconfig.IPVar{Val: &s.Address}, "address", "The IP address to serve on (set to 0.0.0.0 for all interfaces)")
+	fs.IntVar(&s.ConcurrentServiceSyncs, "concurrent-service-syncs", s.ConcurrentServiceSyncs, "The number of service syncing operations that will be done concurrently. Larger number = faster endpoint updating, but more CPU (and network) load")
 	fs.DurationVar(&s.ClusterMonitorPeriod.Duration, "cluster-monitor-period", s.ClusterMonitorPeriod.Duration, "The period for syncing ClusterStatus in ClusterController.")
 	fs.BoolVar(&s.EnableProfiling, "profiling", true, "Enable profiling via web interface host:port/debug/pprof/")
 	fs.StringVar(&s.Master, "master", s.Master, "The address of the federation API server (overrides any value in kubeconfig)")

--- a/federation/pkg/dnsprovider/dns.go
+++ b/federation/pkg/dnsprovider/dns.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dnsprovider
+
+import "k8s.io/kubernetes/federation/pkg/dnsprovider/rrstype"
+
+// Interface an abstract, pluggable interface for DNS providers.
+type Interface interface {
+	Zones() (Zones, bool)
+}
+
+type Zones interface {
+	List() ([]Zone, error)
+}
+
+type Zone interface {
+	Name() string
+	ResourceRecordSets() (ResourceRecordSets, bool)
+}
+
+type ResourceRecordSets interface {
+	List() ([]ResourceRecordSet, error)
+	Add(ResourceRecordSet) (ResourceRecordSet, error)
+	Remove(ResourceRecordSet) error
+	New(name string, rrdatas []string, ttl int64, rrstype rrstype.RrsType) ResourceRecordSet
+}
+
+type ResourceRecordSet interface {
+	Name() string // e.g. "www.example.com"
+	Rrdatas() []string
+	Ttl() int64
+	Type() rrstype.RrsType
+}

--- a/federation/pkg/dnsprovider/doc.go
+++ b/federation/pkg/dnsprovider/doc.go
@@ -1,0 +1,15 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package dnsprovider supplies interfaces and implementations for dns service providers (e.g. Google Cloud DNS, AWS route53, etc)
+package dnsprovider

--- a/federation/pkg/dnsprovider/plugins.go
+++ b/federation/pkg/dnsprovider/plugins.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dnsprovider
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/golang/glog"
+)
+
+// Factory is a function that returns a cloudprovider.Interface.
+// The config parameter provides an io.Reader handler to the factory in
+// order to load specific configurations. If no configuration is provided
+// the parameter is nil.
+type Factory func(config io.Reader) (Interface, error)
+
+// All registered cloud providers.
+var providersMutex sync.Mutex
+var providers = make(map[string]Factory)
+
+// RegisterCloudProvider registers a cloudprovider.Factory by name.  This
+// is expected to happen during app startup.
+func RegisterCloudProvider(name string, cloud Factory) {
+	providersMutex.Lock()
+	defer providersMutex.Unlock()
+	if _, found := providers[name]; found {
+		glog.Fatalf("Cloud provider %q was registered twice", name)
+	}
+	glog.V(1).Infof("Registered cloud provider %q", name)
+	providers[name] = cloud
+}
+
+// GetCloudProvider creates an instance of the named cloud provider, or nil if
+// the name is not known.  The error return is only used if the named provider
+// was known but failed to initialize. The config parameter specifies the
+// io.Reader handler of the configuration file for the cloud provider, or nil
+// for no configuation.
+func GetCloudProvider(name string, config io.Reader) (Interface, error) {
+	providersMutex.Lock()
+	defer providersMutex.Unlock()
+	f, found := providers[name]
+	if !found {
+		return nil, nil
+	}
+	return f(config)
+}
+
+// InitCloudProvider creates an instance of the named cloud provider.
+func InitCloudProvider(name string, configFilePath string) (Interface, error) {
+	var cloud Interface
+	var err error
+
+	if name == "" {
+		glog.Info("No cloud provider specified.")
+		return nil, nil
+	}
+
+	if configFilePath != "" {
+		var config *os.File
+		config, err = os.Open(configFilePath)
+		if err != nil {
+			glog.Fatalf("Couldn't open cloud provider configuration %s: %#v",
+				configFilePath, err)
+		}
+
+		defer config.Close()
+		cloud, err = GetCloudProvider(name, config)
+	} else {
+		// Pass explicit nil so plugins can actually check for nil. See
+		// "Why is my nil error value not equal to nil?" in golang.org/doc/faq.
+		cloud, err = GetCloudProvider(name, nil)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("could not init cloud provider %q: %v", name, err)
+	}
+	if cloud == nil {
+		return nil, fmt.Errorf("unknown cloud provider %q", name)
+	}
+
+	return cloud, nil
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/clouddns.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/clouddns.go
@@ -1,0 +1,15 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// clouddns is the implementation of pkg/dnsprovider interface for Google Cloud DNS
+package clouddns

--- a/federation/pkg/dnsprovider/providers/google/clouddns/clouddns_test.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/clouddns_test.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clouddns
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"k8s.io/kubernetes/federation/pkg/dnsprovider"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/rrstype"
+)
+
+func newTestInterface() dnsprovider.Interface {
+	// return NewInterface()     // Use this to test the real cloud service
+	return newFakeInterface() // Use this to stub out the entire cloud service
+}
+
+func newFakeInterface() dnsprovider.Interface {
+	service := stubs.NewService()
+	interface_ := newInterfaceWithStub(service)
+	zones := service.ManagedZones_
+	// Add a fake zone to test against.
+	zone := &stubs.ManagedZone{zones, "example.com", []stubs.ResourceRecordSet{}}
+	call := zones.Create(projectName, zone)
+	_, err := call.Do()
+	if err != nil {
+		return nil
+	}
+	return interface_
+}
+
+var interface_ dnsprovider.Interface
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	interface_ = newTestInterface()
+	os.Exit(m.Run())
+}
+
+// firstZone returns the first zone for the configured dns provider account/project,
+// or fails if it can't be found
+func firstZone(t *testing.T) dnsprovider.Zone {
+	i := interface_
+	t.Logf("Getting zones")
+	z, supported := i.Zones()
+	if supported {
+		t.Logf("Got zones %v\n", z)
+	} else {
+		t.Fatalf("Zones interface not supported by interface %v", i)
+	}
+	zones, err := z.List()
+	if err != nil {
+		t.Fatalf("Failed to list zones: %v", err)
+	} else {
+		t.Logf("Got zone list: %v\n", zones)
+	}
+	if len(zones) < 1 {
+		t.Fatalf("Zone listing returned %d, expected %d", len(zones), 1)
+	} else {
+		t.Logf("Got at least 1 zone in list:%v\n", zones[0])
+	}
+	return zones[0]
+}
+
+/* rrs returns the ResourceRecordSets interface for a given zone */
+func rrs(t *testing.T, zone dnsprovider.Zone) (r dnsprovider.ResourceRecordSets) {
+	rrsets, supported := zone.ResourceRecordSets()
+	if !supported {
+		t.Fatalf("ResourceRecordSets interface not supported by zone %v", zone)
+		return r
+	}
+	return rrsets
+}
+
+func listRrsOrFail(t *testing.T, rrsets dnsprovider.ResourceRecordSets) []dnsprovider.ResourceRecordSet {
+	rrset, err := rrsets.List()
+	if err != nil {
+		t.Fatalf("Failed to list recordsets: %v", err)
+	} else {
+		if len(rrset) < 0 {
+			t.Fatalf("Record set length=%d, expected >=0", len(rrset))
+		} else {
+			t.Logf("Got %d recordsets: %v", len(rrset), rrset)
+		}
+	}
+	return rrset
+}
+
+func getExampleRrs(zone dnsprovider.Zone) dnsprovider.ResourceRecordSet {
+	rrsets, _ := zone.ResourceRecordSets()
+	return rrsets.New("www11."+zone.Name(), []string{"10.10.10.10", "169.20.20.20"}, 180, rrstype.A)
+}
+
+func getInvalidRrs(zone dnsprovider.Zone) dnsprovider.ResourceRecordSet {
+	rrsets, _ := zone.ResourceRecordSets()
+	return rrsets.New("www12."+zone.Name(), []string{"rubbish", "rubbish"}, 180, rrstype.A)
+}
+
+func addRrsetOrFail(t *testing.T, rrsets dnsprovider.ResourceRecordSets, rrset dnsprovider.ResourceRecordSet) dnsprovider.ResourceRecordSet {
+	result, err := rrsets.Add(rrset)
+	if err != nil {
+		t.Fatalf("Failed to add recordsets: %v", err)
+	}
+	return result
+}
+
+/* TestResourceRecordSetsList verifies that listing of zones succeeds */
+func TestZonesList(t *testing.T) {
+	firstZone(t)
+}
+
+/* TestResourceRecordSetsList verifies that listing of RRS's succeeds */
+func TestResourceRecordSetsList(t *testing.T) {
+	listRrsOrFail(t, rrs(t, firstZone(t)))
+}
+
+/* TestResourceRecordSetsAddSuccess verifies that addition of a valid RRS succeeds */
+func TestResourceRecordSetsAddSuccess(t *testing.T) {
+	zone := firstZone(t)
+	sets := rrs(t, zone)
+	set := addRrsetOrFail(t, sets, getExampleRrs(zone))
+	defer sets.Remove(set)
+	t.Logf("Successfully added resource record set: %v", set)
+}
+
+/* TestResourceRecordSetsAdditionVisible verifies that added RRS is visible after addition */
+func TestResourceRecordSetsAdditionVisible(t *testing.T) {
+	zone := firstZone(t)
+	sets := rrs(t, zone)
+	rrset := getExampleRrs(zone)
+	set := addRrsetOrFail(t, sets, rrset)
+	defer sets.Remove(set)
+	t.Logf("Successfully added resource record set: %v", set)
+	list := listRrsOrFail(t, sets)
+	found := false
+	for _, record := range list {
+		if record.Name() == rrset.Name() {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Failed to find added resource record set %v", rrs)
+	}
+}
+
+/* TestResourceRecordSetsAddDuplicateFail verifies that addition of a duplicate RRS fails */
+func TestResourceRecordSetsAddDuplicateFail(t *testing.T) {
+	zone := firstZone(t)
+	sets := rrs(t, zone)
+	rrset := getExampleRrs(zone)
+	set := addRrsetOrFail(t, sets, rrset)
+	defer sets.Remove(set)
+	t.Logf("Successfully added resource record set: %v", set)
+	// Try to add it again, and verify that the call fails.
+	rrs, err := sets.Add(rrset)
+	if err == nil {
+		defer sets.Remove(rrs)
+		t.Errorf("Should have failed to add duplicate resource record %v, but succeeded instead.", set)
+	} else {
+		t.Logf("Correctly failed to add duplicate resource record %v: %v", set, err)
+	}
+}
+
+/* TestResourceRecordSetsRemove verifies that the removal of an existing RRS succeeds */
+func TestResourceRecordSetsRemove(t *testing.T) {
+	zone := firstZone(t)
+	sets := rrs(t, zone)
+	rrset := getExampleRrs(zone)
+	set := addRrsetOrFail(t, sets, rrset)
+	err := sets.Remove(set)
+	if err != nil {
+		// Try again to clean up.
+		defer sets.Remove(rrset)
+		t.Error("Failed to remove resource record set %v after adding", rrs)
+	} else {
+		t.Logf("Successfully removed resource set %v after adding", rrs)
+	}
+}
+
+/* TestResourceRecordSetsRemoveGone verifies that a removed RRS no longer exists */
+func TestResourceRecordSetsRemoveGone(t *testing.T) {
+	zone := firstZone(t)
+	sets := rrs(t, zone)
+	rrset := getExampleRrs(zone)
+	set := addRrsetOrFail(t, sets, rrset)
+	err := sets.Remove(set)
+	if err != nil {
+		// Try again to clean up.
+		defer sets.Remove(rrset)
+		t.Error("Failed to remove resource record set %v after adding", rrs)
+	} else {
+		t.Logf("Successfully removed resource set %v after adding", rrs)
+	}
+	// Check that it's gone
+	list := listRrsOrFail(t, sets)
+	found := false
+	for _, set := range list {
+		if set.Name() == rrset.Name() {
+			found = true
+			break
+		}
+	}
+	if found {
+		t.Errorf("Deleted resource record set %v is still present", rrs)
+	}
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/interface.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/interface.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clouddns
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/golang/glog"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/dns/v1"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+)
+
+var _ dnsprovider.Interface = Interface{}
+
+type Interface struct {
+	service interfaces.Service
+}
+
+// NewInterface initializes the underlying Google Cloud DNS library
+// and wraps it in a provider-independent interface, which it returns.
+func NewInterface() dnsprovider.Interface {
+	oauthClient, err := getOauthClient()
+	if err != nil {
+		glog.Errorf("Failed to get OAuth Client: %v", err)
+	}
+	service, err := dns.New(oauthClient)
+	if err != nil {
+		glog.Errorf("Failed to get Cloud DNS client: %v", err)
+	}
+	glog.Infof("Successfully got DNS service: %v\n", service)
+	return newInterfaceWithStub(internal.NewService(service))
+}
+
+// newInterfaceWithStub facilitates stubbing out the underlying Google Cloud DNS
+// library for testing purposes.  It returns an provider-independent interface.
+func newInterfaceWithStub(service interfaces.Service) dnsprovider.Interface {
+	return &Interface{service}
+}
+
+func getOauthClient() (*http.Client, error) {
+	tokenSource, err := google.DefaultTokenSource(
+		oauth2.NoContext,
+		compute.CloudPlatformScope,
+		compute.ComputeScope)
+	if err != nil {
+		return nil, err
+	}
+	client := oauth2.NewClient(oauth2.NoContext, tokenSource)
+	if client != nil {
+		return client, nil
+	} else {
+		return nil, fmt.Errorf("Failed to get OAuth client.  No details provided.")
+	}
+}
+
+// Zones returns the provider's Zones interface, or false if not supported.
+func (i Interface) Zones() (zones dnsprovider.Zones, supported bool) {
+	return Zones{i.service.ManagedZones(), &i}, true
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/change.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/change.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"google.golang.org/api/dns/v1"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+)
+
+var _ interfaces.Change = Change{}
+
+type Change struct{ impl *dns.Change }
+
+func (c Change) Additions() (rrsets []interfaces.ResourceRecordSet) {
+	rrsets = make([]interfaces.ResourceRecordSet, len(c.impl.Additions))
+	for index, addition := range c.impl.Additions {
+		rrsets[index] = interfaces.ResourceRecordSet(&ResourceRecordSet{addition})
+	}
+	return rrsets
+}
+
+func (c Change) Deletions() (rrsets []interfaces.ResourceRecordSet) {
+	rrsets = make([]interfaces.ResourceRecordSet, len(c.impl.Deletions))
+	for index, deletion := range c.impl.Deletions {
+		rrsets[index] = interfaces.ResourceRecordSet(&ResourceRecordSet{deletion})
+	}
+	return rrsets
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/changes_create_call.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/changes_create_call.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"google.golang.org/api/dns/v1"
+	"google.golang.org/api/googleapi"
+
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+)
+
+var _ interfaces.ChangesCreateCall = ChangesCreateCall{}
+
+type ChangesCreateCall struct{ impl *dns.ChangesCreateCall }
+
+func (c ChangesCreateCall) Do(opts ...googleapi.CallOption) (interfaces.Change, error) {
+	ch, err := c.impl.Do(opts...)
+	return &Change{ch}, err
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/changes_service.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/changes_service.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"google.golang.org/api/dns/v1"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+)
+
+var _ interfaces.ChangesService = ChangesService{}
+
+type ChangesService struct{ impl *dns.ChangesService }
+
+func (c ChangesService) Create(project string, managedZone string, change interfaces.Change) interfaces.ChangesCreateCall {
+	return &ChangesCreateCall{c.impl.Create(project, managedZone, change.(*Change).impl)}
+}
+
+func (c ChangesService) NewChange(additions, deletions []interfaces.ResourceRecordSet) interfaces.Change {
+	adds := make([]*dns.ResourceRecordSet, len(additions))
+	deletes := make([]*dns.ResourceRecordSet, len(deletions))
+	for i, a := range additions {
+		adds[i] = a.(*ResourceRecordSet).impl
+	}
+	for i, d := range deletions {
+		deletes[i] = d.(*ResourceRecordSet).impl
+	}
+	return &Change{&dns.Change{Additions: adds, Deletions: deletes}}
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/clouddns.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/clouddns.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+// Implementation of internal/interfaces/* on top of Google Cloud DNS API.
+// See https://godoc.org/google.golang.org/api/dns/v1 for details
+// This facilitates stubbing out Google Cloud DNS for unit testing.
+// Only the parts of the API that we use are included.
+// Others can be added as needed.
+
+import "google.golang.org/api/dns/v1"
+
+type (
+	Project struct{ impl *dns.Project }
+
+	ProjectsGetCall struct{ impl *dns.ProjectsGetCall }
+
+	ProjectsService struct{ impl *dns.ProjectsService }
+
+	Quota struct{ impl *dns.Quota }
+)

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces/interfaces.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces/interfaces.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package interfaces
+
+import (
+	"google.golang.org/api/googleapi"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/rrstype"
+)
+
+// Interfaces to directly mirror the Google Cloud DNS API structures.
+// See https://godoc.org/google.golang.org/api/dns/v1 for details
+// This facilitates stubbing out Google Cloud DNS for unit testing.
+// Only the parts of the API that we use are included.
+// Others can be added as needed.
+
+type (
+	Change interface {
+		Additions() []ResourceRecordSet
+		Deletions() []ResourceRecordSet
+		// Id() string  // TODO: Add as needed
+		// Kind() string // TODO: Add as needed
+		// StartTime() string // TODO: Add as needed
+		// Status() string // TODO: Add as needed
+	}
+
+	ChangesCreateCall interface {
+		// Context(ctx context.Context) *ChangesCreateCall // TODO: Add as needed
+		Do(opts ...googleapi.CallOption) (Change, error)
+		// Fields(s ...googleapi.Field) *ChangesCreateCall // TODO: Add as needed
+	}
+
+	ChangesGetCall interface {
+		// Context(ctx context.Context) *ChangesGetCall // TODO: Add as needed
+		Do(opts ...googleapi.CallOption) (*Change, error)
+		// Fields(s ...googleapi.Field) *ChangesGetCall // TODO: Add as needed
+		// IfNoneMatch(entityTag string) *ChangesGetCall // TODO: Add as needed
+	}
+
+	ChangesListCall interface {
+		// Context(ctx context.Context) *ChangesListCall // TODO: Add as needed
+		Do(opts ...googleapi.CallOption) (*ChangesListResponse, error)
+		// Fields(s ...googleapi.Field) *ChangesListCall // TODO: Add as needed
+		// IfNoneMatch(entityTag string) *ChangesListCall // TODO: Add as needed
+		// MaxResults(maxResults int64) *ChangesListCall // TODO: Add as needed
+		// PageToken(pageToken string) *ChangesListCall // TODO: Add as needed
+		// Pages(ctx context.Context, f func(*ChangesListResponse) error) error // TODO: Add as needed
+		// SortBy(sortBy string) *ChangesListCall // TODO: Add as needed
+		// SortOrder(sortOrder string) *ChangesListCall // TODO: Add as needed
+	}
+
+	ChangesListResponse interface {
+		// Changes() []*Change // TODO: Add as needed
+		// Kind() string // TODO: Add as needed
+		// NextPageToken() string // TODO: Add as needed
+		// ServerResponse() googleapi.ServerResponse // TODO: Add as needed
+		// ForceSendFields() []string // TODO: Add as needed
+	}
+
+	ChangesService interface {
+		// Create(project string, managedZone string, change *Change) *ChangesCreateCall // TODO: Add as needed
+		Create(project string, managedZone string, change Change) ChangesCreateCall
+		NewChange(additions, deletions []ResourceRecordSet) Change
+
+		// Get(project string, managedZone string, changeId string) *ChangesGetCall // TODO: Add as needed
+		// List(project string, managedZone string) *ChangesListCall // TODO: Add as needed
+	}
+
+	ManagedZone interface {
+		// CreationTime() string // TODO: Add as needed
+		// Description() string // TODO: Add as needed
+		DnsName() string
+		// Id()  uint64 // TODO: Add as needed
+		// Kind() string // TODO: Add as needed
+		Name() string
+		// NameServerSet() string // TODO: Add as needed
+		// NameServers() []string // TODO: Add as needed
+		// ServerResponse() googleapi.ServerResponse // TODO: Add as needed
+		// ForceSendFields() []string // TODO: Add as needed
+	}
+
+	ManagedZonesCreateCall interface {
+		// Context(ctx context.Context) *ManagedZonesCreateCall // TODO: Add as needed
+		Do(opts ...googleapi.CallOption) (ManagedZone, error)
+		// Fields(s ...googleapi.Field) *ManagedZonesCreateCall // TODO: Add as needed
+	}
+
+	ManagedZonesDeleteCall interface {
+		// Context(ctx context.Context) *ManagedZonesDeleteCall // TODO: Add as needed
+		Do(opts ...googleapi.CallOption) error
+		// Fields(s ...googleapi.Field) *ManagedZonesDeleteCall // TODO: Add as needed
+	}
+
+	ManagedZonesGetCall interface {
+		// Context(ctx context.Context) *ManagedZonesGetCall // TODO: Add as needed
+		Do(opts ...googleapi.CallOption) (ManagedZone, error)
+		// Fields(s ...googleapi.Field) *ManagedZonesGetCall // TODO: Add as needed
+		// IfNoneMatch(entityTag string) *ManagedZonesGetCall // TODO: Add as needed
+	}
+
+	ManagedZonesListCall interface {
+		// Context(ctx context.Context) *ManagedZonesListCall // TODO: Add as needed
+		DnsName(dnsName string) ManagedZonesListCall
+		Do(opts ...googleapi.CallOption) (ManagedZonesListResponse, error)
+		// Fields(s ...googleapi.Field) *ManagedZonesListCall // TODO: Add as needed
+		// IfNoneMatch(entityTag string) *ManagedZonesListCall // TODO: Add as needed
+		// MaxResults(maxResults int64) *ManagedZonesListCall // TODO: Add as needed
+		// PageToken(pageToken string) *ManagedZonesListCall // TODO: Add as needed
+		// Pages(ctx context.Context, f func(*ManagedZonesListResponse) error) error // TODO: Add as needed
+	}
+
+	ManagedZonesListResponse interface {
+		// Kind() string // TODO: Add as needed
+		// ManagedZones() []*ManagedZone // TODO: Add as needed
+		ManagedZones() []ManagedZone
+		// NextPageToken string // TODO: Add as needed
+		// ServerResponse() googleapi.ServerResponse // TODO: Add as needed
+		// ForceSendFields() []string // TODO: Add as needed
+	}
+
+	ManagedZonesService interface {
+		// NewManagedZonesService(s *Service) *ManagedZonesService // TODO: Add to service if needed
+		Create(project string, managedzone ManagedZone) ManagedZonesCreateCall
+		Delete(project string, managedZone string) ManagedZonesDeleteCall
+		Get(project string, managedZone string) ManagedZonesGetCall
+		List(project string) ManagedZonesListCall
+	}
+
+	Project interface {
+		// Id()  string  // TODO: Add as needed
+		// Kind() string // TODO: Add as needed
+		// Number() uint64 // TODO: Add as needed
+		// Quota() *Quota // TODO: Add as needed
+		// ServerResponse()  googleapi.ServerResponse // TODO: Add as needed
+		// ForceSendFields() []string // TODO: Add as needed
+	}
+
+	ProjectsGetCall interface {
+		// TODO: Add as needed
+	}
+
+	ProjectsService interface {
+		// TODO: Add as needed
+	}
+
+	Quota interface {
+		// TODO: Add as needed
+	}
+
+	ResourceRecordSet interface {
+		// Kind() string // TODO: Add as needed
+		Name() string
+		Rrdatas() []string
+		Ttl() int64
+		Type() string
+		// ForceSendFields []string  // TODO: Add as needed
+	}
+
+	ResourceRecordSetsListCall interface {
+		// Context(ctx context.Context) *ResourceRecordSetsListCall  // TODO: Add as needed
+		// Do(opts ...googleapi.CallOption) (*ResourceRecordSetsListResponse, error)  // TODO: Add as needed
+		Do(opts ...googleapi.CallOption) (ResourceRecordSetsListResponse, error)
+		// Fields(s ...googleapi.Field) *ResourceRecordSetsListCall  // TODO: Add as needed
+		// IfNoneMatch(entityTag string) *ResourceRecordSetsListCall  // TODO: Add as needed
+		// MaxResults(maxResults int64) *ResourceRecordSetsListCall  // TODO: Add as needed
+		Name(name string) ResourceRecordSetsListCall
+		// PageToken(pageToken string) *ResourceRecordSetsListCall  // TODO: Add as needed
+		Type(type_ string) ResourceRecordSetsListCall
+	}
+
+	ResourceRecordSetsListResponse interface {
+		// Kind() string  // TODO: Add as needed
+		// NextPageToken() string  // TODO: Add as needed
+		Rrsets() []ResourceRecordSet
+		// ServerResponse() googleapi.ServerResponse  // TODO: Add as needed
+		// ForceSendFields() []string  // TODO: Add as needed
+	}
+
+	ResourceRecordSetsService interface {
+		// NewResourceRecordSetsService(s *Service) *ResourceRecordSetsService // TODO: add to service as needed
+		List(project string, managedZone string) ResourceRecordSetsListCall
+		NewResourceRecordSet(name string, rrdatas []string, ttl int64, type_ rrstype.RrsType) ResourceRecordSet
+	}
+
+	Service interface {
+		// BasePath() string  // TODO: Add as needed
+		// UserAgent() string // TODO: Add as needed
+		Changes() ChangesService
+		ManagedZones() ManagedZonesService
+		Projects() ProjectsService
+		ResourceRecordSets() ResourceRecordSetsService
+	}
+	// New(client *http.Client) (*Service, error)  // TODO: Add as needed
+)

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/managed_zone.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/managed_zone.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"google.golang.org/api/dns/v1"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+)
+
+var _ interfaces.ManagedZone = ManagedZone{}
+
+type ManagedZone struct{ impl *dns.ManagedZone }
+
+func (m ManagedZone) Name() string {
+	return m.impl.Name
+}
+
+func (m ManagedZone) DnsName() string {
+	return m.impl.DnsName
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/managed_zone_create_call.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/managed_zone_create_call.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"google.golang.org/api/dns/v1"
+	"google.golang.org/api/googleapi"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+)
+
+var _ interfaces.ManagedZonesCreateCall = ManagedZonesCreateCall{}
+
+type ManagedZonesCreateCall struct{ impl *dns.ManagedZonesCreateCall }
+
+func (call ManagedZonesCreateCall) Do(opts ...googleapi.CallOption) (interfaces.ManagedZone, error) {
+	m, err := call.impl.Do(opts...)
+	return &ManagedZone{m}, err
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/managed_zones_delete_call.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/managed_zones_delete_call.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"google.golang.org/api/dns/v1"
+	"google.golang.org/api/googleapi"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+)
+
+var _ interfaces.ManagedZonesDeleteCall = ManagedZonesDeleteCall{}
+
+type ManagedZonesDeleteCall struct{ impl *dns.ManagedZonesDeleteCall }
+
+func (call ManagedZonesDeleteCall) Do(opts ...googleapi.CallOption) error {
+	return call.Do(opts...)
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/managed_zones_get_call.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/managed_zones_get_call.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"google.golang.org/api/dns/v1"
+	"google.golang.org/api/googleapi"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+)
+
+var _ interfaces.ManagedZonesGetCall = ManagedZonesGetCall{}
+
+type ManagedZonesGetCall struct{ impl *dns.ManagedZonesGetCall }
+
+func (call ManagedZonesGetCall) Do(opts ...googleapi.CallOption) (interfaces.ManagedZone, error) {
+	m, err := call.impl.Do(opts...)
+	return &ManagedZone{m}, err
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/managed_zones_list_call.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/managed_zones_list_call.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"google.golang.org/api/dns/v1"
+	"google.golang.org/api/googleapi"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+)
+
+var _ interfaces.ManagedZonesListCall = &ManagedZonesListCall{}
+
+type ManagedZonesListCall struct{ impl *dns.ManagedZonesListCall }
+
+func (call *ManagedZonesListCall) Do(opts ...googleapi.CallOption) (interfaces.ManagedZonesListResponse, error) {
+	response, err := call.impl.Do(opts...)
+	return &ManagedZonesListResponse{response}, err
+}
+
+func (call *ManagedZonesListCall) DnsName(dnsName string) interfaces.ManagedZonesListCall {
+	call.impl.DnsName(dnsName)
+	return call
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/managed_zones_list_response.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/managed_zones_list_response.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"google.golang.org/api/dns/v1"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+)
+
+var _ interfaces.ManagedZonesListResponse = &ManagedZonesListResponse{}
+
+type ManagedZonesListResponse struct{ impl *dns.ManagedZonesListResponse }
+
+func (response *ManagedZonesListResponse) ManagedZones() []interfaces.ManagedZone {
+	zones := make([]interfaces.ManagedZone, len(response.impl.ManagedZones))
+	for i, z := range response.impl.ManagedZones {
+		zones[i] = &ManagedZone{z}
+	}
+	return zones
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/managed_zones_service.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/managed_zones_service.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"google.golang.org/api/dns/v1"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+)
+
+var _ interfaces.ManagedZonesService = &ManagedZonesService{}
+
+type ManagedZonesService struct{ impl *dns.ManagedZonesService }
+
+func (m *ManagedZonesService) Create(project string, managedzone interfaces.ManagedZone) interfaces.ManagedZonesCreateCall {
+	return &ManagedZonesCreateCall{m.impl.Create(project, managedzone.(ManagedZone).impl)}
+}
+
+func (m *ManagedZonesService) Delete(project string, managedZone string) interfaces.ManagedZonesDeleteCall {
+	return &ManagedZonesDeleteCall{m.impl.Delete(project, managedZone)}
+}
+
+func (m *ManagedZonesService) Get(project string, managedZone string) interfaces.ManagedZonesGetCall {
+	return &ManagedZonesGetCall{m.impl.Get(project, managedZone)}
+}
+
+func (m *ManagedZonesService) List(project string) interfaces.ManagedZonesListCall {
+	return &ManagedZonesListCall{m.impl.List(project)}
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/rrset.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/rrset.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"google.golang.org/api/dns/v1"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+)
+
+var _ interfaces.ResourceRecordSet = ResourceRecordSet{}
+
+type ResourceRecordSet struct{ impl *dns.ResourceRecordSet }
+
+func (r ResourceRecordSet) Name() string      { return r.impl.Name }
+func (r ResourceRecordSet) Rrdatas() []string { return r.impl.Rrdatas }
+func (r ResourceRecordSet) Ttl() int64        { return r.impl.Ttl }
+func (r ResourceRecordSet) Type() string      { return r.impl.Type }

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/rrsets_list_call.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/rrsets_list_call.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"google.golang.org/api/dns/v1"
+	"google.golang.org/api/googleapi"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+)
+
+var _ interfaces.ResourceRecordSetsListCall = &ResourceRecordSetsListCall{}
+
+type ResourceRecordSetsListCall struct {
+	impl *dns.ResourceRecordSetsListCall
+}
+
+func (call *ResourceRecordSetsListCall) Do(opts ...googleapi.CallOption) (interfaces.ResourceRecordSetsListResponse, error) {
+	response, err := call.impl.Do(opts...)
+	return &ResourceRecordSetsListResponse{response}, err
+}
+
+func (call *ResourceRecordSetsListCall) Name(name string) interfaces.ResourceRecordSetsListCall {
+	call.impl.Name(name)
+	return call
+}
+
+func (call *ResourceRecordSetsListCall) Type(type_ string) interfaces.ResourceRecordSetsListCall {
+	call.impl.Type(type_)
+	return call
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/rrsets_list_response.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/rrsets_list_response.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"google.golang.org/api/dns/v1"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+)
+
+var _ interfaces.ResourceRecordSetsListResponse = &ResourceRecordSetsListResponse{}
+
+type ResourceRecordSetsListResponse struct {
+	impl *dns.ResourceRecordSetsListResponse
+}
+
+func (response *ResourceRecordSetsListResponse) Rrsets() []interfaces.ResourceRecordSet {
+	rrsets := make([]interfaces.ResourceRecordSet, len(response.impl.Rrsets))
+	for i, rrset := range response.impl.Rrsets {
+		rrsets[i] = &ResourceRecordSet{rrset}
+	}
+	return rrsets
+
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/rrsets_service.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/rrsets_service.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"google.golang.org/api/dns/v1"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/rrstype"
+)
+
+var _ interfaces.ResourceRecordSetsService = &ResourceRecordSetsService{}
+
+type ResourceRecordSetsService struct {
+	impl *dns.ResourceRecordSetsService
+}
+
+func (service ResourceRecordSetsService) List(project string, managedZone string) interfaces.ResourceRecordSetsListCall {
+	return &ResourceRecordSetsListCall{service.impl.List(project, managedZone)}
+}
+
+func (service ResourceRecordSetsService) NewResourceRecordSet(name string, rrdatas []string, ttl int64, type_ rrstype.RrsType) interfaces.ResourceRecordSet {
+	rrset := dns.ResourceRecordSet{Name: name, Rrdatas: rrdatas, Ttl: ttl, Type: string(type_)}
+	return &ResourceRecordSet{&rrset}
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/service.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/service.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"google.golang.org/api/dns/v1"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+)
+
+var _ interfaces.Service = &Service{}
+
+type Service struct {
+	impl *dns.Service
+}
+
+func NewService(service *dns.Service) *Service {
+	return &Service{service}
+}
+
+func (s *Service) Changes() interfaces.ChangesService {
+	return &ChangesService{s.impl.Changes}
+}
+
+func (s *Service) ManagedZones() interfaces.ManagedZonesService {
+	return &ManagedZonesService{s.impl.ManagedZones}
+}
+
+func (s *Service) Projects() interfaces.ProjectsService {
+	return &ProjectsService{s.impl.Projects}
+}
+
+func (s *Service) ResourceRecordSets() interfaces.ResourceRecordSetsService {
+	return &ResourceRecordSetsService{s.impl.ResourceRecordSets}
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/change.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/change.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stubs
+
+import "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+
+var _ interfaces.Change = &Change{}
+
+type Change struct {
+	Service    *ChangesService
+	Additions_ []interfaces.ResourceRecordSet
+	Deletions_ []interfaces.ResourceRecordSet
+}
+
+func (c *Change) Additions() (rrsets []interfaces.ResourceRecordSet) {
+	return c.Additions_
+}
+
+func (c *Change) Deletions() (rrsets []interfaces.ResourceRecordSet) {
+	return c.Deletions_
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/changes_create_call.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/changes_create_call.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stubs
+
+import (
+	"fmt"
+
+	"google.golang.org/api/googleapi"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+)
+
+var _ interfaces.ChangesCreateCall = ChangesCreateCall{}
+
+type ChangesCreateCall struct {
+	Service *ChangesService
+	Project string
+	Zone    string
+	Change  interfaces.Change
+	Error   *error // Use this to over-ride response if necessary
+}
+
+func hashKey(set interfaces.ResourceRecordSet) string {
+	return fmt.Sprintf("%s-%d-%s", set.Name(), set.Ttl(), string(set.Type()))
+}
+
+func (c ChangesCreateCall) Do(opts ...googleapi.CallOption) (interfaces.Change, error) {
+	if c.Error != nil {
+		return nil, *c.Error
+	}
+	zone := (c.Service.Service.ManagedZones_.Impl[c.Project][c.Zone]).(*ManagedZone)
+	rrsets := map[string]int{} // Simple mechanism to detect dupes and missing rrsets before committing - stores index+1
+	for i, set := range zone.Rrsets {
+		rrsets[hashKey(set)] = i + 1
+	}
+	for _, add := range c.Change.Additions() {
+		if rrsets[hashKey(add)] > 0 {
+			return nil, fmt.Errorf("Attempt to insert duplicate rrset %v", add)
+		}
+	}
+	for _, del := range c.Change.Deletions() {
+		if !(rrsets[hashKey(del)] > 0) {
+			return nil, fmt.Errorf("Attempt to delete non-existent rrset %v", del)
+		}
+	}
+	for _, add := range c.Change.Additions() {
+		zone.Rrsets = append(zone.Rrsets, *(add.(*ResourceRecordSet)))
+	}
+	for _, del := range c.Change.Deletions() {
+		zone.Rrsets = append(
+			zone.Rrsets[:rrsets[hashKey(del)]-1],
+			zone.Rrsets[rrsets[hashKey(del)]:]...)
+	}
+	return c.Change, nil
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/changes_service.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/changes_service.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stubs
+
+import "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+
+var _ interfaces.ChangesService = &ChangesService{}
+
+type ChangesService struct {
+	Service *Service
+}
+
+func (c *ChangesService) Create(project string, managedZone string, change interfaces.Change) interfaces.ChangesCreateCall {
+	return &ChangesCreateCall{c, project, managedZone, change, nil}
+}
+
+func (c *ChangesService) NewChange(additions, deletions []interfaces.ResourceRecordSet) interfaces.Change {
+	return &Change{c, additions, deletions}
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/clouddns.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/clouddns.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stubs
+
+// Implementation of internal/interfaces/* on top of Google Cloud DNS API.
+// See https://godoc.org/google.golang.org/api/dns/v1 for details
+// This facilitates stubbing out Google Cloud DNS for unit testing.
+// Only the parts of the API that we use are included.
+// Others can be added as needed.
+
+import "google.golang.org/api/dns/v1"
+
+type (
+	// TODO: We dont' need these yet, so they remain unimplemented.  Add later as required.
+	Project         struct{ impl *dns.Project }
+	ProjectsGetCall struct{ impl *dns.ProjectsGetCall }
+	ProjectsService struct{ impl *dns.ProjectsService }
+	Quota           struct{ impl *dns.Quota }
+)

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zone.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zone.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stubs
+
+import "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+
+var _ interfaces.ManagedZone = ManagedZone{}
+
+type ManagedZone struct {
+	Service *ManagedZonesService
+	Name_   string
+	Rrsets  []ResourceRecordSet
+}
+
+func (m ManagedZone) Name() string {
+	return m.Name_
+}
+
+func (m ManagedZone) DnsName() string {
+	return m.Name_ // Don't bother storing a separate DNS name
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zone_create_call.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zone_create_call.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stubs
+
+import (
+	"fmt"
+
+	"google.golang.org/api/googleapi"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+)
+
+var _ interfaces.ManagedZonesCreateCall = ManagedZonesCreateCall{}
+
+type ManagedZonesCreateCall struct {
+	Error       *error // Use to override response for testing
+	Service     *ManagedZonesService
+	Project     string
+	ManagedZone interfaces.ManagedZone
+}
+
+func (call ManagedZonesCreateCall) Do(opts ...googleapi.CallOption) (interfaces.ManagedZone, error) {
+	if call.Error != nil {
+		return nil, *call.Error
+	}
+	if call.Service.Impl[call.Project][call.ManagedZone.DnsName()] != nil {
+		return nil, fmt.Errorf("Error - attempt to create duplicate zone %s in project %s.",
+			call.ManagedZone.DnsName(), call.Project)
+	}
+	if call.Service.Impl == nil {
+		call.Service.Impl = map[string]map[string]interfaces.ManagedZone{}
+	}
+	if call.Service.Impl[call.Project] == nil {
+		call.Service.Impl[call.Project] = map[string]interfaces.ManagedZone{}
+	}
+	call.Service.Impl[call.Project][call.ManagedZone.DnsName()] = call.ManagedZone
+	return call.ManagedZone, nil
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zones_delete_call.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zones_delete_call.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stubs
+
+import (
+	"fmt"
+
+	"google.golang.org/api/googleapi"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+)
+
+var _ interfaces.ManagedZonesDeleteCall = ManagedZonesDeleteCall{}
+
+type ManagedZonesDeleteCall struct {
+	Service  *ManagedZonesService
+	Project  string
+	ZoneName string
+	Error    *error // Use this to overide response for testing if required
+}
+
+func (call ManagedZonesDeleteCall) Do(opts ...googleapi.CallOption) error {
+	if call.Error != nil { // Return the override value
+		return *call.Error
+	} else { // Just try to delete it from the in-memory array.
+		project, ok := call.Service.Impl[call.Project]
+		if ok {
+			zone, ok := project[call.ZoneName]
+			if ok {
+				delete(project, zone.Name())
+				return nil
+			} else {
+				return fmt.Errorf("Failed to find zone %s in project %s to delete it", call.ZoneName, call.Project)
+			}
+		} else {
+			return fmt.Errorf("Failed to find project %s to delete zone %s from it", call.Project, call.ZoneName)
+		}
+	}
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zones_get_call.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zones_get_call.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stubs
+
+import (
+	"google.golang.org/api/googleapi"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+)
+
+var _ interfaces.ManagedZonesGetCall = ManagedZonesGetCall{}
+
+type ManagedZonesGetCall struct {
+	Service  *ManagedZonesService
+	Project  string
+	ZoneName string
+	Response interfaces.ManagedZone // Use this to overide response if required
+	Error    *error                 // Use this to overide response if required
+	DnsName_ string
+}
+
+func (call ManagedZonesGetCall) Do(opts ...googleapi.CallOption) (interfaces.ManagedZone, error) {
+	if call.Response != nil {
+		return call.Response, *call.Error
+	} else {
+		return call.Service.Impl[call.Project][call.ZoneName], nil
+	}
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zones_list_call.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zones_list_call.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stubs
+
+import (
+	"fmt"
+
+	"google.golang.org/api/googleapi"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+)
+
+var _ interfaces.ManagedZonesListCall = &ManagedZonesListCall{}
+
+type ManagedZonesListCall struct {
+	Service  *ManagedZonesService
+	Project  string
+	Response *interfaces.ManagedZonesListResponse // Use this to overide response if required
+	Error    *error                               // Use this to overide response if required
+	DnsName_ string
+}
+
+func (call *ManagedZonesListCall) Do(opts ...googleapi.CallOption) (interfaces.ManagedZonesListResponse, error) {
+	if call.Response != nil {
+		return *call.Response, *call.Error
+	} else {
+		proj, projectFound := call.Service.Impl[call.Project]
+		if !projectFound {
+			return nil, fmt.Errorf("Project %s not found.", call.Project)
+		}
+		if call.DnsName_ != "" {
+			return &ManagedZonesListResponse{[]interfaces.ManagedZone{proj[call.DnsName_]}}, nil
+		}
+		list := []interfaces.ManagedZone{}
+		for _, zone := range proj {
+			list = append(list, zone)
+		}
+		return &ManagedZonesListResponse{list}, nil
+	}
+}
+
+func (call *ManagedZonesListCall) DnsName(dnsName string) interfaces.ManagedZonesListCall {
+	call.DnsName_ = dnsName
+	return call
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zones_list_response.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zones_list_response.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stubs
+
+import "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+
+var _ interfaces.ManagedZonesListResponse = &ManagedZonesListResponse{}
+
+type ManagedZonesListResponse struct{ ManagedZones_ []interfaces.ManagedZone }
+
+func (response *ManagedZonesListResponse) ManagedZones() []interfaces.ManagedZone {
+	return response.ManagedZones_
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zones_service.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zones_service.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stubs
+
+import "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+
+var _ interfaces.ManagedZonesService = &ManagedZonesService{}
+
+type ManagedZonesService struct {
+	Impl map[string]map[string]interfaces.ManagedZone
+}
+
+func (m *ManagedZonesService) Create(project string, managedzone interfaces.ManagedZone) interfaces.ManagedZonesCreateCall {
+	return &ManagedZonesCreateCall{nil, m, project, managedzone.(*ManagedZone)}
+}
+
+func (m *ManagedZonesService) Delete(project string, managedZone string) interfaces.ManagedZonesDeleteCall {
+	return &ManagedZonesDeleteCall{m, project, managedZone, nil}
+}
+
+func (m *ManagedZonesService) Get(project string, managedZone string) interfaces.ManagedZonesGetCall {
+	return &ManagedZonesGetCall{m, project, managedZone, nil, nil, ""}
+}
+
+func (m *ManagedZonesService) List(project string) interfaces.ManagedZonesListCall {
+	return &ManagedZonesListCall{m, project, nil, nil, ""}
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/rrset.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/rrset.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stubs
+
+import "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+
+var _ interfaces.ResourceRecordSet = ResourceRecordSet{}
+
+type ResourceRecordSet struct {
+	Name_    string
+	Rrdatas_ []string
+	Ttl_     int64
+	Type_    string
+}
+
+func (r ResourceRecordSet) Name() string      { return r.Name_ }
+func (r ResourceRecordSet) Rrdatas() []string { return r.Rrdatas_ }
+func (r ResourceRecordSet) Ttl() int64        { return r.Ttl_ }
+func (r ResourceRecordSet) Type() string      { return r.Type_ }

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/rrsets_list_call.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/rrsets_list_call.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stubs
+
+import (
+	"google.golang.org/api/googleapi"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+)
+
+var _ interfaces.ResourceRecordSetsListCall = &ResourceRecordSetsListCall{}
+
+type ResourceRecordSetsListCall struct {
+	Response_ *ResourceRecordSetsListResponse
+	Err_      error
+	Name_     string
+	Type_     string
+}
+
+func (call *ResourceRecordSetsListCall) Do(opts ...googleapi.CallOption) (interfaces.ResourceRecordSetsListResponse, error) {
+	return call.Response_, call.Err_
+}
+
+func (call *ResourceRecordSetsListCall) Name(name string) interfaces.ResourceRecordSetsListCall {
+	call.Name_ = name
+	return call
+}
+
+func (call *ResourceRecordSetsListCall) Type(type_ string) interfaces.ResourceRecordSetsListCall {
+	call.Type_ = type_
+	return call
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/rrsets_list_response.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/rrsets_list_response.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stubs
+
+import "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+
+var _ interfaces.ResourceRecordSetsListResponse = &ResourceRecordSetsListResponse{}
+
+type ResourceRecordSetsListResponse struct {
+	impl []interfaces.ResourceRecordSet
+}
+
+func (response *ResourceRecordSetsListResponse) Rrsets() []interfaces.ResourceRecordSet {
+	return response.impl
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/rrsets_service.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/rrsets_service.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stubs
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/rrstype"
+)
+
+var _ interfaces.ResourceRecordSetsService = &ResourceRecordSetsService{}
+
+type ResourceRecordSetsService struct {
+	Service  *Service
+	ListCall interfaces.ResourceRecordSetsListCall // Use to override response if reqired for testing
+}
+
+func (s ResourceRecordSetsService) List(project string, managedZone string) interfaces.ResourceRecordSetsListCall {
+	if s.ListCall != nil {
+		return s.ListCall
+	}
+	p := s.Service.ManagedZones_.Impl[project]
+	if p == nil {
+		return &ResourceRecordSetsListCall{Err_: fmt.Errorf("Project not found: %s", project)}
+	}
+	z := s.Service.ManagedZones_.Impl[project][managedZone]
+	if z == nil {
+		return &ResourceRecordSetsListCall{
+			Err_: fmt.Errorf("Zone %s not found in project %s", managedZone, project),
+		}
+	}
+	zone := s.Service.ManagedZones_.Impl[project][managedZone].(*ManagedZone)
+	response := &ResourceRecordSetsListResponse{}
+	for _, set := range zone.Rrsets {
+		response.impl = append(response.impl, set)
+	}
+	return &ResourceRecordSetsListCall{Response_: response}
+}
+
+func (service ResourceRecordSetsService) NewResourceRecordSet(name string, rrdatas []string, ttl int64, type_ rrstype.RrsType) interfaces.ResourceRecordSet {
+	rrset := ResourceRecordSet{Name_: name, Rrdatas_: rrdatas, Ttl_: ttl, Type_: string(type_)}
+	return &rrset
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/service.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/service.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stubs
+
+import "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+
+var _ interfaces.Service = &Service{}
+
+type Service struct {
+	Changes_      *ChangesService
+	ManagedZones_ *ManagedZonesService
+	Projects_     *ProjectsService
+	Rrsets_       *ResourceRecordSetsService
+}
+
+func NewService() *Service {
+	s := &Service{}
+	s.Changes_ = &ChangesService{s}
+	s.ManagedZones_ = &ManagedZonesService{}
+	s.Projects_ = &ProjectsService{}
+	s.Rrsets_ = &ResourceRecordSetsService{s, nil}
+	return s
+}
+
+func (s *Service) Changes() interfaces.ChangesService {
+	return s.Changes_
+}
+
+func (s *Service) ManagedZones() interfaces.ManagedZonesService {
+	return s.ManagedZones_
+}
+
+func (s *Service) Projects() interfaces.ProjectsService {
+	return s.Projects_
+}
+
+func (s *Service) ResourceRecordSets() interfaces.ResourceRecordSetsService {
+	return s.Rrsets_
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/rrset.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/rrset.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clouddns
+
+import (
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/rrstype"
+)
+
+type ResourceRecordSet struct {
+	impl   interfaces.ResourceRecordSet
+	rrsets *ResourceRecordSets
+}
+
+func (rrset ResourceRecordSet) Name() string {
+	return rrset.impl.Name()
+}
+
+func (rrset ResourceRecordSet) Rrdatas() []string {
+	return rrset.impl.Rrdatas()
+}
+
+func (rrset ResourceRecordSet) Ttl() int64 {
+	return rrset.impl.Ttl()
+}
+
+func (rrset ResourceRecordSet) Type() rrstype.RrsType {
+	return rrstype.RrsType(rrset.impl.Type())
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/rrsets.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/rrsets.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clouddns
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/federation/pkg/dnsprovider"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/rrstype"
+)
+
+type ResourceRecordSets struct {
+	zone *Zone
+	impl interfaces.ResourceRecordSetsService
+}
+
+func (rrsets ResourceRecordSets) List() ([]dnsprovider.ResourceRecordSet, error) {
+	response, err := rrsets.impl.List(projectName, rrsets.zone.impl.Name()).Do()
+	if err != nil {
+		return []dnsprovider.ResourceRecordSet{}, err
+	}
+	list := make([]dnsprovider.ResourceRecordSet, len(response.Rrsets()))
+	for i, rrset := range response.Rrsets() {
+		list[i] = &ResourceRecordSet{rrset, &rrsets}
+	}
+	return list, nil
+}
+
+func (rrsets ResourceRecordSets) Add(rrset dnsprovider.ResourceRecordSet) (dnsprovider.ResourceRecordSet, error) {
+	service := rrsets.zone.zones.interface_.service.Changes()
+	additions := []interfaces.ResourceRecordSet{rrset.(*ResourceRecordSet).impl}
+	change := service.NewChange(additions, []interfaces.ResourceRecordSet{})
+	newChange, err := service.Create(projectName, rrsets.zone.impl.Name(), change).Do()
+	if err != nil {
+		return dnsprovider.ResourceRecordSet(nil), err
+	}
+	newAdditions := newChange.Additions()
+	if len(newAdditions) != len(additions) {
+		return dnsprovider.ResourceRecordSet(nil), fmt.Errorf("Internal error when adding resource record set.  Call succeeded but number of records returned is incorrect.  Records sent=%d, records returned=%s, record set:%v", len(additions), len(newAdditions), rrset)
+	}
+	return ResourceRecordSet{newChange.Additions()[0], &rrsets}, nil
+}
+
+func (rrsets ResourceRecordSets) Remove(rrset dnsprovider.ResourceRecordSet) error {
+	service := rrsets.zone.zones.interface_.service.Changes()
+	deletions := []interfaces.ResourceRecordSet{rrset.(ResourceRecordSet).impl}
+	change := service.NewChange([]interfaces.ResourceRecordSet{}, deletions)
+	newChange, err := service.Create(projectName, rrsets.zone.impl.Name(), change).Do()
+	if err != nil {
+		return err
+	}
+	newDeletions := newChange.Deletions()
+	if len(newDeletions) != len(deletions) {
+		return fmt.Errorf("Internal error when deleting resource record set.  Call succeeded but number of records returned is incorrect.  Records sent=%d, records returned=%s, record set:%v", len(deletions), len(newDeletions), rrset)
+	}
+	return nil
+}
+
+func (rrsets ResourceRecordSets) New(name string, rrdatas []string, ttl int64, rrstype rrstype.RrsType) dnsprovider.ResourceRecordSet {
+	return &ResourceRecordSet{rrsets.impl.NewResourceRecordSet(name, rrdatas, ttl, rrstype), &rrsets}
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/zone.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/zone.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clouddns
+
+import (
+	"k8s.io/kubernetes/federation/pkg/dnsprovider"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+)
+
+type Zone struct {
+	impl  interfaces.ManagedZone
+	zones *Zones
+}
+
+func (zone *Zone) Name() string {
+	return zone.impl.DnsName()
+}
+
+func (zone *Zone) ResourceRecordSets() (dnsprovider.ResourceRecordSets, bool) {
+	return &ResourceRecordSets{zone, zone.zones.interface_.service.ResourceRecordSets()}, true
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/zones.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/zones.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clouddns
+
+import (
+	"k8s.io/kubernetes/federation/pkg/dnsprovider"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+)
+
+const (
+	projectName = "federation0-cluster00" // TODO - get from config
+)
+
+type Zones struct {
+	impl       interfaces.ManagedZonesService
+	interface_ *Interface
+}
+
+func (zones Zones) List() ([]dnsprovider.Zone, error) {
+	response, err := zones.impl.List(projectName).Do()
+	if err != nil {
+		return []dnsprovider.Zone{}, nil
+	}
+	managedZones := response.ManagedZones()
+	zoneList := make([]dnsprovider.Zone, len(managedZones))
+	for i, zone := range managedZones {
+		zoneList[i] = &Zone{zone, &zones}
+	}
+	return zoneList, nil
+}

--- a/federation/pkg/dnsprovider/rrstype/rrstype.go
+++ b/federation/pkg/dnsprovider/rrstype/rrstype.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rrstype
+
+type (
+	RrsType string
+)
+
+const (
+	A     = RrsType("A")
+	CNAME = RrsType("CNAME")
+	// TODO:  Add other types as required
+)

--- a/federation/pkg/federation-controller/service/cluster_helper.go
+++ b/federation/pkg/federation-controller/service/cluster_helper.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"sync"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
+	cache "k8s.io/kubernetes/pkg/client/cache"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_3"
+	"k8s.io/kubernetes/pkg/controller/framework"
+	pkg_runtime "k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/federation/apis/federation/v1alpha1"
+	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
+	"k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/kubernetes/pkg/util/workqueue"
+	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/pkg/watch"
+
+	"github.com/golang/glog"
+)
+
+type clusterCache struct {
+	clientset          *clientset.Clientset
+	// A store of services, populated by the serviceController
+	serviceStore       cache.StoreToServiceLister
+	// Watches changes to all services
+	serviceController  *framework.Controller
+	// A store of endpoint, populated by the serviceController
+	endpointStore      cache.StoreToEndpointsLister
+	// Watches changes to all endpoints
+	endpointController *framework.Controller
+	// services that need to be synced
+	serviceQueue       *workqueue.Type
+	// endpoints that need to be synced
+	endpointQueue      *workqueue.Type
+}
+
+type clusterClientCache struct {
+	rwlock    sync.Mutex // protects serviceMap
+	clientMap map[string]*clusterCache
+}
+
+func (cc *clusterClientCache) startClusterLW(clientset *clientset.Clientset, clusterName string) {
+	cachedClusterClient := clusterCache {
+		clientset: clientset,
+		serviceQueue: workqueue.New(),
+		endpointQueue: workqueue.New(),
+	}
+	cachedClusterClient.endpointStore.Store, cachedClusterClient.endpointController = framework.NewInformer(
+		&cache.ListWatch{
+			ListFunc: func(options api.ListOptions) (pkg_runtime.Object, error) {
+				return clientset.Core().Endpoints(api.NamespaceAll).List(options)
+			},
+			WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
+				return clientset.Core().Endpoints(api.NamespaceAll).Watch(options)
+			},
+		},
+		&v1.Endpoints{},
+		serviceSyncPeriod,
+		framework.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				cc.enqueueEndpoint(obj, clusterName)
+			},
+			UpdateFunc: func(old, cur interface{}) {
+				cc.enqueueEndpoint(cur, clusterName)
+			},
+			DeleteFunc: func(obj interface{}) {
+				cc.enqueueEndpoint(obj, clusterName)
+			},
+		},
+	)
+
+	cachedClusterClient.serviceStore.Store, cachedClusterClient.serviceController = framework.NewInformer(
+		&cache.ListWatch{
+			ListFunc: func(options api.ListOptions) (pkg_runtime.Object, error) {
+				return clientset.Core().Services(api.NamespaceAll).List(options)
+			},
+			WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
+				return clientset.Core().Services(api.NamespaceAll).Watch(options)
+			},
+		},
+		&v1.Service{},
+		serviceSyncPeriod,
+		framework.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				cc.enqueueService(obj, clusterName)
+			},
+			UpdateFunc: func(old, cur interface{}) {
+				cc.enqueueService(cur, clusterName)
+			},
+			DeleteFunc: func(obj interface{}) {
+				cc.enqueueService(obj, clusterName)
+			},
+		},
+	)
+
+	cc.clientMap[clusterName] = &cachedClusterClient
+	glog.V(2).Infof("Start watching services on cluster %s", clusterName)
+	go cachedClusterClient.serviceController.Run(wait.NeverStop)
+	glog.V(2).Infof("Start watching endpoints on cluster %s", clusterName)
+	go cachedClusterClient.endpointController.Run(wait.NeverStop)
+}
+
+//TODO: copied from cluster controller, to make this as common function in pass 2
+// delFromClusterSet delete a cluster from clusterSet and
+// delete the corresponding restclient from the map clusterKubeClientMap
+func (cc *clusterClientCache) delFromClusterSet(obj interface{}) {
+	cluster, ok := obj.(*v1alpha1.Cluster)
+	cc.rwlock.Lock()
+	defer cc.rwlock.Unlock()
+	if ok {
+		delete(cc.clientMap, cluster.Name)
+	} else {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			glog.Infof("object contained wasn't a cluster or a deleted key: %+v", obj)
+			return
+		}
+		glog.Infof("Found tombstone for %v", obj)
+		delete(cc.clientMap, tombstone.Key)
+	}
+}
+
+// addToClusterSet insert the new cluster to clusterSet and create a corresponding
+// restclient to map clusterKubeClientMap
+func (cc *clusterClientCache) addToClientMap(obj interface{}) {
+	cluster := obj.(*v1alpha1.Cluster)
+	pred := getClusterConditionPredicate()
+	if pred(*cluster) {
+	//if validateCluster(*cluster) {
+		cc.rwlock.Lock()
+		defer cc.rwlock.Unlock()
+		//create the restclient of cluster
+		clientset, err := newClusterClientset(cluster)
+		if err != nil || clientset == nil {
+			glog.Errorf("Failed to create corresponding restclient of kubernetes cluster: %v", err)
+		}
+		cc.startClusterLW(clientset, cluster.Name)
+	}
+	// keep thing going if the cluster status is updated to not ready
+}
+
+func newClusterClientset(c *v1alpha1.Cluster) (*clientset.Clientset, error) {
+	clusterConfig, err := clientcmd.BuildConfigFromFlags(c.Spec.ServerAddressByClientCIDRs[0].ServerAddress, "")
+	if err != nil {
+		return nil, err
+	}
+	clusterConfig.QPS = KubeAPIQPS
+	clusterConfig.Burst = KubeAPIBurst
+	clientset := clientset.NewForConfigOrDie(restclient.AddUserAgent(clusterConfig, UserAgentName))
+	return clientset, nil
+}

--- a/federation/pkg/federation-controller/service/dns.go
+++ b/federation/pkg/federation-controller/service/dns.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+// getClusterZoneName returns the name of the zone where the specified cluster exists (e.g. "us-east1-c" on GCE, or "us-east-1b" on AWS) 
+func getClusterZoneName(clusterName string) string {
+	// TODO: quinton: Get this from the cluster API object - from the annotation on a node in the cluster - it doesn't contain this yet.
+	return "zone-of-cluster-" + clusterName
+}
+
+// getClusterRegionName returns the name of the region where the specified cluster exists (e.g. us-east1 on GCE, or "us-east-1" on AWS) 
+func getClusterRegionName(clusterName string) string {
+	// TODO: quinton: Get this from the cluster API object - from the annotation on a node in the cluster - it doesn't contain this yet.
+	return "region-of-cluster-" + clusterName
+}
+
+// getFederationDNSZoneName returns the name of the managed DNS Zone configured for this federation  
+func getFederationDNSZoneName() string {
+	return "mydomain.com" // TODO: quinton: Get this from the federation configuration.
+}
+
+func ensureDNSRecords(clusterName string, cachedService *cachedService) error {
+	// Quinton: Pseudocode....
+
+	return nil
+}

--- a/federation/pkg/federation-controller/service/doc.go
+++ b/federation/pkg/federation-controller/service/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package service contains code for syncing Kubernetes services,
+// and cloud DNS servers with the federated service registry.
+package service

--- a/federation/pkg/federation-controller/service/endpoint_helper.go
+++ b/federation/pkg/federation-controller/service/endpoint_helper.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_3"
+	"k8s.io/kubernetes/pkg/api/v1"
+	cache "k8s.io/kubernetes/pkg/client/cache"
+	"k8s.io/kubernetes/pkg/controller"
+
+	"github.com/golang/glog"
+)
+
+// worker runs a worker thread that just dequeues items, processes them, and marks them done.
+// It enforces that the syncHandler is never invoked concurrently with the same key.
+func (sc *ServiceController) clusterEndpointWorker() {
+	fedClient := sc.federationClient
+	for clusterName, clusterCache := range sc.clusterCache.clientMap{
+		go func() {
+			for {
+				key, quit := clusterCache.endpointQueue.Get()
+				// update endpoint cache
+				if quit {
+					return
+				}
+				defer clusterCache.endpointQueue.Done(key)
+				err := sc.clusterCache.syncEndpoint(key.(string), clusterName, clusterCache, sc.serviceCache, fedClient)
+				if err != nil {
+					glog.V(2).Infof("failed to sync endpoint: %+v", err)
+					//return err
+				}
+			}
+		}()
+	}
+}
+
+// Whenever there is change on endpoint, the federation service should be updated
+// key is the namespaced name of endpoint
+func (cc *clusterClientCache) syncEndpoint(key, clusterName string, clusterCache *clusterCache, serviceCache *serviceCache, fedClient federation_release_1_3.Interface) error {
+	cachedService, ok := serviceCache.get(key)
+	if !ok {
+		// here we filtered all non-federation services
+		return nil
+	}
+	// obj holds the latest service info from apiserver
+	endpointInterface, exists, err := clusterCache.endpointStore.GetByKey(key)
+	if err != nil {
+		glog.Infof("did not successfully get %v from store: %v, will retry later", key, err)
+		clusterCache.endpointQueue.Add(key)
+		return err
+	}
+	if !exists {
+		// service absence in store means watcher caught the deletion, ensure LB info is cleaned
+		glog.Infof("endpoint has been deleted %v", key)
+		err = cc.processEndpointDeletion(cachedService, clusterName)
+	}
+	if exists {
+		endpoint, ok := endpointInterface.(*v1.Endpoints)
+		if ok {
+			glog.V(4).Infof("Found endpoint for federation service %s/%s from cluster %s", endpoint.Namespace, endpoint.Name, clusterName)
+			err = cc.processEndpointUpdate(cachedService, endpoint, clusterName)
+		} else {
+			_, ok := endpointInterface.(cache.DeletedFinalStateUnknown)
+			if !ok {
+				return fmt.Errorf("object contained wasn't a service or a deleted key: %+v", endpointInterface)
+			}
+			glog.Infof("Found tombstone for %v", key)
+			err = cc.processEndpointDeletion(cachedService, clusterName)
+		}
+	}
+	if err != nil {
+		glog.Errorf("failed to sync service: %+v, put back to service queue", err)
+		clusterCache.endpointQueue.Add(key)
+	}
+	cachedService.resetDNSUpdateDelay()
+	return nil
+}
+
+func (cc *clusterClientCache) processEndpointDeletion(cachedService *cachedService, clusterName string) error {
+	glog.V(4).Infof("Processing endpoint update for %s/%s, cluster %s", cachedService.lastState.Namespace, cachedService.lastState.Name, clusterName)
+	var err error
+	cachedService.rwlock.Lock()
+	defer cachedService.rwlock.Unlock()
+	_, ok := cachedService.endpointMap[clusterName]
+	// TODO remove ok checking? if service controller is restarted, then endpointMap for the cluster does not exist
+	// need to query dns info from dnsprovider and make sure of if deletion is needed
+	if ok {
+		// endpoints lost, clean dns record
+		glog.V(4).Infof("cached endpoint was not found for %s/%s, cluster %s, building one", cachedService.lastState.Namespace, cachedService.lastState.Name, clusterName)
+			// TODO: need to integrate with dns.go:ensureDNSRecords
+		for i := 0; i < clientRetryCount; i++ {
+			err := ensureDNSRecords(clusterName, cachedService)
+			if err == nil {
+				delete(cachedService.endpointMap, clusterName)
+				return nil
+			}
+			time.Sleep(cachedService.nextDNSUpdateDelay())
+		}
+	}
+	return err
+}
+
+// Update dns info when endpoint update event received
+// We do not care about the endpoint info, what we need to make sure here is len(endpoints.subsets)>0
+func (cc *clusterClientCache) processEndpointUpdate(cachedService *cachedService, endpoint *v1.Endpoints, clusterName string) error {
+	glog.V(4).Infof("Processing endpoint update for %s/%s, cluster %s", endpoint.Namespace, endpoint.Name, clusterName)
+	cachedService.rwlock.Lock()
+	defer cachedService.rwlock.Unlock()
+	for _, subset := range endpoint.Subsets {
+		if len(subset.Addresses) > 0 {
+			cachedService.endpointMap[clusterName] = 1
+		}
+	}
+	_, ok := cachedService.endpointMap[clusterName]
+	if !ok {
+		// first time get endpoints, update dns record
+		glog.V(4).Infof("cached endpoint was not found for %s/%s, cluster %s, building one", endpoint.Namespace, endpoint.Name, clusterName)
+		cachedService.endpointMap[clusterName] = 1
+		err := ensureDNSRecords(clusterName, cachedService)
+		if err != nil {
+			// TODO: need to integrate with dns.go:ensureDNSRecords
+			for i := 0; i < clientRetryCount; i++ {
+				time.Sleep(cachedService.nextDNSUpdateDelay())
+				err := ensureDNSRecords(clusterName, cachedService)
+				if err == nil {
+					return nil
+				}
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+// obj could be an *api.Service, or a DeletionFinalStateUnknown marker item.
+func (cc *clusterClientCache) enqueueEndpoint(obj interface{}, clusterName string) {
+	key, err := controller.KeyFunc(obj)
+	if err != nil {
+		glog.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		return
+	}
+	_, ok := cc.clientMap[clusterName]
+	if ok {
+		cc.clientMap[clusterName].endpointQueue.Add(key)
+	}
+}

--- a/federation/pkg/federation-controller/service/endpoint_helper_test.go
+++ b/federation/pkg/federation-controller/service/endpoint_helper_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api/v1"
+)
+
+func buildEndpoint(subsets [][]string) *v1.Endpoints{
+	endpoint := &v1.Endpoints{
+		Subsets: []v1.EndpointSubset{
+			v1.EndpointSubset{Addresses: []v1.EndpointAddress{},},
+		},
+	}
+	for _, element:= range subsets{
+		address := v1.EndpointAddress{element[0],element[1], nil}
+		endpoint.Subsets[0].Addresses = append(endpoint.Subsets[0].Addresses, address)
+	}
+	return endpoint
+}
+
+func TestProcessEndpointUpdate(t *testing.T) {
+	cc := clusterClientCache{
+		clientMap:make(map[string]*clusterCache),
+	}
+	tests := []struct {
+		name			 string
+		cachedService    *cachedService
+		endpoint		 *v1.Endpoints
+		clusterName      string
+		expectResult     int
+	}{
+		{
+			"no-cache",
+			&cachedService{
+				lastState: &v1.Service{},
+				endpointMap: make(map[string]int),
+			},
+			buildEndpoint([][]string{{"ip1",""},}),
+			"foo",
+			1,
+		},
+		{
+			"has-cache",
+			&cachedService{
+				lastState: &v1.Service{},
+				endpointMap: map[string]int{
+					"foo":1,
+				},
+			},
+			buildEndpoint([][]string{{"ip1",""},}),
+			"foo",
+			1,
+		},
+	}
+	for _, test := range tests {
+		cc.processEndpointUpdate(test.cachedService, test.endpoint, test.clusterName)
+		if test.expectResult != test.cachedService.endpointMap[test.clusterName] {
+			t.Errorf("Test failed for %s, expected %v, saw %v", test.name, test.expectResult, test.cachedService.endpointMap[test.clusterName])
+		}
+	}
+}
+
+func TestProcessEndpointDeletion(t *testing.T) {
+	cc := clusterClientCache{
+		clientMap:make(map[string]*clusterCache),
+	}
+	tests := []struct {
+		name			 string
+		cachedService    *cachedService
+		endpoint		 *v1.Endpoints
+		clusterName      string
+		expectResult     int
+	}{
+		{
+			"no-cache",
+			&cachedService{
+				lastState: &v1.Service{},
+				endpointMap: make(map[string]int),
+			},
+			buildEndpoint([][]string{{"ip1",""},}),
+			"foo",
+			0,
+		},
+		{
+			"has-cache",
+			&cachedService{
+				lastState: &v1.Service{},
+				endpointMap: map[string]int{
+					"foo":1,
+				},
+			},
+			buildEndpoint([][]string{{"ip1",""},}),
+			"foo",
+			0,
+		},
+	}
+	for _, test := range tests {
+		cc.processEndpointDeletion(test.cachedService, test.clusterName)
+		if test.expectResult != test.cachedService.endpointMap[test.clusterName] {
+			t.Errorf("Test failed for %s, expected %v, saw %v", test.name, test.expectResult, test.cachedService.endpointMap[test.clusterName])
+		}
+	}
+}

--- a/federation/pkg/federation-controller/service/service_helper.go
+++ b/federation/pkg/federation-controller/service/service_helper.go
@@ -1,0 +1,255 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"time"
+	"fmt"
+
+	"k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_3"
+	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/v1"
+	cache "k8s.io/kubernetes/pkg/client/cache"
+	"k8s.io/kubernetes/pkg/controller"
+
+	"github.com/golang/glog"
+	"reflect"
+	"sort"
+)
+
+// worker runs a worker thread that just dequeues items, processes them, and marks them done.
+// It enforces that the syncHandler is never invoked concurrently with the same key.
+func (sc *ServiceController) clusterServiceWorker() {
+	fedClient := sc.federationClient
+	for clusterName, clusterCache := range sc.clusterCache.clientMap{
+		go func() {
+			for {
+				key, quit := clusterCache.serviceQueue.Get()
+				// update service cache
+				if quit {
+					return
+				}
+				defer clusterCache.serviceQueue.Done(key)
+				err := sc.clusterCache.syncService(key.(string), clusterName, clusterCache, sc.serviceCache, fedClient)
+				if err != nil {
+					glog.Errorf("failed to sync service: %+v", err)
+				}
+			}
+		}()
+	}
+}
+
+// Whenever there is change on service, the federation service should be updated
+func (cc *clusterClientCache) syncService(key, clusterName string, clusterCache *clusterCache, serviceCache *serviceCache, fedClient federation_release_1_3.Interface) error {
+	// obj holds the latest service info from apiserver, return if there is no federation cache for the service
+	cachedService, ok := serviceCache.get(key)
+	if !ok {
+		// here we filtered all non-federation services
+		return nil
+	}
+	serviceInterface, exists, err := clusterCache.serviceStore.GetByKey(key)
+	if err != nil {
+		glog.Infof("did not successfully get %v from store: %v, will retry later", key, err)
+		clusterCache.serviceQueue.Add(key)
+		return err
+	}
+	var needUpdate bool
+	if exists {
+		service, ok := serviceInterface.(*v1.Service)
+		if ok {
+			glog.V(4).Infof("Found service for federation service %s/%s from cluster %s", service.Namespace, service.Name, clusterName)
+			needUpdate = cc.processServiceUpdate(cachedService, service, clusterName)
+		} else {
+			_, ok := serviceInterface.(cache.DeletedFinalStateUnknown)
+			if !ok {
+				return fmt.Errorf("object contained wasn't a service or a deleted key: %+v", serviceInterface)
+			}
+			glog.Infof("Found tombstone for %v", key)
+			needUpdate = cc.processServiceDeletion(cachedService, clusterName)
+		}
+	} else {
+		// service absence in store means watcher caught the deletion
+		glog.Infof("service has been deleted %v", key)
+		needUpdate = cc.processServiceDeletion(cachedService, clusterName)
+	}
+	if needUpdate {
+		err := cc.persistFedServiceUpdate(cachedService, fedClient)
+		if err == nil {
+			cachedService.appliedState = cachedService.lastState
+			cachedService.resetFedUpdateDelay()
+		} else {
+			if err != nil {
+				glog.Errorf("failed to sync service: %+v, put back to service queue", err)
+				clusterCache.serviceQueue.Add(key)
+			}
+		}
+	}
+	return nil
+}
+
+// processServiceDeletion is triggered when a service is delete from underlying k8s cluster
+// the deletion function will wip out the cached ingress info of the service from federation service ingress
+// the function returns a bool to indicate if actual update happend on federation service cache
+// and if the federation service cache is updated, the updated info should be post to federation apiserver
+func (cc *clusterClientCache) processServiceDeletion(cachedService *cachedService, clusterName string) bool{
+	cachedService.rwlock.Lock()
+	defer cachedService.rwlock.Unlock()
+	cachedStatus, ok := cachedService.serviceStatusMap[clusterName]
+	// cached status found, remove ingress info from federation service cache
+	if ok {
+		cachedFedServiceStatus := cachedService.lastState.Status.LoadBalancer
+		removeIndexes := []int{}
+		for i, fed := range cachedFedServiceStatus.Ingress {
+			for _, new := range cachedStatus.Ingress{
+				// remove if same ingress record found
+				if (new.IP == fed.IP && new.Hostname == fed.Hostname) {
+					removeIndexes = append(removeIndexes, i)
+				}
+			}
+		}
+		sort.Ints(removeIndexes)
+		for i := len(removeIndexes)-1; i >= 0; i-- {
+			cachedFedServiceStatus.Ingress = append(cachedFedServiceStatus.Ingress[:removeIndexes[i]], cachedFedServiceStatus.Ingress[removeIndexes[i]+1:]...)
+			glog.V(4).Infof("remove old ingress %d for service %s/%s",removeIndexes[i], cachedService.lastState.Namespace, cachedService.lastState.Name)
+		}
+		delete(cachedService.serviceStatusMap, clusterName)
+		delete(cachedService.endpointMap, clusterName)
+		cachedService.lastState.Status.LoadBalancer = cachedFedServiceStatus
+		return true
+	} else {
+		glog.V(4).Infof("service removal %s/%s from cluster %s observed.", cachedService.lastState.Namespace, cachedService.lastState.Name, clusterName)
+	}
+	return false
+}
+
+// processServiceUpdate Update ingress info when service updated
+// the function returns a bool to indicate if actual update happend on federation service cache
+// and if the federation service cache is updated, the updated info should be post to federation apiserver
+func (cc *clusterClientCache) processServiceUpdate(cachedService *cachedService, service *v1.Service, clusterName string) bool {
+	glog.V(4).Infof("Processing service update for %s/%s, cluster %s", service.Namespace, service.Name, clusterName)
+	cachedService.rwlock.Lock()
+	defer cachedService.rwlock.Unlock()
+	var needUpdate bool
+	newServiceLB := service.Status.LoadBalancer
+	cachedFedServiceStatus := cachedService.lastState.Status.LoadBalancer
+	if len(newServiceLB.Ingress) == 0 {
+		// not yet get LB IP
+		return false
+	}
+
+	cachedStatus, ok := cachedService.serviceStatusMap[clusterName]
+	if ok {
+		if reflect.DeepEqual(cachedStatus, newServiceLB) {
+			glog.V(4).Infof("same ingress info observed for service %s/%s: %+v ", service.Namespace, service.Name, cachedStatus.Ingress)
+		} else{
+			glog.V(4).Infof("ingress info was changed for service %s/%s: cache: %+v, new: %+v ",
+				service.Namespace, service.Name, cachedStatus.Ingress, newServiceLB)
+			needUpdate = true
+		}
+	} else {
+		glog.V(4).Infof("cached service status was not found for %s/%s, cluster %s, building one", service.Namespace, service.Name, clusterName)
+
+		// cache is not always reliable(cache will be cleaned when service controller restart)
+		// two cases will run into this branch:
+		// 1. new service loadbalancer info received -> no info in cache, and no in federation service
+		// 2. service controller being restarted -> no info in cache, but it is in federation service
+
+		// check if the lb info is already in federation service
+
+		cachedService.serviceStatusMap[clusterName] = newServiceLB
+		needUpdate = false
+		// iterate service ingress info
+		for _, new := range newServiceLB.Ingress{
+			var found bool
+			// if it is known by federation service
+			for _, fed := range cachedFedServiceStatus.Ingress {
+				if (new.IP == fed.IP && new.Hostname == fed.Hostname) {
+					found = true
+				}
+			}
+			if !found {
+				needUpdate = true
+				break
+			}
+		}
+	}
+
+	if needUpdate {
+		// new status = cached federation status - cached status + new status from k8s cluster
+
+		removeIndexes := []int{}
+		for i, fed := range cachedFedServiceStatus.Ingress {
+			for _, new := range cachedStatus.Ingress{
+				// remove if same ingress record found
+				if (new.IP == fed.IP && new.Hostname == fed.Hostname) {
+					removeIndexes = append(removeIndexes, i)
+				}
+			}
+		}
+		sort.Ints(removeIndexes)
+		for i := len(removeIndexes)-1; i >= 0; i-- {
+			cachedFedServiceStatus.Ingress = append(cachedFedServiceStatus.Ingress[:removeIndexes[i]], cachedFedServiceStatus.Ingress[removeIndexes[i]+1:]...)
+		}
+		cachedFedServiceStatus.Ingress = append(cachedFedServiceStatus.Ingress, service.Status.LoadBalancer.Ingress...)
+		cachedService.lastState.Status.LoadBalancer = cachedFedServiceStatus
+		glog.V(4).Infof("add new ingress info %+v for service %s/%s", service.Status.LoadBalancer, service.Namespace, service.Name)
+	} else {
+		glog.V(4).Infof("same ingress info found for %s/%s, cluster %s", service.Namespace, service.Name, clusterName)
+	}
+	return needUpdate
+}
+
+
+func (cc *clusterClientCache) persistFedServiceUpdate(cachedService *cachedService, fedClient federation_release_1_3.Interface) error {
+	service := cachedService.lastState
+	glog.V(5).Infof("Persist federation service status %+v", service)
+	var err error
+	for i := 0; i < clientRetryCount; i++ {
+		_, err := fedClient.Core().Services(service.Namespace).UpdateStatus(service)
+		if err == nil {
+			glog.V(2).Infof("Successfully update service %s/%s to federation apiserver", service.Namespace, service.Name)
+			return nil
+		}
+		if errors.IsNotFound(err) {
+			glog.Infof("Not persisting update to service '%s/%s' that no longer exists: %v",
+				service.Namespace, service.Name, err)
+			return nil
+		}
+		if errors.IsConflict(err) {
+			glog.V(4).Infof("Not persisting update to service '%s/%s' that has been changed since we received it: %v",
+				service.Namespace, service.Name, err)
+			return err
+		}
+		time.Sleep(cachedService.nextFedUpdateDelay())
+	}
+	return err
+}
+
+// obj could be an *api.Service, or a DeletionFinalStateUnknown marker item.
+func (cc *clusterClientCache) enqueueService(obj interface{}, clusterName string) {
+	key, err := controller.KeyFunc(obj)
+	if err != nil {
+		glog.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		return
+	}
+	cc.rwlock.Lock()
+	defer cc.rwlock.Unlock()
+	_, ok := cc.clientMap[clusterName]
+	if ok {
+		cc.clientMap[clusterName].serviceQueue.Add(key)
+	}
+}

--- a/federation/pkg/federation-controller/service/service_helper_test.go
+++ b/federation/pkg/federation-controller/service/service_helper_test.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"testing"
+	"reflect"
+
+	"k8s.io/kubernetes/pkg/api/v1"
+)
+
+func buildServiceStatus(ingresses [][]string) v1.LoadBalancerStatus{
+	status := v1.LoadBalancerStatus{
+		Ingress: []v1.LoadBalancerIngress{
+		},
+	}
+	for _, element:= range ingresses {
+		ingress := v1.LoadBalancerIngress{element[0],element[1]}
+		status.Ingress = append(status.Ingress, ingress)
+	}
+	return status
+}
+
+func TestProcessServiceUpdate(t *testing.T) {
+	cc := clusterClientCache{
+		clientMap:make(map[string]*clusterCache),
+	}
+	tests := []struct {
+		name			 string
+		cachedService    *cachedService
+		service		     *v1.Service
+		clusterName      string
+		expectNeedUpdate bool
+		expectStatus     v1.LoadBalancerStatus
+	}{
+		{
+			"no-cache",
+			&cachedService{
+				lastState: &v1.Service{},
+				serviceStatusMap: make(map[string]v1.LoadBalancerStatus),
+			},
+			&v1.Service{Status:v1.ServiceStatus{buildServiceStatus([][]string{{"ip1",""},})}},
+			"foo",
+			true,
+			buildServiceStatus([][]string{{"ip1",""},}),
+		},
+		{
+			"same-ingress",
+			&cachedService{
+				lastState: &v1.Service{Status:v1.ServiceStatus{buildServiceStatus([][]string{{"ip1",""},})}},
+				serviceStatusMap: map[string]v1.LoadBalancerStatus{
+					"foo1":v1.LoadBalancerStatus{Ingress: []v1.LoadBalancerIngress{v1.LoadBalancerIngress{"ip1", ""}}},
+				},
+			},
+			&v1.Service{Status:v1.ServiceStatus{buildServiceStatus([][]string{{"ip1",""},})}},
+			"foo1",
+			false,
+			buildServiceStatus([][]string{{"ip1",""},}),
+		},
+		{
+			"diff-cluster",
+			&cachedService{
+				lastState: &v1.Service{
+					ObjectMeta:v1.ObjectMeta{Name:"bar1"},
+				},
+				serviceStatusMap: map[string]v1.LoadBalancerStatus{
+					"foo2":v1.LoadBalancerStatus{Ingress: []v1.LoadBalancerIngress{v1.LoadBalancerIngress{"ip1", ""}}},
+				},
+			},
+			&v1.Service{Status:v1.ServiceStatus{buildServiceStatus([][]string{{"ip1",""},})}},
+			"foo1",
+			true,
+			buildServiceStatus([][]string{{"ip1",""},}),
+		},
+		{
+			"diff-ingress",
+			&cachedService{
+				lastState: &v1.Service{Status:v1.ServiceStatus{buildServiceStatus([][]string{{"ip4",""},{"ip1",""},{"ip2",""}})}},
+				serviceStatusMap: map[string]v1.LoadBalancerStatus{
+					"foo1":buildServiceStatus([][]string{{"ip4",""},{"ip1",""},{"ip2",""}}),
+				},
+			},
+			&v1.Service{Status:v1.ServiceStatus{buildServiceStatus([][]string{{"ip2",""},{"ip3",""},{"ip5",""}})}},
+			"foo1",
+			true,
+			buildServiceStatus([][]string{{"ip2",""},{"ip3",""},{"ip5",""}}),
+		},
+	}
+	for _, test := range tests {
+		result := cc.processServiceUpdate(test.cachedService, test.service, test.clusterName)
+		if test.expectNeedUpdate != result {
+			t.Errorf("Test failed for %s, expected %v, saw %v", test.name, test.expectNeedUpdate, result)
+		}
+		if !reflect.DeepEqual(test.expectStatus, test.cachedService.lastState.Status.LoadBalancer) {
+			t.Errorf("Test failed for %s, expected %v, saw %v", test.name, test.expectStatus, test.cachedService.lastState.Status.LoadBalancer)
+		}
+	}
+}
+
+func TestProcessServiceDeletion(t *testing.T) {
+	cc := clusterClientCache{
+		clientMap:make(map[string]*clusterCache),
+	}
+	tests := []struct {
+		name			 string
+		cachedService    *cachedService
+		service		     *v1.Service
+		clusterName      string
+		expectNeedUpdate bool
+		expectStatus     v1.LoadBalancerStatus
+	}{
+		{
+			"same-ingress",
+			&cachedService{
+				lastState: &v1.Service{Status:v1.ServiceStatus{buildServiceStatus([][]string{{"ip1",""},})}},
+				serviceStatusMap: map[string]v1.LoadBalancerStatus{
+					"foo1":v1.LoadBalancerStatus{Ingress: []v1.LoadBalancerIngress{v1.LoadBalancerIngress{"ip1", ""}}},
+				},
+			},
+			&v1.Service{Status:v1.ServiceStatus{buildServiceStatus([][]string{{"ip1",""},})}},
+			"foo1",
+			true,
+			buildServiceStatus([][]string{}),
+		},
+		{
+			"diff-ingress",
+			&cachedService{
+				lastState: &v1.Service{Status:v1.ServiceStatus{buildServiceStatus([][]string{{"ip4",""},{"ip1",""},{"ip2",""},{"ip3",""},{"ip5",""},{"ip6",""},{"ip8",""}})}},
+				serviceStatusMap: map[string]v1.LoadBalancerStatus{
+					"foo1":buildServiceStatus([][]string{{"ip1",""},{"ip2",""},{"ip3",""}}),
+					"foo2":buildServiceStatus([][]string{{"ip5",""},{"ip6",""},{"ip8",""}}),
+				},
+			},
+			&v1.Service{Status:v1.ServiceStatus{buildServiceStatus([][]string{{"ip1",""},{"ip2",""},{"ip3",""}})}},
+			"foo1",
+			true,
+			buildServiceStatus([][]string{{"ip4",""},{"ip5",""},{"ip6",""},{"ip8",""}}),
+		},
+	}
+	for _, test := range tests {
+		result := cc.processServiceDeletion(test.cachedService, test.clusterName)
+		if test.expectNeedUpdate != result {
+			t.Errorf("Test failed for %s, expected %v, saw %v", test.name, test.expectNeedUpdate, result)
+		}
+		if !reflect.DeepEqual(test.expectStatus, test.cachedService.lastState.Status.LoadBalancer) {
+			t.Errorf("Test failed for %s, expected %+v, saw %+v", test.name, test.expectStatus, test.cachedService.lastState.Status.LoadBalancer)
+		}
+	}
+}

--- a/federation/pkg/federation-controller/service/servicecontroller.go
+++ b/federation/pkg/federation-controller/service/servicecontroller.go
@@ -1,0 +1,867 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"reflect"
+
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/api/errors"
+	cache "k8s.io/kubernetes/pkg/client/cache"
+	federationcache "k8s.io/kubernetes/federation/client/cache"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_3"
+	federationclientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_3"
+	"k8s.io/kubernetes/pkg/client/record"
+	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/pkg/controller/framework"
+	pkg_runtime "k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/runtime"
+	"k8s.io/kubernetes/pkg/util/workqueue"
+	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/watch"
+	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/federation/apis/federation/v1alpha1"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider"
+	//"k8s.io/kubernetes/federation/pkg/dnsprovider/rrstype"
+
+	"k8s.io/kubernetes/pkg/conversion"
+)
+
+const (
+	// TODO update to 10 mins before merge
+	serviceSyncPeriod = 30 * time.Second
+	clusterSyncPeriod = 100 * time.Second
+
+	// How long to wait before retrying the processing of a service change.
+	// If this changes, the sleep in hack/jenkins/e2e.sh before downing a cluster
+	// should be changed appropriately.
+	minRetryDelay = 5 * time.Second
+	maxRetryDelay = 300 * time.Second
+
+	// client retry count and interval is when accessing a remote kube-apiserver or federation apiserver
+	// how many times should be attempted and how long it should sleep when failure occurs
+	// the retry should be in short time so no exponential backoff
+	clientRetryCount    = 5
+
+	retryable    = true
+
+	doNotRetry = time.Duration(0)
+
+	UserAgentName = "Federation-Service-Controller"
+	KubeAPIQPS    = 20.0
+	KubeAPIBurst  = 30
+)
+
+type cachedService struct {
+
+	//release_1_3 client returns v1 service
+	lastState      *v1.Service
+	// The state as successfully applied to the DNS server
+	appliedState   *v1.Service
+	// cluster endpoint map hold subset info from kubernetes clusters
+	// key clusterName
+	// value is a flag that if there is ready addresses
+	endpointMap    map[string]int
+	// cluster service map hold serivice status info from kubernetes clusters
+	// key clusterName
+
+	serviceStatusMap    map[string]v1.LoadBalancerStatus
+
+	// Ensures only one goroutine can operate on this service at any given time.
+	rwlock         sync.Mutex
+
+	// Controls error back-off for procceeding federation service to k8s clusters
+	lastRetryDelay time.Duration
+	// Controls error back-off for updating federation service back to federation apiserver
+	lastFedUpdateDelay time.Duration
+	// Controls error back-off for dns record update
+	lastDNSUpdateDelay time.Duration
+
+}
+
+type serviceCache struct {
+	rwlock        sync.Mutex // protects serviceMap
+	// federation service map contains all service received from federation apiserver
+	// key serviceName
+	fedServiceMap map[string]*cachedService
+}
+
+type ServiceController struct {
+	dns               dnsprovider.Interface
+	federationClient  federationclientset.Interface
+	federationName    string
+	// each federation should be configured with a single zone (e.g. "mycompany.com")
+	zones             []dnsprovider.Zone
+	serviceCache      *serviceCache
+	clusterCache      *clusterClientCache
+	// A store of services, populated by the serviceController
+	serviceStore      cache.StoreToServiceLister
+	// Watches changes to all services
+	serviceController *framework.Controller
+	// A store of services, populated by the serviceController
+	clusterStore      federationcache.StoreToClusterLister
+	// Watches changes to all services
+	clusterController *framework.Controller
+	eventBroadcaster  record.EventBroadcaster
+	eventRecorder     record.EventRecorder
+	//clusterLister     federationcache.StoreToClusterLister
+	// services that need to be synced
+	queue             *workqueue.Type
+	knownClusterSet   sets.String
+}
+
+// New returns a new service controller to keep DNS provider service resources
+// (like Kubernetes Services and DNS server records for service discovery) in sync with the registry.
+
+func New(federationClient federationclientset.Interface, dns dnsprovider.Interface, federationName string) *ServiceController {
+	broadcaster := record.NewBroadcaster()
+	// federationClient event is not supported yet?
+	//broadcaster.StartRecordingToSink(&unversioned_core.EventSinkImpl{Interface: kubeClient.Core().Events("")})
+	recorder := broadcaster.NewRecorder(api.EventSource{Component: "federated-service-controller"})
+
+	s := &ServiceController{
+		dns:              dns,
+		federationClient: federationClient,
+		federationName:   federationName,
+		serviceCache:     &serviceCache{fedServiceMap: make(map[string]*cachedService)},
+		clusterCache: 	  &clusterClientCache{
+			rwlock: sync.Mutex{},
+			clientMap: make(map[string]*clusterCache),
+		},
+		eventBroadcaster: broadcaster,
+		eventRecorder:    recorder,
+		queue:            workqueue.New(),
+		knownClusterSet:    make(sets.String),
+	}
+	s.serviceStore.Store, s.serviceController = framework.NewInformer(
+		&cache.ListWatch{
+			ListFunc: func(options api.ListOptions) (pkg_runtime.Object, error) {
+				return s.federationClient.Core().Services(api.NamespaceAll).List(options)
+			},
+			WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
+				return s.federationClient.Core().Services(api.NamespaceAll).Watch(options)
+			},
+		},
+		&v1.Service{},
+		serviceSyncPeriod,
+		framework.ResourceEventHandlerFuncs{
+			AddFunc: s.enqueueService,
+			UpdateFunc: func(old, cur interface{}) {
+				// there is case that old and new are equals but we still catch the event now.
+				if !reflect.DeepEqual(old, cur) {
+					s.enqueueService(cur)
+				}
+			},
+			DeleteFunc: s.enqueueService,
+		},
+	)
+	s.clusterStore.Store, s.clusterController = framework.NewInformer(
+		&cache.ListWatch{
+			ListFunc: func(options api.ListOptions) (pkg_runtime.Object, error) {
+				return s.federationClient.Federation().Clusters().List(options)
+			},
+			WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
+				return s.federationClient.Federation().Clusters().Watch(options)
+			},
+		},
+		&v1alpha1.Cluster{},
+		clusterSyncPeriod,
+		framework.ResourceEventHandlerFuncs{
+			DeleteFunc: s.clusterCache.delFromClusterSet,
+			AddFunc:    s.clusterCache.addToClientMap,
+			UpdateFunc:    func(old, cur interface{}) {
+				s.clusterCache.addToClientMap(cur)
+			},
+		},
+	)
+	return s
+}
+
+// obj could be an *api.Service, or a DeletionFinalStateUnknown marker item.
+func (s *ServiceController) enqueueService (obj interface{}) {
+	key, err := controller.KeyFunc(obj)
+	if err != nil {
+		glog.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		return
+	}
+	s.queue.Add(key)
+}
+
+// Run starts a background goroutine that watches for changes to Federated services
+// and ensures that they have Kubernetes services created, updated or deleted appropriately.
+// federationSyncPeriod controls how often we check the federation's services to
+// ensure that the correct Kubernetes services (and associated DNS entries) exist.
+// This is only necessary to fudge over failed watches.
+// clusterSyncPeriod controls how often we check the federation's underlying clusters and
+// their Kubernetes services to ensure that matching services created independently of the Federation
+// (e.g. directly via the underlying cluster's API) are correctly accounted for.
+
+// It's an error to call Run() more than once for a given ServiceController
+// object.
+func (s *ServiceController) Run(workers int, stopCh <-chan struct{}) error {
+	defer runtime.HandleCrash()
+	go s.serviceController.Run(stopCh)
+	go s.clusterController.Run(stopCh)
+	for i := 0; i < workers; i++ {
+		go wait.Until(s.fedServiceWorker, time.Second, stopCh)
+	}
+	go wait.Until(s.clusterEndpointWorker, time.Second, stopCh)
+	go wait.Until(s.clusterServiceWorker, time.Second, stopCh)
+	go wait.Until(s.clusterSyncLoop, clusterSyncPeriod, stopCh)
+	<-stopCh
+	glog.Infof("Shutting down Federation Service Controller")
+	s.queue.ShutDown()
+	return nil
+}
+
+// fedServiceWorker runs a worker thread that just dequeues items, processes them, and marks them done.
+// It enforces that the syncService is never invoked concurrently with the same key.
+func (s *ServiceController) fedServiceWorker() {
+	for {
+		func() {
+			key, quit := s.queue.Get()
+			if quit {
+				return
+			}
+			defer s.queue.Done(key)
+			err := s.syncService(key.(string))
+			if err != nil {
+				glog.Errorf("Error syncing service: %v", err)
+			}
+		}()
+	}
+}
+
+func wantsDNSRecords(service *v1.Service) bool{
+	return service.Spec.Type == v1.ServiceTypeLoadBalancer
+}
+
+// processServiceForCluster creates or updates service to all registered running clusters,
+// update DNS records and update the service info with DNS entries to federation apiserver.
+// the function returns any error caught
+func (s *ServiceController) processServiceForCluster(cachedService *cachedService, clusterName string, service *v1.Service, client *clientset.Clientset) error {
+	glog.V(4).Infof("process service %s/%s for cluster %s", service.Namespace, service.Name, clusterName)
+	// Create or Update k8s Service
+	err := s.ensureClusterService(cachedService, clusterName, service, client)
+	if err != nil {
+		glog.V(4).Infof("Failed to process service %s/%s for cluster %s", service.Namespace, service.Name, clusterName)
+		return err
+	}
+	glog.V(4).Infof("Successfully process service %s/%s for cluster %s", service.Namespace, service.Name, clusterName)
+	return nil
+}
+
+// updateFederationService Returns whatever error occurred along with a boolean indicator of whether it
+// should be retried.
+func (s *ServiceController) updateFederationService(key string, cachedService *cachedService) (error, bool) {
+	// Clone federation service, and create them in underlying k8s cluster
+	clone, err := conversion.NewCloner().DeepCopy(cachedService.lastState)
+	if err != nil {
+		return err, !retryable
+	}
+	service, ok := clone.(*v1.Service)
+	if !ok {
+		return fmt.Errorf("Unexpected service cast error : %v\n", service), !retryable
+	}
+
+	// handle available clusters one by one
+	var hasErr bool
+	for clusterName, cluster := range s.clusterCache.clientMap {
+		go func(){
+			err = s.processServiceForCluster(cachedService, clusterName, service, cluster.clientset)
+			if err != nil {
+				hasErr = true
+			}
+		}()
+	}
+	if hasErr {
+		// detail error has been dumpped inside the loop
+		return fmt.Errorf("service %s/%s was not successfully updated to all clusters", service.Namespace, service.Name), retryable
+	}
+	return nil, !retryable
+}
+
+func (s *ServiceController) deleteFederationService(cachedService *cachedService) (error, bool) {
+	// handle available clusters one by one
+	var hasErr bool
+	for clusterName, cluster := range s.clusterCache.clientMap {
+		err, _ := s.deleteClusterService(clusterName, cachedService, cluster.clientset)
+		if err != nil {
+			hasErr = true
+		}
+	}
+	if hasErr {
+		// detail error has been dumpped inside the loop
+		return fmt.Errorf("service %s/%s was not successfully updated to all clusters", cachedService.lastState.Namespace, cachedService.lastState.Name), retryable
+	}
+	return nil, !retryable
+}
+
+func (s *ServiceController) deleteClusterService(clusterName string, cachedService *cachedService, clientset *clientset.Clientset) (error, bool) {
+	service := cachedService.lastState
+	glog.V(4).Infof("Deleting service %s/%s from cluster %s", service.Namespace, service.Name, clusterName)
+	var err error
+	for i := 0; i < clientRetryCount; i++ {
+		err = clientset.Core().Services(service.Namespace).Delete(service.Name, &api.DeleteOptions{})
+		if err == nil || errors.IsNotFound(err) {
+			glog.V(4).Infof("service %s/%s deleted from cluster %s", service.Namespace, service.Name, clusterName)
+			return nil, !retryable
+		}
+		time.Sleep(cachedService.nextRetryDelay())
+	}
+	glog.V(4).Infof("failed to delete service %s/%s from cluster %s, %+v", service.Namespace, service.Name, clusterName, err)
+	return err, retryable
+}
+
+func (s *ServiceController) ensureClusterService(cachedService *cachedService, clusterName string, service *v1.Service, client *clientset.Clientset) error {
+	var err error
+	var needUpdate bool
+	for i := 0; i < clientRetryCount; i++ {
+		svc, err := client.Core().Services(service.Namespace).Get(service.Name)
+		if err == nil && svc != nil {
+			// service exists
+			glog.V(5).Infof("found service %s/%s from cluster %s", service.Namespace, service.Name, clusterName)
+			//reserve immutable fields
+			service.Spec.ClusterIP = svc.Spec.ClusterIP
+
+			//reserve auto assigned field
+			for i, oldPort := range svc.Spec.Ports{
+				for _, port := range service.Spec.Ports {
+					if port.NodePort == 0 {
+						if !portEqualExcludeNodePort(&oldPort, &port) {
+							svc.Spec.Ports[i] = port
+							needUpdate = true
+						}
+					} else {
+						if !portEqualForLB(&oldPort, &port) {
+							svc.Spec.Ports[i] = port
+							needUpdate = true
+						}
+					}
+				}
+			}
+
+			if needUpdate {
+				// we only apply spec update for now
+				svc.Spec = service.Spec
+				_, err = client.Core().Services(svc.Namespace).Update(svc)
+				if err == nil {
+					glog.V(5).Infof("service %s/%s successfully updated to cluster %s", svc.Namespace, svc.Name, clusterName)
+					return nil
+				} else {
+					glog.V(4).Infof("failed to update %+v", err)
+				}
+			} else {
+				glog.V(5).Infof("service %s/%s is not updated to cluster %s as the spec are identical", svc.Namespace, svc.Name, clusterName)
+				return nil
+			}
+		}
+		if svc == nil || errors.IsNotFound(err) {
+			// Create service if it is not found
+			glog.Infof("Service '%s/%s' does not exist in cluster %s, trying to create new",
+				service.Namespace, service.Name, clusterName)
+			service.ResourceVersion = ""
+			_, err = client.Core().Services(service.Namespace).Create(service)
+			if err == nil {
+				glog.V(5).Infof("service %s/%s successfully created to cluster %s", service.Namespace, service.Name, clusterName)
+				return nil
+			}
+			glog.V(4).Infof("failed to create %+v", err)
+		}
+		if errors.IsConflict(err) {
+			glog.V(4).Infof("Not persisting update to service '%s/%s' that has been changed since we received it: %v",
+				service.Namespace, service.Name, err)
+		}
+		// should we reuse same retry delay for all clusters?
+		time.Sleep(cachedService.nextRetryDelay())
+	}
+	return err
+}
+
+func (s *serviceCache) allServices() []*cachedService {
+	s.rwlock.Lock()
+	defer s.rwlock.Unlock()
+	services := make([]*cachedService, 0, len(s.fedServiceMap))
+	for _, v := range s.fedServiceMap {
+		services = append(services, v)
+	}
+	return services
+}
+
+func (s *serviceCache) get(serviceName string) (*cachedService, bool) {
+	s.rwlock.Lock()
+	defer s.rwlock.Unlock()
+	service, ok := s.fedServiceMap[serviceName]
+	return service, ok
+}
+
+func (s *serviceCache) getOrCreate(serviceName string) *cachedService {
+	s.rwlock.Lock()
+	defer s.rwlock.Unlock()
+	service, ok := s.fedServiceMap[serviceName]
+	if !ok {
+		service = &cachedService {
+			endpointMap: make(map[string]int),
+			serviceStatusMap: make(map[string]v1.LoadBalancerStatus),
+		}
+		s.fedServiceMap[serviceName] = service
+	}
+	return service
+}
+
+func (s *serviceCache) set(serviceName string, service *cachedService) {
+	s.rwlock.Lock()
+	defer s.rwlock.Unlock()
+	s.fedServiceMap[serviceName] = service
+}
+
+func (s *serviceCache) delete(serviceName string) {
+	s.rwlock.Lock()
+	defer s.rwlock.Unlock()
+	delete(s.fedServiceMap, serviceName)
+}
+
+// needsUpdateDNS check if the dns records of the given service should be updated
+func (s *ServiceController) needsUpdateDNS(oldService *v1.Service, newService *v1.Service) bool {
+	if !wantsDNSRecords(oldService) && !wantsDNSRecords(newService) {
+		return false
+	}
+	if wantsDNSRecords(oldService) != wantsDNSRecords(newService) {
+		s.eventRecorder.Eventf(newService, api.EventTypeNormal, "Type", "%v -> %v",
+			oldService.Spec.Type, newService.Spec.Type)
+		return true
+	}
+	if !portsEqualForLB(oldService, newService) || oldService.Spec.SessionAffinity != newService.Spec.SessionAffinity {
+		return true
+	}
+	if !LoadBalancerIPsAreEqual(oldService, newService) {
+		s.eventRecorder.Eventf(newService, api.EventTypeNormal, "LoadbalancerIP", "%v -> %v",
+			oldService.Spec.LoadBalancerIP, newService.Spec.LoadBalancerIP)
+		return true
+	}
+	if len(oldService.Spec.ExternalIPs) != len(newService.Spec.ExternalIPs) {
+		s.eventRecorder.Eventf(newService, api.EventTypeNormal, "ExternalIP", "Count: %v -> %v",
+			len(oldService.Spec.ExternalIPs), len(newService.Spec.ExternalIPs))
+		return true
+	}
+	for i := range oldService.Spec.ExternalIPs {
+		if oldService.Spec.ExternalIPs[i] != newService.Spec.ExternalIPs[i] {
+			s.eventRecorder.Eventf(newService, api.EventTypeNormal, "ExternalIP", "Added: %v",
+				newService.Spec.ExternalIPs[i])
+			return true
+		}
+	}
+	if !reflect.DeepEqual(oldService.Annotations, newService.Annotations) {
+		return true
+	}
+	if oldService.UID != newService.UID {
+		s.eventRecorder.Eventf(newService, api.EventTypeNormal, "UID", "%v -> %v",
+			oldService.UID, newService.UID)
+		return true
+	}
+
+	return false
+}
+
+func getPortsForLB(service *v1.Service) ([]*v1.ServicePort, error) {
+	// TODO: quinton: Probably applies for DNS SVC records.  Come back to this.
+	//var protocol api.Protocol
+
+	ports := []*v1.ServicePort{}
+	for i := range service.Spec.Ports {
+		sp := &service.Spec.Ports[i]
+		// The check on protocol was removed here.  The DNS provider itself is now responsible for all protocol validation
+		ports = append(ports, sp)
+		//TODO:jesse
+		//if protocol == "" {
+		//	protocol = sp.Protocol
+		//} else if protocol != sp.Protocol && wantsLoadBalancer(service) {
+		//	// TODO:  Convert error messages to use event recorder
+		//	return nil, fmt.Errorf("mixed protocol external load balancers are not supported.")
+		//}
+	}
+	return ports, nil
+}
+
+func portsEqualForLB(x, y *v1.Service) bool {
+	xPorts, err := getPortsForLB(x)
+	if err != nil {
+		return false
+	}
+	yPorts, err := getPortsForLB(y)
+	if err != nil {
+		return false
+	}
+	return portSlicesEqualForLB(xPorts, yPorts)
+}
+
+func portSlicesEqualForLB(x, y []*v1.ServicePort) bool {
+	if len(x) != len(y) {
+		return false
+	}
+
+	for i := range x {
+		if !portEqualForLB(x[i], y[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func portEqualForLB(x, y *v1.ServicePort) bool {
+	// TODO: Should we check name?  (In theory, an LB could expose it)
+	if x.Name != y.Name {
+		return false
+	}
+
+	if x.Protocol != y.Protocol {
+		return false
+	}
+
+	if x.Port != y.Port {
+		return false
+	}
+	if x.NodePort != y.NodePort {
+		return false
+	}
+	return true
+}
+
+func portEqualExcludeNodePort(x, y *v1.ServicePort) bool {
+	// TODO: Should we check name?  (In theory, an LB could expose it)
+	if x.Name != y.Name {
+		return false
+	}
+
+	if x.Protocol != y.Protocol {
+		return false
+	}
+
+	if x.Port != y.Port {
+		return false
+	}
+	return true
+}
+
+func clustersFromList(list *v1alpha1.ClusterList) []string {
+	result := []string{}
+	for ix := range list.Items {
+		result = append(result, list.Items[ix].Name)
+	}
+	return result
+}
+
+// getClusterConditionPredicate filter all clusters meet condition of
+// condition.type=Ready and condition.status=true
+func getClusterConditionPredicate() federationcache.ClusterConditionPredicate {
+	return func(cluster v1alpha1.Cluster) bool {
+		// If we have no info, don't accept
+		if len(cluster.Status.Conditions) == 0 {
+			return false
+		}
+		for _, cond := range cluster.Status.Conditions {
+			//We consider the cluster for load balancing only when its ClusterReady condition status
+			//is ConditionTrue
+			if cond.Type == v1alpha1.ClusterReady && cond.Status != v1.ConditionTrue {
+				glog.V(4).Infof("Ignoring cluser %v with %v condition status %v", cluster.Name, cond.Type, cond.Status)
+				return false
+			}
+		}
+		return true
+	}
+}
+
+// clusterSyncLoop observes running clusters changes, and apply all services to new added cluster
+// and add dns records for the changes
+func (s *ServiceController) clusterSyncLoop() {
+	var servicesToUpdate []*cachedService
+	// should we remove cache for cluster from ready to not ready? should remove the condition predicate if no
+	clusters, err := s.clusterStore.ClusterCondition(getClusterConditionPredicate()).List()
+	if err != nil {
+		glog.Infof("fail to get cluster list")
+		return
+	}
+	newClusters := clustersFromList(&clusters)
+	var newSet, increase sets.String
+	newSet = sets.NewString(newClusters...)
+	if newSet.Equal(s.knownClusterSet) {
+		// The set of cluster names in the services in the federation hasn't changed, but we can retry
+		// updating any services that we failed to update last time around.
+		servicesToUpdate = s.updateDNSRecords(servicesToUpdate, newClusters)
+		return
+	}
+	glog.Infof("Detected change in list of cluster names. New  set: %v, Old set: %v", newSet, s.knownClusterSet)
+	increase = newSet.Difference(newSet)
+	// do nothing when cluster is removed.
+	if increase != nil {
+		for newCluster, _ := range increase {
+			glog.Infof("New cluster observed %s", newCluster)
+			s.updateAllServicesToCluster(servicesToUpdate, newCluster)
+		}
+		// Try updating all services, and save the ones that fail to try again next
+		// round.
+		servicesToUpdate = s.serviceCache.allServices()
+		numServices := len(servicesToUpdate)
+		servicesToUpdate = s.updateDNSRecords(servicesToUpdate, newClusters)
+		glog.Infof("Successfully updated %d out of %d DNS records to direct traffic to the updated cluster",
+			numServices-len(servicesToUpdate), numServices)
+	}
+	s.knownClusterSet = newSet
+}
+
+func (s *ServiceController)updateAllServicesToCluster(services []*cachedService, clusterName string){
+	cluster, ok := s.clusterCache.clientMap[clusterName]
+	if ok {
+		for _, cachedService := range services{
+			appliedState := cachedService.appliedState
+			s.processServiceForCluster(cachedService, clusterName, appliedState, cluster.clientset)
+		}
+	}
+}
+
+func (s *ServiceController)removeAllServicesFromCluster(services []*cachedService, clusterName string){
+	client, ok := s.clusterCache.clientMap[clusterName]
+	if ok {
+		for _, cachedService := range services{
+			s.deleteClusterService(clusterName, cachedService, client.clientset)
+		}
+		glog.Infof("synced all services to cluster %s", clusterName)
+	}
+}
+
+// updateDNSRecords updates all existing federated service DNS Records so that
+// they will match the list of cluster names provided.
+// Returns the list of services that couldn't be updated.
+func (s *ServiceController) updateDNSRecords(services []*cachedService, clusters []string) (servicesToRetry []*cachedService) {
+	for _, service := range services {
+		func() {
+			service.rwlock.Lock()
+			defer service.rwlock.Unlock()
+			// If the applied state is nil, that means it hasn't yet been successfully dealt
+			// with by the DNS Record reconciler. We can trust the DNS Record
+			// reconciler to ensure the federated service's DNS records are created to target
+			// the correct backend service IP's
+			if service.appliedState == nil {
+				return
+			}
+			if err := s.lockedUpdateDNSRecords(service, clusters); err != nil {
+				glog.Errorf("External error while updating DNS Records: %v.", err)
+				servicesToRetry = append(servicesToRetry, service)
+			}
+		}()
+	}
+	return servicesToRetry
+}
+
+// lockedUpdateDNSRecords Updates the DNS records of a service, assuming we hold the mutex
+// associated with the service.
+// TODO: quinton: Still screwed up in the same way as above.  Fix.
+func (s *ServiceController) lockedUpdateDNSRecords(service *cachedService, clusterNames []string) error {
+	if !wantsDNSRecords(service.appliedState) {
+		return nil
+	}
+	for key, _ := range s.clusterCache.clientMap {
+		for _, clusterName := range clusterNames {
+			if key == clusterName {
+				ensureDNSRecords(clusterName, service)
+			}
+		}
+	}
+	return nil
+}
+
+func LoadBalancerIPsAreEqual(oldService, newService *v1.Service) bool {
+	return oldService.Spec.LoadBalancerIP == newService.Spec.LoadBalancerIP
+}
+
+// Computes the next retry, using exponential backoff
+// mutex must be held.
+func (s *cachedService) nextRetryDelay() time.Duration {
+	s.lastRetryDelay = s.lastRetryDelay * 2
+	if s.lastRetryDelay < minRetryDelay {
+		s.lastRetryDelay = minRetryDelay
+	}
+	if s.lastRetryDelay > maxRetryDelay {
+		s.lastRetryDelay = maxRetryDelay
+	}
+	return s.lastRetryDelay
+}
+
+// resetRetryDelay Resets the retry exponential backoff.  mutex must be held.
+func (s *cachedService) resetRetryDelay() {
+	s.lastRetryDelay = time.Duration(0)
+}
+
+// Computes the next retry, using exponential backoff
+// mutex must be held.
+func (s *cachedService) nextFedUpdateDelay() time.Duration {
+	s.lastFedUpdateDelay = s.lastFedUpdateDelay * 2
+	if s.lastFedUpdateDelay < minRetryDelay {
+		s.lastFedUpdateDelay = minRetryDelay
+	}
+	if s.lastFedUpdateDelay > maxRetryDelay {
+		s.lastFedUpdateDelay = maxRetryDelay
+	}
+	return s.lastFedUpdateDelay
+}
+
+// resetRetryDelay Resets the retry exponential backoff.  mutex must be held.
+func (s *cachedService) resetFedUpdateDelay() {
+	s.lastFedUpdateDelay = time.Duration(0)
+}
+
+// Computes the next retry, using exponential backoff
+// mutex must be held.
+func (s *cachedService) nextDNSUpdateDelay() time.Duration {
+	s.lastDNSUpdateDelay = s.lastDNSUpdateDelay * 2
+	if s.lastDNSUpdateDelay < minRetryDelay {
+		s.lastDNSUpdateDelay = minRetryDelay
+	}
+	if s.lastDNSUpdateDelay > maxRetryDelay {
+		s.lastDNSUpdateDelay = maxRetryDelay
+	}
+	return s.lastDNSUpdateDelay
+}
+
+// resetRetryDelay Resets the retry exponential backoff.  mutex must be held.
+func (s *cachedService) resetDNSUpdateDelay() {
+	s.lastDNSUpdateDelay = time.Duration(0)
+}
+
+
+// syncService will sync the Service with the given key if it has had its expectations fulfilled,
+// meaning it did not expect to see any more of its pods created or deleted. This function is not meant to be
+// invoked concurrently with the same key.
+func (s *ServiceController) syncService(key string) error {
+	startTime := time.Now()
+	var cachedService *cachedService
+	var retryDelay time.Duration
+	defer func() {
+		glog.V(4).Infof("Finished syncing service %q (%v)", key, time.Now().Sub(startTime))
+	}()
+	// obj holds the latest service info from apiserver
+	obj, exists, err := s.serviceStore.Store.GetByKey(key)
+	if err != nil {
+		glog.Infof("Unable to retrieve service %v from store: %v", key, err)
+		s.queue.Add(key)
+		return err
+	}
+
+	if !exists {
+		// service absence in store means watcher caught the deletion, ensure LB info is cleaned
+		glog.Infof("Service has been deleted %v", key)
+		err, retryDelay = s.processServiceDeletion(key)
+	}
+
+	if exists {
+		service, ok := obj.(*v1.Service)
+		if ok {
+			cachedService = s.serviceCache.getOrCreate(key)
+			err, retryDelay = s.processServiceUpdate(cachedService, service, key)
+		} else {
+			tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+			if !ok {
+				return fmt.Errorf("object contained wasn't a service or a deleted key: %+v", obj)
+			}
+			glog.Infof("Found tombstone for %v", key)
+			err, retryDelay = s.processServiceDeletion(tombstone.Key)
+		}
+	}
+
+	if retryDelay != 0 {
+		s.enqueueService(obj)
+	} else if err != nil {
+		runtime.HandleError(fmt.Errorf("Failed to process service. Not retrying: %v", err))
+	}
+	return nil
+}
+
+// processServiceUpdate returns an error if processing the service update failed, along with a time.Duration
+// indicating whether processing should be retried; zero means no-retry; otherwise
+// we should retry in that Duration.
+func (s *ServiceController) processServiceUpdate(cachedService *cachedService, service *v1.Service, key string) (error, time.Duration) {
+	// Ensure that no other goroutine will interfere with our processing of the
+	// service.
+	cachedService.rwlock.Lock()
+	defer cachedService.rwlock.Unlock()
+
+	// Update the cached service (used above for populating synthetic deletes)
+	// alway trust service, which is retrieve from serviceStore, which keeps the latest service info getting from apiserver
+	// if the same service is changed before this go routine finished, there will be another queue entry to handle that.
+	cachedService.lastState = service
+	err, retry := s.updateFederationService(key, cachedService)
+	if err != nil {
+		message := "Error occurs when updating service to all clusters"
+		if retry {
+			message += " (will retry): "
+		} else {
+			message += " (will not retry): "
+		}
+		message += err.Error()
+		s.eventRecorder.Event(service, api.EventTypeWarning, "UpdateServiceFail", message)
+		return err, cachedService.nextRetryDelay()
+	}
+	// Always update the cache upon success.
+	// NOTE: Since we update the cached service if and only if we successfully
+	// processed it, a cached service being nil implies that it hasn't yet
+	// been successfully processed.
+	//cachedService.appliedState = service
+	s.serviceCache.set(key, cachedService)
+	glog.V(4).Infof("successfully procceeded services %s", key)
+	cachedService.resetRetryDelay()
+	return nil, doNotRetry
+}
+
+// processServiceDeletion returns an error if processing the service deletion failed, along with a time.Duration
+// indicating whether processing should be retried; zero means no-retry; otherwise
+// we should retry in that Duration.
+func (s *ServiceController) processServiceDeletion(key string) (error, time.Duration){
+	glog.V(2).Infof("process service deletion for %v", key)
+	cachedService, ok := s.serviceCache.get(key)
+	if !ok {
+		return fmt.Errorf("Service %s not in cache even though the watcher thought it was. Ignoring the deletion.", key), doNotRetry
+	}
+	service := cachedService.lastState
+	cachedService.rwlock.Lock()
+	defer cachedService.rwlock.Unlock()
+	s.eventRecorder.Event(service, api.EventTypeNormal, "DeletingDNSRecord", "Deleting DNS Records")
+	// TODO should we delete dns info here or wait for endpoint changes? prefer here
+	// or we do nothing for service deletion
+	//err := s.dns.balancer.EnsureLoadBalancerDeleted(service)
+	err, retry := s.deleteFederationService(cachedService)
+	if err != nil {
+		message := "Error occurs when deleting federation service"
+		if retry {
+			message += " (will retry): "
+		} else {
+			message += " (will not retry): "
+		}
+		s.eventRecorder.Event(service, api.EventTypeWarning, "DeletingDNSRecordFailed", message)
+		return err, cachedService.nextRetryDelay()
+	}
+	s.eventRecorder.Event(service, api.EventTypeNormal, "DeletedDNSRecord", "Deleted DNS Records")
+	s.serviceCache.delete(key)
+
+	cachedService.resetRetryDelay()
+	return nil, doNotRetry
+}

--- a/federation/pkg/federation-controller/service/servicecontroller_test.go
+++ b/federation/pkg/federation-controller/service/servicecontroller_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/federation/apis/federation/v1alpha1"
+)
+
+func TestGetClusterConditionPredicate(t *testing.T) {
+	tests := []struct {
+		cluster      v1alpha1.Cluster
+		expectAccept bool
+		name         string
+	}{
+		{
+			cluster:      v1alpha1.Cluster{},
+			expectAccept: false,
+			name:         "empty",
+		},
+		{
+			cluster: v1alpha1.Cluster{
+				Status: v1alpha1.ClusterStatus{
+					Conditions: []v1alpha1.ClusterCondition{
+						{Type: v1alpha1.ClusterReady, Status: v1.ConditionTrue},
+					},
+				},
+			},
+			expectAccept: true,
+			name:         "basic",
+		},
+		{
+			cluster: v1alpha1.Cluster{
+				Status: v1alpha1.ClusterStatus{
+					Conditions: []v1alpha1.ClusterCondition{
+						{Type: v1alpha1.ClusterReady, Status: v1.ConditionFalse},
+					},
+				},
+			},
+			expectAccept: false,
+			name:         "notready",
+		},
+	}
+	pred := getClusterConditionPredicate()
+	for _, test := range tests {
+		accept := pred(test.cluster)
+		if accept != test.expectAccept {
+			t.Errorf("Test failed for %s, expected %v, saw %v", test.name, test.expectAccept, accept)
+		}
+	}
+}


### PR DESCRIPTION
The code is based on Nikhil's latest clientset PR.
There are still lot of things to go.
1. separate the logic of service creation and dns entry written.
when watching the federation apiserver, if there is new service creation or update, the action is to create service in underlying k8s cluster, but do not create dns info.
2. list and watch all underlying k8s clusters for service. if LB info is created, then create dns info
3. generate random name when create k8s service to avoid name conflict.
4. add logic to support service label based on hash, and use the labels to link federation service and k8s services.
5. cluster add path.
6. partial failure handling

@quinton-hoole 
