### PR TITLE
cluster: make gen-uid python3 compatible

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -209,7 +209,7 @@ function gen-kube-bearertoken() {
 # Vars set:
 #   KUBE_UID
 function gen-uid {
-    KUBE_UID=$(python -c 'import uuid; print uuid.uuid1().fields[0]')
+    KUBE_UID=$(python -c 'import uuid; print(uuid.uuid1().fields[0])')
 }
 
 


### PR DESCRIPTION
#24391 incidentally included a change which only works in python2, not python3. This alters it to a cross-python version of the same.

This appears to fix it for me.
