### PR TITLE
Don't trim whitespace from kubectl output in e2e tests

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1550,8 +1550,7 @@ func (b kubectlBuilder) Exec() (string, error) {
 		return "", fmt.Errorf("Timed out waiting for command %v:\nCommand stdout:\n%v\nstderr:\n%v\n", cmd, cmd.Stdout, cmd.Stderr)
 	}
 	Logf("stderr: %q", stderr.String())
-	// TODO: trimspace should be unnecessary after switching to use kubectl binary directly
-	return strings.TrimSpace(stdout.String()), nil
+	return stdout.String(), nil
 }
 
 // RunKubectlOrDie is a convenience wrapper over kubectlBuilder

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -220,7 +220,7 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 		It("should support exec", func() {
 			By("executing a command in the container")
 			execOutput := framework.RunKubectlOrDie("exec", fmt.Sprintf("--namespace=%v", ns), simplePodName, "echo", "running", "in", "container")
-			if e, a := "running in container", execOutput; e != a {
+			if e, a := "running in container", strings.TrimSpace(execOutput); e != a {
 				framework.Failf("Unexpected kubectl exec output. Wanted %q, got %q", e, a)
 			}
 
@@ -244,7 +244,7 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 			execOutput = framework.NewKubectlCommand("exec", fmt.Sprintf("--namespace=%v", ns), "-i", simplePodName, "bash").
 				WithStdinReader(r).
 				ExecOrDie()
-			if e, a := "hi", execOutput; e != a {
+			if e, a := "hi", strings.TrimSpace(execOutput); e != a {
 				framework.Failf("Unexpected kubectl exec output. Wanted %q, got %q", e, a)
 			}
 		})


### PR DESCRIPTION
Part of the fix for #25426. Sending by itself to simplify cherrypicking onto 1.2.
