### PR TITLE
Modify Detach method to take disk name

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2006,7 +2006,8 @@ func (kl *Kubelet) cleanupOrphanedVolumes(pods []*api.Pod, runningPods []*kubeco
 					glog.Errorf("Could not unmount the global mount for %q: %v", name, err)
 				}
 
-				err = detacher.Detach(refs[0], kl.hostname)
+				pdName := path.Base(refs[0])
+				err = detacher.Detach(pdName, kl.hostname)
 				if err != nil {
 					glog.Errorf("Could not detach volume %q at %q: %v", name, volumePath, err)
 				}

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -152,9 +152,8 @@ type Attacher interface {
 
 // Detacher can detach a volume from a node.
 type Detacher interface {
-
-	// Detach the given volume from the given host.
-	Detach(deviceMountPath string, hostName string) error
+	// Detach the given device from the given host.
+	Detach(deviceName, hostName string) error
 
 	// WaitForDetach blocks until the device is detached from this
 	// node. If the device does not detach within the given timeout


### PR DESCRIPTION
Modify `Detach()` method to take disk name instead of mount path, since the attach/detach controller won't have the full path.
