### PR TITLE
Add an option for resource-gatherer to look only on master node

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -149,8 +149,11 @@ func (f *Framework) BeforeEach() {
 		Logf("Skipping waiting for service account")
 	}
 
-	if TestContext.GatherKubeSystemResourceUsageData {
-		f.gatherer, err = NewResourceUsageGatherer(f.Client, ResourceGathererOptions{inKubemark: ProviderIs("kubemark")})
+	if TestContext.GatherKubeSystemResourceUsageData != "false" && TestContext.GatherKubeSystemResourceUsageData != "none" {
+		f.gatherer, err = NewResourceUsageGatherer(f.Client, ResourceGathererOptions{
+			inKubemark: ProviderIs("kubemark"),
+			masterOnly: TestContext.GatherKubeSystemResourceUsageData == "master",
+		})
 		if err != nil {
 			Logf("Error while creating NewResourceUsageGatherer: %v", err)
 		} else {
@@ -209,7 +212,7 @@ func (f *Framework) AfterEach() {
 	}
 
 	summaries := make([]TestDataSummary, 0)
-	if TestContext.GatherKubeSystemResourceUsageData && f.gatherer != nil {
+	if TestContext.GatherKubeSystemResourceUsageData != "false" && TestContext.GatherKubeSystemResourceUsageData != "none" && f.gatherer != nil {
 		By("Collecting resource usage data")
 		summaries = append(summaries, f.gatherer.stopAndSummarize([]int{90, 99, 100}, f.AddonResourceConstraints))
 	}

--- a/test/e2e/framework/resource_usage_gatherer.go
+++ b/test/e2e/framework/resource_usage_gatherer.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
+	"k8s.io/kubernetes/pkg/util/system"
 )
 
 const (
@@ -225,6 +226,7 @@ type containerResourceGatherer struct {
 
 type ResourceGathererOptions struct {
 	inKubemark bool
+	masterOnly bool
 }
 
 func NewResourceUsageGatherer(c *client.Client, options ResourceGathererOptions) (*containerResourceGatherer, error) {
@@ -263,18 +265,21 @@ func NewResourceUsageGatherer(c *client.Client, options ResourceGathererOptions)
 			return nil, err
 		}
 
-		g.workerWg.Add(len(nodeList.Items))
 		for _, node := range nodeList.Items {
-			g.workers = append(g.workers, resourceGatherWorker{
-				c:                    c,
-				nodeName:             node.Name,
-				wg:                   &g.workerWg,
-				containerIDToNameMap: g.containerIDToNameMap,
-				containerIDs:         g.containerIDs,
-				stopCh:               g.stopCh,
-				finished:             false,
-				inKubemark:           false,
-			})
+			if !options.masterOnly || system.IsMasterNode(&node) {
+				g.workerWg.Add(1)
+				g.workers = append(g.workers, resourceGatherWorker{
+					c:                    c,
+					nodeName:             node.Name,
+					wg:                   &g.workerWg,
+					containerIDToNameMap: g.containerIDToNameMap,
+					containerIDs:         g.containerIDs,
+					stopCh:               g.stopCh,
+					finished:             false,
+					inKubemark:           false,
+				})
+				break
+			}
 		}
 	}
 	return &g, nil

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -47,9 +47,10 @@ type TestContextType struct {
 	VerifyServiceAccount  bool
 	DeleteNamespace       bool
 	CleanStart            bool
-	// If set to true framework will start a goroutine monitoring resource usage of system add-ons.
-	// It will read the data every 30 seconds from all Nodes and print summary during afterEach.
-	GatherKubeSystemResourceUsageData bool
+	// If set to 'true' or 'all' framework will start a goroutine monitoring resource usage of system add-ons.
+	// It will read the data every 30 seconds from all Nodes and print summary during afterEach. If set to 'master'
+	// only master Node will be monitored.
+	GatherKubeSystemResourceUsageData string
 	GatherLogsSizes                   bool
 	GatherMetricsAfterTest            bool
 	// Currently supported values are 'hr' for human-readable and 'json'. It's a comma separated list.
@@ -123,7 +124,7 @@ func RegisterFlags() {
 	flag.BoolVar(&TestContext.VerifyServiceAccount, "e2e-verify-service-account", true, "If true tests will verify the service account before running.")
 	flag.BoolVar(&TestContext.DeleteNamespace, "delete-namespace", true, "If true tests will delete namespace after completion. It is only designed to make debugging easier, DO NOT turn it off by default.")
 	flag.BoolVar(&TestContext.CleanStart, "clean-start", false, "If true, purge all namespaces except default and system before running tests. This serves to Cleanup test namespaces from failed/interrupted e2e runs in a long-lived cluster.")
-	flag.BoolVar(&TestContext.GatherKubeSystemResourceUsageData, "gather-resource-usage", false, "If set to true framework will be monitoring resource usage of system add-ons in (some) e2e tests.")
+	flag.StringVar(&TestContext.GatherKubeSystemResourceUsageData, "gather-resource-usage", "false", "If set to 'true' or 'all' framework will be monitoring resource usage of system all add-ons in (some) e2e tests, if set to 'master' framework will be monitoring master node only, if set to 'none' of 'false' monitoring will be turned off.")
 	flag.BoolVar(&TestContext.GatherLogsSizes, "gather-logs-sizes", false, "If set to true framework will be monitoring logs sizes on all machines running e2e tests.")
 	flag.BoolVar(&TestContext.GatherMetricsAfterTest, "gather-metrics-at-teardown", false, "If set to true framwork will gather metrics from all components after each test.")
 	flag.StringVar(&TestContext.OutputPrintType, "output-print-type", "hr", "Comma separated list: 'hr' for human readable summaries 'json' for JSON ones.")


### PR DESCRIPTION
Needed for figuring out resource requirements for master components.
cc @kubernetes/sig-testing 

cc @bgrant0607 - I'm changing the type of the flag in test from bool to string. I'll still handle 'true' and 'false' values, so I think this change is OK.
