### PR TITLE
Populate Node.Status.Addresses with Hostname

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -358,9 +358,8 @@ func (kl *Kubelet) recordNodeStatusEvent(eventtype, event string) {
 	kl.recorder.Eventf(kl.nodeRef, eventtype, event, "Node %s status is now: %s", kl.nodeName, event)
 }
 
-// Set IP addresses for the node.
+// Set IP and hostname addresses for the node.
 func (kl *Kubelet) setNodeAddress(node *api.Node) error {
-
 	if kl.nodeIP != nil {
 		if err := kl.validateNodeIP(); err != nil {
 			return fmt.Errorf("failed to validate nodeIP: %v", err)
@@ -381,20 +380,20 @@ func (kl *Kubelet) setNodeAddress(node *api.Node) error {
 		if err != nil {
 			return fmt.Errorf("failed to get node address from cloud provider: %v", err)
 		}
-
 		if kl.nodeIP != nil {
 			for _, nodeAddress := range nodeAddresses {
 				if nodeAddress.Address == kl.nodeIP.String() {
 					node.Status.Addresses = []api.NodeAddress{
 						{Type: nodeAddress.Type, Address: nodeAddress.Address},
+						{Type: api.NodeHostName, Address: kl.GetHostname()},
 					}
 					return nil
 				}
 			}
 			return fmt.Errorf("failed to get node address from cloud provider that matches ip: %v", kl.nodeIP)
 		}
-
-		node.Status.Addresses = nodeAddresses
+		hostnameAddress := api.NodeAddress{Type: api.NodeHostName, Address: kl.GetHostname()}
+		node.Status.Addresses = append(nodeAddresses, hostnameAddress)
 	} else {
 		var ipAddr net.IP
 		var err error
@@ -429,6 +428,7 @@ func (kl *Kubelet) setNodeAddress(node *api.Node) error {
 			node.Status.Addresses = []api.NodeAddress{
 				{Type: api.NodeLegacyHostIP, Address: ipAddr.String()},
 				{Type: api.NodeInternalIP, Address: ipAddr.String()},
+				{Type: api.NodeHostName, Address: kl.GetHostname()},
 			}
 		}
 	}

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -193,6 +193,7 @@ func TestUpdateNewNodeStatus(t *testing.T) {
 			Addresses: []api.NodeAddress{
 				{Type: api.NodeLegacyHostIP, Address: "127.0.0.1"},
 				{Type: api.NodeInternalIP, Address: "127.0.0.1"},
+				{Type: api.NodeHostName, Address: testKubeletHostname},
 			},
 			Images: expectedImageList,
 		},
@@ -472,6 +473,7 @@ func TestUpdateExistingNodeStatus(t *testing.T) {
 			Addresses: []api.NodeAddress{
 				{Type: api.NodeLegacyHostIP, Address: "127.0.0.1"},
 				{Type: api.NodeInternalIP, Address: "127.0.0.1"},
+				{Type: api.NodeHostName, Address: testKubeletHostname},
 			},
 			// images will be sorted from max to min in node status.
 			Images: []api.ContainerImage{
@@ -777,6 +779,7 @@ func TestUpdateNodeStatusWithRuntimeStateError(t *testing.T) {
 			Addresses: []api.NodeAddress{
 				{Type: api.NodeLegacyHostIP, Address: "127.0.0.1"},
 				{Type: api.NodeInternalIP, Address: "127.0.0.1"},
+				{Type: api.NodeHostName, Address: testKubeletHostname},
 			},
 			Images: []api.ContainerImage{
 				{


### PR DESCRIPTION
This PR is supposed to address #22063 

Currently `NodeName` has to be a resolvable dns address on the master to allow apiserver -> kubelet communication (exec, log, port-forward operations on a pod). In some situations this is unfortunate (see the discussions on the issue).

The PR aims to do the following:
- Populate the `Type: Hostname` in the `Node.Status.Addresses` array, the type is already defined, but was not used so far.
- Add logic to resolve a Node's Hostname when the apiserver initiates communication with the Kubelet, instead of using the Nodename string as Hostname.

```release-note
The hostname of the node (as autodetected by the kubelet, specified via --hostname-override, or determined by the cloudprovider) is now recorded as an address of type "Hostname" in the status of the Node API object. The hostname is expected to be resolveable from the apiserver.
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/25532)

<!-- Reviewable:end -->
