### PR TITLE
s/positive/negative/ in the error message

### DIFF
--- a/hack/verify-flags-underscore.py
+++ b/hack/verify-flags-underscore.py
@@ -233,7 +233,7 @@ def main():
 
     if len(bad_lines) != 0:
         if not args.skip_exceptions:
-            print("Found illegal 'flag' usage. If these are false positives you should run `hack/verify-flags-underscore.py -e > hack/verify-flags/exceptions.txt` to update the list.")
+            print("Found illegal 'flag' usage. If these are false negatives you should run `hack/verify-flags-underscore.py -e > hack/verify-flags/exceptions.txt` to update the list.")
         bad_lines.sort()
         for (relname, line) in bad_lines:
             print("%s:%s" % (relname, line))


### PR DESCRIPTION
I think we meant to imply that "if the error isn't real" then update the
exceptions file - which to me means "false negative", ie. false failure.

Signed-off-by: Doug Davis dug@us.ibm.com
