### PR TITLE
Multiversion client tests

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1761,6 +1761,10 @@
 			"Rev": "8992d7483a06748dea706e4716d042a4a9e73918"
 		},
 		{
+			"ImportPath": "github.com/robfig/cron",
+			"Rev": "0f39cf7ebc65a602f45692f9894bd6a193faf8fa"
+		},
+		{
 			"ImportPath": "github.com/russross/blackfriday",
 			"Comment": "v1.2-42-g77efab5",
 			"Rev": "77efab57b2f74dd3f9051c79752b2e8995c8b789"

--- a/Godeps/LICENSES
+++ b/Godeps/LICENSES
@@ -59126,6 +59126,32 @@ specific language governing permissions and limitations under the License.
 
 
 ================================================================================
+= vendor/github.com/robfig/cron licensed under: =
+
+Copyright (C) 2012 Rob Figueiredo
+All Rights Reserved.
+
+MIT LICENSE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+================================================================================
 = vendor/github.com/russross/blackfriday licensed under: =
 
 Blackfriday is distributed under the Simplified BSD License:

--- a/pkg/api/testapi/testapi.go
+++ b/pkg/api/testapi/testapi.go
@@ -191,7 +191,16 @@ func init() {
 }
 
 func (g TestGroup) ContentConfig() (string, *unversioned.GroupVersion, runtime.Codec) {
-	return "application/json", g.GroupVersion(), g.Codec()
+	return "application/json", g.GroupVersion(), g.Codec(g.GroupVersion())
+}
+
+func (g TestGroup) IsEnabledVersion(v *unversioned.GroupVersion) bool {
+	for _, gv := range g.externalGroupVersions {
+		if gv.String() == v.String() {
+			return true
+		}
+	}
+	return false
 }
 
 func (g TestGroup) GroupVersion() *unversioned.GroupVersion {
@@ -216,8 +225,11 @@ func (g TestGroup) InternalTypes() map[string]reflect.Type {
 
 // Codec returns the codec for the API version to test against, as set by the
 // KUBE_TEST_API_TYPE env var.
-func (g TestGroup) Codec() runtime.Codec {
+func (g TestGroup) Codec(gv *unversioned.GroupVersion) runtime.Codec {
 	if serializer.Serializer == nil {
+		if g.IsEnabledVersion(gv) {
+			return api.Codecs.LegacyCodec(*gv)
+		}
 		return api.Codecs.LegacyCodec(g.externalGroupVersions[0])
 	}
 	return api.Codecs.CodecForVersions(serializer, api.Codecs.UniversalDeserializer(), g.externalGroupVersions, nil)
@@ -293,14 +305,18 @@ func (g TestGroup) SelfLink(resource, name string) string {
 // Returns the appropriate path for the given prefix (watch, proxy, redirect, etc), resource, namespace and name.
 // For ex, this is of the form:
 // /api/v1/watch/namespaces/foo/pods/pod0 for v1.
-func (g TestGroup) ResourcePathWithPrefix(prefix, resource, namespace, name string) string {
+func (g TestGroup) ResourcePathWithPrefix(prefix string, gvr unversioned.GroupVersionResource, namespace, name string) string {
 	var path string
-	if g.externalGroupVersions[0].Group == api.GroupName {
-		path = "/api/" + g.externalGroupVersions[0].Version
+	groupVersion := gvr.GroupVersion()
+	if !g.IsEnabledVersion(&groupVersion) {
+		groupVersion = g.externalGroupVersions[0]
+	}
+	if groupVersion.Group == api.GroupName {
+		path = "/api/" + groupVersion.Version
 	} else {
 		// TODO: switch back once we have proper multiple group support
 		// path = "/apis/" + g.Group + "/" + Version(group...)
-		path = "/apis/" + g.externalGroupVersions[0].Group + "/" + g.externalGroupVersions[0].Version
+		path = "/apis/" + groupVersion.Group + "/" + groupVersion.Version
 	}
 
 	if prefix != "" {
@@ -310,7 +326,7 @@ func (g TestGroup) ResourcePathWithPrefix(prefix, resource, namespace, name stri
 		path = path + "/namespaces/" + namespace
 	}
 	// Resource names are lower case.
-	resource = strings.ToLower(resource)
+	resource := strings.ToLower(gvr.Resource)
 	if resource != "" {
 		path = path + "/" + resource
 	}
@@ -323,7 +339,7 @@ func (g TestGroup) ResourcePathWithPrefix(prefix, resource, namespace, name stri
 // Returns the appropriate path for the given resource, namespace and name.
 // For example, this is of the form:
 // /api/v1/namespaces/foo/pods/pod0 for v1.
-func (g TestGroup) ResourcePath(resource, namespace, name string) string {
+func (g TestGroup) ResourcePath(resource unversioned.GroupVersionResource, namespace, name string) string {
 	return g.ResourcePathWithPrefix("", resource, namespace, name)
 }
 
@@ -354,7 +370,7 @@ func GetCodecForObject(obj runtime.Object) (runtime.Codec, error) {
 		}
 
 		if api.Scheme.Recognizes(kind) {
-			return group.Codec(), nil
+			return group.Codec(group.GroupVersion()), nil
 		}
 	}
 	// Codec used for unversioned types

--- a/pkg/apis/batch/register.go
+++ b/pkg/apis/batch/register.go
@@ -49,10 +49,14 @@ func addKnownTypes(scheme *runtime.Scheme) {
 		&Job{},
 		&JobList{},
 		&JobTemplate{},
+		&ScheduledJob{},
+		&ScheduledJobList{},
 		&api.ListOptions{},
 	)
 }
 
-func (obj *Job) GetObjectKind() unversioned.ObjectKind         { return &obj.TypeMeta }
-func (obj *JobList) GetObjectKind() unversioned.ObjectKind     { return &obj.TypeMeta }
-func (obj *JobTemplate) GetObjectKind() unversioned.ObjectKind { return &obj.TypeMeta }
+func (obj *Job) GetObjectKind() unversioned.ObjectKind              { return &obj.TypeMeta }
+func (obj *JobList) GetObjectKind() unversioned.ObjectKind          { return &obj.TypeMeta }
+func (obj *JobTemplate) GetObjectKind() unversioned.ObjectKind      { return &obj.TypeMeta }
+func (obj *ScheduledJob) GetObjectKind() unversioned.ObjectKind     { return &obj.TypeMeta }
+func (obj *ScheduledJobList) GetObjectKind() unversioned.ObjectKind { return &obj.TypeMeta }

--- a/pkg/apis/batch/types.go
+++ b/pkg/apis/batch/types.go
@@ -165,6 +165,8 @@ type JobCondition struct {
 	Message string `json:"message,omitempty"`
 }
 
+// +genclient=true
+
 // ScheduledJob represents the configuration of a single scheduled job.
 type ScheduledJob struct {
 	unversioned.TypeMeta `json:",inline"`

--- a/pkg/apis/batch/v2alpha1/conversion_generated.go
+++ b/pkg/apis/batch/v2alpha1/conversion_generated.go
@@ -48,6 +48,12 @@ func init() {
 		Convert_unversioned_LabelSelector_To_v2alpha1_LabelSelector,
 		Convert_v2alpha1_LabelSelectorRequirement_To_unversioned_LabelSelectorRequirement,
 		Convert_unversioned_LabelSelectorRequirement_To_v2alpha1_LabelSelectorRequirement,
+		Convert_v2alpha1_ScheduledJob_To_batch_ScheduledJob,
+		Convert_batch_ScheduledJob_To_v2alpha1_ScheduledJob,
+		Convert_v2alpha1_ScheduledJobList_To_batch_ScheduledJobList,
+		Convert_batch_ScheduledJobList_To_v2alpha1_ScheduledJobList,
+		Convert_v2alpha1_ScheduledJobSpec_To_batch_ScheduledJobSpec,
+		Convert_batch_ScheduledJobSpec_To_v2alpha1_ScheduledJobSpec,
 		Convert_v2alpha1_ScheduledJobStatus_To_batch_ScheduledJobStatus,
 		Convert_batch_ScheduledJobStatus_To_v2alpha1_ScheduledJobStatus,
 	); err != nil {
@@ -509,6 +515,141 @@ func autoConvert_unversioned_LabelSelectorRequirement_To_v2alpha1_LabelSelectorR
 
 func Convert_unversioned_LabelSelectorRequirement_To_v2alpha1_LabelSelectorRequirement(in *unversioned.LabelSelectorRequirement, out *LabelSelectorRequirement, s conversion.Scope) error {
 	return autoConvert_unversioned_LabelSelectorRequirement_To_v2alpha1_LabelSelectorRequirement(in, out, s)
+}
+
+func autoConvert_v2alpha1_ScheduledJob_To_batch_ScheduledJob(in *ScheduledJob, out *batch.ScheduledJob, s conversion.Scope) error {
+	SetDefaults_ScheduledJob(in)
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	// TODO: Inefficient conversion - can we improve it?
+	if err := s.Convert(&in.ObjectMeta, &out.ObjectMeta, 0); err != nil {
+		return err
+	}
+	if err := Convert_v2alpha1_ScheduledJobSpec_To_batch_ScheduledJobSpec(&in.Spec, &out.Spec, s); err != nil {
+		return err
+	}
+	if err := Convert_v2alpha1_ScheduledJobStatus_To_batch_ScheduledJobStatus(&in.Status, &out.Status, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Convert_v2alpha1_ScheduledJob_To_batch_ScheduledJob(in *ScheduledJob, out *batch.ScheduledJob, s conversion.Scope) error {
+	return autoConvert_v2alpha1_ScheduledJob_To_batch_ScheduledJob(in, out, s)
+}
+
+func autoConvert_batch_ScheduledJob_To_v2alpha1_ScheduledJob(in *batch.ScheduledJob, out *ScheduledJob, s conversion.Scope) error {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	// TODO: Inefficient conversion - can we improve it?
+	if err := s.Convert(&in.ObjectMeta, &out.ObjectMeta, 0); err != nil {
+		return err
+	}
+	if err := Convert_batch_ScheduledJobSpec_To_v2alpha1_ScheduledJobSpec(&in.Spec, &out.Spec, s); err != nil {
+		return err
+	}
+	if err := Convert_batch_ScheduledJobStatus_To_v2alpha1_ScheduledJobStatus(&in.Status, &out.Status, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Convert_batch_ScheduledJob_To_v2alpha1_ScheduledJob(in *batch.ScheduledJob, out *ScheduledJob, s conversion.Scope) error {
+	return autoConvert_batch_ScheduledJob_To_v2alpha1_ScheduledJob(in, out, s)
+}
+
+func autoConvert_v2alpha1_ScheduledJobList_To_batch_ScheduledJobList(in *ScheduledJobList, out *batch.ScheduledJobList, s conversion.Scope) error {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]batch.ScheduledJob, len(*in))
+		for i := range *in {
+			if err := Convert_v2alpha1_ScheduledJob_To_batch_ScheduledJob(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func Convert_v2alpha1_ScheduledJobList_To_batch_ScheduledJobList(in *ScheduledJobList, out *batch.ScheduledJobList, s conversion.Scope) error {
+	return autoConvert_v2alpha1_ScheduledJobList_To_batch_ScheduledJobList(in, out, s)
+}
+
+func autoConvert_batch_ScheduledJobList_To_v2alpha1_ScheduledJobList(in *batch.ScheduledJobList, out *ScheduledJobList, s conversion.Scope) error {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]ScheduledJob, len(*in))
+		for i := range *in {
+			if err := Convert_batch_ScheduledJob_To_v2alpha1_ScheduledJob(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func Convert_batch_ScheduledJobList_To_v2alpha1_ScheduledJobList(in *batch.ScheduledJobList, out *ScheduledJobList, s conversion.Scope) error {
+	return autoConvert_batch_ScheduledJobList_To_v2alpha1_ScheduledJobList(in, out, s)
+}
+
+func autoConvert_v2alpha1_ScheduledJobSpec_To_batch_ScheduledJobSpec(in *ScheduledJobSpec, out *batch.ScheduledJobSpec, s conversion.Scope) error {
+	out.Schedule = in.Schedule
+	if in.StartingDeadlineSeconds != nil {
+		in, out := &in.StartingDeadlineSeconds, &out.StartingDeadlineSeconds
+		*out = new(int64)
+		**out = **in
+	} else {
+		out.StartingDeadlineSeconds = nil
+	}
+	out.ConcurrencyPolicy = batch.ConcurrencyPolicy(in.ConcurrencyPolicy)
+	out.Suspend = in.Suspend
+	if err := Convert_v2alpha1_JobTemplateSpec_To_batch_JobTemplateSpec(&in.JobTemplate, &out.JobTemplate, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Convert_v2alpha1_ScheduledJobSpec_To_batch_ScheduledJobSpec(in *ScheduledJobSpec, out *batch.ScheduledJobSpec, s conversion.Scope) error {
+	return autoConvert_v2alpha1_ScheduledJobSpec_To_batch_ScheduledJobSpec(in, out, s)
+}
+
+func autoConvert_batch_ScheduledJobSpec_To_v2alpha1_ScheduledJobSpec(in *batch.ScheduledJobSpec, out *ScheduledJobSpec, s conversion.Scope) error {
+	out.Schedule = in.Schedule
+	if in.StartingDeadlineSeconds != nil {
+		in, out := &in.StartingDeadlineSeconds, &out.StartingDeadlineSeconds
+		*out = new(int64)
+		**out = **in
+	} else {
+		out.StartingDeadlineSeconds = nil
+	}
+	out.ConcurrencyPolicy = ConcurrencyPolicy(in.ConcurrencyPolicy)
+	out.Suspend = in.Suspend
+	if err := Convert_batch_JobTemplateSpec_To_v2alpha1_JobTemplateSpec(&in.JobTemplate, &out.JobTemplate, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Convert_batch_ScheduledJobSpec_To_v2alpha1_ScheduledJobSpec(in *batch.ScheduledJobSpec, out *ScheduledJobSpec, s conversion.Scope) error {
+	return autoConvert_batch_ScheduledJobSpec_To_v2alpha1_ScheduledJobSpec(in, out, s)
 }
 
 func autoConvert_v2alpha1_ScheduledJobStatus_To_batch_ScheduledJobStatus(in *ScheduledJobStatus, out *batch.ScheduledJobStatus, s conversion.Scope) error {

--- a/pkg/apis/batch/v2alpha1/deep_copy_generated.go
+++ b/pkg/apis/batch/v2alpha1/deep_copy_generated.go
@@ -287,14 +287,8 @@ func DeepCopy_v2alpha1_ScheduledJobSpec(in ScheduledJobSpec, out *ScheduledJobSp
 	}
 	out.ConcurrencyPolicy = in.ConcurrencyPolicy
 	out.Suspend = in.Suspend
-	if in.JobTemplate != nil {
-		in, out := in.JobTemplate, &out.JobTemplate
-		*out = new(JobTemplateSpec)
-		if err := DeepCopy_v2alpha1_JobTemplateSpec(*in, *out, c); err != nil {
-			return err
-		}
-	} else {
-		out.JobTemplate = nil
+	if err := DeepCopy_v2alpha1_JobTemplateSpec(in.JobTemplate, &out.JobTemplate, c); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/apis/batch/v2alpha1/defaults.go
+++ b/pkg/apis/batch/v2alpha1/defaults.go
@@ -23,6 +23,7 @@ import (
 func addDefaultingFuncs(scheme *runtime.Scheme) {
 	scheme.AddDefaultingFuncs(
 		SetDefaults_Job,
+		SetDefaults_ScheduledJob,
 	)
 }
 
@@ -38,5 +39,11 @@ func SetDefaults_Job(obj *Job) {
 	if obj.Spec.Parallelism == nil {
 		obj.Spec.Parallelism = new(int32)
 		*obj.Spec.Parallelism = 1
+	}
+}
+
+func SetDefaults_ScheduledJob(obj *ScheduledJob) {
+	if obj.Spec.ConcurrencyPolicy == "" {
+		obj.Spec.ConcurrencyPolicy = AllowConcurrent
 	}
 }

--- a/pkg/apis/batch/v2alpha1/generated.pb.go
+++ b/pkg/apis/batch/v2alpha1/generated.pb.go
@@ -644,16 +644,14 @@ func (m *ScheduledJobSpec) MarshalTo(data []byte) (int, error) {
 		data[i] = 0
 	}
 	i++
-	if m.JobTemplate != nil {
-		data[i] = 0x2a
-		i++
-		i = encodeVarintGenerated(data, i, uint64(m.JobTemplate.Size()))
-		n19, err := m.JobTemplate.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n19
+	data[i] = 0x2a
+	i++
+	i = encodeVarintGenerated(data, i, uint64(m.JobTemplate.Size()))
+	n19, err := m.JobTemplate.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
 	}
+	i += n19
 	return i, nil
 }
 
@@ -908,10 +906,8 @@ func (m *ScheduledJobSpec) Size() (n int) {
 	l = len(m.ConcurrencyPolicy)
 	n += 1 + l + sovGenerated(uint64(l))
 	n += 2
-	if m.JobTemplate != nil {
-		l = m.JobTemplate.Size()
-		n += 1 + l + sovGenerated(uint64(l))
-	}
+	l = m.JobTemplate.Size()
+	n += 1 + l + sovGenerated(uint64(l))
 	return n
 }
 
@@ -2771,9 +2767,6 @@ func (m *ScheduledJobSpec) Unmarshal(data []byte) error {
 			postIndex := iNdEx + msglen
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
-			}
-			if m.JobTemplate == nil {
-				m.JobTemplate = &JobTemplateSpec{}
 			}
 			if err := m.JobTemplate.Unmarshal(data[iNdEx:postIndex]); err != nil {
 				return err

--- a/pkg/apis/batch/v2alpha1/register.go
+++ b/pkg/apis/batch/v2alpha1/register.go
@@ -41,11 +41,15 @@ func addKnownTypes(scheme *runtime.Scheme) {
 		&Job{},
 		&JobList{},
 		&JobTemplate{},
+		&ScheduledJob{},
+		&ScheduledJobList{},
 		&v1.ListOptions{},
 	)
 	versionedwatch.AddToGroupVersion(scheme, SchemeGroupVersion)
 }
 
-func (obj *JobTemplate) GetObjectKind() unversioned.ObjectKind { return &obj.TypeMeta }
-func (obj *Job) GetObjectKind() unversioned.ObjectKind         { return &obj.TypeMeta }
-func (obj *JobList) GetObjectKind() unversioned.ObjectKind     { return &obj.TypeMeta }
+func (obj *Job) GetObjectKind() unversioned.ObjectKind              { return &obj.TypeMeta }
+func (obj *JobList) GetObjectKind() unversioned.ObjectKind          { return &obj.TypeMeta }
+func (obj *JobTemplate) GetObjectKind() unversioned.ObjectKind      { return &obj.TypeMeta }
+func (obj *ScheduledJob) GetObjectKind() unversioned.ObjectKind     { return &obj.TypeMeta }
+func (obj *ScheduledJobList) GetObjectKind() unversioned.ObjectKind { return &obj.TypeMeta }

--- a/pkg/apis/batch/v2alpha1/types.generated.go
+++ b/pkg/apis/batch/v2alpha1/types.generated.go
@@ -3599,20 +3599,14 @@ func (x *ScheduledJobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if x.JobTemplate == nil {
-					r.EncodeNil()
-				} else {
-					x.JobTemplate.CodecEncodeSelf(e)
-				}
+				yy18 := &x.JobTemplate
+				yy18.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("jobTemplate"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				if x.JobTemplate == nil {
-					r.EncodeNil()
-				} else {
-					x.JobTemplate.CodecEncodeSelf(e)
-				}
+				yy20 := &x.JobTemplate
+				yy20.CodecEncodeSelf(e)
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
@@ -3711,14 +3705,10 @@ func (x *ScheduledJobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		case "jobTemplate":
 			if r.TryDecodeAsNil() {
-				if x.JobTemplate != nil {
-					x.JobTemplate = nil
-				}
+				x.JobTemplate = JobTemplateSpec{}
 			} else {
-				if x.JobTemplate == nil {
-					x.JobTemplate = new(JobTemplateSpec)
-				}
-				x.JobTemplate.CodecDecodeSelf(d)
+				yyv9 := &x.JobTemplate
+				yyv9.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3)
@@ -3820,14 +3810,10 @@ func (x *ScheduledJobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		if x.JobTemplate != nil {
-			x.JobTemplate = nil
-		}
+		x.JobTemplate = JobTemplateSpec{}
 	} else {
-		if x.JobTemplate == nil {
-			x.JobTemplate = new(JobTemplateSpec)
-		}
-		x.JobTemplate.CodecDecodeSelf(d)
+		yyv16 := &x.JobTemplate
+		yyv16.CodecDecodeSelf(d)
 	}
 	for {
 		yyj10++
@@ -4977,7 +4963,7 @@ func (x codecSelfer1234) decSliceScheduledJob(v *[]ScheduledJob, d *codec1978.De
 
 			yyrg1 := len(yyv1) > 0
 			yyv21 := yyv1
-			yyrl1, yyrt1 = z.DecInferLen(yyl1, z.DecBasicHandle().MaxInitLen, 328)
+			yyrl1, yyrt1 = z.DecInferLen(yyl1, z.DecBasicHandle().MaxInitLen, 1000)
 			if yyrt1 {
 				if yyrl1 <= cap(yyv1) {
 					yyv1 = yyv1[:yyrl1]

--- a/pkg/apis/batch/v2alpha1/types.go
+++ b/pkg/apis/batch/v2alpha1/types.go
@@ -215,7 +215,7 @@ type ScheduledJobSpec struct {
 
 	// JobTemplate is the object that describes the job that will be created when
 	// executing a ScheduledJob.
-	JobTemplate *JobTemplateSpec `json:"jobTemplate" protobuf:"bytes,5,opt,name=jobTemplate"`
+	JobTemplate JobTemplateSpec `json:"jobTemplate" protobuf:"bytes,5,opt,name=jobTemplate"`
 }
 
 // ConcurrencyPolicy describes how the job will be handled.

--- a/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/batch_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/batch_client.go
@@ -25,6 +25,7 @@ import (
 type BatchInterface interface {
 	GetRESTClient() *restclient.RESTClient
 	JobsGetter
+	ScheduledJobsGetter
 }
 
 // BatchClient is used to interact with features provided by the Batch group.
@@ -34,6 +35,10 @@ type BatchClient struct {
 
 func (c *BatchClient) Jobs(namespace string) JobInterface {
 	return newJobs(c, namespace)
+}
+
+func (c *BatchClient) ScheduledJobs(namespace string) ScheduledJobInterface {
+	return newScheduledJobs(c, namespace)
 }
 
 // NewForConfig creates a new BatchClient for the given config.

--- a/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/fake/fake_batch_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/fake/fake_batch_client.go
@@ -30,6 +30,10 @@ func (c *FakeBatch) Jobs(namespace string) unversioned.JobInterface {
 	return &FakeJobs{c, namespace}
 }
 
+func (c *FakeBatch) ScheduledJobs(namespace string) unversioned.ScheduledJobInterface {
+	return &FakeScheduledJobs{c, namespace}
+}
+
 // GetRESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeBatch) GetRESTClient() *restclient.RESTClient {

--- a/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/fake/fake_scheduledjob.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/fake/fake_scheduledjob.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	batch "k8s.io/kubernetes/pkg/apis/batch"
+	core "k8s.io/kubernetes/pkg/client/testing/core"
+	labels "k8s.io/kubernetes/pkg/labels"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeScheduledJobs implements ScheduledJobInterface
+type FakeScheduledJobs struct {
+	Fake *FakeBatch
+	ns   string
+}
+
+var scheduledjobsResource = unversioned.GroupVersionResource{Group: "batch", Version: "", Resource: "scheduledjobs"}
+
+func (c *FakeScheduledJobs) Create(scheduledJob *batch.ScheduledJob) (result *batch.ScheduledJob, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewCreateAction(scheduledjobsResource, c.ns, scheduledJob), &batch.ScheduledJob{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*batch.ScheduledJob), err
+}
+
+func (c *FakeScheduledJobs) Update(scheduledJob *batch.ScheduledJob) (result *batch.ScheduledJob, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateAction(scheduledjobsResource, c.ns, scheduledJob), &batch.ScheduledJob{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*batch.ScheduledJob), err
+}
+
+func (c *FakeScheduledJobs) UpdateStatus(scheduledJob *batch.ScheduledJob) (*batch.ScheduledJob, error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateSubresourceAction(scheduledjobsResource, "status", c.ns, scheduledJob), &batch.ScheduledJob{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*batch.ScheduledJob), err
+}
+
+func (c *FakeScheduledJobs) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(core.NewDeleteAction(scheduledjobsResource, c.ns, name), &batch.ScheduledJob{})
+
+	return err
+}
+
+func (c *FakeScheduledJobs) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+	action := core.NewDeleteCollectionAction(scheduledjobsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &batch.ScheduledJobList{})
+	return err
+}
+
+func (c *FakeScheduledJobs) Get(name string) (result *batch.ScheduledJob, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewGetAction(scheduledjobsResource, c.ns, name), &batch.ScheduledJob{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*batch.ScheduledJob), err
+}
+
+func (c *FakeScheduledJobs) List(opts api.ListOptions) (result *batch.ScheduledJobList, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewListAction(scheduledjobsResource, c.ns, opts), &batch.ScheduledJobList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label := opts.LabelSelector
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &batch.ScheduledJobList{}
+	for _, item := range obj.(*batch.ScheduledJobList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested scheduledJobs.
+func (c *FakeScheduledJobs) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(core.NewWatchAction(scheduledjobsResource, c.ns, opts))
+
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/generated_expansion.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/generated_expansion.go
@@ -17,3 +17,5 @@ limitations under the License.
 package unversioned
 
 type JobExpansion interface{}
+
+type ScheduledJobExpansion interface{}

--- a/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/scheduledjob.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/scheduledjob.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	batch "k8s.io/kubernetes/pkg/apis/batch"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// ScheduledJobsGetter has a method to return a ScheduledJobInterface.
+// A group's client should implement this interface.
+type ScheduledJobsGetter interface {
+	ScheduledJobs(namespace string) ScheduledJobInterface
+}
+
+// ScheduledJobInterface has methods to work with ScheduledJob resources.
+type ScheduledJobInterface interface {
+	Create(*batch.ScheduledJob) (*batch.ScheduledJob, error)
+	Update(*batch.ScheduledJob) (*batch.ScheduledJob, error)
+	UpdateStatus(*batch.ScheduledJob) (*batch.ScheduledJob, error)
+	Delete(name string, options *api.DeleteOptions) error
+	DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error
+	Get(name string) (*batch.ScheduledJob, error)
+	List(opts api.ListOptions) (*batch.ScheduledJobList, error)
+	Watch(opts api.ListOptions) (watch.Interface, error)
+	ScheduledJobExpansion
+}
+
+// scheduledJobs implements ScheduledJobInterface
+type scheduledJobs struct {
+	client *BatchClient
+	ns     string
+}
+
+// newScheduledJobs returns a ScheduledJobs
+func newScheduledJobs(c *BatchClient, namespace string) *scheduledJobs {
+	return &scheduledJobs{
+		client: c,
+		ns:     namespace,
+	}
+}
+
+// Create takes the representation of a scheduledJob and creates it.  Returns the server's representation of the scheduledJob, and an error, if there is any.
+func (c *scheduledJobs) Create(scheduledJob *batch.ScheduledJob) (result *batch.ScheduledJob, err error) {
+	result = &batch.ScheduledJob{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("scheduledjobs").
+		Body(scheduledJob).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a scheduledJob and updates it. Returns the server's representation of the scheduledJob, and an error, if there is any.
+func (c *scheduledJobs) Update(scheduledJob *batch.ScheduledJob) (result *batch.ScheduledJob, err error) {
+	result = &batch.ScheduledJob{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("scheduledjobs").
+		Name(scheduledJob.Name).
+		Body(scheduledJob).
+		Do().
+		Into(result)
+	return
+}
+
+func (c *scheduledJobs) UpdateStatus(scheduledJob *batch.ScheduledJob) (result *batch.ScheduledJob, err error) {
+	result = &batch.ScheduledJob{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("scheduledjobs").
+		Name(scheduledJob.Name).
+		SubResource("status").
+		Body(scheduledJob).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the scheduledJob and deletes it. Returns an error if one occurs.
+func (c *scheduledJobs) Delete(name string, options *api.DeleteOptions) error {
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("scheduledjobs").
+		Name(name).
+		Body(options).
+		Do().
+		Error()
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *scheduledJobs) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("scheduledjobs").
+		VersionedParams(&listOptions, api.ParameterCodec).
+		Body(options).
+		Do().
+		Error()
+}
+
+// Get takes name of the scheduledJob, and returns the corresponding scheduledJob object, and an error if there is any.
+func (c *scheduledJobs) Get(name string) (result *batch.ScheduledJob, err error) {
+	result = &batch.ScheduledJob{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("scheduledjobs").
+		Name(name).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ScheduledJobs that match those selectors.
+func (c *scheduledJobs) List(opts api.ListOptions) (result *batch.ScheduledJobList, err error) {
+	result = &batch.ScheduledJobList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("scheduledjobs").
+		VersionedParams(&opts, api.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested scheduledJobs.
+func (c *scheduledJobs) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("scheduledjobs").
+		VersionedParams(&opts, api.ParameterCodec).
+		Watch()
+}

--- a/pkg/client/unversioned/batch.go
+++ b/pkg/client/unversioned/batch.go
@@ -27,6 +27,7 @@ import (
 
 type BatchInterface interface {
 	JobsNamespacer
+	ScheduledJobsNamespacer
 }
 
 // BatchClient is used to interact with Kubernetes batch features.
@@ -36,6 +37,10 @@ type BatchClient struct {
 
 func (c *BatchClient) Jobs(namespace string) JobInterface {
 	return newJobsV1(c, namespace)
+}
+
+func (c *BatchClient) ScheduledJobs(namespace string) ScheduledJobInterface {
+	return newScheduledJobs(c, namespace)
 }
 
 func NewBatch(c *restclient.Config) (*BatchClient, error) {

--- a/pkg/client/unversioned/daemon_sets_test.go
+++ b/pkg/client/unversioned/daemon_sets_test.go
@@ -17,19 +17,18 @@ limitations under the License.
 package unversioned_test
 
 import (
-	"k8s.io/kubernetes/pkg/client/unversioned/testclient/simple"
-)
-
-import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	"k8s.io/kubernetes/pkg/client/unversioned/testclient/simple"
 )
 
-func getDSResourceName() string {
-	return "daemonsets"
+func getDSResource() unversioned.GroupVersionResource {
+	return v1beta1.SchemeGroupVersion.WithResource("daemonsets")
 }
 
 func TestListDaemonSets(t *testing.T) {
@@ -37,7 +36,7 @@ func TestListDaemonSets(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Extensions.ResourcePath(getDSResourceName(), ns, ""),
+			Path:   testapi.Extensions.ResourcePath(getDSResource(), ns, ""),
 		},
 		Response: simple.Response{StatusCode: 200,
 			Body: &extensions.DaemonSetList{
@@ -57,6 +56,7 @@ func TestListDaemonSets(t *testing.T) {
 				},
 			},
 		},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	receivedDSs, err := c.Setup(t).Extensions().DaemonSets(ns).List(api.ListOptions{})
 	defer c.Close()
@@ -67,7 +67,7 @@ func TestListDaemonSets(t *testing.T) {
 func TestGetDaemonSet(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request: simple.Request{Method: "GET", Path: testapi.Extensions.ResourcePath(getDSResourceName(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "GET", Path: testapi.Extensions.ResourcePath(getDSResource(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body: &extensions.DaemonSet{
@@ -83,6 +83,7 @@ func TestGetDaemonSet(t *testing.T) {
 				},
 			},
 		},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	receivedDaemonSet, err := c.Setup(t).Extensions().DaemonSets(ns).Get("foo")
 	defer c.Close()
@@ -107,7 +108,7 @@ func TestUpdateDaemonSet(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "1"},
 	}
 	c := &simple.Client{
-		Request: simple.Request{Method: "PUT", Path: testapi.Extensions.ResourcePath(getDSResourceName(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "PUT", Path: testapi.Extensions.ResourcePath(getDSResource(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body: &extensions.DaemonSet{
@@ -123,6 +124,7 @@ func TestUpdateDaemonSet(t *testing.T) {
 				},
 			},
 		},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	receivedDaemonSet, err := c.Setup(t).Extensions().DaemonSets(ns).Update(requestDaemonSet)
 	defer c.Close()
@@ -135,7 +137,7 @@ func TestUpdateDaemonSetUpdateStatus(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "1"},
 	}
 	c := &simple.Client{
-		Request: simple.Request{Method: "PUT", Path: testapi.Extensions.ResourcePath(getDSResourceName(), ns, "foo") + "/status", Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "PUT", Path: testapi.Extensions.ResourcePath(getDSResource(), ns, "foo") + "/status", Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body: &extensions.DaemonSet{
@@ -152,6 +154,7 @@ func TestUpdateDaemonSetUpdateStatus(t *testing.T) {
 				Status: extensions.DaemonSetStatus{},
 			},
 		},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	receivedDaemonSet, err := c.Setup(t).Extensions().DaemonSets(ns).UpdateStatus(requestDaemonSet)
 	defer c.Close()
@@ -161,7 +164,7 @@ func TestUpdateDaemonSetUpdateStatus(t *testing.T) {
 func TestDeleteDaemon(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request:  simple.Request{Method: "DELETE", Path: testapi.Extensions.ResourcePath(getDSResourceName(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Request:  simple.Request{Method: "DELETE", Path: testapi.Extensions.ResourcePath(getDSResource(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: 200},
 	}
 	err := c.Setup(t).Extensions().DaemonSets(ns).Delete("foo")
@@ -175,7 +178,7 @@ func TestCreateDaemonSet(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "foo"},
 	}
 	c := &simple.Client{
-		Request: simple.Request{Method: "POST", Path: testapi.Extensions.ResourcePath(getDSResourceName(), ns, ""), Body: requestDaemonSet, Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "POST", Path: testapi.Extensions.ResourcePath(getDSResource(), ns, ""), Body: requestDaemonSet, Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body: &extensions.DaemonSet{
@@ -191,6 +194,7 @@ func TestCreateDaemonSet(t *testing.T) {
 				},
 			},
 		},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	receivedDaemonSet, err := c.Setup(t).Extensions().DaemonSets(ns).Create(requestDaemonSet)
 	defer c.Close()

--- a/pkg/client/unversioned/deployment_test.go
+++ b/pkg/client/unversioned/deployment_test.go
@@ -25,12 +25,13 @@ import (
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient/simple"
 	"k8s.io/kubernetes/pkg/labels"
 )
 
-func getDeploymentsResourceName() string {
-	return "deployments"
+func getDeploymentsResource() unversioned.GroupVersionResource {
+	return v1beta1.SchemeGroupVersion.WithResource("deployments")
 }
 
 func TestDeploymentCreate(t *testing.T) {
@@ -44,11 +45,12 @@ func TestDeploymentCreate(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "POST",
-			Path:   testapi.Extensions.ResourcePath(getDeploymentsResourceName(), ns, ""),
+			Path:   testapi.Extensions.ResourcePath(getDeploymentsResource(), ns, ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   &deployment,
 		},
-		Response: simple.Response{StatusCode: 200, Body: &deployment},
+		Response:     simple.Response{StatusCode: 200, Body: &deployment},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 
 	response, err := c.Setup(t).Deployments(ns).Create(&deployment)
@@ -70,11 +72,12 @@ func TestDeploymentGet(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Extensions.ResourcePath(getDeploymentsResourceName(), ns, "abc"),
+			Path:   testapi.Extensions.ResourcePath(getDeploymentsResource(), ns, "abc"),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
-		Response: simple.Response{StatusCode: 200, Body: deployment},
+		Response:     simple.Response{StatusCode: 200, Body: deployment},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 
 	response, err := c.Setup(t).Deployments(ns).Get("abc")
@@ -97,11 +100,12 @@ func TestDeploymentList(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Extensions.ResourcePath(getDeploymentsResourceName(), ns, ""),
+			Path:   testapi.Extensions.ResourcePath(getDeploymentsResource(), ns, ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
-		Response: simple.Response{StatusCode: 200, Body: deploymentList},
+		Response:     simple.Response{StatusCode: 200, Body: deploymentList},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	response, err := c.Setup(t).Deployments(ns).List(api.ListOptions{})
 	defer c.Close()
@@ -120,10 +124,11 @@ func TestDeploymentUpdate(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "PUT",
-			Path:   testapi.Extensions.ResourcePath(getDeploymentsResourceName(), ns, "abc"),
+			Path:   testapi.Extensions.ResourcePath(getDeploymentsResource(), ns, "abc"),
 			Query:  simple.BuildQueryValues(nil),
 		},
-		Response: simple.Response{StatusCode: 200, Body: deployment},
+		Response:     simple.Response{StatusCode: 200, Body: deployment},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	response, err := c.Setup(t).Deployments(ns).Update(deployment)
 	defer c.Close()
@@ -142,10 +147,11 @@ func TestDeploymentUpdateStatus(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "PUT",
-			Path:   testapi.Extensions.ResourcePath(getDeploymentsResourceName(), ns, "abc") + "/status",
+			Path:   testapi.Extensions.ResourcePath(getDeploymentsResource(), ns, "abc") + "/status",
 			Query:  simple.BuildQueryValues(nil),
 		},
-		Response: simple.Response{StatusCode: 200, Body: deployment},
+		Response:     simple.Response{StatusCode: 200, Body: deployment},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	response, err := c.Setup(t).Deployments(ns).UpdateStatus(deployment)
 	defer c.Close()
@@ -157,10 +163,11 @@ func TestDeploymentDelete(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "DELETE",
-			Path:   testapi.Extensions.ResourcePath(getDeploymentsResourceName(), ns, "foo"),
+			Path:   testapi.Extensions.ResourcePath(getDeploymentsResource(), ns, "foo"),
 			Query:  simple.BuildQueryValues(nil),
 		},
-		Response: simple.Response{StatusCode: 200},
+		Response:     simple.Response{StatusCode: 200},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	err := c.Setup(t).Deployments(ns).Delete("foo", nil)
 	defer c.Close()
@@ -171,10 +178,11 @@ func TestDeploymentWatch(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Extensions.ResourcePathWithPrefix("watch", getDeploymentsResourceName(), "", ""),
+			Path:   testapi.Extensions.ResourcePathWithPrefix("watch", getDeploymentsResource(), "", ""),
 			Query:  url.Values{"resourceVersion": []string{}},
 		},
-		Response: simple.Response{StatusCode: 200},
+		Response:     simple.Response{StatusCode: 200},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	_, err := c.Setup(t).Deployments(api.NamespaceAll).Watch(api.ListOptions{})
 	defer c.Close()
@@ -187,7 +195,7 @@ func TestListDeploymentsLabels(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Extensions.ResourcePath("deployments", ns, ""),
+			Path:   testapi.Extensions.ResourcePath(getDeploymentsResource(), ns, ""),
 			Query:  simple.BuildQueryValues(url.Values{labelSelectorQueryParamName: []string{"foo=bar,name=baz"}})},
 		Response: simple.Response{
 			StatusCode: http.StatusOK,
@@ -204,6 +212,7 @@ func TestListDeploymentsLabels(t *testing.T) {
 				},
 			},
 		},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	c.Setup(t)
 	defer c.Close()
@@ -224,11 +233,12 @@ func TestDeploymentRollback(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "POST",
-			Path:   testapi.Extensions.ResourcePath(getDeploymentsResourceName(), ns, "abc") + "/rollback",
+			Path:   testapi.Extensions.ResourcePath(getDeploymentsResource(), ns, "abc") + "/rollback",
 			Query:  simple.BuildQueryValues(nil),
 			Body:   deploymentRollback,
 		},
-		Response: simple.Response{StatusCode: http.StatusOK},
+		Response:     simple.Response{StatusCode: http.StatusOK},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	err := c.Setup(t).Deployments(ns).Rollback(deploymentRollback)
 	defer c.Close()

--- a/pkg/client/unversioned/endpoints_test.go
+++ b/pkg/client/unversioned/endpoints_test.go
@@ -21,13 +21,19 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient/simple"
 )
+
+func getEndpointsResource() unversioned.GroupVersionResource {
+	return v1.SchemeGroupVersion.WithResource("endpoints")
+}
 
 func TestListEndpoints(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request: simple.Request{Method: "GET", Path: testapi.Default.ResourcePath("endpoints", ns, ""), Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "GET", Path: testapi.Default.ResourcePath(getEndpointsResource(), ns, ""), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: 200,
 			Body: &api.EndpointsList{
 				Items: []api.Endpoints{
@@ -41,6 +47,7 @@ func TestListEndpoints(t *testing.T) {
 				},
 			},
 		},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	receivedEndpointsList, err := c.Setup(t).Endpoints(ns).List(api.ListOptions{})
 	defer c.Close()
@@ -50,8 +57,9 @@ func TestListEndpoints(t *testing.T) {
 func TestGetEndpoints(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request:  simple.Request{Method: "GET", Path: testapi.Default.ResourcePath("endpoints", ns, "endpoint-1"), Query: simple.BuildQueryValues(nil)},
-		Response: simple.Response{StatusCode: 200, Body: &api.Endpoints{ObjectMeta: api.ObjectMeta{Name: "endpoint-1"}}},
+		Request:      simple.Request{Method: "GET", Path: testapi.Default.ResourcePath(getEndpointsResource(), ns, "endpoint-1"), Query: simple.BuildQueryValues(nil)},
+		Response:     simple.Response{StatusCode: 200, Body: &api.Endpoints{ObjectMeta: api.ObjectMeta{Name: "endpoint-1"}}},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	response, err := c.Setup(t).Endpoints(ns).Get("endpoint-1")
 	defer c.Close()

--- a/pkg/client/unversioned/events_test.go
+++ b/pkg/client/unversioned/events_test.go
@@ -17,11 +17,6 @@ limitations under the License.
 package unversioned_test
 
 import (
-	. "k8s.io/kubernetes/pkg/client/unversioned"
-	"k8s.io/kubernetes/pkg/client/unversioned/testclient/simple"
-)
-
-import (
 	"net/url"
 	"reflect"
 	"testing"
@@ -29,13 +24,20 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/v1"
+	. "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/client/unversioned/testclient/simple"
 )
+
+func getEventsResource() unversioned.GroupVersionResource {
+	return v1.SchemeGroupVersion.WithResource("events")
+}
 
 func TestEventSearch(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath("events", "baz", ""),
+			Path:   testapi.Default.ResourcePath(getEventsResource(), "baz", ""),
 			Query: url.Values{
 				unversioned.FieldSelectorQueryParam(testapi.Default.GroupVersion().String()): []string{
 					GetInvolvedObjectNameFieldLabel(testapi.Default.GroupVersion().String()) + "=foo,",
@@ -45,7 +47,8 @@ func TestEventSearch(t *testing.T) {
 				unversioned.LabelSelectorQueryParam(testapi.Default.GroupVersion().String()): []string{},
 			},
 		},
-		Response: simple.Response{StatusCode: 200, Body: &api.EventList{}},
+		Response:     simple.Response{StatusCode: 200, Body: &api.EventList{}},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	eventList, err := c.Setup(t).Events("baz").Search(
 		&api.Pod{
@@ -83,10 +86,11 @@ func TestEventCreate(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "POST",
-			Path:   testapi.Default.ResourcePath("events", api.NamespaceDefault, ""),
+			Path:   testapi.Default.ResourcePath(getEventsResource(), api.NamespaceDefault, ""),
 			Body:   event,
 		},
-		Response: simple.Response{StatusCode: 200, Body: event},
+		Response:     simple.Response{StatusCode: 200, Body: event},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 
 	response, err := c.Setup(t).Events(api.NamespaceDefault).Create(event)
@@ -124,10 +128,11 @@ func TestEventGet(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath("events", "other", "1"),
+			Path:   testapi.Default.ResourcePath(getEventsResource(), "other", "1"),
 			Body:   nil,
 		},
-		Response: simple.Response{StatusCode: 200, Body: event},
+		Response:     simple.Response{StatusCode: 200, Body: event},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 
 	response, err := c.Setup(t).Events("other").Get("1")
@@ -167,10 +172,11 @@ func TestEventList(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath("events", ns, ""),
+			Path:   testapi.Default.ResourcePath(getEventsResource(), ns, ""),
 			Body:   nil,
 		},
-		Response: simple.Response{StatusCode: 200, Body: eventList},
+		Response:     simple.Response{StatusCode: 200, Body: eventList},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	response, err := c.Setup(t).Events(ns).List(api.ListOptions{})
 	defer c.Close()
@@ -195,9 +201,10 @@ func TestEventDelete(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "DELETE",
-			Path:   testapi.Default.ResourcePath("events", ns, "foo"),
+			Path:   testapi.Default.ResourcePath(getEventsResource(), ns, "foo"),
 		},
-		Response: simple.Response{StatusCode: 200},
+		Response:     simple.Response{StatusCode: 200},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	err := c.Setup(t).Events(ns).Delete("foo")
 	defer c.Close()

--- a/pkg/client/unversioned/helper_blackbox_test.go
+++ b/pkg/client/unversioned/helper_blackbox_test.go
@@ -91,7 +91,7 @@ func TestNegotiateVersion(t *testing.T) {
 			expectErr:      func(err error) bool { return strings.Contains(err.Error(), "connection refused") },
 		},
 	}
-	codec := testapi.Default.Codec()
+	codec := testapi.Default.Codec(testapi.Default.GroupVersion())
 
 	for _, test := range tests {
 		fakeClient := &fake.RESTClient{

--- a/pkg/client/unversioned/helper_test.go
+++ b/pkg/client/unversioned/helper_test.go
@@ -41,7 +41,7 @@ func TestSetKubernetesDefaults(t *testing.T) {
 				APIPath: "/api",
 				ContentConfig: restclient.ContentConfig{
 					GroupVersion:         testapi.Default.GroupVersion(),
-					Codec:                testapi.Default.Codec(),
+					Codec:                testapi.Default.Codec(testapi.Default.GroupVersion()),
 					NegotiatedSerializer: testapi.Default.NegotiatedSerializer(),
 				},
 				QPS:   5,
@@ -141,7 +141,7 @@ func TestSetsCodec(t *testing.T) {
 		Prefix string
 		Codec  runtime.Codec
 	}{
-		testapi.Default.GroupVersion().Version: {false, "/api/" + testapi.Default.GroupVersion().Version, testapi.Default.Codec()},
+		testapi.Default.GroupVersion().Version: {false, "/api/" + testapi.Default.GroupVersion().Version, testapi.Default.Codec(testapi.Default.GroupVersion())},
 		// Add this test back when we fixed config and SetKubernetesDefaults
 		// "invalidVersion":                       {true, "", nil},
 	}

--- a/pkg/client/unversioned/horizontalpodautoscaler_test.go
+++ b/pkg/client/unversioned/horizontalpodautoscaler_test.go
@@ -22,12 +22,14 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
+	"k8s.io/kubernetes/pkg/apis/autoscaling/v1"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient/simple"
 )
 
-func getHorizontalPodAutoscalersResoureName() string {
-	return "horizontalpodautoscalers"
+func getHorizontalPodAutoscalersResoure() unversioned.GroupVersionResource {
+	return v1.SchemeGroupVersion.WithResource("horizontalpodautoscalers")
 }
 
 func TestHorizontalPodAutoscalerCreate(t *testing.T) {
@@ -41,12 +43,13 @@ func TestHorizontalPodAutoscalerCreate(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "POST",
-			Path:   testapi.Autoscaling.ResourcePath(getHorizontalPodAutoscalersResoureName(), ns, ""),
+			Path:   testapi.Autoscaling.ResourcePath(getHorizontalPodAutoscalersResoure(), ns, ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   &horizontalPodAutoscaler,
 		},
 		Response:      simple.Response{StatusCode: 200, Body: &horizontalPodAutoscaler},
 		ResourceGroup: autoscaling.GroupName,
+		GroupVersion:  &v1.SchemeGroupVersion,
 	}
 
 	response, err := c.Setup(t).Autoscaling().HorizontalPodAutoscalers(ns).Create(&horizontalPodAutoscaler)
@@ -68,12 +71,13 @@ func TestHorizontalPodAutoscalerGet(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Autoscaling.ResourcePath(getHorizontalPodAutoscalersResoureName(), ns, "abc"),
+			Path:   testapi.Autoscaling.ResourcePath(getHorizontalPodAutoscalersResoure(), ns, "abc"),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
 		Response:      simple.Response{StatusCode: 200, Body: horizontalPodAutoscaler},
 		ResourceGroup: autoscaling.GroupName,
+		GroupVersion:  &v1.SchemeGroupVersion,
 	}
 
 	response, err := c.Setup(t).Autoscaling().HorizontalPodAutoscalers(ns).Get("abc")
@@ -96,12 +100,13 @@ func TestHorizontalPodAutoscalerList(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Autoscaling.ResourcePath(getHorizontalPodAutoscalersResoureName(), ns, ""),
+			Path:   testapi.Autoscaling.ResourcePath(getHorizontalPodAutoscalersResoure(), ns, ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
 		Response:      simple.Response{StatusCode: 200, Body: horizontalPodAutoscalerList},
 		ResourceGroup: autoscaling.GroupName,
+		GroupVersion:  &v1.SchemeGroupVersion,
 	}
 	response, err := c.Setup(t).Autoscaling().HorizontalPodAutoscalers(ns).List(api.ListOptions{})
 	defer c.Close()
@@ -118,9 +123,10 @@ func TestHorizontalPodAutoscalerUpdate(t *testing.T) {
 		},
 	}
 	c := &simple.Client{
-		Request:       simple.Request{Method: "PUT", Path: testapi.Autoscaling.ResourcePath(getHorizontalPodAutoscalersResoureName(), ns, "abc"), Query: simple.BuildQueryValues(nil)},
+		Request:       simple.Request{Method: "PUT", Path: testapi.Autoscaling.ResourcePath(getHorizontalPodAutoscalersResoure(), ns, "abc"), Query: simple.BuildQueryValues(nil)},
 		Response:      simple.Response{StatusCode: 200, Body: horizontalPodAutoscaler},
 		ResourceGroup: autoscaling.GroupName,
+		GroupVersion:  &v1.SchemeGroupVersion,
 	}
 	response, err := c.Setup(t).Autoscaling().HorizontalPodAutoscalers(ns).Update(horizontalPodAutoscaler)
 	defer c.Close()
@@ -137,9 +143,10 @@ func TestHorizontalPodAutoscalerUpdateStatus(t *testing.T) {
 		},
 	}
 	c := &simple.Client{
-		Request:       simple.Request{Method: "PUT", Path: testapi.Autoscaling.ResourcePath(getHorizontalPodAutoscalersResoureName(), ns, "abc") + "/status", Query: simple.BuildQueryValues(nil)},
+		Request:       simple.Request{Method: "PUT", Path: testapi.Autoscaling.ResourcePath(getHorizontalPodAutoscalersResoure(), ns, "abc") + "/status", Query: simple.BuildQueryValues(nil)},
 		Response:      simple.Response{StatusCode: 200, Body: horizontalPodAutoscaler},
 		ResourceGroup: autoscaling.GroupName,
+		GroupVersion:  &v1.SchemeGroupVersion,
 	}
 	response, err := c.Setup(t).Autoscaling().HorizontalPodAutoscalers(ns).UpdateStatus(horizontalPodAutoscaler)
 	defer c.Close()
@@ -149,9 +156,10 @@ func TestHorizontalPodAutoscalerUpdateStatus(t *testing.T) {
 func TestHorizontalPodAutoscalerDelete(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request:       simple.Request{Method: "DELETE", Path: testapi.Autoscaling.ResourcePath(getHorizontalPodAutoscalersResoureName(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Request:       simple.Request{Method: "DELETE", Path: testapi.Autoscaling.ResourcePath(getHorizontalPodAutoscalersResoure(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
 		Response:      simple.Response{StatusCode: 200},
 		ResourceGroup: autoscaling.GroupName,
+		GroupVersion:  &v1.SchemeGroupVersion,
 	}
 	err := c.Setup(t).Autoscaling().HorizontalPodAutoscalers(ns).Delete("foo", nil)
 	defer c.Close()
@@ -162,10 +170,11 @@ func TestHorizontalPodAutoscalerWatch(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Autoscaling.ResourcePathWithPrefix("watch", getHorizontalPodAutoscalersResoureName(), "", ""),
+			Path:   testapi.Autoscaling.ResourcePathWithPrefix("watch", getHorizontalPodAutoscalersResoure(), "", ""),
 			Query:  url.Values{"resourceVersion": []string{}}},
 		Response:      simple.Response{StatusCode: 200},
 		ResourceGroup: autoscaling.GroupName,
+		GroupVersion:  &v1.SchemeGroupVersion,
 	}
 	_, err := c.Setup(t).Autoscaling().HorizontalPodAutoscalers(api.NamespaceAll).Watch(api.ListOptions{})
 	defer c.Close()

--- a/pkg/client/unversioned/ingress_test.go
+++ b/pkg/client/unversioned/ingress_test.go
@@ -21,12 +21,14 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient/simple"
 )
 
-func getIngressResourceName() string {
-	return "ingresses"
+func getIngressResource() unversioned.GroupVersionResource {
+	return v1beta1.SchemeGroupVersion.WithResource("ingresses")
 }
 
 func TestListIngress(t *testing.T) {
@@ -34,7 +36,7 @@ func TestListIngress(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Extensions.ResourcePath(getIngressResourceName(), ns, ""),
+			Path:   testapi.Extensions.ResourcePath(getIngressResource(), ns, ""),
 		},
 		Response: simple.Response{StatusCode: 200,
 			Body: &extensions.IngressList{
@@ -54,6 +56,7 @@ func TestListIngress(t *testing.T) {
 				},
 			},
 		},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	receivedIngressList, err := c.Setup(t).Extensions().Ingress(ns).List(api.ListOptions{})
 	defer c.Close()
@@ -65,7 +68,7 @@ func TestGetIngress(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Extensions.ResourcePath(getIngressResourceName(), ns, "foo"),
+			Path:   testapi.Extensions.ResourcePath(getIngressResource(), ns, "foo"),
 			Query:  simple.BuildQueryValues(nil),
 		},
 		Response: simple.Response{
@@ -83,6 +86,7 @@ func TestGetIngress(t *testing.T) {
 				},
 			},
 		},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	receivedIngress, err := c.Setup(t).Extensions().Ingress(ns).Get("foo")
 	defer c.Close()
@@ -113,7 +117,7 @@ func TestUpdateIngress(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "PUT",
-			Path:   testapi.Extensions.ResourcePath(getIngressResourceName(), ns, "foo"),
+			Path:   testapi.Extensions.ResourcePath(getIngressResource(), ns, "foo"),
 			Query:  simple.BuildQueryValues(nil),
 		},
 		Response: simple.Response{
@@ -131,6 +135,7 @@ func TestUpdateIngress(t *testing.T) {
 				},
 			},
 		},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	receivedIngress, err := c.Setup(t).Extensions().Ingress(ns).Update(requestIngress)
 	defer c.Close()
@@ -157,7 +162,7 @@ func TestUpdateIngressStatus(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "PUT",
-			Path:   testapi.Extensions.ResourcePath(getIngressResourceName(), ns, "foo") + "/status",
+			Path:   testapi.Extensions.ResourcePath(getIngressResource(), ns, "foo") + "/status",
 			Query:  simple.BuildQueryValues(nil),
 		},
 		Response: simple.Response{
@@ -178,6 +183,7 @@ func TestUpdateIngressStatus(t *testing.T) {
 				},
 			},
 		},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	receivedIngress, err := c.Setup(t).Extensions().Ingress(ns).UpdateStatus(requestIngress)
 	defer c.Close()
@@ -189,7 +195,7 @@ func TestDeleteIngress(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "DELETE",
-			Path:   testapi.Extensions.ResourcePath(getIngressResourceName(), ns, "foo"),
+			Path:   testapi.Extensions.ResourcePath(getIngressResource(), ns, "foo"),
 			Query:  simple.BuildQueryValues(nil),
 		},
 		Response: simple.Response{StatusCode: 200},
@@ -210,7 +216,7 @@ func TestCreateIngress(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "POST",
-			Path:   testapi.Extensions.ResourcePath(getIngressResourceName(), ns, ""),
+			Path:   testapi.Extensions.ResourcePath(getIngressResource(), ns, ""),
 			Body:   requestIngress,
 			Query:  simple.BuildQueryValues(nil),
 		},
@@ -229,6 +235,7 @@ func TestCreateIngress(t *testing.T) {
 				},
 			},
 		},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	receivedIngress, err := c.Setup(t).Extensions().Ingress(ns).Create(requestIngress)
 	defer c.Close()

--- a/pkg/client/unversioned/limit_ranges_test.go
+++ b/pkg/client/unversioned/limit_ranges_test.go
@@ -23,11 +23,13 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient/simple"
 )
 
-func getLimitRangesResourceName() string {
-	return "limitranges"
+func getLimitRangesResource() unversioned.GroupVersionResource {
+	return v1.SchemeGroupVersion.WithResource("limitranges")
 }
 
 func TestLimitRangeCreate(t *testing.T) {
@@ -55,11 +57,12 @@ func TestLimitRangeCreate(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "POST",
-			Path:   testapi.Default.ResourcePath(getLimitRangesResourceName(), ns, ""),
+			Path:   testapi.Default.ResourcePath(getLimitRangesResource(), ns, ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   limitRange,
 		},
-		Response: simple.Response{StatusCode: 200, Body: limitRange},
+		Response:     simple.Response{StatusCode: 200, Body: limitRange},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 
 	response, err := c.Setup(t).LimitRanges(ns).Create(limitRange)
@@ -92,11 +95,12 @@ func TestLimitRangeGet(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath(getLimitRangesResourceName(), ns, "abc"),
+			Path:   testapi.Default.ResourcePath(getLimitRangesResource(), ns, "abc"),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
-		Response: simple.Response{StatusCode: 200, Body: limitRange},
+		Response:     simple.Response{StatusCode: 200, Body: limitRange},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 
 	response, err := c.Setup(t).LimitRanges(ns).Get("abc")
@@ -117,11 +121,12 @@ func TestLimitRangeList(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath(getLimitRangesResourceName(), ns, ""),
+			Path:   testapi.Default.ResourcePath(getLimitRangesResource(), ns, ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
-		Response: simple.Response{StatusCode: 200, Body: limitRangeList},
+		Response:     simple.Response{StatusCode: 200, Body: limitRangeList},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	response, err := c.Setup(t).LimitRanges(ns).List(api.ListOptions{})
 	defer c.Close()
@@ -152,8 +157,9 @@ func TestLimitRangeUpdate(t *testing.T) {
 		},
 	}
 	c := &simple.Client{
-		Request:  simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(getLimitRangesResourceName(), ns, "abc"), Query: simple.BuildQueryValues(nil)},
-		Response: simple.Response{StatusCode: 200, Body: limitRange},
+		Request:      simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(getLimitRangesResource(), ns, "abc"), Query: simple.BuildQueryValues(nil)},
+		Response:     simple.Response{StatusCode: 200, Body: limitRange},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	response, err := c.Setup(t).LimitRanges(ns).Update(limitRange)
 	defer c.Close()
@@ -163,8 +169,9 @@ func TestLimitRangeUpdate(t *testing.T) {
 func TestLimitRangeDelete(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request:  simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath(getLimitRangesResourceName(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
-		Response: simple.Response{StatusCode: 200},
+		Request:      simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath(getLimitRangesResource(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Response:     simple.Response{StatusCode: 200},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	err := c.Setup(t).LimitRanges(ns).Delete("foo")
 	defer c.Close()
@@ -175,7 +182,7 @@ func TestLimitRangeWatch(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePathWithPrefix("watch", getLimitRangesResourceName(), "", ""),
+			Path:   testapi.Default.ResourcePathWithPrefix("watch", getLimitRangesResource(), "", ""),
 			Query:  url.Values{"resourceVersion": []string{}}},
 		Response: simple.Response{StatusCode: 200},
 	}

--- a/pkg/client/unversioned/namespaces_test.go
+++ b/pkg/client/unversioned/namespaces_test.go
@@ -22,8 +22,14 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient/simple"
 )
+
+func getNamespaceResource() unversioned.GroupVersionResource {
+	return v1.SchemeGroupVersion.WithResource("namespaces")
+}
 
 func TestNamespaceCreate(t *testing.T) {
 	// we create a namespace relative to another namespace
@@ -33,10 +39,11 @@ func TestNamespaceCreate(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "POST",
-			Path:   testapi.Default.ResourcePath("namespaces", "", ""),
+			Path:   testapi.Default.ResourcePath(getNamespaceResource(), "", ""),
 			Body:   namespace,
 		},
-		Response: simple.Response{StatusCode: 200, Body: namespace},
+		Response:     simple.Response{StatusCode: 200, Body: namespace},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 
 	// from the source ns, provision a new global namespace "foo"
@@ -59,10 +66,11 @@ func TestNamespaceGet(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath("namespaces", "", "foo"),
+			Path:   testapi.Default.ResourcePath(getNamespaceResource(), "", "foo"),
 			Body:   nil,
 		},
-		Response: simple.Response{StatusCode: 200, Body: namespace},
+		Response:     simple.Response{StatusCode: 200, Body: namespace},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 
 	response, err := c.Setup(t).Namespaces().Get("foo")
@@ -88,10 +96,11 @@ func TestNamespaceList(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath("namespaces", "", ""),
+			Path:   testapi.Default.ResourcePath(getNamespaceResource(), "", ""),
 			Body:   nil,
 		},
-		Response: simple.Response{StatusCode: 200, Body: namespaceList},
+		Response:     simple.Response{StatusCode: 200, Body: namespaceList},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	response, err := c.Setup(t).Namespaces().List(api.ListOptions{})
 	defer c.Close()
@@ -127,8 +136,9 @@ func TestNamespaceUpdate(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "PUT",
-			Path:   testapi.Default.ResourcePath("namespaces", "", "foo")},
-		Response: simple.Response{StatusCode: 200, Body: requestNamespace},
+			Path:   testapi.Default.ResourcePath(getNamespaceResource(), "", "foo")},
+		Response:     simple.Response{StatusCode: 200, Body: requestNamespace},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	receivedNamespace, err := c.Setup(t).Namespaces().Update(requestNamespace)
 	defer c.Close()
@@ -152,9 +162,10 @@ func TestNamespaceFinalize(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "PUT",
-			Path:   testapi.Default.ResourcePath("namespaces", "", "foo") + "/finalize",
+			Path:   testapi.Default.ResourcePath(getNamespaceResource(), "", "foo") + "/finalize",
 		},
-		Response: simple.Response{StatusCode: 200, Body: requestNamespace},
+		Response:     simple.Response{StatusCode: 200, Body: requestNamespace},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	receivedNamespace, err := c.Setup(t).Namespaces().Finalize(requestNamespace)
 	defer c.Close()
@@ -163,8 +174,9 @@ func TestNamespaceFinalize(t *testing.T) {
 
 func TestNamespaceDelete(t *testing.T) {
 	c := &simple.Client{
-		Request:  simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath("namespaces", "", "foo")},
-		Response: simple.Response{StatusCode: 200},
+		Request:      simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath(getNamespaceResource(), "", "foo")},
+		Response:     simple.Response{StatusCode: 200},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	err := c.Setup(t).Namespaces().Delete("foo")
 	defer c.Close()
@@ -175,9 +187,10 @@ func TestNamespaceWatch(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePathWithPrefix("watch", "namespaces", "", ""),
+			Path:   testapi.Default.ResourcePathWithPrefix("watch", getNamespaceResource(), "", ""),
 			Query:  url.Values{"resourceVersion": []string{}}},
-		Response: simple.Response{StatusCode: 200},
+		Response:     simple.Response{StatusCode: 200},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	_, err := c.Setup(t).Namespaces().Watch(api.ListOptions{})
 	defer c.Close()

--- a/pkg/client/unversioned/nodes_test.go
+++ b/pkg/client/unversioned/nodes_test.go
@@ -24,21 +24,23 @@ import (
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient/simple"
 	"k8s.io/kubernetes/pkg/labels"
 )
 
-func getNodesResourceName() string {
-	return "nodes"
+func getNodesResource() unversioned.GroupVersionResource {
+	return v1.SchemeGroupVersion.WithResource("nodes")
 }
 
 func TestListNodes(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath(getNodesResourceName(), "", ""),
+			Path:   testapi.Default.ResourcePath(getNodesResource(), "", ""),
 		},
-		Response: simple.Response{StatusCode: 200, Body: &api.NodeList{ListMeta: unversioned.ListMeta{ResourceVersion: "1"}}},
+		Response:     simple.Response{StatusCode: 200, Body: &api.NodeList{ListMeta: unversioned.ListMeta{ResourceVersion: "1"}}},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	response, err := c.Setup(t).Nodes().List(api.ListOptions{})
 	defer c.Close()
@@ -50,7 +52,7 @@ func TestListNodesLabels(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath(getNodesResourceName(), "", ""),
+			Path:   testapi.Default.ResourcePath(getNodesResource(), "", ""),
 			Query:  simple.BuildQueryValues(url.Values{labelSelectorQueryParamName: []string{"foo=bar,name=baz"}})},
 		Response: simple.Response{
 			StatusCode: 200,
@@ -67,6 +69,7 @@ func TestListNodesLabels(t *testing.T) {
 				},
 			},
 		},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	c.Setup(t)
 	defer c.Close()
@@ -81,9 +84,10 @@ func TestGetNode(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath(getNodesResourceName(), "", "1"),
+			Path:   testapi.Default.ResourcePath(getNodesResource(), "", "1"),
 		},
-		Response: simple.Response{StatusCode: 200, Body: &api.Node{ObjectMeta: api.ObjectMeta{Name: "node-1"}}},
+		Response:     simple.Response{StatusCode: 200, Body: &api.Node{ObjectMeta: api.ObjectMeta{Name: "node-1"}}},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	response, err := c.Setup(t).Nodes().Get("1")
 	defer c.Close()
@@ -119,12 +123,13 @@ func TestCreateNode(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "POST",
-			Path:   testapi.Default.ResourcePath(getNodesResourceName(), "", ""),
+			Path:   testapi.Default.ResourcePath(getNodesResource(), "", ""),
 			Body:   requestNode},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body:       requestNode,
 		},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	receivedNode, err := c.Setup(t).Nodes().Create(requestNode)
 	defer c.Close()
@@ -135,9 +140,10 @@ func TestDeleteNode(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "DELETE",
-			Path:   testapi.Default.ResourcePath(getNodesResourceName(), "", "foo"),
+			Path:   testapi.Default.ResourcePath(getNodesResource(), "", "foo"),
 		},
-		Response: simple.Response{StatusCode: 200},
+		Response:     simple.Response{StatusCode: 200},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	err := c.Setup(t).Nodes().Delete("foo")
 	defer c.Close()
@@ -163,9 +169,10 @@ func TestUpdateNode(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "PUT",
-			Path:   testapi.Default.ResourcePath(getNodesResourceName(), "", "foo"),
+			Path:   testapi.Default.ResourcePath(getNodesResource(), "", "foo"),
 		},
-		Response: simple.Response{StatusCode: 200, Body: requestNode},
+		Response:     simple.Response{StatusCode: 200, Body: requestNode},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	response, err := c.Setup(t).Nodes().Update(requestNode)
 	defer c.Close()

--- a/pkg/client/unversioned/persistentvolume_test.go
+++ b/pkg/client/unversioned/persistentvolume_test.go
@@ -23,11 +23,13 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient/simple"
 )
 
-func getPersistentVolumesResoureName() string {
-	return "persistentvolumes"
+func getPersistentVolumesResoure() unversioned.GroupVersionResource {
+	return v1.SchemeGroupVersion.WithResource("persistentvolumes")
 }
 
 func TestPersistentVolumeCreate(t *testing.T) {
@@ -48,11 +50,12 @@ func TestPersistentVolumeCreate(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "POST",
-			Path:   testapi.Default.ResourcePath(getPersistentVolumesResoureName(), "", ""),
+			Path:   testapi.Default.ResourcePath(getPersistentVolumesResoure(), "", ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   pv,
 		},
-		Response: simple.Response{StatusCode: 200, Body: pv},
+		Response:     simple.Response{StatusCode: 200, Body: pv},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 
 	response, err := c.Setup(t).PersistentVolumes().Create(pv)
@@ -78,11 +81,12 @@ func TestPersistentVolumeGet(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath(getPersistentVolumesResoureName(), "", "abc"),
+			Path:   testapi.Default.ResourcePath(getPersistentVolumesResoure(), "", "abc"),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
-		Response: simple.Response{StatusCode: 200, Body: persistentVolume},
+		Response:     simple.Response{StatusCode: 200, Body: persistentVolume},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 
 	response, err := c.Setup(t).PersistentVolumes().Get("abc")
@@ -101,11 +105,12 @@ func TestPersistentVolumeList(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath(getPersistentVolumesResoureName(), "", ""),
+			Path:   testapi.Default.ResourcePath(getPersistentVolumesResoure(), "", ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
-		Response: simple.Response{StatusCode: 200, Body: persistentVolumeList},
+		Response:     simple.Response{StatusCode: 200, Body: persistentVolumeList},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	response, err := c.Setup(t).PersistentVolumes().List(api.ListOptions{})
 	defer c.Close()
@@ -128,8 +133,9 @@ func TestPersistentVolumeUpdate(t *testing.T) {
 		},
 	}
 	c := &simple.Client{
-		Request:  simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(getPersistentVolumesResoureName(), "", "abc"), Query: simple.BuildQueryValues(nil)},
-		Response: simple.Response{StatusCode: 200, Body: persistentVolume},
+		Request:      simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(getPersistentVolumesResoure(), "", "abc"), Query: simple.BuildQueryValues(nil)},
+		Response:     simple.Response{StatusCode: 200, Body: persistentVolume},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	response, err := c.Setup(t).PersistentVolumes().Update(persistentVolume)
 	defer c.Close()
@@ -158,9 +164,10 @@ func TestPersistentVolumeStatusUpdate(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "PUT",
-			Path:   testapi.Default.ResourcePath(getPersistentVolumesResoureName(), "", "abc") + "/status",
+			Path:   testapi.Default.ResourcePath(getPersistentVolumesResoure(), "", "abc") + "/status",
 			Query:  simple.BuildQueryValues(nil)},
-		Response: simple.Response{StatusCode: 200, Body: persistentVolume},
+		Response:     simple.Response{StatusCode: 200, Body: persistentVolume},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	response, err := c.Setup(t).PersistentVolumes().UpdateStatus(persistentVolume)
 	defer c.Close()
@@ -169,8 +176,9 @@ func TestPersistentVolumeStatusUpdate(t *testing.T) {
 
 func TestPersistentVolumeDelete(t *testing.T) {
 	c := &simple.Client{
-		Request:  simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath(getPersistentVolumesResoureName(), "", "foo"), Query: simple.BuildQueryValues(nil)},
-		Response: simple.Response{StatusCode: 200},
+		Request:      simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath(getPersistentVolumesResoure(), "", "foo"), Query: simple.BuildQueryValues(nil)},
+		Response:     simple.Response{StatusCode: 200},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	err := c.Setup(t).PersistentVolumes().Delete("foo")
 	defer c.Close()
@@ -181,9 +189,10 @@ func TestPersistentVolumeWatch(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePathWithPrefix("watch", getPersistentVolumesResoureName(), "", ""),
+			Path:   testapi.Default.ResourcePathWithPrefix("watch", getPersistentVolumesResoure(), "", ""),
 			Query:  url.Values{"resourceVersion": []string{}}},
-		Response: simple.Response{StatusCode: 200},
+		Response:     simple.Response{StatusCode: 200},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	_, err := c.Setup(t).PersistentVolumes().Watch(api.ListOptions{})
 	defer c.Close()

--- a/pkg/client/unversioned/persistentvolumeclaim_test.go
+++ b/pkg/client/unversioned/persistentvolumeclaim_test.go
@@ -23,11 +23,13 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient/simple"
 )
 
-func getPersistentVolumeClaimsResoureName() string {
-	return "persistentvolumeclaims"
+func getPersistentVolumeClaimsResoure() unversioned.GroupVersionResource {
+	return v1.SchemeGroupVersion.WithResource("persistentvolumeclaims")
 }
 
 func TestPersistentVolumeClaimCreate(t *testing.T) {
@@ -52,11 +54,12 @@ func TestPersistentVolumeClaimCreate(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "POST",
-			Path:   testapi.Default.ResourcePath(getPersistentVolumeClaimsResoureName(), ns, ""),
+			Path:   testapi.Default.ResourcePath(getPersistentVolumeClaimsResoure(), ns, ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   pv,
 		},
-		Response: simple.Response{StatusCode: 200, Body: pv},
+		Response:     simple.Response{StatusCode: 200, Body: pv},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 
 	response, err := c.Setup(t).PersistentVolumeClaims(ns).Create(pv)
@@ -86,11 +89,12 @@ func TestPersistentVolumeClaimGet(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath(getPersistentVolumeClaimsResoureName(), ns, "abc"),
+			Path:   testapi.Default.ResourcePath(getPersistentVolumeClaimsResoure(), ns, "abc"),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
-		Response: simple.Response{StatusCode: 200, Body: persistentVolumeClaim},
+		Response:     simple.Response{StatusCode: 200, Body: persistentVolumeClaim},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 
 	response, err := c.Setup(t).PersistentVolumeClaims(ns).Get("abc")
@@ -110,11 +114,12 @@ func TestPersistentVolumeClaimList(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath(getPersistentVolumeClaimsResoureName(), ns, ""),
+			Path:   testapi.Default.ResourcePath(getPersistentVolumeClaimsResoure(), ns, ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
-		Response: simple.Response{StatusCode: 200, Body: persistentVolumeList},
+		Response:     simple.Response{StatusCode: 200, Body: persistentVolumeList},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	response, err := c.Setup(t).PersistentVolumeClaims(ns).List(api.ListOptions{})
 	defer c.Close()
@@ -141,8 +146,9 @@ func TestPersistentVolumeClaimUpdate(t *testing.T) {
 		},
 	}
 	c := &simple.Client{
-		Request:  simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(getPersistentVolumeClaimsResoureName(), ns, "abc"), Query: simple.BuildQueryValues(nil)},
-		Response: simple.Response{StatusCode: 200, Body: persistentVolumeClaim},
+		Request:      simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(getPersistentVolumeClaimsResoure(), ns, "abc"), Query: simple.BuildQueryValues(nil)},
+		Response:     simple.Response{StatusCode: 200, Body: persistentVolumeClaim},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	response, err := c.Setup(t).PersistentVolumeClaims(ns).Update(persistentVolumeClaim)
 	defer c.Close()
@@ -174,9 +180,10 @@ func TestPersistentVolumeClaimStatusUpdate(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "PUT",
-			Path:   testapi.Default.ResourcePath(getPersistentVolumeClaimsResoureName(), ns, "abc") + "/status",
+			Path:   testapi.Default.ResourcePath(getPersistentVolumeClaimsResoure(), ns, "abc") + "/status",
 			Query:  simple.BuildQueryValues(nil)},
-		Response: simple.Response{StatusCode: 200, Body: persistentVolumeClaim},
+		Response:     simple.Response{StatusCode: 200, Body: persistentVolumeClaim},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	response, err := c.Setup(t).PersistentVolumeClaims(ns).UpdateStatus(persistentVolumeClaim)
 	defer c.Close()
@@ -186,8 +193,9 @@ func TestPersistentVolumeClaimStatusUpdate(t *testing.T) {
 func TestPersistentVolumeClaimDelete(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request:  simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath(getPersistentVolumeClaimsResoureName(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
-		Response: simple.Response{StatusCode: 200},
+		Request:      simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath(getPersistentVolumeClaimsResoure(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Response:     simple.Response{StatusCode: 200},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	err := c.Setup(t).PersistentVolumeClaims(ns).Delete("foo")
 	defer c.Close()
@@ -198,9 +206,10 @@ func TestPersistentVolumeClaimWatch(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePathWithPrefix("watch", getPersistentVolumeClaimsResoureName(), "", ""),
+			Path:   testapi.Default.ResourcePathWithPrefix("watch", getPersistentVolumeClaimsResoure(), "", ""),
 			Query:  url.Values{"resourceVersion": []string{}}},
-		Response: simple.Response{StatusCode: 200},
+		Response:     simple.Response{StatusCode: 200},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	_, err := c.Setup(t).PersistentVolumeClaims(api.NamespaceAll).Watch(api.ListOptions{})
 	defer c.Close()

--- a/pkg/client/unversioned/pet_sets_test.go
+++ b/pkg/client/unversioned/pet_sets_test.go
@@ -21,12 +21,14 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/apis/apps"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient/simple"
 )
 
-func getPetSetResourceName() string {
-	return "petsets"
+func getPetSetResource() unversioned.GroupVersionResource {
+	return v1.SchemeGroupVersion.WithResource("petsets")
 }
 
 func TestListPetSets(t *testing.T) {
@@ -34,7 +36,7 @@ func TestListPetSets(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Apps.ResourcePath(getPetSetResourceName(), ns, ""),
+			Path:   testapi.Apps.ResourcePath(getPetSetResource(), ns, ""),
 		},
 		Response: simple.Response{StatusCode: 200,
 			Body: &apps.PetSetList{
@@ -55,6 +57,7 @@ func TestListPetSets(t *testing.T) {
 				},
 			},
 		},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	receivedRSList, err := c.Setup(t).Apps().PetSets(ns).List(api.ListOptions{})
 	c.Validate(t, receivedRSList, err)
@@ -63,7 +66,7 @@ func TestListPetSets(t *testing.T) {
 func TestGetPetSet(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request: simple.Request{Method: "GET", Path: testapi.Apps.ResourcePath(getPetSetResourceName(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "GET", Path: testapi.Apps.ResourcePath(getPetSetResource(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body: &apps.PetSet{
@@ -80,6 +83,7 @@ func TestGetPetSet(t *testing.T) {
 				},
 			},
 		},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	receivedRS, err := c.Setup(t).Apps().PetSets(ns).Get("foo")
 	c.Validate(t, receivedRS, err)
@@ -102,7 +106,7 @@ func TestUpdatePetSet(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "1"},
 	}
 	c := &simple.Client{
-		Request: simple.Request{Method: "PUT", Path: testapi.Apps.ResourcePath(getPetSetResourceName(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "PUT", Path: testapi.Apps.ResourcePath(getPetSetResource(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body: &apps.PetSet{
@@ -119,6 +123,7 @@ func TestUpdatePetSet(t *testing.T) {
 				},
 			},
 		},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	receivedRS, err := c.Setup(t).Apps().PetSets(ns).Update(requestRS)
 	c.Validate(t, receivedRS, err)
@@ -127,8 +132,9 @@ func TestUpdatePetSet(t *testing.T) {
 func TestDeletePetSet(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request:  simple.Request{Method: "DELETE", Path: testapi.Apps.ResourcePath(getPetSetResourceName(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
-		Response: simple.Response{StatusCode: 200},
+		Request:      simple.Request{Method: "DELETE", Path: testapi.Apps.ResourcePath(getPetSetResource(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Response:     simple.Response{StatusCode: 200},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	err := c.Setup(t).Apps().PetSets(ns).Delete("foo", nil)
 	c.Validate(t, nil, err)
@@ -140,7 +146,7 @@ func TestCreatePetSet(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "foo"},
 	}
 	c := &simple.Client{
-		Request: simple.Request{Method: "POST", Path: testapi.Apps.ResourcePath(getPetSetResourceName(), ns, ""), Body: requestRS, Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "POST", Path: testapi.Apps.ResourcePath(getPetSetResource(), ns, ""), Body: requestRS, Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body: &apps.PetSet{
@@ -157,6 +163,7 @@ func TestCreatePetSet(t *testing.T) {
 				},
 			},
 		},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	receivedRS, err := c.Setup(t).Apps().PetSets(ns).Create(requestRS)
 	c.Validate(t, receivedRS, err)

--- a/pkg/client/unversioned/pod_templates_test.go
+++ b/pkg/client/unversioned/pod_templates_test.go
@@ -22,11 +22,13 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient/simple"
 )
 
-func getPodTemplatesResoureName() string {
-	return "podtemplates"
+func getPodTemplatesResoure() unversioned.GroupVersionResource {
+	return v1.SchemeGroupVersion.WithResource("podtemplates")
 }
 
 func TestPodTemplateCreate(t *testing.T) {
@@ -41,11 +43,12 @@ func TestPodTemplateCreate(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "POST",
-			Path:   testapi.Default.ResourcePath(getPodTemplatesResoureName(), ns, ""),
+			Path:   testapi.Default.ResourcePath(getPodTemplatesResoure(), ns, ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   &podTemplate,
 		},
-		Response: simple.Response{StatusCode: 200, Body: &podTemplate},
+		Response:     simple.Response{StatusCode: 200, Body: &podTemplate},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 
 	response, err := c.Setup(t).PodTemplates(ns).Create(&podTemplate)
@@ -65,11 +68,12 @@ func TestPodTemplateGet(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath(getPodTemplatesResoureName(), ns, "abc"),
+			Path:   testapi.Default.ResourcePath(getPodTemplatesResoure(), ns, "abc"),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
-		Response: simple.Response{StatusCode: 200, Body: podTemplate},
+		Response:     simple.Response{StatusCode: 200, Body: podTemplate},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 
 	response, err := c.Setup(t).PodTemplates(ns).Get("abc")
@@ -92,11 +96,12 @@ func TestPodTemplateList(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath(getPodTemplatesResoureName(), ns, ""),
+			Path:   testapi.Default.ResourcePath(getPodTemplatesResoure(), ns, ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
-		Response: simple.Response{StatusCode: 200, Body: podTemplateList},
+		Response:     simple.Response{StatusCode: 200, Body: podTemplateList},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	response, err := c.Setup(t).PodTemplates(ns).List(api.ListOptions{})
 	defer c.Close()
@@ -114,8 +119,9 @@ func TestPodTemplateUpdate(t *testing.T) {
 		Template: api.PodTemplateSpec{},
 	}
 	c := &simple.Client{
-		Request:  simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(getPodTemplatesResoureName(), ns, "abc"), Query: simple.BuildQueryValues(nil)},
-		Response: simple.Response{StatusCode: 200, Body: podTemplate},
+		Request:      simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(getPodTemplatesResoure(), ns, "abc"), Query: simple.BuildQueryValues(nil)},
+		Response:     simple.Response{StatusCode: 200, Body: podTemplate},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	response, err := c.Setup(t).PodTemplates(ns).Update(podTemplate)
 	defer c.Close()
@@ -125,8 +131,9 @@ func TestPodTemplateUpdate(t *testing.T) {
 func TestPodTemplateDelete(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request:  simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath(getPodTemplatesResoureName(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
-		Response: simple.Response{StatusCode: 200},
+		Request:      simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath(getPodTemplatesResoure(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Response:     simple.Response{StatusCode: 200},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	err := c.Setup(t).PodTemplates(ns).Delete("foo", nil)
 	defer c.Close()
@@ -137,9 +144,10 @@ func TestPodTemplateWatch(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePathWithPrefix("watch", getPodTemplatesResoureName(), "", ""),
+			Path:   testapi.Default.ResourcePathWithPrefix("watch", getPodTemplatesResoure(), "", ""),
 			Query:  url.Values{"resourceVersion": []string{}}},
-		Response: simple.Response{StatusCode: 200},
+		Response:     simple.Response{StatusCode: 200},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	_, err := c.Setup(t).PodTemplates(api.NamespaceAll).Watch(api.ListOptions{})
 	defer c.Close()

--- a/pkg/client/unversioned/podsecuritypolicy_test.go
+++ b/pkg/client/unversioned/podsecuritypolicy_test.go
@@ -17,15 +17,20 @@ limitations under the License.
 package unversioned_test
 
 import (
-	"fmt"
 	"net/url"
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient/simple"
 )
+
+func getPSPResource() unversioned.GroupVersionResource {
+	return v1beta1.SchemeGroupVersion.WithResource("podsecuritypolicies")
+}
 
 func TestPodSecurityPolicyCreate(t *testing.T) {
 	ns := api.NamespaceNone
@@ -38,11 +43,12 @@ func TestPodSecurityPolicyCreate(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "POST",
-			Path:   testapi.Extensions.ResourcePath(getPSPResourcename(), ns, ""),
+			Path:   testapi.Extensions.ResourcePath(getPSPResource(), ns, ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   psp,
 		},
-		Response: simple.Response{StatusCode: 200, Body: psp},
+		Response:     simple.Response{StatusCode: 200, Body: psp},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 
 	response, err := c.Setup(t).PodSecurityPolicies().Create(psp)
@@ -59,11 +65,12 @@ func TestPodSecurityPolicyGet(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Extensions.ResourcePath(getPSPResourcename(), ns, "abc"),
+			Path:   testapi.Extensions.ResourcePath(getPSPResource(), ns, "abc"),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
-		Response: simple.Response{StatusCode: 200, Body: psp},
+		Response:     simple.Response{StatusCode: 200, Body: psp},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 
 	response, err := c.Setup(t).PodSecurityPolicies().Get("abc")
@@ -84,11 +91,12 @@ func TestPodSecurityPolicyList(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Extensions.ResourcePath(getPSPResourcename(), ns, ""),
+			Path:   testapi.Extensions.ResourcePath(getPSPResource(), ns, ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
-		Response: simple.Response{StatusCode: 200, Body: pspList},
+		Response:     simple.Response{StatusCode: 200, Body: pspList},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	response, err := c.Setup(t).PodSecurityPolicies().List(api.ListOptions{})
 	c.Validate(t, response, err)
@@ -103,8 +111,9 @@ func TestPodSecurityPolicyUpdate(t *testing.T) {
 		},
 	}
 	c := &simple.Client{
-		Request:  simple.Request{Method: "PUT", Path: testapi.Extensions.ResourcePath(getPSPResourcename(), ns, "abc"), Query: simple.BuildQueryValues(nil)},
-		Response: simple.Response{StatusCode: 200, Body: psp},
+		Request:      simple.Request{Method: "PUT", Path: testapi.Extensions.ResourcePath(getPSPResource(), ns, "abc"), Query: simple.BuildQueryValues(nil)},
+		Response:     simple.Response{StatusCode: 200, Body: psp},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	response, err := c.Setup(t).PodSecurityPolicies().Update(psp)
 	c.Validate(t, response, err)
@@ -113,8 +122,9 @@ func TestPodSecurityPolicyUpdate(t *testing.T) {
 func TestPodSecurityPolicyDelete(t *testing.T) {
 	ns := api.NamespaceNone
 	c := &simple.Client{
-		Request:  simple.Request{Method: "DELETE", Path: testapi.Extensions.ResourcePath(getPSPResourcename(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
-		Response: simple.Response{StatusCode: 200},
+		Request:      simple.Request{Method: "DELETE", Path: testapi.Extensions.ResourcePath(getPSPResource(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Response:     simple.Response{StatusCode: 200},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	err := c.Setup(t).PodSecurityPolicies().Delete("foo")
 	c.Validate(t, nil, err)
@@ -124,14 +134,11 @@ func TestPodSecurityPolicyWatch(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   fmt.Sprintf("%s/watch/%s", testapi.Extensions.ResourcePath("", "", ""), getPSPResourcename()),
+			Path:   testapi.Extensions.ResourcePathWithPrefix("watch", getPSPResource(), "", ""),
 			Query:  url.Values{"resourceVersion": []string{}}},
-		Response: simple.Response{StatusCode: 200},
+		Response:     simple.Response{StatusCode: 200},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	_, err := c.Setup(t).PodSecurityPolicies().Watch(api.ListOptions{})
 	c.Validate(t, nil, err)
-}
-
-func getPSPResourcename() string {
-	return "podsecuritypolicies"
 }

--- a/pkg/client/unversioned/replica_sets_test.go
+++ b/pkg/client/unversioned/replica_sets_test.go
@@ -21,12 +21,14 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient/simple"
 )
 
-func getReplicaSetResourceName() string {
-	return "replicasets"
+func getReplicaSetResource() unversioned.GroupVersionResource {
+	return v1beta1.SchemeGroupVersion.WithResource("replicasets")
 }
 
 func TestListReplicaSets(t *testing.T) {
@@ -34,7 +36,7 @@ func TestListReplicaSets(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Extensions.ResourcePath(getReplicaSetResourceName(), ns, ""),
+			Path:   testapi.Extensions.ResourcePath(getReplicaSetResource(), ns, ""),
 		},
 		Response: simple.Response{StatusCode: 200,
 			Body: &extensions.ReplicaSetList{
@@ -55,6 +57,7 @@ func TestListReplicaSets(t *testing.T) {
 				},
 			},
 		},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	receivedRSList, err := c.Setup(t).Extensions().ReplicaSets(ns).List(api.ListOptions{})
 	c.Validate(t, receivedRSList, err)
@@ -63,7 +66,7 @@ func TestListReplicaSets(t *testing.T) {
 func TestGetReplicaSet(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request: simple.Request{Method: "GET", Path: testapi.Extensions.ResourcePath(getReplicaSetResourceName(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "GET", Path: testapi.Extensions.ResourcePath(getReplicaSetResource(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body: &extensions.ReplicaSet{
@@ -80,6 +83,7 @@ func TestGetReplicaSet(t *testing.T) {
 				},
 			},
 		},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	receivedRS, err := c.Setup(t).Extensions().ReplicaSets(ns).Get("foo")
 	c.Validate(t, receivedRS, err)
@@ -102,7 +106,7 @@ func TestUpdateReplicaSet(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "1"},
 	}
 	c := &simple.Client{
-		Request: simple.Request{Method: "PUT", Path: testapi.Extensions.ResourcePath(getReplicaSetResourceName(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "PUT", Path: testapi.Extensions.ResourcePath(getReplicaSetResource(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body: &extensions.ReplicaSet{
@@ -119,6 +123,7 @@ func TestUpdateReplicaSet(t *testing.T) {
 				},
 			},
 		},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	receivedRS, err := c.Setup(t).Extensions().ReplicaSets(ns).Update(requestRS)
 	c.Validate(t, receivedRS, err)
@@ -130,7 +135,7 @@ func TestUpdateStatusReplicaSet(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "1"},
 	}
 	c := &simple.Client{
-		Request: simple.Request{Method: "PUT", Path: testapi.Extensions.ResourcePath(getReplicaSetResourceName(), ns, "foo") + "/status", Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "PUT", Path: testapi.Extensions.ResourcePath(getReplicaSetResource(), ns, "foo") + "/status", Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body: &extensions.ReplicaSet{
@@ -150,6 +155,7 @@ func TestUpdateStatusReplicaSet(t *testing.T) {
 				},
 			},
 		},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	receivedRS, err := c.Setup(t).Extensions().ReplicaSets(ns).UpdateStatus(requestRS)
 	c.Validate(t, receivedRS, err)
@@ -157,8 +163,9 @@ func TestUpdateStatusReplicaSet(t *testing.T) {
 func TestDeleteReplicaSet(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request:  simple.Request{Method: "DELETE", Path: testapi.Extensions.ResourcePath(getReplicaSetResourceName(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
-		Response: simple.Response{StatusCode: 200},
+		Request:      simple.Request{Method: "DELETE", Path: testapi.Extensions.ResourcePath(getReplicaSetResource(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Response:     simple.Response{StatusCode: 200},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	err := c.Setup(t).Extensions().ReplicaSets(ns).Delete("foo", nil)
 	c.Validate(t, nil, err)
@@ -170,7 +177,7 @@ func TestCreateReplicaSet(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "foo"},
 	}
 	c := &simple.Client{
-		Request: simple.Request{Method: "POST", Path: testapi.Extensions.ResourcePath(getReplicaSetResourceName(), ns, ""), Body: requestRS, Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "POST", Path: testapi.Extensions.ResourcePath(getReplicaSetResource(), ns, ""), Body: requestRS, Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body: &extensions.ReplicaSet{
@@ -187,6 +194,7 @@ func TestCreateReplicaSet(t *testing.T) {
 				},
 			},
 		},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	receivedRS, err := c.Setup(t).Extensions().ReplicaSets(ns).Create(requestRS)
 	c.Validate(t, receivedRS, err)

--- a/pkg/client/unversioned/replication_controllers_test.go
+++ b/pkg/client/unversioned/replication_controllers_test.go
@@ -21,11 +21,13 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient/simple"
 )
 
-func getRCResourceName() string {
-	return "replicationcontrollers"
+func getRCResource() unversioned.GroupVersionResource {
+	return v1.SchemeGroupVersion.WithResource("replicationcontrollers")
 }
 
 func TestListControllers(t *testing.T) {
@@ -33,7 +35,7 @@ func TestListControllers(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath(getRCResourceName(), ns, ""),
+			Path:   testapi.Default.ResourcePath(getRCResource(), ns, ""),
 		},
 		Response: simple.Response{StatusCode: 200,
 			Body: &api.ReplicationControllerList{
@@ -54,6 +56,7 @@ func TestListControllers(t *testing.T) {
 				},
 			},
 		},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	receivedControllerList, err := c.Setup(t).ReplicationControllers(ns).List(api.ListOptions{})
 	defer c.Close()
@@ -64,7 +67,7 @@ func TestListControllers(t *testing.T) {
 func TestGetController(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request: simple.Request{Method: "GET", Path: testapi.Default.ResourcePath(getRCResourceName(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "GET", Path: testapi.Default.ResourcePath(getRCResource(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body: &api.ReplicationController{
@@ -81,6 +84,7 @@ func TestGetController(t *testing.T) {
 				},
 			},
 		},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	receivedController, err := c.Setup(t).ReplicationControllers(ns).Get("foo")
 	defer c.Close()
@@ -105,7 +109,7 @@ func TestUpdateController(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "1"},
 	}
 	c := &simple.Client{
-		Request: simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(getRCResourceName(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(getRCResource(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body: &api.ReplicationController{
@@ -122,6 +126,7 @@ func TestUpdateController(t *testing.T) {
 				},
 			},
 		},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	receivedController, err := c.Setup(t).ReplicationControllers(ns).Update(requestController)
 	defer c.Close()
@@ -134,7 +139,7 @@ func TestUpdateStatusController(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "1"},
 	}
 	c := &simple.Client{
-		Request: simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(getRCResourceName(), ns, "foo") + "/status", Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(getRCResource(), ns, "foo") + "/status", Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body: &api.ReplicationController{
@@ -154,6 +159,7 @@ func TestUpdateStatusController(t *testing.T) {
 				},
 			},
 		},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	receivedController, err := c.Setup(t).ReplicationControllers(ns).UpdateStatus(requestController)
 	defer c.Close()
@@ -162,8 +168,9 @@ func TestUpdateStatusController(t *testing.T) {
 func TestDeleteController(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request:  simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath(getRCResourceName(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
-		Response: simple.Response{StatusCode: 200},
+		Request:      simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath(getRCResource(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Response:     simple.Response{StatusCode: 200},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	err := c.Setup(t).ReplicationControllers(ns).Delete("foo")
 	defer c.Close()
@@ -176,7 +183,7 @@ func TestCreateController(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "foo"},
 	}
 	c := &simple.Client{
-		Request: simple.Request{Method: "POST", Path: testapi.Default.ResourcePath(getRCResourceName(), ns, ""), Body: requestController, Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "POST", Path: testapi.Default.ResourcePath(getRCResource(), ns, ""), Body: requestController, Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body: &api.ReplicationController{
@@ -193,6 +200,7 @@ func TestCreateController(t *testing.T) {
 				},
 			},
 		},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	receivedController, err := c.Setup(t).ReplicationControllers(ns).Create(requestController)
 	defer c.Close()

--- a/pkg/client/unversioned/resource_quotas_test.go
+++ b/pkg/client/unversioned/resource_quotas_test.go
@@ -23,11 +23,13 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient/simple"
 )
 
-func getResourceQuotasResoureName() string {
-	return "resourcequotas"
+func getResourceQuotasResoure() unversioned.GroupVersionResource {
+	return v1.SchemeGroupVersion.WithResource("resourcequotas")
 }
 
 func TestResourceQuotaCreate(t *testing.T) {
@@ -51,11 +53,12 @@ func TestResourceQuotaCreate(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "POST",
-			Path:   testapi.Default.ResourcePath(getResourceQuotasResoureName(), ns, ""),
+			Path:   testapi.Default.ResourcePath(getResourceQuotasResoure(), ns, ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   resourceQuota,
 		},
-		Response: simple.Response{StatusCode: 200, Body: resourceQuota},
+		Response:     simple.Response{StatusCode: 200, Body: resourceQuota},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 
 	response, err := c.Setup(t).ResourceQuotas(ns).Create(resourceQuota)
@@ -84,11 +87,12 @@ func TestResourceQuotaGet(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath(getResourceQuotasResoureName(), ns, "abc"),
+			Path:   testapi.Default.ResourcePath(getResourceQuotasResoure(), ns, "abc"),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
-		Response: simple.Response{StatusCode: 200, Body: resourceQuota},
+		Response:     simple.Response{StatusCode: 200, Body: resourceQuota},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 
 	response, err := c.Setup(t).ResourceQuotas(ns).Get("abc")
@@ -109,11 +113,12 @@ func TestResourceQuotaList(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath(getResourceQuotasResoureName(), ns, ""),
+			Path:   testapi.Default.ResourcePath(getResourceQuotasResoure(), ns, ""),
 			Query:  simple.BuildQueryValues(nil),
 			Body:   nil,
 		},
-		Response: simple.Response{StatusCode: 200, Body: resourceQuotaList},
+		Response:     simple.Response{StatusCode: 200, Body: resourceQuotaList},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	response, err := c.Setup(t).ResourceQuotas(ns).List(api.ListOptions{})
 	defer c.Close()
@@ -140,8 +145,9 @@ func TestResourceQuotaUpdate(t *testing.T) {
 		},
 	}
 	c := &simple.Client{
-		Request:  simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(getResourceQuotasResoureName(), ns, "abc"), Query: simple.BuildQueryValues(nil)},
-		Response: simple.Response{StatusCode: 200, Body: resourceQuota},
+		Request:      simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(getResourceQuotasResoure(), ns, "abc"), Query: simple.BuildQueryValues(nil)},
+		Response:     simple.Response{StatusCode: 200, Body: resourceQuota},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	response, err := c.Setup(t).ResourceQuotas(ns).Update(resourceQuota)
 	defer c.Close()
@@ -170,9 +176,10 @@ func TestResourceQuotaStatusUpdate(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "PUT",
-			Path:   testapi.Default.ResourcePath(getResourceQuotasResoureName(), ns, "abc") + "/status",
+			Path:   testapi.Default.ResourcePath(getResourceQuotasResoure(), ns, "abc") + "/status",
 			Query:  simple.BuildQueryValues(nil)},
-		Response: simple.Response{StatusCode: 200, Body: resourceQuota},
+		Response:     simple.Response{StatusCode: 200, Body: resourceQuota},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	response, err := c.Setup(t).ResourceQuotas(ns).UpdateStatus(resourceQuota)
 	defer c.Close()
@@ -182,8 +189,9 @@ func TestResourceQuotaStatusUpdate(t *testing.T) {
 func TestResourceQuotaDelete(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request:  simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath(getResourceQuotasResoureName(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
-		Response: simple.Response{StatusCode: 200},
+		Request:      simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath(getResourceQuotasResoure(), ns, "foo"), Query: simple.BuildQueryValues(nil)},
+		Response:     simple.Response{StatusCode: 200},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	err := c.Setup(t).ResourceQuotas(ns).Delete("foo")
 	defer c.Close()
@@ -194,9 +202,10 @@ func TestResourceQuotaWatch(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePathWithPrefix("watch", getResourceQuotasResoureName(), "", ""),
+			Path:   testapi.Default.ResourcePathWithPrefix("watch", getResourceQuotasResoure(), "", ""),
 			Query:  url.Values{"resourceVersion": []string{}}},
-		Response: simple.Response{StatusCode: 200},
+		Response:     simple.Response{StatusCode: 200},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	_, err := c.Setup(t).ResourceQuotas(api.NamespaceAll).Watch(api.ListOptions{})
 	defer c.Close()

--- a/pkg/client/unversioned/scheduledjobs.go
+++ b/pkg/client/unversioned/scheduledjobs.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/batch"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// ScheduledJobsNamespacer has methods to work with ScheduledJob resources in a namespace
+type ScheduledJobsNamespacer interface {
+	ScheduledJobs(namespace string) ScheduledJobInterface
+}
+
+// ScheduledJobInterface exposes methods to work on ScheduledJob resources.
+type ScheduledJobInterface interface {
+	List(opts api.ListOptions) (*batch.ScheduledJobList, error)
+	Get(name string) (*batch.ScheduledJob, error)
+	Create(scheduledJob *batch.ScheduledJob) (*batch.ScheduledJob, error)
+	Update(scheduledJob *batch.ScheduledJob) (*batch.ScheduledJob, error)
+	Delete(name string, options *api.DeleteOptions) error
+	Watch(opts api.ListOptions) (watch.Interface, error)
+	UpdateStatus(scheduledJob *batch.ScheduledJob) (*batch.ScheduledJob, error)
+}
+
+// scheduledJobs implements ScheduledJobsNamespacer interface
+type scheduledJobs struct {
+	r  *BatchClient
+	ns string
+}
+
+// newScheduledJobs returns a scheduledJobs
+func newScheduledJobs(c *BatchClient, namespace string) *scheduledJobs {
+	return &scheduledJobs{c, namespace}
+}
+
+// Ensure statically that scheduledJobs implements ScheduledJobInterface.
+var _ ScheduledJobInterface = &scheduledJobs{}
+
+// List returns a list of scheduled jobs that match the label and field selectors.
+func (c *scheduledJobs) List(opts api.ListOptions) (result *batch.ScheduledJobList, err error) {
+	result = &batch.ScheduledJobList{}
+	err = c.r.Get().Namespace(c.ns).Resource("scheduledJobs").VersionedParams(&opts, api.ParameterCodec).Do().Into(result)
+	return
+}
+
+// Get returns information about a particular scheduled job.
+func (c *scheduledJobs) Get(name string) (result *batch.ScheduledJob, err error) {
+	result = &batch.ScheduledJob{}
+	err = c.r.Get().Namespace(c.ns).Resource("scheduledJobs").Name(name).Do().Into(result)
+	return
+}
+
+// Create creates a new scheduled job.
+func (c *scheduledJobs) Create(job *batch.ScheduledJob) (result *batch.ScheduledJob, err error) {
+	result = &batch.ScheduledJob{}
+	err = c.r.Post().Namespace(c.ns).Resource("scheduledJobs").Body(job).Do().Into(result)
+	return
+}
+
+// Update updates an existing scheduled job.
+func (c *scheduledJobs) Update(job *batch.ScheduledJob) (result *batch.ScheduledJob, err error) {
+	result = &batch.ScheduledJob{}
+	err = c.r.Put().Namespace(c.ns).Resource("scheduledJobs").Name(job.Name).Body(job).Do().Into(result)
+	return
+}
+
+// Delete deletes a scheduled job, returns error if one occurs.
+func (c *scheduledJobs) Delete(name string, options *api.DeleteOptions) (err error) {
+	return c.r.Delete().Namespace(c.ns).Resource("scheduledJobs").Name(name).Body(options).Do().Error()
+}
+
+// Watch returns a watch.Interface that watches the requested scheduled jobs.
+func (c *scheduledJobs) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.r.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("scheduledJobs").
+		VersionedParams(&opts, api.ParameterCodec).
+		Watch()
+}
+
+// UpdateStatus takes the name of the scheduled job and the new status.  Returns the server's representation of the scheduled job, and an error, if it occurs.
+func (c *scheduledJobs) UpdateStatus(job *batch.ScheduledJob) (result *batch.ScheduledJob, err error) {
+	result = &batch.ScheduledJob{}
+	err = c.r.Put().Namespace(c.ns).Resource("scheduledJobs").Name(job.Name).SubResource("status").Body(job).Do().Into(result)
+	return
+}

--- a/pkg/client/unversioned/scheduledjobs_test.go
+++ b/pkg/client/unversioned/scheduledjobs_test.go
@@ -1,0 +1,278 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned_test
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apis/batch"
+	"k8s.io/kubernetes/pkg/apis/batch/v2alpha1"
+	"k8s.io/kubernetes/pkg/client/unversioned/testclient/simple"
+)
+
+func getScheduledJobsResource() unversioned.GroupVersionResource {
+	return v2alpha1.SchemeGroupVersion.WithResource("scheduledjobs")
+}
+
+func TestListScheduledJob(t *testing.T) {
+	if !testapi.Batch.IsEnabledVersion(&v2alpha1.SchemeGroupVersion) {
+		return
+	}
+
+	ns := api.NamespaceAll
+	c := &simple.Client{
+		Request: simple.Request{
+			Method: "GET",
+			Path:   testapi.Batch.ResourcePath(getScheduledJobsResource(), ns, ""),
+		},
+		Response: simple.Response{StatusCode: 200,
+			Body: &batch.ScheduledJobList{
+				Items: []batch.ScheduledJob{
+					{
+						ObjectMeta: api.ObjectMeta{
+							Name: "foo",
+							Labels: map[string]string{
+								"foo":  "bar",
+								"name": "baz",
+							},
+						},
+						Spec: batch.ScheduledJobSpec{
+							JobTemplate: batch.JobTemplateSpec{
+								Spec: batch.JobSpec{
+									Template: api.PodTemplateSpec{},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		ResourceGroup: batch.GroupName,
+		GroupVersion:  &v2alpha1.SchemeGroupVersion,
+	}
+	receivedScheduledJobList, err := c.Setup(t).Batch().ScheduledJobs(ns).List(api.ListOptions{})
+	defer c.Close()
+	c.Validate(t, receivedScheduledJobList, err)
+}
+
+func TestGetScheduledJob(t *testing.T) {
+	if !testapi.Batch.IsEnabledVersion(&v2alpha1.SchemeGroupVersion) {
+		return
+	}
+
+	ns := api.NamespaceDefault
+	c := &simple.Client{
+		Request: simple.Request{
+			Method: "GET",
+			Path:   testapi.Batch.ResourcePath(getScheduledJobsResource(), ns, "foo"),
+			Query:  simple.BuildQueryValues(nil),
+		},
+		Response: simple.Response{
+			StatusCode: 200,
+			Body: &batch.ScheduledJob{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Spec: batch.ScheduledJobSpec{
+					JobTemplate: batch.JobTemplateSpec{
+						Spec: batch.JobSpec{
+							Template: api.PodTemplateSpec{},
+						},
+					},
+				},
+			},
+		},
+		ResourceGroup: batch.GroupName,
+		GroupVersion:  &v2alpha1.SchemeGroupVersion,
+	}
+	receivedScheduledJob, err := c.Setup(t).Batch().ScheduledJobs(ns).Get("foo")
+	defer c.Close()
+	c.Validate(t, receivedScheduledJob, err)
+}
+
+func TestUpdateScheduledJob(t *testing.T) {
+	if !testapi.Batch.IsEnabledVersion(&v2alpha1.SchemeGroupVersion) {
+		return
+	}
+
+	ns := api.NamespaceDefault
+	requestScheduledJob := &batch.ScheduledJob{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "foo",
+			Namespace:       ns,
+			ResourceVersion: "1",
+		},
+	}
+	c := &simple.Client{
+		Request: simple.Request{
+			Method: "PUT",
+			Path:   testapi.Batch.ResourcePath(getScheduledJobsResource(), ns, "foo"),
+			Query:  simple.BuildQueryValues(nil),
+		},
+		Response: simple.Response{
+			StatusCode: 200,
+			Body: &batch.ScheduledJob{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Spec: batch.ScheduledJobSpec{
+					JobTemplate: batch.JobTemplateSpec{
+						Spec: batch.JobSpec{
+							Template: api.PodTemplateSpec{},
+						},
+					},
+				},
+			},
+		},
+		ResourceGroup: batch.GroupName,
+		GroupVersion:  &v2alpha1.SchemeGroupVersion,
+	}
+	receivedScheduledJob, err := c.Setup(t).Batch().ScheduledJobs(ns).Update(requestScheduledJob)
+	defer c.Close()
+	c.Validate(t, receivedScheduledJob, err)
+}
+
+func TestUpdateScheduledJobStatus(t *testing.T) {
+	if !testapi.Batch.IsEnabledVersion(&v2alpha1.SchemeGroupVersion) {
+		return
+	}
+
+	ns := api.NamespaceDefault
+	requestScheduledJob := &batch.ScheduledJob{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "foo",
+			Namespace:       ns,
+			ResourceVersion: "1",
+		},
+	}
+	c := &simple.Client{
+		Request: simple.Request{
+			Method: "PUT",
+			Path:   testapi.Batch.ResourcePath(getScheduledJobsResource(), ns, "foo") + "/status",
+			Query:  simple.BuildQueryValues(nil),
+		},
+		Response: simple.Response{
+			StatusCode: 200,
+			Body: &batch.ScheduledJob{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Spec: batch.ScheduledJobSpec{
+					ConcurrencyPolicy: batch.AllowConcurrent,
+					JobTemplate: batch.JobTemplateSpec{
+						Spec: batch.JobSpec{
+							Template: api.PodTemplateSpec{},
+						},
+					},
+				},
+				Status: batch.ScheduledJobStatus{
+					Active: []api.ObjectReference{{Name: "ref"}},
+				},
+			},
+		},
+		ResourceGroup: batch.GroupName,
+		GroupVersion:  &v2alpha1.SchemeGroupVersion,
+	}
+	receivedScheduledJob, err := c.Setup(t).Batch().ScheduledJobs(ns).UpdateStatus(requestScheduledJob)
+	defer c.Close()
+	c.Validate(t, receivedScheduledJob, err)
+}
+
+func TestDeleteScheduledJob(t *testing.T) {
+	if !testapi.Batch.IsEnabledVersion(&v2alpha1.SchemeGroupVersion) {
+		return
+	}
+
+	ns := api.NamespaceDefault
+	c := &simple.Client{
+		Request: simple.Request{
+			Method: "DELETE",
+			Path:   testapi.Batch.ResourcePath(getScheduledJobsResource(), ns, "foo"),
+			Query:  simple.BuildQueryValues(nil),
+		},
+		Response:      simple.Response{StatusCode: 200},
+		ResourceGroup: batch.GroupName,
+		GroupVersion:  &v2alpha1.SchemeGroupVersion,
+	}
+	err := c.Setup(t).Batch().ScheduledJobs(ns).Delete("foo", nil)
+	defer c.Close()
+	c.Validate(t, nil, err)
+}
+
+func TestCreateScheduledJob(t *testing.T) {
+	if !testapi.Batch.IsEnabledVersion(&v2alpha1.SchemeGroupVersion) {
+		return
+	}
+
+	ns := api.NamespaceDefault
+	requestScheduledJob := &batch.ScheduledJob{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "foo",
+			Namespace: ns,
+		},
+	}
+	c := &simple.Client{
+		Request: simple.Request{
+			Method: "POST",
+			Path:   testapi.Batch.ResourcePath(getScheduledJobsResource(), ns, ""),
+			Body:   requestScheduledJob,
+			Query:  simple.BuildQueryValues(nil),
+		},
+		Response: simple.Response{
+			StatusCode: 200,
+			Body: &batch.ScheduledJob{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Spec: batch.ScheduledJobSpec{
+					JobTemplate: batch.JobTemplateSpec{
+						Spec: batch.JobSpec{
+							Template: api.PodTemplateSpec{},
+						},
+					},
+				},
+			},
+		},
+		ResourceGroup: batch.GroupName,
+		GroupVersion:  &v2alpha1.SchemeGroupVersion,
+	}
+	receivedScheduledJob, err := c.Setup(t).Batch().ScheduledJobs(ns).Create(requestScheduledJob)
+	defer c.Close()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	c.Validate(t, receivedScheduledJob, err)
+}

--- a/pkg/client/unversioned/services_test.go
+++ b/pkg/client/unversioned/services_test.go
@@ -23,16 +23,21 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient/simple"
 	"k8s.io/kubernetes/pkg/labels"
 )
+
+func getServicesResource() unversioned.GroupVersionResource {
+	return v1.SchemeGroupVersion.WithResource("services")
+}
 
 func TestListServices(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath("services", ns, ""),
+			Path:   testapi.Default.ResourcePath(getServicesResource(), ns, ""),
 			Query:  simple.BuildQueryValues(nil)},
 		Response: simple.Response{StatusCode: 200,
 			Body: &api.ServiceList{
@@ -54,6 +59,7 @@ func TestListServices(t *testing.T) {
 				},
 			},
 		},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	receivedServiceList, err := c.Setup(t).Services(ns).List(api.ListOptions{})
 	defer c.Close()
@@ -67,7 +73,7 @@ func TestListServicesLabels(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath("services", ns, ""),
+			Path:   testapi.Default.ResourcePath(getServicesResource(), ns, ""),
 			Query:  simple.BuildQueryValues(url.Values{labelSelectorQueryParamName: []string{"foo=bar,name=baz"}})},
 		Response: simple.Response{StatusCode: 200,
 			Body: &api.ServiceList{
@@ -89,6 +95,7 @@ func TestListServicesLabels(t *testing.T) {
 				},
 			},
 		},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	c.Setup(t)
 	defer c.Close()
@@ -104,9 +111,10 @@ func TestGetService(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath("services", ns, "1"),
+			Path:   testapi.Default.ResourcePath(getServicesResource(), ns, "1"),
 			Query:  simple.BuildQueryValues(nil)},
-		Response: simple.Response{StatusCode: 200, Body: &api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1"}}},
+		Response:     simple.Response{StatusCode: 200, Body: &api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1"}}},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	response, err := c.Setup(t).Services(ns).Get("1")
 	defer c.Close()
@@ -130,10 +138,11 @@ func TestCreateService(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "POST",
-			Path:   testapi.Default.ResourcePath("services", ns, ""),
+			Path:   testapi.Default.ResourcePath(getServicesResource(), ns, ""),
 			Body:   &api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1"}},
 			Query:  simple.BuildQueryValues(nil)},
-		Response: simple.Response{StatusCode: 200, Body: &api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1"}}},
+		Response:     simple.Response{StatusCode: 200, Body: &api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1"}}},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	response, err := c.Setup(t).Services(ns).Create(&api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1"}})
 	defer c.Close()
@@ -144,8 +153,9 @@ func TestUpdateService(t *testing.T) {
 	ns := api.NamespaceDefault
 	svc := &api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1", ResourceVersion: "1"}}
 	c := &simple.Client{
-		Request:  simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath("services", ns, "service-1"), Body: svc, Query: simple.BuildQueryValues(nil)},
-		Response: simple.Response{StatusCode: 200, Body: svc},
+		Request:      simple.Request{Method: "PUT", Path: testapi.Default.ResourcePath(getServicesResource(), ns, "service-1"), Body: svc, Query: simple.BuildQueryValues(nil)},
+		Response:     simple.Response{StatusCode: 200, Body: svc},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	response, err := c.Setup(t).Services(ns).Update(svc)
 	defer c.Close()
@@ -155,8 +165,9 @@ func TestUpdateService(t *testing.T) {
 func TestDeleteService(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &simple.Client{
-		Request:  simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath("services", ns, "1"), Query: simple.BuildQueryValues(nil)},
-		Response: simple.Response{StatusCode: 200},
+		Request:      simple.Request{Method: "DELETE", Path: testapi.Default.ResourcePath(getServicesResource(), ns, "1"), Query: simple.BuildQueryValues(nil)},
+		Response:     simple.Response{StatusCode: 200},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	err := c.Setup(t).Services(ns).Delete("1")
 	defer c.Close()
@@ -183,7 +194,7 @@ func TestUpdateServiceStatus(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "PUT",
-			Path:   testapi.Default.ResourcePath("services", ns, "foo") + "/status",
+			Path:   testapi.Default.ResourcePath(getServicesResource(), ns, "foo") + "/status",
 			Query:  simple.BuildQueryValues(nil),
 		},
 		Response: simple.Response{
@@ -202,6 +213,7 @@ func TestUpdateServiceStatus(t *testing.T) {
 				},
 			},
 		},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	receivedService, err := c.Setup(t).Services(ns).UpdateStatus(requestService)
 	defer c.Close()
@@ -214,10 +226,11 @@ func TestServiceProxyGet(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath("services", ns, "service-1") + "/proxy/foo",
+			Path:   testapi.Default.ResourcePath(getServicesResource(), ns, "service-1") + "/proxy/foo",
 			Query:  simple.BuildQueryValues(url.Values{"param-name": []string{"param-value"}}),
 		},
-		Response: simple.Response{StatusCode: 200, RawBody: &body},
+		Response:     simple.Response{StatusCode: 200, RawBody: &body},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	response, err := c.Setup(t).Services(ns).ProxyGet("", "service-1", "", "foo", map[string]string{"param-name": "param-value"}).DoRaw()
 	defer c.Close()
@@ -227,10 +240,11 @@ func TestServiceProxyGet(t *testing.T) {
 	c = &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Default.ResourcePath("services", ns, "https:service-1:my-port") + "/proxy/foo",
+			Path:   testapi.Default.ResourcePath(getServicesResource(), ns, "https:service-1:my-port") + "/proxy/foo",
 			Query:  simple.BuildQueryValues(url.Values{"param-name": []string{"param-value"}}),
 		},
-		Response: simple.Response{StatusCode: 200, RawBody: &body},
+		Response:     simple.Response{StatusCode: 200, RawBody: &body},
+		GroupVersion: &v1.SchemeGroupVersion,
 	}
 	response, err = c.Setup(t).Services(ns).ProxyGet("https", "service-1", "my-port", "foo", map[string]string{"param-name": "param-value"}).DoRaw()
 	defer c.Close()

--- a/pkg/client/unversioned/testclient/fake_scheduledjobs.go
+++ b/pkg/client/unversioned/testclient/fake_scheduledjobs.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/batch"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeScheduledJobs implements ScheduledJobInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the methods you want to test easier.
+type FakeScheduledJobs struct {
+	Fake      *FakeBatch
+	Namespace string
+}
+
+func (c *FakeScheduledJobs) Get(name string) (*batch.ScheduledJob, error) {
+	obj, err := c.Fake.Invokes(NewGetAction("scheduledjobs", c.Namespace, name), &batch.ScheduledJob{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*batch.ScheduledJob), err
+}
+
+func (c *FakeScheduledJobs) List(opts api.ListOptions) (*batch.ScheduledJobList, error) {
+	obj, err := c.Fake.Invokes(NewListAction("scheduledjobs", c.Namespace, opts), &batch.ScheduledJobList{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*batch.ScheduledJobList), err
+}
+
+func (c *FakeScheduledJobs) Create(scheduledJob *batch.ScheduledJob) (*batch.ScheduledJob, error) {
+	obj, err := c.Fake.Invokes(NewCreateAction("scheduledjobs", c.Namespace, scheduledJob), scheduledJob)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*batch.ScheduledJob), err
+}
+
+func (c *FakeScheduledJobs) Update(scheduledJob *batch.ScheduledJob) (*batch.ScheduledJob, error) {
+	obj, err := c.Fake.Invokes(NewUpdateAction("scheduledjobs", c.Namespace, scheduledJob), scheduledJob)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*batch.ScheduledJob), err
+}
+
+func (c *FakeScheduledJobs) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.Invokes(NewDeleteAction("scheduledjobs", c.Namespace, name), &batch.ScheduledJob{})
+	return err
+}
+
+func (c *FakeScheduledJobs) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.Fake.InvokesWatch(NewWatchAction("scheduledjobs", c.Namespace, opts))
+}
+
+func (c *FakeScheduledJobs) UpdateStatus(scheduledJob *batch.ScheduledJob) (result *batch.ScheduledJob, err error) {
+	obj, err := c.Fake.Invokes(NewUpdateSubresourceAction("scheduledjobs", "status", c.Namespace, scheduledJob), scheduledJob)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*batch.ScheduledJob), err
+}

--- a/pkg/client/unversioned/testclient/testclient.go
+++ b/pkg/client/unversioned/testclient/testclient.go
@@ -341,6 +341,10 @@ func (c *FakeBatch) Jobs(namespace string) client.JobInterface {
 	return &FakeJobsV1{Fake: c, Namespace: namespace}
 }
 
+func (c *FakeBatch) ScheduledJobs(namespace string) client.ScheduledJobInterface {
+	return &FakeScheduledJobs{Fake: c, Namespace: namespace}
+}
+
 // NewSimpleFakeExp returns a client that will respond with the provided objects
 func NewSimpleFakeExp(objects ...runtime.Object) *FakeExperimental {
 	return &FakeExperimental{Fake: NewSimpleFake(objects...)}

--- a/pkg/client/unversioned/thirdpartyresources_test.go
+++ b/pkg/client/unversioned/thirdpartyresources_test.go
@@ -21,19 +21,21 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient/simple"
 )
 
-func getThirdPartyResourceName() string {
-	return "thirdpartyresources"
+func getThirdPartyResource() unversioned.GroupVersionResource {
+	return v1beta1.SchemeGroupVersion.WithResource("thirdpartyresources")
 }
 
 func TestListThirdPartyResources(t *testing.T) {
 	c := &simple.Client{
 		Request: simple.Request{
 			Method: "GET",
-			Path:   testapi.Extensions.ResourcePath(getThirdPartyResourceName(), "", ""),
+			Path:   testapi.Extensions.ResourcePath(getThirdPartyResource(), "", ""),
 		},
 		Response: simple.Response{StatusCode: 200,
 			Body: &extensions.ThirdPartyResourceList{
@@ -51,6 +53,7 @@ func TestListThirdPartyResources(t *testing.T) {
 				},
 			},
 		},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	receivedDSs, err := c.Setup(t).Extensions().ThirdPartyResources().List(api.ListOptions{})
 	defer c.Close()
@@ -60,7 +63,7 @@ func TestListThirdPartyResources(t *testing.T) {
 
 func TestGetThirdPartyResource(t *testing.T) {
 	c := &simple.Client{
-		Request: simple.Request{Method: "GET", Path: testapi.Extensions.ResourcePath(getThirdPartyResourceName(), "", "foo"), Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "GET", Path: testapi.Extensions.ResourcePath(getThirdPartyResource(), "", "foo"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body: &extensions.ThirdPartyResource{
@@ -74,6 +77,7 @@ func TestGetThirdPartyResource(t *testing.T) {
 				Description: "test third party resource",
 			},
 		},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	receivedThirdPartyResource, err := c.Setup(t).Extensions().ThirdPartyResources().Get("foo")
 	defer c.Close()
@@ -96,7 +100,7 @@ func TestUpdateThirdPartyResource(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "1"},
 	}
 	c := &simple.Client{
-		Request: simple.Request{Method: "PUT", Path: testapi.Extensions.ResourcePath(getThirdPartyResourceName(), "", "foo"), Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "PUT", Path: testapi.Extensions.ResourcePath(getThirdPartyResource(), "", "foo"), Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body: &extensions.ThirdPartyResource{
@@ -110,6 +114,7 @@ func TestUpdateThirdPartyResource(t *testing.T) {
 				Description: "test third party resource",
 			},
 		},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	receivedThirdPartyResource, err := c.Setup(t).Extensions().ThirdPartyResources().Update(requestThirdPartyResource)
 	defer c.Close()
@@ -121,7 +126,7 @@ func TestUpdateThirdPartyResourceUpdateStatus(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "1"},
 	}
 	c := &simple.Client{
-		Request: simple.Request{Method: "PUT", Path: testapi.Extensions.ResourcePath(getThirdPartyResourceName(), "", "foo") + "/status", Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "PUT", Path: testapi.Extensions.ResourcePath(getThirdPartyResource(), "", "foo") + "/status", Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body: &extensions.ThirdPartyResource{
@@ -135,6 +140,7 @@ func TestUpdateThirdPartyResourceUpdateStatus(t *testing.T) {
 				Description: "test third party resource",
 			},
 		},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	receivedThirdPartyResource, err := c.Setup(t).Extensions().ThirdPartyResources().UpdateStatus(requestThirdPartyResource)
 	defer c.Close()
@@ -143,8 +149,9 @@ func TestUpdateThirdPartyResourceUpdateStatus(t *testing.T) {
 
 func TestDeleteThirdPartyResource(t *testing.T) {
 	c := &simple.Client{
-		Request:  simple.Request{Method: "DELETE", Path: testapi.Extensions.ResourcePath(getThirdPartyResourceName(), "", "foo"), Query: simple.BuildQueryValues(nil)},
-		Response: simple.Response{StatusCode: 200},
+		Request:      simple.Request{Method: "DELETE", Path: testapi.Extensions.ResourcePath(getThirdPartyResource(), "", "foo"), Query: simple.BuildQueryValues(nil)},
+		Response:     simple.Response{StatusCode: 200},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	err := c.Setup(t).Extensions().ThirdPartyResources().Delete("foo")
 	defer c.Close()
@@ -156,7 +163,7 @@ func TestCreateThirdPartyResource(t *testing.T) {
 		ObjectMeta: api.ObjectMeta{Name: "foo"},
 	}
 	c := &simple.Client{
-		Request: simple.Request{Method: "POST", Path: testapi.Extensions.ResourcePath(getThirdPartyResourceName(), "", ""), Body: requestThirdPartyResource, Query: simple.BuildQueryValues(nil)},
+		Request: simple.Request{Method: "POST", Path: testapi.Extensions.ResourcePath(getThirdPartyResource(), "", ""), Body: requestThirdPartyResource, Query: simple.BuildQueryValues(nil)},
 		Response: simple.Response{
 			StatusCode: 200,
 			Body: &extensions.ThirdPartyResource{
@@ -170,6 +177,7 @@ func TestCreateThirdPartyResource(t *testing.T) {
 				Description: "test third party resource",
 			},
 		},
+		GroupVersion: &v1beta1.SchemeGroupVersion,
 	}
 	receivedThirdPartyResource, err := c.Setup(t).Extensions().ThirdPartyResources().Create(requestThirdPartyResource)
 	defer c.Close()

--- a/pkg/kubectl/scale_test.go
+++ b/pkg/kubectl/scale_test.go
@@ -249,7 +249,7 @@ func TestValidateReplicationController(t *testing.T) {
 }
 
 type ErrorJobs struct {
-	testclient.FakeJobs
+	testclient.FakeJobsV1
 	invalid bool
 }
 
@@ -270,16 +270,16 @@ func (c *ErrorJobs) Get(name string) (*batch.Job, error) {
 }
 
 type ErrorJobClient struct {
-	testclient.FakeExperimental
+	testclient.FakeBatch
 	invalid bool
 }
 
 func (c *ErrorJobClient) Jobs(namespace string) client.JobInterface {
-	return &ErrorJobs{testclient.FakeJobs{Fake: &c.FakeExperimental, Namespace: namespace}, c.invalid}
+	return &ErrorJobs{testclient.FakeJobsV1{Fake: &c.FakeBatch, Namespace: namespace}, c.invalid}
 }
 
 func TestJobScaleRetry(t *testing.T) {
-	fake := &ErrorJobClient{FakeExperimental: testclient.FakeExperimental{}, invalid: false}
+	fake := &ErrorJobClient{FakeBatch: testclient.FakeBatch{}, invalid: false}
 	scaler := JobScaler{fake}
 	preconditions := ScalePrecondition{-1, ""}
 	count := uint(3)
@@ -303,7 +303,7 @@ func TestJobScaleRetry(t *testing.T) {
 }
 
 func TestJobScale(t *testing.T) {
-	fake := &testclient.FakeExperimental{Fake: &testclient.Fake{}}
+	fake := &testclient.FakeBatch{Fake: &testclient.Fake{}}
 	scaler := JobScaler{fake}
 	preconditions := ScalePrecondition{-1, ""}
 	count := uint(3)
@@ -323,7 +323,7 @@ func TestJobScale(t *testing.T) {
 }
 
 func TestJobScaleInvalid(t *testing.T) {
-	fake := &ErrorJobClient{FakeExperimental: testclient.FakeExperimental{}, invalid: true}
+	fake := &ErrorJobClient{FakeBatch: testclient.FakeBatch{}, invalid: true}
 	scaler := JobScaler{fake}
 	preconditions := ScalePrecondition{-1, ""}
 	count := uint(3)
@@ -348,7 +348,7 @@ func TestJobScaleFailsPreconditions(t *testing.T) {
 			Parallelism: &ten,
 		},
 	})
-	scaler := JobScaler{&testclient.FakeExperimental{Fake: fake}}
+	scaler := JobScaler{&testclient.FakeBatch{Fake: fake}}
 	preconditions := ScalePrecondition{2, ""}
 	count := uint(3)
 	name := "foo"

--- a/vendor/github.com/robfig/cron/.gitignore
+++ b/vendor/github.com/robfig/cron/.gitignore
@@ -1,0 +1,22 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe

--- a/vendor/github.com/robfig/cron/.travis.yml
+++ b/vendor/github.com/robfig/cron/.travis.yml
@@ -1,0 +1,1 @@
+language: go

--- a/vendor/github.com/robfig/cron/LICENSE
+++ b/vendor/github.com/robfig/cron/LICENSE
@@ -1,0 +1,21 @@
+Copyright (C) 2012 Rob Figueiredo
+All Rights Reserved.
+
+MIT LICENSE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/robfig/cron/README.md
+++ b/vendor/github.com/robfig/cron/README.md
@@ -1,0 +1,2 @@
+[![GoDoc](http://godoc.org/github.com/robfig/cron?status.png)](http://godoc.org/github.com/robfig/cron)
+[![Build Status](https://travis-ci.org/robfig/cron.svg?branch=master)](https://travis-ci.org/robfig/cron)

--- a/vendor/github.com/robfig/cron/constantdelay.go
+++ b/vendor/github.com/robfig/cron/constantdelay.go
@@ -1,0 +1,27 @@
+package cron
+
+import "time"
+
+// ConstantDelaySchedule represents a simple recurring duty cycle, e.g. "Every 5 minutes".
+// It does not support jobs more frequent than once a second.
+type ConstantDelaySchedule struct {
+	Delay time.Duration
+}
+
+// Every returns a crontab Schedule that activates once every duration.
+// Delays of less than a second are not supported (will round up to 1 second).
+// Any fields less than a Second are truncated.
+func Every(duration time.Duration) ConstantDelaySchedule {
+	if duration < time.Second {
+		duration = time.Second
+	}
+	return ConstantDelaySchedule{
+		Delay: duration - time.Duration(duration.Nanoseconds())%time.Second,
+	}
+}
+
+// Next returns the next time this should be run.
+// This rounds so that the next activation time will be on the second.
+func (schedule ConstantDelaySchedule) Next(t time.Time) time.Time {
+	return t.Add(schedule.Delay - time.Duration(t.Nanosecond())*time.Nanosecond)
+}

--- a/vendor/github.com/robfig/cron/cron.go
+++ b/vendor/github.com/robfig/cron/cron.go
@@ -1,0 +1,227 @@
+// This library implements a cron spec parser and runner.  See the README for
+// more details.
+package cron
+
+import (
+	"log"
+	"runtime"
+	"sort"
+	"time"
+)
+
+// Cron keeps track of any number of entries, invoking the associated func as
+// specified by the schedule. It may be started, stopped, and the entries may
+// be inspected while running.
+type Cron struct {
+	entries  []*Entry
+	stop     chan struct{}
+	add      chan *Entry
+	snapshot chan []*Entry
+	running  bool
+	ErrorLog *log.Logger
+}
+
+// Job is an interface for submitted cron jobs.
+type Job interface {
+	Run()
+}
+
+// The Schedule describes a job's duty cycle.
+type Schedule interface {
+	// Return the next activation time, later than the given time.
+	// Next is invoked initially, and then each time the job is run.
+	Next(time.Time) time.Time
+}
+
+// Entry consists of a schedule and the func to execute on that schedule.
+type Entry struct {
+	// The schedule on which this job should be run.
+	Schedule Schedule
+
+	// The next time the job will run. This is the zero time if Cron has not been
+	// started or this entry's schedule is unsatisfiable
+	Next time.Time
+
+	// The last time this job was run. This is the zero time if the job has never
+	// been run.
+	Prev time.Time
+
+	// The Job to run.
+	Job Job
+}
+
+// byTime is a wrapper for sorting the entry array by time
+// (with zero time at the end).
+type byTime []*Entry
+
+func (s byTime) Len() int      { return len(s) }
+func (s byTime) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s byTime) Less(i, j int) bool {
+	// Two zero times should return false.
+	// Otherwise, zero is "greater" than any other time.
+	// (To sort it at the end of the list.)
+	if s[i].Next.IsZero() {
+		return false
+	}
+	if s[j].Next.IsZero() {
+		return true
+	}
+	return s[i].Next.Before(s[j].Next)
+}
+
+// New returns a new Cron job runner.
+func New() *Cron {
+	return &Cron{
+		entries:  nil,
+		add:      make(chan *Entry),
+		stop:     make(chan struct{}),
+		snapshot: make(chan []*Entry),
+		running:  false,
+		ErrorLog: nil,
+	}
+}
+
+// A wrapper that turns a func() into a cron.Job
+type FuncJob func()
+
+func (f FuncJob) Run() { f() }
+
+// AddFunc adds a func to the Cron to be run on the given schedule.
+func (c *Cron) AddFunc(spec string, cmd func()) error {
+	return c.AddJob(spec, FuncJob(cmd))
+}
+
+// AddJob adds a Job to the Cron to be run on the given schedule.
+func (c *Cron) AddJob(spec string, cmd Job) error {
+	schedule, err := Parse(spec)
+	if err != nil {
+		return err
+	}
+	c.Schedule(schedule, cmd)
+	return nil
+}
+
+// Schedule adds a Job to the Cron to be run on the given schedule.
+func (c *Cron) Schedule(schedule Schedule, cmd Job) {
+	entry := &Entry{
+		Schedule: schedule,
+		Job:      cmd,
+	}
+	if !c.running {
+		c.entries = append(c.entries, entry)
+		return
+	}
+
+	c.add <- entry
+}
+
+// Entries returns a snapshot of the cron entries.
+func (c *Cron) Entries() []*Entry {
+	if c.running {
+		c.snapshot <- nil
+		x := <-c.snapshot
+		return x
+	}
+	return c.entrySnapshot()
+}
+
+// Start the cron scheduler in its own go-routine.
+func (c *Cron) Start() {
+	c.running = true
+	go c.run()
+}
+
+func (c *Cron) runWithRecovery(j Job) {
+	defer func() {
+		if r := recover(); r != nil {
+			const size = 64 << 10
+			buf := make([]byte, size)
+			buf = buf[:runtime.Stack(buf, false)]
+			c.logf("cron: panic running job: %v\n%s", r, buf)
+		}
+	}()
+	j.Run()
+}
+
+// Run the scheduler.. this is private just due to the need to synchronize
+// access to the 'running' state variable.
+func (c *Cron) run() {
+	// Figure out the next activation times for each entry.
+	now := time.Now().Local()
+	for _, entry := range c.entries {
+		entry.Next = entry.Schedule.Next(now)
+	}
+
+	for {
+		// Determine the next entry to run.
+		sort.Sort(byTime(c.entries))
+
+		var effective time.Time
+		if len(c.entries) == 0 || c.entries[0].Next.IsZero() {
+			// If there are no entries yet, just sleep - it still handles new entries
+			// and stop requests.
+			effective = now.AddDate(10, 0, 0)
+		} else {
+			effective = c.entries[0].Next
+		}
+
+		select {
+		case now = <-time.After(effective.Sub(now)):
+			// Run every entry whose next time was this effective time.
+			for _, e := range c.entries {
+				if e.Next != effective {
+					break
+				}
+				go c.runWithRecovery(e.Job)
+				e.Prev = e.Next
+				e.Next = e.Schedule.Next(effective)
+			}
+			continue
+
+		case newEntry := <-c.add:
+			c.entries = append(c.entries, newEntry)
+			newEntry.Next = newEntry.Schedule.Next(time.Now().Local())
+
+		case <-c.snapshot:
+			c.snapshot <- c.entrySnapshot()
+
+		case <-c.stop:
+			return
+		}
+
+		// 'now' should be updated after newEntry and snapshot cases.
+		now = time.Now().Local()
+	}
+}
+
+// Logs an error to stderr or to the configured error log
+func (c *Cron) logf(format string, args ...interface{}) {
+	if c.ErrorLog != nil {
+		c.ErrorLog.Printf(format, args...)
+	} else {
+		log.Printf(format, args...)
+	}
+}
+
+// Stop stops the cron scheduler if it is running; otherwise it does nothing.
+func (c *Cron) Stop() {
+	if !c.running {
+		return
+	}
+	c.stop <- struct{}{}
+	c.running = false
+}
+
+// entrySnapshot returns a copy of the current cron entry list.
+func (c *Cron) entrySnapshot() []*Entry {
+	entries := []*Entry{}
+	for _, e := range c.entries {
+		entries = append(entries, &Entry{
+			Schedule: e.Schedule,
+			Next:     e.Next,
+			Prev:     e.Prev,
+			Job:      e.Job,
+		})
+	}
+	return entries
+}

--- a/vendor/github.com/robfig/cron/doc.go
+++ b/vendor/github.com/robfig/cron/doc.go
@@ -1,0 +1,129 @@
+/*
+Package cron implements a cron spec parser and job runner.
+
+Usage
+
+Callers may register Funcs to be invoked on a given schedule.  Cron will run
+them in their own goroutines.
+
+	c := cron.New()
+	c.AddFunc("0 30 * * * *", func() { fmt.Println("Every hour on the half hour") })
+	c.AddFunc("@hourly",      func() { fmt.Println("Every hour") })
+	c.AddFunc("@every 1h30m", func() { fmt.Println("Every hour thirty") })
+	c.Start()
+	..
+	// Funcs are invoked in their own goroutine, asynchronously.
+	...
+	// Funcs may also be added to a running Cron
+	c.AddFunc("@daily", func() { fmt.Println("Every day") })
+	..
+	// Inspect the cron job entries' next and previous run times.
+	inspect(c.Entries())
+	..
+	c.Stop()  // Stop the scheduler (does not stop any jobs already running).
+
+CRON Expression Format
+
+A cron expression represents a set of times, using 6 space-separated fields.
+
+	Field name   | Mandatory? | Allowed values  | Allowed special characters
+	----------   | ---------- | --------------  | --------------------------
+	Seconds      | Yes        | 0-59            | * / , -
+	Minutes      | Yes        | 0-59            | * / , -
+	Hours        | Yes        | 0-23            | * / , -
+	Day of month | Yes        | 1-31            | * / , - ?
+	Month        | Yes        | 1-12 or JAN-DEC | * / , -
+	Day of week  | Yes        | 0-6 or SUN-SAT  | * / , - ?
+
+Note: Month and Day-of-week field values are case insensitive.  "SUN", "Sun",
+and "sun" are equally accepted.
+
+Special Characters
+
+Asterisk ( * )
+
+The asterisk indicates that the cron expression will match for all values of the
+field; e.g., using an asterisk in the 5th field (month) would indicate every
+month.
+
+Slash ( / )
+
+Slashes are used to describe increments of ranges. For example 3-59/15 in the
+1st field (minutes) would indicate the 3rd minute of the hour and every 15
+minutes thereafter. The form "*\/..." is equivalent to the form "first-last/...",
+that is, an increment over the largest possible range of the field.  The form
+"N/..." is accepted as meaning "N-MAX/...", that is, starting at N, use the
+increment until the end of that specific range.  It does not wrap around.
+
+Comma ( , )
+
+Commas are used to separate items of a list. For example, using "MON,WED,FRI" in
+the 5th field (day of week) would mean Mondays, Wednesdays and Fridays.
+
+Hyphen ( - )
+
+Hyphens are used to define ranges. For example, 9-17 would indicate every
+hour between 9am and 5pm inclusive.
+
+Question mark ( ? )
+
+Question mark may be used instead of '*' for leaving either day-of-month or
+day-of-week blank.
+
+Predefined schedules
+
+You may use one of several pre-defined schedules in place of a cron expression.
+
+	Entry                  | Description                                | Equivalent To
+	-----                  | -----------                                | -------------
+	@yearly (or @annually) | Run once a year, midnight, Jan. 1st        | 0 0 0 1 1 *
+	@monthly               | Run once a month, midnight, first of month | 0 0 0 1 * *
+	@weekly                | Run once a week, midnight on Sunday        | 0 0 0 * * 0
+	@daily (or @midnight)  | Run once a day, midnight                   | 0 0 0 * * *
+	@hourly                | Run once an hour, beginning of hour        | 0 0 * * * *
+
+Intervals
+
+You may also schedule a job to execute at fixed intervals.  This is supported by
+formatting the cron spec like this:
+
+    @every <duration>
+
+where "duration" is a string accepted by time.ParseDuration
+(http://golang.org/pkg/time/#ParseDuration).
+
+For example, "@every 1h30m10s" would indicate a schedule that activates every
+1 hour, 30 minutes, 10 seconds.
+
+Note: The interval does not take the job runtime into account.  For example,
+if a job takes 3 minutes to run, and it is scheduled to run every 5 minutes,
+it will have only 2 minutes of idle time between each run.
+
+Time zones
+
+All interpretation and scheduling is done in the machine's local time zone (as
+provided by the Go time package (http://www.golang.org/pkg/time).
+
+Be aware that jobs scheduled during daylight-savings leap-ahead transitions will
+not be run!
+
+Thread safety
+
+Since the Cron service runs concurrently with the calling code, some amount of
+care must be taken to ensure proper synchronization.
+
+All cron methods are designed to be correctly synchronized as long as the caller
+ensures that invocations have a clear happens-before ordering between them.
+
+Implementation
+
+Cron entries are stored in an array, sorted by their next activation time.  Cron
+sleeps until the next job is due to be run.
+
+Upon waking:
+ - it runs each entry that is active on that second
+ - it calculates the next run times for the jobs that were run
+ - it re-sorts the array of entries by next activation time.
+ - it goes to sleep until the soonest job.
+*/
+package cron

--- a/vendor/github.com/robfig/cron/parser.go
+++ b/vendor/github.com/robfig/cron/parser.go
@@ -1,0 +1,231 @@
+package cron
+
+import (
+	"fmt"
+	"log"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Parse returns a new crontab schedule representing the given spec.
+// It returns a descriptive error if the spec is not valid.
+//
+// It accepts
+//   - Full crontab specs, e.g. "* * * * * ?"
+//   - Descriptors, e.g. "@midnight", "@every 1h30m"
+func Parse(spec string) (_ Schedule, err error) {
+	// Convert panics into errors
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("%v", recovered)
+		}
+	}()
+
+	if spec[0] == '@' {
+		return parseDescriptor(spec), nil
+	}
+
+	// Split on whitespace.  We require 5 or 6 fields.
+	// (second) (minute) (hour) (day of month) (month) (day of week, optional)
+	fields := strings.Fields(spec)
+	if len(fields) != 5 && len(fields) != 6 {
+		log.Panicf("Expected 5 or 6 fields, found %d: %s", len(fields), spec)
+	}
+
+	// If a sixth field is not provided (DayOfWeek), then it is equivalent to star.
+	if len(fields) == 5 {
+		fields = append(fields, "*")
+	}
+
+	schedule := &SpecSchedule{
+		Second: getField(fields[0], seconds),
+		Minute: getField(fields[1], minutes),
+		Hour:   getField(fields[2], hours),
+		Dom:    getField(fields[3], dom),
+		Month:  getField(fields[4], months),
+		Dow:    getField(fields[5], dow),
+	}
+
+	return schedule, nil
+}
+
+// getField returns an Int with the bits set representing all of the times that
+// the field represents.  A "field" is a comma-separated list of "ranges".
+func getField(field string, r bounds) uint64 {
+	// list = range {"," range}
+	var bits uint64
+	ranges := strings.FieldsFunc(field, func(r rune) bool { return r == ',' })
+	for _, expr := range ranges {
+		bits |= getRange(expr, r)
+	}
+	return bits
+}
+
+// getRange returns the bits indicated by the given expression:
+//   number | number "-" number [ "/" number ]
+func getRange(expr string, r bounds) uint64 {
+
+	var (
+		start, end, step uint
+		rangeAndStep     = strings.Split(expr, "/")
+		lowAndHigh       = strings.Split(rangeAndStep[0], "-")
+		singleDigit      = len(lowAndHigh) == 1
+	)
+
+	var extra_star uint64
+	if lowAndHigh[0] == "*" || lowAndHigh[0] == "?" {
+		start = r.min
+		end = r.max
+		extra_star = starBit
+	} else {
+		start = parseIntOrName(lowAndHigh[0], r.names)
+		switch len(lowAndHigh) {
+		case 1:
+			end = start
+		case 2:
+			end = parseIntOrName(lowAndHigh[1], r.names)
+		default:
+			log.Panicf("Too many hyphens: %s", expr)
+		}
+	}
+
+	switch len(rangeAndStep) {
+	case 1:
+		step = 1
+	case 2:
+		step = mustParseInt(rangeAndStep[1])
+
+		// Special handling: "N/step" means "N-max/step".
+		if singleDigit {
+			end = r.max
+		}
+	default:
+		log.Panicf("Too many slashes: %s", expr)
+	}
+
+	if start < r.min {
+		log.Panicf("Beginning of range (%d) below minimum (%d): %s", start, r.min, expr)
+	}
+	if end > r.max {
+		log.Panicf("End of range (%d) above maximum (%d): %s", end, r.max, expr)
+	}
+	if start > end {
+		log.Panicf("Beginning of range (%d) beyond end of range (%d): %s", start, end, expr)
+	}
+
+	return getBits(start, end, step) | extra_star
+}
+
+// parseIntOrName returns the (possibly-named) integer contained in expr.
+func parseIntOrName(expr string, names map[string]uint) uint {
+	if names != nil {
+		if namedInt, ok := names[strings.ToLower(expr)]; ok {
+			return namedInt
+		}
+	}
+	return mustParseInt(expr)
+}
+
+// mustParseInt parses the given expression as an int or panics.
+func mustParseInt(expr string) uint {
+	num, err := strconv.Atoi(expr)
+	if err != nil {
+		log.Panicf("Failed to parse int from %s: %s", expr, err)
+	}
+	if num < 0 {
+		log.Panicf("Negative number (%d) not allowed: %s", num, expr)
+	}
+
+	return uint(num)
+}
+
+// getBits sets all bits in the range [min, max], modulo the given step size.
+func getBits(min, max, step uint) uint64 {
+	var bits uint64
+
+	// If step is 1, use shifts.
+	if step == 1 {
+		return ^(math.MaxUint64 << (max + 1)) & (math.MaxUint64 << min)
+	}
+
+	// Else, use a simple loop.
+	for i := min; i <= max; i += step {
+		bits |= 1 << i
+	}
+	return bits
+}
+
+// all returns all bits within the given bounds.  (plus the star bit)
+func all(r bounds) uint64 {
+	return getBits(r.min, r.max, 1) | starBit
+}
+
+// parseDescriptor returns a pre-defined schedule for the expression, or panics
+// if none matches.
+func parseDescriptor(spec string) Schedule {
+	switch spec {
+	case "@yearly", "@annually":
+		return &SpecSchedule{
+			Second: 1 << seconds.min,
+			Minute: 1 << minutes.min,
+			Hour:   1 << hours.min,
+			Dom:    1 << dom.min,
+			Month:  1 << months.min,
+			Dow:    all(dow),
+		}
+
+	case "@monthly":
+		return &SpecSchedule{
+			Second: 1 << seconds.min,
+			Minute: 1 << minutes.min,
+			Hour:   1 << hours.min,
+			Dom:    1 << dom.min,
+			Month:  all(months),
+			Dow:    all(dow),
+		}
+
+	case "@weekly":
+		return &SpecSchedule{
+			Second: 1 << seconds.min,
+			Minute: 1 << minutes.min,
+			Hour:   1 << hours.min,
+			Dom:    all(dom),
+			Month:  all(months),
+			Dow:    1 << dow.min,
+		}
+
+	case "@daily", "@midnight":
+		return &SpecSchedule{
+			Second: 1 << seconds.min,
+			Minute: 1 << minutes.min,
+			Hour:   1 << hours.min,
+			Dom:    all(dom),
+			Month:  all(months),
+			Dow:    all(dow),
+		}
+
+	case "@hourly":
+		return &SpecSchedule{
+			Second: 1 << seconds.min,
+			Minute: 1 << minutes.min,
+			Hour:   all(hours),
+			Dom:    all(dom),
+			Month:  all(months),
+			Dow:    all(dow),
+		}
+	}
+
+	const every = "@every "
+	if strings.HasPrefix(spec, every) {
+		duration, err := time.ParseDuration(spec[len(every):])
+		if err != nil {
+			log.Panicf("Failed to parse duration %s: %s", spec, err)
+		}
+		return Every(duration)
+	}
+
+	log.Panicf("Unrecognized descriptor: %s", spec)
+	return nil
+}

--- a/vendor/github.com/robfig/cron/spec.go
+++ b/vendor/github.com/robfig/cron/spec.go
@@ -1,0 +1,159 @@
+package cron
+
+import "time"
+
+// SpecSchedule specifies a duty cycle (to the second granularity), based on a
+// traditional crontab specification. It is computed initially and stored as bit sets.
+type SpecSchedule struct {
+	Second, Minute, Hour, Dom, Month, Dow uint64
+}
+
+// bounds provides a range of acceptable values (plus a map of name to value).
+type bounds struct {
+	min, max uint
+	names    map[string]uint
+}
+
+// The bounds for each field.
+var (
+	seconds = bounds{0, 59, nil}
+	minutes = bounds{0, 59, nil}
+	hours   = bounds{0, 23, nil}
+	dom     = bounds{1, 31, nil}
+	months  = bounds{1, 12, map[string]uint{
+		"jan": 1,
+		"feb": 2,
+		"mar": 3,
+		"apr": 4,
+		"may": 5,
+		"jun": 6,
+		"jul": 7,
+		"aug": 8,
+		"sep": 9,
+		"oct": 10,
+		"nov": 11,
+		"dec": 12,
+	}}
+	dow = bounds{0, 6, map[string]uint{
+		"sun": 0,
+		"mon": 1,
+		"tue": 2,
+		"wed": 3,
+		"thu": 4,
+		"fri": 5,
+		"sat": 6,
+	}}
+)
+
+const (
+	// Set the top bit if a star was included in the expression.
+	starBit = 1 << 63
+)
+
+// Next returns the next time this schedule is activated, greater than the given
+// time.  If no time can be found to satisfy the schedule, return the zero time.
+func (s *SpecSchedule) Next(t time.Time) time.Time {
+	// General approach:
+	// For Month, Day, Hour, Minute, Second:
+	// Check if the time value matches.  If yes, continue to the next field.
+	// If the field doesn't match the schedule, then increment the field until it matches.
+	// While incrementing the field, a wrap-around brings it back to the beginning
+	// of the field list (since it is necessary to re-verify previous field
+	// values)
+
+	// Start at the earliest possible time (the upcoming second).
+	t = t.Add(1*time.Second - time.Duration(t.Nanosecond())*time.Nanosecond)
+
+	// This flag indicates whether a field has been incremented.
+	added := false
+
+	// If no time is found within five years, return zero.
+	yearLimit := t.Year() + 5
+
+WRAP:
+	if t.Year() > yearLimit {
+		return time.Time{}
+	}
+
+	// Find the first applicable month.
+	// If it's this month, then do nothing.
+	for 1<<uint(t.Month())&s.Month == 0 {
+		// If we have to add a month, reset the other parts to 0.
+		if !added {
+			added = true
+			// Otherwise, set the date at the beginning (since the current time is irrelevant).
+			t = time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, t.Location())
+		}
+		t = t.AddDate(0, 1, 0)
+
+		// Wrapped around.
+		if t.Month() == time.January {
+			goto WRAP
+		}
+	}
+
+	// Now get a day in that month.
+	for !dayMatches(s, t) {
+		if !added {
+			added = true
+			t = time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+		}
+		t = t.AddDate(0, 0, 1)
+
+		if t.Day() == 1 {
+			goto WRAP
+		}
+	}
+
+	for 1<<uint(t.Hour())&s.Hour == 0 {
+		if !added {
+			added = true
+			t = t.Truncate(time.Hour)
+		}
+		t = t.Add(1 * time.Hour)
+
+		if t.Hour() == 0 {
+			goto WRAP
+		}
+	}
+
+	for 1<<uint(t.Minute())&s.Minute == 0 {
+		if !added {
+			added = true
+			t = t.Truncate(time.Minute)
+		}
+		t = t.Add(1 * time.Minute)
+
+		if t.Minute() == 0 {
+			goto WRAP
+		}
+	}
+
+	for 1<<uint(t.Second())&s.Second == 0 {
+		if !added {
+			added = true
+			t = t.Truncate(time.Second)
+		}
+		t = t.Add(1 * time.Second)
+
+		if t.Second() == 0 {
+			goto WRAP
+		}
+	}
+
+	return t
+}
+
+// dayMatches returns true if the schedule's day-of-week and day-of-month
+// restrictions are satisfied by the given time.
+func dayMatches(s *SpecSchedule, t time.Time) bool {
+	var (
+		domMatch bool = 1<<uint(t.Day())&s.Dom > 0
+		dowMatch bool = 1<<uint(t.Weekday())&s.Dow > 0
+	)
+
+	if s.Dom&starBit > 0 || s.Dow&starBit > 0 {
+		return domMatch && dowMatch
+	}
+	return domMatch || dowMatch
+}


### PR DESCRIPTION
@caesarxuchao this is a follow up to the discussion we've had while I was working on the `JobTemplate`, esp. the part about introducing `batch/v2alpha1` (#21675). I've split this from #25475 not to block progress on `ScheduledJobs`, so look only at the last commit. We need some sort of solution for the multi-version client testing and I'm willing to work on it but will need your help. 

In the aforementioned commit I've extended `simpletest_client.go`'s `Config with`GroupVersion`which allows you to specify which version you want to test. This required some additional changes in`testapi.go`to be able to specify which specific version we're testing. See`jobs_test.go`, since with those changes I was easily able to test all possible versions`Job` exists in.

I'm open to suggestions how to improve the code, this is just a dirty plumbing I did to make the test work, while mostly focusing on ScheduledJobs.

@erictune also mentioned there's a plan to get rid of manually writing those clients, in that case it might make sense just to ignore the problems for now and wait for the generated clients make their way. The only question is when will that happen?

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
