### PR TITLE
Fix updating pod condition in scheduler

### DIFF
--- a/pkg/api/resource_helpers.go
+++ b/pkg/api/resource_helpers.go
@@ -118,13 +118,16 @@ func UpdatePodCondition(status *PodStatus, condition *PodCondition) bool {
 		if condition.Status == oldCondition.Status {
 			condition.LastTransitionTime = oldCondition.LastTransitionTime
 		}
+
+		isEqual := condition.Status == oldCondition.Status &&
+			condition.Reason == oldCondition.Reason &&
+			condition.Message == oldCondition.Message &&
+			condition.LastProbeTime.Equal(oldCondition.LastProbeTime) &&
+			condition.LastTransitionTime.Equal(oldCondition.LastTransitionTime)
+
 		status.Conditions[conditionIndex] = *condition
 		// Return true if one of the fields have changed.
-		return condition.Status != oldCondition.Status ||
-			condition.Reason != oldCondition.Reason ||
-			condition.Message != oldCondition.Message ||
-			!condition.LastProbeTime.Equal(oldCondition.LastProbeTime) ||
-			!condition.LastTransitionTime.Equal(oldCondition.LastTransitionTime)
+		return !isEqual
 	}
 }
 


### PR DESCRIPTION
Previously we were never updating pod condition as we were copying new one to old one and they were obviously always identical.

Ref #24404

@mwielgus @piosz 

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
