### PR TITLE
hack/local-up-cluster.sh: Allow pre-existing etcd cluster, with optional TLS auth, allow kubelet overridable service IP range.

### DIFF
--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -18,6 +18,7 @@
 
 ETCD_VERSION=${ETCD_VERSION:-2.2.1}
 ETCD_HOST=${ETCD_HOST:-127.0.0.1}
+ETCD_PROTO=${ETCD_PROTO:-"http"}
 ETCD_PORT=${ETCD_PORT:-4001}
 
 kube::etcd::kubesec() {

--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -18,16 +18,39 @@ kube::util::sortable_date() {
   date "+%Y%m%d-%H%M%S"
 }
 
+kube::util::wait_for_cmd() {
+  local wait=$1
+  local times=$2
+  shift 2
+
+  local i
+  for i in $(seq 1 $times); do
+    local out
+    if out=$(eval "$* >/dev/null"); then
+      kube::log::status "On try ${i}, $*: ${out}"
+      return 0
+    fi
+    sleep ${wait}
+  done
+
+  kube::log::error "Timed out waiting for ${cmd}. Tried ${times} waiting ${wait} between each"
+  return 1
+}
+
+kube::util::fatal_check_path () {
+  which $1 >/dev/null || {
+    kube::log::usage "$1 must be installed"
+    exit 1
+  }
+}
+
 kube::util::wait_for_url() {
   local url=$1
   local prefix=${2:-}
   local wait=${3:-1}
   local times=${4:-30}
 
-  which curl >/dev/null || {
-    kube::log::usage "curl must be installed"
-    exit 1
-  }
+  kube::util::fatal_check_path curl
 
   local i
   for i in $(seq 1 $times); do

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -255,7 +255,6 @@ function set_service_accounts {
 }
 
 function start_apiserver {
-    echo "START API"
     # Admission Controllers to invoke prior to persisting objects in cluster
     if [[ -z "${ALLOW_SECURITY_CONTEXT}" ]]; then
       ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -38,8 +38,14 @@ DNS_REPLICAS=${KUBE_DNS_REPLICAS:-1}
 KUBECTL=${KUBECTL:-cluster/kubectl.sh}
 WAIT_FOR_URL_API_SERVER=${WAIT_FOR_URL_API_SERVER:-10}
 ENABLE_DAEMON=${ENABLE_DAEMON:-false}
+SERVICE_CLUSTER_IP_RANGE=${SERVICE_CLUSTER_IP_RANGE:-"10.0.0.0/24"}
 HOSTNAME_OVERRIDE=${HOSTNAME_OVERRIDE:-"127.0.0.1"}
 CLOUD_PROVIDER=${CLOUD_PROVIDER:-""}
+
+ETCD_PORT=${ETCD_PORT:-4001}
+ETCD_PROTO=${ETCD_PROTO:-"http"}
+
+cd "${KUBE_ROOT}"
 
 if [ "$(id -u)" != "0" ]; then
     echo "WARNING : This script MAY be run as root for docker socket / iptables functionality; if failures occur, retry as root." 2>&1
@@ -249,6 +255,7 @@ function set_service_accounts {
 }
 
 function start_apiserver {
+    echo "START API"
     # Admission Controllers to invoke prior to persisting objects in cluster
     if [[ -z "${ALLOW_SECURITY_CONTEXT}" ]]; then
       ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
@@ -276,9 +283,18 @@ function start_apiserver {
         advertise_address="--advertise_address=${API_HOST}"
     fi
 
+    client_ca_config=""
+    if [[ -f "${CLIENT_CA_PATH:-}" ]]; then
+      client_ca_config="--client-ca-file='${CLIENT_CA_PATH}'"
+    fi
+
     APISERVER_LOG=/tmp/kube-apiserver.log
-    sudo -E "${GO_OUT}/hyperkube" apiserver ${priv_arg} ${runtime_config}\
+    sudo -E "${GO_OUT}/hyperkube" apiserver \
+      ${priv_arg} \
+      ${runtime_config} \
       ${advertise_address} \
+      $(kube::etcd::kubesec) \
+      ${client_ca_config} \
       --v=${LOG_LEVEL} \
       --cert-dir="${CERT_DIR}" \
       --service-account-key-file="${SERVICE_ACCOUNT_KEY}" \
@@ -287,9 +303,10 @@ function start_apiserver {
       --bind-address="${API_BIND_ADDR}" \
       --insecure-bind-address="${API_HOST_IP}" \
       --insecure-port="${API_PORT}" \
-      --etcd-servers="http://${ETCD_HOST}:${ETCD_PORT}" \
       --service-cluster-ip-range="10.0.0.0/24" \
       --cloud-provider="${CLOUD_PROVIDER}" \
+      --etcd-servers="${ETCD_PROTO}://${ETCD_HOST}:${ETCD_PORT}" \
+      --service-cluster-ip-range="${SERVICE_CLUSTER_IP_RANGE}" \
       --cors-allowed-origins="${API_CORS_ALLOWED_ORIGINS}" >"${APISERVER_LOG}" 2>&1 &
     APISERVER_PID=$!
 
@@ -374,7 +391,7 @@ function start_kubelet {
         ${net_plugin_dir_args} \
         ${net_plugin_args} \
         ${kubenet_plugin_args} \
-        --port="$KUBELET_PORT" >"${KUBELET_LOG}" 2>&1 &
+        --port="$KUBELET_PORT" > "${KUBELET_LOG}" 2>&1 &
       KUBELET_PID=$!
     else
       # Docker won't run a container with a cidfile (container id file)
@@ -393,7 +410,7 @@ function start_kubelet {
         -i \
         --cidfile=$KUBELET_CIDFILE \
         gcr.io/google_containers/kubelet \
-        /kubelet --v=3 --containerized ${priv_arg}--chaos-chance="${CHAOS_CHANCE}" --hostname-override="${HOSTNAME_OVERRIDE}" --cloud-provider="${CLOUD_PROVIDER}" --address="127.0.0.1" --api-servers="${API_HOST}:${API_PORT}" --port="$KUBELET_PORT" --resource-container="" &> $KUBELET_LOG &
+        /kubelet --v=3 --containerized ${priv_arg}--chaos-chance="${CHAOS_CHANCE}" --hostname-override="${HOSTNAME_OVERRIDE}" --cloud-provider="${CLOUD_PROVIDER}" --address="$API_HOST" --api-servers="${API_HOST}:${API_PORT}" --port="$KUBELET_PORT" --resource-container="" &> $KUBELET_LOG &
     fi
 }
 

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -44,6 +44,7 @@ CLOUD_PROVIDER=${CLOUD_PROVIDER:-""}
 
 ETCD_PORT=${ETCD_PORT:-4001}
 ETCD_PROTO=${ETCD_PROTO:-"http"}
+ETCD_USE_EXISTING=${ETCD_USE_EXISTING:-false}
 
 cd "${KUBE_ROOT}"
 
@@ -237,11 +238,6 @@ cleanup()
   [[ -n "${ETCD_DIR-}" ]] && kube::etcd::clean_etcd_dir
 
   exit 0
-}
-
-function startETCD {
-    echo "Starting etcd"
-    kube::etcd::start
 }
 
 function set_service_accounts {
@@ -503,7 +499,9 @@ if [[ "${ENABLE_DAEMON}" = false ]]; then
 trap cleanup EXIT
 fi
 echo "Starting services now!"
-startETCD
+
+kube::etcd::ensure
+
 set_service_accounts
 start_apiserver
 start_controller_manager

--- a/hack/update-swagger-spec.sh
+++ b/hack/update-swagger-spec.sh
@@ -63,13 +63,17 @@ kube::etcd::start
 kube::log::status "Starting kube-apiserver"
 "${KUBE_OUTPUT_HOSTBIN}/kube-apiserver" \
   --insecure-bind-address="127.0.0.1" \
+  $(kube::etcd::kubesec) \
   --bind-address="127.0.0.1" \
   --insecure-port="${API_PORT}" \
-  --etcd-servers="http://${ETCD_HOST}:${ETCD_PORT}" \
+  --etcd-servers="${ETCD_PROTO}://${ETCD_HOST}:${ETCD_PORT}" \
   --advertise-address="10.10.10.10" \
   --cert-dir="${TMP_DIR}/certs" \
   --service-cluster-ip-range="10.0.0.0/24" >/tmp/swagger-api-server.log 2>&1 &
+
 APISERVER_PID=$!
+
+echo $APISERVER_PID
 
 kube::util::wait_for_url "http://127.0.0.1:${API_PORT}/healthz" "apiserver: "
 

--- a/hack/update-swagger-spec.sh
+++ b/hack/update-swagger-spec.sh
@@ -58,7 +58,7 @@ API_PORT=${API_PORT:-8050}
 API_HOST=${API_HOST:-127.0.0.1}
 KUBELET_PORT=${KUBELET_PORT:-10250}
 
-kube::etcd::start
+kube::etcd::ensure
 
 # Start kube-apiserver
 kube::log::status "Starting kube-apiserver"

--- a/hack/update-swagger-spec.sh
+++ b/hack/update-swagger-spec.sh
@@ -53,6 +53,7 @@ apiserver=$(kube::util::find-binary "kube-apiserver")
 TMP_DIR=$(mktemp -d /tmp/update-swagger-spec.XXXX)
 ETCD_HOST=${ETCD_HOST:-127.0.0.1}
 ETCD_PORT=${ETCD_PORT:-4001}
+ETCD_PROTO=${ETCD_PROTO:-"http"}
 API_PORT=${API_PORT:-8050}
 API_HOST=${API_HOST:-127.0.0.1}
 KUBELET_PORT=${KUBELET_PORT:-10250}
@@ -72,8 +73,6 @@ kube::log::status "Starting kube-apiserver"
   --service-cluster-ip-range="10.0.0.0/24" >/tmp/swagger-api-server.log 2>&1 &
 
 APISERVER_PID=$!
-
-echo $APISERVER_PID
 
 kube::util::wait_for_url "http://127.0.0.1:${API_PORT}/healthz" "apiserver: "
 


### PR DESCRIPTION
A few things this adds:
- Ability to use pre-existing etcd cluster
- Ability to use an etcd cluster secured by client tls by specifying the cert path in environment variables.
- Symlink etcdctl in addition to existing etcd
- Use etcdctl to check etcd availability
- Ability to specify service IP range
- Kubelet bind address now matches  insecure bind address
