### PR TITLE
Print meta.Accessor errors

### DIFF
--- a/pkg/client/cache/reflector.go
+++ b/pkg/client/cache/reflector.go
@@ -294,7 +294,7 @@ func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 	}
 	metaInterface, err := meta.Accessor(list)
 	if err != nil {
-		return fmt.Errorf("%s: Unable to understand list result %#v", r.name, list)
+		return fmt.Errorf("%s: Unable to understand list result %#v (%v)", r.name, list, err)
 	}
 	resourceVersion = metaInterface.GetResourceVersion()
 	items, err := meta.ExtractList(list)


### PR DESCRIPTION
meta.Accessor returns some very informative messages that are currently discarded by the caller
