### PR TITLE
Add the length detection of the "predicateFuncs" for findNodesThatFit function of generic_scheduler.go

### DIFF
--- a/plugin/pkg/scheduler/generic_scheduler.go
+++ b/plugin/pkg/scheduler/generic_scheduler.go
@@ -137,14 +137,15 @@ func (g *genericScheduler) selectHost(priorityList schedulerapi.HostPriorityList
 // Filters the nodes to find the ones that fit based on the given predicate functions
 // Each node is passed through the predicate functions to determine if it is a fit
 func findNodesThatFit(pod *api.Pod, nodeNameToInfo map[string]*schedulercache.NodeInfo, predicateFuncs map[string]algorithm.FitPredicate, nodes api.NodeList, extenders []algorithm.SchedulerExtender) (api.NodeList, FailedPredicateMap, error) {
-	predicateResultLock := sync.Mutex{}
 	filtered := []api.Node{}
 	failedPredicateMap := FailedPredicateMap{}
-	errs := []error{}
 	
 	if len(predicateFuncs) == 0 {
 		filtered = nodes.Items
 	} else {
+		predicateResultLock := sync.Mutex{}
+		errs := []error{}
+		
 		checkNode := func(i int) {
 			nodeName := nodes.Items[i].Name
 			fits, failedPredicate, err := podFitsOnNode(pod, nodeNameToInfo[nodeName], predicateFuncs)

--- a/plugin/pkg/scheduler/generic_scheduler.go
+++ b/plugin/pkg/scheduler/generic_scheduler.go
@@ -149,7 +149,7 @@ func findNodesThatFit(pod *api.Pod, nodeNameToInfo map[string]*schedulercache.No
 		checkNode := func(i int) {
 			nodeName := nodes.Items[i].Name
 			fits, failedPredicate, err := podFitsOnNode(pod, nodeNameToInfo[nodeName], predicateFuncs)
-	
+
 			predicateResultLock.Lock()
 			defer predicateResultLock.Unlock()
 			if err != nil {


### PR DESCRIPTION
The PR add the length detection of the "predicateFuncs" for "findNodesThatFit" function of generic_scheduler.go. 
In “findNodesThatFit” function, if the length of the "predicateFuncs" parameter is 0, it can set filtered equals nodes.Items, and needn't to traverse the nodes.Items.
