### PR TITLE
GCI: Enable the log of upstart jobs

### DIFF
--- a/cluster/gce/trusty/master.yaml
+++ b/cluster/gce/trusty/master.yaml
@@ -1,4 +1,4 @@
-From nobody Thu Mar 10 10:33:00 2016
+From nobody Thu May 13 20:33:00 2016
 Content-Type: multipart/mixed; boundary="===================================="
 MIME-Version: 1.0
 
@@ -15,6 +15,7 @@ description "Download and install k8s binaries and configurations"
 start on cloud-config
 
 script
+{
 	set -o errexit
 	set -o nounset
 
@@ -29,6 +30,7 @@ script
 	. /etc/kube-env
 	echo "Install kube master binary and configuration files"
 	install_kube_binary_config
+} 2>&1 | logger --priority daemon.info -t ${UPSTART_JOB}
 end script
 
 --====================================
@@ -44,6 +46,7 @@ description "Prepare kube master environment"
 start on stopped kube-install-master
 
 script
+{
 	set -o errexit
 	set -o nounset
 
@@ -64,6 +67,7 @@ script
 	echo "Assemble kubelet command line"
 	# Kubelet command flags will be written in /etc/default/kubelet
 	assemble_kubelet_flags
+} 2>&1 | logger --priority daemon.info -t ${UPSTART_JOB}
 end script
 
 --====================================
@@ -79,11 +83,13 @@ description "Install packages needed to run kubernetes"
 start on stopped kube-install-master
 
 script
+{
 	set -o errexit
 	set -o nounset
 
 	. /etc/kube-configure-helper.sh
 	install_critical_packages
+} 2>&1 | logger --priority daemon.info -t ${UPSTART_JOB}
 end script
 
 --====================================
@@ -99,11 +105,13 @@ description "Install additional packages used by kubernetes"
 start on stopped kube-install-packages
 
 script
+{
 	set -o errexit
 	set -o nounset
 
 	. /etc/kube-configure-helper.sh
 	install_additional_packages
+} 2>&1 | logger --priority daemon.info -t ${UPSTART_JOB}
 end script
 
 --====================================
@@ -121,12 +129,14 @@ start on stopped kube-install-packages and stopped kube-env
 respawn
 
 script
+{
 	set -o errexit
 	set -o nounset
 
 	echo "Start kubelet upstart job"
 	. /etc/default/kubelet
 	/usr/bin/kubelet ${KUBELET_OPTS} 1>>/var/log/kubelet.log 2>&1
+} 2>&1 | logger --priority daemon.info -t ${UPSTART_JOB}
 end script
 
 # Wait for 10s to start kubelet again.
@@ -145,12 +155,14 @@ description "Restart docker daemon"
 start on started kubelet
 
 script
+{
 	set -o errexit
 	set -o nounset
 
 	. /etc/kube-configure-helper.sh
 	. /etc/kube-env
 	restart_docker_daemon
+} 2>&1 | logger --priority daemon.info -t ${UPSTART_JOB}
 end script
 
 --====================================
@@ -166,6 +178,7 @@ description "Start kube-master components and addons pods"
 start on stopped kube-docker
 
 script
+{
 	set -o errexit
 	set -o nounset
 
@@ -178,6 +191,7 @@ script
 	start_kube_controller_manager
 	start_kube_scheduler
 	start_kube_addons
+} 2>&1 | logger --priority daemon.info -t ${UPSTART_JOB}
 end script
 
 --====================================
@@ -195,6 +209,7 @@ start on stopped kube-docker
 respawn
 
 script
+{
 	set -o errexit
 	set -o nounset
 
@@ -204,6 +219,7 @@ script
 	. /etc/kube-configure-helper.sh
 	. /etc/kube-env
 	health_monitoring
+} 2>&1 | logger --priority daemon.info -t ${UPSTART_JOB}
 end script
 
 # Wait for 10s to start it again.

--- a/cluster/gce/trusty/node.yaml
+++ b/cluster/gce/trusty/node.yaml
@@ -1,4 +1,4 @@
-From nobody Thu Mar 10 10:33:00 2016
+From nobody Thu May 13 20:33:00 2016
 Content-Type: multipart/mixed; boundary="===================================="
 MIME-Version: 1.0
 
@@ -15,6 +15,7 @@ description "Download and install k8s binaries and configurations"
 start on cloud-config
 
 script
+{
 	set -o errexit
 	set -o nounset
 
@@ -29,6 +30,7 @@ script
 	. /etc/kube-env
 	echo "Install kube nodes binary and configuration files"
 	install_kube_binary_config
+} 2>&1 | logger --priority daemon.info -t ${UPSTART_JOB}
 end script
 
 --====================================
@@ -44,6 +46,7 @@ description "Prepare kube node environment"
 start on stopped kube-install-node
 
 script
+{
 	set -o errexit
 	set -o nounset
 
@@ -62,6 +65,7 @@ script
 	echo "Assemble kubelet command line"
 	# Kubelet command flags will be in /etc/default/kubelet
 	assemble_kubelet_flags
+} 2>&1 | logger --priority daemon.info -t ${UPSTART_JOB}
 end script
 
 --====================================
@@ -77,11 +81,13 @@ description "Install packages needed to run kubernetes"
 start on stopped kube-install-node
 
 script
+{
 	set -o errexit
 	set -o nounset
 
 	. /etc/kube-configure-helper.sh
 	install_critical_packages
+} 2>&1 | logger --priority daemon.info -t ${UPSTART_JOB}
 end script
 
 --====================================
@@ -97,11 +103,13 @@ description "Install additional packages used by kubernetes"
 start on stopped kube-install-packages
 
 script
+{
 	set -o errexit
 	set -o nounset
 
 	. /etc/kube-configure-helper.sh
 	install_additional_packages
+} 2>&1 | logger --priority daemon.info -t ${UPSTART_JOB}
 end script
 
 --====================================
@@ -119,12 +127,14 @@ start on stopped kube-install-packages and stopped kube-env
 respawn
 
 script
+{
 	set -o errexit
 	set -o nounset
 
 	echo "Start kubelet upstart job"
 	. /etc/default/kubelet
 	/usr/bin/kubelet ${KUBELET_OPTS} 1>>/var/log/kubelet.log 2>&1
+} 2>&1 | logger --priority daemon.info -t ${UPSTART_JOB}
 end script
 
 # Wait for 10s to start kubelet again.
@@ -143,12 +153,14 @@ description "Restart docker daemon"
 start on started kubelet
 
 script
+{
 	set -o errexit
 	set -o nounset
 
 	. /etc/kube-configure-helper.sh
 	. /etc/kube-env
 	restart_docker_daemon
+} 2>&1 | logger --priority daemon.info -t ${UPSTART_JOB}
 end script
 
 --====================================
@@ -164,6 +176,7 @@ description "Start kube-proxy static pod"
 start on stopped kube-docker
 
 script
+{
 	set -o errexit
 	set -o nounset
 
@@ -207,6 +220,7 @@ script
 	fi
 
 	mv -f ${tmp_file} /etc/kubernetes/manifests/
+} 2>&1 | logger --priority daemon.info -t ${UPSTART_JOB}
 end script
 
 --====================================
@@ -222,6 +236,7 @@ description "Install kubelet add-on manifest files"
 start on stopped kube-docker
 
 script
+{
 	set -o errexit
 	set -o nounset
 
@@ -233,6 +248,7 @@ script
 	if [ "${ENABLE_CLUSTER_REGISTRY:-}" = "true" ]; then
 		cp /home/kubernetes/kube-manifests/kubernetes/kube-registry-proxy.yaml /etc/kubernetes/manifests/
 	fi
+} 2>&1 | logger --priority daemon.info -t ${UPSTART_JOB}
 end script
 
 --====================================
@@ -248,6 +264,7 @@ start on stopped kube-docker
 respawn
 
 script
+{
 	set -o nounset
 	set -o errexit
 
@@ -257,6 +274,7 @@ script
 	. /etc/kube-configure-helper.sh
 	. /etc/kube-env
 	health_monitoring
+} 2>&1 | logger --priority daemon.info -t ${UPSTART_JOB}
 end script
 
 # Wait for 10s to start it again.


### PR DESCRIPTION
This PR enables the log of upstart jobs in master.yaml and node.yaml. By default, log of upstart jobs are enabled in Trusty and placed in /var/log/upstart, but not enabled in GCI. This change explicitly directs the log to the system logger. For trusty, they are in /var/log/syslog file. In GCI, we can check it using "journalctl". This change will be useful for debugging if cluster initialization fails.

@roberthbailey @maisem @dchen1107 please review it. This will be useful for issues like #23634. We should also cherry pick it in release-1.2

cc/ @fabioy @zmerlynn @wonderfly FYI.
