### PR TITLE
Update upstream remote regex

### DIFF
--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -313,7 +313,7 @@ kube::util::gv-to-swagger-name() {
 # repo, e.g. "upstream" or "origin".
 kube::util::git_upstream_remote_name() {
   git remote -v | grep fetch |\
-    grep -E 'github.com/kubernetes/kubernetes|k8s.io/kubernetes' |\
+    grep -E 'github.com[/:]kubernetes/kubernetes|k8s.io/kubernetes' |\
     head -n 1 | awk '{print $1}'
 }
 


### PR DESCRIPTION
I've fixed the upstream remote regex so that it properly recognizes ssh link, like this one: 

```
upstream git@github.com:kubernetes/kubernetes.git (fetch)
```

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
