### PR TITLE
Fixed 'Invalid endpoint: https://ec2.us-east-.amazonaws.com'. #24420 #24420

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -95,7 +95,12 @@ source "${KUBE_ROOT}/cluster/aws/${OS_DISTRIBUTION}/util.sh"
 load_distro_utils
 
 # This removes the final character in bash (somehow)
-AWS_REGION=${ZONE%?}
+re='[a-zA-Z]'
+if [[ ${ZONE: -1} =~ $re  ]]; then 
+  AWS_REGION=${ZONE%?}
+else 
+  AWS_REGION=$ZONE
+fi
 
 export AWS_DEFAULT_REGION=${AWS_REGION}
 export AWS_DEFAULT_OUTPUT=text


### PR DESCRIPTION
Addresses:
- https://github.com/kubernetes/kubernetes/issues/24020
- https://github.com/kubernetes/kubectl/issues/1340
