### PR TITLE
README: be more accurate about where k8s can run

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,13 @@ Kubernetes builds upon a [decade and a half of experience at Google running prod
 
 <hr>
 
-### Kubernetes can run anywhere!
-
-However, initial development was done on GCE and so our instructions and scripts are built around that.  If you make it work on other infrastructure please let us know and contribute instructions/code.
-
 ### Kubernetes is ready for Production!
 
 With the [1.0.1 release](https://github.com/kubernetes/kubernetes/releases/tag/v1.0.1) Kubernetes is ready to serve your production workloads.
 
+### Kubernetes can run anywhere!
+
+You can run Kubernetes on your local workstation under Vagrant, cloud providers (e.g. GCE, AWS, Azure), and physical hardware. Essentially, anywhere Linux runs you can run Kubernetes. Checkout the [Getting Started Guides](http://kubernetes.io/docs/getting-started-guides/) for details.
 
 ## Concepts
 


### PR DESCRIPTION
The README really undersells all of the places that can run Kubernetes.
Direct users at the getting started guides and be more optimistics about
the possibilities of running Kubernetes anywhere.
