### PR TITLE
examples: guestbook-go: fix the redis-master version

### DIFF
--- a/examples/guestbook-go/redis-master-controller.json
+++ b/examples/guestbook-go/redis-master-controller.json
@@ -25,7 +25,7 @@
             "containers":[
                {
                   "name":"redis-master",
-                  "image":"redis",
+                  "image":"redis:2.8.23",
                   "ports":[
                      {
                         "name":"redis-server",


### PR DESCRIPTION
The guestbook-go example is broken because the latest tag of redis has
moved to redis 3.0 which speaks a new protocol. This means that the
slaves, which have fixed 2.0 versions, will error out on the protocol:

```
[7] 15 May 23:37:44.403 # Can't handle RDB format version 7
[7] 15 May 23:37:44.403 # Failed trying to load the MASTER synchronization DB from disk
[7] 15 May 23:37:45.333 * Connecting to MASTER redis-master:6379
[7] 15 May 23:37:45.427 * MASTER <-> SLAVE sync started
```

In this case the app simply never persists data.

cc @luebken @Gurpartap
