### PR TITLE
use monotonic now in TestDelNode

### DIFF
--- a/pkg/controller/node/rate_limited_queue_test.go
+++ b/pkg/controller/node/rate_limited_queue_test.go
@@ -62,6 +62,13 @@ func TestAddNode(t *testing.T) {
 }
 
 func TestDelNode(t *testing.T) {
+	defer func() { now = time.Now }()
+	var tick int64
+	now = func() time.Time {
+		t := time.Unix(tick, 0)
+		tick++
+		return t
+	}
 	evictor := NewRateLimitedTimedQueue(flowcontrol.NewFakeAlwaysRateLimiter())
 	evictor.Add("first")
 	evictor.Add("second")


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/24971.

Briefly, the rate_limited_queue uses a `container/heap` to store values, and use this data structure to ensure we can always fetch the value with the minimum `processAt`. However, in some extreme condition, the continuous call to `time.Now()` would get the same value, which causes some unpredictable order in the queue, this fix uses a monotonic `now()` to avoid that.

@smarterclayton please take a look.
