### PR TITLE
Match also repo cloned using ssh

### DIFF
--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -319,7 +319,7 @@ kube::util::gv-to-swagger-name() {
 # repo, e.g. "upstream" or "origin".
 kube::util::git_upstream_remote_name() {
   git remote -v | grep fetch |\
-    grep -E 'github.com/kubernetes/kubernetes|k8s.io/kubernetes' |\
+    grep -E 'github.com[/:]kubernetes/kubernetes|k8s.io/kubernetes' |\
     head -n 1 | awk '{print $1}'
 }
 


### PR DESCRIPTION
For repos cloned via ssh the path is different:
ssh: github.com:kubernetes/kubernetes.git
http: github.com/kubernetes/kubernetes.git
