### PR TITLE
prevent nil pointer when starting controllers before running the shar…

### DIFF
--- a/pkg/controller/framework/shared_informer.go
+++ b/pkg/controller/framework/shared_informer.go
@@ -139,11 +139,12 @@ func (s *sharedIndexInformer) Run(stopCh <-chan struct{}) {
 
 		Process: s.HandleDeltas,
 	}
-	s.controller = New(cfg)
 
 	func() {
 		s.startedLock.Lock()
 		defer s.startedLock.Unlock()
+
+		s.controller = New(cfg)
 		s.started = true
 	}()
 
@@ -158,6 +159,12 @@ func (s *sharedIndexInformer) isStarted() bool {
 }
 
 func (s *sharedIndexInformer) HasSynced() bool {
+	s.startedLock.Lock()
+	defer s.startedLock.Unlock()
+
+	if s.controller == nil {
+		return false
+	}
 	return s.controller.HasSynced()
 }
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/25643.

https://github.com/kubernetes/kubernetes/pull/23795 changed initialization order, so the controller isn't guaranteed to be present at startup.

@mqliang @wojtek-t I'm pretty sure that we're not guaranteed to get back the correct `cache.Indexer` or `cache.Store` either.  I'll look at re-plumbing the `AddIndexer` path to use the same instance so that its safe to use again.
