### PR TITLE
Changing kubectl commands to not default and use dynamic client

### DIFF
--- a/pkg/client/unversioned/fake/fake.go
+++ b/pkg/client/unversioned/fake/fake.go
@@ -42,11 +42,12 @@ func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 
 // RESTClient provides a fake RESTClient interface.
 type RESTClient struct {
-	Client *http.Client
-	Codec  runtime.Codec
-	Req    *http.Request
-	Resp   *http.Response
-	Err    error
+	APIPath string
+	Client  *http.Client
+	Codec   runtime.Codec
+	Req     *http.Request
+	Resp    *http.Response
+	Err     error
 }
 
 func (c *RESTClient) Get() *restclient.Request {
@@ -81,7 +82,7 @@ func (c *RESTClient) request(verb string) *restclient.Request {
 		StreamingSerializer: c.Codec,
 		Framer:              runtime.DefaultFramer,
 	}
-	return restclient.NewRequest(c, verb, &url.URL{Host: "localhost"}, "", config, serializers, nil, nil)
+	return restclient.NewRequest(c, verb, &url.URL{Host: "localhost"}, c.APIPath, config, serializers, nil, nil)
 }
 
 func (c *RESTClient) Do(req *http.Request) (*http.Response, error) {

--- a/pkg/kubectl/cmd/get_test.go
+++ b/pkg/kubectl/cmd/get_test.go
@@ -88,6 +88,19 @@ func testData() (*api.PodList, *api.ServiceList, *api.ReplicationControllerList)
 	return pods, svc, rc
 }
 
+func testDynamicResources() []*unversioned.APIResourceList {
+	return []*unversioned.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []unversioned.APIResource{
+				{Kind: "Pod", Namespaced: true},
+				{Kind: "Service", Namespaced: true},
+				{Kind: "ReplicationController", Namespaced: true},
+			},
+		},
+	}
+}
+
 func testComponentStatusData() *api.ComponentStatusList {
 	good := api.ComponentStatus{
 		Conditions: []api.ComponentCondition{

--- a/pkg/kubectl/cmd/util/dynamic_util.go
+++ b/pkg/kubectl/cmd/util/dynamic_util.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+// DynamicVersionIntefaces provides an object converter and metadata
+// accessor appropriate for use with unstructured objects.
+func DynamicVersionInterfaces(unversioned.GroupVersion) (*meta.VersionInterfaces, error) {
+	return &meta.VersionInterfaces{
+		ObjectConvertor:  &runtime.UnstructuredObjectConverter{},
+		MetadataAccessor: meta.NewAccessor(),
+	}, nil
+}
+
+// NewDiscoveryRESTMapper returns a RESTMapper based on discovery information.
+func NewDiscoveryRESTMapper(resources []*unversioned.APIResourceList, versionFunc meta.VersionInterfacesFunc) (*meta.DefaultRESTMapper, error) {
+	rm := meta.NewDefaultRESTMapper(nil, versionFunc)
+	for _, resourceList := range resources {
+		gv, err := unversioned.ParseGroupVersion(resourceList.GroupVersion)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, resource := range resourceList.APIResources {
+			gvk := gv.WithKind(resource.Kind)
+			scope := meta.RESTScopeRoot
+			if resource.Namespaced {
+				scope = meta.RESTScopeNamespace
+			}
+			rm.Add(gvk, scope)
+		}
+	}
+	return rm, nil
+}
+
+// DynamicObjectTyper provides an ObjectTyper implmentation for
+// runtime.Unstructured object based on discovery information.
+type DynamicObjectTyper struct {
+	registered map[unversioned.GroupVersionKind]bool
+}
+
+func NewDynamicObjectTyper(resources []*unversioned.APIResourceList) (runtime.ObjectTyper, error) {
+	dot := &DynamicObjectTyper{registered: make(map[unversioned.GroupVersionKind]bool)}
+	for _, resourceList := range resources {
+		gv, err := unversioned.ParseGroupVersion(resourceList.GroupVersion)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, resource := range resourceList.APIResources {
+			dot.registered[gv.WithKind(resource.Kind)] = true
+		}
+	}
+	return dot, nil
+}
+
+// ObjectKind returns the group,version,kind of the provided object,
+// or an error if the object in not *runtime.Unstructured or has no
+// group,version,kind information.
+func (dot *DynamicObjectTyper) ObjectKind(obj runtime.Object) (unversioned.GroupVersionKind, error) {
+	if _, ok := obj.(*runtime.Unstructured); !ok {
+		return unversioned.GroupVersionKind{}, fmt.Errorf("type %T is invalid for dynamic object typer", obj)
+	}
+
+	return obj.GetObjectKind().GroupVersionKind(), nil
+}
+
+// ObjectKinds returns a slice of one element with the
+// group,version,kind of the provided object, or an error if the
+// object is not *runtime.Unstructured or has no group,version,kind
+// information.
+func (dot *DynamicObjectTyper) ObjectKinds(obj runtime.Object) ([]unversioned.GroupVersionKind, error) {
+	gvk, err := dot.ObjectKind(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	return []unversioned.GroupVersionKind{gvk}, nil
+}
+
+// Recognizes returns true if the provided group,version,kind was in
+// the discovery information.
+func (dot *DynamicObjectTyper) Recognizes(gvk unversioned.GroupVersionKind) bool {
+	return dot.registered[gvk]
+}
+
+// IsUnversioned returns false always because *runtime.Unstructured
+// objects should always have group,version,kind information set. ok
+// will be true if the object's group,version,kind is registered.
+func (dot *DynamicObjectTyper) IsUnversioned(obj runtime.Object) (unversioned bool, ok bool) {
+	gvk, err := dot.ObjectKind(obj)
+	if err != nil {
+		return false, false
+	}
+
+	return false, dot.registered[gvk]
+}

--- a/pkg/kubectl/cmd/util/dynamic_util_test.go
+++ b/pkg/kubectl/cmd/util/dynamic_util_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api/unversioned"
+)
+
+func TestDiscoveryRESTMapper(t *testing.T) {
+	resources := []*unversioned.APIResourceList{
+		{
+			GroupVersion: "test/beta1",
+			APIResources: []unversioned.APIResource{
+				{
+					Name:       "test_kinds",
+					Namespaced: true,
+					Kind:       "test_kind",
+				},
+			},
+		},
+	}
+
+	gvk := unversioned.GroupVersionKind{
+		Group:   "test",
+		Version: "beta1",
+		Kind:    "test_kind",
+	}
+
+	mapper, err := NewDiscoveryRESTMapper(resources, DynamicVersionInterfaces)
+	if err != nil {
+		t.Fatalf("unexpected error creating mapper: %s", err)
+	}
+
+	for _, res := range []unversioned.GroupVersionResource{
+		{
+			Group:    "test",
+			Version:  "beta1",
+			Resource: "test_kinds",
+		},
+		{
+			Version:  "beta1",
+			Resource: "test_kinds",
+		},
+		{
+			Group:    "test",
+			Resource: "test_kinds",
+		},
+		{
+			Resource: "test_kinds",
+		},
+	} {
+		got, err := mapper.KindFor(res)
+		if err != nil {
+			t.Errorf("KindFor(%#v) unexpected error: %s", res, err)
+			continue
+		}
+
+		if got != gvk {
+			t.Errorf("KindFor(%#v) = %#v; want %#v", res, got, gvk)
+		}
+	}
+}

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -48,6 +48,8 @@ import (
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/apis/metrics"
 	"k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/kubernetes/pkg/client/typed/discovery"
+	"k8s.io/kubernetes/pkg/client/typed/dynamic"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	clientset "k8s.io/kubernetes/pkg/client/unversioned/adapters/internalclientset"
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
@@ -78,6 +80,9 @@ type Factory struct {
 	// Returns interfaces for dealing with arbitrary runtime.Objects. If thirdPartyDiscovery is true, performs API calls
 	// to discovery dynamic API objects registered by third parties.
 	Object func(thirdPartyDiscovery bool) (meta.RESTMapper, runtime.ObjectTyper)
+	// Returns interfaces for dealing with arbitrary
+	// runtime.Unstructured. This performs API calls to discover types.
+	DynamicObject func() (meta.RESTMapper, runtime.ObjectTyper)
 	// Returns interfaces for decoding objects - if toInternal is set, decoded objects will be converted
 	// into their internal form (if possible). Eventually the internal form will be removed as an option,
 	// and only versioned objects will be returned.
@@ -86,6 +91,8 @@ type Factory struct {
 	JSONEncoder func() runtime.Encoder
 	// Returns a client for accessing Kubernetes resources or an error.
 	Client func() (*client.Client, error)
+	// Returns a dynamic client for accessing specified group version.
+	DynamicClient func(unversioned.GroupVersion) (*dynamic.Client, error)
 	// Returns a client.Config for accessing the Kubernetes server.
 	ClientConfig func() (*restclient.Config, error)
 	// Returns a RESTClient for working with the specified RESTMapping or an error. This is intended
@@ -226,6 +233,10 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 	}
 
 	clients := NewClientCache(clientConfig)
+	cfg, err := clientConfig.ClientConfig()
+	CheckErr(err)
+
+	dynamicClientPool := dynamic.NewClientPool(cfg, dynamic.LegacyAPIPathResolverFunc)
 
 	return &Factory{
 		clients: clients,
@@ -301,8 +312,35 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 			}
 			return priorityRESTMapper, api.Scheme
 		},
+		DynamicObject: func() (meta.RESTMapper, runtime.ObjectTyper) {
+			cfg, err := clients.ClientConfigForVersion(nil)
+			CheckErr(err)
+
+			discovery, err := discovery.NewDiscoveryClientForConfig(cfg)
+			CheckErr(err)
+
+			resourceMap, err := discovery.ServerResources()
+			CheckErr(err)
+
+			var resources []*unversioned.APIResourceList
+
+			for _, resourceList := range resourceMap {
+				resources = append(resources, resourceList)
+			}
+
+			mapper, err := NewDiscoveryRESTMapper(resources, DynamicVersionInterfaces)
+			CheckErr(err)
+
+			typer, err := NewDynamicObjectTyper(resources)
+			CheckErr(err)
+
+			return kubectl.ShortcutExpander{RESTMapper: mapper}, typer
+		},
 		Client: func() (*client.Client, error) {
 			return clients.ClientForVersion(nil)
+		},
+		DynamicClient: func(gv unversioned.GroupVersion) (*dynamic.Client, error) {
+			return dynamicClientPool.ClientForGroupVersion(gv)
 		},
 		ClientConfig: func() (*restclient.Config, error) {
 			return clients.ClientConfigForVersion(nil)

--- a/pkg/kubectl/resource/visitor.go
+++ b/pkg/kubectl/resource/visitor.go
@@ -163,6 +163,14 @@ func (i *Info) ResourceMapping() *meta.RESTMapping {
 	return i.Mapping
 }
 
+func (i *Info) APIResource() *unversioned.APIResource {
+	return &unversioned.APIResource{
+		Name:       i.Mapping.Resource,
+		Namespaced: i.Namespaced(),
+		Kind:       i.Mapping.GroupVersionKind.Kind,
+	}
+}
+
 // VisitorList implements Visit for the sub visitors it contains. The first error
 // returned from a child Visitor will terminate iteration.
 type VisitorList []Visitor

--- a/pkg/runtime/unstructured.go
+++ b/pkg/runtime/unstructured.go
@@ -18,6 +18,8 @@ package runtime
 
 import (
 	gojson "encoding/json"
+	"errors"
+	"fmt"
 	"io"
 
 	"k8s.io/kubernetes/pkg/api/unversioned"
@@ -145,4 +147,40 @@ func (s unstructuredJSONScheme) decodeToList(data []byte, list *UnstructuredList
 		list.Items = append(list.Items, unstruct)
 	}
 	return nil
+}
+
+// UnstructuredObjectConverter is an ObjectConverter for use with
+// Unstructured objects. Since it has no schema or type information,
+// it will only succeed for no-op conversions. This is provided as a
+// sane implementation for APIs that require an object converter.
+type UnstructuredObjectConverter struct{}
+
+func (UnstructuredObjectConverter) Convert(in, out interface{}) error {
+	unstructIn, ok := in.(*Unstructured)
+	if !ok {
+		return fmt.Errorf("input type %T in not valid for unstructured conversion", in)
+	}
+
+	unstructOut, ok := out.(*Unstructured)
+	if !ok {
+		return fmt.Errorf("output type %T in not valid for unstructured conversion", out)
+	}
+
+	// maybe deep copy the map? It is documented in the
+	// ObjectConverter interface that this function is not
+	// guaranteeed to not mutate the input. Or maybe set the input
+	// object to nil.
+	unstructOut.Object = unstructIn.Object
+	return nil
+}
+
+func (UnstructuredObjectConverter) ConvertToVersion(in Object, outVersion unversioned.GroupVersion) (Object, error) {
+	if gvk := in.GetObjectKind().GroupVersionKind(); gvk.GroupVersion() != outVersion {
+		return nil, errors.New("unstructured converter cannot convert versions")
+	}
+	return in, nil
+}
+
+func (UnstructuredObjectConverter) ConvertFieldLabel(version, kind, label, value string) (string, string, error) {
+	return "", "", errors.New("unstructured cannot convert field labels")
 }

--- a/pkg/runtime/unstructured.go
+++ b/pkg/runtime/unstructured.go
@@ -98,6 +98,13 @@ func (s unstructuredJSONScheme) decodeInto(data []byte, obj Object) error {
 		return s.decodeToUnstructured(data, x)
 	case *UnstructuredList:
 		return s.decodeToList(data, x)
+	case *VersionedObjects:
+		u := new(Unstructured)
+		err := s.decodeToUnstructured(data, u)
+		if err == nil {
+			x.Objects = []Object{u}
+		}
+		return err
 	default:
 		return json.Unmarshal(data, x)
 	}


### PR DESCRIPTION
Migrating some commands to use the unstructured types and dynamic client. This eliminates client side conversion and defaulting for some commands.

cc @kubernetes/sig-api-machinery @lavalamp @smarterclayton 
#16764 #3955

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/25676)

<!-- Reviewable:end -->
