### PR TITLE
Revert "OS X: Fix hyperkube build by adding empty string to sed invocation"

### DIFF
--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -57,13 +57,13 @@ endif
 
 ifeq ($(ARCH),amd64)
 	# When building "normally" for amd64, remove the whole line, it has no part in the amd64 image
-	cd ${TEMP_DIR} && sed -i ""  "/CROSS_BUILD_/d" Dockerfile
+	cd ${TEMP_DIR} && sed -i "/CROSS_BUILD_/d" Dockerfile
 else
 	# When cross-building, only the placeholder "CROSS_BUILD_" should be removed
 	# Register /usr/bin/qemu-ARCH-static as the handler for ARM binaries in the kernel
 	docker run --rm --privileged multiarch/qemu-user-static:register --reset
 	curl -sSL --retry 5 https://github.com/multiarch/qemu-user-static/releases/download/v2.5.0/x86_64_qemu-${QEMUARCH}-static.tar.xz | tar -xJ -C ${TEMP_DIR}
-	cd ${TEMP_DIR} && sed -i "" "s/CROSS_BUILD_//g" Dockerfile
+	cd ${TEMP_DIR} && sed -i "s/CROSS_BUILD_//g" Dockerfile
 endif
 
 	docker build -t ${REGISTRY}/hyperkube-${ARCH}:${VERSION} ${TEMP_DIR}


### PR DESCRIPTION
Reverts kubernetes/kubernetes#24852

This breaks the Linux build.

cc @johscheuer @zmerlynn 
