### PR TITLE
Support per-test-environment ginkgo flags for node e2e tests to facilitate skipping miss behaving tests in PR builder

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -165,6 +165,7 @@ gather-resource-usage
 gce-project
 gce-service-account
 gce-zone
+ginkgo-flags
 gke-cluster
 go-header-file
 google-json-key

--- a/test/e2e_node/e2e_remote.go
+++ b/test/e2e_node/e2e_remote.go
@@ -35,6 +35,7 @@ var sshOptions = flag.String("ssh-options", "", "Commandline options passed to s
 var sshEnv = flag.String("ssh-env", "", "Use predefined ssh options for environment.  Options: gce")
 var testTimeoutSeconds = flag.Int("test-timeout", 45*60, "How long (in seconds) to wait for ginkgo tests to complete.")
 var resultsDir = flag.String("results-dir", "/tmp/", "Directory to scp test results to.")
+var ginkgoFlags = flag.String("ginkgo-flags", "", "Passed to ginkgo to specify additional flags such as --skip=.")
 
 var sshOptionsMap map[string]string
 
@@ -160,7 +161,7 @@ func RunRemote(archive string, host string, cleanup bool, junitFileNumber int) (
 	cmd = getSshCommand(" && ",
 		fmt.Sprintf("cd %s", tmp),
 		fmt.Sprintf("tar -xzvf ./%s", archiveName),
-		fmt.Sprintf("timeout -k 30s %ds ./e2e_node.test --logtostderr --v 2 --build-services=false --stop-services=%t --node-name=%s --report-dir=%s/results --junit-file-number=%d", *testTimeoutSeconds, cleanup, host, tmp, junitFileNumber),
+		fmt.Sprintf("timeout -k 30s %ds ./e2e_node.test --logtostderr --v 2 --build-services=false --stop-services=%t --node-name=%s --report-dir=%s/results --junit-file-number=%d %s", *testTimeoutSeconds, cleanup, host, tmp, junitFileNumber, *ginkgoFlags),
 	)
 	glog.Infof("Starting tests on %s", host)
 	output, err := RunSshCommand("ssh", host, "--", "sh", "-c", cmd)

--- a/test/e2e_node/jenkins/e2e-node-jenkins.sh
+++ b/test/e2e_node/jenkins/e2e-node-jenkins.sh
@@ -40,4 +40,4 @@ mkdir -p ${ARTIFACTS}
 go run test/e2e_node/runner/run_e2e.go  --logtostderr --vmodule=*=2 --ssh-env="gce" \
   --zone="$GCE_ZONE" --project="$GCE_PROJECT"  \
   --hosts="$GCE_HOSTS" --images="$GCE_IMAGES" --cleanup="$CLEANUP" \
-  --results-dir="$ARTIFACTS"
+  --results-dir="$ARTIFACTS" --ginkgo-flags="$GINKGO_FLAGS"

--- a/test/e2e_node/jenkins/jenkins-ci.properties
+++ b/test/e2e_node/jenkins/jenkins-ci.properties
@@ -8,3 +8,4 @@ GCE_ZONE=us-central1-f
 GCE_PROJECT=kubernetes-jenkins
 INSTALL_GODEP=true
 CLEANUP=true
+GINKGO_FLAGS=

--- a/test/e2e_node/jenkins/jenkins-pull.properties
+++ b/test/e2e_node/jenkins/jenkins-pull.properties
@@ -8,3 +8,4 @@ GCE_ZONE=us-central1-f
 GCE_PROJECT=kubernetes-jenkins-pull
 INSTALL_GODEP=true
 CLEANUP=true
+GINKGO_FLAGS=


### PR DESCRIPTION
We had an issue today where some node e2e tests were timing out in the pr builder.  We want to be able to skip tests in the pr builder and leave them running in the CI if this happens again.

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
