### PR TITLE
kubelet: Move common labels out of dockertools package

### DIFF
--- a/pkg/kubelet/dockertools/labels.go
+++ b/pkg/kubelet/dockertools/labels.go
@@ -24,9 +24,10 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/custommetrics"
+	"k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/types"
+	kubetypes "k8s.io/kubernetes/pkg/types"
 )
 
 // This file contains all docker label related constants and functions, including:
@@ -34,13 +35,9 @@ import (
 //  * label filters (maybe in the future)
 
 const (
-	kubernetesPodNameLabel                   = "io.kubernetes.pod.name"
-	kubernetesPodNamespaceLabel              = "io.kubernetes.pod.namespace"
-	kubernetesPodUIDLabel                    = "io.kubernetes.pod.uid"
 	kubernetesPodDeletionGracePeriodLabel    = "io.kubernetes.pod.deletionGracePeriod"
 	kubernetesPodTerminationGracePeriodLabel = "io.kubernetes.pod.terminationGracePeriod"
 
-	kubernetesContainerNameLabel                   = "io.kubernetes.container.name"
 	kubernetesContainerHashLabel                   = "io.kubernetes.container.hash"
 	kubernetesContainerRestartCountLabel           = "io.kubernetes.container.restartCount"
 	kubernetesContainerTerminationMessagePathLabel = "io.kubernetes.container.terminationMessagePath"
@@ -57,7 +54,7 @@ const (
 type labelledContainerInfo struct {
 	PodName                   string
 	PodNamespace              string
-	PodUID                    types.UID
+	PodUID                    kubetypes.UID
 	PodDeletionGracePeriod    *int64
 	PodTerminationGracePeriod *int64
 	Name                      string
@@ -67,27 +64,11 @@ type labelledContainerInfo struct {
 	PreStopHandler            *api.Handler
 }
 
-func GetContainerName(labels map[string]string) string {
-	return labels[kubernetesContainerNameLabel]
-}
-
-func GetPodName(labels map[string]string) string {
-	return labels[kubernetesPodNameLabel]
-}
-
-func GetPodUID(labels map[string]string) string {
-	return labels[kubernetesPodUIDLabel]
-}
-
-func GetPodNamespace(labels map[string]string) string {
-	return labels[kubernetesPodNamespaceLabel]
-}
-
 func newLabels(container *api.Container, pod *api.Pod, restartCount int, enableCustomMetrics bool) map[string]string {
 	labels := map[string]string{}
-	labels[kubernetesPodNameLabel] = pod.Name
-	labels[kubernetesPodNamespaceLabel] = pod.Namespace
-	labels[kubernetesPodUIDLabel] = string(pod.UID)
+	labels[types.KubernetesPodNameLabel] = pod.Name
+	labels[types.KubernetesPodNamespaceLabel] = pod.Namespace
+	labels[types.KubernetesPodUIDLabel] = string(pod.UID)
 	if pod.DeletionGracePeriodSeconds != nil {
 		labels[kubernetesPodDeletionGracePeriodLabel] = strconv.FormatInt(*pod.DeletionGracePeriodSeconds, 10)
 	}
@@ -95,7 +76,7 @@ func newLabels(container *api.Container, pod *api.Pod, restartCount int, enableC
 		labels[kubernetesPodTerminationGracePeriodLabel] = strconv.FormatInt(*pod.Spec.TerminationGracePeriodSeconds, 10)
 	}
 
-	labels[kubernetesContainerNameLabel] = container.Name
+	labels[types.KubernetesContainerNameLabel] = container.Name
 	labels[kubernetesContainerHashLabel] = strconv.FormatUint(kubecontainer.HashContainer(container), 16)
 	labels[kubernetesContainerRestartCountLabel] = strconv.Itoa(restartCount)
 	labels[kubernetesContainerTerminationMessagePathLabel] = container.TerminationMessagePath
@@ -122,10 +103,10 @@ func newLabels(container *api.Container, pod *api.Pod, restartCount int, enableC
 func getContainerInfoFromLabel(labels map[string]string) *labelledContainerInfo {
 	var err error
 	containerInfo := &labelledContainerInfo{
-		PodName:      getStringValueFromLabel(labels, kubernetesPodNameLabel),
-		PodNamespace: getStringValueFromLabel(labels, kubernetesPodNamespaceLabel),
-		PodUID:       types.UID(getStringValueFromLabel(labels, kubernetesPodUIDLabel)),
-		Name:         getStringValueFromLabel(labels, kubernetesContainerNameLabel),
+		PodName:      getStringValueFromLabel(labels, types.KubernetesPodNameLabel),
+		PodNamespace: getStringValueFromLabel(labels, types.KubernetesPodNamespaceLabel),
+		PodUID:       kubetypes.UID(getStringValueFromLabel(labels, types.KubernetesPodUIDLabel)),
+		Name:         getStringValueFromLabel(labels, types.KubernetesContainerNameLabel),
 		Hash:         getStringValueFromLabel(labels, kubernetesContainerHashLabel),
 		TerminationMessagePath: getStringValueFromLabel(labels, kubernetesContainerTerminationMessagePathLabel),
 	}

--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -48,12 +48,12 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/network/hairpin"
 	proberesults "k8s.io/kubernetes/pkg/kubelet/prober/results"
 	"k8s.io/kubernetes/pkg/kubelet/qos"
-	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
+	"k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/kubelet/util/cache"
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/securitycontext"
-	"k8s.io/kubernetes/pkg/types"
+	kubetypes "k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/flowcontrol"
 	"k8s.io/kubernetes/pkg/util/oom"
 	"k8s.io/kubernetes/pkg/util/procfs"
@@ -176,7 +176,7 @@ type DockerManager struct {
 
 // A subset of the pod.Manager interface extracted for testing purposes.
 type podGetter interface {
-	GetPodByUID(types.UID) (*api.Pod, bool)
+	GetPodByUID(kubetypes.UID) (*api.Pod, bool)
 }
 
 func PodInfraContainerEnv(env map[string]string) kubecontainer.Option {
@@ -205,7 +205,7 @@ func NewDockerManager(
 	osInterface kubecontainer.OSInterface,
 	networkPlugin network.NetworkPlugin,
 	runtimeHelper kubecontainer.RuntimeHelper,
-	httpClient kubetypes.HttpGetter,
+	httpClient types.HttpGetter,
 	execHandler ExecHandler,
 	oomAdjuster *oom.OOMAdjuster,
 	procFs procfs.ProcFSInterface,
@@ -744,14 +744,14 @@ func getDockerContainerNameInfo(c *dockertypes.Container) (*KubeletContainerName
 }
 
 // Get pod UID, name, and namespace by examining the container names.
-func getPodInfoFromContainer(c *dockertypes.Container) (types.UID, string, string, error) {
+func getPodInfoFromContainer(c *dockertypes.Container) (kubetypes.UID, string, string, error) {
 	dockerName, _, err := getDockerContainerNameInfo(c)
 	if err != nil {
-		return types.UID(""), "", "", err
+		return kubetypes.UID(""), "", "", err
 	}
 	name, namespace, err := kubecontainer.ParsePodFullName(dockerName.PodFullName)
 	if err != nil {
-		return types.UID(""), "", "", fmt.Errorf("parse pod full name %q error: %v", dockerName.PodFullName, err)
+		return kubetypes.UID(""), "", "", fmt.Errorf("parse pod full name %q error: %v", dockerName.PodFullName, err)
 	}
 	return dockerName.PodUID, name, namespace, nil
 }
@@ -781,7 +781,7 @@ func (dm *DockerManager) GetPods(all bool) ([]*kubecontainer.Pod, error) {
 	defer func() {
 		metrics.ContainerManagerLatency.WithLabelValues("GetPods").Observe(metrics.SinceInMicroseconds(start))
 	}()
-	pods := make(map[types.UID]*kubecontainer.Pod)
+	pods := make(map[kubetypes.UID]*kubecontainer.Pod)
 	var result []*kubecontainer.Pod
 
 	containers, err := GetKubeletDockerContainers(dm.client, all)
@@ -1375,7 +1375,7 @@ func containerAndPodFromLabels(inspect *dockertypes.ContainerJSON) (pod *api.Pod
 	if body, found := labels[kubernetesPodLabel]; found {
 		pod = &api.Pod{}
 		if err = runtime.DecodeInto(api.Codecs.UniversalDecoder(), []byte(body), pod); err == nil {
-			name := labels[kubernetesContainerNameLabel]
+			name := labels[types.KubernetesContainerNameLabel]
 			for ix := range pod.Spec.Containers {
 				if pod.Spec.Containers[ix].Name == name {
 					container = &pod.Spec.Containers[ix]
@@ -2303,7 +2303,7 @@ func (dm *DockerManager) GarbageCollect(gcPolicy kubecontainer.ContainerGCPolicy
 	return dm.containerGC.GarbageCollect(gcPolicy)
 }
 
-func (dm *DockerManager) GetPodStatus(uid types.UID, name, namespace string) (*kubecontainer.PodStatus, error) {
+func (dm *DockerManager) GetPodStatus(uid kubetypes.UID, name, namespace string) (*kubecontainer.PodStatus, error) {
 	podStatus := &kubecontainer.PodStatus{ID: uid, Name: name, Namespace: namespace}
 	// Now we retain restart count of container as a docker label. Each time a container
 	// restarts, pod will read the restart count from the registered dead container, increment

--- a/pkg/kubelet/dockertools/manager_test.go
+++ b/pkg/kubelet/dockertools/manager_test.go
@@ -44,8 +44,9 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/network"
 	nettest "k8s.io/kubernetes/pkg/kubelet/network/testing"
 	proberesults "k8s.io/kubernetes/pkg/kubelet/prober/results"
+	"k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/types"
+	kubetypes "k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util"
 	uexec "k8s.io/kubernetes/pkg/util/exec"
 	"k8s.io/kubernetes/pkg/util/flowcontrol"
@@ -93,7 +94,7 @@ func (f *fakeRuntimeHelper) GeneratePodHostNameAndDomain(pod *api.Pod) (string, 
 	return "", "", nil
 }
 
-func (f *fakeRuntimeHelper) GetPodDir(types.UID) string {
+func (f *fakeRuntimeHelper) GetPodDir(kubetypes.UID) string {
 	return ""
 }
 
@@ -338,13 +339,13 @@ func TestGetPods(t *testing.T) {
 
 	expected := []*kubecontainer.Pod{
 		{
-			ID:         types.UID("1234"),
+			ID:         kubetypes.UID("1234"),
 			Name:       "qux",
 			Namespace:  "new",
 			Containers: []*kubecontainer.Container{containers[0], containers[1]},
 		},
 		{
-			ID:         types.UID("5678"),
+			ID:         kubetypes.UID("5678"),
 			Name:       "jlk",
 			Namespace:  "wen",
 			Containers: []*kubecontainer.Container{containers[2]},
@@ -458,8 +459,8 @@ func TestKillContainerInPodWithPreStop(t *testing.T) {
 			Name: "/k8s_foo_qux_new_1234_42",
 			Config: &dockercontainer.Config{
 				Labels: map[string]string{
-					kubernetesPodLabel:           string(podString),
-					kubernetesContainerNameLabel: "foo",
+					kubernetesPodLabel:                 string(podString),
+					types.KubernetesContainerNameLabel: "foo",
 				},
 			},
 		},

--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -49,10 +49,10 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/network"
 	"k8s.io/kubernetes/pkg/kubelet/network/hairpin"
 	proberesults "k8s.io/kubernetes/pkg/kubelet/prober/results"
-	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
+	"k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
 	"k8s.io/kubernetes/pkg/securitycontext"
-	"k8s.io/kubernetes/pkg/types"
+	kubetypes "k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/errors"
 	utilexec "k8s.io/kubernetes/pkg/util/exec"
@@ -84,9 +84,6 @@ const (
 
 	k8sRktKubeletAnno                = "rkt.kubernetes.io/managed-by-kubelet"
 	k8sRktKubeletAnnoValue           = "true"
-	k8sRktUIDAnno                    = "rkt.kubernetes.io/uid"
-	k8sRktNameAnno                   = "rkt.kubernetes.io/name"
-	k8sRktNamespaceAnno              = "rkt.kubernetes.io/namespace"
 	k8sRktContainerHashAnno          = "rkt.kubernetes.io/container-hash"
 	k8sRktRestartCountAnno           = "rkt.kubernetes.io/restart-count"
 	k8sRktTerminationMessagePathAnno = "rkt.kubernetes.io/termination-message-path"
@@ -167,12 +164,12 @@ var _ kubecontainer.Runtime = &Runtime{}
 
 // TODO(yifan): Remove this when volumeManager is moved to separate package.
 type VolumeGetter interface {
-	GetVolumes(podUID types.UID) (kubecontainer.VolumeMap, bool)
+	GetVolumes(podUID kubetypes.UID) (kubecontainer.VolumeMap, bool)
 }
 
 // TODO(yifan): This duplicates the podGetter in dockertools.
 type podGetter interface {
-	GetPodByUID(types.UID) (*api.Pod, bool)
+	GetPodByUID(kubetypes.UID) (*api.Pod, bool)
 }
 
 // cliInterface wrapps the command line calls for testing purpose.
@@ -194,7 +191,7 @@ func New(
 	podGetter podGetter,
 	livenessManager proberesults.Manager,
 	volumeGetter VolumeGetter,
-	httpClient kubetypes.HttpGetter,
+	httpClient types.HttpGetter,
 	networkPlugin network.NetworkPlugin,
 	hairpinMode bool,
 	execer utilexec.Interface,
@@ -608,9 +605,9 @@ func (r *Runtime) makePodManifest(pod *api.Pod, pullSecrets []api.Secret) (*appc
 
 	requiresPrivileged := false
 	manifest.Annotations.Set(*appctypes.MustACIdentifier(k8sRktKubeletAnno), k8sRktKubeletAnnoValue)
-	manifest.Annotations.Set(*appctypes.MustACIdentifier(k8sRktUIDAnno), string(pod.UID))
-	manifest.Annotations.Set(*appctypes.MustACIdentifier(k8sRktNameAnno), pod.Name)
-	manifest.Annotations.Set(*appctypes.MustACIdentifier(k8sRktNamespaceAnno), pod.Namespace)
+	manifest.Annotations.Set(*appctypes.MustACIdentifier(types.KubernetesPodUIDLabel), string(pod.UID))
+	manifest.Annotations.Set(*appctypes.MustACIdentifier(types.KubernetesPodNameLabel), pod.Name)
+	manifest.Annotations.Set(*appctypes.MustACIdentifier(types.KubernetesPodNamespaceLabel), pod.Namespace)
 	manifest.Annotations.Set(*appctypes.MustACIdentifier(k8sRktRestartCountAnno), strconv.Itoa(restartCount))
 	if stage1Name, ok := pod.Annotations[k8sRktStage1NameAnno]; ok {
 		requiresPrivileged = true
@@ -676,7 +673,7 @@ func podFinishedMarkCommand(touchPath, podDir, rktUID string) string {
 
 // podFinishedAt returns the time that a pod exited, or a zero time if it has
 // not.
-func (r *Runtime) podFinishedAt(podUID types.UID, rktUID string) time.Time {
+func (r *Runtime) podFinishedAt(podUID kubetypes.UID, rktUID string) time.Time {
 	markerFile := podFinishedMarkerPath(r.runtimeHelper.GetPodDir(podUID), rktUID)
 	stat, err := r.os.Stat(markerFile)
 	if err != nil {
@@ -792,6 +789,10 @@ func (r *Runtime) newAppcRuntimeApp(pod *api.Pod, c api.Container, requiresPrivi
 				Name:  *appctypes.MustACIdentifier(k8sRktContainerHashAnno),
 				Value: strconv.FormatUint(kubecontainer.HashContainer(&c), 10),
 			},
+			{
+				Name:  *appctypes.MustACIdentifier(types.KubernetesContainerNameLabel),
+				Value: c.Name,
+			},
 		},
 	}
 
@@ -824,7 +825,7 @@ func (r *Runtime) newAppcRuntimeApp(pod *api.Pod, c api.Container, requiresPrivi
 	return nil
 }
 
-func runningKubernetesPodFilters(uid types.UID) []*rktapi.PodFilter {
+func runningKubernetesPodFilters(uid kubetypes.UID) []*rktapi.PodFilter {
 	return []*rktapi.PodFilter{
 		{
 			States: []rktapi.PodState{
@@ -836,7 +837,7 @@ func runningKubernetesPodFilters(uid types.UID) []*rktapi.PodFilter {
 					Value: k8sRktKubeletAnnoValue,
 				},
 				{
-					Key:   k8sRktUIDAnno,
+					Key:   types.KubernetesPodUIDLabel,
 					Value: string(uid),
 				},
 			},
@@ -844,7 +845,7 @@ func runningKubernetesPodFilters(uid types.UID) []*rktapi.PodFilter {
 	}
 }
 
-func kubernetesPodFilters(uid types.UID) []*rktapi.PodFilter {
+func kubernetesPodFilters(uid kubetypes.UID) []*rktapi.PodFilter {
 	return []*rktapi.PodFilter{
 		{
 			Annotations: []*rktapi.KeyValue{
@@ -853,7 +854,7 @@ func kubernetesPodFilters(uid types.UID) []*rktapi.PodFilter {
 					Value: k8sRktKubeletAnnoValue,
 				},
 				{
-					Key:   k8sRktUIDAnno,
+					Key:   types.KubernetesPodUIDLabel,
 					Value: string(uid),
 				},
 			},
@@ -1110,7 +1111,7 @@ func (r *Runtime) generateEvents(runtimePod *kubecontainer.Pod, reason string, f
 	return
 }
 
-func makePodNetnsName(podID types.UID) string {
+func makePodNetnsName(podID kubetypes.UID) string {
 	return fmt.Sprintf("%s_%s", kubernetesUnitPrefix, string(podID))
 }
 
@@ -1327,21 +1328,21 @@ func (r *Runtime) convertRktPod(rktpod *rktapi.Pod) (*kubecontainer.Pod, error) 
 		return nil, err
 	}
 
-	podUID, ok := manifest.Annotations.Get(k8sRktUIDAnno)
+	podUID, ok := manifest.Annotations.Get(types.KubernetesPodUIDLabel)
 	if !ok {
-		return nil, fmt.Errorf("pod is missing annotation %s", k8sRktUIDAnno)
+		return nil, fmt.Errorf("pod is missing annotation %s", types.KubernetesPodUIDLabel)
 	}
-	podName, ok := manifest.Annotations.Get(k8sRktNameAnno)
+	podName, ok := manifest.Annotations.Get(types.KubernetesPodNameLabel)
 	if !ok {
-		return nil, fmt.Errorf("pod is missing annotation %s", k8sRktNameAnno)
+		return nil, fmt.Errorf("pod is missing annotation %s", types.KubernetesPodNameLabel)
 	}
-	podNamespace, ok := manifest.Annotations.Get(k8sRktNamespaceAnno)
+	podNamespace, ok := manifest.Annotations.Get(types.KubernetesPodNamespaceLabel)
 	if !ok {
-		return nil, fmt.Errorf("pod is missing annotation %s", k8sRktNamespaceAnno)
+		return nil, fmt.Errorf("pod is missing annotation %s", types.KubernetesPodNamespaceLabel)
 	}
 
 	kubepod := &kubecontainer.Pod{
-		ID:        types.UID(podUID),
+		ID:        kubetypes.UID(podUID),
 		Name:      podName,
 		Namespace: podNamespace,
 	}
@@ -1399,8 +1400,8 @@ func (r *Runtime) GetPods(all bool) ([]*kubecontainer.Pod, error) {
 		return nil, fmt.Errorf("couldn't list pods: %v", err)
 	}
 
-	pods := make(map[types.UID]*kubecontainer.Pod)
-	var podIDs []types.UID
+	pods := make(map[kubetypes.UID]*kubecontainer.Pod)
+	var podIDs []kubetypes.UID
 	for _, pod := range listResp.Pods {
 		pod, err := r.convertRktPod(pod)
 		if err != nil {
@@ -1620,13 +1621,13 @@ func (s podsByCreatedAt) Less(i, j int) bool { return s[i].CreatedAt < s[j].Crea
 
 // getPodUID returns the pod's API UID, it returns
 // empty UID if the UID cannot be determined.
-func getPodUID(pod *rktapi.Pod) types.UID {
+func getPodUID(pod *rktapi.Pod) kubetypes.UID {
 	for _, anno := range pod.Annotations {
-		if anno.Key == k8sRktUIDAnno {
-			return types.UID(anno.Value)
+		if anno.Key == types.KubernetesPodUIDLabel {
+			return kubetypes.UID(anno.Value)
 		}
 	}
-	return types.UID("")
+	return kubetypes.UID("")
 }
 
 // podIsActive returns true if the pod is embryo, preparing or running.
@@ -1645,7 +1646,7 @@ func (r *Runtime) GetNetNS(containerID kubecontainer.ContainerID) (string, error
 	// We pretend the pod.UID is an infra container ID.
 	// This deception is only possible because we played the same trick in
 	// `networkPlugin.SetUpPod` and `networkPlugin.TearDownPod`.
-	return netnsPathFromName(makePodNetnsName(types.UID(containerID.ID))), nil
+	return netnsPathFromName(makePodNetnsName(kubetypes.UID(containerID.ID))), nil
 }
 
 func podDetailsFromServiceFile(serviceFilePath string) (string, string, string, error) {
@@ -1719,7 +1720,7 @@ func (r *Runtime) GarbageCollect(gcPolicy kubecontainer.ContainerGCPolicy) error
 		allPods[pod.Id] = pod
 		if !podIsActive(pod) {
 			uid := getPodUID(pod)
-			if uid == types.UID("") {
+			if uid == kubetypes.UID("") {
 				glog.Errorf("rkt: Cannot get the UID of pod %q, pod is broken, will remove it", pod.Id)
 				removeCandidates = append(removeCandidates, pod)
 				continue
@@ -1788,7 +1789,7 @@ func (r *Runtime) cleanupPodNetworkFromServiceFile(serviceFilePath string) {
 	if err == nil {
 		r.cleanupPodNetwork(&api.Pod{
 			ObjectMeta: api.ObjectMeta{
-				UID:       types.UID(id),
+				UID:       kubetypes.UID(id),
 				Name:      name,
 				Namespace: namespace,
 			},
@@ -2047,7 +2048,7 @@ func populateContainerStatus(pod rktapi.Pod, app rktapi.App, runtimeApp appcsche
 // server doesn't error, but doesn't provide meaningful information about the
 // pod, a status with no information (other than the passed in arguments) is
 // returned anyways.
-func (r *Runtime) GetPodStatus(uid types.UID, name, namespace string) (*kubecontainer.PodStatus, error) {
+func (r *Runtime) GetPodStatus(uid kubetypes.UID, name, namespace string) (*kubecontainer.PodStatus, error) {
 	podStatus := &kubecontainer.PodStatus{
 		ID:        uid,
 		Name:      name,

--- a/pkg/kubelet/rkt/rkt_test.go
+++ b/pkg/kubelet/rkt/rkt_test.go
@@ -37,7 +37,8 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/pkg/kubelet/rkt/mock_os"
 	"k8s.io/kubernetes/pkg/kubelet/rkt/mock_rkt"
-	"k8s.io/kubernetes/pkg/types"
+	"k8s.io/kubernetes/pkg/kubelet/types"
+	kubetypes "k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/errors"
 	utilexec "k8s.io/kubernetes/pkg/util/exec"
 	utiltesting "k8s.io/kubernetes/pkg/util/testing"
@@ -83,15 +84,15 @@ func makeRktPod(rktPodState rktapi.PodState,
 				Value: k8sRktKubeletAnnoValue,
 			},
 			appctypes.Annotation{
-				Name:  *appctypes.MustACIdentifier(k8sRktUIDAnno),
+				Name:  *appctypes.MustACIdentifier(types.KubernetesPodUIDLabel),
 				Value: podUID,
 			},
 			appctypes.Annotation{
-				Name:  *appctypes.MustACIdentifier(k8sRktNameAnno),
+				Name:  *appctypes.MustACIdentifier(types.KubernetesPodNameLabel),
 				Value: podName,
 			},
 			appctypes.Annotation{
-				Name:  *appctypes.MustACIdentifier(k8sRktNamespaceAnno),
+				Name:  *appctypes.MustACIdentifier(types.KubernetesPodNamespaceLabel),
 				Value: podNamespace,
 			},
 			appctypes.Annotation{
@@ -1461,7 +1462,7 @@ func TestGarbageCollect(t *testing.T) {
 					Apps:      []*rktapi.App{fakeApp},
 					Annotations: []*rktapi.KeyValue{
 						{
-							Key:   k8sRktUIDAnno,
+							Key:   types.KubernetesPodUIDLabel,
 							Value: "pod-uid-0",
 						},
 					},
@@ -1474,7 +1475,7 @@ func TestGarbageCollect(t *testing.T) {
 					Apps:      []*rktapi.App{fakeApp},
 					Annotations: []*rktapi.KeyValue{
 						{
-							Key:   k8sRktUIDAnno,
+							Key:   types.KubernetesPodUIDLabel,
 							Value: "pod-uid-1",
 						},
 					},
@@ -1487,7 +1488,7 @@ func TestGarbageCollect(t *testing.T) {
 					Apps:      []*rktapi.App{fakeApp},
 					Annotations: []*rktapi.KeyValue{
 						{
-							Key:   k8sRktUIDAnno,
+							Key:   types.KubernetesPodUIDLabel,
 							Value: "pod-uid-2",
 						},
 					},
@@ -1500,7 +1501,7 @@ func TestGarbageCollect(t *testing.T) {
 					Apps:      []*rktapi.App{fakeApp},
 					Annotations: []*rktapi.KeyValue{
 						{
-							Key:   k8sRktUIDAnno,
+							Key:   types.KubernetesPodUIDLabel,
 							Value: "pod-uid-3",
 						},
 					},
@@ -1513,7 +1514,7 @@ func TestGarbageCollect(t *testing.T) {
 					Apps:      []*rktapi.App{fakeApp},
 					Annotations: []*rktapi.KeyValue{
 						{
-							Key:   k8sRktUIDAnno,
+							Key:   types.KubernetesPodUIDLabel,
 							Value: "pod-uid-4",
 						},
 					},
@@ -1544,7 +1545,7 @@ func TestGarbageCollect(t *testing.T) {
 					Apps:      []*rktapi.App{fakeApp},
 					Annotations: []*rktapi.KeyValue{
 						{
-							Key:   k8sRktUIDAnno,
+							Key:   types.KubernetesPodUIDLabel,
 							Value: "pod-uid-2",
 						},
 					},
@@ -1557,7 +1558,7 @@ func TestGarbageCollect(t *testing.T) {
 					Apps:      []*rktapi.App{fakeApp},
 					Annotations: []*rktapi.KeyValue{
 						{
-							Key:   k8sRktUIDAnno,
+							Key:   types.KubernetesPodUIDLabel,
 							Value: "pod-uid-1",
 						},
 					},
@@ -1570,7 +1571,7 @@ func TestGarbageCollect(t *testing.T) {
 					Apps:      []*rktapi.App{fakeApp},
 					Annotations: []*rktapi.KeyValue{
 						{
-							Key:   k8sRktUIDAnno,
+							Key:   types.KubernetesPodUIDLabel,
 							Value: "pod-uid-0",
 						},
 					},
@@ -1621,7 +1622,7 @@ func TestGarbageCollect(t *testing.T) {
 		cli.Reset()
 		ctrl.Finish()
 		fakeOS.Removes = []string{}
-		getter.pods = make(map[types.UID]*api.Pod)
+		getter.pods = make(map[kubetypes.UID]*api.Pod)
 	}
 }
 
@@ -1664,11 +1665,11 @@ func TestMakePodManifestAnnotations(t *testing.T) {
 						Value: "stage1-override-img",
 					},
 					{
-						Name:  appctypes.ACIdentifier(k8sRktUIDAnno),
+						Name:  appctypes.ACIdentifier(types.KubernetesPodUIDLabel),
 						Value: "uid-1",
 					},
 					{
-						Name:  appctypes.ACIdentifier(k8sRktNameAnno),
+						Name:  appctypes.ACIdentifier(types.KubernetesPodNameLabel),
 						Value: "name-1",
 					},
 					{
@@ -1676,7 +1677,7 @@ func TestMakePodManifestAnnotations(t *testing.T) {
 						Value: "true",
 					},
 					{
-						Name:  appctypes.ACIdentifier(k8sRktNamespaceAnno),
+						Name:  appctypes.ACIdentifier(types.KubernetesPodNamespaceLabel),
 						Value: "namespace-1",
 					},
 					{

--- a/pkg/kubelet/types/labels.go
+++ b/pkg/kubelet/types/labels.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+const (
+	KubernetesPodNameLabel       = "io.kubernetes.pod.name"
+	KubernetesPodNamespaceLabel  = "io.kubernetes.pod.namespace"
+	KubernetesPodUIDLabel        = "io.kubernetes.pod.uid"
+	KubernetesContainerNameLabel = "io.kubernetes.container.name"
+)
+
+func GetContainerName(labels map[string]string) string {
+	return labels[KubernetesContainerNameLabel]
+}
+
+func GetPodName(labels map[string]string) string {
+	return labels[KubernetesPodNameLabel]
+}
+
+func GetPodUID(labels map[string]string) string {
+	return labels[KubernetesPodUIDLabel]
+}
+
+func GetPodNamespace(labels map[string]string) string {
+	return labels[KubernetesPodNamespaceLabel]
+}


### PR DESCRIPTION
moved labels and their Get functions to types

aliases kubernetes/types import to kubetypes to use kubelet/types as types
