### PR TITLE
Use the master IP address rather than it's name for KUBELT_APISERVER

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -450,7 +450,7 @@ function write-master-env {
   # If the user requested that the master be part of the cluster, set the
   # environment variable to program the master kubelet to register itself.
   if [[ "${REGISTER_MASTER_KUBELET:-}" == "true" ]]; then
-    KUBELET_APISERVER="${MASTER_NAME}"
+    KUBELET_APISERVER="${MASTER_INTERNAL_IP}"
   fi
 
   build-kube-env true "${KUBE_TEMP}/master-kube-env.yaml"


### PR DESCRIPTION
Currently a kube-up deploy to AWS with REGISTER_MASTER_KUBELET=true will fail because the kubelet on the master will be using $MASTER_NAME as the api-server. There are multiple ways to go about fixing this, such as setting an entry in /etc/hosts. 

To get this working for myself, I am just setting KUBELET_APISERVER to $MASTER_INTERNAL_IP. This may not be appropriate for other deployment types, if so I would like to get some opinions from others on the correct way to solve this before moving forward.

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
