### PR TITLE
Fixes panic on round tripper when TLS under a proxy

### DIFF
--- a/pkg/util/httpstream/spdy/roundtripper.go
+++ b/pkg/util/httpstream/spdy/roundtripper.go
@@ -125,6 +125,10 @@ func (s *SpdyRoundTripper) dial(req *http.Request) (net.Conn, error) {
 		return nil, err
 	}
 
+	if s.tlsConfig == nil {
+		s.tlsConfig = &tls.Config{}
+	}
+
 	if len(s.tlsConfig.ServerName) == 0 {
 		s.tlsConfig.ServerName = host
 	}


### PR DESCRIPTION
When under a proxy with a valid cert from a trusted authority, the `SpdyRoundTripper` will likely not have a `*tls.Config` (no cert verification nor `InsecureSkipVerify` happened), which will result in a panic. So we have to create a new `*tls.Config` to be able to create a TLS client right after. If `RootCAs` in that new config is nil, the system pool will be used.

@ncdc PTAL 

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
