### PR TITLE
Fix hyperkube's layer caching, and remove --make-symlinks at build time

### DIFF
--- a/cluster/images/hyperkube/Dockerfile
+++ b/cluster/images/hyperkube/Dockerfile
@@ -58,12 +58,7 @@ RUN mkdir -p /opt/cni
 RUN curl https://storage.googleapis.com/kubernetes-release/network-plugins/cni-c864f0e1ea73719b8f4582402b0847064f9883b0.tar.gz \
   | tar xzv -C /opt/cni
 
-# Make scripts executable
-RUN chmod a+rx \
-        /hyperkube \
-        /usr/share/google/safe_format_and_mount \
-        /setup-files.sh \
-        /make-ca-cert.sh
-
 # Create symlinks for each hyperkube server
-RUN /hyperkube --make-symlinks
+# TODO: this is unreliable for now (e.g. running "/kubelet" panics)
+# Also, it doesn't work for other architectures
+# RUN /hyperkube --make-symlinks

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -55,6 +55,14 @@ endif
 	cd ${TEMP_DIR} && sed -i.back "s|BASEIMAGE|${BASEIMAGE}|g" Dockerfile
 	rm ${TEMP_DIR}/*.back
 
+	# Make scripts executable before they are copied into the Docker image. If we make them executable later, in another layer
+	# they'll take up twice the space because the new executable binary differs from the old one, but everything is cached in layers.
+	cd ${TEMP_DIR} && chmod a+rx \
+        hyperkube \
+        safe_format_and_mount \
+        setup-files.sh \
+        make-ca-cert.sh
+
 ifeq ($(ARCH),amd64)
 	# When building "normally" for amd64, remove the whole line, it has no part in the amd64 image
 	cd ${TEMP_DIR} && sed -i ""  "/CROSS_BUILD_/d" Dockerfile


### PR DESCRIPTION
@david-mcmahon This is required before you release. Explanation in the code.
