### PR TITLE
Node E2E: Shorten consistently check timeout of runtime conformance test

### DIFF
--- a/test/e2e_node/runtime_conformance_test.go
+++ b/test/e2e_node/runtime_conformance_test.go
@@ -32,8 +32,9 @@ import (
 )
 
 const (
-	retryTimeout = time.Minute * 5
-	pollInterval = time.Second * 5
+	consistentCheckTimeout = time.Second * 20
+	retryTimeout           = time.Minute * 5
+	pollInterval           = time.Second * 5
 )
 
 type testStatus struct {
@@ -176,7 +177,7 @@ var _ = Describe("Container runtime Conformance Test", func() {
 					Consistently(func() api.PodPhase {
 						status, phase, err = runningContainer.GetStatus()
 						return phase
-					}, retryTimeout, pollInterval).Should(Equal(testStatus.Phase))
+					}, consistentCheckTimeout, pollInterval).Should(Equal(testStatus.Phase))
 					Expect(err).NotTo(HaveOccurred())
 
 					By("it should get the expected 'RestartCount'")
@@ -282,7 +283,7 @@ var _ = Describe("Container runtime Conformance Test", func() {
 					} else {
 						return phase
 					}
-				}, retryTimeout, pollInterval).Should(Equal(testStatus.Phase))
+				}, consistentCheckTimeout, pollInterval).Should(Equal(testStatus.Phase))
 				Expect(err).NotTo(HaveOccurred())
 
 				By("it should get the expected 'RestartCount'")


### PR DESCRIPTION
#24191 increased the node e2e running time by almost half an hour. It makes the test running time exceed 60 minutes timeout, which causes quite a few issues (See https://github.com/kubernetes/kubernetes/issues/25639).

As a quite fix, we'll skip all the runtime conformance test. @liangchenye We should remove redundant test cases in #24191 such as https://github.com/kubernetes/kubernetes/pull/24191#discussion_r62968819, and reduce the test running time as much as possible.
