### PR TITLE
Show hack/build-go.sh output during e2e tests.

### DIFF
--- a/test/e2e_node/e2e_build.go
+++ b/test/e2e_node/e2e_build.go
@@ -36,9 +36,12 @@ func buildGo() {
 	if err != nil {
 		glog.Fatalf("Failed to locate kubernetes root directory %v.", err)
 	}
-	out, err := exec.Command(filepath.Join(k8sRoot, "hack/build-go.sh")).CombinedOutput()
+	cmd := exec.Command(filepath.Join(k8sRoot, "hack/build-go.sh"))
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
 	if err != nil {
-		glog.Fatalf("Failed to build go packages %v.  Output:\n%s", err, out)
+		glog.Fatalf("Failed to build go packages %v\n", err)
 	}
 }
 

--- a/test/e2e_node/e2e_remote.go
+++ b/test/e2e_node/e2e_remote.go
@@ -60,9 +60,12 @@ func CreateTestArchive() string {
 	if err != nil {
 		glog.Fatalf("Failed to locate test/e2e_node directory %v.", err)
 	}
-	out, err := exec.Command("ginkgo", "build", testDir).CombinedOutput()
+	cmd := exec.Command("ginkgo", "build", testDir)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
 	if err != nil {
-		glog.Fatalf("Failed to build e2e tests under %s %v.  Output:\n%s", testDir, err, out)
+		glog.Fatalf("Failed to build e2e tests under %s %v\n", testDir, err)
 	}
 	ginkgoTest := filepath.Join(testDir, "e2e_node.test")
 	if _, err := os.Stat(ginkgoTest); err != nil {
@@ -92,7 +95,7 @@ func CreateTestArchive() string {
 	defer os.RemoveAll(tardir)
 
 	// Copy binaries
-	out, err = exec.Command("cp", ginkgoTest, filepath.Join(tardir, "e2e_node.test")).CombinedOutput()
+	out, err := exec.Command("cp", ginkgoTest, filepath.Join(tardir, "e2e_node.test")).CombinedOutput()
 	if err != nil {
 		glog.Fatalf("Failed to copy e2e_node.test %v.", err)
 	}


### PR DESCRIPTION
[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()

This makes it easier to diagnose slow builds, since the build output will be timestamped by Jenkins.
