### PR TITLE
GCI/Trusty: Fix an issue in using 'find' commands

### DIFF
--- a/cluster/gce/trusty/configure-helper.sh
+++ b/cluster/gce/trusty/configure-helper.sh
@@ -561,15 +561,15 @@ setup_addon_manifests() {
   if [ ! -d "${dst_dir}" ]; then
     mkdir -p "${dst_dir}"
   fi
-  files=$(find "${src_dir}" -name "*.yaml")
+  files=$(find "${src_dir}" -maxdepth 1 -name "*.yaml")
   if [ -n "${files}" ]; then
     cp "${src_dir}/"*.yaml "${dst_dir}"
   fi
-  files=$(find "${src_dir}" -name "*.json")
+  files=$(find "${src_dir}" -maxdepth 1 -name "*.json")
   if [ -n "${files}" ]; then
     cp "${src_dir}/"*.json "${dst_dir}"
   fi
-  files=$(find "${src_dir}" -name "*.yaml.in")
+  files=$(find "${src_dir}" -maxdepth 1 -name "*.yaml.in")
   if [ -n "${files}" ]; then
     cp "${src_dir}/"*.yaml.in "${dst_dir}"
   fi

--- a/cluster/gce/trusty/configure.sh
+++ b/cluster/gce/trusty/configure.sh
@@ -152,9 +152,9 @@ install_kube_binary_config() {
   tar xzf "${kube_home}/${manifests_tar}" -C "${dst_dir}" --overwrite
   readonly kube_addon_registry="${KUBE_ADDON_REGISTRY:-gcr.io/google_containers}"
   if [ "${kube_addon_registry}" != "gcr.io/google_containers" ]; then
-    find "${dst_dir}" -name \*.yaml -or -name \*.yaml.in | \
+    find "${dst_dir}" -maxdepth 1 -name \*.yaml -or -maxdepth 1 -name \*.yaml.in | \
       xargs sed -ri "s@(image:\s.*)gcr.io/google_containers@\1${kube_addon_registry}@"
-    find "${dst_dir}" -name \*.manifest -or -name \*.json | \
+    find "${dst_dir}" -maxdepth 1 -name \*.manifest -or -maxdepth 1 -name \*.json | \
       xargs sed -ri "s@(image\":\s+\")gcr.io/google_containers@\1${kube_addon_registry}@"
   fi
   cp "${dst_dir}/kubernetes/gci-trusty/configure-helper.sh" /etc/kube-configure-helper.sh


### PR DESCRIPTION
This PR makes the logic of 'find' command consistent with the 'cp' command afterwards, i.e., only check one layer of a given dir. Without this fix, we have seen a recent breakage after PR #25309 added the file cluster/addons/fluentd-elasticsearch/es-image/template-k8s-logstash.json. The 'find' command discovers this json file, but the 'cp' command fails. 

@roberthbailey @dchen1107 @zmerlynn please review this fix, and mark it as a cherry pick candidate. I already verified this fix can resolve the breakage.

cc/ @wonderfly @fabioy @kubernetes/goog-image FYI
