### PR TITLE
Fix Incorrect response model for pods/{name}/log

### DIFF
--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -8817,6 +8817,7 @@
        }
       ],
       "produces": [
+       "text/plain",
        "application/json",
        "application/yaml",
        "application/vnd.kubernetes.protobuf"

--- a/docs/api-reference/v1/operations.html
+++ b/docs/api-reference/v1/operations.html
@@ -8705,6 +8705,9 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="ulist">
 <ul>
 <li>
+<p>text/plain</p>
+</li>
+<li>
 <p>application/json</p>
 </li>
 <li>

--- a/pkg/registry/pod/rest/log.go
+++ b/pkg/registry/pod/rest/log.go
@@ -45,6 +45,16 @@ func (r *LogREST) New() runtime.Object {
 	return &api.Pod{}
 }
 
+// LogREST implements StorageMetadata
+func (r *LogREST) ProducesMIMETypes(verb string) []string {
+	// Since the default list does not include "plain/text", we need to
+	// explicitly override ProducesMIMETypes, so that it gets added to
+	// the "produces" section for pods/{name}/log
+	return []string{
+		"text/plain",
+	}
+}
+
 // Get retrieves a runtime.Object that will stream the contents of the pod log
 func (r *LogREST) Get(ctx api.Context, name string, opts runtime.Object) (runtime.Object, error) {
 	logOpts, ok := opts.(*api.PodLogOptions)


### PR DESCRIPTION
The swagger spec for pods/{name}/log does not include
"text/plain" as a possible content-type for the the response.
So we implement ProducesMIMETypes to make sure "text/plain"
gets added to the default list ot content-types.

the v1.json was generated by running:
hack/update-generated-swagger-docs.sh;./hack/update-swagger-spec.sh;
