### PR TITLE
Add a timeout to the node e2e Ginkgo test runner

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -416,6 +416,7 @@ system-reserved
 target-port
 tcp-services
 terminated-pod-gc-threshold
+test-timeout
 tls-cert-file
 tls-private-key-file
 to-version


### PR DESCRIPTION
Also add a few debugging statements to indicate progress.

Should help prevent #25639, since we'll timeout tests before Jenkins times out the build.
