### PR TITLE
Check for an empty value in validateField

### DIFF
--- a/hack/testdata/invalid-rc-with-empty-args.yaml
+++ b/hack/testdata/invalid-rc-with-empty-args.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: kube-dns-v10
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    k8s-app: kube-dns
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-dns
+    spec:
+      containers:
+      - name: carbon-relay
+        image: banno/carbon-relay
+        args:
+        -
+# above is the empty arg string.

--- a/pkg/api/validation/schema.go
+++ b/pkg/api/validation/schema.go
@@ -297,6 +297,10 @@ func (s *SwaggerSchema) isGenericArray(p swagger.ModelProperty) bool {
 var versionRegexp = regexp.MustCompile(`^v.+\..*`)
 
 func (s *SwaggerSchema) validateField(value interface{}, fieldName, fieldType string, fieldDetails *swagger.ModelProperty) []error {
+	allErrs := []error{}
+	if reflect.TypeOf(value) == nil {
+		return append(allErrs, fmt.Errorf("unexpected nil value for field %v", fieldName))
+	}
 	// TODO: caesarxuchao: because we have multiple group/versions and objects
 	// may reference objects in other group, the commented out way of checking
 	// if a filedType is a type defined by us is outdated. We use a hacky way
@@ -310,7 +314,6 @@ func (s *SwaggerSchema) validateField(value interface{}, fieldName, fieldType st
 		// if strings.HasPrefix(fieldType, apiVersion) {
 		return s.ValidateObject(value, fieldName, fieldType)
 	}
-	allErrs := []error{}
 	switch fieldType {
 	case "string":
 		// Be loose about what we accept for 'string' since we use IntOrString in a couple of places

--- a/pkg/api/validation/schema_test.go
+++ b/pkg/api/validation/schema_test.go
@@ -209,6 +209,7 @@ func TestInvalid(t *testing.T) {
 		"invalidPod1.json", // command is a string, instead of []string.
 		"invalidPod2.json", // hostPort if of type string, instead of int.
 		"invalidPod3.json", // volumes is not an array of objects.
+		"invalidPod4.yaml", // string list with empty string.
 		"invalidPod.yaml",  // command is a string, instead of []string.
 	}
 	for _, test := range tests {

--- a/pkg/api/validation/testdata/v1/invalidPod4.yaml
+++ b/pkg/api/validation/testdata/v1/invalidPod4.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    name: redis-master
+  name: name
+spec:
+  containers:
+  - image: gcr.io/fake_project/fake_image:fake_tag
+    name: master
+    args:
+    -
+    command:
+    -


### PR DESCRIPTION
``` release-note
* Fix a panic when args was not supplied with any values.
```

reflect.TypeOf() can take a nil (it then returns a nil), but
Kind() panics on a nil.

Now the user gets the following output:
./kubectl.sh --server=http://localhost:8080 create -f ../../test-files/test-rc.yaml
error validating "../../test-files/test-rc.yaml": error validating data: unexpected nil value for field spec.template.spec.containers[0].args[0]; if you choose to ignore these errors, turn validation off with --validate=false

fixes #20627 and fixes #26927
