### PR TITLE
Use read-only root filesystem capabilities of rkt

### DIFF
--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -764,9 +764,10 @@ func (r *Runtime) newAppcRuntimeApp(pod *api.Pod, c api.Container, pullSecrets [
 	}
 
 	ra := appcschema.RuntimeApp{
-		Name:  convertToACName(c.Name),
-		Image: appcschema.RuntimeImage{ID: *hash},
-		App:   imgManifest.App,
+		Name:           convertToACName(c.Name),
+		Image:          appcschema.RuntimeImage{ID: *hash},
+		App:            imgManifest.App,
+		ReadOnlyRootFS: *c.SecurityContext.ReadOnlyRootFilesystem,
 		Annotations: []appctypes.Annotation{
 			{
 				Name:  *appctypes.MustACIdentifier(k8sRktContainerHashAnno),


### PR DESCRIPTION
Propagates `api.Container.SecurityContext.ReadOnlyRootFileSystem` flag to rkt container runtime.

cc @yifan-gu 

Fixes #23837 
