### PR TITLE
fix reading logs from rkt container

### DIFF
--- a/pkg/kubelet/rkt/log.go
+++ b/pkg/kubelet/rkt/log.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"os/exec"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -112,7 +111,7 @@ func (r *Runtime) GetContainerLogs(pod *api.Pod, containerID kubecontainer.Conta
 		return err
 	}
 
-	cmd := exec.Command("journalctl", "-m", fmt.Sprintf("_MACHINE_ID=%s", strings.Replace(id.uuid, "-", "", -1)), "-u", id.appName, "-a")
+	cmd := exec.Command("journalctl", "-u", fmt.Sprintf("k8s_%s", id.uuid), "-u", id.appName, "-a")
 	// Get the json structured logs.
 	cmd.Args = append(cmd.Args, "-o", "json")
 


### PR DESCRIPTION
Since there is some issue with rkt and using `machinectl` for logs,
we can use directly `journalctl` on systemd unit. Additional advantage
is that `machinectl` is not default installed on some linux distros.
