### PR TITLE
Update fake.go, lost defer keyword

### DIFF
--- a/pkg/client/testing/core/fake.go
+++ b/pkg/client/testing/core/fake.go
@@ -179,7 +179,7 @@ func (c *Fake) InvokesProxy(action Action) restclient.ResponseWrapper {
 // ClearActions clears the history of actions called on the fake client
 func (c *Fake) ClearActions() {
 	c.Lock()
-	c.Unlock()
+	defer c.Unlock()
 
 	c.actions = make([]Action, 0)
 }


### PR DESCRIPTION
ClearActions() should defer c.Unlock()
