### PR TITLE
Added enforcing of setting nodes numbers for cluster autoscaler.

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -107,8 +107,8 @@ ENABLE_CLUSTER_UI="${KUBE_ENABLE_CLUSTER_UI:-true}"
 # Optional: Create autoscaler for cluster's nodes.
 ENABLE_NODE_AUTOSCALER="${KUBE_ENABLE_NODE_AUTOSCALER:-false}"
 if [[ "${ENABLE_NODE_AUTOSCALER}" == "true" ]]; then
-  AUTOSCALER_MIN_NODES="${KUBE_AUTOSCALER_MIN_NODES:-1}"
-  AUTOSCALER_MAX_NODES="${KUBE_AUTOSCALER_MAX_NODES:-${NUM_NODES}}"
+  AUTOSCALER_MIN_NODES="${KUBE_AUTOSCALER_MIN_NODES:-}"
+  AUTOSCALER_MAX_NODES="${KUBE_AUTOSCALER_MAX_NODES:-}"
 fi
 
 # Admission Controllers to invoke prior to persisting objects in cluster

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -128,9 +128,8 @@ ENABLE_CLUSTER_UI="${KUBE_ENABLE_CLUSTER_UI:-true}"
 # Optional: Create autoscaler for cluster's nodes.
 ENABLE_NODE_AUTOSCALER="${KUBE_ENABLE_NODE_AUTOSCALER:-false}"
 if [[ "${ENABLE_NODE_AUTOSCALER}" == "true" ]]; then
-  AUTOSCALER_MIN_NODES="${KUBE_AUTOSCALER_MIN_NODES:-1}"
-  AUTOSCALER_MAX_NODES="${KUBE_AUTOSCALER_MAX_NODES:-${NUM_NODES}}"
-  TARGET_NODE_UTILIZATION="${KUBE_TARGET_NODE_UTILIZATION:-0.7}"
+  AUTOSCALER_MIN_NODES="${KUBE_AUTOSCALER_MIN_NODES:-}"
+  AUTOSCALER_MAX_NODES="${KUBE_AUTOSCALER_MAX_NODES:-}"
 fi
 
 # If we included ResourceQuota, we should keep it at the end of the list to prevent incremeting quota usage prematurely.

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -44,6 +44,18 @@ else
   exit 1
 fi
 
+# Verfiy cluster autoscaler configuration.
+if [[ "${ENABLE_NODE_AUTOSCALER}" == "true" ]]; then
+  if [ -z $AUTOSCALER_MIN_NODES ]; then
+    echo "AUTOSCALER_MIN_NODES not set."
+    exit 1
+  fi
+  if [ -z $AUTOSCALER_MAX_NODES ]; then
+    echo "AUTOSCALER_MAX_NODES not set."
+    exit 1
+  fi
+fi
+
 NODE_INSTANCE_PREFIX="${INSTANCE_PREFIX}-minion"
 
 ALLOCATE_NODE_CIDRS=true


### PR DESCRIPTION
``` release-note
Incompatible change of kube-up.sh: 
when turning on cluster autoscaler by setting KUBE_ENABLE_NODE_AUTOSCALER=true,
KUBE_AUTOSCALER_MIN_NODES and KUBE_AUTOSCALER_MAX_NODES need to be set.
```

Added enforcing of setting nodes numbers for cluster autoscaler in kube-up script.
