### PR TITLE
Stop setting Message when updating PodScheduled condition

### DIFF
--- a/plugin/pkg/scheduler/scheduler.go
+++ b/plugin/pkg/scheduler/scheduler.go
@@ -101,10 +101,9 @@ func (s *Scheduler) scheduleOne() {
 		s.config.Error(pod, err)
 		s.config.Recorder.Eventf(pod, api.EventTypeWarning, "FailedScheduling", "%v", err)
 		s.config.PodConditionUpdater.Update(pod, &api.PodCondition{
-			Type:    api.PodScheduled,
-			Status:  api.ConditionFalse,
-			Reason:  "Unschedulable",
-			Message: err.Error(),
+			Type:   api.PodScheduled,
+			Status: api.ConditionFalse,
+			Reason: "Unschedulable",
 		})
 		return
 	}
@@ -142,10 +141,9 @@ func (s *Scheduler) scheduleOne() {
 			s.config.Error(pod, err)
 			s.config.Recorder.Eventf(pod, api.EventTypeNormal, "FailedScheduling", "Binding rejected: %v", err)
 			s.config.PodConditionUpdater.Update(pod, &api.PodCondition{
-				Type:    api.PodScheduled,
-				Status:  api.ConditionFalse,
-				Reason:  "BindingRejected",
-				Message: err.Error(),
+				Type:   api.PodScheduled,
+				Status: api.ConditionFalse,
+				Reason: "BindingRejected",
 			})
 			return
 		}


### PR DESCRIPTION
Every update of pod status currently will result in immediate attempt to schedule it again (once we get notification about update). As message could be different every time, we cannot set it as it'd break backoff mechanism.

Ref https://github.com/kubernetes/kubernetes/issues/25663

@davidopp @wojtek-t @gmarek 

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
