### PR TITLE
WIP - Add Login Command, and add OIDC implementation.

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -236,6 +236,8 @@ Find more information at https://github.com/kubernetes/kubernetes.`,
 	cmds.AddCommand(NewCmdExplain(f, out))
 	cmds.AddCommand(NewCmdConvert(f, out))
 
+	cmds.AddCommand(NewCmdLogin(f, clientcmd.NewDefaultPathOptions(), out))
+
 	if cmds.Flag("namespace").Annotations == nil {
 		cmds.Flag("namespace").Annotations = map[string][]string{}
 	}

--- a/pkg/kubectl/cmd/login.go
+++ b/pkg/kubectl/cmd/login.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	utilflag "k8s.io/kubernetes/pkg/util/flag"
+)
+
+func NewCmdLogin(f *cmdutil.Factory, pathOptions *clientcmd.PathOptions, out io.Writer) *cobra.Command {
+
+	cmd := &cobra.Command{
+		Use:   "login",
+		Short: "login Log in to the cluster.",
+		Long:  `login obtains the neccesary credentials to make authenticated requests to the cluster. The type of log in depends on the 'auth-provider' type in your configuration, and will likely require some type of user interaction.`,
+
+		Run: func(cmd *cobra.Command, args []string) {
+			err := RunLogin(out, cmd, f, pathOptions, args)
+			cmdutil.CheckErr(err)
+		},
+	}
+
+	return cmd
+}
+
+func RunLogin(out io.Writer, cmd *cobra.Command, f *cmdutil.Factory, pathOptions *clientcmd.PathOptions, args []string) error {
+
+	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+	flags.SetNormalizeFunc(utilflag.WarnWordSepNormalizeFunc) // Warn for "_" flags
+
+	cmdCliCfg := cmdutil.DefaultClientConfig(flags)
+	cliCfg, err := cmdCliCfg.ClientConfig()
+	if err != nil {
+		return err
+	}
+
+	auth, err := restclient.GetAuthProvider(cliCfg.Host,
+		cliCfg.AuthProvider,
+		cliCfg.AuthConfigPersister)
+	if err != nil {
+		return err
+	}
+
+	return auth.Login()
+}

--- a/plugin/pkg/client/auth/oidc/oidc_test.go
+++ b/plugin/pkg/client/auth/oidc/oidc_test.go
@@ -615,6 +615,14 @@ func (t *testOIDCClient) verify() error {
 	return nil
 }
 
+func (o *testOIDCClient) authCodeURL(accessType string) string {
+	return ""
+}
+
+func (o *testOIDCClient) exchangeCode(code string) (oauth2.TokenResponse, error) {
+	return oauth2.TokenResponse{}, nil
+}
+
 func compareJWTs(a, b jose.JWT) string {
 	if a.Encode() == b.Encode() {
 		return ""


### PR DESCRIPTION
OIDC implementation of login command.
Spawns a browser, and sends user to the OIDC IdP to authenticate, after
which they are redirected back to a server running on localhost, which
performs the auth code exchange and persists the ID Token and possibly
refresh token.

NOTE: this is a WIP, rebased off of #25270, which this is dependent on.
