### PR TITLE
Fix gce/util.sh:get-master-root-disk-size

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -629,7 +629,7 @@ function create-network() {
 # Sets:
 #   MASTER_ROOT_DISK_SIZE
 function get-master-root-disk-size() {
-  if [ "$NUM_NODES" -le "1000"]; then
+  if [[ "${NUM_NODES}" -le "1000" ]]; then
     export MASTER_ROOT_DISK_SIZE="10"
   else
     export MASTER_ROOT_DISK_SIZE="50"


### PR DESCRIPTION
Fixes problem from #25670

```
cluster/../cluster/../cluster/gce/util.sh: line 632: [: missing `]'
```

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
