### PR TITLE
Add support for limiting grace period during soft eviction

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -190,6 +190,7 @@ func UnsecuredKubeletConfig(s *options.KubeletServer) (*KubeletConfig, error) {
 	}
 	evictionConfig := eviction.Config{
 		PressureTransitionPeriod: s.EvictionPressureTransitionPeriod.Duration,
+		MaxPodGracePeriodSeconds: int64(s.EvictionMaxPodGracePeriod),
 		Thresholds:               thresholds,
 	}
 

--- a/pkg/kubelet/eviction/helpers.go
+++ b/pkg/kubelet/eviction/helpers.go
@@ -551,3 +551,16 @@ func reclaimResources(thresholds []Threshold) []api.ResourceName {
 	}
 	return results
 }
+
+// isSoftEviction returns true if the thresholds met for the starved resource are only soft thresholds
+func isSoftEviction(thresholds []Threshold, starvedResource api.ResourceName) bool {
+	for _, threshold := range thresholds {
+		if resourceToCheck := signalToResource[threshold.Signal]; resourceToCheck != starvedResource {
+			continue
+		}
+		if threshold.GracePeriod == time.Duration(0) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/kubelet/eviction/types.go
+++ b/pkg/kubelet/eviction/types.go
@@ -44,6 +44,8 @@ const (
 type Config struct {
 	// PressureTransitionPeriod is duration the kubelet has to wait before transititioning out of a pressure condition.
 	PressureTransitionPeriod time.Duration
+	// Maximum allowed grace period (in seconds) to use when terminating pods in response to a soft eviction threshold being met.
+	MaxPodGracePeriodSeconds int64
 	// Thresholds define the set of conditions monitored to trigger eviction.
 	Thresholds []Threshold
 }


### PR DESCRIPTION
Adds eviction manager support in kubelet for max pod graceful termination period when a soft eviction is met.

``` release-note
Kubelet evicts pods when available memory falls below configured eviction thresholds
```

/cc @vishh
