### PR TITLE
Removing indirection from proxy exec test

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1615,6 +1615,11 @@ func NewKubectlCommand(args ...string) *kubectlBuilder {
 	return b
 }
 
+func (b *kubectlBuilder) WithEnv(env []string) *kubectlBuilder {
+	b.cmd.Env = env
+	return b
+}
+
 func (b *kubectlBuilder) WithTimeout(t <-chan time.Time) *kubectlBuilder {
 	b.timeout = t
 	return b


### PR DESCRIPTION
I removed the netexec and goproxy pods from the proxy exec test. Instead
it now runs kubectl locally and the proxy is running in-process. Since
Go won't proxy for localhost requests, this test cannot pass if the API
server is local. However it was already disabled for local clusters.

cc @ncdc @cjcullen @lavalamp @spxtr @ihmccreery @kubernetes/sig-api-machinery 
#24620
