### PR TITLE
e2e: simple pod HTTP proxy test should use amd64 kubectl for GCI

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -298,7 +298,7 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 
 			// Build the static kubectl
 			By("Finding a static kubectl for upload")
-			testStaticKubectlPath, err := findBinary("kubectl", "linux/386")
+			testStaticKubectlPath, err := findBinary("kubectl", "linux/amd64")
 			if err != nil {
 				framework.Logf("No kubectl found: %v.\nAttempting a local build...", err)
 				// Fall back to trying to build a local static kubectl


### PR DESCRIPTION
This PR is for fixing issue #25778. So far GCI is the first distro hitting the issue. So this PR is just for GCI.

@dchen1107 @ixdy @roberthbailey please review it or assign it to a suitable review. We need to cherry pick the fix in release-1.2. Thanks!

The fix is verified using the latest GCI image with 4.4.4 kernel.

cc/ @fabioy @kubernetes/goog-image FYI
