### PR TITLE
Fix the Store to be Indexer in test/component/scheduler/perf

### DIFF
--- a/test/component/scheduler/perf/scheduler_bench_test.go
+++ b/test/component/scheduler/perf/scheduler_bench_test.go
@@ -56,7 +56,7 @@ func benchmarkScheduling(numNodes, numScheduledPods int, b *testing.B) {
 	makeNodes(c, numNodes)
 	makePodsFromRC(c, "rc1", numScheduledPods)
 	for {
-		scheduled := schedulerConfigFactory.ScheduledPodLister.Store.List()
+		scheduled := schedulerConfigFactory.ScheduledPodLister.Indexer.List()
 		if len(scheduled) >= numScheduledPods {
 			break
 		}
@@ -68,7 +68,7 @@ func benchmarkScheduling(numNodes, numScheduledPods int, b *testing.B) {
 	for {
 		// This can potentially affect performance of scheduler, since List() is done under mutex.
 		// TODO: Setup watch on apiserver and wait until all pods scheduled.
-		scheduled := schedulerConfigFactory.ScheduledPodLister.Store.List()
+		scheduled := schedulerConfigFactory.ScheduledPodLister.Indexer.List()
 		if len(scheduled) >= numScheduledPods+b.N {
 			break
 		}

--- a/test/component/scheduler/perf/scheduler_test.go
+++ b/test/component/scheduler/perf/scheduler_test.go
@@ -50,7 +50,7 @@ func schedulePods(numNodes, numPods int) {
 		// This can potentially affect performance of scheduler, since List() is done under mutex.
 		// Listing 10000 pods is an expensive operation, so running it frequently may impact scheduler.
 		// TODO: Setup watch on apiserver and wait until all pods scheduled.
-		scheduled := schedulerConfigFactory.ScheduledPodLister.Store.List()
+		scheduled := schedulerConfigFactory.ScheduledPodLister.Indexer.List()
 		fmt.Printf("%ds\trate: %d\ttotal: %d\n", time.Since(start)/time.Second, len(scheduled)-prev, len(scheduled))
 		if len(scheduled) >= numPods {
 			return


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/25782

Briefly, there is a code broken which references the `Store` from `PodToStoreLister`, it should be `Indexer`.

/cc @hongchaodeng
