### PR TITLE
gcr.io/google_containers/mounttest: use Stat instead of Lstat

### DIFF
--- a/test/images/mount-tester/Makefile
+++ b/test/images/mount-tester/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG = 0.6
+TAG = 0.7
 PREFIX = gcr.io/google_containers
 
 all: push

--- a/test/images/mount-tester/mt.go
+++ b/test/images/mount-tester/mt.go
@@ -162,9 +162,9 @@ func fileMode(path string) error {
 		return nil
 	}
 
-	fileinfo, err := os.Lstat(path)
+	fileinfo, err := os.Stat(path)
 	if err != nil {
-		fmt.Printf("error from Lstat(%q): %v\n", path, err)
+		fmt.Printf("error from Stat(%q): %v\n", path, err)
 		return err
 	}
 
@@ -177,9 +177,9 @@ func filePerm(path string) error {
 		return nil
 	}
 
-	fileinfo, err := os.Lstat(path)
+	fileinfo, err := os.Stat(path)
 	if err != nil {
-		fmt.Printf("error from Lstat(%q): %v\n", path, err)
+		fmt.Printf("error from Stat(%q): %v\n", path, err)
 		return err
 	}
 


### PR DESCRIPTION
The current `mt.go` implementation use `os.Lstat` instead of `os.Stat` which does not read symlinks. Since implementation of `AtomicWriter` (which relies on existence of symlinks), the updated implementation of secret volume using the `AtomicWriter` can not be tested for secret file permission. Replacing `Lstat` with `Stat` allows to read symlinks and return permissions of target file. The change affects `--file_perm` and `--file_mode` options only.

`mounttest` image is currently used by:
##### downwardapi_volume.go
- e2e: Downward API volume
- version: 0.6
- args: --file_content, --break_on_expected_content, --retry_time, --file_content_in_loop
##### empty_dir.go
- e2e: EmptyDir volumes
- version: 0.5
- args: --file_perm, --file_perm, ...
##### host_path.go
- e2e: hostPath
- version: 0.6
- args: --file_mode, ...
##### configmap.go
- e2e: ConfigMap
- version: 0.6
- args: --file_content, --break_on_expected_content, --retry_time, --file_content_in_loop
##### service_accounts.go
- e2e: ServiceAccounts
- version: 0.2
- args: --file_content

Some of the e2e tests use at least one of the affected options. Locally, I have updated all version of mounttest images to 0.7. All e2e tests pass with the new image.
