### PR TITLE
Sort revisions in rollout history as integers

### DIFF
--- a/pkg/util/slice/slice.go
+++ b/pkg/util/slice/slice.go
@@ -48,3 +48,14 @@ func ShuffleStrings(s []string) []string {
 	}
 	return shuffled
 }
+
+// Int64Slice attaches the methods of Interface to []int64,
+// sorting in increasing order.
+type Int64Slice []int64
+
+func (p Int64Slice) Len() int           { return len(p) }
+func (p Int64Slice) Less(i, j int) bool { return p[i] < p[j] }
+func (p Int64Slice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
+// Sorts []int64 in increasing order
+func SortInts64(a []int64) { sort.Sort(Int64Slice(a)) }

--- a/pkg/util/slice/slice_test.go
+++ b/pkg/util/slice/slice_test.go
@@ -68,3 +68,12 @@ func TestShuffleStrings(t *testing.T) {
 		}
 	}
 }
+
+func TestSortInts64(t *testing.T) {
+	src := []int64{10, 1, 2, 3, 4, 5, 6}
+	expected := []int64{1, 2, 3, 4, 5, 6, 10}
+	SortInts64(src)
+	if !reflect.DeepEqual(src, expected) {
+		t.Errorf("func Ints64 didnt sort correctly, %v !- %v", src, expected)
+	}
+}


### PR DESCRIPTION
Previously keys were sorted as strings, thus it was possible to see such order as 1, 10, 2, 3, 4, 5.

fixes: #25788 
