### PR TITLE
Fix JENKINS_USE_SKEW_KUBECTL

### DIFF
--- a/hack/jenkins/e2e-runner.sh
+++ b/hack/jenkins/e2e-runner.sh
@@ -342,9 +342,10 @@ if [[ -n "${JENKINS_PUBLISHED_SKEW_VERSION:-}" ]]; then
     if [[ "${JENKINS_USE_SKEW_TESTS:-}" != "true" ]]; then
         # Back out into the old tests now that we've downloaded & maybe upgraded.
         cd ../kubernetes_old
-    elif [[ "${JENKINS_USE_SKEW_KUBECTL:-}" == "true" ]]; then
-        # Append kubectl-path of skewed kubectl to test args
-        GINKGO_TEST_ARGS="${GINKGO_TEST_ARGS:-} --kubectl-path=$(pwd)/../kubernetes/cluster/kubectl.sh"
+        if [[ "${JENKINS_USE_SKEW_KUBECTL:-}" == "true" ]]; then
+            # Append kubectl-path of skewed kubectl to test args
+            GINKGO_TEST_ARGS="${GINKGO_TEST_ARGS:-} --kubectl-path=$(pwd)/../kubernetes/cluster/kubectl.sh"
+        fi
     fi
 fi
 


### PR DESCRIPTION
I got this logic wrong; the first is a NOT comparison, so the second should only be available if that NOT comparison returns true.
