### PR TITLE
Fix kubectl run to print object on dry run

### DIFF
--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -270,7 +270,7 @@ func Run(f *cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer, cmd *cob
 	}
 
 	outputFormat := cmdutil.GetFlagString(cmd, "output")
-	if outputFormat != "" {
+	if outputFormat != "" || cmdutil.GetFlagBool(cmd, "dry-run") {
 		return f.PrintObject(cmd, mapper, obj, cmdOut)
 	}
 	cmdutil.PrintSuccess(mapper, false, cmdOut, mapping.Resource, args[0], "created")
@@ -422,7 +422,7 @@ func generateService(f *cmdutil.Factory, cmd *cobra.Command, args []string, serv
 		return err
 	}
 
-	if cmdutil.GetFlagString(cmd, "output") != "" {
+	if cmdutil.GetFlagString(cmd, "output") != "" || cmdutil.GetFlagBool(cmd, "dry-run") {
 		return f.PrintObject(cmd, mapper, obj, out)
 	}
 	cmdutil.PrintSuccess(mapper, false, out, mapping.Resource, args[0], "created")


### PR DESCRIPTION
Fixes #19636
