### PR TITLE
Volume Claim With Unbounded Size Example

### DIFF
--- a/docs/user-guide/persistent-volumes/claims/read-only-gce.yaml
+++ b/docs/user-guide/persistent-volumes/claims/read-only-gce.yaml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: claim-0003
+spec:
+  accessModes:
+    - ReadOnlyMany
+  resources:
+    requests:
+      storage:
+  volumeName: pv0003


### PR DESCRIPTION
Added an example of a persistent volume claim with an empty `storage` value

I don't think this needs any release notes.

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
