### PR TITLE
rkt: Get logs via syslog identifier

### DIFF
--- a/pkg/kubelet/rkt/log.go
+++ b/pkg/kubelet/rkt/log.go
@@ -118,7 +118,9 @@ func (r *Runtime) GetContainerLogs(pod *api.Pod, containerID kubecontainer.Conta
 		return err
 	}
 
-	cmd := exec.Command("journalctl", "-m", fmt.Sprintf("_MACHINE_ID=%s", strings.Replace(id.uuid, "-", "", -1)), "-u", id.appName, "-a")
+	// Note: this only works for rkt versions after 1.6.0
+	// See https://github.com/coreos/rkt/issues/2630
+	cmd := exec.Command("journalctl", "-m", fmt.Sprintf("_MACHINE_ID=%s", strings.Replace(id.uuid, "-", "", -1)), "-t", id.appName, "-a")
 	// Get the json structured logs.
 	cmd.Args = append(cmd.Args, "-o", "json")
 

--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -65,11 +65,11 @@ const (
 	RktType                      = "rkt"
 	DefaultRktAPIServiceEndpoint = "localhost:15441"
 
-	minimumAppcVersion       = "0.8.1"
-	minimumRktBinVersion     = "1.6.0"
-	recommendedRktBinVersion = "1.6.0"
-	minimumRktApiVersion     = "1.0.0-alpha"
-	minimumSystemdVersion    = "219"
+	minimumRktBinVersion     = "1.7.0"
+	recommendedRktBinVersion = "1.7.0"
+
+	minimumRktApiVersion  = "1.0.0-alpha"
+	minimumSystemdVersion = "219"
 
 	systemdServiceDir = "/run/systemd/system"
 	rktDataDir        = "/var/lib/rkt"
@@ -1560,7 +1560,7 @@ func (r *Runtime) APIVersion() (kubecontainer.Version, error) {
 
 // Status returns error if rkt is unhealthy, nil otherwise.
 func (r *Runtime) Status() error {
-	return r.checkVersion(minimumRktBinVersion, recommendedRktBinVersion, minimumAppcVersion, minimumRktApiVersion, minimumSystemdVersion)
+	return r.checkVersion(minimumRktBinVersion, recommendedRktBinVersion, minimumRktApiVersion, minimumSystemdVersion)
 }
 
 // SyncPod syncs the running pod to match the specified desired pod.

--- a/pkg/kubelet/rkt/rkt_test.go
+++ b/pkg/kubelet/rkt/rkt_test.go
@@ -172,7 +172,6 @@ func TestCheckVersion(t *testing.T) {
 	tests := []struct {
 		minimumRktBinVersion     string
 		recommendedRktBinVersion string
-		minimumAppcVersion       string
 		minimumRktApiVersion     string
 		minimumSystemdVersion    string
 		err                      error
@@ -183,7 +182,6 @@ func TestCheckVersion(t *testing.T) {
 		{
 			"1.2.3",
 			"1.2.3",
-			"1.2.4",
 			"1.2.5",
 			"99",
 			nil,
@@ -194,7 +192,6 @@ func TestCheckVersion(t *testing.T) {
 		{
 			"1.2.3+git",
 			"1.2.3+git",
-			"1.2.4+git",
 			"1.2.6-alpha",
 			"100",
 			nil,
@@ -205,21 +202,9 @@ func TestCheckVersion(t *testing.T) {
 		{
 			"1.2.4",
 			"1.2.4",
-			"1.2.4",
 			"1.2.6-alpha",
 			"100",
 			fmt.Errorf("rkt: binary version is too old(%v), requires at least %v", fr.info.RktVersion, "1.2.4"),
-			true,
-			true,
-		},
-		// Requires greater Appc version.
-		{
-			"1.2.3",
-			"1.2.3",
-			"1.2.5",
-			"1.2.6-alpha",
-			"100",
-			fmt.Errorf("rkt: appc version is too old(%v), requires at least %v", fr.info.AppcVersion, "1.2.5"),
 			true,
 			true,
 		},
@@ -227,7 +212,6 @@ func TestCheckVersion(t *testing.T) {
 		{
 			"1.2.3",
 			"1.2.3",
-			"1.2.4",
 			"1.2.6",
 			"100",
 			fmt.Errorf("rkt: API version is too old(%v), requires at least %v", fr.info.ApiVersion, "1.2.6"),
@@ -238,7 +222,6 @@ func TestCheckVersion(t *testing.T) {
 		{
 			"1.2.3",
 			"1.2.3",
-			"1.2.4",
 			"1.2.7",
 			"100",
 			fmt.Errorf("rkt: API version is too old(%v), requires at least %v", fr.info.ApiVersion, "1.2.7"),
@@ -249,7 +232,6 @@ func TestCheckVersion(t *testing.T) {
 		{
 			"1.2.3",
 			"1.2.3",
-			"1.2.4",
 			"1.2.7",
 			"101",
 			fmt.Errorf("rkt: systemd version(%v) is too old, requires at least %v", fs.version, "101"),
@@ -260,7 +242,7 @@ func TestCheckVersion(t *testing.T) {
 
 	for i, tt := range tests {
 		testCaseHint := fmt.Sprintf("test case #%d", i)
-		err := r.checkVersion(tt.minimumRktBinVersion, tt.recommendedRktBinVersion, tt.minimumAppcVersion, tt.minimumRktApiVersion, tt.minimumSystemdVersion)
+		err := r.checkVersion(tt.minimumRktBinVersion, tt.recommendedRktBinVersion, tt.minimumRktApiVersion, tt.minimumSystemdVersion)
 		assert.Equal(t, tt.err, err, testCaseHint)
 
 		if tt.calledGetInfo {
@@ -271,7 +253,6 @@ func TestCheckVersion(t *testing.T) {
 		}
 		if err == nil {
 			assert.Equal(t, fr.info.RktVersion, r.versions.binVersion.String(), testCaseHint)
-			assert.Equal(t, fr.info.AppcVersion, r.versions.appcVersion.String(), testCaseHint)
 			assert.Equal(t, fr.info.ApiVersion, r.versions.apiVersion.String(), testCaseHint)
 		}
 		fr.CleanCalls()

--- a/pkg/kubelet/rkt/version.go
+++ b/pkg/kubelet/rkt/version.go
@@ -30,7 +30,6 @@ type versions struct {
 	sync.RWMutex
 	binVersion     rktVersion
 	apiVersion     rktVersion
-	appcVersion    rktVersion
 	systemdVersion systemdVersion
 }
 
@@ -87,12 +86,6 @@ func (r *Runtime) getVersions() error {
 		return err
 	}
 
-	// Get Appc version.
-	r.versions.appcVersion, err = newRktVersion(resp.Info.AppcVersion)
-	if err != nil {
-		return err
-	}
-
 	// Get rkt API version.
 	r.versions.apiVersion, err = newRktVersion(resp.Info.ApiVersion)
 	if err != nil {
@@ -103,7 +96,7 @@ func (r *Runtime) getVersions() error {
 
 // checkVersion tests whether the rkt/systemd/rkt-api-service that meet the version requirement.
 // If all version requirements are met, it returns nil.
-func (r *Runtime) checkVersion(minimumRktBinVersion, recommendedRktBinVersion, minimumAppcVersion, minimumRktApiVersion, minimumSystemdVersion string) error {
+func (r *Runtime) checkVersion(minimumRktBinVersion, recommendedRktBinVersion, minimumRktApiVersion, minimumSystemdVersion string) error {
 	if err := r.getVersions(); err != nil {
 		return err
 	}
@@ -135,15 +128,6 @@ func (r *Runtime) checkVersion(minimumRktBinVersion, recommendedRktBinVersion, m
 	if result != 0 {
 		// TODO(yifan): Record an event to expose the information.
 		glog.Warningf("rkt: current binary version %q is not recommended (recommended version %q)", r.versions.binVersion, recommendedRktBinVersion)
-	}
-
-	// Check Appc version.
-	result, err = r.versions.appcVersion.Compare(minimumAppcVersion)
-	if err != nil {
-		return err
-	}
-	if result < 0 {
-		return fmt.Errorf("rkt: appc version is too old(%v), requires at least %v", r.versions.appcVersion, minimumAppcVersion)
 	}
 
 	// Check rkt API version.


### PR DESCRIPTION
This change works around https://github.com/coreos/rkt/issues/2630
Without this change, logs cannot reliably be collected for containers
with short lifetimes.

With this change, logs cannot be collected on rkt versions v1.6.0 and
before.

I'd like to also bump the required rkt version, but I don't want to do that until there's a released version that can be pointed to (so the next rkt release).

I haven't added tests (which were missing) because this code will be removed if/when logs are retrieved via the API. I have run E2E tests with this merged in and verified the tests which previously failed no longer fail.

cc @yifan-gu 
