### PR TITLE
Fixed #25858 Limit elasticsearch memory usage for fielddata to avoid `too large Data exception`

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-image/config/elasticsearch.yml
+++ b/cluster/addons/fluentd-elasticsearch/es-image/config/elasticsearch.yml
@@ -12,3 +12,5 @@ network.host: 0.0.0.0
 
 discovery.zen.minimum_master_nodes: ${MINIMUM_MASTER_NODES}
 discovery.zen.ping.multicast.enabled: false
+
+indices.fielddata.cache.size: 20%


### PR DESCRIPTION
Fixes #25858

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/25859)

<!-- Reviewable:end -->
