### PR TITLE
Fix problems with container restarts and flocker volumes

### DIFF
--- a/pkg/volume/flocker/plugin.go
+++ b/pkg/volume/flocker/plugin.go
@@ -18,18 +18,16 @@ package flocker
 
 import (
 	"fmt"
-	"path"
 	"time"
 
-	flockerclient "github.com/ClusterHQ/flocker-go"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/env"
 	"k8s.io/kubernetes/pkg/util/exec"
 	"k8s.io/kubernetes/pkg/util/mount"
-	"k8s.io/kubernetes/pkg/util/strings"
 	"k8s.io/kubernetes/pkg/volume"
-	volumeutil "k8s.io/kubernetes/pkg/volume/util"
+
+	flockerclient "github.com/ClusterHQ/flocker-go"
 )
 
 const (
@@ -165,15 +163,6 @@ func (b flockerMounter) newFlockerClient() (*flockerclient.Client, error) {
 	return c, err
 }
 
-func (b *flockerMounter) getMetaDir() string {
-	return path.Join(
-		b.plugin.host.GetPodPluginDir(
-			b.flocker.pod.UID, strings.EscapeQualifiedNameForDisk(flockerPluginName),
-		),
-		b.datasetName,
-	)
-}
-
 /*
 SetUpAt will setup a Flocker volume following this flow of calls to the Flocker
 control service:
@@ -186,10 +175,6 @@ control service:
 5. Wait until the Primary UUID was updated or timeout.
 */
 func (b flockerMounter) SetUpAt(dir string, fsGroup *int64) error {
-	if volumeutil.IsReady(b.getMetaDir()) {
-		return nil
-	}
-
 	if b.client == nil {
 		c, err := b.newFlockerClient()
 		if err != nil {
@@ -226,7 +211,6 @@ func (b flockerMounter) SetUpAt(dir string, fsGroup *int64) error {
 		b.flocker.path = s.Path
 	}
 
-	volumeutil.SetReady(b.getMetaDir())
 	return nil
 }
 


### PR DESCRIPTION
[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()

The issue is described in #22436. A pod with a flocker volume attached can't be restarted. A complete new pod has to be created, then everything is working fine.

The problem is around the `isReady` check. This ready state is not getting cleaned up for restarting containers. IMHO we don't need this ready state stored at all. Maybe it was meant to not call the flocker API during pod restarts, but I would rather have it removed... (happy about some hints why we need this lines)

I tested it in a AWS/flocker cluster: starting/restarting/rescheduling on another node (in the same zone) works perfectly fine.
