### PR TITLE
Check status of framework.CheckPodsRunningReady

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -253,7 +253,7 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 			podPath = framework.ReadOrDie(path.Join(kubeCtlManifestPath, "pod-with-readiness-probe.yaml"))
 			By(fmt.Sprintf("creating the pod from %v", string(podPath)))
 			framework.RunKubectlOrDieInput(string(podPath[:]), "create", "-f", "-", fmt.Sprintf("--namespace=%v", ns))
-			framework.CheckPodsRunningReady(c, ns, []string{simplePodName}, framework.PodStartTimeout)
+			Expect(framework.CheckPodsRunningReady(c, ns, []string{simplePodName}, framework.PodStartTimeout)).To(BeTrue())
 		})
 		AfterEach(func() {
 			cleanupKubectlInputs(string(podPath[:]), ns, simplePodSelector)
@@ -647,7 +647,7 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 			By("creating the pod")
 			nsFlag = fmt.Sprintf("--namespace=%v", ns)
 			framework.RunKubectlOrDieInput(string(pod), "create", "-f", "-", nsFlag)
-			framework.CheckPodsRunningReady(c, ns, []string{simplePodName}, framework.PodStartTimeout)
+			Expect(framework.CheckPodsRunningReady(c, ns, []string{simplePodName}, framework.PodStartTimeout)).To(BeTrue())
 		})
 		AfterEach(func() {
 			cleanupKubectlInputs(string(pod[:]), ns, simplePodSelector)


### PR DESCRIPTION
Check status of framework.CheckPodsRunningReady and fail test if it's false, instead of silently
ignoring the failure.

This doesn't fix whatever is causing the pod not to start in #17523 but it does fail the test as soon as it detects the pod didn't start, instead of allowing the testing to proceed.

cc @kubernetes/sig-testing @spxtr @ixdy @kubernetes/rh-cluster-infra 
