### PR TITLE
Improves ceph functionality, also addresses #8735 for aws kube-up

### DIFF
--- a/cluster/aws/config-default.sh
+++ b/cluster/aws/config-default.sh
@@ -141,6 +141,10 @@ ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolume
 # Important Note: disable only if you have setup a NAT instance for internet access and configured appropriate routes!
 ENABLE_NODE_PUBLIC_IP=${KUBE_ENABLE_NODE_PUBLIC_IP:-true}
 
+# This enables nodes to resolve services via skyDNS. Useful for mounting network file systems hosted within your k8s cluster
+# Currently this also makes DNS wonky on the master, since it can't reach cluster ips
+KUBE_ENABLE_NODE_SKYDNS=${KUBE_ENABLE_NODE_SKYDNS:-false}
+
 # OS options for minions
 KUBE_OS_DISTRIBUTION="${KUBE_OS_DISTRIBUTION:-jessie}"
 KUBE_MASTER_OS_DISTRIBUTION="${KUBE_OS_DISTRIBUTION}"

--- a/cluster/aws/templates/configure-vm-aws.sh
+++ b/cluster/aws/templates/configure-vm-aws.sh
@@ -101,6 +101,12 @@ EOF
 EOF
   fi
 
+  if [[ "${KUBE_ENABLE_NODE_SKYDNS}" == "true" ]]; then
+    cat <<EOF >>/etc/salt/minion.d/grains.conf
+  enable_dhcp_cron: true
+EOF
+  fi
+
   env-to-grains "runtime_config"
 }
 
@@ -113,6 +119,12 @@ grains:
   cloud: aws
   api_servers: '${API_SERVERS}'
 EOF
+
+  if [[ "${KUBE_ENABLE_NODE_SKYDNS}" == "true" ]]; then
+    cat <<EOF >>/etc/salt/minion.d/grains.conf
+  enable_dhcp_cron: true
+EOF
+  fi
 
   # We set the hostname_override to the full EC2 private dns name
   # we'd like to use EC2 instance-id, but currently the kubelet health-check assumes the name

--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -580,6 +580,7 @@ KUBE_ADDON_REGISTRY: $(yaml-quote ${KUBE_ADDON_REGISTRY:-})
 MULTIZONE: $(yaml-quote ${MULTIZONE:-})
 NON_MASQUERADE_CIDR: $(yaml-quote ${NON_MASQUERADE_CIDR:-})
 KUBE_UID: $(yaml-quote ${KUBE_UID:-})
+KUBE_ENABLE_NODE_SKYDNS: $(yaml-quote ${KUBE_ENABLE_NODE_SKYDNS:-})
 EOF
   if [ -n "${KUBELET_PORT:-}" ]; then
     cat >>$file <<EOF

--- a/cluster/saltbase/salt/base.sls
+++ b/cluster/saltbase/salt/base.sls
@@ -2,15 +2,17 @@ pkg-core:
   pkg.installed:
     - names:
       - curl
+      - socat
 {% if grains['os_family'] == 'RedHat' %}
       - python
       - git
-      - socat
+      - ceph
 {% else %}
       - apt-transport-https
       - python-apt
       - nfs-common
-      - socat
+      - ceph-fs-common
+      - ceph-common
 {% endif %}
 # Ubuntu installs netcat-openbsd by default, but on GCE/Debian netcat-traditional is installed.
 # They behave slightly differently.

--- a/cluster/saltbase/salt/dhcp-cron/cron
+++ b/cluster/saltbase/salt/dhcp-cron/cron
@@ -1,0 +1,1 @@
+*/5 * * * * root /sbin/dhclient

--- a/cluster/saltbase/salt/dhcp-cron/init.sls
+++ b/cluster/saltbase/salt/dhcp-cron/init.sls
@@ -1,0 +1,7 @@
+/etc/cron.d/dhcp:
+  file:
+    - managed
+    - source: salt://dhcp-cron/cron
+    - user: root
+    - group: root
+    - mode: 644

--- a/cluster/saltbase/salt/top.sls
+++ b/cluster/saltbase/salt/top.sls
@@ -50,6 +50,9 @@ base:
 {% endif %}
     - logrotate
     - supervisor
+{% if grains.get('enable_dhcp_cron') == true %}
+    - dhcp-cron
+{% endif %}
 {% if pillar.get('network_policy_provider', '').lower() == 'calico' %}
     - calico.node
 {% endif %}


### PR DESCRIPTION
[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
This provides ceph packages for saltstack based kube-up providers.

Also enables resolution of service names from nodes for aws.

This way ceph volumes hosted inside k8s can be mounted in k8s pods. Similar patterns can be done for the other kube-up scripts.

This is disabled by default via KUBE_ENABLE_NODE_SKYDNS, as DNS resolution is negatively affected on the Master due to the inability reach ClusterIPs.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/25941)

<!-- Reviewable:end -->
