### PR TITLE
Fix apiVersion of Jobs in kubectl edit/get

### DIFF
--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -300,6 +300,8 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 				},
 				KindPriority: []unversioned.GroupVersionKind{
 					{Group: api.GroupName, Version: meta.AnyVersion, Kind: meta.AnyKind},
+					// Ensure that types like "Job" from "v1" batch group gets picked first
+					{Group: batch.GroupName, Version: "v1", Kind: meta.AnyKind},
 					{Group: extensions.GroupName, Version: meta.AnyVersion, Kind: meta.AnyKind},
 					{Group: metrics.GroupName, Version: meta.AnyVersion, Kind: meta.AnyKind},
 					{Group: federation.GroupName, Version: meta.AnyVersion, Kind: meta.AnyKind},


### PR DESCRIPTION
"Jobs" co-exists in both extensions and batch groups for backwards
compatability. While looking up apiVersion let's make sure that
we have higher priority for the newer API version.

Fixes Issue #22517
