### PR TITLE
Increase goroutinemap unit test timeouts.

### DIFF
--- a/pkg/util/goroutinemap/goroutinemap_test.go
+++ b/pkg/util/goroutinemap/goroutinemap_test.go
@@ -24,6 +24,11 @@ import (
 	"k8s.io/kubernetes/pkg/util/wait"
 )
 
+// testTimeout is a timeout of goroutines to finish. This _should_ be just a
+// "context switch" and it should take several ms, however, Clayton says "We
+// have had flakes due to tests that assumed that 15s is long enough to sleep")
+const testTimeout = 1 * time.Minute
+
 func Test_NewGoRoutineMap_Positive_SingleOp(t *testing.T) {
 	// Arrange
 	grm := NewGoRoutineMap()
@@ -210,8 +215,7 @@ func Test_NewGoRoutineMap_Positive_WaitEmpty(t *testing.T) {
 	}()
 
 	// Assert
-	// Tolerate 50 milliseconds for goroutine context switches etc.
-	err := waitChannelWithTimeout(waitDoneCh, 50*time.Millisecond)
+	err := waitChannelWithTimeout(waitDoneCh, testTimeout)
 	if err != nil {
 		t.Errorf("Error waiting for GoRoutineMap.Wait: %v", err)
 	}
@@ -236,18 +240,11 @@ func Test_NewGoRoutineMap_Positive_Wait(t *testing.T) {
 		waitDoneCh <- true
 	}()
 
-	// Assert
-	// Check that Wait() really blocks
-	err = waitChannelWithTimeout(waitDoneCh, 100*time.Millisecond)
-	if err == nil {
-		t.Fatalf("Expected Wait() to block but it returned early")
-	}
-
 	// Finish the operation
 	operation1DoneCh <- true
 
-	// check that Wait() finishes in reasonable time
-	err = waitChannelWithTimeout(waitDoneCh, 50*time.Millisecond)
+	// Assert
+	err = waitChannelWithTimeout(waitDoneCh, testTimeout)
 	if err != nil {
 		t.Fatalf("Error waiting for GoRoutineMap.Wait: %v", err)
 	}


### PR DESCRIPTION
50ms is flaky in Jenkins. This makes the test to take at least 0.5s to check that things that should block and wait for something really do block and wait (was 100ms before).

Fixes #25825
