### PR TITLE
Update run.sh

### DIFF
--- a/examples/cassandra/image/run.sh
+++ b/examples/cassandra/image/run.sh
@@ -14,6 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-perl -pi -e "s/%%ip%%/$(hostname -I)/g" /etc/cassandra/cassandra.yaml
+perl -pi -e "s/%%ip%%/$(hostname -i)/g" /etc/cassandra/cassandra.yaml
 export CLASSPATH=/kubernetes-cassandra.jar
 cassandra -f


### PR DESCRIPTION
Update `run.sh` script for running cassandra cluster. 

This should fix/improve a `listen_address` config issue.

I am not sure why we are previously using `-I` to the get the host ip address. Since it gets all addresses for the host, which could provide multiple address and cause `listen_address` config errors, because `listen_address`  must correspond to a SINGEL address, not multiple.

I test this new bash script with my k8s CoreOS cluster and it works. (Not working previously due to `-I` parameter)
