### PR TITLE
Set Dashboard UI version to v1.1.0-beta1

### DIFF
--- a/cluster/addons/dashboard/dashboard-controller.yaml
+++ b/cluster/addons/dashboard/dashboard-controller.yaml
@@ -3,11 +3,11 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: kubernetes-dashboard-v1.0.1
+  name: kubernetes-dashboard-v1.1.0-beta1
   namespace: kube-system
   labels:
     k8s-app: kubernetes-dashboard
-    version: v1.0.1
+    version: v1.1.0-beta1
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
@@ -17,12 +17,12 @@ spec:
     metadata:
       labels:
         k8s-app: kubernetes-dashboard
-        version: v1.0.1
+        version: v1.1.0-beta1
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.0.1
+        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.1.0-beta1
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:

--- a/cluster/gce/coreos/kube-manifests/addons/dashboard/dashboard-controller.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/dashboard/dashboard-controller.yaml
@@ -1,13 +1,12 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  # Keep the name in sync with image version and
-  # gce/coreos/kube-manifests/addons/dashboard counterparts
-  name: kubernetes-dashboard-v1.0.1
+  # Keep this file in sync with addons/dashboard/dashboard-controller.yaml
+  name: kubernetes-dashboard-v1.1.0-beta1
   namespace: kube-system
   labels:
     k8s-app: kubernetes-dashboard
-    version: v1.0.1
+    version: v1.1.0-beta1
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
@@ -17,12 +16,12 @@ spec:
     metadata:
       labels:
         k8s-app: kubernetes-dashboard
-        version: v1.0.1
+        version: v1.1.0-beta1
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.0.1
+        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.1.0-beta1
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:

--- a/cluster/images/hyperkube/addons/dashboard-rc.yaml
+++ b/cluster/images/hyperkube/addons/dashboard-rc.yaml
@@ -20,25 +20,25 @@ metadata:
   namespace: kube-system
   labels:
     app: kubernetes-dashboard
-    version: v1.0.1
+    version: v1.1.0-beta1
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
   selector:
     app: kubernetes-dashboard
-    version: v1.0.1
+    version: v1.1.0-beta1
     kubernetes.io/cluster-service: "true"
   template:
     metadata:
       labels:
         app: kubernetes-dashboard
-        version: v1.0.1
+        version: v1.1.0-beta1
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
       - name: kubernetes-dashboard
         # ARCH will be replaced with the architecture it's built for. Check out the Makefile for more details
-        image: gcr.io/google_containers/kubernetes-dashboard-ARCH:v1.0.1
+        image: gcr.io/google_containers/kubernetes-dashboard-ARCH:v1.1.0-beta1
         imagePullPolicy: Always
         ports:
         - containerPort: 9090


### PR DESCRIPTION
[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()

This is first of our betas. From now on, we'll be doing weekly releases
of new betas till we reach final v1.1 version.

https://github.com/kubernetes/dashboard/releases/tag/v1.1.0-beta1

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/kubernetes/25963)

<!-- Reviewable:end -->
