### PR TITLE
Use pause image depending on the server's platform when testing

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -785,7 +785,7 @@ func runSchedulerNoPhantomPodsTest(client *client.Client) {
 			Containers: []api.Container{
 				{
 					Name:  "c1",
-					Image: "gcr.io/google_containers/pause-amd64:3.0",
+					Image: e2e.GetPauseImageName(client),
 					Ports: []api.ContainerPort{
 						{ContainerPort: 1234, HostPort: 9999},
 					},
@@ -795,7 +795,7 @@ func runSchedulerNoPhantomPodsTest(client *client.Client) {
 		},
 	}
 
-	// Assuming we only have two kublets, the third pod here won't schedule
+	// Assuming we only have two kubelets, the third pod here won't schedule
 	// if the scheduler doesn't correctly handle the delete for the second
 	// pod.
 	pod.ObjectMeta.Name = "phantom.foo"

--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -39,6 +39,7 @@ const (
 	defaultRootDir             = "/var/lib/kubelet"
 	experimentalFlannelOverlay = false
 
+	// When these values are updated, also update test/e2e/util.go
 	defaultPodInfraContainerImageName    = "gcr.io/google_containers/pause"
 	defaultPodInfraContainerImageVersion = "3.0"
 )

--- a/examples/kubectl-container/Makefile
+++ b/examples/kubectl-container/Makefile
@@ -19,8 +19,11 @@
 # `make container` will build a container-- you must supply a tag.
 # `make push` will push the container-- you must supply a tag.
 
+GOARCH?=$(shell go env GOARCH)
+GOOS?=$(shell go env GOOS)
+
 kubectl:
-	KUBE_STATIC_OVERRIDES="kubectl" ../../hack/build-go.sh cmd/kubectl; cp ../../_output/local/bin/linux/amd64/kubectl .
+	KUBE_STATIC_OVERRIDES="kubectl" ../../hack/build-go.sh cmd/kubectl; cp ../../_output/local/bin/$(GOOS)/$(GOARCH)/kubectl .
 
 .tag: kubectl
 	./kubectl version -c | grep -o 'GitVersion:"[^"]*"' | cut -f 2 -d '"' > .tag

--- a/test/component/scheduler/perf/util.go
+++ b/test/component/scheduler/perf/util.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/scheduler"
 	_ "k8s.io/kubernetes/plugin/pkg/scheduler/algorithmprovider"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/factory"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/integration/framework"
 )
 
@@ -113,7 +114,7 @@ func makePodSpec() api.PodSpec {
 	return api.PodSpec{
 		Containers: []api.Container{{
 			Name:  "pause",
-			Image: "gcr.io/google_containers/pause:1.0",
+			Image: e2e.GetPauseImageNameForHostArch(),
 			Ports: []api.ContainerPort{{ContainerPort: 80}},
 			Resources: api.ResourceRequirements{
 				Limits: api.ResourceList{

--- a/test/e2e/cluster_size_autoscaling.go
+++ b/test/e2e/cluster_size_autoscaling.go
@@ -86,7 +86,7 @@ func CreateHostPortPods(f *framework.Framework, id string, replicas int, expectR
 		Name:      id,
 		Namespace: f.Namespace.Name,
 		Timeout:   scaleTimeout,
-		Image:     "gcr.io/google_containers/pause-amd64:3.0",
+		Image:     framework.GetPauseImageName(f.Client),
 		Replicas:  replicas,
 		HostPorts: map[string]int{"port1": 4321},
 	}
@@ -105,7 +105,7 @@ func ReserveCpu(f *framework.Framework, id string, replicas, millicores int) {
 		Name:       id,
 		Namespace:  f.Namespace.Name,
 		Timeout:    scaleTimeout,
-		Image:      "gcr.io/google_containers/pause-amd64:3.0",
+		Image:      framework.GetPauseImageName(f.Client),
 		Replicas:   replicas,
 		CpuRequest: request,
 	}
@@ -120,7 +120,7 @@ func ReserveMemory(f *framework.Framework, id string, replicas, megabytes int, e
 		Name:       id,
 		Namespace:  f.Namespace.Name,
 		Timeout:    scaleTimeout,
-		Image:      "gcr.io/google_containers/pause-amd64:3.0",
+		Image:      framework.GetPauseImageName(f.Client),
 		Replicas:   replicas,
 		MemRequest: request,
 	}

--- a/test/e2e/daemon_restart.go
+++ b/test/e2e/daemon_restart.go
@@ -209,7 +209,7 @@ var _ = framework.KubeDescribe("DaemonRestart [Disruptive]", func() {
 			Client:      f.Client,
 			Name:        rcName,
 			Namespace:   ns,
-			Image:       "gcr.io/google_containers/pause-amd64:3.0",
+			Image:       framework.GetPauseImageName(f.Client),
 			Replicas:    numPods,
 			CreatedPods: &[]*api.Pod{},
 		}

--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -294,7 +294,7 @@ var _ = framework.KubeDescribe("Density", func() {
 			for i := 0; i < numberOrRCs; i++ {
 				RCName = "density" + strconv.Itoa(totalPods) + "-" + strconv.Itoa(i) + "-" + uuid
 				RCConfigs[i] = framework.RCConfig{Client: c,
-					Image:                "gcr.io/google_containers/pause-amd64:3.0",
+					Image:                framework.GetPauseImageName(f.Client),
 					Name:                 RCName,
 					Namespace:            ns,
 					Labels:               map[string]string{"type": "densityPod"},
@@ -522,7 +522,7 @@ var _ = framework.KubeDescribe("Density", func() {
 				}
 				for i := 1; i <= nodeCount; i++ {
 					name := additionalPodsPrefix + "-" + strconv.Itoa(i)
-					go createRunningPodFromRC(&wg, c, name, ns, "gcr.io/google_containers/pause-amd64:3.0", additionalPodsPrefix, cpuRequest, memRequest)
+					go createRunningPodFromRC(&wg, c, name, ns, framework.GetPauseImageName(f.Client), additionalPodsPrefix, cpuRequest, memRequest)
 					time.Sleep(200 * time.Millisecond)
 				}
 				wg.Wait()

--- a/test/e2e/etcd_failure.go
+++ b/test/e2e/etcd_failure.go
@@ -44,7 +44,7 @@ var _ = framework.KubeDescribe("Etcd failure [Disruptive]", func() {
 			Client:    f.Client,
 			Name:      "baz",
 			Namespace: f.Namespace.Name,
-			Image:     "gcr.io/google_containers/pause-amd64:3.0",
+			Image:     framework.GetPauseImageName(f.Client),
 			Replicas:  1,
 		})).NotTo(HaveOccurred())
 	})

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -1429,37 +1429,6 @@ func streamingUpload(file *os.File, fileName string, postBodyWriter *multipart.W
 	}
 }
 
-var binPrefixes = []string{
-	"_output/dockerized/bin",
-	"_output/local/bin",
-	"platforms",
-}
-
-// findBinary searches through likely paths to find the specified binary.  It
-// takes the one that has been built most recently.  Platform should be
-// specified as '<os>/<arch>'.  For example: 'linux/amd64'.
-func findBinary(binName string, platform string) (string, error) {
-	var binTime time.Time
-	var binPath string
-
-	for _, pre := range binPrefixes {
-		tryPath := path.Join(framework.TestContext.RepoRoot, pre, platform, binName)
-		fi, err := os.Stat(tryPath)
-		if err != nil {
-			continue
-		}
-		if fi.ModTime().After(binTime) {
-			binPath = tryPath
-			binTime = fi.ModTime()
-		}
-	}
-
-	if len(binPath) > 0 {
-		return binPath, nil
-	}
-	return binPath, fmt.Errorf("Could not find %v for %v", binName, platform)
-}
-
 func startLocalProxy() (srv *httptest.Server, logs *bytes.Buffer) {
 	logs = &bytes.Buffer{}
 	p := goproxy.NewProxyHttpServer()

--- a/test/e2e/kubelet.go
+++ b/test/e2e/kubelet.go
@@ -128,7 +128,7 @@ var _ = framework.KubeDescribe("kubelet", func() {
 					Client:    f.Client,
 					Name:      rcName,
 					Namespace: f.Namespace.Name,
-					Image:     "gcr.io/google_containers/pause-amd64:3.0",
+					Image:     framework.GetPauseImageName(f.Client),
 					Replicas:  totalPods,
 				})).NotTo(HaveOccurred())
 				// Perform a sanity check so that we know all desired pods are

--- a/test/e2e/kubelet_perf.go
+++ b/test/e2e/kubelet_perf.go
@@ -69,7 +69,7 @@ func runResourceTrackingTest(f *framework.Framework, podsPerNode int, nodeNames 
 		Client:    f.Client,
 		Name:      rcName,
 		Namespace: f.Namespace.Name,
-		Image:     "gcr.io/google_containers/pause-amd64:3.0",
+		Image:     framework.GetPauseImageName(f.Client),
 		Replicas:  totalPods,
 	})).NotTo(HaveOccurred())
 

--- a/test/e2e/limit_range.go
+++ b/test/e2e/limit_range.go
@@ -53,7 +53,7 @@ var _ = framework.KubeDescribe("LimitRange", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Creating a Pod with no resource requirements")
-		pod := newTestPod("pod-no-resources", api.ResourceList{}, api.ResourceList{})
+		pod := newTestPod(f, "pod-no-resources", api.ResourceList{}, api.ResourceList{})
 		pod, err = f.Client.Pods(f.Namespace.Name).Create(pod)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -70,7 +70,7 @@ var _ = framework.KubeDescribe("LimitRange", func() {
 		}
 
 		By("Creating a Pod with partial resource requirements")
-		pod = newTestPod("pod-partial-resources", getResourceList("", "150Mi"), getResourceList("300m", ""))
+		pod = newTestPod(f, "pod-partial-resources", getResourceList("", "150Mi"), getResourceList("300m", ""))
 		pod, err = f.Client.Pods(f.Namespace.Name).Create(pod)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -91,12 +91,12 @@ var _ = framework.KubeDescribe("LimitRange", func() {
 		}
 
 		By("Failing to create a Pod with less than min resources")
-		pod = newTestPod(podName, getResourceList("10m", "50Mi"), api.ResourceList{})
+		pod = newTestPod(f, podName, getResourceList("10m", "50Mi"), api.ResourceList{})
 		pod, err = f.Client.Pods(f.Namespace.Name).Create(pod)
 		Expect(err).To(HaveOccurred())
 
 		By("Failing to create a Pod with more than max resources")
-		pod = newTestPod(podName, getResourceList("600m", "600Mi"), api.ResourceList{})
+		pod = newTestPod(f, podName, getResourceList("600m", "600Mi"), api.ResourceList{})
 		pod, err = f.Client.Pods(f.Namespace.Name).Create(pod)
 		Expect(err).To(HaveOccurred())
 	})
@@ -167,7 +167,7 @@ func newLimitRange(name string, limitType api.LimitType,
 }
 
 // newTestPod returns a pod that has the specified requests and limits
-func newTestPod(name string, requests api.ResourceList, limits api.ResourceList) *api.Pod {
+func newTestPod(f *framework.Framework, name string, requests api.ResourceList, limits api.ResourceList) *api.Pod {
 	return &api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Name: name,
@@ -175,8 +175,8 @@ func newTestPod(name string, requests api.ResourceList, limits api.ResourceList)
 		Spec: api.PodSpec{
 			Containers: []api.Container{
 				{
-					Name:  "nginx",
-					Image: "gcr.io/google_containers/pause-amd64:3.0",
+					Name:  "pause",
+					Image: framework.GetPauseImageName(f.Client),
 					Resources: api.ResourceRequirements{
 						Requests: requests,
 						Limits:   limits,

--- a/test/e2e/mesos.go
+++ b/test/e2e/mesos.go
@@ -94,7 +94,7 @@ var _ = framework.KubeDescribe("Mesos", func() {
 				Containers: []api.Container{
 					{
 						Name:  podName,
-						Image: "beta.gcr.io/google_containers/pause-amd64:3.0",
+						Image: framework.GetPauseImageName(f.Client),
 					},
 				},
 			},

--- a/test/e2e/namespace.go
+++ b/test/e2e/namespace.go
@@ -97,7 +97,7 @@ func ensurePodsAreRemovedWhenNamespaceIsDeleted(f *framework.Framework) {
 			Containers: []api.Container{
 				{
 					Name:  "nginx",
-					Image: "gcr.io/google_containers/pause-amd64:3.0",
+					Image: framework.GetPauseImageName(f.Client),
 				},
 			},
 		},

--- a/test/e2e/nodeoutofdisk.go
+++ b/test/e2e/nodeoutofdisk.go
@@ -179,7 +179,7 @@ func createOutOfDiskPod(c *client.Client, ns, name string, milliCPU int64) {
 			Containers: []api.Container{
 				{
 					Name:  "pause",
-					Image: "beta.gcr.io/google_containers/pause-amd64:3.0",
+					Image: framework.GetPauseImageName(c),
 					Resources: api.ResourceRequirements{
 						Requests: api.ResourceList{
 							// Request enough CPU to fit only two pods on a given node.

--- a/test/e2e/pods.go
+++ b/test/e2e/pods.go
@@ -219,7 +219,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 				Containers: []api.Container{
 					{
 						Name:  "test",
-						Image: "gcr.io/google_containers/pause-amd64:3.0",
+						Image: framework.GetPauseImageName(f.Client),
 					},
 				},
 			},
@@ -244,7 +244,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 				Containers: []api.Container{
 					{
 						Name:  "nginx",
-						Image: "gcr.io/google_containers/pause-amd64:3.0",
+						Image: framework.GetPauseImageName(f.Client),
 						Resources: api.ResourceRequirements{
 							Limits: api.ResourceList{
 								api.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
@@ -754,7 +754,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 				Containers: []api.Container{
 					{
 						Name:  "run1",
-						Image: "gcr.io/google_containers/pause:2.0",
+						Image: framework.GetPauseImageName(f.Client),
 						Resources: api.ResourceRequirements{
 							Limits: api.ResourceList{
 								api.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
@@ -823,7 +823,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 				Containers: []api.Container{
 					{
 						Name:  "run1",
-						Image: "gcr.io/google_containers/pause:2.0",
+						Image: framework.GetPauseImageName(f.Client),
 						Resources: api.ResourceRequirements{
 							Limits: api.ResourceList{
 								api.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),

--- a/test/e2e/resource_quota.go
+++ b/test/e2e/resource_quota.go
@@ -328,7 +328,7 @@ var _ = framework.KubeDescribe("ResourceQuota", func() {
 		requests := api.ResourceList{}
 		requests[api.ResourceCPU] = resource.MustParse("500m")
 		requests[api.ResourceMemory] = resource.MustParse("252Mi")
-		pod := newTestPodForQuota(podName, requests, api.ResourceList{})
+		pod := newTestPodForQuota(f, podName, requests, api.ResourceList{})
 		pod, err = f.Client.Pods(f.Namespace.Name).Create(pod)
 		Expect(err).NotTo(HaveOccurred())
 		podToUpdate := pod
@@ -345,7 +345,7 @@ var _ = framework.KubeDescribe("ResourceQuota", func() {
 		requests = api.ResourceList{}
 		requests[api.ResourceCPU] = resource.MustParse("600m")
 		requests[api.ResourceMemory] = resource.MustParse("100Mi")
-		pod = newTestPodForQuota("fail-pod", requests, api.ResourceList{})
+		pod = newTestPodForQuota(f, "fail-pod", requests, api.ResourceList{})
 		pod, err = f.Client.Pods(f.Namespace.Name).Create(pod)
 		Expect(err).To(HaveOccurred())
 
@@ -509,7 +509,7 @@ var _ = framework.KubeDescribe("ResourceQuota", func() {
 		limits := api.ResourceList{}
 		limits[api.ResourceCPU] = resource.MustParse("1")
 		limits[api.ResourceMemory] = resource.MustParse("400Mi")
-		pod := newTestPodForQuota(podName, requests, limits)
+		pod := newTestPodForQuota(f, podName, requests, limits)
 		pod, err = f.Client.Pods(f.Namespace.Name).Create(pod)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -546,7 +546,7 @@ var _ = framework.KubeDescribe("ResourceQuota", func() {
 
 		By("Creating a terminating pod")
 		podName = "terminating-pod"
-		pod = newTestPodForQuota(podName, requests, limits)
+		pod = newTestPodForQuota(f, podName, requests, limits)
 		activeDeadlineSeconds := int64(3600)
 		pod.Spec.ActiveDeadlineSeconds = &activeDeadlineSeconds
 		pod, err = f.Client.Pods(f.Namespace.Name).Create(pod)
@@ -604,7 +604,7 @@ var _ = framework.KubeDescribe("ResourceQuota", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Creating a best-effort pod")
-		pod := newTestPodForQuota(podName, api.ResourceList{}, api.ResourceList{})
+		pod := newTestPodForQuota(f, podName, api.ResourceList{}, api.ResourceList{})
 		pod, err = f.Client.Pods(f.Namespace.Name).Create(pod)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -634,7 +634,7 @@ var _ = framework.KubeDescribe("ResourceQuota", func() {
 		limits := api.ResourceList{}
 		limits[api.ResourceCPU] = resource.MustParse("1")
 		limits[api.ResourceMemory] = resource.MustParse("400Mi")
-		pod = newTestPodForQuota("burstable-pod", requests, limits)
+		pod = newTestPodForQuota(f, "burstable-pod", requests, limits)
 		pod, err = f.Client.Pods(f.Namespace.Name).Create(pod)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -697,7 +697,7 @@ func newTestResourceQuota(name string) *api.ResourceQuota {
 }
 
 // newTestPodForQuota returns a pod that has the specified requests and limits
-func newTestPodForQuota(name string, requests api.ResourceList, limits api.ResourceList) *api.Pod {
+func newTestPodForQuota(f *framework.Framework, name string, requests api.ResourceList, limits api.ResourceList) *api.Pod {
 	return &api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Name: name,
@@ -705,8 +705,8 @@ func newTestPodForQuota(name string, requests api.ResourceList, limits api.Resou
 		Spec: api.PodSpec{
 			Containers: []api.Container{
 				{
-					Name:  "nginx",
-					Image: "gcr.io/google_containers/pause-amd64:3.0",
+					Name:  "pause",
+					Image: framework.GetPauseImageName(f.Client),
 					Resources: api.ResourceRequirements{
 						Requests: requests,
 						Limits:   limits,

--- a/test/e2e/scheduler_predicates.go
+++ b/test/e2e/scheduler_predicates.go
@@ -238,7 +238,7 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 				Containers: []api.Container{
 					{
 						Name:  "",
-						Image: "gcr.io/google_containers/pause-amd64:3.0",
+						Image: framework.GetPauseImageName(f.Client),
 					},
 				},
 			},
@@ -257,7 +257,7 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 				Containers: []api.Container{
 					{
 						Name:  podName,
-						Image: "gcr.io/google_containers/pause-amd64:3.0",
+						Image: framework.GetPauseImageName(f.Client),
 					},
 				},
 			},
@@ -315,7 +315,7 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 				Containers: []api.Container{
 					{
 						Name:  "",
-						Image: "gcr.io/google_containers/pause-amd64:3.0",
+						Image: framework.GetPauseImageName(f.Client),
 						Resources: api.ResourceRequirements{
 							Limits: api.ResourceList{
 								"cpu": *resource.NewMilliQuantity(milliCpuPerPod, "DecimalSI"),
@@ -342,7 +342,7 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 				Containers: []api.Container{
 					{
 						Name:  podName,
-						Image: "gcr.io/google_containers/pause-amd64:3.0",
+						Image: framework.GetPauseImageName(f.Client),
 						Resources: api.ResourceRequirements{
 							Limits: api.ResourceList{
 								"cpu": *resource.NewMilliQuantity(milliCpuPerPod, "DecimalSI"),
@@ -382,7 +382,7 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 				Containers: []api.Container{
 					{
 						Name:  podName,
-						Image: "gcr.io/google_containers/pause-amd64:3.0",
+						Image: framework.GetPauseImageName(f.Client),
 					},
 				},
 				NodeSelector: map[string]string{
@@ -425,7 +425,7 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 				Containers: []api.Container{
 					{
 						Name:  podName,
-						Image: "gcr.io/google_containers/pause-amd64:3.0",
+						Image: framework.GetPauseImageName(f.Client),
 					},
 				},
 			},
@@ -461,7 +461,7 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 				Containers: []api.Container{
 					{
 						Name:  podName,
-						Image: "gcr.io/google_containers/pause-amd64:3.0",
+						Image: framework.GetPauseImageName(f.Client),
 					},
 				},
 			},
@@ -499,7 +499,7 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 				Containers: []api.Container{
 					{
 						Name:  labelPodName,
-						Image: "gcr.io/google_containers/pause-amd64:3.0",
+						Image: framework.GetPauseImageName(f.Client),
 					},
 				},
 				NodeSelector: map[string]string{
@@ -563,7 +563,7 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 				Containers: []api.Container{
 					{
 						Name:  podName,
-						Image: "gcr.io/google_containers/pause-amd64:3.0",
+						Image: framework.GetPauseImageName(f.Client),
 					},
 				},
 			},
@@ -598,7 +598,7 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 				Containers: []api.Container{
 					{
 						Name:  podName,
-						Image: "gcr.io/google_containers/pause-amd64:3.0",
+						Image: framework.GetPauseImageName(f.Client),
 					},
 				},
 			},
@@ -654,7 +654,7 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 				Containers: []api.Container{
 					{
 						Name:  labelPodName,
-						Image: "gcr.io/google_containers/pause-amd64:3.0",
+						Image: framework.GetPauseImageName(f.Client),
 					},
 				},
 			},
@@ -692,7 +692,7 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 				Containers: []api.Container{
 					{
 						Name:  podName,
-						Image: "gcr.io/google_containers/pause-amd64:3.0",
+						Image: framework.GetPauseImageName(f.Client),
 					},
 				},
 			},
@@ -771,7 +771,7 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 				Containers: []api.Container{
 					{
 						Name:  podName,
-						Image: "gcr.io/google_containers/pause:2.0",
+						Image: framework.GetPauseImageName(f.Client),
 					},
 				},
 			},
@@ -822,7 +822,7 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 				Containers: []api.Container{
 					{
 						Name:  podName,
-						Image: "gcr.io/google_containers/pause:2.0",
+						Image: framework.GetPauseImageName(f.Client),
 					},
 				},
 			},
@@ -857,7 +857,7 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 				Containers: []api.Container{
 					{
 						Name:  podName,
-						Image: "gcr.io/google_containers/pause:2.0",
+						Image: framework.GetPauseImageName(f.Client),
 					},
 				},
 			},
@@ -910,7 +910,7 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 				Containers: []api.Container{
 					{
 						Name:  labelPodName,
-						Image: "gcr.io/google_containers/pause:2.0",
+						Image: framework.GetPauseImageName(f.Client),
 					},
 				},
 			},
@@ -949,7 +949,7 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 				Containers: []api.Container{
 					{
 						Name:  podName,
-						Image: "gcr.io/google_containers/pause:2.0",
+						Image: framework.GetPauseImageName(f.Client),
 					},
 				},
 			},
@@ -1002,7 +1002,7 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 				Containers: []api.Container{
 					{
 						Name:  labelPodName,
-						Image: "gcr.io/google_containers/pause:2.0",
+						Image: framework.GetPauseImageName(f.Client),
 					},
 				},
 			},
@@ -1037,7 +1037,7 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 				Containers: []api.Container{
 					{
 						Name:  podName,
-						Image: "gcr.io/google_containers/pause:2.0",
+						Image: framework.GetPauseImageName(f.Client),
 					},
 				},
 			},
@@ -1098,7 +1098,7 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 				Containers: []api.Container{
 					{
 						Name:  labelPodName,
-						Image: "gcr.io/google_containers/pause:2.0",
+						Image: framework.GetPauseImageName(f.Client),
 					},
 				},
 			},
@@ -1137,7 +1137,7 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 				Containers: []api.Container{
 					{
 						Name:  podName,
-						Image: "gcr.io/google_containers/pause:2.0",
+						Image: framework.GetPauseImageName(f.Client),
 					},
 				},
 			},
@@ -1201,7 +1201,7 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 				Containers: []api.Container{
 					{
 						Name:  labelPodName,
-						Image: "gcr.io/google_containers/pause:2.0",
+						Image: framework.GetPauseImageName(f.Client),
 					},
 				},
 			},
@@ -1240,7 +1240,7 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 				Containers: []api.Container{
 					{
 						Name:  podName,
-						Image: "gcr.io/google_containers/pause:2.0",
+						Image: framework.GetPauseImageName(f.Client),
 					},
 				},
 			},
@@ -1304,7 +1304,7 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 				Containers: []api.Container{
 					{
 						Name:  podName,
-						Image: "gcr.io/google_containers/pause-amd64:3.0",
+						Image: framework.GetPauseImageName(f.Client),
 					},
 				},
 			},
@@ -1369,7 +1369,7 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 				Containers: []api.Container{
 					{
 						Name:  tolerationPodName,
-						Image: "gcr.io/google_containers/pause-amd64:3.0",
+						Image: framework.GetPauseImageName(f.Client),
 					},
 				},
 			},
@@ -1426,7 +1426,7 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 				Containers: []api.Container{
 					{
 						Name:  podName,
-						Image: "gcr.io/google_containers/pause-amd64:3.0",
+						Image: framework.GetPauseImageName(f.Client),
 					},
 				},
 			},
@@ -1481,7 +1481,7 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 				Containers: []api.Container{
 					{
 						Name:  podNameNoTolerations,
-						Image: "gcr.io/google_containers/pause-amd64:3.0",
+						Image: framework.GetPauseImageName(f.Client),
 					},
 				},
 			},

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -1138,8 +1138,8 @@ func createPodOrFail(c *client.Client, ns, name string, labels map[string]string
 		Spec: api.PodSpec{
 			Containers: []api.Container{
 				{
-					Name:  "test",
-					Image: "gcr.io/google_containers/pause-amd64:3.0",
+					Name:  "pause",
+					Image: framework.GetPauseImageName(c),
 					Ports: containerPorts,
 					// Add a dummy environment variable to work around a docker issue.
 					// https://github.com/docker/docker/issues/14203

--- a/test/e2e/service_latency.go
+++ b/test/e2e/service_latency.go
@@ -118,7 +118,7 @@ var _ = framework.KubeDescribe("Service endpoints latency", func() {
 func runServiceLatencies(f *framework.Framework, inParallel, total int) (output []time.Duration, err error) {
 	cfg := framework.RCConfig{
 		Client:       f.Client,
-		Image:        "gcr.io/google_containers/pause-amd64:3.0",
+		Image:        framework.GetPauseImageName(f.Client),
 		Name:         "svc-latency-rc",
 		Namespace:    f.Namespace.Name,
 		Replicas:     1,

--- a/test/e2e/ubernetes_lite.go
+++ b/test/e2e/ubernetes_lite.go
@@ -88,7 +88,7 @@ func SpreadServiceOrFail(f *framework.Framework, replicaCount int, image string)
 			Containers: []api.Container{
 				{
 					Name:  "test",
-					Image: "gcr.io/google_containers/pause-amd64:3.0",
+					Image: framework.GetPauseImageName(f.Client),
 				},
 			},
 		},

--- a/test/e2e_node/container_list.go
+++ b/test/e2e_node/container_list.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+
+	"k8s.io/kubernetes/test/e2e/framework"
 )
 
 const (
@@ -45,7 +47,7 @@ var ImageRegistry = map[int]string{
 	hostExecImage: "gcr.io/google_containers/hostexec:1.2",
 	netExecImage:  "gcr.io/google_containers/netexec:1.4",
 	nginxImage:    "gcr.io/google_containers/nginx:1.7.9",
-	pauseImage:    "gcr.io/google_containers/pause-amd64:3.0",
+	pauseImage:    framework.GetPauseImageNameForHostArch(),
 }
 
 // These are used by tests that explicitly test the ability to pull images

--- a/test/integration/client_test.go
+++ b/test/integration/client_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/version"
 	"k8s.io/kubernetes/pkg/watch"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/integration/framework"
 )
 
@@ -234,8 +235,8 @@ func TestMultiWatch(t *testing.T) {
 			},
 			Spec: api.PodSpec{
 				Containers: []api.Container{{
-					Name:  "nothing",
-					Image: "gcr.io/google_containers/pause-amd64:3.0",
+					Name:  "pause",
+					Image: e2e.GetPauseImageName(client),
 				}},
 			},
 		})
@@ -341,7 +342,7 @@ func TestMultiWatch(t *testing.T) {
 						Spec: api.PodSpec{
 							Containers: []api.Container{{
 								Name:  "nothing",
-								Image: "gcr.io/google_containers/pause-amd64:3.0",
+								Image: e2e.GetPauseImageName(client),
 							}},
 						},
 					})
@@ -372,7 +373,7 @@ func TestMultiWatch(t *testing.T) {
 			if err != nil {
 				panic(fmt.Sprintf("Couldn't get %v: %v", name, err))
 			}
-			pod.Spec.Containers[0].Image = "gcr.io/google_containers/pause-amd64:3.0"
+			pod.Spec.Containers[0].Image = e2e.GetPauseImageName(client)
 			sentTimes <- timePair{time.Now(), name}
 			if _, err := client.Pods(ns).Update(pod); err != nil {
 				panic(fmt.Sprintf("Couldn't make %v: %v", name, err))

--- a/test/integration/extender_test.go
+++ b/test/integration/extender_test.go
@@ -42,6 +42,7 @@ import (
 	_ "k8s.io/kubernetes/plugin/pkg/scheduler/algorithmprovider"
 	schedulerapi "k8s.io/kubernetes/plugin/pkg/scheduler/api"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/factory"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/integration/framework"
 )
 
@@ -283,7 +284,7 @@ func DoTestPodScheduling(t *testing.T, restClient *client.Client) {
 	pod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{Name: "extender-test-pod"},
 		Spec: api.PodSpec{
-			Containers: []api.Container{{Name: "container", Image: "gcr.io/google_containers/pause-amd64:3.0"}},
+			Containers: []api.Container{{Name: "container", Image: e2e.GetPauseImageName(restClient)}},
 		},
 	}
 


### PR DESCRIPTION
Removed all pause image constant strings, now the pause image is chosen by arch. Part of the effort of making e2e arch-agnostic.

The pause image name and version is also now only in two places, and it's documented to bump both
Also removed "amd64" constants in the code. Such constants should be replaced by `runtime.GOARCH` or by looking up the server platform

Fixes: #22876 and #15140
Makes it easier for: #25730
Related: #17981

This is for `v1.3`
@ixdy @thockin @vishh @kubernetes/sig-testing @andyzheng0831 @pensu 
