### PR TITLE
Make UnsafeConversion fast by inlining copies

### DIFF
--- a/federation/apis/federation/v1alpha1/conversion_generated.go
+++ b/federation/apis/federation/v1alpha1/conversion_generated.go
@@ -275,13 +275,7 @@ func autoConvert_v1alpha1_ClusterStatus_To_federation_ClusterStatus(in *ClusterS
 	if err := Convert_v1alpha1_ClusterMeta_To_federation_ClusterMeta(&in.ClusterMeta, &out.ClusterMeta, s); err != nil {
 		return err
 	}
-	if in.Zones != nil {
-		in, out := &in.Zones, &out.Zones
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Zones = nil
-	}
+	out.Zones = in.Zones
 	out.Region = in.Region
 	return nil
 }
@@ -331,13 +325,7 @@ func autoConvert_federation_ClusterStatus_To_v1alpha1_ClusterStatus(in *federati
 	if err := Convert_federation_ClusterMeta_To_v1alpha1_ClusterMeta(&in.ClusterMeta, &out.ClusterMeta, s); err != nil {
 		return err
 	}
-	if in.Zones != nil {
-		in, out := &in.Zones, &out.Zones
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Zones = nil
-	}
+	out.Zones = in.Zones
 	out.Region = in.Region
 	return nil
 }

--- a/pkg/api/conversion.go
+++ b/pkg/api/conversion.go
@@ -158,7 +158,6 @@ func Convert_fields_Selector_To_string(in *fields.Selector, out *string, s conve
 	return nil
 }
 func Convert_resource_Quantity_To_resource_Quantity(in *resource.Quantity, out *resource.Quantity, s conversion.Scope) error {
-	// Cannot deep copy these, because inf.Dec has unexported fields.
-	*out = *in.Copy()
+	*out = *in
 	return nil
 }

--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"reflect"
@@ -78,6 +79,13 @@ func dataAsString(data []byte) string {
 func roundTrip(t *testing.T, codec runtime.Codec, item runtime.Object) {
 	printer := spew.ConfigState{DisableMethods: true}
 
+	original := item
+	copied, err := api.Scheme.DeepCopy(item)
+	if err != nil {
+		panic(fmt.Sprintf("unable to copy: %v", err))
+	}
+	item = copied.(runtime.Object)
+
 	name := reflect.TypeOf(item).Elem().Name()
 	data, err := runtime.Encode(codec, item)
 	if err != nil {
@@ -85,13 +93,18 @@ func roundTrip(t *testing.T, codec runtime.Codec, item runtime.Object) {
 		return
 	}
 
+	if !api.Semantic.DeepEqual(original, item) {
+		t.Errorf("0: %v: encode altered the object, diff: %v", name, diff.ObjectReflectDiff(original, item))
+		return
+	}
+
 	obj2, err := runtime.Decode(codec, data)
 	if err != nil {
-		t.Errorf("0: %v: %v\nCodec: %v\nData: %s\nSource: %#v", name, err, codec, dataAsString(data), printer.Sprintf("%#v", item))
+		t.Errorf("0: %v: %v\nCodec: %#v\nData: %s\nSource: %#v", name, err, codec, dataAsString(data), printer.Sprintf("%#v", item))
 		panic("failed")
 	}
-	if !api.Semantic.DeepEqual(item, obj2) {
-		t.Errorf("\n1: %v: diff: %v\nCodec: %v\nSource:\n\n%#v\n\nEncoded:\n\n%s\n\nFinal:\n\n%#v", name, diff.ObjectGoPrintDiff(item, obj2), codec, printer.Sprintf("%#v", item), dataAsString(data), printer.Sprintf("%#v", obj2))
+	if !api.Semantic.DeepEqual(original, obj2) {
+		t.Errorf("\n1: %v: diff: %v\nCodec: %#v\nSource:\n\n%#v\n\nEncoded:\n\n%s\n\nFinal:\n\n%#v", name, diff.ObjectReflectDiff(item, obj2), codec, printer.Sprintf("%#v", item), dataAsString(data), printer.Sprintf("%#v", obj2))
 		return
 	}
 
@@ -101,7 +114,7 @@ func roundTrip(t *testing.T, codec runtime.Codec, item runtime.Object) {
 		return
 	}
 	if !api.Semantic.DeepEqual(item, obj3) {
-		t.Errorf("3: %v: diff: %v\nCodec: %v", name, diff.ObjectDiff(item, obj3), codec)
+		t.Errorf("3: %v: diff: %v\nCodec: %#v", name, diff.ObjectReflectDiff(item, obj3), codec)
 		return
 	}
 }

--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -358,6 +358,7 @@ func benchmarkItems() []v1.Pod {
 	for i := range items {
 		var pod api.Pod
 		apiObjectFuzzer.Fuzz(&pod)
+		pod.Spec.InitContainers, pod.Status.InitContainerStatuses = nil, nil
 		out, err := api.Scheme.ConvertToVersion(&pod, v1.SchemeGroupVersion)
 		if err != nil {
 			panic(err)

--- a/pkg/api/v1/conversion.go
+++ b/pkg/api/v1/conversion.go
@@ -199,16 +199,8 @@ func addConversionFuncs(scheme *runtime.Scheme) {
 }
 
 func Convert_api_ReplicationControllerSpec_To_v1_ReplicationControllerSpec(in *api.ReplicationControllerSpec, out *ReplicationControllerSpec, s conversion.Scope) error {
-	out.Replicas = new(int32)
-	*out.Replicas = int32(in.Replicas)
-	if in.Selector != nil {
-		out.Selector = make(map[string]string)
-		for key, val := range in.Selector {
-			out.Selector[key] = val
-		}
-	} else {
-		out.Selector = nil
-	}
+	out.Replicas = &in.Replicas
+	out.Selector = in.Selector
 	//if in.TemplateRef != nil {
 	//	out.TemplateRef = new(ObjectReference)
 	//	if err := Convert_api_ObjectReference_To_v1_ObjectReference(in.TemplateRef, out.TemplateRef, s); err != nil {
@@ -230,14 +222,8 @@ func Convert_api_ReplicationControllerSpec_To_v1_ReplicationControllerSpec(in *a
 
 func Convert_v1_ReplicationControllerSpec_To_api_ReplicationControllerSpec(in *ReplicationControllerSpec, out *api.ReplicationControllerSpec, s conversion.Scope) error {
 	out.Replicas = *in.Replicas
-	if in.Selector != nil {
-		out.Selector = make(map[string]string)
-		for key, val := range in.Selector {
-			out.Selector[key] = val
-		}
-	} else {
-		out.Selector = nil
-	}
+	out.Selector = in.Selector
+
 	//if in.TemplateRef != nil {
 	//	out.TemplateRef = new(api.ObjectReference)
 	//	if err := Convert_v1_ObjectReference_To_api_ObjectReference(in.TemplateRef, out.TemplateRef, s); err != nil {
@@ -262,6 +248,12 @@ func Convert_api_PodStatusResult_To_v1_PodStatusResult(in *api.PodStatusResult, 
 		return err
 	}
 
+	if old := out.Annotations; old != nil {
+		out.Annotations = make(map[string]string, len(old))
+		for k, v := range old {
+			out.Annotations[k] = v
+		}
+	}
 	if len(out.Status.InitContainerStatuses) > 0 {
 		if out.Annotations == nil {
 			out.Annotations = make(map[string]string)
@@ -290,7 +282,14 @@ func Convert_v1_PodStatusResult_To_api_PodStatusResult(in *PodStatusResult, out 
 	if err := autoConvert_v1_PodStatusResult_To_api_PodStatusResult(in, out, s); err != nil {
 		return err
 	}
-	delete(out.Annotations, PodInitContainerStatusesAnnotationKey)
+	if len(out.Annotations) > 0 {
+		old := out.Annotations
+		out.Annotations = make(map[string]string, len(old))
+		for k, v := range old {
+			out.Annotations[k] = v
+		}
+		delete(out.Annotations, PodInitContainerStatusesAnnotationKey)
+	}
 	return nil
 }
 
@@ -300,6 +299,12 @@ func Convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in *api.PodTemplateSpec, 
 	}
 
 	// TODO: when we move init container to beta, remove these conversions
+	if old := out.Annotations; old != nil {
+		out.Annotations = make(map[string]string, len(old))
+		for k, v := range old {
+			out.Annotations[k] = v
+		}
+	}
 	if len(out.Spec.InitContainers) > 0 {
 		if out.Annotations == nil {
 			out.Annotations = make(map[string]string)
@@ -328,7 +333,14 @@ func Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in *PodTemplateSpec, out 
 	if err := autoConvert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in, out, s); err != nil {
 		return err
 	}
-	delete(out.Annotations, PodInitContainersAnnotationKey)
+	if len(out.Annotations) > 0 {
+		old := out.Annotations
+		out.Annotations = make(map[string]string, len(old))
+		for k, v := range old {
+			out.Annotations[k] = v
+		}
+		delete(out.Annotations, PodInitContainersAnnotationKey)
+	}
 	return nil
 }
 
@@ -365,28 +377,13 @@ func Convert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *PodSpec, s conversi
 	} else {
 		out.Containers = nil
 	}
+
 	out.RestartPolicy = RestartPolicy(in.RestartPolicy)
-	if in.TerminationGracePeriodSeconds != nil {
-		out.TerminationGracePeriodSeconds = new(int64)
-		*out.TerminationGracePeriodSeconds = *in.TerminationGracePeriodSeconds
-	} else {
-		out.TerminationGracePeriodSeconds = nil
-	}
-	if in.ActiveDeadlineSeconds != nil {
-		out.ActiveDeadlineSeconds = new(int64)
-		*out.ActiveDeadlineSeconds = *in.ActiveDeadlineSeconds
-	} else {
-		out.ActiveDeadlineSeconds = nil
-	}
+	out.TerminationGracePeriodSeconds = in.TerminationGracePeriodSeconds
+	out.ActiveDeadlineSeconds = in.ActiveDeadlineSeconds
 	out.DNSPolicy = DNSPolicy(in.DNSPolicy)
-	if in.NodeSelector != nil {
-		out.NodeSelector = make(map[string]string)
-		for key, val := range in.NodeSelector {
-			out.NodeSelector[key] = val
-		}
-	} else {
-		out.NodeSelector = nil
-	}
+	out.NodeSelector = in.NodeSelector
+
 	out.ServiceAccountName = in.ServiceAccountName
 	// DeprecatedServiceAccount is an alias for ServiceAccountName.
 	out.DeprecatedServiceAccount = in.ServiceAccountName
@@ -451,27 +448,10 @@ func Convert_v1_PodSpec_To_api_PodSpec(in *PodSpec, out *api.PodSpec, s conversi
 		out.Containers = nil
 	}
 	out.RestartPolicy = api.RestartPolicy(in.RestartPolicy)
-	if in.TerminationGracePeriodSeconds != nil {
-		out.TerminationGracePeriodSeconds = new(int64)
-		*out.TerminationGracePeriodSeconds = *in.TerminationGracePeriodSeconds
-	} else {
-		out.TerminationGracePeriodSeconds = nil
-	}
-	if in.ActiveDeadlineSeconds != nil {
-		out.ActiveDeadlineSeconds = new(int64)
-		*out.ActiveDeadlineSeconds = *in.ActiveDeadlineSeconds
-	} else {
-		out.ActiveDeadlineSeconds = nil
-	}
+	out.TerminationGracePeriodSeconds = in.TerminationGracePeriodSeconds
+	out.ActiveDeadlineSeconds = in.ActiveDeadlineSeconds
 	out.DNSPolicy = api.DNSPolicy(in.DNSPolicy)
-	if in.NodeSelector != nil {
-		out.NodeSelector = make(map[string]string)
-		for key, val := range in.NodeSelector {
-			out.NodeSelector[key] = val
-		}
-	} else {
-		out.NodeSelector = nil
-	}
+	out.NodeSelector = in.NodeSelector
 	// We support DeprecatedServiceAccount as an alias for ServiceAccountName.
 	// If both are specified, ServiceAccountName (the new field) wins.
 	out.ServiceAccountName = in.ServiceAccountName
@@ -515,10 +495,16 @@ func Convert_api_Pod_To_v1_Pod(in *api.Pod, out *Pod, s conversion.Scope) error 
 	}
 
 	// TODO: when we move init container to beta, remove these conversions
-	if len(out.Spec.InitContainers) > 0 {
-		if out.Annotations == nil {
-			out.Annotations = make(map[string]string)
+	if len(out.Spec.InitContainers) > 0 || len(out.Status.InitContainerStatuses) > 0 {
+		old := out.Annotations
+		out.Annotations = make(map[string]string, len(old))
+		for k, v := range old {
+			out.Annotations[k] = v
 		}
+		delete(out.Annotations, PodInitContainersAnnotationKey)
+		delete(out.Annotations, PodInitContainerStatusesAnnotationKey)
+	}
+	if len(out.Spec.InitContainers) > 0 {
 		value, err := json.Marshal(out.Spec.InitContainers)
 		if err != nil {
 			return err
@@ -528,9 +514,6 @@ func Convert_api_Pod_To_v1_Pod(in *api.Pod, out *Pod, s conversion.Scope) error 
 		delete(out.Annotations, PodInitContainersAnnotationKey)
 	}
 	if len(out.Status.InitContainerStatuses) > 0 {
-		if out.Annotations == nil {
-			out.Annotations = make(map[string]string)
-		}
 		value, err := json.Marshal(out.Status.InitContainerStatuses)
 		if err != nil {
 			return err
@@ -574,8 +557,15 @@ func Convert_v1_Pod_To_api_Pod(in *Pod, out *api.Pod, s conversion.Scope) error 
 	if err := autoConvert_v1_Pod_To_api_Pod(in, out, s); err != nil {
 		return err
 	}
-	delete(out.Annotations, PodInitContainersAnnotationKey)
-	delete(out.Annotations, PodInitContainerStatusesAnnotationKey)
+	if len(out.Annotations) > 0 {
+		old := out.Annotations
+		out.Annotations = make(map[string]string, len(old))
+		for k, v := range old {
+			out.Annotations[k] = v
+		}
+		delete(out.Annotations, PodInitContainersAnnotationKey)
+		delete(out.Annotations, PodInitContainerStatusesAnnotationKey)
+	}
 	return nil
 }
 
@@ -584,9 +574,7 @@ func Convert_api_ServiceSpec_To_v1_ServiceSpec(in *api.ServiceSpec, out *Service
 		return err
 	}
 	// Publish both externalIPs and deprecatedPublicIPs fields in v1.
-	for _, ip := range in.ExternalIPs {
-		out.DeprecatedPublicIPs = append(out.DeprecatedPublicIPs, ip)
-	}
+	out.DeprecatedPublicIPs = in.ExternalIPs
 	return nil
 }
 
@@ -596,10 +584,7 @@ func Convert_v1_ServiceSpec_To_api_ServiceSpec(in *ServiceSpec, out *api.Service
 	}
 	// Prefer the legacy deprecatedPublicIPs field, if provided.
 	if len(in.DeprecatedPublicIPs) > 0 {
-		out.ExternalIPs = nil
-		for _, ip := range in.DeprecatedPublicIPs {
-			out.ExternalIPs = append(out.ExternalIPs, ip)
-		}
+		out.ExternalIPs = in.DeprecatedPublicIPs
 	}
 	return nil
 }
@@ -614,24 +599,9 @@ func Convert_api_PodSecurityContext_To_v1_PodSecurityContext(in *api.PodSecurity
 	} else {
 		out.SELinuxOptions = nil
 	}
-	if in.RunAsUser != nil {
-		out.RunAsUser = new(int64)
-		*out.RunAsUser = *in.RunAsUser
-	} else {
-		out.RunAsUser = nil
-	}
-	if in.RunAsNonRoot != nil {
-		out.RunAsNonRoot = new(bool)
-		*out.RunAsNonRoot = *in.RunAsNonRoot
-	} else {
-		out.RunAsNonRoot = nil
-	}
-	if in.FSGroup != nil {
-		out.FSGroup = new(int64)
-		*out.FSGroup = *in.FSGroup
-	} else {
-		out.FSGroup = nil
-	}
+	out.RunAsUser = in.RunAsUser
+	out.RunAsNonRoot = in.RunAsNonRoot
+	out.FSGroup = in.FSGroup
 	return nil
 }
 
@@ -645,24 +615,9 @@ func Convert_v1_PodSecurityContext_To_api_PodSecurityContext(in *PodSecurityCont
 	} else {
 		out.SELinuxOptions = nil
 	}
-	if in.RunAsUser != nil {
-		out.RunAsUser = new(int64)
-		*out.RunAsUser = *in.RunAsUser
-	} else {
-		out.RunAsUser = nil
-	}
-	if in.RunAsNonRoot != nil {
-		out.RunAsNonRoot = new(bool)
-		*out.RunAsNonRoot = *in.RunAsNonRoot
-	} else {
-		out.RunAsNonRoot = nil
-	}
-	if in.FSGroup != nil {
-		out.FSGroup = new(int64)
-		*out.FSGroup = *in.FSGroup
-	} else {
-		out.FSGroup = nil
-	}
+	out.RunAsUser = in.RunAsUser
+	out.RunAsNonRoot = in.RunAsNonRoot
+	out.FSGroup = in.FSGroup
 	return nil
 }
 
@@ -671,18 +626,16 @@ func Convert_v1_ResourceList_To_api_ResourceList(in *ResourceList, out *api.Reso
 		return nil
 	}
 
-	converted := make(api.ResourceList)
+	if *out == nil {
+		*out = make(api.ResourceList, len(*in))
+	}
 	for key, val := range *in {
-		value := val.Copy()
-
 		// TODO(#18538): We round up resource values to milli scale to maintain API compatibility.
 		// In the future, we should instead reject values that need rounding.
 		const milliScale = -3
-		value.RoundUp(milliScale)
+		val.RoundUp(milliScale)
 
-		converted[api.ResourceName(key)] = *value
+		(*out)[api.ResourceName(key)] = val
 	}
-
-	*out = converted
 	return nil
 }

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -23,10 +23,8 @@ package v1
 import (
 	api "k8s.io/kubernetes/pkg/api"
 	resource "k8s.io/kubernetes/pkg/api/resource"
-	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
 	conversion "k8s.io/kubernetes/pkg/conversion"
 	runtime "k8s.io/kubernetes/pkg/runtime"
-	types "k8s.io/kubernetes/pkg/types"
 )
 
 func init() {
@@ -536,13 +534,7 @@ func Convert_api_Capabilities_To_v1_Capabilities(in *api.Capabilities, out *Capa
 }
 
 func autoConvert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in *CephFSVolumeSource, out *api.CephFSVolumeSource, s conversion.Scope) error {
-	if in.Monitors != nil {
-		in, out := &in.Monitors, &out.Monitors
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Monitors = nil
-	}
+	out.Monitors = in.Monitors
 	out.Path = in.Path
 	out.User = in.User
 	out.SecretFile = in.SecretFile
@@ -564,13 +556,7 @@ func Convert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in *CephFSVolumeSou
 }
 
 func autoConvert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in *api.CephFSVolumeSource, out *CephFSVolumeSource, s conversion.Scope) error {
-	if in.Monitors != nil {
-		in, out := &in.Monitors, &out.Monitors
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Monitors = nil
-	}
+	out.Monitors = in.Monitors
 	out.Path = in.Path
 	out.User = in.User
 	out.SecretFile = in.SecretFile
@@ -745,15 +731,7 @@ func autoConvert_v1_ConfigMap_To_api_ConfigMap(in *ConfigMap, out *api.ConfigMap
 	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if in.Data != nil {
-		in, out := &in.Data, &out.Data
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	} else {
-		out.Data = nil
-	}
+	out.Data = in.Data
 	return nil
 }
 
@@ -768,15 +746,7 @@ func autoConvert_api_ConfigMap_To_v1_ConfigMap(in *api.ConfigMap, out *ConfigMap
 	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if in.Data != nil {
-		in, out := &in.Data, &out.Data
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	} else {
-		out.Data = nil
-	}
+	out.Data = in.Data
 	return nil
 }
 
@@ -906,20 +876,8 @@ func autoConvert_v1_Container_To_api_Container(in *Container, out *api.Container
 	SetDefaults_Container(in)
 	out.Name = in.Name
 	out.Image = in.Image
-	if in.Command != nil {
-		in, out := &in.Command, &out.Command
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Command = nil
-	}
-	if in.Args != nil {
-		in, out := &in.Args, &out.Args
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Args = nil
-	}
+	out.Command = in.Command
+	out.Args = in.Args
 	out.WorkingDir = in.WorkingDir
 	if in.Ports != nil {
 		in, out := &in.Ports, &out.Ports
@@ -1008,20 +966,8 @@ func Convert_v1_Container_To_api_Container(in *Container, out *api.Container, s 
 func autoConvert_api_Container_To_v1_Container(in *api.Container, out *Container, s conversion.Scope) error {
 	out.Name = in.Name
 	out.Image = in.Image
-	if in.Command != nil {
-		in, out := &in.Command, &out.Command
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Command = nil
-	}
-	if in.Args != nil {
-		in, out := &in.Args, &out.Args
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Args = nil
-	}
+	out.Command = in.Command
+	out.Args = in.Args
 	out.WorkingDir = in.WorkingDir
 	if in.Ports != nil {
 		in, out := &in.Ports, &out.Ports
@@ -1108,13 +1054,7 @@ func Convert_api_Container_To_v1_Container(in *api.Container, out *Container, s 
 }
 
 func autoConvert_v1_ContainerImage_To_api_ContainerImage(in *ContainerImage, out *api.ContainerImage, s conversion.Scope) error {
-	if in.Names != nil {
-		in, out := &in.Names, &out.Names
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Names = nil
-	}
+	out.Names = in.Names
 	out.SizeBytes = in.SizeBytes
 	return nil
 }
@@ -1124,13 +1064,7 @@ func Convert_v1_ContainerImage_To_api_ContainerImage(in *ContainerImage, out *ap
 }
 
 func autoConvert_api_ContainerImage_To_v1_ContainerImage(in *api.ContainerImage, out *ContainerImage, s conversion.Scope) error {
-	if in.Names != nil {
-		in, out := &in.Names, &out.Names
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Names = nil
-	}
+	out.Names = in.Names
 	out.SizeBytes = in.SizeBytes
 	return nil
 }
@@ -1378,13 +1312,7 @@ func autoConvert_v1_DeleteOptions_To_api_DeleteOptions(in *DeleteOptions, out *a
 	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if in.GracePeriodSeconds != nil {
-		in, out := &in.GracePeriodSeconds, &out.GracePeriodSeconds
-		*out = new(int64)
-		**out = **in
-	} else {
-		out.GracePeriodSeconds = nil
-	}
+	out.GracePeriodSeconds = in.GracePeriodSeconds
 	if in.Preconditions != nil {
 		in, out := &in.Preconditions, &out.Preconditions
 		*out = new(api.Preconditions)
@@ -1394,13 +1322,7 @@ func autoConvert_v1_DeleteOptions_To_api_DeleteOptions(in *DeleteOptions, out *a
 	} else {
 		out.Preconditions = nil
 	}
-	if in.OrphanDependents != nil {
-		in, out := &in.OrphanDependents, &out.OrphanDependents
-		*out = new(bool)
-		**out = **in
-	} else {
-		out.OrphanDependents = nil
-	}
+	out.OrphanDependents = in.OrphanDependents
 	return nil
 }
 
@@ -1412,13 +1334,7 @@ func autoConvert_api_DeleteOptions_To_v1_DeleteOptions(in *api.DeleteOptions, ou
 	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
-	if in.GracePeriodSeconds != nil {
-		in, out := &in.GracePeriodSeconds, &out.GracePeriodSeconds
-		*out = new(int64)
-		**out = **in
-	} else {
-		out.GracePeriodSeconds = nil
-	}
+	out.GracePeriodSeconds = in.GracePeriodSeconds
 	if in.Preconditions != nil {
 		in, out := &in.Preconditions, &out.Preconditions
 		*out = new(Preconditions)
@@ -1428,13 +1344,7 @@ func autoConvert_api_DeleteOptions_To_v1_DeleteOptions(in *api.DeleteOptions, ou
 	} else {
 		out.Preconditions = nil
 	}
-	if in.OrphanDependents != nil {
-		in, out := &in.OrphanDependents, &out.OrphanDependents
-		*out = new(bool)
-		**out = **in
-	} else {
-		out.OrphanDependents = nil
-	}
+	out.OrphanDependents = in.OrphanDependents
 	return nil
 }
 
@@ -2052,13 +1962,7 @@ func Convert_api_EventSource_To_v1_EventSource(in *api.EventSource, out *EventSo
 }
 
 func autoConvert_v1_ExecAction_To_api_ExecAction(in *ExecAction, out *api.ExecAction, s conversion.Scope) error {
-	if in.Command != nil {
-		in, out := &in.Command, &out.Command
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Command = nil
-	}
+	out.Command = in.Command
 	return nil
 }
 
@@ -2067,13 +1971,7 @@ func Convert_v1_ExecAction_To_api_ExecAction(in *ExecAction, out *api.ExecAction
 }
 
 func autoConvert_api_ExecAction_To_v1_ExecAction(in *api.ExecAction, out *ExecAction, s conversion.Scope) error {
-	if in.Command != nil {
-		in, out := &in.Command, &out.Command
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Command = nil
-	}
+	out.Command = in.Command
 	return nil
 }
 
@@ -2108,20 +2006,8 @@ func Convert_api_ExportOptions_To_v1_ExportOptions(in *api.ExportOptions, out *E
 }
 
 func autoConvert_v1_FCVolumeSource_To_api_FCVolumeSource(in *FCVolumeSource, out *api.FCVolumeSource, s conversion.Scope) error {
-	if in.TargetWWNs != nil {
-		in, out := &in.TargetWWNs, &out.TargetWWNs
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.TargetWWNs = nil
-	}
-	if in.Lun != nil {
-		in, out := &in.Lun, &out.Lun
-		*out = new(int32)
-		**out = **in
-	} else {
-		out.Lun = nil
-	}
+	out.TargetWWNs = in.TargetWWNs
+	out.Lun = in.Lun
 	out.FSType = in.FSType
 	out.ReadOnly = in.ReadOnly
 	return nil
@@ -2132,20 +2018,8 @@ func Convert_v1_FCVolumeSource_To_api_FCVolumeSource(in *FCVolumeSource, out *ap
 }
 
 func autoConvert_api_FCVolumeSource_To_v1_FCVolumeSource(in *api.FCVolumeSource, out *FCVolumeSource, s conversion.Scope) error {
-	if in.TargetWWNs != nil {
-		in, out := &in.TargetWWNs, &out.TargetWWNs
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.TargetWWNs = nil
-	}
-	if in.Lun != nil {
-		in, out := &in.Lun, &out.Lun
-		*out = new(int32)
-		**out = **in
-	} else {
-		out.Lun = nil
-	}
+	out.TargetWWNs = in.TargetWWNs
+	out.Lun = in.Lun
 	out.FSType = in.FSType
 	out.ReadOnly = in.ReadOnly
 	return nil
@@ -2168,15 +2042,7 @@ func autoConvert_v1_FlexVolumeSource_To_api_FlexVolumeSource(in *FlexVolumeSourc
 		out.SecretRef = nil
 	}
 	out.ReadOnly = in.ReadOnly
-	if in.Options != nil {
-		in, out := &in.Options, &out.Options
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	} else {
-		out.Options = nil
-	}
+	out.Options = in.Options
 	return nil
 }
 
@@ -2197,15 +2063,7 @@ func autoConvert_api_FlexVolumeSource_To_v1_FlexVolumeSource(in *api.FlexVolumeS
 		out.SecretRef = nil
 	}
 	out.ReadOnly = in.ReadOnly
-	if in.Options != nil {
-		in, out := &in.Options, &out.Options
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	} else {
-		out.Options = nil
-	}
+	out.Options = in.Options
 	return nil
 }
 
@@ -2842,13 +2700,7 @@ func autoConvert_v1_ListOptions_To_api_ListOptions(in *ListOptions, out *api.Lis
 	}
 	out.Watch = in.Watch
 	out.ResourceVersion = in.ResourceVersion
-	if in.TimeoutSeconds != nil {
-		in, out := &in.TimeoutSeconds, &out.TimeoutSeconds
-		*out = new(int64)
-		**out = **in
-	} else {
-		out.TimeoutSeconds = nil
-	}
+	out.TimeoutSeconds = in.TimeoutSeconds
 	return nil
 }
 
@@ -2868,13 +2720,7 @@ func autoConvert_api_ListOptions_To_v1_ListOptions(in *api.ListOptions, out *Lis
 	}
 	out.Watch = in.Watch
 	out.ResourceVersion = in.ResourceVersion
-	if in.TimeoutSeconds != nil {
-		in, out := &in.TimeoutSeconds, &out.TimeoutSeconds
-		*out = new(int64)
-		**out = **in
-	} else {
-		out.TimeoutSeconds = nil
-	}
+	out.TimeoutSeconds = in.TimeoutSeconds
 	return nil
 }
 
@@ -3413,13 +3259,7 @@ func Convert_api_NodeSelector_To_v1_NodeSelector(in *api.NodeSelector, out *Node
 func autoConvert_v1_NodeSelectorRequirement_To_api_NodeSelectorRequirement(in *NodeSelectorRequirement, out *api.NodeSelectorRequirement, s conversion.Scope) error {
 	out.Key = in.Key
 	out.Operator = api.NodeSelectorOperator(in.Operator)
-	if in.Values != nil {
-		in, out := &in.Values, &out.Values
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Values = nil
-	}
+	out.Values = in.Values
 	return nil
 }
 
@@ -3430,13 +3270,7 @@ func Convert_v1_NodeSelectorRequirement_To_api_NodeSelectorRequirement(in *NodeS
 func autoConvert_api_NodeSelectorRequirement_To_v1_NodeSelectorRequirement(in *api.NodeSelectorRequirement, out *NodeSelectorRequirement, s conversion.Scope) error {
 	out.Key = in.Key
 	out.Operator = NodeSelectorOperator(in.Operator)
-	if in.Values != nil {
-		in, out := &in.Values, &out.Values
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Values = nil
-	}
+	out.Values = in.Values
 	return nil
 }
 
@@ -3703,40 +3537,10 @@ func autoConvert_v1_ObjectMeta_To_api_ObjectMeta(in *ObjectMeta, out *api.Object
 	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.CreationTimestamp, &out.CreationTimestamp, s); err != nil {
 		return err
 	}
-	if in.DeletionTimestamp != nil {
-		in, out := &in.DeletionTimestamp, &out.DeletionTimestamp
-		*out = new(unversioned.Time)
-		if err := api.Convert_unversioned_Time_To_unversioned_Time(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.DeletionTimestamp = nil
-	}
-	if in.DeletionGracePeriodSeconds != nil {
-		in, out := &in.DeletionGracePeriodSeconds, &out.DeletionGracePeriodSeconds
-		*out = new(int64)
-		**out = **in
-	} else {
-		out.DeletionGracePeriodSeconds = nil
-	}
-	if in.Labels != nil {
-		in, out := &in.Labels, &out.Labels
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	} else {
-		out.Labels = nil
-	}
-	if in.Annotations != nil {
-		in, out := &in.Annotations, &out.Annotations
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	} else {
-		out.Annotations = nil
-	}
+	out.DeletionTimestamp = in.DeletionTimestamp
+	out.DeletionGracePeriodSeconds = in.DeletionGracePeriodSeconds
+	out.Labels = in.Labels
+	out.Annotations = in.Annotations
 	if in.OwnerReferences != nil {
 		in, out := &in.OwnerReferences, &out.OwnerReferences
 		*out = make([]api.OwnerReference, len(*in))
@@ -3748,13 +3552,7 @@ func autoConvert_v1_ObjectMeta_To_api_ObjectMeta(in *ObjectMeta, out *api.Object
 	} else {
 		out.OwnerReferences = nil
 	}
-	if in.Finalizers != nil {
-		in, out := &in.Finalizers, &out.Finalizers
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Finalizers = nil
-	}
+	out.Finalizers = in.Finalizers
 	return nil
 }
 
@@ -3773,40 +3571,10 @@ func autoConvert_api_ObjectMeta_To_v1_ObjectMeta(in *api.ObjectMeta, out *Object
 	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.CreationTimestamp, &out.CreationTimestamp, s); err != nil {
 		return err
 	}
-	if in.DeletionTimestamp != nil {
-		in, out := &in.DeletionTimestamp, &out.DeletionTimestamp
-		*out = new(unversioned.Time)
-		if err := api.Convert_unversioned_Time_To_unversioned_Time(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.DeletionTimestamp = nil
-	}
-	if in.DeletionGracePeriodSeconds != nil {
-		in, out := &in.DeletionGracePeriodSeconds, &out.DeletionGracePeriodSeconds
-		*out = new(int64)
-		**out = **in
-	} else {
-		out.DeletionGracePeriodSeconds = nil
-	}
-	if in.Labels != nil {
-		in, out := &in.Labels, &out.Labels
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	} else {
-		out.Labels = nil
-	}
-	if in.Annotations != nil {
-		in, out := &in.Annotations, &out.Annotations
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	} else {
-		out.Annotations = nil
-	}
+	out.DeletionTimestamp = in.DeletionTimestamp
+	out.DeletionGracePeriodSeconds = in.DeletionGracePeriodSeconds
+	out.Labels = in.Labels
+	out.Annotations = in.Annotations
 	if in.OwnerReferences != nil {
 		in, out := &in.OwnerReferences, &out.OwnerReferences
 		*out = make([]OwnerReference, len(*in))
@@ -3818,13 +3586,7 @@ func autoConvert_api_ObjectMeta_To_v1_ObjectMeta(in *api.ObjectMeta, out *Object
 	} else {
 		out.OwnerReferences = nil
 	}
-	if in.Finalizers != nil {
-		in, out := &in.Finalizers, &out.Finalizers
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Finalizers = nil
-	}
+	out.Finalizers = in.Finalizers
 	return nil
 }
 
@@ -4642,23 +4404,8 @@ func Convert_api_PodAffinity_To_v1_PodAffinity(in *api.PodAffinity, out *PodAffi
 }
 
 func autoConvert_v1_PodAffinityTerm_To_api_PodAffinityTerm(in *PodAffinityTerm, out *api.PodAffinityTerm, s conversion.Scope) error {
-	if in.LabelSelector != nil {
-		in, out := &in.LabelSelector, &out.LabelSelector
-		*out = new(unversioned.LabelSelector)
-		// TODO: Inefficient conversion - can we improve it?
-		if err := s.Convert(*in, *out, 0); err != nil {
-			return err
-		}
-	} else {
-		out.LabelSelector = nil
-	}
-	if in.Namespaces != nil {
-		in, out := &in.Namespaces, &out.Namespaces
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Namespaces = nil
-	}
+	out.LabelSelector = in.LabelSelector
+	out.Namespaces = in.Namespaces
 	out.TopologyKey = in.TopologyKey
 	return nil
 }
@@ -4668,23 +4415,8 @@ func Convert_v1_PodAffinityTerm_To_api_PodAffinityTerm(in *PodAffinityTerm, out 
 }
 
 func autoConvert_api_PodAffinityTerm_To_v1_PodAffinityTerm(in *api.PodAffinityTerm, out *PodAffinityTerm, s conversion.Scope) error {
-	if in.LabelSelector != nil {
-		in, out := &in.LabelSelector, &out.LabelSelector
-		*out = new(unversioned.LabelSelector)
-		// TODO: Inefficient conversion - can we improve it?
-		if err := s.Convert(*in, *out, 0); err != nil {
-			return err
-		}
-	} else {
-		out.LabelSelector = nil
-	}
-	if in.Namespaces != nil {
-		in, out := &in.Namespaces, &out.Namespaces
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Namespaces = nil
-	}
+	out.LabelSelector = in.LabelSelector
+	out.Namespaces = in.Namespaces
 	out.TopologyKey = in.TopologyKey
 	return nil
 }
@@ -4832,13 +4564,7 @@ func autoConvert_v1_PodExecOptions_To_api_PodExecOptions(in *PodExecOptions, out
 	out.Stderr = in.Stderr
 	out.TTY = in.TTY
 	out.Container = in.Container
-	if in.Command != nil {
-		in, out := &in.Command, &out.Command
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Command = nil
-	}
+	out.Command = in.Command
 	return nil
 }
 
@@ -4855,13 +4581,7 @@ func autoConvert_api_PodExecOptions_To_v1_PodExecOptions(in *api.PodExecOptions,
 	out.Stderr = in.Stderr
 	out.TTY = in.TTY
 	out.Container = in.Container
-	if in.Command != nil {
-		in, out := &in.Command, &out.Command
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Command = nil
-	}
+	out.Command = in.Command
 	return nil
 }
 
@@ -4926,37 +4646,11 @@ func autoConvert_v1_PodLogOptions_To_api_PodLogOptions(in *PodLogOptions, out *a
 	out.Container = in.Container
 	out.Follow = in.Follow
 	out.Previous = in.Previous
-	if in.SinceSeconds != nil {
-		in, out := &in.SinceSeconds, &out.SinceSeconds
-		*out = new(int64)
-		**out = **in
-	} else {
-		out.SinceSeconds = nil
-	}
-	if in.SinceTime != nil {
-		in, out := &in.SinceTime, &out.SinceTime
-		*out = new(unversioned.Time)
-		if err := api.Convert_unversioned_Time_To_unversioned_Time(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.SinceTime = nil
-	}
+	out.SinceSeconds = in.SinceSeconds
+	out.SinceTime = in.SinceTime
 	out.Timestamps = in.Timestamps
-	if in.TailLines != nil {
-		in, out := &in.TailLines, &out.TailLines
-		*out = new(int64)
-		**out = **in
-	} else {
-		out.TailLines = nil
-	}
-	if in.LimitBytes != nil {
-		in, out := &in.LimitBytes, &out.LimitBytes
-		*out = new(int64)
-		**out = **in
-	} else {
-		out.LimitBytes = nil
-	}
+	out.TailLines = in.TailLines
+	out.LimitBytes = in.LimitBytes
 	return nil
 }
 
@@ -4971,37 +4665,11 @@ func autoConvert_api_PodLogOptions_To_v1_PodLogOptions(in *api.PodLogOptions, ou
 	out.Container = in.Container
 	out.Follow = in.Follow
 	out.Previous = in.Previous
-	if in.SinceSeconds != nil {
-		in, out := &in.SinceSeconds, &out.SinceSeconds
-		*out = new(int64)
-		**out = **in
-	} else {
-		out.SinceSeconds = nil
-	}
-	if in.SinceTime != nil {
-		in, out := &in.SinceTime, &out.SinceTime
-		*out = new(unversioned.Time)
-		if err := api.Convert_unversioned_Time_To_unversioned_Time(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.SinceTime = nil
-	}
+	out.SinceSeconds = in.SinceSeconds
+	out.SinceTime = in.SinceTime
 	out.Timestamps = in.Timestamps
-	if in.TailLines != nil {
-		in, out := &in.TailLines, &out.TailLines
-		*out = new(int64)
-		**out = **in
-	} else {
-		out.TailLines = nil
-	}
-	if in.LimitBytes != nil {
-		in, out := &in.LimitBytes, &out.LimitBytes
-		*out = new(int64)
-		**out = **in
-	} else {
-		out.LimitBytes = nil
-	}
+	out.TailLines = in.TailLines
+	out.LimitBytes = in.LimitBytes
 	return nil
 }
 
@@ -5043,34 +4711,10 @@ func autoConvert_v1_PodSecurityContext_To_api_PodSecurityContext(in *PodSecurity
 	} else {
 		out.SELinuxOptions = nil
 	}
-	if in.RunAsUser != nil {
-		in, out := &in.RunAsUser, &out.RunAsUser
-		*out = new(int64)
-		**out = **in
-	} else {
-		out.RunAsUser = nil
-	}
-	if in.RunAsNonRoot != nil {
-		in, out := &in.RunAsNonRoot, &out.RunAsNonRoot
-		*out = new(bool)
-		**out = **in
-	} else {
-		out.RunAsNonRoot = nil
-	}
-	if in.SupplementalGroups != nil {
-		in, out := &in.SupplementalGroups, &out.SupplementalGroups
-		*out = make([]int64, len(*in))
-		copy(*out, *in)
-	} else {
-		out.SupplementalGroups = nil
-	}
-	if in.FSGroup != nil {
-		in, out := &in.FSGroup, &out.FSGroup
-		*out = new(int64)
-		**out = **in
-	} else {
-		out.FSGroup = nil
-	}
+	out.RunAsUser = in.RunAsUser
+	out.RunAsNonRoot = in.RunAsNonRoot
+	out.SupplementalGroups = in.SupplementalGroups
+	out.FSGroup = in.FSGroup
 	return nil
 }
 
@@ -5109,30 +4753,10 @@ func autoConvert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *PodSpec, s conv
 		out.Containers = nil
 	}
 	out.RestartPolicy = RestartPolicy(in.RestartPolicy)
-	if in.TerminationGracePeriodSeconds != nil {
-		in, out := &in.TerminationGracePeriodSeconds, &out.TerminationGracePeriodSeconds
-		*out = new(int64)
-		**out = **in
-	} else {
-		out.TerminationGracePeriodSeconds = nil
-	}
-	if in.ActiveDeadlineSeconds != nil {
-		in, out := &in.ActiveDeadlineSeconds, &out.ActiveDeadlineSeconds
-		*out = new(int64)
-		**out = **in
-	} else {
-		out.ActiveDeadlineSeconds = nil
-	}
+	out.TerminationGracePeriodSeconds = in.TerminationGracePeriodSeconds
+	out.ActiveDeadlineSeconds = in.ActiveDeadlineSeconds
 	out.DNSPolicy = DNSPolicy(in.DNSPolicy)
-	if in.NodeSelector != nil {
-		in, out := &in.NodeSelector, &out.NodeSelector
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	} else {
-		out.NodeSelector = nil
-	}
+	out.NodeSelector = in.NodeSelector
 	out.ServiceAccountName = in.ServiceAccountName
 	out.NodeName = in.NodeName
 	if in.SecurityContext != nil {
@@ -5177,15 +4801,7 @@ func autoConvert_v1_PodStatus_To_api_PodStatus(in *PodStatus, out *api.PodStatus
 	out.Reason = in.Reason
 	out.HostIP = in.HostIP
 	out.PodIP = in.PodIP
-	if in.StartTime != nil {
-		in, out := &in.StartTime, &out.StartTime
-		*out = new(unversioned.Time)
-		if err := api.Convert_unversioned_Time_To_unversioned_Time(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.StartTime = nil
-	}
+	out.StartTime = in.StartTime
 	if in.InitContainerStatuses != nil {
 		in, out := &in.InitContainerStatuses, &out.InitContainerStatuses
 		*out = make([]api.ContainerStatus, len(*in))
@@ -5232,15 +4848,7 @@ func autoConvert_api_PodStatus_To_v1_PodStatus(in *api.PodStatus, out *PodStatus
 	out.Reason = in.Reason
 	out.HostIP = in.HostIP
 	out.PodIP = in.PodIP
-	if in.StartTime != nil {
-		in, out := &in.StartTime, &out.StartTime
-		*out = new(unversioned.Time)
-		if err := api.Convert_unversioned_Time_To_unversioned_Time(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.StartTime = nil
-	}
+	out.StartTime = in.StartTime
 	if in.InitContainerStatuses != nil {
 		in, out := &in.InitContainerStatuses, &out.InitContainerStatuses
 		*out = make([]ContainerStatus, len(*in))
@@ -5401,13 +5009,7 @@ func autoConvert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in *api.PodTemplateSp
 }
 
 func autoConvert_v1_Preconditions_To_api_Preconditions(in *Preconditions, out *api.Preconditions, s conversion.Scope) error {
-	if in.UID != nil {
-		in, out := &in.UID, &out.UID
-		*out = new(types.UID)
-		**out = **in
-	} else {
-		out.UID = nil
-	}
+	out.UID = in.UID
 	return nil
 }
 
@@ -5416,13 +5018,7 @@ func Convert_v1_Preconditions_To_api_Preconditions(in *Preconditions, out *api.P
 }
 
 func autoConvert_api_Preconditions_To_v1_Preconditions(in *api.Preconditions, out *Preconditions, s conversion.Scope) error {
-	if in.UID != nil {
-		in, out := &in.UID, &out.UID
-		*out = new(types.UID)
-		**out = **in
-	} else {
-		out.UID = nil
-	}
+	out.UID = in.UID
 	return nil
 }
 
@@ -5488,13 +5084,7 @@ func Convert_api_Probe_To_v1_Probe(in *api.Probe, out *Probe, s conversion.Scope
 }
 
 func autoConvert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in *RBDVolumeSource, out *api.RBDVolumeSource, s conversion.Scope) error {
-	if in.CephMonitors != nil {
-		in, out := &in.CephMonitors, &out.CephMonitors
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.CephMonitors = nil
-	}
+	out.CephMonitors = in.CephMonitors
 	out.RBDImage = in.RBDImage
 	out.FSType = in.FSType
 	out.RBDPool = in.RBDPool
@@ -5518,13 +5108,7 @@ func Convert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in *RBDVolumeSource, out 
 }
 
 func autoConvert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in *api.RBDVolumeSource, out *RBDVolumeSource, s conversion.Scope) error {
-	if in.CephMonitors != nil {
-		in, out := &in.CephMonitors, &out.CephMonitors
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.CephMonitors = nil
-	}
+	out.CephMonitors = in.CephMonitors
 	out.RBDImage = in.RBDImage
 	out.FSType = in.FSType
 	out.RBDPool = in.RBDPool
@@ -5990,19 +5574,7 @@ func autoConvert_v1_Secret_To_api_Secret(in *Secret, out *api.Secret, s conversi
 	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if in.Data != nil {
-		in, out := &in.Data, &out.Data
-		*out = make(map[string][]byte, len(*in))
-		for key, val := range *in {
-			newVal := new([]byte)
-			if err := conversion.Convert_Slice_byte_To_Slice_byte(&val, newVal, s); err != nil {
-				return err
-			}
-			(*out)[key] = *newVal
-		}
-	} else {
-		out.Data = nil
-	}
+	out.Data = in.Data
 	out.Type = api.SecretType(in.Type)
 	return nil
 }
@@ -6018,19 +5590,7 @@ func autoConvert_api_Secret_To_v1_Secret(in *api.Secret, out *Secret, s conversi
 	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if in.Data != nil {
-		in, out := &in.Data, &out.Data
-		*out = make(map[string][]byte, len(*in))
-		for key, val := range *in {
-			newVal := new([]byte)
-			if err := conversion.Convert_Slice_byte_To_Slice_byte(&val, newVal, s); err != nil {
-				return err
-			}
-			(*out)[key] = *newVal
-		}
-	} else {
-		out.Data = nil
-	}
+	out.Data = in.Data
 	out.Type = SecretType(in.Type)
 	return nil
 }
@@ -6163,13 +5723,7 @@ func autoConvert_v1_SecurityContext_To_api_SecurityContext(in *SecurityContext, 
 	} else {
 		out.Capabilities = nil
 	}
-	if in.Privileged != nil {
-		in, out := &in.Privileged, &out.Privileged
-		*out = new(bool)
-		**out = **in
-	} else {
-		out.Privileged = nil
-	}
+	out.Privileged = in.Privileged
 	if in.SELinuxOptions != nil {
 		in, out := &in.SELinuxOptions, &out.SELinuxOptions
 		*out = new(api.SELinuxOptions)
@@ -6179,27 +5733,9 @@ func autoConvert_v1_SecurityContext_To_api_SecurityContext(in *SecurityContext, 
 	} else {
 		out.SELinuxOptions = nil
 	}
-	if in.RunAsUser != nil {
-		in, out := &in.RunAsUser, &out.RunAsUser
-		*out = new(int64)
-		**out = **in
-	} else {
-		out.RunAsUser = nil
-	}
-	if in.RunAsNonRoot != nil {
-		in, out := &in.RunAsNonRoot, &out.RunAsNonRoot
-		*out = new(bool)
-		**out = **in
-	} else {
-		out.RunAsNonRoot = nil
-	}
-	if in.ReadOnlyRootFilesystem != nil {
-		in, out := &in.ReadOnlyRootFilesystem, &out.ReadOnlyRootFilesystem
-		*out = new(bool)
-		**out = **in
-	} else {
-		out.ReadOnlyRootFilesystem = nil
-	}
+	out.RunAsUser = in.RunAsUser
+	out.RunAsNonRoot = in.RunAsNonRoot
+	out.ReadOnlyRootFilesystem = in.ReadOnlyRootFilesystem
 	return nil
 }
 
@@ -6217,13 +5753,7 @@ func autoConvert_api_SecurityContext_To_v1_SecurityContext(in *api.SecurityConte
 	} else {
 		out.Capabilities = nil
 	}
-	if in.Privileged != nil {
-		in, out := &in.Privileged, &out.Privileged
-		*out = new(bool)
-		**out = **in
-	} else {
-		out.Privileged = nil
-	}
+	out.Privileged = in.Privileged
 	if in.SELinuxOptions != nil {
 		in, out := &in.SELinuxOptions, &out.SELinuxOptions
 		*out = new(SELinuxOptions)
@@ -6233,27 +5763,9 @@ func autoConvert_api_SecurityContext_To_v1_SecurityContext(in *api.SecurityConte
 	} else {
 		out.SELinuxOptions = nil
 	}
-	if in.RunAsUser != nil {
-		in, out := &in.RunAsUser, &out.RunAsUser
-		*out = new(int64)
-		**out = **in
-	} else {
-		out.RunAsUser = nil
-	}
-	if in.RunAsNonRoot != nil {
-		in, out := &in.RunAsNonRoot, &out.RunAsNonRoot
-		*out = new(bool)
-		**out = **in
-	} else {
-		out.RunAsNonRoot = nil
-	}
-	if in.ReadOnlyRootFilesystem != nil {
-		in, out := &in.ReadOnlyRootFilesystem, &out.ReadOnlyRootFilesystem
-		*out = new(bool)
-		**out = **in
-	} else {
-		out.ReadOnlyRootFilesystem = nil
-	}
+	out.RunAsUser = in.RunAsUser
+	out.RunAsNonRoot = in.RunAsNonRoot
+	out.ReadOnlyRootFilesystem = in.ReadOnlyRootFilesystem
 	return nil
 }
 
@@ -6568,33 +6080,13 @@ func autoConvert_v1_ServiceSpec_To_api_ServiceSpec(in *ServiceSpec, out *api.Ser
 	} else {
 		out.Ports = nil
 	}
-	if in.Selector != nil {
-		in, out := &in.Selector, &out.Selector
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	} else {
-		out.Selector = nil
-	}
+	out.Selector = in.Selector
 	out.ClusterIP = in.ClusterIP
 	out.Type = api.ServiceType(in.Type)
-	if in.ExternalIPs != nil {
-		in, out := &in.ExternalIPs, &out.ExternalIPs
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.ExternalIPs = nil
-	}
+	out.ExternalIPs = in.ExternalIPs
 	out.SessionAffinity = api.ServiceAffinity(in.SessionAffinity)
 	out.LoadBalancerIP = in.LoadBalancerIP
-	if in.LoadBalancerSourceRanges != nil {
-		in, out := &in.LoadBalancerSourceRanges, &out.LoadBalancerSourceRanges
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.LoadBalancerSourceRanges = nil
-	}
+	out.LoadBalancerSourceRanges = in.LoadBalancerSourceRanges
 	return nil
 }
 
@@ -6611,32 +6103,12 @@ func autoConvert_api_ServiceSpec_To_v1_ServiceSpec(in *api.ServiceSpec, out *Ser
 	} else {
 		out.Ports = nil
 	}
-	if in.Selector != nil {
-		in, out := &in.Selector, &out.Selector
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	} else {
-		out.Selector = nil
-	}
+	out.Selector = in.Selector
 	out.ClusterIP = in.ClusterIP
-	if in.ExternalIPs != nil {
-		in, out := &in.ExternalIPs, &out.ExternalIPs
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.ExternalIPs = nil
-	}
+	out.ExternalIPs = in.ExternalIPs
 	out.LoadBalancerIP = in.LoadBalancerIP
 	out.SessionAffinity = ServiceAffinity(in.SessionAffinity)
-	if in.LoadBalancerSourceRanges != nil {
-		in, out := &in.LoadBalancerSourceRanges, &out.LoadBalancerSourceRanges
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.LoadBalancerSourceRanges = nil
-	}
+	out.LoadBalancerSourceRanges = in.LoadBalancerSourceRanges
 	return nil
 }
 

--- a/pkg/api/v1/conversion_test.go
+++ b/pkg/api/v1/conversion_test.go
@@ -204,8 +204,8 @@ func TestResourceListConversion(t *testing.T) {
 		},
 	}
 
-	output := api.ResourceList{}
 	for i, test := range tests {
+		output := api.ResourceList{}
 		err := api.Scheme.Convert(&test.input, &output)
 		if err != nil {
 			t.Fatalf("unexpected error for case %d: %v", i, err)

--- a/pkg/apis/apps/v1alpha1/conversion_generated.go
+++ b/pkg/apis/apps/v1alpha1/conversion_generated.go
@@ -136,13 +136,7 @@ func Convert_apps_PetSetList_To_v1alpha1_PetSetList(in *apps.PetSetList, out *Pe
 }
 
 func autoConvert_v1alpha1_PetSetStatus_To_apps_PetSetStatus(in *PetSetStatus, out *apps.PetSetStatus, s conversion.Scope) error {
-	if in.ObservedGeneration != nil {
-		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int64)
-		**out = **in
-	} else {
-		out.ObservedGeneration = nil
-	}
+	out.ObservedGeneration = in.ObservedGeneration
 	out.Replicas = int(in.Replicas)
 	return nil
 }
@@ -152,13 +146,7 @@ func Convert_v1alpha1_PetSetStatus_To_apps_PetSetStatus(in *PetSetStatus, out *a
 }
 
 func autoConvert_apps_PetSetStatus_To_v1alpha1_PetSetStatus(in *apps.PetSetStatus, out *PetSetStatus, s conversion.Scope) error {
-	if in.ObservedGeneration != nil {
-		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int64)
-		**out = **in
-	} else {
-		out.ObservedGeneration = nil
-	}
+	out.ObservedGeneration = in.ObservedGeneration
 	out.Replicas = int32(in.Replicas)
 	return nil
 }

--- a/pkg/apis/authentication.k8s.io/v1beta1/conversion_generated.go
+++ b/pkg/apis/authentication.k8s.io/v1beta1/conversion_generated.go
@@ -121,27 +121,8 @@ func Convert_authenticationk8sio_TokenReviewStatus_To_v1beta1_TokenReviewStatus(
 func autoConvert_v1beta1_UserInfo_To_authenticationk8sio_UserInfo(in *UserInfo, out *authentication_k8s_io.UserInfo, s conversion.Scope) error {
 	out.Username = in.Username
 	out.UID = in.UID
-	if in.Groups != nil {
-		in, out := &in.Groups, &out.Groups
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Groups = nil
-	}
-	if in.Extra != nil {
-		in, out := &in.Extra, &out.Extra
-		*out = make(map[string][]string, len(*in))
-		for key, val := range *in {
-			newVal := new([]string)
-			// TODO: Inefficient conversion - can we improve it?
-			if err := s.Convert(&val, newVal, 0); err != nil {
-				return err
-			}
-			(*out)[key] = *newVal
-		}
-	} else {
-		out.Extra = nil
-	}
+	out.Groups = in.Groups
+	out.Extra = in.Extra
 	return nil
 }
 
@@ -152,27 +133,8 @@ func Convert_v1beta1_UserInfo_To_authenticationk8sio_UserInfo(in *UserInfo, out 
 func autoConvert_authenticationk8sio_UserInfo_To_v1beta1_UserInfo(in *authentication_k8s_io.UserInfo, out *UserInfo, s conversion.Scope) error {
 	out.Username = in.Username
 	out.UID = in.UID
-	if in.Groups != nil {
-		in, out := &in.Groups, &out.Groups
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Groups = nil
-	}
-	if in.Extra != nil {
-		in, out := &in.Extra, &out.Extra
-		*out = make(map[string][]string, len(*in))
-		for key, val := range *in {
-			newVal := new([]string)
-			// TODO: Inefficient conversion - can we improve it?
-			if err := s.Convert(&val, newVal, 0); err != nil {
-				return err
-			}
-			(*out)[key] = *newVal
-		}
-	} else {
-		out.Extra = nil
-	}
+	out.Groups = in.Groups
+	out.Extra = in.Extra
 	return nil
 }
 

--- a/pkg/apis/authorization/v1beta1/conversion_generated.go
+++ b/pkg/apis/authorization/v1beta1/conversion_generated.go
@@ -274,27 +274,8 @@ func autoConvert_v1beta1_SubjectAccessReviewSpec_To_authorization_SubjectAccessR
 		out.NonResourceAttributes = nil
 	}
 	out.User = in.User
-	if in.Groups != nil {
-		in, out := &in.Groups, &out.Groups
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Groups = nil
-	}
-	if in.Extra != nil {
-		in, out := &in.Extra, &out.Extra
-		*out = make(map[string][]string, len(*in))
-		for key, val := range *in {
-			newVal := new([]string)
-			// TODO: Inefficient conversion - can we improve it?
-			if err := s.Convert(&val, newVal, 0); err != nil {
-				return err
-			}
-			(*out)[key] = *newVal
-		}
-	} else {
-		out.Extra = nil
-	}
+	out.Groups = in.Groups
+	out.Extra = in.Extra
 	return nil
 }
 
@@ -322,27 +303,8 @@ func autoConvert_authorization_SubjectAccessReviewSpec_To_v1beta1_SubjectAccessR
 		out.NonResourceAttributes = nil
 	}
 	out.User = in.User
-	if in.Groups != nil {
-		in, out := &in.Groups, &out.Groups
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Groups = nil
-	}
-	if in.Extra != nil {
-		in, out := &in.Extra, &out.Extra
-		*out = make(map[string][]string, len(*in))
-		for key, val := range *in {
-			newVal := new([]string)
-			// TODO: Inefficient conversion - can we improve it?
-			if err := s.Convert(&val, newVal, 0); err != nil {
-				return err
-			}
-			(*out)[key] = *newVal
-		}
-	} else {
-		out.Extra = nil
-	}
+	out.Groups = in.Groups
+	out.Extra = in.Extra
 	return nil
 }
 

--- a/pkg/apis/autoscaling/v1/conversion_generated.go
+++ b/pkg/apis/autoscaling/v1/conversion_generated.go
@@ -22,7 +22,6 @@ package v1
 
 import (
 	api "k8s.io/kubernetes/pkg/api"
-	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
 	autoscaling "k8s.io/kubernetes/pkg/apis/autoscaling"
 	conversion "k8s.io/kubernetes/pkg/conversion"
 )
@@ -170,21 +169,9 @@ func autoConvert_v1_HorizontalPodAutoscalerSpec_To_autoscaling_HorizontalPodAuto
 	if err := Convert_v1_CrossVersionObjectReference_To_autoscaling_CrossVersionObjectReference(&in.ScaleTargetRef, &out.ScaleTargetRef, s); err != nil {
 		return err
 	}
-	if in.MinReplicas != nil {
-		in, out := &in.MinReplicas, &out.MinReplicas
-		*out = new(int32)
-		**out = **in
-	} else {
-		out.MinReplicas = nil
-	}
+	out.MinReplicas = in.MinReplicas
 	out.MaxReplicas = in.MaxReplicas
-	if in.TargetCPUUtilizationPercentage != nil {
-		in, out := &in.TargetCPUUtilizationPercentage, &out.TargetCPUUtilizationPercentage
-		*out = new(int32)
-		**out = **in
-	} else {
-		out.TargetCPUUtilizationPercentage = nil
-	}
+	out.TargetCPUUtilizationPercentage = in.TargetCPUUtilizationPercentage
 	return nil
 }
 
@@ -196,21 +183,9 @@ func autoConvert_autoscaling_HorizontalPodAutoscalerSpec_To_v1_HorizontalPodAuto
 	if err := Convert_autoscaling_CrossVersionObjectReference_To_v1_CrossVersionObjectReference(&in.ScaleTargetRef, &out.ScaleTargetRef, s); err != nil {
 		return err
 	}
-	if in.MinReplicas != nil {
-		in, out := &in.MinReplicas, &out.MinReplicas
-		*out = new(int32)
-		**out = **in
-	} else {
-		out.MinReplicas = nil
-	}
+	out.MinReplicas = in.MinReplicas
 	out.MaxReplicas = in.MaxReplicas
-	if in.TargetCPUUtilizationPercentage != nil {
-		in, out := &in.TargetCPUUtilizationPercentage, &out.TargetCPUUtilizationPercentage
-		*out = new(int32)
-		**out = **in
-	} else {
-		out.TargetCPUUtilizationPercentage = nil
-	}
+	out.TargetCPUUtilizationPercentage = in.TargetCPUUtilizationPercentage
 	return nil
 }
 
@@ -219,31 +194,11 @@ func Convert_autoscaling_HorizontalPodAutoscalerSpec_To_v1_HorizontalPodAutoscal
 }
 
 func autoConvert_v1_HorizontalPodAutoscalerStatus_To_autoscaling_HorizontalPodAutoscalerStatus(in *HorizontalPodAutoscalerStatus, out *autoscaling.HorizontalPodAutoscalerStatus, s conversion.Scope) error {
-	if in.ObservedGeneration != nil {
-		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int64)
-		**out = **in
-	} else {
-		out.ObservedGeneration = nil
-	}
-	if in.LastScaleTime != nil {
-		in, out := &in.LastScaleTime, &out.LastScaleTime
-		*out = new(unversioned.Time)
-		if err := api.Convert_unversioned_Time_To_unversioned_Time(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.LastScaleTime = nil
-	}
+	out.ObservedGeneration = in.ObservedGeneration
+	out.LastScaleTime = in.LastScaleTime
 	out.CurrentReplicas = in.CurrentReplicas
 	out.DesiredReplicas = in.DesiredReplicas
-	if in.CurrentCPUUtilizationPercentage != nil {
-		in, out := &in.CurrentCPUUtilizationPercentage, &out.CurrentCPUUtilizationPercentage
-		*out = new(int32)
-		**out = **in
-	} else {
-		out.CurrentCPUUtilizationPercentage = nil
-	}
+	out.CurrentCPUUtilizationPercentage = in.CurrentCPUUtilizationPercentage
 	return nil
 }
 
@@ -252,31 +207,11 @@ func Convert_v1_HorizontalPodAutoscalerStatus_To_autoscaling_HorizontalPodAutosc
 }
 
 func autoConvert_autoscaling_HorizontalPodAutoscalerStatus_To_v1_HorizontalPodAutoscalerStatus(in *autoscaling.HorizontalPodAutoscalerStatus, out *HorizontalPodAutoscalerStatus, s conversion.Scope) error {
-	if in.ObservedGeneration != nil {
-		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int64)
-		**out = **in
-	} else {
-		out.ObservedGeneration = nil
-	}
-	if in.LastScaleTime != nil {
-		in, out := &in.LastScaleTime, &out.LastScaleTime
-		*out = new(unversioned.Time)
-		if err := api.Convert_unversioned_Time_To_unversioned_Time(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.LastScaleTime = nil
-	}
+	out.ObservedGeneration = in.ObservedGeneration
+	out.LastScaleTime = in.LastScaleTime
 	out.CurrentReplicas = in.CurrentReplicas
 	out.DesiredReplicas = in.DesiredReplicas
-	if in.CurrentCPUUtilizationPercentage != nil {
-		in, out := &in.CurrentCPUUtilizationPercentage, &out.CurrentCPUUtilizationPercentage
-		*out = new(int32)
-		**out = **in
-	} else {
-		out.CurrentCPUUtilizationPercentage = nil
-	}
+	out.CurrentCPUUtilizationPercentage = in.CurrentCPUUtilizationPercentage
 	return nil
 }
 

--- a/pkg/apis/batch/v1/conversion_generated.go
+++ b/pkg/apis/batch/v1/conversion_generated.go
@@ -180,27 +180,9 @@ func Convert_batch_JobList_To_v1_JobList(in *batch.JobList, out *JobList, s conv
 }
 
 func autoConvert_v1_JobSpec_To_batch_JobSpec(in *JobSpec, out *batch.JobSpec, s conversion.Scope) error {
-	if in.Parallelism != nil {
-		in, out := &in.Parallelism, &out.Parallelism
-		*out = new(int32)
-		**out = **in
-	} else {
-		out.Parallelism = nil
-	}
-	if in.Completions != nil {
-		in, out := &in.Completions, &out.Completions
-		*out = new(int32)
-		**out = **in
-	} else {
-		out.Completions = nil
-	}
-	if in.ActiveDeadlineSeconds != nil {
-		in, out := &in.ActiveDeadlineSeconds, &out.ActiveDeadlineSeconds
-		*out = new(int64)
-		**out = **in
-	} else {
-		out.ActiveDeadlineSeconds = nil
-	}
+	out.Parallelism = in.Parallelism
+	out.Completions = in.Completions
+	out.ActiveDeadlineSeconds = in.ActiveDeadlineSeconds
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
 		*out = new(unversioned.LabelSelector)
@@ -210,13 +192,7 @@ func autoConvert_v1_JobSpec_To_batch_JobSpec(in *JobSpec, out *batch.JobSpec, s 
 	} else {
 		out.Selector = nil
 	}
-	if in.ManualSelector != nil {
-		in, out := &in.ManualSelector, &out.ManualSelector
-		*out = new(bool)
-		**out = **in
-	} else {
-		out.ManualSelector = nil
-	}
+	out.ManualSelector = in.ManualSelector
 	if err := api_v1.Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
@@ -224,27 +200,9 @@ func autoConvert_v1_JobSpec_To_batch_JobSpec(in *JobSpec, out *batch.JobSpec, s 
 }
 
 func autoConvert_batch_JobSpec_To_v1_JobSpec(in *batch.JobSpec, out *JobSpec, s conversion.Scope) error {
-	if in.Parallelism != nil {
-		in, out := &in.Parallelism, &out.Parallelism
-		*out = new(int32)
-		**out = **in
-	} else {
-		out.Parallelism = nil
-	}
-	if in.Completions != nil {
-		in, out := &in.Completions, &out.Completions
-		*out = new(int32)
-		**out = **in
-	} else {
-		out.Completions = nil
-	}
-	if in.ActiveDeadlineSeconds != nil {
-		in, out := &in.ActiveDeadlineSeconds, &out.ActiveDeadlineSeconds
-		*out = new(int64)
-		**out = **in
-	} else {
-		out.ActiveDeadlineSeconds = nil
-	}
+	out.Parallelism = in.Parallelism
+	out.Completions = in.Completions
+	out.ActiveDeadlineSeconds = in.ActiveDeadlineSeconds
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
 		*out = new(LabelSelector)
@@ -254,13 +212,7 @@ func autoConvert_batch_JobSpec_To_v1_JobSpec(in *batch.JobSpec, out *JobSpec, s 
 	} else {
 		out.Selector = nil
 	}
-	if in.ManualSelector != nil {
-		in, out := &in.ManualSelector, &out.ManualSelector
-		*out = new(bool)
-		**out = **in
-	} else {
-		out.ManualSelector = nil
-	}
+	out.ManualSelector = in.ManualSelector
 	if err := api_v1.Convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
@@ -279,24 +231,8 @@ func autoConvert_v1_JobStatus_To_batch_JobStatus(in *JobStatus, out *batch.JobSt
 	} else {
 		out.Conditions = nil
 	}
-	if in.StartTime != nil {
-		in, out := &in.StartTime, &out.StartTime
-		*out = new(unversioned.Time)
-		if err := api.Convert_unversioned_Time_To_unversioned_Time(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.StartTime = nil
-	}
-	if in.CompletionTime != nil {
-		in, out := &in.CompletionTime, &out.CompletionTime
-		*out = new(unversioned.Time)
-		if err := api.Convert_unversioned_Time_To_unversioned_Time(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.CompletionTime = nil
-	}
+	out.StartTime = in.StartTime
+	out.CompletionTime = in.CompletionTime
 	out.Active = in.Active
 	out.Succeeded = in.Succeeded
 	out.Failed = in.Failed
@@ -319,24 +255,8 @@ func autoConvert_batch_JobStatus_To_v1_JobStatus(in *batch.JobStatus, out *JobSt
 	} else {
 		out.Conditions = nil
 	}
-	if in.StartTime != nil {
-		in, out := &in.StartTime, &out.StartTime
-		*out = new(unversioned.Time)
-		if err := api.Convert_unversioned_Time_To_unversioned_Time(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.StartTime = nil
-	}
-	if in.CompletionTime != nil {
-		in, out := &in.CompletionTime, &out.CompletionTime
-		*out = new(unversioned.Time)
-		if err := api.Convert_unversioned_Time_To_unversioned_Time(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.CompletionTime = nil
-	}
+	out.StartTime = in.StartTime
+	out.CompletionTime = in.CompletionTime
 	out.Active = in.Active
 	out.Succeeded = in.Succeeded
 	out.Failed = in.Failed
@@ -348,15 +268,7 @@ func Convert_batch_JobStatus_To_v1_JobStatus(in *batch.JobStatus, out *JobStatus
 }
 
 func autoConvert_v1_LabelSelector_To_unversioned_LabelSelector(in *LabelSelector, out *unversioned.LabelSelector, s conversion.Scope) error {
-	if in.MatchLabels != nil {
-		in, out := &in.MatchLabels, &out.MatchLabels
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	} else {
-		out.MatchLabels = nil
-	}
+	out.MatchLabels = in.MatchLabels
 	if in.MatchExpressions != nil {
 		in, out := &in.MatchExpressions, &out.MatchExpressions
 		*out = make([]unversioned.LabelSelectorRequirement, len(*in))
@@ -376,15 +288,7 @@ func Convert_v1_LabelSelector_To_unversioned_LabelSelector(in *LabelSelector, ou
 }
 
 func autoConvert_unversioned_LabelSelector_To_v1_LabelSelector(in *unversioned.LabelSelector, out *LabelSelector, s conversion.Scope) error {
-	if in.MatchLabels != nil {
-		in, out := &in.MatchLabels, &out.MatchLabels
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	} else {
-		out.MatchLabels = nil
-	}
+	out.MatchLabels = in.MatchLabels
 	if in.MatchExpressions != nil {
 		in, out := &in.MatchExpressions, &out.MatchExpressions
 		*out = make([]LabelSelectorRequirement, len(*in))
@@ -406,13 +310,7 @@ func Convert_unversioned_LabelSelector_To_v1_LabelSelector(in *unversioned.Label
 func autoConvert_v1_LabelSelectorRequirement_To_unversioned_LabelSelectorRequirement(in *LabelSelectorRequirement, out *unversioned.LabelSelectorRequirement, s conversion.Scope) error {
 	out.Key = in.Key
 	out.Operator = unversioned.LabelSelectorOperator(in.Operator)
-	if in.Values != nil {
-		in, out := &in.Values, &out.Values
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Values = nil
-	}
+	out.Values = in.Values
 	return nil
 }
 
@@ -423,13 +321,7 @@ func Convert_v1_LabelSelectorRequirement_To_unversioned_LabelSelectorRequirement
 func autoConvert_unversioned_LabelSelectorRequirement_To_v1_LabelSelectorRequirement(in *unversioned.LabelSelectorRequirement, out *LabelSelectorRequirement, s conversion.Scope) error {
 	out.Key = in.Key
 	out.Operator = LabelSelectorOperator(in.Operator)
-	if in.Values != nil {
-		in, out := &in.Values, &out.Values
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Values = nil
-	}
+	out.Values = in.Values
 	return nil
 }
 

--- a/pkg/apis/batch/v2alpha1/conversion_generated.go
+++ b/pkg/apis/batch/v2alpha1/conversion_generated.go
@@ -192,27 +192,9 @@ func Convert_batch_JobList_To_v2alpha1_JobList(in *batch.JobList, out *JobList, 
 }
 
 func autoConvert_v2alpha1_JobSpec_To_batch_JobSpec(in *JobSpec, out *batch.JobSpec, s conversion.Scope) error {
-	if in.Parallelism != nil {
-		in, out := &in.Parallelism, &out.Parallelism
-		*out = new(int32)
-		**out = **in
-	} else {
-		out.Parallelism = nil
-	}
-	if in.Completions != nil {
-		in, out := &in.Completions, &out.Completions
-		*out = new(int32)
-		**out = **in
-	} else {
-		out.Completions = nil
-	}
-	if in.ActiveDeadlineSeconds != nil {
-		in, out := &in.ActiveDeadlineSeconds, &out.ActiveDeadlineSeconds
-		*out = new(int64)
-		**out = **in
-	} else {
-		out.ActiveDeadlineSeconds = nil
-	}
+	out.Parallelism = in.Parallelism
+	out.Completions = in.Completions
+	out.ActiveDeadlineSeconds = in.ActiveDeadlineSeconds
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
 		*out = new(unversioned.LabelSelector)
@@ -222,13 +204,7 @@ func autoConvert_v2alpha1_JobSpec_To_batch_JobSpec(in *JobSpec, out *batch.JobSp
 	} else {
 		out.Selector = nil
 	}
-	if in.ManualSelector != nil {
-		in, out := &in.ManualSelector, &out.ManualSelector
-		*out = new(bool)
-		**out = **in
-	} else {
-		out.ManualSelector = nil
-	}
+	out.ManualSelector = in.ManualSelector
 	if err := v1.Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
@@ -236,27 +212,9 @@ func autoConvert_v2alpha1_JobSpec_To_batch_JobSpec(in *JobSpec, out *batch.JobSp
 }
 
 func autoConvert_batch_JobSpec_To_v2alpha1_JobSpec(in *batch.JobSpec, out *JobSpec, s conversion.Scope) error {
-	if in.Parallelism != nil {
-		in, out := &in.Parallelism, &out.Parallelism
-		*out = new(int32)
-		**out = **in
-	} else {
-		out.Parallelism = nil
-	}
-	if in.Completions != nil {
-		in, out := &in.Completions, &out.Completions
-		*out = new(int32)
-		**out = **in
-	} else {
-		out.Completions = nil
-	}
-	if in.ActiveDeadlineSeconds != nil {
-		in, out := &in.ActiveDeadlineSeconds, &out.ActiveDeadlineSeconds
-		*out = new(int64)
-		**out = **in
-	} else {
-		out.ActiveDeadlineSeconds = nil
-	}
+	out.Parallelism = in.Parallelism
+	out.Completions = in.Completions
+	out.ActiveDeadlineSeconds = in.ActiveDeadlineSeconds
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
 		*out = new(LabelSelector)
@@ -266,13 +224,7 @@ func autoConvert_batch_JobSpec_To_v2alpha1_JobSpec(in *batch.JobSpec, out *JobSp
 	} else {
 		out.Selector = nil
 	}
-	if in.ManualSelector != nil {
-		in, out := &in.ManualSelector, &out.ManualSelector
-		*out = new(bool)
-		**out = **in
-	} else {
-		out.ManualSelector = nil
-	}
+	out.ManualSelector = in.ManualSelector
 	if err := v1.Convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
@@ -291,24 +243,8 @@ func autoConvert_v2alpha1_JobStatus_To_batch_JobStatus(in *JobStatus, out *batch
 	} else {
 		out.Conditions = nil
 	}
-	if in.StartTime != nil {
-		in, out := &in.StartTime, &out.StartTime
-		*out = new(unversioned.Time)
-		if err := api.Convert_unversioned_Time_To_unversioned_Time(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.StartTime = nil
-	}
-	if in.CompletionTime != nil {
-		in, out := &in.CompletionTime, &out.CompletionTime
-		*out = new(unversioned.Time)
-		if err := api.Convert_unversioned_Time_To_unversioned_Time(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.CompletionTime = nil
-	}
+	out.StartTime = in.StartTime
+	out.CompletionTime = in.CompletionTime
 	out.Active = in.Active
 	out.Succeeded = in.Succeeded
 	out.Failed = in.Failed
@@ -331,24 +267,8 @@ func autoConvert_batch_JobStatus_To_v2alpha1_JobStatus(in *batch.JobStatus, out 
 	} else {
 		out.Conditions = nil
 	}
-	if in.StartTime != nil {
-		in, out := &in.StartTime, &out.StartTime
-		*out = new(unversioned.Time)
-		if err := api.Convert_unversioned_Time_To_unversioned_Time(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.StartTime = nil
-	}
-	if in.CompletionTime != nil {
-		in, out := &in.CompletionTime, &out.CompletionTime
-		*out = new(unversioned.Time)
-		if err := api.Convert_unversioned_Time_To_unversioned_Time(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.CompletionTime = nil
-	}
+	out.StartTime = in.StartTime
+	out.CompletionTime = in.CompletionTime
 	out.Active = in.Active
 	out.Succeeded = in.Succeeded
 	out.Failed = in.Failed
@@ -426,15 +346,7 @@ func Convert_batch_JobTemplateSpec_To_v2alpha1_JobTemplateSpec(in *batch.JobTemp
 }
 
 func autoConvert_v2alpha1_LabelSelector_To_unversioned_LabelSelector(in *LabelSelector, out *unversioned.LabelSelector, s conversion.Scope) error {
-	if in.MatchLabels != nil {
-		in, out := &in.MatchLabels, &out.MatchLabels
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	} else {
-		out.MatchLabels = nil
-	}
+	out.MatchLabels = in.MatchLabels
 	if in.MatchExpressions != nil {
 		in, out := &in.MatchExpressions, &out.MatchExpressions
 		*out = make([]unversioned.LabelSelectorRequirement, len(*in))
@@ -454,15 +366,7 @@ func Convert_v2alpha1_LabelSelector_To_unversioned_LabelSelector(in *LabelSelect
 }
 
 func autoConvert_unversioned_LabelSelector_To_v2alpha1_LabelSelector(in *unversioned.LabelSelector, out *LabelSelector, s conversion.Scope) error {
-	if in.MatchLabels != nil {
-		in, out := &in.MatchLabels, &out.MatchLabels
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	} else {
-		out.MatchLabels = nil
-	}
+	out.MatchLabels = in.MatchLabels
 	if in.MatchExpressions != nil {
 		in, out := &in.MatchExpressions, &out.MatchExpressions
 		*out = make([]LabelSelectorRequirement, len(*in))
@@ -484,13 +388,7 @@ func Convert_unversioned_LabelSelector_To_v2alpha1_LabelSelector(in *unversioned
 func autoConvert_v2alpha1_LabelSelectorRequirement_To_unversioned_LabelSelectorRequirement(in *LabelSelectorRequirement, out *unversioned.LabelSelectorRequirement, s conversion.Scope) error {
 	out.Key = in.Key
 	out.Operator = unversioned.LabelSelectorOperator(in.Operator)
-	if in.Values != nil {
-		in, out := &in.Values, &out.Values
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Values = nil
-	}
+	out.Values = in.Values
 	return nil
 }
 
@@ -501,13 +399,7 @@ func Convert_v2alpha1_LabelSelectorRequirement_To_unversioned_LabelSelectorRequi
 func autoConvert_unversioned_LabelSelectorRequirement_To_v2alpha1_LabelSelectorRequirement(in *unversioned.LabelSelectorRequirement, out *LabelSelectorRequirement, s conversion.Scope) error {
 	out.Key = in.Key
 	out.Operator = LabelSelectorOperator(in.Operator)
-	if in.Values != nil {
-		in, out := &in.Values, &out.Values
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Values = nil
-	}
+	out.Values = in.Values
 	return nil
 }
 
@@ -610,13 +502,7 @@ func Convert_batch_ScheduledJobList_To_v2alpha1_ScheduledJobList(in *batch.Sched
 
 func autoConvert_v2alpha1_ScheduledJobSpec_To_batch_ScheduledJobSpec(in *ScheduledJobSpec, out *batch.ScheduledJobSpec, s conversion.Scope) error {
 	out.Schedule = in.Schedule
-	if in.StartingDeadlineSeconds != nil {
-		in, out := &in.StartingDeadlineSeconds, &out.StartingDeadlineSeconds
-		*out = new(int64)
-		**out = **in
-	} else {
-		out.StartingDeadlineSeconds = nil
-	}
+	out.StartingDeadlineSeconds = in.StartingDeadlineSeconds
 	out.ConcurrencyPolicy = batch.ConcurrencyPolicy(in.ConcurrencyPolicy)
 	out.Suspend = in.Suspend
 	if err := Convert_v2alpha1_JobTemplateSpec_To_batch_JobTemplateSpec(&in.JobTemplate, &out.JobTemplate, s); err != nil {
@@ -631,13 +517,7 @@ func Convert_v2alpha1_ScheduledJobSpec_To_batch_ScheduledJobSpec(in *ScheduledJo
 
 func autoConvert_batch_ScheduledJobSpec_To_v2alpha1_ScheduledJobSpec(in *batch.ScheduledJobSpec, out *ScheduledJobSpec, s conversion.Scope) error {
 	out.Schedule = in.Schedule
-	if in.StartingDeadlineSeconds != nil {
-		in, out := &in.StartingDeadlineSeconds, &out.StartingDeadlineSeconds
-		*out = new(int64)
-		**out = **in
-	} else {
-		out.StartingDeadlineSeconds = nil
-	}
+	out.StartingDeadlineSeconds = in.StartingDeadlineSeconds
 	out.ConcurrencyPolicy = ConcurrencyPolicy(in.ConcurrencyPolicy)
 	out.Suspend = in.Suspend
 	if err := Convert_batch_JobTemplateSpec_To_v2alpha1_JobTemplateSpec(&in.JobTemplate, &out.JobTemplate, s); err != nil {
@@ -663,15 +543,7 @@ func autoConvert_v2alpha1_ScheduledJobStatus_To_batch_ScheduledJobStatus(in *Sch
 	} else {
 		out.Active = nil
 	}
-	if in.LastScheduleTime != nil {
-		in, out := &in.LastScheduleTime, &out.LastScheduleTime
-		*out = new(unversioned.Time)
-		if err := api.Convert_unversioned_Time_To_unversioned_Time(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.LastScheduleTime = nil
-	}
+	out.LastScheduleTime = in.LastScheduleTime
 	return nil
 }
 
@@ -692,15 +564,7 @@ func autoConvert_batch_ScheduledJobStatus_To_v2alpha1_ScheduledJobStatus(in *bat
 	} else {
 		out.Active = nil
 	}
-	if in.LastScheduleTime != nil {
-		in, out := &in.LastScheduleTime, &out.LastScheduleTime
-		*out = new(unversioned.Time)
-		if err := api.Convert_unversioned_Time_To_unversioned_Time(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.LastScheduleTime = nil
-	}
+	out.LastScheduleTime = in.LastScheduleTime
 	return nil
 }
 

--- a/pkg/apis/componentconfig/v1alpha1/conversion_generated.go
+++ b/pkg/apis/componentconfig/v1alpha1/conversion_generated.go
@@ -50,39 +50,18 @@ func autoConvert_v1alpha1_KubeProxyConfiguration_To_componentconfig_KubeProxyCon
 	out.HealthzBindAddress = in.HealthzBindAddress
 	out.HealthzPort = in.HealthzPort
 	out.HostnameOverride = in.HostnameOverride
-	if in.IPTablesMasqueradeBit != nil {
-		in, out := &in.IPTablesMasqueradeBit, &out.IPTablesMasqueradeBit
-		*out = new(int32)
-		**out = **in
-	} else {
-		out.IPTablesMasqueradeBit = nil
-	}
-	// TODO: Inefficient conversion - can we improve it?
-	if err := s.Convert(&in.IPTablesSyncPeriod, &out.IPTablesSyncPeriod, 0); err != nil {
-		return err
-	}
+	out.IPTablesMasqueradeBit = in.IPTablesMasqueradeBit
+	out.IPTablesSyncPeriod = in.IPTablesSyncPeriod
 	out.KubeconfigPath = in.KubeconfigPath
 	out.MasqueradeAll = in.MasqueradeAll
 	out.Master = in.Master
-	if in.OOMScoreAdj != nil {
-		in, out := &in.OOMScoreAdj, &out.OOMScoreAdj
-		*out = new(int32)
-		**out = **in
-	} else {
-		out.OOMScoreAdj = nil
-	}
+	out.OOMScoreAdj = in.OOMScoreAdj
 	out.Mode = componentconfig.ProxyMode(in.Mode)
 	out.PortRange = in.PortRange
 	out.ResourceContainer = in.ResourceContainer
-	// TODO: Inefficient conversion - can we improve it?
-	if err := s.Convert(&in.UDPIdleTimeout, &out.UDPIdleTimeout, 0); err != nil {
-		return err
-	}
+	out.UDPIdleTimeout = in.UDPIdleTimeout
 	out.ConntrackMax = in.ConntrackMax
-	// TODO: Inefficient conversion - can we improve it?
-	if err := s.Convert(&in.ConntrackTCPEstablishedTimeout, &out.ConntrackTCPEstablishedTimeout, 0); err != nil {
-		return err
-	}
+	out.ConntrackTCPEstablishedTimeout = in.ConntrackTCPEstablishedTimeout
 	return nil
 }
 
@@ -99,39 +78,18 @@ func autoConvert_componentconfig_KubeProxyConfiguration_To_v1alpha1_KubeProxyCon
 	out.HealthzBindAddress = in.HealthzBindAddress
 	out.HealthzPort = in.HealthzPort
 	out.HostnameOverride = in.HostnameOverride
-	if in.IPTablesMasqueradeBit != nil {
-		in, out := &in.IPTablesMasqueradeBit, &out.IPTablesMasqueradeBit
-		*out = new(int32)
-		**out = **in
-	} else {
-		out.IPTablesMasqueradeBit = nil
-	}
-	// TODO: Inefficient conversion - can we improve it?
-	if err := s.Convert(&in.IPTablesSyncPeriod, &out.IPTablesSyncPeriod, 0); err != nil {
-		return err
-	}
+	out.IPTablesMasqueradeBit = in.IPTablesMasqueradeBit
+	out.IPTablesSyncPeriod = in.IPTablesSyncPeriod
 	out.KubeconfigPath = in.KubeconfigPath
 	out.MasqueradeAll = in.MasqueradeAll
 	out.Master = in.Master
-	if in.OOMScoreAdj != nil {
-		in, out := &in.OOMScoreAdj, &out.OOMScoreAdj
-		*out = new(int32)
-		**out = **in
-	} else {
-		out.OOMScoreAdj = nil
-	}
+	out.OOMScoreAdj = in.OOMScoreAdj
 	out.Mode = ProxyMode(in.Mode)
 	out.PortRange = in.PortRange
 	out.ResourceContainer = in.ResourceContainer
-	// TODO: Inefficient conversion - can we improve it?
-	if err := s.Convert(&in.UDPIdleTimeout, &out.UDPIdleTimeout, 0); err != nil {
-		return err
-	}
+	out.UDPIdleTimeout = in.UDPIdleTimeout
 	out.ConntrackMax = in.ConntrackMax
-	// TODO: Inefficient conversion - can we improve it?
-	if err := s.Convert(&in.ConntrackTCPEstablishedTimeout, &out.ConntrackTCPEstablishedTimeout, 0); err != nil {
-		return err
-	}
+	out.ConntrackTCPEstablishedTimeout = in.ConntrackTCPEstablishedTimeout
 	return nil
 }
 
@@ -199,18 +157,9 @@ func autoConvert_v1alpha1_LeaderElectionConfiguration_To_componentconfig_LeaderE
 	if err := api.Convert_Pointer_bool_To_bool(&in.LeaderElect, &out.LeaderElect, s); err != nil {
 		return err
 	}
-	// TODO: Inefficient conversion - can we improve it?
-	if err := s.Convert(&in.LeaseDuration, &out.LeaseDuration, 0); err != nil {
-		return err
-	}
-	// TODO: Inefficient conversion - can we improve it?
-	if err := s.Convert(&in.RenewDeadline, &out.RenewDeadline, 0); err != nil {
-		return err
-	}
-	// TODO: Inefficient conversion - can we improve it?
-	if err := s.Convert(&in.RetryPeriod, &out.RetryPeriod, 0); err != nil {
-		return err
-	}
+	out.LeaseDuration = in.LeaseDuration
+	out.RenewDeadline = in.RenewDeadline
+	out.RetryPeriod = in.RetryPeriod
 	return nil
 }
 
@@ -222,18 +171,9 @@ func autoConvert_componentconfig_LeaderElectionConfiguration_To_v1alpha1_LeaderE
 	if err := api.Convert_bool_To_Pointer_bool(&in.LeaderElect, &out.LeaderElect, s); err != nil {
 		return err
 	}
-	// TODO: Inefficient conversion - can we improve it?
-	if err := s.Convert(&in.LeaseDuration, &out.LeaseDuration, 0); err != nil {
-		return err
-	}
-	// TODO: Inefficient conversion - can we improve it?
-	if err := s.Convert(&in.RenewDeadline, &out.RenewDeadline, 0); err != nil {
-		return err
-	}
-	// TODO: Inefficient conversion - can we improve it?
-	if err := s.Convert(&in.RetryPeriod, &out.RetryPeriod, 0); err != nil {
-		return err
-	}
+	out.LeaseDuration = in.LeaseDuration
+	out.RenewDeadline = in.RenewDeadline
+	out.RetryPeriod = in.RetryPeriod
 	return nil
 }
 

--- a/pkg/apis/extensions/v1beta1/conversion_generated.go
+++ b/pkg/apis/extensions/v1beta1/conversion_generated.go
@@ -28,7 +28,6 @@ import (
 	batch "k8s.io/kubernetes/pkg/apis/batch"
 	extensions "k8s.io/kubernetes/pkg/apis/extensions"
 	conversion "k8s.io/kubernetes/pkg/conversion"
-	intstr "k8s.io/kubernetes/pkg/util/intstr"
 )
 
 func init() {
@@ -564,15 +563,7 @@ func autoConvert_v1beta1_DeploymentRollback_To_extensions_DeploymentRollback(in 
 		return err
 	}
 	out.Name = in.Name
-	if in.UpdatedAnnotations != nil {
-		in, out := &in.UpdatedAnnotations, &out.UpdatedAnnotations
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	} else {
-		out.UpdatedAnnotations = nil
-	}
+	out.UpdatedAnnotations = in.UpdatedAnnotations
 	if err := Convert_v1beta1_RollbackConfig_To_extensions_RollbackConfig(&in.RollbackTo, &out.RollbackTo, s); err != nil {
 		return err
 	}
@@ -588,15 +579,7 @@ func autoConvert_extensions_DeploymentRollback_To_v1beta1_DeploymentRollback(in 
 		return err
 	}
 	out.Name = in.Name
-	if in.UpdatedAnnotations != nil {
-		in, out := &in.UpdatedAnnotations, &out.UpdatedAnnotations
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	} else {
-		out.UpdatedAnnotations = nil
-	}
+	out.UpdatedAnnotations = in.UpdatedAnnotations
 	if err := Convert_extensions_RollbackConfig_To_v1beta1_RollbackConfig(&in.RollbackTo, &out.RollbackTo, s); err != nil {
 		return err
 	}
@@ -857,31 +840,11 @@ func Convert_autoscaling_HorizontalPodAutoscalerList_To_v1beta1_HorizontalPodAut
 }
 
 func autoConvert_v1beta1_HorizontalPodAutoscalerStatus_To_autoscaling_HorizontalPodAutoscalerStatus(in *HorizontalPodAutoscalerStatus, out *autoscaling.HorizontalPodAutoscalerStatus, s conversion.Scope) error {
-	if in.ObservedGeneration != nil {
-		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int64)
-		**out = **in
-	} else {
-		out.ObservedGeneration = nil
-	}
-	if in.LastScaleTime != nil {
-		in, out := &in.LastScaleTime, &out.LastScaleTime
-		*out = new(unversioned.Time)
-		if err := api.Convert_unversioned_Time_To_unversioned_Time(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.LastScaleTime = nil
-	}
+	out.ObservedGeneration = in.ObservedGeneration
+	out.LastScaleTime = in.LastScaleTime
 	out.CurrentReplicas = in.CurrentReplicas
 	out.DesiredReplicas = in.DesiredReplicas
-	if in.CurrentCPUUtilizationPercentage != nil {
-		in, out := &in.CurrentCPUUtilizationPercentage, &out.CurrentCPUUtilizationPercentage
-		*out = new(int32)
-		**out = **in
-	} else {
-		out.CurrentCPUUtilizationPercentage = nil
-	}
+	out.CurrentCPUUtilizationPercentage = in.CurrentCPUUtilizationPercentage
 	return nil
 }
 
@@ -890,31 +853,11 @@ func Convert_v1beta1_HorizontalPodAutoscalerStatus_To_autoscaling_HorizontalPodA
 }
 
 func autoConvert_autoscaling_HorizontalPodAutoscalerStatus_To_v1beta1_HorizontalPodAutoscalerStatus(in *autoscaling.HorizontalPodAutoscalerStatus, out *HorizontalPodAutoscalerStatus, s conversion.Scope) error {
-	if in.ObservedGeneration != nil {
-		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int64)
-		**out = **in
-	} else {
-		out.ObservedGeneration = nil
-	}
-	if in.LastScaleTime != nil {
-		in, out := &in.LastScaleTime, &out.LastScaleTime
-		*out = new(unversioned.Time)
-		if err := api.Convert_unversioned_Time_To_unversioned_Time(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.LastScaleTime = nil
-	}
+	out.ObservedGeneration = in.ObservedGeneration
+	out.LastScaleTime = in.LastScaleTime
 	out.CurrentReplicas = in.CurrentReplicas
 	out.DesiredReplicas = in.DesiredReplicas
-	if in.CurrentCPUUtilizationPercentage != nil {
-		in, out := &in.CurrentCPUUtilizationPercentage, &out.CurrentCPUUtilizationPercentage
-		*out = new(int32)
-		**out = **in
-	} else {
-		out.CurrentCPUUtilizationPercentage = nil
-	}
+	out.CurrentCPUUtilizationPercentage = in.CurrentCPUUtilizationPercentage
 	return nil
 }
 
@@ -1239,13 +1182,7 @@ func Convert_extensions_IngressStatus_To_v1beta1_IngressStatus(in *extensions.In
 }
 
 func autoConvert_v1beta1_IngressTLS_To_extensions_IngressTLS(in *IngressTLS, out *extensions.IngressTLS, s conversion.Scope) error {
-	if in.Hosts != nil {
-		in, out := &in.Hosts, &out.Hosts
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Hosts = nil
-	}
+	out.Hosts = in.Hosts
 	out.SecretName = in.SecretName
 	return nil
 }
@@ -1255,13 +1192,7 @@ func Convert_v1beta1_IngressTLS_To_extensions_IngressTLS(in *IngressTLS, out *ex
 }
 
 func autoConvert_extensions_IngressTLS_To_v1beta1_IngressTLS(in *extensions.IngressTLS, out *IngressTLS, s conversion.Scope) error {
-	if in.Hosts != nil {
-		in, out := &in.Hosts, &out.Hosts
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Hosts = nil
-	}
+	out.Hosts = in.Hosts
 	out.SecretName = in.SecretName
 	return nil
 }
@@ -1411,24 +1342,8 @@ func autoConvert_v1beta1_JobStatus_To_batch_JobStatus(in *JobStatus, out *batch.
 	} else {
 		out.Conditions = nil
 	}
-	if in.StartTime != nil {
-		in, out := &in.StartTime, &out.StartTime
-		*out = new(unversioned.Time)
-		if err := api.Convert_unversioned_Time_To_unversioned_Time(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.StartTime = nil
-	}
-	if in.CompletionTime != nil {
-		in, out := &in.CompletionTime, &out.CompletionTime
-		*out = new(unversioned.Time)
-		if err := api.Convert_unversioned_Time_To_unversioned_Time(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.CompletionTime = nil
-	}
+	out.StartTime = in.StartTime
+	out.CompletionTime = in.CompletionTime
 	out.Active = in.Active
 	out.Succeeded = in.Succeeded
 	out.Failed = in.Failed
@@ -1451,24 +1366,8 @@ func autoConvert_batch_JobStatus_To_v1beta1_JobStatus(in *batch.JobStatus, out *
 	} else {
 		out.Conditions = nil
 	}
-	if in.StartTime != nil {
-		in, out := &in.StartTime, &out.StartTime
-		*out = new(unversioned.Time)
-		if err := api.Convert_unversioned_Time_To_unversioned_Time(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.StartTime = nil
-	}
-	if in.CompletionTime != nil {
-		in, out := &in.CompletionTime, &out.CompletionTime
-		*out = new(unversioned.Time)
-		if err := api.Convert_unversioned_Time_To_unversioned_Time(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.CompletionTime = nil
-	}
+	out.StartTime = in.StartTime
+	out.CompletionTime = in.CompletionTime
 	out.Active = in.Active
 	out.Succeeded = in.Succeeded
 	out.Failed = in.Failed
@@ -1480,15 +1379,7 @@ func Convert_batch_JobStatus_To_v1beta1_JobStatus(in *batch.JobStatus, out *JobS
 }
 
 func autoConvert_v1beta1_LabelSelector_To_unversioned_LabelSelector(in *LabelSelector, out *unversioned.LabelSelector, s conversion.Scope) error {
-	if in.MatchLabels != nil {
-		in, out := &in.MatchLabels, &out.MatchLabels
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	} else {
-		out.MatchLabels = nil
-	}
+	out.MatchLabels = in.MatchLabels
 	if in.MatchExpressions != nil {
 		in, out := &in.MatchExpressions, &out.MatchExpressions
 		*out = make([]unversioned.LabelSelectorRequirement, len(*in))
@@ -1508,15 +1399,7 @@ func Convert_v1beta1_LabelSelector_To_unversioned_LabelSelector(in *LabelSelecto
 }
 
 func autoConvert_unversioned_LabelSelector_To_v1beta1_LabelSelector(in *unversioned.LabelSelector, out *LabelSelector, s conversion.Scope) error {
-	if in.MatchLabels != nil {
-		in, out := &in.MatchLabels, &out.MatchLabels
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	} else {
-		out.MatchLabels = nil
-	}
+	out.MatchLabels = in.MatchLabels
 	if in.MatchExpressions != nil {
 		in, out := &in.MatchExpressions, &out.MatchExpressions
 		*out = make([]LabelSelectorRequirement, len(*in))
@@ -1538,13 +1421,7 @@ func Convert_unversioned_LabelSelector_To_v1beta1_LabelSelector(in *unversioned.
 func autoConvert_v1beta1_LabelSelectorRequirement_To_unversioned_LabelSelectorRequirement(in *LabelSelectorRequirement, out *unversioned.LabelSelectorRequirement, s conversion.Scope) error {
 	out.Key = in.Key
 	out.Operator = unversioned.LabelSelectorOperator(in.Operator)
-	if in.Values != nil {
-		in, out := &in.Values, &out.Values
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Values = nil
-	}
+	out.Values = in.Values
 	return nil
 }
 
@@ -1555,13 +1432,7 @@ func Convert_v1beta1_LabelSelectorRequirement_To_unversioned_LabelSelectorRequir
 func autoConvert_unversioned_LabelSelectorRequirement_To_v1beta1_LabelSelectorRequirement(in *unversioned.LabelSelectorRequirement, out *LabelSelectorRequirement, s conversion.Scope) error {
 	out.Key = in.Key
 	out.Operator = LabelSelectorOperator(in.Operator)
-	if in.Values != nil {
-		in, out := &in.Values, &out.Values
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Values = nil
-	}
+	out.Values = in.Values
 	return nil
 }
 
@@ -1776,15 +1647,7 @@ func autoConvert_v1beta1_NetworkPolicyPort_To_extensions_NetworkPolicyPort(in *N
 	} else {
 		out.Protocol = nil
 	}
-	if in.Port != nil {
-		in, out := &in.Port, &out.Port
-		*out = new(intstr.IntOrString)
-		if err := api.Convert_intstr_IntOrString_To_intstr_IntOrString(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Port = nil
-	}
+	out.Port = in.Port
 	return nil
 }
 
@@ -1800,15 +1663,7 @@ func autoConvert_extensions_NetworkPolicyPort_To_v1beta1_NetworkPolicyPort(in *e
 	} else {
 		out.Protocol = nil
 	}
-	if in.Port != nil {
-		in, out := &in.Port, &out.Port
-		*out = new(intstr.IntOrString)
-		if err := api.Convert_intstr_IntOrString_To_intstr_IntOrString(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.Port = nil
-	}
+	out.Port = in.Port
 	return nil
 }
 

--- a/pkg/apis/policy/v1alpha1/conversion_generated.go
+++ b/pkg/apis/policy/v1alpha1/conversion_generated.go
@@ -22,7 +22,6 @@ package v1alpha1
 
 import (
 	api "k8s.io/kubernetes/pkg/api"
-	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
 	policy "k8s.io/kubernetes/pkg/apis/policy"
 	conversion "k8s.io/kubernetes/pkg/conversion"
 )
@@ -139,16 +138,7 @@ func autoConvert_v1alpha1_PodDisruptionBudgetSpec_To_policy_PodDisruptionBudgetS
 	if err := api.Convert_intstr_IntOrString_To_intstr_IntOrString(&in.MinAvailable, &out.MinAvailable, s); err != nil {
 		return err
 	}
-	if in.Selector != nil {
-		in, out := &in.Selector, &out.Selector
-		*out = new(unversioned.LabelSelector)
-		// TODO: Inefficient conversion - can we improve it?
-		if err := s.Convert(*in, *out, 0); err != nil {
-			return err
-		}
-	} else {
-		out.Selector = nil
-	}
+	out.Selector = in.Selector
 	return nil
 }
 
@@ -160,16 +150,7 @@ func autoConvert_policy_PodDisruptionBudgetSpec_To_v1alpha1_PodDisruptionBudgetS
 	if err := api.Convert_intstr_IntOrString_To_intstr_IntOrString(&in.MinAvailable, &out.MinAvailable, s); err != nil {
 		return err
 	}
-	if in.Selector != nil {
-		in, out := &in.Selector, &out.Selector
-		*out = new(unversioned.LabelSelector)
-		// TODO: Inefficient conversion - can we improve it?
-		if err := s.Convert(*in, *out, 0); err != nil {
-			return err
-		}
-	} else {
-		out.Selector = nil
-	}
+	out.Selector = in.Selector
 	return nil
 }
 

--- a/pkg/apis/rbac/v1alpha1/conversion_generated.go
+++ b/pkg/apis/rbac/v1alpha1/conversion_generated.go
@@ -268,44 +268,14 @@ func Convert_rbac_ClusterRoleList_To_v1alpha1_ClusterRoleList(in *rbac.ClusterRo
 }
 
 func autoConvert_v1alpha1_PolicyRule_To_rbac_PolicyRule(in *PolicyRule, out *rbac.PolicyRule, s conversion.Scope) error {
-	if in.Verbs != nil {
-		in, out := &in.Verbs, &out.Verbs
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Verbs = nil
-	}
+	out.Verbs = in.Verbs
 	if err := runtime.Convert_runtime_RawExtension_To_runtime_Object(&in.AttributeRestrictions, &out.AttributeRestrictions, s); err != nil {
 		return err
 	}
-	if in.APIGroups != nil {
-		in, out := &in.APIGroups, &out.APIGroups
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.APIGroups = nil
-	}
-	if in.Resources != nil {
-		in, out := &in.Resources, &out.Resources
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Resources = nil
-	}
-	if in.ResourceNames != nil {
-		in, out := &in.ResourceNames, &out.ResourceNames
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.ResourceNames = nil
-	}
-	if in.NonResourceURLs != nil {
-		in, out := &in.NonResourceURLs, &out.NonResourceURLs
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.NonResourceURLs = nil
-	}
+	out.APIGroups = in.APIGroups
+	out.Resources = in.Resources
+	out.ResourceNames = in.ResourceNames
+	out.NonResourceURLs = in.NonResourceURLs
 	return nil
 }
 
@@ -314,44 +284,14 @@ func Convert_v1alpha1_PolicyRule_To_rbac_PolicyRule(in *PolicyRule, out *rbac.Po
 }
 
 func autoConvert_rbac_PolicyRule_To_v1alpha1_PolicyRule(in *rbac.PolicyRule, out *PolicyRule, s conversion.Scope) error {
-	if in.Verbs != nil {
-		in, out := &in.Verbs, &out.Verbs
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Verbs = nil
-	}
+	out.Verbs = in.Verbs
 	if err := runtime.Convert_runtime_Object_To_runtime_RawExtension(&in.AttributeRestrictions, &out.AttributeRestrictions, s); err != nil {
 		return err
 	}
-	if in.APIGroups != nil {
-		in, out := &in.APIGroups, &out.APIGroups
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.APIGroups = nil
-	}
-	if in.Resources != nil {
-		in, out := &in.Resources, &out.Resources
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.Resources = nil
-	}
-	if in.ResourceNames != nil {
-		in, out := &in.ResourceNames, &out.ResourceNames
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.ResourceNames = nil
-	}
-	if in.NonResourceURLs != nil {
-		in, out := &in.NonResourceURLs, &out.NonResourceURLs
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	} else {
-		out.NonResourceURLs = nil
-	}
+	out.APIGroups = in.APIGroups
+	out.Resources = in.Resources
+	out.ResourceNames = in.ResourceNames
+	out.NonResourceURLs = in.NonResourceURLs
 	return nil
 }
 

--- a/pkg/util/diff/diff.go
+++ b/pkg/util/diff/diff.go
@@ -20,10 +20,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"reflect"
+	"sort"
 	"strings"
 	"text/tabwriter"
 
 	"github.com/davecgh/go-spew/spew"
+
+	"k8s.io/kubernetes/pkg/util/validation/field"
 )
 
 // StringDiff diffs a and b and returns a human readable diff.
@@ -72,6 +76,148 @@ func ObjectGoPrintDiff(a, b interface{}) string {
 		s.Sprintf("%#v", a),
 		s.Sprintf("%#v", b),
 	)
+}
+
+func ObjectReflectDiff(a, b interface{}) string {
+	vA, vB := reflect.ValueOf(a), reflect.ValueOf(b)
+	if vA.Type() != vB.Type() {
+		return fmt.Sprintf("type A %T and type B %T do not match", a, b)
+	}
+	diffs := objectReflectDiff(field.NewPath("object"), vA, vB)
+	if len(diffs) == 0 {
+		return ""
+	}
+	out := []string{""}
+	for _, d := range diffs {
+		out = append(out,
+			fmt.Sprintf("%s:", d.path),
+			limit(fmt.Sprintf("  a: %#v", d.a), 80),
+			limit(fmt.Sprintf("  b: %#v", d.b), 80),
+		)
+	}
+	return strings.Join(out, "\n")
+}
+
+func limit(s string, max int) string {
+	if len(s) > max {
+		return s[:max]
+	}
+	return s
+}
+
+func public(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	return s[:1] == strings.ToUpper(s[:1])
+}
+
+type diff struct {
+	path *field.Path
+	a, b interface{}
+}
+
+type orderedDiffs []diff
+
+func (d orderedDiffs) Len() int      { return len(d) }
+func (d orderedDiffs) Swap(i, j int) { d[i], d[j] = d[j], d[i] }
+func (d orderedDiffs) Less(i, j int) bool {
+	a, b := d[i].path.String(), d[j].path.String()
+	if a < b {
+		return true
+	}
+	return false
+}
+
+func objectReflectDiff(path *field.Path, a, b reflect.Value) []diff {
+	switch a.Type().Kind() {
+	case reflect.Struct:
+		var changes []diff
+		for i := 0; i < a.Type().NumField(); i++ {
+			if !public(a.Type().Field(i).Name) {
+				if reflect.DeepEqual(a.Interface(), b.Interface()) {
+					return nil
+				}
+				return []diff{{path: path, a: fmt.Sprintf("%#v", a), b: fmt.Sprintf("%#v", b)}}
+			}
+			if sub := objectReflectDiff(path.Child(a.Type().Field(i).Name), a.Field(i), b.Field(i)); len(sub) > 0 {
+				changes = append(changes, sub...)
+			}
+		}
+		return changes
+	case reflect.Ptr:
+		if a.IsNil() || b.IsNil() {
+			switch {
+			case a.IsNil() && b.IsNil():
+				return nil
+			case a.IsNil():
+				return []diff{{path: path, a: nil, b: b.Interface()}}
+			default:
+				return []diff{{path: path, a: a.Interface(), b: nil}}
+			}
+		}
+		return objectReflectDiff(path, a.Elem(), b.Elem())
+	case reflect.Chan:
+		if !reflect.DeepEqual(a.Interface(), b.Interface()) {
+			return []diff{{path: path, a: a.Interface(), b: b.Interface()}}
+		}
+		return nil
+	case reflect.Slice:
+		if reflect.DeepEqual(a, b) {
+			return nil
+		}
+		lA, lB := a.Len(), b.Len()
+		l := lA
+		if lB < lA {
+			l = lB
+		}
+		for i := 0; i < l; i++ {
+			if !reflect.DeepEqual(a.Index(i), b.Index(i)) {
+				return objectReflectDiff(path.Index(i), a.Index(i), b.Index(i))
+			}
+		}
+		var diffs []diff
+		for i := l; l < lA; i++ {
+			diffs = append(diffs, diff{path: path.Index(i), a: a.Index(i), b: nil})
+		}
+		for i := l; l < lB; i++ {
+			diffs = append(diffs, diff{path: path.Index(i), a: nil, b: b.Index(i)})
+		}
+		return diffs
+	case reflect.Map:
+		if reflect.DeepEqual(a, b) {
+			return nil
+		}
+		aKeys := make(map[interface{}]interface{})
+		for _, key := range a.MapKeys() {
+			aKeys[key.Interface()] = a.MapIndex(key).Interface()
+		}
+		var missing []diff
+		for _, key := range b.MapKeys() {
+			if _, ok := aKeys[key.Interface()]; ok {
+				delete(aKeys, key.Interface())
+				if reflect.DeepEqual(a.MapIndex(key).Interface(), b.MapIndex(key).Interface()) {
+					continue
+				}
+				missing = append(missing, diff{path: path.Key(fmt.Sprintf("%s", key.Interface())), a: a.MapIndex(key).Interface(), b: b.MapIndex(key).Interface()})
+				continue
+			}
+			missing = append(missing, diff{path: path.Key(fmt.Sprintf("%s", key.Interface())), a: nil, b: b.MapIndex(key).Interface()})
+		}
+		for key, value := range aKeys {
+			missing = append(missing, diff{path: path.Key(fmt.Sprintf("%s", key)), a: value, b: nil})
+		}
+		sort.Sort(orderedDiffs(missing))
+		return missing
+	default:
+		if reflect.DeepEqual(a.Interface(), b.Interface()) {
+			return nil
+		}
+		if !a.CanInterface() {
+			return []diff{{path: path, a: fmt.Sprintf("%#v", a), b: fmt.Sprintf("%#v", b)}}
+		}
+		return []diff{{path: path, a: a.Interface(), b: b.Interface()}}
+	}
 }
 
 // ObjectGoPrintSideBySide prints a and b as textual dumps side by side,

--- a/pkg/util/diff/diff_test.go
+++ b/pkg/util/diff/diff_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diff
+
+import (
+	"testing"
+)
+
+func TestObjectReflectDiff(t *testing.T) {
+	expect := `
+object[other]:
+  a: 2
+  b: <nil>
+object[test]:
+  a: 1
+  b: 2
+object[third]:
+  a: <nil>
+  b: 3`
+	a := map[string]int{"test": 1, "other": 2}
+	b := map[string]int{"test": 2, "third": 3}
+	if actual := ObjectReflectDiff(a, b); actual != expect {
+		t.Errorf("unexpected output: %s", actual)
+	}
+}


### PR DESCRIPTION
Not ready yet (need to add a copy to "safe" conversion and add mutation tests to roundtrip api/serialization_test).

Cuts another 10% off decode and encode.
