### PR TITLE
Updating CentOS image, adding heat back to the required cli tools.

### DIFF
--- a/cluster/openstack-heat/config-image.sh
+++ b/cluster/openstack-heat/config-image.sh
@@ -20,7 +20,7 @@
 OPENSTACK_IMAGE_NAME=${OPENSTACK_IMAGE_NAME:-CentOS7}
 
 # Downloaded image name for Openstack project
-IMAGE_FILE=${IMAGE_FILE:-CentOS-7-x86_64-GenericCloud-1510.qcow2}
+IMAGE_FILE=${IMAGE_FILE:-CentOS-7-x86_64-GenericCloud-1604.qcow2}
 
 # Absolute path where image file is stored.
 IMAGE_PATH=${IMAGE_PATH:-~/Downloads/openstack}

--- a/cluster/openstack-heat/util.sh
+++ b/cluster/openstack-heat/util.sh
@@ -32,7 +32,7 @@ fi
 # Verify prereqs on host machine
 function verify-prereqs() {
  # Check the OpenStack command-line clients
- for client in swift glance nova openstack;
+ for client in swift glance nova heat openstack;
  do
   if which $client >/dev/null 2>&1; then
     echo "${client} client installed"


### PR DESCRIPTION
[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
Updated the CentOS cloudimage to the latest available, and also added heat to the required list of cli tools. This is an interim step to replacing all the commands with openstackclient.
