### PR TITLE
Fixed error message in gce_pd unit test

### DIFF
--- a/pkg/volume/gce_pd/gce_pd_test.go
+++ b/pkg/volume/gce_pd/gce_pd_test.go
@@ -182,7 +182,7 @@ func TestPlugin(t *testing.T) {
 		}
 	}
 	if !fakeManager.attachCalled {
-		t.Errorf("Attach watch not called")
+		t.Errorf("Attach was not called")
 	}
 
 	fakeManager = &fakePDManager{}
@@ -203,7 +203,7 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("SetUp() failed: %v", err)
 	}
 	if !fakeManager.detachCalled {
-		t.Errorf("Detach watch not called")
+		t.Errorf("Detach was not called")
 	}
 
 	// Test Provisioner


### PR DESCRIPTION
I corrected the error message when the unit test fails because of an uncalled attach/detach from `xxx watch not called` to `xxx was not called`
