### PR TITLE
Attempt 2: Bump GCE containerVM to container-v1-3-v20160517 (Docker 1.11.1) again.

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"math/rand"
 	"net"
 	"net/http"
@@ -667,6 +668,22 @@ func RunKubelet(kcfg *KubeletConfig) error {
 	}
 
 	util.ApplyRLimitForSelf(kcfg.MaxOpenFiles)
+
+	// TODO(dawnchen): remove this once we deprecated old debian containervm images.
+	// This is a workaround for issue: https://github.com/opencontainers/runc/issues/726
+	// The current chosen number is consistent with most of other os dist.
+	const maxkey_path = "/proc/sys/kernel/keys/root_maxkeys"
+	glog.Infof("Setting keys quota in %s to %d", maxkey_path, 1000000)
+	err = ioutil.WriteFile(maxkey_path, []byte(fmt.Sprintf("%d", uint32(1000000))), 0644)
+	if err != nil {
+		return fmt.Errorf("failed to update %s: %v", maxkey_path, err)
+	}
+	const maxbyte_path = "/proc/sys/kernel/keys/root_maxbytes"
+	glog.Infof("Setting keys bytes in %s to %d", maxbyte_path, 25000000)
+	err = ioutil.WriteFile(maxbyte_path, []byte(fmt.Sprintf("%d", uint32(25000000))), 0644)
+	if err != nil {
+		return fmt.Errorf("failed to update %s: %v", maxbyte_path, err)
+	}
 
 	// process pods and exit.
 	if kcfg.Runonce {

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -672,17 +672,37 @@ func RunKubelet(kcfg *KubeletConfig) error {
 	// TODO(dawnchen): remove this once we deprecated old debian containervm images.
 	// This is a workaround for issue: https://github.com/opencontainers/runc/issues/726
 	// The current chosen number is consistent with most of other os dist.
-	const maxkey_path = "/proc/sys/kernel/keys/root_maxkeys"
-	glog.Infof("Setting keys quota in %s to %d", maxkey_path, 1000000)
-	err = ioutil.WriteFile(maxkey_path, []byte(fmt.Sprintf("%d", uint32(1000000))), 0644)
+	const maxkeysPath = "/proc/sys/kernel/keys/root_maxkeys"
+	const minKeys uint64 = 1000000
+	key, err := ioutil.ReadFile(maxkeysPath)
 	if err != nil {
-		return fmt.Errorf("failed to update %s: %v", maxkey_path, err)
+		glog.Errorf("Cannot read keys quota in %s", maxkeysPath)
+	} else {
+		fields := strings.Fields(string(key))
+		nkey, _ := strconv.ParseUint(fields[0], 10, 64)
+		if nkey < minKeys {
+			glog.Infof("Setting keys quota in %s to %d", maxkeysPath, minKeys)
+			err = ioutil.WriteFile(maxkeysPath, []byte(fmt.Sprintf("%d", uint64(minKeys))), 0644)
+			if err != nil {
+				glog.Warningf("Failed to update %s: %v", maxkeysPath, err)
+			}
+		}
 	}
-	const maxbyte_path = "/proc/sys/kernel/keys/root_maxbytes"
-	glog.Infof("Setting keys bytes in %s to %d", maxbyte_path, 25000000)
-	err = ioutil.WriteFile(maxbyte_path, []byte(fmt.Sprintf("%d", uint32(25000000))), 0644)
+	const maxbytesPath = "/proc/sys/kernel/keys/root_maxbytes"
+	const minBytes uint64 = 25000000
+	bytes, err := ioutil.ReadFile(maxbytesPath)
 	if err != nil {
-		return fmt.Errorf("failed to update %s: %v", maxbyte_path, err)
+		glog.Errorf("Cannot read keys bytes in %s", maxbytesPath)
+	} else {
+		fields := strings.Fields(string(bytes))
+		nbyte, _ := strconv.ParseUint(fields[0], 10, 64)
+		if nbyte < minBytes {
+			glog.Infof("Setting keys bytes in %s to %d", maxbytesPath, minBytes)
+			err = ioutil.WriteFile(maxbytesPath, []byte(fmt.Sprintf("%d", uint64(minBytes))), 0644)
+			if err != nil {
+				glog.Warningf("Failed to update %s: %v", maxbytesPath, err)
+			}
+		}
 	}
 
 	// process pods and exit.


### PR DESCRIPTION
Workaround the issue of small root_maxkeys on the debian based container-vm image, and bump our image to the new alpha version for docker 1.11.1 validation. 

ref: #23397 #25893

cc/ @vishh @timstclair 
