### PR TITLE
cluster/gce/coreos: Set service-cluster-ip-range

### DIFF
--- a/cluster/gce/coreos/kube-manifests/kube-controller-manager.yaml
+++ b/cluster/gce/coreos/kube-manifests/kube-controller-manager.yaml
@@ -12,6 +12,7 @@ spec:
       --master=127.0.0.1:8080
       --cluster-name=${INSTANCE_PREFIX}
       --cluster-cidr=${CLUSTER_IP_RANGE}
+      --service-cluster-ip-range="${SERVICE_CLUSTER_IP_RANGE}"
       --allocate-node-cidrs=true
       --cloud-provider=gce
       --service-account-private-key-file=/srv/kubernetes/server.key


### PR DESCRIPTION
Broken by #19242 

See also #26002 

This is necessary to kube-up for me, but depending on how #26002 plays out, this PR might not be necessary. Happy to close this or merge or whatever depending on what's best.

cc @yifan-gu @sjpotter @mikedanese 
