### PR TITLE
scheduler: remove unused random generator

### DIFF
--- a/plugin/pkg/scheduler/extender_test.go
+++ b/plugin/pkg/scheduler/extender_test.go
@@ -18,7 +18,6 @@ package scheduler
 
 import (
 	"fmt"
-	"math/rand"
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
@@ -281,12 +280,11 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		random := rand.New(rand.NewSource(0))
 		extenders := []algorithm.SchedulerExtender{}
 		for ii := range test.extenders {
 			extenders = append(extenders, &test.extenders[ii])
 		}
-		scheduler := NewGenericScheduler(schedulertesting.PodsToCache(test.pods), test.predicates, test.prioritizers, extenders, random)
+		scheduler := NewGenericScheduler(schedulertesting.PodsToCache(test.pods), test.predicates, test.prioritizers, extenders)
 		machine, err := scheduler.Schedule(test.pod, algorithm.FakeNodeLister(makeNodeList(test.nodes)))
 		if test.expectsErr {
 			if err == nil {

--- a/plugin/pkg/scheduler/factory/factory.go
+++ b/plugin/pkg/scheduler/factory/factory.go
@@ -20,7 +20,6 @@ package factory
 
 import (
 	"fmt"
-	"math/rand"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -317,9 +316,7 @@ func (f *ConfigFactory) CreateFromKeys(predicateKeys, priorityKeys sets.String, 
 
 	f.Run()
 
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-
-	algo := scheduler.NewGenericScheduler(f.schedulerCache, predicateFuncs, priorityConfigs, extenders, r)
+	algo := scheduler.NewGenericScheduler(f.schedulerCache, predicateFuncs, priorityConfigs, extenders)
 
 	podBackoff := podBackoff{
 		perPodBackoff: map[types.NamespacedName]*backoffEntry{},

--- a/plugin/pkg/scheduler/generic_scheduler.go
+++ b/plugin/pkg/scheduler/generic_scheduler.go
@@ -19,7 +19,6 @@ package scheduler
 import (
 	"bytes"
 	"fmt"
-	"math/rand"
 	"sort"
 	"sync"
 	"time"
@@ -56,14 +55,13 @@ func (f *FitError) Error() string {
 }
 
 type genericScheduler struct {
-	cache         schedulercache.Cache
-	predicates    map[string]algorithm.FitPredicate
-	prioritizers  []algorithm.PriorityConfig
-	extenders     []algorithm.SchedulerExtender
-	pods          algorithm.PodLister
-	random        *rand.Rand
-	randomLock    sync.Mutex
-	lastNodeIndex uint64
+	cache             schedulercache.Cache
+	predicates        map[string]algorithm.FitPredicate
+	prioritizers      []algorithm.PriorityConfig
+	extenders         []algorithm.SchedulerExtender
+	pods              algorithm.PodLister
+	lastNodeIndexLock sync.Mutex
+	lastNodeIndex     uint64
 }
 
 // Schedule tries to schedule the given pod to one of node in the node list.
@@ -116,7 +114,7 @@ func (g *genericScheduler) Schedule(pod *api.Pod, nodeLister algorithm.NodeListe
 }
 
 // selectHost takes a prioritized list of nodes and then picks one
-// randomly from the nodes that had the highest score.
+// in a round-robin manner from the nodes that had the highest score.
 func (g *genericScheduler) selectHost(priorityList schedulerapi.HostPriorityList) (string, error) {
 	if len(priorityList) == 0 {
 		return "", fmt.Errorf("empty priorityList")
@@ -126,10 +124,10 @@ func (g *genericScheduler) selectHost(priorityList schedulerapi.HostPriorityList
 	maxScore := priorityList[0].Score
 	firstAfterMaxScore := sort.Search(len(priorityList), func(i int) bool { return priorityList[i].Score < maxScore })
 
-	g.randomLock.Lock()
+	g.lastNodeIndexLock.Lock()
 	ix := int(g.lastNodeIndex % uint64(firstAfterMaxScore))
 	g.lastNodeIndex++
-	g.randomLock.Unlock()
+	g.lastNodeIndexLock.Unlock()
 
 	return priorityList[ix].Host, nil
 }
@@ -324,12 +322,11 @@ func EqualPriority(_ *api.Pod, nodeNameToInfo map[string]*schedulercache.NodeInf
 	return result, nil
 }
 
-func NewGenericScheduler(cache schedulercache.Cache, predicates map[string]algorithm.FitPredicate, prioritizers []algorithm.PriorityConfig, extenders []algorithm.SchedulerExtender, random *rand.Rand) algorithm.ScheduleAlgorithm {
+func NewGenericScheduler(cache schedulercache.Cache, predicates map[string]algorithm.FitPredicate, prioritizers []algorithm.PriorityConfig, extenders []algorithm.SchedulerExtender) algorithm.ScheduleAlgorithm {
 	return &genericScheduler{
 		cache:        cache,
 		predicates:   predicates,
 		prioritizers: prioritizers,
 		extenders:    extenders,
-		random:       random,
 	}
 }

--- a/plugin/pkg/scheduler/generic_scheduler_test.go
+++ b/plugin/pkg/scheduler/generic_scheduler_test.go
@@ -19,7 +19,6 @@ package scheduler
 import (
 	"fmt"
 	"math"
-	"math/rand"
 	"reflect"
 	"strconv"
 	"testing"
@@ -114,7 +113,7 @@ func makeNodeList(nodeNames []string) api.NodeList {
 }
 
 func TestSelectHost(t *testing.T) {
-	scheduler := genericScheduler{random: rand.New(rand.NewSource(0))}
+	scheduler := genericScheduler{}
 	tests := []struct {
 		list          schedulerapi.HostPriorityList
 		possibleHosts sets.String
@@ -277,7 +276,6 @@ func TestGenericScheduler(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		random := rand.New(rand.NewSource(0))
 		cache := schedulercache.New(time.Duration(0), wait.NeverStop)
 		for _, pod := range test.pods {
 			cache.AddPod(pod)
@@ -285,7 +283,7 @@ func TestGenericScheduler(t *testing.T) {
 		for _, name := range test.nodes {
 			cache.AddNode(&api.Node{ObjectMeta: api.ObjectMeta{Name: name}})
 		}
-		scheduler := NewGenericScheduler(cache, test.predicates, test.prioritizers, []algorithm.SchedulerExtender{}, random)
+		scheduler := NewGenericScheduler(cache, test.predicates, test.prioritizers, []algorithm.SchedulerExtender{})
 		machine, err := scheduler.Schedule(test.pod, algorithm.FakeNodeLister(makeNodeList(test.nodes)))
 		if test.expectsErr {
 			if err == nil {

--- a/plugin/pkg/scheduler/scheduler_test.go
+++ b/plugin/pkg/scheduler/scheduler_test.go
@@ -19,7 +19,6 @@ package scheduler
 import (
 	"errors"
 	"fmt"
-	"math/rand"
 	"reflect"
 	"sync"
 	"testing"
@@ -218,8 +217,7 @@ func TestSchedulerForgetAssumedPodAfterDelete(t *testing.T) {
 		cache,
 		map[string]algorithm.FitPredicate{"PodFitsHostPorts": predicates.PodFitsHostPorts},
 		[]algorithm.PriorityConfig{},
-		[]algorithm.SchedulerExtender{},
-		rand.New(rand.NewSource(time.Now().UnixNano())))
+		[]algorithm.SchedulerExtender{})
 
 	var gotBinding *api.Binding
 	c := &Config{


### PR DESCRIPTION
The way scheduler selecting host has been changed to round-robin.
Clean up leftover.
