### PR TITLE
Fix useless error message in scheduler log

### DIFF
--- a/plugin/pkg/scheduler/scheduler.go
+++ b/plugin/pkg/scheduler/scheduler.go
@@ -137,7 +137,7 @@ func (s *Scheduler) scheduleOne() {
 		// it's atomic with setting host.
 		err := s.config.Binder.Bind(b)
 		if err != nil {
-			glog.V(1).Infof("Failed to bind pod: %+v", err)
+			glog.V(1).Infof("Failed to bind pod: %v/%v", pod.Namespace, pod.Name)
 			s.config.Error(pod, err)
 			s.config.Recorder.Eventf(pod, api.EventTypeNormal, "FailedScheduling", "Binding rejected: %v", err)
 			s.config.PodConditionUpdater.Update(pod, &api.PodCondition{


### PR DESCRIPTION
Print the Namespace and Name instead of Kind/ApiVersion.

fixes #25950
