### PR TITLE
Fix panic in auth test failure

### DIFF
--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -1311,11 +1311,11 @@ func TestWebhookTokenAuthenticator(t *testing.T) {
 
 		func() {
 			resp, err := transport.RoundTrip(req)
-			defer resp.Body.Close()
 			if err != nil {
 				t.Logf("case %v", r)
 				t.Fatalf("unexpected error: %v", err)
 			}
+			defer resp.Body.Close()
 			// Expect all of Alice's actions to at least get past authn/authz.
 			if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
 				t.Logf("case %v", r)


### PR DESCRIPTION
I got a spurious failure in the webhook integration test, but couldn't see the error returned because a panic was hit that assumed a body was always returned with the response
