### PR TITLE
Make all Kubernetes binaries statically linked

### DIFF
--- a/test/e2e_node/e2e_build.go
+++ b/test/e2e_node/e2e_build.go
@@ -44,7 +44,7 @@ func buildGo() error {
 		return fmt.Errorf("failed to locate kubernetes root directory %v.", err)
 	}
 	targets := strings.Join(buildTargets, " ")
-	cmd := exec.Command("make", "-C", k8sRoot, fmt.Sprintf("WHAT=%s", targets))
+	cmd := exec.Command("sudo", filepath.Join(k8sRoot, "build/run.sh"), "make", fmt.Sprintf("WHAT=%s", targets))
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err = cmd.Run()
@@ -107,7 +107,7 @@ func getK8sBuildOutputDir() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	buildOutputDir := filepath.Join(k8sRoot, "_output/local/go/bin")
+	buildOutputDir := filepath.Join(k8sRoot, fmt.Sprintf("_output/dockerized/bin/%s/%s", runtime.GOOS, runtime.GOARCH))
 	if _, err := os.Stat(buildOutputDir); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This statically compiles binaries that includes C code, by passing `-static` to the underlying gcc linker.
It also adds all other binaries that doesn't use C to the list of static binaries. When they're 100% written in Go, it's annoying to rely on `glibc`.

You may decide if you want this for `v1.3` or the next release. For me it doesn't matter.

@vishh @mikedanese @david-mcmahon @ihmccreery @ixdy @lavalamp @smarterclayton

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/26028)

<!-- Reviewable:end -->
