### PR TITLE
Get install-etcd.sh to work on OSX

### DIFF
--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -68,8 +68,16 @@ kube::etcd::cleanup() {
 kube::etcd::install() {
   (
     cd "${KUBE_ROOT}/third_party"
-    curl -fsSL --retry 3 https://github.com/coreos/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-linux-amd64.tar.gz | tar xzf -
-    ln -fns "etcd-v${ETCD_VERSION}-linux-amd64" etcd
+    if [[ $(uname) == "Darwin" ]]; then
+      download_file="etcd-v${ETCD_VERSION}-darwin-amd64.zip"
+      curl -fsSLO --retry 3 https://github.com/coreos/etcd/releases/download/v${ETCD_VERSION}/"${download_file}"
+      unzip -o "${download_file}"
+      ln -fns "etcd-v${ETCD_VERSION}-darwin-amd64" etcd
+      rm "${download_file}"
+    else
+      curl -fsSL --retry 3 https://github.com/coreos/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-linux-amd64.tar.gz | tar xzf -
+      ln -fns "etcd-v${ETCD_VERSION}-linux-amd64" etcd
+    fi
     kube::log::info "etcd v${ETCD_VERSION} installed. To use:"
     kube::log::info "export PATH=\${PATH}:$(pwd)/etcd"
   )


### PR DESCRIPTION
Check the platform before we download the etcd binary. On OSX, save
the zip file, unzip it and link the directory with the correct
name.

Fixes #26041
