### PR TITLE
Make service-range flag in controller-manager optional

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -225,9 +225,14 @@ func StartControllers(s *options.CMServer, kubeClient *client.Client, kubeconfig
 		glog.Fatalf("Cloud provider could not be initialized: %v", err)
 	}
 
-	// this cidr has been validated already
-	_, clusterCIDR, _ := net.ParseCIDR(s.ClusterCIDR)
-	_, serviceCIDR, _ := net.ParseCIDR(s.ServiceCIDR)
+	_, clusterCIDR, err := net.ParseCIDR(s.ClusterCIDR)
+	if err != nil {
+		glog.Warningf("Unsuccessful parsing of cluster CIDR %v: %v", s.ClusterCIDR, err)
+	}
+	_, serviceCIDR, err := net.ParseCIDR(s.ServiceCIDR)
+	if err != nil {
+		glog.Warningf("Unsuccessful parsing of service CIDR %v: %v", s.ServiceCIDR, err)
+	}
 	nodeController := nodecontroller.NewNodeController(cloud, clientset.NewForConfigOrDie(restclient.AddUserAgent(kubeconfig, "node-controller")),
 		s.PodEvictionTimeout.Duration, flowcontrol.NewTokenBucketRateLimiter(s.DeletingPodsQps, int(s.DeletingPodsBurst)),
 		flowcontrol.NewTokenBucketRateLimiter(s.DeletingPodsQps, int(s.DeletingPodsBurst)),

--- a/pkg/controller/node/nodecontroller.go
+++ b/pkg/controller/node/nodecontroller.go
@@ -265,7 +265,11 @@ func NewNodeController(
 // Run starts an asynchronous loop that monitors the status of cluster nodes.
 func (nc *NodeController) Run(period time.Duration) {
 	if nc.allocateNodeCIDRs {
-		nc.filterOutServiceRange()
+		if nc.serviceCIDR != nil {
+			nc.filterOutServiceRange()
+		} else {
+			glog.Info("No Service CIDR provided. Skipping filtering out service addresses.")
+		}
 	}
 
 	go nc.nodeController.Run(wait.NeverStop)


### PR DESCRIPTION
NodeController won't require service CIDR - if it won't be provided it won't filter anything, hence we make the service CIDR filtering a best effort thing.

Fixes. #26002

cc @mqliang @bgrant0607 @wojtek-t 
