### PR TITLE
Don't dump everything in kubemarks

### DIFF
--- a/test/kubemark/run-e2e-tests.sh
+++ b/test/kubemark/run-e2e-tests.sh
@@ -39,4 +39,4 @@ else
 	ARGS=$@
 fi
 
-go run ./hack/e2e.go -v --test --test_args="--e2e-verify-service-account=false ${ARGS}"
+go run ./hack/e2e.go -v --test --test_args="--e2e-verify-service-account=false --dump-logs-on-failure=false ${ARGS}"


### PR DESCRIPTION
Don't dump all events etc. in kubemark failures, those are useless anyway with that amount of data.
