### PR TITLE
cache: return watchHandler errors from reflectors

### DIFF
--- a/pkg/client/cache/reflector.go
+++ b/pkg/client/cache/reflector.go
@@ -333,7 +333,7 @@ func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 			if err != errorStopRequested {
 				glog.Warningf("%s: watch of %v ended with: %v", r.name, r.expectedType, err)
 			}
-			return nil
+			return err
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/26065

@xiang90 @wojtek-t PTAL
