### PR TITLE
Make node-instance-group base names unique to prevent collisions

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -778,7 +778,7 @@ function create-nodes() {
         create "${group_name}" \
         --project "${PROJECT}" \
         --zone "${ZONE}" \
-        --base-instance-name "${NODE_INSTANCE_PREFIX}" \
+        --base-instance-name "${group_name}" \
         --size "${this_mig_size}" \
         --template "$template_name" || true;
     gcloud compute instance-groups managed wait-until-stable \


### PR DESCRIPTION
We create multiple IGMs for >1000 Node clusters. When we have a conflict on base name IGMs will fight over ownership of the VM that happen to have the name belonging to multiple IGMs.

This change will increase reliability of starting big clusters.

cc @wojtek-t @alex-mohr @roberthbailey @mikedanese 
