### PR TITLE
Fix panic when the namespace flag is not present

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -235,13 +235,15 @@ Find more information at https://github.com/kubernetes/kubernetes.`,
 	cmds.AddCommand(NewCmdExplain(f, out))
 	cmds.AddCommand(NewCmdConvert(f, out))
 
-	if cmds.Flag("namespace").Annotations == nil {
-		cmds.Flag("namespace").Annotations = map[string][]string{}
+	if cmds.Flag("namespace") != nil {
+		if cmds.Flag("namespace").Annotations == nil {
+			cmds.Flag("namespace").Annotations = map[string][]string{}
+		}
+		cmds.Flag("namespace").Annotations[cobra.BashCompCustom] = append(
+			cmds.Flag("namespace").Annotations[cobra.BashCompCustom],
+			"__kubectl_get_namespaces",
+		)
 	}
-	cmds.Flag("namespace").Annotations[cobra.BashCompCustom] = append(
-		cmds.Flag("namespace").Annotations[cobra.BashCompCustom],
-		"__kubectl_get_namespaces",
-	)
 
 	return cmds
 }


### PR DESCRIPTION
We don't set the namespace in OpenShift, so we need to check if the namespace flag is present.
