### PR TITLE
Delay flush if the watch queue has pending items

### DIFF
--- a/pkg/apiserver/watch.go
+++ b/pkg/apiserver/watch.go
@@ -168,13 +168,14 @@ func (s *WatchServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	flusher.Flush()
 
 	buf := &bytes.Buffer{}
+	ch := s.watching.ResultChan()
 	for {
 		select {
 		case <-cn.CloseNotify():
 			return
 		case <-timeoutCh:
 			return
-		case event, ok := <-s.watching.ResultChan():
+		case event, ok := <-ch:
 			if !ok {
 				// End of results.
 				return
@@ -196,7 +197,9 @@ func (s *WatchServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 				// client disconnect.
 				return
 			}
-			flusher.Flush()
+			if len(ch) == 0 {
+				flusher.Flush()
+			}
 
 			buf.Reset()
 		}


### PR DESCRIPTION
Simple deferral of flush can reduce Syscalls when watch queues build up.

Simpler version of #24768

Fixes #24729

@xiang90 @wojtek-t
