### PR TITLE
Node e2e junit test artifacts

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -201,6 +201,7 @@ ir-password
 ir-user
 jenkins-host
 jenkins-jobs
+junit-file-number
 k8s-bin-dir
 k8s-build-output
 keep-gogoproto
@@ -366,6 +367,7 @@ resolv-conf
 resource-container
 resource-quota-sync-period
 resource-version
+results-dir
 retry_time
 rkt-api-endpoint
 rkt-path

--- a/test/e2e_node/container_list.go
+++ b/test/e2e_node/container_list.go
@@ -53,7 +53,7 @@ func PrePullAllImages() error {
 	for _, image := range ImageRegistry {
 		output, err := exec.Command("docker", "pull", image).CombinedOutput()
 		if err != nil {
-			glog.Warning("Could not pre-pull image %s %v output:  %s", image, err, output)
+			glog.Warningf("Could not pre-pull image %s %v output:  %s", image, err, output)
 			return err
 		}
 	}

--- a/test/e2e_node/jenkins/copy-e2e-image.sh
+++ b/test/e2e_node/jenkins/copy-e2e-image.sh
@@ -14,20 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${KUBE_ROOT}/hack/lib/init.sh"
+# Usage: copy-e2e-image.sh <image-name> <from-project-name> <to-project-name>
 
-focus=${FOCUS:-""}
-skip=${SKIP:-""}
-report=${REPORT:-"/tmp/"}
+set -e
+set -x
 
-ginkgo=$(kube::util::find-binary "ginkgo")
-if [[ -z "${ginkgo}" ]]; then
-  echo "You do not appear to have ginkgo built. Try 'make WHAT=vendor/github.com/onsi/ginkgo/ginkgo'"
-  exit 1
-fi
-
-# Provided for backwards compatibility
-"${ginkgo}" --focus=$focus --skip=$skip "${KUBE_ROOT}/test/e2e_node/" --report-dir=${report} -- --alsologtostderr --v 2 --node-name $(hostname) --build-services=true --start-services=true --stop-services=true
-
-exit $?
+echo "Copying image $1 from project $2 to project $3..."
+gcloud compute --project $3 disks create $1 --image=https://www.googleapis.com/compute/v1/projects/$2/global/images/$1
+gcloud compute --project $3 images create $1 --source-disk=$1
+gcloud compute --project $3 disks delete $1

--- a/test/e2e_node/jenkins/e2e-node-jenkins.sh
+++ b/test/e2e_node/jenkins/e2e-node-jenkins.sh
@@ -35,6 +35,9 @@ if [ "$INSTALL_GODEP" = true ] ; then
 fi
 
 go build test/e2e_node/environment/conformance.go
+ARTIFACTS=${WORKSPACE}/_artifacts
+mkdir -p ${ARTIFACTS}
 go run test/e2e_node/runner/run_e2e.go  --logtostderr --vmodule=*=2 --ssh-env="gce" \
   --zone="$GCE_ZONE" --project="$GCE_PROJECT"  \
-  --hosts="$GCE_HOSTS" --images="$GCE_IMAGES" --cleanup="$CLEANUP"
+  --hosts="$GCE_HOSTS" --images="$GCE_IMAGES" --cleanup="$CLEANUP" \
+  --results-dir="$ARTIFACTS"


### PR DESCRIPTION
[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
- Add junit test reported
- Write etcd.log, kubelet.log and kube-apiserver.log to files instead of stdout
- Scp artifacts to the jenkins WORKSPACE

Fixes #25966
