### PR TITLE
ScheduledJob validation

### DIFF
--- a/pkg/apis/batch/deep_copy_generated.go
+++ b/pkg/apis/batch/deep_copy_generated.go
@@ -246,7 +246,13 @@ func DeepCopy_batch_ScheduledJobSpec(in ScheduledJobSpec, out *ScheduledJobSpec,
 		out.StartingDeadlineSeconds = nil
 	}
 	out.ConcurrencyPolicy = in.ConcurrencyPolicy
-	out.Suspend = in.Suspend
+	if in.Suspend != nil {
+		in, out := in.Suspend, &out.Suspend
+		*out = new(bool)
+		**out = *in
+	} else {
+		out.Suspend = nil
+	}
 	if err := DeepCopy_batch_JobTemplateSpec(in.JobTemplate, &out.JobTemplate, c); err != nil {
 		return err
 	}

--- a/pkg/apis/batch/types.generated.go
+++ b/pkg/apis/batch/types.generated.go
@@ -3602,33 +3602,43 @@ func (x *ScheduledJobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym15 := z.EncBinary()
-				_ = yym15
-				if false {
+				if x.Suspend == nil {
+					r.EncodeNil()
 				} else {
-					r.EncodeBool(bool(x.Suspend))
+					yy15 := *x.Suspend
+					yym16 := z.EncBinary()
+					_ = yym16
+					if false {
+					} else {
+						r.EncodeBool(bool(yy15))
+					}
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("suspend"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym16 := z.EncBinary()
-				_ = yym16
-				if false {
+				if x.Suspend == nil {
+					r.EncodeNil()
 				} else {
-					r.EncodeBool(bool(x.Suspend))
+					yy17 := *x.Suspend
+					yym18 := z.EncBinary()
+					_ = yym18
+					if false {
+					} else {
+						r.EncodeBool(bool(yy17))
+					}
 				}
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy18 := &x.JobTemplate
-				yy18.CodecEncodeSelf(e)
+				yy20 := &x.JobTemplate
+				yy20.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("jobTemplate"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy20 := &x.JobTemplate
-				yy20.CodecEncodeSelf(e)
+				yy22 := &x.JobTemplate
+				yy22.CodecEncodeSelf(e)
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
@@ -3721,16 +3731,26 @@ func (x *ScheduledJobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		case "suspend":
 			if r.TryDecodeAsNil() {
-				x.Suspend = false
+				if x.Suspend != nil {
+					x.Suspend = nil
+				}
 			} else {
-				x.Suspend = bool(r.DecodeBool())
+				if x.Suspend == nil {
+					x.Suspend = new(bool)
+				}
+				yym9 := z.DecBinary()
+				_ = yym9
+				if false {
+				} else {
+					*((*bool)(x.Suspend)) = r.DecodeBool()
+				}
 			}
 		case "jobTemplate":
 			if r.TryDecodeAsNil() {
 				x.JobTemplate = JobTemplateSpec{}
 			} else {
-				yyv9 := &x.JobTemplate
-				yyv9.CodecDecodeSelf(d)
+				yyv10 := &x.JobTemplate
+				yyv10.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3)
@@ -3743,16 +3763,16 @@ func (x *ScheduledJobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj10 int
-	var yyb10 bool
-	var yyhl10 bool = l >= 0
-	yyj10++
-	if yyhl10 {
-		yyb10 = yyj10 > l
+	var yyj11 int
+	var yyb11 bool
+	var yyhl11 bool = l >= 0
+	yyj11++
+	if yyhl11 {
+		yyb11 = yyj11 > l
 	} else {
-		yyb10 = r.CheckBreak()
+		yyb11 = r.CheckBreak()
 	}
-	if yyb10 {
+	if yyb11 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -3762,13 +3782,13 @@ func (x *ScheduledJobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Schedule = string(r.DecodeString())
 	}
-	yyj10++
-	if yyhl10 {
-		yyb10 = yyj10 > l
+	yyj11++
+	if yyhl11 {
+		yyb11 = yyj11 > l
 	} else {
-		yyb10 = r.CheckBreak()
+		yyb11 = r.CheckBreak()
 	}
-	if yyb10 {
+	if yyb11 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -3781,20 +3801,20 @@ func (x *ScheduledJobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		if x.StartingDeadlineSeconds == nil {
 			x.StartingDeadlineSeconds = new(int64)
 		}
-		yym13 := z.DecBinary()
-		_ = yym13
+		yym14 := z.DecBinary()
+		_ = yym14
 		if false {
 		} else {
 			*((*int64)(x.StartingDeadlineSeconds)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj10++
-	if yyhl10 {
-		yyb10 = yyj10 > l
+	yyj11++
+	if yyhl11 {
+		yyb11 = yyj11 > l
 	} else {
-		yyb10 = r.CheckBreak()
+		yyb11 = r.CheckBreak()
 	}
-	if yyb10 {
+	if yyb11 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -3804,29 +3824,39 @@ func (x *ScheduledJobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.ConcurrencyPolicy = ConcurrencyPolicy(r.DecodeString())
 	}
-	yyj10++
-	if yyhl10 {
-		yyb10 = yyj10 > l
+	yyj11++
+	if yyhl11 {
+		yyb11 = yyj11 > l
 	} else {
-		yyb10 = r.CheckBreak()
+		yyb11 = r.CheckBreak()
 	}
-	if yyb10 {
+	if yyb11 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.Suspend = false
+		if x.Suspend != nil {
+			x.Suspend = nil
+		}
 	} else {
-		x.Suspend = bool(r.DecodeBool())
+		if x.Suspend == nil {
+			x.Suspend = new(bool)
+		}
+		yym17 := z.DecBinary()
+		_ = yym17
+		if false {
+		} else {
+			*((*bool)(x.Suspend)) = r.DecodeBool()
+		}
 	}
-	yyj10++
-	if yyhl10 {
-		yyb10 = yyj10 > l
+	yyj11++
+	if yyhl11 {
+		yyb11 = yyj11 > l
 	} else {
-		yyb10 = r.CheckBreak()
+		yyb11 = r.CheckBreak()
 	}
-	if yyb10 {
+	if yyb11 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -3834,21 +3864,21 @@ func (x *ScheduledJobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	if r.TryDecodeAsNil() {
 		x.JobTemplate = JobTemplateSpec{}
 	} else {
-		yyv16 := &x.JobTemplate
-		yyv16.CodecDecodeSelf(d)
+		yyv18 := &x.JobTemplate
+		yyv18.CodecDecodeSelf(d)
 	}
 	for {
-		yyj10++
-		if yyhl10 {
-			yyb10 = yyj10 > l
+		yyj11++
+		if yyhl11 {
+			yyb11 = yyj11 > l
 		} else {
-			yyb10 = r.CheckBreak()
+			yyb11 = r.CheckBreak()
 		}
-		if yyb10 {
+		if yyb11 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj10-1, "")
+		z.DecStructFieldNotFound(yyj11-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }

--- a/pkg/apis/batch/types.go
+++ b/pkg/apis/batch/types.go
@@ -209,7 +209,7 @@ type ScheduledJobSpec struct {
 
 	// Suspend flag tells the controller to suspend subsequent executions, it does
 	// not apply to already started executions.  Defaults to false.
-	Suspend bool `json:"suspend"`
+	Suspend *bool `json:"suspend"`
 
 	// JobTemplate is the object that describes the job that will be created when
 	// executing a ScheduledJob.

--- a/pkg/apis/batch/v2alpha1/deep_copy_generated.go
+++ b/pkg/apis/batch/v2alpha1/deep_copy_generated.go
@@ -286,7 +286,13 @@ func DeepCopy_v2alpha1_ScheduledJobSpec(in ScheduledJobSpec, out *ScheduledJobSp
 		out.StartingDeadlineSeconds = nil
 	}
 	out.ConcurrencyPolicy = in.ConcurrencyPolicy
-	out.Suspend = in.Suspend
+	if in.Suspend != nil {
+		in, out := in.Suspend, &out.Suspend
+		*out = new(bool)
+		**out = *in
+	} else {
+		out.Suspend = nil
+	}
 	if err := DeepCopy_v2alpha1_JobTemplateSpec(in.JobTemplate, &out.JobTemplate, c); err != nil {
 		return err
 	}

--- a/pkg/apis/batch/v2alpha1/generated.pb.go
+++ b/pkg/apis/batch/v2alpha1/generated.pb.go
@@ -636,14 +636,16 @@ func (m *ScheduledJobSpec) MarshalTo(data []byte) (int, error) {
 	i++
 	i = encodeVarintGenerated(data, i, uint64(len(m.ConcurrencyPolicy)))
 	i += copy(data[i:], m.ConcurrencyPolicy)
-	data[i] = 0x20
-	i++
-	if m.Suspend {
-		data[i] = 1
-	} else {
-		data[i] = 0
+	if m.Suspend != nil {
+		data[i] = 0x20
+		i++
+		if *m.Suspend {
+			data[i] = 1
+		} else {
+			data[i] = 0
+		}
+		i++
 	}
-	i++
 	data[i] = 0x2a
 	i++
 	i = encodeVarintGenerated(data, i, uint64(m.JobTemplate.Size()))
@@ -905,7 +907,9 @@ func (m *ScheduledJobSpec) Size() (n int) {
 	}
 	l = len(m.ConcurrencyPolicy)
 	n += 1 + l + sovGenerated(uint64(l))
-	n += 2
+	if m.Suspend != nil {
+		n += 2
+	}
 	l = m.JobTemplate.Size()
 	n += 1 + l + sovGenerated(uint64(l))
 	return n
@@ -2741,7 +2745,8 @@ func (m *ScheduledJobSpec) Unmarshal(data []byte) error {
 					break
 				}
 			}
-			m.Suspend = bool(v != 0)
+			b := bool(v != 0)
+			m.Suspend = &b
 		case 5:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field JobTemplate", wireType)

--- a/pkg/apis/batch/v2alpha1/generated.proto
+++ b/pkg/apis/batch/v2alpha1/generated.proto
@@ -24,7 +24,6 @@ package k8s.io.kubernetes.pkg.apis.batch.v2alpha1;
 import "k8s.io/kubernetes/pkg/api/resource/generated.proto";
 import "k8s.io/kubernetes/pkg/api/unversioned/generated.proto";
 import "k8s.io/kubernetes/pkg/api/v1/generated.proto";
-import "k8s.io/kubernetes/pkg/runtime/generated.proto";
 import "k8s.io/kubernetes/pkg/util/intstr/generated.proto";
 
 // Package-wide variables from generator "generated".

--- a/pkg/apis/batch/v2alpha1/types.generated.go
+++ b/pkg/apis/batch/v2alpha1/types.generated.go
@@ -3578,33 +3578,43 @@ func (x *ScheduledJobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym15 := z.EncBinary()
-				_ = yym15
-				if false {
+				if x.Suspend == nil {
+					r.EncodeNil()
 				} else {
-					r.EncodeBool(bool(x.Suspend))
+					yy15 := *x.Suspend
+					yym16 := z.EncBinary()
+					_ = yym16
+					if false {
+					} else {
+						r.EncodeBool(bool(yy15))
+					}
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("suspend"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym16 := z.EncBinary()
-				_ = yym16
-				if false {
+				if x.Suspend == nil {
+					r.EncodeNil()
 				} else {
-					r.EncodeBool(bool(x.Suspend))
+					yy17 := *x.Suspend
+					yym18 := z.EncBinary()
+					_ = yym18
+					if false {
+					} else {
+						r.EncodeBool(bool(yy17))
+					}
 				}
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yy18 := &x.JobTemplate
-				yy18.CodecEncodeSelf(e)
+				yy20 := &x.JobTemplate
+				yy20.CodecEncodeSelf(e)
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("jobTemplate"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yy20 := &x.JobTemplate
-				yy20.CodecEncodeSelf(e)
+				yy22 := &x.JobTemplate
+				yy22.CodecEncodeSelf(e)
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
@@ -3697,16 +3707,26 @@ func (x *ScheduledJobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		case "suspend":
 			if r.TryDecodeAsNil() {
-				x.Suspend = false
+				if x.Suspend != nil {
+					x.Suspend = nil
+				}
 			} else {
-				x.Suspend = bool(r.DecodeBool())
+				if x.Suspend == nil {
+					x.Suspend = new(bool)
+				}
+				yym9 := z.DecBinary()
+				_ = yym9
+				if false {
+				} else {
+					*((*bool)(x.Suspend)) = r.DecodeBool()
+				}
 			}
 		case "jobTemplate":
 			if r.TryDecodeAsNil() {
 				x.JobTemplate = JobTemplateSpec{}
 			} else {
-				yyv9 := &x.JobTemplate
-				yyv9.CodecDecodeSelf(d)
+				yyv10 := &x.JobTemplate
+				yyv10.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3)
@@ -3719,16 +3739,16 @@ func (x *ScheduledJobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj10 int
-	var yyb10 bool
-	var yyhl10 bool = l >= 0
-	yyj10++
-	if yyhl10 {
-		yyb10 = yyj10 > l
+	var yyj11 int
+	var yyb11 bool
+	var yyhl11 bool = l >= 0
+	yyj11++
+	if yyhl11 {
+		yyb11 = yyj11 > l
 	} else {
-		yyb10 = r.CheckBreak()
+		yyb11 = r.CheckBreak()
 	}
-	if yyb10 {
+	if yyb11 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -3738,13 +3758,13 @@ func (x *ScheduledJobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Schedule = string(r.DecodeString())
 	}
-	yyj10++
-	if yyhl10 {
-		yyb10 = yyj10 > l
+	yyj11++
+	if yyhl11 {
+		yyb11 = yyj11 > l
 	} else {
-		yyb10 = r.CheckBreak()
+		yyb11 = r.CheckBreak()
 	}
-	if yyb10 {
+	if yyb11 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -3757,20 +3777,20 @@ func (x *ScheduledJobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		if x.StartingDeadlineSeconds == nil {
 			x.StartingDeadlineSeconds = new(int64)
 		}
-		yym13 := z.DecBinary()
-		_ = yym13
+		yym14 := z.DecBinary()
+		_ = yym14
 		if false {
 		} else {
 			*((*int64)(x.StartingDeadlineSeconds)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj10++
-	if yyhl10 {
-		yyb10 = yyj10 > l
+	yyj11++
+	if yyhl11 {
+		yyb11 = yyj11 > l
 	} else {
-		yyb10 = r.CheckBreak()
+		yyb11 = r.CheckBreak()
 	}
-	if yyb10 {
+	if yyb11 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -3780,29 +3800,39 @@ func (x *ScheduledJobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.ConcurrencyPolicy = ConcurrencyPolicy(r.DecodeString())
 	}
-	yyj10++
-	if yyhl10 {
-		yyb10 = yyj10 > l
+	yyj11++
+	if yyhl11 {
+		yyb11 = yyj11 > l
 	} else {
-		yyb10 = r.CheckBreak()
+		yyb11 = r.CheckBreak()
 	}
-	if yyb10 {
+	if yyb11 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.Suspend = false
+		if x.Suspend != nil {
+			x.Suspend = nil
+		}
 	} else {
-		x.Suspend = bool(r.DecodeBool())
+		if x.Suspend == nil {
+			x.Suspend = new(bool)
+		}
+		yym17 := z.DecBinary()
+		_ = yym17
+		if false {
+		} else {
+			*((*bool)(x.Suspend)) = r.DecodeBool()
+		}
 	}
-	yyj10++
-	if yyhl10 {
-		yyb10 = yyj10 > l
+	yyj11++
+	if yyhl11 {
+		yyb11 = yyj11 > l
 	} else {
-		yyb10 = r.CheckBreak()
+		yyb11 = r.CheckBreak()
 	}
-	if yyb10 {
+	if yyb11 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -3810,21 +3840,21 @@ func (x *ScheduledJobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	if r.TryDecodeAsNil() {
 		x.JobTemplate = JobTemplateSpec{}
 	} else {
-		yyv16 := &x.JobTemplate
-		yyv16.CodecDecodeSelf(d)
+		yyv18 := &x.JobTemplate
+		yyv18.CodecDecodeSelf(d)
 	}
 	for {
-		yyj10++
-		if yyhl10 {
-			yyb10 = yyj10 > l
+		yyj11++
+		if yyhl11 {
+			yyb11 = yyj11 > l
 		} else {
-			yyb10 = r.CheckBreak()
+			yyb11 = r.CheckBreak()
 		}
-		if yyb10 {
+		if yyb11 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj10-1, "")
+		z.DecStructFieldNotFound(yyj11-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }

--- a/pkg/apis/batch/v2alpha1/types.go
+++ b/pkg/apis/batch/v2alpha1/types.go
@@ -211,7 +211,7 @@ type ScheduledJobSpec struct {
 
 	// Suspend flag tells the controller to suspend subsequent executions, it does
 	// not apply to already started executions.  Defaults to false.
-	Suspend bool `json:"suspend" protobuf:"varint,4,opt,name=suspend"`
+	Suspend *bool `json:"suspend" protobuf:"varint,4,opt,name=suspend"`
 
 	// JobTemplate is the object that describes the job that will be created when
 	// executing a ScheduledJob.

--- a/pkg/registry/scheduledjob/strategy_test.go
+++ b/pkg/registry/scheduledjob/strategy_test.go
@@ -41,13 +41,7 @@ func TestScheduledJobStrategy(t *testing.T) {
 		t.Errorf("ScheduledJob should not allow create on update")
 	}
 
-	validSelector := &unversioned.LabelSelector{
-		MatchLabels: map[string]string{"a": "b"},
-	}
 	validPodTemplateSpec := api.PodTemplateSpec{
-		ObjectMeta: api.ObjectMeta{
-			Labels: validSelector.MatchLabels,
-		},
 		Spec: api.PodSpec{
 			RestartPolicy: api.RestartPolicyOnFailure,
 			DNSPolicy:     api.DNSClusterFirst,
@@ -64,9 +58,7 @@ func TestScheduledJobStrategy(t *testing.T) {
 			ConcurrencyPolicy: batch.AllowConcurrent,
 			JobTemplate: batch.JobTemplateSpec{
 				Spec: batch.JobSpec{
-					Selector:       validSelector,
-					Template:       validPodTemplateSpec,
-					ManualSelector: newBool(true),
+					Template: validPodTemplateSpec,
 				},
 			},
 		},
@@ -110,13 +102,7 @@ func TestScheduledJobStatusStrategy(t *testing.T) {
 	if StatusStrategy.AllowCreateOnUpdate() {
 		t.Errorf("ScheduledJob should not allow create on update")
 	}
-	validSelector := &unversioned.LabelSelector{
-		MatchLabels: map[string]string{"a": "b"},
-	}
 	validPodTemplateSpec := api.PodTemplateSpec{
-		ObjectMeta: api.ObjectMeta{
-			Labels: validSelector.MatchLabels,
-		},
 		Spec: api.PodSpec{
 			RestartPolicy: api.RestartPolicyOnFailure,
 			DNSPolicy:     api.DNSClusterFirst,
@@ -135,9 +121,7 @@ func TestScheduledJobStatusStrategy(t *testing.T) {
 			ConcurrencyPolicy: batch.AllowConcurrent,
 			JobTemplate: batch.JobTemplateSpec{
 				Spec: batch.JobSpec{
-					Selector:       validSelector,
-					Template:       validPodTemplateSpec,
-					ManualSelector: newBool(true),
+					Template: validPodTemplateSpec,
 				},
 			},
 		},
@@ -154,9 +138,7 @@ func TestScheduledJobStatusStrategy(t *testing.T) {
 			ConcurrencyPolicy: batch.AllowConcurrent,
 			JobTemplate: batch.JobTemplateSpec{
 				Spec: batch.JobSpec{
-					Selector:       validSelector,
-					Template:       validPodTemplateSpec,
-					ManualSelector: newBool(true),
+					Template: validPodTemplateSpec,
 				},
 			},
 		},


### PR DESCRIPTION
@erictune while playing earlier today I've noticed `suspend` isn't a pointer which requires it to be set. Additionally the validation for job selectors is too strict in that it requires the selector to match produced pods, which doesn't make sense for SJ, I've changed it to being forbidden to set entirely.

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
