### PR TITLE
pkg/client/leaderelection: log err when retrieving endpoint

### DIFF
--- a/pkg/client/leaderelection/leaderelection.go
+++ b/pkg/client/leaderelection/leaderelection.go
@@ -250,6 +250,7 @@ func (le *LeaderElector) tryAcquireOrRenew() bool {
 	e, err := le.config.Client.Endpoints(le.config.EndpointsMeta.Namespace).Get(le.config.EndpointsMeta.Name)
 	if err != nil {
 		if !errors.IsNotFound(err) {
+			glog.Errorf("error retrieving endpoint: %v", err)
 			return false
 		}
 


### PR DESCRIPTION
The leader election code currently suppresses errors when trying to retrieve an endpoint. This can lead to difficult to debug situations.

In the case of a mis-configured controller-manager or scheduler - where they fail to contact an apiserver - this currently leads to no log output in the default case, or `failed to renew lease foo/bar` in `--v=4`, which isn't very actionable. 
