### PR TITLE
Add dnsmasq as a DNS cache in kube-dns pod

### DIFF
--- a/build/kube-dns/Makefile
+++ b/build/kube-dns/Makefile
@@ -22,7 +22,7 @@
 # Default registry, arch and tag. This can be overwritten by arguments to make
 PLATFORM?=linux
 ARCH?=amd64
-TAG?=1.0
+TAG?=1.1
 REGISTRY?=gcr.io/google_containers
 
 GOLANG_VERSION=1.6

--- a/cluster/saltbase/salt/kube-dns/kubedns-rc.yaml.in
+++ b/cluster/saltbase/salt/kube-dns/kubedns-rc.yaml.in
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/kubedns-amd64:1.0
+        image: gcr.io/google_containers/kubedns-amd64:1.1
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -54,6 +54,20 @@ spec:
         args:
         # command = "/kube-dns"
         - --domain={{ pillar['dns_domain'] }}.
+        - --dns-port=10053
+        ports:
+        - containerPort: 10053
+          name: dns-local
+          protocol: UDP
+        - containerPort: 10053
+          name: dns-tcp-local
+          protocol: TCP
+      - name: dnsmasq
+        image: gcr.io/google_containers/dnsmasq:1.1
+        args:
+        - --cache-size=1000
+        - --no-resolv
+        - --server=127.0.0.1#10053
         ports:
         - containerPort: 53
           name: dns

--- a/cmd/kube-dns/app/options/options.go
+++ b/cmd/kube-dns/app/options/options.go
@@ -33,6 +33,7 @@ type KubeDNSConfig struct {
 	KubeConfigFile string
 	KubeMasterURL  string
 	HealthzPort    int
+	DNSPort        int
 	// Federations maps federation names to their registered domain names.
 	Federations map[string]string
 }
@@ -43,6 +44,7 @@ func NewKubeDNSConfig() *KubeDNSConfig {
 		KubeConfigFile: "",
 		KubeMasterURL:  "",
 		HealthzPort:    8081,
+		DNSPort:        53,
 		Federations:    make(map[string]string),
 	}
 }
@@ -140,5 +142,6 @@ func (s *KubeDNSConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.KubeConfigFile, "kubecfg-file", s.KubeConfigFile, "Location of kubecfg file for access to kubernetes master service; --kube-master-url overrides the URL part of this; if neither this nor --kube-master-url are provided, defaults to service account tokens")
 	fs.Var(kubeMasterURLVar{&s.KubeMasterURL}, "kube-master-url", "URL to reach kubernetes master. Env variables in this flag will be expanded.")
 	fs.IntVar(&s.HealthzPort, "healthz-port", s.HealthzPort, "port on which to serve a kube-dns HTTP readiness probe.")
+	fs.IntVar(&s.DNSPort, "dns-port", s.DNSPort, "port on which to serve DNS requests.")
 	fs.Var(federationsVar{s.Federations}, "federations", "a comma separated list of the federation names and their corresponding domain names to which this cluster belongs. Example: \"myfederation1=example.com,myfederation2=example2.com,myfederation3=example.com\"")
 }

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -90,6 +90,7 @@ deployment-label-key
 deserialization-cache-size
 dest-file
 disable-filter
+dns-port
 docker-email
 docker-endpoint
 docker-exec-handler

--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -29,9 +29,8 @@ import (
 	"github.com/stretchr/testify/require"
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
-	v1 "k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/client/cache"
-	fake "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_3/fake"
+	fake "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 )
 
 const (
@@ -276,17 +275,17 @@ func testInvalidFederationQueries(t *testing.T, kd *KubeDNS) {
 	}
 }
 
-func newNodes() *v1.NodeList {
-	return &v1.NodeList{
-		Items: []v1.Node{
+func newNodes() *kapi.NodeList {
+	return &kapi.NodeList{
+		Items: []kapi.Node{
 			// Node without annotation.
 			{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: kapi.ObjectMeta{
 					Name: "testnode-0",
 				},
 			},
 			{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: kapi.ObjectMeta{
 					Name: "testnode-1",
 					Annotations: map[string]string{
 						// Note: The zone name here is an arbitrary string and doesn't exactly follow the


### PR DESCRIPTION
1. added dns-port flag
2. updated imports to not use the v1 version of the api objects.
