### PR TITLE
docker: don't set timeout for image pulling requests

### DIFF
--- a/pkg/kubelet/dockertools/kube_docker_client.go
+++ b/pkg/kubelet/dockertools/kube_docker_client.go
@@ -198,13 +198,10 @@ func (d *kubeDockerClient) PullImage(image string, auth dockertypes.AuthConfig, 
 	if err != nil {
 		return err
 	}
-	ctx, cancel := getDefaultContext()
-	defer cancel()
 	opts.RegistryAuth = base64Auth
-	resp, err := d.client.ImagePull(ctx, image, opts)
-	if ctxErr := contextError(ctx); ctxErr != nil {
-		return ctxErr
-	}
+	// Don't set timeout for the context because image pulling can be
+	// take an arbitrarily long time.
+	resp, err := d.client.ImagePull(context.Background(), image, opts)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Image pulling can take an arbitrarily long time. Don't set timeout for such requests.

See https://github.com/kubernetes/kubernetes/issues/26075#issuecomment-221122556

/cc @Random-Liu 
