### PR TITLE
federation: replacing string credentials field by secretRef

### DIFF
--- a/federation/apis/federation/deep_copy_generated.go
+++ b/federation/apis/federation/deep_copy_generated.go
@@ -110,7 +110,15 @@ func DeepCopy_federation_ClusterSpec(in ClusterSpec, out *ClusterSpec, c *conver
 	} else {
 		out.ServerAddressByClientCIDRs = nil
 	}
-	out.Credential = in.Credential
+	if in.SecretRef != nil {
+		in, out := in.SecretRef, &out.SecretRef
+		*out = new(api.LocalObjectReference)
+		if err := api.DeepCopy_api_LocalObjectReference(*in, *out, c); err != nil {
+			return err
+		}
+	} else {
+		out.SecretRef = nil
+	}
 	return nil
 }
 

--- a/federation/apis/federation/types.generated.go
+++ b/federation/apis/federation/types.generated.go
@@ -64,7 +64,7 @@ func init() {
 		panic(err)
 	}
 	if false { // reference the types, but skip this branch at build/run time
-		var v0 pkg1_api.ConditionStatus
+		var v0 pkg1_api.LocalObjectReference
 		var v1 pkg3_resource.Quantity
 		var v2 pkg2_unversioned.Time
 		var v3 pkg4_types.UID
@@ -293,12 +293,11 @@ func (x *ClusterSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2 [2]bool
 			_, _, _ = yysep2, yyq2, yy2arr2
 			const yyr2 bool = false
-			yyq2[1] = x.Credential != ""
 			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn2 = 1
+				yynn2 = 2
 				for _, b := range yyq2 {
 					if b {
 						yynn2++
@@ -336,27 +335,19 @@ func (x *ClusterSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[1] {
-					yym7 := z.EncBinary()
-					_ = yym7
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Credential))
-					}
+				if x.SecretRef == nil {
+					r.EncodeNil()
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					x.SecretRef.CodecEncodeSelf(e)
 				}
 			} else {
-				if yyq2[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("credential"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym8 := z.EncBinary()
-					_ = yym8
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Credential))
-					}
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("secretRef"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				if x.SecretRef == nil {
+					r.EncodeNil()
+				} else {
+					x.SecretRef.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2 || yy2arr2 {
@@ -432,11 +423,16 @@ func (x *ClusterSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 					h.decSliceServerAddressByClientCIDR((*[]ServerAddressByClientCIDR)(yyv4), d)
 				}
 			}
-		case "credential":
+		case "secretRef":
 			if r.TryDecodeAsNil() {
-				x.Credential = ""
+				if x.SecretRef != nil {
+					x.SecretRef = nil
+				}
 			} else {
-				x.Credential = string(r.DecodeString())
+				if x.SecretRef == nil {
+					x.SecretRef = new(pkg1_api.LocalObjectReference)
+				}
+				x.SecretRef.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3)
@@ -486,9 +482,14 @@ func (x *ClusterSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.Credential = ""
+		if x.SecretRef != nil {
+			x.SecretRef = nil
+		}
 	} else {
-		x.Credential = string(r.DecodeString())
+		if x.SecretRef == nil {
+			x.SecretRef = new(pkg1_api.LocalObjectReference)
+		}
+		x.SecretRef.CodecDecodeSelf(d)
 	}
 	for {
 		yyj7++
@@ -2447,7 +2448,7 @@ func (x codecSelfer1234) decSliceCluster(v *[]Cluster, d *codec1978.Decoder) {
 
 			yyrg1 := len(yyv1) > 0
 			yyv21 := yyv1
-			yyrl1, yyrt1 = z.DecInferLen(yyl1, z.DecBasicHandle().MaxInitLen, 336)
+			yyrl1, yyrt1 = z.DecInferLen(yyl1, z.DecBasicHandle().MaxInitLen, 328)
 			if yyrt1 {
 				if yyrl1 <= cap(yyv1) {
 					yyv1 = yyv1[:yyrl1]

--- a/federation/apis/federation/types.go
+++ b/federation/apis/federation/types.go
@@ -37,10 +37,11 @@ type ClusterSpec struct {
 	// Clients can use the appropriate server address as per the CIDR that they match.
 	// In case of multiple matches, clients should use the longest matching CIDR.
 	ServerAddressByClientCIDRs []ServerAddressByClientCIDR `json:"serverAddressByClientCIDRs" patchStrategy:"merge" patchMergeKey:"clientCIDR"`
-	// the type (e.g. bearer token, client certificate etc) and data of the credential used to access cluster.
-	// It’s used for system routines (not behalf of users)
-	// TODO: string may not enough, https://github.com/kubernetes/kubernetes/pull/23847#discussion_r59301275
-	Credential string `json:"credential,omitempty"`
+	// Name of the secret containing kubeconfig to access this cluster.
+	// The secret is read from the kubernetes cluster that is hosting federation control plane.
+	// Admin needs to ensure that the required secret exists. Secret should be in the same namespace where federation control plane is hosted and it should have kubeconfig in its data with key "kubeconfig".
+	// This will later be changed to a reference to secret in federation control plane when the federation control plane supports secrets.
+	SecretRef *api.LocalObjectReference `json:"secretRef"`
 }
 
 type ClusterConditionType string

--- a/federation/apis/federation/v1alpha1/conversion_generated.go
+++ b/federation/apis/federation/v1alpha1/conversion_generated.go
@@ -208,7 +208,16 @@ func autoConvert_v1alpha1_ClusterSpec_To_federation_ClusterSpec(in *ClusterSpec,
 	} else {
 		out.ServerAddressByClientCIDRs = nil
 	}
-	out.Credential = in.Credential
+	if in.SecretRef != nil {
+		in, out := &in.SecretRef, &out.SecretRef
+		*out = new(api.LocalObjectReference)
+		// TODO: Inefficient conversion - can we improve it?
+		if err := s.Convert(*in, *out, 0); err != nil {
+			return err
+		}
+	} else {
+		out.SecretRef = nil
+	}
 	return nil
 }
 
@@ -228,7 +237,16 @@ func autoConvert_federation_ClusterSpec_To_v1alpha1_ClusterSpec(in *federation.C
 	} else {
 		out.ServerAddressByClientCIDRs = nil
 	}
-	out.Credential = in.Credential
+	if in.SecretRef != nil {
+		in, out := &in.SecretRef, &out.SecretRef
+		*out = new(v1.LocalObjectReference)
+		// TODO: Inefficient conversion - can we improve it?
+		if err := s.Convert(*in, *out, 0); err != nil {
+			return err
+		}
+	} else {
+		out.SecretRef = nil
+	}
 	return nil
 }
 

--- a/federation/apis/federation/v1alpha1/deep_copy_generated.go
+++ b/federation/apis/federation/v1alpha1/deep_copy_generated.go
@@ -111,7 +111,15 @@ func DeepCopy_v1alpha1_ClusterSpec(in ClusterSpec, out *ClusterSpec, c *conversi
 	} else {
 		out.ServerAddressByClientCIDRs = nil
 	}
-	out.Credential = in.Credential
+	if in.SecretRef != nil {
+		in, out := in.SecretRef, &out.SecretRef
+		*out = new(v1.LocalObjectReference)
+		if err := v1.DeepCopy_v1_LocalObjectReference(*in, *out, c); err != nil {
+			return err
+		}
+	} else {
+		out.SecretRef = nil
+	}
 	return nil
 }
 

--- a/federation/apis/federation/v1alpha1/generated.pb.go
+++ b/federation/apis/federation/v1alpha1/generated.pb.go
@@ -266,10 +266,16 @@ func (m *ClusterSpec) MarshalTo(data []byte) (int, error) {
 			i += n
 		}
 	}
-	data[i] = 0x12
-	i++
-	i = encodeVarintGenerated(data, i, uint64(len(m.Credential)))
-	i += copy(data[i:], m.Credential)
+	if m.SecretRef != nil {
+		data[i] = 0x12
+		i++
+		i = encodeVarintGenerated(data, i, uint64(m.SecretRef.Size()))
+		n7, err := m.SecretRef.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n7
+	}
 	return i, nil
 }
 
@@ -315,11 +321,11 @@ func (m *ClusterStatus) MarshalTo(data []byte) (int, error) {
 			data[i] = 0x12
 			i++
 			i = encodeVarintGenerated(data, i, uint64((&v).Size()))
-			n7, err := (&v).MarshalTo(data[i:])
+			n8, err := (&v).MarshalTo(data[i:])
 			if err != nil {
 				return 0, err
 			}
-			i += n7
+			i += n8
 		}
 	}
 	if len(m.Allocatable) > 0 {
@@ -337,21 +343,21 @@ func (m *ClusterStatus) MarshalTo(data []byte) (int, error) {
 			data[i] = 0x12
 			i++
 			i = encodeVarintGenerated(data, i, uint64((&v).Size()))
-			n8, err := (&v).MarshalTo(data[i:])
+			n9, err := (&v).MarshalTo(data[i:])
 			if err != nil {
 				return 0, err
 			}
-			i += n8
+			i += n9
 		}
 	}
 	data[i] = 0x22
 	i++
 	i = encodeVarintGenerated(data, i, uint64(m.ClusterMeta.Size()))
-	n9, err := m.ClusterMeta.MarshalTo(data[i:])
+	n10, err := m.ClusterMeta.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n9
+	i += n10
 	return i, nil
 }
 
@@ -469,8 +475,10 @@ func (m *ClusterSpec) Size() (n int) {
 			n += 1 + l + sovGenerated(uint64(l))
 		}
 	}
-	l = len(m.Credential)
-	n += 1 + l + sovGenerated(uint64(l))
+	if m.SecretRef != nil {
+		l = m.SecretRef.Size()
+		n += 1 + l + sovGenerated(uint64(l))
+	}
 	return n
 }
 
@@ -1147,9 +1155,9 @@ func (m *ClusterSpec) Unmarshal(data []byte) error {
 			iNdEx = postIndex
 		case 2:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Credential", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field SecretRef", wireType)
 			}
-			var stringLen uint64
+			var msglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return ErrIntOverflowGenerated
@@ -1159,20 +1167,24 @@ func (m *ClusterSpec) Unmarshal(data []byte) error {
 				}
 				b := data[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				msglen |= (int(b) & 0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
+			if msglen < 0 {
 				return ErrInvalidLengthGenerated
 			}
-			postIndex := iNdEx + intStringLen
+			postIndex := iNdEx + msglen
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Credential = string(data[iNdEx:postIndex])
+			if m.SecretRef == nil {
+				m.SecretRef = &k8s_io_kubernetes_pkg_api_v1.LocalObjectReference{}
+			}
+			if err := m.SecretRef.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/federation/apis/federation/v1alpha1/generated.proto
+++ b/federation/apis/federation/v1alpha1/generated.proto
@@ -87,10 +87,11 @@ message ClusterSpec {
   // In case of multiple matches, clients should use the longest matching CIDR.
   repeated ServerAddressByClientCIDR serverAddressByClientCIDRs = 1;
 
-  // the type (e.g. bearer token, client certificate etc) and data of the credential used to access cluster.
-  // It’s used for system routines (not behalf of users)
-  // TODO: string may not enough, https://github.com/kubernetes/kubernetes/pull/23847#discussion_r59301275
-  optional string credential = 2;
+  // Name of the secret containing kubeconfig to access this cluster.
+  // The secret is read from the kubernetes cluster that is hosting federation control plane.
+  // Admin needs to ensure that the required secret exists. Secret should be in the same namespace where federation control plane is hosted and it should have kubeconfig in its data with key "kubeconfig".
+  // This will later be changed to a reference to secret in federation control plane when the federation control plane supports secrets.
+  optional k8s.io.kubernetes.pkg.api.v1.LocalObjectReference secretRef = 2;
 }
 
 // ClusterStatus is information about the current status of a cluster updated by cluster controller peridocally.

--- a/federation/apis/federation/v1alpha1/types.generated.go
+++ b/federation/apis/federation/v1alpha1/types.generated.go
@@ -66,7 +66,7 @@ func init() {
 	if false { // reference the types, but skip this branch at build/run time
 		var v0 pkg3_resource.Quantity
 		var v1 pkg2_unversioned.Time
-		var v2 pkg1_v1.ConditionStatus
+		var v2 pkg1_v1.LocalObjectReference
 		var v3 pkg4_types.UID
 		var v4 time.Time
 		_, _, _, _, _ = v0, v1, v2, v3, v4
@@ -293,12 +293,11 @@ func (x *ClusterSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2 [2]bool
 			_, _, _ = yysep2, yyq2, yy2arr2
 			const yyr2 bool = false
-			yyq2[1] = x.Credential != ""
 			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn2 = 1
+				yynn2 = 2
 				for _, b := range yyq2 {
 					if b {
 						yynn2++
@@ -336,27 +335,19 @@ func (x *ClusterSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[1] {
-					yym7 := z.EncBinary()
-					_ = yym7
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Credential))
-					}
+				if x.SecretRef == nil {
+					r.EncodeNil()
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
+					x.SecretRef.CodecEncodeSelf(e)
 				}
 			} else {
-				if yyq2[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("credential"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					yym8 := z.EncBinary()
-					_ = yym8
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Credential))
-					}
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("secretRef"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				if x.SecretRef == nil {
+					r.EncodeNil()
+				} else {
+					x.SecretRef.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2 || yy2arr2 {
@@ -432,11 +423,16 @@ func (x *ClusterSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 					h.decSliceServerAddressByClientCIDR((*[]ServerAddressByClientCIDR)(yyv4), d)
 				}
 			}
-		case "credential":
+		case "secretRef":
 			if r.TryDecodeAsNil() {
-				x.Credential = ""
+				if x.SecretRef != nil {
+					x.SecretRef = nil
+				}
 			} else {
-				x.Credential = string(r.DecodeString())
+				if x.SecretRef == nil {
+					x.SecretRef = new(pkg1_v1.LocalObjectReference)
+				}
+				x.SecretRef.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3)
@@ -486,9 +482,14 @@ func (x *ClusterSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.Credential = ""
+		if x.SecretRef != nil {
+			x.SecretRef = nil
+		}
 	} else {
-		x.Credential = string(r.DecodeString())
+		if x.SecretRef == nil {
+			x.SecretRef = new(pkg1_v1.LocalObjectReference)
+		}
+		x.SecretRef.CodecDecodeSelf(d)
 	}
 	for {
 		yyj7++
@@ -2447,7 +2448,7 @@ func (x codecSelfer1234) decSliceCluster(v *[]Cluster, d *codec1978.Decoder) {
 
 			yyrg1 := len(yyv1) > 0
 			yyv21 := yyv1
-			yyrl1, yyrt1 = z.DecInferLen(yyl1, z.DecBasicHandle().MaxInitLen, 336)
+			yyrl1, yyrt1 = z.DecInferLen(yyl1, z.DecBasicHandle().MaxInitLen, 328)
 			if yyrt1 {
 				if yyrl1 <= cap(yyv1) {
 					yyv1 = yyv1[:yyrl1]

--- a/federation/apis/federation/v1alpha1/types.go
+++ b/federation/apis/federation/v1alpha1/types.go
@@ -37,10 +37,11 @@ type ClusterSpec struct {
 	// Clients can use the appropriate server address as per the CIDR that they match.
 	// In case of multiple matches, clients should use the longest matching CIDR.
 	ServerAddressByClientCIDRs []ServerAddressByClientCIDR `json:"serverAddressByClientCIDRs" patchStrategy:"merge" patchMergeKey:"clientCIDR" protobuf:"bytes,1,rep,name=serverAddressByClientCIDRs"`
-	// the type (e.g. bearer token, client certificate etc) and data of the credential used to access cluster.
-	// It’s used for system routines (not behalf of users)
-	// TODO: string may not enough, https://github.com/kubernetes/kubernetes/pull/23847#discussion_r59301275
-	Credential string `json:"credential,omitempty" protobuf:"bytes,2,opt,name=credential"`
+	// Name of the secret containing kubeconfig to access this cluster.
+	// The secret is read from the kubernetes cluster that is hosting federation control plane.
+	// Admin needs to ensure that the required secret exists. Secret should be in the same namespace where federation control plane is hosted and it should have kubeconfig in its data with key "kubeconfig".
+	// This will later be changed to a reference to secret in federation control plane when the federation control plane supports secrets.
+	SecretRef *v1.LocalObjectReference `json:"secretRef" protobuf:"bytes,2,opt,name=secretRef"`
 }
 
 type ClusterConditionType string

--- a/federation/registry/cluster/etcd/etcd_test.go
+++ b/federation/registry/cluster/etcd/etcd_test.go
@@ -87,7 +87,9 @@ func TestUpdate(t *testing.T) {
 		// updateFunc
 		func(obj runtime.Object) runtime.Object {
 			object := obj.(*federation.Cluster)
-			object.Spec.Credential = "bar"
+			object.Spec.SecretRef = &api.LocalObjectReference{
+				Name: "bar",
+			}
 			return object
 		},
 	)

--- a/federation/registry/cluster/strategy_test.go
+++ b/federation/registry/cluster/strategy_test.go
@@ -54,13 +54,11 @@ func validNewCluster() *federation.Cluster {
 }
 
 func invalidNewCluster() *federation.Cluster {
+	// Create a cluster with empty ServerAddressByClientCIDRs (which is a required field).
 	return &federation.Cluster{
 		ObjectMeta: api.ObjectMeta{
 			Name:            "foo2",
 			ResourceVersion: "5",
-		},
-		Spec: federation.ClusterSpec{
-			Credential: "bar",
 		},
 		Status: federation.ClusterStatus{
 			Conditions: []federation.ClusterCondition{

--- a/pkg/client/unversioned/clientcmd/client_config.go
+++ b/pkg/client/unversioned/clientcmd/client_config.go
@@ -399,3 +399,12 @@ func BuildConfigFromFlags(masterUrl, kubeconfigPath string) (*restclient.Config,
 		&ClientConfigLoadingRules{ExplicitPath: kubeconfigPath},
 		&ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: masterUrl}}).ClientConfig()
 }
+
+// BuildConfigFromKubeconfigGetter is a helper function that builds configs from a master
+// url and a kubeconfigGetter.
+func BuildConfigFromKubeconfigGetter(masterUrl string, kubeconfigGetter KubeconfigGetter) (*restclient.Config, error) {
+	cc := NewNonInteractiveDeferredLoadingClientConfig(
+		&ClientConfigGetter{kubeconfigGetter: kubeconfigGetter},
+		&ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: masterUrl}})
+	return cc.ClientConfig()
+}

--- a/pkg/client/unversioned/clientcmd/client_config.go
+++ b/pkg/client/unversioned/clientcmd/client_config.go
@@ -403,6 +403,7 @@ func BuildConfigFromFlags(masterUrl, kubeconfigPath string) (*restclient.Config,
 // BuildConfigFromKubeconfigGetter is a helper function that builds configs from a master
 // url and a kubeconfigGetter.
 func BuildConfigFromKubeconfigGetter(masterUrl string, kubeconfigGetter KubeconfigGetter) (*restclient.Config, error) {
+	// TODO: We do not need a DeferredLoader here. Refactor code and see if we can use DirectClientConfig here.
 	cc := NewNonInteractiveDeferredLoadingClientConfig(
 		&ClientConfigGetter{kubeconfigGetter: kubeconfigGetter},
 		&ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: masterUrl}})


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/25761

Replaced the string Credentials field in ClusterSpec by secretRef as discussed in https://github.com/kubernetes/kubernetes/issues/25761.
Also updated the clusterController to use this new secretRef field while creating a client to talk to a k8s cluster.

cc @lavalamp @kubernetes/sig-cluster-federation 
