### PR TITLE
GCE provider: Rate limit all API calls

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_test.go
@@ -17,11 +17,15 @@ limitations under the License.
 package gce
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
 
 	compute "google.golang.org/api/compute/v1"
+	"k8s.io/kubernetes/pkg/util/flowcontrol"
 	"k8s.io/kubernetes/pkg/util/rand"
+	utiltesting "k8s.io/kubernetes/pkg/util/testing"
 )
 
 func TestGetRegion(t *testing.T) {
@@ -259,4 +263,32 @@ func TestComputeUpdate(t *testing.T) {
 		// 	t.Errorf("computeTargetPool(%v, %v) => removed %v, wanted %v", tc.tp, tc.instances, gotRem, tc.wantToRemove)
 		// }
 	}
+}
+
+func TestRateLimitedRoundTripper(t *testing.T) {
+	handler := utiltesting.FakeHandler{StatusCode: 200}
+	server := httptest.NewServer(&handler)
+	defer server.Close()
+
+	method := "GET"
+	path := "/foo/bar"
+
+	req, err := http.NewRequest(method, server.URL+path, nil)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// TODO(zmerlynn): Validate the rate limiter is actually getting called.
+	client := http.Client{
+		Transport: &rateLimitedRoundTripper{
+			rt:      http.DefaultTransport,
+			limiter: flowcontrol.NewFakeAlwaysRateLimiter(),
+		},
+	}
+	_, err = client.Do(req)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	handler.ValidateRequest(t, path, method, nil)
 }


### PR DESCRIPTION
[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()

Instead of just rate limits to operation polling, send all API calls
through a rate limited RoundTripper.

This isn't a perfect solution, since the QPS is obviously getting
split between different controllers, etc., but it's also spread across
different APIs, which, in practice, rate limit differently.

Fixes #26119 (hopefully)
