### PR TITLE
Fixed check in kubectl autoscale.

### DIFF
--- a/pkg/kubectl/cmd/autoscale.go
+++ b/pkg/kubectl/cmd/autoscale.go
@@ -192,12 +192,9 @@ func RunAutoscale(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []
 
 func validateFlags(cmd *cobra.Command) error {
 	errs := []error{}
-	max, min, cpu := cmdutil.GetFlagInt(cmd, "max"), cmdutil.GetFlagInt(cmd, "min"), cmdutil.GetFlagInt(cmd, "cpu-percent")
+	max, min := cmdutil.GetFlagInt(cmd, "max"), cmdutil.GetFlagInt(cmd, "min")
 	if max < 1 || max < min {
 		errs = append(errs, fmt.Errorf("--max=MAXPODS is required, and must be at least 1 and --min=MINPODS"))
-	}
-	if cpu > 100 {
-		errs = append(errs, fmt.Errorf("CPU utilization (%%) cannot exceed 100"))
 	}
 	return utilerrors.NewAggregate(errs)
 }


### PR DESCRIPTION
``` release-note
Fixed check in kubectl autoscale: cpu consumption can be higher than 100%.
```

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()

Fixed check in kubectl autoscale: cpu consumption can be higher than 100%. Fixes #25815.
