### PR TITLE
Flake 21484: retrieve pod log during e2e error

### DIFF
--- a/test/e2e/proxy.go
+++ b/test/e2e/proxy.go
@@ -243,6 +243,13 @@ func proxyContext(version string) {
 		wg.Wait()
 
 		if len(errors) != 0 {
+			body, err := f.Client.Pods(f.Namespace.Name).GetLogs(pods[0].Name, &api.PodLogOptions{}).Do().Raw()
+			if err != nil {
+				framework.Logf("Error getting logs for pod %s: %v", pods[0].Name, err)
+			} else {
+				framework.Logf("Pod %s has the following error logs: %s", pods[0].Name, body)
+			}
+
 			Fail(strings.Join(errors, "\n"))
 		}
 	})


### PR DESCRIPTION
Print the pod log when an error occurs in

> Proxy version 1 should proxy through a service and a pod [Conformance]

e2e test. This will help to understand flake https://github.com/kubernetes/kubernetes/issues/21484 better.
