### PR TITLE
Fix race between periodic sync and delete event.

### DIFF
--- a/pkg/controller/framework/controller.go
+++ b/pkg/controller/framework/controller.go
@@ -242,10 +242,17 @@ func NewInformer(
 						}
 						h.OnUpdate(old, d.Object)
 					} else {
-						if err := clientState.Add(d.Object); err != nil {
-							return err
+						if d.Type != cache.Sync {
+							if err := clientState.Add(d.Object); err != nil {
+								return err
+							}
+							h.OnAdd(d.Object)
+						} else {
+							// The object was in clientState when periodic sync
+							// was scheduled and it is not there any longer.
+							// It must have been deleted in the meantime,
+							// ignore this periodic sync.
 						}
-						h.OnAdd(d.Object)
 					}
 				case cache.Deleted:
 					if err := clientState.Delete(d.Object); err != nil {
@@ -308,10 +315,17 @@ func NewIndexerInformer(
 						}
 						h.OnUpdate(old, d.Object)
 					} else {
-						if err := clientState.Add(d.Object); err != nil {
-							return err
+						if d.Type != cache.Sync {
+							if err := clientState.Add(d.Object); err != nil {
+								return err
+							}
+							h.OnAdd(d.Object)
+						} else {
+							// The object was in clientState when periodic sync
+							// was scheduled and it is not there any longer.
+							// It must have been deleted in the meantime,
+							// ignore this periodic sync.
 						}
-						h.OnAdd(d.Object)
 					}
 				case cache.Deleted:
 					if err := clientState.Delete(d.Object); err != nil {


### PR DESCRIPTION
Controller should ignore "Sync" event on deleted objects. When controller receives 'object deleted' event from etcd and at the same time it starts periodic sync, "Sync" event can be enqueued after "Delete" event. Processing "Deleted" event, controller removes the object from its cache. It should not create the object there when processing "Sync" event after that.

Fixes #26082

Please review carefully, I'm not sure if it's the right thing to do - this must have been tested to death, everybody uses `NewInformer()`...

Also, an unit test would be nice, however all controller tests are in `framework_test` package and I can't call `controller.config.Queue.Resync()` from there to simulate periodic resync (`controller.config` is not exported). Is there a reliable way to wait for periodic sync in a `AddFunc` callback? I could sleep, but that's flaky...
