### PR TITLE
Log requests to GCE

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -118,7 +118,10 @@ type rateLimitedRoundTripper struct {
 }
 
 func (rl *rateLimitedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	startTime := time.Now()
 	rl.limiter.Accept()
+	// TODO: Reduce verbosity once #26119 is fixed.
+	glog.V(0).Infof("GCE api call: %s %s (throttled for %v)", req.Method, req.URL.String(), time.Now().Sub(startTime))
 	return rl.rt.RoundTrip(req)
 }
 


### PR DESCRIPTION
Ref #26119

This should simplify debugging what requests we are sending to GCE (and why we are throttled in routecontroller).

@zmerlynn @gmarek 
