### PR TITLE
add discovery restmapper for known types

### DIFF
--- a/pkg/api/meta/multirestmapper.go
+++ b/pkg/api/meta/multirestmapper.go
@@ -163,7 +163,17 @@ func (m MultiRESTMapper) RESTMapping(gk unversioned.GroupKind, versions ...strin
 			continue
 		}
 
-		allMappings = append(allMappings, currMapping)
+		// decimate dupes
+		found := false
+		for _, addedMapping := range allMappings {
+			if addedMapping.Scope == currMapping.Scope && addedMapping.GroupVersionKind == currMapping.GroupVersionKind && addedMapping.Resource == currMapping.Resource {
+				found = true
+				break
+			}
+		}
+		if !found {
+			allMappings = append(allMappings, currMapping)
+		}
 	}
 
 	// if we got exactly one mapping, then use it even if other requested failed

--- a/pkg/api/meta/priority.go
+++ b/pkg/api/meta/priority.go
@@ -67,7 +67,17 @@ func (m PriorityRESTMapper) ResourceFor(partiallySpecifiedResource unversioned.G
 		matchedGVRs := []unversioned.GroupVersionResource{}
 		for _, gvr := range remainingGVRs {
 			if resourceMatches(pattern, gvr) {
-				matchedGVRs = append(matchedGVRs, gvr)
+				// decimate dupes
+				found := false
+				for _, matchedGVR := range matchedGVRs {
+					if gvr == matchedGVR {
+						found = true
+						break
+					}
+				}
+				if !found {
+					matchedGVRs = append(matchedGVRs, gvr)
+				}
 			}
 		}
 
@@ -103,7 +113,17 @@ func (m PriorityRESTMapper) KindFor(partiallySpecifiedResource unversioned.Group
 		matchedGVKs := []unversioned.GroupVersionKind{}
 		for _, gvr := range remainingGVKs {
 			if kindMatches(pattern, gvr) {
-				matchedGVKs = append(matchedGVKs, gvr)
+				// decimate dupes
+				found := false
+				for _, matchedGVK := range matchedGVKs {
+					if gvr == matchedGVK {
+						found = true
+						break
+					}
+				}
+				if !found {
+					matchedGVKs = append(matchedGVKs, gvr)
+				}
 			}
 		}
 

--- a/pkg/client/typed/discovery/restmapper.go
+++ b/pkg/client/typed/discovery/restmapper.go
@@ -1,0 +1,166 @@
+package discovery
+
+import (
+	"sync"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apimachinery/registered"
+)
+
+type discoveryRESTMapper struct {
+	discoveryClient DiscoveryInterface
+
+	delegate meta.RESTMapper
+
+	initLock sync.Mutex
+}
+
+// NewRESTMapper that initializes using the discovery APIs, relying on group ordering and preferred versions
+// to build its appropriate priorities.  Only versions are registered with API machinery are added now.
+// TODO make this work with generic resources at some point.  For now, this handles enabled and disabled resources cleanly.
+func NewRESTMapper(discoveryClient DiscoveryInterface) meta.RESTMapper {
+	return &discoveryRESTMapper{discoveryClient: discoveryClient}
+}
+
+func (d *discoveryRESTMapper) getDelegate() (meta.RESTMapper, error) {
+	d.initLock.Lock()
+	defer d.initLock.Unlock()
+
+	if d.delegate != nil {
+		return d.delegate, nil
+	}
+
+	serverGroups, err := d.discoveryClient.ServerGroups()
+	if err != nil {
+		return nil, err
+	}
+
+	// always prefer our default group for now.  The version should be discovered from discovery, but this will hold us
+	// for quite some time.
+	resourcePriority := []unversioned.GroupVersionResource{
+		{Group: kapi.GroupName, Version: meta.AnyVersion, Resource: meta.AnyResource},
+	}
+	kindPriority := []unversioned.GroupVersionKind{
+		{Group: kapi.GroupName, Version: meta.AnyVersion, Kind: meta.AnyKind},
+	}
+	groupPriority := []string{}
+
+	unionMapper := meta.MultiRESTMapper{}
+
+	for _, group := range serverGroups.Groups {
+		if len(group.Versions) == 0 {
+			continue
+		}
+		groupPriority = append(groupPriority, group.Name)
+
+		if len(group.PreferredVersion.Version) != 0 {
+			preferredVersion := unversioned.GroupVersion{Group: group.Name, Version: group.PreferredVersion.Version}
+			if registered.IsEnabledVersion(preferredVersion) {
+				resourcePriority = append(resourcePriority, preferredVersion.WithResource(meta.AnyResource))
+				kindPriority = append(kindPriority, preferredVersion.WithKind(meta.AnyKind))
+			}
+		}
+
+		for _, discoveryVersion := range group.Versions {
+			version := unversioned.GroupVersion{Group: group.Name, Version: discoveryVersion.Version}
+			if !registered.IsEnabledVersion(version) {
+				continue
+			}
+			groupMeta, err := registered.Group(group.Name)
+			if err != nil {
+				return nil, err
+			}
+			resources, err := d.discoveryClient.ServerResourcesForGroupVersion(version.String())
+			if err != nil {
+				return nil, err
+			}
+
+			versionMapper := meta.NewDefaultRESTMapper([]unversioned.GroupVersion{version}, groupMeta.InterfacesFor)
+			for _, resource := range resources.APIResources {
+				// TODO properly handle resource versus kind
+				gvk := version.WithKind(resource.Kind)
+
+				scope := meta.RESTScopeNamespace
+				if !resource.Namespaced {
+					scope = meta.RESTScopeRoot
+				}
+				versionMapper.Add(gvk, scope)
+
+				// TODO formalize this by checking to see if they support listing
+				versionMapper.Add(version.WithKind(resource.Kind+"List"), scope)
+			}
+
+			// we need to add List.  Its a special case of something we need that isn't in the discovery doc
+			if group.Name == kapi.GroupName {
+				versionMapper.Add(version.WithKind("List"), meta.RESTScopeNamespace)
+			}
+
+			unionMapper = append(unionMapper, versionMapper)
+		}
+	}
+
+	for _, group := range groupPriority {
+		resourcePriority = append(resourcePriority, unversioned.GroupVersionResource{Group: group, Version: meta.AnyVersion, Resource: meta.AnyResource})
+		kindPriority = append(kindPriority, unversioned.GroupVersionKind{Group: group, Version: meta.AnyVersion, Kind: meta.AnyKind})
+	}
+
+	return meta.PriorityRESTMapper{Delegate: unionMapper, ResourcePriority: resourcePriority, KindPriority: kindPriority}, nil
+}
+
+func (d *discoveryRESTMapper) KindFor(resource unversioned.GroupVersionResource) (unversioned.GroupVersionKind, error) {
+	delegate, err := d.getDelegate()
+	if err != nil {
+		return unversioned.GroupVersionKind{}, err
+	}
+	return delegate.KindFor(resource)
+}
+
+func (d *discoveryRESTMapper) KindsFor(resource unversioned.GroupVersionResource) ([]unversioned.GroupVersionKind, error) {
+	delegate, err := d.getDelegate()
+	if err != nil {
+		return nil, err
+	}
+	return delegate.KindsFor(resource)
+}
+
+func (d *discoveryRESTMapper) ResourceFor(input unversioned.GroupVersionResource) (unversioned.GroupVersionResource, error) {
+	delegate, err := d.getDelegate()
+	if err != nil {
+		return unversioned.GroupVersionResource{}, err
+	}
+	return delegate.ResourceFor(input)
+}
+
+func (d *discoveryRESTMapper) ResourcesFor(input unversioned.GroupVersionResource) ([]unversioned.GroupVersionResource, error) {
+	delegate, err := d.getDelegate()
+	if err != nil {
+		return nil, err
+	}
+	return delegate.ResourcesFor(input)
+}
+
+func (d *discoveryRESTMapper) RESTMapping(gk unversioned.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	delegate, err := d.getDelegate()
+	if err != nil {
+		return nil, err
+	}
+	return delegate.RESTMapping(gk, versions...)
+}
+
+func (d *discoveryRESTMapper) AliasesForResource(resource string) ([]string, bool) {
+	delegate, err := d.getDelegate()
+	if err != nil {
+		return nil, false
+	}
+	return delegate.AliasesForResource(resource)
+}
+
+func (d *discoveryRESTMapper) ResourceSingularizer(resource string) (singular string, err error) {
+	delegate, err := d.getDelegate()
+	if err != nil {
+		return resource, err
+	}
+	return delegate.ResourceSingularizer(resource)
+}

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -50,6 +50,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/metrics"
 	"k8s.io/kubernetes/pkg/apis/policy"
 	"k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/kubernetes/pkg/client/typed/discovery"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	clientset "k8s.io/kubernetes/pkg/client/unversioned/adapters/internalclientset"
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
@@ -252,9 +253,11 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 			if cfg.GroupVersion != nil {
 				cmdApiVersion = *cfg.GroupVersion
 			}
+
+			client, clientErr := clients.ClientForVersion(&unversioned.GroupVersion{Version: "v1"})
+
 			if discoverDynamicAPIs {
-				client, err := clients.ClientForVersion(&unversioned.GroupVersion{Version: "v1"})
-				CheckErr(err)
+				CheckErr(clientErr)
 
 				versions, gvks, err := GetThirdPartyGroupVersions(client.Discovery())
 				CheckErr(err)
@@ -297,23 +300,35 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 					mapper.RESTMapper = priorityMapper
 				}
 			}
-			outputRESTMapper := kubectl.OutputVersionMapper{RESTMapper: mapper, OutputVersions: []unversioned.GroupVersion{cmdApiVersion}}
-			priorityRESTMapper := meta.PriorityRESTMapper{
-				Delegate: outputRESTMapper,
-				ResourcePriority: []unversioned.GroupVersionResource{
-					{Group: api.GroupName, Version: meta.AnyVersion, Resource: meta.AnyResource},
-					{Group: extensions.GroupName, Version: meta.AnyVersion, Resource: meta.AnyResource},
-					{Group: metrics.GroupName, Version: meta.AnyVersion, Resource: meta.AnyResource},
-					{Group: federation.GroupName, Version: meta.AnyVersion, Resource: meta.AnyResource},
-				},
-				KindPriority: []unversioned.GroupVersionKind{
-					{Group: api.GroupName, Version: meta.AnyVersion, Kind: meta.AnyKind},
-					{Group: extensions.GroupName, Version: meta.AnyVersion, Kind: meta.AnyKind},
-					{Group: metrics.GroupName, Version: meta.AnyVersion, Kind: meta.AnyKind},
-					{Group: federation.GroupName, Version: meta.AnyVersion, Kind: meta.AnyKind},
-				},
+
+			// if we don't have a client, use the hardcoded RESTMapper as the next best thing
+			if client == nil {
+				outputRESTMapper := kubectl.OutputVersionMapper{RESTMapper: mapper, OutputVersions: []unversioned.GroupVersion{cmdApiVersion}}
+				priorityRESTMapper := meta.PriorityRESTMapper{
+					Delegate: outputRESTMapper,
+					ResourcePriority: []unversioned.GroupVersionResource{
+						{Group: api.GroupName, Version: meta.AnyVersion, Resource: meta.AnyResource},
+						{Group: extensions.GroupName, Version: meta.AnyVersion, Resource: meta.AnyResource},
+						{Group: metrics.GroupName, Version: meta.AnyVersion, Resource: meta.AnyResource},
+						{Group: federation.GroupName, Version: meta.AnyVersion, Resource: meta.AnyResource},
+					},
+					KindPriority: []unversioned.GroupVersionKind{
+						{Group: api.GroupName, Version: meta.AnyVersion, Kind: meta.AnyKind},
+						{Group: extensions.GroupName, Version: meta.AnyVersion, Kind: meta.AnyKind},
+						{Group: metrics.GroupName, Version: meta.AnyVersion, Kind: meta.AnyKind},
+						{Group: federation.GroupName, Version: meta.AnyVersion, Kind: meta.AnyKind},
+					},
+				}
+				return priorityRESTMapper, api.Scheme
 			}
-			return priorityRESTMapper, api.Scheme
+
+			return kubectl.OutputVersionMapper{
+				RESTMapper: meta.MultiRESTMapper{
+					discovery.NewRESTMapper(client.Discovery()),
+					mapper,
+				},
+				OutputVersions: []unversioned.GroupVersion{cmdApiVersion},
+			}, api.Scheme
 		},
 		Client: func() (*client.Client, error) {
 			return clients.ClientForVersion(nil)


### PR DESCRIPTION
Drop-in `DiscoveryRESTMapper` that handles known types so that disabling a resource on a server prevents the client from trying to hit it and allows that client to fall-back to an alternate location/resource. 

@krousey ptal.  We just created this downstream.  https://github.com/openshift/origin/pull/8991
