### PR TITLE
GCE provider: Retry all rate limited calls

### DIFF
--- a/pkg/util/testing/fake_handler.go
+++ b/pkg/util/testing/fake_handler.go
@@ -118,3 +118,18 @@ func (f *FakeHandler) ValidateRequest(t TestInterface, expectedPath, expectedMet
 		}
 	}
 }
+
+// Returns a HandlerFunc that handles count requests using
+// firstHandler, then passes control to nextHandler, e.g.
+// HandleNRequestsThen(3, FakeHandler(someError), FakeHandler(success))
+func HandleNRequestsThen(count int, firstHandler, nextHandler http.HandlerFunc) http.HandlerFunc {
+	calls := 0
+	return func(w http.ResponseWriter, req *http.Request) {
+		if calls < count {
+			calls++
+			firstHandler(w, req)
+			return
+		}
+		nextHandler(w, req)
+	}
+}


### PR DESCRIPTION
[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()

Whenever we see "Limit Exceeded", retry the GCE call. This is based on
some internal work I did on the GKE side as well, but it's actually
easier in k8s because I can hook the RoundTripper more easily.

More towards #26119
