### PR TITLE
nodecontroller: Fix log message on successful update

### DIFF
--- a/pkg/controller/node/nodecontroller.go
+++ b/pkg/controller/node/nodecontroller.go
@@ -375,8 +375,9 @@ func (nc *NodeController) allocateOrOccupyCIDR(obj interface{}) {
 	glog.V(4).Infof("Assigning node %s CIDR %s", node.Name, podCIDR)
 	for rep := 0; rep < podCIDRUpdateRetry; rep++ {
 		node.Spec.PodCIDR = podCIDR.String()
-		if _, err := nc.kubeClient.Core().Nodes().Update(node); err == nil {
-			glog.Errorf("Failed while updating Node.Spec.PodCIDR : %v", err)
+		if _, err := nc.kubeClient.Core().Nodes().Update(node); err != nil {
+			glog.Errorf("Failed while updating Node.Spec.PodCIDR (%d retries left): %v", podCIDRUpdateRetry-rep-1, err)
+		} else {
 			break
 		}
 		node, err = nc.kubeClient.Core().Nodes().Get(node.Name)


### PR DESCRIPTION
Seen in logs as:

```
E0524 20:05:01.102671      16 nodecontroller.go:379] Failed while updating Node.Spec.PodCIDR : <nil>
```

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
