### PR TITLE
Volume Deleter and Recycler are not Volumes

### DIFF
--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -102,7 +102,6 @@ type Unmounter interface {
 
 // Recycler provides methods to reclaim the volume resource.
 type Recycler interface {
-	Volume
 	// Recycle reclaims the resource.  Calls to this method should block until the recycling task is complete.
 	// Any error returned indicates the volume has failed to be reclaimed.  A nil return indicates success.
 	Recycle() error
@@ -121,7 +120,6 @@ type Provisioner interface {
 // the deletion is complete. Any error returned indicates the volume has failed to be reclaimed.
 // A nil return indicates success.
 type Deleter interface {
-	Volume
 	// This method should block until completion.
 	Delete() error
 }


### PR DESCRIPTION
Cargo cult fix.  Mounter/Unmounter (nee Builder/Cleaner) model a single volume.  Deleter and Recycler do not.  Mounter and Unmounter have a reason for this approach (different structs and information available), the others do not.  This is part of a simplification series.
