### PR TITLE
Teach create-kubeconfig() to deal with multi path KUBECONFIG

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -71,10 +71,16 @@ function create-kubeconfig() {
   fi
 
   # KUBECONFIG determines the file we write to, but it may not exist yet
-  if [[ ! -e "${KUBECONFIG}" ]]; then
-    mkdir -p $(dirname "${KUBECONFIG}")
-    touch "${KUBECONFIG}"
-  fi
+  OLD_IFS=$IFS
+  IFS=':'
+  for cfg in ${KUBECONFIG} ; do
+    if [[ ! -e "${cfg}" ]]; then
+      mkdir -p "$(dirname "${cfg}")"
+      touch "${cfg}"
+    fi
+  done
+  IFS=$OLD_IFS
+
   local cluster_args=(
       "--server=${KUBE_SERVER:-https://${KUBE_MASTER_IP}}"
   )


### PR DESCRIPTION
When KUBECONFIG is in the form "A:B:C" make sure each file is
created.

fixes #17778

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/26244)

<!-- Reviewable:end -->
