### PR TITLE
Increase the cpu reservation for the fluentd-es pod so that it can survive the scalability tests.

### DIFF
--- a/cluster/saltbase/salt/fluentd-es/fluentd-es.yaml
+++ b/cluster/saltbase/salt/fluentd-es/fluentd-es.yaml
@@ -13,7 +13,7 @@ spec:
       limits:
         memory: 200Mi
       requests:
-        cpu: 100m
+        cpu: 200m
         memory: 200Mi
     volumeMounts:
     - name: varlog


### PR DESCRIPTION
xref: https://github.com/kubernetes/kubernetes/issues/26185
