### PR TITLE
Add assert.NotNil for test case

### DIFF
--- a/pkg/kubelet/server/stats/summary.go
+++ b/pkg/kubelet/server/stats/summary.go
@@ -344,7 +344,7 @@ func (sb *summaryBuilder) containerInfoV2ToNetworkStats(name string, info *cadvi
 			}
 		}
 	}
-	glog.Warningf("Missing default interface %q for s", network.DefaultInterfaceName, name)
+	glog.Warningf("Missing default interface %q for %s", network.DefaultInterfaceName, name)
 	return nil
 }
 

--- a/pkg/kubelet/server/stats/summary_test.go
+++ b/pkg/kubelet/server/stats/summary_test.go
@@ -321,6 +321,7 @@ func testTime(base time.Time, seed int) time.Time {
 }
 
 func checkNetworkStats(t *testing.T, label string, seed int, stats *kubestats.NetworkStats) {
+	assert.NotNil(t, stats)
 	assert.EqualValues(t, testTime(timestamp, seed).Unix(), stats.Time.Time.Unix(), label+".Net.Time")
 	assert.EqualValues(t, seed+offsetNetRxBytes, *stats.RxBytes, label+".Net.RxBytes")
 	assert.EqualValues(t, seed+offsetNetRxErrors, *stats.RxErrors, label+".Net.RxErrors")


### PR DESCRIPTION
I hardcode the `DefaultInterfaceName` from `eth0` to `eth-k8sdefault` at release 1.2.0,  in order to test my CNI plugins. When running the test, it panics and prints wrongly formatted messages as below.

In the test case `TestBuildSummary`, `containerInfoV2ToNetworkStats` will return `nil` if `DefaultInterfaceName` is not `eth0`. So maybe we should add `assert.NotNil` to the test case.

```
ok      k8s.io/kubernetes/pkg/kubelet/server    0.591s
W0523 03:25:28.257074    2257 summary.go:311] Missing default interface "eth-k8sdefault" for s%!(EXTRA string=node:FooNode)
W0523 03:25:28.257322    2257 summary.go:311] Missing default interface "eth-k8sdefault" for s%!(EXTRA string=pod:test0_pod1)
W0523 03:25:28.257361    2257 summary.go:311] Missing default interface "eth-k8sdefault" for s%!(EXTRA string=pod:test0_pod0)
W0523 03:25:28.257419    2257 summary.go:311] Missing default interface "eth-k8sdefault" for s%!(EXTRA string=pod:test2_pod0)
--- FAIL: TestBuildSummary (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x471817]

goroutine 16 [running]:
testing.func·006()
        /usr/src/go/src/testing/testing.go:441 +0x181
k8s.io/kubernetes/pkg/kubelet/server/stats.checkNetworkStats(0xc20806d3b0, 0x140bbc0, 0x4, 0x0, 0x0)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubelet/server/stats/summary_test.go:296 +0xc07
k8s.io/kubernetes/pkg/kubelet/server/stats.TestBuildSummary(0xc20806d3b0)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubelet/server/stats/summary_test.go:124 +0x11d2
testing.tRunner(0xc20806d3b0, 0x1e43180)
        /usr/src/go/src/testing/testing.go:447 +0xbf
created by testing.RunTests
        /usr/src/go/src/testing/testing.go:555 +0xa8b
```
