### PR TITLE
Use --cluster-version for GKE regardless of DOGFOOD_GCLOUD

### DIFF
--- a/cluster/gke/util.sh
+++ b/cluster/gke/util.sh
@@ -143,11 +143,7 @@ function kube-up() {
     "--num-nodes=${NUM_MINIONS}"
     "--network=${NETWORK}"
   )
-  if [[ ! -z "${DOGFOOD_GCLOUD:-}" ]]; then
-    create_args+=("--cluster-version=${CLUSTER_API_VERSION:-}")
-  else
-    create_args+=("--cluster-api-version=${CLUSTER_API_VERSION:-}")
-  fi
+  create_args+=("--cluster-version=${CLUSTER_API_VERSION:-}")
 
   # Bring up the cluster.
   "${GCLOUD}" ${CMD_GROUP:-} container clusters create "${CLUSTER_NAME}" "${create_args[@]}"


### PR DESCRIPTION
`--cluster-api-version` no longer exists in `gcloud`, and shouldn't be used.

This is necessary is for v1.0 -> v1.2 upgrade tests.
