### PR TITLE
Enable node e2e accounting on systemd

### DIFF
--- a/test/e2e_node/environment/setup_host.sh
+++ b/test/e2e_node/environment/setup_host.sh
@@ -25,6 +25,22 @@
 # - centos 7
 # - debian jessie
 
+# RHEL os detection
+cat /etc/*-release | grep "ID=\"rhel\""
+OS_RHEL=$?
+
+# On a systemd environment, enable cpu and memory accounting for all processes by default.
+if [ -d /etc/systemd ]; then
+  cat <<EOF >kubernetes-accounting.conf
+[Manager]
+DefaultCPUAccounting=yes
+DefaultMemoryAccounting=yes
+EOF
+  sudo mkdir -p /etc/systemd/system.conf.d/
+  sudo cp kubernetes-accounting.conf /etc/systemd/system.conf.d
+  sudo systemctl daemon-reload
+fi
+
 # Fixup sudoers require tty
 sudo grep -q "# Defaults    requiretty" /etc/sudoers
 if [ $? -ne 0 ] ; then
@@ -44,9 +60,18 @@ fi
 # Install docker
 hash docker 2>/dev/null
 if [ $? -ne 0 ]; then
-  curl -fsSL https://get.docker.com/ | sh
-  sudo service docker start
-  sudo systemctl enable docker.service
+  # RHEL platforms should always install from RHEL repository
+  # This will install the latest supported stable docker platform on RHEL
+  if [ $OS_RHEL -eq 0 ]; then
+    sudo yum install -y docker-latest
+    sudo groupadd docker
+    sudo systemctl enable docker-latest.service
+    sudo systemctl start docker-latest.service
+  else
+    curl -fsSL https://get.docker.com/ | sh
+    sudo service docker start
+    sudo systemctl enable docker.service
+  fi
 fi
 
 # Allow jenkins access to docker
@@ -55,10 +80,13 @@ sudo usermod -a -G docker jenkins
 # install lxc
 cat /etc/*-release | grep "ID=debian"
 if [ $? -ne 0 ]; then
-  sudo apt-get install lxc -y
-  lxc-checkconfig
-  sudo sed -i 's/GRUB_CMDLINE_LINUX="\(.*\)"/GRUB_CMDLINE_LINUX="\1 cgroup_enable=memory"/' /etc/default/grub
-  sudo update-grub
+  hash apt-get 2>/dev/null
+  if [ $? -ne 1 ]; then
+    sudo apt-get install lxc -y
+    lxc-checkconfig
+    sudo sed -i 's/GRUB_CMDLINE_LINUX="\(.*\)"/GRUB_CMDLINE_LINUX="\1 cgroup_enable=memory"/' /etc/default/grub
+    sudo update-grub  
+  fi
 fi
 
 # delete init kubelet from containervm so that is doesn't startup


### PR DESCRIPTION
Updated the e2e setup.sh script to enable cpu and memory accounting.

Related to https://github.com/kubernetes/kubernetes/issues/26198

/cc @pwittrock 
