### PR TITLE
routecontroller: Add wait.NonSlidingUntil, use it

### DIFF
--- a/pkg/controller/route/routecontroller.go
+++ b/pkg/controller/route/routecontroller.go
@@ -50,7 +50,7 @@ func New(routes cloudprovider.Routes, kubeClient clientset.Interface, clusterNam
 }
 
 func (rc *RouteController) Run(syncPeriod time.Duration) {
-	go wait.Until(func() {
+	go wait.NonSlidingUntil(func() {
 		if err := rc.reconcileNodeRoutes(); err != nil {
 			glog.Errorf("Couldn't reconcile node routes: %v", err)
 		}

--- a/pkg/kubelet/server/stats/volume_stat_caculator.go
+++ b/pkg/kubelet/server/stats/volume_stat_caculator.go
@@ -61,7 +61,7 @@ func (s *volumeStatCalculator) StartOnce() *volumeStatCalculator {
 	s.startO.Do(func() {
 		go wait.JitterUntil(func() {
 			s.calcAndStoreStats()
-		}, s.jitterPeriod, 1.0, s.stopChannel)
+		}, s.jitterPeriod, 1.0, true, s.stopChannel)
 	})
 	return s
 }

--- a/pkg/util/wait/wait_test.go
+++ b/pkg/util/wait/wait_test.go
@@ -45,6 +45,26 @@ func TestUntil(t *testing.T) {
 	<-called
 }
 
+func TestNonSlidingUntil(t *testing.T) {
+	ch := make(chan struct{})
+	close(ch)
+	NonSlidingUntil(func() {
+		t.Fatal("should not have been invoked")
+	}, 0, ch)
+
+	ch = make(chan struct{})
+	called := make(chan struct{})
+	go func() {
+		NonSlidingUntil(func() {
+			called <- struct{}{}
+		}, 0, ch)
+		close(called)
+	}()
+	<-called
+	close(ch)
+	<-called
+}
+
 func TestUntilReturnsImmediately(t *testing.T) {
 	now := time.Now()
 	ch := make(chan struct{})
@@ -63,14 +83,14 @@ func TestJitterUntil(t *testing.T) {
 	close(ch)
 	JitterUntil(func() {
 		t.Fatal("should not have been invoked")
-	}, 0, 1.0, ch)
+	}, 0, 1.0, true, ch)
 
 	ch = make(chan struct{})
 	called := make(chan struct{})
 	go func() {
 		JitterUntil(func() {
 			called <- struct{}{}
-		}, 0, 1.0, ch)
+		}, 0, 1.0, true, ch)
 		close(called)
 	}()
 	<-called
@@ -83,7 +103,7 @@ func TestJitterUntilReturnsImmediately(t *testing.T) {
 	ch := make(chan struct{})
 	JitterUntil(func() {
 		close(ch)
-	}, 30*time.Second, 1.0, ch)
+	}, 30*time.Second, 1.0, true, ch)
 	if now.Add(25 * time.Second).Before(time.Now()) {
 		t.Errorf("JitterUntil did not return immediately when the stop chan was closed inside the func")
 	}
@@ -98,7 +118,7 @@ func TestJitterUntilNegativeFactor(t *testing.T) {
 		JitterUntil(func() {
 			called <- struct{}{}
 			<-received
-		}, time.Second, -30.0, ch)
+		}, time.Second, -30.0, true, ch)
 	}()
 	// first loop
 	<-called


### PR DESCRIPTION
[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]() Make sure the reconciliation loop kicks in again immediately if it
takes a loooooong time.
