### PR TITLE
GCE provider: Revert rate limits

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -118,10 +118,7 @@ type rateLimitedRoundTripper struct {
 }
 
 func (rl *rateLimitedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	startTime := time.Now()
 	rl.limiter.Accept()
-	// TODO: Reduce verbosity once #26119 is fixed.
-	glog.V(0).Infof("GCE api call: %s %s (throttled for %v)", req.Method, req.URL.String(), time.Now().Sub(startTime))
 	return rl.rt.RoundTrip(req)
 }
 

--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -76,15 +76,16 @@ const (
 
 // GCECloud is an implementation of Interface, LoadBalancer and Instances for Google Compute Engine.
 type GCECloud struct {
-	service           *compute.Service
-	containerService  *container.Service
-	projectID         string
-	region            string
-	localZone         string   // The zone in which we are running
-	managedZones      []string // List of zones we are spanning (for Ubernetes-Lite, primarily when running on master)
-	networkURL        string
-	nodeTags          []string // List of tags to use on firewall rules for load balancers
-	useMetadataServer bool
+	service                  *compute.Service
+	containerService         *container.Service
+	projectID                string
+	region                   string
+	localZone                string   // The zone in which we are running
+	managedZones             []string // List of zones we are spanning (for Ubernetes-Lite, primarily when running on master)
+	networkURL               string
+	nodeTags                 []string // List of tags to use on firewall rules for load balancers
+	useMetadataServer        bool
+	operationPollRateLimiter flowcontrol.RateLimiter
 }
 
 type Config struct {
@@ -110,16 +111,6 @@ func init() {
 // Raw access to the underlying GCE service, probably should only be used for e2e tests
 func (g *GCECloud) GetComputeService() *compute.Service {
 	return g.service
-}
-
-type rateLimitedRoundTripper struct {
-	rt      http.RoundTripper
-	limiter flowcontrol.RateLimiter
-}
-
-func (rl *rateLimitedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	rl.limiter.Accept()
-	return rl.rt.RoundTrip(req)
 }
 
 func getProjectAndZone() (string, string, error) {
@@ -292,11 +283,6 @@ func CreateGCECloud(projectID, region, zone string, managedZones []string, netwo
 	}
 
 	client := oauth2.NewClient(oauth2.NoContext, tokenSource)
-	// Override the transport to make it rate-limited.
-	client.Transport = &rateLimitedRoundTripper{
-		rt:      client.Transport,
-		limiter: flowcontrol.NewTokenBucketRateLimiter(10, 100), // 10 qps, 100 bucket size.
-	}
 	svc, err := compute.New(client)
 	if err != nil {
 		return nil, err
@@ -325,16 +311,19 @@ func CreateGCECloud(projectID, region, zone string, managedZones []string, netwo
 		glog.Infof("managing multiple zones: %v", managedZones)
 	}
 
+	operationPollRateLimiter := flowcontrol.NewTokenBucketRateLimiter(10, 100) // 10 qps, 100 bucket size.
+
 	return &GCECloud{
-		service:           svc,
-		containerService:  containerSvc,
-		projectID:         projectID,
-		region:            region,
-		localZone:         zone,
-		managedZones:      managedZones,
-		networkURL:        networkURL,
-		nodeTags:          nodeTags,
-		useMetadataServer: useMetadataServer,
+		service:                  svc,
+		containerService:         containerSvc,
+		projectID:                projectID,
+		region:                   region,
+		localZone:                zone,
+		managedZones:             managedZones,
+		networkURL:               networkURL,
+		nodeTags:                 nodeTags,
+		useMetadataServer:        useMetadataServer,
+		operationPollRateLimiter: operationPollRateLimiter,
 	}, nil
 }
 
@@ -415,6 +404,7 @@ func (gce *GCECloud) waitForOp(op *compute.Operation, getOperation func(operatio
 	opName := op.Name
 	return wait.Poll(operationPollInterval, operationPollTimeoutDuration, func() (bool, error) {
 		start := time.Now()
+		gce.operationPollRateLimiter.Accept()
 		duration := time.Now().Sub(start)
 		if duration > 5*time.Second {
 			glog.Infof("pollOperation: waited %v for %v", duration, opName)

--- a/pkg/cloudprovider/providers/gce/gce_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_test.go
@@ -17,15 +17,11 @@ limitations under the License.
 package gce
 
 import (
-	"net/http"
-	"net/http/httptest"
 	"reflect"
 	"testing"
 
 	compute "google.golang.org/api/compute/v1"
-	"k8s.io/kubernetes/pkg/util/flowcontrol"
 	"k8s.io/kubernetes/pkg/util/rand"
-	utiltesting "k8s.io/kubernetes/pkg/util/testing"
 )
 
 func TestGetRegion(t *testing.T) {
@@ -263,32 +259,4 @@ func TestComputeUpdate(t *testing.T) {
 		// 	t.Errorf("computeTargetPool(%v, %v) => removed %v, wanted %v", tc.tp, tc.instances, gotRem, tc.wantToRemove)
 		// }
 	}
-}
-
-func TestRateLimitedRoundTripper(t *testing.T) {
-	handler := utiltesting.FakeHandler{StatusCode: 200}
-	server := httptest.NewServer(&handler)
-	defer server.Close()
-
-	method := "GET"
-	path := "/foo/bar"
-
-	req, err := http.NewRequest(method, server.URL+path, nil)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	// TODO(zmerlynn): Validate the rate limiter is actually getting called.
-	client := http.Client{
-		Transport: &rateLimitedRoundTripper{
-			rt:      http.DefaultTransport,
-			limiter: flowcontrol.NewFakeAlwaysRateLimiter(),
-		},
-	}
-	_, err = client.Do(req)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	handler.ValidateRequest(t, path, method, nil)
 }


### PR DESCRIPTION
[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]() This reverts #26140 and #26170. After testing with #26263, #26140 is unnecessary, and we need to be able to prioritize normal GET / POST requests over operation polling requests, which is what the pre-#26140 requests do.

c.f. #26119 
