### PR TITLE
Move the defaults setting of GCI to util.sh

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -34,21 +34,17 @@ REGISTER_MASTER_KUBELET=${REGISTER_MASTER:-true}
 PREEMPTIBLE_NODE=${PREEMPTIBLE_NODE:-false}
 PREEMPTIBLE_MASTER=${PREEMPTIBLE_MASTER:-false}
 
-
-# Today the cluster startup scripts asssume the master and the nodes use the
-# same OS distro, thus same set of initialization instructions (e.g., metadata,
-# startup scripts, etc.). The current workaround is the hack in util.sh that
-# reloads <os_distro>/helper.sh in the gap between when the master is created
-# and when the nodes are created.
 # TODO(#26183): Provide a way to differentiate master OS distro and node OS
 # distro.
 OS_DISTRIBUTION=${KUBE_OS_DISTRIBUTION:-gci}
-# For GCI, leaving it blank will auto-select the latest GCI image on the `dev`
-# channel.
+# By default a cluster will be started with the master on GCI and nodes on
+# containervm. If you are updating the containervm version, update this
+# variable.
+CVM_VERSION=container-v1-3-v20160517
 MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-}
 MASTER_IMAGE_PROJECT=${KUBE_GCE_MASTER_PROJECT:-google-containers}
-NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-container-v1-3-v20160517}
-NODE_IMAGE_PROJECT=${KUBE_GCE_NODE_PROJECT:-google-containers}
+NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-"${MASTER_IMAGE}"}
+NODE_IMAGE_PROJECT=${KUBE_GCE_NODE_PROJECT:-"${MASTER_IMAGE_PROJECT}"}
 CONTAINER_RUNTIME=${KUBE_CONTAINER_RUNTIME:-docker}
 RKT_VERSION=${KUBE_RKT_VERSION:-0.5.5}
 

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -35,13 +35,17 @@ KUBE_APISERVER_REQUEST_TIMEOUT=300
 PREEMPTIBLE_NODE=${PREEMPTIBLE_NODE:-false}
 PREEMPTIBLE_MASTER=${PREEMPTIBLE_MASTER:-false}
 
+# TODO(#26183): Provide a way to differentiate master OS distro and node OS
+# distro.
 OS_DISTRIBUTION=${KUBE_OS_DISTRIBUTION:-gci}
-# For GCI, leaving it blank will auto-select the latest GCI image on the `dev`
-# channel.
+# By default a cluster will be started with the master on GCI and nodes on
+# containervm. If you are updating the containervm version, update this
+# variable.
+CVM_VERSION=container-v1-3-v20160517
 MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-}
 MASTER_IMAGE_PROJECT=${KUBE_GCE_MASTER_PROJECT:-google-containers}
-NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-container-v1-3-v20160517}
-NODE_IMAGE_PROJECT=${KUBE_GCE_NODE_PROJECT:-google-containers}
+NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-"${MASTER_IMAGE}"}
+NODE_IMAGE_PROJECT=${KUBE_GCE_NODE_PROJECT:-"${MASTER_IMAGE_PROJECT}"}
 CONTAINER_RUNTIME=${KUBE_CONTAINER_RUNTIME:-docker}
 RKT_VERSION=${KUBE_RKT_VERSION:-0.5.5}
 

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -31,19 +31,16 @@ else
 fi
 
 if [[ "${OS_DISTRIBUTION}" == "gci" ]]; then
-  # If the master or node image is not set, we use the latest GCI dev image.
-  # Otherwise, we respect whatever set by the user.
+  # If the master image is not set, we use the latest GCI dev image.
+  # Otherwise, we respect whatever is set by the user.
   gci_images=( $(gcloud compute images list --project google-containers \
       --regexp='gci-dev.*' --format='value(name)') )
-  if [[ -z "${MASTER_IMAGE:-}" ]]; then
-    MASTER_IMAGE="${gci_images[0]}"
-    MASTER_IMAGE_PROJECT="google-containers"
-  fi
-  if [[ -z "${NODE_IMAGE:-}" ]]; then
-    NODE_IMAGE="${gci_images[0]}"
-    NODE_IMAGE_PROJECT="google-containers"
-  fi
-
+  MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-"${gci_images[0]}"}
+  MASTER_IMAGE_PROJECT=${KUBE_GCE_MASTER_PROJECT:-google-containers}
+  # The default node image when using GCI is still the Debian based ContainerVM
+  # until GCI gets validated for node usage.
+  NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-${CVM_VERSION}}
+  NODE_IMAGE_PROJECT=${KUBE_GCE_NODE_PROJECT:-google-containers}
 fi
 
 # Verfiy cluster autoscaler configuration.

--- a/hack/verify-flags/exceptions.txt
+++ b/hack/verify-flags/exceptions.txt
@@ -9,6 +9,7 @@ cluster/aws/templates/configure-vm-aws.sh:  env-to-grains "runtime_config"
 cluster/aws/templates/configure-vm-aws.sh:  kubelet_api_servers: '${KUBELET_APISERVER}'
 cluster/centos/util.sh:  local node_ip=${node#*@}
 cluster/gce/config-default.sh:# reloads <os_distro>/helper.sh in the gap between when the master is created
+cluster/gce/config-test.sh:# reloads <os_distro>/helper.sh in the gap between when the master is created
 cluster/gce/configure-vm.sh:  advertise_address: '${EXTERNAL_IP}'
 cluster/gce/configure-vm.sh:  api_servers: '${KUBERNETES_MASTER_NAME}'
 cluster/gce/configure-vm.sh:  cloud_config: ${CLOUD_CONFIG}


### PR DESCRIPTION
fixes #26291 

This change recovers some of the side effects of
https://github.com/kubernetes/kubernetes/pull/26197, i.e., keeps the defaults of
`NODE_IMAGE` and `NODE_IMAGE_PROJECT` to `MASTER_IMAGE` and
`MASTER_IMAGE_PROJECT`, for backward compatibility. Although it keeps
`OS_DISTRIBUTION` defaulting to `gci`, the default settings of these vars are
moved to `cluster/gce/util.sh` and conditioned on `OS_DISTRIBUTION==gci`.

@euank @roberthbailey Can you review?
