### PR TITLE
Allow for pods to define container labels

### DIFF
--- a/pkg/kubelet/dockertools/labels_test.go
+++ b/pkg/kubelet/dockertools/labels_test.go
@@ -61,6 +61,11 @@ func TestLabels(t *testing.T) {
 			Namespace: "test_pod_namespace",
 			UID:       "test_pod_uid",
 			DeletionGracePeriodSeconds: &deletionGracePeriod,
+			Annotations: map[string]string{
+				"annot1": "value1",
+				kubernetesAnnotationContainerLabelPrefix:           "value2",
+				kubernetesAnnotationContainerLabelPrefix + "name1": "value3",
+			},
 		},
 		Spec: api.PodSpec{
 			Containers:                    []api.Container{*container},
@@ -85,6 +90,13 @@ func TestLabels(t *testing.T) {
 	containerInfo := getContainerInfoFromLabel(labels)
 	if !reflect.DeepEqual(containerInfo, expected) {
 		t.Errorf("expected %v, got %v", expected, containerInfo)
+	}
+	if labels["name1"] != "value3" {
+		t.Errorf("wrong labels, got %v, didn't have 'name1=value3'", labels)
+	}
+	if labels["containers.label"] != "" || labels["containers.label/"] != "" ||
+		labels["annot1"] != "" {
+		t.Errorf("wrong labels, got %v - shouldn't have container.label or annot1")
 	}
 
 	// Test when DeletionGracePeriodSeconds, TerminationGracePeriodSeconds and Lifecycle are nil,


### PR DESCRIPTION
See https://groups.google.com/forum/#!topic/kubernetes-sig-node/gijxbYC7HT8 for some background.

Usecase:
we need a way to attach labels to the containers in a pod so that we can filter them "by labels" when we do a `docker ps` on that node. In this case we use labels to store a tenant ID and use the `--filter` option on `docker ps` to ensure that we only expose containers to the correct tenants.

Additional Discussion:
- the idea of using an env var for this metadata came up, but we can't filter on env vars in a `docker ps`
- eventually we may want to enable support for labels on the container spec in a pod, but that would require an API change

Code Change:
When a pod has an annotation of the form: `container.label/XXX=YYY`
then a label on each container in the pod will be created of the form: `XXX=YYY`

Signed-off-by: Doug Davis dug@us.ibm.com
