### PR TITLE
Use ubuntu-slim to reduce size of the iperf:e2e image

### DIFF
--- a/test/images/iperf/Dockerfile
+++ b/test/images/iperf/Dockerfile
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM fedora
+FROM gcr.io/google_containers/ubuntu-slim:0.2
 MAINTAINER jay@apache.org
-RUN dnf install -y git gcc gcc-c++ make
-RUN git clone https://github.com/esnet/iperf.git
-RUN cd iperf && git checkout 2.0.4-RELEASE && ./configure && make && make install && rm -rf iperf
+RUN apt-get update && apt-get install -y --no-install-recommends iperf bash \
+  && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/* \
+  && ln -s /usr/bin/iperf /usr/local/bin/iperf
 RUN ls -altrh /usr/local/bin/iperf


### PR DESCRIPTION
from

```
gcr.io/google_containers/iperf     e2e      8b3cc7064090        5 weeks ago     737.9 MB
```

to

```
gcr.io/google_containers/iperf     e2e      204325491636        33 seconds ago  61.09 MB
```

related to https://github.com/kubernetes/kubernetes/pull/25784#issuecomment-221706886
ping @bprashanth 
