### PR TITLE
AWS: Fix long-standing bug in stringSetToPointers

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws_utils.go
+++ b/pkg/cloudprovider/providers/aws/aws_utils.go
@@ -25,7 +25,7 @@ func stringSetToPointers(in sets.String) []*string {
 	if in == nil {
 		return nil
 	}
-	out := make([]*string, len(in))
+	out := make([]*string, 0, len(in))
 	for k := range in {
 		out = append(out, aws.String(k))
 	}


### PR DESCRIPTION
Instead of N pointers, we were returning N null pointers, followed by the real
thing. It's not clear why we didn't trip on this until now, maybe there is a
new server-side check for empty subnetID strings.

Also add better logging around this.

Please remove release-note tag, bump priority to P1 (or P0, since this can cause customer throttling if enough services need to be synced at the same time), and backport to 1.2/1.1. I don't think I can do any of those.

cc @justinsb 
