### PR TITLE
kubectl: fix URLVisitor error message

### DIFF
--- a/pkg/kubectl/resource/visitor.go
+++ b/pkg/kubectl/resource/visitor.go
@@ -259,7 +259,7 @@ func readHttpWithRetries(get httpget, duration time.Duration, u string, attempts
 
 		// Error - Set the error condition from the StatusCode
 		if statusCode != 200 {
-			err = fmt.Errorf("unable to read URL %q, server reported %d %s", u, statusCode, status)
+			err = fmt.Errorf("unable to read URL %q, server reported %s, status code=%d", u, status, statusCode)
 		}
 
 		if statusCode >= 500 && statusCode < 600 {


### PR DESCRIPTION
The status of a failed fetch will usually include the code, resulting in a duplicate code in the error message:

```
unable to read URL "http://git:8080/ruby-hello-world.git", server reported 401 401 Unauthorized
```

This change rearranges them so at least the message doesn't stutter (and includes the code in case it's not part of the status):

```
unable to read URL "http://git:8080/ruby-hello-world.git", server reported 401 Unauthorized, status code 401
```

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
