### PR TITLE
Increase cluster resize timeout in e2e tests from 2 min to 5 min

### DIFF
--- a/test/e2e/cluster_size_autoscaling.go
+++ b/test/e2e/cluster_size_autoscaling.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	scaleTimeout = 2 * time.Minute
+	scaleTimeout = 5 * time.Minute
 )
 
 var _ = framework.KubeDescribe("Cluster size autoscaling [Feature:ClusterSizeAutoscaling] [Slow]", func() {


### PR DESCRIPTION
cc: @piosz @fgrzadkowski 
