### PR TITLE
[WIP] Add resolution tips for volume mount errors via describe events

### DIFF
--- a/pkg/kubelet/volumes_util.go
+++ b/pkg/kubelet/volumes_util.go
@@ -1,0 +1,79 @@
+package kubelet
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/golang/glog"
+)
+
+// AddMountErrorHint performs some basic analysis
+// on the current mount error returned and will
+// add a user hint or resolution tip for enhanced UXP
+func (kl *Kubelet) AddMountErrorHint(volpath string, volname string, inerr error) error{
+	glog.V(4).Infof("Analyzing mount error and adding user resolution hint")
+
+	//General - applies to all
+	if strings.Contains(inerr.Error(), "lstat") && strings.Contains(inerr.Error(), "permission denied"){
+		return fmt.Errorf("%v\nResolution hint: (%s) The pod is running, and the mount succeeded, however the mount is not accessbile due to permissions.\nCheck the POSIX based permissions (owner, groups and others) on your mounted directory.\nIf needed containers and pods can utilize and pass in a securityContext specifying runAsUser (uid/owner), or additional linux groups such as fsGroup (for block) or SupplementalGroups (for shared).\nWork with the storage adminstrator to properly set up access\n", inerr, volname)
+	}
+	if strings.Contains(inerr.Error(), "endpoints") && strings.Contains(inerr.Error(), "not found") {
+		return fmt.Errorf("%v\nResolution hint: (%s) Make sure the above endpoint exists. To persist endpoints, they should be created as a service.\n", inerr, volname)
+	}
+	if strings.Contains(inerr.Error(), "secrets") && strings.Contains(inerr.Error(), "missing") {
+		return fmt.Errorf("%v\nResolution hint: (%s) Make sure the above secret exists.  Secret is needed for rbd mount and access\n", inerr, volname)
+	}
+
+
+	// NFS
+	if strings.Contains(volpath, "kubernetes.io~nfs"){
+		if strings.Contains(inerr.Error(), "access denied by server") {
+			return fmt.Errorf("%v\nResolution hint: (%s) Check the NFS Server exports, likely that the host/node was not added. (/etc/exports).  Rerun exportfs -ra on NFS Server after updated.\n", inerr, volname)
+		}
+		if strings.Contains(inerr.Error(), "Connection timed out"){
+			return fmt.Errorf("%v\nResolution hint: (%s) Check and make sure the NFS Server exists (ensure that correct IPAddress/Hostname was given) and is available/reachable.\n Also make sure firewall ports are open on both client and NFS Server (2049 v4 and 2049, 20048 and 111 for v3)\ntelnet <nfs server> <port> and showmount <nfs server> are useful commands to try.\n", inerr, volname)
+		}
+		if strings.Contains(inerr.Error(), "wrong fs type, bad option, bad superblock"){
+			return fmt.Errorf("%v\nResolution hint: (%s) This typically means that the nfs client packages are not installed on the host/node (nfsutils and rpcbind).  Make sure they are installed and running on your host client\n", inerr, volname)
+		}
+	}
+
+	// Glusterfs (this depends on PR 24808 to read proper root cause error from log)
+	if strings.Contains(volpath, "kubernetes.io~glusterfs"){
+		if strings.Contains(inerr.Error(), "Connection timed out") || strings.Contains(inerr.Error(), "Transport endpoint is not connected"){
+			return fmt.Errorf("%v\nResolution hint: (%s) Check and make sure the Gluster Server exists (ensure that correct IPAddress/Hostname was given in the endpoints) and is available/reachable.\n", inerr, volname)
+		}
+		if strings.Contains(inerr.Error(), "mount: unknown filesystem type"){
+			return fmt.Errorf("%v\nResolution hint: (%s) Check and make sure the glusterfs-client package is installed (rpm -qa 'gluster*') on your nodes.\nIf not, install the client package on your nodes (i.e. yum install glusterfs-client -y).\n", inerr, volname)
+		}
+		// this should only get hit if 24808 doesn't merge or an undefined error happens
+		if strings.Contains(inerr.Error(), "Mount failed. Please check the log"){
+			return fmt.Errorf("%v\nResolution hint: (%s) Open the gluster log file, you can see this above in the mount arguments from the error (i.e. --log-file=<path>.\n", inerr, volname)
+		}
+	}
+
+	// AWS
+	if strings.Contains(volpath, "kubernetes.io~aws-ebs"){
+		if strings.Contains(inerr.Error(), "InvalidVolume.NotFound") {
+			return fmt.Errorf("%v\nResolution hint: (%s) Check AWS available volumes for the appropriate availability zone, and make sure the specified volumeID exists and is spelled correctly.\n", inerr, volname)
+		}
+		if strings.Contains(inerr.Error(), "InvalidParameterValue") && strings.Contains(inerr.Error(), "volume is invalid. Expected: 'vol-") {
+			return fmt.Errorf("%v\nResolution hint: (%s) Check AWS available volumes, make sure the specified volumeID exists, is spelled and typed correctly and is valid format.\n", inerr, volname)
+		}
+		if strings.Contains(inerr.Error(), "VolumeInUse:") || strings.Contains(inerr.Error(), "is already attached to an instance") {
+			return fmt.Errorf("%v\nResolution hint: (%s) The AWS volume is already attached to another instance and only one node per volume is allowed for EBS block devices (can not share across nodes). Another volume will need to be provisioned for use with this pod\n", inerr, volname)
+		}
+	}
+
+
+	//GCE
+
+
+
+	//RBD
+
+
+
+	// TODO: rest of plugins as errors are reported
+	return inerr
+}


### PR DESCRIPTION
This is based on UXP and the idea of offering users some tips and hints on how to resolve common mounting errors.  I've tossed around several implementation ideas for this but think this is the best approach since it centralizes the logic within the volumes.mountExternalVolumes.

Also there is some additional discussion for this in issue #23982

This also depends (at least for Glusterfs) that PR #24808 merges.

Anyway wanted to start some discussion on this.  Below are some examples of the output a user would see based on this PR

```
Events:
  FirstSeen LastSeen    Count   From            SubobjectPath   Type        Reason      Message
  --------- --------    -----   ----            -------------   --------    ------      -------
  12s       12s     1   {default-scheduler }            Normal      Scheduled   Successfully assigned bb-gluster-pod1 to 127.0.0.1
  12s       2s      2   {kubelet 127.0.0.1}         Warning     FailedMount Unable to mount volumes for pod "bb-gluster-pod1_default(86253c16-2282-11e6-a845-525400495970)": failed to instantiate mounter for volume: glustervol using plugin: kubernetes.io/glusterfs with a root cause: endpoints "glusterfs-cluster" not found
Resolution hint: (glustervol) Make sure the above endpoint exists. To persist endpoints, they should be created as a service.
```

```
 14s    14s 1   {kubelet 127.0.0.1}     Warning FailedMount Unable to mount volumes for pod "bb-gluster-pod1_default(86253c16-2282-11e6-a845-525400495970)": glusterfs: mount failed: Mount failed: exit status 32
Mounting arguments: 192.168.122.222:myVol2 /var/lib/kubelet/pods/86253c16-2282-11e6-a845-525400495970/volumes/kubernetes.io~glusterfs/glustervol glusterfs [log-file=/var/lib/kubelet/plugins/kubernetes.io/glusterfs/glustervol/glusterfs.log]
Output: mount: unknown filesystem type 'glusterfs'
Resolution hint: (glustervol) Check and make sure the glusterfs-client package is installed (rpm -qa 'gluster*') on your nodes.
If not, install the client package on your nodes (i.e. yum install glusterfs-client -y).
```

```
  6s        5s      2   {kubelet 127.0.0.1}                 Warning     FailedMount Unable to mount volumes for pod "nfs-bb-pod1_default(de44ed68-21ea-11e6-be31-525400495970)": lstat /var/lib/kubelet/pods/de44ed68-21ea-11e6-be31-525400495970/volumes/kubernetes.io~nfs/nfsvol/..: permission denied
Resolution hint: (nfsvol) The pod is running, and the mount succeeded, however the mount is not accessbile due to permissions.  
Check the POSIX based permissions (owner, groups and others) on your mounted directory.  
If needed containers and pods can utilize and pass in a securityContext specifying runAsUser (uid/owner), or additional linux groups such as fsGroup (for block) or SupplementalGroups (for shared).
Work with the storage adminstrator to properly set up access
```

```
Events:
  FirstSeen LastSeen    Count   From                            SubobjectPath   Type        Reason      Message
  --------- --------    -----   ----                            -------------   --------    ------      -------
  1m        1m      1   {default-scheduler }                            Normal      Scheduled   Successfully assigned aws-ebs-bb-pod2 to ip-172-30-0-215.us-west-2.compute.internal
  19s       19s     1   {kubelet ip-172-30-0-215.us-west-2.compute.internal}            Warning     FailedMount Unable to mount volumes for pod "aws-ebs-bb-pod2_default(fb68166a-1ea6-11e6-88cc-06155fc6b4db)": Could not attach EBS Disk "vol-5634f7f2": Error attaching EBS volume: InvalidVolume.NotFound: The volume 'vol-5634f7f2' does not exist.
        status code: 400, request id: 
Resolution hint: (ebsvol) Check AWS available volumes for the appropriate availability zone, and make sure the specified volumeID exists and is spelled correctly.
```

```
Events:
  FirstSeen LastSeen    Count   From                            SubobjectPath   Type        Reason      Message
  --------- --------    -----   ----                            -------------   --------    ------      -------
  1m        1m      1   {default-scheduler }                            Normal      Scheduled   Successfully assigned aws-ebs-bb-pod1 to ip-172-30-0-113.us-west-2.compute.internal
  52s       52s     1   {kubelet ip-172-30-0-113.us-west-2.compute.internal}            Warning     FailedMount Unable to mount volumes for pod "aws-ebs-bb-pod1_default(1b7c79a2-1ea7-11e6-802a-06cfea9d6949)": Could not attach EBS Disk "vol-b877020a": Error attaching EBS volume: VolumeInUse: vol-b877020a is already attached to an instance
        status code: 400, request id: 
Resolution hint: (ebsvol) The AWS volume is already attached to another instance and only one node per volume is allowed for EBS block devices (can not share across nodes). Another volume will need to be provisioned for use with this pod
```

if no match is found, then the normal error is returned without any additional hints...

Alternative Approaches could be:
1.  at each error point in the plugin add the resolution hint (nfs.go, aws_ebs.go, etc...).  I didn't do this approach because it would result in more code and more files being touched as opposed to catching the error in the centralized mountExternalVolume
1.  rather than keep the logic in code, could externalize into a file/resource that could be added to, edited/customized by admins, seemed like overkill at this point, but might be a good future direction.

@pmorie @erinboyd 
