### PR TITLE
e2e: fix the expectation of always running kube-system pods

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -4080,3 +4080,19 @@ func UpdatePodWithRetries(client *client.Client, ns, name string, update func(*a
 	}
 	return nil, fmt.Errorf("Too many retries updating Pod %q", name)
 }
+
+func GetPodsInNamespace(c *client.Client, ns string, ignoreLabels map[string]string) ([]*api.Pod, error) {
+	pods, err := c.Pods(ns).List(api.ListOptions{})
+	if err != nil {
+		return []*api.Pod{}, err
+	}
+	ignoreSelector := labels.SelectorFromSet(ignoreLabels)
+	filtered := []*api.Pod{}
+	for _, p := range pods.Items {
+		if len(ignoreLabels) != 0 && ignoreSelector.Matches(labels.Set(p.Labels)) {
+			continue
+		}
+		filtered = append(filtered, &p)
+	}
+	return filtered, nil
+}

--- a/test/e2e/resize_nodes.go
+++ b/test/e2e/resize_nodes.go
@@ -346,12 +346,14 @@ var _ = framework.KubeDescribe("Nodes [Disruptive]", func() {
 	var systemPodsNo int32
 	var c *client.Client
 	var ns string
+	ignoreLabels := framework.ImagePullerLabels
 	BeforeEach(func() {
 		c = f.Client
 		ns = f.Namespace.Name
-		systemPods, err := c.Pods(api.NamespaceSystem).List(api.ListOptions{})
+		systemPods, err := framework.GetPodsInNamespace(c, ns, ignoreLabels)
 		Expect(err).NotTo(HaveOccurred())
-		systemPodsNo = int32(len(systemPods.Items))
+		systemPodsNo = int32(len(systemPods))
+
 	})
 
 	// Slow issue #13323 (8 min)
@@ -396,7 +398,7 @@ var _ = framework.KubeDescribe("Nodes [Disruptive]", func() {
 			// the cluster is restored to health.
 			By("waiting for system pods to successfully restart")
 
-			err := framework.WaitForPodsRunningReady(api.NamespaceSystem, systemPodsNo, framework.PodReadyBeforeTimeout, framework.ImagePullerLabels)
+			err := framework.WaitForPodsRunningReady(api.NamespaceSystem, systemPodsNo, framework.PodReadyBeforeTimeout, ignoreLabels)
 			Expect(err).NotTo(HaveOccurred())
 		})
 


### PR DESCRIPTION
Instruct the tests to ignore image prepull pods.

This fixes the kubernetes-e2e-gce-serial suite.

/cc @bprashanth  @k8s-oncall
