### PR TITLE
Reduce unit test latency: only one etcd registry prefix, api version; do not duplicate builds

### DIFF
--- a/hack/jenkins/test-dockerized.sh
+++ b/hack/jenkins/test-dockerized.sh
@@ -36,17 +36,15 @@ export PATH=${GOPATH}/bin:${PWD}/third_party/etcd:/usr/local/go/bin:${PATH}
 retry go get github.com/tools/godep && godep version
 retry go get github.com/jstemmer/go-junit-report
 
-# Enable the Go race detector.
-export KUBE_RACE=-race
-# Disable coverage report
-export KUBE_COVER="n"
-# Produce a JUnit-style XML test report for Jenkins.
-export KUBE_JUNIT_REPORT_DIR=${WORKSPACE}/artifacts
 export ARTIFACTS_DIR=${WORKSPACE}/artifacts
-# Save the verbose stdout as well.
-export KUBE_KEEP_VERBOSE_TEST_OUTPUT=y
-export KUBE_TIMEOUT='-timeout 300s'
+export KUBE_COVER="n"  # Disable coverage report
 export KUBE_INTEGRATION_TEST_MAX_CONCURRENCY=4
+export KUBE_JUNIT_REPORT_DIR=${WORKSPACE}/artifacts  # junix xml files
+export KUBE_KEEP_VERBOSE_TEST_OUTPUT=y  # Save the verbose stdout as well.
+export KUBE_RACE=-race  # Enable the Go race detector.
+export KUBE_TEST_API_VERSIONS="${KUBE_TEST_API_VERSIONS:-v1}"
+export KUBE_TEST_ETCD_PREFIXES="${KUBE_TEST_ETCD_PREFIXES:-kubernetes.io/registry}"
+export KUBE_TIMEOUT='-timeout 300s'
 export LOG_LEVEL=4
 
 cd /go/src/k8s.io/kubernetes

--- a/hack/jenkins/test-dockerized.sh
+++ b/hack/jenkins/test-dockerized.sh
@@ -50,7 +50,6 @@ export LOG_LEVEL=4
 cd /go/src/k8s.io/kubernetes
 rm -rf Godeps/_workspace # Temporary until _workspace is fully obliterated
 
-./hack/build-go.sh
 go install ./cmd/...
 ./hack/install-etcd.sh
 


### PR DESCRIPTION
Ref #25940

WIll just test one on presubmit; will change postcommit jenkins to do everything
Also skip hack/build-go.sh as this is already done before the tests start.
