### PR TITLE
Fix docker load error in federation image push

### DIFF
--- a/federation/cluster/common.sh
+++ b/federation/cluster/common.sh
@@ -156,7 +156,7 @@ function push-federated-images {
 
 	echo "Load: ${imageFile}"
 	# Load the image. Trust we know what it's called, as docker load provides no help there :(
-	docker load -q < "${imageFile}"
+	docker load < "${imageFile}"
 
 	local srcImageTag="$(cat ${imageFolder}/${binary}.docker_tag)"
 	local dstImageTag="${FEDERATION_IMAGE_TAG:-$srcImageTag}"


### PR DESCRIPTION
from kubernetes-federation-build log

``` sh
Load: /var/lib/jenkins/workspace/kubernetes-federation-build/cluster/../_output/release-stage/server/linux-amd64/kubernetes/server/bin/federation-apiserver.tar
flag provided but not defined: -q
See 'docker load --help'.
!!! Error in /var/lib/jenkins/workspace/kubernetes-federation-build/federation/cluster/common.sh:159
  'docker load -q < "${imageFile}"' exited with status 2
Call stack:
  1: /var/lib/jenkins/workspace/kubernetes-federation-build/federation/cluster/common.sh:159 push-federated-images(...)
  2: ./build/push-ci-build.sh:54 main(...)
Exiting with status 1
```

\cc @nikhiljindal @quinton-hoole 

The version of docker on the Kubernetes Jenkins server does not support `docker load -q`, so I've removed that flag.

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
