### PR TITLE
rkt: Fix panic in setting ReadOnlyRootFS

### DIFF
--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -784,16 +784,19 @@ func (r *Runtime) newAppcRuntimeApp(pod *api.Pod, c api.Container, requiresPrivi
 	}
 
 	ra := appcschema.RuntimeApp{
-		Name:           convertToACName(c.Name),
-		Image:          appcschema.RuntimeImage{ID: *hash},
-		App:            imgManifest.App,
-		ReadOnlyRootFS: *c.SecurityContext.ReadOnlyRootFilesystem,
+		Name:  convertToACName(c.Name),
+		Image: appcschema.RuntimeImage{ID: *hash},
+		App:   imgManifest.App,
 		Annotations: []appctypes.Annotation{
 			{
 				Name:  *appctypes.MustACIdentifier(k8sRktContainerHashAnno),
 				Value: strconv.FormatUint(kubecontainer.HashContainer(&c), 10),
 			},
 		},
+	}
+
+	if c.SecurityContext != nil && c.SecurityContext.ReadOnlyRootFilesystem != nil {
+		ra.ReadOnlyRootFS = *c.SecurityContext.ReadOnlyRootFilesystem
 	}
 
 	if mnt != nil {


### PR DESCRIPTION
What the title says. I wish this method were broken out in a reasonably unit testable way. fixing this panic is more important for the second though, testing will come in a later commit.

I observed the panic in a `./hack/local-up-cluster.sh` run with rkt as the container runtime.

This is also the panic that's failing our jenkins against master ([recent run](https://console.cloud.google.com/m/cloudstorage/b/rktnetes-jenkins/o/logs/kubernetes-e2e-gce/1946/artifacts/jenkins-e2e-minion-group-qjh3/kubelet.log for the log output of a recent run))

cc @tmrts @yifan-gu 
