### PR TITLE
Various kubenet fixes (panics and bugs and cidrs, oh my)

### DIFF
--- a/pkg/kubelet/network/cni/testing/mock_cni.go
+++ b/pkg/kubelet/network/cni/testing/mock_cni.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// mock_cni is a mock of the `libcni.CNI` interface. It's a handwritten mock
+// because there are only two functions to deal with.
+package mock_cni
+
+import (
+	"github.com/appc/cni/libcni"
+	"github.com/appc/cni/pkg/types"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockCNI struct {
+	mock.Mock
+}
+
+func (m *MockCNI) AddNetwork(net *libcni.NetworkConfig, rt *libcni.RuntimeConf) (*types.Result, error) {
+	args := m.Called(net, rt)
+	return args.Get(0).(*types.Result), args.Error(1)
+}
+
+func (m *MockCNI) DelNetwork(net *libcni.NetworkConfig, rt *libcni.RuntimeConf) error {
+	args := m.Called(net, rt)
+	return args.Error(0)
+}

--- a/pkg/kubelet/network/kubenet/kubenet_linux.go
+++ b/pkg/kubelet/network/kubenet/kubenet_linux.go
@@ -67,7 +67,7 @@ type kubenetNetworkPlugin struct {
 	host        network.Host
 	netConfig   *libcni.NetworkConfig
 	loConfig    *libcni.NetworkConfig
-	cniConfig   *libcni.CNIConfig
+	cniConfig   libcni.CNI
 	shaper      bandwidth.BandwidthShaper
 	podCIDRs    map[kubecontainer.ContainerID]string
 	MTU         int
@@ -374,7 +374,7 @@ func (plugin *kubenetNetworkPlugin) TearDownPod(namespace string, name string, i
 	if hasCIDR {
 		glog.V(5).Infof("Removing pod CIDR %s from shaper", cidr)
 		// shaper wants /32
-		if addr, _, err := net.ParseCIDR(cidr); err != nil {
+		if addr, _, err := net.ParseCIDR(cidr); err == nil {
 			if err = plugin.shaper.Reset(fmt.Sprintf("%s/32", addr.String())); err != nil {
 				glog.Warningf("Failed to remove pod CIDR %s from shaper: %v", cidr, err)
 			}

--- a/pkg/kubelet/network/kubenet/kubenet_linux.go
+++ b/pkg/kubelet/network/kubenet/kubenet_linux.go
@@ -317,7 +317,7 @@ func (plugin *kubenetNetworkPlugin) SetUpPod(namespace string, name string, id k
 	if err != nil {
 		return err
 	}
-	if res.IP4 == nil || res.IP4.IP.IP.String() == "" {
+	if res.IP4 == nil || len(res.IP4.IP.IP) != net.IPv4len {
 		return fmt.Errorf("CNI plugin reported no IPv4 address for container %v.", id)
 	}
 	plugin.podIPs[id] = res.IP4.IP.IP.String()

--- a/pkg/kubelet/network/kubenet/kubenet_linux.go
+++ b/pkg/kubelet/network/kubenet/kubenet_linux.go
@@ -317,10 +317,14 @@ func (plugin *kubenetNetworkPlugin) SetUpPod(namespace string, name string, id k
 	if err != nil {
 		return err
 	}
-	if res.IP4 == nil || len(res.IP4.IP.IP) != net.IPv4len {
+	if res.IP4 == nil {
 		return fmt.Errorf("CNI plugin reported no IPv4 address for container %v.", id)
 	}
-	plugin.podIPs[id] = res.IP4.IP.IP.String()
+	ip4 := res.IP4.IP.IP.To4()
+	if ip4 == nil {
+		return fmt.Errorf("CNI plugin reported an invalid IPv4 address for container %v: %+v.", id, res.IP4)
+	}
+	plugin.podIPs[id] = ip4.String()
 
 	// Put the container bridge into promiscuous mode to force it to accept hairpin packets.
 	// TODO: Remove this once the kernel bug (#20096) is fixed.

--- a/pkg/kubelet/network/kubenet/kubenet_linux.go
+++ b/pkg/kubelet/network/kubenet/kubenet_linux.go
@@ -369,7 +369,8 @@ func (plugin *kubenetNetworkPlugin) TearDownPod(namespace string, name string, i
 		glog.V(5).Infof("Removing pod IP %s from shaper", podIP)
 		// shaper wants /32
 		if err := plugin.shaper().Reset(fmt.Sprintf("%s/32", podIP)); err != nil {
-			glog.Warningf("Failed to remove pod IP %s from shaper: %v", podIP, err)
+			// Possible bandwidth shaping wasn't enabled for this pod anyways
+			glog.V(4).Infof("Failed to remove pod IP %s from shaper: %v", podIP, err)
 		}
 	}
 	if err := plugin.delContainerFromNetwork(plugin.netConfig, network.DefaultInterfaceName, namespace, name, id); err != nil {

--- a/pkg/kubelet/network/kubenet/kubenet_linux_test.go
+++ b/pkg/kubelet/network/kubenet/kubenet_linux_test.go
@@ -135,8 +135,8 @@ func TestTeardownCallsShaper(t *testing.T) {
 	mockcni := &mock_cni.MockCNI{}
 	kubenet := newFakeKubenetPlugin(map[kubecontainer.ContainerID]string{}, fexec, fhost)
 	kubenet.cniConfig = mockcni
-	kubenet.shaper = fshaper
 	kubenet.iptables = ipttest.NewFake()
+	kubenet.bandwidthShaper = fshaper
 
 	mockcni.On("DelNetwork", mock.AnythingOfType("*libcni.NetworkConfig"), mock.AnythingOfType("*libcni.RuntimeConf")).Return(nil)
 

--- a/pkg/kubelet/network/kubenet/kubenet_linux_test.go
+++ b/pkg/kubelet/network/kubenet/kubenet_linux_test.go
@@ -19,14 +19,24 @@ package kubenet
 import (
 	"fmt"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"testing"
+
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/network"
+	"k8s.io/kubernetes/pkg/kubelet/network/cni/testing"
 	nettest "k8s.io/kubernetes/pkg/kubelet/network/testing"
+	"k8s.io/kubernetes/pkg/util/bandwidth"
 	"k8s.io/kubernetes/pkg/util/exec"
-	"testing"
+	ipttest "k8s.io/kubernetes/pkg/util/iptables/testing"
 )
 
-func newFakeKubenetPlugin(initMap map[kubecontainer.ContainerID]string, execer exec.Interface, host network.Host) network.NetworkPlugin {
+// test it fulfills the NetworkPlugin interface
+var _ network.NetworkPlugin = &kubenetNetworkPlugin{}
+
+func newFakeKubenetPlugin(initMap map[kubecontainer.ContainerID]string, execer exec.Interface, host network.Host) *kubenetNetworkPlugin {
 	return &kubenetNetworkPlugin{
 		podCIDRs: initMap,
 		execer:   execer,
@@ -109,6 +119,40 @@ func TestGetPodNetworkStatus(t *testing.T) {
 			t.Errorf("Test case %d expects ip %s but got %s", i, tc.expectIP, out.IP.String())
 		}
 	}
+}
+
+// TestTeardownBeforeSetUp tests that a `TearDown` call does call
+// `shaper.Reset`
+func TestTeardownCallsShaper(t *testing.T) {
+	fexec := &exec.FakeExec{
+		CommandScript: []exec.FakeCommandAction{},
+		LookPathFunc: func(file string) (string, error) {
+			return fmt.Sprintf("/fake-bin/%s", file), nil
+		},
+	}
+	fhost := nettest.NewFakeHost(nil)
+	fshaper := &bandwidth.FakeShaper{}
+	mockcni := &mock_cni.MockCNI{}
+	kubenet := newFakeKubenetPlugin(map[kubecontainer.ContainerID]string{}, fexec, fhost)
+	kubenet.cniConfig = mockcni
+	kubenet.shaper = fshaper
+	kubenet.iptables = ipttest.NewFake()
+
+	mockcni.On("DelNetwork", mock.AnythingOfType("*libcni.NetworkConfig"), mock.AnythingOfType("*libcni.RuntimeConf")).Return(nil)
+
+	details := make(map[string]interface{})
+	details[network.NET_PLUGIN_EVENT_POD_CIDR_CHANGE_DETAIL_CIDR] = "10.0.0.1/24"
+	kubenet.Event(network.NET_PLUGIN_EVENT_POD_CIDR_CHANGE, details)
+
+	existingContainerID := kubecontainer.BuildContainerID("docker", "123")
+	kubenet.podCIDRs[existingContainerID] = "10.0.0.1/24"
+
+	if err := kubenet.TearDownPod("namespace", "name", existingContainerID); err != nil {
+		t.Fatalf("Unexpected error in TearDownPod: %v", err)
+	}
+	assert.Equal(t, []string{"10.0.0.1/32"}, fshaper.ResetCIDRs, "shaper.Reset should have been called")
+
+	mockcni.AssertExpectations(t)
 }
 
 //TODO: add unit test for each implementation of network plugin interface

--- a/pkg/kubelet/network/kubenet/kubenet_linux_test.go
+++ b/pkg/kubelet/network/kubenet/kubenet_linux_test.go
@@ -38,17 +38,17 @@ var _ network.NetworkPlugin = &kubenetNetworkPlugin{}
 
 func newFakeKubenetPlugin(initMap map[kubecontainer.ContainerID]string, execer exec.Interface, host network.Host) *kubenetNetworkPlugin {
 	return &kubenetNetworkPlugin{
-		podCIDRs: initMap,
-		execer:   execer,
-		MTU:      1460,
-		host:     host,
+		podIPs: initMap,
+		execer: execer,
+		MTU:    1460,
+		host:   host,
 	}
 }
 
 func TestGetPodNetworkStatus(t *testing.T) {
 	podIPMap := make(map[kubecontainer.ContainerID]string)
-	podIPMap[kubecontainer.ContainerID{ID: "1"}] = "10.245.0.2/32"
-	podIPMap[kubecontainer.ContainerID{ID: "2"}] = "10.245.0.3/32"
+	podIPMap[kubecontainer.ContainerID{ID: "1"}] = "10.245.0.2"
+	podIPMap[kubecontainer.ContainerID{ID: "2"}] = "10.245.0.3"
 
 	testCases := []struct {
 		id          string
@@ -145,7 +145,7 @@ func TestTeardownCallsShaper(t *testing.T) {
 	kubenet.Event(network.NET_PLUGIN_EVENT_POD_CIDR_CHANGE, details)
 
 	existingContainerID := kubecontainer.BuildContainerID("docker", "123")
-	kubenet.podCIDRs[existingContainerID] = "10.0.0.1/24"
+	kubenet.podIPs[existingContainerID] = "10.0.0.1"
 
 	if err := kubenet.TearDownPod("namespace", "name", existingContainerID); err != nil {
 		t.Fatalf("Unexpected error in TearDownPod: %v", err)


### PR DESCRIPTION
This PR fixes the following issues:
1. Corrects an inverse error-check that prevented `shaper.Reset` from ever being called with a correct ip address
2. Fix an issue where `parseCIDR` would fail after a kubelet restart due to an IP being stored instead of a CIDR being stored in the cache.
3. Fix an issue where kubenet could panic in TearDownPod if it was called before SetUpPod (e.g. after a kubelet restart).. because of bug number 1, this didn't happen except in rare situations (see 2 for why such a rare situation might happen)

This adds a test, but more would definitely be useful.
The commits are also granular enough I could split this up more if desired.

I'm also not super-familiar with this code, so review and feedback would be welcome.

Testing done:

```
$ cat examples/egress/egress.yml
 apiVersion: v1
kind: Pod
metadata:
  labels:
    name: egress
  name: egress-output
  annotations: {"kubernetes.io/ingress-bandwidth": "300k"}
spec:
  restartPolicy: Never
  containers:
    - name: egress
      image: busybox
      command: ["sh", "-c", "sleep 60"]
$ cat kubelet.log
...
Running: tc filter add dev cbr0 protocol ip parent 1:0 prio 1 u32 match ip dst 10.0.0.5/32 flowid 1:1
# setup
...
Running: tc filter del dev cbr0 parent 1:proto ip prio 1 handle 800::800 u32
# teardown
```

I also did various other bits of manual testing and logging to hunt down the panic and other issues, but don't have anything to paste for that 

cc @dcbw @kubernetes/sig-network 
