### PR TITLE
Avoid duplicate building in Jenkins unit/integration job

### DIFF
--- a/hack/jenkins/test-dockerized.sh
+++ b/hack/jenkins/test-dockerized.sh
@@ -52,7 +52,6 @@ export LOG_LEVEL=4
 cd /go/src/k8s.io/kubernetes
 rm -rf Godeps/_workspace # Temporary until _workspace is fully obliterated
 
-./hack/build-go.sh
 go install ./cmd/...
 ./hack/install-etcd.sh
 

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -126,8 +126,13 @@ function kubectl-with-retry()
 }
 
 kube::util::trap_add cleanup EXIT SIGINT
-
 kube::util::ensure-temp-dir
+
+"${KUBE_ROOT}/hack/build-go.sh" \
+    cmd/kubectl \
+    cmd/kube-apiserver \
+    cmd/kube-controller-manager
+
 kube::etcd::start
 
 ETCD_HOST=${ETCD_HOST:-127.0.0.1}
@@ -163,6 +168,9 @@ kube::log::status "Running kubectl with no options"
 
 # Only run kubelet on platforms it supports
 if [[ "$(go env GOHOSTOS)" == "linux" ]]; then
+
+"${KUBE_ROOT}/hack/build-go.sh" \
+    cmd/kubelet
 
 kube::log::status "Starting kubelet in masterless mode"
 "${KUBE_OUTPUT_HOSTBIN}/kubelet" \


### PR DESCRIPTION
Partially adopts #26392: don't run `hack/build-go.sh` in the unit/integration job, since we do that already for e2e.

We do need to still build kubectl, however, so do that in `hack/test-cmd.sh`.

x-ref #25940
