### PR TITLE
Add shell completion of POD to port-forward

### DIFF
--- a/contrib/completions/bash/kubectl
+++ b/contrib/completions/bash/kubectl
@@ -322,7 +322,7 @@ __custom_func() {
             __kubectl_require_pod_and_container
             return
             ;;
-        kubectl_exec)
+        kubectl_exec | kubectl_port-forward)
             __kubectl_get_resource_pod
             return
             ;;


### PR DESCRIPTION
Includes the port-forward command as something that needs completion of the pod.
