### PR TITLE
Reduce shared informer ResyncPeriod

### DIFF
--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -63,7 +63,7 @@ func NewCMServer() *CMServer {
 			PVClaimBinderSyncPeriod:           unversioned.Duration{Duration: 10 * time.Minute},
 			HorizontalPodAutoscalerSyncPeriod: unversioned.Duration{Duration: 30 * time.Second},
 			DeploymentControllerSyncPeriod:    unversioned.Duration{Duration: 30 * time.Second},
-			MinResyncPeriod:                   unversioned.Duration{Duration: 12 * time.Hour},
+			MinResyncPeriod:                   unversioned.Duration{Duration: 1 * time.Minute},
 			RegisterRetryCount:                10,
 			PodEvictionTimeout:                unversioned.Duration{Duration: 5 * time.Minute},
 			NodeMonitorGracePeriod:            unversioned.Duration{Duration: 40 * time.Second},

--- a/pkg/controller/volume/attach_detach_controller.go
+++ b/pkg/controller/volume/attach_detach_controller.go
@@ -74,20 +74,6 @@ func NewAttachDetachController(
 	pvInformer framework.SharedInformer,
 	cloud cloudprovider.Interface,
 	plugins []volume.VolumePlugin) (AttachDetachController, error) {
-	// TODO: The default resyncPeriod for shared informers is 12 hours, this is
-	// unacceptable for the attach/detach controller. For example, if a pod is
-	// skipped because the node it is scheduled to didn't set its annotation in
-	// time, we don't want to have to wait 12hrs before processing the pod
-	// again.
-	// Luckily https://github.com/kubernetes/kubernetes/issues/23394 is being
-	// worked on and will split resync in to resync and relist. Once that
-	// happens the resync period can be set to something much faster (30
-	// seconds).
-	// If that issue is not resolved in time, then this controller will have to
-	// consider some unappealing alternate options: use a non-shared informer
-	// and set a faster resync period even if it causes relist, or requeue
-	// dropped pods so they are continuously processed until it is accepted or
-	// deleted (probably can't do this with sharedInformer), etc.
 	adc := &attachDetachController{
 		kubeClient:  kubeClient,
 		pvcInformer: pvcInformer,


### PR DESCRIPTION
The default resyncPeriod for shared informers is 12 hours, this is unacceptable for the attach/detach controller. For example, if a pod is skipped because the node it is scheduled to didn't set its annotation in
time, we don't want to have to wait 12hrs before processing the pod again.

With Issue https://github.com/kubernetes/kubernetes/issues/23394 (PR https://github.com/kubernetes/kubernetes/pull/24142) resync is split into resync and relist. Where relist is the expensive call to API server and resync just requeues items in the existing cache. Therefore, it should now be safe to set a much more aggressive ResyncPeriod (1 minute seems reasonable).

CC @kubernetes/goog-control-plane @kubernetes/sig-api-machinery @kubernetes/sig-scalability @timothysc @rrati @wojtek-t 
