### PR TITLE
Fix data race in volume controller unit test.

### DIFF
--- a/pkg/controller/persistentvolume/framework_test.go
+++ b/pkg/controller/persistentvolume/framework_test.go
@@ -472,6 +472,62 @@ func (r *volumeReactor) waitTest() {
 	}
 }
 
+// deleteVolumeEvent simulates that a volume has been deleted in etcd and
+// the controller receives 'volume deleted' event.
+func (r *volumeReactor) deleteVolumeEvent(volume *api.PersistentVolume) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	// Remove the volume from list of resulting volumes.
+	delete(r.volumes, volume.Name)
+
+	// Generate deletion event. Cloned volume is needed to prevent races (and we
+	// would get a clone from etcd too).
+	clone, _ := conversion.NewCloner().DeepCopy(volume)
+	volumeClone := clone.(*api.PersistentVolume)
+	r.volumeSource.Delete(volumeClone)
+}
+
+// deleteClaimEvent simulates that a claim has been deleted in etcd and the
+// controller receives 'claim deleted' event.
+func (r *volumeReactor) deleteClaimEvent(claim *api.PersistentVolumeClaim) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	// Remove the claim from list of resulting claims.
+	delete(r.claims, claim.Name)
+
+	// Generate deletion event. Cloned volume is needed to prevent races (and we
+	// would get a clone from etcd too).
+	clone, _ := conversion.NewCloner().DeepCopy(claim)
+	claimClone := clone.(*api.PersistentVolumeClaim)
+	r.claimSource.Delete(claimClone)
+}
+
+// addVolumeEvent simulates that a volume has been added in etcd and the
+// controller receives 'volume added' event.
+func (r *volumeReactor) addVolumeEvent(volume *api.PersistentVolume) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	r.volumes[volume.Name] = volume
+	// Generate event. No cloning is needed, this claim is not stored in the
+	// controller cache yet.
+	r.volumeSource.Add(volume)
+}
+
+// addClaimEvent simulates that a claim has been deleted in etcd and the
+// controller receives 'claim added' event.
+func (r *volumeReactor) addClaimEvent(claim *api.PersistentVolumeClaim) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	r.claims[claim.Name] = claim
+	// Generate event. No cloning is needed, this claim is not stored in the
+	// controller cache yet.
+	r.claimSource.Add(claim)
+}
+
 func newVolumeReactor(client *fake.Clientset, ctrl *PersistentVolumeController, volumeSource, claimSource *framework.FakeControllerSource, errors []reactorError) *volumeReactor {
 	reactor := &volumeReactor{
 		volumes:      make(map[string]*api.PersistentVolume),


### PR DESCRIPTION
Reactor must be locked when fiddling with reactor.volumes and reactor.claims. Therefore add new functions to add/delete volume/claim with sending an event.

Fixes #26345
