### PR TITLE
 Added warning msg for `kubectl get pods` and clarification msg for `kubectl create/run` in case of conflict with terminated pods/jobs 

### DIFF
--- a/pkg/api/resource_helpers.go
+++ b/pkg/api/resource_helpers.go
@@ -79,6 +79,11 @@ func IsPodReady(pod *Pod) bool {
 	return IsPodReadyConditionTrue(pod.Status)
 }
 
+// IsPodTerminated returns true if a pod is terminated with any status; false otherwise.
+func IsPodTerminated(pod *Pod) bool {
+	return pod.Status.Phase == PodSucceeded || pod.Status.Phase == PodFailed
+}
+
 // IsPodReady retruns true if a pod is ready; false otherwise.
 func IsPodReadyConditionTrue(status PodStatus) bool {
 	condition := GetPodReadyCondition(status)

--- a/pkg/apis/batch/resource_helpers.go
+++ b/pkg/apis/batch/resource_helpers.go
@@ -1,0 +1,12 @@
+package batch
+
+import "k8s.io/kubernetes/pkg/api"
+
+func IsJobFinished(j Job) bool {
+	for _, c := range j.Status.Conditions {
+		if (c.Type == JobComplete || c.Type == JobFailed) && c.Status == api.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/controller/job/controller.go
+++ b/pkg/controller/job/controller.go
@@ -113,7 +113,7 @@ func NewJobController(podInformer framework.SharedIndexInformer, kubeClient clie
 		framework.ResourceEventHandlerFuncs{
 			AddFunc: jm.enqueueController,
 			UpdateFunc: func(old, cur interface{}) {
-				if job := cur.(*batch.Job); !isJobFinished(job) {
+				if job := cur.(*batch.Job); !batch.IsJobFinished(*job) {
 					jm.enqueueController(job)
 				}
 			},
@@ -347,7 +347,7 @@ func (jm *JobController) syncJob(key string) error {
 		job.Status.StartTime = &now
 	}
 	// if job was finished previously, we don't want to redo the termination
-	if isJobFinished(&job) {
+	if batch.IsJobFinished(job) {
 		return nil
 	}
 	if pastActiveDeadline(&job) {
@@ -557,15 +557,6 @@ func filterPods(pods []api.Pod, phase api.PodPhase) int {
 		}
 	}
 	return result
-}
-
-func isJobFinished(j *batch.Job) bool {
-	for _, c := range j.Status.Conditions {
-		if (c.Type == batch.JobComplete || c.Type == batch.JobFailed) && c.Status == api.ConditionTrue {
-			return true
-		}
-	}
-	return false
 }
 
 // byCreationTimestamp sorts a list by creation timestamp, using their names as a tie breaker.

--- a/pkg/controller/job/controller_test.go
+++ b/pkg/controller/job/controller_test.go
@@ -646,17 +646,17 @@ func TestIsJobFinished(t *testing.T) {
 		},
 	}
 
-	if !isJobFinished(job) {
+	if !batch.IsJobFinished(*job) {
 		t.Error("Job was expected to be finished")
 	}
 
 	job.Status.Conditions[0].Status = api.ConditionFalse
-	if isJobFinished(job) {
+	if batch.IsJobFinished(*job) {
 		t.Error("Job was not expected to be finished")
 	}
 
 	job.Status.Conditions[0].Status = api.ConditionUnknown
-	if isJobFinished(job) {
+	if batch.IsJobFinished(*job) {
 		t.Error("Job was not expected to be finished")
 	}
 }

--- a/pkg/kubectl/cmd/autoscale.go
+++ b/pkg/kubectl/cmd/autoscale.go
@@ -168,7 +168,7 @@ func RunAutoscale(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []
 			return err
 		}
 
-		object, err = resource.NewHelper(hpa.Client, hpa.Mapping).Create(namespace, false, object)
+		object, err = resource.NewHelper(hpa.Client, hpa.Mapping).Create(namespace, name, false, object)
 		if err != nil {
 			return err
 		}

--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -152,7 +152,7 @@ func RunCreate(f *cmdutil.Factory, cmd *cobra.Command, out io.Writer, options *C
 
 // createAndRefresh creates an object from input info and refreshes info with that object
 func createAndRefresh(info *resource.Info) error {
-	obj, err := resource.NewHelper(info.Client, info.Mapping).Create(info.Namespace, true, info.Object)
+	obj, err := resource.NewHelper(info.Client, info.Mapping).Create(info.Namespace, info.Name, true, info.Object)
 	if err != nil {
 		return err
 	}
@@ -217,7 +217,7 @@ func RunCreateSubcommand(f *cmdutil.Factory, cmd *cobra.Command, out io.Writer, 
 		return err
 	}
 	if !options.DryRun {
-		obj, err = resource.NewHelper(client, mapping).Create(namespace, false, info.Object)
+		obj, err = resource.NewHelper(client, mapping).Create(namespace, "", false, info.Object)
 		if err != nil {
 			return err
 		}

--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -264,7 +264,7 @@ func RunExpose(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []str
 		}
 
 		// Serialize the object with the annotation applied.
-		object, err = resource.NewHelper(info.Client, info.Mapping).Create(namespace, false, object)
+		object, err = resource.NewHelper(info.Client, info.Mapping).Create(namespace, name, false, object)
 		if err != nil {
 			return err
 		}

--- a/pkg/kubectl/cmd/get_test.go
+++ b/pkg/kubectl/cmd/get_test.go
@@ -520,6 +520,7 @@ func TestGetMultipleTypeObjectsAsList(t *testing.T) {
 	cmd.SetOutput(buf)
 
 	cmd.Flags().Set("output", "json")
+	cmd.Flags().Set("no-headers", "true")
 	cmd.Run(cmd, []string{"pods,services"})
 
 	if tf.Printer.(*testPrinter).Objects != nil {

--- a/pkg/kubectl/cmd/replace.go
+++ b/pkg/kubectl/cmd/replace.go
@@ -237,7 +237,7 @@ func forceReplace(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []
 			}
 		}
 
-		obj, err := resource.NewHelper(info.Client, info.Mapping).Create(info.Namespace, true, info.Object)
+		obj, err := resource.NewHelper(info.Client, info.Mapping).Create(info.Namespace, info.Name, true, info.Object)
 		if err != nil {
 			return err
 		}

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -494,7 +494,7 @@ func createGeneratedObject(f *cmdutil.Factory, cmd *cobra.Command, generator kub
 			return nil, "", nil, nil, err
 		}
 
-		obj, err = resource.NewHelper(client, mapping).Create(namespace, false, info.Object)
+		obj, err = resource.NewHelper(client, mapping).Create(namespace, info.Name, false, info.Object)
 		if err != nil {
 			return nil, "", nil, nil, err
 		}

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -30,6 +30,11 @@ import (
 
 const (
 	kubectlAnnotationPrefix = "kubectl.kubernetes.io/"
+	Warn                    = `
+WARN: By default only active pods are displayed, to display terminated
+pods as well set -a, --show-all option. It is done intentionally to let see
+statuses they finish with.
+`
 	// TODO: auto-generate this
 	PossibleResourceTypes = `Possible resource types include (case insensitive): pods (po), services (svc), deployments,
 replicasets (rs), replicationcontrollers (rc), nodes (no), events (ev), limitranges (limits),

--- a/pkg/kubectl/resource/helper_test.go
+++ b/pkg/kubectl/resource/helper_test.go
@@ -202,7 +202,7 @@ func TestHelperCreate(t *testing.T) {
 			Versioner:       testapi.Default.MetadataAccessor(),
 			NamespaceScoped: true,
 		}
-		_, err := modifier.Create("bar", test.Modify, test.Object)
+		_, err := modifier.Create("bar", "", test.Modify, test.Object)
 		if (err != nil) != test.Err {
 			t.Errorf("%d: unexpected error: %t %v", i, test.Err, err)
 		}


### PR DESCRIPTION
Fixes #22986
    - added printing clarification on pod or job creation AlreadyExists error in case of the failure is due    to conflicting with pod/job in terminated state
    - added warning description regarding terminated pods to `get` long help message
    - added printing of warning message in case of `get pods`
## **Output examples:**
### # kubectl get pods

```
NAME             READY     STATUS       RESTARTS   AGE
test.pod             1/1       Running      0          6d
test3.pod            1/1       Running      0          3d

WARN: By default only active pods displayed, to display terminated
pods as well set -a, --show-all option. It is done intentionally to let see
statuses they finish with.
```
### # kubectl get pods -a

```
NAME                   READY     STATUS       RESTARTS   AGE
test.pod                   1/1       Running      0          6d
test2.pod             0/1       Completed    0          7d
test3.pod            1/1       Running      0          3d
```
### # kubectl get jobs

```
NAME                   READY     STATUS       RESTARTS   AGE
test.pod               1/1       Running      0          6d
test2.pod              0/1       Completed    0          7d
test3.pod              1/1       Running      0          3d

```
### # kubectl create -f ./pod.yaml

```
Error from server: error when creating "../../kubernetes/pod.yaml": pods "test2.pod" already exists
 Existant pod is in termanited state! Please check its status and delete it!
 Use `kubectl get pods/test2.pod`
```
### # kubectl  create -f ./job.yaml

```
Error from server: error when creating "../../kubernetes/job.yaml": jobs.extensions "test.job" already exists
 Existant job is in termanited state! Please check its status and delete it!
 Use `kubectl get jobs/test.job`
```
### #kubectl run load-generator --image=busybox --restart=Never

```
Error from server: jobs.extensions "load-generator" already exists
 Existant job is in termanited state! Please check its status and delete it!
 Use `kubectl get jobs/load-generator`
```
### # kubectl get -h

```
Display one or many resources.

WARN: By default only active pods displayed, to display terminated
pods as well set -a, --show-all option. It is done intentionally to let see
statuses they finish with.

Possible resource types include (case insensitive): pods (po), services (svc), deployments,
replicasets (rs), replicationcontrollers (rc), nodes (no), events (ev), limitranges (limits),
persistentvolumes (pv), persistentvolumeclaims (pvc), resourcequotas (quota), namespaces (ns),
serviceaccounts (sa), ingresses (ing), horizontalpodautoscalers (hpa), daemonsets (ds), configmaps,
componentstatuses (cs), endpoints (ep), and secrets.

By specifying the output as 'template' and providing a Go template as the value
of the --template flag, you can filter the attributes of the fetched resource(s).

Usage:
.......

```
