### PR TITLE
Add -addr option to hack/lib/etcd.h

### DIFF
--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -41,8 +41,8 @@ kube::etcd::start() {
 
   # Start etcd
   ETCD_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t test-etcd.XXXXXX)
-  kube::log::info "etcd -data-dir ${ETCD_DIR} --bind-addr ${ETCD_HOST}:${ETCD_PORT} >/dev/null 2>/dev/null"
-  etcd -data-dir ${ETCD_DIR} --bind-addr ${ETCD_HOST}:${ETCD_PORT} >/dev/null 2>/dev/null &
+  kube::log::info "etcd -addr ${ETCD_HOST}:${ETCD_PORT} -data-dir ${ETCD_DIR} --bind-addr ${ETCD_HOST}:${ETCD_PORT} >/dev/null 2>/dev/null"
+  etcd -addr ${ETCD_HOST}:${ETCD_PORT} -data-dir ${ETCD_DIR} --bind-addr ${ETCD_HOST}:${ETCD_PORT} >/dev/null 2>/dev/null &
   ETCD_PID=$!
 
   echo "Waiting for etcd to come up."


### PR DESCRIPTION
Added -addr to etcd hack script so it listens on the same address specified in the `host` variable.

Signed-off-by: André Martins aanm90@gmail.com
