### PR TITLE
Add more global options to local-up-cluster.sh

### DIFF
--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -17,11 +17,10 @@
 # A set of helpers for starting/running etcd for tests
 
 ETCD_VERSION=${ETCD_VERSION:-2.2.1}
+ETCD_HOST=${ETCD_HOST:-127.0.0.1}
+ETCD_PORT=${ETCD_PORT:-4001}
 
 kube::etcd::start() {
-  local host=${ETCD_HOST:-127.0.0.1}
-  local port=${ETCD_PORT:-4001}
-
   which etcd >/dev/null || {
     kube::log::usage "etcd must be in your PATH"
     exit 1
@@ -42,13 +41,13 @@ kube::etcd::start() {
 
   # Start etcd
   ETCD_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t test-etcd.XXXXXX)
-  kube::log::info "etcd -data-dir ${ETCD_DIR} --bind-addr ${host}:${port} >/dev/null 2>/dev/null"
-  etcd -data-dir ${ETCD_DIR} --bind-addr ${host}:${port} >/dev/null 2>/dev/null &
+  kube::log::info "etcd -data-dir ${ETCD_DIR} --bind-addr ${ETCD_HOST}:${ETCD_PORT} >/dev/null 2>/dev/null"
+  etcd -data-dir ${ETCD_DIR} --bind-addr ${ETCD_HOST}:${ETCD_PORT} >/dev/null 2>/dev/null &
   ETCD_PID=$!
 
   echo "Waiting for etcd to come up."
-  kube::util::wait_for_url "http://${host}:${port}/v2/machines" "etcd: " 0.25 80
-  curl -fs -X PUT "http://${host}:${port}/v2/keys/_test"
+  kube::util::wait_for_url "http://${ETCD_HOST}:${ETCD_PORT}/v2/machines" "etcd: " 0.25 80
+  curl -fs -X PUT "http://${ETCD_HOST}:${ETCD_PORT}/v2/keys/_test"
 }
 
 kube::etcd::stop() {

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -105,6 +105,7 @@ set +e
 
 API_PORT=${API_PORT:-8080}
 API_HOST=${API_HOST:-127.0.0.1}
+KUBELET_HOST=${KUBELET_HOST:-"127.0.0.1"}
 # By default only allow CORS for requests on localhost
 API_CORS_ALLOWED_ORIGINS=${API_CORS_ALLOWED_ORIGINS:-"/127.0.0.1(:[0-9]+)?$,/localhost(:[0-9]+)?$"}
 KUBELET_PORT=${KUBELET_PORT:-10250}
@@ -277,7 +278,7 @@ function start_apiserver {
       --insecure-bind-address="${API_HOST}" \
       --insecure-port="${API_PORT}" \
       --advertise-address="${API_HOST}" \
-      --etcd-servers="http://127.0.0.1:4001" \
+      --etcd-servers="http://${ETCD_HOST}:${ETCD_PORT}" \
       --service-cluster-ip-range="10.0.0.0/24" \
       --cloud-provider="${CLOUD_PROVIDER}" \
       --cors-allowed-origins="${API_CORS_ALLOWED_ORIGINS}" >"${APISERVER_LOG}" 2>&1 &
@@ -352,7 +353,7 @@ function start_kubelet {
         --rkt-stage1-image="${RKT_STAGE1_IMAGE}" \
         --hostname-override="${HOSTNAME_OVERRIDE}" \
         --cloud-provider="${CLOUD_PROVIDER}" \
-        --address="127.0.0.1" \
+        --address="${KUBELET_HOST}" \
         --api-servers="${API_HOST}:${API_PORT}" \
         --cpu-cfs-quota=${CPU_CFS_QUOTA} \
         ${dns_args} \


### PR DESCRIPTION
I added a couple more global variables to the `local-up-cluster.sh` script.

The `KUBELET_HOST` environment name make sense to me. If it isn't the best name I will change it.

The `ETCD` ones make sense since they are being used under `hack/lib/etcd.sh`

Signed-off-by: André Martins aanm90@gmail.com
