### PR TITLE
[GarbageCollector] Fixes 25890 flake. Let GC convert ListOptions to v1 before passing it to the dynamic client

### DIFF
--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -52,6 +52,7 @@ func TestNewGarbageCollector(t *testing.T) {
 type fakeAction struct {
 	method string
 	path   string
+	query  string
 }
 
 // String returns method=path to aid in testing
@@ -78,7 +79,7 @@ func (f *fakeActionHandler) ServeHTTP(response http.ResponseWriter, request *htt
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
-	f.actions = append(f.actions, fakeAction{method: request.Method, path: request.URL.Path})
+	f.actions = append(f.actions, fakeAction{method: request.Method, path: request.URL.Path, query: request.URL.RawQuery})
 	fakeResponse, ok := f.response[request.Method+request.URL.Path]
 	if !ok {
 		fakeResponse.statusCode = 200
@@ -316,4 +317,29 @@ func TestDependentsRace(t *testing.T) {
 			gc.orphanFinalizer()
 		}
 	}()
+}
+
+// test the list and watch functions correctly converts the ListOptions
+func TestGCListWatcher(t *testing.T) {
+	testHandler := &fakeActionHandler{}
+	srv, clientConfig := testServerAndClientConfig(testHandler.ServeHTTP)
+	defer srv.Close()
+	clientPool := dynamic.NewClientPool(clientConfig, dynamic.LegacyAPIPathResolverFunc)
+	podResource := unversioned.GroupVersionResource{Version: "v1", Resource: "pods"}
+	client, err := clientPool.ClientForGroupVersion(podResource.GroupVersion())
+	if err != nil {
+		t.Fatal(err)
+	}
+	lw := gcListWatcher(client, podResource)
+	lw.Watch(api.ListOptions{ResourceVersion: "1"})
+	lw.List(api.ListOptions{ResourceVersion: "1"})
+	if e, a := 2, len(testHandler.actions); e != a {
+		t.Errorf("expect %d requests, got %d", e, a)
+	}
+	if e, a := "resourceVersion=1", testHandler.actions[0].query; e != a {
+		t.Errorf("expect %s, got %s", e, a)
+	}
+	if e, a := "resourceVersion=1", testHandler.actions[1].query; e != a {
+		t.Errorf("expect %s, got %s", e, a)
+	}
 }

--- a/test/integration/garbage_collector_test.go
+++ b/test/integration/garbage_collector_test.go
@@ -149,9 +149,6 @@ func setup(t *testing.T) (*garbagecollector.GarbageCollector, clientset.Interfac
 
 // This test simulates the cascading deletion.
 func TestCascadingDeletion(t *testing.T) {
-	// TODO: Figure out what's going on with this test!
-	t.Log("This test is failing too much-- lavalamp removed it to stop the submit queue bleeding")
-	return
 	gc, clientSet := setup(t)
 	oldEnableGarbageCollector := registry.EnableGarbageCollector
 	registry.EnableGarbageCollector = true


### PR DESCRIPTION
GC's ListWatcher directly passed the api.ListOptions to the dynamic client, but the parameter codec of dynamic client converts the options to queries based on the tags in the struct, which are not present in api.ListOptions, so the queries are not sent to the server. As a result, the Watch request was sent without a resourceVersion, causing missed events. Flake #25890 is caused by the missed deletion events.

This PR converts the api.ListOptions to v1.ListOptions before the GC passes it to the dynamic codec. The flaky test has successfully passed 79 times ([log](https://00e9e64bacd064560a027fbee9c5a373a1614f3a56e652ae40-apidata.googleusercontent.com/download/storage/v1_internal/b/kubernetes-jenkins/o/pr-logs%2Fpull%2F25923%2Fkubernetes-pull-test-unit-integration%2F28364%2Fbuild-log.txt?qk=AD5uMEv72OjSUqDyk5i-ZLurcmM4i7gket1c7WaqR7yuIYz7WhPYT7ewVBafijV0ymnPTYqxRYt1kp6S9YQv7chPwC-3UtrKetKfhYnvAFrPGXAIBxHytTmpFohRAYgsARN1B6j1f9vyK5lM-8jyzRGhCK3sCRsAPnbDBWIWFlbH4b1n3vUET3P71QamHrF5itYyaqRU5pMZV3Cwwr81X8q7h5hCzm3Ip78RpMzfjEqTG0RcM2TLGccUrlkWVBLh4hn0NFpUIkzVFugFA5ooJffo-0AdJnO3mGWEOnXNVFWftJbK8cKnTns0DISrYFOyH_PlOe_YHCxgIXIT-dW8G-nbqoUjn5SBqunr36rcpaYCIwe2va4W_AcLCT43xiEAezRER_U9AuIqi_22KMd6SuHTyljhmWFPvPk8-gpjthLWXhcE7LPO5dV41hnZHnbI4n_9eI1nSVm7q9XdSvX1sWKV1GCwn8oj017AnxVvl9bScultko_0dTC747UqJ6UTFakLuFcHFe-F5Tz7ItDWlBVPoXeC7gTpyuicFKLsdqGlW9F5X6kIwNrBRj9uRsS-QuzSER-fVkQCn4dUTcokttRH_0bYvyfr9oqiDXmywMgOp-L0sKayk8JOVynh2q0Tju9sdkvFr0PxoAjhofomfIC1SZ_JkOzwAT1TUW8dLjPHluMct34xW_-qna1AmkoxM4bZQLhllap96NTC-0IdtzeKDrTul8p7u3WXSJjjEMSijibTNMlnkB0AluT1_RNO94OnzuFv4YlcV24FPhJzchhbyKREkOb_wzgcnSbRwGHjIcfRgkX-IzoXHVBcMYFUrPmsXrnRcfad4XwjkUOgvivkURW2_EwnzgrLDh-IKek51_0FpT1MnFCSG0gQbVSs_iMVPr6UXNAw62LGbKVtl3ZMXyapEpcO8azNbn6Wvd550R704JXxYlU)).

@lavalamp @krousey @smarterclayton

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/26493)

<!-- Reviewable:end -->
