### PR TITLE
Enable WatchCache in test/integration/ tests

### DIFF
--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -198,6 +198,7 @@ func NewMasterConfig() *master.Config {
 			Authorizer:              apiserver.NewAlwaysAllowAuthorizer(),
 			AdmissionControl:        admit.NewAlwaysAdmit(),
 			Serializer:              api.Codecs,
+			EnableWatchCache:        true,
 		},
 		KubeletClient: kubeletclient.FakeKubeletClient{},
 	}


### PR DESCRIPTION
We already run cmd/integration/ with watch cache on. We should also run tests in test/integration/ with watch cache on.

@wojtek-t @lavalamp
