### PR TITLE
scheduler cache: print err if AssumePod fail

### DIFF
--- a/plugin/pkg/scheduler/scheduler.go
+++ b/plugin/pkg/scheduler/scheduler.go
@@ -119,7 +119,9 @@ func (s *Scheduler) scheduleOne() {
 	// will self-repair.
 	assumed := *pod
 	assumed.Spec.NodeName = dest
-	s.config.SchedulerCache.AssumePod(&assumed)
+	if err := s.config.SchedulerCache.AssumePod(&assumed); err != nil {
+		glog.Errorf("scheduler cache AssumePod failed: %v", err)
+	}
 
 	go func() {
 		defer metrics.E2eSchedulingLatency.Observe(metrics.SinceInMicroseconds(start))


### PR DESCRIPTION
ref:
- https://github.com/kubernetes/kubernetes/issues/19681#issuecomment-222337964
- #26043

Print error to help debug flake.
