### PR TITLE
Revert "Make Privileged pods node e2e use the framework"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ check test:
 #   make test_integration
 test_integration:
 	hack/test-integration.sh
-.PHONY: test_integration
+.PHONY: test_integration test_integ
 
 # Build and run end-to-end tests.
 #
@@ -98,7 +98,7 @@ test_e2e:
 # Example:
 #   make test_e2e_node FOCUS=kubelet SKIP=container
 # Build and run tests.
-test_e2e_node: ginkgo
+test_e2e_node:
 	hack/e2e-node-test.sh FOCUS=$(FOCUS) SKIP=$(SKIP)
 .PHONY: test_e2e_node
 
@@ -146,10 +146,3 @@ release-skip-tests quick-release:
 	KUBE_RELEASE_RUN_TESTS=n KUBE_FASTBUILD=true build/release.sh
 .PHONY: release-skip-tests quick-release
 
-# Build ginkgo for tests
-#
-# Example:
-#   make ginkgo
-ginkgo:
-	hack/build-go.sh vendor/github.com/onsi/ginkgo/ginkgo
-.PHONY: ginkgo

--- a/hack/e2e-node-test.sh
+++ b/hack/e2e-node-test.sh
@@ -23,7 +23,7 @@ report=${REPORT:-"/tmp/"}
 
 ginkgo=$(kube::util::find-binary "ginkgo")
 if [[ -z "${ginkgo}" ]]; then
-  echo "You do not appear to have ginkgo built. 'make WHAT=vendor/github.com/onsi/ginkgo/ginkgo'"
+  echo "You do not appear to have ginkgo built. Try 'make WHAT=vendor/github.com/onsi/ginkgo/ginkgo'"
   exit 1
 fi
 

--- a/test/e2e_node/exec_util.go
+++ b/test/e2e_node/exec_util.go
@@ -24,9 +24,9 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/restclient"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/remotecommand"
 	remotecommandserver "k8s.io/kubernetes/pkg/kubelet/server/remotecommand"
-	"k8s.io/kubernetes/test/e2e/framework"
 )
 
 func execute(method string, url *url.URL, config *restclient.Config, stdin io.Reader, stdout, stderr io.Writer, tty bool) error {
@@ -37,11 +37,11 @@ func execute(method string, url *url.URL, config *restclient.Config, stdin io.Re
 	return exec.Stream(remotecommandserver.SupportedStreamingProtocols, stdin, stdout, stderr, tty)
 }
 
-func execCommandInContainer(config *restclient.Config, f *framework.Framework, ns, podName, containerName string, cmd []string) (string, error) {
+func execCommandInContainer(config *restclient.Config, c *client.Client, ns, podName, containerName string, cmd []string) (string, error) {
 	var stdout, stderr bytes.Buffer
 	var stdin io.Reader
 	tty := false
-	req := f.Client.RESTClient.Post().
+	req := c.RESTClient.Post().
 		Resource("pods").
 		Name(podName).
 		Namespace(ns).

--- a/test/e2e_node/privileged_test.go
+++ b/test/e2e_node/privileged_test.go
@@ -24,9 +24,9 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
-	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -45,60 +45,55 @@ const (
 	privilegedCommand          = "ip link add dummy1 type dummy"
 )
 
+type PrivilegedPodTestConfig struct {
+	config        *restclient.Config
+	client        *client.Client
+	namespace     string
+	hostExecPod   *api.Pod
+	privilegedPod *api.Pod
+}
+
 var _ = Describe("PrivilegedPod", func() {
-	f := NewDefaultFramework("privileged-pod")
+	var c *client.Client
+	restClientConfig := &restclient.Config{Host: *apiServerAddress}
+	BeforeEach(func() {
+		// Setup the apiserver client
+		c = client.NewOrDie(restClientConfig)
+	})
 	It("should test privileged pod", func() {
-		restClientConfig := &restclient.Config{Host: *apiServerAddress}
+		namespace := "privileged-pods"
+		config := &PrivilegedPodTestConfig{
+			client:    c,
+			config:    restClientConfig,
+			namespace: namespace,
+		}
 		By("Creating a host exec pod")
-		podClient := f.Client.Pods(f.Namespace.Name)
-		hostExecPod := newHostExecPodSpec("hostexec")
-		defer podClient.Delete(hostExecPod.Name, nil)
-		_, err := podClient.Create(hostExecPod)
-		Expect(err).To(BeNil(), fmt.Sprintf("Error creating Pod %v", err))
-
-		By("Waiting for host exec pod to be running")
-		framework.ExpectNoError(f.WaitForPodRunning(hostExecPod.Name))
-
-		By("Getting status of the host exec pod")
-		hostExecPod, err = podClient.Get(hostExecPod.Name)
-		Expect(err).To(BeNil(), fmt.Sprintf("Error getting Pod %v", err))
+		config.hostExecPod = createPodAndWaitUntilRunning(c, newHostExecPodSpec(config.namespace, "hostexec"))
 
 		By("Creating a privileged pod")
-		privilegedPod := createPrivilegedPodSpec()
-		defer podClient.Delete(privilegedPod.Name, nil)
-		_, err = podClient.Create(privilegedPod)
-		Expect(err).To(BeNil(), fmt.Sprintf("Error creating Pod %v", err))
-
-		By("Waiting for privileged pod to be running")
-		framework.ExpectNoError(f.WaitForPodRunning(privilegedPod.Name))
-
-		By("Getting status of privileged pod")
-		privilegedPod, err = podClient.Get(privilegedPod.Name)
-		Expect(err).To(BeNil(), fmt.Sprintf("Error getting Pod %v", err))
+		config.privilegedPod = createPodAndWaitUntilRunning(c, config.createPrivilegedPodSpec())
 
 		By("Executing privileged command on privileged container")
-		outputMap := dialFromContainer(restClientConfig, f, hostExecPod, privilegedPod.Status.PodIP, privilegedHttpPort)
-		Expect(outputMap["error"]).To(BeEmpty(), fmt.Sprintf("Privileged command failed unexpectedly on privileged container, output: %v", outputMap))
+		config.runPrivilegedCommandOnPrivilegedContainer()
 
 		By("Executing privileged command on non-privileged container")
-		outputMap = dialFromContainer(restClientConfig, f, hostExecPod, privilegedPod.Status.PodIP, notPrivilegedHttpPort)
-		Expect(outputMap["error"]).To(BeEmpty(), fmt.Sprintf("Privileged command should have failed on non-privileged container, output: %v", outputMap))
+		config.runPrivilegedCommandOnNonPrivilegedContainer()
 	})
 })
 
-func createPrivilegedPodSpec() *api.Pod {
+func (config *PrivilegedPodTestConfig) createPrivilegedPodSpec() *api.Pod {
 	isPrivileged := true
 	notPrivileged := false
 	pod := &api.Pod{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Pod",
-			APIVersion: "v1",
+			APIVersion: registered.GroupOrDie(api.GroupName).GroupVersion.String(),
 		},
 		ObjectMeta: api.ObjectMeta{
-			Name: privilegedPodName,
+			Name:      privilegedPodName,
+			Namespace: config.namespace,
 		},
 		Spec: api.PodSpec{
-			NodeName: *nodeName,
 			Containers: []api.Container{
 				{
 					Name:            privilegedContainerName,
@@ -128,7 +123,17 @@ func createPrivilegedPodSpec() *api.Pod {
 	return pod
 }
 
-func dialFromContainer(config *restclient.Config, f *framework.Framework, hostExecPod *api.Pod, containerIP string, containerHttpPort int) map[string]string {
+func (config *PrivilegedPodTestConfig) runPrivilegedCommandOnPrivilegedContainer() {
+	outputMap := config.dialFromContainer(config.privilegedPod.Status.PodIP, privilegedHttpPort)
+	Expect(len(outputMap["error"]) == 0).To(BeTrue(), fmt.Sprintf("Privileged command failed unexpectedly on privileged container, output: %v", outputMap))
+}
+
+func (config *PrivilegedPodTestConfig) runPrivilegedCommandOnNonPrivilegedContainer() {
+	outputMap := config.dialFromContainer(config.privilegedPod.Status.PodIP, notPrivilegedHttpPort)
+	Expect(len(outputMap["error"]) > 0).To(BeTrue(), fmt.Sprintf("Privileged command should have failed on non-privileged container, output: %v", outputMap))
+}
+
+func (config *PrivilegedPodTestConfig) dialFromContainer(containerIP string, containerHttpPort int) map[string]string {
 	v := url.Values{}
 	v.Set("shellCommand", "ip link add dummy1 type dummy")
 	cmd := fmt.Sprintf("curl -q 'http://%s:%d/shell?%s'",
@@ -137,7 +142,8 @@ func dialFromContainer(config *restclient.Config, f *framework.Framework, hostEx
 		v.Encode())
 	By(fmt.Sprintf("Exec-ing into container over http. Running command: %s", cmd))
 
-	stdout, err := execCommandInContainer(config, f, f.Namespace.Name, hostExecPod.Name, hostExecPod.Spec.Containers[0].Name, []string{"/bin/sh", "-c", cmd})
+	stdout, err := execCommandInContainer(config.config, config.client, config.hostExecPod.Namespace, config.hostExecPod.Name, config.hostExecPod.Spec.Containers[0].Name,
+		[]string{"/bin/sh", "-c", cmd})
 	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Error running command %q: %v", cmd, err))
 
 	var output map[string]string
@@ -147,17 +153,17 @@ func dialFromContainer(config *restclient.Config, f *framework.Framework, hostEx
 }
 
 // newHostExecPodSpec returns the pod spec of hostexec pod
-func newHostExecPodSpec(name string) *api.Pod {
+func newHostExecPodSpec(ns, name string) *api.Pod {
 	return &api.Pod{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Pod",
-			APIVersion: "v1",
+			APIVersion: registered.GroupOrDie(api.GroupName).GroupVersion.String(),
 		},
 		ObjectMeta: api.ObjectMeta{
-			Name: name,
+			Name:      name,
+			Namespace: ns,
 		},
 		Spec: api.PodSpec{
-			NodeName: *nodeName,
 			Containers: []api.Container{
 				{
 					Name:            "hostexec",


### PR DESCRIPTION
Reverts kubernetes/kubernetes#26228

It seems that this PR broke e2e-node suite:
"PrivilegedPod [It] should test privileged pod"
