### PR TITLE
Update azure cli so it works with node > 6

### DIFF
--- a/docs/getting-started-guides/coreos/azure/package.json
+++ b/docs/getting-started-guides/coreos/azure/package.json
@@ -9,7 +9,7 @@
   "author": "Ilya Dmitrichenko <errordeveloper@gmail.com>",
   "license": "Apache 2.0",
   "dependencies": {
-    "azure-cli": "^0.9.9",
+    "azure-cli": "^0.10.0",
     "colors": "^1.0.3",
     "js-yaml": "^3.2.5",
     "openssl-wrapper": "^0.2.1",


### PR DESCRIPTION
Fix for azure example update azure-cli to support node 6

``` release-note
* Now you can provision k8s cluster using node 6
```

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
