### PR TITLE
pkg/storage/etcd3: remove name field in test

### DIFF
--- a/pkg/storage/etcd3/store_test.go
+++ b/pkg/storage/etcd3/store_test.go
@@ -274,7 +274,6 @@ func TestGuaranteedUpdate(t *testing.T) {
 
 	tests := []struct {
 		key                 string
-		name                string
 		ignoreNotFound      bool
 		precondition        *storage.Preconditions
 		expectNotFoundErr   bool


### PR DESCRIPTION
Current test gets the name with its test table index,
so there seems to be no reason to have name field in test table.
