### PR TITLE
Fix error handling in endpoint controller

### DIFF
--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -273,6 +273,7 @@ func (e *EndpointController) deletePod(obj interface{}) {
 	podKey, err := keyFunc(obj)
 	if err != nil {
 		glog.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		return
 	}
 	glog.Infof("Pod %q was deleted but we don't have a record of its final state, so it will take up to %v before it will be removed from all endpoint records.", podKey, FullServiceResyncPeriod)
 
@@ -284,6 +285,7 @@ func (e *EndpointController) enqueueService(obj interface{}) {
 	key, err := keyFunc(obj)
 	if err != nil {
 		glog.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		return
 	}
 
 	e.queue.Add(key)


### PR DESCRIPTION
Added missing returns, subsequent statements depend on key
