### PR TITLE
Extract more event reason constants to pkg/kubelet/container/event.go

### DIFF
--- a/contrib/mesos/pkg/scheduler/components/controller/controller.go
+++ b/contrib/mesos/pkg/scheduler/components/controller/controller.go
@@ -27,13 +27,11 @@ import (
 	"k8s.io/kubernetes/contrib/mesos/pkg/scheduler/components/binder"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/record"
+	"k8s.io/kubernetes/pkg/kubelet/container"
 )
 
 const (
 	recoveryDelay = 100 * time.Millisecond // delay after scheduler plugin crashes, before we resume scheduling
-
-	FailedScheduling = "FailedScheduling"
-	Scheduled        = "Scheduled"
 )
 
 type Controller interface {
@@ -87,7 +85,7 @@ func (s *controller) scheduleOne() {
 	dest, err := s.algorithm.Schedule(pod)
 	if err != nil {
 		log.V(1).Infof("Failed to schedule: %+v", pod)
-		s.recorder.Eventf(pod, api.EventTypeWarning, FailedScheduling, "Error scheduling: %v", err)
+		s.recorder.Eventf(pod, api.EventTypeWarning, container.FailedScheduling, "Error scheduling: %v", err)
 		s.error(pod, err)
 		return
 	}
@@ -100,9 +98,9 @@ func (s *controller) scheduleOne() {
 	}
 	if err := s.binder.Bind(b); err != nil {
 		log.V(1).Infof("Failed to bind pod: %+v", err)
-		s.recorder.Eventf(pod, api.EventTypeWarning, FailedScheduling, "Binding rejected: %v", err)
+		s.recorder.Eventf(pod, api.EventTypeWarning, container.FailedScheduling, "Binding rejected: %v", err)
 		s.error(pod, err)
 		return
 	}
-	s.recorder.Eventf(pod, api.EventTypeNormal, Scheduled, "Successfully assigned %v to %v", pod.Name, dest)
+	s.recorder.Eventf(pod, api.EventTypeNormal, container.Scheduled, "Successfully assigned %v to %v", pod.Name, dest)
 }

--- a/contrib/mesos/pkg/scheduler/integration/integration_test.go
+++ b/contrib/mesos/pkg/scheduler/integration/integration_test.go
@@ -37,7 +37,6 @@ import (
 	"k8s.io/kubernetes/contrib/mesos/pkg/scheduler"
 	"k8s.io/kubernetes/contrib/mesos/pkg/scheduler/components"
 	"k8s.io/kubernetes/contrib/mesos/pkg/scheduler/components/algorithm/podschedulers"
-	"k8s.io/kubernetes/contrib/mesos/pkg/scheduler/components/controller"
 	"k8s.io/kubernetes/contrib/mesos/pkg/scheduler/components/framework"
 	schedcfg "k8s.io/kubernetes/contrib/mesos/pkg/scheduler/config"
 	"k8s.io/kubernetes/contrib/mesos/pkg/scheduler/ha"
@@ -51,6 +50,7 @@ import (
 	"k8s.io/kubernetes/pkg/client/cache"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/watch"
@@ -652,7 +652,7 @@ func TestScheduler_LifeCycle(t *testing.T) {
 	lt.podsListWatch.Add(pod, true) // notify watchers
 
 	// wait for failedScheduling event because there is no offer
-	assert.EventWithReason(lt.eventObs, controller.FailedScheduling, "failedScheduling event not received")
+	assert.EventWithReason(lt.eventObs, container.FailedScheduling, "failedScheduling event not received")
 
 	// add some matching offer
 	offers := []*mesos.Offer{NewTestOffer(fmt.Sprintf("offer%d", i))}
@@ -665,7 +665,7 @@ func TestScheduler_LifeCycle(t *testing.T) {
 	lt.framework.ResourceOffers(nil, offers)
 
 	// and wait for scheduled pod
-	assert.EventWithReason(lt.eventObs, controller.Scheduled)
+	assert.EventWithReason(lt.eventObs, container.Scheduled)
 	select {
 	case launchedTask := <-launchedTasks:
 		// report back that the task has been staged, and then started by mesos
@@ -702,7 +702,7 @@ func TestScheduler_LifeCycle(t *testing.T) {
 	// Launch a pod and wait until the scheduler driver is called
 	schedulePodWithOffers := func(pod *api.Pod, offers []*mesos.Offer) (*api.Pod, *LaunchedTask, *mesos.Offer) {
 		// wait for failedScheduling event because there is no offer
-		assert.EventWithReason(lt.eventObs, controller.FailedScheduling, "failedScheduling event not received")
+		assert.EventWithReason(lt.eventObs, container.FailedScheduling, "failedScheduling event not received")
 
 		// supply a matching offer
 		lt.framework.ResourceOffers(lt.driver, offers)
@@ -717,7 +717,7 @@ func TestScheduler_LifeCycle(t *testing.T) {
 		}
 
 		// and wait to get scheduled
-		assert.EventWithReason(lt.eventObs, controller.Scheduled)
+		assert.EventWithReason(lt.eventObs, container.Scheduled)
 
 		// wait for driver.launchTasks call
 		select {

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -32,6 +32,7 @@ import (
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/client/record"
 	"k8s.io/kubernetes/pkg/controller/framework"
+	"k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
@@ -450,7 +451,7 @@ func (r RealPodControl) createPods(nodeName, namespace string, template *api.Pod
 		return fmt.Errorf("unable to create pods, no labels")
 	}
 	if newPod, err := r.KubeClient.Core().Pods(namespace).Create(pod); err != nil {
-		r.Recorder.Eventf(object, api.EventTypeWarning, "FailedCreate", "Error creating: %v", err)
+		r.Recorder.Eventf(object, api.EventTypeWarning, container.FailedCreate, "Error creating: %v", err)
 		return fmt.Errorf("unable to create pods: %v", err)
 	} else {
 		accessor, err := meta.Accessor(object)
@@ -459,7 +460,7 @@ func (r RealPodControl) createPods(nodeName, namespace string, template *api.Pod
 			return nil
 		}
 		glog.V(4).Infof("Controller %v created pod %v", accessor.GetName(), newPod.Name)
-		r.Recorder.Eventf(object, api.EventTypeNormal, "SuccessfulCreate", "Created pod: %v", newPod.Name)
+		r.Recorder.Eventf(object, api.EventTypeNormal, container.SuccessfulCreate, "Created pod: %v", newPod.Name)
 	}
 	return nil
 }
@@ -470,11 +471,11 @@ func (r RealPodControl) DeletePod(namespace string, podID string, object runtime
 		return fmt.Errorf("object does not have ObjectMeta, %v", err)
 	}
 	if err := r.KubeClient.Core().Pods(namespace).Delete(podID, nil); err != nil {
-		r.Recorder.Eventf(object, api.EventTypeWarning, "FailedDelete", "Error deleting: %v", err)
+		r.Recorder.Eventf(object, api.EventTypeWarning, container.FailedDelete, "Error deleting: %v", err)
 		return fmt.Errorf("unable to delete pods: %v", err)
 	} else {
 		glog.V(4).Infof("Controller %v deleted pod %v", accessor.GetName(), podID)
-		r.Recorder.Eventf(object, api.EventTypeNormal, "SuccessfulDelete", "Deleted pod: %v", podID)
+		r.Recorder.Eventf(object, api.EventTypeNormal, container.SuccessfulDelete, "Deleted pod: %v", podID)
 	}
 	return nil
 }

--- a/pkg/controller/job/controller.go
+++ b/pkg/controller/job/controller.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/controller/framework"
 	"k8s.io/kubernetes/pkg/controller/framework/informers"
 	replicationcontroller "k8s.io/kubernetes/pkg/controller/replication"
+	"k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/metrics"
 	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
@@ -371,8 +372,8 @@ func (jm *JobController) syncJob(key string) error {
 		// update status values accordingly
 		failed += active
 		active = 0
-		job.Status.Conditions = append(job.Status.Conditions, newCondition(batch.JobFailed, "DeadlineExceeded", "Job was active longer than specified deadline"))
-		jm.recorder.Event(&job, api.EventTypeNormal, "DeadlineExceeded", "Job was active longer than specified deadline")
+		job.Status.Conditions = append(job.Status.Conditions, newCondition(batch.JobFailed, container.DeadlineExceeded, "Job was active longer than specified deadline"))
+		jm.recorder.Event(&job, api.EventTypeNormal, container.DeadlineExceeded, "Job was active longer than specified deadline")
 	} else {
 		if jobNeedsSync {
 			active = jm.manageJob(activePods, succeeded, &job)
@@ -397,10 +398,10 @@ func (jm *JobController) syncJob(key string) error {
 			if completions >= *job.Spec.Completions {
 				complete = true
 				if active > 0 {
-					jm.recorder.Event(&job, api.EventTypeWarning, "TooManyActivePods", "Too many active pods running after completion count reached")
+					jm.recorder.Event(&job, api.EventTypeWarning, container.TooManyActivePods, "Too many active pods running after completion count reached")
 				}
 				if completions > *job.Spec.Completions {
-					jm.recorder.Event(&job, api.EventTypeWarning, "TooManySucceededPods", "Too many succeeded pods running after completion count reached")
+					jm.recorder.Event(&job, api.EventTypeWarning, container.TooManySucceededPods, "Too many succeeded pods running after completion count reached")
 				}
 			}
 		}

--- a/pkg/controller/petset/fakes.go
+++ b/pkg/controller/petset/fakes.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/apps"
 	"k8s.io/kubernetes/pkg/client/record"
+	"k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/sets"
 )
@@ -166,7 +167,7 @@ func (f *fakePetClient) Delete(p *pcb) error {
 	for i, pet := range f.pets {
 		if p.pod.Name == pet.pod.Name {
 			found = true
-			f.recorder.Eventf(pet.parent, api.EventTypeNormal, "SuccessfulDelete", "pet: %v", pet.pod.Name)
+			f.recorder.Eventf(pet.parent, api.EventTypeNormal, container.SuccessfulDelete, "pet: %v", pet.pod.Name)
 			continue
 		}
 		pets = append(pets, f.pets[i])
@@ -197,7 +198,7 @@ func (f *fakePetClient) Create(p *pcb) error {
 			return fmt.Errorf("Create failed: pet %v already exists", p.pod.Name)
 		}
 	}
-	f.recorder.Eventf(p.parent, api.EventTypeNormal, "SuccessfulCreate", "pet: %v", p.pod.Name)
+	f.recorder.Eventf(p.parent, api.EventTypeNormal, container.SuccessfulCreate, "pet: %v", p.pod.Name)
 	f.pets = append(f.pets, p)
 	f.petsCreated++
 	return nil
@@ -294,7 +295,7 @@ func (f *fakePetClient) SyncPVCs(pet *pcb) error {
 	for _, remaining := range updateClaims {
 		claimList = append(claimList, remaining)
 		f.claimsCreated++
-		f.recorder.Eventf(pet.parent, api.EventTypeNormal, "SuccessfulCreate", "pvc: %v", remaining.Name)
+		f.recorder.Eventf(pet.parent, api.EventTypeNormal, container.SuccessfulCreate, "pvc: %v", remaining.Name)
 	}
 	f.claims = claimList
 	return nil
@@ -312,7 +313,7 @@ func (f *fakePetClient) DeletePVCs(pet *pcb) error {
 		if deleteClaimNames.Has(existing.Name) {
 			deleteClaimNames.Delete(existing.Name)
 			f.claimsDeleted++
-			f.recorder.Eventf(pet.parent, api.EventTypeNormal, "SuccessfulDelete", "pvc: %v", existing.Name)
+			f.recorder.Eventf(pet.parent, api.EventTypeNormal, container.SuccessfulDelete, "pvc: %v", existing.Name)
 			continue
 		}
 		pvcs = append(pvcs, f.claims[i])

--- a/pkg/kubelet/container/event.go
+++ b/pkg/kubelet/container/event.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package container
 
+// The following is not exhaustive.
+
 const (
 	// Container event reason list
 	CreatedContainer        = "Created"
@@ -57,8 +59,21 @@ const (
 	// Probe event reason list
 	ContainerUnhealthy = "Unhealthy"
 
+	// Pod lifetime event reason list
+	Scheduled        = "Scheduled"
+	FailedScheduling = "FailedScheduling"
+	FailedCreate     = "FailedCreate"
+	SuccessfulCreate = "SuccessfulCreate"
+	FailedDelete     = "FailedDelete"
+	SuccessfulDelete = "SuccessfulDelete"
+
 	// Pod worker event reason list
 	FailedSync = "FailedSync"
+
+	// Job controller event reason list
+	DeadlineExceeded     = "DeadlineExceeded"
+	TooManyActivePods    = "TooManyActivePods"
+	TooManySucceededPods = "TooManySucceededPods"
 
 	// Config event reason list
 	FailedValidation = "FailedValidation"

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -3556,11 +3556,10 @@ func (kl *Kubelet) generateAPIPodStatus(pod *api.Pod, podStatus *kubecontainer.P
 	// TODO: Consider include the container information.
 	// TODO: move this into a sync/evictor
 	if kl.pastActiveDeadline(pod) {
-		reason := "DeadlineExceeded"
-		kl.recorder.Eventf(pod, api.EventTypeNormal, reason, "Pod was active on the node longer than specified deadline")
+		kl.recorder.Eventf(pod, api.EventTypeNormal, kubecontainer.DeadlineExceeded, "Pod was active on the node longer than specified deadline")
 		return api.PodStatus{
 			Phase:   api.PodFailed,
-			Reason:  reason,
+			Reason:  kubecontainer.DeadlineExceeded,
 			Message: "Pod was active on the node longer than specified deadline"}
 	}
 

--- a/plugin/pkg/scheduler/scheduler.go
+++ b/plugin/pkg/scheduler/scheduler.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/record"
+	"k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/metrics"
@@ -99,7 +100,7 @@ func (s *Scheduler) scheduleOne() {
 	if err != nil {
 		glog.V(1).Infof("Failed to schedule: %+v", pod)
 		s.config.Error(pod, err)
-		s.config.Recorder.Eventf(pod, api.EventTypeWarning, "FailedScheduling", "%v", err)
+		s.config.Recorder.Eventf(pod, api.EventTypeWarning, container.FailedScheduling, "%v", err)
 		s.config.PodConditionUpdater.Update(pod, &api.PodCondition{
 			Type:   api.PodScheduled,
 			Status: api.ConditionFalse,
@@ -139,7 +140,7 @@ func (s *Scheduler) scheduleOne() {
 		if err != nil {
 			glog.V(1).Infof("Failed to bind pod: %v/%v", pod.Namespace, pod.Name)
 			s.config.Error(pod, err)
-			s.config.Recorder.Eventf(pod, api.EventTypeNormal, "FailedScheduling", "Binding rejected: %v", err)
+			s.config.Recorder.Eventf(pod, api.EventTypeNormal, container.FailedScheduling, "Binding rejected: %v", err)
 			s.config.PodConditionUpdater.Update(pod, &api.PodCondition{
 				Type:   api.PodScheduled,
 				Status: api.ConditionFalse,
@@ -148,6 +149,6 @@ func (s *Scheduler) scheduleOne() {
 			return
 		}
 		metrics.BindingLatency.Observe(metrics.SinceInMicroseconds(bindingStart))
-		s.config.Recorder.Eventf(pod, api.EventTypeNormal, "Scheduled", "Successfully assigned %v to %v", pod.Name, dest)
+		s.config.Recorder.Eventf(pod, api.EventTypeNormal, container.Scheduled, "Successfully assigned %v to %v", pod.Name, dest)
 	}()
 }


### PR DESCRIPTION
We have code[1] receiving some kubernetes events and classifying them by reason.
I went looking for an "official" list of reasons; didn't find it in documentation, pkg/kubelet/container/event.go seems to be the closest thing.  It includes consts for most but not all of the events we happened to care about, so I figured I'll try adding the rest and see what you think of that.
(I'm not familiar with k8s source to judge if this is a step forward, or even makes sense.)
- Unclear if these belong in kubelet/container/ but all kinds of events are already there.
- The selection I covered is semi-random.  Many literal string reasons remain, especially under pkg/controller/ (`ag 'EventType\w+,\s*"'` is an effective way to find them).
- I named the consts 1:1 with their values.  Half the point of b0f0c294d998cb3ed0ee329f0d2a8a8a7329418a was non-1:1 meaningful const names (e.g. FailedToCreateContainer = FailedToStartContainer  = "Failed") but I don't know enough to do any better.
  - I specifically suspect the 2 "DeadlineExceeded" I extracted mean different things?

[1] https://github.com/ManageIQ/manageiq/blob/1e8ccb6/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb#L3-L12

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/26506)

<!-- Reviewable:end -->
