### PR TITLE
Fill controller caches on startup

### DIFF
--- a/pkg/controller/persistentvolume/controller.go
+++ b/pkg/controller/persistentvolume/controller.go
@@ -108,8 +108,10 @@ const createProvisionedPVInterval = 10 * time.Second
 type PersistentVolumeController struct {
 	volumeController       *framework.Controller
 	volumeControllerStopCh chan struct{}
+	volumeSource           cache.ListerWatcher
 	claimController        *framework.Controller
 	claimControllerStopCh  chan struct{}
+	claimSource            cache.ListerWatcher
 	kubeClient             clientset.Interface
 	eventRecorder          record.EventRecorder
 	cloud                  cloudprovider.Interface

--- a/pkg/controller/persistentvolume/controller_test.go
+++ b/pkg/controller/persistentvolume/controller_test.go
@@ -146,9 +146,10 @@ func TestControllerSync(t *testing.T) {
 		go ctrl.Run()
 
 		// Wait for the controller to pass initial sync.
-		for !ctrl.isFullySynced() {
+		for !ctrl.volumeController.HasSynced() || !ctrl.claimController.HasSynced() {
 			time.Sleep(10 * time.Millisecond)
 		}
+		glog.V(4).Infof("controller synced, starting test")
 
 		count := reactor.getChangeCount()
 


### PR DESCRIPTION
The controller needs to fill its caches before it starts binding/recycling/ deleting or provisioning volumes and claims. This was done using blocking initial 'xxx added' from going through syncClaim/syncVolume. However, when the caches were full, the controller waited for the next sync period to do actual binding/recycling etc.

In this patch, the controller fills its caches directly from etcd and then processes initial 'xxx added' events to reconcile the world and bind/recycle/ delete/provision stuff, resulting in faster binding after startup.

Fixes #25967 (properly)
