### PR TITLE
Cover policy.ExtenderConfigs with tests

### DIFF
--- a/plugin/pkg/scheduler/api/validation/validation_test.go
+++ b/plugin/pkg/scheduler/api/validation/validation_test.go
@@ -30,14 +30,14 @@ func TestValidatePriorityWithNoWeight(t *testing.T) {
 }
 
 func TestValidatePriorityWithZeroWeight(t *testing.T) {
-	policy := api.Policy{Priorities: []api.PriorityPolicy{{Name: "NoWeightPriority", Weight: 0}}}
+	policy := api.Policy{Priorities: []api.PriorityPolicy{{Name: "ZeroWeightPriority", Weight: 0}}}
 	if ValidatePolicy(policy) == nil {
 		t.Errorf("Expected error about priority weight not being positive")
 	}
 }
 
-func TestValidatePriorityWithNonZeroWeight(t *testing.T) {
-	policy := api.Policy{Priorities: []api.PriorityPolicy{{Name: "WeightPriority", Weight: 2}}}
+func TestValidatePriorityWithPositiveWeight(t *testing.T) {
+	policy := api.Policy{Priorities: []api.PriorityPolicy{{Name: "PositiveWeightPriority", Weight: 2}}}
 	errs := ValidatePolicy(policy)
 	if errs != nil {
 		t.Errorf("Unexpected errors %v", errs)
@@ -45,8 +45,51 @@ func TestValidatePriorityWithNonZeroWeight(t *testing.T) {
 }
 
 func TestValidatePriorityWithNegativeWeight(t *testing.T) {
-	policy := api.Policy{Priorities: []api.PriorityPolicy{{Name: "WeightPriority", Weight: -2}}}
+	policy := api.Policy{Priorities: []api.PriorityPolicy{{Name: "NegativeWeightPriority", Weight: -2}}}
 	if ValidatePolicy(policy) == nil {
 		t.Errorf("Expected error about priority weight not being positive")
+	}
+}
+
+func TestValidateExtenderConfigWithNoWeight(t *testing.T) {
+	policy := api.Policy{
+		Priorities:      []api.PriorityPolicy{{Name: "PositiveWeightPriority", Weight: 2}},
+		ExtenderConfigs: []api.ExtenderConfig{{URLPrefix: "http://NoWeightExtenderConfig"}},
+	}
+	errs := ValidatePolicy(policy)
+	if errs != nil {
+		t.Errorf("Unexpected errors %v", errs)
+	}
+}
+
+func TestValidateExtenderConfigWithZeroWeight(t *testing.T) {
+	policy := api.Policy{
+		Priorities:      []api.PriorityPolicy{{Name: "PositiveWeightPriority", Weight: 2}},
+		ExtenderConfigs: []api.ExtenderConfig{{URLPrefix: "http://ZeroWeightExtenderConfig", Weight: 0}},
+	}
+	errs := ValidatePolicy(policy)
+	if errs != nil {
+		t.Errorf("Unexpected errors %v", errs)
+	}
+}
+
+func TestValidateExtenderConfigWithPositiveWeight(t *testing.T) {
+	policy := api.Policy{
+		Priorities:      []api.PriorityPolicy{{Name: "PositiveWeightPriority", Weight: 2}},
+		ExtenderConfigs: []api.ExtenderConfig{{URLPrefix: "http://PositiveWeightExtenderConfig", Weight: 2}},
+	}
+	errs := ValidatePolicy(policy)
+	if errs != nil {
+		t.Errorf("Unexpected errors %v", errs)
+	}
+}
+
+func TestValidateExtenderConfigWithNegativeWeight(t *testing.T) {
+	policy := api.Policy{
+		Priorities:      []api.PriorityPolicy{{Name: "PositiveWeightPriority", Weight: 2}},
+		ExtenderConfigs: []api.ExtenderConfig{{URLPrefix: "http://NegativeWeightExtenderConfig", Weight: -2}},
+	}
+	if ValidatePolicy(policy) == nil {
+		t.Errorf("Expected error about extender config weight being negative")
 	}
 }


### PR DESCRIPTION
The current test cases in validation_test.go haven't covered [policy.ExtenderConfigs](https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/scheduler/api/validation/validation.go#L37). Add test cases for it. Also rename something for clarity.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/26520)

<!-- Reviewable:end -->
