### PR TITLE
Fixes #26526 - hack/update-api-reference-docs.sh

### DIFF
--- a/hack/update-api-reference-docs.sh
+++ b/hack/update-api-reference-docs.sh
@@ -95,7 +95,7 @@ while read file; do
 
     # By now, the contents should be normalized and stripped of any
     # auto-managed content.
-    if diff -Bw >/dev/null <(echo "${original}") <(echo "${generated}"); then
+    if diff -B >/dev/null <(echo "${original}") <(echo "${generated}"); then
       # actual contents same, overwrite generated with original.
       cp "${OUTPUT}/${file}" "${OUTPUT_TMP}/${file}"
     fi


### PR DESCRIPTION
I opened a Pull request to fix this issue https://github.com/kubernetes/kubernetes/issues/26526

The problem is that the update script ignores white spaces but the verify script doesn't which leads to a strange behaviour -> you use the update script but the verify script tells you that the api docs are not up to date.
