### PR TITLE
federation cluster controller: load secretRef only if it is present

### DIFF
--- a/federation/apis/federation/types.generated.go
+++ b/federation/apis/federation/types.generated.go
@@ -293,11 +293,12 @@ func (x *ClusterSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2 [2]bool
 			_, _, _ = yysep2, yyq2, yy2arr2
 			const yyr2 bool = false
+			yyq2[1] = x.SecretRef != nil
 			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn2 = 2
+				yynn2 = 1
 				for _, b := range yyq2 {
 					if b {
 						yynn2++
@@ -335,19 +336,25 @@ func (x *ClusterSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if x.SecretRef == nil {
-					r.EncodeNil()
+				if yyq2[1] {
+					if x.SecretRef == nil {
+						r.EncodeNil()
+					} else {
+						x.SecretRef.CodecEncodeSelf(e)
+					}
 				} else {
-					x.SecretRef.CodecEncodeSelf(e)
+					r.EncodeNil()
 				}
 			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("secretRef"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				if x.SecretRef == nil {
-					r.EncodeNil()
-				} else {
-					x.SecretRef.CodecEncodeSelf(e)
+				if yyq2[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("secretRef"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if x.SecretRef == nil {
+						r.EncodeNil()
+					} else {
+						x.SecretRef.CodecEncodeSelf(e)
+					}
 				}
 			}
 			if yyr2 || yy2arr2 {

--- a/federation/apis/federation/types.go
+++ b/federation/apis/federation/types.go
@@ -41,7 +41,8 @@ type ClusterSpec struct {
 	// The secret is read from the kubernetes cluster that is hosting federation control plane.
 	// Admin needs to ensure that the required secret exists. Secret should be in the same namespace where federation control plane is hosted and it should have kubeconfig in its data with key "kubeconfig".
 	// This will later be changed to a reference to secret in federation control plane when the federation control plane supports secrets.
-	SecretRef *api.LocalObjectReference `json:"secretRef"`
+	// This can be left empty if the cluster allows insecure access.
+	SecretRef *api.LocalObjectReference `json:"secretRef,omitempty"`
 }
 
 type ClusterConditionType string

--- a/federation/apis/federation/v1alpha1/generated.proto
+++ b/federation/apis/federation/v1alpha1/generated.proto
@@ -91,6 +91,7 @@ message ClusterSpec {
   // The secret is read from the kubernetes cluster that is hosting federation control plane.
   // Admin needs to ensure that the required secret exists. Secret should be in the same namespace where federation control plane is hosted and it should have kubeconfig in its data with key "kubeconfig".
   // This will later be changed to a reference to secret in federation control plane when the federation control plane supports secrets.
+  // This can be left empty if the cluster allows insecure access.
   optional k8s.io.kubernetes.pkg.api.v1.LocalObjectReference secretRef = 2;
 }
 

--- a/federation/apis/federation/v1alpha1/types.generated.go
+++ b/federation/apis/federation/v1alpha1/types.generated.go
@@ -293,11 +293,12 @@ func (x *ClusterSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2 [2]bool
 			_, _, _ = yysep2, yyq2, yy2arr2
 			const yyr2 bool = false
+			yyq2[1] = x.SecretRef != nil
 			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn2 = 2
+				yynn2 = 1
 				for _, b := range yyq2 {
 					if b {
 						yynn2++
@@ -335,19 +336,25 @@ func (x *ClusterSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if x.SecretRef == nil {
-					r.EncodeNil()
+				if yyq2[1] {
+					if x.SecretRef == nil {
+						r.EncodeNil()
+					} else {
+						x.SecretRef.CodecEncodeSelf(e)
+					}
 				} else {
-					x.SecretRef.CodecEncodeSelf(e)
+					r.EncodeNil()
 				}
 			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("secretRef"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				if x.SecretRef == nil {
-					r.EncodeNil()
-				} else {
-					x.SecretRef.CodecEncodeSelf(e)
+				if yyq2[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("secretRef"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if x.SecretRef == nil {
+						r.EncodeNil()
+					} else {
+						x.SecretRef.CodecEncodeSelf(e)
+					}
 				}
 			}
 			if yyr2 || yy2arr2 {

--- a/federation/apis/federation/v1alpha1/types.go
+++ b/federation/apis/federation/v1alpha1/types.go
@@ -41,7 +41,8 @@ type ClusterSpec struct {
 	// The secret is read from the kubernetes cluster that is hosting federation control plane.
 	// Admin needs to ensure that the required secret exists. Secret should be in the same namespace where federation control plane is hosted and it should have kubeconfig in its data with key "kubeconfig".
 	// This will later be changed to a reference to secret in federation control plane when the federation control plane supports secrets.
-	SecretRef *v1.LocalObjectReference `json:"secretRef" protobuf:"bytes,2,opt,name=secretRef"`
+	// This can be left empty if the cluster allows insecure access.
+	SecretRef *v1.LocalObjectReference `json:"secretRef,omitempty" protobuf:"bytes,2,opt,name=secretRef"`
 }
 
 type ClusterConditionType string


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/pull/26132#issuecomment-222614042

Updated the code to load the secretRef only if it is present in the spec. This allows unsecured access to the cluster.

cc @kubernetes/sig-cluster-federation @mfanjie 
