### PR TITLE
Minor typo in comment, SSLv3 instead of SSLv4

### DIFF
--- a/pkg/client/transport/transport.go
+++ b/pkg/client/transport/transport.go
@@ -63,7 +63,7 @@ func TLSConfigFor(c *Config) (*tls.Config, error) {
 	}
 
 	tlsConfig := &tls.Config{
-		// Can't use SSLv4 because of POODLE and BEAST
+		// Can't use SSLv3 because of POODLE and BEAST
 		// Can't use TLSv1.0 because of POODLE and BEAST using CBC cipher
 		// Can't use TLSv1.1 because of RC4 cipher usage
 		MinVersion:         tls.VersionTLS12,


### PR DESCRIPTION
Minor fix in a comment from this PR https://github.com/kubernetes/kubernetes/pull/26169
