### PR TITLE
pin GCI version to milestone 52

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -34,7 +34,8 @@ if [[ "${OS_DISTRIBUTION}" == "gci" ]]; then
   # If the master image is not set, we use the latest GCI dev image.
   # Otherwise, we respect whatever is set by the user.
   gci_images=( $(gcloud compute images list --project google-containers \
-      --regexp='gci-dev.*' --format='value(name)') )
+      --show-deprecated --no-standard-images --sort-by='~creationTimestamp' \
+      --regexp='gci-[a-z]+-52-.*' --format='table[no-heading](name)') )
   MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-"${gci_images[0]}"}
   MASTER_IMAGE_PROJECT=${KUBE_GCE_MASTER_PROJECT:-google-containers}
   # The default node image when using GCI is still the Debian based ContainerVM


### PR DESCRIPTION
This is mainly for pinning the 1.2 branch to GCI milestone 52
which contains correct docker and kubelet built in.
Doing this allows us to upgrade docker to v1.11 (issue #26455)
in GCI 53 without breaking the 1.2 release branch.

@kubernetes/goog-image @dchen1107 @roberthbailey @andyzheng0831 
