### PR TITLE
Collect l7 controller e2e logs

### DIFF
--- a/cluster/log-dump.sh
+++ b/cluster/log-dump.sh
@@ -77,7 +77,7 @@ function save-logs() {
 readonly master_ssh_supported_providers="gce aws kubemark"
 readonly node_ssh_supported_providers="gce gke aws"
 
-readonly master_logfiles="kube-apiserver kube-scheduler kube-controller-manager etcd"
+readonly master_logfiles="kube-apiserver kube-scheduler kube-controller-manager etcd glbc"
 readonly node_logfiles="kube-proxy"
 readonly aws_logfiles="cloud-init-output"
 readonly gce_logfiles="startupscript"


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/26048#issuecomment-222758050
I meant to check e2e output and see if the logs were being collected, but it merged before i could. 
