### PR TITLE
[fix] allow ALLOW_PRIVILEGED to be passed to kubelet and kube-api

### DIFF
--- a/cluster/ubuntu/config-default.sh
+++ b/cluster/ubuntu/config-default.sh
@@ -17,7 +17,7 @@
 ## Contains configuration values for the Ubuntu cluster
 
 # Define all your cluster nodes, MASTER node comes first"
-# And separated with blank space like <user_1@ip_1> <user_2@ip_2> <user_3@ip_3> 
+# And separated with blank space like <user_1@ip_1> <user_2@ip_2> <user_3@ip_3>
 export nodes=${nodes:-"vcap@10.10.103.250 vcap@10.10.103.162 vcap@10.10.103.223"}
 
 # Define all your nodes role: a(master) or i(minion) or ai(both master and minion),
@@ -111,6 +111,9 @@ ENABLE_CLUSTER_UI="${KUBE_ENABLE_CLUSTER_UI:-true}"
 # Optional: Add http or https proxy when download easy-rsa.
 # Add environment variable separated with blank space like "http_proxy=http://10.x.x.x:8080 https_proxy=https://10.x.x.x:8443"
 PROXY_SETTING=${PROXY_SETTING:-""}
+
+# Optional: Allows kublet/kube-api to be run in privileged mode
+ALLOW_PRIVILEGED=${ALLOW_PRIVILEGED:-"false"}
 
 DEBUG=${DEBUG:-"false"}
 

--- a/cluster/ubuntu/util.sh
+++ b/cluster/ubuntu/util.sh
@@ -234,6 +234,7 @@ EOF
 # $2: Admission Controllers to invoke in the API server.
 # $3: A port range to reserve for services with NodePort visibility.
 # $4: The IP address on which to advertise the apiserver to members of the cluster.
+# $5: Tells kube-api to run in privileged mode
 function create-kube-apiserver-opts() {
   cat <<EOF > ~/kube/default/kube-apiserver
 KUBE_APISERVER_OPTS="\


### PR DESCRIPTION
This is something that we need for running docker in docker. Please let me know if you would consider this change. Thanks :)
