### PR TITLE
cluster/coreos: Update heapster addon to beta2

### DIFF
--- a/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -1,26 +1,26 @@
-apiVersion: extensions/v1beta1
+apiVersion: extensions/v1beta2
 kind: Deployment
 metadata:
-  name: heapster-v1.1.0.beta1
+  name: heapster-v1.1.0.beta2
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
-    version: v1.1.0.beta1
+    version: v1.1.0.beta2
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.1.0.beta1
+      version: v1.1.0.beta2
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.1.0.beta1
+        version: v1.1.0.beta2
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v1.1.0-beta1
+        - image: gcr.io/google_containers/heapster:v1.1.0-beta2
           name: heapster
           resources:
             # keep request = limit to keep this container in guaranteed class
@@ -42,7 +42,7 @@ spec:
             - name: usrsharecacerts
               mountPath: /usr/share/ca-certificates
               readOnly: true
-        - image: gcr.io/google_containers/heapster:v1.1.0-beta1
+        - image: gcr.io/google_containers/heapster:v1.1.0-beta2
           name: eventer
           resources:
             # keep request = limit to keep this container in guaranteed class
@@ -88,7 +88,7 @@ spec:
             - --memory=300Mi
             - --extra-memory=4Mi
             - --threshold=5
-            - --deployment=heapster-v1.1.0.beta1
+            - --deployment=heapster-v1.1.0.beta2
             - --container=heapster
             - --poll-period=300000
         - image: gcr.io/google_containers/addon-resizer:1.0
@@ -116,7 +116,7 @@ spec:
             - --memory=300Mi
             - --extra-memory=307200Ki
             - --threshold=5
-            - --deployment=heapster-v1.1.0.beta1
+            - --deployment=heapster-v1.1.0.beta2
             - --container=eventer
             - --poll-period=300000
       volumes:

--- a/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -34,7 +34,6 @@ spec:
             - /heapster
             - --source=kubernetes.summary_api:''
             - --sink=gcm
-            - --metric_resolution=60s
           volumeMounts:
             - name: ssl-certs
               mountPath: /etc/ssl/certs

--- a/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -1,26 +1,26 @@
-apiVersion: extensions/v1beta1
+apiVersion: extensions/v1beta2
 kind: Deployment
 metadata:
-  name: heapster-v1.1.0.beta1
+  name: heapster-v1.1.0.beta2
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
-    version: v1.1.0.beta1
+    version: v1.1.0.beta2
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.1.0.beta1
+      version: v1.1.0.beta2
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.1.0.beta1
+        version: v1.1.0.beta2
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v1.1.0-beta1
+        - image: gcr.io/google_containers/heapster:v1.1.0-beta2
           name: heapster
           resources:
             # keep request = limit to keep this container in guaranteed class
@@ -43,7 +43,7 @@ spec:
             - name: usrsharecacerts
               mountPath: /usr/share/ca-certificates
               readOnly: true
-        - image: gcr.io/google_containers/heapster:v1.1.0-beta1
+        - image: gcr.io/google_containers/heapster:v1.1.0-beta2
           name: eventer
           resources:
             # keep request = limit to keep this container in guaranteed class
@@ -89,7 +89,7 @@ spec:
             - --memory=300Mi
             - --extra-memory=4Mi
             - --threshold=5
-            - --deployment=heapster-v1.1.0.beta1
+            - --deployment=heapster-v1.1.0.beta2
             - --container=heapster
             - --poll-period=300000
         - image: gcr.io/google_containers/addon-resizer:1.0
@@ -117,7 +117,7 @@ spec:
             - --memory=300Mi
             - --extra-memory=307200Ki
             - --threshold=5
-            - --deployment=heapster-v1.1.0.beta1
+            - --deployment=heapster-v1.1.0.beta2
             - --container=eventer
             - --poll-period=300000
       volumes:

--- a/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -35,7 +35,6 @@ spec:
             - --source=kubernetes.summary_api:''
             - --sink=influxdb:http://monitoring-influxdb:8086
             - --sink=gcm:?metrics=autoscaling
-            - --metric_resolution=60s
           volumeMounts:
             - name: ssl-certs
               mountPath: /etc/ssl/certs

--- a/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -1,26 +1,26 @@
-apiVersion: extensions/v1beta1
+apiVersion: extensions/v1beta2
 kind: Deployment
 metadata:
-  name: heapster-v1.1.0.beta1
+  name: heapster-v1.1.0.beta2
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
-    version: v1.1.0.beta1
+    version: v1.1.0.beta2
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.1.0.beta1
+      version: v1.1.0.beta2
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.1.0.beta1
+        version: v1.1.0.beta2
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v1.1.0-beta1
+        - image: gcr.io/google_containers/heapster:v1.1.0-beta2
           name: heapster
           resources:
             # keep request = limit to keep this container in guaranteed class
@@ -35,7 +35,7 @@ spec:
             - --source=kubernetes.summary_api:''
             - --sink=influxdb:http://monitoring-influxdb:8086
             - --metric_resolution=60s
-        - image: gcr.io/google_containers/heapster:v1.1.0-beta1
+        - image: gcr.io/google_containers/heapster:v1.1.0-beta2
           name: eventer
           resources:
             # keep request = limit to keep this container in guaranteed class
@@ -74,7 +74,7 @@ spec:
             - --memory=300Mi
             - --extra-memory=4Mi
             - --threshold=5
-            - --deployment=heapster-v1.1.0.beta1
+            - --deployment=heapster-v1.1.0.beta2
             - --container=heapster
             - --poll-period=300000
         - image: gcr.io/google_containers/addon-resizer:1.0
@@ -102,6 +102,6 @@ spec:
             - --memory=300Mi
             - --extra-memory=307200Ki
             - --threshold=5
-            - --deployment=heapster-v1.1.0.beta1
+            - --deployment=heapster-v1.1.0.beta2
             - --container=eventer
             - --poll-period=300000

--- a/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -34,7 +34,6 @@ spec:
             - /heapster
             - --source=kubernetes.summary_api:''
             - --sink=influxdb:http://monitoring-influxdb:8086
-            - --metric_resolution=60s
         - image: gcr.io/google_containers/heapster:v1.1.0-beta2
           name: eventer
           resources:

--- a/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -1,26 +1,26 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.1.0.beta1
+  name: heapster-v1.1.0.beta2
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
-    version: v1.1.0.beta1
+    version: v1.1.0.beta2
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.1.0.beta1
+      version: v1.1.0.beta2
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.1.0.beta1
+        version: v1.1.0.beta2
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v1.1.0-beta1
+        - image: gcr.io/google_containers/heapster:v1.1.0-beta2
           name: heapster
           resources:
             # keep request = limit to keep this container in guaranteed class
@@ -59,6 +59,6 @@ spec:
             - --memory=300Mi
             - --extra-memory=4Mi
             - --threshold=5
-            - --deployment=heapster-v1.1.0.beta1
+            - --deployment=heapster-v1.1.0.beta2
             - --container=heapster
             - --poll-period=300000

--- a/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -33,7 +33,6 @@ spec:
           command:
             - /heapster
             - --source=kubernetes.summary_api:''
-            - --metric_resolution=60s
         - image: gcr.io/google_containers/addon-resizer:1.0
           name: heapster-nanny
           resources:


### PR DESCRIPTION
fixes #26616 

As noted there, heapster was updated but not for gce/coreos which breaks anything that depends on heapster's new metrics API (i.e. autoscaling)
