### PR TITLE
Add kubectl version guard around kubectl port-forward

### DIFF
--- a/test/e2e/portforward.go
+++ b/test/e2e/portforward.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"os/exec"
@@ -29,6 +30,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/pkg/version"
 
 	. "github.com/onsi/ginkgo"
 )
@@ -38,7 +40,10 @@ const (
 )
 
 // TODO support other ports besides 80
-var portForwardRegexp = regexp.MustCompile("Forwarding from 127.0.0.1:([0-9]+) -> 80")
+var (
+	portForwardRegexp = regexp.MustCompile("Forwarding from 127.0.0.1:([0-9]+) -> 80")
+	portForwardPortToStdOutV = version.MustParse("v1.3.0-alpha.4")
+)
 
 func pfPod(expectedClientData, chunks, chunkSize, chunkIntervalMillis string) *api.Pod {
 	return &api.Pod{
@@ -123,16 +128,29 @@ func runPortForward(ns, podName string, port int) *portForwardCommand {
 	// by the port-forward command. We don't want to hard code the port as we have no
 	// way of guaranteeing we can pick one that isn't in use, particularly on Jenkins.
 	Logf("starting port-forward command and streaming output")
-	_, stderr, err := startCmdAndStreamOutput(cmd)
+	stdout, stderr, err := startCmdAndStreamOutput(cmd)
 	if err != nil {
 		Failf("Failed to start port-forward command: %v", err)
 	}
 
 	buf := make([]byte, 128)
+
+	// After v1.3.0-alpha.4 (#17030), kubectl port-forward outputs port
+	// info to stdout, not stderr, so for version-skewed tests, look there
+	// instead.
+	var portOutput io.ReadCloser
+	if useStdOut, err := kubectlVersionGTE(portForwardPortToStdOutV); err != nil {
+		Failf("Failed to get kubectl version: %v", err)
+	} else if useStdOut {
+		portOutput = stdout
+	} else {
+		portOutput = stderr
+	}
+
 	var n int
-	Logf("reading from `kubectl port-forward` command's stderr")
-	if n, err = stderr.Read(buf); err != nil {
-		Failf("Failed to read from kubectl port-forward stderr: %v", err)
+	Logf("reading from `kubectl port-forward` command")
+	if n, err = portOutput.Read(buf); err != nil {
+		Failf("Failed to read from kubectl port-forward: %v", err)
 	}
 	portForwardOutput := string(buf[:n])
 	match := portForwardRegexp.FindStringSubmatch(portForwardOutput)

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -31,6 +31,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -129,6 +130,10 @@ const (
 
 	// How long claims have to become dynamically provisioned
 	claimProvisionTimeout = 5 * time.Minute
+)
+
+var (
+	gitVersionRegexp = regexp.MustCompile("GitVersion:\"(v.+?)\"")
 )
 
 // SubResource proxy should have been functional in v1.0.0, but SubResource
@@ -1275,8 +1280,8 @@ func (r podProxyResponseChecker) checkAllResponses() (done bool, err error) {
 	return true, nil
 }
 
-// serverVersionGTE returns true if v is greater than or equal to the server
-// version.
+// serverVersionGTE returns true if the server version is greater than or
+// equal to v.
 //
 // TODO(18726): This should be incorporated into client.VersionInterface.
 func serverVersionGTE(v semver.Version, c discovery.ServerVersionInterface) (bool, error) {
@@ -1289,6 +1294,29 @@ func serverVersionGTE(v semver.Version, c discovery.ServerVersionInterface) (boo
 		return false, fmt.Errorf("Unable to parse server version %q: %v", serverVersion.GitVersion, err)
 	}
 	return sv.GTE(v), nil
+}
+
+// kubectlVersionGTE returns true if the kubectl version is greater than or
+// equal to v.
+func kubectlVersionGTE(v semver.Version) (bool, error) {
+	kv, err := kubectlVersion()
+	if err != nil {
+		return false, err
+	}
+	return kv.GTE(v), nil
+}
+
+// kubectlVersion gets the version of kubectl that's currently being used (see
+// --kubectl-path in e2e.go to use an alternate kubectl).
+func kubectlVersion() (semver.Version, error) {
+	output := runKubectlOrDie("version", "--client")
+	matches := gitVersionRegexp.FindStringSubmatch(output)
+	if len(matches) != 2 {
+		return semver.Version{}, fmt.Errorf("Could not find kubectl version in output %v", output)
+	}
+	// Don't use the full match, as it contains "GitVersion:\"" and a
+	// trailing "\"".  Just use the submatch.
+	return version.Parse(matches[1])
 }
 
 func podsResponding(c *client.Client, ns, name string, wantName bool, pods *api.PodList) error {


### PR DESCRIPTION
Work toward #26594.  This gets it to actually read from the right stream, though the test still doesn't pass against a v1.3 `kubectl` (see https://github.com/kubernetes/kubernetes/issues/26594#issuecomment-222848917).
