### PR TITLE
kubelet e2e: bumping cpu limit

### DIFF
--- a/test/e2e/kubelet_perf.go
+++ b/test/e2e/kubelet_perf.go
@@ -246,7 +246,7 @@ var _ = framework.KubeDescribe("Kubelet [Serial] [Slow]", func() {
 			},
 			{
 				cpuLimits: framework.ContainersCPUSummary{
-					stats.SystemContainerKubelet: {0.50: 0.15, 0.95: 0.20},
+					stats.SystemContainerKubelet: {0.50: 0.17, 0.95: 0.22},
 					stats.SystemContainerRuntime: {0.50: 0.06, 0.95: 0.09},
 				},
 				podsPerNode: 100,


### PR DESCRIPTION
The previous limit was too aggressive and caused kubernetes-e2e-gce-serial build 1404 to fail.
