### PR TITLE
Reduce size of fluentd-gcp image using ubuntu-slim

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Dockerfile
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Dockerfile
@@ -22,7 +22,7 @@
 # Please see http://docs.fluentd.org/articles/install-by-deb for more
 # information about installing fluentd using deb package.
 
-FROM ubuntu:14.04
+FROM gcr.io/google_containers/ubuntu-slim:0.1
 MAINTAINER Alex Robinson "arob@google.com"
 MAINTAINER Jimmi Dyson "jimmidyson@gmail.com"
 
@@ -32,24 +32,11 @@ RUN ulimit -n 65536
 # Disable prompts from apt.
 ENV DEBIAN_FRONTEND noninteractive
 
-# Install prerequisites.
-RUN apt-get update && \
-    apt-get install -y -q curl make g++ && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# Install Fluentd.
-RUN /usr/bin/curl -L https://td-toolbelt.herokuapp.com/sh/install-ubuntu-trusty-td-agent2.sh | sh
-
-# Change the default user and group to root.
-# Needed to allow access to /var/log/docker/... files.
-RUN sed -i -e "s/USER=td-agent/USER=root/" -e "s/GROUP=td-agent/GROUP=root/" /etc/init.d/td-agent
-
-# Install the Elasticsearch Fluentd plug-in.
-RUN td-agent-gem install fluent-plugin-kubernetes_metadata_filter fluent-plugin-elasticsearch
-
 # Copy the Fluentd configuration file.
 COPY td-agent.conf /etc/td-agent/td-agent.conf
+
+COPY build.sh /tmp/build.sh
+RUN /tmp/build.sh
 
 # Run the Fluentd service.
 ENTRYPOINT ["td-agent"]

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
@@ -15,7 +15,7 @@
 .PHONY:	build push
 
 IMAGE = fluentd-elasticsearch
-TAG = 1.17
+TAG = 1.16
 
 build:	
 	docker build -t gcr.io/google_containers/$(IMAGE):$(TAG) .

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/build.sh
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/build.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Install prerequisites.
+apt-get update
+
+apt-get install -y -q --no-install-recommends \
+  curl ca-certificates make g++ sudo bash
+
+# Install Fluentd.
+/usr/bin/curl -sSL https://td-toolbelt.herokuapp.com/sh/install-ubuntu-trusty-td-agent2.sh | bash
+
+# Change the default user and group to root.
+# Needed to allow access to /var/log/docker/... files.
+sed -i -e "s/USER=td-agent/USER=root/" -e "s/GROUP=td-agent/GROUP=root/" /etc/init.d/td-agent
+
+# Install the Elasticsearch Fluentd plug-in.
+td-agent-gem install fluent-plugin-kubernetes_metadata_filter fluent-plugin-elasticsearch
+
+apt-get remove -y make g++
+apt-get autoremove -y 
+apt-get clean -y 
+
+rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Dockerfile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Dockerfile
@@ -20,7 +20,7 @@
 # scope and that the Logging API has been enabled for the project
 # in the Google Developer Console. 
 
-FROM gcr.io/google_containers/ubuntu-slim:0.2
+FROM gcr.io/google_containers/ubuntu-slim:0.1
 MAINTAINER Alex Robinson "arob@google.com"
 
 # Disable prompts from apt.
@@ -47,7 +47,6 @@ RUN apt-get update && apt-get install --reinstall -y --no-install-recommends \
   /var/log/google-fluentd
 
 # Install the record reformer plugin.
-# Remove the misleading log file that gets generated when the agent is installed
 RUN /usr/sbin/google-fluentd-gem install fluent-plugin-record-reformer
 
 # Copy the Fluentd configuration file for logging Docker container logs.

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Dockerfile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Dockerfile
@@ -20,7 +20,7 @@
 # scope and that the Logging API has been enabled for the project
 # in the Google Developer Console. 
 
-FROM ubuntu:14.04
+FROM gcr.io/google_containers/ubuntu-slim:0.2
 MAINTAINER Alex Robinson "arob@google.com"
 
 # Disable prompts from apt.
@@ -28,16 +28,27 @@ ENV DEBIAN_FRONTEND noninteractive
 # Keeps unneeded configs from being installed along with fluentd.
 ENV DO_NOT_INSTALL_CATCH_ALL_CONFIG true
 
-RUN apt-get -q update && \
-    apt-get install -y curl && \
-    apt-get clean && \
-    curl -s https://dl.google.com/cloudagents/install-logging-agent.sh | bash
+# --reinstall is required to install lsb-base (required by install-logging-agent.sh)
+RUN apt-get update && apt-get install --reinstall -y --no-install-recommends \
+  curl ca-certificates \
+  bash \
+  lsb-base \
+  lsb-release && \
+  curl -sSL https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+  curl -sSL https://dl.google.com/cloudagents/install-logging-agent.sh | bash && \
+  apt-get autoremove -y && \
+  apt-get clean -y && \
+  rm -rf /var/lib/apt/lists/* \
+  /opt/google-fluentd/embedded/share/doc \
+  /opt/google-fluentd/embedded/share/gtk-doc \
+  /opt/google-fluentd/embedded/lib/postgresql \
+  /opt/google-fluentd/embedded/bin/postgres \
+  /opt/google-fluentd/embedded/share/postgresql \
+  /var/log/google-fluentd
 
 # Install the record reformer plugin.
-RUN /usr/sbin/google-fluentd-gem install fluent-plugin-record-reformer
-
 # Remove the misleading log file that gets generated when the agent is installed
-RUN rm -rf /var/log/google-fluentd
+RUN /usr/sbin/google-fluentd-gem install fluent-plugin-record-reformer
 
 # Copy the Fluentd configuration file for logging Docker container logs.
 COPY google-fluentd.conf /etc/google-fluentd/google-fluentd.conf

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
@@ -28,7 +28,7 @@
 
 .PHONY:	kbuild kpush
 
-TAG = 1.20
+TAG = 1.19
 
 # Rules for building the test image for deployment to Dockerhub with user kubernetes.
 

--- a/cluster/saltbase/salt/fluentd-es/fluentd-es.yaml
+++ b/cluster/saltbase/salt/fluentd-es/fluentd-es.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
   - name: fluentd-elasticsearch
-    image: gcr.io/google_containers/fluentd-elasticsearch:1.17
+    image: gcr.io/google_containers/fluentd-elasticsearch:1.16
     resources:
       limits:
         memory: 200Mi

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -9,7 +9,7 @@ spec:
   dnsPolicy: Default
   containers:
   - name: fluentd-cloud-logging
-    image: gcr.io/google_containers/fluentd-gcp:1.20
+    image: gcr.io/google_containers/fluentd-gcp:1.19
     resources:
       limits:
         memory: 200Mi


### PR DESCRIPTION
```
gcr.io/google_containers/fluentd-gcp  1.18   ed70ff4ab587  12 weeks ago        411.5 MB
gcr.io/google_containers/fluentd-gcp  1.19   052dc36b53a9  About a minute ago  258.3 MB
```
