### PR TITLE
Improve Pod network status info

### DIFF
--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -18531,6 +18531,18 @@
       "type": "string",
       "description": "IP address allocated to the pod. Routable at least within the cluster. Empty if not yet allocated."
      },
+     "podMAC": {
+      "type": "string",
+      "description": "MAC address allocated to the pod. Empty if not yet allocated, or if not set by the Kubelet. Note that in some cases, such as IPVLAN, all the pods on a given node may share the same MAC address."
+     },
+     "podGatewayIP": {
+      "type": "string",
+      "description": "Default gateway for the pod. Empty if not yet allocated, or if not configured on the pod. This could be the case of a CNI network without a default gateway."
+     },
+     "podLinkStatus": {
+      "type": "string",
+      "description": "Current link status of the Pod. Empty if the interface has not yet been configured."
+     },
      "startTime": {
       "type": "string",
       "description": "RFC 3339 date and time at which the object was acknowledged by the Kubelet. This is before the Kubelet pulled the container image(s) for the pod."

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -2376,6 +2376,9 @@ func DeepCopy_api_PodStatus(in PodStatus, out *PodStatus, c *conversion.Cloner) 
 	out.Reason = in.Reason
 	out.HostIP = in.HostIP
 	out.PodIP = in.PodIP
+	out.PodMAC = in.PodMAC
+	out.PodGatewayIP = in.PodGatewayIP
+	out.PodLinkStatus = in.PodLinkStatus
 	if in.StartTime != nil {
 		in, out := in.StartTime, &out.StartTime
 		*out = new(unversioned.Time)

--- a/pkg/api/types.generated.go
+++ b/pkg/api/types.generated.go
@@ -27633,7 +27633,7 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 		} else {
 			yysep2 := !z.EncBinary()
 			yy2arr2 := z.EncBasicHandle().StructToArray
-			var yyq2 [8]bool
+			var yyq2 [11]bool
 			_, _, _ = yysep2, yyq2, yy2arr2
 			const yyr2 bool = false
 			yyq2[0] = x.Phase != ""
@@ -27642,11 +27642,14 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2[3] = x.Reason != ""
 			yyq2[4] = x.HostIP != ""
 			yyq2[5] = x.PodIP != ""
-			yyq2[6] = x.StartTime != nil
-			yyq2[7] = len(x.ContainerStatuses) != 0
+			yyq2[6] = x.PodMAC != ""
+			yyq2[7] = x.PodGatewayIP != ""
+			yyq2[8] = x.PodLinkStatus != ""
+			yyq2[9] = x.StartTime != nil
+			yyq2[10] = len(x.ContainerStatuses) != 0
 			var yynn2 int
 			if yyr2 || yy2arr2 {
-				r.EncodeArrayStart(8)
+				r.EncodeArrayStart(11)
 			} else {
 				yynn2 = 0
 				for _, b := range yyq2 {
@@ -27808,16 +27811,91 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[6] {
+					yym22 := z.EncBinary()
+					_ = yym22
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.PodMAC))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("podMAC"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym23 := z.EncBinary()
+					_ = yym23
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.PodMAC))
+					}
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2[7] {
+					yym25 := z.EncBinary()
+					_ = yym25
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.PodGatewayIP))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("podGatewayIP"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym26 := z.EncBinary()
+					_ = yym26
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.PodGatewayIP))
+					}
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2[8] {
+					yym28 := z.EncBinary()
+					_ = yym28
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.PodLinkStatus))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2[8] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("podLinkStatus"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym29 := z.EncBinary()
+					_ = yym29
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.PodLinkStatus))
+					}
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2[9] {
 					if x.StartTime == nil {
 						r.EncodeNil()
 					} else {
-						yym22 := z.EncBinary()
-						_ = yym22
+						yym31 := z.EncBinary()
+						_ = yym31
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
-						} else if yym22 {
+						} else if yym31 {
 							z.EncBinaryMarshal(x.StartTime)
-						} else if !yym22 && z.IsJSONHandle() {
+						} else if !yym31 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.StartTime)
 						} else {
 							z.EncFallback(x.StartTime)
@@ -27827,20 +27905,20 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2[6] {
+				if yyq2[9] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("startTime"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.StartTime == nil {
 						r.EncodeNil()
 					} else {
-						yym23 := z.EncBinary()
-						_ = yym23
+						yym32 := z.EncBinary()
+						_ = yym32
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
-						} else if yym23 {
+						} else if yym32 {
 							z.EncBinaryMarshal(x.StartTime)
-						} else if !yym23 && z.IsJSONHandle() {
+						} else if !yym32 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.StartTime)
 						} else {
 							z.EncFallback(x.StartTime)
@@ -27850,12 +27928,12 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[7] {
+				if yyq2[10] {
 					if x.ContainerStatuses == nil {
 						r.EncodeNil()
 					} else {
-						yym25 := z.EncBinary()
-						_ = yym25
+						yym34 := z.EncBinary()
+						_ = yym34
 						if false {
 						} else {
 							h.encSliceContainerStatus(([]ContainerStatus)(x.ContainerStatuses), e)
@@ -27865,15 +27943,15 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2[7] {
+				if yyq2[10] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("containerStatuses"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.ContainerStatuses == nil {
 						r.EncodeNil()
 					} else {
-						yym26 := z.EncBinary()
-						_ = yym26
+						yym35 := z.EncBinary()
+						_ = yym35
 						if false {
 						} else {
 							h.encSliceContainerStatus(([]ContainerStatus)(x.ContainerStatuses), e)
@@ -27984,6 +28062,24 @@ func (x *PodStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			} else {
 				x.PodIP = string(r.DecodeString())
 			}
+		case "podMAC":
+			if r.TryDecodeAsNil() {
+				x.PodMAC = ""
+			} else {
+				x.PodMAC = string(r.DecodeString())
+			}
+		case "podGatewayIP":
+			if r.TryDecodeAsNil() {
+				x.PodGatewayIP = ""
+			} else {
+				x.PodGatewayIP = string(r.DecodeString())
+			}
+		case "podLinkStatus":
+			if r.TryDecodeAsNil() {
+				x.PodLinkStatus = ""
+			} else {
+				x.PodLinkStatus = string(r.DecodeString())
+			}
 		case "startTime":
 			if r.TryDecodeAsNil() {
 				if x.StartTime != nil {
@@ -27993,13 +28089,13 @@ func (x *PodStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.StartTime == nil {
 					x.StartTime = new(pkg2_unversioned.Time)
 				}
-				yym12 := z.DecBinary()
-				_ = yym12
+				yym15 := z.DecBinary()
+				_ = yym15
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.StartTime) {
-				} else if yym12 {
+				} else if yym15 {
 					z.DecBinaryUnmarshal(x.StartTime)
-				} else if !yym12 && z.IsJSONHandle() {
+				} else if !yym15 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.StartTime)
 				} else {
 					z.DecFallback(x.StartTime, false)
@@ -28009,12 +28105,12 @@ func (x *PodStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ContainerStatuses = nil
 			} else {
-				yyv13 := &x.ContainerStatuses
-				yym14 := z.DecBinary()
-				_ = yym14
+				yyv16 := &x.ContainerStatuses
+				yym17 := z.DecBinary()
+				_ = yym17
 				if false {
 				} else {
-					h.decSliceContainerStatus((*[]ContainerStatus)(yyv13), d)
+					h.decSliceContainerStatus((*[]ContainerStatus)(yyv16), d)
 				}
 			}
 		default:
@@ -28028,16 +28124,16 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj15 int
-	var yyb15 bool
-	var yyhl15 bool = l >= 0
-	yyj15++
-	if yyhl15 {
-		yyb15 = yyj15 > l
+	var yyj18 int
+	var yyb18 bool
+	var yyhl18 bool = l >= 0
+	yyj18++
+	if yyhl18 {
+		yyb18 = yyj18 > l
 	} else {
-		yyb15 = r.CheckBreak()
+		yyb18 = r.CheckBreak()
 	}
-	if yyb15 {
+	if yyb18 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -28047,13 +28143,13 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Phase = PodPhase(r.DecodeString())
 	}
-	yyj15++
-	if yyhl15 {
-		yyb15 = yyj15 > l
+	yyj18++
+	if yyhl18 {
+		yyb18 = yyj18 > l
 	} else {
-		yyb15 = r.CheckBreak()
+		yyb18 = r.CheckBreak()
 	}
-	if yyb15 {
+	if yyb18 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -28061,21 +28157,21 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Conditions = nil
 	} else {
-		yyv17 := &x.Conditions
-		yym18 := z.DecBinary()
-		_ = yym18
+		yyv20 := &x.Conditions
+		yym21 := z.DecBinary()
+		_ = yym21
 		if false {
 		} else {
-			h.decSlicePodCondition((*[]PodCondition)(yyv17), d)
+			h.decSlicePodCondition((*[]PodCondition)(yyv20), d)
 		}
 	}
-	yyj15++
-	if yyhl15 {
-		yyb15 = yyj15 > l
+	yyj18++
+	if yyhl18 {
+		yyb18 = yyj18 > l
 	} else {
-		yyb15 = r.CheckBreak()
+		yyb18 = r.CheckBreak()
 	}
-	if yyb15 {
+	if yyb18 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -28085,13 +28181,13 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Message = string(r.DecodeString())
 	}
-	yyj15++
-	if yyhl15 {
-		yyb15 = yyj15 > l
+	yyj18++
+	if yyhl18 {
+		yyb18 = yyj18 > l
 	} else {
-		yyb15 = r.CheckBreak()
+		yyb18 = r.CheckBreak()
 	}
-	if yyb15 {
+	if yyb18 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -28101,13 +28197,13 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Reason = string(r.DecodeString())
 	}
-	yyj15++
-	if yyhl15 {
-		yyb15 = yyj15 > l
+	yyj18++
+	if yyhl18 {
+		yyb18 = yyj18 > l
 	} else {
-		yyb15 = r.CheckBreak()
+		yyb18 = r.CheckBreak()
 	}
-	if yyb15 {
+	if yyb18 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -28117,13 +28213,13 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.HostIP = string(r.DecodeString())
 	}
-	yyj15++
-	if yyhl15 {
-		yyb15 = yyj15 > l
+	yyj18++
+	if yyhl18 {
+		yyb18 = yyj18 > l
 	} else {
-		yyb15 = r.CheckBreak()
+		yyb18 = r.CheckBreak()
 	}
-	if yyb15 {
+	if yyb18 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -28133,13 +28229,61 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.PodIP = string(r.DecodeString())
 	}
-	yyj15++
-	if yyhl15 {
-		yyb15 = yyj15 > l
+	yyj18++
+	if yyhl18 {
+		yyb18 = yyj18 > l
 	} else {
-		yyb15 = r.CheckBreak()
+		yyb18 = r.CheckBreak()
 	}
-	if yyb15 {
+	if yyb18 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.PodMAC = ""
+	} else {
+		x.PodMAC = string(r.DecodeString())
+	}
+	yyj18++
+	if yyhl18 {
+		yyb18 = yyj18 > l
+	} else {
+		yyb18 = r.CheckBreak()
+	}
+	if yyb18 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.PodGatewayIP = ""
+	} else {
+		x.PodGatewayIP = string(r.DecodeString())
+	}
+	yyj18++
+	if yyhl18 {
+		yyb18 = yyj18 > l
+	} else {
+		yyb18 = r.CheckBreak()
+	}
+	if yyb18 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.PodLinkStatus = ""
+	} else {
+		x.PodLinkStatus = string(r.DecodeString())
+	}
+	yyj18++
+	if yyhl18 {
+		yyb18 = yyj18 > l
+	} else {
+		yyb18 = r.CheckBreak()
+	}
+	if yyb18 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -28152,25 +28296,25 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.StartTime == nil {
 			x.StartTime = new(pkg2_unversioned.Time)
 		}
-		yym24 := z.DecBinary()
-		_ = yym24
+		yym30 := z.DecBinary()
+		_ = yym30
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.StartTime) {
-		} else if yym24 {
+		} else if yym30 {
 			z.DecBinaryUnmarshal(x.StartTime)
-		} else if !yym24 && z.IsJSONHandle() {
+		} else if !yym30 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.StartTime)
 		} else {
 			z.DecFallback(x.StartTime, false)
 		}
 	}
-	yyj15++
-	if yyhl15 {
-		yyb15 = yyj15 > l
+	yyj18++
+	if yyhl18 {
+		yyb18 = yyj18 > l
 	} else {
-		yyb15 = r.CheckBreak()
+		yyb18 = r.CheckBreak()
 	}
-	if yyb15 {
+	if yyb18 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -28178,26 +28322,26 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ContainerStatuses = nil
 	} else {
-		yyv25 := &x.ContainerStatuses
-		yym26 := z.DecBinary()
-		_ = yym26
+		yyv31 := &x.ContainerStatuses
+		yym32 := z.DecBinary()
+		_ = yym32
 		if false {
 		} else {
-			h.decSliceContainerStatus((*[]ContainerStatus)(yyv25), d)
+			h.decSliceContainerStatus((*[]ContainerStatus)(yyv31), d)
 		}
 	}
 	for {
-		yyj15++
-		if yyhl15 {
-			yyb15 = yyj15 > l
+		yyj18++
+		if yyhl18 {
+			yyb18 = yyj18 > l
 		} else {
-			yyb15 = r.CheckBreak()
+			yyb18 = r.CheckBreak()
 		}
-		if yyb15 {
+		if yyb18 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj15-1, "")
+		z.DecStructFieldNotFound(yyj18-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -54309,7 +54453,7 @@ func (x codecSelfer1234) decSlicePod(v *[]Pod, d *codec1978.Decoder) {
 
 			yyrg1 := len(yyv1) > 0
 			yyv21 := yyv1
-			yyrl1, yyrt1 = z.DecInferLen(yyl1, z.DecBasicHandle().MaxInitLen, 624)
+			yyrl1, yyrt1 = z.DecInferLen(yyl1, z.DecBasicHandle().MaxInitLen, 672)
 			if yyrt1 {
 				if yyrl1 <= cap(yyv1) {
 					yyv1 = yyv1[:yyrl1]

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1526,8 +1526,11 @@ type PodStatus struct {
 	// A brief CamelCase message indicating details about why the pod is in this state. e.g. 'OutOfDisk'
 	Reason string `json:"reason,omitempty"`
 
-	HostIP string `json:"hostIP,omitempty"`
-	PodIP  string `json:"podIP,omitempty"`
+	HostIP        string `json:"hostIP,omitempty"`
+	PodIP         string `json:"podIP,omitempty"`
+	PodMAC        string `json:"podMAC,omitempty"`
+	PodGatewayIP  string `json:"podGatewayIP,omitempty"`
+	PodLinkStatus string `json:"podLinkStatus,omitempty"`
 
 	// Date and time at which the object was acknowledged by the Kubelet.
 	// This is before the Kubelet pulled the container image(s) for the pod.

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -4805,6 +4805,9 @@ func autoConvert_v1_PodStatus_To_api_PodStatus(in *PodStatus, out *api.PodStatus
 	out.Reason = in.Reason
 	out.HostIP = in.HostIP
 	out.PodIP = in.PodIP
+	out.PodMAC = in.PodMAC
+	out.PodGatewayIP = in.PodGatewayIP
+	out.PodLinkStatus = in.PodLinkStatus
 	out.StartTime = in.StartTime
 	if in.InitContainerStatuses != nil {
 		in, out := &in.InitContainerStatuses, &out.InitContainerStatuses
@@ -4852,6 +4855,9 @@ func autoConvert_api_PodStatus_To_v1_PodStatus(in *api.PodStatus, out *PodStatus
 	out.Reason = in.Reason
 	out.HostIP = in.HostIP
 	out.PodIP = in.PodIP
+	out.PodMAC = in.PodMAC
+	out.PodGatewayIP = in.PodGatewayIP
+	out.PodLinkStatus = in.PodLinkStatus
 	out.StartTime = in.StartTime
 	if in.InitContainerStatuses != nil {
 		in, out := &in.InitContainerStatuses, &out.InitContainerStatuses

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -2324,6 +2324,9 @@ func DeepCopy_v1_PodStatus(in PodStatus, out *PodStatus, c *conversion.Cloner) e
 	out.Reason = in.Reason
 	out.HostIP = in.HostIP
 	out.PodIP = in.PodIP
+	out.PodMAC = in.PodMAC
+	out.PodGatewayIP = in.PodGatewayIP
+	out.PodLinkStatus = in.PodLinkStatus
 	if in.StartTime != nil {
 		in, out := in.StartTime, &out.StartTime
 		*out = new(unversioned.Time)

--- a/pkg/api/v1/generated.pb.go
+++ b/pkg/api/v1/generated.pb.go
@@ -5782,6 +5782,18 @@ func (m *PodStatus) MarshalTo(data []byte) (int, error) {
 			i += n
 		}
 	}
+	data[i] = 0x4a
+	i++
+	i = encodeVarintGenerated(data, i, uint64(len(m.PodMAC)))
+	i += copy(data[i:], m.PodMAC)
+	data[i] = 0x52
+	i++
+	i = encodeVarintGenerated(data, i, uint64(len(m.PodGatewayIP)))
+	i += copy(data[i:], m.PodGatewayIP)
+	data[i] = 0x5a
+	i++
+	i = encodeVarintGenerated(data, i, uint64(len(m.PodLinkStatus)))
+	i += copy(data[i:], m.PodLinkStatus)
 	return i, nil
 }
 
@@ -9477,6 +9489,12 @@ func (m *PodStatus) Size() (n int) {
 			n += 1 + l + sovGenerated(uint64(l))
 		}
 	}
+	l = len(m.PodMAC)
+	n += 1 + l + sovGenerated(uint64(l))
+	l = len(m.PodGatewayIP)
+	n += 1 + l + sovGenerated(uint64(l))
+	l = len(m.PodLinkStatus)
+	n += 1 + l + sovGenerated(uint64(l))
 	return n
 }
 
@@ -27556,6 +27574,93 @@ func (m *PodStatus) Unmarshal(data []byte) error {
 			if err := m.ContainerStatuses[len(m.ContainerStatuses)-1].Unmarshal(data[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		case 9:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PodMAC", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.PodMAC = string(data[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 10:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PodGatewayIP", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.PodGatewayIP = string(data[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 11:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PodLinkStatus", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.PodLinkStatus = string(data[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/api/v1/generated.proto
+++ b/pkg/api/v1/generated.proto
@@ -2138,6 +2138,19 @@ message PodStatus {
   // Empty if not yet allocated.
   optional string podIP = 6;
 
+  // MAC address allocated to the pod. Empty if not yet allocated, or if not set by
+  // the Kubelet. Note that in some cases, such as IPVLAN, all the pods on a given node
+  // may share the same MAC address.
+  optional string podMAC = 9;
+
+  // Default gateway for the pod. Empty if not yet allocated, or if not configured
+  // on the pod. This could be the case of a CNI network without a default gateway.
+  optional string podGatewayIP = 10;
+
+  // Current link status of the Pod. Empty if the interface has not yet been
+  // configured.
+  optional string podLinkStatus = 11;
+
   // RFC 3339 date and time at which the object was acknowledged by the Kubelet.
   // This is before the Kubelet pulled the container image(s) for the pod.
   optional k8s.io.kubernetes.pkg.api.unversioned.Time startTime = 7;

--- a/pkg/api/v1/types.generated.go
+++ b/pkg/api/v1/types.generated.go
@@ -26898,7 +26898,7 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 		} else {
 			yysep2 := !z.EncBinary()
 			yy2arr2 := z.EncBasicHandle().StructToArray
-			var yyq2 [8]bool
+			var yyq2 [11]bool
 			_, _, _ = yysep2, yyq2, yy2arr2
 			const yyr2 bool = false
 			yyq2[0] = x.Phase != ""
@@ -26907,11 +26907,14 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2[3] = x.Reason != ""
 			yyq2[4] = x.HostIP != ""
 			yyq2[5] = x.PodIP != ""
-			yyq2[6] = x.StartTime != nil
-			yyq2[7] = len(x.ContainerStatuses) != 0
+			yyq2[6] = x.PodMAC != ""
+			yyq2[7] = x.PodGatewayIP != ""
+			yyq2[8] = x.PodLinkStatus != ""
+			yyq2[9] = x.StartTime != nil
+			yyq2[10] = len(x.ContainerStatuses) != 0
 			var yynn2 int
 			if yyr2 || yy2arr2 {
-				r.EncodeArrayStart(8)
+				r.EncodeArrayStart(11)
 			} else {
 				yynn2 = 0
 				for _, b := range yyq2 {
@@ -27073,16 +27076,91 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[6] {
+					yym22 := z.EncBinary()
+					_ = yym22
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.PodMAC))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("podMAC"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym23 := z.EncBinary()
+					_ = yym23
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.PodMAC))
+					}
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2[7] {
+					yym25 := z.EncBinary()
+					_ = yym25
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.PodGatewayIP))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2[7] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("podGatewayIP"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym26 := z.EncBinary()
+					_ = yym26
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.PodGatewayIP))
+					}
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2[8] {
+					yym28 := z.EncBinary()
+					_ = yym28
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.PodLinkStatus))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2[8] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("podLinkStatus"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym29 := z.EncBinary()
+					_ = yym29
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.PodLinkStatus))
+					}
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2[9] {
 					if x.StartTime == nil {
 						r.EncodeNil()
 					} else {
-						yym22 := z.EncBinary()
-						_ = yym22
+						yym31 := z.EncBinary()
+						_ = yym31
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
-						} else if yym22 {
+						} else if yym31 {
 							z.EncBinaryMarshal(x.StartTime)
-						} else if !yym22 && z.IsJSONHandle() {
+						} else if !yym31 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.StartTime)
 						} else {
 							z.EncFallback(x.StartTime)
@@ -27092,20 +27170,20 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2[6] {
+				if yyq2[9] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("startTime"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.StartTime == nil {
 						r.EncodeNil()
 					} else {
-						yym23 := z.EncBinary()
-						_ = yym23
+						yym32 := z.EncBinary()
+						_ = yym32
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
-						} else if yym23 {
+						} else if yym32 {
 							z.EncBinaryMarshal(x.StartTime)
-						} else if !yym23 && z.IsJSONHandle() {
+						} else if !yym32 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.StartTime)
 						} else {
 							z.EncFallback(x.StartTime)
@@ -27115,12 +27193,12 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[7] {
+				if yyq2[10] {
 					if x.ContainerStatuses == nil {
 						r.EncodeNil()
 					} else {
-						yym25 := z.EncBinary()
-						_ = yym25
+						yym34 := z.EncBinary()
+						_ = yym34
 						if false {
 						} else {
 							h.encSliceContainerStatus(([]ContainerStatus)(x.ContainerStatuses), e)
@@ -27130,15 +27208,15 @@ func (x *PodStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2[7] {
+				if yyq2[10] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("containerStatuses"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.ContainerStatuses == nil {
 						r.EncodeNil()
 					} else {
-						yym26 := z.EncBinary()
-						_ = yym26
+						yym35 := z.EncBinary()
+						_ = yym35
 						if false {
 						} else {
 							h.encSliceContainerStatus(([]ContainerStatus)(x.ContainerStatuses), e)
@@ -27249,6 +27327,24 @@ func (x *PodStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			} else {
 				x.PodIP = string(r.DecodeString())
 			}
+		case "podMAC":
+			if r.TryDecodeAsNil() {
+				x.PodMAC = ""
+			} else {
+				x.PodMAC = string(r.DecodeString())
+			}
+		case "podGatewayIP":
+			if r.TryDecodeAsNil() {
+				x.PodGatewayIP = ""
+			} else {
+				x.PodGatewayIP = string(r.DecodeString())
+			}
+		case "podLinkStatus":
+			if r.TryDecodeAsNil() {
+				x.PodLinkStatus = ""
+			} else {
+				x.PodLinkStatus = string(r.DecodeString())
+			}
 		case "startTime":
 			if r.TryDecodeAsNil() {
 				if x.StartTime != nil {
@@ -27258,13 +27354,13 @@ func (x *PodStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.StartTime == nil {
 					x.StartTime = new(pkg2_unversioned.Time)
 				}
-				yym12 := z.DecBinary()
-				_ = yym12
+				yym15 := z.DecBinary()
+				_ = yym15
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.StartTime) {
-				} else if yym12 {
+				} else if yym15 {
 					z.DecBinaryUnmarshal(x.StartTime)
-				} else if !yym12 && z.IsJSONHandle() {
+				} else if !yym15 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.StartTime)
 				} else {
 					z.DecFallback(x.StartTime, false)
@@ -27274,12 +27370,12 @@ func (x *PodStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ContainerStatuses = nil
 			} else {
-				yyv13 := &x.ContainerStatuses
-				yym14 := z.DecBinary()
-				_ = yym14
+				yyv16 := &x.ContainerStatuses
+				yym17 := z.DecBinary()
+				_ = yym17
 				if false {
 				} else {
-					h.decSliceContainerStatus((*[]ContainerStatus)(yyv13), d)
+					h.decSliceContainerStatus((*[]ContainerStatus)(yyv16), d)
 				}
 			}
 		default:
@@ -27293,16 +27389,16 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj15 int
-	var yyb15 bool
-	var yyhl15 bool = l >= 0
-	yyj15++
-	if yyhl15 {
-		yyb15 = yyj15 > l
+	var yyj18 int
+	var yyb18 bool
+	var yyhl18 bool = l >= 0
+	yyj18++
+	if yyhl18 {
+		yyb18 = yyj18 > l
 	} else {
-		yyb15 = r.CheckBreak()
+		yyb18 = r.CheckBreak()
 	}
-	if yyb15 {
+	if yyb18 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -27312,13 +27408,13 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Phase = PodPhase(r.DecodeString())
 	}
-	yyj15++
-	if yyhl15 {
-		yyb15 = yyj15 > l
+	yyj18++
+	if yyhl18 {
+		yyb18 = yyj18 > l
 	} else {
-		yyb15 = r.CheckBreak()
+		yyb18 = r.CheckBreak()
 	}
-	if yyb15 {
+	if yyb18 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -27326,21 +27422,21 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.Conditions = nil
 	} else {
-		yyv17 := &x.Conditions
-		yym18 := z.DecBinary()
-		_ = yym18
+		yyv20 := &x.Conditions
+		yym21 := z.DecBinary()
+		_ = yym21
 		if false {
 		} else {
-			h.decSlicePodCondition((*[]PodCondition)(yyv17), d)
+			h.decSlicePodCondition((*[]PodCondition)(yyv20), d)
 		}
 	}
-	yyj15++
-	if yyhl15 {
-		yyb15 = yyj15 > l
+	yyj18++
+	if yyhl18 {
+		yyb18 = yyj18 > l
 	} else {
-		yyb15 = r.CheckBreak()
+		yyb18 = r.CheckBreak()
 	}
-	if yyb15 {
+	if yyb18 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -27350,13 +27446,13 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Message = string(r.DecodeString())
 	}
-	yyj15++
-	if yyhl15 {
-		yyb15 = yyj15 > l
+	yyj18++
+	if yyhl18 {
+		yyb18 = yyj18 > l
 	} else {
-		yyb15 = r.CheckBreak()
+		yyb18 = r.CheckBreak()
 	}
-	if yyb15 {
+	if yyb18 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -27366,13 +27462,13 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Reason = string(r.DecodeString())
 	}
-	yyj15++
-	if yyhl15 {
-		yyb15 = yyj15 > l
+	yyj18++
+	if yyhl18 {
+		yyb18 = yyj18 > l
 	} else {
-		yyb15 = r.CheckBreak()
+		yyb18 = r.CheckBreak()
 	}
-	if yyb15 {
+	if yyb18 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -27382,13 +27478,13 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.HostIP = string(r.DecodeString())
 	}
-	yyj15++
-	if yyhl15 {
-		yyb15 = yyj15 > l
+	yyj18++
+	if yyhl18 {
+		yyb18 = yyj18 > l
 	} else {
-		yyb15 = r.CheckBreak()
+		yyb18 = r.CheckBreak()
 	}
-	if yyb15 {
+	if yyb18 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -27398,13 +27494,61 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.PodIP = string(r.DecodeString())
 	}
-	yyj15++
-	if yyhl15 {
-		yyb15 = yyj15 > l
+	yyj18++
+	if yyhl18 {
+		yyb18 = yyj18 > l
 	} else {
-		yyb15 = r.CheckBreak()
+		yyb18 = r.CheckBreak()
 	}
-	if yyb15 {
+	if yyb18 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.PodMAC = ""
+	} else {
+		x.PodMAC = string(r.DecodeString())
+	}
+	yyj18++
+	if yyhl18 {
+		yyb18 = yyj18 > l
+	} else {
+		yyb18 = r.CheckBreak()
+	}
+	if yyb18 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.PodGatewayIP = ""
+	} else {
+		x.PodGatewayIP = string(r.DecodeString())
+	}
+	yyj18++
+	if yyhl18 {
+		yyb18 = yyj18 > l
+	} else {
+		yyb18 = r.CheckBreak()
+	}
+	if yyb18 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.PodLinkStatus = ""
+	} else {
+		x.PodLinkStatus = string(r.DecodeString())
+	}
+	yyj18++
+	if yyhl18 {
+		yyb18 = yyj18 > l
+	} else {
+		yyb18 = r.CheckBreak()
+	}
+	if yyb18 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -27417,25 +27561,25 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.StartTime == nil {
 			x.StartTime = new(pkg2_unversioned.Time)
 		}
-		yym24 := z.DecBinary()
-		_ = yym24
+		yym30 := z.DecBinary()
+		_ = yym30
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.StartTime) {
-		} else if yym24 {
+		} else if yym30 {
 			z.DecBinaryUnmarshal(x.StartTime)
-		} else if !yym24 && z.IsJSONHandle() {
+		} else if !yym30 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.StartTime)
 		} else {
 			z.DecFallback(x.StartTime, false)
 		}
 	}
-	yyj15++
-	if yyhl15 {
-		yyb15 = yyj15 > l
+	yyj18++
+	if yyhl18 {
+		yyb18 = yyj18 > l
 	} else {
-		yyb15 = r.CheckBreak()
+		yyb18 = r.CheckBreak()
 	}
-	if yyb15 {
+	if yyb18 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -27443,26 +27587,26 @@ func (x *PodStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ContainerStatuses = nil
 	} else {
-		yyv25 := &x.ContainerStatuses
-		yym26 := z.DecBinary()
-		_ = yym26
+		yyv31 := &x.ContainerStatuses
+		yym32 := z.DecBinary()
+		_ = yym32
 		if false {
 		} else {
-			h.decSliceContainerStatus((*[]ContainerStatus)(yyv25), d)
+			h.decSliceContainerStatus((*[]ContainerStatus)(yyv31), d)
 		}
 	}
 	for {
-		yyj15++
-		if yyhl15 {
-			yyb15 = yyj15 > l
+		yyj18++
+		if yyhl18 {
+			yyb18 = yyj18 > l
 		} else {
-			yyb15 = r.CheckBreak()
+			yyb18 = r.CheckBreak()
 		}
-		if yyb15 {
+		if yyb18 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj15-1, "")
+		z.DecStructFieldNotFound(yyj18-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -55552,7 +55696,7 @@ func (x codecSelfer1234) decSlicePod(v *[]Pod, d *codec1978.Decoder) {
 
 			yyrg1 := len(yyv1) > 0
 			yyv21 := yyv1
-			yyrl1, yyrt1 = z.DecInferLen(yyl1, z.DecBasicHandle().MaxInitLen, 648)
+			yyrl1, yyrt1 = z.DecInferLen(yyl1, z.DecBasicHandle().MaxInitLen, 696)
 			if yyrt1 {
 				if yyrl1 <= cap(yyv1) {
 					yyv1 = yyv1[:yyrl1]

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -1809,6 +1809,16 @@ type PodStatus struct {
 	// IP address allocated to the pod. Routable at least within the cluster.
 	// Empty if not yet allocated.
 	PodIP string `json:"podIP,omitempty" protobuf:"bytes,6,opt,name=podIP"`
+	// MAC address allocated to the pod. Empty if not yet allocated, or if not set by
+	// the Kubelet. Note that in some cases, such as IPVLAN, all the pods on a given node
+	// may share the same MAC address.
+	PodMAC string `json:"podMAC,omitempty" protobuf:"bytes,9,opt,name=podMAC"`
+	// Default gateway for the pod. Empty if not yet allocated, or if not configured
+	// on the pod. This could be the case of a CNI network without a default gateway.
+	PodGatewayIP string `json:"podGatewayIP,omitempty" protobuf:"bytes,10,opt,name=podGatewayIP"`
+	// Current link status of the Pod. Empty if the interface has not yet been
+	// configured.
+	PodLinkStatus string `json:"podLinkStatus,omitempty" protobuf:"bytes,11,opt,name=podLinkStatus"`
 
 	// RFC 3339 date and time at which the object was acknowledged by the Kubelet.
 	// This is before the Kubelet pulled the container image(s) for the pod.

--- a/pkg/api/v1/types_swagger_doc_generated.go
+++ b/pkg/api/v1/types_swagger_doc_generated.go
@@ -1248,6 +1248,9 @@ var map_PodStatus = map[string]string{
 	"reason":            "A brief CamelCase message indicating details about why the pod is in this state. e.g. 'OutOfDisk'",
 	"hostIP":            "IP address of the host to which the pod is assigned. Empty if not yet scheduled.",
 	"podIP":             "IP address allocated to the pod. Routable at least within the cluster. Empty if not yet allocated.",
+	"podMAC":            "MAC address allocated to the pod. Empty if not yet allocated, or if not set by the Kubelet. Note that in some cases, such as IPVLAN, all the pods on a given node may share the same MAC address.",
+	"podGatewayIP":      "Default gateway for the pod. Empty if not yet allocated, or if not configured on the pod. This could be the case of a CNI network without a default gateway.",
+	"podLinkStatus":     "Current link status of the Pod. Empty if the interface has not yet been configured.",
 	"startTime":         "RFC 3339 date and time at which the object was acknowledged by the Kubelet. This is before the Kubelet pulled the container image(s) for the pod.",
 	"containerStatuses": "The list has one entry per container in the manifest. Each entry is currently the output of `docker inspect`. More info: http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#container-statuses",
 }

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -253,8 +253,15 @@ type PodStatus struct {
 	Name string
 	// Namspace of the pod.
 	Namespace string
+	// TODO(salv-orlando): Switch to a network.PodNetworkStatus member
 	// IP of the pod.
 	IP string
+	// Gateway IP of the Pod
+	GatewayIP string
+	// Mac of the pod.
+	MAC string
+	// Link status of the pod.
+	LinkStatus string
 	// Status of containers in the pod.
 	ContainerStatuses []*ContainerStatus
 }

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -3653,6 +3653,9 @@ func (kl *Kubelet) generateAPIPodStatus(pod *api.Pod, podStatus *kubecontainer.P
 func (kl *Kubelet) convertStatusToAPIStatus(pod *api.Pod, podStatus *kubecontainer.PodStatus) *api.PodStatus {
 	var apiPodStatus api.PodStatus
 	apiPodStatus.PodIP = podStatus.IP
+	apiPodStatus.PodMAC = podStatus.MAC
+	apiPodStatus.PodGatewayIP = podStatus.GatewayIP
+	apiPodStatus.PodLinkStatus = podStatus.LinkStatus
 
 	apiPodStatus.ContainerStatuses = kl.convertToAPIContainerStatuses(
 		pod, podStatus,

--- a/pkg/kubelet/network/cni/cni.go
+++ b/pkg/kubelet/network/cni/cni.go
@@ -18,9 +18,7 @@ package cni
 
 import (
 	"fmt"
-	"net"
 	"sort"
-	"strings"
 
 	"github.com/appc/cni/libcni"
 	cnitypes "github.com/appc/cni/pkg/types"
@@ -142,15 +140,11 @@ func (plugin *cniNetworkPlugin) GetPodNetworkStatus(namespace string, name strin
 	if !ok {
 		return nil, fmt.Errorf("CNI execution called on non-docker runtime")
 	}
-	ipStr, err := runtime.GetContainerIP(id.ID, network.DefaultInterfaceName)
+	result, err := runtime.GetContainerIP(id.ID, network.DefaultInterfaceName)
 	if err != nil {
 		return nil, err
 	}
-	ip, _, err := net.ParseCIDR(strings.Trim(ipStr, "\n"))
-	if err != nil {
-		return nil, err
-	}
-	return &network.PodNetworkStatus{IP: ip}, nil
+	return result, nil
 }
 
 func (network *cniNetwork) addToNetwork(podName string, podNamespace string, podInfraContainerID kubecontainer.ContainerID, podNetnsPath string) (*cnitypes.Result, error) {

--- a/pkg/kubelet/network/cni/cni.go
+++ b/pkg/kubelet/network/cni/cni.go
@@ -140,7 +140,7 @@ func (plugin *cniNetworkPlugin) GetPodNetworkStatus(namespace string, name strin
 	if !ok {
 		return nil, fmt.Errorf("CNI execution called on non-docker runtime")
 	}
-	result, err := runtime.GetContainerIP(id.ID, network.DefaultInterfaceName)
+	result, err := runtime.GetContainerNetworkInfo(id.ID, network.DefaultInterfaceName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubelet/network/plugins.go
+++ b/pkg/kubelet/network/plugins.go
@@ -90,6 +90,19 @@ type PodNetworkStatus struct {
 	//   - service endpoints are constructed with
 	//   - will be reported in the PodStatus.PodIP field (will override the IP reported by docker)
 	IP net.IP `json:"ip" description:"Primary IP address of the pod"`
+
+	// Gateway is the pod's default gateway.
+	// It will be reported in PodStatus.PODgatewayIP field
+	Gateway net.IP
+
+	// MAC is the pod's hardware network address
+	// It will be reported in PodStatus.PodMAC field
+	MAC net.HardwareAddr `json:"mac" description:"MAC address of the pod"`
+
+	// LinkStatus is the link status of the primary pod interface
+	// it will be reported in PodStatus.PodLinkStatus
+	// TODO: Move away from string representation
+	LinkStatus string
 }
 
 // Host is an interface that plugins can use to access the kubelet.


### PR DESCRIPTION
This pull request fixes #25868

Provide more information about pod networking in the pod status attribute.
More specifically: MAC address, Link Status, and default gateway

These information might be useful for debugging purposes and can be leveraged for integration with third-party networking backends.

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/26660)

<!-- Reviewable:end -->
