### PR TITLE
Fixed problem with too long name in e2e autoscaling tests.

### DIFF
--- a/test/e2e/autoscaling_utils.go
+++ b/test/e2e/autoscaling_utils.go
@@ -99,7 +99,7 @@ func newResourceConsumer(name, kind string, replicas, initCPUTotal, initMemoryTo
 	runServiceAndWorkloadForResourceConsumer(f.Client, f.Namespace.Name, name, kind, replicas, cpuLimit, memLimit)
 	rc := &ResourceConsumer{
 		name:                     name,
-		controllerName:           name + "-controller",
+		controllerName:           name + "-ctrl",
 		kind:                     kind,
 		framework:                f,
 		cpu:                      make(chan int),
@@ -361,7 +361,7 @@ func runServiceAndWorkloadForResourceConsumer(c *client.Client, ns, name, kind s
 	}
 
 	By(fmt.Sprintf("Running controller"))
-	controllerName := name + "-controller"
+	controllerName := name + "-ctrl"
 	_, err = c.Services(ns).Create(&api.Service{
 		ObjectMeta: api.ObjectMeta{
 			Name: controllerName,


### PR DESCRIPTION
[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()

Fixed problem with too long name in e2e autoscaling tests.
