### PR TITLE
Update scheduler_extender.md

### DIFF
--- a/docs/design/scheduler_extender.md
+++ b/docs/design/scheduler_extender.md
@@ -125,7 +125,7 @@ type ExtenderArgs struct {
 }
 ```
 
-The "filter" call returns a list of nodes (api.NodeList). The "prioritize" call
+The "filter" call returns a list of nodes (schedulerapi.ExtenderFilterResult). The "prioritize" call
 returns priorities for each node (schedulerapi.HostPriorityList).
 
 The "filter" call may prune the set of nodes based on its predicates. Scores


### PR DESCRIPTION
[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()

The filter call should actually return a schedulerapi.ExtenderFilterResult with an api.NodeList in it, instead of a raw api.NodeList.
