### PR TITLE
remove DCOS section from README.md

### DIFF
--- a/contrib/mesos/README.md
+++ b/contrib/mesos/README.md
@@ -10,14 +10,6 @@ Kubernetes gains the following benefits when installed on Mesos:
 - **Resource Sharing** - Co-location of Kubernetes with other popular next-generation services on the same cluster (e.g. [Hadoop](https://github.com/mesos/hadoop), [Spark](http://spark.apache.org/), and [Chronos](https://mesos.github.io/chronos/), [Cassandra](http://mesosphere.github.io/cassandra-mesos/), etc.). Resources are allocated to the frameworks based on fairness and can be claimed or passed on depending on framework load.
 - **Independence from special Network Infrastructure** - Mesos can (but of course doesn't have to) run on networks which cannot assign a routable IP to every container. The Kubernetes on Mesos endpoint controller is specially modified to allow pods to communicate with services in such an environment.
 
-## Features On DCOS
-
-Kubernetes can also be installed on [Mesosphere DCOS](https://mesosphere.com/learn/), which runs Mesos as its core. This provides the following *additional* enterprise features:
-
-- **High Availability** - Kubernetes components themselves run within Marathon, which manages restarting/recreating them if they fail, even on a different host if the original host might fail completely.
-- **Easy Installation** - One-step installation via the [DCOS CLI](https://github.com/mesosphere/dcos-cli) or DCOS UI. Both download releases from the [Mesosphere Universe](https://github.com/mesosphere/universe), [Multiverse](https://github.com/mesosphere/multiverse), or private package repositories.
-- **Easy Maintenance** - See what's going on in the cluster with the DCOS UI.
-
 For more information about how Kubernetes-Mesos is different from Kubernetes, see [Architecture](./docs/architecture.md).
 
 


### PR DESCRIPTION
[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()

As far as I can tell, as of DCOS 1.7, the Kubernetes-Mesos framework is no longer available in the DCOS Universe. This PR reflects that change so as not to cause confusion.
