### PR TITLE
GCI: correct the fix in #26363

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -624,7 +624,7 @@ function start-kube-scheduler {
 
 # Starts cluster autoscaler.
 function start-cluster-autoscaler {
-  if [ "${ENABLE_NODE_AUTOSCALER:-}" = "true" ]; then
+  if [[ "${ENABLE_NODE_AUTOSCALER:-}" == "true" ]]; then
     echo "Start kubernetes cluster autoscaler"
     prepare-log-file /var/log/cluster-autoscaler.log
 
@@ -712,9 +712,6 @@ function start-kube-addons {
     sed -i -e "s@{{ *metrics_memory_per_node *}}@${metrics_memory_per_node}@g" "${controller_yaml}"
     sed -i -e "s@{{ *eventer_memory_per_node *}}@${eventer_memory_per_node}@g" "${controller_yaml}"
   fi
-  if [[ "${ENABLE_L7_LOADBALANCING:-}" == "glbc" ]]; then
-    setup-addon-manifests "addons" "cluster-loadbalancing/glbc"
-  fi
   if [[ "${ENABLE_CLUSTER_DNS:-}" == "true" ]]; then
     setup-addon-manifests "addons" "dns"
     local -r dns_rc_file="${dst_dir}/dns/skydns-rc.yaml"
@@ -771,8 +768,9 @@ function start-lb-controller {
   if [[ "${ENABLE_L7_LOADBALANCING:-}" == "glbc" ]]; then
     echo "Starting GCE L7 pod"
     prepare-log-file /var/log/glbc.log
-    local -r src_file="${KUBE_HOME}/kube-manifests/kubernetes/gci-trusty/glbc.manifest"
-    cp "${src_file}" /etc/kubernetes/manifests/
+    setup-addon-manifests "addons" "cluster-loadbalancing/glbc"
+    cp "${KUBE_HOME}/kube-manifests/kubernetes/gci-trusty/glbc.manifest" \
+       /etc/kubernetes/manifests/
   fi
 }
 

--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -165,9 +165,9 @@ function install-kube-binary-config {
   tar xzf "${KUBE_HOME}/${manifests_tar}" -C "${dst_dir}" --overwrite
   local -r kube_addon_registry="${KUBE_ADDON_REGISTRY:-gcr.io/google_containers}"
   if [[ "${kube_addon_registry}" != "gcr.io/google_containers" ]]; then
-    find "${dst_dir}/kubernetes" -maxdepth 1 -name \*.yaml -or -name \*.yaml.in | \
+    find "${dst_dir}" -name \*.yaml -or -name \*.yaml.in | \
       xargs sed -ri "s@(image:\s.*)gcr.io/google_containers@\1${kube_addon_registry}@"
-    find "${dst_dir}/kubernetes" -maxdepth 1 -name \*.manifest -or -name \*.json | \
+    find "${dst_dir}" -name \*.manifest -or -name \*.json | \
       xargs sed -ri "s@(image\":\s+\")gcr.io/google_containers@\1${kube_addon_registry}@"
   fi
   cp "${dst_dir}/kubernetes/gci-trusty/gci-configure-helper.sh" "${KUBE_HOME}/bin/configure-helper.sh"


### PR DESCRIPTION
This PR is mainly for correcting the fix to 'find' command in #26363. I added "-maxdepth 1" in an earlier change, and #26363 tried to fix it by changing the search path. This is potentially incorrect, when yaml files are in more than one layer deep. The real fix should be removing the "-maxdepth 1" flag from 'find' command. This PR also updates two minor places in the file configure-helper.sh introduced by two previous PR #26413 and #26048.

@roberthbailey @wonderfly 

cc/ @dchen1107 @fabioy @kubernetes/goog-image 
