### PR TITLE
Trusty: fix 'find' commands and add k8s license and motd info

### DIFF
--- a/cluster/gce/trusty/configure-helper.sh
+++ b/cluster/gce/trusty/configure-helper.sh
@@ -301,13 +301,23 @@ create_master_auth() {
     echo "${KUBE_PROXY_TOKEN},kube_proxy,kube_proxy" >> "${known_tokens_csv}"
   fi
 
-  if [ -n "${PROJECT_ID:-}" ] && [ -n "${TOKEN_URL:-}" ] && [ -n "${TOKEN_BODY:-}" ] && [ -n "${NODE_NETWORK:-}" ]; then
-    cat <<EOF >/etc/gce.conf
+  use_cloud_config="false"
+  cat <<EOF >/etc/gce.conf
 [global]
+EOF
+  if [ -n "${PROJECT_ID:-}" ] && [ -n "${TOKEN_URL:-}" ] && [ -n "${TOKEN_BODY:-}" ] && [ -n "${NODE_NETWORK:-}" ]; then
+  use_cloud_config="true"
+  cat <<EOF >>/etc/gce.conf
 token-url = ${TOKEN_URL}
 token-body = ${TOKEN_BODY}
 project-id = ${PROJECT_ID}
 network-name = ${NODE_NETWORK}
+EOF
+  fi
+  if [ -n "${NODE_INSTANCE_PREFIX:-}" ]; then
+    use_cloud_config="true"
+    cat <<EOF >>/etc/gce.conf
+node-tags = ${NODE_INSTANCE_PREFIX}
 EOF
   fi
   if [ -n "${MULTIZONE:-}" ]; then
@@ -315,7 +325,9 @@ EOF
 multizone = ${MULTIZONE}
 EOF
   fi
-
+  if [ "${use_cloud_config}" != "true" ]; then
+    rm -f /etc/gce.conf
+  fi
   if [ -n "${GCP_AUTHN_URL:-}" ]; then
     cat <<EOF >/etc/gcp_authn.config
 clusters:
@@ -753,4 +765,33 @@ start_kube_addons() {
 
   # Place addon manager pod manifest
   cp "${addon_src_dir}/kube-addon-manager.yaml" /etc/kubernetes/manifests
+}
+
+reset_motd() {
+  # kubelet is installed both on the master and nodes, and the version is easy to parse (unlike kubectl)
+  readonly version="$(/usr/bin/kubelet --version=true | cut -f2 -d " ")"
+  # This logic grabs either a release tag (v1.2.1 or v1.2.1-alpha.1),
+  # or the git hash that's in the build info.
+  gitref="$(echo "${version}" | sed -r "s/(v[0-9]+\.[0-9]+\.[0-9]+)(-[a-z]+\.[0-9]+)?.*/\1\2/g")"
+  devel=""
+  if [ "${gitref}" != "${version}" ]; then
+    devel="
+Note: This looks like a development version, which might not be present on GitHub.
+If it isn't, the closest tag is at:
+  https://github.com/kubernetes/kubernetes/tree/${gitref}
+"
+    gitref="${version//*+/}"
+  fi
+  cat > /etc/motd <<EOF
+Welcome to Kubernetes ${version}!
+You can find documentation for Kubernetes at:
+  http://docs.kubernetes.io/
+You can download the build image for this release at:
+  https://storage.googleapis.com/kubernetes-release/release/${version}/kubernetes-src.tar.gz
+It is based on the Kubernetes source at:
+  https://github.com/kubernetes/kubernetes/tree/${gitref}
+${devel}
+For Kubernetes copyright and licensing information, see:
+  /home/kubernetes/LICENSES
+EOF
 }

--- a/cluster/gce/trusty/master.yaml
+++ b/cluster/gce/trusty/master.yaml
@@ -25,6 +25,7 @@ script
 		-o /etc/kube-configure.sh \
 		http://metadata.google.internal/computeMetadata/v1/instance/attributes/configure-sh
 	. /etc/kube-configure.sh
+	set_broken_motd
 	echo "Downloading kube-env file"
 	download_kube_env
 	. /etc/kube-env
@@ -192,6 +193,7 @@ script
 	start_kube_scheduler
 	start_kube_addons
 	start_cluster_autoscaler
+	reset_motd
 } 2>&1 | logger --priority daemon.info -t ${UPSTART_JOB}
 end script
 

--- a/cluster/gce/trusty/node.yaml
+++ b/cluster/gce/trusty/node.yaml
@@ -25,6 +25,7 @@ script
 		-o /etc/kube-configure.sh \
 		http://metadata.google.internal/computeMetadata/v1/instance/attributes/configure-sh
 	. /etc/kube-configure.sh
+	set_broken_motd
 	echo "Downloading kube-env file"
 	download_kube_env
 	. /etc/kube-env
@@ -248,6 +249,7 @@ script
 	if [ "${ENABLE_CLUSTER_REGISTRY:-}" = "true" ]; then
 		cp /home/kubernetes/kube-manifests/kubernetes/kube-registry-proxy.yaml /etc/kubernetes/manifests/
 	fi
+	reset_motd
 } 2>&1 | logger --priority daemon.info -t ${UPSTART_JOB}
 end script
 


### PR DESCRIPTION
This PR fixes several things which should be also cherry picked in release-1.2 branch:
- Fix the 'find' command failure. See issue #26350 for the background;
- Add k8s license file into /home/kubernetes and set /etc/motd info. We fixed this in cluster/gce/gci for 1.3 branch, but have not done it for 1.2 branch. This PR simply copies the code from the GCI support.

Please note that the trusty code in master branch is under best-effort maintenance and we don't guarantee prompt fixes. But for 1.2 branch, we need to guarantee its correctness. I will test this in 1.2 branch.

@roberthbailey and @zmerlynn please review it.

cc/ @dchen1107 @fabioy @kubernetes/goog-image FYI.
