### PR TITLE
Ubuntu: Enable ssh compression when downloading binaries during cluster creation

### DIFF
--- a/cluster/centos/util.sh
+++ b/cluster/centos/util.sh
@@ -19,7 +19,7 @@
 # exit on any error
 set -e
 
-SSH_OPTS="-oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -oLogLevel=ERROR"
+SSH_OPTS="-oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -oLogLevel=ERROR -C"
 
 # Use the config file specified in $KUBE_CONFIG_FILE, or default to
 # config-default.sh.

--- a/cluster/photon-controller/config-default.sh
+++ b/cluster/photon-controller/config-default.sh
@@ -54,7 +54,7 @@ VM_USER=kube
 # will be reused, and the ssh keys will be different. This prevents us from seeing error
 # due to this, and it will not save the SSH key to the known_hosts file, so users will
 # still have standard ssh security checks.
-SSH_OPTS="-oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -oLogLevel=ERROR"
+SSH_OPTS="-oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -oLogLevel=ERROR -C"
 
 # Optional: Enable node logging.
 # Note: currently untested

--- a/cluster/ubuntu/util.sh
+++ b/cluster/ubuntu/util.sh
@@ -18,7 +18,7 @@
 # must implement to use cluster/kube-*.sh scripts.
 set -e
 
-SSH_OPTS="-oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -oLogLevel=ERROR"
+SSH_OPTS="-oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -oLogLevel=ERROR -C"
 
 MASTER=""
 MASTER_IP=""

--- a/cluster/vsphere/config-common.sh
+++ b/cluster/vsphere/config-common.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SSH_OPTS="-oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -oLogLevel=ERROR"
+SSH_OPTS="-oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -oLogLevel=ERROR -C"
 
 # These need to be set
 #export GOVC_URL=


### PR DESCRIPTION
<!--
Checklist for submitting a Pull Request

Please remove this comment block before submitting.

1. Please read our [contributor guidelines](https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md).
2. See our [developer guide](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md).
3. If you want this PR to automatically close an issue when it is merged,
   add `fixes #<issue number>` or `fixes #<issue number>, fixes #<issue number>`
   to close multiple issues (see: https://github.com/blog/1506-closing-issues-via-pull-requests).
4. Follow the instructions for [labeling and writing a release note for this PR](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes) in the block below.
-->

resolves #20971 by using the options provided by ssh. 

Native ssh compression has existed for years, and the server is free to disregard the setting, so this should be safe.

With things like the kube binaries I see about a 2x speed increase. 

```
λ time scp kubes-bin.tar   9.30.182.251:/mnt/build/kubin
kubes-bin.tar                                                                                                            100%  344MB  10.7MB/s   00:32

real    0m32.284s
user    0m1.679s
sys 0m1.263s

λ time scp -C kubes-bin.tar   9.30.182.251:/mnt/build/kubin
kubes-bin.tar                                                                                                            100%  344MB  22.9MB/s   00:15

real    0m14.810s
user    0m12.858s
sys 0m0.994s

λ ls -lah kubes-bin.tar
-rw-r--r--  1 mhb  staff   344M Jun  2 15:29 kubes-bin.tar

λ tar -tf kubes-bin.tar
kubectl
master/
master/etcd
master/etcdctl
master/flanneld
master/kube-apiserver
master/kube-controller-manager
master/kube-scheduler
node/
node/flanneld
node/kube-proxy
node/kubelet
```
