### PR TITLE
bugfix:lookupcache's Get method can not be called concurrently

### DIFF
--- a/pkg/controller/lookup_cache.go
+++ b/pkg/controller/lookup_cache.go
@@ -72,8 +72,10 @@ func (c *MatchingCache) Add(labelObj objectWithMeta, selectorObj objectWithMeta)
 // we need check in the external request to ensure the cache data is not dirty.
 func (c *MatchingCache) GetMatchingObject(labelObj objectWithMeta) (controller interface{}, exists bool) {
 	key := keyFunc(labelObj)
-	c.mutex.RLock()
-	defer c.mutex.RUnlock()
+	// NOTE: we use Lock() instead of RLock() here because lru's Get() method also modifies state(
+	// it need update the least recently usage information). So we can not call it concurrently.
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	return c.cache.Get(key)
 }
 


### PR DESCRIPTION
ref https://github.com/kubernetes/kubernetes/issues/26376

@lavalamp @therc @mikedanese  
