### PR TITLE
Update thread_safe_store.go, optimize deleteFromIndices method

### DIFF
--- a/pkg/client/cache/thread_safe_store.go
+++ b/pkg/client/cache/thread_safe_store.go
@@ -261,8 +261,8 @@ func (c *threadSafeMap) deleteFromIndices(obj interface{}, key string) error {
 		}
 
 		index := c.indices[name]
-		for _, indexValue := range indexValues {
-			if index != nil {
+		if index != nil {
+			for _, indexValue := range indexValues {
 				set := index[indexValue]
 				if set != nil {
 					set.Delete(key)

--- a/pkg/client/cache/thread_safe_store.go
+++ b/pkg/client/cache/thread_safe_store.go
@@ -261,14 +261,16 @@ func (c *threadSafeMap) deleteFromIndices(obj interface{}, key string) error {
 		}
 
 		index := c.indices[name]
-		if index != nil {
-			for _, indexValue := range indexValues {
-				set := index[indexValue]
-				if set != nil {
-					set.Delete(key)
-				}
+		if index == nil {
+			continue
+		}
+		for _, indexValue := range indexValues {
+			set := index[indexValue]
+			if set != nil {
+				set.Delete(key)
 			}
 		}
+		
 	}
 	return nil
 }


### PR DESCRIPTION
As all methods of thread_safe_store are threadsafe, so i think, in deleteFromIndices method, if the index is nil, need not run the for structure below, the if shuold position outside
