### PR TITLE
Wait for all volumes/claims to get synced in unit test.

### DIFF
--- a/pkg/controller/persistentvolume/controller_test.go
+++ b/pkg/controller/persistentvolume/controller_test.go
@@ -111,8 +111,12 @@ func TestControllerSync(t *testing.T) {
 		defer ctrl.Stop()
 		go ctrl.Run()
 
-		// Wait for the controller to pass initial sync.
-		for !ctrl.volumeController.HasSynced() || !ctrl.claimController.HasSynced() {
+		// Wait for the controller to pass initial sync and fill its caches.
+		for !ctrl.volumeController.HasSynced() ||
+			!ctrl.claimController.HasSynced() ||
+			len(ctrl.claims.ListKeys()) < len(test.initialClaims) ||
+			len(ctrl.volumes.store.ListKeys()) < len(test.initialVolumes) {
+
 			time.Sleep(10 * time.Millisecond)
 		}
 		glog.V(4).Infof("controller synced, starting test")


### PR DESCRIPTION
Controller.HasSynced() returns true when all initial claims/volumes were sent
to appropriate goroutines, not when the goroutine has actually processed them.

Fixes #26712
