### PR TITLE
Fix GCE attacher/detacher to ignore return value of failed calls.

### DIFF
--- a/pkg/volume/gce_pd/attacher.go
+++ b/pkg/volume/gce_pd/attacher.go
@@ -76,7 +76,7 @@ func (attacher *gcePersistentDiskAttacher) Attach(spec *volume.Spec, hostName st
 			pdName, hostName, err)
 	}
 
-	if attached {
+	if err == nil && attached {
 		// Volume is already attached to node.
 		glog.Infof("Attach operation is successful. PD %q is already attached to node %q.", pdName, hostName)
 		return nil
@@ -198,7 +198,7 @@ func (detacher *gcePersistentDiskDetacher) Detach(deviceMountPath string, hostNa
 			pdName, hostName, err)
 	}
 
-	if !attached {
+	if err == nil && !attached {
 		// Volume is not attached to node. Success!
 		glog.Infof("Detach operation is successful. PD %q was not attached to node %q.", pdName, hostName)
 		return nil


### PR DESCRIPTION
The plugin should ignore any return value if err is set. Found when writing unit tests in #26615 - my dummy `DiskIsAttached` returned `false, errors.New('fake error')` and the volume was **not** detached although the log message `"Error checking if PD (%q) is already attached to current node (%q). Will continue and try detach anyway."` suggested otherwise 

@saad-ali, PTAL
@kubernetes/sig-storage 
