### PR TITLE
Set Dashboard UI version to v1.1.0-beta2

### DIFF
--- a/cluster/addons/dashboard/dashboard-controller.yaml
+++ b/cluster/addons/dashboard/dashboard-controller.yaml
@@ -3,11 +3,11 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: kubernetes-dashboard-v1.1.0-beta1
+  name: kubernetes-dashboard-v1.1.0-beta2
   namespace: kube-system
   labels:
     k8s-app: kubernetes-dashboard
-    version: v1.1.0-beta1
+    version: v1.1.0-beta2
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
@@ -17,12 +17,12 @@ spec:
     metadata:
       labels:
         k8s-app: kubernetes-dashboard
-        version: v1.1.0-beta1
+        version: v1.1.0-beta2
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.1.0-beta1
+        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.1.0-beta2
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:

--- a/cluster/gce/coreos/kube-manifests/addons/dashboard/dashboard-controller.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/dashboard/dashboard-controller.yaml
@@ -2,11 +2,11 @@ apiVersion: v1
 kind: ReplicationController
 metadata:
   # Keep this file in sync with addons/dashboard/dashboard-controller.yaml
-  name: kubernetes-dashboard-v1.1.0-beta1
+  name: kubernetes-dashboard-v1.1.0-beta2
   namespace: kube-system
   labels:
     k8s-app: kubernetes-dashboard
-    version: v1.1.0-beta1
+    version: v1.1.0-beta2
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
@@ -16,12 +16,12 @@ spec:
     metadata:
       labels:
         k8s-app: kubernetes-dashboard
-        version: v1.1.0-beta1
+        version: v1.1.0-beta2
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.1.0-beta1
+        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.1.0-beta2
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:

--- a/cluster/images/hyperkube/addons/dashboard-rc.yaml
+++ b/cluster/images/hyperkube/addons/dashboard-rc.yaml
@@ -20,25 +20,25 @@ metadata:
   namespace: kube-system
   labels:
     app: kubernetes-dashboard
-    version: v1.1.0-beta1
+    version: v1.1.0-beta2
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
   selector:
     app: kubernetes-dashboard
-    version: v1.1.0-beta1
+    version: v1.1.0-beta2
     kubernetes.io/cluster-service: "true"
   template:
     metadata:
       labels:
         app: kubernetes-dashboard
-        version: v1.1.0-beta1
+        version: v1.1.0-beta2
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
       - name: kubernetes-dashboard
         # ARCH will be replaced with the architecture it's built for. Check out the Makefile for more details
-        image: gcr.io/google_containers/kubernetes-dashboard-ARCH:v1.1.0-beta1
+        image: gcr.io/google_containers/kubernetes-dashboard-ARCH:v1.1.0-beta2
         imagePullPolicy: Always
         ports:
         - containerPort: 9090


### PR DESCRIPTION
This is our second beta. Next will come weekly till we reach final v1.1 version.

https://github.com/kubernetes/dashboard/releases/tag/v1.1.0-beta2

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
