### PR TITLE
Enable volume mount resolution hints for users to improve uxp and help resolve issues

### DIFF
--- a/pkg/volume/aws_ebs/aws_ebs.go
+++ b/pkg/volume/aws_ebs/aws_ebs.go
@@ -252,7 +252,7 @@ func (b *awsElasticBlockStoreMounter) GetAttributes() volume.Attributes {
 
 // SetUp attaches the disk and bind mounts to the volume path.
 func (b *awsElasticBlockStoreMounter) SetUp(fsGroup *int64) error {
-	return b.SetUpAt(b.GetPath(), fsGroup)
+	return AwsEbsMountErrorHint(b.SetUpAt(b.GetPath(), fsGroup))
 }
 
 // SetUpAt attaches the disk and bind mounts to the volume path.
@@ -313,6 +313,36 @@ func (b *awsElasticBlockStoreMounter) SetUpAt(dir string, fsGroup *int64) error 
 
 	glog.V(4).Infof("Successfully mounted %s", dir)
 	return nil
+}
+
+// AwsEbsMountErrorHint performs some basic analysis
+// on the current mount error returned from the plugin
+// and will add a user hint or resolution tip for enhanced UXP
+// If no matches then original error is returned
+func AwsEbsMountErrorHint (inErr error) error {
+	if inErr == nil {
+		return nil
+	}
+	if strings.Contains(inErr.Error(), "lstat") && strings.Contains(inErr.Error(), "permission denied") {
+		return fmt.Errorf("%v\n\nAdditional Info: The pod is running, and the mount succeeded, however the mount is not accessible due to permissions.\nCheck the permissions on your mounted directory.\nIf needed, containers and pods can utilize and pass in a securityContext specifying runAsUser (uid/owner), or additional linux groups such as fsGroup (for block).\nWork with the storage adminstrator to ensure correct volume access.\n", inErr)
+	}
+	if strings.Contains(inErr.Error(), "InvalidVolume.NotFound") {
+		return fmt.Errorf("%v\n\nAdditional Info: Check AWS available volumes for the appropriate availability zone, and make sure the specified volumeID exists and is spelled correctly.\n", inErr)
+	}
+	if strings.Contains(inErr.Error(), "InvalidParameterValue") && strings.Contains(inErr.Error(), "volume is invalid. Expected: 'vol-") {
+		return fmt.Errorf("%v\n\nAdditional Info: Check AWS available volumes, make sure the specified volumeID exists, is spelled and typed correctly and is valid format.\n", inErr)
+	}
+	if strings.Contains(inErr.Error(), "VolumeInUse:") || strings.Contains(inErr.Error(), "is already attached to an instance") {
+		return fmt.Errorf("%v\n\nAdditional Info: The AWS volume is already attached to another instance and only one node per volume is allowed for EBS block devices (can not share across nodes). Another volume will need to be provisioned for use with this pod.\n", inErr)
+	}
+	if strings.Contains(inErr.Error(), "already formatted with") {
+		return fmt.Errorf("%v\n\nAdditional Info: The volume is already formatted, and can not be reformatted or all data will be lost.\n", inErr)
+	}
+	if strings.Contains(inErr.Error(), "failed to fetch PVC") || (strings.Contains(inErr.Error(), "persistentvolumeclaims") && (strings.Contains(inErr.Error(), "not found"))) {
+		return fmt.Errorf("%v\n\nAdditional Info: Check the pod spec to make sure the persistentVolumeClaim.name correctly matches the actual PVC name.\n", inErr)
+	}
+
+	return inErr
 }
 
 func makeGlobalPDPath(host volume.VolumeHost, volumeID string) string {

--- a/pkg/volume/gce_pd/gce_pd.go
+++ b/pkg/volume/gce_pd/gce_pd.go
@@ -21,13 +21,14 @@ import (
 	"os"
 	"path"
 	"strconv"
+	"strings"
 
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/mount"
-	"k8s.io/kubernetes/pkg/util/strings"
+	kstrings "k8s.io/kubernetes/pkg/util/strings"
 	"k8s.io/kubernetes/pkg/volume"
 )
 
@@ -50,7 +51,7 @@ const (
 )
 
 func getPath(uid types.UID, volName string, host volume.VolumeHost) string {
-	return host.GetPodVolumeDir(uid, strings.EscapeQualifiedNameForDisk(gcePersistentDiskPluginName), volName)
+	return host.GetPodVolumeDir(uid, kstrings.EscapeQualifiedNameForDisk(gcePersistentDiskPluginName), volName)
 }
 
 func (plugin *gcePersistentDiskPlugin) Init(host volume.VolumeHost) error {
@@ -243,7 +244,7 @@ func (b *gcePersistentDiskMounter) GetAttributes() volume.Attributes {
 
 // SetUp bind mounts the disk global mount to the volume path.
 func (b *gcePersistentDiskMounter) SetUp(fsGroup *int64) error {
-	return b.SetUpAt(b.GetPath(), fsGroup)
+	return GcePdMountErrorHint(b.SetUpAt(b.GetPath(), fsGroup))
 }
 
 // SetUp bind mounts the disk global mount to the give volume path.
@@ -307,6 +308,31 @@ func (b *gcePersistentDiskMounter) SetUpAt(dir string, fsGroup *int64) error {
 
 	glog.V(4).Infof("Successfully mounted %s", dir)
 	return nil
+}
+
+// GcePdMountErrorHint performs some basic analysis
+// on the current mount error returned from the plugin
+// and will add a user hint or resolution tip for enhanced UXP
+// If no matches then original error is returned
+func GcePdMountErrorHint (inErr error) error {
+	if inErr == nil {
+		return nil
+	}
+	if strings.Contains(inErr.Error(), "lstat") && strings.Contains(inErr.Error(), "permission denied") {
+		return fmt.Errorf("%v\nAdditional Info: The pod is running, and the mount succeeded, however the mount is not accessible due to permissions.\nCheck the permissions on your mounted directory.\nIf needed, containers and pods can utilize and pass in a securityContext specifying runAsUser (uid/owner), or additional linux groups such as fsGroup (for block).\nWork with the storage adminstrator to ensure correct volume access.\n", inErr)
+	}
+
+	if strings.Contains(inErr.Error(), "NoDiskConflict") || strings.Contains(inErr.Error(), "fit failure on node") {
+		return fmt.Errorf("%v\n\nAdditional Info: The pod is trying to attach a pdDisk volume that is already attached and being used by another pod.\nMultiple pods can attach to the same pdDisk as long as they are accessed in ReadOnly mode.\n", inErr)
+	}
+	if strings.Contains(inErr.Error(), "failed to fetch PVC") || (strings.Contains(inErr.Error(), "persistentvolumeclaims") && (strings.Contains(inErr.Error(), "not found"))) {
+		return fmt.Errorf("%v\n\nAdditional Info: Check the pod spec to make sure the persistentVolumeClaim.name correctly matches the actual PVC name.\n", inErr)
+	}
+	if strings.Contains(inErr.Error(), "already formatted with") {
+		return fmt.Errorf("%v\n\nAdditional Info: The volume is already formatted, and can not be reformatted or all data will be lost.\n", inErr)
+	}
+
+	return inErr
 }
 
 func makeGlobalPDName(host volume.VolumeHost, devName string) string {

--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/exec"
 	"k8s.io/kubernetes/pkg/util/mount"
-	"k8s.io/kubernetes/pkg/util/strings"
+	kstrings "k8s.io/kubernetes/pkg/util/strings"
 	"k8s.io/kubernetes/pkg/volume"
 	volutil "k8s.io/kubernetes/pkg/volume/util"
 )
@@ -115,7 +115,7 @@ func (plugin *glusterfsPlugin) NewMounter(spec *volume.Spec, pod *api.Pod, _ vol
 	ep, err := plugin.host.GetKubeClient().Core().Endpoints(ns).Get(ep_name)
 	if err != nil {
 		glog.Errorf("glusterfs: failed to get endpoints %s[%v]", ep_name, err)
-		return nil, err
+		return nil, GlusterFsMountErrorHint(err)
 	}
 	glog.V(1).Infof("glusterfs: endpoints %v", ep)
 	return plugin.newMounterInternal(spec, ep, pod, plugin.host.GetMounter(), exec.New())
@@ -206,7 +206,7 @@ func (b *glusterfsMounter) GetAttributes() volume.Attributes {
 
 // SetUp attaches the disk and bind mounts to the volume path.
 func (b *glusterfsMounter) SetUp(fsGroup *int64) error {
-	return b.SetUpAt(b.GetPath(), fsGroup)
+	return GlusterFsMountErrorHint(b.SetUpAt(b.GetPath(), fsGroup))
 }
 
 func (b *glusterfsMounter) SetUpAt(dir string, fsGroup *int64) error {
@@ -231,9 +231,41 @@ func (b *glusterfsMounter) SetUpAt(dir string, fsGroup *int64) error {
 	return err
 }
 
+// GlusterFsMountErrorHint performs some basic analysis
+// on the current mount error returned from the plugin
+// and will add a user hint or resolution tip for enhanced UXP
+// If no matches then original error is returned
+func GlusterFsMountErrorHint (inErr error) error {
+	if inErr == nil {
+		return nil
+	}
+	if dstrings.Contains(inErr.Error(), "lstat") && dstrings.Contains(inErr.Error(), "permission denied") {
+		return fmt.Errorf("%v\n\nAdditional Info: The pod is running, and the mount succeeded, however the mount is not accessible due to permissions.\nCheck the POSIX based permissions (owner, groups and others) on your mounted directory.\nIf needed, containers and pods can utilize and pass in a securityContext specifying runAsUser (uid/owner), or additional linux groups such as fsGroup (for block) or SupplementalGroups (for shared).\nWork with the storage adminstrator to ensure correct volume access.\n", inErr)
+	}
+	if dstrings.Contains(inErr.Error(), "endpoints") && dstrings.Contains(inErr.Error(), "not found") {
+		return fmt.Errorf("%v\n\nAdditional Info: Make sure the above endpoint exists, as they are needed for the node to communicate with the Gluster cluster.\nTo persist endpoints, they should be created as a service.\n", inErr)
+	}
+	if dstrings.Contains(inErr.Error(), "Connection timed out") || dstrings.Contains(inErr.Error(), "Transport endpoint is not connected") {
+		return fmt.Errorf("%v\n\nAdditional Info: Check and make sure the Gluster Server exists (ensure that correct IPAddress/Hostname was given in the endpoints) and is available/reachable.\n", inErr)
+	}
+	if dstrings.Contains(inErr.Error(), "failed to fetch PVC") || (dstrings.Contains(inErr.Error(), "persistentvolumeclaims") && (dstrings.Contains(inErr.Error(), "not found"))) {
+		return fmt.Errorf("%v\n\nAdditional Info: Check the pod spec to make sure the persistentVolumeClaim.name correctly matches the actual PVC name.\n", inErr)
+	}
+	if dstrings.Contains(inErr.Error(), "mount: unknown filesystem type") {
+		return fmt.Errorf("%v\n\nAdditional Info: Check and make sure the glusterfs-client package is installed (rpm -qa 'gluster*') on your nodes.\nIf not, install the client package on your nodes (i.e. yum install glusterfs-client -y).\nAfter installation to enable the gluster fuse client run 'modprobe fuse' on the node.\n", inErr)
+	}
+	// this should only get hit if an undefined error occurs or
+	// the gluster log file is not able to be read for some reason
+	if dstrings.Contains(inErr.Error(), "Mount failed. Please check the log") {
+		return fmt.Errorf("%v\n\nAdditional Info: Open the gluster log file, you can see this above in the mount arguments from the error (i.e. --log-file=<path>.\n", inErr)
+	}
+
+	return inErr
+}
+
 func (glusterfsVolume *glusterfs) GetPath() string {
 	name := glusterfsPluginName
-	return glusterfsVolume.plugin.host.GetPodVolumeDir(glusterfsVolume.pod.UID, strings.EscapeQualifiedNameForDisk(name), glusterfsVolume.volName)
+	return glusterfsVolume.plugin.host.GetPodVolumeDir(glusterfsVolume.pod.UID, kstrings.EscapeQualifiedNameForDisk(name), glusterfsVolume.volName)
 }
 
 type glusterfsUnmounter struct {
@@ -397,7 +429,7 @@ type glusterfsVolumeDeleter struct {
 
 func (d *glusterfsVolumeDeleter) GetPath() string {
 	name := glusterfsPluginName
-	return d.plugin.host.GetPodVolumeDir(d.glusterfsMounter.glusterfs.pod.UID, strings.EscapeQualifiedNameForDisk(name), d.glusterfsMounter.glusterfs.volName)
+	return d.plugin.host.GetPodVolumeDir(d.glusterfsMounter.glusterfs.pod.UID, kstrings.EscapeQualifiedNameForDisk(name), d.glusterfsMounter.glusterfs.volName)
 }
 
 func (d *glusterfsVolumeDeleter) Delete() error {

--- a/pkg/volume/rbd/rbd.go
+++ b/pkg/volume/rbd/rbd.go
@@ -104,7 +104,7 @@ func (plugin *rbdPlugin) NewMounter(spec *volume.Spec, pod *api.Pod, _ volume.Vo
 	if source.SecretRef != nil {
 		if secret, err = parseSecret(pod.Namespace, source.SecretRef.Name, plugin.host.GetKubeClient()); err != nil {
 			glog.Errorf("Couldn't get secret from %v/%v", pod.Namespace, source.SecretRef)
-			return nil, err
+			return nil, RbdMountErrorHint(err)
 		}
 	}
 
@@ -403,7 +403,7 @@ func (b *rbd) GetAttributes() volume.Attributes {
 }
 
 func (b *rbdMounter) SetUp(fsGroup *int64) error {
-	return b.SetUpAt(b.GetPath(), fsGroup)
+	return RbdMountErrorHint(b.SetUpAt(b.GetPath(), fsGroup))
 }
 
 func (b *rbdMounter) SetUpAt(dir string, fsGroup *int64) error {
@@ -414,6 +414,30 @@ func (b *rbdMounter) SetUpAt(dir string, fsGroup *int64) error {
 		glog.Errorf("rbd: failed to setup mount %s %v", dir, err)
 	}
 	return err
+}
+
+// RbdMountErrorHint performs some basic analysis
+// on the current mount error returned from the plugin
+// and will add a user hint or resolution tip for enhanced UXP
+// If no matches then original error is returned
+func RbdMountErrorHint (inErr error) error {
+	if inErr == nil {
+		return nil
+	}
+	if dstrings.Contains(inErr.Error(), "lstat") && dstrings.Contains(inErr.Error(), "permission denied") {
+		return fmt.Errorf("%v\nAdditional Info: The pod is running, and the mount succeeded, however the mount is not accessible due to permissions.\nCheck the permissions on your mounted directory.\nIf needed, containers and pods can utilize and pass in a securityContext specifying runAsUser (uid/owner), or additional linux groups such as fsGroup (for block).\nWork with the storage adminstrator to ensure correct volume access.\n", inErr)
+	}
+	if dstrings.Contains(inErr.Error(), "failed to fetch PVC") || (dstrings.Contains(inErr.Error(), "persistentvolumeclaims") && (dstrings.Contains(inErr.Error(), "not found"))) {
+		return fmt.Errorf("%v\n\nAdditional Info: Check the pod spec to make sure the persistentVolumeClaim.name correctly matches the actual PVC name.\n", inErr)
+	}
+	if dstrings.Contains(inErr.Error(), "secrets") && dstrings.Contains(inErr.Error(), "missing") {
+		return fmt.Errorf("%v\n\nAdditional Info: Make sure the above secret exists.  Secret is needed for rbd mount and access.\n", inErr)
+	}
+	if dstrings.Contains(inErr.Error(), "already formatted with") {
+		return fmt.Errorf("%v\n\nAdditional Info: The volume is already formatted, and can not be reformatted or all data will be lost.\n", inErr)
+	}
+
+	return inErr
 }
 
 type rbdUnmounter struct {


### PR DESCRIPTION
Fixes #23982 

This is to help improve uxp, now that we are exposing all/most volume mount errors, to help users better consume these errors we can offer resolution hints:

here are just a few examples:

```
Events:
  FirstSeen LastSeen    Count   From            SubobjectPath           Type        Reason      Message
  --------- --------    -----   ----            -------------           --------    ------      -------
  11s       11s     1   {default-scheduler }                    Normal      Scheduled   Successfully assigned nfs-bb-pod1 to 127.0.0.1
  10s       10s     1   {kubelet 127.0.0.1} spec.containers{nfs-bb-pod1}    Normal      Pulling     pulling image "busybox"
  7s        7s      1   {kubelet 127.0.0.1} spec.containers{nfs-bb-pod1}    Normal      Pulled      Successfully pulled image "busybox"
  6s        6s      1   {kubelet 127.0.0.1} spec.containers{nfs-bb-pod1}    Normal      Created     Created container with docker id e94809870367
  6s        6s      1   {kubelet 127.0.0.1} spec.containers{nfs-bb-pod1}    Normal      Started     Started container with docker id e94809870367
  6s        5s      2   {kubelet 127.0.0.1}                 Warning     FailedMount Unable to mount volumes for pod "nfs-bb-pod1_default(de44ed68-21ea-11e6-be31-525400495970)": lstat /var/lib/kubelet/pods/de44ed68-21ea-11e6-be31-525400495970/volumes/kubernetes.io~nfs/nfsvol/..: permission denied

Resolution hint: The pod is running, and the mount succeeded, however the mount is not accessbile due to permissions.  
Check the POSIX based permissions (owner, groups and others) on your mounted directory.  
If needed containers and pods can utilize and pass in a securityContext specifying runAsUser (uid/owner), or additional linux groups such as fsGroup (for block) or SupplementalGroups (for shared).
Work with the storage adminstrator to properly set up access
```

```
Events:
  FirstSeen LastSeen    Count   From                            SubobjectPath   Type        Reason      Message
  --------- --------    -----   ----                            -------------   --------    ------      -------
  1m        1m      1   {default-scheduler }                            Normal      Scheduled   Successfully assigned aws-ebs-bb-pod1 to ip-172-30-0-113.us-west-2.compute.internal
  52s       52s     1   {kubelet ip-172-30-0-113.us-west-2.compute.internal}            Warning     FailedMount Unable to mount volumes for pod "aws-ebs-bb-pod1_default(1b7c79a2-1ea7-11e6-802a-06cfea9d6949)": Could not attach EBS Disk "vol-b877020a": Error attaching EBS volume: VolumeInUse: vol-b877020a is already attached to an instance
        status code: 400, request id: 

Resolution hint: The AWS volume is already attached to another instance and only one node per volume is allowed for EBS block devices (can not share across nodes). Another volume will need to be provisioned for use with this pod
```

```
Events:
  FirstSeen LastSeen    Count   From            SubobjectPath   Type        Reason      Message
  --------- --------    -----   ----            -------------   --------    ------      -------
  12s       12s     1   {default-scheduler }            Normal      Scheduled   Successfully assigned bb-gluster-pod1 to 127.0.0.1
  12s       2s      2   {kubelet 127.0.0.1}         Warning     FailedMount Unable to mount volumes for pod "bb-gluster-pod1_default(86253c16-2282-11e6-a845-525400495970)": failed to instantiate mounter for volume: glustervol using plugin: kubernetes.io/glusterfs with a root cause: endpoints "glusterfs-cluster" not found

Resolution hint: Make sure the above endpoint exists, as they are needed for your node to communicate with the Gluster cluster. To persist endpoints, they should be created as a service.
```

```
  9s    9s  1   {kubelet 127.0.0.1}     Warning FailedSync  Error syncing pod, skipping: glusterfs: mount failed: Mount failed: exit status 32
Mounting arguments: 192.168.123.222:myVol2 /var/lib/kubelet/pods/485013cb-29ab-11e6-89e6-525400acac48/volumes/kubernetes.io~glusterfs/glustervol glusterfs [log-level=ERROR log-file=/var/lib/kubelet/plugins/kubernetes.io/glusterfs/glustervol/bb-gluster-pod1-glusterfs.log]
Output: mount: unknown filesystem type 'glusterfs'

 the following error information was pulled from the glusterfs log to help diagnose this issue: glusterfs: could not open log file for pod: bb-gluster-pod1

Resolution hint: Check and make sure the glusterfs-client package is installed (rpm -qa 'gluster*') on your nodes.
If not, install the client package on your nodes (i.e. yum install glusterfs-client -y).
After installation to enable the gluster fuse client run 'modprobe fuse' on the node.
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/26786)

<!-- Reviewable:end -->
