### PR TITLE
Fixing logic to generate ExternalHost in genericapiserver

### DIFF
--- a/api/swagger-spec/api.json
+++ b/api/swagger-spec/api.json
@@ -1,7 +1,7 @@
 {
   "swaggerVersion": "1.2",
   "apiVersion": "",
-  "basePath": "https://10.10.10.10:443",
+  "basePath": "https://10.10.10.10:6443",
   "resourcePath": "/api",
   "apis": [
    {

--- a/api/swagger-spec/apis.json
+++ b/api/swagger-spec/apis.json
@@ -1,7 +1,7 @@
 {
   "swaggerVersion": "1.2",
   "apiVersion": "",
-  "basePath": "https://10.10.10.10:443",
+  "basePath": "https://10.10.10.10:6443",
   "resourcePath": "/apis",
   "apis": [
    {

--- a/api/swagger-spec/apps.json
+++ b/api/swagger-spec/apps.json
@@ -1,7 +1,7 @@
 {
   "swaggerVersion": "1.2",
   "apiVersion": "",
-  "basePath": "https://10.10.10.10:443",
+  "basePath": "https://10.10.10.10:6443",
   "resourcePath": "/apis/apps",
   "apis": [
    {

--- a/api/swagger-spec/apps_v1alpha1.json
+++ b/api/swagger-spec/apps_v1alpha1.json
@@ -1,7 +1,7 @@
 {
   "swaggerVersion": "1.2",
   "apiVersion": "apps/v1alpha1",
-  "basePath": "https://10.10.10.10:443",
+  "basePath": "https://10.10.10.10:6443",
   "resourcePath": "/apis/apps/v1alpha1",
   "apis": [
    {

--- a/api/swagger-spec/autoscaling.json
+++ b/api/swagger-spec/autoscaling.json
@@ -1,7 +1,7 @@
 {
   "swaggerVersion": "1.2",
   "apiVersion": "",
-  "basePath": "https://10.10.10.10:443",
+  "basePath": "https://10.10.10.10:6443",
   "resourcePath": "/apis/autoscaling",
   "apis": [
    {

--- a/api/swagger-spec/autoscaling_v1.json
+++ b/api/swagger-spec/autoscaling_v1.json
@@ -1,7 +1,7 @@
 {
   "swaggerVersion": "1.2",
   "apiVersion": "autoscaling/v1",
-  "basePath": "https://10.10.10.10:443",
+  "basePath": "https://10.10.10.10:6443",
   "resourcePath": "/apis/autoscaling/v1",
   "apis": [
    {

--- a/api/swagger-spec/batch.json
+++ b/api/swagger-spec/batch.json
@@ -1,7 +1,7 @@
 {
   "swaggerVersion": "1.2",
   "apiVersion": "",
-  "basePath": "https://10.10.10.10:443",
+  "basePath": "https://10.10.10.10:6443",
   "resourcePath": "/apis/batch",
   "apis": [
    {

--- a/api/swagger-spec/batch_v1.json
+++ b/api/swagger-spec/batch_v1.json
@@ -1,7 +1,7 @@
 {
   "swaggerVersion": "1.2",
   "apiVersion": "batch/v1",
-  "basePath": "https://10.10.10.10:443",
+  "basePath": "https://10.10.10.10:6443",
   "resourcePath": "/apis/batch/v1",
   "apis": [
    {

--- a/api/swagger-spec/batch_v2alpha1.json
+++ b/api/swagger-spec/batch_v2alpha1.json
@@ -1,7 +1,7 @@
 {
   "swaggerVersion": "1.2",
   "apiVersion": "batch/v2alpha1",
-  "basePath": "https://10.10.10.10:443",
+  "basePath": "https://10.10.10.10:6443",
   "resourcePath": "/apis/batch/v2alpha1",
   "apis": [
    {

--- a/api/swagger-spec/extensions.json
+++ b/api/swagger-spec/extensions.json
@@ -1,7 +1,7 @@
 {
   "swaggerVersion": "1.2",
   "apiVersion": "",
-  "basePath": "https://10.10.10.10:443",
+  "basePath": "https://10.10.10.10:6443",
   "resourcePath": "/apis/extensions",
   "apis": [
    {

--- a/api/swagger-spec/extensions_v1beta1.json
+++ b/api/swagger-spec/extensions_v1beta1.json
@@ -1,7 +1,7 @@
 {
   "swaggerVersion": "1.2",
   "apiVersion": "extensions/v1beta1",
-  "basePath": "https://10.10.10.10:443",
+  "basePath": "https://10.10.10.10:6443",
   "resourcePath": "/apis/extensions/v1beta1",
   "apis": [
    {

--- a/api/swagger-spec/policy.json
+++ b/api/swagger-spec/policy.json
@@ -1,7 +1,7 @@
 {
   "swaggerVersion": "1.2",
   "apiVersion": "",
-  "basePath": "https://10.10.10.10:443",
+  "basePath": "https://10.10.10.10:6443",
   "resourcePath": "/apis/policy",
   "apis": [
    {

--- a/api/swagger-spec/policy_v1alpha1.json
+++ b/api/swagger-spec/policy_v1alpha1.json
@@ -1,7 +1,7 @@
 {
   "swaggerVersion": "1.2",
   "apiVersion": "policy/v1alpha1",
-  "basePath": "https://10.10.10.10:443",
+  "basePath": "https://10.10.10.10:6443",
   "resourcePath": "/apis/policy/v1alpha1",
   "apis": [
    {

--- a/api/swagger-spec/rbac.authorization.k8s.io.json
+++ b/api/swagger-spec/rbac.authorization.k8s.io.json
@@ -1,7 +1,7 @@
 {
   "swaggerVersion": "1.2",
   "apiVersion": "",
-  "basePath": "https://10.10.10.10:443",
+  "basePath": "https://10.10.10.10:6443",
   "resourcePath": "/apis/rbac.authorization.k8s.io",
   "apis": [
    {

--- a/api/swagger-spec/rbac.authorization.k8s.io_v1alpha1.json
+++ b/api/swagger-spec/rbac.authorization.k8s.io_v1alpha1.json
@@ -1,7 +1,7 @@
 {
   "swaggerVersion": "1.2",
   "apiVersion": "rbac.authorization.k8s.io/v1alpha1",
-  "basePath": "https://10.10.10.10:443",
+  "basePath": "https://10.10.10.10:6443",
   "resourcePath": "/apis/rbac.authorization.k8s.io/v1alpha1",
   "apis": [
    {

--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -1,7 +1,7 @@
 {
   "swaggerVersion": "1.2",
   "apiVersion": "v1",
-  "basePath": "https://10.10.10.10:443",
+  "basePath": "https://10.10.10.10:6443",
   "resourcePath": "/api/v1",
   "apis": [
    {

--- a/api/swagger-spec/version.json
+++ b/api/swagger-spec/version.json
@@ -1,7 +1,7 @@
 {
   "swaggerVersion": "1.2",
   "apiVersion": "",
-  "basePath": "https://10.10.10.10:443",
+  "basePath": "https://10.10.10.10:6443",
   "resourcePath": "/version",
   "apis": [
    {

--- a/pkg/genericapiserver/genericapiserver.go
+++ b/pkg/genericapiserver/genericapiserver.go
@@ -303,7 +303,7 @@ func setDefaults(c *Config) {
 	if len(c.ExternalHost) == 0 && c.PublicAddress != nil {
 		hostAndPort := c.PublicAddress.String()
 		if c.ReadWritePort != 0 {
-			hostAndPort = net.JoinHostPort(hostAndPort, strconv.Itoa(c.ServiceReadWritePort))
+			hostAndPort = net.JoinHostPort(hostAndPort, strconv.Itoa(c.ReadWritePort))
 		}
 		c.ExternalHost = hostAndPort
 	}


### PR DESCRIPTION
@ncdc pointed it out (https://kubernetes.slack.com/archives/sig-api-machinery/p1464974528000139) that lines 305 and 306 dont match. We should be using ReadWritePort instead of ServiceReadWritePort in line 306.

https://github.com/kubernetes/kubernetes/pull/20626 seems to be the culprit PR.
