### PR TITLE
federation: Updating federation-controller-manager to use secret to get federation-apiserver's kubeconfig

### DIFF
--- a/federation/cmd/federation-controller-manager/app/controllermanager.go
+++ b/federation/cmd/federation-controller-manager/app/controllermanager.go
@@ -44,6 +44,11 @@ import (
 	"github.com/spf13/pflag"
 )
 
+const (
+	// "federation-apiserver-secret" is a reserved secret name which stores the kubeconfig for federation-apiserver.
+	FederationAPIServerSecretName = "federation-apiserver-secret"
+)
+
 // NewControllerManagerCommand creates a *cobra.Command object with default parameters
 func NewControllerManagerCommand() *cobra.Command {
 	s := options.NewCMServer()
@@ -71,7 +76,9 @@ func Run(s *options.CMServer) error {
 	} else {
 		glog.Errorf("unable to register configz: %s", err)
 	}
-	restClientCfg, err := clientcmd.BuildConfigFromFlags(s.Master, s.Kubeconfig)
+	// Create the config to talk to federation-apiserver.
+	kubeconfigGetter := clustercontroller.KubeconfigGetterForSecret(FederationAPIServerSecretName)
+	restClientCfg, err := clientcmd.BuildConfigFromKubeconfigGetter(s.Master, kubeconfigGetter)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixing the credentials problem: https://github.com/kubernetes/kubernetes/issues/26762#issuecomment-223690990.

Admin will create a secret with the name "federation-apiserver-secret" in the k8s cluster hosting the federation control plane. This secret will contain the kubeconfig to access federation-apiserver.
federation-controller-manager will use this secret to contact the federation-apiserver.
This flow is same as the one used by all federation-controllers to contact k8s apiservers that are part of the federation.

cc @kubernetes/sig-cluster-federation @lavalamp @erictune @colhom 
