### PR TITLE
Bump GCE debian image to container-v1-3-v20160604

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -40,7 +40,7 @@ OS_DISTRIBUTION=${KUBE_OS_DISTRIBUTION:-gci}
 # By default a cluster will be started with the master on GCI and nodes on
 # containervm. If you are updating the containervm version, update this
 # variable.
-CVM_VERSION=container-v1-3-v20160517
+CVM_VERSION=container-v1-3-v20160604
 MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-}
 MASTER_IMAGE_PROJECT=${KUBE_GCE_MASTER_PROJECT:-google-containers}
 NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-"${MASTER_IMAGE}"}

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -41,7 +41,7 @@ OS_DISTRIBUTION=${KUBE_OS_DISTRIBUTION:-gci}
 # By default a cluster will be started with the master on GCI and nodes on
 # containervm. If you are updating the containervm version, update this
 # variable.
-CVM_VERSION=container-v1-3-v20160517
+CVM_VERSION=container-v1-3-v20160604
 MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-}
 MASTER_IMAGE_PROJECT=${KUBE_GCE_MASTER_PROJECT:-google-containers}
 NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-"${MASTER_IMAGE}"}


### PR DESCRIPTION
[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()Includes Docker 1.11.2

Wait for enough results from [kubernetes-e2e-gce-container-vm](http://kubekins.dls.corp.google.com/job/kubernetes-e2e-gce-container-vm/) before merging. (c.f. https://github.com/kubernetes/test-infra/pull/116)

cc @kubernetes/sig-node @kubernetes/goog-image 
