### PR TITLE
Adds override for Heapster discovery

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -333,6 +333,7 @@ func StartControllers(s *options.CMServer, kubeClient *client.Client, kubeconfig
 				metrics.DefaultHeapsterScheme,
 				metrics.DefaultHeapsterService,
 				metrics.DefaultHeapsterPort,
+				s.MetricSourceUrl,
 			)
 			go podautoscaler.NewHorizontalController(hpaClient.Core(), hpaClient.Extensions(), hpaClient, metricsClient, s.HorizontalPodAutoscalerSyncPeriod.Duration).
 				Run(wait.NeverStop)

--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -65,6 +65,7 @@ func NewCMServer() *CMServer {
 			NamespaceSyncPeriod:               unversioned.Duration{Duration: 5 * time.Minute},
 			PVClaimBinderSyncPeriod:           unversioned.Duration{Duration: 15 * time.Second},
 			HorizontalPodAutoscalerSyncPeriod: unversioned.Duration{Duration: 30 * time.Second},
+			MetricSourceUrl:                   "",
 			DeploymentControllerSyncPeriod:    unversioned.Duration{Duration: 30 * time.Second},
 			MinResyncPeriod:                   unversioned.Duration{Duration: 12 * time.Hour},
 			RegisterRetryCount:                10,
@@ -139,6 +140,7 @@ func (s *CMServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.VolumeConfiguration.FlexVolumePluginDir, "flex-volume-plugin-dir", s.VolumeConfiguration.FlexVolumePluginDir, "Full path of the directory in which the flex volume plugin should search for additional third party volume plugins.")
 	fs.Int32Var(&s.TerminatedPodGCThreshold, "terminated-pod-gc-threshold", s.TerminatedPodGCThreshold, "Number of terminated pods that can exist before the terminated pod garbage collector starts deleting terminated pods. If <= 0, the terminated pod garbage collector is disabled.")
 	fs.DurationVar(&s.HorizontalPodAutoscalerSyncPeriod.Duration, "horizontal-pod-autoscaler-sync-period", s.HorizontalPodAutoscalerSyncPeriod.Duration, "The period for syncing the number of pods in horizontal pod autoscaler.")
+	fs.StringVar(&s.MetricSourceUrl, "metrics-source-url", s.MetricSourceUrl, "URL to the metrics source backend (overrides service proxy discovery)")
 	fs.DurationVar(&s.DeploymentControllerSyncPeriod.Duration, "deployment-controller-sync-period", s.DeploymentControllerSyncPeriod.Duration, "Period for syncing the deployments.")
 	fs.DurationVar(&s.PodEvictionTimeout.Duration, "pod-eviction-timeout", s.PodEvictionTimeout.Duration, "The grace period for deleting pods on failed nodes.")
 	fs.Float32Var(&s.DeletingPodsQps, "deleting-pods-qps", 0.1, "Number of nodes per second on which pods are deleted in case of node failure.")

--- a/contrib/mesos/pkg/controllermanager/controllermanager.go
+++ b/contrib/mesos/pkg/controllermanager/controllermanager.go
@@ -255,6 +255,7 @@ func (s *CMServer) Run(_ []string) error {
 				metrics.DefaultHeapsterScheme,
 				metrics.DefaultHeapsterService,
 				metrics.DefaultHeapsterPort,
+				"",
 			)
 			go podautoscaler.NewHorizontalController(hpaClient.Core(), hpaClient.Extensions(), hpaClient, metricsClient, s.HorizontalPodAutoscalerSyncPeriod.Duration).
 				Run(wait.NeverStop)

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -331,6 +331,7 @@ mesos-launch-grace-period
 mesos-master
 mesos-sandbox-overlay
 mesos-user
+metrics-source-url
 min-pr-number
 min-request-timeout
 min-resync-period

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -565,6 +565,8 @@ type KubeControllerManagerConfiguration struct {
 	// horizontalPodAutoscalerSyncPeriod is the period for syncing the number of
 	// pods in horizontal pod autoscaler.
 	HorizontalPodAutoscalerSyncPeriod unversioned.Duration `json:"horizontalPodAutoscalerSyncPeriod"`
+	// URL to a metrics backend.
+	MetricSourceUrl string `json:"metricSourceUrl"`
 	// deploymentControllerSyncPeriod is the period for syncing the deployments.
 	DeploymentControllerSyncPeriod unversioned.Duration `json:"deploymentControllerSyncPeriod"`
 	// podEvictionTimeout is the grace period for deleting pods on failed nodes.

--- a/pkg/apis/componentconfig/zz_generated.deepcopy.go
+++ b/pkg/apis/componentconfig/zz_generated.deepcopy.go
@@ -92,6 +92,7 @@ func DeepCopy_componentconfig_KubeControllerManagerConfiguration(in interface{},
 		out.MinResyncPeriod = in.MinResyncPeriod
 		out.TerminatedPodGCThreshold = in.TerminatedPodGCThreshold
 		out.HorizontalPodAutoscalerSyncPeriod = in.HorizontalPodAutoscalerSyncPeriod
+		out.MetricSourceUrl = in.MetricSourceUrl
 		out.DeploymentControllerSyncPeriod = in.DeploymentControllerSyncPeriod
 		out.PodEvictionTimeout = in.PodEvictionTimeout
 		out.DeletingPodsQps = in.DeletingPodsQps

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -408,7 +408,7 @@ func (tc *testCase) verifyResults(t *testing.T) {
 
 func (tc *testCase) runTest(t *testing.T) {
 	testClient := tc.prepareTestClient(t)
-	metricsClient := metrics.NewHeapsterMetricsClient(testClient, metrics.DefaultHeapsterNamespace, metrics.DefaultHeapsterScheme, metrics.DefaultHeapsterService, metrics.DefaultHeapsterPort)
+	metricsClient := metrics.NewHeapsterMetricsClient(testClient, metrics.DefaultHeapsterNamespace, metrics.DefaultHeapsterScheme, metrics.DefaultHeapsterService, metrics.DefaultHeapsterPort, "")
 
 	broadcaster := record.NewBroadcasterForTests(0)
 	broadcaster.StartRecordingToSink(&unversionedcore.EventSinkImpl{Interface: testClient.Core().Events("")})

--- a/pkg/controller/podautoscaler/metrics/metrics_client.go
+++ b/pkg/controller/podautoscaler/metrics/metrics_client.go
@@ -19,6 +19,8 @@ package metrics
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"strings"
 	"time"
 
@@ -74,6 +76,7 @@ type HeapsterMetricsClient struct {
 	heapsterScheme    string
 	heapsterService   string
 	heapsterPort      string
+	heapsterUrl       string
 }
 
 var averageFunction = func(metrics heapster.MetricResultList) (intAndFloat, int, time.Time) {
@@ -91,13 +94,14 @@ func getHeapsterCustomMetricDefinition(metricName string) metricDefinition {
 }
 
 // NewHeapsterMetricsClient returns a new instance of Heapster-based implementation of MetricsClient interface.
-func NewHeapsterMetricsClient(client clientset.Interface, namespace, scheme, service, port string) *HeapsterMetricsClient {
+func NewHeapsterMetricsClient(client clientset.Interface, namespace, scheme, service, port, url string) *HeapsterMetricsClient {
 	return &HeapsterMetricsClient{
 		client:            client,
 		heapsterNamespace: namespace,
 		heapsterScheme:    scheme,
 		heapsterService:   service,
 		heapsterPort:      port,
+		heapsterUrl:       url,
 	}
 }
 
@@ -154,12 +158,7 @@ func (h *HeapsterMetricsClient) GetCpuConsumptionAndRequestInMillis(namespace st
 }
 
 func (h *HeapsterMetricsClient) getCpuUtilizationForPods(namespace string, selector labels.Selector, podNames map[string]struct{}) (int64, time.Time, error) {
-	metricPath := fmt.Sprintf("/apis/metrics/v1alpha1/namespaces/%s/pods", namespace)
-	params := map[string]string{"labelSelector": selector.String()}
-
-	resultRaw, err := h.client.Core().Services(h.heapsterNamespace).
-		ProxyGet(h.heapsterScheme, h.heapsterService, h.heapsterPort, metricPath, params).
-		DoRaw()
+	resultRaw, err := queryMetricsSource(h, fmt.Sprintf("/apis/metrics/v1alpha1/namespaces/%s/pods", namespace), map[string]string{"labelSelector": selector.String()})
 	if err != nil {
 		return 0, time.Time{}, fmt.Errorf("failed to get pods metrics: %v", err)
 	}
@@ -247,10 +246,7 @@ func (h *HeapsterMetricsClient) getCustomMetricForPods(metricSpec metricDefiniti
 		strings.Join(podNames, ","),
 		metricSpec.name)
 
-	resultRaw, err := h.client.Core().Services(h.heapsterNamespace).
-		ProxyGet(h.heapsterScheme, h.heapsterService, h.heapsterPort, metricPath, map[string]string{"start": startTime.Format(time.RFC3339)}).
-		DoRaw()
-
+	resultRaw, err := queryMetricsSource(h, metricPath, map[string]string{"start": startTime.Format(time.RFC3339)})
 	if err != nil {
 		return nil, time.Time{}, fmt.Errorf("failed to get pods metrics: %v", err)
 	}
@@ -330,4 +326,30 @@ func calculateSumFromTimeSample(metrics heapster.MetricResultList, duration time
 		timestamp = *oldest
 	}
 	return sum, count, timestamp
+}
+
+func queryMetricsSource(h *HeapsterMetricsClient, path string, params map[string]string) ([]byte, error) {
+	// Use service proxy discovery.
+	if h.heapsterUrl == "" {
+		return h.client.Core().Services(h.heapsterNamespace).
+			ProxyGet(h.heapsterScheme, h.heapsterService, h.heapsterPort, path, params).
+			DoRaw()
+	}
+
+	req, _ := http.NewRequest("GET", h.heapsterUrl+path, nil)
+
+	if len(params) > 0 {
+		q := req.URL.Query()
+		for k, v := range params {
+			q.Add(k, v)
+		}
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return ioutil.ReadAll(resp.Body)
 }

--- a/pkg/controller/podautoscaler/metrics/metrics_client.go
+++ b/pkg/controller/podautoscaler/metrics/metrics_client.go
@@ -343,6 +343,7 @@ func queryMetricsSource(h *HeapsterMetricsClient, path string, params map[string
 		for k, v := range params {
 			q.Add(k, v)
 		}
+		req.URL.RawQuery = q.Encode()
 	}
 
 	client := &http.Client{}

--- a/pkg/controller/podautoscaler/metrics/metrics_client_test.go
+++ b/pkg/controller/podautoscaler/metrics/metrics_client_test.go
@@ -200,7 +200,7 @@ func (tc *testCase) verifyResults(t *testing.T, val *float64, timestamp time.Tim
 
 func (tc *testCase) runTest(t *testing.T) {
 	testClient := tc.prepareTestClient(t)
-	metricsClient := NewHeapsterMetricsClient(testClient, DefaultHeapsterNamespace, DefaultHeapsterScheme, DefaultHeapsterService, DefaultHeapsterPort)
+	metricsClient := NewHeapsterMetricsClient(testClient, DefaultHeapsterNamespace, DefaultHeapsterScheme, DefaultHeapsterService, DefaultHeapsterPort, "")
 	if tc.targetResource == "cpu-usage" {
 		val, _, timestamp, err := metricsClient.GetCpuConsumptionAndRequestInMillis(tc.namespace, tc.selector)
 		fval := float64(val)


### PR DESCRIPTION
fixes #23942
- Adds a `--metrics-source-url` url flag to the controller component.

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/26858)

<!-- Reviewable:end -->
