### PR TITLE
Removed optional parameters for cni network-plugin

### DIFF
--- a/pkg/kubelet/network/cni/cni.go
+++ b/pkg/kubelet/network/cni/cni.go
@@ -196,11 +196,6 @@ func buildCNIRuntimeConf(podName string, podNs string, podInfraContainerID kubec
 		ContainerID: podInfraContainerID.ID,
 		NetNS:       podNetnsPath,
 		IfName:      network.DefaultInterfaceName,
-		Args: [][2]string{
-			{"K8S_POD_NAMESPACE", podNs},
-			{"K8S_POD_NAME", podName},
-			{"K8S_POD_INFRA_CONTAINER_ID", podInfraContainerID.ID},
-		},
 	}
 
 	return rt, nil

--- a/pkg/kubelet/network/cni/cni_test.go
+++ b/pkg/kubelet/network/cni/cni_test.go
@@ -78,7 +78,7 @@ env > {{.OutputEnv}}
 echo "%@" >> {{.OutputEnv}}
 export $(echo ${CNI_ARGS} | sed 's/;/ /g') &> /dev/null
 mkdir -p {{.OutputDir}} &> /dev/null
-echo -n "$CNI_COMMAND $CNI_NETNS $K8S_POD_NAMESPACE $K8S_POD_NAME $K8S_POD_INFRA_CONTAINER_ID" >& {{.OutputFile}}
+echo -n "$CNI_COMMAND $CNI_CONTAINERID $CNI_NETNS" >& {{.OutputFile}}
 echo -n "{ \"ip4\": { \"ip\": \"10.1.0.23/24\" } }"
 `
 	execTemplateData := &map[string]interface{}{
@@ -191,7 +191,7 @@ func TestCNIPlugin(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to read output file %s: %v (env %s err %v)", outputFile, err, eo, eerr)
 	}
-	expectedOutput := "ADD /proc/12345/ns/net podNamespace podName test_infra_container"
+	expectedOutput := "ADD test_infra_container /proc/12345/ns/net"
 	if string(output) != expectedOutput {
 		t.Errorf("Mismatch in expected output for setup hook. Expected '%s', got '%s'", expectedOutput, string(output))
 	}
@@ -200,7 +200,7 @@ func TestCNIPlugin(t *testing.T) {
 		t.Errorf("Expected nil: %v", err)
 	}
 	output, err = ioutil.ReadFile(path.Join(testNetworkConfigPath, pluginName, pluginName+".out"))
-	expectedOutput = "DEL /proc/12345/ns/net podNamespace podName test_infra_container"
+	expectedOutput = "DEL test_infra_container /proc/12345/ns/net"
 	if string(output) != expectedOutput {
 		t.Errorf("Mismatch in expected output for setup hook. Expected '%s', got '%s'", expectedOutput, string(output))
 	}


### PR DESCRIPTION
I am experimenting with CNI network-plugin. 

I used the following setup:
- CNI plugin `brigde` and IPAM `host-local`  (as described here https://github.com/containernetworking/cni)
- I run the command: `sudo ./kubelet --network-plugin="cni" --network-plugin-dir="/etc/cni/net.d" --config=/home/cheld/Downloads/manifest`

Problem:
Kubelet does not start properly. Some optional parameters are passed to CNI, but rejected.

Solution:
Add this point I just removed all optional parameters. After that kubelet starts and the pods receive an IP from the CNI subnet. 
Not sure if the optional parameters serve a particular purpose. Maybe the behavior should be changed in CNI. I think CNI should ignore optional parameters.

@freehan, @mikedanese 

CC @zreigz, @luxas 
