### PR TITLE
optimize deleteFromIndices method in  thread_safe_store.go

### DIFF
--- a/pkg/client/cache/thread_safe_store.go
+++ b/pkg/client/cache/thread_safe_store.go
@@ -261,12 +261,13 @@ func (c *threadSafeMap) deleteFromIndices(obj interface{}, key string) error {
 		}
 
 		index := c.indices[name]
+		if index == nil {
+			continue
+		}	
 		for _, indexValue := range indexValues {
-			if index != nil {
-				set := index[indexValue]
-				if set != nil {
-					set.Delete(key)
-				}
+			set := index[indexValue]
+			if set != nil {
+				set.Delete(key)
 			}
 		}
 	}


### PR DESCRIPTION
As all methods of thread_safe_store are threadsafe, so i think, in deleteFromIndices method, if the index is nil, need not run the for structure below
