### PR TITLE
explicitly time unit tests and print to logs

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -324,7 +324,12 @@ for (( i=0, j=0; ; )); do
   etcdPrefix=${etcdPrefixes[j]}
   echo "Running tests for APIVersion: $apiVersion with etcdPrefix: $etcdPrefix"
   # KUBE_TEST_API sets the version of each group to be tested.
-  KUBE_TEST_API="${apiVersion}" ETCD_PREFIX=${etcdPrefix} runTests "$@"
+  time {
+   kube::log::status "Starting tests at '$(date)'"
+   KUBE_TEST_API="${apiVersion}" ETCD_PREFIX=${etcdPrefix} runTests "$@"
+   kube::log::status "Finished tests at '$(date)'"
+  }
+
   i=${i}+1
   j=${j}+1
   if [[ i -eq ${apiVersionsCount} ]] && [[ j -eq ${etcdPrefixesCount} ]]; then


### PR DESCRIPTION
To make collecting stats eaiser.

ref https://github.com/kubernetes/kubernetes/issues/25940
