### PR TITLE
Resource quantity must support leading and trailing whitespace in JSON for back-compat

### DIFF
--- a/pkg/api/resource/quantity.go
+++ b/pkg/api/resource/quantity.go
@@ -626,10 +626,7 @@ func (q *Quantity) UnmarshalJSON(value []byte) error {
 		q.i = int64Amount{}
 		return nil
 	}
-	if l < 2 {
-		return ErrFormatWrong
-	}
-	if value[0] == '"' && value[l-1] == '"' {
+	if l >= 2 && value[0] == '"' && value[l-1] == '"' {
 		value = value[1 : l-1]
 	}
 

--- a/pkg/api/resource/quantity.go
+++ b/pkg/api/resource/quantity.go
@@ -259,7 +259,6 @@ Suffix:
 		switch str[i] {
 		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
 		default:
-			pos = i
 			break Suffix
 		}
 	}
@@ -619,6 +618,7 @@ func (q Quantity) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface.
+// TODO: Remove support for leading/trailing whitespace
 func (q *Quantity) UnmarshalJSON(value []byte) error {
 	l := len(value)
 	if l == 4 && bytes.Equal(value, []byte("null")) {
@@ -633,7 +633,7 @@ func (q *Quantity) UnmarshalJSON(value []byte) error {
 		value = value[1 : l-1]
 	}
 
-	parsed, err := ParseQuantity(string(value))
+	parsed, err := ParseQuantity(strings.TrimSpace(string(value)))
 	if err != nil {
 		return err
 	}

--- a/pkg/api/resource/quantity_test.go
+++ b/pkg/api/resource/quantity_test.go
@@ -19,7 +19,9 @@ package resource
 import (
 	"encoding/json"
 	"math/rand"
+	"strings"
 	"testing"
+	"unicode"
 
 	fuzz "github.com/google/gofuzz"
 	"github.com/spf13/pflag"
@@ -231,6 +233,9 @@ func TestQuantityParse(t *testing.T) {
 		{"0Ti", decQuantity(0, 0, BinarySI)},
 		{"0T", decQuantity(0, 0, DecimalSI)},
 
+		// Quantity less numbers are allowed
+		{"1", decQuantity(1, 0, DecimalSI)},
+
 		// Binary suffixes
 		{"1Ki", decQuantity(1024, 0, BinarySI)},
 		{"8Ki", decQuantity(8*1024, 0, BinarySI)},
@@ -422,7 +427,7 @@ func TestQuantityParse(t *testing.T) {
 		desired := &inf.Dec{}
 		expect := Quantity{d: infDecAmount{Dec: desired}}
 		for _, item := range table {
-			got, err := ParseQuantity("-" + item.input)
+			got, err := ParseQuantity("-" + strings.TrimLeftFunc(item.input, unicode.IsSpace))
 			if err != nil {
 				t.Errorf("-%v: unexpected error: %v", item.input, err)
 				continue
@@ -444,7 +449,7 @@ func TestQuantityParse(t *testing.T) {
 
 		// Try everything with an explicit +
 		for _, item := range table {
-			got, err := ParseQuantity("+" + item.input)
+			got, err := ParseQuantity("+" + strings.TrimLeftFunc(item.input, unicode.IsSpace))
 			if err != nil {
 				t.Errorf("-%v: unexpected error: %v", item.input, err)
 				continue
@@ -472,6 +477,10 @@ func TestQuantityParse(t *testing.T) {
 		"1i",
 		"-3.01i",
 		"-3.01e-",
+
+		// trailing whitespace is forbidden
+		" 1",
+		"1 ",
 	}
 	for _, item := range invalid {
 		_, err := ParseQuantity(item)
@@ -811,6 +820,18 @@ func TestJSON(t *testing.T) {
 		}
 		if q2.Cmp(*q) != 0 {
 			t.Errorf("Expected equal: %v, %v (json was '%v')", q, q2, string(b))
+		}
+	}
+}
+
+func TestJSONWhitespace(t *testing.T) {
+	q := Quantity{}
+	for _, s := range []string{" 1", "1 "} {
+		if err := json.Unmarshal([]byte(`"`+s+`"`), &q); err != nil {
+			t.Errorf("%q: %v", s, err)
+		}
+		if q.String() != "1" {
+			t.Errorf("unexpected string: %q", q.String())
 		}
 	}
 }

--- a/pkg/api/resource/quantity_test.go
+++ b/pkg/api/resource/quantity_test.go
@@ -826,11 +826,24 @@ func TestJSON(t *testing.T) {
 
 func TestJSONWhitespace(t *testing.T) {
 	q := Quantity{}
-	for _, s := range []string{" 1", "1 "} {
-		if err := json.Unmarshal([]byte(`"`+s+`"`), &q); err != nil {
-			t.Errorf("%q: %v", s, err)
+	testCases := []struct {
+		in     string
+		expect string
+	}{
+		{`" 1"`, "1"},
+		{`"1 "`, "1"},
+		{`1`, "1"},
+		{` 1`, "1"},
+		{`1 `, "1"},
+		{`10`, "10"},
+		{`-1`, "-1"},
+		{` -1`, "-1"},
+	}
+	for _, test := range testCases {
+		if err := json.Unmarshal([]byte(test.in), &q); err != nil {
+			t.Errorf("%q: %v", test.in, err)
 		}
-		if q.String() != "1" {
+		if q.String() != test.expect {
 			t.Errorf("unexpected string: %q", q.String())
 		}
 	}


### PR DESCRIPTION
For backwards compatibility reasons, we must continue to support leading or trailing whitespace on Quantity values when deserialized from JSON.  We must also support numbers serialized into yaml (`cpu: 1`) and JSON (`"cpu": 1`)

Fixes #26898
