### PR TITLE
Handle multiple MIGs (single-zone) properly in GKE scripts.

### DIFF
--- a/cluster/gke/util.sh
+++ b/cluster/gke/util.sh
@@ -255,8 +255,8 @@ function detect-nodes() {
 
 # Detect minions created in the minion group
 #
-# Note that this will only return the nodes from one of the cluster's instance
-# groups, regardless of how many the cluster has.
+# Note that this will only select nodes in the same zone as the
+# cluster, meaning that it won't include all nodes in a multi-zone cluster.
 #
 # Assumed vars:
 #   none
@@ -265,11 +265,14 @@ function detect-nodes() {
 function detect-node-names {
   echo "... in gke:detect-node-names()" >&2
   detect-project
-  detect-node-instance-group
-  NODE_NAMES=($(gcloud compute instance-groups managed list-instances \
-    "${NODE_INSTANCE_GROUP}" --zone "${ZONE}" --project "${PROJECT}" \
-    --format='value(instance)'))
+  detect-node-instance-groups
 
+  NODE_NAMES=()
+  for group in "${NODE_INSTANCE_GROUPS[@]:-}"; do
+    NODE_NAMES+=($(gcloud compute instance-groups managed list-instances \
+      "${group}" --zone "${ZONE}" \
+      --project "${PROJECT}" --format='value(instance)'))
+  done
   echo "NODE_NAMES=${NODE_NAMES[*]:-}"
 }
 
@@ -284,13 +287,17 @@ function detect-node-names {
 #   ZONE
 #   CLUSTER_NAME
 # Vars set:
-#   NODE_INSTANCE_GROUP
-function detect-node-instance-group {
-  echo "... in gke:detect-node-instance-group()" >&2
-  local url=$("${GCLOUD}" ${CMD_GROUP:-} container clusters describe \
+#   NODE_INSTANCE_GROUPS
+function detect-node-instance-groups {
+  echo "... in gke:detect-node-instance-groups()" >&2
+  local urls=$("${GCLOUD}" ${CMD_GROUP:-} container clusters describe \
     --project="${PROJECT}" --zone="${ZONE}" \
     --format='value(instanceGroupUrls)' "${CLUSTER_NAME}")
-  NODE_INSTANCE_GROUP="${url##*/}"
+  urls=(${urls//;/ })
+  NODE_INSTANCE_GROUPS=()
+  for url in "${urls[@]:-}"; do
+    NODE_INSTANCE_GROUPS+=("${url##*/}")
+  done
 }
 
 # SSH to a node by name ($1) and run a command ($2).

--- a/cluster/lib/util.sh
+++ b/cluster/lib/util.sh
@@ -25,6 +25,17 @@ kube::util::wait-for-jobs() {
   return ${fail}
 }
 
+# kube::util::join <delim> <list...>
+# Concatenates the list elements with the delimiter passed as first parameter
+#
+# Ex: kube::util::join , a b c
+#  -> a,b,c
+function kube::util::join {
+  local IFS="$1"
+  shift
+  echo "$*"
+}
+
 # Some useful colors.
 if [[ -z "${color_start-}" ]]; then
   declare -r color_start="\033["

--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -86,7 +86,8 @@ if [[ "${KUBERNETES_PROVIDER}" == "gce" ]]; then
 fi
 
 if [[ "${KUBERNETES_PROVIDER}" == "gke" ]]; then
-  detect-node-instance-group
+  detect-node-instance-groups
+  NODE_INSTANCE_GROUP=$(kube::util::join , NODE_INSTANCE_GROUPS)
 fi
 
 ginkgo_args=()


### PR DESCRIPTION
Change the scripts for GKE to handle multiple node pools (MIGs) in the same zone. 

Fixes https://github.com/kubernetes/test-infra/issues/100.

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
