### PR TITLE
Allow conformance tests to run on non-GCE providers

### DIFF
--- a/cluster/kube-util.sh
+++ b/cluster/kube-util.sh
@@ -14,87 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This script contains skeletons of helper functions that each provider hosting
-# Kubernetes must implement to use cluster/kube-*.sh scripts.
-# It sets KUBERNETES_PROVIDER to its default value (gce) if it is unset, and
-# then sources cluster/${KUBERNETES_PROVIDER}/util.sh.
-
-KUBERNETES_PROVIDER="${KUBERNETES_PROVIDER:-gce}"
-
-# Must ensure that the following ENV vars are set
-function detect-master {
-	echo "KUBE_MASTER_IP: $KUBE_MASTER_IP" 1>&2
-	echo "KUBE_MASTER: $KUBE_MASTER" 1>&2
-}
-
-# Get node names if they are not static.
-function detect-node-names {
-	echo "NODE_NAMES: [${NODE_NAMES[*]}]" 1>&2
-}
-
-# Get node IP addresses and store in KUBE_NODE_IP_ADDRESSES[]
-function detect-nodes {
-	echo "KUBE_NODE_IP_ADDRESSES: [${KUBE_NODE_IP_ADDRESSES[*]}]" 1>&2
-}
-
-# Verify prereqs on host machine
-function verify-prereqs {
-	echo "TODO: verify-prereqs" 1>&2
-}
-
-# Validate a kubernetes cluster
-function validate-cluster {
-	# by default call the generic validate-cluster.sh script, customizable by
-	# any cluster provider if this does not fit.
-	"${KUBE_ROOT}/cluster/validate-cluster.sh"
-}
-
-# Instantiate a kubernetes cluster
-function kube-up {
-	echo "TODO: kube-up" 1>&2
-}
-
-# Delete a kubernetes cluster
-function kube-down {
-	echo "TODO: kube-down" 1>&2
-}
-
-# Update a kubernetes cluster
-function kube-push {
-	echo "TODO: kube-push" 1>&2
-}
-
-# Prepare update a kubernetes component
-function prepare-push {
-	echo "TODO: prepare-push" 1>&2
-}
-
-# Update a kubernetes master
-function push-master {
-	echo "TODO: push-master" 1>&2
-}
-
-# Update a kubernetes node
-function push-node {
-	echo "TODO: push-node" 1>&2
-}
-
-# Execute prior to running tests to build a release if required for env
-function test-build-release {
-	echo "TODO: test-build-release" 1>&2
-}
-
-# Execute prior to running tests to initialize required structure
-function test-setup {
-	echo "TODO: test-setup" 1>&2
-}
-
-# Execute after running tests to perform any required clean-up
-function test-teardown {
-	echo "TODO: test-teardown" 1>&2
-}
+# This script will source the default skeleton helper functions, then sources
+# cluster/${KUBERNETES_PROVIDER}/util.sh where KUBERNETES_PROVIDER, if unset,
+# will use its default value (gce).
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+source "${KUBE_ROOT}/cluster/skeleton/util.sh"
+
+KUBERNETES_PROVIDER="${KUBERNETES_PROVIDER:-gce}"
 PROVIDER_UTILS="${KUBE_ROOT}/cluster/${KUBERNETES_PROVIDER}/util.sh"
 if [ -f ${PROVIDER_UTILS} ]; then
     source "${PROVIDER_UTILS}"
@@ -112,7 +40,7 @@ function set-federated-zone-vars {
 
 	export KUBE_GCE_ZONE="$zone"
 	# gcloud has a 61 character limit, and for firewall rules this
-	# prefix gets appended to itslef, with some extra information
+	# prefix gets appended to itself, with some extra information
 	# need tot keep it short
 	export KUBE_GCE_INSTANCE_PREFIX="${USER}-${zone}"
 

--- a/cluster/skeleton/util.sh
+++ b/cluster/skeleton/util.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script contains the helper functions that each provider hosting
+# Kubernetes must implement to use cluster/kube-*.sh scripts.
+
+# Must ensure that the following ENV vars are set
+function detect-master {
+	echo "KUBE_MASTER_IP: $KUBE_MASTER_IP" 1>&2
+	echo "KUBE_MASTER: $KUBE_MASTER" 1>&2
+}
+
+# Get node names if they are not static.
+function detect-node-names {
+	echo "NODE_NAMES: [${NODE_NAMES[*]}]" 1>&2
+}
+
+# Get node IP addresses and store in KUBE_NODE_IP_ADDRESSES[]
+function detect-nodes {
+	echo "KUBE_NODE_IP_ADDRESSES: [${KUBE_NODE_IP_ADDRESSES[*]}]" 1>&2
+}
+
+# Verify prereqs on host machine
+function verify-prereqs {
+	echo "Skeleton Provider: verify-prereqs not implemented" 1>&2
+}
+
+# Validate a kubernetes cluster
+function validate-cluster {
+	# by default call the generic validate-cluster.sh script, customizable by
+	# any cluster provider if this does not fit.
+	"${KUBE_ROOT}/cluster/validate-cluster.sh"
+}
+
+# Instantiate a kubernetes cluster
+function kube-up {
+	echo "Skeleton Provider: kube-up not implemented" 1>&2
+}
+
+# Delete a kubernetes cluster
+function kube-down {
+	echo "Skeleton Provider: kube-down not implemented" 1>&2
+}
+
+# Update a kubernetes cluster
+function kube-push {
+	echo "Skeleton Provider: kube-push not implemented" 1>&2
+}
+
+# Prepare update a kubernetes component
+function prepare-push {
+	echo "Skeleton Provider: prepare-push not implemented" 1>&2
+}
+
+# Update a kubernetes master
+function push-master {
+	echo "Skeleton Provider: push-master not implemented" 1>&2
+}
+
+# Update a kubernetes node
+function push-node {
+	echo "Skeleton Provider: push-node not implemented" 1>&2
+}
+
+# Execute prior to running tests to build a release if required for env
+function test-build-release {
+	echo "Skeleton Provider: test-build-release not implemented" 1>&2
+}
+
+# Execute prior to running tests to initialize required structure
+function test-setup {
+	echo "Skeleton Provider: test-setup not implemented" 1>&2
+}
+
+# Execute after running tests to perform any required clean-up
+function test-teardown {
+	echo "Skeleton Provider: test-teardown not implemented" 1>&2
+}
+
+function prepare-e2e {
+	echo "Skeleton Provider: prepare-e2e not implemented" 1>&2
+}

--- a/docs/devel/e2e-tests.md
+++ b/docs/devel/e2e-tests.md
@@ -354,6 +354,7 @@ credentials.
 # setup for conformance tests
 export KUBECONFIG=/path/to/kubeconfig
 export KUBERNETES_CONFORMANCE_TEST=y
+export KUBERNETES_PROVIDER=skeleton
 
 # run all conformance tests
 go run hack/e2e.go -v --test --test_args="--ginkgo.focus=\[Conformance\]"

--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -46,7 +46,7 @@ source "${KUBE_ROOT}/cluster/kube-util.sh"
 # ---- Do cloud-provider-specific setup
 if [[ -n "${KUBERNETES_CONFORMANCE_TEST:-}" ]]; then
     echo "Conformance test: not doing test setup."
-    KUBERNETES_PROVIDER=""
+    KUBERNETES_PROVIDER="skeleton"
 
     detect-master-from-kubeconfig
 


### PR DESCRIPTION
fixes https://github.com/kubernetes/kubernetes/issues/26869

Creates a skeleton provider which has all the required function stubs -- but will allow a previously set "skeleton" KUBERNETES_PROVIDER to not be overriden with "gce".
