### PR TITLE
rkt: Fix incomplete selinux context string when the option is partial.

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1209,7 +1209,7 @@ func (kl *Kubelet) relabelVolumes(pod *api.Pod, volumes kubecontainer.VolumeMap)
 		return err
 	}
 
-	chconRunner := selinux.NewChconRunner()
+	selinuxRunner := selinux.NewSelinuxContextRunner()
 	// Apply the pod's Level to the rootDirContext
 	rootDirSELinuxOptions, err := securitycontext.ParseSELinuxOptions(rootDirContext)
 	if err != nil {
@@ -1226,7 +1226,7 @@ func (kl *Kubelet) relabelVolumes(pod *api.Pod, volumes kubecontainer.VolumeMap)
 				if err != nil {
 					return err
 				}
-				return chconRunner.SetContext(path, volumeContext)
+				return selinuxRunner.SetContext(path, volumeContext)
 			})
 			if err != nil {
 				return err

--- a/pkg/kubelet/rkt/rkt_test.go
+++ b/pkg/kubelet/rkt/rkt_test.go
@@ -1172,27 +1172,6 @@ func TestGenerateRunCommand(t *testing.T) {
 			nil,
 			fmt.Sprintf("/bin/rkt/rkt --insecure-options=image,ondisk --local-config=/var/rkt/local/data --dir=/var/data run-prepared --net=host --hostname=%s rkt-uuid-foo", hostName),
 		},
-		// Case #5, returns --net=host --no-overlay
-		{
-			&api.Pod{
-				ObjectMeta: api.ObjectMeta{
-					Name: "pod-name-foo",
-				},
-				Spec: api.PodSpec{
-					SecurityContext: &api.PodSecurityContext{
-						HostNetwork:    true,
-						SELinuxOptions: &api.SELinuxOptions{},
-					},
-				},
-			},
-			"rkt-uuid-foo",
-			"",
-			[]string{""},
-			[]string{""},
-			"pod-hostname-foo",
-			nil,
-			fmt.Sprintf("/bin/rkt/rkt --insecure-options=image,ondisk --local-config=/var/rkt/local/data --dir=/var/data run-prepared --no-overlay=true --net=host --hostname=%s rkt-uuid-foo", hostName),
-		},
 	}
 
 	rkt := &Runtime{

--- a/pkg/util/selinux/selinux.go
+++ b/pkg/util/selinux/selinux.go
@@ -16,12 +16,14 @@ limitations under the License.
 
 package selinux
 
-// chconRunner knows how to chcon a directory.
-type ChconRunner interface {
+// SelinuxContextRunner knows how to chcon of a directory and
+// how to get the selinux context of a file.
+type SelinuxContextRunner interface {
 	SetContext(dir, context string) error
+	Getfilecon(path string) (string, error)
 }
 
-// newChconRunner returns a new chconRunner.
-func NewChconRunner() ChconRunner {
-	return &realChconRunner{}
+// NewSelinuxContextRunner returns a new chconRunner.
+func NewSelinuxContextRunner() SelinuxContextRunner {
+	return &realSelinuxContextRunner{}
 }

--- a/pkg/util/selinux/selinux_linux.go
+++ b/pkg/util/selinux/selinux_linux.go
@@ -19,16 +19,25 @@ limitations under the License.
 package selinux
 
 import (
+	"fmt"
+
 	"github.com/opencontainers/runc/libcontainer/selinux"
 )
 
-type realChconRunner struct{}
+type realSelinuxContextRunner struct{}
 
-func (_ *realChconRunner) SetContext(dir, context string) error {
+func (_ *realSelinuxContextRunner) SetContext(dir, context string) error {
 	// If SELinux is not enabled, return an empty string
 	if !selinux.SelinuxEnabled() {
 		return nil
 	}
 
 	return selinux.Setfilecon(dir, context)
+}
+
+func (_ *realSelinuxContextRunner) Getfilecon(path string) (string, error) {
+	if !selinux.SelinuxEnabled() {
+		return "", fmt.Errorf("SELinux is not enabled")
+	}
+	return selinux.Getfilecon(path)
 }

--- a/pkg/util/selinux/selinux_unsupported.go
+++ b/pkg/util/selinux/selinux_unsupported.go
@@ -18,9 +18,14 @@ limitations under the License.
 
 package selinux
 
-type realChconRunner struct{}
+type realSelinuxContextRunner struct{}
 
-func (_ *realChconRunner) SetContext(dir, context string) error {
+func (_ *realSelinuxContextRunner) SetContext(dir, context string) error {
 	// NOP
 	return nil
+}
+
+func (_ *realSelinuxContextRunner) Getfilecon(path string) (string, error) {
+	// NOP
+	return "", nil
 }


### PR DESCRIPTION
Fix "EmptyDir" e2e tests failures caused by #https://github.com/kubernetes/kubernetes/pull/24901

As mentioned in https://github.com/kubernetes/kubernetes/pull/24901#discussion_r61372312
We should apply the selinux context of the rkt data directory (/var/lib/rkt) when users do not specify all the selinux options.

Due to my fault, the change was missed during rebase, thus caused the regression.

After applying this PR, the e2e tests passed.

```
$ go run hack/e2e.go -v -test --test_args="--ginkgo.dryRun=false --ginkgo.focus=EmptyDir"
...
Ran 19 of 313 Specs in 199.319 seconds
SUCCESS! -- 19 Passed | 0 Failed | 0 Pending | 294 Skipped PASS
```

BTW, the test is removed because the `--no-overlay=true` flag will only be there on non-coreos distro.

cc @euank @kubernetes/sig-node 
