### PR TITLE
fixes the usage doc in package healthz

### DIFF
--- a/pkg/healthz/doc.go
+++ b/pkg/healthz/doc.go
@@ -16,5 +16,6 @@ limitations under the License.
 
 // Package healthz implements basic http server health checking.
 // Usage:
-//   import _ "healthz" registers a handler on the path '/healthz', that serves 200s
+//   import "k8s.io/kubernetes/pkg/healthz"
+//   healthz.DefaultHealthz()
 package healthz // import "k8s.io/kubernetes/pkg/healthz"


### PR DESCRIPTION
Briefly, the comments in `pkg/healthz/doc.go` is not correct.
