### PR TITLE
Fix panic in schema test

### DIFF
--- a/pkg/api/validation/schema_test.go
+++ b/pkg/api/validation/schema_test.go
@@ -135,7 +135,7 @@ func TestLoad(t *testing.T) {
 func TestValidateOk(t *testing.T) {
 	schema, err := loadSchemaForTest()
 	if err != nil {
-		t.Errorf("Failed to load: %v", err)
+		t.Fatalf("Failed to load: %v", err)
 	}
 	tests := []struct {
 		obj      runtime.Object
@@ -167,7 +167,7 @@ func TestValidateOk(t *testing.T) {
 func TestValidateDifferentApiVersions(t *testing.T) {
 	schema, err := loadSchemaForTest()
 	if err != nil {
-		t.Errorf("Failed to load: %v", err)
+		t.Fatalf("Failed to load: %v", err)
 	}
 
 	pod := &api.Pod{}
@@ -203,7 +203,7 @@ func TestValidateDifferentApiVersions(t *testing.T) {
 func TestInvalid(t *testing.T) {
 	schema, err := loadSchemaForTest()
 	if err != nil {
-		t.Errorf("Failed to load: %v", err)
+		t.Fatalf("Failed to load: %v", err)
 	}
 	tests := []string{
 		"invalidPod1.json", // command is a string, instead of []string.
@@ -227,7 +227,7 @@ func TestInvalid(t *testing.T) {
 func TestValid(t *testing.T) {
 	schema, err := loadSchemaForTest()
 	if err != nil {
-		t.Errorf("Failed to load: %v", err)
+		t.Fatalf("Failed to load: %v", err)
 	}
 	tests := []string{
 		"validPod.yaml",
@@ -239,7 +239,7 @@ func TestValid(t *testing.T) {
 		}
 		err = schema.ValidateBytes(pod)
 		if err != nil {
-			t.Errorf("unexpected error %s, for pod %s", err, pod)
+			t.Errorf("unexpected error: %s, for pod %s", err, pod)
 		}
 	}
 }
@@ -274,7 +274,7 @@ func TestVersionRegex(t *testing.T) {
 
 // Tests that validation works fine when spec contains "type": "any" instead of "type": "object"
 // Ref: https://github.com/kubernetes/kubernetes/issues/24309
-func TestTypeOAny(t *testing.T) {
+func TestTypeAny(t *testing.T) {
 	data, err := readSwaggerFile()
 	if err != nil {
 		t.Errorf("failed to read swagger file: %v", err)
@@ -283,7 +283,7 @@ func TestTypeOAny(t *testing.T) {
 	newData := strings.Replace(string(data), `"type": "object"`, `"type": "any"`, -1)
 	schema, err := NewSwaggerSchemaFromBytes([]byte(newData), nil)
 	if err != nil {
-		t.Errorf("Failed to load: %v", err)
+		t.Fatalf("Failed to load: %v", err)
 	}
 	tests := []string{
 		"validPod.yaml",
@@ -304,7 +304,7 @@ func TestTypeOAny(t *testing.T) {
 		}
 		err = schema.ValidateBytes(podBytes)
 		if err != nil {
-			t.Errorf("unexpected error %s, for pod %s", err, string(podBytes))
+			t.Errorf("unexpected error: %s, for pod %s", err, string(podBytes))
 		}
 	}
 }


### PR DESCRIPTION
If the swagger files for testing are lost, the func `loadSchemaForTest` or `NewSwaggerSchemaFromBytes` will return a non-nil error and a nil schema. In this case, the calling for `ValidateBytes` will result in panic. So, call Fatalf instead of Errorf.

Also fix minor typos.

Test logs:

```
--- FAIL: TestLoad (0.01s)
    schema_test.go:131: Failed to load: open ../../../api/swagger-spec/v1.json: no such file or directory
--- FAIL: TestValidateOk (0.00s)
    schema_test.go:138: Failed to load: open ../../../api/swagger-spec/v1.json: no such file or directory
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
    panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x20 pc=0x4d52df]

goroutine 10 [running]:
panic(0x15fffa0, 0xc8200100a0)
    /usr/local/go/src/runtime/panic.go:481 +0x3e6
testing.tRunner.func1(0xc820085a70)
    /usr/local/go/src/testing/testing.go:467 +0x192
panic(0x15fffa0, 0xc8200100a0)
    /usr/local/go/src/runtime/panic.go:443 +0x4e9
k8s.io/kubernetes/pkg/api/validation.TestValidateOk(0xc820085a70)
    /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/api/validation/schema_test.go:159 +0x79f
testing.tRunner(0xc820085a70, 0x22aad68)
    /usr/local/go/src/testing/testing.go:473 +0x98
created by testing.RunTests
    /usr/local/go/src/testing/testing.go:582 +0x892
FAIL    k8s.io/kubernetes/pkg/api/validation    0.048s
```
