### PR TITLE
Add a TODO to enable admission control in federation apiserver when the support is added.

### DIFF
--- a/federation/manifests/federation-apiserver-deployment.yaml
+++ b/federation/manifests/federation-apiserver-deployment.yaml
@@ -23,6 +23,7 @@ spec:
         - --service-cluster-ip-range={{.FEDERATION_SERVICE_CIDR}}
         - --secure-port=443
         - --advertise-address={{.FEDERATION_API_HOST}}
+        # TODO: --admission-control values must be set when support is added for each type of control.
         - --token-auth-file=/srv/kubernetes/known-tokens.csv
         ports:
         - containerPort: 443


### PR DESCRIPTION
Only the last commit here needs review.

Depends on #26951.

cc @kubernetes/sig-cluster-federation

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
