### PR TITLE
Add clientset support for federation e2e tests.

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 	"time"
 
+	"k8s.io/kubernetes/federation/client/clientset_generated/federation_internalclientset"
 	unversionedfederation "k8s.io/kubernetes/federation/client/clientset_generated/federation_internalclientset/typed/federation/unversioned"
 	"k8s.io/kubernetes/pkg/api"
 	apierrs "k8s.io/kubernetes/pkg/api/errors"
@@ -55,6 +56,8 @@ type Framework struct {
 	Clientset_1_2 *release_1_2.Clientset
 	Clientset_1_3 *release_1_3.Clientset
 
+	FederationClientset *federation_internalclientset.Clientset
+	// TODO: remove FederationClient, all the client access must be through FederationClientset
 	FederationClient *unversionedfederation.FederationClient
 
 	Namespace                *api.Namespace   // Every test has at least one namespace
@@ -146,11 +149,19 @@ func (f *Framework) BeforeEach() {
 		Expect(err).NotTo(HaveOccurred())
 	}
 
-	if f.federated && f.FederationClient == nil {
-		By("Creating a federated kubernetes client")
-		var err error
-		f.FederationClient, err = LoadFederationClient()
-		Expect(err).NotTo(HaveOccurred())
+	if f.federated {
+		if f.FederationClient == nil {
+			By("Creating a federated kubernetes client")
+			var err error
+			f.FederationClient, err = LoadFederationClient()
+			Expect(err).NotTo(HaveOccurred())
+		}
+		if f.FederationClientset == nil {
+			By("Creating a federation Clientset")
+			var err error
+			f.FederationClientset, err = LoadFederationClientset()
+			Expect(err).NotTo(HaveOccurred())
+		}
 	}
 
 	By("Building a namespace api object")
@@ -229,7 +240,11 @@ func (f *Framework) AfterEach() {
 	if f.federated {
 		defer func() {
 			if f.FederationClient == nil {
-				Logf("Warning: framework is marked federated, but has no FederationClient")
+				Logf("Warning: framework is marked federated, but has no federation client")
+				return
+			}
+			if f.FederationClientset == nil {
+				Logf("Warning: framework is marked federated, but has no federation clientset")
 				return
 			}
 			if err := f.FederationClient.Clusters().DeleteCollection(nil, api.ListOptions{}); err != nil {

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -37,6 +37,7 @@ import (
 	"sync"
 	"time"
 
+	"k8s.io/kubernetes/federation/client/clientset_generated/federation_internalclientset"
 	unversionedfederation "k8s.io/kubernetes/federation/client/clientset_generated/federation_internalclientset/typed/federation/unversioned"
 	"k8s.io/kubernetes/pkg/api"
 	apierrs "k8s.io/kubernetes/pkg/api/errors"
@@ -1628,6 +1629,32 @@ func loadClientFromConfig(config *restclient.Config) (*client.Client, error) {
 		c.Client.Timeout = SingleCallTimeout
 	}
 	return c, nil
+}
+
+func loadFederationClientsetFromConfig(config *restclient.Config) (*federation_internalclientset.Clientset, error) {
+	c, err := federation_internalclientset.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("error creating federation clientset: %v", err.Error())
+	}
+	// Set timeout for each client in the set.
+	if c.DiscoveryClient.Client.Timeout == 0 {
+		c.DiscoveryClient.Client.Timeout = SingleCallTimeout
+	}
+	if c.FederationClient.Client.Timeout == 0 {
+		c.FederationClient.Client.Timeout = SingleCallTimeout
+	}
+	if c.CoreClient.Client.Timeout == 0 {
+		c.CoreClient.Client.Timeout = SingleCallTimeout
+	}
+	return c, nil
+}
+
+func LoadFederationClientset() (*federation_internalclientset.Clientset, error) {
+	config, err := LoadFederatedConfig()
+	if err != nil {
+		return nil, fmt.Errorf("error creating federated client config: %v", err.Error())
+	}
+	return loadFederationClientsetFromConfig(config)
 }
 
 func loadFederationClientFromConfig(config *restclient.Config) (*unversionedfederation.FederationClient, error) {


### PR DESCRIPTION
Only the last commit here needs review.

Depends on #26952.

cc @colhom @kubernetes/sig-cluster-federation

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
