### PR TITLE
ResourceQuota BestEffort scope aligned with Pod level QoS

### DIFF
--- a/pkg/quota/evaluator/core/pods.go
+++ b/pkg/quota/evaluator/core/pods.go
@@ -172,16 +172,7 @@ func PodMatchesScopeFunc(scope api.ResourceQuotaScope, object runtime.Object) bo
 }
 
 func isBestEffort(pod *api.Pod) bool {
-	// TODO: when we have request/limits on a pod scope, we need to revisit this
-	for _, container := range pod.Spec.Containers {
-		qosPerResource := util.GetQoS(&container)
-		for _, qos := range qosPerResource {
-			if util.BestEffort == qos {
-				return true
-			}
-		}
-	}
-	return false
+	return util.GetPodQos(pod) == util.BestEffort
 }
 
 func isTerminating(pod *api.Pod) bool {


### PR DESCRIPTION
This aligns quota with the changes in kubelet and CLI.

So if quota allows 10 `BestEffort` pods, it will now track properly with what the user sees with changes in 1.3.

```
apiVersion: v1
kind: ResourceQuota
metadata:
  name: best-effort
spec:
  hard:
    pods: "10"
  scopes:
  - BestEffort
```

/cc @vishh @kubernetes/rh-cluster-infra 
