### PR TITLE
Disable CoreOS image from node e2e testing.

### DIFF
--- a/test/e2e_node/jenkins/jenkins-ci.properties
+++ b/test/e2e_node/jenkins/jenkins-ci.properties
@@ -3,7 +3,10 @@ GCE_HOSTS=
 # To copy an image between projects:
 # `gcloud compute --project <to-project> disks create <image name> --image=https://www.googleapis.com/compute/v1/projects/<from-project>/global/images/<image-name>`
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
-GCE_IMAGES=e2e-node-ubuntu-trusty-docker10-image,e2e-node-ubuntu-trusty-docker9-image,e2e-node-ubuntu-trusty-docker8-image,e2e-node-coreos-stable20160531-image,e2e-node-containervm-v20160321-image
+#
+# Testing disabled on the following images: 
+# e2e-node-coreos-stable20160531-image - Github Issue #26903
+GCE_IMAGES=e2e-node-ubuntu-trusty-docker10-image,e2e-node-ubuntu-trusty-docker9-image,e2e-node-ubuntu-trusty-docker8-image,e2e-node-containervm-v20160321-image
 GCE_ZONE=us-central1-f
 GCE_PROJECT=kubernetes-jenkins
 GCE_IMAGE_PROJECT=kubernetes-jenkins

--- a/test/e2e_node/jenkins/jenkins-pull.properties
+++ b/test/e2e_node/jenkins/jenkins-pull.properties
@@ -3,7 +3,10 @@ GCE_HOSTS=
 # To copy an image between projects:
 # `gcloud compute --project <to-project> disks create <image name> --image=https://www.googleapis.com/compute/v1/projects/<from-project>/global/images/<image-name>`
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
-GCE_IMAGES=e2e-node-ubuntu-trusty-docker10-image,e2e-node-ubuntu-trusty-docker9-image,e2e-node-ubuntu-trusty-docker8-image,e2e-node-coreos-stable20160531-image,e2e-node-containervm-v20160321-image
+#
+# Testing disabled on the following images: 
+# e2e-node-coreos-stable20160531-image - Github Issue #26903
+GCE_IMAGES=e2e-node-ubuntu-trusty-docker10-image,e2e-node-ubuntu-trusty-docker9-image,e2e-node-ubuntu-trusty-docker8-image,e2e-node-containervm-v20160321-image
 GCE_ZONE=us-central1-f
 GCE_PROJECT=kubernetes-jenkins-pull
 GCE_IMAGE_PROJECT=kubernetes-jenkins-pull


### PR DESCRIPTION
For #26903

Marking this as a `P0` since it is failing node e2e consistently.
