### PR TITLE
Fix "bufio.Scanner: token too long" failures

### DIFF
--- a/pkg/util/yaml/decoder.go
+++ b/pkg/util/yaml/decoder.go
@@ -30,6 +30,10 @@ import (
 	"github.com/golang/glog"
 )
 
+const (
+	MaxScanTokenSize = 512 * 1024
+)
+
 // ToJSON converts a single YAML document into a JSON document
 // or returns an error. If the document appears to be JSON the
 // YAML decoding path is not used (so that error messages are
@@ -54,6 +58,7 @@ type YAMLToJSONDecoder struct {
 // yaml.YAMLToJSON, and then passing it to json.Decoder.
 func NewYAMLToJSONDecoder(r io.Reader) *YAMLToJSONDecoder {
 	scanner := bufio.NewScanner(r)
+	scanner.Buffer(nil, MaxScanTokenSize)
 	scanner.Split(splitYAMLDocument)
 	return &YAMLToJSONDecoder{
 		scanner: scanner,
@@ -93,6 +98,7 @@ type YAMLDecoder struct {
 // the caller in framing the chunk.
 func NewDocumentDecoder(r io.ReadCloser) io.ReadCloser {
 	scanner := bufio.NewScanner(r)
+	scanner.Buffer(nil, MaxScanTokenSize)
 	scanner.Split(splitYAMLDocument)
 	return &YAMLDecoder{
 		r:       r,

--- a/pkg/util/yaml/decoder_test.go
+++ b/pkg/util/yaml/decoder_test.go
@@ -126,6 +126,19 @@ stuff: 1
 	}
 }
 
+func TestReallyLongYAML(t *testing.T) {
+	text := `---
+username: ` + strings.Repeat("x", 128 * 1024)
+	text += `
+
+---`
+	obj := generic{}
+	s := NewYAMLToJSONDecoder(bytes.NewReader([]byte(text)))
+	if err := s.Decode(&obj); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestDecodeBrokenYAML(t *testing.T) {
 	s := NewYAMLOrJSONDecoder(bytes.NewReader([]byte(`---
 stuff: 1


### PR DESCRIPTION
Just bump the max in bufio from 64kb to 512kb

Fixes #12582
