### PR TITLE
GCI: fix the issue #26379

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -356,6 +356,11 @@ function start-kubelet {
   fi
   echo "KUBELET_OPTS=\"${flags}\"" > /etc/default/kubelet
 
+  # Delete docker0 to avoid interference
+  iptables -t nat -F || true
+  ip link set docker0 down || true
+  brctl delbr docker0 || true
+
   systemctl start kubelet.service
 }
 


### PR DESCRIPTION
This PR deletes docker0 explicitly to fix the issue. In some cases, coexistence of docker0 and cbr0 make troubles in GCI-based cluster instances.

I verified it in GKE. With the fix, fluentd-gcp pod shows no error. "curl google.com" can work inside a pod. Mark it as P0 to match the issue priority.

@a-robinson @roberthbailey @freehan @kubernetes/goog-image 
