### PR TITLE
Fixed an error in lvm bash script

### DIFF
--- a/examples/flexvolume/lvm
+++ b/examples/flexvolume/lvm
@@ -49,7 +49,7 @@ attach() {
 	VG=$(echo $1|jq -r '.volumegroup')
 
 	# LVM substitutes - with --
-	VOLUMEID= `echo $VOLUMEID|sed s/-/--/g`
+	VOLUMEID=`echo $VOLUMEID|sed s/-/--/g`
 	VG=`echo $VG|sed s/-/--/g`
 
 	DMDEV="/dev/mapper/${VG}-${VOLUMEID}"


### PR DESCRIPTION
The space in this script is an obvious typo and caused an error
(trying to call volume_id as command).
