### PR TITLE
Add possibility to run integration tests in parallel

### DIFF
--- a/test/integration/framework/etcd_utils.go
+++ b/test/integration/framework/etcd_utils.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/storage"
 	etcdstorage "k8s.io/kubernetes/pkg/storage/etcd"
 	"k8s.io/kubernetes/pkg/storage/etcd/etcdtest"
+	"k8s.io/kubernetes/pkg/util/env"
 )
 
 // If you need to start an etcd instance by hand, you also need to insert a key
@@ -37,9 +38,15 @@ func init() {
 	RequireEtcd()
 }
 
+func GetEtcdURLFromEnv() string {
+	url := env.GetEnvAsStringOrFallback("KUBE_INTEGRATION_ETCD_URL", "http://127.0.0.1:4001")
+	glog.V(4).Infof("Using KUBE_INTEGRATION_ETCD_URL=%q", url)
+	return url
+}
+
 func NewEtcdClient() etcd.Client {
 	cfg := etcd.Config{
-		Endpoints: []string{"http://127.0.0.1:4001"},
+		Endpoints: []string{GetEtcdURLFromEnv()},
 	}
 	client, err := etcd.New(cfg)
 	if err != nil {

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -154,7 +154,7 @@ func startMasterOrDie(masterConfig *master.Config) (*master.Master, *httptest.Se
 // Returns a basic master config.
 func NewMasterConfig() *master.Config {
 	config := storagebackend.Config{
-		ServerList: []string{"http://127.0.0.1:4001"},
+		ServerList: []string{GetEtcdURLFromEnv()},
 		// This causes the integration tests to exercise the etcd
 		// prefix code, so please don't change without ensuring
 		// sufficient coverage in other ways.

--- a/test/integration/utils.go
+++ b/test/integration/utils.go
@@ -27,11 +27,12 @@ import (
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/test/integration/framework"
 )
 
 func newEtcdClient() etcd.Client {
 	cfg := etcd.Config{
-		Endpoints: []string{"http://127.0.0.1:4001"},
+		Endpoints: []string{framework.GetEtcdURLFromEnv()},
 	}
 	client, err := etcd.New(cfg)
 	if err != nil {


### PR DESCRIPTION
- add env. variable with etcd URL to intergration tests
- update documentation with example how to use it to find flakes
