### PR TITLE
federation setup scripts: delete the kubeconfig files that were used to create secrets

### DIFF
--- a/federation/cluster/common.sh
+++ b/federation/cluster/common.sh
@@ -235,4 +235,7 @@ function cleanup-federated-api-objects {
   $host_kubectl delete pods,svc,rc,deployment,secret -lapp=federated-cluster
   # Delete all resources in FEDERATION_NAMESPACE.
   $host_kubectl delete pods,svc,rc,deployment,secret --namespace=${FEDERATION_NAMESPACE} --all
+  # Also delete the kubeconfig files that were used to create secrets.
+  KUBECONFIG_DIR=$(dirname ${KUBECONFIG:-$DEFAULT_KUBECONFIG})
+  rm -rf ${KUBECONFIG_DIR}/federation
 }


### PR DESCRIPTION
Missed it in https://github.com/kubernetes/kubernetes/pull/26914

While bringing down the federation control plane, also delete the kubeconfig files that were used to create secrets. This allows the next run to be independent.

cc @kubernetes/sig-cluster-federation 
