### PR TITLE
Don't ignore error when Discovery().ServerResources() in kubectl run

### DIFF
--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -155,9 +155,9 @@ func Run(f *cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer, cmd *cob
 			return err
 		}
 		resourcesList, err := client.Discovery().ServerResources()
+		// ServerResources ignores errors for old servers do not expose discovery
 		if err != nil {
-			// this cover the cases where old servers do not expose discovery
-			resourcesList = nil
+			return fmt.Errorf("failed to discover supported resources: %v", err)
 		}
 		switch restartPolicy {
 		case api.RestartPolicyAlways:


### PR DESCRIPTION
Ref #27014
This doesn't fix the flake directly, but expose the error happened when the flake happens. 

@kubernetes/kubectl @caesarxuchao 

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
