### PR TITLE
kubectl: improve error message when non-resource urls return 403s

### DIFF
--- a/pkg/api/errors/errors.go
+++ b/pkg/api/errors/errors.go
@@ -287,7 +287,7 @@ func NewTimeoutError(message string, retryAfterSeconds int) *StatusError {
 }
 
 // NewGenericServerResponse returns a new error for server responses that are not in a recognizable form.
-func NewGenericServerResponse(code int, verb string, qualifiedResource unversioned.GroupResource, name, serverMessage string, retryAfterSeconds int, isUnexpectedResponse bool) *StatusError {
+func NewGenericServerResponse(path string, code int, verb string, qualifiedResource unversioned.GroupResource, name, serverMessage string, retryAfterSeconds int, isUnexpectedResponse bool) *StatusError {
 	reason := unversioned.StatusReasonUnknown
 	message := fmt.Sprintf("the server responded with the status code %d but did not return more information", code)
 	switch code {
@@ -333,6 +333,8 @@ func NewGenericServerResponse(code int, verb string, qualifiedResource unversion
 		message = fmt.Sprintf("%s (%s %s %s)", message, strings.ToLower(verb), qualifiedResource.String(), name)
 	case !qualifiedResource.IsEmpty():
 		message = fmt.Sprintf("%s (%s %s)", message, strings.ToLower(verb), qualifiedResource.String())
+	case len(path) > 0:
+		message = fmt.Sprintf("%s (%s)", message, path)
 	}
 	var causes []unversioned.StatusCause
 	if isUnexpectedResponse {

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -213,7 +213,7 @@ func logStackOnRecover(s runtime.NegotiatedSerializer, panicReason interface{}, 
 	if ct := w.Header().Get("Content-Type"); len(ct) > 0 {
 		headers.Set("Accept", ct)
 	}
-	errorNegotiated(apierrors.NewGenericServerResponse(http.StatusInternalServerError, "", api.Resource(""), "", "", 0, false), s, unversioned.GroupVersion{}, w, &http.Request{Header: headers})
+	errorNegotiated(apierrors.NewGenericServerResponse("", http.StatusInternalServerError, "", api.Resource(""), "", "", 0, false), s, unversioned.GroupVersion{}, w, &http.Request{Header: headers})
 }
 
 func InstallServiceErrorHandler(s runtime.NegotiatedSerializer, container *restful.Container, requestResolver *RequestInfoResolver, apiVersions []string) {
@@ -223,7 +223,7 @@ func InstallServiceErrorHandler(s runtime.NegotiatedSerializer, container *restf
 }
 
 func serviceErrorHandler(s runtime.NegotiatedSerializer, requestResolver *RequestInfoResolver, apiVersions []string, serviceErr restful.ServiceError, request *restful.Request, response *restful.Response) {
-	errorNegotiated(apierrors.NewGenericServerResponse(serviceErr.Code, "", api.Resource(""), "", "", 0, false), s, unversioned.GroupVersion{}, response.ResponseWriter, request.Request)
+	errorNegotiated(apierrors.NewGenericServerResponse(request.Request.URL.Path, serviceErr.Code, "", api.Resource(""), "", "", 0, false), s, unversioned.GroupVersion{}, response.ResponseWriter, request.Request)
 }
 
 // Adds a service to return the supported api versions at the legacy /api.

--- a/pkg/client/restclient/request.go
+++ b/pkg/client/restclient/request.go
@@ -977,7 +977,12 @@ func (r *Request) transformUnstructuredResponseError(resp *http.Response, req *h
 		message = strings.TrimSpace(string(body))
 	}
 	retryAfter, _ := retryAfterSeconds(resp)
+	path := ""
+	if resp.Request != nil {
+		path = resp.Request.URL.Path
+	}
 	return errors.NewGenericServerResponse(
+		path,
 		resp.StatusCode,
 		req.Method,
 		unversioned.GroupResource{

--- a/pkg/client/typed/discovery/discovery_client.go
+++ b/pkg/client/typed/discovery/discovery_client.go
@@ -110,7 +110,7 @@ func (d *DiscoveryClient) ServerGroups() (apiGroupList *unversioned.APIGroupList
 	if err == nil {
 		apiGroup = apiVersionsToAPIGroup(v)
 	}
-	if err != nil && !errors.IsNotFound(err) && !errors.IsForbidden(err) {
+	if err != nil {
 		return nil, err
 	}
 

--- a/pkg/registry/generic/rest/response_checker.go
+++ b/pkg/registry/generic/rest/response_checker.go
@@ -53,15 +53,20 @@ func (checker GenericHttpResponseChecker) Check(resp *http.Response) error {
 		}
 		bodyText := string(bodyBytes)
 
+		path := ""
+		if resp.Request != nil {
+			path = resp.Request.URL.Path
+		}
+
 		switch {
 		case resp.StatusCode == http.StatusInternalServerError:
 			return errors.NewInternalError(fmt.Errorf("%s", bodyText))
 		case resp.StatusCode == http.StatusBadRequest:
 			return errors.NewBadRequest(bodyText)
 		case resp.StatusCode == http.StatusNotFound:
-			return errors.NewGenericServerResponse(resp.StatusCode, "", checker.QualifiedResource, checker.Name, bodyText, 0, false)
+			return errors.NewGenericServerResponse(path, resp.StatusCode, "", checker.QualifiedResource, checker.Name, bodyText, 0, false)
 		}
-		return errors.NewGenericServerResponse(resp.StatusCode, "", checker.QualifiedResource, checker.Name, bodyText, 0, false)
+		return errors.NewGenericServerResponse(path, resp.StatusCode, "", checker.QualifiedResource, checker.Name, bodyText, 0, false)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR improves the error message for authenticated users with no permissions.

Error message before this change.

```
$ ./kubectl  get pods
error: failed to negotiate an api version; server supports: map[], client supports: map[componentconfig/v1alpha1:{} policy/v1alpha1:{} apps/v1alpha1:{} autoscaling/v1:{} batch/v1:{} authentication.k8s.io/v1beta1:{} federation/v1alpha1:{} authorization.k8s.io/v1beta1:{} batch/v2alpha1:{} extensions/v1beta1:{} rbac.authorization.k8s.io/v1alpha1:{} v1:{}]
```

Error message after.

```
$ ./kubectl  get pods
Error from server: the server does not allow access to the requested resource (/api)
```

Closes #26909

cc: @janetkuo 
cc: @kubernetes/kubectl

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/27066)

<!-- Reviewable:end -->
