### PR TITLE
Bump azure-cli to 0.10.1 due to incompatibility issues with node v6.0.0+

### DIFF
--- a/docs/getting-started-guides/coreos/azure/package.json
+++ b/docs/getting-started-guides/coreos/azure/package.json
@@ -9,7 +9,7 @@
   "author": "Ilya Dmitrichenko <errordeveloper@gmail.com>",
   "license": "Apache 2.0",
   "dependencies": {
-    "azure-cli": "^0.9.9",
+    "azure-cli": "^0.10.1",
     "colors": "^1.0.3",
     "js-yaml": "^3.2.5",
     "openssl-wrapper": "^0.2.1",


### PR DESCRIPTION
Related to https://github.com/Azure/azure-xplat-cli/issues/2820

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
