### PR TITLE
Mark known-flags to merge via union.

### DIFF
--- a/hack/verify-flags/.gitattributes
+++ b/hack/verify-flags/.gitattributes
@@ -1,0 +1,1 @@
+known-flags.txt merge=union


### PR DESCRIPTION
This avoids pointless merge conflicts in a simple text file.
Fixes #27088.
