### PR TITLE
cluster/gce/coreos: Update heapster apiVersion

### DIFF
--- a/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta2
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: heapster-v1.1.0.beta2

--- a/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta2
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: heapster-v1.1.0.beta2

--- a/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta2
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: heapster-v1.1.0.beta2

--- a/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
@@ -71,3 +71,4 @@ spec:
         emptyDir: {}
       - name: grafana-persistent-storage
         emptyDir: {}
+


### PR DESCRIPTION
This fixes an inadvertant search-replace error in #26617.
The error was missed then because the search-replace issue wasn't
present in the standalone controllers, but was in all the others.

I verified that with this change heapster comes up under the default influxdb monitoring and without this change addon manager spits out validation failure errors for the heapster yaml.

cc @yifan-gu 
