### PR TITLE
rkt: Replace 'journalctl' with rkt's GetLogs() API.

### DIFF
--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -66,8 +66,8 @@ const (
 	RktType                      = "rkt"
 	DefaultRktAPIServiceEndpoint = "localhost:15441"
 
-	minimumRktBinVersion     = "1.7.0"
-	recommendedRktBinVersion = "1.7.0"
+	minimumRktBinVersion     = "1.8.0"
+	recommendedRktBinVersion = "1.8.0"
 
 	minimumRktApiVersion  = "1.0.0-alpha"
 	minimumSystemdVersion = "219"


### PR DESCRIPTION
This replaced the `journactl` shell out with rkt's GetLogs() API.
Fixes #26997 

To make this fully work, we need rkt to have this patch #https://github.com/coreos/rkt/pull/2763

cc @kubernetes/sig-node @euank @alban @iaguis @jonboulle 
