### PR TITLE
Fix Informer Race

### DIFF
--- a/pkg/client/cache/delta_fifo.go
+++ b/pkg/client/cache/delta_fifo.go
@@ -61,6 +61,18 @@ func NewDeltaFIFO(keyFunc KeyFunc, compressor DeltaCompressor, knownObjects *Syn
 	return f
 }
 
+func NewDeltaFIFOWithKeyListerGetter(keyFunc KeyFunc, compressor DeltaCompressor, keyLG KeyListerGetter) *DeltaFIFO {
+	f := &DeltaFIFO{
+		items:           map[string]Deltas{},
+		queue:           []string{},
+		keyFunc:         keyFunc,
+		deltaCompressor: compressor,
+		knownObjects:    NewSyncStore(&keyLG2Store{keyLG}),
+	}
+	f.cond.L = &f.lock
+	return f
+}
+
 // DeltaFIFO is like FIFO, but allows you to process deletes.
 //
 // DeltaFIFO is a producer-consumer queue, where a Reflector is
@@ -584,3 +596,17 @@ type DeletedFinalStateUnknown struct {
 	Key string
 	Obj interface{}
 }
+
+type keyLG2Store struct {
+	KeyListerGetter
+}
+
+func (s *keyLG2Store) Add(obj interface{}) error    { return nil }
+func (s *keyLG2Store) Update(obj interface{}) error { return nil }
+func (s *keyLG2Store) Delete(obj interface{}) error { return nil }
+func (s *keyLG2Store) List() []interface{}          { return nil }
+func (s *keyLG2Store) Get(obj interface{}) (item interface{}, exists bool, err error) {
+	return nil, false, nil
+}
+func (s *keyLG2Store) Replace([]interface{}, string) error { return nil }
+func (s *keyLG2Store) Resync() error                       { return nil }

--- a/pkg/client/cache/sync_store.go
+++ b/pkg/client/cache/sync_store.go
@@ -1,0 +1,34 @@
+package cache
+
+import "sync"
+
+type SyncStore struct {
+	Store
+	cond sync.Cond
+}
+
+func NewSyncStore(s Store) *SyncStore {
+	return &SyncStore{Store: s}
+}
+
+func (s *SyncStore) Add(obj interface{}) error {
+	err := s.Store.Add(obj)
+	s.cond.Signal()
+	return err
+}
+
+func (s *SyncStore) Update(obj interface{}) error {
+	err := s.Store.Update(obj)
+	s.cond.Signal()
+	return err
+}
+
+func (s *SyncStore) Delete(obj interface{}) error {
+	err := s.Store.Delete(obj)
+	s.cond.Signal()
+	return err
+}
+
+func (s *SyncStore) Sync() {
+	s.cond.Wait()
+}

--- a/pkg/client/cache/sync_store.go
+++ b/pkg/client/cache/sync_store.go
@@ -13,22 +13,30 @@ func NewSyncStore(s Store) *SyncStore {
 
 func (s *SyncStore) Add(obj interface{}) error {
 	err := s.Store.Add(obj)
-	s.cond.Signal()
+	if s.cond.L != nil {
+		s.cond.Signal()
+	}
 	return err
 }
 
 func (s *SyncStore) Update(obj interface{}) error {
 	err := s.Store.Update(obj)
-	s.cond.Signal()
+	if s.cond.L != nil {
+		s.cond.Signal()
+	}
 	return err
 }
 
 func (s *SyncStore) Delete(obj interface{}) error {
 	err := s.Store.Delete(obj)
-	s.cond.Signal()
+	if s.cond.L != nil {
+		s.cond.Signal()
+	}
 	return err
 }
 
 func (s *SyncStore) Sync() {
-	s.cond.Wait()
+	if s.cond.L != nil {
+		s.cond.Wait()
+	}
 }

--- a/pkg/controller/framework/controller.go
+++ b/pkg/controller/framework/controller.go
@@ -217,7 +217,7 @@ func NewInformer(
 	h ResourceEventHandler,
 ) (cache.Store, *Controller) {
 	// This will hold the client state, as we know it.
-	clientState := cache.NewStore(DeletionHandlingMetaNamespaceKeyFunc)
+	clientState := cache.NewSyncStore(cache.NewStore(DeletionHandlingMetaNamespaceKeyFunc))
 
 	// This will hold incoming changes. Note how we pass clientState in as a
 	// KeyLister, that way resync operations will result in the correct set
@@ -283,7 +283,7 @@ func NewIndexerInformer(
 	indexers cache.Indexers,
 ) (cache.Indexer, *Controller) {
 	// This will hold the client state, as we know it.
-	clientState := cache.NewIndexer(DeletionHandlingMetaNamespaceKeyFunc, indexers)
+	clientState := cache.NewSyncStore(cache.NewIndexer(DeletionHandlingMetaNamespaceKeyFunc, indexers))
 
 	// This will hold incoming changes. Note how we pass clientState in as a
 	// KeyLister, that way resync operations will result in the correct set
@@ -323,5 +323,5 @@ func NewIndexerInformer(
 			return nil
 		},
 	}
-	return clientState, New(cfg)
+	return clientState.Store.(cache.Indexer), New(cfg)
 }

--- a/pkg/controller/framework/controller_test.go
+++ b/pkg/controller/framework/controller_test.go
@@ -56,7 +56,7 @@ func Example() {
 	// This will hold incoming changes. Note how we pass downstream in as a
 	// KeyLister, that way resync operations will result in the correct set
 	// of update/delete deltas.
-	fifo := cache.NewDeltaFIFO(cache.MetaNamespaceKeyFunc, nil, downstream)
+	fifo := cache.NewDeltaFIFO(cache.MetaNamespaceKeyFunc, nil, cache.NewSyncStore(downstream))
 
 	// Let's do threadsafe output to get predictable test results.
 	deletionCounter := make(chan string, 1000)

--- a/pkg/controller/service/servicecontroller.go
+++ b/pkg/controller/service/servicecontroller.go
@@ -136,7 +136,7 @@ func (s *ServiceController) Run(serviceSyncPeriod, nodeSyncPeriod time.Duration)
 	// and updates of services.
 	// A delta compressor is needed for the DeltaFIFO queue because we only ever
 	// care about the most recent state.
-	serviceQueue := cache.NewDeltaFIFO(
+	serviceQueue := cache.NewDeltaFIFOWithKeyListerGetter(
 		cache.MetaNamespaceKeyFunc,
 		cache.DeltaCompressorFunc(func(d cache.Deltas) cache.Deltas {
 			if len(d) == 0 {


### PR DESCRIPTION
ref: #27004

This is a possible workaround. It force the queue to wait for Replace, Add, Update, Delete synchronized with store side.

I have a couple of thoughts during my path to finding the solution:
- Resync is unnecessary. Even though with this workaround there is still race. I remember from the original resync issue&PR, RH folks mentioned that they were missing events. Now I'm not surprised with the race we found. Once we fix the race we shouldn't use resync at all.
- The store and queue is tightly coupled. There is a lot of race conditions without locking the entire store, e.g. between ListKeys() and GetKeyBy(X), between queue.Add() and store.Add()... I would like to spend more time on redesigning the interaction between queue and store and make synchronization in one place -- preferably the store.
