### PR TITLE
Let kubelet log the DeletionTimestamp if it's not nil in update

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2638,7 +2638,7 @@ func (kl *Kubelet) syncLoopIteration(configCh <-chan kubetypes.PodUpdate, handle
 			// once we have checkpointing.
 			handler.HandlePodAdditions(u.Pods)
 		case kubetypes.UPDATE:
-			glog.V(2).Infof("SyncLoop (UPDATE, %q): %q", u.Source, format.Pods(u.Pods))
+			glog.V(2).Infof("SyncLoop (UPDATE, %q): %q", u.Source, format.PodsWithDeletiontimestamps(u.Pods))
 			handler.HandlePodUpdates(u.Pods)
 		case kubetypes.REMOVE:
 			glog.V(2).Infof("SyncLoop (REMOVE, %q): %q", u.Source, format.Pods(u.Pods))

--- a/pkg/kubelet/util/format/pod.go
+++ b/pkg/kubelet/util/format/pod.go
@@ -19,6 +19,7 @@ package format
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"k8s.io/kubernetes/pkg/api"
 )
@@ -33,10 +34,26 @@ func Pod(pod *api.Pod) string {
 	return fmt.Sprintf("%s_%s(%s)", pod.Name, pod.Namespace, pod.UID)
 }
 
+// PodWithDeletionTimestamp is the same as Pod. In addition, it prints the
+// deletion timestamp of the pod if it's not nil.
+func PodWithDeletionTimestamp(pod *api.Pod) string {
+	var deletionTimestamp string
+	if pod.DeletionTimestamp != nil {
+		deletionTimestamp = ":DeletionTimestamp=" + pod.DeletionTimestamp.UTC().Format(time.RFC3339)
+	}
+	return Pod(pod) + deletionTimestamp
+}
+
 // Pods returns a string representating a list of pods in a human
 // readable format.
 func Pods(pods []*api.Pod) string {
 	return aggregatePods(pods, Pod)
+}
+
+// PodsWithDeletiontimestamps is the same as Pods. In addition, it prints the
+// deletion timestamps of the pods if they are not nil.
+func PodsWithDeletiontimestamps(pods []*api.Pod) string {
+	return aggregatePods(pods, PodWithDeletionTimestamp)
 }
 
 func aggregatePods(pods []*api.Pod, handler podHandler) string {


### PR DESCRIPTION
This helps to debug if it's the kubelet to blame when a pod is not deleted. 

Example output:

```
SyncLoop (UPDATE, "api"): "redis-master_default(c6782276-2dd4-11e6-b874-64510650ab1c):DeletionTimestamp=2016-06-08T23:58:12Z"
```

ref #26290
cc @Random-Liu 
