### PR TITLE
Fixed GetGroupNodes method: wrong regexp function was used.

### DIFF
--- a/test/e2e/resize_nodes.go
+++ b/test/e2e/resize_nodes.go
@@ -87,7 +87,7 @@ func GetGroupNodes(group string) ([]string, error) {
 			return nil, err
 		}
 		re := regexp.MustCompile(".*RUNNING")
-		lines := re.FindStringSubmatch(string(output))
+		lines := re.FindAllString(string(output), -1)
 		for i, line := range lines {
 			lines[i] = line[:strings.Index(line, " ")]
 		}


### PR DESCRIPTION
[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()

Fixed GetGroupNodes method: wrong regexp function was used. Should fix flakiness of "should add node to the particular mig" e2e test.
