### PR TITLE
Fix GKE upgrade e2e util.

### DIFF
--- a/test/e2e/framework/nodes_util.go
+++ b/test/e2e/framework/nodes_util.go
@@ -50,9 +50,9 @@ func masterUpgradeGCE(rawV string) error {
 func masterUpgradeGKE(v string) error {
 	Logf("Upgrading master to %q", v)
 	_, _, err := RunCmd("gcloud", "container",
+		"clusters",
 		fmt.Sprintf("--project=%s", TestContext.CloudConfig.ProjectID),
 		fmt.Sprintf("--zone=%s", TestContext.CloudConfig.Zone),
-		"clusters",
 		"upgrade",
 		TestContext.CloudConfig.Cluster,
 		"--master",
@@ -252,9 +252,9 @@ func cleanupNodeUpgradeGCE(tmplBefore string) {
 func nodeUpgradeGKE(v string) error {
 	Logf("Upgrading nodes to %q", v)
 	_, _, err := RunCmd("gcloud", "container",
+		"clusters",
 		fmt.Sprintf("--project=%s", TestContext.CloudConfig.ProjectID),
 		fmt.Sprintf("--zone=%s", TestContext.CloudConfig.Zone),
-		"clusters",
 		"upgrade",
 		TestContext.CloudConfig.Cluster,
 		fmt.Sprintf("--cluster-version=%s", v),


### PR DESCRIPTION
containers command group at HEAD no longer accepts --zone. Flag
has to be specified after subcommand group. Fix #27011
