### PR TITLE
Trusty: fix the 'ping' issue and fluentd-gcp issue #26379

### DIFF
--- a/cluster/gce/trusty/master.yaml
+++ b/cluster/gce/trusty/master.yaml
@@ -134,9 +134,8 @@ script
 	set -o errexit
 	set -o nounset
 
-	echo "Start kubelet upstart job"
-	. /etc/default/kubelet
-	/usr/bin/kubelet ${KUBELET_OPTS} 1>>/var/log/kubelet.log 2>&1
+	. /etc/kube-configure-helper.sh
+	start_kubelet
 } 2>&1 | logger --priority daemon.info -t ${UPSTART_JOB}
 end script
 

--- a/cluster/gce/trusty/node.yaml
+++ b/cluster/gce/trusty/node.yaml
@@ -132,9 +132,8 @@ script
 	set -o errexit
 	set -o nounset
 
-	echo "Start kubelet upstart job"
-	. /etc/default/kubelet
-	/usr/bin/kubelet ${KUBELET_OPTS} 1>>/var/log/kubelet.log 2>&1
+	. /etc/kube-configure-helper.sh
+	start_kubelet
 } 2>&1 | logger --priority daemon.info -t ${UPSTART_JOB}
 end script
 


### PR DESCRIPTION
This PR is mainly for being picking up the fix in #27016 and #27102 in trusty code, so that we can fix the issues in the release-1.2 branch for GCI. It contains two parts:

(1) Adding iptables rules to accept ICMP traffic, otherwise 'ping' from a pod does not work;

(2) Revising the code for cleaning up docker0 stuff including the bridge and iptables rules. I slightly refactor the code of starting kubelet and removing docker0 stuff before starting kubelet. The old code did it after starting kubelet but before restarting docker. I think doing it before starting kubelet is safter.

cc/ @roberthbailey @fabioy @dchen1107 @a-robinson @kubernetes/goog-image 
