### PR TITLE
only add api groups to KUBE_TEST_API_VERSIONS if they have multiple versions

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -58,7 +58,7 @@ KUBE_GOVERALLS_BIN=${KUBE_GOVERALLS_BIN:-}
 # Lists of API Versions of each groups that should be tested, groups are
 # separated by comma, lists are separated by semicolon. e.g.,
 # "v1,compute/v1alpha1,experimental/v1alpha2;v1,compute/v2,experimental/v1alpha3"
-KUBE_TEST_API_VERSIONS=${KUBE_TEST_API_VERSIONS:-"v1,extensions/v1beta1,federation/v1alpha1;v1,autoscaling/v1,batch/v1,batch/v2alpha1,extensions/v1beta1,apps/v1alpha1,federation/v1alpha1,policy/v1alpha1,rbac.authorization.k8s.io/v1alpha1"}
+KUBE_TEST_API_VERSIONS=${KUBE_TEST_API_VERSIONS:-"batch/v1;batch/v2alpha1"}
 # once we have multiple group supports
 # Run tests with the standard (registry) etcd prefix.
 KUBE_TEST_ETCD_PREFIXES=${KUBE_TEST_ETCD_PREFIXES:-"registry"}

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -27,9 +27,7 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 # Lists of API Versions of each groups that should be tested, groups are
 # separated by comma, lists are separated by semicolon. e.g.,
 # "v1,compute/v1alpha1,experimental/v1alpha2;v1,compute/v2,experimental/v1alpha3"
-# TODO: It's going to be:
-# KUBE_TEST_API_VERSIONS=${KUBE_TEST_API_VERSIONS:-"v1,extensions/v1beta1"}
-KUBE_TEST_API_VERSIONS=${KUBE_TEST_API_VERSIONS:-"v1,extensions/v1beta1;v1,autoscaling/v1,batch/v1,apps/v1alpha1,policy/v1alpha1,extensions/v1beta1,rbac.authorization.k8s.io/v1alpha1"}
+KUBE_TEST_API_VERSIONS=${KUBE_TEST_API_VERSIONS:-"batch/v1;batch/v2alpha1"}
 
 # Give integration tests longer to run
 # TODO: allow a larger value to be passed in

--- a/pkg/api/testing/fuzzer.go
+++ b/pkg/api/testing/fuzzer.go
@@ -169,6 +169,10 @@ func FuzzerFor(t *testing.T, version unversioned.GroupVersion, src rand.Source) 
 				j.ManualSelector = nil
 			}
 		},
+		func(cp *batch.ConcurrencyPolicy, c fuzz.Continue) {
+			policies := []batch.ConcurrencyPolicy{batch.AllowConcurrent, batch.ForbidConcurrent, batch.ReplaceConcurrent}
+			*cp = policies[c.Rand.Intn(len(policies))]
+		},
 		func(j *api.List, c fuzz.Continue) {
 			c.FuzzNoCustom(j) // fuzz self without calling this function again
 			// TODO: uncomment when round trip starts from a versioned object

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -430,6 +430,19 @@ func TestDiscoveryAtAPIS(t *testing.T) {
 				Version:      testapi.Autoscaling.GroupVersion().Version,
 			},
 		},
+		// batch is using its pkg/apis/batch/ types here since during installation
+		// both versions get installed and testapi.go currently does not support
+		// multi-versioned clients
+		batch.GroupName: {
+			{
+				GroupVersion: batchapiv1.SchemeGroupVersion.String(),
+				Version:      batchapiv1.SchemeGroupVersion.Version,
+			},
+			{
+				GroupVersion: batchapiv2alpha1.SchemeGroupVersion.String(),
+				Version:      batchapiv2alpha1.SchemeGroupVersion.Version,
+			},
+		},
 		apps.GroupName: {
 			{
 				GroupVersion: testapi.Apps.GroupVersion().String(),
@@ -443,14 +456,6 @@ func TestDiscoveryAtAPIS(t *testing.T) {
 			},
 		},
 	}
-	var batchVersions []unversioned.GroupVersionForDiscovery
-	for _, gv := range testapi.Batch.GroupVersions() {
-		batchVersions = append(batchVersions, unversioned.GroupVersionForDiscovery{
-			GroupVersion: gv.String(),
-			Version:      gv.Version,
-		})
-	}
-	expectVersions[batch.GroupName] = batchVersions
 
 	expectPreferredVersion := map[string]unversioned.GroupVersionForDiscovery{
 		autoscaling.GroupName: {


### PR DESCRIPTION
If an api group isn't included in this list, we test the default api group so we only need to include apigroups here that have multiple versions. Since the only group with multiple versions is batch, only batch should be included here.

Furthermore, before this change, both batch versions are on the same side of the `;` (same test set) which makes no sense. Since the testapi packages uses the last version of a group in a particular test set, the only reason this tested everything was by dumb luck. This change should be a functional noop.

Reported-by: @caesarxuchao
Cc: @lavalamp
Cc: @ixdy
