### PR TITLE
support for mounting local-ssds on GCI

### DIFF
--- a/cluster/gce/configure-vm.sh
+++ b/cluster/gce/configure-vm.sh
@@ -58,9 +58,9 @@ ensure-local-disks() {
  for ssd in /dev/disk/by-id/google-local-ssd-*; do
     if [ -e "$ssd" ]; then
       ssdnum=`echo $ssd | sed -e 's/\/dev\/disk\/by-id\/google-local-ssd-\([0-9]*\)/\1/'`
-      echo "Formatting and mounting local SSD $ssd to /mnt/ssd$ssdnum"
-      mkdir -p /mnt/ssd$ssdnum
-      /usr/share/google/safe_format_and_mount -m "mkfs.ext4 -F" "${ssd}" /mnt/ssd$ssdnum &>/var/log/local-ssd-$ssdnum-mount.log || \
+      echo "Formatting and mounting local SSD $ssd to /mnt/disks/ssd$ssdnum"
+      mkdir -p /mnt/disks/ssd$ssdnum
+      /usr/share/google/safe_format_and_mount -m "mkfs.ext4 -F" "${ssd}" /mnt/disks/ssd$ssdnum &>/var/log/local-ssd-$ssdnum-mount.log || \
       { echo "Local SSD $ssdnum mount failed, review /var/log/local-ssd-$ssdnum-mount.log"; return 1; }
     else
       echo "No local SSD disks found."

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -46,6 +46,23 @@ function create-dirs {
   fi
 }
 
+# Local ssds, if present, are mounted at /mnt/disks/ssdN.
+function ensure-local-ssds() {
+  for ssd in /dev/disk/by-id/google-local-ssd-*; do
+    if [ -e "${ssd}" ]; then
+      ssdnum=`echo ${ssd} | sed -e 's/\/dev\/disk\/by-id\/google-local-ssd-\([0-9]*\)/\1/'`
+      ssdmount="/mnt/disks/ssd${ssdnum}/"
+      echo "Formatting and mounting local SSD $ssd to ${ssdmount}"
+      mkdir -p ${ssdmount}
+      /usr/share/google/safe_format_and_mount -m "mkfs.ext4 -F" "${ssd}" ${ssdmount} || \
+      { echo "Local SSD $ssdnum mount failed"; return 1; }
+      chmod a+w ${ssdmount}
+    else
+      echo "No local SSD disks found."
+    fi
+  done
+}
+
 # Finds the master PD device; returns it in MASTER_PD_DEVICE
 function find-master-pd {
   MASTER_PD_DEVICE=""
@@ -870,6 +887,7 @@ fi
 source "${KUBE_HOME}/kube-env"
 config-ip-firewall
 create-dirs
+ensure-local-ssds
 if [[ "${KUBERNETES_MASTER:-}" == "true" ]]; then
   mount-master-pd
   create-master-auth

--- a/test/e2e/gke_local_ssd.go
+++ b/test/e2e/gke_local_ssd.go
@@ -54,7 +54,7 @@ func createNodePoolWithLocalSsds(nodePoolName string) {
 }
 
 func doTestWriteAndReadToLocalSsd(f *framework.Framework) {
-	var pod = testPodWithSsd("echo 'hello world' > /mnt/ssd0/data  && sleep 1 && cat /mnt/ssd0/data")
+	var pod = testPodWithSsd("echo 'hello world' > /mnt/disks/ssd0/data  && sleep 1 && cat /mnt/disks/ssd0/data")
 	var msg string
 	var out = []string{"hello world"}
 
@@ -64,7 +64,7 @@ func doTestWriteAndReadToLocalSsd(f *framework.Framework) {
 func testPodWithSsd(command string) *api.Pod {
 	containerName := "test-container"
 	volumeName := "test-ssd-volume"
-	path := "/mnt/ssd0"
+	path := "/mnt/disks/ssd0"
 	podName := "pod-" + string(util.NewUUID())
 	image := "ubuntu:14.04"
 	return &api.Pod{


### PR DESCRIPTION
This change adds support for mounting local ssds on GCI.
It updates the previous container-vm behavior as well to
match that for GCI nodes by mounting the local-ssds under
the same path (/mnt/disks/ssdN).

@vulpecula @roberthbailey @andyzheng0831 @kubernetes/goog-image 
