### PR TITLE
oidc: fix test nil pointer

### DIFF
--- a/plugin/pkg/client/auth/oidc/oidc_test.go
+++ b/plugin/pkg/client/auth/oidc/oidc_test.go
@@ -48,11 +48,11 @@ func TestNewOIDCAuthProvider(t *testing.T) {
 	oidctesting.GenerateSelfSignedCert(t, "127.0.0.1", cert, key)
 	op := oidctesting.NewOIDCProvider(t)
 	srv, err := op.ServeTLSWithKeyPair(cert, key)
-	op.AddMinimalProviderConfig(srv)
 	if err != nil {
 		t.Fatalf("Cannot start server %v", err)
 	}
 	defer srv.Close()
+	op.AddMinimalProviderConfig(srv)
 
 	certData, err := ioutil.ReadFile(cert)
 	if err != nil {


### PR DESCRIPTION
```
2016-06-09 13:12:37.262983 I | http: TLS handshake error from 127.0.0.1:32814: remote error: bad certificate
PASS
--- FAIL: TestNewOIDCAuthProvider (0.87s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x5d91ca]

goroutine 12 [running]:
panic(0x124bd00, 0xc8200101f0)
        /usr/local/google/home/mikedanese/.gimme/versions/go1.6.1.linux.amd64/src/runtime/panic.go:464 +0x3e6
testing.tRunner.func1(0xc820023b90)
        /usr/local/google/home/mikedanese/.gimme/versions/go1.6.1.linux.amd64/src/testing/testing.go:467 +0x192
panic(0x124bd00, 0xc8200101f0)
        /usr/local/google/home/mikedanese/.gimme/versions/go1.6.1.linux.amd64/src/runtime/panic.go:426 +0x4e9
k8s.io/kubernetes/plugin/pkg/auth/authenticator/token/oidc/testing.(*OIDCProvider).AddMinimalProviderConfig(0xc820020580, 0x0)
        /usr/local/google/home/mikedanese/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/plugin/pkg/auth/authenticator/token/oidc/testing/provider.go:85 +0x2a
k8s.io/kubernetes/plugin/pkg/client/auth/oidc.TestNewOIDCAuthProvider(0xc820023b90)
        /usr/local/google/home/mikedanese/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/plugin/pkg/client/auth/oidc/oidc_test.go:51 +0x367
testing.tRunner(0xc820023b90, 0x1d0a360)
        /usr/local/google/home/mikedanese/.gimme/versions/go1.6.1.linux.amd64/src/testing/testing.go:473 +0x98
created by testing.RunTests
        /usr/local/google/home/mikedanese/.gimme/versions/go1.6.1.linux.amd64/src/testing/testing.go:582 +0x892
FAIL    k8s.io/kubernetes/plugin/pkg/client/auth/oidc   3.081s
```

cc @bobbyrullo @yifan-gu 
