### PR TITLE
Remove unnecessary configuration for apiserver host and port.

### DIFF
--- a/cluster/addons/node-problem-detector/node-problem-detector.yaml
+++ b/cluster/addons/node-problem-detector/node-problem-detector.yaml
@@ -19,12 +19,6 @@ spec:
       containers:
       - name: node-problem-detector
         image: gcr.io/google_containers/node-problem-detector:v0.1
-        env:
-        # Config the host ip and port of apiserver.
-        - name: "KUBERNETES_SERVICE_HOST"
-          value: "{{ pillar['master_node'] }}"
-        - name: "KUBERNETES_SERVICE_PORT"
-          value: "443"
         securityContext:
           privileged: true
         resources:

--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -594,7 +594,6 @@ ENABLE_MANIFEST_URL: $(yaml-quote ${ENABLE_MANIFEST_URL:-false})
 MANIFEST_URL: $(yaml-quote ${MANIFEST_URL:-})
 MANIFEST_URL_HEADER: $(yaml-quote ${MANIFEST_URL_HEADER:-})
 NUM_NODES: $(yaml-quote ${NUM_NODES})
-MASTER_NAME: $(yaml-quote ${MASTER_NAME})
 EOF
     if [ -n "${APISERVER_TEST_ARGS:-}" ]; then
       cat >>$file <<EOF

--- a/cluster/gce/configure-vm.sh
+++ b/cluster/gce/configure-vm.sh
@@ -449,7 +449,6 @@ enable_manifest_url: '$(echo "${ENABLE_MANIFEST_URL:-}" | sed -e "s/'/''/g")'
 manifest_url: '$(echo "${MANIFEST_URL:-}" | sed -e "s/'/''/g")'
 manifest_url_header: '$(echo "${MANIFEST_URL_HEADER:-}" | sed -e "s/'/''/g")'
 num_nodes: $(echo "${NUM_NODES:-}" | sed -e "s/'/''/g")
-master_node: $(echo "${MASTER_NAME:-}" | sed -e "s/'/''/g")
 e2e_storage_test_environment: '$(echo "$E2E_STORAGE_TEST_ENVIRONMENT" | sed -e "s/'/''/g")'
 kube_uid: '$(echo "${KUBE_UID}" | sed -e "s/'/''/g")'
 EOF

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -752,10 +752,6 @@ function start-kube-addons {
   fi
   if [[ "${ENABLE_NODE_PROBLEM_DETECTOR:-}" == "true" ]]; then
     setup-addon-manifests "addons" "node-problem-detector"
-    local -r node_problem_detector_file="${dst_dir}/node-problem-detector/node-problem-detector.yaml"
-    mv "${dst_dir}/node-problem-detector/node-problem-detector.yaml.in" "${node_problem_detector_file}"
-    # Replace the salt configurations with variable values.
-    sed -i -e "s@{{ *pillar\['master_node'\] *}}@${MASTER_NAME}@g" "${node_problem_detector_file}"
   fi
   if echo "${ADMISSION_CONTROL:-}" | grep -q "LimitRanger"; then
     setup-addon-manifests "admission-controls" "limit-range"

--- a/cluster/saltbase/salt/kube-addons/init.sls
+++ b/cluster/saltbase/salt/kube-addons/init.sls
@@ -153,8 +153,7 @@ addon-dir-create:
 {% if pillar.get('enable_node_problem_detector', '').lower() == 'true' %}
 /etc/kubernetes/addons/node-problem-detector/node-problem-detector.yaml:
   file.managed:
-    - source: salt://kube-addons/node-problem-detector/node-problem-detector.yaml.in
-    - template: jinja
+    - source: salt://kube-addons/node-problem-detector/node-problem-detector.yaml
     - user: root
     - group: root
     - file_mode: 644


### PR DESCRIPTION
This is kubernetes side of https://github.com/kubernetes/node-problem-detector/pull/18.

There is no need to configure apiserver host and port with salt and pillar, the default ENV values
in the container are enough. I've tried this PR in my local cluster, everything works fine.

@mikedanese for the salt change. :)
/cc @dchen1107 

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
