### PR TITLE
Set Dashboard UI version to v1.1.0-beta3

### DIFF
--- a/cluster/addons/dashboard/dashboard-controller.yaml
+++ b/cluster/addons/dashboard/dashboard-controller.yaml
@@ -3,11 +3,11 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: kubernetes-dashboard-v1.1.0-beta2
+  name: kubernetes-dashboard-v1.1.0-beta3
   namespace: kube-system
   labels:
     k8s-app: kubernetes-dashboard
-    version: v1.1.0-beta2
+    version: v1.1.0-beta3
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
@@ -17,12 +17,12 @@ spec:
     metadata:
       labels:
         k8s-app: kubernetes-dashboard
-        version: v1.1.0-beta2
+        version: v1.1.0-beta3
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.1.0-beta2
+        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.1.0-beta3
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:

--- a/cluster/gce/coreos/kube-manifests/addons/dashboard/dashboard-controller.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/dashboard/dashboard-controller.yaml
@@ -2,11 +2,11 @@ apiVersion: v1
 kind: ReplicationController
 metadata:
   # Keep this file in sync with addons/dashboard/dashboard-controller.yaml
-  name: kubernetes-dashboard-v1.1.0-beta2
+  name: kubernetes-dashboard-v1.1.0-beta3
   namespace: kube-system
   labels:
     k8s-app: kubernetes-dashboard
-    version: v1.1.0-beta2
+    version: v1.1.0-beta3
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
@@ -16,12 +16,12 @@ spec:
     metadata:
       labels:
         k8s-app: kubernetes-dashboard
-        version: v1.1.0-beta2
+        version: v1.1.0-beta3
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.1.0-beta2
+        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.1.0-beta3
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:

--- a/cluster/images/hyperkube/addons/dashboard-rc.yaml
+++ b/cluster/images/hyperkube/addons/dashboard-rc.yaml
@@ -20,25 +20,25 @@ metadata:
   namespace: kube-system
   labels:
     app: kubernetes-dashboard
-    version: v1.1.0-beta2
+    version: v1.1.0-beta3
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
   selector:
     app: kubernetes-dashboard
-    version: v1.1.0-beta2
+    version: v1.1.0-beta3
     kubernetes.io/cluster-service: "true"
   template:
     metadata:
       labels:
         app: kubernetes-dashboard
-        version: v1.1.0-beta2
+        version: v1.1.0-beta3
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
       - name: kubernetes-dashboard
         # ARCH will be replaced with the architecture it's built for. Check out the Makefile for more details
-        image: gcr.io/google_containers/kubernetes-dashboard-ARCH:v1.1.0-beta2
+        image: gcr.io/google_containers/kubernetes-dashboard-ARCH:v1.1.0-beta3
         imagePullPolicy: Always
         ports:
         - containerPort: 9090


### PR DESCRIPTION
We expect 1-2 more betas before final release. 

Release info: https://github.com/kubernetes/dashboard/releases/tag/v1.1.0-beta3

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
