### PR TITLE
Remove EncodeToStream(..., []unversioned.GroupVersion)

### DIFF
--- a/pkg/api/serialization_proto_test.go
+++ b/pkg/api/serialization_proto_test.go
@@ -51,7 +51,7 @@ func TestUniversalDeserializer(t *testing.T) {
 			t.Fatal(mediaType)
 		}
 		buf := &bytes.Buffer{}
-		if err := e.EncodeToStream(expected, buf); err != nil {
+		if err := e.Encode(expected, buf); err != nil {
 			t.Fatalf("%s: %v", mediaType, err)
 		}
 		obj, _, err := d.Decode(buf.Bytes(), &unversioned.GroupVersionKind{Kind: "Pod", Version: "v1"}, nil)

--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -308,7 +308,7 @@ func TestObjectWatchFraming(t *testing.T) {
 
 		// write a single object through the framer and back out
 		obj := &bytes.Buffer{}
-		if err := s.EncodeToStream(v1secret, obj); err != nil {
+		if err := s.Encode(v1secret, obj); err != nil {
 			t.Fatal(err)
 		}
 		out := &bytes.Buffer{}
@@ -330,13 +330,13 @@ func TestObjectWatchFraming(t *testing.T) {
 
 		// write a watch event through and back out
 		obj = &bytes.Buffer{}
-		if err := embedded.EncodeToStream(v1secret, obj); err != nil {
+		if err := embedded.Encode(v1secret, obj); err != nil {
 			t.Fatal(err)
 		}
 		event := &versioned.Event{Type: string(watch.Added)}
 		event.Object.Raw = obj.Bytes()
 		obj = &bytes.Buffer{}
-		if err := s.EncodeToStream(event, obj); err != nil {
+		if err := s.Encode(event, obj); err != nil {
 			t.Fatal(err)
 		}
 		out = &bytes.Buffer{}

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -255,9 +255,9 @@ type stripVersionEncoder struct {
 	serializer runtime.Serializer
 }
 
-func (c stripVersionEncoder) EncodeToStream(obj runtime.Object, w io.Writer, overrides ...unversioned.GroupVersion) error {
+func (c stripVersionEncoder) Encode(obj runtime.Object, w io.Writer) error {
 	buf := bytes.NewBuffer([]byte{})
-	err := c.encoder.EncodeToStream(obj, buf, overrides...)
+	err := c.encoder.Encode(obj, buf)
 	if err != nil {
 		return err
 	}
@@ -268,7 +268,7 @@ func (c stripVersionEncoder) EncodeToStream(obj runtime.Object, w io.Writer, ove
 	gvk.Group = ""
 	gvk.Version = ""
 	roundTrippedObj.GetObjectKind().SetGroupVersionKind(*gvk)
-	return c.serializer.EncodeToStream(roundTrippedObj, w)
+	return c.serializer.Encode(roundTrippedObj, w)
 }
 
 // StripVersionNegotiatedSerializer will return stripVersionEncoder when
@@ -443,7 +443,7 @@ func writeNegotiated(s runtime.NegotiatedSerializer, gv unversioned.GroupVersion
 	w.WriteHeader(statusCode)
 
 	encoder := s.EncoderForVersion(serializer, gv)
-	if err := encoder.EncodeToStream(object, w); err != nil {
+	if err := encoder.Encode(object, w); err != nil {
 		errorJSONFatal(err, encoder, w)
 	}
 }

--- a/pkg/apiserver/watch.go
+++ b/pkg/apiserver/watch.go
@@ -185,7 +185,7 @@ func (s *WatchServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 			obj := event.Object
 			s.fixup(obj)
-			if err := s.embeddedEncoder.EncodeToStream(obj, buf); err != nil {
+			if err := s.embeddedEncoder.Encode(obj, buf); err != nil {
 				// unexpected error
 				utilruntime.HandleError(fmt.Errorf("unable to encode watch object: %v", err))
 				return
@@ -235,7 +235,7 @@ func (s *WatchServer) HandleWS(ws *websocket.Conn) {
 			}
 			obj := event.Object
 			s.fixup(obj)
-			if err := s.embeddedEncoder.EncodeToStream(obj, buf); err != nil {
+			if err := s.embeddedEncoder.Encode(obj, buf); err != nil {
 				// unexpected error
 				utilruntime.HandleError(fmt.Errorf("unable to encode watch object: %v", err))
 				return
@@ -248,7 +248,7 @@ func (s *WatchServer) HandleWS(ws *websocket.Conn) {
 
 			// the internal event will be versioned by the encoder
 			*internalEvent = versioned.InternalEvent(event)
-			if err := s.encoder.EncodeToStream(internalEvent, streamBuf); err != nil {
+			if err := s.encoder.Encode(internalEvent, streamBuf); err != nil {
 				// encoding error
 				utilruntime.HandleError(fmt.Errorf("unable to encode event: %v", err))
 				s.watching.Stop()

--- a/pkg/client/typed/dynamic/client.go
+++ b/pkg/client/typed/dynamic/client.go
@@ -253,8 +253,8 @@ func (dynamicCodec) Decode(data []byte, gvk *unversioned.GroupVersionKind, obj r
 	return obj, gvk, nil
 }
 
-func (dynamicCodec) EncodeToStream(obj runtime.Object, w io.Writer, overrides ...unversioned.GroupVersion) error {
-	return runtime.UnstructuredJSONScheme.EncodeToStream(obj, w, overrides...)
+func (dynamicCodec) Encode(obj runtime.Object, w io.Writer) error {
+	return runtime.UnstructuredJSONScheme.Encode(obj, w)
 }
 
 // paramaterCodec is a codec converts an API object to query

--- a/pkg/client/typed/dynamic/client_test.go
+++ b/pkg/client/typed/dynamic/client_test.go
@@ -235,7 +235,7 @@ func TestDelete(t *testing.T) {
 			}
 
 			w.Header().Set("Content-Type", runtime.ContentTypeJSON)
-			runtime.UnstructuredJSONScheme.EncodeToStream(statusOK, w)
+			runtime.UnstructuredJSONScheme.Encode(statusOK, w)
 		})
 		if err != nil {
 			t.Errorf("unexpected error when creating client: %v", err)
@@ -284,7 +284,7 @@ func TestDeleteCollection(t *testing.T) {
 			}
 
 			w.Header().Set("Content-Type", runtime.ContentTypeJSON)
-			runtime.UnstructuredJSONScheme.EncodeToStream(statusOK, w)
+			runtime.UnstructuredJSONScheme.Encode(statusOK, w)
 		})
 		if err != nil {
 			t.Errorf("unexpected error when creating client: %v", err)

--- a/pkg/registry/thirdpartyresourcedata/codec.go
+++ b/pkg/registry/thirdpartyresourcedata/codec.go
@@ -483,10 +483,10 @@ func encodeToJSON(obj *extensions.ThirdPartyResourceData, stream io.Writer) erro
 	return encoder.Encode(objMap)
 }
 
-func (t *thirdPartyResourceDataEncoder) EncodeToStream(obj runtime.Object, stream io.Writer, overrides ...unversioned.GroupVersion) (err error) {
+func (t *thirdPartyResourceDataEncoder) Encode(obj runtime.Object, stream io.Writer) (err error) {
 	switch obj := obj.(type) {
 	case *versioned.InternalEvent:
-		return t.delegate.EncodeToStream(obj, stream, overrides...)
+		return t.delegate.Encode(obj, stream)
 	case *extensions.ThirdPartyResourceData:
 		return encodeToJSON(obj, stream)
 	case *extensions.ThirdPartyResourceDataList:
@@ -504,7 +504,7 @@ func (t *thirdPartyResourceDataEncoder) EncodeToStream(obj runtime.Object, strea
 		fmt.Fprintf(stream, template, t.gvk.Kind+"List", gv.String(), strings.Join(dataStrings, ","))
 		return nil
 	case *unversioned.Status, *unversioned.APIResourceList:
-		return t.delegate.EncodeToStream(obj, stream, overrides...)
+		return t.delegate.Encode(obj, stream)
 	default:
 		return fmt.Errorf("unexpected object to encode: %#v", obj)
 	}

--- a/pkg/runtime/codec.go
+++ b/pkg/runtime/codec.go
@@ -40,10 +40,10 @@ func NewCodec(e Encoder, d Decoder) Codec {
 }
 
 // Encode is a convenience wrapper for encoding to a []byte from an Encoder
-func Encode(e Encoder, obj Object, overrides ...unversioned.GroupVersion) ([]byte, error) {
+func Encode(e Encoder, obj Object) ([]byte, error) {
 	// TODO: reuse buffer
 	buf := &bytes.Buffer{}
-	if err := e.EncodeToStream(obj, buf, overrides...); err != nil {
+	if err := e.Encode(obj, buf); err != nil {
 		return nil, err
 	}
 	return buf.Bytes(), nil
@@ -98,7 +98,7 @@ type NoopEncoder struct {
 
 var _ Serializer = NoopEncoder{}
 
-func (n NoopEncoder) EncodeToStream(obj Object, w io.Writer, overrides ...unversioned.GroupVersion) error {
+func (n NoopEncoder) Encode(obj Object, w io.Writer) error {
 	return fmt.Errorf("encoding is not allowed for this codec: %v", reflect.TypeOf(n.Decoder))
 }
 
@@ -181,9 +181,9 @@ func NewBase64Serializer(s Serializer) Serializer {
 	return &base64Serializer{s}
 }
 
-func (s base64Serializer) EncodeToStream(obj Object, stream io.Writer, overrides ...unversioned.GroupVersion) error {
+func (s base64Serializer) Encode(obj Object, stream io.Writer) error {
 	e := base64.NewEncoder(base64.StdEncoding, stream)
-	err := s.Serializer.EncodeToStream(obj, e, overrides...)
+	err := s.Serializer.Encode(obj, e)
 	e.Close()
 	return err
 }

--- a/pkg/runtime/helper.go
+++ b/pkg/runtime/helper.go
@@ -113,10 +113,10 @@ func FieldPtr(v reflect.Value, fieldName string, dest interface{}) error {
 
 // EncodeList ensures that each object in an array is converted to a Unknown{} in serialized form.
 // TODO: accept a content type.
-func EncodeList(e Encoder, objects []Object, overrides ...unversioned.GroupVersion) error {
+func EncodeList(e Encoder, objects []Object) error {
 	var errs []error
 	for i := range objects {
-		data, err := Encode(e, objects[i], overrides...)
+		data, err := Encode(e, objects[i])
 		if err != nil {
 			errs = append(errs, err)
 			continue

--- a/pkg/runtime/interfaces.go
+++ b/pkg/runtime/interfaces.go
@@ -31,10 +31,9 @@ const (
 )
 
 type Encoder interface {
-	// EncodeToStream writes an object to a stream. Override versions may be provided for each group
-	// that enforce a certain versioning. Implementations may return errors if the versions are incompatible,
-	// or if no conversion is defined.
-	EncodeToStream(obj Object, stream io.Writer, overrides ...unversioned.GroupVersion) error
+	// Encode writes an object to a stream. Implementations may return errors if the versions are
+	// incompatible, or if no conversion is defined.
+	Encode(obj Object, w io.Writer) error
 }
 
 type Decoder interface {

--- a/pkg/runtime/serializer/codec_factory.go
+++ b/pkg/runtime/serializer/codec_factory.go
@@ -339,7 +339,7 @@ type DirectCodec struct {
 }
 
 // EncodeToStream does not do conversion. It sets the gvk during serialization. overrides are ignored.
-func (c DirectCodec) EncodeToStream(obj runtime.Object, stream io.Writer, overrides ...unversioned.GroupVersion) error {
+func (c DirectCodec) Encode(obj runtime.Object, stream io.Writer) error {
 	gvks, _, err := c.ObjectTyper.ObjectKinds(obj)
 	if err != nil {
 		return err
@@ -347,7 +347,7 @@ func (c DirectCodec) EncodeToStream(obj runtime.Object, stream io.Writer, overri
 	kind := obj.GetObjectKind()
 	oldGVK := kind.GroupVersionKind()
 	kind.SetGroupVersionKind(gvks[0])
-	err = c.Serializer.EncodeToStream(obj, stream, overrides...)
+	err = c.Serializer.Encode(obj, stream)
 	kind.SetGroupVersionKind(oldGVK)
 	return err
 }

--- a/pkg/runtime/serializer/json/json.go
+++ b/pkg/runtime/serializer/json/json.go
@@ -159,8 +159,8 @@ func (s *Serializer) Decode(originalData []byte, gvk *unversioned.GroupVersionKi
 	return obj, actual, nil
 }
 
-// EncodeToStream serializes the provided object to the given writer. Overrides is ignored.
-func (s *Serializer) EncodeToStream(obj runtime.Object, w io.Writer, overrides ...unversioned.GroupVersion) error {
+// Encode serializes the provided object to the given writer.
+func (s *Serializer) Encode(obj runtime.Object, w io.Writer) error {
 	if s.yaml {
 		json, err := json.Marshal(obj)
 		if err != nil {

--- a/pkg/runtime/serializer/protobuf/protobuf.go
+++ b/pkg/runtime/serializer/protobuf/protobuf.go
@@ -165,8 +165,8 @@ func (s *Serializer) Decode(originalData []byte, gvk *unversioned.GroupVersionKi
 	return unmarshalToObject(s.typer, s.creater, &actual, into, unk.Raw)
 }
 
-// EncodeToStream serializes the provided object to the given writer. Overrides is ignored.
-func (s *Serializer) EncodeToStream(obj runtime.Object, w io.Writer, overrides ...unversioned.GroupVersion) error {
+// Encode serializes the provided object to the given writer.
+func (s *Serializer) Encode(obj runtime.Object, w io.Writer) error {
 	var unk runtime.Unknown
 	kind := obj.GetObjectKind().GroupVersionKind()
 	unk = runtime.Unknown{
@@ -388,8 +388,8 @@ func unmarshalToObject(typer runtime.ObjectTyper, creater runtime.ObjectCreater,
 	return obj, actual, nil
 }
 
-// EncodeToStream serializes the provided object to the given writer. Overrides is ignored.
-func (s *RawSerializer) EncodeToStream(obj runtime.Object, w io.Writer, overrides ...unversioned.GroupVersion) error {
+// Encode serializes the provided object to the given writer. Overrides is ignored.
+func (s *RawSerializer) Encode(obj runtime.Object, w io.Writer) error {
 	switch t := obj.(type) {
 	case bufferedMarshaller:
 		// this path performs a single allocation during write but requires the caller to implement

--- a/pkg/runtime/serializer/streaming/streaming.go
+++ b/pkg/runtime/serializer/streaming/streaming.go
@@ -30,8 +30,8 @@ import (
 // Encoder is a runtime.Encoder on a stream.
 type Encoder interface {
 	// Encode will write the provided object to the stream or return an error. It obeys the same
-	// contract as runtime.Encoder.
-	Encode(obj runtime.Object, overrides ...unversioned.GroupVersion) error
+	// contract as runtime.VersionedEncoder.
+	Encode(obj runtime.Object) error
 }
 
 // Decoder is a runtime.Decoder from a stream.
@@ -127,8 +127,8 @@ func NewEncoder(w io.Writer, e runtime.Encoder) Encoder {
 }
 
 // Encode writes the provided object to the nested writer.
-func (e *encoder) Encode(obj runtime.Object, overrides ...unversioned.GroupVersion) error {
-	if err := e.encoder.EncodeToStream(obj, e.buf, overrides...); err != nil {
+func (e *encoder) Encode(obj runtime.Object) error {
+	if err := e.encoder.Encode(obj, e.buf); err != nil {
 		return err
 	}
 	_, err := e.writer.Write(e.buf.Bytes())

--- a/pkg/runtime/serializer/versioning/versioning_test.go
+++ b/pkg/runtime/serializer/versioning/versioning_test.go
@@ -261,9 +261,8 @@ func (c *checkConvertor) ConvertFieldLabel(version, kind, label, value string) (
 }
 
 type mockSerializer struct {
-	err      error
-	obj      runtime.Object
-	versions []unversioned.GroupVersion
+	err error
+	obj runtime.Object
 
 	defaults, actual *unversioned.GroupVersionKind
 	into             runtime.Object
@@ -275,9 +274,8 @@ func (s *mockSerializer) Decode(data []byte, defaults *unversioned.GroupVersionK
 	return s.obj, s.actual, s.err
 }
 
-func (s *mockSerializer) EncodeToStream(obj runtime.Object, w io.Writer, versions ...unversioned.GroupVersion) error {
+func (s *mockSerializer) Encode(obj runtime.Object, w io.Writer) error {
 	s.obj = obj
-	s.versions = versions
 	return s.err
 }
 

--- a/pkg/runtime/unstructured.go
+++ b/pkg/runtime/unstructured.go
@@ -54,7 +54,7 @@ func (s unstructuredJSONScheme) Decode(data []byte, _ *unversioned.GroupVersionK
 	return obj, &gvk, nil
 }
 
-func (unstructuredJSONScheme) EncodeToStream(obj Object, w io.Writer, overrides ...unversioned.GroupVersion) error {
+func (unstructuredJSONScheme) Encode(obj Object, w io.Writer) error {
 	switch t := obj.(type) {
 	case *Unstructured:
 		return json.NewEncoder(w).Encode(t.Object)


### PR DESCRIPTION
Was not being used. Is a signature change and is necessary for post 1.3 work on Templates and other objects that nest objects.

Extracted from #26044
