### PR TITLE
Pass object being deleted to admission controller

### DIFF
--- a/federation/registry/cluster/registry.go
+++ b/federation/registry/cluster/registry.go
@@ -76,6 +76,6 @@ func (s *storage) UpdateCluster(ctx api.Context, cluster *federation.Cluster) er
 }
 
 func (s *storage) DeleteCluster(ctx api.Context, name string) error {
-	_, err := s.Delete(ctx, name, nil)
+	_, err := s.Delete(ctx, name, nil, nil)
 	return err
 }

--- a/pkg/api/rest/rest.go
+++ b/pkg/api/rest/rest.go
@@ -128,7 +128,7 @@ type GracefulDeleter interface {
 	// returned error value err when the specified resource is not found.
 	// Delete *may* return the object that was deleted, or a status object indicating additional
 	// information about deletion.
-	Delete(ctx api.Context, name string, options *api.DeleteOptions) (runtime.Object, error)
+	Delete(ctx api.Context, name string, options *api.DeleteOptions, precondition ObjectFunc) (runtime.Object, error)
 }
 
 // GracefulDeleteAdapter adapts the Deleter interface to GracefulDeleter
@@ -137,7 +137,7 @@ type GracefulDeleteAdapter struct {
 }
 
 // Delete implements RESTGracefulDeleter in terms of Deleter
-func (w GracefulDeleteAdapter) Delete(ctx api.Context, name string, options *api.DeleteOptions) (runtime.Object, error) {
+func (w GracefulDeleteAdapter) Delete(ctx api.Context, name string, options *api.DeleteOptions, precondition ObjectFunc) (runtime.Object, error) {
 	return w.Deleter.Delete(ctx, name)
 }
 
@@ -149,7 +149,7 @@ type CollectionDeleter interface {
 	// them or return an invalid request error.
 	// DeleteCollection may not be atomic - i.e. it may delete some objects and still
 	// return an error after it. On success, returns a list of deleted objects.
-	DeleteCollection(ctx api.Context, options *api.DeleteOptions, listOptions *api.ListOptions) (runtime.Object, error)
+	DeleteCollection(ctx api.Context, options *api.DeleteOptions, listOptions *api.ListOptions, precondition ObjectFunc) (runtime.Object, error)
 }
 
 // Creater is an object that can create an instance of a RESTful object.

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -52,7 +52,7 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/admission/admit"
 	"k8s.io/kubernetes/plugin/pkg/admission/deny"
 
-	"github.com/emicklei/go-restful"
+	restful "github.com/emicklei/go-restful"
 )
 
 func convert(obj runtime.Object) (runtime.Object, error) {
@@ -467,15 +467,22 @@ func (storage *SimpleRESTStorage) checkContext(ctx api.Context) {
 	storage.actualNamespace, storage.namespacePresent = api.NamespaceFrom(ctx)
 }
 
-func (storage *SimpleRESTStorage) Delete(ctx api.Context, id string, options *api.DeleteOptions) (runtime.Object, error) {
+func (storage *SimpleRESTStorage) Delete(ctx api.Context, id string, options *api.DeleteOptions, precondition rest.ObjectFunc) (runtime.Object, error) {
 	storage.checkContext(ctx)
 	storage.deleted = id
 	storage.deleteOptions = options
+
 	if err := storage.errors["delete"]; err != nil {
 		return nil, err
 	}
-	var obj runtime.Object = &unversioned.Status{Status: unversioned.StatusSuccess}
+	status := &unversioned.Status{Status: unversioned.StatusSuccess}
+	var obj runtime.Object = status
 	var err error
+
+	if precondition != nil {
+		err = precondition(obj)
+	}
+
 	if storage.injectedFunction != nil {
 		obj, err = storage.injectedFunction(&apiservertesting.Simple{ObjectMeta: api.ObjectMeta{Name: id}})
 	}
@@ -615,7 +622,7 @@ type LegacyRESTStorage struct {
 }
 
 func (storage LegacyRESTStorage) Delete(ctx api.Context, id string) (runtime.Object, error) {
-	return storage.SimpleRESTStorage.Delete(ctx, id, nil)
+	return storage.SimpleRESTStorage.Delete(ctx, id, nil, nil)
 }
 
 type MetadataRESTStorage struct {
@@ -2016,6 +2023,61 @@ func TestDeleteMissing(t *testing.T) {
 
 	if response.StatusCode != http.StatusNotFound {
 		t.Errorf("Unexpected response %#v", response)
+	}
+}
+
+type testDeleteAdmission struct {
+	expectedObjectName string
+	admitCalled        bool
+}
+
+func (t *testDeleteAdmission) Handles(o admission.Operation) bool {
+	return true
+}
+
+func (t *testDeleteAdmission) Admit(a admission.Attributes) error {
+	obj := a.GetOldObject()
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return fmt.Errorf("unexpected error creating accessor for %#v: %s", obj, err)
+	}
+
+	if accessor.GetName() != t.expectedObjectName {
+		return fmt.Errorf("expected OldObject to be populated on attributes, got nil")
+	}
+
+	t.admitCalled = true
+	return nil
+}
+
+// TestDeletePopulateOldObject verifies that the OldObject field on
+// AdmissionAttributes is populated with the current state of the object being
+// deleted.
+func TestDeletePopulateOldObject(t *testing.T) {
+	storage := map[string]rest.Storage{}
+	simpleStorage := SimpleRESTStorage{}
+	ID := "id"
+	storage["simple"] = &simpleStorage
+	admit := &testDeleteAdmission{expectedObjectName: simpleStorage.item.Name}
+	handler := handleInternal(storage, admit, selfLinker)
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	client := http.Client{}
+	request, err := http.NewRequest("DELETE", server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/"+ID, nil)
+	res, err := client.Do(request)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.StatusCode != http.StatusOK {
+		t.Errorf("unexpected response: expected status code %d and got %d", http.StatusOK, res.StatusCode)
+	}
+
+	if !admit.admitCalled {
+		t.Errorf("expected testDeleteAdmission.Admit() to be called during request, but it wasn't")
+	}
+	if simpleStorage.deleted != ID {
+		t.Errorf("Unexpected delete: %s, expected %s", simpleStorage.deleted, ID)
 	}
 }
 

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -689,7 +689,7 @@ func (m *Master) removeAllThirdPartyResources(registry *thirdpartyresourcedataet
 	}
 	for ix := range list.Items {
 		item := &list.Items[ix]
-		if _, err := registry.Delete(ctx, item.Name, nil); err != nil {
+		if _, err := registry.Delete(ctx, item.Name, nil, nil); err != nil {
 			return err
 		}
 	}

--- a/pkg/registry/certificates/registry.go
+++ b/pkg/registry/certificates/registry.go
@@ -87,6 +87,6 @@ func (s *storage) GetCSR(ctx api.Context, name string) (*certificates.Certificat
 }
 
 func (s *storage) DeleteCSR(ctx api.Context, name string) error {
-	_, err := s.Delete(ctx, name, nil)
+	_, err := s.Delete(ctx, name, nil, nil)
 	return err
 }

--- a/pkg/registry/clusterrole/registry.go
+++ b/pkg/registry/clusterrole/registry.go
@@ -76,6 +76,6 @@ func (s *storage) GetClusterRole(ctx api.Context, name string) (*rbac.ClusterRol
 }
 
 func (s *storage) DeleteClusterRole(ctx api.Context, name string) error {
-	_, err := s.Delete(ctx, name, nil)
+	_, err := s.Delete(ctx, name, nil, nil)
 	return err
 }

--- a/pkg/registry/clusterrolebinding/registry.go
+++ b/pkg/registry/clusterrolebinding/registry.go
@@ -76,6 +76,6 @@ func (s *storage) GetClusterRoleBinding(ctx api.Context, name string) (*rbac.Clu
 }
 
 func (s *storage) DeleteClusterRoleBinding(ctx api.Context, name string) error {
-	_, err := s.Delete(ctx, name, nil)
+	_, err := s.Delete(ctx, name, nil, nil)
 	return err
 }

--- a/pkg/registry/configmap/registry.go
+++ b/pkg/registry/configmap/registry.go
@@ -84,7 +84,7 @@ func (s *storage) UpdateConfigMap(ctx api.Context, cfg *api.ConfigMap) (*api.Con
 }
 
 func (s *storage) DeleteConfigMap(ctx api.Context, name string) error {
-	_, err := s.Delete(ctx, name, nil)
+	_, err := s.Delete(ctx, name, nil, nil)
 
 	return err
 }

--- a/pkg/registry/controller/registry.go
+++ b/pkg/registry/controller/registry.go
@@ -87,6 +87,6 @@ func (s *storage) UpdateController(ctx api.Context, controller *api.ReplicationC
 }
 
 func (s *storage) DeleteController(ctx api.Context, controllerID string) error {
-	_, err := s.Delete(ctx, controllerID, nil)
+	_, err := s.Delete(ctx, controllerID, nil, nil)
 	return err
 }

--- a/pkg/registry/deployment/registry.go
+++ b/pkg/registry/deployment/registry.go
@@ -79,6 +79,6 @@ func (s *storage) UpdateDeployment(ctx api.Context, deployment *extensions.Deplo
 }
 
 func (s *storage) DeleteDeployment(ctx api.Context, deploymentID string) error {
-	_, err := s.Delete(ctx, deploymentID, nil)
+	_, err := s.Delete(ctx, deploymentID, nil, nil)
 	return err
 }

--- a/pkg/registry/endpoint/registry.go
+++ b/pkg/registry/endpoint/registry.go
@@ -68,6 +68,6 @@ func (s *storage) UpdateEndpoints(ctx api.Context, endpoints *api.Endpoints) err
 }
 
 func (s *storage) DeleteEndpoints(ctx api.Context, name string) error {
-	_, err := s.Delete(ctx, name, nil)
+	_, err := s.Delete(ctx, name, nil, nil)
 	return err
 }

--- a/pkg/registry/generic/registry/store_test.go
+++ b/pkg/registry/generic/registry/store_test.go
@@ -529,7 +529,7 @@ func TestStoreDelete(t *testing.T) {
 	defer server.Terminate(t)
 
 	// test failure condition
-	_, err := registry.Delete(testContext, podA.Name, nil)
+	_, err := registry.Delete(testContext, podA.Name, nil, nil)
 	if !errors.IsNotFound(err) {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -541,7 +541,7 @@ func TestStoreDelete(t *testing.T) {
 	}
 
 	// delete object
-	_, err = registry.Delete(testContext, podA.Name, nil)
+	_, err = registry.Delete(testContext, podA.Name, nil, nil)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -573,7 +573,7 @@ func TestStoreHandleFinalizers(t *testing.T) {
 	}
 
 	// delete object with nil delete options doesn't delete the object
-	_, err = registry.Delete(testContext, podWithFinalizer.Name, nil)
+	_, err = registry.Delete(testContext, podWithFinalizer.Name, nil, nil)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -782,7 +782,7 @@ func TestStoreDeleteWithOrphanDependents(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
-		_, err = registry.Delete(testContext, tc.pod.Name, tc.options)
+		_, err = registry.Delete(testContext, tc.pod.Name, tc.options, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -830,7 +830,7 @@ func TestStoreDeleteCollection(t *testing.T) {
 	}
 
 	// Delete all pods.
-	deleted, err := registry.DeleteCollection(testContext, nil, &api.ListOptions{})
+	deleted, err := registry.DeleteCollection(testContext, nil, &api.ListOptions{}, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -871,7 +871,7 @@ func TestStoreDeleteCollectionNotFound(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				_, err := registry.DeleteCollection(testContext, nil, &api.ListOptions{})
+				_, err := registry.DeleteCollection(testContext, nil, &api.ListOptions{}, nil)
 				if err != nil {
 					t.Fatalf("Unexpected error: %v", err)
 				}
@@ -909,7 +909,7 @@ func TestStoreDeleteCollectionWithWatch(t *testing.T) {
 	}
 	defer watcher.Stop()
 
-	if _, err := registry.DeleteCollection(testContext, nil, &api.ListOptions{}); err != nil {
+	if _, err := registry.DeleteCollection(testContext, nil, &api.ListOptions{}, nil); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 

--- a/pkg/registry/namespace/etcd/etcd.go
+++ b/pkg/registry/namespace/etcd/etcd.go
@@ -90,7 +90,7 @@ func NewREST(opts generic.RESTOptions) (*REST, *StatusREST, *FinalizeREST) {
 }
 
 // Delete enforces life-cycle rules for namespace termination
-func (r *REST) Delete(ctx api.Context, name string, options *api.DeleteOptions) (runtime.Object, error) {
+func (r *REST) Delete(ctx api.Context, name string, options *api.DeleteOptions, precondition rest.ObjectFunc) (runtime.Object, error) {
 	nsObj, err := r.Get(ctx, name)
 	if err != nil {
 		return nil, err
@@ -99,22 +99,7 @@ func (r *REST) Delete(ctx api.Context, name string, options *api.DeleteOptions) 
 	namespace := nsObj.(*api.Namespace)
 
 	// Ensure we have a UID precondition
-	if options == nil {
-		options = api.NewDeleteOptions(0)
-	}
-	if options.Preconditions == nil {
-		options.Preconditions = &api.Preconditions{}
-	}
-	if options.Preconditions.UID == nil {
-		options.Preconditions.UID = &namespace.UID
-	} else if *options.Preconditions.UID != namespace.UID {
-		err = apierrors.NewConflict(
-			api.Resource("namespaces"),
-			name,
-			fmt.Errorf("Precondition failed: UID in precondition: %v, UID in object meta: %v", *options.Preconditions.UID, namespace.UID),
-		)
-		return nil, err
-	}
+	precondition = rest.AllFuncs(precondition, rest.NewUIDObjectFunc(namespace.UID, r.Store.QualifiedResource))
 
 	// upon first request to delete, we switch the phase to start namespace termination
 	// TODO: enhance graceful deletion's calls to DeleteStrategy to allow phase change and finalizer patterns
@@ -124,7 +109,7 @@ func (r *REST) Delete(ctx api.Context, name string, options *api.DeleteOptions) 
 			return nil, err
 		}
 
-		preconditions := storage.Preconditions{UID: options.Preconditions.UID}
+		preconditions := storage.Preconditions{UID: &namespace.UID}
 
 		out := r.Store.NewFunc()
 		err = r.Store.Storage.GuaranteedUpdate(
@@ -165,7 +150,7 @@ func (r *REST) Delete(ctx api.Context, name string, options *api.DeleteOptions) 
 		err = apierrors.NewConflict(api.Resource("namespaces"), namespace.Name, fmt.Errorf("The system is ensuring all content is removed from this namespace.  Upon completion, this namespace will automatically be purged by the system."))
 		return nil, err
 	}
-	return r.Store.Delete(ctx, name, options)
+	return r.Store.Delete(ctx, name, options, precondition)
 }
 
 func (r *StatusREST) New() runtime.Object {

--- a/pkg/registry/namespace/etcd/etcd_test.go
+++ b/pkg/registry/namespace/etcd/etcd_test.go
@@ -150,7 +150,7 @@ func TestDeleteNamespaceWithIncompleteFinalizers(t *testing.T) {
 	if err := storage.Storage.Create(ctx, key, namespace, nil, 0); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if _, err := storage.Delete(ctx, "foo", nil); err == nil {
+	if _, err := storage.Delete(ctx, "foo", nil, nil); err == nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
@@ -174,7 +174,7 @@ func TestDeleteNamespaceWithCompleteFinalizers(t *testing.T) {
 	if err := storage.Storage.Create(ctx, key, namespace, nil, 0); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if _, err := storage.Delete(ctx, "foo", nil); err != nil {
+	if _, err := storage.Delete(ctx, "foo", nil, nil); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 }

--- a/pkg/registry/namespace/registry.go
+++ b/pkg/registry/namespace/registry.go
@@ -74,6 +74,6 @@ func (s *storage) UpdateNamespace(ctx api.Context, namespace *api.Namespace) err
 }
 
 func (s *storage) DeleteNamespace(ctx api.Context, namespaceID string) error {
-	_, err := s.Delete(ctx, namespaceID, nil)
+	_, err := s.Delete(ctx, namespaceID, nil, nil)
 	return err
 }

--- a/pkg/registry/node/registry.go
+++ b/pkg/registry/node/registry.go
@@ -75,6 +75,6 @@ func (s *storage) GetNode(ctx api.Context, name string) (*api.Node, error) {
 }
 
 func (s *storage) DeleteNode(ctx api.Context, name string) error {
-	_, err := s.Delete(ctx, name, nil)
+	_, err := s.Delete(ctx, name, nil, nil)
 	return err
 }

--- a/pkg/registry/pod/etcd/etcd_test.go
+++ b/pkg/registry/pod/etcd/etcd_test.go
@@ -137,7 +137,7 @@ type FailDeletionStorage struct {
 	Called *bool
 }
 
-func (f FailDeletionStorage) Delete(ctx context.Context, key string, out runtime.Object, precondition *storage.Preconditions) error {
+func (f FailDeletionStorage) Delete(ctx context.Context, key string, out runtime.Object, precondition rest.ObjectFunc) error {
 	*f.Called = true
 	return storage.NewKeyNotFoundError(key, 0)
 }
@@ -158,7 +158,7 @@ func TestIgnoreDeleteNotFound(t *testing.T) {
 	defer server.Terminate(t)
 
 	// should fail if pod A is not created yet.
-	_, err := registry.Delete(testContext, pod.Name, nil)
+	_, err := registry.Delete(testContext, pod.Name, nil, nil)
 	if !errors.IsNotFound(err) {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -173,7 +173,7 @@ func TestIgnoreDeleteNotFound(t *testing.T) {
 	// registry shouldn't get any error since we ignore the NotFound error.
 	zero := int64(0)
 	opt := &api.DeleteOptions{GracePeriodSeconds: &zero}
-	obj, err := registry.Delete(testContext, pod.Name, opt)
+	obj, err := registry.Delete(testContext, pod.Name, opt, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/pkg/registry/pod/strategy_test.go
+++ b/pkg/registry/pod/strategy_test.go
@@ -139,7 +139,7 @@ func TestCheckGracefulDelete(t *testing.T) {
 			t.Errorf("out grace period was nil but supposed to be %v", tc.gracePeriod)
 		}
 		if *(out.GracePeriodSeconds) != tc.gracePeriod {
-			t.Errorf("out grace period was %v but was expected to be %v", *out, tc.gracePeriod)
+			t.Errorf("out grace period was %v but was expected to be %v", *out.GracePeriodSeconds, tc.gracePeriod)
 		}
 	}
 }

--- a/pkg/registry/registrytest/etcd.go
+++ b/pkg/registry/registrytest/etcd.go
@@ -220,7 +220,7 @@ func (t *Tester) emitObject(obj runtime.Object, action string) error {
 		if err != nil {
 			return err
 		}
-		_, err = t.storage.Delete(ctx, accessor.GetName(), nil)
+		_, err = t.storage.Delete(ctx, accessor.GetName(), nil, nil)
 	default:
 		err = fmt.Errorf("unexpected action: %v", action)
 	}

--- a/pkg/registry/replicaset/registry.go
+++ b/pkg/registry/replicaset/registry.go
@@ -88,6 +88,6 @@ func (s *storage) UpdateReplicaSet(ctx api.Context, replicaSet *extensions.Repli
 }
 
 func (s *storage) DeleteReplicaSet(ctx api.Context, replicaSetID string) error {
-	_, err := s.Delete(ctx, replicaSetID, nil)
+	_, err := s.Delete(ctx, replicaSetID, nil, nil)
 	return err
 }

--- a/pkg/registry/role/registry.go
+++ b/pkg/registry/role/registry.go
@@ -76,6 +76,6 @@ func (s *storage) GetRole(ctx api.Context, name string) (*rbac.Role, error) {
 }
 
 func (s *storage) DeleteRole(ctx api.Context, name string) error {
-	_, err := s.Delete(ctx, name, nil)
+	_, err := s.Delete(ctx, name, nil, nil)
 	return err
 }

--- a/pkg/registry/rolebinding/registry.go
+++ b/pkg/registry/rolebinding/registry.go
@@ -77,6 +77,6 @@ func (s *storage) GetRoleBinding(ctx api.Context, name string) (*rbac.RoleBindin
 }
 
 func (s *storage) DeleteRoleBinding(ctx api.Context, name string) error {
-	_, err := s.Delete(ctx, name, nil)
+	_, err := s.Delete(ctx, name, nil, nil)
 	return err
 }

--- a/pkg/registry/secret/registry.go
+++ b/pkg/registry/secret/registry.go
@@ -74,6 +74,6 @@ func (s *storage) UpdateSecret(ctx api.Context, secret *api.Secret) (*api.Secret
 }
 
 func (s *storage) DeleteSecret(ctx api.Context, name string) error {
-	_, err := s.Delete(ctx, name, nil)
+	_, err := s.Delete(ctx, name, nil, nil)
 	return err
 }

--- a/pkg/registry/service/registry.go
+++ b/pkg/registry/service/registry.go
@@ -72,7 +72,7 @@ func (s *storage) GetService(ctx api.Context, name string) (*api.Service, error)
 }
 
 func (s *storage) DeleteService(ctx api.Context, name string) error {
-	_, err := s.Delete(ctx, name, nil)
+	_, err := s.Delete(ctx, name, nil, nil)
 	return err
 }
 

--- a/pkg/registry/serviceaccount/registry.go
+++ b/pkg/registry/serviceaccount/registry.go
@@ -74,6 +74,6 @@ func (s *storage) UpdateServiceAccount(ctx api.Context, serviceAccount *api.Serv
 }
 
 func (s *storage) DeleteServiceAccount(ctx api.Context, name string) error {
-	_, err := s.Delete(ctx, name, nil)
+	_, err := s.Delete(ctx, name, nil, nil)
 	return err
 }

--- a/pkg/registry/thirdpartyresourcedata/registry.go
+++ b/pkg/registry/thirdpartyresourcedata/registry.go
@@ -75,6 +75,6 @@ func (s *storage) UpdateThirdPartyResourceData(ctx api.Context, ThirdPartyResour
 }
 
 func (s *storage) DeleteThirdPartyResourceData(ctx api.Context, name string) error {
-	_, err := s.Delete(ctx, name, nil)
+	_, err := s.Delete(ctx, name, nil, nil)
 	return err
 }

--- a/pkg/storage/cacher.go
+++ b/pkg/storage/cacher.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/api/rest"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/cache"
 	"k8s.io/kubernetes/pkg/conversion"
@@ -195,8 +196,8 @@ func (c *Cacher) Create(ctx context.Context, key string, obj, out runtime.Object
 }
 
 // Implements storage.Interface.
-func (c *Cacher) Delete(ctx context.Context, key string, out runtime.Object, preconditions *Preconditions) error {
-	return c.storage.Delete(ctx, key, out, preconditions)
+func (c *Cacher) Delete(ctx context.Context, key string, out runtime.Object, precondition rest.ObjectFunc) error {
+	return c.storage.Delete(ctx, key, out, precondition)
 }
 
 // Implements storage.Interface.

--- a/pkg/storage/etcd/etcd_helper_test.go
+++ b/pkg/storage/etcd/etcd_helper_test.go
@@ -27,8 +27,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/rest"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/conversion"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/runtime/serializer"
@@ -497,7 +499,7 @@ func TestDeleteUIDMismatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error %#v", err)
 	}
-	err = helper.Delete(context.TODO(), "/some/key", obj, storage.NewUIDPreconditions("B"))
+	err = helper.Delete(context.TODO(), "/some/key", obj, rest.NewUIDObjectFunc("B", unversioned.GroupResource{Group: api.GroupName, Resource: "pods"}))
 	if !storage.IsTestFailed(err) {
 		t.Fatalf("Expect a Test Failed (write conflict) error, got: %v", err)
 	}
@@ -548,7 +550,7 @@ func TestDeleteWithRetry(t *testing.T) {
 		t.Errorf("Unexpected error %#v", err)
 	}
 
-	err = helper.Delete(context.TODO(), "/some/key", obj, storage.NewUIDPreconditions("A"))
+	err = helper.Delete(context.TODO(), "/some/key", obj, rest.NewUIDObjectFunc("A", unversioned.GroupResource{Group: api.GroupName, Resource: "pods"}))
 	if err != nil {
 		t.Errorf("Unexpected error %#v", err)
 	}

--- a/pkg/storage/etcd3/watcher_test.go
+++ b/pkg/storage/etcd3/watcher_test.go
@@ -232,7 +232,7 @@ func TestWatchDeleteEventObjectHaveLatestRV(t *testing.T) {
 	}
 	etcdW := cluster.RandClient().Watch(ctx, "/", clientv3.WithPrefix())
 
-	if err := store.Delete(ctx, key, &api.Pod{}, &storage.Preconditions{}); err != nil {
+	if err := store.Delete(ctx, key, &api.Pod{}, nil); err != nil {
 		t.Fatalf("Delete failed: %v", err)
 	}
 

--- a/pkg/storage/interfaces.go
+++ b/pkg/storage/interfaces.go
@@ -18,6 +18,8 @@ package storage
 
 import (
 	"golang.org/x/net/context"
+
+	"k8s.io/kubernetes/pkg/api/rest"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/watch"
@@ -95,7 +97,7 @@ type Interface interface {
 
 	// Delete removes the specified key and returns the value that existed at that spot.
 	// If key didn't exist, it will return NotFound storage error.
-	Delete(ctx context.Context, key string, out runtime.Object, preconditions *Preconditions) error
+	Delete(ctx context.Context, key string, out runtime.Object, precondition rest.ObjectFunc) error
 
 	// Watch begins watching the specified key. Events are decoded into API objects,
 	// and any items passing 'filter' are sent down to returned watch.Interface.


### PR DESCRIPTION
The `GetOldObject()` method on the `admission.Attributes` interface passed to `Admit` will now yield the object which is about to be deleted. This is potentially useful for admission controllers that need information about the object to determine whether the operation should proceed. In order to accomplish this:
- The signature of `storage.Interface.Delete` has been modified to accept a function which takes the state of the object being deleted and returns an error to indicate whether the operation should succeed. The UID check previously being performed in this method has been refactored to be a part of this function argument.
- The `rest.DeleteOptions` type was added, which contains settings from the `api.DeleteOptions` struct passed by the client and additionally includes a slice of functions which are passed down to `storage.Interface.Delete` as described above. This allows us to add more arbitrary checks prior to a delete operation being finalized.
- `admission.Interface.Admit` is passed down to `storage` rather than being called directly in the delete handler. This allows us to supply the current state of the object being deleted to the admission controller without performing an additional fetch of the object.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/27193)

<!-- Reviewable:end -->
