### PR TITLE
version bump for gci to milestone 53

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -35,7 +35,7 @@ if [[ "${OS_DISTRIBUTION}" == "gci" ]]; then
   # Otherwise, we respect whatever is set by the user.
   gci_images=( $(gcloud compute images list --project google-containers \
       --show-deprecated --no-standard-images --sort-by='~creationTimestamp' \
-      --regexp='gci-[a-z]+-52-.*' --format='table[no-heading](name)') )
+      --regexp='gci-[a-z]+-53-.*' --format='table[no-heading](name)') )
   MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-"${gci_images[0]}"}
   MASTER_IMAGE_PROJECT=${KUBE_GCE_MASTER_PROJECT:-google-containers}
   # The default node image when using GCI is still the Debian based ContainerVM


### PR DESCRIPTION
Fixes #26455

GCI release 53 includes kubernetes v1.3.0-alpha.5 with docker-1.11.2.

@dchen1107 @kubernetes/goog-image @andyzheng0831 
