### PR TITLE
Revert "third time charm for #27144"

### DIFF
--- a/hack/jenkins/e2e-runner.sh
+++ b/hack/jenkins/e2e-runner.sh
@@ -35,11 +35,8 @@ function fetch_output_tars() {
 
 function fetch_server_version_tars() {
     local -r build_version="$(gcloud ${CMD_GROUP:-} container get-server-config --project=${PROJECT} --zone=${ZONE}  --format='value(defaultClusterVersion)')"
-    # Use latest build of the server version's branch for test files.
-    fetch_published_version_tars "ci/latest-${build_version:0:3}"
-    # Unset cluster api version; we want to use server default for the cluster
-    # version.
-    unset CLUSTER_API_VERSION
+    # Use latest build of the server version's branch.
+    fetch_tars_from_gcs "ci" "latest-${build_version:0:3}"
     unpack_binaries
 }
 


### PR DESCRIPTION
Reverts kubernetes/kubernetes#27215 to stop the bleeding for both kubernetes-e2e-gke and kubernetes-e2e-gke-slow 

Fixed https://github.com/kubernetes/kubernetes/issues/27219 
