### PR TITLE
Make priority score info clearer

### DIFF
--- a/plugin/pkg/scheduler/algorithm/priorities/priorities.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/priorities.go
@@ -61,10 +61,10 @@ func calculateResourceOccupancy(pod *api.Pod, node api.Node, nodeInfo *scheduler
 	cpuScore := calculateScore(totalMilliCPU, capacityMilliCPU, node.Name)
 	memoryScore := calculateScore(totalMemory, capacityMemory, node.Name)
 	glog.V(10).Infof(
-		"%v -> %v: Least Requested Priority, Absolute/Requested: (%d, %d) / (%d, %d) Score: (%d, %d)",
+		"%v -> %v: Least Requested Priority, capacity %d millicores %d memory bytes, total request %d millicores %d memory bytes, score %d CPU %d memory",
 		pod.Name, node.Name,
-		totalMilliCPU, totalMemory,
 		capacityMilliCPU, capacityMemory,
+		totalMilliCPU, totalMemory,
 		cpuScore, memoryScore,
 	)
 
@@ -254,10 +254,10 @@ func calculateBalancedResourceAllocation(pod *api.Pod, node api.Node, nodeInfo *
 		score = int(10 - diff*10)
 	}
 	glog.V(10).Infof(
-		"%v -> %v: Balanced Resource Allocation, Absolute/Requested: (%d, %d) / (%d, %d) Score: (%d)",
+		"%v -> %v: Balanced Resource Allocation, capacity %d millicores %d memory bytes, total request %d millicores %d memory bytes, score %d",
 		pod.Name, node.Name,
-		totalMilliCPU, totalMemory,
 		capacityMilliCPU, capacityMemory,
+		totalMilliCPU, totalMemory,
 		score,
 	)
 

--- a/plugin/pkg/scheduler/algorithm/priorities/taint_toleration.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/taint_toleration.go
@@ -17,6 +17,7 @@ limitations under the License.
 package priorities
 
 import (
+	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
 	schedulerapi "k8s.io/kubernetes/plugin/pkg/scheduler/api"
@@ -104,6 +105,8 @@ func (s *TaintToleration) ComputeTaintTolerationPriority(pod *api.Pod, nodeNameT
 		if maxCount > 0 {
 			fScore = (1.0 - float64(counts[node.Name])/float64(maxCount)) * 10
 		}
+		glog.V(10).Infof("%v -> %v: Taint Toleration Priority, Score: (%d)", pod.Name, node.Name, int(fScore))
+
 		result = append(result, schedulerapi.HostPriority{Host: node.Name, Score: int(fScore)})
 	}
 	return result, nil


### PR DESCRIPTION
When I trace the scheduler workflow, the log info makes me a bit confused:
Taint Toleration Priority Score info is lacking.
The values of Absolute and Requested resources are in the reverse order.
The values of resources have no type and unit.

This PR tries to make the log info clearer.

before:

```
I0609 15:18:17.978739   32560 node_affinity.go:92] mongo -> vm: NodeAffinityPriority, Score: (0)
I0609 15:18:17.978756   32560 priorities.go:69] mongo -> vm: Least Requested Priority, Absolute/Requested: (100, 209715200) / (4000, 8372678656) Score: (9, 9)
I0609 15:18:17.978896   32560 priorities.go:262] mongo -> vm: Balanced Resource Allocation, Absolute/Requested: (100, 209715200) / (4000, 8372678656) Score: (9)
I0609 15:18:17.978971   32560 selector_spreading.go:233] mongo -> vm: SelectorSpreadPriority, Score: (10)
I0609 15:18:17.979043   32560 generic_scheduler.go:301] Host vm Score 38
```

after:

```
I0611 06:58:23.132306   28814 taint_toleration.go:108] mongo -> vm: Taint Toleration Priority, Score: (10)
I0611 06:58:23.132326   28814 priorities.go:69] mongo -> vm: Least Requested Priority, Absolute/Requested(CPU:millicores, memory:bytes): (4000, 8372678656) / (100, 209715200) Score: (9, 9)
I0611 06:58:23.132367   28814 node_affinity.go:92] mongo -> vm: NodeAffinityPriority, Score: (0)
I0611 06:58:23.132400   28814 priorities.go:262] mongo -> vm: Balanced Resource Allocation, Absolute/Requested(CPU:millicores, memory:bytes): (4000, 8372678656) / (100, 209715200) Score: (9)
I0611 06:58:23.132544   28814 selector_spreading.go:233] mongo -> vm: SelectorSpreadPriority, Score: (10)
I0611 06:58:23.132567   28814 generic_scheduler.go:301] Host vm Score 38
```
