### PR TITLE
resource.Builder should not alter error type from server

### DIFF
--- a/pkg/kubectl/resource/selector.go
+++ b/pkg/kubectl/resource/selector.go
@@ -50,6 +50,15 @@ func (r *Selector) Visit(fn VisitorFunc) error {
 	list, err := NewHelper(r.Client, r.Mapping).List(r.Namespace, r.ResourceMapping().GroupVersionKind.GroupVersion().String(), r.Selector, r.Export)
 	if err != nil {
 		if errors.IsBadRequest(err) || errors.IsNotFound(err) {
+			if se, ok := err.(*errors.StatusError); ok {
+				// modify the message without hiding this is an API error
+				if r.Selector.Empty() {
+					se.ErrStatus.Message = fmt.Sprintf("Unable to list %q: %v", r.Mapping.Resource, se.ErrStatus.Message)
+				} else {
+					se.ErrStatus.Message = fmt.Sprintf("Unable to find %q that match the selector %q: %v", r.Mapping.Resource, r.Selector, se.ErrStatus.Message)
+				}
+				return se
+			}
 			if r.Selector.Empty() {
 				return fmt.Errorf("Unable to list %q: %v", r.Mapping.Resource, err)
 			} else {


### PR DESCRIPTION
The current helpful message loses the error type, which means
resource.Builder consumers can't filter errors or have downstream logic.

If the error is a known type, only mutate the message, not the message
type.
