### PR TITLE
Set network related flags for container gen-swagger-docs

### DIFF
--- a/hack/update-api-reference-docs.sh
+++ b/hack/update-api-reference-docs.sh
@@ -71,6 +71,7 @@ for ver in $VERSIONS; do
     --rm -v "${TMP_IN_HOST}":/output:z \
     -v "${SWAGGER_PATH}":/swagger-source:z \
     -v "${REGISTER_FILE}":/register.go:z \
+    --net=host -e "https_proxy=${KUBERNETES_HTTPS_PROXY:-}" \
     gcr.io/google_containers/gen-swagger-docs:v6 \
     "${SWAGGER_JSON_NAME}"
 done


### PR DESCRIPTION
When running `hack/update-api-reference-docs.sh`, I get failure messages as below. This is because:

My env is behind a proxy, I have to input username/password in a page first for authentication before visiting internet. But I have no any way to visit that page in GUI mode in the container gen-swagger-docs. Can we run the container gen-swagger-docs using host network and passing an env variable `https_proxy` to it? I try this way and it works well. This would be helpful for me and other developers who may have this issue.

cc @caesarxuchao Thanks!

```
root@vm:/home/paas/zxp/code/k8s/fork/kubernetes# hack/update-api-reference-docs.sh
Note: This assumes that swagger spec has been updated. Please run hack/update-swagger-spec.sh to ensure that.
Generating api reference docs at /home/paas/zxp/code/k8s/fork/kubernetes/_output/generated_html
Reading swagger spec from: /home/paas/zxp/code/k8s/fork/kubernetes/api/swagger-spec/
--2016-06-09 16:35:26--  https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/api/v1/register.go
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... failed: Name or service not known.
wget: unable to resolve host address ‘raw.githubusercontent.com’
--2016-06-09 16:36:06--  https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/api/v1/register.go
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... failed: Name or service not known.
wget: unable to resolve host address ‘raw.githubusercontent.com’
--2016-06-09 16:36:46--  https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/api/v1/register.go
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... failed: Name or service not known.
wget: unable to resolve host address ‘raw.githubusercontent.com’
!!! Error in hack/update-api-reference-docs.sh:71
  'docker run ${user_flags} --rm -v "${TMP_IN_HOST}":/output:z -v "${SWAGGER_PATH}":/swagger-source:z gcr.io/google_containers/gen-swagger-docs:v5 "${SWAGGER_JSON_NAME}" "${REGISTER_FILE_URL}"' exited with status 1
Call stack:
  1: hack/update-api-reference-docs.sh:71 main(...)
Exiting with status 1
```
