### PR TITLE
WIP / PoC: Spread volume creation across zones

### DIFF
--- a/pkg/controller/persistentvolume/controller.go
+++ b/pkg/controller/persistentvolume/controller.go
@@ -1119,6 +1119,7 @@ func (ctrl *PersistentVolumeController) provisionClaimOperation(claimObj interfa
 	tags[cloudVolumeCreatedForClaimNameTag] = claim.Name
 	tags[cloudVolumeCreatedForVolumeNameTag] = pvName
 
+	zoneHint := claim.Annotations["volume.alpha.kubernetes.io/spread"]
 	options := vol.VolumeOptions{
 		Capacity:                      claim.Spec.Resources.Requests[api.ResourceName(api.ResourceStorage)],
 		AccessModes:                   claim.Spec.AccessModes,
@@ -1126,6 +1127,7 @@ func (ctrl *PersistentVolumeController) provisionClaimOperation(claimObj interfa
 		CloudTags:                     &tags,
 		ClusterName:                   ctrl.clusterName,
 		PVName:                        pvName,
+		ZoneHint:                      zoneHint,
 	}
 
 	// Provision the volume

--- a/pkg/controller/petset/identity_mappers.go
+++ b/pkg/controller/petset/identity_mappers.go
@@ -169,6 +169,12 @@ func (v *VolumeIdentityMapper) GetClaims(id string) map[string]api.PersistentVol
 		claim.Namespace = v.ps.Namespace
 		claim.Labels = v.ps.Spec.Selector.MatchLabels
 
+		// Include the petset id in the annotations, to force spreading across zones
+		if claim.Annotations == nil {
+			claim.Annotations = make(map[string]string)
+		}
+		claim.Annotations["volume.alpha.kubernetes.io/spread"] = id
+
 		// TODO: We're assuming that the claim template has a volume QoS key, eg:
 		// volume.alpha.kubernetes.io/storage-class: anything
 		petClaims[pvc.Name] = claim

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -58,6 +58,8 @@ type VolumeOptions struct {
 	ClusterName string
 	// Tags to attach to the real volume in the cloud provider - e.g. AWS EBS
 	CloudTags *map[string]string
+	// Zone hint for multizone deployments
+	ZoneHint string
 }
 
 // VolumePlugin is an interface to volume plugins that can be used on a


### PR DESCRIPTION
Strawman / PoC / WIP for #27256 

In order to spread volumes across zones, we define a zone hint annotation on
PVCs.  The value can either be an explicit zone name, or it can be an
integer value.

The cloud provider (currently just implemented for AWS) looks at the
zone hint and matches it to the zones:
- If it's an explicit zone name it uses that zone
- If it's an integer it chooses the Nth zone mod # zones
- Otherwise it hashes the zone hint or volume name, and uses that as the
  index

A PetSet sets the annotation with the index in the PetSet.

The intention here is that we will generally spread across zones, and if
a PetSet is created the volumes should land in different zones (assuming
there are enough zones).

A shortcoming is that if the set of zones changes, the allocations are
no longer consistent.  Further, if this happens to happen in the middle
of a PetSet creation, we might allocate volumes in the same zone when we
didn't have to.
