### PR TITLE
Updating federation up scripts to work in non e2e setup

### DIFF
--- a/federation/cluster/common.sh
+++ b/federation/cluster/common.sh
@@ -46,7 +46,7 @@ if [[ -z "${FEDERATION_PUSH_REPO_BASE}" ]]; then
 fi
 
 FEDERATION_IMAGE_REPO_BASE=${FEDERATION_IMAGE_REPO_BASE:-'gcr.io/google_containers'}
-FEDERATION_NAMESPACE=${FEDERATION_NAMESPACE:-federation-e2e}
+FEDERATION_NAMESPACE=${FEDERATION_NAMESPACE:-federation}
 
 KUBE_PLATFORM=${KUBE_PLATFORM:-linux}
 KUBE_ARCH=${KUBE_ARCH:-amd64}
@@ -98,7 +98,7 @@ function create-federation-api-objects {
 
     FEDERATION_KUBECONFIG_PATH="${KUBE_ROOT}/federation/cluster/kubeconfig"
 
-    federation_kubectl="${KUBE_ROOT}/cluster/kubectl.sh --context=federated-cluster --namespace=default"
+    federation_kubectl="${KUBE_ROOT}/cluster/kubectl.sh --context=federation-cluster --namespace=default"
 
     manifests_root="${KUBE_ROOT}/federation/manifests/"
 
@@ -151,7 +151,7 @@ function create-federation-api-objects {
     # controller manager can use to talk to the federation-apiserver.
     # Note that the file name should be "kubeconfig" so that the secret key gets the same name.
     KUBECONFIG_DIR=$(dirname ${KUBECONFIG:-$DEFAULT_KUBECONFIG})
-    CONTEXT=federated-cluster \
+    CONTEXT=federation-cluster \
 	   KUBE_BEARER_TOKEN="$FEDERATION_API_TOKEN" \
            KUBECONFIG="${KUBECONFIG_DIR}/federation/federation-apiserver/kubeconfig" \
 	   create-kubeconfig
@@ -168,7 +168,7 @@ function create-federation-api-objects {
     done
 
     # Update the users kubeconfig to include federation-apiserver credentials.
-    CONTEXT=federated-cluster \
+    CONTEXT=federation-cluster \
 	   KUBE_BEARER_TOKEN="$FEDERATION_API_TOKEN" \
 	   SECONDARY_KUBECONFIG=true \
 	   create-kubeconfig

--- a/federation/cluster/federation-up.sh
+++ b/federation/cluster/federation-up.sh
@@ -22,8 +22,11 @@ KUBE_ROOT=$(readlink -m $(dirname "${BASH_SOURCE}")/../../)
 
 . ${KUBE_ROOT}/federation/cluster/common.sh
 
-if [[ -f "${KUBE_ROOT}/federation/manifests/federated-image.tag" ]]; then
-    export FEDERATION_IMAGE_TAG="$(cat "${KUBE_ROOT}/federation/manifests/federated-image.tag")"
+tagfile="${KUBE_ROOT}/federation/manifests/federated-image.tag"
+if [[ ! -f "$tagfile" ]]; then
+    echo "FATAL: tagfile ${tagfile} does not exist. Make sure that you have run build/push-federation-images.sh"
+    exit 1
 fi
+export FEDERATION_IMAGE_TAG="$(cat "${KUBE_ROOT}/federation/manifests/federated-image.tag")"
 
 create-federation-api-objects

--- a/federation/cluster/federation-up.sh
+++ b/federation/cluster/federation-up.sh
@@ -22,4 +22,8 @@ KUBE_ROOT=$(readlink -m $(dirname "${BASH_SOURCE}")/../../)
 
 . ${KUBE_ROOT}/federation/cluster/common.sh
 
+if [[ -f "${KUBE_ROOT}/federation/manifests/federated-image.tag" ]]; then
+    export FEDERATION_IMAGE_TAG="$(cat "${KUBE_ROOT}/federation/manifests/federated-image.tag")"
+fi
+
 create-federation-api-objects

--- a/federation/cluster/template.go
+++ b/federation/cluster/template.go
@@ -64,7 +64,7 @@ func main() {
 }
 
 func templateYamlFile(params map[string]string, inpath string, out io.Writer) error {
-	if tmpl, err := template.New(path.Base(inpath)).ParseFiles(inpath); err != nil {
+	if tmpl, err := template.New(path.Base(inpath)).Option("missingkey=zero").ParseFiles(inpath); err != nil {
 		return err
 	} else {
 		if err := tmpl.Execute(out, params); err != nil {

--- a/hack/e2e-internal/e2e-status.sh
+++ b/hack/e2e-internal/e2e-status.sh
@@ -30,7 +30,7 @@ source "${KUBE_ROOT}/cluster/kube-util.sh"
 prepare-e2e
 
 if [[ "${FEDERATION:-}" == "true" ]];then
-    FEDERATION_NAMESPACE=${FEDERATION_NAMESPACE:-federation-e2e}
+    FEDERATION_NAMESPACE=${FEDERATION_NAMESPACE:-federation}
     #TODO(colhom): the last cluster that was created in the loop above is the current context.
     # Hence, it will be the cluster that hosts the federated components.
     # In the future, we will want to loop through the all the federated contexts,

--- a/hack/e2e-internal/e2e-up.sh
+++ b/hack/e2e-internal/e2e-up.sh
@@ -40,9 +40,13 @@ if [[ "${FEDERATION:-}" == "true" ]];then
 	    test-setup
 	)
     done
-    if [[ -f "${KUBE_ROOT}/federation/manifests/federated-image.tag" ]];then
-	export FEDERATION_IMAGE_TAG="$(cat "${KUBE_ROOT}/federation/manifests/federated-image.tag")"
+    tagfile="${KUBE_ROOT}/federation/manifests/federated-image.tag"
+    if [[ ! -f "$tagfile" ]]; then
+        echo "FATAL: tagfile ${tagfile} does not exist. Make sure that you have run build/push-federation-images.sh"
+        exit 1
     fi
+    export FEDERATION_IMAGE_TAG="$(cat "${KUBE_ROOT}/federation/manifests/federated-image.tag")"
+
     "${KUBE_ROOT}/federation/cluster/federation-up.sh"
 else
     test-setup

--- a/test/e2e/federation-apiserver.go
+++ b/test/e2e/federation-apiserver.go
@@ -27,7 +27,7 @@ import (
 
 // Create/delete cluster api objects
 var _ = framework.KubeDescribe("Federation apiserver [Feature:Federation]", func() {
-	f := framework.NewDefaultFederatedFramework("federated-cluster")
+	f := framework.NewDefaultFederatedFramework("federation-cluster")
 	It("should allow creation of cluster api objects", func() {
 		framework.SkipUnlessFederated(f.Client)
 

--- a/test/e2e/federation-apiserver.go
+++ b/test/e2e/federation-apiserver.go
@@ -18,10 +18,13 @@ package e2e
 
 import (
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	federationapi "k8s.io/kubernetes/federation/apis/federation"
+	"k8s.io/kubernetes/federation/client/clientset_generated/federation_internalclientset"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
@@ -54,16 +57,34 @@ var _ = framework.KubeDescribe("Federation apiserver [Feature:Federation]", func
 					},
 				},
 			}
-			_, err := f.FederationClient.Clusters().Create(&cluster)
+			_, err := f.FederationClientset.Federation().Clusters().Create(&cluster)
 			framework.ExpectNoError(err, fmt.Sprintf("creating cluster: %+v", err))
 		}
 
 		for _, context := range contexts {
-			c, err := f.FederationClient.Clusters().Get(context.Name)
+			c, err := f.FederationClientset.Federation().Clusters().Get(context.Name)
 			framework.ExpectNoError(err, fmt.Sprintf("get cluster: %+v", err))
 			if c.ObjectMeta.Name != context.Name {
 				framework.Failf("cluster name does not match input context: actual=%+v, expected=%+v", c, context)
 			}
+			err = isReady(context.Name, f.FederationClientset)
+			framework.ExpectNoError(err, fmt.Sprintf("unexpected error in verifying if cluster %s is ready: %+v", context.Name, err))
 		}
 	})
 })
+
+// Verify that the cluster is marked ready.
+func isReady(clusterName string, clientset *federation_internalclientset.Clientset) error {
+	return wait.PollImmediate(time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+		c, err := clientset.Federation().Clusters().Get(clusterName)
+		if err != nil {
+			return false, err
+		}
+		for _, condition := range c.Status.Conditions {
+			if condition.Type == federationapi.ClusterReady && condition.Status == api.ConditionTrue {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -586,7 +586,7 @@ func (f *Framework) GetUnderlyingFederatedContexts() []E2EContext {
 
 	e2eContexts := []E2EContext{}
 	for _, context := range kubeconfig.Contexts {
-		if strings.HasPrefix(context.Name, "federation-e2e") {
+		if strings.HasPrefix(context.Name, "federation") {
 
 			user := kubeconfig.findUser(context.Context.User)
 			if user == nil {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -586,7 +586,7 @@ func (f *Framework) GetUnderlyingFederatedContexts() []E2EContext {
 
 	e2eContexts := []E2EContext{}
 	for _, context := range kubeconfig.Contexts {
-		if strings.HasPrefix(context.Name, "federation") {
+		if strings.HasPrefix(context.Name, "federation") && context.Name != "federation-cluster" {
 
 			user := kubeconfig.findUser(context.Context.User)
 			if user == nil {

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -92,7 +92,7 @@ func RegisterFlags() {
 	flag.StringVar(&TestContext.KubeConfig, clientcmd.RecommendedConfigPathFlag, os.Getenv(clientcmd.RecommendedConfigPathEnvVar), "Path to kubeconfig containing embedded authinfo.")
 	flag.StringVar(&TestContext.KubeContext, clientcmd.FlagContext, "", "kubeconfig context to use/override. If unset, will use value from 'current-context'")
 	flag.StringVar(&TestContext.KubeAPIContentType, "kube-api-content-type", "", "ContentType used to communicate with apiserver")
-	flag.StringVar(&federatedKubeContext, "federated-kube-context", "federated-cluster", "kubeconfig context for federated-cluster.")
+	flag.StringVar(&federatedKubeContext, "federated-kube-context", "federation-cluster", "kubeconfig context for federation-cluster.")
 
 	flag.StringVar(&TestContext.KubeVolumeDir, "volume-dir", "/var/lib/kubelet", "Path to the directory containing the kubelet volumes.")
 	flag.StringVar(&TestContext.CertDir, "cert-dir", "", "Path to the directory containing the certs. Default is empty, which doesn't use certs.")

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -383,7 +383,7 @@ func SkipUnlessServerVersionGTE(v semver.Version, c discovery.ServerVersionInter
 func SkipUnlessFederated(c *client.Client) {
 	federationNS := os.Getenv("FEDERATION_NAMESPACE")
 	if federationNS == "" {
-		federationNS = "federation-e2e"
+		federationNS = "federation"
 	}
 
 	_, err := c.Namespaces().Get(federationNS)


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kubernetes.github.io/pull/656

Updating the federation up scripts so that they work as per steps in https://github.com/kubernetes/kubernetes.github.io/pull/656.

Changes are:
- Updating the default namespace to be "federation" instead of "federation-e2e"
- Updated the kubeconfig context to be named "federation-cluster" instead of "federated-context"
- Fixing federation-up so that FEDERATION_IMAGE_TAG is set even when federation-up is run without running `e2e.go --up`. e2e-up.sh sets it here: https://github.com/kubernetes/kubernetes/blob/6a388d4a0d9e7fc2549ab89c97bf29ce53982e39/hack/e2e-internal/e2e-up.sh#L44.
- Adding a "missingkey=zero" option to template parser. Without this, the parser adds `"<no value>"` at the place of an env var that is not set. With this change, it instead replaces it with the corresponding zero value (for ex "" for strings). This is required for the FEDERATION_DNS_PROVIDER_CONFIG env var.

cc @kubernetes/sig-cluster-federation @colhom @mml 
