### PR TITLE
Dynamically derive AttachOptions.CommandName

### DIFF
--- a/pkg/kubectl/cmd/attach.go
+++ b/pkg/kubectl/cmd/attach.go
@@ -53,8 +53,6 @@ func NewCmdAttach(f *cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer)
 		Out: cmdOut,
 		Err: cmdErr,
 
-		CommandName: "kubectl attach",
-
 		Attach: &DefaultRemoteAttach{},
 	}
 	cmd := &cobra.Command{
@@ -141,6 +139,10 @@ func (p *AttachOptions) Complete(f *cmdutil.Factory, cmd *cobra.Command, argsIn 
 		return err
 	}
 	p.Client = client
+
+	if p.CommandName == "" {
+		p.CommandName = cmd.CommandPath()
+	}
 
 	return nil
 }

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -227,6 +227,8 @@ func Run(f *cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer, cmd *cob
 			Stdin: interactive,
 			TTY:   tty,
 
+			CommandName: cmd.Parent().CommandPath() + " attach",
+
 			Attach: &DefaultRemoteAttach{},
 		}
 		config, err := f.ClientConfig()
@@ -346,7 +348,6 @@ func handleAttachPod(f *cmdutil.Factory, c *client.Client, pod *api.Pod, opts *A
 	opts.Client = c
 	opts.PodName = pod.Name
 	opts.Namespace = pod.Namespace
-	opts.CommandName = "kubectl attach"
 	if err := opts.Run(); err != nil {
 		fmt.Fprintf(opts.Out, "Error attaching, falling back to logs: %v\n", err)
 		req, err := f.LogsForObject(pod, &api.PodLogOptions{Container: opts.GetContainerName(pod)})


### PR DESCRIPTION
This PR sets AttachOptions.CommandName dynamically depending on the corba Command
hierarchy. If the root command is named e.g. "oc" (for the OpenShift cli) this
will result in "oc attach" instead of the static "kubectl attach" before this
patch.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1341450
