### PR TITLE
Implement first version of indexing in cacher

### DIFF
--- a/examples/apiserver/rest/reststorage.go
+++ b/examples/apiserver/rest/reststorage.go
@@ -38,7 +38,7 @@ func NewREST(s storage.Interface, storageDecorator generic.StorageDecorator) *RE
 	// Usually you should reuse your RESTCreateStrategy.
 	strategy := &NotNamespaceScoped{}
 	storageInterface := storageDecorator(
-		s, 100, &testgroup.TestType{}, prefix, strategy, newListFunc)
+		s, 100, &testgroup.TestType{}, prefix, strategy, newListFunc, storage.NoTriggerPublisher)
 	store := &registry.Store{
 		NewFunc: func() runtime.Object { return &testgroup.TestType{} },
 		// NewListFunc returns an object capable of storing results of an etcd list.

--- a/federation/registry/cluster/etcd/etcd.go
+++ b/federation/registry/cluster/etcd/etcd.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 )
 
 type REST struct {
@@ -49,7 +50,14 @@ func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
 
 	newListFunc := func() runtime.Object { return &federation.ClusterList{} }
 	storageInterface := opts.Decorator(
-		opts.Storage, 100, &federation.Cluster{}, prefix, cluster.Strategy, newListFunc)
+		opts.Storage,
+		100,
+		&federation.Cluster{},
+		prefix,
+		cluster.Strategy,
+		newListFunc,
+		storage.NoTriggerPublisher,
+	)
 
 	store := &registry.Store{
 		NewFunc:     func() runtime.Object { return &federation.Cluster{} },

--- a/pkg/registry/certificates/etcd/etcd.go
+++ b/pkg/registry/certificates/etcd/etcd.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 )
 
 // REST implements a RESTStorage for CertificateSigningRequest against etcd
@@ -39,7 +40,15 @@ func NewREST(opts generic.RESTOptions) (*REST, *StatusREST, *ApprovalREST) {
 	prefix := "/certificatesigningrequests"
 
 	newListFunc := func() runtime.Object { return &certificates.CertificateSigningRequestList{} }
-	storageInterface := opts.Decorator(opts.Storage, cachesize.GetWatchCacheSizeByResource(cachesize.CertificateSigningRequests), &certificates.CertificateSigningRequest{}, prefix, csrregistry.Strategy, newListFunc)
+	storageInterface := opts.Decorator(
+		opts.Storage,
+		cachesize.GetWatchCacheSizeByResource(cachesize.CertificateSigningRequests),
+		&certificates.CertificateSigningRequest{},
+		prefix,
+		csrregistry.Strategy,
+		newListFunc,
+		storage.NoTriggerPublisher,
+	)
 
 	store := &registry.Store{
 		NewFunc:     func() runtime.Object { return &certificates.CertificateSigningRequest{} },

--- a/pkg/registry/clusterrole/etcd/etcd.go
+++ b/pkg/registry/clusterrole/etcd/etcd.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 )
 
 // REST implements a RESTStorage for ClusterRole against etcd
@@ -43,6 +44,7 @@ func NewREST(opts generic.RESTOptions) *REST {
 		prefix,
 		clusterrole.Strategy,
 		newListFunc,
+		storage.NoTriggerPublisher,
 	)
 
 	store := &registry.Store{

--- a/pkg/registry/clusterrolebinding/etcd/etcd.go
+++ b/pkg/registry/clusterrolebinding/etcd/etcd.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 )
 
 // REST implements a RESTStorage for ClusterRoleBinding against etcd
@@ -43,6 +44,7 @@ func NewREST(opts generic.RESTOptions) *REST {
 		prefix,
 		clusterrolebinding.Strategy,
 		newListFunc,
+		storage.NoTriggerPublisher,
 	)
 
 	store := &registry.Store{

--- a/pkg/registry/configmap/etcd/etcd.go
+++ b/pkg/registry/configmap/etcd/etcd.go
@@ -20,9 +20,9 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/registry/configmap"
 	"k8s.io/kubernetes/pkg/registry/generic"
-	"k8s.io/kubernetes/pkg/runtime"
-
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 )
 
 // REST implements a RESTStorage for ConfigMap against etcd
@@ -36,7 +36,7 @@ func NewREST(opts generic.RESTOptions) *REST {
 
 	newListFunc := func() runtime.Object { return &api.ConfigMapList{} }
 	storageInterface := opts.Decorator(
-		opts.Storage, 100, &api.ConfigMap{}, prefix, configmap.Strategy, newListFunc)
+		opts.Storage, 100, &api.ConfigMap{}, prefix, configmap.Strategy, newListFunc, storage.NoTriggerPublisher)
 
 	store := &registry.Store{
 		NewFunc: func() runtime.Object {

--- a/pkg/registry/controller/etcd/etcd.go
+++ b/pkg/registry/controller/etcd/etcd.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 )
 
 // ControllerStorage includes dummy storage for Replication Controllers and for Scale subresource.
@@ -62,7 +63,14 @@ func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
 
 	newListFunc := func() runtime.Object { return &api.ReplicationControllerList{} }
 	storageInterface := opts.Decorator(
-		opts.Storage, cachesize.GetWatchCacheSizeByResource(cachesize.Controllers), &api.ReplicationController{}, prefix, controller.Strategy, newListFunc)
+		opts.Storage,
+		cachesize.GetWatchCacheSizeByResource(cachesize.Controllers),
+		&api.ReplicationController{},
+		prefix,
+		controller.Strategy,
+		newListFunc,
+		storage.NoTriggerPublisher,
+	)
 
 	store := &registry.Store{
 		NewFunc: func() runtime.Object { return &api.ReplicationController{} },

--- a/pkg/registry/daemonset/etcd/etcd.go
+++ b/pkg/registry/daemonset/etcd/etcd.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 )
 
 // rest implements a RESTStorage for DaemonSets against etcd
@@ -38,7 +39,14 @@ func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
 
 	newListFunc := func() runtime.Object { return &extensions.DaemonSetList{} }
 	storageInterface := opts.Decorator(
-		opts.Storage, cachesize.GetWatchCacheSizeByResource(cachesize.Daemonsets), &extensions.DaemonSet{}, prefix, daemonset.Strategy, newListFunc)
+		opts.Storage,
+		cachesize.GetWatchCacheSizeByResource(cachesize.Daemonsets),
+		&extensions.DaemonSet{},
+		prefix,
+		daemonset.Strategy,
+		newListFunc,
+		storage.NoTriggerPublisher,
+	)
 
 	store := &registry.Store{
 		NewFunc: func() runtime.Object { return &extensions.DaemonSet{} },

--- a/pkg/registry/deployment/etcd/etcd.go
+++ b/pkg/registry/deployment/etcd/etcd.go
@@ -63,7 +63,14 @@ func NewREST(opts generic.RESTOptions) (*REST, *StatusREST, *RollbackREST) {
 
 	newListFunc := func() runtime.Object { return &extensions.DeploymentList{} }
 	storageInterface := opts.Decorator(
-		opts.Storage, cachesize.GetWatchCacheSizeByResource(cachesize.Deployments), &extensions.Deployment{}, prefix, deployment.Strategy, newListFunc)
+		opts.Storage,
+		cachesize.GetWatchCacheSizeByResource(cachesize.Deployments),
+		&extensions.Deployment{},
+		prefix,
+		deployment.Strategy,
+		newListFunc,
+		storage.NoTriggerPublisher,
+	)
 
 	store := &registry.Store{
 		NewFunc: func() runtime.Object { return &extensions.Deployment{} },

--- a/pkg/registry/endpoint/etcd/etcd.go
+++ b/pkg/registry/endpoint/etcd/etcd.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 )
 
 type REST struct {
@@ -35,7 +36,14 @@ func NewREST(opts generic.RESTOptions) *REST {
 
 	newListFunc := func() runtime.Object { return &api.EndpointsList{} }
 	storageInterface := opts.Decorator(
-		opts.Storage, cachesize.GetWatchCacheSizeByResource(cachesize.Endpoints), &api.Endpoints{}, prefix, endpoint.Strategy, newListFunc)
+		opts.Storage,
+		cachesize.GetWatchCacheSizeByResource(cachesize.Endpoints),
+		&api.Endpoints{},
+		prefix,
+		endpoint.Strategy,
+		newListFunc,
+		storage.NoTriggerPublisher,
+	)
 
 	store := &registry.Store{
 		NewFunc:     func() runtime.Object { return &api.Endpoints{} },

--- a/pkg/registry/generic/matcher.go
+++ b/pkg/registry/generic/matcher.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 )
 
 // AttrFunc returns label and field sets for List or Watch to compare against, or an error.
@@ -50,9 +51,10 @@ func MergeFieldsSets(source fields.Set, fragment fields.Set) fields.Set {
 // SelectionPredicate implements a generic predicate that can be passed to
 // GenericRegistry's List or Watch methods. Implements the Matcher interface.
 type SelectionPredicate struct {
-	Label    labels.Selector
-	Field    fields.Selector
-	GetAttrs AttrFunc
+	Label       labels.Selector
+	Field       fields.Selector
+	GetAttrs    AttrFunc
+	IndexFields []string
 }
 
 // Matches returns true if the given object's labels and fields (as
@@ -79,6 +81,20 @@ func (s *SelectionPredicate) MatchesSingle() (string, bool) {
 	return "", false
 }
 
+// For any index defined by IndexFields, if a matcher can match only (a subset)
+// of objects that return <value> for a given index, a pair (<index name>, <value>)
+// wil be returned.
+// TODO: Consider supporting also labels.
+func (s *SelectionPredicate) MatcherIndex() []storage.MatchValue {
+	var result []storage.MatchValue
+	for _, field := range s.IndexFields {
+		if value, ok := s.Field.RequiresExactMatch(field); ok {
+			result = append(result, storage.MatchValue{IndexName: field, Value: value})
+		}
+	}
+	return result
+}
+
 // Matcher can return true if an object matches the Matcher's selection
 // criteria. If it is known that the matcher will match only a single object
 // then MatchesSingle should return the key of that object and true. This is an
@@ -93,9 +109,10 @@ type Matcher interface {
 	// include the object's namespace.
 	MatchesSingle() (key string, matchesSingleObject bool)
 
-	// TODO: when we start indexing objects, add something like the below:
-	//         MatchesIndices() (indexName []string, indexValue []string)
-	//       where indexName/indexValue are the same length.
+	// For any known index, if a matcher can match only (a subset) of objects
+	// that return <value> for a given index, a pair (<index name>, <value>)
+	// will be returned.
+	MatcherIndex() []storage.MatchValue
 }
 
 // MatcherFunc makes a matcher from the provided function. For easy definition
@@ -115,6 +132,11 @@ func (m matcherFunc) Matches(obj runtime.Object) (bool, error) {
 // implementation of Matcher.
 func (m matcherFunc) MatchesSingle() (string, bool) {
 	return "", false
+}
+
+// MatcherIndex always returns empty list.
+func (m matcherFunc) MatcherIndex() []storage.MatchValue {
+	return nil
 }
 
 // MatchOnKey returns a matcher that will send only the object matching key

--- a/pkg/registry/generic/registry/storage_factory.go
+++ b/pkg/registry/generic/registry/storage_factory.go
@@ -30,15 +30,17 @@ func StorageWithCacher(
 	objectType runtime.Object,
 	resourcePrefix string,
 	scopeStrategy rest.NamespaceScopedStrategy,
-	newListFunc func() runtime.Object) storage.Interface {
+	newListFunc func() runtime.Object,
+	triggerFunc storage.TriggerPublisherFunc) storage.Interface {
 
 	config := storage.CacherConfig{
-		CacheCapacity:  capacity,
-		Storage:        storageInterface,
-		Versioner:      etcdstorage.APIObjectVersioner{},
-		Type:           objectType,
-		ResourcePrefix: resourcePrefix,
-		NewListFunc:    newListFunc,
+		CacheCapacity:        capacity,
+		Storage:              storageInterface,
+		Versioner:            etcdstorage.APIObjectVersioner{},
+		Type:                 objectType,
+		ResourcePrefix:       resourcePrefix,
+		NewListFunc:          newListFunc,
+		TriggerPublisherFunc: triggerFunc,
 	}
 	if scopeStrategy.NamespaceScoped() {
 		config.KeyFunc = func(obj runtime.Object) (string, error) {

--- a/pkg/registry/generic/registry/store.go
+++ b/pkg/registry/generic/registry/store.go
@@ -190,10 +190,10 @@ func (e *Store) List(ctx api.Context, options *api.ListOptions) (runtime.Object,
 // ListPredicate returns a list of all the items matching m.
 func (e *Store) ListPredicate(ctx api.Context, m generic.Matcher, options *api.ListOptions) (runtime.Object, error) {
 	list := e.NewListFunc()
-	filterFunc := e.filterAndDecorateFunction(m)
+	filter := e.createFilter(m)
 	if name, ok := m.MatchesSingle(); ok {
 		if key, err := e.KeyFunc(ctx, name); err == nil {
-			err := e.Storage.GetToList(ctx, key, filterFunc, list)
+			err := e.Storage.GetToList(ctx, key, filter, list)
 			return list, storeerr.InterpretListError(err, e.QualifiedResource)
 		}
 		// if we cannot extract a key based on the current context, the optimization is skipped
@@ -202,7 +202,7 @@ func (e *Store) ListPredicate(ctx api.Context, m generic.Matcher, options *api.L
 	if options == nil {
 		options = &api.ListOptions{ResourceVersion: "0"}
 	}
-	err := e.Storage.List(ctx, e.KeyRootFunc(ctx), options.ResourceVersion, filterFunc, list)
+	err := e.Storage.List(ctx, e.KeyRootFunc(ctx), options.ResourceVersion, filter, list)
 	return list, storeerr.InterpretListError(err, e.QualifiedResource)
 }
 
@@ -798,23 +798,23 @@ func (e *Store) Watch(ctx api.Context, options *api.ListOptions) (watch.Interfac
 
 // WatchPredicate starts a watch for the items that m matches.
 func (e *Store) WatchPredicate(ctx api.Context, m generic.Matcher, resourceVersion string) (watch.Interface, error) {
-	filterFunc := e.filterAndDecorateFunction(m)
+	filter := e.createFilter(m)
 
 	if name, ok := m.MatchesSingle(); ok {
 		if key, err := e.KeyFunc(ctx, name); err == nil {
 			if err != nil {
 				return nil, err
 			}
-			return e.Storage.Watch(ctx, key, resourceVersion, filterFunc)
+			return e.Storage.Watch(ctx, key, resourceVersion, filter)
 		}
 		// if we cannot extract a key based on the current context, the optimization is skipped
 	}
 
-	return e.Storage.WatchList(ctx, e.KeyRootFunc(ctx), resourceVersion, filterFunc)
+	return e.Storage.WatchList(ctx, e.KeyRootFunc(ctx), resourceVersion, filter)
 }
 
-func (e *Store) filterAndDecorateFunction(m generic.Matcher) func(runtime.Object) bool {
-	return func(obj runtime.Object) bool {
+func (e *Store) createFilter(m generic.Matcher) storage.Filter {
+	filterFunc := func(obj runtime.Object) bool {
 		matches, err := m.Matches(obj)
 		if err != nil {
 			glog.Errorf("unable to match watch: %v", err)
@@ -828,6 +828,7 @@ func (e *Store) filterAndDecorateFunction(m generic.Matcher) func(runtime.Object
 		}
 		return matches
 	}
+	return storage.NewSimpleFilter(filterFunc)
 }
 
 // calculateTTL is a helper for retrieving the updated TTL for an object or returning an error

--- a/pkg/registry/generic/registry/store.go
+++ b/pkg/registry/generic/registry/store.go
@@ -828,7 +828,7 @@ func (e *Store) createFilter(m generic.Matcher) storage.Filter {
 		}
 		return matches
 	}
-	return storage.NewSimpleFilter(filterFunc)
+	return storage.NewSimpleFilter(filterFunc, m.MatcherIndex)
 }
 
 // calculateTTL is a helper for retrieving the updated TTL for an object or returning an error

--- a/pkg/registry/generic/registry/store_test.go
+++ b/pkg/registry/generic/registry/store_test.go
@@ -105,6 +105,10 @@ func (sm setMatcher) MatchesSingle() (string, bool) {
 	return "", false
 }
 
+func (sm setMatcher) MatcherIndex() []storage.MatchValue {
+	return nil
+}
+
 // everythingMatcher matches everything
 type everythingMatcher struct{}
 
@@ -114,6 +118,10 @@ func (everythingMatcher) Matches(obj runtime.Object) (bool, error) {
 
 func (everythingMatcher) MatchesSingle() (string, bool) {
 	return "", false
+}
+
+func (everythingMatcher) MatcherIndex() []storage.MatchValue {
+	return nil
 }
 
 func TestStoreList(t *testing.T) {

--- a/pkg/registry/generic/storage_decorator.go
+++ b/pkg/registry/generic/storage_decorator.go
@@ -30,7 +30,8 @@ type StorageDecorator func(
 	objectType runtime.Object,
 	resourcePrefix string,
 	scopeStrategy rest.NamespaceScopedStrategy,
-	newListFunc func() runtime.Object) storage.Interface
+	newListFunc func() runtime.Object,
+	trigger storage.TriggerPublisherFunc) storage.Interface
 
 // Returns given 'storageInterface' without any decoration.
 func UndecoratedStorage(
@@ -39,6 +40,7 @@ func UndecoratedStorage(
 	objectType runtime.Object,
 	resourcePrefix string,
 	scopeStrategy rest.NamespaceScopedStrategy,
-	newListFunc func() runtime.Object) storage.Interface {
+	newListFunc func() runtime.Object,
+	trigger storage.TriggerPublisherFunc) storage.Interface {
 	return storageInterface
 }

--- a/pkg/registry/horizontalpodautoscaler/etcd/etcd.go
+++ b/pkg/registry/horizontalpodautoscaler/etcd/etcd.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/registry/horizontalpodautoscaler"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 )
 
 type REST struct {
@@ -37,7 +38,14 @@ func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
 
 	newListFunc := func() runtime.Object { return &autoscaling.HorizontalPodAutoscalerList{} }
 	storageInterface := opts.Decorator(
-		opts.Storage, cachesize.GetWatchCacheSizeByResource(cachesize.HorizontalPodAutoscalers), &autoscaling.HorizontalPodAutoscaler{}, prefix, horizontalpodautoscaler.Strategy, newListFunc)
+		opts.Storage,
+		cachesize.GetWatchCacheSizeByResource(cachesize.HorizontalPodAutoscalers),
+		&autoscaling.HorizontalPodAutoscaler{},
+		prefix,
+		horizontalpodautoscaler.Strategy,
+		newListFunc,
+		storage.NoTriggerPublisher,
+	)
 
 	store := &registry.Store{
 		NewFunc: func() runtime.Object { return &autoscaling.HorizontalPodAutoscaler{} },

--- a/pkg/registry/ingress/etcd/etcd.go
+++ b/pkg/registry/ingress/etcd/etcd.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	ingress "k8s.io/kubernetes/pkg/registry/ingress"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 )
 
 // rest implements a RESTStorage for replication controllers against etcd
@@ -38,7 +39,14 @@ func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
 
 	newListFunc := func() runtime.Object { return &extensions.IngressList{} }
 	storageInterface := opts.Decorator(
-		opts.Storage, cachesize.GetWatchCacheSizeByResource(cachesize.Ingress), &extensions.Ingress{}, prefix, ingress.Strategy, newListFunc)
+		opts.Storage,
+		cachesize.GetWatchCacheSizeByResource(cachesize.Ingress),
+		&extensions.Ingress{},
+		prefix,
+		ingress.Strategy,
+		newListFunc,
+		storage.NoTriggerPublisher,
+	)
 
 	store := &registry.Store{
 		NewFunc: func() runtime.Object { return &extensions.Ingress{} },

--- a/pkg/registry/job/etcd/etcd.go
+++ b/pkg/registry/job/etcd/etcd.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/registry/job"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 )
 
 // REST implements a RESTStorage for jobs against etcd
@@ -38,7 +39,14 @@ func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
 
 	newListFunc := func() runtime.Object { return &batch.JobList{} }
 	storageInterface := opts.Decorator(
-		opts.Storage, cachesize.GetWatchCacheSizeByResource(cachesize.Jobs), &batch.Job{}, prefix, job.Strategy, newListFunc)
+		opts.Storage,
+		cachesize.GetWatchCacheSizeByResource(cachesize.Jobs),
+		&batch.Job{},
+		prefix,
+		job.Strategy,
+		newListFunc,
+		storage.NoTriggerPublisher,
+	)
 
 	store := &registry.Store{
 		NewFunc: func() runtime.Object { return &batch.Job{} },

--- a/pkg/registry/limitrange/etcd/etcd.go
+++ b/pkg/registry/limitrange/etcd/etcd.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/registry/limitrange"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 )
 
 type REST struct {
@@ -35,7 +36,14 @@ func NewREST(opts generic.RESTOptions) *REST {
 
 	newListFunc := func() runtime.Object { return &api.LimitRangeList{} }
 	storageInterface := opts.Decorator(
-		opts.Storage, cachesize.GetWatchCacheSizeByResource(cachesize.LimitRanges), &api.LimitRange{}, prefix, limitrange.Strategy, newListFunc)
+		opts.Storage,
+		cachesize.GetWatchCacheSizeByResource(cachesize.LimitRanges),
+		&api.LimitRange{},
+		prefix,
+		limitrange.Strategy,
+		newListFunc,
+		storage.NoTriggerPublisher,
+	)
 
 	store := &registry.Store{
 		NewFunc:     func() runtime.Object { return &api.LimitRange{} },

--- a/pkg/registry/namespace/etcd/etcd.go
+++ b/pkg/registry/namespace/etcd/etcd.go
@@ -54,7 +54,14 @@ func NewREST(opts generic.RESTOptions) (*REST, *StatusREST, *FinalizeREST) {
 
 	newListFunc := func() runtime.Object { return &api.NamespaceList{} }
 	storageInterface := opts.Decorator(
-		opts.Storage, cachesize.GetWatchCacheSizeByResource(cachesize.Namespaces), &api.Namespace{}, prefix, namespace.Strategy, newListFunc)
+		opts.Storage,
+		cachesize.GetWatchCacheSizeByResource(cachesize.Namespaces),
+		&api.Namespace{},
+		prefix,
+		namespace.Strategy,
+		newListFunc,
+		storage.NoTriggerPublisher,
+	)
 
 	store := &registry.Store{
 		NewFunc:     func() runtime.Object { return &api.Namespace{} },

--- a/pkg/registry/networkpolicy/etcd/etcd.go
+++ b/pkg/registry/networkpolicy/etcd/etcd.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/registry/networkpolicy"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 )
 
 // rest implements a RESTStorage for network policies against etcd
@@ -37,7 +38,14 @@ func NewREST(opts generic.RESTOptions) *REST {
 
 	newListFunc := func() runtime.Object { return &extensionsapi.NetworkPolicyList{} }
 	storageInterface := opts.Decorator(
-		opts.Storage, cachesize.GetWatchCacheSizeByResource(cachesize.NetworkPolicys), &extensionsapi.NetworkPolicy{}, prefix, networkpolicy.Strategy, newListFunc)
+		opts.Storage,
+		cachesize.GetWatchCacheSizeByResource(cachesize.NetworkPolicys),
+		&extensionsapi.NetworkPolicy{},
+		prefix,
+		networkpolicy.Strategy,
+		newListFunc,
+		storage.NoTriggerPublisher,
+	)
 
 	store := &registry.Store{
 		NewFunc: func() runtime.Object { return &extensionsapi.NetworkPolicy{} },

--- a/pkg/registry/node/etcd/etcd.go
+++ b/pkg/registry/node/etcd/etcd.go
@@ -70,7 +70,13 @@ func NewStorage(opts generic.RESTOptions, connection client.ConnectionInfoGetter
 
 	newListFunc := func() runtime.Object { return &api.NodeList{} }
 	storageInterface := opts.Decorator(
-		opts.Storage, cachesize.GetWatchCacheSizeByResource(cachesize.Nodes), &api.Node{}, prefix, node.Strategy, newListFunc)
+		opts.Storage,
+		cachesize.GetWatchCacheSizeByResource(cachesize.Nodes),
+		&api.Node{},
+		prefix,
+		node.Strategy,
+		newListFunc,
+		node.NodeNameTriggerFunc)
 
 	store := &registry.Store{
 		NewFunc:     func() runtime.Object { return &api.Node{} },

--- a/pkg/registry/node/strategy.go
+++ b/pkg/registry/node/strategy.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/kubernetes/pkg/master/ports"
 	"k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/runtime"
+	pkgstorage "k8s.io/kubernetes/pkg/storage"
 	utilnet "k8s.io/kubernetes/pkg/util/net"
 	nodeutil "k8s.io/kubernetes/pkg/util/node"
 	"k8s.io/kubernetes/pkg/util/validation/field"
@@ -157,7 +158,14 @@ func MatchNode(label labels.Selector, field fields.Selector) generic.Matcher {
 			}
 			return labels.Set(nodeObj.ObjectMeta.Labels), NodeToSelectableFields(nodeObj), nil
 		},
+		IndexFields: []string{"metadata.name"},
 	}
+}
+
+func NodeNameTriggerFunc(obj runtime.Object) []pkgstorage.MatchValue {
+	node := obj.(*api.Node)
+	result := pkgstorage.MatchValue{IndexName: "metadata.name", Value: node.ObjectMeta.Name}
+	return []pkgstorage.MatchValue{result}
 }
 
 // ResourceLocation returns an URL and transport which one can use to send traffic for the specified node.

--- a/pkg/registry/persistentvolume/etcd/etcd.go
+++ b/pkg/registry/persistentvolume/etcd/etcd.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/registry/persistentvolume"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 )
 
 type REST struct {
@@ -36,7 +37,14 @@ func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
 
 	newListFunc := func() runtime.Object { return &api.PersistentVolumeList{} }
 	storageInterface := opts.Decorator(
-		opts.Storage, cachesize.GetWatchCacheSizeByResource(cachesize.PersistentVolumes), &api.PersistentVolume{}, prefix, persistentvolume.Strategy, newListFunc)
+		opts.Storage,
+		cachesize.GetWatchCacheSizeByResource(cachesize.PersistentVolumes),
+		&api.PersistentVolume{},
+		prefix,
+		persistentvolume.Strategy,
+		newListFunc,
+		storage.NoTriggerPublisher,
+	)
 
 	store := &registry.Store{
 		NewFunc:     func() runtime.Object { return &api.PersistentVolume{} },

--- a/pkg/registry/persistentvolumeclaim/etcd/etcd.go
+++ b/pkg/registry/persistentvolumeclaim/etcd/etcd.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/registry/persistentvolumeclaim"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 )
 
 type REST struct {
@@ -36,7 +37,14 @@ func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
 
 	newListFunc := func() runtime.Object { return &api.PersistentVolumeClaimList{} }
 	storageInterface := opts.Decorator(
-		opts.Storage, cachesize.GetWatchCacheSizeByResource(cachesize.PersistentVolumeClaims), &api.PersistentVolumeClaim{}, prefix, persistentvolumeclaim.Strategy, newListFunc)
+		opts.Storage,
+		cachesize.GetWatchCacheSizeByResource(cachesize.PersistentVolumeClaims),
+		&api.PersistentVolumeClaim{},
+		prefix,
+		persistentvolumeclaim.Strategy,
+		newListFunc,
+		storage.NoTriggerPublisher,
+	)
 
 	store := &registry.Store{
 		NewFunc:     func() runtime.Object { return &api.PersistentVolumeClaim{} },

--- a/pkg/registry/petset/etcd/etcd.go
+++ b/pkg/registry/petset/etcd/etcd.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/registry/petset"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 )
 
 // rest implements a RESTStorage for replication controllers against etcd
@@ -38,7 +39,14 @@ func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
 
 	newListFunc := func() runtime.Object { return &appsapi.PetSetList{} }
 	storageInterface := opts.Decorator(
-		opts.Storage, cachesize.GetWatchCacheSizeByResource(cachesize.PetSet), &appsapi.PetSet{}, prefix, petset.Strategy, newListFunc)
+		opts.Storage,
+		cachesize.GetWatchCacheSizeByResource(cachesize.PetSet),
+		&appsapi.PetSet{},
+		prefix,
+		petset.Strategy,
+		newListFunc,
+		storage.NoTriggerPublisher,
+	)
 
 	store := &registry.Store{
 		NewFunc: func() runtime.Object { return &appsapi.PetSet{} },

--- a/pkg/registry/pod/etcd/etcd.go
+++ b/pkg/registry/pod/etcd/etcd.go
@@ -61,7 +61,14 @@ func NewStorage(opts generic.RESTOptions, k client.ConnectionInfoGetter, proxyTr
 
 	newListFunc := func() runtime.Object { return &api.PodList{} }
 	storageInterface := opts.Decorator(
-		opts.Storage, cachesize.GetWatchCacheSizeByResource(cachesize.Pods), &api.Pod{}, prefix, pod.Strategy, newListFunc)
+		opts.Storage,
+		cachesize.GetWatchCacheSizeByResource(cachesize.Pods),
+		&api.Pod{},
+		prefix,
+		pod.Strategy,
+		newListFunc,
+		pod.NodeNameTriggerFunc,
+	)
 
 	store := &registry.Store{
 		NewFunc:     func() runtime.Object { return &api.Pod{} },

--- a/pkg/registry/pod/strategy.go
+++ b/pkg/registry/pod/strategy.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 	utilnet "k8s.io/kubernetes/pkg/util/net"
 	"k8s.io/kubernetes/pkg/util/validation/field"
 )
@@ -177,7 +178,14 @@ func MatchPod(label labels.Selector, field fields.Selector) generic.Matcher {
 			}
 			return podLabels, podFields, nil
 		},
+		IndexFields: []string{"spec.nodeName"},
 	}
+}
+
+func NodeNameTriggerFunc(obj runtime.Object) []storage.MatchValue {
+	pod := obj.(*api.Pod)
+	result := storage.MatchValue{IndexName: "spec.nodeName", Value: pod.Spec.NodeName}
+	return []storage.MatchValue{result}
 }
 
 // PodToSelectableFields returns a field set that represents the object

--- a/pkg/registry/poddisruptionbudget/etcd/etcd.go
+++ b/pkg/registry/poddisruptionbudget/etcd/etcd.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/registry/poddisruptionbudget"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 )
 
 // rest implements a RESTStorage for pod disruption budgets against etcd
@@ -38,7 +39,14 @@ func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
 
 	newListFunc := func() runtime.Object { return &policyapi.PodDisruptionBudgetList{} }
 	storageInterface := opts.Decorator(
-		opts.Storage, cachesize.GetWatchCacheSizeByResource(cachesize.PodDisruptionBudget), &policyapi.PodDisruptionBudget{}, prefix, poddisruptionbudget.Strategy, newListFunc)
+		opts.Storage,
+		cachesize.GetWatchCacheSizeByResource(cachesize.PodDisruptionBudget),
+		&policyapi.PodDisruptionBudget{},
+		prefix,
+		poddisruptionbudget.Strategy,
+		newListFunc,
+		storage.NoTriggerPublisher,
+	)
 
 	store := &registry.Store{
 		NewFunc: func() runtime.Object { return &policyapi.PodDisruptionBudget{} },

--- a/pkg/registry/podsecuritypolicy/etcd/etcd.go
+++ b/pkg/registry/podsecuritypolicy/etcd/etcd.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/registry/podsecuritypolicy"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 )
 
 // REST implements a RESTStorage for PodSecurityPolicies against etcd.
@@ -36,7 +37,14 @@ const Prefix = "/podsecuritypolicies"
 func NewREST(opts generic.RESTOptions) *REST {
 	newListFunc := func() runtime.Object { return &extensions.PodSecurityPolicyList{} }
 	storageInterface := opts.Decorator(
-		opts.Storage, 100, &extensions.PodSecurityPolicy{}, Prefix, podsecuritypolicy.Strategy, newListFunc)
+		opts.Storage,
+		100,
+		&extensions.PodSecurityPolicy{},
+		Prefix,
+		podsecuritypolicy.Strategy,
+		newListFunc,
+		storage.NoTriggerPublisher,
+	)
 
 	store := &registry.Store{
 		NewFunc:     func() runtime.Object { return &extensions.PodSecurityPolicy{} },

--- a/pkg/registry/podtemplate/etcd/etcd.go
+++ b/pkg/registry/podtemplate/etcd/etcd.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/registry/podtemplate"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 )
 
 type REST struct {
@@ -35,7 +36,14 @@ func NewREST(opts generic.RESTOptions) *REST {
 
 	newListFunc := func() runtime.Object { return &api.PodTemplateList{} }
 	storageInterface := opts.Decorator(
-		opts.Storage, cachesize.GetWatchCacheSizeByResource(cachesize.PodTemplates), &api.PodTemplate{}, prefix, podtemplate.Strategy, newListFunc)
+		opts.Storage,
+		cachesize.GetWatchCacheSizeByResource(cachesize.PodTemplates),
+		&api.PodTemplate{},
+		prefix,
+		podtemplate.Strategy,
+		newListFunc,
+		storage.NoTriggerPublisher,
+	)
 
 	store := &registry.Store{
 		NewFunc:     func() runtime.Object { return &api.PodTemplate{} },

--- a/pkg/registry/replicaset/etcd/etcd.go
+++ b/pkg/registry/replicaset/etcd/etcd.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/registry/replicaset"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 )
 
 // ReplicaSetStorage includes dummy storage for ReplicaSets and for Scale subresource.
@@ -61,7 +62,14 @@ func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
 
 	newListFunc := func() runtime.Object { return &extensions.ReplicaSetList{} }
 	storageInterface := opts.Decorator(
-		opts.Storage, cachesize.GetWatchCacheSizeByResource(cachesize.Replicasets), &extensions.ReplicaSet{}, prefix, replicaset.Strategy, newListFunc)
+		opts.Storage,
+		cachesize.GetWatchCacheSizeByResource(cachesize.Replicasets),
+		&extensions.ReplicaSet{},
+		prefix,
+		replicaset.Strategy,
+		newListFunc,
+		storage.NoTriggerPublisher,
+	)
 
 	store := &registry.Store{
 		NewFunc: func() runtime.Object { return &extensions.ReplicaSet{} },

--- a/pkg/registry/resourcequota/etcd/etcd.go
+++ b/pkg/registry/resourcequota/etcd/etcd.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/registry/resourcequota"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 )
 
 type REST struct {
@@ -36,7 +37,14 @@ func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
 
 	newListFunc := func() runtime.Object { return &api.ResourceQuotaList{} }
 	storageInterface := opts.Decorator(
-		opts.Storage, cachesize.GetWatchCacheSizeByResource(cachesize.ResourceQuotas), &api.ResourceQuota{}, prefix, resourcequota.Strategy, newListFunc)
+		opts.Storage,
+		cachesize.GetWatchCacheSizeByResource(cachesize.ResourceQuotas),
+		&api.ResourceQuota{},
+		prefix,
+		resourcequota.Strategy,
+		newListFunc,
+		storage.NoTriggerPublisher,
+	)
 
 	store := &registry.Store{
 		NewFunc:     func() runtime.Object { return &api.ResourceQuota{} },

--- a/pkg/registry/role/etcd/etcd.go
+++ b/pkg/registry/role/etcd/etcd.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/registry/role"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 )
 
 // REST implements a RESTStorage for Role against etcd
@@ -43,6 +44,7 @@ func NewREST(opts generic.RESTOptions) *REST {
 		prefix,
 		role.Strategy,
 		newListFunc,
+		storage.NoTriggerPublisher,
 	)
 
 	store := &registry.Store{

--- a/pkg/registry/rolebinding/etcd/etcd.go
+++ b/pkg/registry/rolebinding/etcd/etcd.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/registry/rolebinding"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 )
 
 // REST implements a RESTStorage for RoleBinding against etcd
@@ -43,6 +44,7 @@ func NewREST(opts generic.RESTOptions) *REST {
 		prefix,
 		rolebinding.Strategy,
 		newListFunc,
+		storage.NoTriggerPublisher,
 	)
 
 	store := &registry.Store{

--- a/pkg/registry/secret/etcd/etcd.go
+++ b/pkg/registry/secret/etcd/etcd.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/registry/secret"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 )
 
 type REST struct {
@@ -35,7 +36,14 @@ func NewREST(opts generic.RESTOptions) *REST {
 
 	newListFunc := func() runtime.Object { return &api.SecretList{} }
 	storageInterface := opts.Decorator(
-		opts.Storage, cachesize.GetWatchCacheSizeByResource(cachesize.Secrets), &api.Secret{}, prefix, secret.Strategy, newListFunc)
+		opts.Storage,
+		cachesize.GetWatchCacheSizeByResource(cachesize.Secrets),
+		&api.Secret{},
+		prefix,
+		secret.Strategy,
+		newListFunc,
+		storage.NoTriggerPublisher,
+	)
 
 	store := &registry.Store{
 		NewFunc:     func() runtime.Object { return &api.Secret{} },

--- a/pkg/registry/service/etcd/etcd.go
+++ b/pkg/registry/service/etcd/etcd.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/registry/service"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 )
 
 type REST struct {
@@ -36,7 +37,14 @@ func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
 
 	newListFunc := func() runtime.Object { return &api.ServiceList{} }
 	storageInterface := opts.Decorator(
-		opts.Storage, cachesize.GetWatchCacheSizeByResource(cachesize.Services), &api.Service{}, prefix, service.Strategy, newListFunc)
+		opts.Storage,
+		cachesize.GetWatchCacheSizeByResource(cachesize.Services),
+		&api.Service{},
+		prefix,
+		service.Strategy,
+		newListFunc,
+		storage.NoTriggerPublisher,
+	)
 
 	store := &registry.Store{
 		NewFunc:     func() runtime.Object { return &api.Service{} },

--- a/pkg/registry/serviceaccount/etcd/etcd.go
+++ b/pkg/registry/serviceaccount/etcd/etcd.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/registry/serviceaccount"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 )
 
 type REST struct {
@@ -35,7 +36,14 @@ func NewREST(opts generic.RESTOptions) *REST {
 
 	newListFunc := func() runtime.Object { return &api.ServiceAccountList{} }
 	storageInterface := opts.Decorator(
-		opts.Storage, cachesize.GetWatchCacheSizeByResource(cachesize.ServiceAccounts), &api.ServiceAccount{}, prefix, serviceaccount.Strategy, newListFunc)
+		opts.Storage,
+		cachesize.GetWatchCacheSizeByResource(cachesize.ServiceAccounts),
+		&api.ServiceAccount{},
+		prefix,
+		serviceaccount.Strategy,
+		newListFunc,
+		storage.NoTriggerPublisher,
+	)
 
 	store := &registry.Store{
 		NewFunc:     func() runtime.Object { return &api.ServiceAccount{} },

--- a/pkg/storage/cacher_test.go
+++ b/pkg/storage/cacher_test.go
@@ -340,7 +340,7 @@ func TestFiltering(t *testing.T) {
 		}
 		return selector.Matches(labels.Set(metadata.GetLabels()))
 	}
-	filter := storage.NewSimpleFilter(filterFunc)
+	filter := storage.NewSimpleFilter(filterFunc, storage.NoTriggerFunc)
 	watcher, err := cacher.Watch(context.TODO(), "pods/ns/foo", fooCreated.ResourceVersion, filter)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)

--- a/pkg/storage/cacher_test.go
+++ b/pkg/storage/cacher_test.go
@@ -185,7 +185,7 @@ type injectListError struct {
 	storage.Interface
 }
 
-func (self *injectListError) List(ctx context.Context, key string, resourceVersion string, filter storage.FilterFunc, listObj runtime.Object) error {
+func (self *injectListError) List(ctx context.Context, key string, resourceVersion string, filter storage.Filter, listObj runtime.Object) error {
 	if self.errors > 0 {
 		self.errors--
 		return fmt.Errorf("injected error")
@@ -332,7 +332,7 @@ func TestFiltering(t *testing.T) {
 
 	// Set up Watch for object "podFoo" with label filter set.
 	selector := labels.SelectorFromSet(labels.Set{"filter": "foo"})
-	filter := func(obj runtime.Object) bool {
+	filterFunc := func(obj runtime.Object) bool {
 		metadata, err := meta.Accessor(obj)
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
@@ -340,6 +340,7 @@ func TestFiltering(t *testing.T) {
 		}
 		return selector.Matches(labels.Set(metadata.GetLabels()))
 	}
+	filter := storage.NewSimpleFilter(filterFunc)
 	watcher, err := cacher.Watch(context.TODO(), "pods/ns/foo", fooCreated.ResourceVersion, filter)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)

--- a/pkg/storage/etcd/etcd_helper_test.go
+++ b/pkg/storage/etcd/etcd_helper_test.go
@@ -158,7 +158,7 @@ func TestListFiltered(t *testing.T) {
 		pod := obj.(*api.Pod)
 		return pod.Name == "bar"
 	}
-	filter := storage.NewSimpleFilter(filterFunc)
+	filter := storage.NewSimpleFilter(filterFunc, storage.NoTriggerFunc)
 
 	var got api.PodList
 	err := helper.List(context.TODO(), key, "", filter, &got)

--- a/pkg/storage/etcd/etcd_helper_test.go
+++ b/pkg/storage/etcd/etcd_helper_test.go
@@ -154,10 +154,11 @@ func TestListFiltered(t *testing.T) {
 	}
 
 	createPodList(t, helper, &list)
-	filter := func(obj runtime.Object) bool {
+	filterFunc := func(obj runtime.Object) bool {
 		pod := obj.(*api.Pod)
 		return pod.Name == "bar"
 	}
+	filter := storage.NewSimpleFilter(filterFunc)
 
 	var got api.PodList
 	err := helper.List(context.TODO(), key, "", filter, &got)

--- a/pkg/storage/etcd/etcd_watcher.go
+++ b/pkg/storage/etcd/etcd_watcher.go
@@ -88,7 +88,7 @@ type etcdWatcher struct {
 	list    bool // If we're doing a recursive watch, should be true.
 	quorum  bool // If we enable quorum, shoule be true
 	include includeFunc
-	filter  storage.FilterFunc
+	filter  storage.Filter
 
 	etcdIncoming  chan *etcd.Response
 	etcdError     chan error
@@ -116,7 +116,7 @@ const watchWaitDuration = 100 * time.Millisecond
 // newEtcdWatcher returns a new etcdWatcher; if list is true, watch sub-nodes.
 // The versioner must be able to handle the objects that transform creates.
 func newEtcdWatcher(
-	list bool, quorum bool, include includeFunc, filter storage.FilterFunc,
+	list bool, quorum bool, include includeFunc, filter storage.Filter,
 	encoding runtime.Codec, versioner storage.Versioner, transform TransformFunc,
 	cache etcdCache) *etcdWatcher {
 	w := &etcdWatcher{
@@ -364,7 +364,7 @@ func (w *etcdWatcher) sendAdd(res *etcd.Response) {
 		// the resourceVersion to resume will never be able to get past a bad value.
 		return
 	}
-	if !w.filter(obj) {
+	if !w.filter.Filter(obj) {
 		return
 	}
 	action := watch.Added
@@ -393,7 +393,7 @@ func (w *etcdWatcher) sendModify(res *etcd.Response) {
 		// the resourceVersion to resume will never be able to get past a bad value.
 		return
 	}
-	curObjPasses := w.filter(curObj)
+	curObjPasses := w.filter.Filter(curObj)
 	oldObjPasses := false
 	var oldObj runtime.Object
 	if res.PrevNode != nil && res.PrevNode.Value != "" {
@@ -402,7 +402,7 @@ func (w *etcdWatcher) sendModify(res *etcd.Response) {
 			if err := w.versioner.UpdateObject(oldObj, res.Node.ModifiedIndex); err != nil {
 				utilruntime.HandleError(fmt.Errorf("failure to version api object (%d) %#v: %v", res.Node.ModifiedIndex, oldObj, err))
 			}
-			oldObjPasses = w.filter(oldObj)
+			oldObjPasses = w.filter.Filter(oldObj)
 		}
 	}
 	// Some changes to an object may cause it to start or stop matching a filter.
@@ -451,7 +451,7 @@ func (w *etcdWatcher) sendDelete(res *etcd.Response) {
 		// the resourceVersion to resume will never be able to get past a bad value.
 		return
 	}
-	if !w.filter(obj) {
+	if !w.filter.Filter(obj) {
 		return
 	}
 	w.emit(watch.Event{

--- a/pkg/storage/etcd/etcd_watcher_test.go
+++ b/pkg/storage/etcd/etcd_watcher_test.go
@@ -56,6 +56,10 @@ func (f *firstLetterIsB) Filter(obj runtime.Object) bool {
 	return obj.(*api.Pod).Name[0] == 'b'
 }
 
+func (f *firstLetterIsB) Trigger() []storage.MatchValue {
+	return nil
+}
+
 func TestWatchInterpretations(t *testing.T) {
 	codec := testapi.Default.Codec()
 	// Declare some pods to make the test cases compact.
@@ -230,7 +234,7 @@ func TestSendResultDeleteEventHaveLatestIndex(t *testing.T) {
 	filterFunc := func(obj runtime.Object) bool {
 		return obj.(*api.Pod).Name != "bar"
 	}
-	filter := storage.NewSimpleFilter(filterFunc)
+	filter := storage.NewSimpleFilter(filterFunc, storage.NoTriggerFunc)
 	w := newEtcdWatcher(false, false, nil, filter, codec, versioner, nil, &fakeEtcdCache{})
 
 	eventChan := make(chan watch.Event, 1)

--- a/pkg/storage/etcd/etcd_watcher_test.go
+++ b/pkg/storage/etcd/etcd_watcher_test.go
@@ -39,7 +39,7 @@ var versioner = APIObjectVersioner{}
 // Implements etcdCache interface as empty methods (i.e. does not cache any objects)
 type fakeEtcdCache struct{}
 
-func (f *fakeEtcdCache) getFromCache(index uint64, filter storage.FilterFunc) (runtime.Object, bool) {
+func (f *fakeEtcdCache) getFromCache(index uint64, filter storage.Filter) (runtime.Object, bool) {
 	return nil, false
 }
 
@@ -48,17 +48,22 @@ func (f *fakeEtcdCache) addToCache(index uint64, obj runtime.Object) {
 
 var _ etcdCache = &fakeEtcdCache{}
 
+// firstLetterIsB implements storage.Filter interface.
+type firstLetterIsB struct {
+}
+
+func (f *firstLetterIsB) Filter(obj runtime.Object) bool {
+	return obj.(*api.Pod).Name[0] == 'b'
+}
+
 func TestWatchInterpretations(t *testing.T) {
 	codec := testapi.Default.Codec()
 	// Declare some pods to make the test cases compact.
 	podFoo := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}}
 	podBar := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "bar"}}
 	podBaz := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "baz"}}
-	firstLetterIsB := func(obj runtime.Object) bool {
-		return obj.(*api.Pod).Name[0] == 'b'
-	}
 
-	// All of these test cases will be run with the firstLetterIsB FilterFunc.
+	// All of these test cases will be run with the firstLetterIsB Filter.
 	table := map[string]struct {
 		actions       []string // Run this test item for every action here.
 		prevNodeValue string
@@ -131,7 +136,7 @@ func TestWatchInterpretations(t *testing.T) {
 
 	for name, item := range table {
 		for _, action := range item.actions {
-			w := newEtcdWatcher(true, false, nil, firstLetterIsB, codec, versioner, nil, &fakeEtcdCache{})
+			w := newEtcdWatcher(true, false, nil, &firstLetterIsB{}, codec, versioner, nil, &fakeEtcdCache{})
 			emitCalled := false
 			w.emit = func(event watch.Event) {
 				emitCalled = true
@@ -222,9 +227,10 @@ func TestWatchInterpretation_ResponseBadData(t *testing.T) {
 
 func TestSendResultDeleteEventHaveLatestIndex(t *testing.T) {
 	codec := testapi.Default.Codec()
-	filter := func(obj runtime.Object) bool {
+	filterFunc := func(obj runtime.Object) bool {
 		return obj.(*api.Pod).Name != "bar"
 	}
+	filter := storage.NewSimpleFilter(filterFunc)
 	w := newEtcdWatcher(false, false, nil, filter, codec, versioner, nil, &fakeEtcdCache{})
 
 	eventChan := make(chan watch.Event, 1)

--- a/pkg/storage/etcd3/store.go
+++ b/pkg/storage/etcd3/store.go
@@ -274,7 +274,7 @@ func (s *store) GuaranteedUpdate(ctx context.Context, key string, out runtime.Ob
 }
 
 // GetToList implements storage.Interface.GetToList.
-func (s *store) GetToList(ctx context.Context, key string, filter storage.FilterFunc, listObj runtime.Object) error {
+func (s *store) GetToList(ctx context.Context, key string, filter storage.Filter, listObj runtime.Object) error {
 	listPtr, err := meta.GetItemsPtr(listObj)
 	if err != nil {
 		return err
@@ -300,7 +300,7 @@ func (s *store) GetToList(ctx context.Context, key string, filter storage.Filter
 }
 
 // List implements storage.Interface.List.
-func (s *store) List(ctx context.Context, key, resourceVersion string, filter storage.FilterFunc, listObj runtime.Object) error {
+func (s *store) List(ctx context.Context, key, resourceVersion string, filter storage.Filter, listObj runtime.Object) error {
 	listPtr, err := meta.GetItemsPtr(listObj)
 	if err != nil {
 		return err
@@ -332,16 +332,16 @@ func (s *store) List(ctx context.Context, key, resourceVersion string, filter st
 }
 
 // Watch implements storage.Interface.Watch.
-func (s *store) Watch(ctx context.Context, key string, resourceVersion string, filter storage.FilterFunc) (watch.Interface, error) {
+func (s *store) Watch(ctx context.Context, key string, resourceVersion string, filter storage.Filter) (watch.Interface, error) {
 	return s.watch(ctx, key, resourceVersion, filter, false)
 }
 
 // WatchList implements storage.Interface.WatchList.
-func (s *store) WatchList(ctx context.Context, key string, resourceVersion string, filter storage.FilterFunc) (watch.Interface, error) {
+func (s *store) WatchList(ctx context.Context, key string, resourceVersion string, filter storage.Filter) (watch.Interface, error) {
 	return s.watch(ctx, key, resourceVersion, filter, true)
 }
 
-func (s *store) watch(ctx context.Context, key string, rv string, filter storage.FilterFunc, recursive bool) (watch.Interface, error) {
+func (s *store) watch(ctx context.Context, key string, rv string, filter storage.Filter, recursive bool) (watch.Interface, error) {
 	rev, err := storage.ParseWatchResourceVersion(rv)
 	if err != nil {
 		return nil, err
@@ -435,7 +435,7 @@ func decode(codec runtime.Codec, versioner storage.Versioner, value []byte, objP
 
 // decodeList decodes a list of values into a list of objects, with resource version set to corresponding rev.
 // On success, ListPtr would be set to the list of objects.
-func decodeList(elems []*elemForDecode, filter storage.FilterFunc, ListPtr interface{}, codec runtime.Codec, versioner storage.Versioner) error {
+func decodeList(elems []*elemForDecode, filter storage.Filter, ListPtr interface{}, codec runtime.Codec, versioner storage.Versioner) error {
 	v, err := conversion.EnforcePtr(ListPtr)
 	if err != nil || v.Kind() != reflect.Slice {
 		panic("need ptr to slice")
@@ -447,7 +447,7 @@ func decodeList(elems []*elemForDecode, filter storage.FilterFunc, ListPtr inter
 		}
 		// being unable to set the version does not prevent the object from being extracted
 		versioner.UpdateObject(obj, elem.rev)
-		if filter(obj) {
+		if filter.Filter(obj) {
 			v.Set(reflect.Append(v, reflect.ValueOf(obj).Elem()))
 		}
 	}

--- a/pkg/storage/etcd3/store_test.go
+++ b/pkg/storage/etcd3/store_test.go
@@ -226,15 +226,15 @@ func TestGetToList(t *testing.T) {
 
 	tests := []struct {
 		key         string
-		filter      storage.FilterFunc
+		filter      func(runtime.Object) bool
 		expectedOut []*api.Pod
 	}{{ // test GetToList on existing key
 		key:         key,
-		filter:      storage.Everything,
+		filter:      storage.EverythingFunc,
 		expectedOut: []*api.Pod{storedObj},
 	}, { // test GetToList on non-existing key
 		key:         "/non-existing",
-		filter:      storage.Everything,
+		filter:      storage.EverythingFunc,
 		expectedOut: nil,
 	}, { // test GetToList with filter to reject the pod
 		key: "/non-existing",
@@ -250,7 +250,8 @@ func TestGetToList(t *testing.T) {
 
 	for i, tt := range tests {
 		out := &api.PodList{}
-		err := store.GetToList(ctx, tt.key, tt.filter, out)
+		filter := storage.NewSimpleFilter(tt.filter)
+		err := store.GetToList(ctx, tt.key, filter, out)
 		if err != nil {
 			t.Fatalf("GetToList failed: %v", err)
 		}
@@ -487,15 +488,15 @@ func TestList(t *testing.T) {
 
 	tests := []struct {
 		prefix      string
-		filter      storage.FilterFunc
+		filter      func(runtime.Object) bool
 		expectedOut []*api.Pod
 	}{{ // test List on existing key
 		prefix:      "/one-level/",
-		filter:      storage.Everything,
+		filter:      storage.EverythingFunc,
 		expectedOut: []*api.Pod{preset[0].storedObj},
 	}, { // test List on non-existing key
 		prefix:      "/non-existing/",
-		filter:      storage.Everything,
+		filter:      storage.EverythingFunc,
 		expectedOut: nil,
 	}, { // test List with filter
 		prefix: "/one-level/",
@@ -509,13 +510,14 @@ func TestList(t *testing.T) {
 		expectedOut: nil,
 	}, { // test List with multiple levels of directories and expect flattened result
 		prefix:      "/two-level/",
-		filter:      storage.Everything,
+		filter:      storage.EverythingFunc,
 		expectedOut: []*api.Pod{preset[1].storedObj, preset[2].storedObj},
 	}}
 
 	for i, tt := range tests {
 		out := &api.PodList{}
-		err := store.List(ctx, tt.prefix, "0", tt.filter, out)
+		filter := storage.NewSimpleFilter(tt.filter)
+		err := store.List(ctx, tt.prefix, "0", filter, out)
 		if err != nil {
 			t.Fatalf("List failed: %v", err)
 		}

--- a/pkg/storage/etcd3/store_test.go
+++ b/pkg/storage/etcd3/store_test.go
@@ -227,14 +227,17 @@ func TestGetToList(t *testing.T) {
 	tests := []struct {
 		key         string
 		filter      func(runtime.Object) bool
+		trigger     func() []storage.MatchValue
 		expectedOut []*api.Pod
 	}{{ // test GetToList on existing key
 		key:         key,
 		filter:      storage.EverythingFunc,
+		trigger:     storage.NoTriggerFunc,
 		expectedOut: []*api.Pod{storedObj},
 	}, { // test GetToList on non-existing key
 		key:         "/non-existing",
 		filter:      storage.EverythingFunc,
+		trigger:     storage.NoTriggerFunc,
 		expectedOut: nil,
 	}, { // test GetToList with filter to reject the pod
 		key: "/non-existing",
@@ -245,12 +248,13 @@ func TestGetToList(t *testing.T) {
 			}
 			return pod.Name != storedObj.Name
 		},
+		trigger:     storage.NoTriggerFunc,
 		expectedOut: nil,
 	}}
 
 	for i, tt := range tests {
 		out := &api.PodList{}
-		filter := storage.NewSimpleFilter(tt.filter)
+		filter := storage.NewSimpleFilter(tt.filter, tt.trigger)
 		err := store.GetToList(ctx, tt.key, filter, out)
 		if err != nil {
 			t.Fatalf("GetToList failed: %v", err)
@@ -489,14 +493,17 @@ func TestList(t *testing.T) {
 	tests := []struct {
 		prefix      string
 		filter      func(runtime.Object) bool
+		trigger     func() []storage.MatchValue
 		expectedOut []*api.Pod
 	}{{ // test List on existing key
 		prefix:      "/one-level/",
 		filter:      storage.EverythingFunc,
+		trigger:     storage.NoTriggerFunc,
 		expectedOut: []*api.Pod{preset[0].storedObj},
 	}, { // test List on non-existing key
 		prefix:      "/non-existing/",
 		filter:      storage.EverythingFunc,
+		trigger:     storage.NoTriggerFunc,
 		expectedOut: nil,
 	}, { // test List with filter
 		prefix: "/one-level/",
@@ -507,16 +514,18 @@ func TestList(t *testing.T) {
 			}
 			return pod.Name != preset[0].storedObj.Name
 		},
+		trigger:     storage.NoTriggerFunc,
 		expectedOut: nil,
 	}, { // test List with multiple levels of directories and expect flattened result
 		prefix:      "/two-level/",
 		filter:      storage.EverythingFunc,
+		trigger:     storage.NoTriggerFunc,
 		expectedOut: []*api.Pod{preset[1].storedObj, preset[2].storedObj},
 	}}
 
 	for i, tt := range tests {
 		out := &api.PodList{}
-		filter := storage.NewSimpleFilter(tt.filter)
+		filter := storage.NewSimpleFilter(tt.filter, tt.trigger)
 		err := store.List(ctx, tt.prefix, "0", filter, out)
 		if err != nil {
 			t.Fatalf("List failed: %v", err)

--- a/pkg/storage/etcd3/watcher.go
+++ b/pkg/storage/etcd3/watcher.go
@@ -53,7 +53,7 @@ type watchChan struct {
 	key               string
 	initialRev        int64
 	recursive         bool
-	filter            storage.FilterFunc
+	filter            storage.Filter
 	ctx               context.Context
 	cancel            context.CancelFunc
 	incomingEventChan chan *event
@@ -76,7 +76,7 @@ func newWatcher(client *clientv3.Client, codec runtime.Codec, versioner storage.
 // If recursive is false, it watches on given key.
 // If recursive is true, it watches any children and directories under the key, excluding the root key itself.
 // filter must be non-nil. Only if filter returns true will the changes be returned.
-func (w *watcher) Watch(ctx context.Context, key string, rev int64, recursive bool, filter storage.FilterFunc) (watch.Interface, error) {
+func (w *watcher) Watch(ctx context.Context, key string, rev int64, recursive bool, filter storage.Filter) (watch.Interface, error) {
 	if recursive && !strings.HasSuffix(key, "/") {
 		key += "/"
 	}
@@ -85,7 +85,7 @@ func (w *watcher) Watch(ctx context.Context, key string, rev int64, recursive bo
 	return wc, nil
 }
 
-func (w *watcher) createWatchChan(ctx context.Context, key string, rev int64, recursive bool, filter storage.FilterFunc) *watchChan {
+func (w *watcher) createWatchChan(ctx context.Context, key string, rev int64, recursive bool, filter storage.Filter) *watchChan {
 	wc := &watchChan{
 		watcher:           w,
 		key:               key,
@@ -221,7 +221,7 @@ func (wc *watchChan) transform(e *event) (res *watch.Event) {
 
 	switch {
 	case e.isDeleted:
-		if !wc.filter(oldObj) {
+		if !wc.filter.Filter(oldObj) {
 			return nil
 		}
 		res = &watch.Event{
@@ -229,7 +229,7 @@ func (wc *watchChan) transform(e *event) (res *watch.Event) {
 			Object: oldObj,
 		}
 	case e.isCreated:
-		if !wc.filter(curObj) {
+		if !wc.filter.Filter(curObj) {
 			return nil
 		}
 		res = &watch.Event{
@@ -237,8 +237,8 @@ func (wc *watchChan) transform(e *event) (res *watch.Event) {
 			Object: curObj,
 		}
 	default:
-		curObjPasses := wc.filter(curObj)
-		oldObjPasses := wc.filter(oldObj)
+		curObjPasses := wc.filter.Filter(curObj)
+		oldObjPasses := wc.filter.Filter(oldObj)
 		switch {
 		case curObjPasses && oldObjPasses:
 			res = &watch.Event{

--- a/pkg/storage/etcd3/watcher_test.go
+++ b/pkg/storage/etcd3/watcher_test.go
@@ -58,15 +58,18 @@ func testWatch(t *testing.T, recursive bool) {
 	tests := []struct {
 		key        string
 		filter     func(runtime.Object) bool
+		trigger    func() []storage.MatchValue
 		watchTests []*testWatchStruct
 	}{{ // create a key
 		key:        "/somekey-1",
 		watchTests: []*testWatchStruct{{podFoo, true, watch.Added}},
 		filter:     storage.EverythingFunc,
+		trigger:    storage.NoTriggerFunc,
 	}, { // create a key but obj gets filtered
 		key:        "/somekey-2",
 		watchTests: []*testWatchStruct{{podFoo, false, ""}},
 		filter:     func(runtime.Object) bool { return false },
+		trigger:    storage.NoTriggerFunc,
 	}, { // create a key but obj gets filtered. Then update it with unfiltered obj
 		key:        "/somekey-3",
 		watchTests: []*testWatchStruct{{podFoo, false, ""}, {podBar, true, watch.Added}},
@@ -74,10 +77,12 @@ func testWatch(t *testing.T, recursive bool) {
 			pod := obj.(*api.Pod)
 			return pod.Name == "bar"
 		},
+		trigger: storage.NoTriggerFunc,
 	}, { // update
 		key:        "/somekey-4",
 		watchTests: []*testWatchStruct{{podFoo, true, watch.Added}, {podBar, true, watch.Modified}},
 		filter:     storage.EverythingFunc,
+		trigger:    storage.NoTriggerFunc,
 	}, { // delete because of being filtered
 		key:        "/somekey-5",
 		watchTests: []*testWatchStruct{{podFoo, true, watch.Added}, {podBar, true, watch.Deleted}},
@@ -85,9 +90,10 @@ func testWatch(t *testing.T, recursive bool) {
 			pod := obj.(*api.Pod)
 			return pod.Name != "bar"
 		},
+		trigger: storage.NoTriggerFunc,
 	}}
 	for i, tt := range tests {
-		filter := storage.NewSimpleFilter(tt.filter)
+		filter := storage.NewSimpleFilter(tt.filter, tt.trigger)
 		w, err := store.watch(ctx, tt.key, "0", filter, recursive)
 		if err != nil {
 			t.Fatalf("Watch failed: %v", err)

--- a/pkg/storage/etcd3/watcher_test.go
+++ b/pkg/storage/etcd3/watcher_test.go
@@ -57,12 +57,12 @@ func testWatch(t *testing.T, recursive bool) {
 
 	tests := []struct {
 		key        string
-		filter     storage.FilterFunc
+		filter     func(runtime.Object) bool
 		watchTests []*testWatchStruct
 	}{{ // create a key
 		key:        "/somekey-1",
 		watchTests: []*testWatchStruct{{podFoo, true, watch.Added}},
-		filter:     storage.Everything,
+		filter:     storage.EverythingFunc,
 	}, { // create a key but obj gets filtered
 		key:        "/somekey-2",
 		watchTests: []*testWatchStruct{{podFoo, false, ""}},
@@ -77,7 +77,7 @@ func testWatch(t *testing.T, recursive bool) {
 	}, { // update
 		key:        "/somekey-4",
 		watchTests: []*testWatchStruct{{podFoo, true, watch.Added}, {podBar, true, watch.Modified}},
-		filter:     storage.Everything,
+		filter:     storage.EverythingFunc,
 	}, { // delete because of being filtered
 		key:        "/somekey-5",
 		watchTests: []*testWatchStruct{{podFoo, true, watch.Added}, {podBar, true, watch.Deleted}},
@@ -87,7 +87,8 @@ func testWatch(t *testing.T, recursive bool) {
 		},
 	}}
 	for i, tt := range tests {
-		w, err := store.watch(ctx, tt.key, "0", tt.filter, recursive)
+		filter := storage.NewSimpleFilter(tt.filter)
+		w, err := store.watch(ctx, tt.key, "0", filter, recursive)
 		if err != nil {
 			t.Fatalf("Watch failed: %v", err)
 		}

--- a/pkg/storage/interfaces.go
+++ b/pkg/storage/interfaces.go
@@ -51,12 +51,21 @@ type ResponseMeta struct {
 	ResourceVersion uint64
 }
 
-// FilterFunc is a predicate which takes an API object and returns true
-// if and only if the object should remain in the set.
-type FilterFunc func(obj runtime.Object) bool
+// Filter is interface that is used to pass filtering mechanism.
+type Filter interface {
+	// Filter is a predicate which takes an API object and returns true
+	// if and only if the object should remain in the set.
+	Filter(obj runtime.Object) bool
+}
 
-// Everything is a FilterFunc which accepts all objects.
-func Everything(runtime.Object) bool {
+// Everything is a Filter which accepts all objects.
+var Everything Filter = everything{}
+
+// everything is implementation of Everything.
+type everything struct {
+}
+
+func (e everything) Filter(_ runtime.Object) bool {
 	return true
 }
 
@@ -102,14 +111,14 @@ type Interface interface {
 	// resourceVersion may be used to specify what version to begin watching,
 	// which should be the current resourceVersion, and no longer rv+1
 	// (e.g. reconnecting without missing any updates).
-	Watch(ctx context.Context, key string, resourceVersion string, filter FilterFunc) (watch.Interface, error)
+	Watch(ctx context.Context, key string, resourceVersion string, filter Filter) (watch.Interface, error)
 
 	// WatchList begins watching the specified key's items. Items are decoded into API
 	// objects and any item passing 'filter' are sent down to returned watch.Interface.
 	// resourceVersion may be used to specify what version to begin watching,
 	// which should be the current resourceVersion, and no longer rv+1
 	// (e.g. reconnecting without missing any updates).
-	WatchList(ctx context.Context, key string, resourceVersion string, filter FilterFunc) (watch.Interface, error)
+	WatchList(ctx context.Context, key string, resourceVersion string, filter Filter) (watch.Interface, error)
 
 	// Get unmarshals json found at key into objPtr. On a not found error, will either
 	// return a zero object of the requested type, or an error, depending on ignoreNotFound.
@@ -118,13 +127,13 @@ type Interface interface {
 
 	// GetToList unmarshals json found at key and opaque it into *List api object
 	// (an object that satisfies the runtime.IsList definition).
-	GetToList(ctx context.Context, key string, filter FilterFunc, listObj runtime.Object) error
+	GetToList(ctx context.Context, key string, filter Filter, listObj runtime.Object) error
 
 	// List unmarshalls jsons found at directory defined by key and opaque them
 	// into *List api object (an object that satisfies runtime.IsList definition).
 	// The returned contents may be delayed, but it is guaranteed that they will
 	// be have at least 'resourceVersion'.
-	List(ctx context.Context, key string, resourceVersion string, filter FilterFunc, listObj runtime.Object) error
+	List(ctx context.Context, key string, resourceVersion string, filter Filter, listObj runtime.Object) error
 
 	// GuaranteedUpdate keeps calling 'tryUpdate()' to update key 'key' (of type 'ptrToType')
 	// retrying the update until success if there is index conflict.

--- a/pkg/storage/util.go
+++ b/pkg/storage/util.go
@@ -36,6 +36,25 @@ func SimpleUpdate(fn SimpleUpdateFunc) UpdateFunc {
 	}
 }
 
+// SimpleFilter implements Filter interface.
+type SimpleFilter struct {
+	filterFunc func(runtime.Object) bool
+}
+
+func (s *SimpleFilter) Filter(obj runtime.Object) bool {
+	return s.filterFunc(obj)
+}
+
+func NewSimpleFilter(filterFunc func(runtime.Object) bool) Filter {
+	return &SimpleFilter{
+		filterFunc: filterFunc,
+	}
+}
+
+func EverythingFunc(runtime.Object) bool {
+	return true
+}
+
 // ParseWatchResourceVersion takes a resource version argument and converts it to
 // the etcd version we should pass to helper.Watch(). Because resourceVersion is
 // an opaque value, the default watch behavior for non-zero watch is to watch

--- a/pkg/storage/util.go
+++ b/pkg/storage/util.go
@@ -38,21 +38,37 @@ func SimpleUpdate(fn SimpleUpdateFunc) UpdateFunc {
 
 // SimpleFilter implements Filter interface.
 type SimpleFilter struct {
-	filterFunc func(runtime.Object) bool
+	filterFunc  func(runtime.Object) bool
+	triggerFunc func() []MatchValue
 }
 
 func (s *SimpleFilter) Filter(obj runtime.Object) bool {
 	return s.filterFunc(obj)
 }
 
-func NewSimpleFilter(filterFunc func(runtime.Object) bool) Filter {
+func (s *SimpleFilter) Trigger() []MatchValue {
+	return s.triggerFunc()
+}
+
+func NewSimpleFilter(
+	filterFunc func(runtime.Object) bool,
+	triggerFunc func() []MatchValue) Filter {
 	return &SimpleFilter{
-		filterFunc: filterFunc,
+		filterFunc:  filterFunc,
+		triggerFunc: triggerFunc,
 	}
 }
 
 func EverythingFunc(runtime.Object) bool {
 	return true
+}
+
+func NoTriggerFunc() []MatchValue {
+	return nil
+}
+
+func NoTriggerPublisher(runtime.Object) []MatchValue {
+	return nil
 }
 
 // ParseWatchResourceVersion takes a resource version argument and converts it to


### PR DESCRIPTION
This PR adds a first version of indexing in cacher.

It has a really significant impact on performance - **in empty 2000-node cluster, apiserver cpu usage drops by ~75%.**

Not for 1.3, but we need this soon after 1.3 is done.

@lavalamp @mqliang @davidopp @gmarek @kubernetes/sig-scalability 
