### PR TITLE
kubelet/rkt - treat pod container as the infra - only network stats

### DIFF
--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/kubernetes/pkg/client/record"
 	"k8s.io/kubernetes/pkg/credentialprovider"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/kubelet/leaky"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/pkg/kubelet/network"
 	"k8s.io/kubernetes/pkg/kubelet/network/hairpin"
@@ -618,6 +619,7 @@ func (r *Runtime) makePodManifest(pod *api.Pod, podIP string, pullSecrets []api.
 	manifest.Annotations.Set(*appctypes.MustACIdentifier(types.KubernetesPodUIDLabel), string(pod.UID))
 	manifest.Annotations.Set(*appctypes.MustACIdentifier(types.KubernetesPodNameLabel), pod.Name)
 	manifest.Annotations.Set(*appctypes.MustACIdentifier(types.KubernetesPodNamespaceLabel), pod.Namespace)
+	manifest.Annotations.Set(*appctypes.MustACIdentifier(types.KubernetesContainerNameLabel), leaky.PodInfraContainerName)
 	manifest.Annotations.Set(*appctypes.MustACIdentifier(k8sRktRestartCountAnno), strconv.Itoa(restartCount))
 	if stage1Name, ok := pod.Annotations[k8sRktStage1NameAnno]; ok {
 		requiresPrivileged = true

--- a/pkg/kubelet/rkt/rkt_test.go
+++ b/pkg/kubelet/rkt/rkt_test.go
@@ -1755,6 +1755,10 @@ func TestMakePodManifestAnnotations(t *testing.T) {
 			out: &appcschema.PodManifest{
 				Annotations: []appctypes.Annotation{
 					{
+						Name:  "io.kubernetes.container.name",
+						Value: "POD",
+					},
+					{
 						Name:  appctypes.ACIdentifier(k8sRktStage1NameAnno),
 						Value: "stage1-override-img",
 					},
@@ -1787,11 +1791,11 @@ func TestMakePodManifestAnnotations(t *testing.T) {
 		hint := fmt.Sprintf("case #%d", i)
 
 		result, err := r.makePodManifest(testCase.in, "", []api.Secret{})
-		assert.Equal(t, err, testCase.outerr, hint)
+		assert.Equal(t, testCase.outerr, err, hint)
 		if err == nil {
 			sort.Sort(annotationsByName(result.Annotations))
 			sort.Sort(annotationsByName(testCase.out.Annotations))
-			assert.Equal(t, result.Annotations, testCase.out.Annotations, hint)
+			assert.Equal(t, testCase.out.Annotations, result.Annotations, hint)
 		}
 	}
 }


### PR DESCRIPTION
As no "container name" annotation was being applied to the pod as a whole, the rkt pod container didn't have a container name label. This means that in stat/summary it came up as a nameless container that belonged to the pod.

this was problematic as it caused double counting of container stats.

this adds a container name annotation to the pod level which will be overridden during label creation by annotations of the same name at the container level for the containers themselves.

stats/summary will do the right thing as it will treat it the same as the infra container, just get network stats from it.

Suppress #26759

cc @kubernetes/sig-node @kubernetes/rktnetes-maintainers 
