### PR TITLE
[client-gen]Add Patch to clientset

### DIFF
--- a/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup.k8s.io/unversioned/fake/fake_testtype.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup.k8s.io/unversioned/fake/fake_testtype.go
@@ -114,3 +114,14 @@ func (c *FakeTestTypes) Watch(opts api.ListOptions) (watch.Interface, error) {
 		InvokesWatch(core.NewWatchAction(testtypesResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched testType.
+func (c *FakeTestTypes) Patch(name string, pt api.PatchType, data []byte) (result *testgroup_k8s_io.TestType, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(testtypesResource, c.ns, name, data), &testgroup_k8s_io.TestType{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*testgroup_k8s_io.TestType), err
+}

--- a/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup.k8s.io/unversioned/testgroup_test.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup.k8s.io/unversioned/testgroup_test.go
@@ -245,3 +245,25 @@ func TestExpansionInterface(t *testing.T) {
 		t.Errorf("expansion failed")
 	}
 }
+
+func TestPatchTestType(t *testing.T) {
+	ns := api.NamespaceDefault
+	requestTestType := &testgroup.TestType{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "foo",
+			ResourceVersion: "1",
+			Labels: map[string]string{
+				"foo":  "bar",
+				"name": "baz",
+			},
+		},
+	}
+	c := DecoratedSimpleClient{
+		simpleClient: simple.Client{
+			Request:  simple.Request{Method: "PATCH", Path: testHelper.ResourcePath("testtypes", ns, "foo"), Query: simple.BuildQueryValues(nil)},
+			Response: simple.Response{StatusCode: http.StatusOK, Body: requestTestType},
+		},
+	}
+	receivedTestType, err := c.Setup(t).TestTypes(ns).Patch(requestTestType.Name, api.StrategicMergePatchType, []byte{})
+	c.simpleClient.Validate(t, receivedTestType, err)
+}

--- a/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup.k8s.io/unversioned/testtype.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup.k8s.io/unversioned/testtype.go
@@ -38,6 +38,7 @@ type TestTypeInterface interface {
 	Get(name string) (*testgroup_k8s_io.TestType, error)
 	List(opts api.ListOptions) (*testgroup_k8s_io.TestTypeList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *testgroup_k8s_io.TestType, err error)
 	TestTypeExpansion
 }
 
@@ -147,4 +148,17 @@ func (c *testTypes) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("testtypes").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched testType.
+func (c *testTypes) Patch(name string, pt api.PatchType, data []byte) (result *testgroup_k8s_io.TestType, err error) {
+	result = &testgroup_k8s_io.TestType{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("testtypes").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/federation/client/clientset_generated/federation_internalclientset/typed/core/unversioned/fake/fake_service.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/core/unversioned/fake/fake_service.go
@@ -113,3 +113,14 @@ func (c *FakeServices) Watch(opts api.ListOptions) (watch.Interface, error) {
 		InvokesWatch(core.NewWatchAction(servicesResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched service.
+func (c *FakeServices) Patch(name string, pt api.PatchType, data []byte) (result *api.Service, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(servicesResource, c.ns, name, data), &api.Service{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Service), err
+}

--- a/federation/client/clientset_generated/federation_internalclientset/typed/core/unversioned/service.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/core/unversioned/service.go
@@ -37,6 +37,7 @@ type ServiceInterface interface {
 	Get(name string) (*api.Service, error)
 	List(opts api.ListOptions) (*api.ServiceList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *api.Service, err error)
 	ServiceExpansion
 }
 
@@ -146,4 +147,17 @@ func (c *services) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("services").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched service.
+func (c *services) Patch(name string, pt api.PatchType, data []byte) (result *api.Service, err error) {
+	result = &api.Service{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("services").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/federation/client/clientset_generated/federation_internalclientset/typed/federation/unversioned/cluster.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/federation/unversioned/cluster.go
@@ -38,6 +38,7 @@ type ClusterInterface interface {
 	Get(name string) (*federation.Cluster, error)
 	List(opts api.ListOptions) (*federation.ClusterList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *federation.Cluster, err error)
 	ClusterExpansion
 }
 
@@ -137,4 +138,16 @@ func (c *clusters) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("clusters").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched cluster.
+func (c *clusters) Patch(name string, pt api.PatchType, data []byte) (result *federation.Cluster, err error) {
+	result = &federation.Cluster{}
+	err = c.client.Patch(pt).
+		Resource("clusters").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/federation/client/clientset_generated/federation_internalclientset/typed/federation/unversioned/fake/fake_cluster.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/federation/unversioned/fake/fake_cluster.go
@@ -106,3 +106,13 @@ func (c *FakeClusters) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(core.NewRootWatchAction(clustersResource, opts))
 }
+
+// Patch applies the patch and returns the patched cluster.
+func (c *FakeClusters) Patch(name string, pt api.PatchType, data []byte) (result *federation.Cluster, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootPatchAction(clustersResource, name, data), &federation.Cluster{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*federation.Cluster), err
+}

--- a/federation/client/clientset_generated/federation_release_1_3/typed/core/v1/fake/fake_service.go
+++ b/federation/client/clientset_generated/federation_release_1_3/typed/core/v1/fake/fake_service.go
@@ -114,3 +114,14 @@ func (c *FakeServices) Watch(opts api.ListOptions) (watch.Interface, error) {
 		InvokesWatch(core.NewWatchAction(servicesResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched service.
+func (c *FakeServices) Patch(name string, pt api.PatchType, data []byte) (result *v1.Service, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(servicesResource, c.ns, name, data), &v1.Service{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1.Service), err
+}

--- a/federation/client/clientset_generated/federation_release_1_3/typed/core/v1/service.go
+++ b/federation/client/clientset_generated/federation_release_1_3/typed/core/v1/service.go
@@ -38,6 +38,7 @@ type ServiceInterface interface {
 	Get(name string) (*v1.Service, error)
 	List(opts api.ListOptions) (*v1.ServiceList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *v1.Service, err error)
 	ServiceExpansion
 }
 
@@ -147,4 +148,17 @@ func (c *services) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("services").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched service.
+func (c *services) Patch(name string, pt api.PatchType, data []byte) (result *v1.Service, err error) {
+	result = &v1.Service{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("services").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/federation/client/clientset_generated/federation_release_1_3/typed/federation/v1alpha1/cluster.go
+++ b/federation/client/clientset_generated/federation_release_1_3/typed/federation/v1alpha1/cluster.go
@@ -38,6 +38,7 @@ type ClusterInterface interface {
 	Get(name string) (*v1alpha1.Cluster, error)
 	List(opts api.ListOptions) (*v1alpha1.ClusterList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *v1alpha1.Cluster, err error)
 	ClusterExpansion
 }
 
@@ -137,4 +138,16 @@ func (c *clusters) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("clusters").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched cluster.
+func (c *clusters) Patch(name string, pt api.PatchType, data []byte) (result *v1alpha1.Cluster, err error) {
+	result = &v1alpha1.Cluster{}
+	err = c.client.Patch(pt).
+		Resource("clusters").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/federation/client/clientset_generated/federation_release_1_3/typed/federation/v1alpha1/fake/fake_cluster.go
+++ b/federation/client/clientset_generated/federation_release_1_3/typed/federation/v1alpha1/fake/fake_cluster.go
@@ -106,3 +106,13 @@ func (c *FakeClusters) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(core.NewRootWatchAction(clustersResource, opts))
 }
+
+// Patch applies the patch and returns the patched cluster.
+func (c *FakeClusters) Patch(name string, pt api.PatchType, data []byte) (result *v1alpha1.Cluster, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootPatchAction(clustersResource, name, data), &v1alpha1.Cluster{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1alpha1.Cluster), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/autoscaling/unversioned/fake/fake_horizontalpodautoscaler.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/autoscaling/unversioned/fake/fake_horizontalpodautoscaler.go
@@ -114,3 +114,14 @@ func (c *FakeHorizontalPodAutoscalers) Watch(opts api.ListOptions) (watch.Interf
 		InvokesWatch(core.NewWatchAction(horizontalpodautoscalersResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched horizontalPodAutoscaler.
+func (c *FakeHorizontalPodAutoscalers) Patch(name string, pt api.PatchType, data []byte) (result *autoscaling.HorizontalPodAutoscaler, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(horizontalpodautoscalersResource, c.ns, name, data), &autoscaling.HorizontalPodAutoscaler{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*autoscaling.HorizontalPodAutoscaler), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/autoscaling/unversioned/horizontalpodautoscaler.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/autoscaling/unversioned/horizontalpodautoscaler.go
@@ -38,6 +38,7 @@ type HorizontalPodAutoscalerInterface interface {
 	Get(name string) (*autoscaling.HorizontalPodAutoscaler, error)
 	List(opts api.ListOptions) (*autoscaling.HorizontalPodAutoscalerList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *autoscaling.HorizontalPodAutoscaler, err error)
 	HorizontalPodAutoscalerExpansion
 }
 
@@ -147,4 +148,17 @@ func (c *horizontalPodAutoscalers) Watch(opts api.ListOptions) (watch.Interface,
 		Resource("horizontalpodautoscalers").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched horizontalPodAutoscaler.
+func (c *horizontalPodAutoscalers) Patch(name string, pt api.PatchType, data []byte) (result *autoscaling.HorizontalPodAutoscaler, err error) {
+	result = &autoscaling.HorizontalPodAutoscaler{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("horizontalpodautoscalers").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/fake/fake_job.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/fake/fake_job.go
@@ -114,3 +114,14 @@ func (c *FakeJobs) Watch(opts api.ListOptions) (watch.Interface, error) {
 		InvokesWatch(core.NewWatchAction(jobsResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched job.
+func (c *FakeJobs) Patch(name string, pt api.PatchType, data []byte) (result *batch.Job, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(jobsResource, c.ns, name, data), &batch.Job{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*batch.Job), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/fake/fake_scheduledjob.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/fake/fake_scheduledjob.go
@@ -114,3 +114,14 @@ func (c *FakeScheduledJobs) Watch(opts api.ListOptions) (watch.Interface, error)
 		InvokesWatch(core.NewWatchAction(scheduledjobsResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched scheduledJob.
+func (c *FakeScheduledJobs) Patch(name string, pt api.PatchType, data []byte) (result *batch.ScheduledJob, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(scheduledjobsResource, c.ns, name, data), &batch.ScheduledJob{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*batch.ScheduledJob), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/job.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/job.go
@@ -38,6 +38,7 @@ type JobInterface interface {
 	Get(name string) (*batch.Job, error)
 	List(opts api.ListOptions) (*batch.JobList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *batch.Job, err error)
 	JobExpansion
 }
 
@@ -147,4 +148,17 @@ func (c *jobs) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("jobs").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched job.
+func (c *jobs) Patch(name string, pt api.PatchType, data []byte) (result *batch.Job, err error) {
+	result = &batch.Job{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("jobs").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/scheduledjob.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/batch/unversioned/scheduledjob.go
@@ -38,6 +38,7 @@ type ScheduledJobInterface interface {
 	Get(name string) (*batch.ScheduledJob, error)
 	List(opts api.ListOptions) (*batch.ScheduledJobList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *batch.ScheduledJob, err error)
 	ScheduledJobExpansion
 }
 
@@ -147,4 +148,17 @@ func (c *scheduledJobs) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("scheduledjobs").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched scheduledJob.
+func (c *scheduledJobs) Patch(name string, pt api.PatchType, data []byte) (result *batch.ScheduledJob, err error) {
+	result = &batch.ScheduledJob{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("scheduledjobs").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/componentstatus.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/componentstatus.go
@@ -36,6 +36,7 @@ type ComponentStatusInterface interface {
 	Get(name string) (*api.ComponentStatus, error)
 	List(opts api.ListOptions) (*api.ComponentStatusList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *api.ComponentStatus, err error)
 	ComponentStatusExpansion
 }
 
@@ -123,4 +124,16 @@ func (c *componentStatuses) Watch(opts api.ListOptions) (watch.Interface, error)
 		Resource("componentstatuses").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched componentStatus.
+func (c *componentStatuses) Patch(name string, pt api.PatchType, data []byte) (result *api.ComponentStatus, err error) {
+	result = &api.ComponentStatus{}
+	err = c.client.Patch(pt).
+		Resource("componentstatuses").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/configmap.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/configmap.go
@@ -36,6 +36,7 @@ type ConfigMapInterface interface {
 	Get(name string) (*api.ConfigMap, error)
 	List(opts api.ListOptions) (*api.ConfigMapList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *api.ConfigMap, err error)
 	ConfigMapExpansion
 }
 
@@ -132,4 +133,17 @@ func (c *configMaps) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("configmaps").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched configMap.
+func (c *configMaps) Patch(name string, pt api.PatchType, data []byte) (result *api.ConfigMap, err error) {
+	result = &api.ConfigMap{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("configmaps").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/endpoints.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/endpoints.go
@@ -36,6 +36,7 @@ type EndpointsInterface interface {
 	Get(name string) (*api.Endpoints, error)
 	List(opts api.ListOptions) (*api.EndpointsList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *api.Endpoints, err error)
 	EndpointsExpansion
 }
 
@@ -132,4 +133,17 @@ func (c *endpoints) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("endpoints").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched endpoints.
+func (c *endpoints) Patch(name string, pt api.PatchType, data []byte) (result *api.Endpoints, err error) {
+	result = &api.Endpoints{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("endpoints").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/event.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/event.go
@@ -36,6 +36,7 @@ type EventInterface interface {
 	Get(name string) (*api.Event, error)
 	List(opts api.ListOptions) (*api.EventList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *api.Event, err error)
 	EventExpansion
 }
 
@@ -132,4 +133,17 @@ func (c *events) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("events").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched event.
+func (c *events) Patch(name string, pt api.PatchType, data []byte) (result *api.Event, err error) {
+	result = &api.Event{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("events").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/event_expansion.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/event_expansion.go
@@ -30,7 +30,7 @@ type EventExpansion interface {
 	CreateWithEventNamespace(event *api.Event) (*api.Event, error)
 	// UpdateWithEventNamespace is the same as a Update, except that it sends the request to the event.Namespace.
 	UpdateWithEventNamespace(event *api.Event) (*api.Event, error)
-	Patch(event *api.Event, data []byte) (*api.Event, error)
+	PatchWithEventNamespace(event *api.Event, data []byte) (*api.Event, error)
 	// Search finds events about the specified object
 	Search(objOrRef runtime.Object) (*api.EventList, error)
 	// Returns the appropriate field selector based on the API version being used to communicate with the server.
@@ -73,11 +73,15 @@ func (e *events) UpdateWithEventNamespace(event *api.Event) (*api.Event, error) 
 	return result, err
 }
 
-// Patch modifies an existing event. It returns the copy of the event that the server returns, or an
-// error. The namespace and name of the target event is deduced from the incompleteEvent. The
-// namespace must either match this event client's namespace, or this event client must have been
+// PatchWithEventNamespace modifies an existing event. It returns the copy of
+// the event that the server returns, or an error. The namespace and name of the
+// target event is deduced from the incompleteEvent. The namespace must either
+// match this event client's namespace, or this event client must have been
 // created with the "" namespace.
-func (e *events) Patch(incompleteEvent *api.Event, data []byte) (*api.Event, error) {
+func (e *events) PatchWithEventNamespace(incompleteEvent *api.Event, data []byte) (*api.Event, error) {
+	if e.ns != "" && incompleteEvent.Namespace != e.ns {
+		return nil, fmt.Errorf("can't patch an event with namespace '%v' in namespace '%v'", incompleteEvent.Namespace, e.ns)
+	}
 	result := &api.Event{}
 	err := e.client.Patch(api.StrategicMergePatchType).
 		NamespaceIfScoped(incompleteEvent.Namespace, len(incompleteEvent.Namespace) > 0).
@@ -153,5 +157,5 @@ func (e *EventSinkImpl) Update(event *api.Event) (*api.Event, error) {
 }
 
 func (e *EventSinkImpl) Patch(event *api.Event, data []byte) (*api.Event, error) {
-	return e.Interface.Patch(event, data)
+	return e.Interface.PatchWithEventNamespace(event, data)
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_componentstatus.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_componentstatus.go
@@ -96,3 +96,13 @@ func (c *FakeComponentStatuses) Watch(opts api.ListOptions) (watch.Interface, er
 	return c.Fake.
 		InvokesWatch(core.NewRootWatchAction(componentstatusesResource, opts))
 }
+
+// Patch applies the patch and returns the patched componentStatus.
+func (c *FakeComponentStatuses) Patch(name string, pt api.PatchType, data []byte) (result *api.ComponentStatus, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootPatchAction(componentstatusesResource, name, data), &api.ComponentStatus{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ComponentStatus), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_configmap.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_configmap.go
@@ -103,3 +103,14 @@ func (c *FakeConfigMaps) Watch(opts api.ListOptions) (watch.Interface, error) {
 		InvokesWatch(core.NewWatchAction(configmapsResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched configMap.
+func (c *FakeConfigMaps) Patch(name string, pt api.PatchType, data []byte) (result *api.ConfigMap, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(configmapsResource, c.ns, name, data), &api.ConfigMap{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ConfigMap), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_endpoints.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_endpoints.go
@@ -103,3 +103,14 @@ func (c *FakeEndpoints) Watch(opts api.ListOptions) (watch.Interface, error) {
 		InvokesWatch(core.NewWatchAction(endpointsResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched endpoints.
+func (c *FakeEndpoints) Patch(name string, pt api.PatchType, data []byte) (result *api.Endpoints, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(endpointsResource, c.ns, name, data), &api.Endpoints{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Endpoints), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_event.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_event.go
@@ -103,3 +103,14 @@ func (c *FakeEvents) Watch(opts api.ListOptions) (watch.Interface, error) {
 		InvokesWatch(core.NewWatchAction(eventsResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched event.
+func (c *FakeEvents) Patch(name string, pt api.PatchType, data []byte) (result *api.Event, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(eventsResource, c.ns, name, data), &api.Event{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Event), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_event_expansion.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_event_expansion.go
@@ -50,11 +50,11 @@ func (c *FakeEvents) UpdateWithEventNamespace(event *api.Event) (*api.Event, err
 	return obj.(*api.Event), err
 }
 
-// Patch patches an existing event. Returns the copy of the event the server returns, or an error.
-func (c *FakeEvents) Patch(event *api.Event, data []byte) (*api.Event, error) {
-	action := core.NewRootPatchAction(eventsResource, event)
+// PatchWithEventNamespace patches an existing event. Returns the copy of the event the server returns, or an error.
+func (c *FakeEvents) PatchWithEventNamespace(event *api.Event, data []byte) (*api.Event, error) {
+	action := core.NewRootPatchAction(eventsResource, event.Name, data)
 	if c.ns != "" {
-		action = core.NewPatchAction(eventsResource, c.ns, event)
+		action = core.NewPatchAction(eventsResource, c.ns, event.Name, data)
 	}
 	obj, err := c.Fake.Invokes(action, event)
 	if obj == nil {

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_limitrange.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_limitrange.go
@@ -103,3 +103,14 @@ func (c *FakeLimitRanges) Watch(opts api.ListOptions) (watch.Interface, error) {
 		InvokesWatch(core.NewWatchAction(limitrangesResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched limitRange.
+func (c *FakeLimitRanges) Patch(name string, pt api.PatchType, data []byte) (result *api.LimitRange, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(limitrangesResource, c.ns, name, data), &api.LimitRange{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.LimitRange), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_namespace.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_namespace.go
@@ -105,3 +105,13 @@ func (c *FakeNamespaces) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(core.NewRootWatchAction(namespacesResource, opts))
 }
+
+// Patch applies the patch and returns the patched namespace.
+func (c *FakeNamespaces) Patch(name string, pt api.PatchType, data []byte) (result *api.Namespace, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootPatchAction(namespacesResource, name, data), &api.Namespace{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Namespace), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_node.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_node.go
@@ -105,3 +105,13 @@ func (c *FakeNodes) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(core.NewRootWatchAction(nodesResource, opts))
 }
+
+// Patch applies the patch and returns the patched node.
+func (c *FakeNodes) Patch(name string, pt api.PatchType, data []byte) (result *api.Node, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootPatchAction(nodesResource, name, data), &api.Node{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Node), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_persistentvolume.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_persistentvolume.go
@@ -105,3 +105,13 @@ func (c *FakePersistentVolumes) Watch(opts api.ListOptions) (watch.Interface, er
 	return c.Fake.
 		InvokesWatch(core.NewRootWatchAction(persistentvolumesResource, opts))
 }
+
+// Patch applies the patch and returns the patched persistentVolume.
+func (c *FakePersistentVolumes) Patch(name string, pt api.PatchType, data []byte) (result *api.PersistentVolume, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootPatchAction(persistentvolumesResource, name, data), &api.PersistentVolume{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.PersistentVolume), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_persistentvolumeclaim.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_persistentvolumeclaim.go
@@ -113,3 +113,14 @@ func (c *FakePersistentVolumeClaims) Watch(opts api.ListOptions) (watch.Interfac
 		InvokesWatch(core.NewWatchAction(persistentvolumeclaimsResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched persistentVolumeClaim.
+func (c *FakePersistentVolumeClaims) Patch(name string, pt api.PatchType, data []byte) (result *api.PersistentVolumeClaim, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(persistentvolumeclaimsResource, c.ns, name, data), &api.PersistentVolumeClaim{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.PersistentVolumeClaim), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_pod.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_pod.go
@@ -113,3 +113,14 @@ func (c *FakePods) Watch(opts api.ListOptions) (watch.Interface, error) {
 		InvokesWatch(core.NewWatchAction(podsResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched pod.
+func (c *FakePods) Patch(name string, pt api.PatchType, data []byte) (result *api.Pod, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(podsResource, c.ns, name, data), &api.Pod{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Pod), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_podtemplate.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_podtemplate.go
@@ -103,3 +103,14 @@ func (c *FakePodTemplates) Watch(opts api.ListOptions) (watch.Interface, error) 
 		InvokesWatch(core.NewWatchAction(podtemplatesResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched podTemplate.
+func (c *FakePodTemplates) Patch(name string, pt api.PatchType, data []byte) (result *api.PodTemplate, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(podtemplatesResource, c.ns, name, data), &api.PodTemplate{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.PodTemplate), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_replicationcontroller.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_replicationcontroller.go
@@ -113,3 +113,14 @@ func (c *FakeReplicationControllers) Watch(opts api.ListOptions) (watch.Interfac
 		InvokesWatch(core.NewWatchAction(replicationcontrollersResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched replicationController.
+func (c *FakeReplicationControllers) Patch(name string, pt api.PatchType, data []byte) (result *api.ReplicationController, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(replicationcontrollersResource, c.ns, name, data), &api.ReplicationController{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ReplicationController), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_resourcequota.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_resourcequota.go
@@ -113,3 +113,14 @@ func (c *FakeResourceQuotas) Watch(opts api.ListOptions) (watch.Interface, error
 		InvokesWatch(core.NewWatchAction(resourcequotasResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched resourceQuota.
+func (c *FakeResourceQuotas) Patch(name string, pt api.PatchType, data []byte) (result *api.ResourceQuota, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(resourcequotasResource, c.ns, name, data), &api.ResourceQuota{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ResourceQuota), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_secret.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_secret.go
@@ -103,3 +103,14 @@ func (c *FakeSecrets) Watch(opts api.ListOptions) (watch.Interface, error) {
 		InvokesWatch(core.NewWatchAction(secretsResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched secret.
+func (c *FakeSecrets) Patch(name string, pt api.PatchType, data []byte) (result *api.Secret, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(secretsResource, c.ns, name, data), &api.Secret{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Secret), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_service.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_service.go
@@ -113,3 +113,14 @@ func (c *FakeServices) Watch(opts api.ListOptions) (watch.Interface, error) {
 		InvokesWatch(core.NewWatchAction(servicesResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched service.
+func (c *FakeServices) Patch(name string, pt api.PatchType, data []byte) (result *api.Service, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(servicesResource, c.ns, name, data), &api.Service{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Service), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_serviceaccount.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_serviceaccount.go
@@ -103,3 +103,14 @@ func (c *FakeServiceAccounts) Watch(opts api.ListOptions) (watch.Interface, erro
 		InvokesWatch(core.NewWatchAction(serviceaccountsResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched serviceAccount.
+func (c *FakeServiceAccounts) Patch(name string, pt api.PatchType, data []byte) (result *api.ServiceAccount, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(serviceaccountsResource, c.ns, name, data), &api.ServiceAccount{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ServiceAccount), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/limitrange.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/limitrange.go
@@ -36,6 +36,7 @@ type LimitRangeInterface interface {
 	Get(name string) (*api.LimitRange, error)
 	List(opts api.ListOptions) (*api.LimitRangeList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *api.LimitRange, err error)
 	LimitRangeExpansion
 }
 
@@ -132,4 +133,17 @@ func (c *limitRanges) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("limitranges").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched limitRange.
+func (c *limitRanges) Patch(name string, pt api.PatchType, data []byte) (result *api.LimitRange, err error) {
+	result = &api.LimitRange{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("limitranges").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/namespace.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/namespace.go
@@ -37,6 +37,7 @@ type NamespaceInterface interface {
 	Get(name string) (*api.Namespace, error)
 	List(opts api.ListOptions) (*api.NamespaceList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *api.Namespace, err error)
 	NamespaceExpansion
 }
 
@@ -136,4 +137,16 @@ func (c *namespaces) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("namespaces").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched namespace.
+func (c *namespaces) Patch(name string, pt api.PatchType, data []byte) (result *api.Namespace, err error) {
+	result = &api.Namespace{}
+	err = c.client.Patch(pt).
+		Resource("namespaces").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/node.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/node.go
@@ -37,6 +37,7 @@ type NodeInterface interface {
 	Get(name string) (*api.Node, error)
 	List(opts api.ListOptions) (*api.NodeList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *api.Node, err error)
 	NodeExpansion
 }
 
@@ -136,4 +137,16 @@ func (c *nodes) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("nodes").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched node.
+func (c *nodes) Patch(name string, pt api.PatchType, data []byte) (result *api.Node, err error) {
+	result = &api.Node{}
+	err = c.client.Patch(pt).
+		Resource("nodes").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/persistentvolume.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/persistentvolume.go
@@ -37,6 +37,7 @@ type PersistentVolumeInterface interface {
 	Get(name string) (*api.PersistentVolume, error)
 	List(opts api.ListOptions) (*api.PersistentVolumeList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *api.PersistentVolume, err error)
 	PersistentVolumeExpansion
 }
 
@@ -136,4 +137,16 @@ func (c *persistentVolumes) Watch(opts api.ListOptions) (watch.Interface, error)
 		Resource("persistentvolumes").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched persistentVolume.
+func (c *persistentVolumes) Patch(name string, pt api.PatchType, data []byte) (result *api.PersistentVolume, err error) {
+	result = &api.PersistentVolume{}
+	err = c.client.Patch(pt).
+		Resource("persistentvolumes").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/persistentvolumeclaim.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/persistentvolumeclaim.go
@@ -37,6 +37,7 @@ type PersistentVolumeClaimInterface interface {
 	Get(name string) (*api.PersistentVolumeClaim, error)
 	List(opts api.ListOptions) (*api.PersistentVolumeClaimList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *api.PersistentVolumeClaim, err error)
 	PersistentVolumeClaimExpansion
 }
 
@@ -146,4 +147,17 @@ func (c *persistentVolumeClaims) Watch(opts api.ListOptions) (watch.Interface, e
 		Resource("persistentvolumeclaims").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched persistentVolumeClaim.
+func (c *persistentVolumeClaims) Patch(name string, pt api.PatchType, data []byte) (result *api.PersistentVolumeClaim, err error) {
+	result = &api.PersistentVolumeClaim{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("persistentvolumeclaims").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/pod.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/pod.go
@@ -37,6 +37,7 @@ type PodInterface interface {
 	Get(name string) (*api.Pod, error)
 	List(opts api.ListOptions) (*api.PodList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *api.Pod, err error)
 	PodExpansion
 }
 
@@ -146,4 +147,17 @@ func (c *pods) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("pods").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched pod.
+func (c *pods) Patch(name string, pt api.PatchType, data []byte) (result *api.Pod, err error) {
+	result = &api.Pod{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("pods").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/podtemplate.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/podtemplate.go
@@ -36,6 +36,7 @@ type PodTemplateInterface interface {
 	Get(name string) (*api.PodTemplate, error)
 	List(opts api.ListOptions) (*api.PodTemplateList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *api.PodTemplate, err error)
 	PodTemplateExpansion
 }
 
@@ -132,4 +133,17 @@ func (c *podTemplates) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("podtemplates").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched podTemplate.
+func (c *podTemplates) Patch(name string, pt api.PatchType, data []byte) (result *api.PodTemplate, err error) {
+	result = &api.PodTemplate{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("podtemplates").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/replicationcontroller.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/replicationcontroller.go
@@ -37,6 +37,7 @@ type ReplicationControllerInterface interface {
 	Get(name string) (*api.ReplicationController, error)
 	List(opts api.ListOptions) (*api.ReplicationControllerList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *api.ReplicationController, err error)
 	ReplicationControllerExpansion
 }
 
@@ -146,4 +147,17 @@ func (c *replicationControllers) Watch(opts api.ListOptions) (watch.Interface, e
 		Resource("replicationcontrollers").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched replicationController.
+func (c *replicationControllers) Patch(name string, pt api.PatchType, data []byte) (result *api.ReplicationController, err error) {
+	result = &api.ReplicationController{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("replicationcontrollers").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/resourcequota.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/resourcequota.go
@@ -37,6 +37,7 @@ type ResourceQuotaInterface interface {
 	Get(name string) (*api.ResourceQuota, error)
 	List(opts api.ListOptions) (*api.ResourceQuotaList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *api.ResourceQuota, err error)
 	ResourceQuotaExpansion
 }
 
@@ -146,4 +147,17 @@ func (c *resourceQuotas) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("resourcequotas").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched resourceQuota.
+func (c *resourceQuotas) Patch(name string, pt api.PatchType, data []byte) (result *api.ResourceQuota, err error) {
+	result = &api.ResourceQuota{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("resourcequotas").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/secret.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/secret.go
@@ -36,6 +36,7 @@ type SecretInterface interface {
 	Get(name string) (*api.Secret, error)
 	List(opts api.ListOptions) (*api.SecretList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *api.Secret, err error)
 	SecretExpansion
 }
 
@@ -132,4 +133,17 @@ func (c *secrets) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("secrets").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched secret.
+func (c *secrets) Patch(name string, pt api.PatchType, data []byte) (result *api.Secret, err error) {
+	result = &api.Secret{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("secrets").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/service.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/service.go
@@ -37,6 +37,7 @@ type ServiceInterface interface {
 	Get(name string) (*api.Service, error)
 	List(opts api.ListOptions) (*api.ServiceList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *api.Service, err error)
 	ServiceExpansion
 }
 
@@ -146,4 +147,17 @@ func (c *services) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("services").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched service.
+func (c *services) Patch(name string, pt api.PatchType, data []byte) (result *api.Service, err error) {
+	result = &api.Service{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("services").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/serviceaccount.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/unversioned/serviceaccount.go
@@ -36,6 +36,7 @@ type ServiceAccountInterface interface {
 	Get(name string) (*api.ServiceAccount, error)
 	List(opts api.ListOptions) (*api.ServiceAccountList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *api.ServiceAccount, err error)
 	ServiceAccountExpansion
 }
 
@@ -132,4 +133,17 @@ func (c *serviceAccounts) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("serviceaccounts").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched serviceAccount.
+func (c *serviceAccounts) Patch(name string, pt api.PatchType, data []byte) (result *api.ServiceAccount, err error) {
+	result = &api.ServiceAccount{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("serviceaccounts").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/daemonset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/daemonset.go
@@ -38,6 +38,7 @@ type DaemonSetInterface interface {
 	Get(name string) (*extensions.DaemonSet, error)
 	List(opts api.ListOptions) (*extensions.DaemonSetList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *extensions.DaemonSet, err error)
 	DaemonSetExpansion
 }
 
@@ -147,4 +148,17 @@ func (c *daemonSets) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("daemonsets").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched daemonSet.
+func (c *daemonSets) Patch(name string, pt api.PatchType, data []byte) (result *extensions.DaemonSet, err error) {
+	result = &extensions.DaemonSet{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("daemonsets").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/deployment.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/deployment.go
@@ -38,6 +38,7 @@ type DeploymentInterface interface {
 	Get(name string) (*extensions.Deployment, error)
 	List(opts api.ListOptions) (*extensions.DeploymentList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *extensions.Deployment, err error)
 	DeploymentExpansion
 }
 
@@ -147,4 +148,17 @@ func (c *deployments) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("deployments").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched deployment.
+func (c *deployments) Patch(name string, pt api.PatchType, data []byte) (result *extensions.Deployment, err error) {
+	result = &extensions.Deployment{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("deployments").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/fake/fake_daemonset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/fake/fake_daemonset.go
@@ -114,3 +114,14 @@ func (c *FakeDaemonSets) Watch(opts api.ListOptions) (watch.Interface, error) {
 		InvokesWatch(core.NewWatchAction(daemonsetsResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched daemonSet.
+func (c *FakeDaemonSets) Patch(name string, pt api.PatchType, data []byte) (result *extensions.DaemonSet, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(daemonsetsResource, c.ns, name, data), &extensions.DaemonSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.DaemonSet), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/fake/fake_deployment.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/fake/fake_deployment.go
@@ -114,3 +114,14 @@ func (c *FakeDeployments) Watch(opts api.ListOptions) (watch.Interface, error) {
 		InvokesWatch(core.NewWatchAction(deploymentsResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched deployment.
+func (c *FakeDeployments) Patch(name string, pt api.PatchType, data []byte) (result *extensions.Deployment, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(deploymentsResource, c.ns, name, data), &extensions.Deployment{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Deployment), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/fake/fake_ingress.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/fake/fake_ingress.go
@@ -114,3 +114,14 @@ func (c *FakeIngresses) Watch(opts api.ListOptions) (watch.Interface, error) {
 		InvokesWatch(core.NewWatchAction(ingressesResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched ingress.
+func (c *FakeIngresses) Patch(name string, pt api.PatchType, data []byte) (result *extensions.Ingress, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(ingressesResource, c.ns, name, data), &extensions.Ingress{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Ingress), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/fake/fake_podsecuritypolicy.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/fake/fake_podsecuritypolicy.go
@@ -97,3 +97,13 @@ func (c *FakePodSecurityPolicies) Watch(opts api.ListOptions) (watch.Interface, 
 	return c.Fake.
 		InvokesWatch(core.NewRootWatchAction(podsecuritypoliciesResource, opts))
 }
+
+// Patch applies the patch and returns the patched podSecurityPolicy.
+func (c *FakePodSecurityPolicies) Patch(name string, pt api.PatchType, data []byte) (result *extensions.PodSecurityPolicy, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootPatchAction(podsecuritypoliciesResource, name, data), &extensions.PodSecurityPolicy{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.PodSecurityPolicy), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/fake/fake_replicaset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/fake/fake_replicaset.go
@@ -114,3 +114,14 @@ func (c *FakeReplicaSets) Watch(opts api.ListOptions) (watch.Interface, error) {
 		InvokesWatch(core.NewWatchAction(replicasetsResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched replicaSet.
+func (c *FakeReplicaSets) Patch(name string, pt api.PatchType, data []byte) (result *extensions.ReplicaSet, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(replicasetsResource, c.ns, name, data), &extensions.ReplicaSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.ReplicaSet), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/fake/fake_thirdpartyresource.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/fake/fake_thirdpartyresource.go
@@ -97,3 +97,13 @@ func (c *FakeThirdPartyResources) Watch(opts api.ListOptions) (watch.Interface, 
 	return c.Fake.
 		InvokesWatch(core.NewRootWatchAction(thirdpartyresourcesResource, opts))
 }
+
+// Patch applies the patch and returns the patched thirdPartyResource.
+func (c *FakeThirdPartyResources) Patch(name string, pt api.PatchType, data []byte) (result *extensions.ThirdPartyResource, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootPatchAction(thirdpartyresourcesResource, name, data), &extensions.ThirdPartyResource{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.ThirdPartyResource), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/ingress.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/ingress.go
@@ -38,6 +38,7 @@ type IngressInterface interface {
 	Get(name string) (*extensions.Ingress, error)
 	List(opts api.ListOptions) (*extensions.IngressList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *extensions.Ingress, err error)
 	IngressExpansion
 }
 
@@ -147,4 +148,17 @@ func (c *ingresses) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("ingresses").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched ingress.
+func (c *ingresses) Patch(name string, pt api.PatchType, data []byte) (result *extensions.Ingress, err error) {
+	result = &extensions.Ingress{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("ingresses").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/podsecuritypolicy.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/podsecuritypolicy.go
@@ -37,6 +37,7 @@ type PodSecurityPolicyInterface interface {
 	Get(name string) (*extensions.PodSecurityPolicy, error)
 	List(opts api.ListOptions) (*extensions.PodSecurityPolicyList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *extensions.PodSecurityPolicy, err error)
 	PodSecurityPolicyExpansion
 }
 
@@ -124,4 +125,16 @@ func (c *podSecurityPolicies) Watch(opts api.ListOptions) (watch.Interface, erro
 		Resource("podsecuritypolicies").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched podSecurityPolicy.
+func (c *podSecurityPolicies) Patch(name string, pt api.PatchType, data []byte) (result *extensions.PodSecurityPolicy, err error) {
+	result = &extensions.PodSecurityPolicy{}
+	err = c.client.Patch(pt).
+		Resource("podsecuritypolicies").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/replicaset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/replicaset.go
@@ -38,6 +38,7 @@ type ReplicaSetInterface interface {
 	Get(name string) (*extensions.ReplicaSet, error)
 	List(opts api.ListOptions) (*extensions.ReplicaSetList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *extensions.ReplicaSet, err error)
 	ReplicaSetExpansion
 }
 
@@ -147,4 +148,17 @@ func (c *replicaSets) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("replicasets").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched replicaSet.
+func (c *replicaSets) Patch(name string, pt api.PatchType, data []byte) (result *extensions.ReplicaSet, err error) {
+	result = &extensions.ReplicaSet{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("replicasets").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/thirdpartyresource.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/thirdpartyresource.go
@@ -37,6 +37,7 @@ type ThirdPartyResourceInterface interface {
 	Get(name string) (*extensions.ThirdPartyResource, error)
 	List(opts api.ListOptions) (*extensions.ThirdPartyResourceList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *extensions.ThirdPartyResource, err error)
 	ThirdPartyResourceExpansion
 }
 
@@ -124,4 +125,16 @@ func (c *thirdPartyResources) Watch(opts api.ListOptions) (watch.Interface, erro
 		Resource("thirdpartyresources").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched thirdPartyResource.
+func (c *thirdPartyResources) Patch(name string, pt api.PatchType, data []byte) (result *extensions.ThirdPartyResource, err error) {
+	result = &extensions.ThirdPartyResource{}
+	err = c.client.Patch(pt).
+		Resource("thirdpartyresources").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/clusterrole.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/clusterrole.go
@@ -37,6 +37,7 @@ type ClusterRoleInterface interface {
 	Get(name string) (*rbac.ClusterRole, error)
 	List(opts api.ListOptions) (*rbac.ClusterRoleList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *rbac.ClusterRole, err error)
 	ClusterRoleExpansion
 }
 
@@ -124,4 +125,16 @@ func (c *clusterRoles) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("clusterroles").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched clusterRole.
+func (c *clusterRoles) Patch(name string, pt api.PatchType, data []byte) (result *rbac.ClusterRole, err error) {
+	result = &rbac.ClusterRole{}
+	err = c.client.Patch(pt).
+		Resource("clusterroles").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/clusterrolebinding.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/clusterrolebinding.go
@@ -37,6 +37,7 @@ type ClusterRoleBindingInterface interface {
 	Get(name string) (*rbac.ClusterRoleBinding, error)
 	List(opts api.ListOptions) (*rbac.ClusterRoleBindingList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *rbac.ClusterRoleBinding, err error)
 	ClusterRoleBindingExpansion
 }
 
@@ -124,4 +125,16 @@ func (c *clusterRoleBindings) Watch(opts api.ListOptions) (watch.Interface, erro
 		Resource("clusterrolebindings").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched clusterRoleBinding.
+func (c *clusterRoleBindings) Patch(name string, pt api.PatchType, data []byte) (result *rbac.ClusterRoleBinding, err error) {
+	result = &rbac.ClusterRoleBinding{}
+	err = c.client.Patch(pt).
+		Resource("clusterrolebindings").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/fake/fake_clusterrole.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/fake/fake_clusterrole.go
@@ -97,3 +97,13 @@ func (c *FakeClusterRoles) Watch(opts api.ListOptions) (watch.Interface, error) 
 	return c.Fake.
 		InvokesWatch(core.NewRootWatchAction(clusterrolesResource, opts))
 }
+
+// Patch applies the patch and returns the patched clusterRole.
+func (c *FakeClusterRoles) Patch(name string, pt api.PatchType, data []byte) (result *rbac.ClusterRole, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootPatchAction(clusterrolesResource, name, data), &rbac.ClusterRole{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*rbac.ClusterRole), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/fake/fake_clusterrolebinding.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/fake/fake_clusterrolebinding.go
@@ -97,3 +97,13 @@ func (c *FakeClusterRoleBindings) Watch(opts api.ListOptions) (watch.Interface, 
 	return c.Fake.
 		InvokesWatch(core.NewRootWatchAction(clusterrolebindingsResource, opts))
 }
+
+// Patch applies the patch and returns the patched clusterRoleBinding.
+func (c *FakeClusterRoleBindings) Patch(name string, pt api.PatchType, data []byte) (result *rbac.ClusterRoleBinding, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootPatchAction(clusterrolebindingsResource, name, data), &rbac.ClusterRoleBinding{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*rbac.ClusterRoleBinding), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/fake/fake_role.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/fake/fake_role.go
@@ -104,3 +104,14 @@ func (c *FakeRoles) Watch(opts api.ListOptions) (watch.Interface, error) {
 		InvokesWatch(core.NewWatchAction(rolesResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched role.
+func (c *FakeRoles) Patch(name string, pt api.PatchType, data []byte) (result *rbac.Role, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(rolesResource, c.ns, name, data), &rbac.Role{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*rbac.Role), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/fake/fake_rolebinding.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/fake/fake_rolebinding.go
@@ -104,3 +104,14 @@ func (c *FakeRoleBindings) Watch(opts api.ListOptions) (watch.Interface, error) 
 		InvokesWatch(core.NewWatchAction(rolebindingsResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched roleBinding.
+func (c *FakeRoleBindings) Patch(name string, pt api.PatchType, data []byte) (result *rbac.RoleBinding, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(rolebindingsResource, c.ns, name, data), &rbac.RoleBinding{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*rbac.RoleBinding), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/role.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/role.go
@@ -37,6 +37,7 @@ type RoleInterface interface {
 	Get(name string) (*rbac.Role, error)
 	List(opts api.ListOptions) (*rbac.RoleList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *rbac.Role, err error)
 	RoleExpansion
 }
 
@@ -133,4 +134,17 @@ func (c *roles) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("roles").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched role.
+func (c *roles) Patch(name string, pt api.PatchType, data []byte) (result *rbac.Role, err error) {
+	result = &rbac.Role{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("roles").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/rolebinding.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned/rolebinding.go
@@ -37,6 +37,7 @@ type RoleBindingInterface interface {
 	Get(name string) (*rbac.RoleBinding, error)
 	List(opts api.ListOptions) (*rbac.RoleBindingList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *rbac.RoleBinding, err error)
 	RoleBindingExpansion
 }
 
@@ -133,4 +134,17 @@ func (c *roleBindings) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("rolebindings").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched roleBinding.
+func (c *roleBindings) Patch(name string, pt api.PatchType, data []byte) (result *rbac.RoleBinding, err error) {
+	result = &rbac.RoleBinding{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("rolebindings").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/release_1_3/typed/autoscaling/v1/fake/fake_horizontalpodautoscaler.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/autoscaling/v1/fake/fake_horizontalpodautoscaler.go
@@ -114,3 +114,14 @@ func (c *FakeHorizontalPodAutoscalers) Watch(opts api.ListOptions) (watch.Interf
 		InvokesWatch(core.NewWatchAction(horizontalpodautoscalersResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched horizontalPodAutoscaler.
+func (c *FakeHorizontalPodAutoscalers) Patch(name string, pt api.PatchType, data []byte) (result *v1.HorizontalPodAutoscaler, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(horizontalpodautoscalersResource, c.ns, name, data), &v1.HorizontalPodAutoscaler{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1.HorizontalPodAutoscaler), err
+}

--- a/pkg/client/clientset_generated/release_1_3/typed/autoscaling/v1/horizontalpodautoscaler.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/autoscaling/v1/horizontalpodautoscaler.go
@@ -38,6 +38,7 @@ type HorizontalPodAutoscalerInterface interface {
 	Get(name string) (*v1.HorizontalPodAutoscaler, error)
 	List(opts api.ListOptions) (*v1.HorizontalPodAutoscalerList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *v1.HorizontalPodAutoscaler, err error)
 	HorizontalPodAutoscalerExpansion
 }
 
@@ -147,4 +148,17 @@ func (c *horizontalPodAutoscalers) Watch(opts api.ListOptions) (watch.Interface,
 		Resource("horizontalpodautoscalers").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched horizontalPodAutoscaler.
+func (c *horizontalPodAutoscalers) Patch(name string, pt api.PatchType, data []byte) (result *v1.HorizontalPodAutoscaler, err error) {
+	result = &v1.HorizontalPodAutoscaler{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("horizontalpodautoscalers").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/release_1_3/typed/batch/v1/fake/fake_job.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/batch/v1/fake/fake_job.go
@@ -114,3 +114,14 @@ func (c *FakeJobs) Watch(opts api.ListOptions) (watch.Interface, error) {
 		InvokesWatch(core.NewWatchAction(jobsResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched job.
+func (c *FakeJobs) Patch(name string, pt api.PatchType, data []byte) (result *v1.Job, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(jobsResource, c.ns, name, data), &v1.Job{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1.Job), err
+}

--- a/pkg/client/clientset_generated/release_1_3/typed/batch/v1/job.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/batch/v1/job.go
@@ -38,6 +38,7 @@ type JobInterface interface {
 	Get(name string) (*v1.Job, error)
 	List(opts api.ListOptions) (*v1.JobList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *v1.Job, err error)
 	JobExpansion
 }
 
@@ -147,4 +148,17 @@ func (c *jobs) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("jobs").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched job.
+func (c *jobs) Patch(name string, pt api.PatchType, data []byte) (result *v1.Job, err error) {
+	result = &v1.Job{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("jobs").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/componentstatus.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/componentstatus.go
@@ -37,6 +37,7 @@ type ComponentStatusInterface interface {
 	Get(name string) (*v1.ComponentStatus, error)
 	List(opts api.ListOptions) (*v1.ComponentStatusList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *v1.ComponentStatus, err error)
 	ComponentStatusExpansion
 }
 
@@ -124,4 +125,16 @@ func (c *componentStatuses) Watch(opts api.ListOptions) (watch.Interface, error)
 		Resource("componentstatuses").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched componentStatus.
+func (c *componentStatuses) Patch(name string, pt api.PatchType, data []byte) (result *v1.ComponentStatus, err error) {
+	result = &v1.ComponentStatus{}
+	err = c.client.Patch(pt).
+		Resource("componentstatuses").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/configmap.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/configmap.go
@@ -37,6 +37,7 @@ type ConfigMapInterface interface {
 	Get(name string) (*v1.ConfigMap, error)
 	List(opts api.ListOptions) (*v1.ConfigMapList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *v1.ConfigMap, err error)
 	ConfigMapExpansion
 }
 
@@ -133,4 +134,17 @@ func (c *configMaps) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("configmaps").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched configMap.
+func (c *configMaps) Patch(name string, pt api.PatchType, data []byte) (result *v1.ConfigMap, err error) {
+	result = &v1.ConfigMap{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("configmaps").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/endpoints.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/endpoints.go
@@ -37,6 +37,7 @@ type EndpointsInterface interface {
 	Get(name string) (*v1.Endpoints, error)
 	List(opts api.ListOptions) (*v1.EndpointsList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *v1.Endpoints, err error)
 	EndpointsExpansion
 }
 
@@ -133,4 +134,17 @@ func (c *endpoints) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("endpoints").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched endpoints.
+func (c *endpoints) Patch(name string, pt api.PatchType, data []byte) (result *v1.Endpoints, err error) {
+	result = &v1.Endpoints{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("endpoints").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/event.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/event.go
@@ -37,6 +37,7 @@ type EventInterface interface {
 	Get(name string) (*v1.Event, error)
 	List(opts api.ListOptions) (*v1.EventList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *v1.Event, err error)
 	EventExpansion
 }
 
@@ -133,4 +134,17 @@ func (c *events) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("events").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched event.
+func (c *events) Patch(name string, pt api.PatchType, data []byte) (result *v1.Event, err error) {
+	result = &v1.Event{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("events").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/event_expansion.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/event_expansion.go
@@ -31,7 +31,7 @@ type EventExpansion interface {
 	CreateWithEventNamespace(event *v1.Event) (*v1.Event, error)
 	// UpdateWithEventNamespace is the same as a Update, except that it sends the request to the event.Namespace.
 	UpdateWithEventNamespace(event *v1.Event) (*v1.Event, error)
-	Patch(event *v1.Event, data []byte) (*v1.Event, error)
+	PatchWithEventNamespace(event *v1.Event, data []byte) (*v1.Event, error)
 	// Search finds events about the specified object
 	Search(objOrRef runtime.Object) (*v1.EventList, error)
 	// Returns the appropriate field selector based on the API version being used to communicate with the server.
@@ -74,11 +74,15 @@ func (e *events) UpdateWithEventNamespace(event *v1.Event) (*v1.Event, error) {
 	return result, err
 }
 
-// Patch modifies an existing event. It returns the copy of the event that the server returns, or an
-// error. The namespace and name of the target event is deduced from the incompleteEvent. The
-// namespace must either match this event client's namespace, or this event client must have been
+// PatchWithEventNamespace modifies an existing event. It returns the copy of
+// the event that the server returns, or an error. The namespace and name of the
+// target event is deduced from the incompleteEvent. The namespace must either
+// match this event client's namespace, or this event client must have been
 // created with the "" namespace.
-func (e *events) Patch(incompleteEvent *v1.Event, data []byte) (*v1.Event, error) {
+func (e *events) PatchWithEventNamespace(incompleteEvent *v1.Event, data []byte) (*v1.Event, error) {
+	if e.ns != "" && incompleteEvent.Namespace != e.ns {
+		return nil, fmt.Errorf("can't patch an event with namespace '%v' in namespace '%v'", incompleteEvent.Namespace, e.ns)
+	}
 	result := &v1.Event{}
 	err := e.client.Patch(api.StrategicMergePatchType).
 		NamespaceIfScoped(incompleteEvent.Namespace, len(incompleteEvent.Namespace) > 0).
@@ -154,5 +158,5 @@ func (e *EventSinkImpl) Update(event *v1.Event) (*v1.Event, error) {
 }
 
 func (e *EventSinkImpl) Patch(event *v1.Event, data []byte) (*v1.Event, error) {
-	return e.Interface.Patch(event, data)
+	return e.Interface.PatchWithEventNamespace(event, data)
 }

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_componentstatus.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_componentstatus.go
@@ -97,3 +97,13 @@ func (c *FakeComponentStatuses) Watch(opts api.ListOptions) (watch.Interface, er
 	return c.Fake.
 		InvokesWatch(core.NewRootWatchAction(componentstatusesResource, opts))
 }
+
+// Patch applies the patch and returns the patched componentStatus.
+func (c *FakeComponentStatuses) Patch(name string, pt api.PatchType, data []byte) (result *v1.ComponentStatus, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootPatchAction(componentstatusesResource, name, data), &v1.ComponentStatus{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1.ComponentStatus), err
+}

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_configmap.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_configmap.go
@@ -104,3 +104,14 @@ func (c *FakeConfigMaps) Watch(opts api.ListOptions) (watch.Interface, error) {
 		InvokesWatch(core.NewWatchAction(configmapsResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched configMap.
+func (c *FakeConfigMaps) Patch(name string, pt api.PatchType, data []byte) (result *v1.ConfigMap, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(configmapsResource, c.ns, name, data), &v1.ConfigMap{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1.ConfigMap), err
+}

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_endpoints.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_endpoints.go
@@ -104,3 +104,14 @@ func (c *FakeEndpoints) Watch(opts api.ListOptions) (watch.Interface, error) {
 		InvokesWatch(core.NewWatchAction(endpointsResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched endpoints.
+func (c *FakeEndpoints) Patch(name string, pt api.PatchType, data []byte) (result *v1.Endpoints, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(endpointsResource, c.ns, name, data), &v1.Endpoints{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1.Endpoints), err
+}

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_event.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_event.go
@@ -104,3 +104,14 @@ func (c *FakeEvents) Watch(opts api.ListOptions) (watch.Interface, error) {
 		InvokesWatch(core.NewWatchAction(eventsResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched event.
+func (c *FakeEvents) Patch(name string, pt api.PatchType, data []byte) (result *v1.Event, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(eventsResource, c.ns, name, data), &v1.Event{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1.Event), err
+}

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_event_expansion.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_event_expansion.go
@@ -51,11 +51,11 @@ func (c *FakeEvents) UpdateWithEventNamespace(event *v1.Event) (*v1.Event, error
 	return obj.(*v1.Event), err
 }
 
-// Patch patches an existing event. Returns the copy of the event the server returns, or an error.
-func (c *FakeEvents) Patch(event *v1.Event, data []byte) (*v1.Event, error) {
-	action := core.NewRootPatchAction(eventsResource, event)
+// PatchWithEventNamespace patches an existing event. Returns the copy of the event the server returns, or an error.
+func (c *FakeEvents) PatchWithEventNamespace(event *v1.Event, data []byte) (*v1.Event, error) {
+	action := core.NewRootPatchAction(eventsResource, event.Name, data)
 	if c.ns != "" {
-		action = core.NewPatchAction(eventsResource, c.ns, event)
+		action = core.NewPatchAction(eventsResource, c.ns, event.Name, data)
 	}
 	obj, err := c.Fake.Invokes(action, event)
 	if obj == nil {

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_limitrange.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_limitrange.go
@@ -104,3 +104,14 @@ func (c *FakeLimitRanges) Watch(opts api.ListOptions) (watch.Interface, error) {
 		InvokesWatch(core.NewWatchAction(limitrangesResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched limitRange.
+func (c *FakeLimitRanges) Patch(name string, pt api.PatchType, data []byte) (result *v1.LimitRange, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(limitrangesResource, c.ns, name, data), &v1.LimitRange{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1.LimitRange), err
+}

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_namespace.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_namespace.go
@@ -106,3 +106,13 @@ func (c *FakeNamespaces) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(core.NewRootWatchAction(namespacesResource, opts))
 }
+
+// Patch applies the patch and returns the patched namespace.
+func (c *FakeNamespaces) Patch(name string, pt api.PatchType, data []byte) (result *v1.Namespace, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootPatchAction(namespacesResource, name, data), &v1.Namespace{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1.Namespace), err
+}

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_node.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_node.go
@@ -106,3 +106,13 @@ func (c *FakeNodes) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(core.NewRootWatchAction(nodesResource, opts))
 }
+
+// Patch applies the patch and returns the patched node.
+func (c *FakeNodes) Patch(name string, pt api.PatchType, data []byte) (result *v1.Node, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootPatchAction(nodesResource, name, data), &v1.Node{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1.Node), err
+}

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_persistentvolume.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_persistentvolume.go
@@ -106,3 +106,13 @@ func (c *FakePersistentVolumes) Watch(opts api.ListOptions) (watch.Interface, er
 	return c.Fake.
 		InvokesWatch(core.NewRootWatchAction(persistentvolumesResource, opts))
 }
+
+// Patch applies the patch and returns the patched persistentVolume.
+func (c *FakePersistentVolumes) Patch(name string, pt api.PatchType, data []byte) (result *v1.PersistentVolume, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootPatchAction(persistentvolumesResource, name, data), &v1.PersistentVolume{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1.PersistentVolume), err
+}

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_pod.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_pod.go
@@ -114,3 +114,14 @@ func (c *FakePods) Watch(opts api.ListOptions) (watch.Interface, error) {
 		InvokesWatch(core.NewWatchAction(podsResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched pod.
+func (c *FakePods) Patch(name string, pt api.PatchType, data []byte) (result *v1.Pod, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(podsResource, c.ns, name, data), &v1.Pod{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1.Pod), err
+}

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_podtemplate.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_podtemplate.go
@@ -104,3 +104,14 @@ func (c *FakePodTemplates) Watch(opts api.ListOptions) (watch.Interface, error) 
 		InvokesWatch(core.NewWatchAction(podtemplatesResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched podTemplate.
+func (c *FakePodTemplates) Patch(name string, pt api.PatchType, data []byte) (result *v1.PodTemplate, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(podtemplatesResource, c.ns, name, data), &v1.PodTemplate{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1.PodTemplate), err
+}

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_replicationcontroller.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_replicationcontroller.go
@@ -114,3 +114,14 @@ func (c *FakeReplicationControllers) Watch(opts api.ListOptions) (watch.Interfac
 		InvokesWatch(core.NewWatchAction(replicationcontrollersResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched replicationController.
+func (c *FakeReplicationControllers) Patch(name string, pt api.PatchType, data []byte) (result *v1.ReplicationController, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(replicationcontrollersResource, c.ns, name, data), &v1.ReplicationController{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1.ReplicationController), err
+}

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_resourcequota.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_resourcequota.go
@@ -114,3 +114,14 @@ func (c *FakeResourceQuotas) Watch(opts api.ListOptions) (watch.Interface, error
 		InvokesWatch(core.NewWatchAction(resourcequotasResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched resourceQuota.
+func (c *FakeResourceQuotas) Patch(name string, pt api.PatchType, data []byte) (result *v1.ResourceQuota, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(resourcequotasResource, c.ns, name, data), &v1.ResourceQuota{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1.ResourceQuota), err
+}

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_secret.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_secret.go
@@ -104,3 +104,14 @@ func (c *FakeSecrets) Watch(opts api.ListOptions) (watch.Interface, error) {
 		InvokesWatch(core.NewWatchAction(secretsResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched secret.
+func (c *FakeSecrets) Patch(name string, pt api.PatchType, data []byte) (result *v1.Secret, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(secretsResource, c.ns, name, data), &v1.Secret{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1.Secret), err
+}

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_service.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_service.go
@@ -114,3 +114,14 @@ func (c *FakeServices) Watch(opts api.ListOptions) (watch.Interface, error) {
 		InvokesWatch(core.NewWatchAction(servicesResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched service.
+func (c *FakeServices) Patch(name string, pt api.PatchType, data []byte) (result *v1.Service, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(servicesResource, c.ns, name, data), &v1.Service{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1.Service), err
+}

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_serviceaccount.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/fake/fake_serviceaccount.go
@@ -104,3 +104,14 @@ func (c *FakeServiceAccounts) Watch(opts api.ListOptions) (watch.Interface, erro
 		InvokesWatch(core.NewWatchAction(serviceaccountsResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched serviceAccount.
+func (c *FakeServiceAccounts) Patch(name string, pt api.PatchType, data []byte) (result *v1.ServiceAccount, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(serviceaccountsResource, c.ns, name, data), &v1.ServiceAccount{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1.ServiceAccount), err
+}

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/limitrange.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/limitrange.go
@@ -37,6 +37,7 @@ type LimitRangeInterface interface {
 	Get(name string) (*v1.LimitRange, error)
 	List(opts api.ListOptions) (*v1.LimitRangeList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *v1.LimitRange, err error)
 	LimitRangeExpansion
 }
 
@@ -133,4 +134,17 @@ func (c *limitRanges) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("limitranges").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched limitRange.
+func (c *limitRanges) Patch(name string, pt api.PatchType, data []byte) (result *v1.LimitRange, err error) {
+	result = &v1.LimitRange{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("limitranges").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/namespace.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/namespace.go
@@ -38,6 +38,7 @@ type NamespaceInterface interface {
 	Get(name string) (*v1.Namespace, error)
 	List(opts api.ListOptions) (*v1.NamespaceList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *v1.Namespace, err error)
 	NamespaceExpansion
 }
 
@@ -137,4 +138,16 @@ func (c *namespaces) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("namespaces").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched namespace.
+func (c *namespaces) Patch(name string, pt api.PatchType, data []byte) (result *v1.Namespace, err error) {
+	result = &v1.Namespace{}
+	err = c.client.Patch(pt).
+		Resource("namespaces").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/node.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/node.go
@@ -38,6 +38,7 @@ type NodeInterface interface {
 	Get(name string) (*v1.Node, error)
 	List(opts api.ListOptions) (*v1.NodeList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *v1.Node, err error)
 	NodeExpansion
 }
 
@@ -137,4 +138,16 @@ func (c *nodes) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("nodes").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched node.
+func (c *nodes) Patch(name string, pt api.PatchType, data []byte) (result *v1.Node, err error) {
+	result = &v1.Node{}
+	err = c.client.Patch(pt).
+		Resource("nodes").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/persistentvolume.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/persistentvolume.go
@@ -38,6 +38,7 @@ type PersistentVolumeInterface interface {
 	Get(name string) (*v1.PersistentVolume, error)
 	List(opts api.ListOptions) (*v1.PersistentVolumeList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *v1.PersistentVolume, err error)
 	PersistentVolumeExpansion
 }
 
@@ -137,4 +138,16 @@ func (c *persistentVolumes) Watch(opts api.ListOptions) (watch.Interface, error)
 		Resource("persistentvolumes").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched persistentVolume.
+func (c *persistentVolumes) Patch(name string, pt api.PatchType, data []byte) (result *v1.PersistentVolume, err error) {
+	result = &v1.PersistentVolume{}
+	err = c.client.Patch(pt).
+		Resource("persistentvolumes").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/pod.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/pod.go
@@ -38,6 +38,7 @@ type PodInterface interface {
 	Get(name string) (*v1.Pod, error)
 	List(opts api.ListOptions) (*v1.PodList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *v1.Pod, err error)
 	PodExpansion
 }
 
@@ -147,4 +148,17 @@ func (c *pods) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("pods").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched pod.
+func (c *pods) Patch(name string, pt api.PatchType, data []byte) (result *v1.Pod, err error) {
+	result = &v1.Pod{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("pods").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/podtemplate.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/podtemplate.go
@@ -37,6 +37,7 @@ type PodTemplateInterface interface {
 	Get(name string) (*v1.PodTemplate, error)
 	List(opts api.ListOptions) (*v1.PodTemplateList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *v1.PodTemplate, err error)
 	PodTemplateExpansion
 }
 
@@ -133,4 +134,17 @@ func (c *podTemplates) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("podtemplates").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched podTemplate.
+func (c *podTemplates) Patch(name string, pt api.PatchType, data []byte) (result *v1.PodTemplate, err error) {
+	result = &v1.PodTemplate{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("podtemplates").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/replicationcontroller.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/replicationcontroller.go
@@ -38,6 +38,7 @@ type ReplicationControllerInterface interface {
 	Get(name string) (*v1.ReplicationController, error)
 	List(opts api.ListOptions) (*v1.ReplicationControllerList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *v1.ReplicationController, err error)
 	ReplicationControllerExpansion
 }
 
@@ -147,4 +148,17 @@ func (c *replicationControllers) Watch(opts api.ListOptions) (watch.Interface, e
 		Resource("replicationcontrollers").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched replicationController.
+func (c *replicationControllers) Patch(name string, pt api.PatchType, data []byte) (result *v1.ReplicationController, err error) {
+	result = &v1.ReplicationController{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("replicationcontrollers").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/resourcequota.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/resourcequota.go
@@ -38,6 +38,7 @@ type ResourceQuotaInterface interface {
 	Get(name string) (*v1.ResourceQuota, error)
 	List(opts api.ListOptions) (*v1.ResourceQuotaList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *v1.ResourceQuota, err error)
 	ResourceQuotaExpansion
 }
 
@@ -147,4 +148,17 @@ func (c *resourceQuotas) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("resourcequotas").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched resourceQuota.
+func (c *resourceQuotas) Patch(name string, pt api.PatchType, data []byte) (result *v1.ResourceQuota, err error) {
+	result = &v1.ResourceQuota{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("resourcequotas").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/secret.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/secret.go
@@ -37,6 +37,7 @@ type SecretInterface interface {
 	Get(name string) (*v1.Secret, error)
 	List(opts api.ListOptions) (*v1.SecretList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *v1.Secret, err error)
 	SecretExpansion
 }
 
@@ -133,4 +134,17 @@ func (c *secrets) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("secrets").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched secret.
+func (c *secrets) Patch(name string, pt api.PatchType, data []byte) (result *v1.Secret, err error) {
+	result = &v1.Secret{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("secrets").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/service.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/service.go
@@ -38,6 +38,7 @@ type ServiceInterface interface {
 	Get(name string) (*v1.Service, error)
 	List(opts api.ListOptions) (*v1.ServiceList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *v1.Service, err error)
 	ServiceExpansion
 }
 
@@ -147,4 +148,17 @@ func (c *services) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("services").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched service.
+func (c *services) Patch(name string, pt api.PatchType, data []byte) (result *v1.Service, err error) {
+	result = &v1.Service{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("services").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/release_1_3/typed/core/v1/serviceaccount.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/core/v1/serviceaccount.go
@@ -37,6 +37,7 @@ type ServiceAccountInterface interface {
 	Get(name string) (*v1.ServiceAccount, error)
 	List(opts api.ListOptions) (*v1.ServiceAccountList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *v1.ServiceAccount, err error)
 	ServiceAccountExpansion
 }
 
@@ -133,4 +134,17 @@ func (c *serviceAccounts) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("serviceaccounts").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched serviceAccount.
+func (c *serviceAccounts) Patch(name string, pt api.PatchType, data []byte) (result *v1.ServiceAccount, err error) {
+	result = &v1.ServiceAccount{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("serviceaccounts").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/daemonset.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/daemonset.go
@@ -38,6 +38,7 @@ type DaemonSetInterface interface {
 	Get(name string) (*v1beta1.DaemonSet, error)
 	List(opts api.ListOptions) (*v1beta1.DaemonSetList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.DaemonSet, err error)
 	DaemonSetExpansion
 }
 
@@ -147,4 +148,17 @@ func (c *daemonSets) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("daemonsets").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched daemonSet.
+func (c *daemonSets) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.DaemonSet, err error) {
+	result = &v1beta1.DaemonSet{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("daemonsets").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/deployment.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/deployment.go
@@ -38,6 +38,7 @@ type DeploymentInterface interface {
 	Get(name string) (*v1beta1.Deployment, error)
 	List(opts api.ListOptions) (*v1beta1.DeploymentList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.Deployment, err error)
 	DeploymentExpansion
 }
 
@@ -147,4 +148,17 @@ func (c *deployments) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("deployments").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched deployment.
+func (c *deployments) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.Deployment, err error) {
+	result = &v1beta1.Deployment{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("deployments").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/fake/fake_daemonset.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/fake/fake_daemonset.go
@@ -114,3 +114,14 @@ func (c *FakeDaemonSets) Watch(opts api.ListOptions) (watch.Interface, error) {
 		InvokesWatch(core.NewWatchAction(daemonsetsResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched daemonSet.
+func (c *FakeDaemonSets) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.DaemonSet, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(daemonsetsResource, c.ns, name, data), &v1beta1.DaemonSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.DaemonSet), err
+}

--- a/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/fake/fake_deployment.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/fake/fake_deployment.go
@@ -114,3 +114,14 @@ func (c *FakeDeployments) Watch(opts api.ListOptions) (watch.Interface, error) {
 		InvokesWatch(core.NewWatchAction(deploymentsResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched deployment.
+func (c *FakeDeployments) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.Deployment, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(deploymentsResource, c.ns, name, data), &v1beta1.Deployment{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.Deployment), err
+}

--- a/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/fake/fake_horizontalpodautoscaler.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/fake/fake_horizontalpodautoscaler.go
@@ -114,3 +114,14 @@ func (c *FakeHorizontalPodAutoscalers) Watch(opts api.ListOptions) (watch.Interf
 		InvokesWatch(core.NewWatchAction(horizontalpodautoscalersResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched horizontalPodAutoscaler.
+func (c *FakeHorizontalPodAutoscalers) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.HorizontalPodAutoscaler, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(horizontalpodautoscalersResource, c.ns, name, data), &v1beta1.HorizontalPodAutoscaler{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.HorizontalPodAutoscaler), err
+}

--- a/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/fake/fake_ingress.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/fake/fake_ingress.go
@@ -114,3 +114,14 @@ func (c *FakeIngresses) Watch(opts api.ListOptions) (watch.Interface, error) {
 		InvokesWatch(core.NewWatchAction(ingressesResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched ingress.
+func (c *FakeIngresses) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.Ingress, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(ingressesResource, c.ns, name, data), &v1beta1.Ingress{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.Ingress), err
+}

--- a/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/fake/fake_job.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/fake/fake_job.go
@@ -114,3 +114,14 @@ func (c *FakeJobs) Watch(opts api.ListOptions) (watch.Interface, error) {
 		InvokesWatch(core.NewWatchAction(jobsResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched job.
+func (c *FakeJobs) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.Job, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(jobsResource, c.ns, name, data), &v1beta1.Job{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.Job), err
+}

--- a/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/fake/fake_podsecuritypolicy.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/fake/fake_podsecuritypolicy.go
@@ -97,3 +97,13 @@ func (c *FakePodSecurityPolicies) Watch(opts api.ListOptions) (watch.Interface, 
 	return c.Fake.
 		InvokesWatch(core.NewRootWatchAction(podsecuritypoliciesResource, opts))
 }
+
+// Patch applies the patch and returns the patched podSecurityPolicy.
+func (c *FakePodSecurityPolicies) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.PodSecurityPolicy, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootPatchAction(podsecuritypoliciesResource, name, data), &v1beta1.PodSecurityPolicy{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.PodSecurityPolicy), err
+}

--- a/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/fake/fake_replicaset.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/fake/fake_replicaset.go
@@ -114,3 +114,14 @@ func (c *FakeReplicaSets) Watch(opts api.ListOptions) (watch.Interface, error) {
 		InvokesWatch(core.NewWatchAction(replicasetsResource, c.ns, opts))
 
 }
+
+// Patch applies the patch and returns the patched replicaSet.
+func (c *FakeReplicaSets) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.ReplicaSet, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchAction(replicasetsResource, c.ns, name, data), &v1beta1.ReplicaSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.ReplicaSet), err
+}

--- a/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/fake/fake_thirdpartyresource.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/fake/fake_thirdpartyresource.go
@@ -97,3 +97,13 @@ func (c *FakeThirdPartyResources) Watch(opts api.ListOptions) (watch.Interface, 
 	return c.Fake.
 		InvokesWatch(core.NewRootWatchAction(thirdpartyresourcesResource, opts))
 }
+
+// Patch applies the patch and returns the patched thirdPartyResource.
+func (c *FakeThirdPartyResources) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.ThirdPartyResource, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootPatchAction(thirdpartyresourcesResource, name, data), &v1beta1.ThirdPartyResource{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.ThirdPartyResource), err
+}

--- a/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/horizontalpodautoscaler.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/horizontalpodautoscaler.go
@@ -38,6 +38,7 @@ type HorizontalPodAutoscalerInterface interface {
 	Get(name string) (*v1beta1.HorizontalPodAutoscaler, error)
 	List(opts api.ListOptions) (*v1beta1.HorizontalPodAutoscalerList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.HorizontalPodAutoscaler, err error)
 	HorizontalPodAutoscalerExpansion
 }
 
@@ -147,4 +148,17 @@ func (c *horizontalPodAutoscalers) Watch(opts api.ListOptions) (watch.Interface,
 		Resource("horizontalpodautoscalers").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched horizontalPodAutoscaler.
+func (c *horizontalPodAutoscalers) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.HorizontalPodAutoscaler, err error) {
+	result = &v1beta1.HorizontalPodAutoscaler{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("horizontalpodautoscalers").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/ingress.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/ingress.go
@@ -38,6 +38,7 @@ type IngressInterface interface {
 	Get(name string) (*v1beta1.Ingress, error)
 	List(opts api.ListOptions) (*v1beta1.IngressList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.Ingress, err error)
 	IngressExpansion
 }
 
@@ -147,4 +148,17 @@ func (c *ingresses) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("ingresses").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched ingress.
+func (c *ingresses) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.Ingress, err error) {
+	result = &v1beta1.Ingress{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("ingresses").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/job.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/job.go
@@ -38,6 +38,7 @@ type JobInterface interface {
 	Get(name string) (*v1beta1.Job, error)
 	List(opts api.ListOptions) (*v1beta1.JobList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.Job, err error)
 	JobExpansion
 }
 
@@ -147,4 +148,17 @@ func (c *jobs) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("jobs").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched job.
+func (c *jobs) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.Job, err error) {
+	result = &v1beta1.Job{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("jobs").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/podsecuritypolicy.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/podsecuritypolicy.go
@@ -37,6 +37,7 @@ type PodSecurityPolicyInterface interface {
 	Get(name string) (*v1beta1.PodSecurityPolicy, error)
 	List(opts api.ListOptions) (*v1beta1.PodSecurityPolicyList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.PodSecurityPolicy, err error)
 	PodSecurityPolicyExpansion
 }
 
@@ -124,4 +125,16 @@ func (c *podSecurityPolicies) Watch(opts api.ListOptions) (watch.Interface, erro
 		Resource("podsecuritypolicies").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched podSecurityPolicy.
+func (c *podSecurityPolicies) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.PodSecurityPolicy, err error) {
+	result = &v1beta1.PodSecurityPolicy{}
+	err = c.client.Patch(pt).
+		Resource("podsecuritypolicies").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/replicaset.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/replicaset.go
@@ -38,6 +38,7 @@ type ReplicaSetInterface interface {
 	Get(name string) (*v1beta1.ReplicaSet, error)
 	List(opts api.ListOptions) (*v1beta1.ReplicaSetList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.ReplicaSet, err error)
 	ReplicaSetExpansion
 }
 
@@ -147,4 +148,17 @@ func (c *replicaSets) Watch(opts api.ListOptions) (watch.Interface, error) {
 		Resource("replicasets").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched replicaSet.
+func (c *replicaSets) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.ReplicaSet, err error) {
+	result = &v1beta1.ReplicaSet{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("replicasets").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/thirdpartyresource.go
+++ b/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/thirdpartyresource.go
@@ -37,6 +37,7 @@ type ThirdPartyResourceInterface interface {
 	Get(name string) (*v1beta1.ThirdPartyResource, error)
 	List(opts api.ListOptions) (*v1beta1.ThirdPartyResourceList, error)
 	Watch(opts api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.ThirdPartyResource, err error)
 	ThirdPartyResourceExpansion
 }
 
@@ -124,4 +125,16 @@ func (c *thirdPartyResources) Watch(opts api.ListOptions) (watch.Interface, erro
 		Resource("thirdpartyresources").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
+}
+
+// Patch applies the patch and returns the patched thirdPartyResource.
+func (c *thirdPartyResources) Patch(name string, pt api.PatchType, data []byte) (result *v1beta1.ThirdPartyResource, err error) {
+	result = &v1beta1.ThirdPartyResource{}
+	err = c.client.Patch(pt).
+		Resource("thirdpartyresources").
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/client/testing/core/actions.go
+++ b/pkg/client/testing/core/actions.go
@@ -118,21 +118,23 @@ func NewUpdateAction(resource unversioned.GroupVersionResource, namespace string
 	return action
 }
 
-func NewRootPatchAction(resource unversioned.GroupVersionResource, object runtime.Object) PatchActionImpl {
+func NewRootPatchAction(resource unversioned.GroupVersionResource, name string, patch []byte) PatchActionImpl {
 	action := PatchActionImpl{}
 	action.Verb = "patch"
 	action.Resource = resource
-	action.Object = object
+	action.Name = name
+	action.Patch = patch
 
 	return action
 }
 
-func NewPatchAction(resource unversioned.GroupVersionResource, namespace string, object runtime.Object) PatchActionImpl {
+func NewPatchAction(resource unversioned.GroupVersionResource, namespace string, name string, patch []byte) PatchActionImpl {
 	action := PatchActionImpl{}
 	action.Verb = "patch"
 	action.Resource = resource
 	action.Namespace = namespace
-	action.Object = object
+	action.Name = name
+	action.Patch = patch
 
 	return action
 }
@@ -392,11 +394,16 @@ func (a UpdateActionImpl) GetObject() runtime.Object {
 
 type PatchActionImpl struct {
 	ActionImpl
-	Object runtime.Object
+	Name  string
+	Patch []byte
 }
 
-func (a PatchActionImpl) GetObject() runtime.Object {
-	return a.Object
+func (a PatchActionImpl) GetName() string {
+	return a.Name
+}
+
+func (a PatchActionImpl) GetPatch() []byte {
+	return a.Patch
 }
 
 type DeleteActionImpl struct {

--- a/pkg/controller/node/nodecontroller_test.go
+++ b/pkg/controller/node/nodecontroller_test.go
@@ -161,6 +161,10 @@ func (m *FakeNodeHandler) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return nil, nil
 }
 
+func (m *FakeNodeHandler) Patch(name string, pt api.PatchType, data []byte) (*api.Node, error) {
+	return nil, nil
+}
+
 func TestMonitorNodeStatusEvictPods(t *testing.T) {
 	fakeNow := unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC)
 	evictionTimeout := 10 * time.Minute


### PR DESCRIPTION
- add the Patch() method to the clientset. 
- I have to rename the existing Patch() method of `Event` to PatchWithEventNamespace() to avoid overriding.
- some minor changes to the fake Patch action.

cc @Random-Liu since he asked for the method
@kubernetes/sig-api-machinery 

ref #26580 

``` release-note
Add the Patch method to the generated clientset.
```
