### PR TITLE
httplog: Increase stack size

### DIFF
--- a/pkg/httplog/log.go
+++ b/pkg/httplog/log.go
@@ -210,7 +210,7 @@ func (rl *respLogger) recordStatus(status int) {
 	rl.statusRecorded = true
 	if rl.logStacktracePred(status) {
 		// Only log stacks for errors
-		stack := make([]byte, 2048)
+		stack := make([]byte, 50*1024)
 		stack = stack[:runtime.Stack(stack, false)]
 		rl.statusStack = "\n" + string(stack)
 	} else {


### PR DESCRIPTION
The previous size, of 2KB, in practice always was filled mostly by
http server-releated stuff well above the panic itself, and truncated
before anything of real value was printed in some cases.

This increases the stack size so that panics are printed in full (well, except for really large ones).

cc @lavalamp 
