### PR TITLE
kubelt: Remove a couple lines of dead code

### DIFF
--- a/pkg/kubelet/server/stats/summary.go
+++ b/pkg/kubelet/server/stats/summary.go
@@ -18,7 +18,6 @@ package stats
 
 import (
 	"fmt"
-	"runtime"
 	"strings"
 	"time"
 
@@ -53,8 +52,6 @@ var _ SummaryProvider = &summaryProviderImpl{}
 
 // NewSummaryProvider returns a new SummaryProvider
 func NewSummaryProvider(statsProvider StatsProvider, fsResourceAnalyzer fsResourceAnalyzerInterface, cruntime container.Runtime) SummaryProvider {
-	stackBuff := []byte{}
-	runtime.Stack(stackBuff, false)
 	return &summaryProviderImpl{statsProvider, fsResourceAnalyzer, cruntime}
 }
 


### PR DESCRIPTION
Presumably that code was added for debugging reasons and never removed. Hopefully.

If it's actually important and there's a good reason to do what looks like a no-op to get pause-the-world behaviour or whatever, I'd hope there'd be a comment.

cc @pwittrock 
