### PR TITLE
GCE provider: Fix minor cosmetic logging issue

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -445,9 +445,9 @@ func (gce *GCECloud) waitForOp(op *compute.Operation, getOperation func(operatio
 			duration := time.Now().Sub(opStart)
 			if duration > 1*time.Minute {
 				// Log the JSON. It's cleaner than the %v structure.
-				enc, err := op.MarshalJSON()
+				enc, err := pollOp.MarshalJSON()
 				if err != nil {
-					glog.Warningf("waitForOperation: long operation (%v): %v (failed to encode to JSON: %v)", duration, op, err)
+					glog.Warningf("waitForOperation: long operation (%v): %v (failed to encode to JSON: %v)", duration, pollOp, err)
 				} else {
 					glog.Infof("waitForOperation: long operation (%v): %v", duration, string(enc))
 				}


### PR DESCRIPTION
[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()

Log the pollOp, not the base op. (This will include the final status/timestamp and any errors.)
