### PR TITLE
Node e2e: switch most of the tests to use the e2e framework

### DIFF
--- a/test/e2e_node/image_conformance_test.go
+++ b/test/e2e_node/image_conformance_test.go
@@ -19,9 +19,6 @@ package e2e_node
 import (
 	"time"
 
-	"k8s.io/kubernetes/pkg/client/restclient"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -34,13 +31,6 @@ const (
 )
 
 var _ = Describe("Image Container Conformance Test", func() {
-	var cl *client.Client
-
-	BeforeEach(func() {
-		// Setup the apiserver client
-		cl = client.NewOrDie(&restclient.Config{Host: *apiServerAddress})
-	})
-
 	Describe("[FLAKY] image conformance blackbox test", func() {
 		Context("when testing images that exist", func() {
 			var conformImages []ConformanceImage

--- a/test/e2e_node/kubelet_test.go
+++ b/test/e2e_node/kubelet_test.go
@@ -38,9 +38,8 @@ import (
 )
 
 var _ = framework.KubeDescribe("Kubelet", func() {
+	f := NewDefaultFramework("kubelet-test")
 	Context("when scheduling a busybox command in a pod", func() {
-		// Setup the framework
-		f := NewDefaultFramework("pod-scheduling")
 		podName := "busybox-scheduling-" + string(util.NewUUID())
 		It("it should print the output to logs", func() {
 			podClient := f.Client.Pods(f.Namespace.Name)
@@ -81,7 +80,6 @@ var _ = framework.KubeDescribe("Kubelet", func() {
 	})
 
 	Context("when scheduling a read only busybox container", func() {
-		f := NewDefaultFramework("pod-scheduling")
 		podName := "busybox-readonly-fs" + string(util.NewUUID())
 		It("it should not write to root filesystem", func() {
 			podClient := f.Client.Pods(f.Namespace.Name)
@@ -123,8 +121,6 @@ var _ = framework.KubeDescribe("Kubelet", func() {
 		})
 	})
 	Describe("metrics api", func() {
-		// Setup the framework
-		f := NewDefaultFramework("kubelet-metrics-api")
 		Context("when querying /stats/summary", func() {
 			It("it should report resource usage through the stats api", func() {
 				podNamePrefix := "stats-busybox-" + string(util.NewUUID())

--- a/test/e2e_node/runtime_conformance_test.go
+++ b/test/e2e_node/runtime_conformance_test.go
@@ -24,8 +24,6 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/client/restclient"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -48,15 +46,9 @@ type testCase struct {
 }
 
 var _ = Describe("Container Runtime Conformance Test", func() {
-	var cl *client.Client
-
-	BeforeEach(func() {
-		// Setup the apiserver client
-		cl = client.NewOrDie(&restclient.Config{Host: *apiServerAddress})
-	})
+	f := NewDefaultFramework("runtime-conformance")
 
 	Describe("container runtime conformance blackbox test", func() {
-		namespace := "runtime-conformance"
 
 		Context("when starting a container that exits", func() {
 			It("it should run with the expected status [Conformance]", func() {
@@ -108,11 +100,11 @@ while true; do sleep 1; done
 					testContainer.Command = []string{"sh", "-c", tmpCmd}
 					terminateContainer := ConformanceContainer{
 						Container:     testContainer,
-						Client:        cl,
+						Client:        f.Client,
 						RestartPolicy: testCase.RestartPolicy,
 						Volumes:       testVolumes,
 						NodeName:      *nodeName,
-						Namespace:     namespace,
+						Namespace:     f.Namespace.Name,
 					}
 					Expect(terminateContainer.Create()).To(Succeed())
 					defer terminateContainer.Delete()
@@ -152,10 +144,10 @@ while true; do sleep 1; done
 				testContainer.Name = testCase.Name
 				invalidImageContainer := ConformanceContainer{
 					Container:     testContainer,
-					Client:        cl,
+					Client:        f.Client,
 					RestartPolicy: testCase.RestartPolicy,
 					NodeName:      *nodeName,
-					Namespace:     namespace,
+					Namespace:     f.Namespace.Name,
 				}
 				Expect(invalidImageContainer.Create()).To(Succeed())
 				defer invalidImageContainer.Delete()


### PR DESCRIPTION
This commit switches the tests to use the e2e framework, so that namespace
creation/deletion is handled between tests.
