### PR TITLE
Add kubectl version guard around kubectl port-forward

### DIFF
--- a/test/e2e/portforward.go
+++ b/test/e2e/portforward.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"os/exec"
@@ -29,6 +30,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/pkg/version"
 	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
@@ -39,7 +41,10 @@ const (
 )
 
 // TODO support other ports besides 80
-var portForwardRegexp = regexp.MustCompile("Forwarding from 127.0.0.1:([0-9]+) -> 80")
+var (
+	portForwardRegexp        = regexp.MustCompile("Forwarding from 127.0.0.1:([0-9]+) -> 80")
+	portForwardPortToStdOutV = version.MustParse("v1.3.0-alpha.4")
+)
 
 func pfPod(expectedClientData, chunks, chunkSize, chunkIntervalMillis string) *api.Pod {
 	return &api.Pod{
@@ -124,15 +129,28 @@ func runPortForward(ns, podName string, port int) *portForwardCommand {
 	// by the port-forward command. We don't want to hard code the port as we have no
 	// way of guaranteeing we can pick one that isn't in use, particularly on Jenkins.
 	framework.Logf("starting port-forward command and streaming output")
-	stdout, _, err := framework.StartCmdAndStreamOutput(cmd)
+	stdout, stderr, err := framework.StartCmdAndStreamOutput(cmd)
 	if err != nil {
 		framework.Failf("Failed to start port-forward command: %v", err)
 	}
 
 	buf := make([]byte, 128)
+
+	// After v1.3.0-alpha.4 (#17030), kubectl port-forward outputs port
+	// info to stdout, not stderr, so for version-skewed tests, look there
+	// instead.
+	var portOutput io.ReadCloser
+	if useStdOut, err := framework.KubectlVersionGTE(portForwardPortToStdOutV); err != nil {
+		framework.Failf("Failed to get kubectl version: %v", err)
+	} else if useStdOut {
+		portOutput = stdout
+	} else {
+		portOutput = stderr
+	}
+
 	var n int
 	framework.Logf("reading from `kubectl port-forward` command's stdout")
-	if n, err = stdout.Read(buf); err != nil {
+	if n, err = portOutput.Read(buf); err != nil {
 		framework.Failf("Failed to read from kubectl port-forward stdout: %v", err)
 	}
 	portForwardOutput := string(buf[:n])


### PR DESCRIPTION
Fixes #26594 (once this gets backported to v1.2 and v1.3).
