### PR TITLE
Fixes and improvements to Photon Controller backend for kube-up

### DIFF
--- a/cluster/photon-controller/templates/create-dynamic-salt-files.sh
+++ b/cluster/photon-controller/templates/create-dynamic-salt-files.sh
@@ -125,6 +125,3 @@ cluster_cidr: "$NODE_IP_RANGES"
 allocate_node_cidrs: "${ALLOCATE_NODE_CIDRS:-true}"
 admission_control: NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
 EOF
-
-mkdir -p /srv/salt-overlay/salt/nginx
-echo ${MASTER_HTPASSWD} > /srv/salt-overlay/salt/nginx/htpasswd

--- a/cluster/photon-controller/templates/salt-master.sh
+++ b/cluster/photon-controller/templates/salt-master.sh
@@ -28,6 +28,7 @@ grains:
   cbr-cidr: $MASTER_IP_RANGE
   cloud: photon-controller
   master_extra_sans: $MASTER_EXTRA_SANS
+  api_servers: $MASTER_NAME
 EOF
 
 # Auto accept all keys from minions that try to join

--- a/cluster/saltbase/salt/docker/init.sls
+++ b/cluster/saltbase/salt/docker/init.sls
@@ -94,13 +94,13 @@ fix-service-docker:
     - require:
       - pkg: docker-engine
 
-'apt-key':
+apt-key:
    cmd.run:
      - name: 'apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D'
      - unless: 'apt-key finger | grep "5811 8E89"'
 
-'apt-update':
-  cmd.wait:
+apt-update:
+  cmd.run:
     - name: '/usr/bin/apt-get update -y'
     - require:
        - cmd : 'apt-key'

--- a/cluster/saltbase/salt/kube-apiserver/init.sls
+++ b/cluster/saltbase/salt/kube-apiserver/init.sls
@@ -1,4 +1,4 @@
-{% if grains['cloud'] is defined and grains.cloud in ['aws', 'gce', 'vagrant', 'vsphere', 'openstack'] %}
+{% if grains['cloud'] is defined and grains.cloud in ['aws', 'gce', 'vagrant', 'vsphere', 'photon-controller', 'openstack'] %}
 # TODO: generate and distribute tokens on other cloud providers.
 /srv/kubernetes/known_tokens.csv:
   file.managed:

--- a/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
+++ b/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
@@ -76,7 +76,7 @@
 {% set basic_auth_file = "" -%}
 {% set authz_mode = "" -%}
 {% set abac_policy_file = "" -%}
-{% if grains['cloud'] is defined and grains.cloud in [ 'aws', 'gce', 'vagrant', 'vsphere', 'openstack']  %}
+{% if grains['cloud'] is defined and grains.cloud in [ 'aws', 'gce', 'vagrant', 'vsphere', 'photon-controller', 'openstack']  %}
   {% set token_auth_file = " --token-auth-file=/srv/kubernetes/known_tokens.csv" -%}
   {% set basic_auth_file = " --basic-auth-file=/srv/kubernetes/basic_auth.csv" -%}
   {% set authz_mode = " --authorization-mode=ABAC" -%}

--- a/hack/verify-flags/exceptions.txt
+++ b/hack/verify-flags/exceptions.txt
@@ -29,8 +29,9 @@ cluster/log-dump.sh:    for node_name in "${NODE_NAMES[@]}"; do
 cluster/log-dump.sh:    local -r node_name="${1}"
 cluster/log-dump.sh:readonly report_dir="${1:-_artifacts}"
 cluster/mesos/docker/km/build.sh:  km_path=$(find-binary km darwin/amd64)
+cluster/photon-controller/templates/salt-master.sh:  api_servers: $MASTER_NAME
 cluster/photon-controller/templates/salt-minion.sh:  hostname_override: $(ip route get 1.1.1.1 | awk '{print $7}')
-cluster/photon-controller/util.sh:    node_ip=$(${PHOTON} vm networks "${node_id}" | grep -v "^-" | grep -E '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | head -1 | awk -F'\t' '{print $3}')
+cluster/photon-controller/util.sh:    node_ip=$(${PHOTON} vm networks "${node_id}" | grep -i $'\t'"00:0C:29" | grep -E '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | head -1 | awk -F'\t' '{print $3}')
 cluster/photon-controller/util.sh:  local cert_dir="/srv/kubernetes"
 cluster/photon-controller/util.sh:  node_name=${1}
 cluster/rackspace/util.sh:    local node_ip=$(nova show --minimal ${NODE_NAMES[$i]} \


### PR DESCRIPTION
- Improve reliability of network address detection by using MAC
  address. VMware has a MAC OUI that reliably distinguishes the VM's
  NICs from the other NICs (like the CBR). This doesn't rely on the
  unreliable reporting of the portgroup.
- Persist route changes. We configure routes on the master and nodes,
  but previously we didn't persist them so they didn't last across
  reboots. This persists them in /etc/network/interfaces
- Fix regression that didn't configure auth for kube-apiserver with
  Photon Controller.
- Reliably run apt-get update: Not doing this can cause apt to fail.
- Remove unused nginx config in salt
