### PR TITLE
vSphere provider - Getting node data by ip instead of uuid

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -17,12 +17,11 @@ limitations under the License.
 package vsphere
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/url"
-	"os/exec"
 	"strings"
 
 	"github.com/vmware/govmomi"
@@ -96,14 +95,12 @@ func init() {
 }
 
 func readInstanceID(cfg *VSphereConfig) (string, error) {
-	cmd := exec.Command("bash", "-c", `dmidecode -t 1 | grep UUID | tr -d ' ' | cut -f 2 -d ':'`)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	err := cmd.Run()
+	addrs, err := net.InterfaceAddrs()
 	if err != nil {
 		return "", err
 	}
-	if out.Len() == 0 {
+
+	if len(addrs) == 0 {
 		return "", fmt.Errorf("unable to retrieve Instance ID")
 	}
 
@@ -130,7 +127,22 @@ func readInstanceID(cfg *VSphereConfig) (string, error) {
 
 	s := object.NewSearchIndex(c.Client)
 
-	svm, err := s.FindByUuid(ctx, dc, strings.ToLower(strings.TrimSpace(out.String())), true, nil)
+	var svm object.Reference
+	for _, v := range addrs {
+		ip, _, err := net.ParseCIDR(v.String())
+		if err != nil {
+			return "", fmt.Errorf("unable to parse cidr from ip")
+		}
+
+		svm, err = s.FindByIp(ctx, dc, ip.String(), true)
+		if err == nil && svm != nil {
+			break
+		}
+	}
+	if svm == nil {
+		return "", fmt.Errorf("unable to retrieve vm reference from vSphere")
+	}
+
 	var vm mo.VirtualMachine
 	err = s.Properties(ctx, svm.Reference(), []string{"name"}, &vm)
 	if err != nil {


### PR DESCRIPTION
To get the uuid we need the service to be running as root. This change
allows us to run the controller-manager and api server as non-root.
