### PR TITLE
federation: setting a default value for FEDERATION_NAME

### DIFF
--- a/federation/cluster/common.sh
+++ b/federation/cluster/common.sh
@@ -93,6 +93,7 @@ function create-federation-api-objects {
     #We will use loadbalancer services where we can
     export FEDERATION_API_NODEPORT=32111
     export FEDERATION_NAMESPACE
+    export FEDERATION_NAME="${FEDERATION_NAME:-federation}"
 
     template="go run ${KUBE_ROOT}/federation/cluster/template.go"
 


### PR DESCRIPTION
federation tests are failing right now on jenkins:

http://kubekins.dls.corp.google.com/view/Critical%20Builds/job/kubernetes-e2e-gce-federation/694/

```
FEDERATION_NAME environment variable must be set
```

Setting a default value to "federation"

cc @kubernetes/sig-cluster-federation @mml 
