### PR TITLE
Add a generic admission controller that uses JSONPath for rules.

### DIFF
--- a/cmd/kube-apiserver/app/plugins.go
+++ b/cmd/kube-apiserver/app/plugins.go
@@ -30,6 +30,7 @@ import (
 	_ "k8s.io/kubernetes/plugin/pkg/admission/deny"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/exec"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/initialresources"
+	_ "k8s.io/kubernetes/plugin/pkg/admission/jsonpath"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/limitranger"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/namespace/autoprovision"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/namespace/exists"

--- a/pkg/util/jsonpath/jsonpath.go
+++ b/pkg/util/jsonpath/jsonpath.go
@@ -110,7 +110,7 @@ func (j *JSONPath) FindResults(data interface{}) ([][]reflect.Value, error) {
 // PrintResults write the results into writer
 func (j *JSONPath) PrintResults(wr io.Writer, results []reflect.Value) error {
 	for i, r := range results {
-		text, err := j.evalToText(r)
+		text, err := j.EvalToText(r)
 		if err != nil {
 			return err
 		}
@@ -474,8 +474,8 @@ func (j *JSONPath) evalFilter(input []reflect.Value, node *FilterNode) ([]reflec
 	return results, nil
 }
 
-// evalToText translates reflect value to corresponding text
-func (j *JSONPath) evalToText(v reflect.Value) ([]byte, error) {
+// EvalToText translates reflect value to corresponding text
+func (j *JSONPath) EvalToText(v reflect.Value) ([]byte, error) {
 	iface, ok := template.PrintableValue(v)
 	if !ok {
 		return nil, fmt.Errorf("can't print type %s", v.Type())

--- a/plugin/pkg/admission/jsonpath/admission.go
+++ b/plugin/pkg/admission/jsonpath/admission.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jsonpath
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"regexp"
+
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+
+	"k8s.io/kubernetes/pkg/admission"
+	util_jsonpath "k8s.io/kubernetes/pkg/util/jsonpath"
+	"k8s.io/kubernetes/pkg/util/yaml"
+)
+
+var jsonRegexp = regexp.MustCompile("^\\{\\.?([^{}]+)\\}$|^\\.?([^{}]+)$")
+
+// MassageJSONPath attempts to be flexible with JSONPath expressions, it accepts:
+//   * metadata.name (no leading '.' or curly brances '{...}'
+//   * {metadata.name} (no leading '.')
+//   * .metadata.name (no curly braces '{...}')
+//   * {.metadata.name} (complete expression)
+// And transforms them all into a valid jsonpat expression:
+//   {.metadata.name}
+// TODO: This is copied from pkg/kubectl/custom_column_printer.go move into the pkg/util/jsonpath package.
+func massageJSONPath(pathExpression string) (string, error) {
+	if len(pathExpression) == 0 {
+		return pathExpression, nil
+	}
+	submatches := jsonRegexp.FindStringSubmatch(pathExpression)
+	if submatches == nil {
+		return "", fmt.Errorf("unexpected path string, expected a 'name1.name2' or '.name1.name2' or '{name1.name2}' or '{.name1.name2}'")
+	}
+	if len(submatches) != 3 {
+		return "", fmt.Errorf("unexpected submatch list: %v", submatches)
+	}
+	var fieldSpec string
+	if len(submatches[1]) != 0 {
+		fieldSpec = submatches[1]
+	} else {
+		fieldSpec = submatches[2]
+	}
+	return fmt.Sprintf("{.%s}", fieldSpec), nil
+}
+
+type JSONPathAdmissionRule struct {
+	// Version indicates the version for the rule.  For now this has to be "v1"
+	Version string
+
+	// Name is the name of this rule
+	Name string
+
+	// KindRegexp holds a regular expression used to determine which Kinds of
+	// objects this rule applies to.
+	KindRegexp string `json:"kindRegexp", yaml:"kindRegexp"`
+
+	// Path holds a JSONPath expression to select particular fields
+	Path string `json:"path", yaml:"path"`
+
+	// MatchRegexp holds a matching expression, all values returned by the JSONPath expression (above)
+	// must match this expression for the object to be admitted
+	MatchRegexp string `json:"matchRegexp", yaml:"matchRegexp"`
+
+	// AcceptEmptyMatch indicates if an empty match is acceptable.  Empty match means that the
+	// JSONPath expression above returns no values.  Default is false, meaning that at least one
+	// value that matches MatchRegexp is required for admission
+	AcceptEmptyMatch bool `json:"acceptEmptyMatch", yaml:"acceptEmptyMatch"`
+}
+
+type JSONPathAdmissionConfig struct {
+	Rules []JSONPathAdmissionRule `json:"rules", yaml:"rules"`
+}
+
+func init() {
+	admission.RegisterPlugin("jsonpath", func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
+		if config == nil {
+			return nil, errors.New("Config file is required for JSONPath Admission Controller")
+		}
+		jsonConfig := JSONPathAdmissionConfig{}
+		data, err := ioutil.ReadAll(config)
+		if err != nil {
+			return nil, err
+		}
+		jsonData, err := yaml.ToJSON(data)
+		if err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal(jsonData, &jsonConfig); err != nil {
+			return nil, err
+		}
+		return NewJSONPathAdmission(jsonConfig)
+	})
+}
+
+type jsonPathRule struct {
+	name            string
+	kindRE          *regexp.Regexp
+	path            *util_jsonpath.JSONPath
+	matchRE         *regexp.Regexp
+	acceptNoMatches bool
+}
+
+func (r *jsonPathRule) String() string {
+	return fmt.Sprintf("%s: %s %s %s %v", r.name, r.kindRE.String(), r.path, r.matchRE.String(), r.acceptNoMatches)
+}
+
+func (r *jsonPathRule) admit(a admission.Attributes) error {
+	if !r.kindRE.MatchString(a.GetKind().Kind) {
+		return nil
+	}
+
+	vals, err := r.path.FindResults(a.GetObject())
+	if err != nil {
+		return err
+	}
+	resultCount := 0
+	buff := &bytes.Buffer{}
+	r.path.Execute(buff, a.GetObject())
+	for _, arr := range vals {
+		resultCount += len(arr)
+		for _, val := range arr {
+			text, err := r.path.EvalToText(val)
+			if err != nil {
+				return err
+			}
+			if !r.matchRE.Match(text) {
+				return errors.New(fmt.Sprintf("Rule %s: failed to match value (%s, %s)", r.name, r.matchRE.String(), string(text)))
+			}
+		}
+	}
+	if resultCount == 0 && !r.acceptNoMatches {
+		return errors.New(fmt.Sprintf("Rule %s failed: No matches", r.name))
+	}
+
+	return nil
+}
+
+type jsonPath struct {
+	rules []jsonPathRule
+}
+
+func (j *jsonPath) Admit(a admission.Attributes) (err error) {
+	for ix := range j.rules {
+		if err := j.rules[ix].admit(a); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (j *jsonPath) Handles(operation admission.Operation) bool {
+	return true
+}
+
+func makeRule(rule *JSONPathAdmissionRule) (*jsonPathRule, error) {
+	kre, err := regexp.Compile(rule.KindRegexp)
+	if err != nil {
+		return nil, err
+	}
+	path := util_jsonpath.New(rule.Name)
+	mPath, err := massageJSONPath(rule.Path)
+	if err != nil {
+		return nil, err
+	}
+	if err := path.Parse(mPath); err != nil {
+		return nil, err
+	}
+	mre, err := regexp.Compile(rule.MatchRegexp)
+	if err != nil {
+		return nil, err
+	}
+	return &jsonPathRule{
+		kindRE:          kre,
+		path:            path,
+		matchRE:         mre,
+		name:            rule.Name,
+		acceptNoMatches: rule.AcceptEmptyMatch,
+	}, nil
+}
+
+// NewJSONPathAdmission creates an admission controller based on a JSONPathConfig
+func NewJSONPathAdmission(config JSONPathAdmissionConfig) (admission.Interface, error) {
+	result := &jsonPath{}
+	for ix := range config.Rules {
+		rule, err := makeRule(&config.Rules[ix])
+		if err != nil {
+			return nil, err
+		}
+		result.rules = append(result.rules, *rule)
+	}
+	return result, nil
+}

--- a/plugin/pkg/admission/jsonpath/admission.go
+++ b/plugin/pkg/admission/jsonpath/admission.go
@@ -168,7 +168,7 @@ func (j *jsonPath) Admit(a admission.Attributes) (err error) {
 }
 
 func (j *jsonPath) Handles(operation admission.Operation) bool {
-	return true
+	return operation == admission.Create || operation == admission.Update
 }
 
 func makeRule(rule *JSONPathAdmissionRule) (*jsonPathRule, error) {

--- a/plugin/pkg/admission/jsonpath/admission_test.go
+++ b/plugin/pkg/admission/jsonpath/admission_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package jsonpath
 
 import (
@@ -24,7 +40,10 @@ func makeAttributes(kind, resource string, obj runtime.Object, ops []admission.O
 }
 
 func TestHandles(t *testing.T) {
-	j := &jsonPath{}
+	j, err := NewJSONPathAdmission(JSONPathAdmissionConfig{})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	handles := []admission.Operation{admission.Create, admission.Update}
 	for _, op := range handles {
@@ -44,17 +63,20 @@ func TestHandles(t *testing.T) {
 func TestJSONPathMultiRule(t *testing.T) {
 	config := JSONPathAdmissionConfig{
 		Rules: []JSONPathAdmissionRule{
-			JSONPathAdmissionRule{
+			{
+				APIVersion:  "v1",
 				KindRegexp:  "Pod",
 				Path:        ".metadata.name",
 				MatchRegexp: "^Foo.*$",
 			},
-			JSONPathAdmissionRule{
+			{
+				APIVersion:  "v1",
 				KindRegexp:  "Service",
 				Path:        ".metadata.name",
 				MatchRegexp: "^Foo.*$",
 			},
-			JSONPathAdmissionRule{
+			{
+				APIVersion:  "v1",
 				KindRegexp:  "Pod",
 				Path:        ".spec.containers[*].name",
 				MatchRegexp: "^Foo.*$",
@@ -119,7 +141,7 @@ func TestJSONPathMultiRule(t *testing.T) {
 				},
 				Spec: api.PodSpec{
 					Containers: []api.Container{
-						api.Container{
+						{
 							Name: "FooBaz",
 						},
 					},
@@ -175,6 +197,7 @@ func TestJSONPathRule(t *testing.T) {
 		{
 			name: "simple",
 			rule: JSONPathAdmissionRule{
+				APIVersion:  "v1",
 				KindRegexp:  "Pod",
 				Path:        ".metadata.name",
 				MatchRegexp: "^Foo.*$",
@@ -191,6 +214,7 @@ func TestJSONPathRule(t *testing.T) {
 		{
 			name: "simple fail",
 			rule: JSONPathAdmissionRule{
+				APIVersion:  "v1",
 				KindRegexp:  "Pod",
 				Path:        ".metadata.name",
 				MatchRegexp: "^Foo.*$",
@@ -207,6 +231,7 @@ func TestJSONPathRule(t *testing.T) {
 		{
 			name: "no kind match",
 			rule: JSONPathAdmissionRule{
+				APIVersion:  "v1",
 				KindRegexp:  "Pod",
 				Path:        ".metadata.name",
 				MatchRegexp: "^Foo.*$",
@@ -223,6 +248,7 @@ func TestJSONPathRule(t *testing.T) {
 		{
 			name: "complicated kind-match",
 			rule: JSONPathAdmissionRule{
+				APIVersion:  "v1",
 				KindRegexp:  "(Service)|(Pod)",
 				Path:        ".metadata.name",
 				MatchRegexp: "^Foo.*$",
@@ -239,6 +265,7 @@ func TestJSONPathRule(t *testing.T) {
 		{
 			name: "complicated kind-match",
 			rule: JSONPathAdmissionRule{
+				APIVersion:  "v1",
 				KindRegexp:  "(Service)|(Pod)",
 				Path:        ".metadata.name",
 				MatchRegexp: "^Foo.*$",
@@ -255,6 +282,7 @@ func TestJSONPathRule(t *testing.T) {
 		{
 			name: "multi-match",
 			rule: JSONPathAdmissionRule{
+				APIVersion:  "v1",
 				KindRegexp:  "Pod",
 				Path:        ".spec.containers[*].name",
 				MatchRegexp: "^Foo.*$",
@@ -265,10 +293,10 @@ func TestJSONPathRule(t *testing.T) {
 			obj: &api.Pod{
 				Spec: api.PodSpec{
 					Containers: []api.Container{
-						api.Container{
+						{
 							Name: "FooBar",
 						},
-						api.Container{
+						{
 							Name: "FooBaz",
 						},
 					},
@@ -278,6 +306,7 @@ func TestJSONPathRule(t *testing.T) {
 		{
 			name: "multi-match fail",
 			rule: JSONPathAdmissionRule{
+				APIVersion:  "v1",
 				KindRegexp:  "Pod",
 				Path:        ".spec.containers[*].name",
 				MatchRegexp: "^Foo.*$",
@@ -288,13 +317,13 @@ func TestJSONPathRule(t *testing.T) {
 			obj: &api.Pod{
 				Spec: api.PodSpec{
 					Containers: []api.Container{
-						api.Container{
+						{
 							Name: "FooBar",
 						},
-						api.Container{
+						{
 							Name: "FooBaz",
 						},
-						api.Container{
+						{
 							Name: "BazFooBar",
 						},
 					},
@@ -304,6 +333,7 @@ func TestJSONPathRule(t *testing.T) {
 		{
 			name: "multi-match no match fail",
 			rule: JSONPathAdmissionRule{
+				APIVersion:  "v1",
 				KindRegexp:  "Pod",
 				Path:        ".spec.containers[*].name",
 				MatchRegexp: "^Foo.*$",
@@ -320,6 +350,7 @@ func TestJSONPathRule(t *testing.T) {
 		{
 			name: "multi-match no match ok",
 			rule: JSONPathAdmissionRule{
+				APIVersion:       "v1",
 				KindRegexp:       "Pod",
 				Path:             ".spec.containers[*].name",
 				MatchRegexp:      "^Foo.*$",

--- a/plugin/pkg/admission/jsonpath/admission_test.go
+++ b/plugin/pkg/admission/jsonpath/admission_test.go
@@ -1,0 +1,338 @@
+package jsonpath
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/admission"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+func makeAttributes(kind, resource string, obj runtime.Object, ops []admission.Operation) []admission.Attributes {
+	if ops == nil {
+		ops = []admission.Operation{admission.Update, admission.Delete, admission.Connect}
+	}
+	result := []admission.Attributes{}
+	for _, op := range ops {
+		result = append(result, admission.NewAttributesRecord(obj, nil, api.Kind(kind).WithVersion("version"), "myns", "myname", api.Resource(resource).WithVersion("version"), "", op, nil))
+	}
+	return result
+}
+
+func TestJSONPathMultiRule(t *testing.T) {
+	config := JSONPathAdmissionConfig{
+		Rules: []JSONPathAdmissionRule{
+			JSONPathAdmissionRule{
+				KindRegexp:  "Pod",
+				Path:        ".metadata.name",
+				MatchRegexp: "^Foo.*$",
+			},
+			JSONPathAdmissionRule{
+				KindRegexp:  "Service",
+				Path:        ".metadata.name",
+				MatchRegexp: "^Foo.*$",
+			},
+			JSONPathAdmissionRule{
+				KindRegexp:  "Pod",
+				Path:        ".spec.containers[*].name",
+				MatchRegexp: "^Foo.*$",
+			},
+		},
+	}
+	file, err := ioutil.TempFile(os.TempDir(), "config")
+	if err != nil {
+		t.Errorf("unexpected error making tmp file: %v", err)
+		return
+	}
+	defer os.Remove(file.Name())
+	data, err := json.Marshal(config)
+	if err != nil {
+		t.Errorf("unexpected error marshaling data: %v", err)
+		return
+	}
+	fmt.Fprintf(file, string(data))
+	if err := file.Close(); err != nil {
+		t.Errorf("unexpected error closing file: %v", err)
+	}
+
+	a := admission.InitPlugin("jsonpath", nil, file.Name())
+	if a == nil {
+		t.Errorf("unexpected nil plugin")
+		return
+	}
+
+	tests := []struct {
+		name  string
+		kind  string
+		rsrc  string
+		obj   runtime.Object
+		admit bool
+	}{
+		{
+			name:  "empty",
+			kind:  "Pod",
+			rsrc:  "pods",
+			obj:   &api.Pod{},
+			admit: false,
+		},
+		{
+			name: "one condition",
+			kind: "Pod",
+			rsrc: "pods",
+			obj: &api.Pod{
+				ObjectMeta: api.ObjectMeta{
+					Name: "FooBar",
+				},
+			},
+			admit: false,
+		},
+		{
+			name: "all condition",
+			kind: "Pod",
+			rsrc: "pods",
+			obj: &api.Pod{
+				ObjectMeta: api.ObjectMeta{
+					Name: "FooBar",
+				},
+				Spec: api.PodSpec{
+					Containers: []api.Container{
+						api.Container{
+							Name: "FooBaz",
+						},
+					},
+				},
+			},
+			admit: true,
+		},
+		{
+			name: "other kind",
+			kind: "Service",
+			rsrc: "services",
+			obj: &api.Service{
+				ObjectMeta: api.ObjectMeta{
+					Name: "FooBar",
+				},
+			},
+			admit: true,
+		},
+		{
+			name:  "other kind empty",
+			kind:  "Service",
+			rsrc:  "services",
+			obj:   &api.Service{},
+			admit: false,
+		},
+	}
+	for _, test := range tests {
+		attrs := makeAttributes(test.kind, test.rsrc, test.obj, nil)
+		for _, attr := range attrs {
+			err := a.Admit(attr)
+			if test.admit && err != nil {
+				t.Errorf("expected no error, saw: %v for %s", err, test.name)
+				continue
+			}
+			if !test.admit && err == nil {
+				t.Errorf("unexpected non-error for %s", test.name)
+			}
+		}
+	}
+
+}
+
+func TestJSONPathRule(t *testing.T) {
+	tests := []struct {
+		name  string
+		rule  JSONPathAdmissionRule
+		admit bool
+		kind  string
+		rsrc  string
+		obj   runtime.Object
+		ops   []admission.Operation
+	}{
+		{
+			name: "simple",
+			rule: JSONPathAdmissionRule{
+				KindRegexp:  "Pod",
+				Path:        ".metadata.name",
+				MatchRegexp: "^Foo.*$",
+			},
+			admit: true,
+			kind:  "Pod",
+			rsrc:  "pods",
+			obj: &api.Pod{
+				ObjectMeta: api.ObjectMeta{
+					Name: "FooBar",
+				},
+			},
+		},
+		{
+			name: "simple fail",
+			rule: JSONPathAdmissionRule{
+				KindRegexp:  "Pod",
+				Path:        ".metadata.name",
+				MatchRegexp: "^Foo.*$",
+			},
+			admit: false,
+			kind:  "Pod",
+			rsrc:  "pods",
+			obj: &api.Pod{
+				ObjectMeta: api.ObjectMeta{
+					Name: "BazFooBar",
+				},
+			},
+		},
+		{
+			name: "no kind match",
+			rule: JSONPathAdmissionRule{
+				KindRegexp:  "Pod",
+				Path:        ".metadata.name",
+				MatchRegexp: "^Foo.*$",
+			},
+			admit: true,
+			kind:  "Service",
+			rsrc:  "services",
+			obj: &api.Service{
+				ObjectMeta: api.ObjectMeta{
+					Name: "BazFooBar",
+				},
+			},
+		},
+		{
+			name: "complicated kind-match",
+			rule: JSONPathAdmissionRule{
+				KindRegexp:  "(Service)|(Pod)",
+				Path:        ".metadata.name",
+				MatchRegexp: "^Foo.*$",
+			},
+			admit: true,
+			kind:  "Pod",
+			rsrc:  "pods",
+			obj: &api.Pod{
+				ObjectMeta: api.ObjectMeta{
+					Name: "FooBar",
+				},
+			},
+		},
+		{
+			name: "complicated kind-match",
+			rule: JSONPathAdmissionRule{
+				KindRegexp:  "(Service)|(Pod)",
+				Path:        ".metadata.name",
+				MatchRegexp: "^Foo.*$",
+			},
+			admit: false,
+			kind:  "Service",
+			rsrc:  "services",
+			obj: &api.Service{
+				ObjectMeta: api.ObjectMeta{
+					Name: "BazFooBar",
+				},
+			},
+		},
+		{
+			name: "multi-match",
+			rule: JSONPathAdmissionRule{
+				KindRegexp:  "Pod",
+				Path:        ".spec.containers[*].name",
+				MatchRegexp: "^Foo.*$",
+			},
+			admit: true,
+			kind:  "Pod",
+			rsrc:  "pods",
+			obj: &api.Pod{
+				Spec: api.PodSpec{
+					Containers: []api.Container{
+						api.Container{
+							Name: "FooBar",
+						},
+						api.Container{
+							Name: "FooBaz",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multi-match fail",
+			rule: JSONPathAdmissionRule{
+				KindRegexp:  "Pod",
+				Path:        ".spec.containers[*].name",
+				MatchRegexp: "^Foo.*$",
+			},
+			admit: false,
+			kind:  "Pod",
+			rsrc:  "pods",
+			obj: &api.Pod{
+				Spec: api.PodSpec{
+					Containers: []api.Container{
+						api.Container{
+							Name: "FooBar",
+						},
+						api.Container{
+							Name: "FooBaz",
+						},
+						api.Container{
+							Name: "BazFooBar",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multi-match no match fail",
+			rule: JSONPathAdmissionRule{
+				KindRegexp:  "Pod",
+				Path:        ".spec.containers[*].name",
+				MatchRegexp: "^Foo.*$",
+			},
+			admit: false,
+			kind:  "Pod",
+			rsrc:  "pods",
+			obj: &api.Pod{
+				Spec: api.PodSpec{
+					Containers: []api.Container{},
+				},
+			},
+		},
+		{
+			name: "multi-match no match ok",
+			rule: JSONPathAdmissionRule{
+				KindRegexp:       "Pod",
+				Path:             ".spec.containers[*].name",
+				MatchRegexp:      "^Foo.*$",
+				AcceptEmptyMatch: true,
+			},
+			admit: true,
+			kind:  "Pod",
+			rsrc:  "pods",
+			obj: &api.Pod{
+				Spec: api.PodSpec{
+					Containers: []api.Container{},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		attrs := makeAttributes(test.kind, test.rsrc, test.obj, test.ops)
+		for _, attr := range attrs {
+			rule, err := makeRule(&test.rule)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				continue
+			}
+			err = rule.admit(attr)
+			if test.admit && err != nil {
+				t.Errorf("Expected nil, got %v for %s", err, test.name)
+				continue
+			}
+			if !test.admit && err == nil {
+				t.Errorf("Unexpected nil for %s", test.name)
+			}
+		}
+	}
+}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -322,7 +322,7 @@ func (f *Framework) AfterEach() {
 		case "json":
 			for i := range summaries {
 				typeName := reflect.TypeOf(summaries[i]).String()
-				Logf("%v JSON\n%v", typeName[strings.LastIndex(typeName, ".")+1:len(typeName)], summaries[i].PrintJSON())
+				Logf("%v JSON\n%v", typeName[strings.LastIndex(typeName, ".")+1:], summaries[i].PrintJSON())
 				Logf("Finished")
 			}
 		default:


### PR DESCRIPTION
@derekwaynecarr @liggitt @smarterclayton @erictune fyi

Now that I wrote this, it probably already exists upstream...

This allows you to write a config like:

``` yaml
rules:
  # Require all Pods and Services names to start with "Foo"
  - name: FooName
    kindRegexp: "^(Pod)|(Service)$"
    path: ".metadata.name"
    apiVersion: "v1"
    matchRegexp: "^Foo.*"
 # Require all container images to be from gcr.io
 - name: GCRRegistry
   kindRegexp: "^Pod$"
   path: "spec.containers[*].image"
   apiVersion: "v1"
   matchRegexp: "^gcr.io/.*$"
```

Which will then enforce those rules via admission control.  This enables users to easily customize different admission controllers to suit their needs.

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/27336)

<!-- Reviewable:end -->
