### PR TITLE
Add image pulling node e2e

### DIFF
--- a/test/e2e_node/container_list.go
+++ b/test/e2e_node/container_list.go
@@ -38,8 +38,10 @@ const (
 	pauseImage
 
 	// Images just used for explicitly testing pulling of images
-	pullTestExecHealthz
+	pullTestAlpine
 	pullTestAlpineWithBash
+	pullTestAuthenticatedAlpine
+	pullTestExecHealthz
 )
 
 var ImageRegistry = map[int]string{
@@ -51,9 +53,11 @@ var ImageRegistry = map[int]string{
 }
 
 // These are used by tests that explicitly test the ability to pull images
-var NoPullImagRegistry = map[int]string{
-	pullTestAlpineWithBash: "gcr.io/google_containers/alpine-with-bash:1.0",
-	pullTestExecHealthz:    "gcr.io/google_containers/exechealthz:1.0",
+var NoPullImageRegistry = map[int]string{
+	pullTestExecHealthz:         "gcr.io/google_containers/exechealthz:1.0",
+	pullTestAlpine:              "alpine:3.1",
+	pullTestAlpineWithBash:      "gcr.io/google_containers/alpine-with-bash:1.0",
+	pullTestAuthenticatedAlpine: "gcr.io/authenticated-image-pulling/alpine:3.1",
 }
 
 // Pre-fetch all images tests depend on so that we don't fail in an actual test

--- a/test/e2e_node/image_conformance_test.go
+++ b/test/e2e_node/image_conformance_test.go
@@ -36,8 +36,8 @@ var _ = Describe("Image Container Conformance Test", func() {
 			var conformImages []ConformanceImage
 			BeforeEach(func() {
 				existImageTags := []string{
-					NoPullImagRegistry[pullTestExecHealthz],
-					NoPullImagRegistry[pullTestAlpineWithBash],
+					NoPullImageRegistry[pullTestExecHealthz],
+					NoPullImageRegistry[pullTestAlpineWithBash],
 				}
 				for _, existImageTag := range existImageTags {
 					conformImage, _ := NewConformanceImage("docker", existImageTag)

--- a/test/e2e_node/image_conformance_test.go
+++ b/test/e2e_node/image_conformance_test.go
@@ -19,9 +19,6 @@ package e2e_node
 import (
 	"time"
 
-	"k8s.io/kubernetes/pkg/client/restclient"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -34,13 +31,6 @@ const (
 )
 
 var _ = Describe("Image Container Conformance Test", func() {
-	var cl *client.Client
-
-	BeforeEach(func() {
-		// Setup the apiserver client
-		cl = client.NewOrDie(&restclient.Config{Host: *apiServerAddress})
-	})
-
 	Describe("[FLAKY] image conformance blackbox test", func() {
 		Context("when testing images that exist", func() {
 			var conformImages []ConformanceImage

--- a/test/e2e_node/kubelet_test.go
+++ b/test/e2e_node/kubelet_test.go
@@ -38,9 +38,8 @@ import (
 )
 
 var _ = framework.KubeDescribe("Kubelet", func() {
+	f := NewDefaultFramework("kubelet-test")
 	Context("when scheduling a busybox command in a pod", func() {
-		// Setup the framework
-		f := NewDefaultFramework("pod-scheduling")
 		podName := "busybox-scheduling-" + string(util.NewUUID())
 		It("it should print the output to logs", func() {
 			podClient := f.Client.Pods(f.Namespace.Name)
@@ -81,7 +80,6 @@ var _ = framework.KubeDescribe("Kubelet", func() {
 	})
 
 	Context("when scheduling a read only busybox container", func() {
-		f := NewDefaultFramework("pod-scheduling")
 		podName := "busybox-readonly-fs" + string(util.NewUUID())
 		It("it should not write to root filesystem", func() {
 			podClient := f.Client.Pods(f.Namespace.Name)
@@ -123,8 +121,6 @@ var _ = framework.KubeDescribe("Kubelet", func() {
 		})
 	})
 	Describe("metrics api", func() {
-		// Setup the framework
-		f := NewDefaultFramework("kubelet-metrics-api")
 		Context("when querying /stats/summary", func() {
 			It("it should report resource usage through the stats api", func() {
 				podNamePrefix := "stats-busybox-" + string(util.NewUUID())

--- a/test/e2e_node/runtime_conformance_test.go
+++ b/test/e2e_node/runtime_conformance_test.go
@@ -24,8 +24,6 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/client/restclient"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -48,15 +46,9 @@ type testCase struct {
 }
 
 var _ = Describe("Container Runtime Conformance Test", func() {
-	var cl *client.Client
-
-	BeforeEach(func() {
-		// Setup the apiserver client
-		cl = client.NewOrDie(&restclient.Config{Host: *apiServerAddress})
-	})
+	f := NewDefaultFramework("runtime-conformance")
 
 	Describe("container runtime conformance blackbox test", func() {
-		namespace := "runtime-conformance"
 
 		Context("when starting a container that exits", func() {
 			It("it should run with the expected status [Conformance]", func() {
@@ -108,11 +100,11 @@ while true; do sleep 1; done
 					testContainer.Command = []string{"sh", "-c", tmpCmd}
 					terminateContainer := ConformanceContainer{
 						Container:     testContainer,
-						Client:        cl,
+						Client:        f.Client,
 						RestartPolicy: testCase.RestartPolicy,
 						Volumes:       testVolumes,
 						NodeName:      *nodeName,
-						Namespace:     namespace,
+						Namespace:     f.Namespace.Name,
 					}
 					Expect(terminateContainer.Create()).To(Succeed())
 					defer terminateContainer.Delete()
@@ -152,10 +144,10 @@ while true; do sleep 1; done
 				testContainer.Name = testCase.Name
 				invalidImageContainer := ConformanceContainer{
 					Container:     testContainer,
-					Client:        cl,
+					Client:        f.Client,
 					RestartPolicy: testCase.RestartPolicy,
 					NodeName:      *nodeName,
-					Namespace:     namespace,
+					Namespace:     f.Namespace.Name,
 				}
 				Expect(invalidImageContainer.Create()).To(Succeed())
 				defer invalidImageContainer.Delete()

--- a/test/e2e_node/runtime_conformance_test.go
+++ b/test/e2e_node/runtime_conformance_test.go
@@ -24,32 +24,23 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 const (
-	consistentCheckTimeout = time.Second * 10
+	consistentCheckTimeout = time.Second * 5
 	retryTimeout           = time.Minute * 5
-	pollInterval           = time.Second * 5
+	pollInterval           = time.Second * 1
 )
 
-type testCase struct {
-	Name             string
-	RestartPolicy    api.RestartPolicy
-	Phase            api.PodPhase
-	State            ContainerState
-	RestartCountOper string
-	RestartCount     int32
-	Ready            bool
-}
-
-var _ = Describe("Container Runtime Conformance Test", func() {
+var _ = framework.KubeDescribe("Container Runtime Conformance Test", func() {
 	f := NewDefaultFramework("runtime-conformance")
 
 	Describe("container runtime conformance blackbox test", func() {
-
 		Context("when starting a container that exits", func() {
 			It("it should run with the expected status [Conformance]", func() {
 				restartCountVolumeName := "restart-count"
@@ -73,10 +64,17 @@ var _ = Describe("Container Runtime Conformance Test", func() {
 						},
 					},
 				}
-				testCases := []testCase{
-					{"terminate-cmd-rpa", api.RestartPolicyAlways, api.PodRunning, ContainerStateRunning, "==", 2, true},
-					{"terminate-cmd-rpof", api.RestartPolicyOnFailure, api.PodSucceeded, ContainerStateTerminated, "==", 1, false},
-					{"terminate-cmd-rpn", api.RestartPolicyNever, api.PodFailed, ContainerStateTerminated, "==", 0, false},
+				testCases := []struct {
+					Name          string
+					RestartPolicy api.RestartPolicy
+					Phase         api.PodPhase
+					State         ContainerState
+					RestartCount  int32
+					Ready         bool
+				}{
+					{"terminate-cmd-rpa", api.RestartPolicyAlways, api.PodRunning, ContainerStateRunning, 2, true},
+					{"terminate-cmd-rpof", api.RestartPolicyOnFailure, api.PodSucceeded, ContainerStateTerminated, 1, false},
+					{"terminate-cmd-rpn", api.RestartPolicyNever, api.PodFailed, ContainerStateTerminated, 0, false},
 				}
 				for _, testCase := range testCases {
 					tmpFile, err := ioutil.TempFile("", "restartCount")
@@ -113,7 +111,7 @@ while true; do sleep 1; done
 					Eventually(func() (int32, error) {
 						status, err := terminateContainer.GetStatus()
 						return status.RestartCount, err
-					}, retryTimeout, pollInterval).Should(BeNumerically(testCase.RestartCountOper, testCase.RestartCount))
+					}, retryTimeout, pollInterval).Should(Equal(testCase.RestartCount))
 
 					By("it should get the expected 'Phase'")
 					Eventually(terminateContainer.GetPhase, retryTimeout, pollInterval).Should(Equal(testCase.Phase))
@@ -134,43 +132,110 @@ while true; do sleep 1; done
 			})
 		})
 
-		Context("when running a container with invalid image", func() {
-			It("it should run with the expected status [Conformance]", func() {
-				testContainer := api.Container{
-					Image:   "foo.com/foo/foo",
-					Command: []string{"false"},
-				}
-				testCase := testCase{"invalid-image-rpa", api.RestartPolicyAlways, api.PodPending, ContainerStateWaiting, "==", 0, false}
-				testContainer.Name = testCase.Name
-				invalidImageContainer := ConformanceContainer{
-					Container:     testContainer,
-					Client:        f.Client,
-					RestartPolicy: testCase.RestartPolicy,
-					NodeName:      *nodeName,
-					Namespace:     f.Namespace.Name,
-				}
-				Expect(invalidImageContainer.Create()).To(Succeed())
-				defer invalidImageContainer.Delete()
+		Context("when running a container with a new image", func() {
+			// The service account only has pull permission
+			auth := `
+{
+	"auths": {
+		"https://gcr.io": {
+			"auth": "X2pzb25fa2V5OnsKICAidHlwZSI6ICJzZXJ2aWNlX2FjY291bnQiLAogICJwcm9qZWN0X2lkIjogImF1dGhlbnRpY2F0ZWQtaW1hZ2UtcHVsbGluZyIsCiAgInByaXZhdGVfa2V5X2lkIjogImI5ZjJhNjY0YWE5YjIwNDg0Y2MxNTg2MDYzZmVmZGExOTIyNGFjM2IiLAogICJwcml2YXRlX2tleSI6ICItLS0tLUJFR0lOIFBSSVZBVEUgS0VZLS0tLS1cbk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQzdTSG5LVEVFaVlMamZcbkpmQVBHbUozd3JCY2VJNTBKS0xxS21GWE5RL3REWGJRK2g5YVl4aldJTDhEeDBKZTc0bVovS01uV2dYRjVLWlNcbm9BNktuSU85Yi9SY1NlV2VpSXRSekkzL1lYVitPNkNjcmpKSXl4anFWam5mVzJpM3NhMzd0OUE5VEZkbGZycm5cbjR6UkpiOWl4eU1YNGJMdHFGR3ZCMDNOSWl0QTNzVlo1ODhrb1FBZmgzSmhhQmVnTWorWjRSYko0aGVpQlFUMDNcbnZVbzViRWFQZVQ5RE16bHdzZWFQV2dydDZOME9VRGNBRTl4bGNJek11MjUzUG4vSzgySFpydEx4akd2UkhNVXhcbng0ZjhwSnhmQ3h4QlN3Z1NORit3OWpkbXR2b0wwRmE3ZGducFJlODZWRDY2ejNZenJqNHlLRXRqc2hLZHl5VWRcbkl5cVhoN1JSQWdNQkFBRUNnZ0VBT3pzZHdaeENVVlFUeEFka2wvSTVTRFVidi9NazRwaWZxYjJEa2FnbmhFcG9cbjFJajJsNGlWMTByOS9uenJnY2p5VlBBd3pZWk1JeDFBZVF0RDdoUzRHWmFweXZKWUc3NkZpWFpQUm9DVlB6b3VcbmZyOGRDaWFwbDV0enJDOWx2QXNHd29DTTdJWVRjZmNWdDdjRTEyRDNRS3NGNlo3QjJ6ZmdLS251WVBmK0NFNlRcbmNNMHkwaCtYRS9kMERvSERoVy96YU1yWEhqOFRvd2V1eXRrYmJzNGYvOUZqOVBuU2dET1lQd2xhbFZUcitGUWFcbkpSd1ZqVmxYcEZBUW14M0Jyd25rWnQzQ2lXV2lGM2QrSGk5RXRVYnRWclcxYjZnK1JRT0licWFtcis4YlJuZFhcbjZWZ3FCQWtKWjhSVnlkeFVQMGQxMUdqdU9QRHhCbkhCbmM0UW9rSXJFUUtCZ1FEMUNlaWN1ZGhXdGc0K2dTeGJcbnplanh0VjFONDFtZHVjQnpvMmp5b1dHbzNQVDh3ckJPL3lRRTM0cU9WSi9pZCs4SThoWjRvSWh1K0pBMDBzNmdcblRuSXErdi9kL1RFalk4MW5rWmlDa21SUFdiWHhhWXR4UjIxS1BYckxOTlFKS2ttOHRkeVh5UHFsOE1veUdmQ1dcbjJ2aVBKS05iNkhabnY5Q3lqZEo5ZzJMRG5RS0JnUUREcVN2eURtaGViOTIzSW96NGxlZ01SK205Z2xYVWdTS2dcbkVzZlllbVJmbU5XQitDN3ZhSXlVUm1ZNU55TXhmQlZXc3dXRldLYXhjK0krYnFzZmx6elZZdFpwMThNR2pzTURcbmZlZWZBWDZCWk1zVXQ3Qmw3WjlWSjg1bnRFZHFBQ0xwWitaLzN0SVJWdWdDV1pRMWhrbmxHa0dUMDI0SkVFKytcbk55SDFnM2QzUlFLQmdRQ1J2MXdKWkkwbVBsRklva0tGTkh1YTBUcDNLb1JTU1hzTURTVk9NK2xIckcxWHJtRjZcbkMwNGNTKzQ0N0dMUkxHOFVUaEpKbTRxckh0Ti9aK2dZOTYvMm1xYjRIakpORDM3TVhKQnZFYTN5ZUxTOHEvK1JcbjJGOU1LamRRaU5LWnhQcG84VzhOSlREWTVOa1BaZGh4a2pzSHdVNGRTNjZwMVRESUU0MGd0TFpaRFFLQmdGaldcbktyblFpTnEzOS9iNm5QOFJNVGJDUUFKbmR3anhTUU5kQTVmcW1rQTlhRk9HbCtqamsxQ1BWa0tNSWxLSmdEYkpcbk9heDl2OUc2Ui9NSTFIR1hmV3QxWU56VnRocjRIdHNyQTB0U3BsbWhwZ05XRTZWejZuQURqdGZQSnMyZUdqdlhcbmpQUnArdjhjY21MK3dTZzhQTGprM3ZsN2VlNXJsWWxNQndNdUdjUHhBb0dBZWRueGJXMVJMbVZubEFpSEx1L0xcbmxtZkF3RFdtRWlJMFVnK1BMbm9Pdk81dFE1ZDRXMS94RU44bFA0cWtzcGtmZk1Rbk5oNFNZR0VlQlQzMlpxQ1RcbkpSZ2YwWGpveXZ2dXA5eFhqTWtYcnBZL3ljMXpmcVRaQzBNTzkvMVVjMWJSR2RaMmR5M2xSNU5XYXA3T1h5Zk9cblBQcE5Gb1BUWGd2M3FDcW5sTEhyR3pNPVxuLS0tLS1FTkQgUFJJVkFURSBLRVktLS0tLVxuIiwKICAiY2xpZW50X2VtYWlsIjogImltYWdlLXB1bGxpbmdAYXV0aGVudGljYXRlZC1pbWFnZS1wdWxsaW5nLmlhbS5nc2VydmljZWFjY291bnQuY29tIiwKICAiY2xpZW50X2lkIjogIjExMzc5NzkxNDUzMDA3MzI3ODcxMiIsCiAgImF1dGhfdXJpIjogImh0dHBzOi8vYWNjb3VudHMuZ29vZ2xlLmNvbS9vL29hdXRoMi9hdXRoIiwKICAidG9rZW5fdXJpIjogImh0dHBzOi8vYWNjb3VudHMuZ29vZ2xlLmNvbS9vL29hdXRoMi90b2tlbiIsCiAgImF1dGhfcHJvdmlkZXJfeDUwOV9jZXJ0X3VybCI6ICJodHRwczovL3d3dy5nb29nbGVhcGlzLmNvbS9vYXV0aDIvdjEvY2VydHMiLAogICJjbGllbnRfeDUwOV9jZXJ0X3VybCI6ICJodHRwczovL3d3dy5nb29nbGVhcGlzLmNvbS9yb2JvdC92MS9tZXRhZGF0YS94NTA5L2ltYWdlLXB1bGxpbmclNDBhdXRoZW50aWNhdGVkLWltYWdlLXB1bGxpbmcuaWFtLmdzZXJ2aWNlYWNjb3VudC5jb20iCn0=",
+			"email": "image-pulling@authenticated-image-pulling.iam.gserviceaccount.com"
+		}
+	}
+}`
+			secret := &api.Secret{
+				Data: map[string][]byte{api.DockerConfigJsonKey: []byte(auth)},
+				Type: api.SecretTypeDockerConfigJson,
+			}
+			for _, testCase := range []struct {
+				description string
+				image       string
+				secret      bool
+				phase       api.PodPhase
+				state       ContainerState
+			}{
+				{
+					description: "should not be able to pull image from invalid registry",
+					image:       "invalid.com/invalid/alpine:3.1",
+					phase:       api.PodPending,
+					state:       ContainerStateWaiting,
+				},
+				{
+					description: "should not be able to pull non-existing image from gcr.io",
+					image:       "gcr.io/google_containers/invalid-image:invalid-tag",
+					phase:       api.PodPending,
+					state:       ContainerStateWaiting,
+				},
+				{
+					description: "should be able to pull image from gcr.io",
+					image:       NoPullImageRegistry[pullTestAlpineWithBash],
+					phase:       api.PodRunning,
+					state:       ContainerStateRunning,
+				},
+				{
+					description: "should be able to pull image from docker hub",
+					image:       NoPullImageRegistry[pullTestAlpine],
+					phase:       api.PodRunning,
+					state:       ContainerStateRunning,
+				},
+				{
+					description: "should not be able to pull from private registry without secret",
+					image:       NoPullImageRegistry[pullTestAuthenticatedAlpine],
+					phase:       api.PodPending,
+					state:       ContainerStateWaiting,
+				},
+				{
+					description: "should be able to pull from private registry with secret",
+					image:       NoPullImageRegistry[pullTestAuthenticatedAlpine],
+					secret:      true,
+					phase:       api.PodRunning,
+					state:       ContainerStateRunning,
+				},
+			} {
+				testCase := testCase
+				It(testCase.description, func() {
+					name := "image-pull-test"
+					command := []string{"/bin/sh", "-c", "while true; do sleep 1; done"}
+					container := ConformanceContainer{
+						Container: api.Container{
+							Name:    name,
+							Image:   testCase.image,
+							Command: command,
+							// PullAlways makes sure that the image will always be pulled even if it is present before the test.
+							ImagePullPolicy: api.PullAlways,
+						},
+						Client:        f.Client,
+						RestartPolicy: api.RestartPolicyNever,
+						NodeName:      *nodeName,
+						Namespace:     f.Namespace.Name,
+					}
+					if testCase.secret {
+						secret.Name = "image-pull-secret-" + string(util.NewUUID())
+						By("create image pull secret")
+						_, err := f.Client.Secrets(f.Namespace.Name).Create(secret)
+						Expect(err).NotTo(HaveOccurred())
+						defer f.Client.Secrets(f.Namespace.Name).Delete(secret.Name)
+						container.ImagePullSecrets = []string{secret.Name}
+					}
 
-				Eventually(invalidImageContainer.GetPhase, retryTimeout, pollInterval).Should(Equal(testCase.Phase))
-				Consistently(invalidImageContainer.GetPhase, consistentCheckTimeout, pollInterval).Should(Equal(testCase.Phase))
+					By("create the container")
+					Expect(container.Create()).To(Succeed())
+					defer container.Delete()
 
-				status, err := invalidImageContainer.GetStatus()
-				Expect(err).NotTo(HaveOccurred())
+					By("check the pod phase")
+					Eventually(container.GetPhase, retryTimeout, pollInterval).Should(Equal(testCase.phase))
+					Consistently(container.GetPhase, consistentCheckTimeout, pollInterval).Should(Equal(testCase.phase))
 
-				By("it should get the expected 'RestartCount'")
-				Expect(status.RestartCount).To(BeNumerically(testCase.RestartCountOper, testCase.RestartCount))
+					By("check the container state")
+					status, err := container.GetStatus()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(GetContainerState(status.State)).To(Equal(testCase.state))
 
-				By("it should get the expected 'Ready' status")
-				Expect(status.Ready).To(Equal(testCase.Ready))
-
-				By("it should get the expected 'State'")
-				Expect(GetContainerState(status.State)).To(Equal(testCase.State))
-
-				By("it should be possible to delete [Conformance]")
-				Expect(invalidImageContainer.Delete()).To(Succeed())
-				Eventually(invalidImageContainer.Present, retryTimeout, pollInterval).Should(BeFalse())
-			})
+					By("it should be possible to delete")
+					Expect(container.Delete()).To(Succeed())
+					Eventually(container.Present, retryTimeout, pollInterval).Should(BeFalse())
+				})
+			}
 		})
 	})
 })


### PR DESCRIPTION
Fixes #27007.
Based on #27309, will rebase after #27309 gets merged.

This PR added all tests mentioned in #27007:
- Pull an image from invalid registry;
- Pull an invalid image from gcr;
- Pull an image from gcr;
- Pull an image from docker hub;
- Pull an image needs auth with/without secrets.

For the imagePullSecrets test, I created a new gcloud project "authenticated-image-pulling", and the service account in the code only has "Storage Object Viewer" permission.

/cc @pwittrock @vishh 

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
