### PR TITLE
Add not-running check to kubectl-exec

### DIFF
--- a/pkg/kubectl/cmd/exec.go
+++ b/pkg/kubectl/cmd/exec.go
@@ -174,6 +174,10 @@ func (p *ExecOptions) Run() error {
 		return err
 	}
 
+	if pod.Status.Phase == api.PodSucceeded || pod.Status.Phase == api.PodFailed {
+		return fmt.Errorf("cannot exec into a container in a completed pod; current phase is %s", pod.Status.Phase)
+	}
+
 	containerName := p.ContainerName
 	if len(containerName) == 0 {
 		glog.V(4).Infof("defaulting container name to %s", pod.Spec.Containers[0].Name)


### PR DESCRIPTION
Different cases:
- pod is started, container terminated: 

```
error: error executing remote command: error executing command in container: container not found ("sleep1")
```
- pod has terminated:

```
error: cannot exec into a container in a completed pod; current phase is Succeeded
```
- container does not exist in pod spec:

```
Error from server: container foo is not valid for pod multi-container
```

Fixes https://github.com/openshift/origin/issues/8472#event-681794952
