### PR TITLE
Update "kubectl get all" to display resource type as part of name

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -423,6 +423,7 @@ session-affinity
 setup-node
 show-all
 show-events
+show-kind
 show-labels
 shutdown-fd
 shutdown-fifo

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -103,6 +103,7 @@ func NewCmdGet(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().StringP("selector", "l", "", "Selector (label query) to filter on")
 	cmd.Flags().BoolP("watch", "w", false, "After listing/getting the requested object, watch for changes.")
 	cmd.Flags().Bool("watch-only", false, "Watch for changes to the requested object(s), without listing/getting first.")
+	cmd.Flags().Bool("show-kind", false, "If present, list the resource type for the requested object(s).")
 	cmd.Flags().Bool("all-namespaces", false, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
 	cmd.Flags().StringSliceP("label-columns", "L", []string{}, "Accepts a comma separated list of labels that are going to be presented as columns. Names are case-sensitive. You can also use multiple flag statements like -L label1 -L label2...")
 	cmd.Flags().Bool("export", false, "If true, use 'export' for the resources.  Exported resources are stripped of cluster-specific information.")
@@ -118,6 +119,7 @@ func NewCmdGet(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string, options *GetOptions) error {
 	selector := cmdutil.GetFlagString(cmd, "selector")
 	allNamespaces := cmdutil.GetFlagBool(cmd, "all-namespaces")
+	allKinds := cmdutil.GetFlagBool(cmd, "show-kind")
 	mapper, typer := f.Object(cmdutil.GetIncludeThirdPartyAPIs(cmd))
 
 	cmdNamespace, enforceNamespace, err := f.DefaultNamespace()
@@ -294,8 +296,28 @@ func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string
 	// use the default printer for each object
 	printer = nil
 	var lastMapping *meta.RESTMapping
+	var withKind bool = allKinds
 	w := kubectl.GetNewTabWriter(out)
 	defer w.Flush()
+
+	// determine if printing multiple kinds of
+	// objects and enforce "show-kinds" flag if so
+	for ix := range objs {
+		var mapping *meta.RESTMapping
+		if sorter != nil {
+			mapping = infos[sorter.OriginalPosition(ix)].Mapping
+		} else {
+			mapping = infos[ix].Mapping
+		}
+
+		// display "kind" column only if we have mixed resources
+		if lastMapping != nil && mapping.Resource != lastMapping.Resource {
+			withKind = true
+		}
+		lastMapping = mapping
+	}
+
+	lastMapping = nil
 
 	for ix := range objs {
 		var mapping *meta.RESTMapping
@@ -315,7 +337,16 @@ func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string
 			}
 			lastMapping = mapping
 		}
-		if _, found := printer.(*kubectl.HumanReadablePrinter); found {
+		if resourcePrinter, found := printer.(*kubectl.HumanReadablePrinter); found {
+			resourceName := mapping.Resource
+			if alias, ok := kubectl.ResourceShortFormFor(mapping.Resource); ok {
+				resourceName = alias
+			} else if resourceName == "" {
+				resourceName = "none"
+			}
+
+			resourcePrinter.Options.WithKind = withKind
+			resourcePrinter.Options.KindName = resourceName
 			if err := printer.PrintObj(original, w); err != nil {
 				allErrs = append(allErrs, err)
 			}

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -164,6 +164,19 @@ var shortForms = map[string]string{
 	"svc":    "services",
 }
 
+// Look-up for resource short forms by value
+func ResourceShortFormFor(resource string) (string, bool) {
+	var alias string
+	exists := false
+	for k, val := range shortForms {
+		if val == resource {
+			alias = k
+			exists = true
+		}
+	}
+	return alias, exists
+}
+
 // expandResourceShortcut will return the expanded version of resource
 // (something that a pkg/api/meta.RESTMapper can understand), if it is
 // indeed a shortcut. Otherwise, will return resource unmodified.


### PR DESCRIPTION
fixes #23838
release-note-none

When running "kubectl get all", or printing any output with mixed resource kinds, an additional column is added to the output with each resource's kind:

`kubectl get all --all-namespaces`

```
NAMESPACE     NAME                         DESIRED          CURRENT       AGE
default       rc/docker-registry-1         1                1             23h
testproject   rc/node-1                    0                0             2d
NAMESPACE     NAME                         CLUSTER-IP       EXTERNAL-IP   PORT(S)                 AGE
default       svc/docker-registry          172.30.36.42     <none>        5000/TCP                23h
default       svc/kubernetes               172.30.0.1       <none>        443/TCP,53/UDP,53/TCP   7d
testproject   svc/ruby-ex                  172.30.187.128   <none>        8080/TCP                6d
NAMESPACE     NAME                         READY            STATUS        RESTARTS                AGE
default       po/docker-registry-1-cpf8o   1/1              Running       1                       23h
```

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
