### PR TITLE
in nsenter mounter, read  hosts PID 1 /proc/mounts to list the mounts

### DIFF
--- a/pkg/util/mount/nsenter_mount.go
+++ b/pkg/util/mount/nsenter_mount.go
@@ -88,7 +88,7 @@ var _ = Interface(&NsenterMounter{})
 
 const (
 	hostRootFsPath     = "/rootfs"
-	hostProcMountsPath = "/rootfs/proc/mounts"
+	hostProcMountsPath = "/rootfs/proc/1/mounts"
 	nsenterPath        = "nsenter"
 )
 


### PR DESCRIPTION
fix #27378 
