### PR TITLE
Fix problem specifying fqdn:port in command line

### DIFF
--- a/pkg/client/restclient/url_utils.go
+++ b/pkg/client/restclient/url_utils.go
@@ -36,7 +36,7 @@ func DefaultServerURL(host, apiPath string, groupVersion unversioned.GroupVersio
 	if err != nil {
 		return nil, "", err
 	}
-	if hostURL.Scheme == "" {
+	if hostURL.Scheme == "" || hostURL.Host == "" {
 		scheme := "http://"
 		if defaultTLS {
 			scheme = "https://"


### PR DESCRIPTION
When specifying --server in kubectl for example, we end up
with failure if you use "localhost:8080" instead of
"127.0.0.1:8080". This is because of the way url.Parse
works as shown in snippet:
https://play.golang.org/p/luD57S6sEz

Essentially localhost ends up as the Scheme and NOT as the Host.
So we add another check to make sure we prepend the scheme
when Host ends up being empty as well. Tested with
"kubectl --server localhost:8080 get po"

Fixes #2967
