### PR TITLE
federation: choosing a default federation name in test instead of failing

### DIFF
--- a/test/e2e/federated-service.go
+++ b/test/e2e/federated-service.go
@@ -49,6 +49,8 @@ const (
 	FederatedServiceName = "federated-service"
 	FederatedServicePod  = "federated-service-test-pod"
 
+	DefaultFederationName = "federation"
+
 	// TODO: Only suppoprts IPv4 addresses. Also add a regexp for IPv6 addresses.
 	FederatedIPAddrRegexp  = `(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])`
 	FederatedDNS1123Regexp = `([a-z0-9]([-a-z0-9]*[a-z0-9])?\.)*([a-z0-9]([-a-z0-9]*[a-z0-9])?)`
@@ -64,8 +66,7 @@ var _ = framework.KubeDescribe("Service [Feature:Federation]", func() {
 
 		// TODO: Federation API server should be able to answer this.
 		if federationName = os.Getenv("FEDERATION_NAME"); federationName == "" {
-			// Tests cannot proceed without this value, so fail early here.
-			framework.Failf("FEDERATION_NAME environment variable must be set")
+			federationName = DefaultFederationName
 		}
 
 		contexts := f.GetUnderlyingFederatedContexts()


### PR DESCRIPTION
The tests are failing right now:
http://kubekins.dls.corp.google.com/job/kubernetes-e2e-gce-federation/

```
[k8s.io] Service [Feature:Federation] should be able to discover a non-local federated service

/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/federated-service.go:130 Jun 14 12:40:35.091: FEDERATION_NAME environment variable must be set


[k8s.io] Service [Feature:Federation] should be able to discover a federated service

/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/federated-service.go:130 Jun 14 12:40:40.802: FEDERATION_NAME environment variable must be set
```

This is to fix them.

cc @kubernetes/sig-cluster-federation @mml 
