### PR TITLE
including federation binaries in the list of images we push during release

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -1511,6 +1511,8 @@ function kube::release::docker::release() {
     "kube-scheduler"
     "kube-proxy"
     "hyperkube"
+    "federation-apiserver"
+    "federation-controller-manager"
   )
 
   local docker_push_cmd=("${DOCKER[@]}")


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/27382

Added `federation-apiserver` and `federation-controller-manager` to that list.

cc @kubernetes/sig-cluster-federation @colhom @david-mcmahon 
