### PR TITLE
federation-apiserver test: Increasing timeout for clusters to be ready

### DIFF
--- a/test/e2e/federation-apiserver.go
+++ b/test/e2e/federation-apiserver.go
@@ -75,7 +75,7 @@ var _ = framework.KubeDescribe("Federation apiserver [Feature:Federation]", func
 
 // Verify that the cluster is marked ready.
 func isReady(clusterName string, clientset *federation_internalclientset.Clientset) error {
-	return wait.PollImmediate(time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+	return wait.PollImmediate(time.Second, 5*time.Minute, func() (bool, error) {
 		c, err := clientset.Federation().Clusters().Get(clusterName)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/26762

federation-apiserver test is flaking on Jenkins.
The test has failed 25 times in the last 29 runs.
The most recent run passed.

Turns out wait.ForeverTestTimeout is only 30 secs.
Looking at waitFor\* methods in test/e2e/framework/util.go looks like most tests use a timeout of 2 mins or 5 mins.
Setting it to 5 mins here to account for cross cluster communication.

We use 5 mins already in federated-service test.

cc @kubernetes/sig-cluster-federation @mml 
