### PR TITLE
Allow specifying base location for test etcd data

### DIFF
--- a/docs/devel/testing.md
+++ b/docs/devel/testing.md
@@ -50,6 +50,7 @@ Updated: 5/21/2016
     - [Benchmark unit tests](#benchmark-unit-tests)
   - [Integration tests](#integration-tests)
     - [Install etcd dependency](#install-etcd-dependency)
+    - [Etcd test data](#etcd-test-data)
     - [Run integration tests](#run-integration-tests)
     - [Run a specific integration test](#run-a-specific-integration-test)
   - [End-to-End tests](#end-to-end-tests)
@@ -212,6 +213,14 @@ grep -E "image.*etcd" cluster/saltbase/etcd/etcd.manifest  # Find version
 # Install that version using yum/apt-get/etc
 echo export PATH="$PATH:<LOCATION>" >> ~/.profile  # Add to PATH
 ```
+
+### Etcd test data
+
+Many tests start an etcd server internally, storing test data in the operating system's temporary directory.
+
+If you see test failures because the temporary directory does not have sufficient space,
+or is on a volume with unpredictable write latency, you can override the test data directory
+for those internal etcd instances with the `TEST_ETCD_DIR` environment variable.
 
 ### Run integration tests
 

--- a/pkg/storage/etcd/testing/utils.go
+++ b/pkg/storage/etcd/testing/utils.go
@@ -113,7 +113,13 @@ func configureTestCluster(t *testing.T, name string) *EtcdTestServer {
 		t.Fatal(err)
 	}
 
-	m.CertificatesDir, err = ioutil.TempDir(os.TempDir(), "etcd_certificates")
+	// Allow test launches to control where etcd data goes, for space or performance reasons
+	baseDir := os.Getenv("TEST_ETCD_DIR")
+	if len(baseDir) == 0 {
+		baseDir = os.TempDir()
+	}
+
+	m.CertificatesDir, err = ioutil.TempDir(baseDir, "etcd_certificates")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -138,7 +144,7 @@ func configureTestCluster(t *testing.T, name string) *EtcdTestServer {
 	}
 
 	m.Name = name
-	m.DataDir, err = ioutil.TempDir(os.TempDir(), "etcd")
+	m.DataDir, err = ioutil.TempDir(baseDir, "etcd")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Allows controlling where etcd test data goes. Needed in some environments (like AWS/EBS) to allow putting etcd data on a higher performing volume than /tmp
