### PR TITLE
fix updatePod() of RS and RC controllers

### DIFF
--- a/pkg/controller/replication/replication_controller_test.go
+++ b/pkg/controller/replication/replication_controller_test.go
@@ -531,16 +531,32 @@ func TestUpdatePods(t *testing.T) {
 	testControllerSpec2.Name = "barfoo"
 	manager.rcStore.Indexer.Add(&testControllerSpec2)
 
-	// Put one pod in the podStore
+	// case 1: We put in the podStore a pod with labels matching
+	// testControllerSpec1, then update its labels to match testControllerSpec2.
+	// We expect to receive a sync request for both controllers.
 	pod1 := newPodList(manager.podStore.Indexer, 1, api.PodRunning, testControllerSpec1, "pod").Items[0]
 	pod2 := pod1
 	pod2.Labels = testControllerSpec2.Spec.Selector
-
-	// Send an update of the same pod with modified labels, and confirm we get a sync request for
-	// both controllers
 	manager.updatePod(&pod1, &pod2)
-
 	expected := sets.NewString(testControllerSpec1.Name, testControllerSpec2.Name)
+	for _, name := range expected.List() {
+		t.Logf("Expecting update for %+v", name)
+		select {
+		case got := <-received:
+			if !expected.Has(got) {
+				t.Errorf("Expected keys %#v got %v", expected, got)
+			}
+		case <-time.After(wait.ForeverTestTimeout):
+			t.Errorf("Expected update notifications for controllers within 100ms each")
+		}
+	}
+
+	// case 2: pod1 in the podStore has labels matching testControllerSpec1.
+	// We update its labels to match no replication controller.  We expect to
+	// receive a sync request for testControllerSpec1.
+	pod2.Labels = make(map[string]string)
+	manager.updatePod(&pod1, &pod2)
+	expected = sets.NewString(testControllerSpec1.Name)
 	for _, name := range expected.List() {
 		t.Logf("Expecting update for %+v", name)
 		select {


### PR DESCRIPTION
Fix updatePod of replication controller manager and replica set controller to handle pod label updates that match no RC or RS.

Fix #27405
