### PR TITLE
Allow emitting PersistentVolume events.

### DIFF
--- a/pkg/api/validation/events.go
+++ b/pkg/api/validation/events.go
@@ -25,15 +25,16 @@ import (
 // ValidateEvent makes sure that the event makes sense.
 func ValidateEvent(event *api.Event) field.ErrorList {
 	allErrs := field.ErrorList{}
-	// There is no namespace required for node.
+	// There is no namespace required for node or persistent volume.
 	// However, older client code accidentally sets event.Namespace
 	// to api.NamespaceDefault, so we accept that too, but "" is preferred.
-	if event.InvolvedObject.Kind == "Node" &&
+	if (event.InvolvedObject.Kind == "Node" || event.InvolvedObject.Kind == "PersistentVolume") &&
 		event.Namespace != api.NamespaceDefault &&
 		event.Namespace != "" {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("involvedObject", "namespace"), event.InvolvedObject.Namespace, "not allowed for node"))
 	}
 	if event.InvolvedObject.Kind != "Node" &&
+		event.InvolvedObject.Kind != "PersistentVolume" &&
 		event.Namespace != event.InvolvedObject.Namespace {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("involvedObject", "namespace"), event.InvolvedObject.Namespace, "does not match involvedObject"))
 	}


### PR DESCRIPTION
Similarly to Nodes, PersistentVolumes are not in any namespace and we should
not block events on them. Currently, these events are rejected with
`Event "nfs.145841cf9c8cfaf0" is invalid: involvedObject.namespace: Invalid value: "": does not match involvedObject`
