### PR TITLE
Fill PV.Status.Message with deleter/recycler errors.

### DIFF
--- a/pkg/controller/persistentvolume/delete_test.go
+++ b/pkg/controller/persistentvolume/delete_test.go
@@ -57,7 +57,7 @@ func TestDeleteSync(t *testing.T) {
 			// delete failure - plugin not found
 			"8-3 - plugin not found",
 			newVolumeArray("volume8-3", "1Gi", "uid8-3", "claim8-3", api.VolumeBound, api.PersistentVolumeReclaimDelete),
-			newVolumeArray("volume8-3", "1Gi", "uid8-3", "claim8-3", api.VolumeFailed, api.PersistentVolumeReclaimDelete),
+			withMessage("Error getting deleter volume plugin for volume \"volume8-3\": no volume plugin matched", newVolumeArray("volume8-3", "1Gi", "uid8-3", "claim8-3", api.VolumeFailed, api.PersistentVolumeReclaimDelete)),
 			noclaims,
 			noclaims,
 			[]string{"Warning VolumeFailedDelete"}, noerrors, testSyncVolume,
@@ -66,7 +66,7 @@ func TestDeleteSync(t *testing.T) {
 			// delete failure - newDeleter returns error
 			"8-4 - newDeleter returns error",
 			newVolumeArray("volume8-4", "1Gi", "uid8-4", "claim8-4", api.VolumeBound, api.PersistentVolumeReclaimDelete),
-			newVolumeArray("volume8-4", "1Gi", "uid8-4", "claim8-4", api.VolumeFailed, api.PersistentVolumeReclaimDelete),
+			withMessage("Failed to create deleter for volume \"volume8-4\": Mock plugin error: no deleteCalls configured", newVolumeArray("volume8-4", "1Gi", "uid8-4", "claim8-4", api.VolumeFailed, api.PersistentVolumeReclaimDelete)),
 			noclaims,
 			noclaims,
 			[]string{"Warning VolumeFailedDelete"}, noerrors,
@@ -76,7 +76,7 @@ func TestDeleteSync(t *testing.T) {
 			// delete failure - delete() returns error
 			"8-5 - delete returns error",
 			newVolumeArray("volume8-5", "1Gi", "uid8-5", "claim8-5", api.VolumeBound, api.PersistentVolumeReclaimDelete),
-			newVolumeArray("volume8-5", "1Gi", "uid8-5", "claim8-5", api.VolumeFailed, api.PersistentVolumeReclaimDelete),
+			withMessage("Delete of volume \"volume8-5\" failed: Mock delete error", newVolumeArray("volume8-5", "1Gi", "uid8-5", "claim8-5", api.VolumeFailed, api.PersistentVolumeReclaimDelete)),
 			noclaims,
 			noclaims,
 			[]string{"Warning VolumeFailedDelete"}, noerrors,

--- a/pkg/controller/persistentvolume/framework_test.go
+++ b/pkg/controller/persistentvolume/framework_test.go
@@ -665,6 +665,14 @@ func withLabelSelector(labels map[string]string, claims []*api.PersistentVolumeC
 	return claims
 }
 
+// withMessage saves given message into volume.Status.Message of the first
+// volume in the array and returns the array.  Meant to be used to compose
+// volumes specified inline in a test.
+func withMessage(message string, volumes []*api.PersistentVolume) []*api.PersistentVolume {
+	volumes[0].Status.Message = message
+	return volumes
+}
+
 // newVolumeArray returns array with a single volume that would be returned by
 // newVolume() with the same parameters.
 func newVolumeArray(name, capacity, boundToClaimUID, boundToClaimName string, phase api.PersistentVolumePhase, reclaimPolicy api.PersistentVolumeReclaimPolicy, annotations ...string) []*api.PersistentVolume {

--- a/pkg/controller/persistentvolume/recycle_test.go
+++ b/pkg/controller/persistentvolume/recycle_test.go
@@ -57,7 +57,7 @@ func TestRecycleSync(t *testing.T) {
 			// recycle failure - plugin not found
 			"6-3 - plugin not found",
 			newVolumeArray("volume6-3", "1Gi", "uid6-3", "claim6-3", api.VolumeBound, api.PersistentVolumeReclaimRecycle),
-			newVolumeArray("volume6-3", "1Gi", "uid6-3", "claim6-3", api.VolumeFailed, api.PersistentVolumeReclaimRecycle),
+			withMessage("No recycler plugin found for the volume!", newVolumeArray("volume6-3", "1Gi", "uid6-3", "claim6-3", api.VolumeFailed, api.PersistentVolumeReclaimRecycle)),
 			noclaims,
 			noclaims,
 			[]string{"Warning VolumeFailedRecycle"}, noerrors, testSyncVolume,
@@ -66,7 +66,7 @@ func TestRecycleSync(t *testing.T) {
 			// recycle failure - newRecycler returns error
 			"6-4 - newRecycler returns error",
 			newVolumeArray("volume6-4", "1Gi", "uid6-4", "claim6-4", api.VolumeBound, api.PersistentVolumeReclaimRecycle),
-			newVolumeArray("volume6-4", "1Gi", "uid6-4", "claim6-4", api.VolumeFailed, api.PersistentVolumeReclaimRecycle),
+			withMessage("Failed to create recycler: Mock plugin error: no recycleCalls configured", newVolumeArray("volume6-4", "1Gi", "uid6-4", "claim6-4", api.VolumeFailed, api.PersistentVolumeReclaimRecycle)),
 			noclaims,
 			noclaims,
 			[]string{"Warning VolumeFailedRecycle"}, noerrors,
@@ -76,7 +76,7 @@ func TestRecycleSync(t *testing.T) {
 			// recycle failure - recycle returns error
 			"6-5 - recycle returns error",
 			newVolumeArray("volume6-5", "1Gi", "uid6-5", "claim6-5", api.VolumeBound, api.PersistentVolumeReclaimRecycle),
-			newVolumeArray("volume6-5", "1Gi", "uid6-5", "claim6-5", api.VolumeFailed, api.PersistentVolumeReclaimRecycle),
+			withMessage("Recycler failed: Mock recycle error", newVolumeArray("volume6-5", "1Gi", "uid6-5", "claim6-5", api.VolumeFailed, api.PersistentVolumeReclaimRecycle)),
 			noclaims,
 			noclaims,
 			[]string{"Warning VolumeFailedRecycle"}, noerrors,
@@ -154,7 +154,7 @@ func TestRecycleSync(t *testing.T) {
 			// volume has unknown reclaim policy - failure expected
 			"6-10 - unknown reclaim policy",
 			newVolumeArray("volume6-10", "1Gi", "uid6-10", "claim6-10", api.VolumeBound, "Unknown"),
-			newVolumeArray("volume6-10", "1Gi", "uid6-10", "claim6-10", api.VolumeFailed, "Unknown"),
+			withMessage("Volume has unrecognized PersistentVolumeReclaimPolicy", newVolumeArray("volume6-10", "1Gi", "uid6-10", "claim6-10", api.VolumeFailed, "Unknown")),
 			noclaims,
 			noclaims,
 			[]string{"Warning VolumeUnknownReclaimPolicy"}, noerrors, testSyncVolume,


### PR DESCRIPTION
Instead of empty `Message` `kubectl describe pv` now shows:

```
Name:       nfs
Labels:     <none>
Status:     Failed
Claim:      default/nfs
Reclaim Policy: Recycle
Access Modes:   RWX
Capacity:   1Mi
Message:    Recycler failed: Pod was active on the node longer than specified deadline
Source:
    Type:   NFS (an NFS mount that lasts the lifetime of a pod)
    Server: 10.999.999.999
    Path:   /
    ReadOnly:   false
```

This is actually a regression since 1.2

@kubernetes/sig-storage 
