### PR TITLE
Add e2e tests for network policy

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -384,6 +384,7 @@ pv-recycler-pod-template-filepath-hostpath
 pv-recycler-pod-template-filepath-nfs
 pv-recycler-timeout-increment-hostpath
 pvclaimbinder-sync-period
+query-port
 read-only-port
 really-crash-for-testing
 reconcile-cidr
@@ -396,6 +397,7 @@ registry-burst
 registry-qps
 reject-methods
 reject-paths
+remote-tcp-port-name
 repair-malformed-updates
 replicaset-lookup-cache-size
 replication-controller-lookup-cache-size
@@ -472,6 +474,7 @@ system-pods-startup-timeout
 system-reserved
 target-port
 target-ram-mb
+tcp-port
 tcp-services
 terminated-pod-gc-threshold
 test-timeout

--- a/test/e2e/network_policy.go
+++ b/test/e2e/network_policy.go
@@ -1,0 +1,439 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/util/intstr"
+	"k8s.io/kubernetes/test/e2e/framework"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+/*
+These Network Policy tests create two services A and B.
+There is a single pod in the service A , and a single pod on each node in
+the service B.
+
+Each pod is running a network monitor container (see test/images/network-monitor):
+-  The A pod uses service discovery to locate the B pods and waits
+   to establish communication (if expected) with those pods.
+-  Each B pod uses service discovery to locate the A pod and waits to
+   establish communication (if expected) with that pod.
+
+We test the following:
+-  Policy on, or off.  When policy is on we expect isolation between all pods across the
+   namespaces.
+-  Policy on, but with rules allowing TCP communication between the pods in two services.
+
+TODO:
+-  Test UDP traffic
+*/
+
+// Summary is the data returned by /summary API on the network monitor container
+type Summary struct {
+	TCPNumOutboundConnected int
+	TCPNumInboundConnected  int
+}
+
+const (
+	serviceAName        = "service-a"
+	serviceBName        = "service-b"
+	netMonitorContainer = "gcr.io/google_containers/netmonitor:1.0"
+	convergenceTimeout  = 1 // Connection convergence timeout in minutes
+)
+
+var _ = framework.KubeDescribe("NetworkPolicy", func() {
+	f := framework.NewDefaultFramework("network-policy")
+
+	BeforeEach(func() {
+		// Assert basic external connectivity.
+		// Since this is not really a test of Kubernetes in any way, we
+		// leave it as a pre-test assertion, rather than a Gingko test.
+		By("Executing a successful http request from the external internet")
+		resp, err := http.Get("http://google.com")
+		if err != nil {
+			framework.Failf("Unable to connect/talk to the internet: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			framework.Failf("Unexpected error code, expected 200, got, %v (%v)", resp.StatusCode, resp)
+		}
+	})
+
+
+	It("should isolate containers in the same namespace when NetworkIsolation is enabled [NetworkPolicy]", func() {
+		nsA := f.Namespace
+		runIsolatedToBidirectionalTest(f, nsA, nsA)
+	})
+
+	It("should isolate containers in different namespaces when NetworkIsolation is enabled [NetworkPolicy]", func() {
+		// This test use two namespaces.  A single namespace is created by
+		// default.  Create another.
+		nsA := f.Namespace
+		nsB, err := f.CreateNamespace(f.BaseName+"-b", map[string]string{
+			"e2e-framework": f.BaseName + "-b",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		runIsolatedToBidirectionalTest(f, nsA, nsB)
+	})
+})
+
+// Run a test that starts with fully isolated pods in two services (in different namespaces) and adds
+// policy objects to allow mono-directional and then bi-directional traffic between the pods in the
+// two services.
+func runIsolatedToBidirectionalTest(f *framework.Framework, nsA, nsB *api.Namespace) {
+
+	var err error
+
+	// Turn on isolation on both namespaces.
+	setNetworkIsolationAnnotations(f, nsA, true)
+	setNetworkIsolationAnnotations(f, nsB, true)
+
+	// Get the available nodes.
+	nodes := framework.GetReadySchedulableNodesOrDie(f.Client)
+
+	if len(nodes.Items) == 1 {
+		// In general, the test requires two nodes. But for local development, often a one node cluster
+		// is created, for simplicity and speed. We permit one-node test only in local development.
+		if !framework.ProviderIs("local") {
+			framework.Failf(fmt.Sprintf("The test requires two Ready nodes on %v, but found just one.", framework.TestContext.Provider))
+		}
+		framework.Logf("Only one ready node is detected. The test has limited scope in such setting. " +
+			"Rerun it with at least two nodes to get complete coverage.")
+	}
+
+	// Create service A and B in namespaces A and B respectively.  The services are used
+	// for pod discovery by the net monitor containers.
+	serviceA := createNetworkPolicyService(f, nsA, serviceAName)
+	serviceB := createNetworkPolicyService(f, nsB, serviceBName)
+
+	// Clean up services
+	defer func() {
+		By("Cleaning up the service A")
+		if err = f.Client.Services(nsA.Name).Delete(serviceA.Name); err != nil {
+			framework.Failf("unable to delete svc %v: %v", serviceA.Name, err)
+		}
+	}()
+	defer func() {
+		By("Cleaning up the service B")
+		if err = f.Client.Services(nsB.Name).Delete(serviceB.Name); err != nil {
+			framework.Failf("unable to delete svc %v: %v", serviceB.Name, err)
+		}
+	}()
+
+	By("Creating a webserver (pending) pod on each node")
+	podAName, podBNames := launchNetMonitorPods(f, nsA, nsB, nodes)
+
+	// Deferred clean up of the pods.
+	defer func() {
+		By("Cleaning up the webserver pods")
+		if err = f.Client.Pods(nsA.Name).Delete(podAName, nil); err != nil {
+			framework.Logf("Failed to delete pod %v: %v", podAName, err)
+		}
+		for _, podName := range podBNames {
+			if err = f.Client.Pods(nsB.Name).Delete(podName, nil); err != nil {
+				framework.Logf("Failed to delete pod %v: %v", podName, err)
+			}
+		}
+	}()
+
+	// Wait for all pods to be running.
+	By(fmt.Sprintf("Waiting for pod %v to be running", podAName))
+	err = framework.WaitForPodRunningInNamespace(f.Client, podAName, nsA.Name)
+	Expect(err).NotTo(HaveOccurred())
+	for _, podName := range podBNames {
+		By(fmt.Sprintf("Waiting for pod %v to be running", podName))
+		err = framework.WaitForPodRunningInNamespace(f.Client, podName, nsB.Name)
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	// Open up TCP port used to access the network monitor HTTP API (8080).  Until we do this, all
+	// pods in all namespaces are isolated and the test cannot query the netmonitor pods to pull
+	// the connectivity information.
+	By("Open up monitoring port so that test can pull connectivity data from services")
+	addNetworkPolicyOpenPort(f, nsA, "query1", 8080, api.ProtocolTCP)
+	addNetworkPolicyOpenPort(f, nsB, "query2", 8080, api.ProtocolTCP)
+
+	// We expect full isolation between all pods in all namespaces.  Monitor, wait for a little and
+	// re-check we are still isolated.
+	By("Checking full isolation")
+	expected := Summary{
+		TCPNumOutboundConnected: 0,
+		TCPNumInboundConnected:  0,
+	}
+	monitorConnectivity(f, nsA, serviceA.Name, expected)
+	monitorConnectivity(f, nsB, serviceB.Name, expected)
+
+	By("Waiting and rechecking full isolation")
+	time.Sleep(10 * time.Second)
+	monitorConnectivity(f, nsA, serviceA.Name, expected)
+	monitorConnectivity(f, nsB, serviceB.Name, expected)
+
+	if nsA != nsB {
+		// Add policy to one namespace to accept all traffic to the TCP port used for inter-pod pings (8081).
+		// We should see mono-directional traffic.  We only do this if the two namespaces are different - since
+		// we open up ports on a per-namespace basis.  If the namespaces are identical we'll end up straight
+		// away with bi-directional traffic.
+		By("Checking mono-directional TCP between namespaces with isolation enabled and policy applied to one namespace")
+		addNetworkPolicyOpenPort(f, nsB, "tcp", 8081, api.ProtocolTCP)
+
+		// We now expect ingress TCP to pods in service B to be allowed.
+		expected = Summary{
+			TCPNumOutboundConnected: len(nodes.Items),
+			TCPNumInboundConnected:  0,
+		}
+		monitorConnectivity(f, nsA, serviceA.Name, expected)
+		expected = Summary{
+			TCPNumOutboundConnected: 0,
+			TCPNumInboundConnected:  1,
+		}
+		monitorConnectivity(f, nsB, serviceB.Name, expected)
+	}
+
+	// Add policy to other namespace to accept all traffic to the TCP port used for inter-pod pings (8081).
+	// We should see bi-directional traffic.
+	By("Checking bi-direction TCP between namespaces with isolation enabled and policy applied to both namespaces")
+	addNetworkPolicyOpenPort(f, nsA, "tcp", 8081, api.ProtocolTCP)
+
+	// We now expect ingress TCP to pods in both services A and B to be allowed.
+	expected = Summary{
+		TCPNumOutboundConnected: len(nodes.Items),
+		TCPNumInboundConnected:  len(nodes.Items),
+	}
+	monitorConnectivity(f, nsA, serviceA.Name, expected)
+	expected = Summary{
+		TCPNumOutboundConnected: 1,
+		TCPNumInboundConnected:  1,
+	}
+	monitorConnectivity(f, nsB, serviceB.Name, expected)
+}
+
+// Create a service which exposes TCP ports:
+// -  8080: HTTP monitoring API to query inter-pod connectivity
+// -  8081: inter-pod connectivity pings
+func createNetworkPolicyService(f *framework.Framework, namespace *api.Namespace, name string) *api.Service {
+	By(fmt.Sprintf("Creating a service named %v in namespace %v", name, namespace.Name))
+	svc, err := f.Client.Services(namespace.Name).Create(&api.Service{
+		ObjectMeta: api.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"name": name,
+			},
+		},
+		Spec: api.ServiceSpec{
+			Ports: []api.ServicePort{{
+				Protocol:   "TCP",
+				Port:       8080,
+				TargetPort: intstr.FromInt(8080),
+				Name:       "net-monitor-query",
+			}, {
+				Protocol:   "TCP",
+				Port:       8081,
+				TargetPort: intstr.FromInt(8081),
+				Name:       "net-monitor-tcp-ping",
+			}},
+			Selector: map[string]string{
+				"name": name,
+			},
+		},
+	})
+	if err != nil {
+		framework.Failf("unable to create test service named [%v] %v", svc.Name, err)
+	}
+	return svc
+}
+
+// Launch the required set of network monitor pods for the test.  This creates a single pod
+// in namespaceA/serviceA which peers with a pod on each node in namespaceB/serviceB.
+func launchNetMonitorPods(f *framework.Framework, namespaceA *api.Namespace, namespaceB *api.Namespace, nodes *api.NodeList) (string, []string) {
+	podBNames := []string{}
+
+	// Create the A pod on the first node.  It will find all of the B
+	// pods (one for each node).
+	podAName := createNetMonitorPod(f, namespaceA, namespaceB, serviceAName, serviceBName, &nodes.Items[0])
+
+	// Now create the B pods, one on each node - each should just search
+	// for the single A pod peer.
+	for _, node := range nodes.Items {
+		podName := createNetMonitorPod(f, namespaceB, namespaceA, serviceBName, serviceAName, &node)
+		podBNames = append(podBNames, podName)
+	}
+
+	return podAName, podBNames
+}
+
+// Create a network monitor pod which peers with other network monitor pods.
+func createNetMonitorPod(f *framework.Framework,
+	namespace *api.Namespace, peerNamespace *api.Namespace,
+	serviceName string, peerServiceName string,
+	node *api.Node) string {
+	pod, err := f.Client.Pods(namespace.Name).Create(&api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			GenerateName: serviceName + "-",
+			Labels: map[string]string{
+				"name": serviceName,
+			},
+		},
+		Spec: api.PodSpec{
+			Containers: []api.Container{
+				{
+					Name:  "webserver",
+					Image: netMonitorContainer,
+					Args: []string{
+						"--namespace=" + peerNamespace.Name,
+						"--service=" + peerServiceName},
+					Ports:           []api.ContainerPort{{ContainerPort: 8080}, {ContainerPort: 8081}},
+					ImagePullPolicy: api.PullAlways,
+				},
+			},
+			NodeName:      node.Name,
+			RestartPolicy: api.RestartPolicyNever,
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+	framework.Logf("Created pod %v on node %v", pod.ObjectMeta.Name, node.Name)
+
+	return pod.ObjectMeta.Name
+}
+
+// Monitor the connectivity matrix from the network monitor pods, until the returned
+// connectivity summary matches the supplied summary.
+//
+// If convergence does not happen within the required time limit, the test fails.
+func monitorConnectivity(f *framework.Framework, namespace *api.Namespace, serviceName string, expected Summary) {
+	By(fmt.Sprintf("Verifying expected connectivity on service %v", serviceName))
+	passed := false
+
+	// Once response OK, evaluate response body for pass/fail.
+	var err error
+	var body []byte
+	getDetails := func() ([]byte, error) {
+		proxyRequest, errProxy := framework.GetServicesProxyRequest(f.Client, f.Client.Get())
+		if errProxy != nil {
+			return nil, errProxy
+		}
+		return proxyRequest.Namespace(namespace.Name).
+			Name(serviceName + ":net-monitor-query").
+			Suffix("details").
+			DoRaw()
+	}
+
+	getSummary := func() ([]byte, error) {
+		proxyRequest, errProxy := framework.GetServicesProxyRequest(f.Client, f.Client.Get())
+		if errProxy != nil {
+			return nil, errProxy
+		}
+		return proxyRequest.Namespace(namespace.Name).
+			Name(serviceName + ":net-monitor-query").
+			Suffix("summary").
+			DoRaw()
+	}
+
+	// The netmonitor container will continuously poll for named service endpoints and then
+	// check connectivity between the two specified services.
+	timeout := time.Now().Add(convergenceTimeout * time.Minute)
+	for i := 0; !passed && timeout.After(time.Now()); i++ {
+		time.Sleep(2 * time.Second)
+		framework.Logf("About to make a proxy summary call")
+		start := time.Now()
+		body, err = getSummary()
+		framework.Logf("Proxy summary call returned in %v", time.Since(start))
+		if err != nil {
+			framework.Logf("Attempt %v: service/pod still starting. (error: '%v')", i, err)
+			continue
+		}
+
+		var summary Summary
+		err = json.Unmarshal(body, &summary)
+		if err != nil {
+			framework.Logf("Warning: unable to unmarshal response (%v): '%v'", string(body), err)
+			continue
+		}
+
+		framework.Logf("Summary: %v", string(body))
+		passed = summary == expected
+		if passed {
+			break
+		}
+	}
+
+	if !passed {
+		if body, err = getDetails(); err != nil {
+			framework.Failf("Timed out. Cleaning up. Error reading details: %v", err)
+		} else {
+			framework.Failf("Timed out. Cleaning up. Details:\n%s", string(body))
+		}
+	}
+	Expect(passed).To(Equal(true))
+}
+
+// Configure namespace network isolation by setting the network-isolation annotation
+// on the namespace.
+func setNetworkIsolationAnnotations(f *framework.Framework, namespace *api.Namespace, enableIsolation bool) {
+	var annotations = map[string]string{}
+	if enableIsolation {
+		By(fmt.Sprintf("Enabling isolation through namespace annotations on namespace %v", namespace.Name))
+		annotations["net.beta.kubernetes.io/network-policy"] = `{"ingress":{"isolation":"DefaultDeny"}}`
+	} else {
+		By(fmt.Sprintf("Disabling isolation through namespace annotations on namespace %v", namespace.Name))
+		delete(annotations, "net.beta.kubernetes.io/network-policy")
+	}
+
+	// Update the namespace.  We set the resource version to be an empty
+	// string, this forces the update.  If we weren't to do this, we would
+	// either need to re-query the namespace, or update the namespace
+	// references with the one returned by the update.  This approach
+	// requires less plumbing.
+	namespace.ObjectMeta.Annotations = annotations
+	namespace.ObjectMeta.ResourceVersion = ""
+	_, err := f.Client.Namespaces().Update(namespace)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+// Add a network policy object to open up ingress traffic to a specific port on a namespace.
+func addNetworkPolicyOpenPort(f *framework.Framework, namespace *api.Namespace, name string, port int32, protocol api.Protocol) {
+	By(fmt.Sprintf("Setting network policy to allow proxy traffic for namespace %v", namespace.Name))
+
+	lport := intstr.IntOrString{IntVal: port}
+
+	framework.Logf("Creating policy %v", name)
+	_, err := f.Client.NetworkPolicies(namespace.Name).Create(&extensions.NetworkPolicy{
+		ObjectMeta: api.ObjectMeta{
+			Name: name,
+		},
+		Spec: extensions.NetworkPolicySpec{
+			Ingress: []extensions.NetworkPolicyIngressRule{
+				extensions.NetworkPolicyIngressRule{
+					Ports: []extensions.NetworkPolicyPort{
+						{
+							Protocol: &protocol,
+							Port:     &lport,
+						},
+					},
+				},
+			},
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+}

--- a/test/e2e/network_policy.go
+++ b/test/e2e/network_policy.go
@@ -81,7 +81,6 @@ var _ = framework.KubeDescribe("NetworkPolicy", func() {
 		}
 	})
 
-
 	It("should isolate containers in the same namespace when NetworkIsolation is enabled [NetworkPolicy]", func() {
 		nsA := f.Namespace
 		runIsolatedToBidirectionalTest(f, nsA, nsA)

--- a/test/e2e/network_policy.go
+++ b/test/e2e/network_policy.go
@@ -81,12 +81,12 @@ var _ = framework.KubeDescribe("NetworkPolicy", func() {
 		}
 	})
 
-	It("should isolate containers in the same namespace when NetworkIsolation is enabled [NetworkPolicy]", func() {
+	It("should isolate containers in the same namespace when NetworkIsolation is enabled [Feature:NetworkPolicy]", func() {
 		nsA := f.Namespace
 		runIsolatedToBidirectionalTest(f, nsA, nsA)
 	})
 
-	It("should isolate containers in different namespaces when NetworkIsolation is enabled [NetworkPolicy]", func() {
+	It("should isolate containers in different namespaces when NetworkIsolation is enabled [Feature:NetworkPolicy]", func() {
 		// This test use two namespaces.  A single namespace is created by
 		// default.  Create another.
 		nsA := f.Namespace

--- a/test/e2e/network_policy.go
+++ b/test/e2e/network_policy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 The Kubernetes Authors All rights reserved.
+Copyright 2016 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -423,7 +423,7 @@ func addNetworkPolicyOpenPort(f *framework.Framework, namespace *api.Namespace, 
 		},
 		Spec: extensions.NetworkPolicySpec{
 			Ingress: []extensions.NetworkPolicyIngressRule{
-				extensions.NetworkPolicyIngressRule{
+				{
 					Ports: []extensions.NetworkPolicyPort{
 						{
 							Protocol: &protocol,

--- a/test/images/network-monitor/.gitignore
+++ b/test/images/network-monitor/.gitignore
@@ -1,0 +1,1 @@
+netmonitor

--- a/test/images/network-monitor/Dockerfile
+++ b/test/images/network-monitor/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2016 The Kubernetes Authors All rights reserved.
+# Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/images/network-monitor/Dockerfile
+++ b/test/images/network-monitor/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM scratch
+MAINTAINER Rob Brockbank <rob@projectcalico.org>
+ADD netmonitor netmonitor
+EXPOSE 8080
+ENTRYPOINT ["/netmonitor"]

--- a/test/images/network-monitor/Makefile
+++ b/test/images/network-monitor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2016 The Kubernetes Authors All rights reserved.
+# Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/images/network-monitor/Makefile
+++ b/test/images/network-monitor/Makefile
@@ -1,0 +1,33 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TAG = 1.0
+PREFIX = gcr.io/google_containers
+
+all: push
+
+netmonitor: netmonitor.go
+	CGO_ENABLED=0 GOOS=linux godep go build -a -installsuffix cgo -ldflags '-w' ./netmonitor.go
+
+container: image
+
+image: netmonitor
+	docker build -t $(PREFIX)/netmonitor:$(TAG) .
+
+push: image
+	#gcloud docker push $(PREFIX)/netmonitor:$(TAG)
+	docker push $(PREFIX)/netmonitor:$(TAG)
+
+clean:
+	rm -f netmonitor

--- a/test/images/network-monitor/netmonitor.go
+++ b/test/images/network-monitor/netmonitor.go
@@ -1,0 +1,422 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Based on the network-tester, this implements a network monitor that can
+// be used to continuously monitor connectivity between a netmonitor container
+// and a set of peer netmonitor containers (discovered through namespace/service
+// query).
+//
+// Connectivity between the containers is monitored using a lightweight web
+// server (for TCP traffic).  This container tracks when the last message was
+// responded to by each peer, _and_ when it last received a request from the
+// peer - thus this tracks both inbound and outbound connectivity separately.
+//
+// The container also serves webserver UI to allow a client to receive the
+// connectivity information between the pods.  It serves the following endpoints:
+//
+// /quit       : to shut down
+// /summary    : to see a summary status of connections
+// /details    : to see the detailed internal state
+//
+// The internal facing webserver serves up the following:
+// /ping
+//
+// The external query UI uses a different port to the internal inter-container "ping" port.
+// This allows policy lockdown of the inter-container port whilst still being able to
+// monitor the connectivity through the UI port.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/util/sets"
+)
+
+// Information about an individual peer message.
+type TCPMessage struct {
+	// Values in this structure require the State lock to be held before
+	// reading or writing.
+	NextIndex           int
+	LastSuccessIndex    int
+	LastSuccessTime     *time.Time
+	TimeBetweenMessages []time.Duration
+}
+
+// State tracks the internal connection state of all peers.
+type State struct {
+	// Hostname is set once and never changed-- it's always safe to read.
+	Hostname string
+
+	// The below fields require that lock is held before reading or writing.
+	TCPOutbound map[string]TCPMessage
+	TCPInbound  map[string]TCPMessage
+
+	lock sync.Mutex
+}
+
+// HTTPPingMessage is the format that (json encoded) requests to the /ping handler should take,
+// and is returned directly as the response.
+type HTTPPingMessage struct {
+	Index    int
+	SourceID string
+}
+
+// Summary is returned by /summary
+type Summary struct {
+	TCPNumOutboundConnected int
+	TCPNumInboundConnected  int
+}
+
+var (
+	// Runtime flags
+	tcpPort           = flag.Int("tcp-port", 8081, "Local TCP Port number used for pod-to-pod connectivity testing.")
+	queryPort         = flag.Int("query-port", 8080, "Local TCP Port number used for HTTP queries to obtain summary and detailed connectivity information.")
+	remoteTCPPortName = flag.String("remote-tcp-port-name", "net-monitor-tcp-ping", "Port name used to identify the remote pod-to-pod TCP testing ports.")
+	namespace         = flag.String("namespace", "default", "Namespace containing peer network monitor pods.")
+	service           = flag.String("service", "netmonitor", "Service containing peer network monitor pods.")
+	expireFactor      = flag.Int64("expiration-factor", 3, "Factor to multiple time between received messages which is then used to tune the expiration time (chosen as the maximum of the current value and the factored time).")
+	delayShutdown     = flag.Int("delay-shutdown", 0, "Number of seconds to delay shutdown when receiving SIGTERM.")
+
+	// Number of message times to keep track of
+	msgHistory = 3
+)
+
+// Log an error message to stdout.
+func logErr(err error) {
+	if err != nil {
+		log.Printf("Error: %v", err)
+	}
+}
+
+// Look at the current TCP message data to determine if the TCP connection is currently
+// connected.
+func (t *TCPMessage) isConnected(now time.Time) bool {
+	if t.LastSuccessTime == nil {
+		return false
+	}
+
+	// We only consider ourselves connected when we have received at least a
+	// couple of consecutive messages so that we know what the approximate time
+	// between messages is - without that we can't determine what constitutes
+	// a fail.
+	if len(t.TimeBetweenMessages) == 0 {
+		return false
+	}
+
+	// Calculate the average time between messages.  We multiply this by our
+	// expiration factor to determine when there is no connection.
+	timeBetweenMessages := time.Duration(0)
+	for i := 0; i < len(t.TimeBetweenMessages); i++ {
+		timeBetweenMessages += t.TimeBetweenMessages[i]
+	}
+	timeBetweenMessages = timeBetweenMessages / time.Duration(len(t.TimeBetweenMessages))
+
+	// Check if the time of last success indicates that the channel is still
+	// connected.
+	return now.Sub(*t.LastSuccessTime) < (timeBetweenMessages * time.Duration(*expireFactor))
+}
+
+// serveSummary returns a JSON dictionary containing a summary of
+// counts of successful inbound and outbound peers connections.
+// e.g.
+//   {
+//     "TCPNumInboundConnected": 10,
+//     "TCPNumOutboundConnected": 4
+//   }
+func (s *State) serveSummary(w http.ResponseWriter, r *http.Request) {
+	log.Printf("Serving summary")
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	now := time.Now()
+	summary := Summary{
+		TCPNumInboundConnected:  0,
+		TCPNumOutboundConnected: 0,
+	}
+
+	for _, v := range s.TCPOutbound {
+		if v.isConnected(now) {
+			summary.TCPNumOutboundConnected += 1
+		}
+	}
+
+	for _, v := range s.TCPInbound {
+		if v.isConnected(now) {
+			summary.TCPNumInboundConnected += 1
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+	b, err := json.MarshalIndent(&summary, "", "\t")
+	logErr(err)
+	_, err = w.Write(b)
+	logErr(err)
+}
+
+// serveDetails writes our json encoded state
+func (s *State) serveDetails(w http.ResponseWriter, r *http.Request) {
+	log.Printf("Serving details")
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	w.WriteHeader(http.StatusOK)
+	b, err := json.MarshalIndent(s, "", "\t")
+	logErr(err)
+	_, err = w.Write(b)
+	logErr(err)
+}
+
+// servePing responds to a ping from a peer, and records the peer contact in our
+// received state.
+func (s *State) servePing(w http.ResponseWriter, r *http.Request) {
+	log.Printf("Serving ping")
+	defer r.Body.Close()
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	w.WriteHeader(http.StatusOK)
+	var msg HTTPPingMessage
+	logErr(json.NewDecoder(r.Body).Decode(&msg))
+	if msg.SourceID == "" {
+		logErr(fmt.Errorf("%v: Got request with no source ID", s.Hostname))
+	} else {
+		now := time.Now()
+		stored := s.TCPInbound[msg.SourceID]
+		if msg.Index >= stored.NextIndex {
+			if msg.Index == stored.NextIndex && stored.LastSuccessTime != nil {
+				// This is a consecutive message so we can record the time between
+				// messages.  We use this to adjust our expiration times based
+				// on load.
+				stored.TimeBetweenMessages = append(stored.TimeBetweenMessages, now.Sub(*stored.LastSuccessTime))
+				if len(stored.TimeBetweenMessages) > msgHistory {
+					stored.TimeBetweenMessages = stored.TimeBetweenMessages[1:]
+				}
+			}
+
+			// Store the index and the current time.
+			stored.LastSuccessTime = &now
+			stored.LastSuccessIndex = msg.Index
+
+			// Update the next index we expect.
+			stored.NextIndex = msg.Index + 1
+		}
+
+		// Update the map to store the data for this connection.
+		s.TCPInbound[msg.SourceID] = stored
+	}
+
+	// Send the original request back as the response.
+	logErr(json.NewEncoder(w).Encode(&msg))
+}
+
+// Monitor a single TCP peer by sending an HTTP ping and waiting for the response.
+func (s *State) monitorTCPPeer(endpoint string) {
+	var index int
+
+	// Obtain the current index for this peer and increment it in our shared data.  We
+	// need to hold the lock for this, but only want to hold it for the minimum amount
+	// of time.
+	func() {
+		log.Printf("Processing endpoing: %s", endpoint)
+		s.lock.Lock()
+		defer s.lock.Unlock()
+
+		data := s.TCPOutbound[endpoint]
+		index = data.NextIndex
+		data.NextIndex += 1
+		s.TCPOutbound[endpoint] = data
+	}()
+
+	// Send the HTTP ping request.
+	log.Printf("Attempting to contact %s", endpoint)
+	body, err := json.Marshal(&HTTPPingMessage{
+		Index:    index,
+		SourceID: s.Hostname,
+	})
+	if err != nil {
+		log.Fatalf("json marshal error: %v", err)
+	}
+	resp, err := http.Post(endpoint+"/ping", "application/json", bytes.NewReader(body))
+	if err != nil {
+		log.Printf("Warning: unable to contact the endpoint %q: %v", endpoint, err)
+		return
+	}
+	defer resp.Body.Close()
+
+	// Read and unmarshal the response.
+	body, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Printf("Warning: unable to read response from '%v': '%v'", endpoint, err)
+		return
+	}
+	log.Printf("Response from endpoint: %v", string(body))
+
+	var response HTTPPingMessage
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		log.Printf("Warning: unable to unmarshal response (%v) from '%v': '%v'", string(body), endpoint, err)
+		return
+	}
+
+	// Update our state information based on the response.
+	func() {
+		log.Printf("Successful response")
+		s.lock.Lock()
+		defer s.lock.Unlock()
+
+		now := time.Now()
+		data := s.TCPOutbound[endpoint]
+		log.Printf("Index: %d, %d", index, data.LastSuccessIndex)
+		if index == data.LastSuccessIndex+1 && data.LastSuccessTime != nil {
+			// This is a consecutive message so we can record the time between
+			// messages.  We use this to adjust our expiration times based
+			// on load.
+			log.Printf("Update time between messages")
+			data.TimeBetweenMessages = append(data.TimeBetweenMessages, now.Sub(*data.LastSuccessTime))
+			if len(data.TimeBetweenMessages) > msgHistory {
+				data.TimeBetweenMessages = data.TimeBetweenMessages[1:]
+			}
+		}
+
+		if index > data.LastSuccessIndex {
+			log.Printf("Update last success time")
+			data.LastSuccessIndex = index
+			data.LastSuccessTime = &now
+		}
+		s.TCPOutbound[endpoint] = data
+	}()
+}
+
+// Find all sibling pods in the service and post to their /write handler.
+func (s *State) monitorPeers() {
+	log.Printf("Monitor peers")
+	client, err := client.NewInCluster()
+	if err != nil {
+		log.Fatalf("Unable to create client; error: %v\n", err)
+	}
+	// Double check that that worked by getting the server version.
+	if v, err := client.Discovery().ServerVersion(); err != nil {
+		log.Fatalf("Unable to get server version: %v\n", err)
+	} else {
+		log.Printf("Server version: %#v\n", v)
+	}
+
+	// Repeatedly obtain the endpoint list and monitor the TCP connections.
+	for {
+		tcp_eps := getEndpoints(client)
+		for ep := range tcp_eps {
+			s.monitorTCPPeer(ep)
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
+
+// Listen to a particular port and serve responses.
+func listenAndServe(port int) {
+	err := http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", port), nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+// getEndpoints returns the endpoints as set of String:
+// -  TCP endpoints:  "http://{ip}:{port}"
+func getEndpoints(client *client.Client) sets.String {
+	endpoints, err := client.Endpoints(*namespace).Get(*service)
+	tcp_eps := sets.String{}
+	if err != nil {
+		log.Printf("Unable to read the endpoints for %v/%v: %v.", *namespace, *service, err)
+		return tcp_eps
+	}
+	for _, ss := range endpoints.Subsets {
+		for _, a := range ss.Addresses {
+			for _, p := range ss.Ports {
+				// Inter-pod ping ports are discovered by name.
+				if p.Protocol == api.ProtocolTCP && p.Name == *remoteTCPPortName {
+					tcp_eps.Insert(fmt.Sprintf("http://%s:%d", a.IP, p.Port))
+				}
+			}
+		}
+	}
+	return tcp_eps
+}
+
+// Main.  Parse arguments, initialize state, start monitoring and start the web servers.
+func main() {
+	log.Printf("Parsing arguments")
+	flag.Parse()
+
+	if *service == "" {
+		log.Fatal("Must provide -service flag.")
+	}
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		log.Fatalf("Error getting hostname: %v", err)
+	}
+
+	if *delayShutdown > 0 {
+		log.Printf("Configure delayed shutdown")
+		termCh := make(chan os.Signal)
+		signal.Notify(termCh, syscall.SIGTERM)
+		go func() {
+			<-termCh
+			log.Printf("Sleeping %d seconds before exit ...", *delayShutdown)
+			time.Sleep(time.Duration(*delayShutdown) * time.Second)
+			os.Exit(0)
+		}()
+	}
+
+	log.Printf("Initialize state")
+	state := State{
+		Hostname:    hostname,
+		TCPOutbound: map[string]TCPMessage{},
+		TCPInbound:  map[string]TCPMessage{},
+	}
+
+	go state.monitorPeers()
+
+	log.Printf("Configure handler functions")
+	http.HandleFunc("/quit", func(w http.ResponseWriter, r *http.Request) {
+		os.Exit(0)
+	})
+	http.HandleFunc("/summary", state.serveSummary)
+	http.HandleFunc("/details", state.serveDetails)
+	http.HandleFunc("/ping", state.servePing)
+
+	// Start up the server on the required ports - by default the inter-pod communication
+	// is on a different port to the UX.  Both can be handled by the same default
+	// handler though.
+	log.Printf("Listening on inter-pod port: %d", *tcpPort)
+	go listenAndServe(*tcpPort)
+	if *queryPort != *tcpPort {
+		log.Printf("Listening on monitor port: %d", *queryPort)
+		go listenAndServe(*queryPort)
+	}
+
+	select {}
+}

--- a/test/images/network-monitor/netmonitor.go
+++ b/test/images/network-monitor/netmonitor.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 The Kubernetes Authors All rights reserved.
+Copyright 2016 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR adds a new set of e2e tests for testing network policy.  It has been run successfully against a deployment using Calico as the network policy provider.

See https://github.com/kubernetes/kubernetes/pull/25638 for PR that added NetworkPolicy resource.

The PR consists of:
-  A new netmonitor container.  This is based on the existing network-tester container (test/images/network-tester) but rather than being a single-shot (succeed when connectivity is X), this container returns a dynamic view of the connectivity - thus is more suitable to changing network policy in-place and seeing how connectivity is affected.  The initial implementation in this PR just supports TCP - but could be updated to support UDP as well.  The interface is sufficiently different to network-tester to warrant a separate container.
- A new e2e test file (/test/e2e/network_policy.go) which tests TCP connectivity between pods in two services, with full isolation, mono-directional connectivity and bi-directional connectivity.

Future work, not included in this PR would be to include:
-  UDP connectivity
-  Other more complicated label based policy

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/27447)

<!-- Reviewable:end -->
