### PR TITLE
e2e: Allow skipping tests for specific runtimes, skip a few tests under rkt

### DIFF
--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -119,6 +119,7 @@ export PATH=$(dirname "${e2e_test}"):"${PATH}"
   --node-instance-group="${NODE_INSTANCE_GROUP:-}" \
   --prefix="${KUBE_GCE_INSTANCE_PREFIX:-e2e}" \
   ${OS_DISTRIBUTION:+"--os-distro=${OS_DISTRIBUTION}"} \
+  ${KUBE_CONTAINER_RUNTIME:+"--container-runtime=${KUBE_CONTAINER_RUNTIME}"} \
   ${NUM_NODES:+"--num-nodes=${NUM_NODES}"} \
   ${E2E_CLEAN_START:+"--clean-start=true"} \
   ${E2E_MIN_STARTUP_PODS:+"--minStartupPods=${E2E_MIN_STARTUP_PODS}"} \

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -47,6 +47,7 @@ type TestContextType struct {
 	UpgradeTarget            string
 	PrometheusPushGateway    string
 	OSDistro                 string
+	ContainerRuntime         string
 	VerifyServiceAccount     bool
 	DeleteNamespace          bool
 	CleanStart               bool
@@ -108,6 +109,7 @@ func RegisterFlags() {
 	flag.StringVar(&TestContext.ReportPrefix, "report-prefix", "", "Optional prefix for JUnit XML reports. Default is empty, which doesn't prepend anything to the default name.")
 	flag.StringVar(&TestContext.Prefix, "prefix", "e2e", "A prefix to be added to cloud resources created during testing.")
 	flag.StringVar(&TestContext.OSDistro, "os-distro", "debian", "The OS distribution of cluster VM instances (debian, trusty, or coreos).")
+	flag.StringVar(&TestContext.ContainerRuntime, "container-runtime", "docker", "The container runtime of cluster VM instances (docker or rkt).")
 
 	// TODO: Flags per provider?  Rename gce-project/gce-zone?
 	cloudConfig := &TestContext.CloudConfig

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -366,6 +366,14 @@ func SkipUnlessProviderIs(supportedProviders ...string) {
 	}
 }
 
+func SkipIfContainerRuntimeIs(runtimes ...string) {
+	for _, runtime := range runtimes {
+		if runtime == TestContext.ContainerRuntime {
+			Skipf("Not supported under container runtime %s", runtime)
+		}
+	}
+}
+
 func ProviderIs(providers ...string) bool {
 	for _, provider := range providers {
 		if strings.ToLower(provider) == strings.ToLower(TestContext.Provider) {

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -348,6 +348,7 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 		})
 
 		It("should support inline execution and attach", func() {
+			framework.SkipIfContainerRuntimeIs("rkt") // #23335
 			framework.SkipUnlessServerVersionGTE(jobsVersion, c)
 
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
@@ -1044,6 +1045,8 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 		jobName := "e2e-test-rm-busybox-job"
 
 		It("should create a job from an image, then delete the job [Conformance]", func() {
+			// The rkt runtime doesn't support attach, see #23335
+			framework.SkipIfContainerRuntimeIs("rkt")
 			framework.SkipUnlessServerVersionGTE(jobsVersion, c)
 
 			By("executing a command with run --rm and attach with stdin")

--- a/test/e2e/pods.go
+++ b/test/e2e/pods.go
@@ -664,6 +664,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 	})
 
 	It("should invoke init containers on a RestartNever pod", func() {
+		framework.SkipIfContainerRuntimeIs("rkt") // #25988
 		podClient := f.Client.Pods(f.Namespace.Name)
 
 		By("creating the pod")
@@ -729,6 +730,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 	})
 
 	It("should invoke init containers on a RestartAlways pod", func() {
+		framework.SkipIfContainerRuntimeIs("rkt") // #25988
 		podClient := f.Client.Pods(f.Namespace.Name)
 
 		By("creating the pod")
@@ -798,6 +800,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 	})
 
 	It("should not start app containers if init containers fail on a RestartAlways pod", func() {
+		framework.SkipIfContainerRuntimeIs("rkt") // #25988
 		podClient := f.Client.Pods(f.Namespace.Name)
 
 		By("creating the pod")
@@ -913,6 +916,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 	})
 
 	It("should not start app containers and fail the pod if init containers fail on a RestartNever pod", func() {
+		framework.SkipIfContainerRuntimeIs("rkt") // #25988
 		podClient := f.Client.Pods(f.Namespace.Name)
 
 		By("creating the pod")


### PR DESCRIPTION
The main benefit of this is that it gives a developer more useful output (more signal to noise) for things that are known broken on that runtime.

cc @kubernetes/rktnetes-maintainers , @ixdy 

I'll run this PR through our jenkins and make sure things look happy and compare to the e2e results for this PR.
