### PR TITLE
Introduce Shared Security Group to Allow Traffic from Unlimited Number of ELBs. fixes #26670

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,11 +9,3 @@
 **Which issue this PR fixes** *(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
 
 **Special notes for your reviewer**:
-
-**Release note**:
-<!--  Steps to write your release note:
-1. Use the release-note-* labels to set the release note state (if you have access) 
-2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
--->
-```release-note
-```

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -2551,7 +2551,7 @@ func (c *Cloud) EnsureLoadBalancer(clusterName string, apiService *api.Service, 
 
 	// Add sharedSecurityGroupID into instances' rules only.
 	if c.cfg.Global.EnableSharedSecurityGroupIngress {
-		err = s.updateInstanceSharedSecurityGroups(sharedSecurityGroupID, instances)
+		err = c.updateInstanceSharedSecurityGroups(sharedSecurityGroupID, instances)
 		if err != nil {
 			glog.Warningf("Error opening ingress rules for the shared security group to the instances: %v", err)
 			return nil, err

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
 
@@ -115,6 +116,7 @@ type FakeAWSServices struct {
 	selfInstance            *ec2.Instance
 	networkInterfacesMacs   []string
 	networkInterfacesVpcIDs []string
+	securityGroups          []*ec2.SecurityGroup
 
 	ec2      *FakeEC2
 	elb      *FakeELB
@@ -394,20 +396,78 @@ func (ec2 *FakeEC2) DeleteVolume(request *ec2.DeleteVolumeInput) (resp *ec2.Dele
 	panic("Not implemented")
 }
 
-func (ec2 *FakeEC2) DescribeSecurityGroups(request *ec2.DescribeSecurityGroupsInput) ([]*ec2.SecurityGroup, error) {
-	panic("Not implemented")
+func (e *FakeEC2) DescribeSecurityGroups(request *ec2.DescribeSecurityGroupsInput) ([]*ec2.SecurityGroup, error) {
+	matches := []*ec2.SecurityGroup{}
+	for _, securityGroup := range e.aws.securityGroups {
+		if request.GroupIds != nil {
+			if securityGroup.GroupId == nil {
+				glog.Warning("Security group with no group id: ", securityGroup)
+				continue
+			}
+
+			found := false
+			for _, securityGroupID := range request.GroupIds {
+				if *securityGroupID == *securityGroup.GroupId {
+					found = true
+					break
+				}
+			}
+			if !found {
+				continue
+			}
+		}
+		if request.Filters != nil {
+			allMatch := true
+			for _, filter := range request.Filters {
+				if !securityGroupMatchesFilter(securityGroup, filter) {
+					allMatch = false
+					break
+				}
+			}
+			if !allMatch {
+				continue
+			}
+		}
+		matches = append(matches, securityGroup)
+	}
+	return matches, nil
 }
 
 func (ec2 *FakeEC2) CreateSecurityGroup(*ec2.CreateSecurityGroupInput) (*ec2.CreateSecurityGroupOutput, error) {
 	panic("Not implemented")
 }
 
+func securityGroupMatchesFilter(securityGroup *ec2.SecurityGroup, filter *ec2.Filter) bool {
+	name := *filter.Name
+	if strings.HasPrefix(name, "tag:") {
+		tagName := name[4:]
+		for _, securityGroupTag := range securityGroup.Tags {
+			if aws.StringValue(securityGroupTag.Key) == tagName && contains(filter.Values, aws.StringValue(securityGroupTag.Value)) {
+				return true
+			}
+		}
+	}
+	panic("Unknown filter name: " + name)
+}
+
 func (ec2 *FakeEC2) DeleteSecurityGroup(*ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error) {
 	panic("Not implemented")
 }
 
-func (ec2 *FakeEC2) AuthorizeSecurityGroupIngress(*ec2.AuthorizeSecurityGroupIngressInput) (*ec2.AuthorizeSecurityGroupIngressOutput, error) {
-	panic("Not implemented")
+func (e *FakeEC2) AuthorizeSecurityGroupIngress(request *ec2.AuthorizeSecurityGroupIngressInput) (*ec2.AuthorizeSecurityGroupIngressOutput, error) {
+	for _, securityGroup := range e.aws.securityGroups {
+		if *securityGroup.GroupId == *request.GroupId {
+			for _, permission := range request.IpPermissions {
+				for _, existingPermission := range securityGroup.IpPermissions {
+					if ipPermissionExists(permission, existingPermission, false) {
+						return nil, awserr.New("InvalidPermission.Duplicate", "", nil)
+					}
+				}
+				securityGroup.IpPermissions = append(securityGroup.IpPermissions, permission)
+			}
+		}
+	}
+	return nil, awserr.New("InvalidGroup.NotFound", "", nil)
 }
 
 func (ec2 *FakeEC2) RevokeSecurityGroupIngress(*ec2.RevokeSecurityGroupIngressInput) (*ec2.RevokeSecurityGroupIngressOutput, error) {
@@ -1208,6 +1268,74 @@ func TestDescribeLoadBalancerOnEnsure(t *testing.T) {
 	awsServices.elb.expectDescribeLoadBalancers("aid")
 
 	c.EnsureLoadBalancer(TestClusterName, &api.Service{ObjectMeta: api.ObjectMeta{Name: "myservice", UID: "id"}}, []string{})
+}
+
+func TestUpdateInstanceSharedSecurityGroups(t *testing.T) {
+	// Instantiating a fake AWSServices, and AWSCloud.
+	awsServices := NewFakeAWSServices()
+	c, _ := newAWSCloud(strings.NewReader("[global]"), awsServices)
+	awsServices.elb.expectDescribeLoadBalancers("aid")
+
+	// testTags that are attached to security groups
+	testTags := []*ec2.Tag{
+		&ec2.Tag{
+			Key: aws.String(TagNameKubernetesCluster),
+			Value: aws.String(TestClusterId),
+		},
+	}
+
+	// Initialize one default security group and one shared security group
+	awsServices.securityGroups = []*ec2.SecurityGroup{
+		// security group to which we will add shared security group rule
+		&ec2.SecurityGroup{
+			Description: aws.String("example-security-group-description"),
+			GroupName: aws.String("example-security-group-name"),
+			GroupId: aws.String("example-security-group-id"),
+			VpcId: &c.vpcID,
+			Tags: testTags,
+		},
+		// shared security group
+		&ec2.SecurityGroup{
+			Description: aws.String("shared-security-group-description"),
+			GroupName: aws.String("shared-security-group-name"),
+			GroupId: aws.String("shared-security-group-id"),
+			VpcId: &c.vpcID,
+			Tags: testTags,
+		},
+	}
+
+	// Make sure this instance has the security group we intend to test a.k.a sgInput security group
+	instance1 := ec2.Instance {
+		InstanceId: aws.String("i-1"),
+		PrivateDnsName: aws.String("instance-same.ec2.internal"),
+		PrivateIpAddress: aws.String("192.168.0.2"),
+		PublicIpAddress: aws.String("1.2.3.4"),
+		InstanceType: aws.String("c3.large"),
+		Placement: &ec2.Placement{AvailabilityZone: aws.String("us-east-1a")},
+		State: &ec2.InstanceState{Name: aws.String("running")},
+		SecurityGroups: []*ec2.GroupIdentifier{
+			&ec2.GroupIdentifier {
+				GroupId: awsServices.securityGroups[0].GroupId,
+				GroupName: awsServices.securityGroups[0].GroupName,
+			},
+		},
+	}
+
+	awsServices.instances = append(awsServices.instances, &instance1)
+
+	// Set flags properly in order to test updateInstanceSharedSecurityGroups
+	c.cfg.Global.DisableSecurityGroupIngress = false
+	c.cfg.Global.EnableSharedSecurityGroupIngress = true
+
+	c.updateInstanceSharedSecurityGroups("shared-security-group-id", awsServices.instances)
+
+	// Now check if "open to every protocol" rule has been successfully added to the security group
+	assert.Equal(t, "-1", *awsServices.securityGroups[0].IpPermissions[0].IpProtocol)
+	assert.Equal(t, "shared-security-group-id", *awsServices.securityGroups[0].IpPermissions[0].UserIdGroupPairs[0].GroupId)
+
+	// Now try updateInstanceSharedSecurityGroups again and check that AuthorizeSecurityGroupIngress is never called
+	err := c.updateInstanceSharedSecurityGroups("shared-security-group-id", awsServices.instances)
+	assert.Equal(t, nil, err)
 }
 
 func TestBuildListener(t *testing.T) {


### PR DESCRIPTION
Currently, Kubernetes adds every ELB’s security group rule to instances, which means the number of rules included in instance’s security group grows as the number of ELB grows.

AWS supports up to 50 inbound rules per security group and 5 security groups per network interface.  http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Appendix_Limits.html#vpc-limits-security-groups

With this AWS limit and the current setup of Kubernetes, there is a hard limit of 250 services for each Kubernetes cluster. This problem arises mainly because every ELB creation results in a new rule added to every instance security group. 

We can resolve this issue by introducing a shared security group per Kubernetes cluster. A simple solution is to modify codes in aws.go such that when ELB is created, it either finds or creates a shared security group with no rule and attaches it to ELB. Also, instead of adding the ELB’s own security group rule to instances, it tests if each instance already has the shared security group id as one of the source group id. Here, we also have to make sure each instance accepts every traffic coming from the shared security group source. If it finds that some instances do not have the shared security group id added yet, it does so. 

With this revision, the number of security group rules for instances becomes independent of the number of ELBs, which means the number of service it can support is not limited by the AWS limit.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/27474)

<!-- Reviewable:end -->
