### PR TITLE
fix nslookup invocation

### DIFF
--- a/test/e2e/federated-service.go
+++ b/test/e2e/federated-service.go
@@ -256,6 +256,10 @@ func createService(fcs *federation_internalclientset.Clientset, clusterClientSet
 }
 
 func discoverService(f *framework.Framework, name string, exists bool) {
+	command := []string{"nslookup", name}
+
+	framework.Logf("Looking for the service with pod command %q", command)
+
 	pod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Name:   FederatedServicePod,
@@ -266,7 +270,7 @@ func discoverService(f *framework.Framework, name string, exists bool) {
 				{
 					Name:    "federated-service-discovery-container",
 					Image:   "gcr.io/google_containers/busybox:1.24",
-					Command: []string{"sh", "-c", "nslookup", name},
+					Command: command,
 				},
 			},
 			RestartPolicy: api.RestartPolicyNever,


### PR DESCRIPTION
The old way with 'sh -c' was not correct.

For #26762
