### PR TITLE
Call NewFramework constructor instead of hand creating framework.

### DIFF
--- a/test/e2e/ingress.go
+++ b/test/e2e/ingress.go
@@ -393,7 +393,7 @@ var _ = framework.KubeDescribe("GCE L7 LoadBalancer Controller [Feature:Ingress]
 	var responseTimes, creationTimes []time.Duration
 	var ingController *IngressController
 
-	f := framework.Framework{BaseName: "glbc"}
+	f := framework.NewDefaultFramework("glbc")
 
 	BeforeEach(func() {
 		// This test requires a GCE/GKE only cluster-addon


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/issues/27486, probably because we defined a new clientConfigGetter for node e2es and this test was hand creating the framework. 
