### PR TITLE
Set the podAttachAndMountTimeout to a lower value

### DIFF
--- a/pkg/kubelet/volume/volume_manager.go
+++ b/pkg/kubelet/volume/volume_manager.go
@@ -49,12 +49,13 @@ const (
 	desiredStateOfWorldPopulatorLoopSleepPeriod time.Duration = 100 * time.Millisecond
 
 	// podAttachAndMountTimeout is the maximum amount of time the
-	// GetVolumesForPod call will wait for all volumes in the specified pod to
-	// be attached and mounted. Set to 20 minutes because we've seen cloud
-	// operations take several minutes to complete for some volume plugins in
-	// some cases. While the GetVolumesForPod method is waiting it only blocks
-	// other operations on the same pod, other pods are not affected.
-	podAttachAndMountTimeout time.Duration = 20 * time.Minute
+	// WaitForAttachAndMount call will wait for all volumes in the specified pod
+	// to be attached and mounted. Even though cloud operations can take several
+	// minutes to complete, we set the timeout to 2 minutes because kubelet
+	// will retry in the next sync iteration. This frees the associated
+	// goroutine of the pod to process newer updates if needed (e.g., a delete
+	// request to the pod).
+	podAttachAndMountTimeout time.Duration = 2 * time.Minute
 
 	// podAttachAndMountRetryInterval is the amount of time the GetVolumesForPod
 	// call waits before retrying


### PR DESCRIPTION
If the mount operation exceeds the timeout, it will return an error and the
pod worker will retry in the next sync (10s or less). Compared with the
original value (i.e., 10 minutes), this frees the pod worker sooner to process
pod updates, if there are any.

This partially addresses #26290
