### PR TITLE
Dumping logs of federation pods (federation-apiserver, federation-controller-manager) on e2e test failure

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -264,6 +264,10 @@ func (f *Framework) AfterEach() {
 		DumpAllNamespaceInfo(f.Client, f.Namespace.Name)
 		By(fmt.Sprintf("Dumping a list of prepulled images on each node"))
 		LogPodsWithLabels(f.Client, api.NamespaceSystem, ImagePullerLabels)
+		if f.federated {
+			// Print logs of federation control plane pods (federation-apiserver and federation-controller-manager)
+			LogPodsWithLabels(f.Client, "federation", map[string]string{"app": "federated-cluster"})
+		}
 	}
 
 	summaries := make([]TestDataSummary, 0)


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/26762

This should help with debugging failures.
Right now there is no way to access those logs.

@kubernetes/sig-cluster-federation @colhom 
