### PR TITLE
federation: only reachable endpoint should be treated as healthy

### DIFF
--- a/federation/pkg/federation-controller/service/dns.go
+++ b/federation/pkg/federation-controller/service/dns.go
@@ -44,6 +44,10 @@ func (s *ServiceController) getHealthyEndpoints(clusterName string, cachedServic
 			return nil, nil, nil, err
 		}
 		for _, ingress := range lbStatus.Ingress {
+			readyEndpoints, ok := cachedService.endpointMap[lbClusterName]
+			if !ok || readyEndpoints == 0 {
+				continue
+			}
 			var address string
 			// We should get either an IP address or a hostname - use whichever one we get
 			if ingress.IP != "" {


### PR DESCRIPTION
@quinton-hoole it seems all Ingress IP for the same service is treated as healthy, so I made a fix to filter the Ingress without ready endpoints.

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
