### PR TITLE
Fix attach command for InitContainers

### DIFF
--- a/pkg/kubectl/cmd/attach.go
+++ b/pkg/kubectl/cmd/attach.go
@@ -167,9 +167,11 @@ func (p *AttachOptions) Run() error {
 		if err != nil {
 			return err
 		}
-		if pod.Status.Phase != api.PodRunning {
-			return fmt.Errorf("pod %s is not running and cannot be attached to; current phase is %s", p.PodName, pod.Status.Phase)
+
+		if pod.Status.Phase == api.PodSucceeded || pod.Status.Phase == api.PodFailed {
+			return fmt.Errorf("cannot attach a container in a completed pod; current phase is %s", pod.Status.Phase)
 		}
+
 		p.Pod = pod
 		// TODO: convert this to a clean "wait" behavior
 	}
@@ -229,6 +231,11 @@ func (p *AttachOptions) Run() error {
 func (p *AttachOptions) GetContainer(pod *api.Pod) api.Container {
 	if len(p.ContainerName) > 0 {
 		for _, container := range pod.Spec.Containers {
+			if container.Name == p.ContainerName {
+				return container
+			}
+		}
+		for _, container := range pod.Spec.InitContainers {
 			if container.Name == p.ContainerName {
 				return container
 			}

--- a/pkg/kubectl/cmd/attach_test.go
+++ b/pkg/kubectl/cmd/attach_test.go
@@ -79,7 +79,15 @@ func TestPodAndContainerAttach(t *testing.T) {
 			expectedContainer: "bar",
 			name:              "container in flag",
 		},
+		{
+			p:                 &AttachOptions{ContainerName: "initfoo"},
+			args:              []string{"foo"},
+			expectedPod:       "foo",
+			expectedContainer: "initfoo",
+			name:              "init container in flag",
+		},
 	}
+
 	for _, test := range tests {
 		f, tf, codec := NewAPIFactory()
 		tf.Client = &fake.RESTClient{
@@ -269,6 +277,11 @@ func attachPod() *api.Pod {
 			Containers: []api.Container{
 				{
 					Name: "bar",
+				},
+			},
+			InitContainers: []api.Container{
+				{
+					Name: "initfoo",
 				},
 			},
 		},


### PR DESCRIPTION
Added InitContainers to the things that GetContainer in attach.go has to look for to find a container to attach. Also test case added.

fixes #27540
