### PR TITLE
Bumped Heapster to v1.1.0

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -16,26 +16,26 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.1.0.beta2
+  name: heapster-v1.1.0
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
-    version: v1.1.0.beta2
+    version: v1.1.0
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.1.0.beta2
+      version: v1.1.0
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.1.0.beta2
+        version: v1.1.0
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v1.1.0-beta2
+        - image: gcr.io/google_containers/heapster:v1.1.0
           name: heapster
           resources:
             # keep request = limit to keep this container in guaranteed class
@@ -53,7 +53,7 @@ spec:
             - name: ssl-certs
               mountPath: /etc/ssl/certs
               readOnly: true
-        - image: gcr.io/google_containers/heapster:v1.1.0-beta2
+        - image: gcr.io/google_containers/heapster:v1.1.0
           name: eventer
           resources:
             # keep request = limit to keep this container in guaranteed class
@@ -96,7 +96,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{metrics_memory_per_node}}Mi
             - --threshold=5
-            - --deployment=heapster-v1.1.0.beta2
+            - --deployment=heapster-v1.1.0
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
@@ -125,7 +125,7 @@ spec:
             - --memory={{base_eventer_memory}}
             - --extra-memory={{eventer_memory_per_node}}Ki
             - --threshold=5
-            - --deployment=heapster-v1.1.0.beta2
+            - --deployment=heapster-v1.1.0
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -16,26 +16,26 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.1.0.beta2
+  name: heapster-v1.1.0
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
-    version: v1.1.0.beta2
+    version: v1.1.0
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.1.0.beta2
+      version: v1.1.0
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.1.0.beta2
+        version: v1.1.0
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v1.1.0-beta2
+        - image: gcr.io/google_containers/heapster:v1.1.0
           name: heapster
           resources:
             # keep request = limit to keep this container in guaranteed class
@@ -54,7 +54,7 @@ spec:
             - name: ssl-certs
               mountPath: /etc/ssl/certs
               readOnly: true
-        - image: gcr.io/google_containers/heapster:v1.1.0-beta2
+        - image: gcr.io/google_containers/heapster:v1.1.0
           name: eventer
           resources:
             # keep request = limit to keep this container in guaranteed class
@@ -97,7 +97,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.1.0.beta2
+            - --deployment=heapster-v1.1.0
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
@@ -126,7 +126,7 @@ spec:
             - --memory={{ base_eventer_memory }}
             - --extra-memory={{ eventer_memory_per_node }}Ki
             - --threshold=5
-            - --deployment=heapster-v1.1.0.beta2
+            - --deployment=heapster-v1.1.0
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -16,26 +16,26 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.1.0.beta2
+  name: heapster-v1.1.0
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
-    version: v1.1.0.beta2
+    version: v1.1.0
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.1.0.beta2
+      version: v1.1.0
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.1.0.beta2
+        version: v1.1.0
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v1.1.0-beta2
+        - image: gcr.io/google_containers/heapster:v1.1.0
           name: heapster
           resources:
             # keep request = limit to keep this container in guaranteed class
@@ -49,7 +49,7 @@ spec:
             - /heapster
             - --source=kubernetes.summary_api:''
             - --sink=influxdb:http://monitoring-influxdb:8086
-        - image: gcr.io/google_containers/heapster:v1.1.0-beta2
+        - image: gcr.io/google_containers/heapster:v1.1.0
           name: eventer
           resources:
             # keep request = limit to keep this container in guaranteed class
@@ -88,7 +88,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.1.0.beta2
+            - --deployment=heapster-v1.1.0
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
@@ -117,7 +117,7 @@ spec:
             - --memory={{ base_eventer_memory }}
             - --extra-memory={{ eventer_memory_per_node }}Ki
             - --threshold=5
-            - --deployment=heapster-v1.1.0.beta2
+            - --deployment=heapster-v1.1.0
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -12,26 +12,26 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.1.0.beta2
+  name: heapster-v1.1.0
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
-    version: v1.1.0.beta2
+    version: v1.1.0
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.1.0.beta2
+      version: v1.1.0
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.1.0.beta2
+        version: v1.1.0
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v1.1.0-beta2
+        - image: gcr.io/google_containers/heapster:v1.1.0
           name: heapster
           resources:
             # keep request = limit to keep this container in guaranteed class
@@ -69,7 +69,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.1.0.beta2
+            - --deployment=heapster-v1.1.0
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential

--- a/test/kubemark/resources/heapster_template.json
+++ b/test/kubemark/resources/heapster_template.json
@@ -2,23 +2,23 @@
 	"kind": "ReplicationController",
 	"apiVersion": "v1",
 	"metadata": {
-		"name": "heapster-v1.1.0.beta1",
+		"name": "heapster-v1.1.0",
 		"labels": {
 			"k8s-app": "heapster",
-			"version": "v1.1.0.beta1"
+			"version": "v1.1.0"
 		}
 	},
 	"spec": {
 		"replicas": 1,
 		"selector": {
 			"k8s-app": "heapster",
-			"version": "v1.1.0.beta1"
+			"version": "v1.1.0"
 		},
 		"template": {
 			"metadata": {
 				"labels": {
 					"k8s-app": "heapster",
-					"version": "v1.1.0.beta1"
+					"version": "v1.1.0"
 				}
 			},
 			"spec": {
@@ -33,7 +33,7 @@
 				"containers": [
 				{
 					"name": "heapster",
-					"image": "gcr.io/google_containers/heapster:v1.1.0-beta1",
+					"image": "gcr.io/google_containers/heapster:v1.1.0",
 					"resources": {
 						"requests": {
 							"cpu": "100m",
@@ -55,7 +55,7 @@
 				},
 				{
 					"name": "eventer",
-					"image": "gcr.io/google_containers/heapster:v1.1.0-beta1",
+					"image": "gcr.io/google_containers/heapster:v1.1.0",
 					"resources": {
 						"requests": {
 							"cpu": "100m",


### PR DESCRIPTION
``` release-note
Bumped Heapster to v1.1.0.
More details about the release https://github.com/kubernetes/heapster/releases/tag/v1.1.0
```

Version 1.1.0 doesn't differ from the previous one v1.1.0-beta2 significantly - just fixed few small issues during stabilization period.

cc @a-robinson @jszczepkowski @mwielgus 

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
