### PR TITLE
cloudprovider/aws: prefer '/dev/xvdX' over '/dev/sdX' for device names

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -1298,9 +1298,12 @@ func (c *AWSCloud) AttachDisk(diskName string, instanceName string, readOnly boo
 	hostDevice := "/dev/xvd" + string(mountDevice)
 	// In the EC2 API, it is sometimes is /dev/sdX and sometimes /dev/xvdX
 	// We are running on the node here, so we check if /dev/xvda exists to determine this
-	ec2Device := "/dev/xvd" + string(mountDevice)
-	if _, err := os.Stat("/dev/xvda"); os.IsNotExist(err) {
-		ec2Device = "/dev/sd" + string(mountDevice)
+	//
+	// TODO: This check fails when running on KCM, as it's only checking the
+	// device name on the kcm and not on the actual instance
+	ec2Device := "/dev/sd" + string(mountDevice)
+	if _, err := os.Stat("/dev/sda"); os.IsNotExist(err) {
+		ec2Device = "/dev/xvd" + string(mountDevice)
 	}
 
 	// attachEnded is set to true if the attach operation completed


### PR DESCRIPTION
<!--
Checklist for submitting a Pull Request

Please remove this comment block before submitting.

1. Please read our [contributor guidelines](https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md).
2. See our [developer guide](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md).
3. If you want this PR to automatically close an issue when it is merged,
   add `fixes #<issue number>` or `fixes #<issue number>, fixes #<issue number>`
   to close multiple issues (see: https://github.com/blog/1506-closing-issues-via-pull-requests).
4. Follow the instructions for [labeling and writing a release note for this PR](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes) in the block below.
-->

``` release-note
* cloudprovider/aws: prefer '/dev/xvdX' over '/dev/sdX' for device names
```

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()

If the root device name can not be detected on AWS, fallback to `/dev/xvdX` instead of `/dev/sdX` device names.  
- cf. #27534
