### PR TITLE
swap FIRSTSEEN/LASTSEEN columns in `kubectl get event -w`

### DIFF
--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -425,7 +425,7 @@ var petSetColumns = []string{"NAME", "DESIRED", "CURRENT", "AGE"}
 var endpointColumns = []string{"NAME", "ENDPOINTS", "AGE"}
 var nodeColumns = []string{"NAME", "STATUS", "AGE"}
 var daemonSetColumns = []string{"NAME", "DESIRED", "CURRENT", "NODE-SELECTOR", "AGE"}
-var eventColumns = []string{"FIRSTSEEN", "LASTSEEN", "COUNT", "NAME", "KIND", "SUBOBJECT", "TYPE", "REASON", "SOURCE", "MESSAGE"}
+var eventColumns = []string{"LASTSEEN", "FIRSTSEEN", "COUNT", "NAME", "KIND", "SUBOBJECT", "TYPE", "REASON", "SOURCE", "MESSAGE"}
 var limitRangeColumns = []string{"NAME", "AGE"}
 var resourceQuotaColumns = []string{"NAME", "AGE"}
 var namespaceColumns = []string{"NAME", "STATUS", "AGE"}
@@ -1477,8 +1477,8 @@ func printEvent(event *api.Event, w io.Writer, options PrintOptions) error {
 
 	if _, err := fmt.Fprintf(
 		w, "%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s",
-		FirstTimestamp,
 		LastTimestamp,
+		FirstTimestamp,
 		event.Count,
 		event.InvolvedObject.Name,
 		event.InvolvedObject.Kind,


### PR DESCRIPTION
``` release-note
Show LASTSEEN, the sorting key, as the first column in `kubectl get event` output
```

Not having LASTSEEN as the first column can confuse users into thinking
that events are not delivered in order.

Fixes #27060
