### PR TITLE
clarify kubectl recursive flag description

### DIFF
--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -334,7 +334,7 @@ func AddValidateFlags(cmd *cobra.Command) {
 }
 
 func AddRecursiveFlag(cmd *cobra.Command, value *bool) {
-	cmd.Flags().BoolVarP(value, "recursive", "R", *value, "If true, process directory recursively.")
+	cmd.Flags().BoolVarP(value, "recursive", "R", *value, "Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.")
 }
 
 // AddDryRunFlag adds dry-run flag to a command. Usually used by mutations.


### PR DESCRIPTION
Clarify the description of the recursive flag in `kubectl` so that it's more intuitive to the user

This should make it into v1.3 as the rest of the recursive feature PR's will be available in 1.3
