### PR TITLE
Allocate default killCmd structs in newE2eService function

### DIFF
--- a/test/e2e_node/e2e_service.go
+++ b/test/e2e_node/e2e_service.go
@@ -314,9 +314,15 @@ type killCmd struct {
 }
 
 func (k *killCmd) Kill() error {
+	if k == nil {
+		glog.V(2).Infof("The killCmd is nil, nothing will be killed")
+		return nil
+	}
+
 	if k.override != nil {
 		return k.override.Run()
 	}
+
 	name := k.name
 	cmd := k.cmd
 


### PR DESCRIPTION
Fixes #27582 

[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/.github/PULL_REQUEST_TEMPLATE.md?pixel)]()
