### PR TITLE
federation: reverse the order of creating controller manager and secret since controller requires secret

### DIFF
--- a/federation/cluster/common.sh
+++ b/federation/cluster/common.sh
@@ -145,9 +145,6 @@ function create-federation-api-objects {
     FEDERATION_API_TOKEN="$(dd if=/dev/urandom bs=128 count=1 2>/dev/null | base64 | tr -d "=+/" | dd bs=32 count=1 2>/dev/null)"
     export FEDERATION_API_KNOWN_TOKENS="${FEDERATION_API_TOKEN},admin,admin"
 
-    $template "${manifests_root}/federation-apiserver-"{deployment,secrets}".yaml" | $host_kubectl create -f -
-    $template "${manifests_root}/federation-controller-manager-deployment.yaml" | $host_kubectl create -f -
-
     # Create a kubeconfig with credentails for federation-apiserver. We will
     # then use this kubeconfig to create a secret which the federation
     # controller manager can use to talk to the federation-apiserver.
@@ -168,6 +165,9 @@ function create-federation-api-objects {
       name=$(basename $dir)
       $host_kubectl create secret generic ${name} --from-file="${dir}/kubeconfig" --namespace="${FEDERATION_NAMESPACE}"
     done
+
+    $template "${manifests_root}/federation-apiserver-"{deployment,secrets}".yaml" | $host_kubectl create -f -
+    $template "${manifests_root}/federation-controller-manager-deployment.yaml" | $host_kubectl create -f -
 
     # Update the users kubeconfig to include federation-apiserver credentials.
     CONTEXT=federation-cluster \


### PR DESCRIPTION
Ref #26762

federation-controller-manager fails if the secret is not there when it comes up: https://github.com/kubernetes/kubernetes/blob/970104df3199eeb30710d1067da28f952ae36403/federation/cmd/federation-controller-manager/app/controllermanager.go#L82.

Updating the bring up scripts to first create the secrets and then create the deployments.

@kubernetes/sig-cluster-federation @mml
