### PR TITLE
Refactor func canRunPod

### DIFF
--- a/pkg/kubelet/util.go
+++ b/pkg/kubelet/util.go
@@ -27,7 +27,24 @@ import (
 
 // Check whether we have the capabilities to run the specified pod.
 func canRunPod(pod *api.Pod) error {
-	if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.HostNetwork {
+	if !capabilities.Get().AllowPrivileged {
+		for _, container := range pod.Spec.Containers {
+			if securitycontext.HasPrivilegedRequest(&container) {
+				return fmt.Errorf("pod with UID %q specified privileged container, but is disallowed", pod.UID)
+			}
+		}
+		for _, container := range pod.Spec.InitContainers {
+			if securitycontext.HasPrivilegedRequest(&container) {
+				return fmt.Errorf("pod with UID %q specified privileged init container, but is disallowed", pod.UID)
+			}
+		}
+	}
+
+	if pod.Spec.SecurityContext == nil {
+		return nil
+	}
+
+	if pod.Spec.SecurityContext.HostNetwork {
 		allowed, err := allowHostNetwork(pod)
 		if err != nil {
 			return err
@@ -37,7 +54,7 @@ func canRunPod(pod *api.Pod) error {
 		}
 	}
 
-	if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.HostPID {
+	if pod.Spec.SecurityContext.HostPID {
 		allowed, err := allowHostPID(pod)
 		if err != nil {
 			return err
@@ -47,7 +64,7 @@ func canRunPod(pod *api.Pod) error {
 		}
 	}
 
-	if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.HostIPC {
+	if pod.Spec.SecurityContext.HostIPC {
 		allowed, err := allowHostIPC(pod)
 		if err != nil {
 			return err
@@ -57,18 +74,6 @@ func canRunPod(pod *api.Pod) error {
 		}
 	}
 
-	if !capabilities.Get().AllowPrivileged {
-		for _, container := range pod.Spec.Containers {
-			if securitycontext.HasPrivilegedRequest(&container) {
-				return fmt.Errorf("pod with UID %q specified privileged container, but is disallowed", pod.UID)
-			}
-		}
-		for _, container := range pod.Spec.InitContainers {
-			if securitycontext.HasPrivilegedRequest(&container) {
-				return fmt.Errorf("pod with UID %q specified privileged container, but is disallowed", pod.UID)
-			}
-		}
-	}
 	return nil
 }
 


### PR DESCRIPTION
After refactoring, we only need to check `if pod.Spec.SecurityContext == nil` once. The logic is a bit clearer.
