### PR TITLE
Cleanups following #27587

### DIFF
--- a/test/e2e/federated-service.go
+++ b/test/e2e/federated-service.go
@@ -176,6 +176,8 @@ var _ = framework.KubeDescribe("Service [Feature:Federation]", func() {
 				framework.SkipUnlessFederated(f.Client)
 
 				// Delete a federated service shard in the default e2e Kubernetes cluster.
+				// TODO(mml): This should not work: #27623.  We should use a load
+				// balancer with actual back-ends, some of which we delete or disable.
 				err := f.Clientset_1_3.Core().Services(f.Namespace.Name).Delete(FederatedServiceName, &api.DeleteOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				waitForFederatedServiceShard(f.Clientset_1_3, f.Namespace.Name, nil, 0)

--- a/test/e2e/federated-service.go
+++ b/test/e2e/federated-service.go
@@ -329,8 +329,6 @@ func discoverService(f *framework.Framework, name string, exists bool) {
 	command := []string{"sh", "-c", fmt.Sprintf("until nslookup '%s'; do sleep 1; done", name)}
 	By(fmt.Sprintf("Looking up %q", name))
 
-	defer f.Client.Pods(f.Namespace.Name).Delete(FederatedServicePod, api.NewDeleteOptions(0))
-
 	pod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Name:   FederatedServicePod,
@@ -349,8 +347,8 @@ func discoverService(f *framework.Framework, name string, exists bool) {
 	}
 
 	_, err := f.Client.Pods(f.Namespace.Name).Create(pod)
-	Expect(err).
-		NotTo(HaveOccurred(), "Trying to create pod to run %q", command)
+	Expect(err).NotTo(HaveOccurred(), "Trying to create pod to run %q", command)
+	defer f.Client.Pods(f.Namespace.Name).Delete(FederatedServicePod, api.NewDeleteOptions(0))
 
 	if exists {
 		// TODO(mml): Eventually check the IP address is correct, too.

--- a/test/e2e/federated-service.go
+++ b/test/e2e/federated-service.go
@@ -194,11 +194,9 @@ var _ = framework.KubeDescribe("Service [Feature:Federation]", func() {
 					discoverService(f, name, true)
 				}
 
-				// TODO(mml): Unclear how to make this meaningful and not terribly
-				// slow.  How long (how many minutes?) do we verify that a given DNS
-				// lookup *doesn't* work before we call it a success?  For now,
-				// commenting out.
-				/*
+				// TODO(mml): This currently takes 9 minutes.  Consider reducing the
+				// TTL and/or running the pods in parallel.
+				Context("[Slow]", func() {
 					localSvcDNSNames := []string{
 						FederatedServiceName,
 						fmt.Sprintf("%s.%s", FederatedServiceName, f.Namespace.Name),
@@ -207,7 +205,7 @@ var _ = framework.KubeDescribe("Service [Feature:Federation]", func() {
 					for _, name := range localSvcDNSNames {
 						discoverService(f, name, false)
 					}
-				*/
+				})
 			})
 		})
 	})

--- a/test/e2e/federated-service.go
+++ b/test/e2e/federated-service.go
@@ -50,6 +50,9 @@ const (
 	FederatedServicePod  = "federated-service-test-pod"
 
 	DefaultFederationName = "federation"
+
+	// We use this to decide how long to wait for our DNS probes to succeed.
+	DNSTTL = 180 * time.Second
 )
 
 var _ = framework.KubeDescribe("Service [Feature:Federation]", func() {
@@ -345,6 +348,6 @@ func discoverService(f *framework.Framework, name string) {
 		}
 
 		return logerr(fmt.Errorf("exited %d", status.State.Terminated.ExitCode))
-	}, time.Minute*2, time.Second*2).
+	}, DNSTTL, time.Second*2).
 		Should(BeNil(), "%q should exit 0, but it never did", command)
 }


### PR DESCRIPTION
- Add back the negative assertions, but mark them [Slow].
- Use the current DNS TTL of 180 sec as our timeout for all DNS tests.
- Assorted cleanups and refactoring.
