### PR TITLE
Remove pod mutation for volumes annotated with supplemental groups

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1414,7 +1414,8 @@ func (kl *Kubelet) GenerateRunContainerOptions(pod *api.Pod, container *api.Cont
 		return nil, err
 	}
 	opts.Hostname = hostname
-	volumes := kl.volumeManager.GetVolumesForPodAndAppendSupplementalGroups(pod)
+	podName := volumehelper.GetUniquePodName(pod)
+	volumes := kl.volumeManager.GetMountedVolumesForPod(podName)
 
 	opts.PortMappings = makePortMappings(container)
 	// Docker does not relabel volumes if the container is running


### PR DESCRIPTION
Removes the pod mutation added in #20490 -- partially resolves #27197 from the standpoint of making the feature inactive in 1.3.  Our plan is to make this work correctly in 1.4.

@kubernetes/sig-storage 
