### PR TITLE
Trusty: Fix the motd reset

### DIFF
--- a/cluster/gce/trusty/configure-helper.sh
+++ b/cluster/gce/trusty/configure-helper.sh
@@ -726,7 +726,7 @@ Note: This looks like a development version, which might not be present on GitHu
 If it isn't, the closest tag is at:
   https://github.com/kubernetes/kubernetes/tree/${gitref}
 "
-    gitref="${version//*+/}"
+    gitref=$(echo ${version} | sed -e 's/.*+//')
   fi
   cat > /etc/motd <<EOF
 Welcome to Kubernetes ${version}!

--- a/cluster/gce/trusty/master.yaml
+++ b/cluster/gce/trusty/master.yaml
@@ -213,6 +213,7 @@ script
 	set -o errexit
 	set -o nounset
 
+	. /etc/kube-configure-helper.sh
 	. /etc/kube-env
 	export HOME="/root"
 	export KUBECTL_BIN="/usr/bin/kubectl"


### PR DESCRIPTION
I made a couple of fixes about GCI motd in the master  and release-1.3 branches. But while I made a cherrypick, there was much conflict, and manually solving the conflict apparently made a mistake of omitting something. This PR is for fixing such a problem. Please note that this is the minimal change to make GCI in release-1.2 green.

@zmerlynn please help me set the milestone. The v1.2 is not visible to me now. Thanks!
