### PR TITLE
federation-apiserver test: Fixing the AfterEach order in e2e test

### DIFF
--- a/test/e2e/federation-apiserver.go
+++ b/test/e2e/federation-apiserver.go
@@ -34,52 +34,54 @@ import (
 var _ = framework.KubeDescribe("Federation apiserver [Feature:Federation]", func() {
 	f := framework.NewDefaultFederatedFramework("federation-cluster")
 
-	AfterEach(func() {
-		// framework.SkipUnlessFederated(f.Client)  TODO: quinton-hoole: Temporarily disabled
+	Describe("Cluster objects", func() {
+		AfterEach(func() {
+			framework.SkipUnlessFederated(f.Client)
 
-		// Delete registered clusters.
-		// This is if a test failed, it should not affect other tests.
-		clusterList, err := f.FederationClientset.Federation().Clusters().List(api.ListOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		for _, cluster := range clusterList.Items {
-			err := f.FederationClientset.Federation().Clusters().Delete(cluster.Name, &api.DeleteOptions{})
+			// Delete registered clusters.
+			// This is if a test failed, it should not affect other tests.
+			clusterList, err := f.FederationClientset.Federation().Clusters().List(api.ListOptions{})
 			Expect(err).NotTo(HaveOccurred())
-		}
-	})
+			for _, cluster := range clusterList.Items {
+				err := f.FederationClientset.Federation().Clusters().Delete(cluster.Name, &api.DeleteOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			}
+		})
 
-	It("should allow creation and deletion of cluster api objects", func() {
-		framework.SkipUnlessFederated(f.Client)
+		It("should be created and deleted successfully", func() {
+			framework.SkipUnlessFederated(f.Client)
 
-		contexts := f.GetUnderlyingFederatedContexts()
+			contexts := f.GetUnderlyingFederatedContexts()
 
-		framework.Logf("Creating %d cluster objects", len(contexts))
-		for _, context := range contexts {
-			createClusterObjectOrFail(f, &context)
-		}
+			framework.Logf("Creating %d cluster objects", len(contexts))
+			for _, context := range contexts {
+				createClusterObjectOrFail(f, &context)
+			}
 
-		framework.Logf("Checking that %d clusters are Ready", len(contexts))
-		for _, context := range contexts {
-			clusterIsReadyOrFail(f, &context)
-		}
-		framework.Logf("%d clusters are Ready", len(contexts))
+			framework.Logf("Checking that %d clusters are Ready", len(contexts))
+			for _, context := range contexts {
+				clusterIsReadyOrFail(f, &context)
+			}
+			framework.Logf("%d clusters are Ready", len(contexts))
 
-		// Verify that deletion works.
-		framework.Logf("Deleting %d clusters", len(contexts))
-		for _, context := range contexts {
-			framework.Logf("Deleting cluster object: %s (%s, secret: %s)", context.Name, context.Cluster.Cluster.Server, context.Name)
-			err := f.FederationClientset.Federation().Clusters().Delete(context.Name, &api.DeleteOptions{})
-			framework.ExpectNoError(err, fmt.Sprintf("unexpected error in deleting cluster %s: %+v", context.Name, err))
-			framework.Logf("Successfully deleted cluster object: %s (%s, secret: %s)", context.Name, context.Cluster.Cluster.Server, context.Name)
-		}
+			// Verify that deletion works.
+			framework.Logf("Deleting %d clusters", len(contexts))
+			for _, context := range contexts {
+				framework.Logf("Deleting cluster object: %s (%s, secret: %s)", context.Name, context.Cluster.Cluster.Server, context.Name)
+				err := f.FederationClientset.Federation().Clusters().Delete(context.Name, &api.DeleteOptions{})
+				framework.ExpectNoError(err, fmt.Sprintf("unexpected error in deleting cluster %s: %+v", context.Name, err))
+				framework.Logf("Successfully deleted cluster object: %s (%s, secret: %s)", context.Name, context.Cluster.Cluster.Server, context.Name)
+			}
 
-		// There should not be any remaining cluster.
-		framework.Logf("Verifying that zero clusters remain")
-		clusterList, err := f.FederationClientset.Federation().Clusters().List(api.ListOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		if len(clusterList.Items) != 0 {
-			framework.Failf("there should not have been any remaining clusters. Found: %+v", clusterList)
-		}
-		framework.Logf("Verified that zero clusters remain")
+			// There should not be any remaining cluster.
+			framework.Logf("Verifying that zero clusters remain")
+			clusterList, err := f.FederationClientset.Federation().Clusters().List(api.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			if len(clusterList.Items) != 0 {
+				framework.Failf("there should not have been any remaining clusters. Found: %+v", clusterList)
+			}
+			framework.Logf("Verified that zero clusters remain")
+		})
 	})
 })
 


### PR DESCRIPTION
Moving "It" and "AfterEach" into a "Describe" fixes the order of AfterEach.
Verified that now, test.AfterEach is run before running framework.AfterEach.

Removing the temporary disabling of framework.SkipUnlessFederated(f.Client) in AfterEach.

cc @kubernetes/sig-cluster-federation @mml 
