### PR TITLE
Enhance kubedns pod health checks to cover kubedns container

### DIFF
--- a/cluster/saltbase/salt/kube-dns/skydns-rc.yaml.base
+++ b/cluster/saltbase/salt/kube-dns/skydns-rc.yaml.base
@@ -107,7 +107,7 @@ spec:
             cpu: 10m
             memory: 20Mi
         args:
-        - -cmd=nslookup kubernetes.default.svc.__PILLAR__DNS__DOMAIN__ 127.0.0.1 >/dev/null
+        - -cmd=nslookup kubernetes.default.svc.__PILLAR__DNS__DOMAIN__ 127.0.0.1 >/dev/null && nslookup kubernetes.default.svc.__PILLAR__DNS__DOMAIN__ 127.0.0.1:10053 >/dev/null
         - -port=8080
         - -quiet
         ports:

--- a/cluster/saltbase/salt/kube-dns/skydns-rc.yaml.in
+++ b/cluster/saltbase/salt/kube-dns/skydns-rc.yaml.in
@@ -107,7 +107,7 @@ spec:
             cpu: 10m
             memory: 20Mi
         args:
-        - -cmd=nslookup kubernetes.default.svc.{{ pillar['dns_domain'] }} 127.0.0.1 >/dev/null
+        - -cmd=nslookup kubernetes.default.svc.{{ pillar['dns_domain'] }} 127.0.0.1 >/dev/null && nslookup kubernetes.default.svc.{{ pillar['dns_domain'] }} 127.0.0.1:10053 >/dev/null
         - -port=8080
         - -quiet
         ports:

--- a/cluster/saltbase/salt/kube-dns/skydns-rc.yaml.sed
+++ b/cluster/saltbase/salt/kube-dns/skydns-rc.yaml.sed
@@ -106,7 +106,7 @@ spec:
             cpu: 10m
             memory: 20Mi
         args:
-        - -cmd=nslookup kubernetes.default.svc.$DNS_DOMAIN 127.0.0.1 >/dev/null
+        - -cmd=nslookup kubernetes.default.svc.$DNS_DOMAIN 127.0.0.1 >/dev/null && nslookup kubernetes.default.svc.$DNS_DOMAIN 127.0.0.1:10053 >/dev/null
         - -port=8080
         - -quiet
         ports:


### PR DESCRIPTION
The existing health check hits port 53, the dnsmasq container, with the same domain name every time. Since dnsmasq looks up and caches results from the kubedns container, running on port 10053, the health check is not covering the kubedns container after the first query (and once every TTL expiration).

This PR enhances the health check to directly hit port 10053 (kubedns) in addition to port 53.
